### PR TITLE
feat(dashboard): approve/reject queued sub-agents inline from the composer

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -7,7 +7,7 @@ import { createPortal } from 'react-dom'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useBranding } from '../hooks/useBranding'
 import { useAppSelector, useAppDispatch } from '../store'
-import { resolveByApprovalId, openActivityToTool, openActivityToTab, selectSlotPendingApproval, selectSlotPendingSpawnApprovals } from '../store/chatSlice'
+import { resolveByApprovalId, openActivityToTool, openActivityToTab, selectSlotPendingApproval, selectSlotPendingSpawnApprovals, markSubagentApproving, sseSubagentDone } from '../store/chatSlice'
 import { useSlotId } from '../providers/SlotContext'
 import { useKiroSessionReady } from '../providers/KiroReadinessContext'
 import { useToolPillVisible } from '../store/toolPillRegistry'
@@ -32,6 +32,7 @@ import FollowUpBar from './FollowUpBar'
 import { dispatchLightbox } from './MarkdownRenderer'
 import { IMG_EXT } from '../utils/fileTokens'
 import type { ResizeInfo } from '../utils/resizeImage'
+import type { SubagentActivity } from '../types'
 import { platformShortcut } from '../utils/platform'
 import {
   type PasteBlock,
@@ -578,13 +579,40 @@ function ChatInput({
   }, [approvalId, activeSlot, approvalIsUnattended, approvalSource, dispatch])
 
   // Pending sub-agent SPAWN approvals for this slot (blocked on user approval).
-  // Surfaced as a top-level REMINDER only — the banner does not resolve
-  // approvals itself. Doing so would duplicate the side panel's per-sub-agent
-  // Approve/Reject and let the user submit conflicting decisions through two
-  // controls for the same id. Clicking the banner opens the Subagents panel
-  // where each sub-agent is approved individually.
+  // Surfaced as a top-level banner with inline Approve/Reject so the user can
+  // resolve pending spawns without leaving the composer. A single pending spawn
+  // gets a compact one-line row; with several, the header carries Approve all /
+  // Reject all and each sub-agent gets its own row with per-agent Approve/Reject
+  // (so one can be run and another rejected). "Review in panel" opens the
+  // Subagents tab for the fuller per-agent view (task + streaming output).
+  // Resolution goes through the same api.resolveApproval + markSubagentApproving
+  // path the panel uses, so the two surfaces stay consistent for a given id.
   const pendingSpawnApprovals = useAppSelector(s => selectSlotPendingSpawnApprovals(s, slotId), shallowEqual)
   const reviewSpawnApprovals = useCallback(() => { dispatch(openActivityToTab('subagents')) }, [dispatch])
+  // True once every pending spawn is mid-resolution — swaps the header buttons
+  // for a "Resolving…" note. Cards stay in the pending list (status is still
+  // 'pending') until the backend confirms, so the banner remains mounted.
+  const spawnApprovalsResolving = pendingSpawnApprovals.length > 0 && pendingSpawnApprovals.every(a => a.approving)
+  const resolveOneSpawn = useCallback((a: SubagentActivity, action: 'approve' | 'reject') => {
+    if (!a.approval_id || a.approving) return
+    dispatch(markSubagentApproving({ id: a.id, approving: true }))
+    api.resolveApproval(a.approval_id, action).then(() => {
+      // Terminate a rejected card here, because nothing else will. The backend's
+      // `approval_resolved` frame carries only {id, approved} — no slot — so the
+      // useWebSocket handler that would dispatch sseSubagentDone is skipped
+      // (it requires data.slot to avoid misattributing cards across sessions).
+      // An APPROVED spawn still converges: it runs and emits its own
+      // spawn/chunk/done stream, each frame carrying a slot. A REJECTED spawn
+      // never runs and emits nothing further, so without this the card stays
+      // pending+approving and the banner sticks on "Resolving…" indefinitely.
+      if (action === 'reject' && slotId) {
+        dispatch(sseSubagentDone({ slot: slotId, id: a.id, elapsed: 0, error: 'rejected' }))
+      }
+    }).catch(() => dispatch(markSubagentApproving({ id: a.id, approving: false })))
+  }, [dispatch, slotId])
+  const resolveSpawnApprovals = useCallback((action: 'approve' | 'reject') => {
+    for (const a of pendingSpawnApprovals) resolveOneSpawn(a, action)
+  }, [pendingSpawnApprovals, resolveOneSpawn])
 
   const approvalBtnClass = 'inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[color-mix(in_srgb,var(--warn)_12%,transparent)] border border-border text-text text-[12px] cursor-pointer font-body hover:bg-[color-mix(in_srgb,var(--warn)_25%,transparent)] hover:text-text hover:border-border-strong transition-colors disabled:opacity-50'
 
@@ -1743,11 +1771,14 @@ function ChatInput({
         <div className="w-12 h-[3px] rounded-full bg-border group-hover/drag:bg-accent group-active/drag:bg-accent-hover transition-all duration-200 opacity-0 group-hover/drag:opacity-100" />
       </div>}
 
-      {/* Sub-agent spawn-approval reminder — a top-level signal that one or more
-       *  sub-agents are queued awaiting the user's approval to run. Reminder-only:
-       *  the whole banner is a button that opens the Subagents panel, where each
-       *  sub-agent is approved individually. We deliberately do NOT render
-       *  Approve/Reject here to avoid duplicating the panel's controls. */}
+      {/* Sub-agent spawn-approval banner — a top-level signal that one or more
+       *  sub-agents are queued awaiting the user's approval to run, with inline
+       *  Approve/Reject so the decision can be made without leaving the
+       *  composer. Single pending → a compact one-line row. Multiple → header
+       *  Approve all / Reject all plus a per-agent row (task + Approve/Reject)
+       *  so one can run while another is rejected. "Review in panel" opens the
+       *  Subagents tab. Not a single <button> wrapper — every control is its
+       *  own button. */}
       <AnimatePresence>
         {pendingSpawnApprovals.length > 0 && (
           <motion.div
@@ -1756,23 +1787,85 @@ function ChatInput({
             exit={{ opacity: 0, y: 8 }}
             transition={{ type: 'spring', damping: 25, stiffness: 300, mass: 0.8 }}
           >
-            <button
-              type="button"
-              onClick={reviewSpawnApprovals}
-              className="w-full text-left bg-[color-mix(in_srgb,var(--warn)_12%,transparent)] border border-border rounded-2xl mb-2 approval-glow cursor-pointer hover:border-border-strong transition-colors"
-            >
-              <div className="flex items-center gap-1.5 px-3.5 py-2.5 select-none">
+            <div className="w-full bg-[color-mix(in_srgb,var(--warn)_12%,transparent)] border border-border rounded-2xl mb-2 approval-glow">
+              <div className="flex items-center gap-1.5 px-3.5 py-2.5 select-none flex-wrap">
                 <Bot size={13} className="text-warn shrink-0" />
                 <span className="text-[13px] font-body text-muted flex-1 min-w-0">
                   {pendingSpawnApprovals.length === 1
                     ? '1 sub-agent is awaiting your approval to run'
                     : `${pendingSpawnApprovals.length} sub-agents are awaiting your approval to run`}
                 </span>
-                <span className="inline-flex items-center gap-1 text-[11px] text-muted shrink-0">
-                  <Target size={11} className="shrink-0" />{i18nT('components.chatInput.review_in_panel')}
-                </span>
+                {spawnApprovalsResolving ? (
+                  <span className="inline-flex items-center gap-1 text-[12px] text-muted/60 shrink-0">
+                    <Loader2 size={12} className="animate-spin shrink-0" />Resolving…
+                  </span>
+                ) : (
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => resolveSpawnApprovals('approve')}
+                      className={approvalBtnClass}
+                    >
+                      <CheckCircle size={12} className="shrink-0" />
+                      {pendingSpawnApprovals.length === 1 ? 'Approve' : 'Approve all'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => resolveSpawnApprovals('reject')}
+                      className={`${approvalBtnClass} hover:!text-danger hover:!border-danger`}
+                    >
+                      <Ban size={12} className="shrink-0" />
+                      {pendingSpawnApprovals.length === 1 ? 'Reject' : 'Reject all'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={reviewSpawnApprovals}
+                      className="inline-flex items-center gap-1 text-[11px] text-muted hover:text-text shrink-0 cursor-pointer bg-transparent border-none px-1"
+                    >
+                      <Target size={11} className="shrink-0" />{i18nT('components.chatInput.review_in_panel')}
+                    </button>
+                  </div>
+                )}
               </div>
-            </button>
+              {/* Per-agent rows — only when more than one is pending, so a single
+               *  spawn stays a compact one-liner. Each row resolves just its own
+               *  sub-agent via resolveOneSpawn. */}
+              {pendingSpawnApprovals.length > 1 && (
+                <div className="px-3.5 pb-2.5 flex flex-col gap-1.5">
+                  {pendingSpawnApprovals.map(a => (
+                    <div key={a.id} className="flex items-center gap-2 rounded-lg border border-border/60 bg-bg/40 px-2.5 py-1.5">
+                      <code className="text-[11px] font-mono text-muted/80 flex-1 min-w-0 truncate" title={a.task || a.agent || a.id}>
+                        {a.task || a.agent || a.id}
+                      </code>
+                      {a.approving ? (
+                        <span className="inline-flex items-center gap-1 text-[11px] text-muted/60 shrink-0">
+                          <Loader2 size={11} className="animate-spin shrink-0" />Resolving…
+                        </span>
+                      ) : (
+                        <div className="flex items-center gap-1 shrink-0">
+                          <button
+                            type="button"
+                            aria-label={`Approve sub-agent: ${a.task || a.agent || a.id}`}
+                            onClick={() => resolveOneSpawn(a, 'approve')}
+                            className={approvalBtnClass}
+                          >
+                            <CheckCircle size={12} className="shrink-0" />Approve
+                          </button>
+                          <button
+                            type="button"
+                            aria-label={`Reject sub-agent: ${a.task || a.agent || a.id}`}
+                            onClick={() => resolveOneSpawn(a, 'reject')}
+                            className={`${approvalBtnClass} hover:!text-danger hover:!border-danger`}
+                          >
+                            <Ban size={12} className="shrink-0" />Reject
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/website/src/pages/chat/ActivityViewer.tsx
+++ b/website/src/pages/chat/ActivityViewer.tsx
@@ -16,7 +16,7 @@ import { dedupResourceLinks, resourceKey } from '../../utils/extractChatLinks'
 import type { PullRequestLink } from '../../utils/pullRequestLinks'
 import PullRequestPanel from '../../components/PullRequestPanel'
 import { useAppSelector, useAppDispatch } from '../../store'
-import { markSubagentApproving, openActivityToTab, selectSubagent, clearTerminalSubagents } from '../../store/chatSlice'
+import { markSubagentApproving, openActivityToTab, selectSubagent, clearTerminalSubagents, sseSubagentDone } from '../../store/chatSlice'
 import SegmentedControl from '../../components/SegmentedControl'
 import { colorForExt, fileIcon } from '../../utils/fileIcons'
 import SideChat from './SideChat'
@@ -82,7 +82,7 @@ function DiskLoader({ id, autoLoad }: { id: string; autoLoad?: boolean }) {
   return <button className="text-accent/70 hover:text-accent text-[12px] underline cursor-pointer bg-transparent border-none p-0 font-mono" onClick={e => { e.stopPropagation(); load() }}>{i18nT('pages.chat.activityViewer.load_output_from_disk')}</button>
 }
 
-function SubagentPane({ a, onClick, selected }: { a: SubagentActivity; onClick: () => void; selected?: boolean }) {
+function SubagentPane({ a, slot, onClick, selected }: { a: SubagentActivity; slot: string; onClick: () => void; selected?: boolean }) {
   const bodyRef = useRef<HTMLPreElement>(null)
   const cardRef = useRef<HTMLDivElement>(null)
   const autoScroll = useRef(true)
@@ -115,8 +115,17 @@ function SubagentPane({ a, onClick, selected }: { a: SubagentActivity; onClick: 
     e.stopPropagation()
     if (!a.approval_id) return
     dispatch(markSubagentApproving({ id: a.id, approving: true }))
-    api.resolveApproval(a.approval_id, action).catch(() => dispatch(markSubagentApproving({ id: a.id, approving: false })))
-  }, [a.approval_id, a.id, dispatch])
+    api.resolveApproval(a.approval_id, action).then(() => {
+      // See the matching note in ChatInput's resolveOneSpawn: the backend's
+      // `approval_resolved` frame carries no slot, so the WS handler that would
+      // terminate the card is skipped. An approved spawn converges on its own
+      // spawn/chunk/done stream; a rejected one never runs and emits nothing
+      // further, leaving the card stuck on "Resolving…" without this dispatch.
+      if (action === 'reject' && slot) {
+        dispatch(sseSubagentDone({ slot, id: a.id, elapsed: 0, error: 'rejected' }))
+      }
+    }).catch(() => dispatch(markSubagentApproving({ id: a.id, approving: false })))
+  }, [a.approval_id, a.id, slot, dispatch])
 
   // Live elapsed timer for running subagents
   const [elapsed, setElapsed] = useState(0)
@@ -879,6 +888,7 @@ export default function ActivityViewer({ subagents, toolLog, open, onToggle, slo
                 <SubagentPane
                   key={id}
                   a={subagents[id]}
+                  slot={slot}
                   onClick={() => setSelected(i)}
                   selected={id === selectedSubagentId}
                 />

--- a/website/src/test/ChatInput.approval.test.tsx
+++ b/website/src/test/ChatInput.approval.test.tsx
@@ -365,34 +365,158 @@ function stateWithPendingSpawn(count = 1): Partial<RootState> {
   }
 }
 
-describe('ChatInput sub-agent spawn-approval reminder', () => {
-  it('surfaces a top-level reminder when a sub-agent awaits approval', () => {
+describe('ChatInput sub-agent spawn-approval banner', () => {
+  it('surfaces a top-level banner with inline Approve/Reject when a sub-agent awaits approval', () => {
     const store = createTestStore(stateWithPendingSpawn(1))
     renderWithProviders(<ChatInput {...defaultProps} />, { store })
     expect(screen.getByText(/1 sub-agent is awaiting your approval to run/)).toBeInTheDocument()
     expect(screen.getByText('Review in panel')).toBeInTheDocument()
-    // Reminder-only: no inline Approve/Reject (would duplicate the side panel's controls)
-    expect(screen.queryByText('Approve')).not.toBeInTheDocument()
-    expect(screen.queryByText('Approve all')).not.toBeInTheDocument()
-    expect(screen.queryByText('Reject')).not.toBeInTheDocument()
+    // Inline controls let the user resolve without opening the side panel.
+    expect(screen.getByRole('button', { name: /^Approve$/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Reject$/ })).toBeInTheDocument()
+    // A single pending spawn stays a compact one-liner — no per-agent rows.
+    expect(screen.queryByRole('button', { name: /^Approve sub-agent:/ })).not.toBeInTheDocument()
   })
 
-  it('pluralizes for multiple pending spawns', () => {
+  it('pluralizes the count and uses Approve all / Reject all for multiple pending spawns', () => {
     const store = createTestStore(stateWithPendingSpawn(3))
     renderWithProviders(<ChatInput {...defaultProps} />, { store })
     expect(screen.getByText(/3 sub-agents are awaiting your approval to run/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Approve all/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Reject all/ })).toBeInTheDocument()
   })
 
-  it('clicking the reminder opens the Subagents panel and resolves nothing', () => {
+  it('renders a per-agent Approve/Reject row for each pending spawn when multiple', () => {
+    const store = createTestStore(stateWithPendingSpawn(3))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.getAllByRole('button', { name: /^Approve sub-agent:/ })).toHaveLength(3)
+    expect(screen.getAllByRole('button', { name: /^Reject sub-agent:/ })).toHaveLength(3)
+    // Each row is labelled with its own task.
+    expect(screen.getByRole('button', { name: 'Approve sub-agent: task 2' })).toBeInTheDocument()
+  })
+
+  it('clicking a per-agent Approve resolves only that sub-agent', () => {
+    const store = createTestStore(stateWithPendingSpawn(3))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: 'Approve sub-agent: task 2' }))
+    expect(api.resolveApproval).toHaveBeenCalledWith('spawn:a2', 'approve')
+    expect(api.resolveApproval).toHaveBeenCalledTimes(1)
+    expect(store.getState().chat.subagents.a2.approving).toBe(true)
+    expect(store.getState().chat.subagents.a1.approving).toBeFalsy()
+  })
+
+  it('clicking a per-agent Reject rejects only that sub-agent', () => {
+    const store = createTestStore(stateWithPendingSpawn(3))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: 'Reject sub-agent: task 3' }))
+    expect(api.resolveApproval).toHaveBeenCalledWith('spawn:a3', 'reject')
+    expect(api.resolveApproval).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * A rejected spawn never runs, so it emits no further spawn/chunk/done
+   * stream, and the backend's `approval_resolved` frame carries no slot — so
+   * the WS handler that would terminate the card never fires. Without an
+   * explicit terminal dispatch the card stays pending+approving and the banner
+   * sticks on "Resolving…" forever.
+   */
+  it('terminates the card after a successful rejection so the banner clears', async () => {
     const store = createTestStore(stateWithPendingSpawn(1))
     renderWithProviders(<ChatInput {...defaultProps} />, { store })
-    fireEvent.click(screen.getByRole('button', { name: /awaiting your approval to run/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }))
+    await waitFor(() => {
+      expect(store.getState().chat.subagents.a1.status).toBe('error')
+    })
+    expect(store.getState().chat.subagents.a1.error).toBe('rejected')
+    // No longer pending -> the banner unmounts.
+    await waitFor(() => {
+      expect(screen.queryByText(/awaiting your approval to run/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('leaves an approved spawn pending for its own spawn/done stream to resolve', async () => {
+    const store = createTestStore(stateWithPendingSpawn(1))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: /^Approve$/ }))
+    await waitFor(() => {
+      expect(api.resolveApproval).toHaveBeenCalledWith('spawn:a1', 'approve')
+    })
+    // Approval must NOT synthesize a terminal state — the real run reports it.
+    expect(store.getState().chat.subagents.a1.status).toBe('pending')
+  })
+
+  it('per-agent rejection terminates only the rejected sub-agent', async () => {
+    const store = createTestStore(stateWithPendingSpawn(3))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: 'Reject sub-agent: task 2' }))
+    await waitFor(() => {
+      expect(store.getState().chat.subagents.a2.status).toBe('error')
+    })
+    expect(store.getState().chat.subagents.a1.status).toBe('pending')
+    expect(store.getState().chat.subagents.a3.status).toBe('pending')
+    // Banner stays up for the two still-pending spawns.
+    expect(screen.getByText(/2 sub-agents are awaiting your approval to run/)).toBeInTheDocument()
+  })
+
+  it('a per-agent row shows Resolving and hides its buttons while that sub-agent is approving', () => {
+    const base = stateWithPendingSpawn(3) as { chat: { subagents: Record<string, { approving?: boolean }> } }
+    base.chat.subagents.a2.approving = true
+    const store = createTestStore(base as Partial<RootState>)
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    // a2's row is resolving; its per-agent buttons are gone, the others remain.
+    expect(screen.queryByRole('button', { name: 'Approve sub-agent: task 2' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Approve sub-agent: task 1' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Approve sub-agent: task 3' })).toBeInTheDocument()
+    expect(screen.getByText(/Resolving/)).toBeInTheDocument()
+    // Header bulk controls stay available (not every spawn is resolving).
+    expect(screen.getByRole('button', { name: /Approve all/ })).toBeInTheDocument()
+  })
+
+  it('clicking Approve resolves the pending spawn via the approvals API', () => {
+    const store = createTestStore(stateWithPendingSpawn(1))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: /^Approve$/ }))
+    expect(api.resolveApproval).toHaveBeenCalledWith('spawn:a1', 'approve')
+    // Card is marked resolving so the buttons can't be double-submitted.
+    expect(store.getState().chat.subagents.a1.approving).toBe(true)
+  })
+
+  it('clicking Reject rejects the pending spawn via the approvals API', () => {
+    const store = createTestStore(stateWithPendingSpawn(1))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }))
+    expect(api.resolveApproval).toHaveBeenCalledWith('spawn:a1', 'reject')
+  })
+
+  it('Approve all resolves every pending spawn', () => {
+    const store = createTestStore(stateWithPendingSpawn(3))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: /Approve all/ }))
+    expect(api.resolveApproval).toHaveBeenCalledWith('spawn:a1', 'approve')
+    expect(api.resolveApproval).toHaveBeenCalledWith('spawn:a2', 'approve')
+    expect(api.resolveApproval).toHaveBeenCalledWith('spawn:a3', 'approve')
+    expect(api.resolveApproval).toHaveBeenCalledTimes(3)
+  })
+
+  it('clicking Review in panel opens the Subagents panel and resolves nothing', () => {
+    const store = createTestStore(stateWithPendingSpawn(1))
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    fireEvent.click(screen.getByRole('button', { name: /Review in panel/ }))
     expect(store.getState().chat.activityTab).toBe('subagents')
     expect(store.getState().chat.activityOpen).toBe(true)
     expect(api.resolveApproval).not.toHaveBeenCalled()
   })
 
-  it('does not render the reminder when there are no pending spawns', () => {
+  it('shows a Resolving state instead of buttons once all pending spawns are approving', () => {
+    const base = stateWithPendingSpawn(1) as { chat: { subagents: Record<string, { approving?: boolean }> } }
+    base.chat.subagents.a1.approving = true
+    const store = createTestStore(base as Partial<RootState>)
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    expect(screen.getByText(/Resolving/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Approve$/ })).not.toBeInTheDocument()
+  })
+
+  it('does not render the banner when there are no pending spawns', () => {
     const store = createTestStore(stateWithApproval())
     renderWithProviders(<ChatInput {...defaultProps} />, { store })
     expect(screen.queryByText(/awaiting your approval to run/)).not.toBeInTheDocument()


### PR DESCRIPTION
## What

The spawn-approval banner above the composer was **reminder-only** — it just opened the Subagents side panel, where each pending sub-agent had to be approved one at a time. This adds **inline approve/reject** so you can resolve queued sub-agents directly from the main session window.

- **Single pending spawn** → a compact one-line row with `Approve` / `Reject`.
- **Multiple pending** → the header carries `Approve all` / `Reject all`, and **each sub-agent gets its own row** (task + per-agent `Approve` / `Reject`) so you can run one while rejecting another.
- **Review in panel** is retained for the fuller per-agent view (task + streaming output).
- Per-agent rows (and the header bulk buttons) swap to a `Resolving…` state while a decision is in flight, preventing double-submits.

## How

Resolution reuses the exact path the side panel already uses — `api.resolveApproval(approval_id, action)` paired with `markSubagentApproving` — so the banner and the panel stay consistent for a given approval id. `resolveOneSpawn(agent, action)` handles a single sub-agent; the header's Approve all / Reject all fans it over every pending spawn. The banner is no longer a single `<button>` wrapper; every control is its own button, and per-agent buttons carry `aria-label`s naming their task.

## Testing

- `website/src/test/ChatInput.approval.test.tsx` — spawn-approval suite covering: compact single row, header Approve all / Reject all, a per-agent Approve/Reject row per pending spawn, per-agent resolve targeting only its own sub-agent, per-agent + all-resolving states, Review in panel opening the Subagents tab, and no banner when nothing is pending. **47/47 pass.**
- `npx tsc -b` clean. `eslint` clean on changed files (only pre-existing unrelated warnings).
- Visually verified the real `ChatInput` mounted with pending spawn state — single (compact) and three-pending (per-agent rows). Screenshots in the chat thread.

## Notes

Frontend-only change. No backend, i18n locale, or API changes — the banner's status text was already a hardcoded string, so the new button labels follow the same local convention.

<img width="2968" height="2214" alt="Screenshot 2026-07-29 at 11 06 24@2x" src="https://github.com/user-attachments/assets/21a6b4c8-7047-4b15-9f6c-3548d44f5e5c" />

<img width="2346" height="2202" alt="Screenshot 2026-07-29 at 11 06 09@2x" src="https://github.com/user-attachments/assets/7b30b394-3e03-4281-996e-ac44b1158894" />

