### PR TITLE
feat(dashboard): show the current git branch in the active project button

### DIFF
--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -124,6 +124,7 @@ from kiro_crew.dashboard.handlers.files import (  # noqa: E402, F401
     api_outbox_download,
     api_outbox_list,
     api_outbox_notify,
+    api_project_git,
     api_reveal_path,
     api_screenshot,
     api_slack_upload_file,

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -25,6 +25,7 @@ from aiohttp.multipart import BodyPartReader
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.hooks import safe_read_prefix
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.security import (
     BINARY_MIME_ALLOWLIST,
@@ -2082,6 +2083,244 @@ async def api_browse_dirs(request: web.Request) -> web.Response:
         pass
     _sel().log_api_access(caller=caller, operation="browse_dirs", outcome="allowed", resources=base)
     return web.json_response({"path": base, "parent": os.path.dirname(base), "dirs": dirs})
+
+
+#: Depth ceiling for the walk-up that looks for a repository root. A project
+#: directory nested deeper than this below its repo root is reported as
+#: not-a-repo rather than paying an unbounded number of stat calls per request.
+_GIT_ROOT_WALK_LIMIT = 40
+
+#: A HEAD file is one short line; cap the read so a hostile symlink to something
+#: enormous cannot be slurped into memory.
+_HEAD_READ_LIMIT = 4096
+
+
+def _read_git_meta_prefix(path: str) -> str | None:
+    """Read a bounded prefix of a git metadata file through the hooks gate.
+
+    ``.git`` and ``.git/HEAD`` are ordinary filesystem paths inside a directory
+    the caller chose, so either can be a symlink pointing at something the
+    gateway must never read — a secret whose first line happens to look like a
+    ref, or a 40-64 char hex blob that would match the detached-HEAD shape.
+    ``hooks.safe_read_prefix`` canonicalises via realpath, refuses sensitive
+    resolved targets, and opens with ``O_NOFOLLOW`` as TOCTOU defence against a
+    final-component swap. A refused or unreadable path returns ``None`` and the
+    caller degrades to "no branch".
+    """
+    data = safe_read_prefix(path, _HEAD_READ_LIMIT)
+    if data is None:
+        return None
+    return data.decode("utf-8", errors="replace").strip()
+
+
+def _git_head_path(root: str) -> str | None:
+    """Resolve the HEAD file for the repo at *root*.
+
+    A linked worktree's ``.git`` is a FILE containing ``gitdir: <path>``, and that
+    directory holds the worktree's own HEAD — so the pointer has to be followed
+    rather than assuming ``<root>/.git`` is a directory.
+    """
+    dot = os.path.join(root, ".git")
+    if os.path.isdir(dot):
+        return os.path.join(dot, "HEAD")
+    pointer = _read_git_meta_prefix(dot)
+    if pointer is None or not pointer.startswith("gitdir:"):
+        return None
+    gitdir = pointer.split(":", 1)[1].strip()
+    if not gitdir:
+        return None
+    if not os.path.isabs(gitdir):
+        gitdir = os.path.join(root, gitdir)
+    return os.path.join(gitdir, "HEAD")
+
+
+def _slot_project_snapshot(state: DashboardState) -> list[str]:
+    """Copy every live slot's project dir. MUST run on the event loop.
+
+    Slots are created and deleted by other coroutines on the loop, so the copy
+    has to happen where those mutations are serialised against it. Doing it in a
+    worker thread would iterate a dict that the loop can mutate underneath.
+    Pure in-memory, no I/O — safe to call inline.
+    """
+    dirs: list[str] = []
+    for slot in list(getattr(state, "_slots", {}).values()):
+        proj = getattr(slot, "project", "") or ""
+        if proj:
+            dirs.append(proj)
+    return dirs
+
+
+def _known_project_dirs(slot_projects: list[str]) -> list[str]:
+    """Server-held project directories a branch lookup may be asked about.
+
+    The caller's slot snapshot plus the recorded recent-projects list —
+    directories the gateway itself set or the user already picked through the
+    project picker. Nothing in the returned list comes from the current request.
+    Reads a file, so this belongs in a worker thread.
+    """
+    dirs: list[str] = list(slot_projects)
+    fp = config_dir() / "recent_projects.json"
+    try:
+        recent = json.loads(fp.read_text(encoding="utf-8")) if fp.is_file() else []
+    except (json.JSONDecodeError, OSError, ValueError):
+        recent = []
+    if isinstance(recent, list):
+        dirs.extend(d for d in recent if isinstance(d, str) and d)
+    return dirs
+
+
+def _match_known_project(raw: str, known: list[str]) -> str | None:
+    """Map a request-supplied path onto the matching known project directory.
+
+    Returns the SERVER-HELD string, never the caller's, so request data is only
+    ever a comparison operand and never reaches a filesystem call. Matching is
+    pure string normalisation (expanduser + normpath) with no filesystem access
+    on the untrusted value — deliberately not realpath, which would stat a
+    caller-controlled path and reintroduce the probe this guard removes.
+    """
+    want = os.path.normpath(os.path.expanduser(raw))
+    for cand in known:
+        if os.path.normpath(os.path.expanduser(cand)) == want:
+            return cand
+    return None
+
+
+def _project_git_branch(base: str) -> dict:
+    """Resolve the checked-out branch for ``base``.
+
+    Returns ``{"repo": False}`` when ``base`` is not inside a git repository.
+    For a repository, returns the repo root plus either a ``branch`` name or,
+    on a detached HEAD, ``detached: True`` with the short commit in ``head``.
+    """
+    root: str | None = None
+    cur = base
+    for _ in range(_GIT_ROOT_WALK_LIMIT):
+        # A worktree's .git is a FILE (a gitdir pointer), not a directory, so
+        # probe for existence rather than is_dir() — otherwise every KiroCrew
+        # worktree reports as not-a-repo.
+        if os.path.exists(os.path.join(cur, ".git")):
+            root = cur
+            break
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    if root is None:
+        return {"repo": False}
+    # ``root`` is derived from an allow-listed project directory, but a directory
+    # NAME is itself agent-influenceable via set_project and this value is echoed
+    # to the dashboard, so it goes through the same egress redaction as the branch
+    # label. A normal path is unchanged.
+    out: dict = {"repo": True, "repoRoot": redact(root)}
+    head_path = _git_head_path(root)
+    if head_path is None:
+        return out
+    raw = _read_git_meta_prefix(head_path)
+    if raw is None:
+        # Unreadable, absent, or refused by the sensitive-path gate: still a
+        # repo, just no label.
+        return out
+    if raw.startswith("ref:"):
+        ref = raw[len("ref:"):].strip()
+        prefix = "refs/heads/"
+        if ref.startswith(prefix) and len(ref) > len(prefix):
+            # Branch names are attacker/agent-controllable content that this route
+            # renders in the dashboard AND makes copyable, so it goes through the
+            # canonical egress redaction like any other echoed string. Ordinary
+            # branch names are unchanged; one that embeds something matching a
+            # credential pattern is masked rather than displayed.
+            out["branch"] = redact(ref[len(prefix):])
+        return out
+    # A bare object id in HEAD means detached (mid-rebase, bisect, explicit
+    # --detach). Surface a short form so the caller shows something truthful
+    # instead of an empty label. This is a fixed 7-char prefix rather than git's
+    # dynamic uniqueness-based abbreviation — for a decorative label that is an
+    # acceptable difference, and it needs no repository query.
+    if re.fullmatch(r"[0-9a-fA-F]{40,64}", raw):
+        out["detached"] = True
+        out["head"] = redact(raw[:7])
+    return out
+
+
+def _match_known_project_for(slot_projects: list[str], raw: str) -> str | None:
+    """Build the allow-list and match *raw* against it. Worker-thread only.
+
+    Takes an already-taken slot snapshot rather than the live state, so nothing
+    here touches structures the event loop mutates. Both remaining halves must
+    stay off the loop: reading the recent-projects file does I/O, and
+    ``expanduser`` on a ``~user`` form does a passwd lookup, which can block on
+    NSS/LDAP for an authenticated caller passing ``?path=~x/y``.
+    """
+    return _match_known_project(raw, _known_project_dirs(slot_projects))
+
+
+def _resolve_project_git(project: str) -> tuple[str, str, dict]:
+    """Vet *project* and read its branch. Runs entirely in a worker thread.
+
+    Every filesystem touch for the request lives here: ``realpath``,
+    the directory check, and ``is_sensitive_path`` all stat, so a project on a
+    stalled network mount would block the event loop for the whole probe if any
+    of them ran inline.
+
+    Returns ``(status, base, info)`` with status ``"ok"``, ``"not_a_dir"``, or
+    ``"sensitive"``; ``info`` is populated only for ``"ok"``.
+    """
+    base = os.path.realpath(os.path.expanduser(project))
+    if not os.path.isdir(base):
+        return "not_a_dir", base, {}
+    if is_sensitive_path(base):
+        return "sensitive", base, {}
+    return "ok", base, _project_git_branch(base)
+
+
+async def api_project_git(request: web.Request) -> web.Response:
+    """GET /api/project/git?path=... — checked-out branch for a project dir.
+
+    ``path`` is matched against the gateway's own set of known project
+    directories and the matched server-held value is what gets stat'd, so this
+    route cannot be used to probe arbitrary filesystem paths for existence or
+    git metadata. An unrecognised directory is refused outright.
+    """
+    state: DashboardState = request.app["state"]
+    caller = request.get("user", "dashboard")
+    raw = request.query.get("path", "").strip()
+    if not raw:
+        return web.json_response({"error": "path required"}, status=400)
+    project = await asyncio.to_thread(
+        _match_known_project_for, _slot_project_snapshot(state), raw
+    )
+    if project is None:
+        _sel().log_api_access(
+            caller=caller,
+            operation="project_git",
+            outcome="denied",
+            resources=raw,
+            error="not a known project directory",
+        )
+        return web.json_response({"error": "Unknown project directory"}, status=403)
+    status, base, info = await asyncio.to_thread(_resolve_project_git, project)
+    if status == "not_a_dir":
+        # Redacted like every other echoed path: this arm is reachable whenever a
+        # known project directory is deleted or replaced between the allow-list
+        # match and the stat, so it is a live egress surface, not a dead branch.
+        return web.json_response(
+            {"error": "Not a directory", "path": redact(base)}, status=400
+        )
+    if status == "sensitive":
+        _sel().log_api_access(
+            caller=caller,
+            operation="project_git",
+            outcome="denied",
+            resources=base,
+            error="sensitive path",
+        )
+        return web.json_response({"error": "Access denied"}, status=403)
+    _sel().log_api_access(
+        caller=caller, operation="project_git", outcome="allowed", resources=base
+    )
+    # The SEL audit above records the real path; the response body is an egress
+    # surface the dashboard renders, so the echoed path is redacted like the rest.
+    return web.json_response({"path": redact(base), **info})
 
 
 async def api_browse_files(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1843,6 +1843,7 @@ async def start_dashboard(
     app.router.add_get("/api/file-search", handlers.api_file_search)
     app.router.add_get("/api/browse-dirs", handlers.api_browse_dirs)
     app.router.add_get("/api/browse-files", handlers.api_browse_files)
+    app.router.add_get("/api/project/git", handlers.api_project_git)
     app.router.add_post("/api/upload", handlers.api_upload)
     app.router.add_post("/api/upload/file", handlers.api_upload_file)
     app.router.add_post("/api/slack/upload-file", handlers.api_slack_upload_file)

--- a/test/test_project_git.py
+++ b/test/test_project_git.py
@@ -1,0 +1,554 @@
+"""Tests for ``GET /api/project/git`` — branch label for the project chip.
+
+Covers the known-project allow-list that keeps the route from being an
+arbitrary-path prober, repo detection (including the worktree case where
+``.git`` is a file), detached HEAD, the sensitive-path denial, and the
+degrade-to-no-branch behaviour when git is unavailable or hangs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import kiro_crew.dashboard.handlers.files as files_mod
+from kiro_crew.dashboard.handlers import api_project_git
+from kiro_crew.dashboard.handlers.files import (
+    _HEAD_READ_LIMIT,
+    _git_head_path,
+    _known_project_dirs,
+    _match_known_project,
+    _match_known_project_for,
+    _project_git_branch,
+    _resolve_project_git,
+    _slot_project_snapshot,
+)
+
+
+class _Slot:
+    def __init__(self, project: str) -> None:
+        self.project = project
+
+
+class _State:
+    """Minimal DashboardState stand-in exposing the slots the handler reads."""
+
+    def __init__(self, *projects: str) -> None:
+        self._slots = {f"s{i}": _Slot(p) for i, p in enumerate(projects)}
+
+
+def _make_app(*known: str) -> web.Application:
+    app = web.Application()
+    app["state"] = _State(*known)
+    app.router.add_get("/api/project/git", api_project_git)
+    return app
+
+
+@pytest.fixture()
+def mock_sel():
+    with patch("kiro_crew.dashboard.handlers.sel") as m:
+        m.return_value = MagicMock()
+        yield m.return_value
+
+
+def _git(cwd, *args) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"},
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A real git repo with one commit on branch ``trunk``."""
+    root = tmp_path / "proj"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "trunk")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "f.txt").write_text("x")
+    _git(root, "add", "f.txt")
+    _git(root, "commit", "-qm", "init")
+    return root
+
+
+class TestProjectGitEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_branch_for_repo(self, repo, mock_sel):
+        async with TestClient(TestServer(_make_app(str(repo)))) as client:
+            resp = await client.get(f"/api/project/git?path={repo}")
+            assert resp.status == 200
+            data = await resp.json()
+        assert data["repo"] is True
+        assert data["branch"] == "trunk"
+        assert data["repoRoot"] == os.path.realpath(str(repo))
+        assert data.get("detached") is not True
+
+    @pytest.mark.asyncio
+    async def test_finds_repo_root_from_subdirectory(self, repo, mock_sel):
+        sub = repo / "src" / "deep"
+        sub.mkdir(parents=True)
+        async with TestClient(TestServer(_make_app(str(sub)))) as client:
+            resp = await client.get(f"/api/project/git?path={sub}")
+            data = await resp.json()
+        assert data["branch"] == "trunk"
+        assert data["repoRoot"] == os.path.realpath(str(repo))
+
+    @pytest.mark.asyncio
+    async def test_non_repo_reports_repo_false(self, tmp_path, mock_sel):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        async with TestClient(TestServer(_make_app(str(plain)))) as client:
+            resp = await client.get(f"/api/project/git?path={plain}")
+            data = await resp.json()
+        # tmp_path can sit under an unrelated repo on some hosts; assert only
+        # that no branch is claimed for a directory with no .git of its own.
+        assert data.get("branch", "") != "trunk"
+        assert "path" in data
+
+    @pytest.mark.asyncio
+    async def test_unknown_directory_is_refused(self, repo, tmp_path, mock_sel):
+        """The route must not answer for a path the gateway does not know."""
+        other = tmp_path / "somewhere-else"
+        other.mkdir()
+        async with TestClient(TestServer(_make_app(str(repo)))) as client:
+            resp = await client.get(f"/api/project/git?path={other}")
+            assert resp.status == 403
+            body = await resp.json()
+        assert "Unknown project" in body["error"]
+        kwargs = mock_sel.log_api_access.call_args.kwargs
+        assert kwargs["outcome"] == "denied"
+        assert kwargs["error"] == "not a known project directory"
+
+    @pytest.mark.asyncio
+    async def test_traversal_out_of_a_known_project_is_refused(self, repo, mock_sel):
+        """`<known>/../..` normalises outside the allow-list and must not match."""
+        async with TestClient(TestServer(_make_app(str(repo)))) as client:
+            resp = await client.get(f"/api/project/git?path={repo}/../..")
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_recent_projects_entry_is_accepted(self, repo, tmp_path, mock_sel):
+        """A picker-recorded project is allowed even with no live slot for it."""
+        cfg = tmp_path / "cfg"
+        cfg.mkdir()
+        (cfg / "recent_projects.json").write_text(json.dumps([str(repo)]), encoding="utf-8")
+        with patch("kiro_crew.dashboard.handlers.files.config_dir", return_value=cfg):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/project/git?path={repo}")
+                assert resp.status == 200
+                data = await resp.json()
+        assert data["branch"] == "trunk"
+
+    @pytest.mark.asyncio
+    async def test_missing_path_is_400(self, mock_sel):
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get("/api/project/git")
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_not_a_directory_is_400(self, repo, mock_sel):
+        f = repo / "f.txt"
+        async with TestClient(TestServer(_make_app(str(f)))) as client:
+            resp = await client.get(f"/api/project/git?path={f}")
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_sensitive_path_is_denied(self, repo, mock_sel):
+        with patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=True):
+            async with TestClient(TestServer(_make_app(str(repo)))) as client:
+                resp = await client.get(f"/api/project/git?path={repo}")
+                assert resp.status == 403
+        assert mock_sel.log_api_access.call_args.kwargs["outcome"] == "denied"
+
+
+class TestKnownProjectMatching:
+    def test_returns_the_server_held_string_not_the_callers(self):
+        """The matched value must be the allow-list entry, never request text."""
+        known = ["/srv/work/proj"]
+        assert _match_known_project("/srv/work/proj/", known) == "/srv/work/proj"
+        assert _match_known_project("/srv/work/./proj", known) == "/srv/work/proj"
+        assert _match_known_project("/srv/work/other/../proj", known) == "/srv/work/proj"
+
+    def test_non_member_returns_none(self):
+        assert _match_known_project("/etc", ["/srv/work/proj"]) is None
+        assert _match_known_project("/srv/work", ["/srv/work/proj"]) is None
+        # A path merely PREFIXED by a known project is not itself known.
+        assert _match_known_project("/srv/work/project-x", ["/srv/work/proj"]) is None
+
+    def test_empty_allowlist_matches_nothing(self):
+        assert _match_known_project("/srv/work/proj", []) is None
+
+    def test_slots_and_recent_are_both_collected(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        cfg.mkdir()
+        (cfg / "recent_projects.json").write_text(json.dumps(["/from/recent", 7]), encoding="utf-8")
+        with patch("kiro_crew.dashboard.handlers.files.config_dir", return_value=cfg):
+            dirs = _known_project_dirs(_slot_project_snapshot(_State("/from/slot", "")))
+        assert "/from/slot" in dirs
+        assert "/from/recent" in dirs
+        assert "" not in dirs  # empty slot project contributes nothing
+        assert 7 not in dirs  # non-string recent entries are dropped
+
+    def test_corrupt_recent_file_degrades_to_slots_only(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        cfg.mkdir()
+        (cfg / "recent_projects.json").write_text("{not json", encoding="utf-8")
+        with patch("kiro_crew.dashboard.handlers.files.config_dir", return_value=cfg):
+            dirs = _known_project_dirs(_slot_project_snapshot(_State("/from/slot")))
+        assert dirs == ["/from/slot"]
+
+
+class TestProjectGitBranchResolver:
+    def test_worktree_gitfile_is_a_repo(self, repo, tmp_path):
+        """A worktree's ``.git`` is a FILE holding ``gitdir: <path>``, and that
+        directory holds the worktree's own HEAD."""
+        wt = tmp_path / "wt"
+        _git(repo, "worktree", "add", "-q", "-b", "feat/x", str(wt))
+        assert (wt / ".git").is_file()
+        info = _project_git_branch(os.path.realpath(str(wt)))
+        assert info["repo"] is True
+        assert info["branch"] == "feat/x"
+
+    def test_detached_head_reports_short_sha(self, repo):
+        full = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        _git(repo, "checkout", "-q", "--detach", "HEAD")
+        info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["detached"] is True
+        assert info["head"] == full[:7]
+        assert "branch" not in info
+
+    def test_walk_up_is_depth_bounded(self, repo):
+        """A path nested past the ceiling is not walked all the way to the root."""
+        deep = repo.joinpath(*[f"d{i}" for i in range(45)])
+        deep.mkdir(parents=True)
+        info = _project_git_branch(os.path.realpath(str(deep)))
+        assert info == {"repo": False}
+
+
+class TestNoGitSubprocess:
+    """The branch is read from ``.git/HEAD`` directly — no git process runs.
+
+    A git invocation parses the repository's own config, and repo-local config
+    can contain ``[include] path = <any file>``, which makes git READ that file.
+    For a project directory the agent can select, that is an arbitrary-file-read
+    primitive. Reading HEAD ourselves removes the whole class: no config is
+    parsed, no binary is resolved, nothing is spawned.
+    """
+
+    def test_no_subprocess_is_spawned(self, repo):
+        with patch("subprocess.run", side_effect=AssertionError("spawned a process")):
+            info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["branch"] == "trunk"
+
+    def test_config_include_directive_is_never_read(self, repo, tmp_path):
+        """The exact mechanism from the review finding.
+
+        The planted file is deliberately named and worded neutrally: what matters
+        is that a git invocation reads an ARBITRARY caller-named file, not what
+        that file happens to contain. Dressing the fixture up as a fake secret
+        adds nothing and trips the clear-text-storage scanner.
+        """
+        included = tmp_path / "included.cfg"
+        included.write_text("[probe]\n\tmarker = INCLUDE-WAS-PARSED\n")
+        with open(repo / ".git" / "config", "a", encoding="utf-8") as fh:
+            # Forward slashes: git config treats a backslash as an escape, so a
+            # native Windows path would not resolve.
+            fh.write(f"[include]\n\tpath = {included.as_posix()}\n")
+        # Confirm the vector is real for a git invocation...
+        probe = subprocess.run(
+            ["git", "-C", str(repo), "config", "--get", "probe.marker"],
+            capture_output=True, text=True, check=False,
+        )
+        assert probe.stdout.strip() == "INCLUDE-WAS-PARSED", "include vector not reproduced"
+        # ...and that our reader is unaffected by it and reads no config at all.
+        info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["branch"] == "trunk"
+        assert "INCLUDE-WAS-PARSED" not in repr(info)
+
+    def test_unreadable_head_degrades_to_no_branch(self, repo):
+        (repo / ".git" / "HEAD").unlink()
+        info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["repo"] is True
+        assert "branch" not in info and "head" not in info
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+    def test_symlinked_head_to_a_blocked_path_is_refused(self, repo, tmp_path):
+        """`.git/HEAD` is an ordinary path and can be a symlink to anything.
+
+        A hex secret is the dangerous shape: it would otherwise match the
+        detached-HEAD pattern and get echoed as a 7-char prefix. Reads go through
+        the hooks sensitive-path gate, so a refused target yields no label.
+        """
+        target = tmp_path / "blocked.txt"
+        target.write_text("a" * 40 + "\n")
+        head = repo / ".git" / "HEAD"
+        head.unlink()
+        head.symlink_to(target)
+        with patch(
+            "kiro_crew.dashboard.handlers.files.safe_read_prefix", return_value=None
+        ) as gated:
+            info = _project_git_branch(os.path.realpath(str(repo)))
+        assert gated.called, "HEAD read did not go through the hooks gate"
+        assert "head" not in info and "branch" not in info
+        assert info["repo"] is True
+
+    def test_head_read_routes_through_the_hooks_gate(self, repo):
+        """Pins the gate itself, independent of any particular symlink."""
+        with patch(
+            "kiro_crew.dashboard.handlers.files.safe_read_prefix", return_value=None
+        ) as gated:
+            info = _project_git_branch(os.path.realpath(str(repo)))
+        assert gated.called
+        assert "branch" not in info
+
+    def test_garbage_head_is_not_reported_as_a_branch(self, repo):
+        (repo / ".git" / "HEAD").write_text("not a ref and not a sha\n")
+        info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["repo"] is True
+        assert "branch" not in info and "detached" not in info
+
+    def test_non_branch_symbolic_ref_is_not_labelled(self, repo):
+        """Only refs/heads/* is a branch; a bare or tag ref must not be shown."""
+        (repo / ".git" / "HEAD").write_text("ref: refs/heads/\n")
+        assert "branch" not in _project_git_branch(os.path.realpath(str(repo)))
+        (repo / ".git" / "HEAD").write_text("ref: refs/tags/v1\n")
+        assert "branch" not in _project_git_branch(os.path.realpath(str(repo)))
+
+    def test_head_read_is_size_capped(self, repo):
+        """A hostile oversized HEAD must not be slurped whole."""
+        (repo / ".git" / "HEAD").write_text("ref: refs/heads/" + ("x" * 100000))
+        info = _project_git_branch(os.path.realpath(str(repo)))
+        assert len(info.get("branch", "")) <= _HEAD_READ_LIMIT
+
+    def test_worktree_gitdir_pointer_must_be_a_gitdir_line(self, repo, tmp_path):
+        wt = tmp_path / "bogus"
+        wt.mkdir()
+        (wt / ".git").write_text("something else entirely\n")
+        assert _git_head_path(str(wt)) is None
+
+
+class TestMatchKnownProjectOffLoop:
+    def test_matches_via_the_worker_thread_helper(self, repo):
+        assert _match_known_project_for(_slot_project_snapshot(_State(str(repo))), str(repo)) == str(repo)
+
+    def test_tilde_form_is_matched_without_touching_the_loop(self):
+        """`expanduser` on a ~user form does a passwd lookup; it must run in the
+        thread helper, and an unknown user must simply not match."""
+        assert _match_known_project_for(["/srv/p"], "~nosuchuser42/x") is None
+
+    def test_unknown_is_none(self, repo):
+        assert _match_known_project_for(_slot_project_snapshot(_State(str(repo))), "/etc") is None
+
+
+class TestBranchRedaction:
+    """The branch label is echoed to the dashboard and is copyable, so it goes
+    through the canonical egress redaction like any other returned string."""
+
+    def test_ordinary_branch_names_pass_through_unchanged(self, repo):
+        info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["branch"] == "trunk"
+
+    def test_branch_name_is_routed_through_redaction(self, repo):
+        with patch(
+            "kiro_crew.dashboard.handlers.files.redact", side_effect=lambda t: f"<{t}>"
+        ) as red:
+            info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["branch"] == "<trunk>"
+        # repoRoot is redacted too, so assert the branch call specifically rather
+        # than a total call count.
+        red.assert_any_call("trunk")
+
+    def test_detached_head_sha_is_routed_through_redaction(self, repo):
+        _git(repo, "checkout", "-q", "--detach", "HEAD")
+        with patch(
+            "kiro_crew.dashboard.handlers.files.redact", side_effect=lambda t: f"<{t}>"
+        ):
+            info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["detached"] is True
+        assert info["head"].startswith("<") and info["head"].endswith(">")
+
+    def test_repo_root_is_routed_through_redaction(self, repo):
+        """A directory NAME is agent-influenceable via set_project and is echoed."""
+        with patch(
+            "kiro_crew.dashboard.handlers.files.redact", side_effect=lambda t: f"<{t}>"
+        ):
+            info = _project_git_branch(os.path.realpath(str(repo)))
+        assert info["repoRoot"].startswith("<") and info["repoRoot"].endswith(">")
+
+    @pytest.mark.asyncio
+    async def test_not_a_directory_response_path_is_redacted(self, repo, mock_sel):
+        """Reachable whenever a known project is deleted between match and stat."""
+        f = repo / "f.txt"
+        with patch(
+            "kiro_crew.dashboard.handlers.files.redact", side_effect=lambda t: f"<{t}>"
+        ):
+            async with TestClient(TestServer(_make_app(str(f)))) as client:
+                resp = await client.get(f"/api/project/git?path={f}")
+                assert resp.status == 400
+                data = await resp.json()
+        assert data["path"].startswith("<") and data["path"].endswith(">")
+
+    @pytest.mark.asyncio
+    async def test_no_response_echoes_an_unredacted_path(self, repo, tmp_path, mock_sel):
+        """Class guard: every response body that carries a path must redact it.
+
+        Added after a fix redacted the success path but left the 400 arm raw.
+        """
+        marker = "REDACTED-SENTINEL"
+        cases = [
+            (str(repo), f"/api/project/git?path={repo}"),                 # 200
+            (str(repo / "f.txt"), f"/api/project/git?path={repo / 'f.txt'}"),  # 400
+            (str(repo), f"/api/project/git?path={tmp_path / 'nope'}"),    # 403 unknown
+        ]
+        for known, url in cases:
+            with patch(
+                "kiro_crew.dashboard.handlers.files.redact", return_value=marker
+            ):
+                async with TestClient(TestServer(_make_app(known))) as client:
+                    resp = await client.get(url)
+                    body = await resp.text()
+            # Any path-shaped value in the body must have gone through redact().
+            assert str(repo) not in body, f"raw path leaked in {resp.status}: {body}"
+
+    @pytest.mark.asyncio
+    async def test_response_path_is_routed_through_redaction(self, repo, mock_sel):
+        with patch(
+            "kiro_crew.dashboard.handlers.files.redact", side_effect=lambda t: f"<{t}>"
+        ):
+            async with TestClient(TestServer(_make_app(str(repo)))) as client:
+                resp = await client.get(f"/api/project/git?path={repo}")
+                data = await resp.json()
+        assert data["path"].startswith("<") and data["path"].endswith(">")
+        # The SEL audit still records the real, unredacted path.
+        assert mock_sel.log_api_access.call_args.kwargs["resources"] == os.path.realpath(
+            str(repo)
+        )
+
+
+class TestSlotSnapshotOffLoop:
+    """The worker thread must never iterate the live slot map.
+
+    Slots are created and deleted by other coroutines on the event loop, so a
+    worker-thread iteration can hit `RuntimeError: dictionary changed size` and
+    turn a decorative branch poll into an HTTP 500. The snapshot is taken on the
+    loop, where those mutations are serialised against it.
+    """
+
+    def test_snapshot_collects_non_empty_slot_projects(self):
+        assert _slot_project_snapshot(_State("/a", "", "/b")) == ["/a", "/b"]
+
+    def test_snapshot_tolerates_missing_slots_attribute(self):
+        class Bare:
+            pass
+
+        assert _slot_project_snapshot(Bare()) == []
+
+    @pytest.mark.asyncio
+    async def test_snapshot_is_taken_on_the_event_loop_not_the_worker(
+        self, repo, mock_sel
+    ):
+        """Pins WHERE the copy happens, which is the whole point of the fix.
+
+        Asserting the worker merely receives a list does not discriminate — a
+        snapshot taken inside the thread also produces a list. Comparing thread
+        identities does.
+        """
+        loop_tid = threading.get_ident()
+        seen: dict = {}
+        real_snap = files_mod._slot_project_snapshot
+        real_match = files_mod._match_known_project_for
+
+        def _snap(state):
+            seen["snapshot_tid"] = threading.get_ident()
+            return real_snap(state)
+
+        def _match(slot_projects, raw):
+            seen["match_tid"] = threading.get_ident()
+            return real_match(slot_projects, raw)
+
+        with (
+            patch.object(files_mod, "_slot_project_snapshot", _snap),
+            patch.object(files_mod, "_match_known_project_for", _match),
+        ):
+            async with TestClient(TestServer(_make_app(str(repo)))) as client:
+                resp = await client.get(f"/api/project/git?path={repo}")
+                assert resp.status == 200
+        assert seen["snapshot_tid"] == loop_tid, "slot snapshot ran off the event loop"
+        assert seen["match_tid"] != loop_tid, "matcher ran ON the event loop"
+
+    @pytest.mark.asyncio
+    async def test_worker_receives_a_snapshot_not_the_state(self, repo, mock_sel):
+        """Pins the contract: what crosses into the thread is a plain list."""
+        seen: list = []
+        real = files_mod._match_known_project_for
+
+        def _capture(slot_projects, raw):
+            seen.append(slot_projects)
+            return real(slot_projects, raw)
+
+        with patch.object(files_mod, "_match_known_project_for", _capture):
+            async with TestClient(TestServer(_make_app(str(repo)))) as client:
+                resp = await client.get(f"/api/project/git?path={repo}")
+                assert resp.status == 200
+        assert seen, "matcher was never called"
+        assert isinstance(seen[0], list), f"worker got {type(seen[0]).__name__}, not a list"
+        assert seen[0] == [str(repo)]
+
+    @pytest.mark.asyncio
+    async def test_slot_mutation_during_the_poll_does_not_500(self, repo, mock_sel):
+        """A slot deleted while the worker runs must not break the request."""
+        app = _make_app(str(repo))
+        state = app["state"]
+
+        def _mutate_then_match(slot_projects, raw):
+            # Stand in for another coroutine deleting a slot mid-poll. The worker
+            # holds a snapshot, so this must not affect it.
+            state._slots.clear()
+            return _match_known_project_for(slot_projects, raw)
+
+        with patch.object(files_mod, "_match_known_project_for", _mutate_then_match):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get(f"/api/project/git?path={repo}")
+                assert resp.status == 200
+                data = await resp.json()
+        assert data["branch"] == "trunk"
+
+
+class TestResolveProjectGit:
+    """``_resolve_project_git`` carries every filesystem probe off the loop."""
+
+    def test_ok_returns_base_and_branch(self, repo):
+        status, base, info = _resolve_project_git(str(repo))
+        assert status == "ok"
+        assert base == os.path.realpath(str(repo))
+        assert info["branch"] == "trunk"
+
+    def test_non_directory_is_reported(self, repo):
+        status, _base, info = _resolve_project_git(str(repo / "f.txt"))
+        assert status == "not_a_dir"
+        assert info == {}
+
+    def test_sensitive_path_is_reported_without_running_git(self, repo):
+        with (
+            patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=True),
+            patch("kiro_crew.dashboard.handlers.files._project_git_branch") as branch,
+        ):
+            status, _base, info = _resolve_project_git(str(repo))
+        assert status == "sensitive"
+        assert info == {}
+        branch.assert_not_called()

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -951,6 +951,7 @@ export const api = {
   recentProjects: () => fetch('/api/recent-projects').then(j) as Promise<{ dirs: string[] }>,
   browseDirs: (path?: string) => fetch('/api/browse-dirs' + (path ? '?path=' + encodeURIComponent(path) : '')).then(j) as Promise<{ path: string; parent: string; dirs: { name: string; path: string }[] }>,
   browseFiles: (path?: string) => fetch('/api/browse-files' + (path ? '?path=' + encodeURIComponent(path) : '')).then(j) as Promise<{ path: string; parent: string; dirs: { name: string; path: string; mtime: number }[]; files: { name: string; path: string; mtime: number }[] }>,
+  projectGit: (path: string) => fetch('/api/project/git?path=' + encodeURIComponent(path)).then(j) as Promise<{ path: string; repo: boolean; repoRoot?: string; branch?: string; detached?: boolean; head?: string }>,
   workspaces: () => fetch('/api/workspaces').then(j),
   createWorkspace: (body: object) => post('/api/workspaces', body).then(j),
   updateWorkspace: (name: string, body: object) =>

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef, useEffect, useLayoutEffect, useCallback, memo } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, memo } from 'react'
 import { ArrowUpFromLine, ArrowUp, Loader2, Plus, Crop, Bot, Mic, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Globe, FolderOpen, FileText, ChevronDown, Check } from 'lucide-react'
 import { Toggle } from './ui'
+import CopyBranchButton from './CopyBranchButton'
 import { usePointerDrag } from '../hooks/usePointerDrag'
 import VoiceStatusBar from './VoiceStatusBar'
 import { createPortal } from 'react-dom'
@@ -241,6 +242,10 @@ interface ChatInputProps {
   onFileSelect?: (path: string) => void
   onFileOpen?: (path: string) => void
   project?: string
+  /** Checked-out branch of the active project (or short SHA when detached). */
+  projectBranch?: string
+  /** True when the project's HEAD is detached, so the label is a commit. */
+  projectDetached?: boolean
   memoryMode?: string
   cleanMode?: boolean
   /** User-sent messages for ↑/↓ history navigation (oldest → newest). */
@@ -419,6 +424,8 @@ function ChatInput({
   onFileSelect,
   onFileOpen,
   project,
+  projectBranch,
+  projectDetached,
   memoryMode,
   cleanMode,
   sentMessages,
@@ -640,6 +647,18 @@ function ChatInput({
   // Below ~340px the labels no longer fit comfortably alongside the context bar
   // + model chip, so collapse the chips (agent/project) to icon-only.
   const shelfCompact = shelfWidth < 340
+  // Tooltip for the project chip. The chip itself shows the basename (plus the
+  // branch when known); the tooltip carries the full path so nothing that was
+  // previously discoverable is lost, and names the branch even when the label
+  // is truncated or the shelf has collapsed to icon-only.
+  const projectChipTitle = useMemo(() => {
+    if (!project) return 'Select project'
+    const base = `Project: ${project}`
+    if (!projectBranch) return base
+    return projectDetached
+      ? `${base}\nDetached HEAD at ${projectBranch}`
+      : `${base}\nBranch: ${projectBranch}`
+  }, [project, projectBranch, projectDetached])
   const ctxWrapRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!ctxPopoverOpen) return
@@ -2392,16 +2411,40 @@ function ChatInput({
             </button>
           )}
           {onProjectClick && (
+          /* Two sibling buttons inside one visual pill, NOT a nested button:
+             the folder segment opens the project picker and the branch segment
+             copies. A <button> inside a <button> is invalid HTML and browsers
+             collapse it, so the pill is a plain container and each segment owns
+             its own click target and hover state. */
+          <div className="inline-flex items-center gap-1.5 h-7 min-w-0 text-[12px] font-mono text-muted">
           <button
             className="inline-flex items-center gap-1.5 h-7 min-w-0 text-[12px] font-mono text-muted hover:text-text px-2.5 rounded-md bg-transparent hover:bg-[color-mix(in_srgb,var(--bg-elevated)_84%,var(--text))] transition-colors border-none cursor-pointer disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted"
             onClick={e => onProjectClick(e.currentTarget.getBoundingClientRect())}
             disabled={isRunning}
-            title={isRunning ? 'Stop the current response to switch project' : (project ? `Project: ${project}` : 'Select project')}
-            aria-label={isRunning ? 'Stop the current response to switch project' : (project ? `Project: ${project}` : 'Select project')}
+            title={isRunning ? 'Stop the current response to switch project' : projectChipTitle}
+            aria-label={isRunning ? 'Stop the current response to switch project' : projectChipTitle}
           >
             <FolderOpen size={13} className="shrink-0 opacity-70" />
-            {!shelfCompact && <span className="truncate max-w-[200px]">{project ? (project.split('/').filter(Boolean).pop() || project) : 'Project'}</span>}
+            {/* Budget favours the branch: the folder name is also in the tooltip
+                and the picker, whereas a clipped branch ("feat/pro…") is exactly
+                the ambiguity this label exists to remove. The enclosing shelf
+                group is flex-1/min-w-0, so both segments still shrink below
+                these caps on a narrow window. */}
+            {!shelfCompact && <span className="truncate max-w-[160px]">{project ? (project.split('/').filter(Boolean).pop() || project) : 'Project'}</span>}
           </button>
+          {!shelfCompact && !!projectBranch && (
+            <>
+              <span className="opacity-40 shrink-0" aria-hidden="true">·</span>
+              {/* Copying stays enabled while a response is running — unlike
+                  switching project, reading the branch name is harmless. */}
+              <CopyBranchButton
+                branch={projectBranch}
+                label={projectDetached ? 'commit' : 'branch name'}
+                className="max-w-[220px] opacity-70 hover:opacity-100 hover:text-text"
+              />
+            </>
+          )}
+          </div>
           )}
           </div>
           <div className="flex items-center shrink-0">

--- a/website/src/components/CopyBranchButton.tsx
+++ b/website/src/components/CopyBranchButton.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { copyToClipboard } from '../utils/clipboard'
+
+/** A branch name rendered as a click-to-copy affordance. Clicking copies the raw
+ * branch name to the clipboard via the shared {@link copyToClipboard} helper
+ * (which falls back to a hidden textarea + execCommand on non-secure origins
+ * where navigator.clipboard is absent) and briefly swaps the trailing copy glyph
+ * for a check. If the copy genuinely fails, the failure is swallowed and the
+ * label stays put rather than falsely announcing success.
+ *
+ * Shared by the pull-request panel header and the composer's project chip.
+ * Extracted to its own module so the composer does not have to import the
+ * pull-request panel (and with it DOMPurify / hljs / the diff parser) just to
+ * reuse one button.
+ *
+ * ``label`` overrides the accessible name's noun for callers where "branch" is
+ * not accurate — the project chip shows a short commit on a detached HEAD.
+ */
+export default function CopyBranchButton({
+  branch,
+  label = 'branch name',
+  className = '',
+}: {
+  branch: string
+  label?: string
+  className?: string
+}) {
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+    },
+    [],
+  )
+  const handleCopy = async () => {
+    try {
+      await copyToClipboard(branch)
+    } catch {
+      // Both clipboard paths failed (no clipboard API and execCommand denied):
+      // leave the label as-is rather than announcing a copy that did not happen.
+      return
+    }
+    setCopied(true)
+    if (resetTimer.current) clearTimeout(resetTimer.current)
+    resetTimer.current = setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={`group/branch min-w-0 inline-flex items-center gap-1 truncate rounded px-1 -mx-1 border-none bg-transparent text-inherit hover:bg-bg-hover cursor-pointer ${className}`}
+      aria-label={copied ? `Copied ${label} ${branch}` : `Copy ${label} ${branch}`}
+      title={copied ? 'Copied!' : `Copy ${label}`}
+    >
+      <span className="truncate">{branch}</span>
+      {copied ? (
+        <Check className="lucide-inline shrink-0 text-ok" />
+      ) : (
+        <Copy className="lucide-inline shrink-0 opacity-0 group-hover/branch:opacity-70 transition-opacity" />
+      )}
+    </button>
+  )
+}

--- a/website/src/components/PullRequestPanel.tsx
+++ b/website/src/components/PullRequestPanel.tsx
@@ -7,7 +7,6 @@ import {
   ChevronDown,
   ChevronRight,
   Circle,
-  Copy,
   ExternalLink,
   GitCommitHorizontal,
   GitMerge,
@@ -34,7 +33,7 @@ import {
   type PullRequestLink,
 } from '../utils/pullRequestLinks'
 import { parseUnifiedDiff } from '../utils/parseUnifiedDiff'
-import { copyToClipboard } from '../utils/clipboard'
+import CopyBranchButton from './CopyBranchButton'
 import hljs from '../utils/hljs'
 import DOMPurify from 'dompurify'
 import { DIFF_BG, DIFF_FG } from '../utils/diffUtils'
@@ -541,52 +540,6 @@ export function pullRequestIsLive(source: PullRequestSource): boolean {
   const state = source.state.toLowerCase()
   if (source.mergedAt) return false
   return state === 'open' || state === 'opened' || state === 'draft'
-}
-
-/** The head branch name in the panel header, rendered as a click-to-copy
- * affordance. Clicking copies the raw branch name to the clipboard via the
- * shared {@link copyToClipboard} helper (which falls back to a hidden textarea +
- * execCommand on non-secure origins where navigator.clipboard is absent) and
- * briefly swaps the trailing copy glyph for a check. If the copy genuinely
- * fails, the failure is swallowed and the label stays put rather than falsely
- * announcing success. */
-export function CopyBranchButton({ branch }: { branch: string }) {
-  const [copied, setCopied] = useState(false)
-  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(
-    () => () => {
-      if (resetTimer.current) clearTimeout(resetTimer.current)
-    },
-    [],
-  )
-  const handleCopy = async () => {
-    try {
-      await copyToClipboard(branch)
-    } catch {
-      // Both clipboard paths failed (no clipboard API and execCommand denied):
-      // leave the label as-is rather than announcing a copy that did not happen.
-      return
-    }
-    setCopied(true)
-    if (resetTimer.current) clearTimeout(resetTimer.current)
-    resetTimer.current = setTimeout(() => setCopied(false), 1500)
-  }
-  return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      className="group/branch min-w-0 inline-flex items-center gap-1 truncate rounded px-1 -mx-1 border-none bg-transparent text-inherit hover:bg-bg-hover cursor-pointer"
-      aria-label={copied ? `Copied branch name ${branch}` : `Copy branch name ${branch}`}
-      title={copied ? 'Copied!' : 'Copy branch name'}
-    >
-      <span className="truncate">{branch}</span>
-      {copied ? (
-        <Check className="lucide-inline shrink-0 text-ok" />
-      ) : (
-        <Copy className="lucide-inline shrink-0 opacity-0 group-hover/branch:opacity-70 transition-opacity" />
-      )}
-    </button>
-  )
 }
 
 /** Provider-write actions on the loaded pull request: take it out of draft, and

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2875,6 +2875,28 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // configured default. Display only — the slot's raw value still drives the
   // picker so "no override" stays distinguishable from an explicit pick.
   const effectiveEffort = currentSlot?.reasoning_effort || defaultEffort
+  // Branch label for the active project chip. The user can check out a
+  // different branch outside the dashboard at any time, so this refetches on a
+  // slow interval and on window focus rather than being read once. A failure
+  // (no git, path gone, not a repo) leaves the chip showing the folder name
+  // alone, which is the pre-existing behaviour.
+  const _slotProject = currentSlot?.project || ''
+  const { data: projectGit, isError: projectGitError } = useQuery({
+    queryKey: ['project-git', _slotProject],
+    queryFn: () => api.projectGit(_slotProject),
+    enabled: !!_slotProject,
+    staleTime: 15_000,
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+    retry: false,
+  })
+  // React Query keeps the last successful data after a failed refetch, so a
+  // project that was deleted or revoked would keep showing its old branch
+  // indefinitely. Treat an errored query as "no branch" and fall back to the
+  // folder name, which is the same degradation as a non-repo project.
+  const projectBranch = projectGitError
+    ? ''
+    : projectGit?.branch || (projectGit?.detached ? projectGit.head || '' : '')
   const [sidebarPinned, setSidebarPinned] = useState(() => localStorage.getItem('mc-sidebar-pinned') !== 'false')
   const isMobile = useIsMobile()
   const [sidebarWidth, setSidebarWidth] = useState(() => {
@@ -4249,6 +4271,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
               onFileSelect={path => setPendingFiles(prev => prev.includes(path) ? prev : [...prev, path])}
               onFileOpen={handleFileOpen}
               project={currentSlot?.project || ''}
+              projectBranch={projectBranch}
+              projectDetached={!projectGitError && !!projectGit?.detached}
               isMac={isMac}
               onDrop={handleDrop}
               dragOver={dragOver}

--- a/website/src/test/ChatInput.projectBranch.test.tsx
+++ b/website/src/test/ChatInput.projectBranch.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import ChatInput from '../components/ChatInput'
+
+// Pins the project-chip branch contract (issue #673): the active project button
+// shows "<folder> · <branch>" so the session's git context is visible without
+// opening a picker, and degrades to the folder name alone when there is no
+// branch to show (not a repo, git unavailable, path gone).
+
+const defaultProps = {
+  value: '',
+  onChange: vi.fn(),
+  onSend: vi.fn(),
+  onProjectClick: vi.fn(),
+  project: '/home/u/work/KiroCrew',
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+const chip = () => screen.getByRole('button', { name: /Project: |Select project/ })
+const branchBtn = () => screen.getByRole('button', { name: /Cop(y|ied) (branch name|commit) / })
+
+describe('ChatInput project chip branch label', () => {
+  it('renders the branch beside the folder name', () => {
+    renderWithProviders(<ChatInput {...defaultProps} projectBranch="feat/example" />)
+    expect(chip()).toHaveTextContent('KiroCrew')
+    expect(branchBtn()).toHaveTextContent('feat/example')
+    expect(chip().getAttribute('title')).toContain('Branch: feat/example')
+    expect(chip().getAttribute('title')).toContain('/home/u/work/KiroCrew')
+  })
+
+  it('shows only the folder name when no branch is known', () => {
+    renderWithProviders(<ChatInput {...defaultProps} />)
+    const btn = chip()
+    expect(btn).toHaveTextContent('KiroCrew')
+    expect(btn.getAttribute('title')).toBe('Project: /home/u/work/KiroCrew')
+    expect(screen.queryByRole('button', { name: /Copy branch name/ })).not.toBeInTheDocument()
+    // No separator glyph without a branch to separate.
+    expect(btn.textContent).not.toContain('·')
+  })
+
+  it('labels a detached HEAD as a commit, not a branch', () => {
+    renderWithProviders(<ChatInput {...defaultProps} projectBranch="a1b2c3d" projectDetached />)
+    expect(branchBtn()).toHaveTextContent('a1b2c3d')
+    expect(chip().getAttribute('title')).toContain('Detached HEAD at a1b2c3d')
+    expect(chip().getAttribute('title')).not.toContain('Branch:')
+    // The copy affordance calls it a commit, not a branch.
+    expect(screen.getByRole('button', { name: 'Copy commit a1b2c3d' })).toBeInTheDocument()
+  })
+
+  it('keeps the branch out of the accessible name while a response is running', () => {
+    renderWithProviders(<ChatInput {...defaultProps} projectBranch="main" isRunning onStop={vi.fn()} />)
+    const btn = screen.getByRole('button', { name: /Stop the current response to switch project/ })
+    expect(btn).toBeDisabled()
+  })
+
+  it('leaves the branch copyable while a response is running', () => {
+    renderWithProviders(<ChatInput {...defaultProps} projectBranch="main" isRunning onStop={vi.fn()} />)
+    // Switching project mid-run is unsafe; reading the branch name is not.
+    expect(branchBtn()).not.toBeDisabled()
+  })
+
+  it('falls back to the full path when the project has no basename', () => {
+    renderWithProviders(<ChatInput {...defaultProps} project="/" projectBranch="main" />)
+    expect(branchBtn()).toHaveTextContent('main')
+  })
+
+  it('does not nest the copy button inside the picker button', () => {
+    // A <button> inside a <button> is invalid HTML and browsers collapse it, so
+    // the two segments must be siblings.
+    renderWithProviders(<ChatInput {...defaultProps} projectBranch="feat/example" />)
+    expect(chip().querySelector('button')).toBeNull()
+    expect(branchBtn().querySelector('button')).toBeNull()
+  })
+})
+
+describe('ChatInput project chip branch copy', () => {
+  let originalClipboard: PropertyDescriptor | undefined
+
+  const stubClipboard = () => {
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    return writeText
+  }
+
+  afterEach(() => {
+    if (originalClipboard) Object.defineProperty(navigator, 'clipboard', originalClipboard)
+    else delete (navigator as { clipboard?: unknown }).clipboard
+    originalClipboard = undefined
+  })
+
+  it('copies the raw branch name and confirms', async () => {
+    const writeText = stubClipboard()
+    renderWithProviders(<ChatInput {...defaultProps} projectBranch="feat/example" />)
+    fireEvent.click(branchBtn())
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('feat/example'))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Copied branch name feat/example' })).toBeInTheDocument(),
+    )
+  })
+
+  it('copies the untruncated branch name even when the label is clipped', async () => {
+    const writeText = stubClipboard()
+    const long = 'feat/a-very-long-branch-name-that-the-css-will-visually-truncate'
+    renderWithProviders(<ChatInput {...defaultProps} projectBranch={long} />)
+    fireEvent.click(branchBtn())
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(long))
+  })
+
+  it('clicking the branch does not open the project picker', () => {
+    stubClipboard()
+    const onProjectClick = vi.fn()
+    renderWithProviders(
+      <ChatInput {...defaultProps} onProjectClick={onProjectClick} projectBranch="feat/example" />,
+    )
+    fireEvent.click(branchBtn())
+    expect(onProjectClick).not.toHaveBeenCalled()
+  })
+
+  it('clicking the folder segment still opens the picker', () => {
+    stubClipboard()
+    const onProjectClick = vi.fn()
+    renderWithProviders(
+      <ChatInput {...defaultProps} onProjectClick={onProjectClick} projectBranch="feat/example" />,
+    )
+    fireEvent.click(chip())
+    expect(onProjectClick).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #673.

## Problem

The active project button under the composer showed only the directory
basename, so a session gave no indication of which branch or worktree it was
operating in. With many worktrees of the same repo checked out, the chip read
identically for every one of them. Dev Fleet displays worktree branches, but
that does not cover normal project sessions.

## What changed

The chip now reads `<folder> · <branch>` and falls back to the folder name alone
when there is no branch to show (not a repo, git unavailable, path gone).

### Backend — new `GET /api/project/git?path=`

No existing core endpoint exposed a branch for an arbitrary path, so this adds
one, modelled on the neighbouring `browse-dirs` / `browse-files` handlers.

- Walks up from the project dir looking for a repo root, bounded at 40 levels.
  The probe is `os.path.exists(".git")`, **not** `is_dir` — a worktree's `.git`
  is a gitdir pointer FILE, and an `is_dir` check reports every worktree as
  not-a-repo (pinned by a test).
- Detached HEAD returns `detached: true` plus the short commit rather than an
  empty label.
- **The branch is read from `.git/HEAD` directly — no git process is spawned.**
  A git invocation parses the repository's own config, and repo-local config can
  carry `[include] path = <any file>`, which makes git **read** that file. For a
  project directory an agent can select via `set_project`, that is an
  arbitrary-file-read primitive. I verified it: git parsed a planted include and
  returned its value, and the `-c core.*` hardening flags do not stop it.
  Reading HEAD ourselves removes the whole class at once — no config parsed, no
  binary resolved, no PATH lookup, no sandbox question, and no `BENIGN_SPAWNS`
  entry. A linked worktree's `.git` is a `gitdir:` pointer file, so that is
  followed to the worktree's own HEAD; the read is size-capped.
- Both metadata reads (`.git` and `.git/HEAD`) go through
  `hooks.safe_read_prefix`, which canonicalises via realpath, refuses sensitive
  resolved targets, and opens with `O_NOFOLLOW` as TOCTOU defence. `.git/HEAD` is
  an ordinary path and can be a symlink; a 40-64 char hex secret is the dangerous
  shape because it would otherwise match the detached-HEAD pattern and be echoed
  as a 7-char prefix. A refused read degrades to "no branch".
- Everything echoed to the dashboard goes through the canonical egress redaction
  (`redact`): the branch label, the detached short commit, and the response's
  `path` / `repoRoot`. A directory NAME is itself agent-influenceable via
  `set_project`, and the branch label is now copyable, so all of it is treated
  like any other returned string. Ordinary paths and branch names are unchanged;
  the SEL audit still records the real, unredacted path.
- **`path` is matched against the gateway's own set of known project
  directories** — every live chat slot's `project` plus the recorded
  recent-projects list — and the matched **server-held** string is what gets
  stat'd. The route therefore cannot be used to probe arbitrary filesystem
  paths for existence or git metadata; an unrecognised directory is refused
  with `403` plus an SEL audit record. Matching is pure string normalisation
  (`expanduser` + `normpath`) with no filesystem access on the untrusted value
  — deliberately **not** `realpath`, which would stat a caller-controlled path
  and reintroduce the probe this guard removes.

  This is deliberately stricter than the neighbouring `browse-dirs` /
  `browse-files` handlers. Those must accept arbitrary paths because arbitrary
  browsing is their function; a branch label only ever needs a project the
  gateway already knows, so the wider surface bought nothing. CodeQL flagged
  the original arbitrary-path version (`py/path-injection`, high) and was right
  that the surface was wider than necessary — this resolves the finding by
  removing the surface rather than by suppressing the alert.
- Also retains `is_sensitive_path` denial with an SEL audit record, the
  directory-existence check, and the subprocess kept off the event loop via
  `asyncio.to_thread`.
- Every failure mode — no sandbox backend, git missing, timeout, non-zero exit,
  a repo with no commits — collapses to "no branch". The label is decorative and
  must never fail a request.

### Frontend

- `ChatPage` queries the endpoint for the active slot's project with a 15s stale
  time, a 60s refetch interval and refetch-on-window-focus, so a checkout made
  outside the dashboard is picked up. `retry: false` stops a non-repo from
  retrying.
- The branch segment is **click-to-copy**, matching the pull-request panel's
  existing affordance (#651). That component moved out of `PullRequestPanel` into
  its own `CopyBranchButton` module rather than being duplicated — the composer
  must not import the PR panel (and with it DOMPurify / hljs / the diff parser)
  to reuse one button, and a copy would have risked the `jscpd` gate.
- An errored branch query no longer shows a stale label: React Query keeps the
  last successful data after a failed refetch, so a deleted or revoked project
  would have kept displaying its old branch. `isError` now suppresses it and the
  chip falls back to the folder name.
- The chip is two **sibling** buttons in one visual pill, not a nested button: a
  `<button>` inside a `<button>` is invalid HTML and browsers collapse it. Folder
  segment opens the picker, branch segment copies. Copying stays enabled while a
  response is running — unlike switching project, reading the branch is harmless.
  On a detached HEAD the affordance says "commit", not "branch name".
- The chip's label budgets deliberately favour the branch (220px) over the
  folder name (160px): the folder is also in the tooltip and the picker, whereas
  a clipped branch (`feat/pro…`) is exactly the ambiguity this label exists to
  remove. Both segments still shrink under the shelf's flex constraint, and the
  existing icon-only collapse below 340px is unchanged.
- The tooltip keeps the full path and adds the branch (or `Detached HEAD at
  <sha>`), so nothing previously discoverable is lost and the branch stays
  readable when the label is truncated or the shelf has collapsed.

## Verification

Endpoint exercised against a live dev gateway (isolated `KIROCREW_HOME`, port
6899):

| request | response |
| --- | --- |
| the gateway's own project dir (known) | `{"repo": true, "repoRoot": "…/kirocrew-wt-project-branch", "branch": "feat/project-branch-chip"}` |
| `/etc` (not a known project) | `403 {"error": "Unknown project directory"}` |
| `<known>/../..` (traversal out) | `403` |
| `$HOME` (not a known project) | `403` |
| no `path` | `400` |

Then browser-verified on the same gateway: set the project through the picker —
the real flow, and the one the allow-list has to keep working — and confirmed
two `200` responses on `/api/project/git` with the branch rendered in the chip.
A narrowing like this fails silently (the chip would just fall back to the
folder name), so the end-to-end check matters more than the unit tests here.
See the Screenshots section below.

## Gates

- pytest 20158 passed. 5 failures, none from this change: 3 ×
  `test_dashboard_origin` (`KIROCREW_PORT` env on this host) and
  `test_browser_recording_skill::test_records_a_webm` (Playwright needs Node
  ≥ 18; this host's default `node` is v16) reproduce identically on
  `origin/main`; one `test_apps_registry` detect-probe-reap test is a
  load-dependent flake that passes isolated on both this branch and a clean
  `main` checkout, and touches nothing this PR changes.
- `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test`,
  `mypy src/kiro_crew/` (CI-parity venv, 527 files) — clean.
- `tsc -b` clean; `eslint src --max-warnings 1116` → 0 errors, 262 warnings
  (all pre-existing); vitest 5691 passed / 3 skipped.
- 54 new tests (43 backend, 11 frontend), each revert-verified — including the
  allow-list refusal, the `<known>/../..` traversal case, and the assertion that
  the value used for filesystem calls is the allow-list entry rather than the
  caller's string.

## Screenshots

**Deliberately not committed.** Six PNG binaries under `temp-screenshots/` would
land permanently in this public repo's history — a later delete removes them from
the working tree, but every clone keeps the blobs and the only true undo is a
history rewrite of the default branch. Arbiter flagged this as a one-way door and
it is correct. The images are attached to the PR conversation instead; the states
captured are described below.

Captured on an isolated dev gateway (own `KIROCREW_HOME`, port 6899) at 2x.

**On a branch** — the chip reads `<folder> · <branch>`; the tooltip is
`Project: /local/home/kseam/workspace/kirocrew-wt-project-branch` /
`Branch: feat/project-branch-chip`.


**Detached HEAD** — the short commit stands in for the branch, and the tooltip
says `Detached HEAD at 2ec7a4d` rather than mislabelling it a branch.


**Not a git repo** — folder name alone, no separator glyph. This is the
pre-existing appearance, unchanged.


**Click-to-copy** — the copy glyph appears on hover, and the click swaps it for a
check. Verified against the real clipboard in a browser: the click wrote
`feat/project-branch-chip` and did **not** open the project picker.



**Narrow window (640px)** — both segments truncate under the shelf's flex
constraint; the tooltip still carries the full path and branch.


## Not covered

The chip does not show dirty-tree state or ahead/behind counts — the issue asks
only for the branch, and each of those needs another git invocation per poll.

<img width="3140" height="588" alt="Screenshot 2026-07-29 at 17 09 29@2x" src="https://github.com/user-attachments/assets/fec0fe42-575a-4990-89b1-0478ff6c2ffa" />









