### PR TITLE
fix(subagent): count only top-level agents in the progress pill

### DIFF
--- a/website/src/pages/chat/SubagentProgressBar.tsx
+++ b/website/src/pages/chat/SubagentProgressBar.tsx
@@ -33,7 +33,13 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   // Aggregate "waiting to start" count for this slot — agents accepted but
   // queued behind the concurrency cap / stagger gate (no individual card yet).
   const queued = useAppSelector(s => s.chat.subagentQueued?.[slot ?? ''] ?? 0)
-  const all = useMemo(() => Object.values(subagents), [subagents])
+  // Only top-level (managed) subagents belong in the chip — its count must
+  // match the "spawned N" prose. Native kiro-cli sub-agents (native:* ids,
+  // surfaced from _kiro.dev/subagent/list_update) are nested UNDER a managed
+  // agent, not launched by this session's spawn_run, so counting them inflated
+  // the histogram past what was actually spawned (e.g. 4 spawned → 9 tracked).
+  // They remain fully visible in the Subagents activity sidebar.
+  const all = useMemo(() => Object.values(subagents).filter(a => !a.id.startsWith('native:')), [subagents])
   // Exception-first ordering: retrying/stalled agents need eyes; the healthy
   // majority collapses behind the summary row at scale.
   const activeList = useMemo(() => {
@@ -51,7 +57,8 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
     stopped: all.filter(a => a.status === 'stopped').length,
     stalled: activeList.filter(a => a.stalled).length,
   }), [all, activeList])
-  const failedIds = useMemo(() => all.filter(a => a.status === 'error' && !a.id.startsWith('native:')).map(a => a.id), [all])
+  // `all` already excludes native:* ids, so error entries here are managed.
+  const failedIds = useMemo(() => all.filter(a => a.status === 'error').map(a => a.id), [all])
   const activeListRef = useRef(activeList)
   activeListRef.current = activeList
   // Mount when anything is in flight — running OR queued. Including queued is

--- a/website/src/test/SubagentProgressBar.test.tsx
+++ b/website/src/test/SubagentProgressBar.test.tsx
@@ -67,6 +67,23 @@ describe('SubagentProgressBar — in-chat stop controls', () => {
     expect(screen.queryByLabelText('Stop all running subagents')).not.toBeInTheDocument()
   })
 
+  it('excludes native (nested) kiro-cli subagents from the count and rows so it matches "spawned N"', () => {
+    // 2 top-level managed agents + 2 native:* nested agents surfaced from the
+    // kiro-cli list_update. The chip must show only the 2 managed ones.
+    renderBar(makeStore(['a1', 'a2', 'native:sess-x', 'native:sess-y']))
+    // Running histogram counts managed only.
+    expect(screen.getByTestId('subagent-running-count')).toHaveTextContent('2')
+    // Exactly two rows, both managed; no native task rows.
+    const rows = screen.getAllByTestId('subagent-row')
+    expect(rows).toHaveLength(2)
+    // "Stop all" acts on the 2 managed agents, never the native ones.
+    fireEvent.click(screen.getByLabelText('Stop all running subagents'))
+    expect(api.spawnDelete).toHaveBeenCalledTimes(2)
+    expect(api.spawnDelete).toHaveBeenCalledWith('a1')
+    expect(api.spawnDelete).toHaveBeenCalledWith('a2')
+    expect(api.spawnDelete).not.toHaveBeenCalledWith('native:sess-x')
+  })
+
   it('renders no stop controls when every active agent is pending (stoppableCount === 0)', () => {
     renderBar(makeStore([], 'p1'))
     // The pending agent still shows in the header, but offers no stop affordance.


### PR DESCRIPTION
## Problem
The subagent progress pill above the chat input shows a count that doesn't match the "spawned N" prose. In a session that said "spawned 4 parallel investigations," the pill read `↻2 ✓7` — 9 tracked — leaving the user unable to reconcile the chip against what they actually launched.

## Why it matters
The chip is the at-a-glance signal for how many agents a turn kicked off. When it silently counts more than were spawned, it reads as a bug (runaway/duplicate spawning) and erodes trust in the orchestration visibility that is a core feature — even though nothing is actually over-spawning.

## Fix (symptom → root cause → change)
- **Symptom:** pill count (9) > spawned count (4).
- **Root cause:** the pill's histogram is derived from `Object.values(state.chat.subagents)`, which holds **two** populations: top-level agents launched by this session's `spawn_run`, *and* native kiro-cli sub-agents (`native:*` ids surfaced from the `_kiro.dev/subagent/list_update` notification via `chat_runner._native_subagent_sync`). Native agents are nested *under* a managed agent, not launched by `spawn_run`. Counting both inflated the histogram past the spawned count (4 managed + 5 native = 9). KiroCrew's own spawner forbids recursion, but it cannot stop the kiro-cli agent inside a subagent from using kiro-cli's native fan-out — and that fan-out was being counted.
- **Change:** narrow the pill's source set once — `all = Object.values(subagents).filter(a => !a.id.startsWith('native:'))`. Every downstream derivation (running/done/failed histogram, rows, `failedIds`, `stoppableCount`, `stopAll`, and the 30s reconcile loop) now reads from the pre-filtered set, so the chip reflects exactly what `spawn_run` launched. The now-redundant `native:` guard in `failedIds` is removed since `all` is already native-free. Native agents remain fully visible in the Subagents activity sidebar — only the top-line chip changes.

## Tests
- `website/src/test/SubagentProgressBar.test.tsx`: new case `excludes native (nested) kiro-cli subagents from the count and rows so it matches "spawned N"` — seeds 2 managed + 2 `native:*` agents and asserts the running count is 2, exactly 2 rows render, and "Stop all" calls `spawnDelete` only for the managed ids (never the native ones). Locks in that native activity never inflates the chip and is never targeted by the chip's stop controls.
- Existing 11 tests unchanged and green (stop-single/stop-all/pending semantics unaffected).

## Manual verification
Ran locally: `tsc --noEmit` clean; `vitest run SubagentProgressBar.test.tsx` → 12/12 pass. Behavior confirmed by reasoning + the new test: `native:*` entries are excluded from `all` before any count/row/stop derivation.

## Screenshots
N/A — this is a numeric count change on an existing chip, not a new/changed visual surface. Reproducing the mismatched state requires a live session where a kiro-cli subagent performs native nested fan-out, which cannot be staged deterministically for a screenshot; the new unit test captures the count/row/stop behavior instead.
