### PR TITLE
fix(mcp-apps): unblock ESM-CDN app iframes in CSP and keep them out of the collapse

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -331,11 +331,20 @@ _MIXED_INTERNAL_API_PATHS = frozenset(
 # instances-mode ``frame-src`` extension.
 _BASE_CSP = (
     "default-src 'self'; "
+    # https://esm.sh: MCP App (SEP-1865) srcdoc iframes INHERIT this header
+    # CSP (a srcdoc document has no HTTP response of its own), and the real
+    # excalidraw/pdf MCP apps load their ESM runtime (React, @excalidraw/…)
+    # from esm.sh via importmap. Without these allowances the app's module
+    # imports are blocked no matter what the per-app srcdoc <meta> CSP says
+    # (when two policies apply, the most restrictive wins per directive).
+    # Same pattern as the widget CDN allowances (tailwind/jsdelivr/cdnjs).
     "script-src 'self' 'unsafe-inline' "
-    "https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; "
-    "style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; "
+    "https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com "
+    "https://esm.sh; "
+    "style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net "
+    "https://esm.sh; "
     "img-src 'self' data: blob: https:; "
-    "font-src 'self' data:; "
+    "font-src 'self' data: https://esm.sh; "
     # Loopback http(s) origins ({connect_src_extra}) mirror the frame-src note
     # below: WebPreviewPanel does not merely FRAME the local dev server, it also
     # polls it with a no-cors `fetch` liveness probe (a cross-origin iframe
@@ -344,7 +353,8 @@ _BASE_CSP = (
     # preview to "server stopped responding" and unmounted the iframe. The
     # probe is no-cors, so no response data is ever readable — this admits the
     # reachability check only, and to the same origins frame-src already allows.
-    "connect-src 'self' ws://localhost:* ws://127.0.0.1:*{connect_src_extra}; "
+    "connect-src 'self' ws://localhost:* ws://127.0.0.1:* "
+    "https://esm.sh{connect_src_extra}; "
     "media-src 'self' blob:; "
     "worker-src 'self' blob:; "
     # https://*.cloudfront.net: live preview iframes for deployed webapp

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -21,6 +21,7 @@ import {
   toggleActivity, openActivityPanel, openActivityToTab,
   setActiveSlot, truncateAfterIndex, replaceMessages,
   requestStop, pendingQuestionFor, clearFollowupCard, dismissFollowupItem,
+  mcpAppKey,
 } from '../store/chatSlice'
 import { addNotification, removeNotificationByTs } from '../store/notificationsSlice'
 import { onTerminalReady, sendToTerminalSession } from '../utils/terminalRegistry'
@@ -524,6 +525,10 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
   return <>{body}{cards}</>
 }
 
+/** Stable empty set so the mcpApps-derived selector returns a referentially
+ *  equal value when the slot has no app renders (avoids useless re-renders). */
+const EMPTY_APP_ID_SET: ReadonlySet<string> = new Set()
+
 export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?: string; embedded?: boolean; embedMode?: 'chat' | 'sessions'; popout?: boolean } = {}) {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
@@ -557,6 +562,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   const refreshTrigger = useAppSelector(s => s.dashboard.refreshTrigger)
   const connected = useConnected()
   const activeSlot = useAppSelector(s => s.chat.activeSlot)
+  // tool_call_ids in THIS slot that have a live MCP App render payload. Passed
+  // to TurnBlock so app-bearing rows (which mount an interactive iframe) never
+  // fold into a collapsible pane — collapsing hides the app, and re-expanding
+  // remounts the iframe and loses in-canvas state. Kept here rather than inside
+  // TurnBlock because that component is also rendered by app-sdk/ChatEmbed with
+  // no Redux Provider mounted. The custom equality fn keeps the derived Set
+  // referentially stable across unrelated chat-state updates.
+  const appToolCallIds = useAppSelector(s => {
+    const apps = s.chat.mcpApps
+    if (!activeSlot || !apps) return EMPTY_APP_ID_SET
+    const prefix = mcpAppKey(activeSlot, '')
+    const ids = Object.keys(apps).filter(k => k.startsWith(prefix)).map(k => k.slice(prefix.length))
+    return ids.length ? new Set(ids) : EMPTY_APP_ID_SET
+  }, (a, b) => a.size === b.size && [...a].every(id => b.has(id)))
   const messages = useAppSelector(s => s.chat.messages)
   const messagesRef = useRef(messages)
   messagesRef.current = messages
@@ -4003,7 +4022,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
                       })() : renderMessage(it.idx, it.msg)}
                     </div>
                   }
-                  return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx}><TurnBlock turn={item} renderItem={renderTurnItem} collapseAll={chatConfig.collapseAllSteps} /></div>
+                  return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx}><TurnBlock turn={item} renderItem={renderTurnItem} collapseAll={chatConfig.collapseAllSteps} appToolCallIds={appToolCallIds} /></div>
                 }
                 return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx} className={`px-5 mx-auto w-full py-1`} style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>{item.kind === 'group' ? (() => {
                 const unresolvedGroupPerms = item.msgs.filter(m => m.role === 'permission' && !m.meta?.resolved)

--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -22,8 +22,20 @@ const isSpawnRunItem = (it: TurnItem) =>
 // visible even when a turn's reasoning is collapsed (collapseAll mode).
 const isWorkflowCompletionItem = (it: TurnItem) =>
   it.kind === 'single' && isWorkflowCompletionMessage(it.msg)
-const isTool = (it: TurnItem) =>
-  it.kind === 'single' && it.msg.role === 'tool' && !isWorkflowRunItem(it) && !isSpawnRunItem(it)
+// An MCP App (SEP-1865) render is anchored to its tool-call row (ToolCallLine
+// mounts the sandboxed iframe below the row). Folding that row into a
+// collapsed pane hides the interactive app — and re-expanding REMOUNTS the
+// iframe, reloading the app and losing in-canvas state. Treat app-bearing
+// tool calls like workflow_run / spawn_run cards: first-class, always visible.
+// ``appToolCallIds`` is the set of tool_call_ids with a live render payload
+// in chat.mcpApps for this slot (computed once per turn render).
+const isMcpAppItem = (it: TurnItem, appToolCallIds: ReadonlySet<string>) =>
+  it.kind === 'single' && it.msg.role === 'tool' &&
+  typeof it.msg.meta?.tool_call_id === 'string' &&
+  appToolCallIds.has(it.msg.meta.tool_call_id)
+const isTool = (it: TurnItem, appToolCallIds: ReadonlySet<string>) =>
+  it.kind === 'single' && it.msg.role === 'tool' && !isWorkflowRunItem(it) &&
+  !isSpawnRunItem(it) && !isMcpAppItem(it, appToolCallIds)
 const isHiddenTool = (it: TurnItem) => it.kind === 'single' && it.msg.role === 'tool' && !it.msg.content.startsWith('🔧')
 const isConclusion = (it: TurnItem) => it.kind === 'single' && (it.msg.role === 'assistant' || it.msg.role === 'streaming' || it.msg.role === 'file')
 /**
@@ -46,9 +58,17 @@ const isRenderable = (it: TurnItem) =>
   it.kind === 'single' && isConclusion(it) && (it.msg.role === 'file' || HAS_RENDERABLE_RE.test(it.msg.content))
 
 /** Either a renderable assistant message (widget/image) or a role that must
- *  surface inline (mcp_oauth, error), or a workflow_run launch card. All bypass
- *  the collapse pane. */
-const isVisibleInline = (it: TurnItem) => isRenderable(it) || isAlwaysVisible(it) || isWorkflowRunItem(it) || isSpawnRunItem(it) || isWorkflowCompletionItem(it)
+ *  surface inline (mcp_oauth, error), a workflow_run / spawn_run launch card, or
+ *  an MCP App-bearing tool call (interactive iframe anchored to the row). All
+ *  bypass the collapse pane. */
+const isVisibleInline = (it: TurnItem, appToolCallIds: ReadonlySet<string>) =>
+  isRenderable(it) || isAlwaysVisible(it) || isWorkflowRunItem(it) ||
+  isSpawnRunItem(it) || isWorkflowCompletionItem(it) ||
+  isMcpAppItem(it, appToolCallIds)
+
+/** Stable empty set so the mcpApps selector returns a referentially-equal
+ *  value when the slot has no app renders (avoids useless re-renders). */
+const EMPTY_ID_SET: ReadonlySet<string> = new Set()
 
 /** Strip OPTIONS/markdown formatting and return plain text content length */
 function substantiveLength(text: string): number {
@@ -76,8 +96,16 @@ function findConclusionIdx(items: TurnItem[]): number {
   return conclusionIdx === -1 ? fallbackIdx : conclusionIdx
 }
 
-/** Collapsible agent turn. collapseAll=false (default): only tool calls collapse. collapseAll=true: all working steps collapse, only final assistant text visible. */
-export default function TurnBlock({ turn, renderItem, collapseAll = false }: { turn: Extract<DisplayItem, {kind:'turn'}>; renderItem: (item: TurnItem, i: number) => ReactNode; collapseAll?: boolean }) {
+/** Collapsible agent turn. collapseAll=false (default): only tool calls collapse. collapseAll=true: all working steps collapse, only final assistant text visible.
+ *
+ *  ``appToolCallIds``: tool_call_ids in THIS pane's slot that have a live MCP
+ *  App render payload. Those rows carry an interactive iframe and must never
+ *  fold into the collapse (see isMcpAppItem). Passed in as a prop rather than
+ *  read from Redux so this component stays store-free — app-sdk/ChatMessageList
+ *  renders it for ChatEmbed with no Provider mounted, and a pane must scope the
+ *  set to its OWN session key, not the globally-active slot.
+ */
+export default function TurnBlock({ turn, renderItem, collapseAll = false, appToolCallIds = EMPTY_ID_SET }: { turn: Extract<DisplayItem, {kind:'turn'}>; renderItem: (item: TurnItem, i: number) => ReactNode; collapseAll?: boolean; appToolCallIds?: ReadonlySet<string> }) {
   const [expanded, setExpanded] = useState(!turn.complete)
   const wasComplete = useRef(turn.complete)
   useEffect(() => {
@@ -106,8 +134,8 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false }: { t
     const conclusionIdx = findConclusionIdx(turn.items)
     const beforeItems = conclusionIdx > 0 ? turn.items.slice(0, conclusionIdx) : []
     // Only the non-visible-inline pre-conclusion items are actually collapsed.
-    return beforeItems.some(it => !isVisibleInline(it) && msgIdxs(it).includes(currentMessageIdx))
-  }, [turn.items, term, currentMessageIdx, collapseAll])
+    return beforeItems.some(it => !isVisibleInline(it, appToolCallIds) && msgIdxs(it).includes(currentMessageIdx))
+  }, [turn.items, term, currentMessageIdx, collapseAll, appToolCallIds])
   useEffect(() => {
     if (matchInCollapsedSegment) setExpanded(true)
   }, [matchInCollapsedSegment])
@@ -129,7 +157,7 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false }: { t
     const segs: Seg[] = []
     for (let i = 0; i < beforeItems.length; i++) {
       const it = beforeItems[i]
-      if (isVisibleInline(it)) {
+      if (isVisibleInline(it, appToolCallIds)) {
         segs.push({ type: 'visible', it, idx: i })
       } else {
         const last = segs[segs.length - 1]
@@ -164,7 +192,7 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false }: { t
   }
 
   // Default: only collapse tool calls
-  const toolCount = turn.items.filter(isTool).length
+  const toolCount = turn.items.filter(it => isTool(it, appToolCallIds)).length
   if (!turn.complete || toolCount === 0) {
     return <>{turn.items.map((it, i) => renderItem(it, i))}</>
   }
@@ -173,7 +201,7 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false }: { t
   const segments: Segment[] = []
   for (let i = 0; i < turn.items.length; i++) {
     const it = turn.items[i]
-    if (isTool(it)) {
+    if (isTool(it, appToolCallIds)) {
       const last = segments[segments.length - 1]
       if (last?.type === 'tools') last.items.push({ it, idx: i })
       else segments.push({ type: 'tools', items: [{ it, idx: i }] })

--- a/website/src/test/TurnBlock.test.tsx
+++ b/website/src/test/TurnBlock.test.tsx
@@ -202,3 +202,51 @@ describe('TurnBlock — spawn_run launch visibility', () => {
   })
 
 })
+
+/**
+ * An MCP App (SEP-1865) render mounts an interactive iframe anchored to its
+ * tool-call row. Folding that row into a collapsible pane hides the app, and
+ * re-expanding REMOUNTS the iframe — reloading it and losing in-canvas state.
+ * So an app-bearing row must bypass the collapse in both modes. The set is a
+ * prop (not Redux) because TurnBlock also renders under app-sdk/ChatEmbed,
+ * which mounts no Provider.
+ */
+describe('TurnBlock — MCP App-bearing tool calls stay visible', () => {
+  const items: TurnItem[] = [
+    { kind: 'single', msg: { role: 'tool', content: '🔧 Running: read_me', ts: '1', meta: { tool_call_id: 'tc-plain' } }, idx: 0 },
+    { kind: 'single', msg: { role: 'tool', content: '🔧 Running: create_view', ts: '2', meta: { tool_call_id: 'tc-app-1' } }, idx: 1 },
+    { kind: 'single', msg: { role: 'assistant', content: 'Rendered a diagram with plenty of descriptive text to be substantive.', ts: '3' }, idx: 2 },
+  ]
+
+  const renderApp = (collapseAll: boolean, appIds: ReadonlySet<string>) =>
+    render(
+      <TurnBlock
+        turn={makeTurn(items)}
+        collapseAll={collapseAll}
+        appToolCallIds={appIds}
+        renderItem={(it) => (
+          <div data-testid={`item-${it.kind === 'single' ? `${it.msg.role}-${(it.msg.meta?.tool_call_id as string) ?? 'x'}` : 'group'}`} />
+        )}
+      />,
+    )
+
+  it('default mode: app-bearing row renders outside the collapsed tool group', () => {
+    renderApp(false, new Set(['tc-app-1']))
+    // The app-bearing row is visible without expanding anything…
+    expect(screen.getByTestId('item-tool-tc-app-1')).toBeInTheDocument()
+    // …while the plain tool call stays behind the collapse (unmounted).
+    expect(screen.queryByTestId('item-tool-tc-plain')).not.toBeInTheDocument()
+  })
+
+  it('collapseAll mode: app-bearing row renders outside the reasoning pane', () => {
+    renderApp(true, new Set(['tc-app-1']))
+    expect(screen.getByTestId('item-tool-tc-app-1')).toBeInTheDocument()
+    expect(screen.getByTestId('item-assistant-x')).toBeInTheDocument()
+  })
+
+  it('without the prop, tool rows collapse exactly as before (embed/no-store path)', () => {
+    renderApp(false, new Set())
+    expect(screen.queryByTestId('item-tool-tc-app-1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('item-tool-tc-plain')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Problem

An MCP App (SEP-1865) render — e.g. excalidraw's `create_view` diagram — reached the chat bubble correctly but was **invisible**. Two independent bugs, each sufficient on its own:

1. **Blank iframe.** A `srcdoc` iframe has no HTTP response of its own, so it **inherits the parent document's header CSP** *in addition to* its per-app `<meta>` CSP — and when two policies apply, the most restrictive wins per directive. Real MCP apps load their runtime from `https://esm.sh` via importmap, which `_BASE_CSP` did not allow, so every module import was blocked no matter how permissive the per-app meta CSP was. The app's React root never mounted and the iframe painted empty.

2. **App vanishes when steps collapse.** An app render is anchored to its tool-call row, and `TurnBlock` folds tool rows into collapsible panes that **unmount** their children. Collapsing the thinking/steps pane hid the interactive app, and re-expanding **remounted** the iframe — reloading the app and losing in-canvas state.

## Why it matters

Without (1) no MCP App using a CDN-hosted runtime renders at all — the feature looks broken rather than degraded. Without (2) the app silently disappears on a routine UI interaction and cannot be recovered without losing state.

## Fix

**`src/kiro_crew/dashboard/server.py`** — add `https://esm.sh` to `script-src`, `style-src`, `font-src`, `connect-src` in `_BASE_CSP`, following the existing widget CDN allowance pattern (`cdn.tailwindcss.com` / `cdn.jsdelivr.net` / `cdnjs.cloudflare.com`). The upstream `{connect_src_extra}` loopback-preview placeholder is preserved. A comment records the srcdoc-inheritance reasoning so the allowance is not mistaken for dashboard-level trust.

**`website/src/pages/chat/TurnBlock.tsx`** — new `isMcpAppItem` predicate; app-bearing tool calls bypass the collapse in both modes, reusing the existing escape hatch for mcwidget / image / `workflow_run` / `spawn_run` items.

**`website/src/pages/ChatPage.tsx`** — derives the set of app-bearing `tool_call_id`s from `chat.mcpApps`, scoped to its own slot, with a referential-stability equality fn, and passes it down.

### Design note: prop, not a store read

The set is a **prop** on `TurnBlock` (defaulting to a stable empty set) rather than a `useAppSelector` inside it. `app-sdk/ChatMessageList` renders `TurnBlock` for `ChatEmbed` under an explicit *\"No Redux, no React Router\"* contract with no Provider mounted, so a store read there throws `could not find react-redux context value`. It is also wrong on a second axis: a background `ChatPane` must scope the set to **its own** session key, not the globally-active slot (mirroring how `ToolCallLine` uses `slot ?? activeSlot`). Keeping the selector in `ChatPage` — which is Redux-connected and owns `activeSlot` — fixes both and leaves `TurnBlock` store-free.

## Tests

- `website/src/test/TurnBlock.test.tsx` — 3 new tests: app-bearing row escapes the collapse in default mode and in `collapseAll` mode, plus a guard that **without** the prop behavior is unchanged (the embed / no-store path).
- Full frontend suite: **5690 passed**, 3 skipped (471 files). `tsc -b` clean. `eslint` 0 errors on changed files.
- Backend CSP suites (`test_dashboard_security_headers.py`, `test_webapp_preview.py`): **54 passed**. `flake8` + `isort` clean.

## Manual verification

Confirmed live on the dashboard at `:5476`: an excalidraw `create_view` call renders its diagram inline in the response bubble, and the diagram stays visible (and keeps canvas state) when the steps pane is collapsed. Gateway logs show the full pipeline — `tools/list` harvest → `tools/call` intercept → `ui://excalidraw/mcp-app.html` spool. Note the parent document's CSP is fixed at page-navigation time and the PWA service worker caches `index.html`, so a **hard reload** is required to pick up the new header.

## Scope notes

- **Not** included: the sandbox bind-mount overlay approach for MCP pooling. `main` already pools via ACP `session/new` injection (`session_servers.py`, #665), which is strictly better — it works with `agent.sandbox: off` and on macOS/Windows, neither of which can bind-mount.
- `_mcp_apps_enabled()` remains **default-OFF** on `main`; MCP apps still require `KIROCREW_MCP_APPS=1` in gatewayd's environment. Flipping that default is a separate change (it invalidates the flag-OFF byte-identical tests from #339) and is deliberately not bundled here.

## Follow-ups (not in this PR)

1. **Dedicated-origin MCP app documents** — serve app HTML from its own route/origin with a per-app CSP *header* built from the spooled `csp.resourceDomains`, eliminating parent-CSP inheritance and the need to allowlist CDNs in `_BASE_CSP` at all.
2. **Self-contained excalidraw-mcp bundle** — inline React + `@excalidraw/excalidraw` + morphdom via `vite-plugin-singlefile` so `mcp-app.html` needs no runtime CDN, which would let `esm.sh` be removed again.


https://github.com/user-attachments/assets/38fab616-93fb-42ca-b92f-66179066d3c2

