### PR TITLE
fix(data-home): stop five writers recreating the pre-move data home

### DIFF
--- a/packages/kirocrew-client-py/kirocrew_client/client.py
+++ b/packages/kirocrew-client-py/kirocrew_client/client.py
@@ -48,7 +48,7 @@ def _compute_backoff(attempt: int, base_delay: float) -> float:
 
 def _read_app_secret(app_name: str) -> str:
     """Read the per-app secret from disk. Returns empty string if unavailable."""
-    home = os.environ.get("KIROCREW_HOME", str(Path.home() / ".kirocrew"))
+    home = os.environ.get("KIROCREW_HOME", str(Path.home() / ".kiro" / "crew"))
     secret_path = Path(home) / "apps" / app_name / ".app_secret"
     try:
         return secret_path.read_text(encoding="utf-8").strip()
@@ -408,7 +408,7 @@ class KiroCrewClient:
     # ── App Storage ──
 
     def get_app_data_dir(self) -> Path:
-        home = os.environ.get("KIROCREW_HOME", str(Path.home() / ".kirocrew"))
+        home = os.environ.get("KIROCREW_HOME", str(Path.home() / ".kiro" / "crew"))
         return Path(home) / "apps" / (self.app_name or "unknown") / "data"
 
     async def get_app_config(self) -> dict[str, Any]:

--- a/packages/kirocrew-client-py/tests/test_client.py
+++ b/packages/kirocrew-client-py/tests/test_client.py
@@ -1,6 +1,8 @@
 """Tests for kirocrew_client — mirrors TS @kirocrew/client test coverage."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from kirocrew_client import KiroCrewClient, KiroCrewError
@@ -116,9 +118,14 @@ class TestContextBuffer:
 
 
 class TestAppDataDir:
-    def test_contains_app_name(self):
+    def test_contains_app_name(self, monkeypatch):
+        # The default path is what this asserts, so a developer running with
+        # KIROCREW_HOME set (e.g. an isolated pod home) must not shadow it.
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
         mc = KiroCrewClient(app_name="my-tool")
         d = mc.get_app_data_dir()
         assert "my-tool" in str(d)
-        assert ".kirocrew" in str(d)
+        # The current data home, not the pre-move ~/.kirocrew. Compared as a
+        # Path so the assertion holds on Windows separators too.
+        assert str(Path.home() / ".kiro" / "crew") in str(d)
         assert "apps" in str(d)

--- a/scripts/install-demo-app.sh
+++ b/scripts/install-demo-app.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Install the demo app to ~/.kirocrew/apps/ so the full pipeline can be tested.
+# Install the demo app to the data home's apps/ dir so the full pipeline can be tested.
 # Run this once, then navigate to /apps/demo-app in the KiroCrew dashboard.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_SOURCE="$SCRIPT_DIR/../frontend/public/apps/demo-app"
-APP_DEST="$HOME/.kirocrew/apps/demo-app"
+APP_DEST="${KIROCREW_HOME:-$HOME/.kiro/crew}/apps/demo-app"
 
 if [ -d "$APP_DEST" ]; then
     echo "Demo app already installed at $APP_DEST"

--- a/scripts/refresh-playwright-cookies.py
+++ b/scripts/refresh-playwright-cookies.py
@@ -9,8 +9,10 @@ import os
 import sys
 import time
 
-COOKIE_JAR_PATH = os.path.expanduser("~/.kirocrew/browser-cookies.txt")
-STORAGE_STATE_PATH = os.path.expanduser("~/.kirocrew/playwright-storage-state.json")
+
+_DATA_HOME = os.environ.get("KIROCREW_HOME", os.path.expanduser("~/.kiro/crew"))
+COOKIE_JAR_PATH = os.path.join(_DATA_HOME, "browser-cookies.txt")
+STORAGE_STATE_PATH = os.path.join(_DATA_HOME, "playwright-storage-state.json")
 
 
 def parse_netscape_cookies(cookie_file_path):

--- a/src/kiro_crew/config/defaults.json
+++ b/src/kiro_crew/config/defaults.json
@@ -48,7 +48,7 @@
     "postToolUse": [
       {
         "matcher": "execute_bash",
-        "command": "{ echo \"$(date -u +%Y-%m-%dT%H:%M:%SZ) BASH:\"; cat; echo; } >> ~/.kirocrew/audit.log"
+        "command": "{ echo \"$(date -u +%Y-%m-%dT%H:%M:%SZ) BASH:\"; cat; echo; } >> \"${KIROCREW_HOME:-$HOME/.kiro/crew}/audit.log\""
       }
     ]
   }

--- a/src/kiro_crew/mcp_gateway/stub_wrapper.sh
+++ b/src/kiro_crew/mcp_gateway/stub_wrapper.sh
@@ -66,7 +66,12 @@ channel_id=$(_walk_env KIROCREW_CHANNEL_ID)
 # Single-line JSON to $KIROCREW_HOME/logs/stub_wrapper.jsonl capturing the
 # PPID, the server name from argv, and the channel_id we recovered. Best-
 # effort; failures to log are silently swallowed so MCP traffic stays up.
-_LOG_DIR="${KIROCREW_HOME:-$HOME/.kirocrew}/logs"
+#
+# The fallback is the CURRENT data home. It used to be the pre-move
+# ~/.kirocrew, and since kiro-cli strips env when spawning MCP subprocesses the
+# fallback is the branch that actually runs -- so this line was the writer that
+# re-created the abandoned home on every launch.
+_LOG_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}/logs"
 _LOG_FILE="$_LOG_DIR/stub_wrapper.jsonl"
 _server=""
 for ((i=1; i<=$#; i++)); do

--- a/test/test_runtime_home_write_paths.py
+++ b/test/test_runtime_home_write_paths.py
@@ -1,0 +1,232 @@
+"""Guard: code that WRITES into the data home must target the current one.
+
+``test_skill_home_paths.py`` covers skill *guidance*. This module covers the
+other half of the same bug class -- runtime **write** paths -- and exists because
+five of them were missed by the ``~/.kirocrew`` -> ``~/.kiro/crew`` data-home
+move and kept re-creating the abandoned home seconds after every launch:
+
+* ``config/defaults.json`` -- the default ``postToolUse`` bash-audit hook.
+  ``build_agent_config()`` overwrites the generated spec's hooks from the bundled
+  defaults on every launch (so a user override cannot drop the ``PreToolUse``
+  security gate), so this literal is the ONLY place the path can be corrected --
+  hand-editing the generated spec regresses on the next start.
+* ``mcp_gateway/stub_wrapper.sh`` -- the invocation log's fallback. kiro-cli
+  strips env when spawning MCP subprocesses, so the fallback is the branch that
+  actually runs.
+* ``scripts/install-demo-app.sh`` -- installed the demo app into the legacy home.
+* ``scripts/refresh-playwright-cookies.py`` -- wrote the browser storage state
+  there with ``O_CREAT``, so every refresh resurrected the directory.
+* ``packages/kirocrew-client-py`` -- the shipped client defaulted to the legacy
+  home, so ``_read_app_secret`` silently returned ``""`` (app auth degraded to
+  unauthenticated) and ``get_app_data_dir`` handed callers a legacy-rooted dir.
+
+Between them the legacy dir was re-created on every boot, and the data-home
+conflict WARNING in ``config/paths.py`` reported it as debris forever --
+un-actionable, because deleting it just brought it back.
+
+Scope, stated honestly: these tests assert on **write targets in code**, across
+four shapes -- shell ``${KIROCREW_HOME:-...}`` fallbacks, bare legacy literals on
+non-comment shell lines, Python ``KIROCREW_HOME`` defaults in shipped packages,
+and Python ``expanduser`` of a hardcoded legacy literal. Comment/doc prose is
+deliberately NOT asserted (a comment cannot create a directory;
+``test_skill_home_paths.py`` owns guidance text), and neither are modules that
+reference the legacy home *on purpose* to migrate it, seed from it, or keep
+detecting it (``home_migration.py``, ``config/paths.py``, ``security.py``,
+``sandbox.py``, ``history.py``, ``cloud/source.py``,
+``apps/builtins/file_explorer/server.py``, ``kiro_prerequisite.py``,
+``instances/token_mint.py``, plus the two allow-listed scripts below).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+STUB_WRAPPER = REPO_ROOT / "src" / "kiro_crew" / "mcp_gateway" / "stub_wrapper.sh"
+DEFAULTS_JSON = REPO_ROOT / "src" / "kiro_crew" / "config" / "defaults.json"
+
+# ``.kirocrew`` NOT followed by ``-`` or ``.`` -- so the top-level siblings that
+# genuinely did not move (``.kirocrew-pods``, ``.kirocrew-dev``,
+# ``.kirocrew.breadcrumb``, ``.kirocrew.archived``) are not false positives.
+LEGACY_HOME = re.compile(r"\.kirocrew(?![-.])")
+
+CURRENT_HOME = "/.kiro/crew"
+
+# Scripts whose bare legacy reference is a deliberate READ, not a write target,
+# and must therefore stay. Keyed on repo-RELATIVE paths, not basenames: the scan
+# is repo-wide, so a basename key would hand an unconditional pass to any future
+# file that happened to share the name.
+LEGACY_READER_SCRIPTS = frozenset(
+    {
+        # seeds a dev home FROM the pre-move home on a not-yet-migrated box
+        "dev-seed.sh",
+        # sensitive-path denylist; must still refuse the legacy tree
+        "src/kiro_crew/deploy/skills/artifact-deploy/scripts/_common.sh",
+    }
+)
+
+# Directories that are vendored, generated, or dependency trees.
+SKIP_DIR_PARTS = frozenset({"node_modules", "_vendor", ".venv", "build", "dist", ".git"})
+
+
+def _shell_scripts() -> list[Path]:
+    """Every shell script in the repo, vendored/generated trees excluded."""
+    return [
+        p
+        for p in sorted(REPO_ROOT.rglob("*.sh"))
+        if not SKIP_DIR_PARTS.intersection(p.relative_to(REPO_ROOT).parts)
+    ]
+
+
+def _shipped_python() -> list[Path]:
+    """Python that ships to users: the package plus the standalone client packages.
+
+    ``test/`` is excluded on purpose -- test fixtures legitimately construct the
+    legacy path to assert migration and sensitive-path behavior.
+    """
+    roots = [REPO_ROOT / "src" / "kiro_crew", REPO_ROOT / "packages"]
+    files: list[Path] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        files += [
+            p
+            for p in sorted(root.rglob("*.py"))
+            if not SKIP_DIR_PARTS.intersection(p.relative_to(REPO_ROOT).parts)
+        ]
+    return files
+
+
+def test_default_audit_hook_writes_to_the_current_data_home() -> None:
+    """The packaged ``postToolUse`` hook must not append into the legacy home."""
+    hooks = json.loads(DEFAULTS_JSON.read_text(encoding="utf-8"))["hooks"]
+    audit = [c["command"] for c in hooks["postToolUse"] if "audit.log" in c["command"]]
+    assert audit, "expected a default audit hook in defaults.json"
+    for command in audit:
+        assert not LEGACY_HOME.search(command), (
+            "the default audit hook writes into the pre-move legacy home; it is "
+            "baked into every generated agent spec, so this regresses on each "
+            f"launch: {command}"
+        )
+        assert CURRENT_HOME in command, (
+            f"the audit hook should target {CURRENT_HOME}, got: {command}"
+        )
+
+
+def test_stub_wrapper_log_dir_targets_the_current_data_home() -> None:
+    """The wrapper's log-dir fallback must be the current home.
+
+    ``KIROCREW_HOME`` is normally unset here -- kiro-cli strips env when spawning
+    MCP subprocesses -- so the fallback is the branch that actually runs, which
+    is why the pre-move literal made this a writer rather than a dormant default.
+    """
+    lines = [
+        ln for ln in STUB_WRAPPER.read_text(encoding="utf-8").splitlines()
+        if ln.startswith("_LOG_DIR=")
+    ]
+    assert len(lines) == 1, f"expected one _LOG_DIR assignment, got {lines}"
+    assert not LEGACY_HOME.search(lines[0]), f"wrapper log dir uses the legacy home: {lines[0]}"
+    assert CURRENT_HOME in lines[0], f"wrapper log dir should target {CURRENT_HOME}: {lines[0]}"
+
+
+def test_no_shell_home_default_points_at_the_legacy_home() -> None:
+    """Every ``${KIROCREW_HOME:-...}`` fallback must name the current home."""
+    scripts = _shell_scripts()
+    assert len(scripts) > 5, f"guard scanned too few scripts: {len(scripts)}"
+
+    pattern = re.compile(r"\$\{KIROCREW_HOME:-([^}]*)\}")
+    offenders: list[str] = []
+    for path in scripts:
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for default in pattern.findall(line):
+                if LEGACY_HOME.search(default):
+                    offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "A shell KIROCREW_HOME fallback still names the pre-move home. Unset is "
+        "the COMMON case (kiro-cli strips env for MCP subprocesses), so the "
+        "fallback is what actually runs:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_shell_script_uses_a_bare_legacy_home_path() -> None:
+    """No executable shell line may name the legacy home directly.
+
+    Comment lines are skipped: prose cannot create a directory, and skill/doc
+    wording is guarded by ``test_skill_home_paths.py``. Deliberate legacy
+    *readers* are allow-listed above with their reason.
+    """
+    offenders: list[str] = []
+    for path in _shell_scripts():
+        # ``as_posix()`` (not ``str()``): on Windows ``relative_to`` renders
+        # backslashes, which would miss the forward-slash allowlist entries and
+        # redden only the Windows CI shard.
+        if path.relative_to(REPO_ROOT).as_posix() in LEGACY_READER_SCRIPTS:
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if line.lstrip().startswith("#"):
+                continue
+            if LEGACY_HOME.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "A shell script names the pre-move legacy home on an executable line, so "
+        "running it re-creates the abandoned directory. If the reference is a "
+        "deliberate read (migration/seed/denylist), add the script to "
+        "LEGACY_READER_SCRIPTS with a reason:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_shipped_python_defaults_to_the_legacy_home() -> None:
+    """A shipped ``KIROCREW_HOME`` default must not resolve to the legacy home.
+
+    Regression guard for the client package, where the legacy default made
+    ``_read_app_secret`` return ``""`` -- silently downgrading app auth to
+    unauthenticated -- rather than failing loudly.
+    """
+    # Only the DEFAULT is inspected, and only in real call sites -- docstring
+    # prose mentioning the legacy home cannot match this shape.
+    pattern = re.compile(
+        r"""(?:os\.environ\.get|os\.getenv)\(\s*["']KIROCREW_HOME["']\s*,(?P<default>.*)$"""
+    )
+    offenders: list[str] = []
+    for path in _shipped_python():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            match = pattern.search(line)
+            if match and LEGACY_HOME.search(match.group("default")):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "Shipped Python defaults KIROCREW_HOME to the pre-move home. Unset is the "
+        "normal case, so the default is what runs:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_python_expands_a_hardcoded_legacy_home() -> None:
+    """No Python may build a path by expanding a literal ``~/.kirocrew``.
+
+    Fourth shape, and the one the other three could not see: a hardcoded
+    ``os.path.expanduser("~/.kirocrew/...")`` is not a shell script, need not be
+    in a shipped package, and never mentions ``KIROCREW_HOME`` -- which is how
+    ``scripts/refresh-playwright-cookies.py`` kept re-creating the legacy home.
+
+    Scanned repo-wide, excluding ``test/`` where fixtures legitimately construct
+    the legacy path to exercise migration behavior.
+    """
+    pattern = re.compile(r"expanduser\(\s*[^)]*\.kirocrew(?![-.])")
+    offenders: list[str] = []
+    for path in sorted(REPO_ROOT.rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT)
+        if SKIP_DIR_PARTS.intersection(rel.parts) or rel.parts[0] == "test":
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if pattern.search(line):
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "Python expands a hardcoded legacy home into a real path:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Problem

On any install that went through the `~/.kirocrew` → `~/.kiro/crew` data-home move, the abandoned legacy directory reappears within seconds of every launch, and `config/paths.py` logs a data-home conflict warning on every boot:

> data-home conflict: completion marker present at `~/.kiro/crew` but a non-empty legacy home `~/.kirocrew` also exists — the new home is authoritative and the legacy dir is NOT used (treated as debris). Investigate and remove it manually once confirmed stale.

The warning's advice does not work: deleting the directory does not help, because five code paths still hardcode it and recreate it on the next launch. On the box this was found on, the legacy home was recreated ~1 second after the gateway started, and `audit.log` there had grown to 1.4 MB of live traffic.

## Why it matters

Three user-visible consequences beyond the recurring, un-actionable warning:

- **The bash audit trail silently splits.** The default `postToolUse` hook appends to the legacy path, so the security-relevant command log lands in a directory the product explicitly treats as ignored debris.
- **App auth degrades to unauthenticated, silently.** `kirocrew_client._read_app_secret` reads `<legacy>/apps/<app>/.app_secret`, which does not exist post-migration, and returns `""` instead of failing loudly. `get_app_data_dir()` likewise hands external app authors a legacy-rooted directory they then write into.
- **Browser auth breaks quietly.** `scripts/refresh-playwright-cookies.py` writes the Playwright storage state into the legacy home with `O_CREAT`, so a cookie refresh both resurrects the directory and puts the state where the configured `storageState` path is not looking.

## Fix (symptoms → root cause → change)

**Symptom:** the legacy home reappears every launch, and hand-fixing the generated agent spec does not stick.

**Root cause:** five runtime write paths hardcode the pre-move literal. The audit hook is the non-obvious one — `build_agent_config()` (`agent.py:1330`) and the security-field refresh (`:1424`) both do `config["hooks"] = _kiro_hooks_only(bundled_hooks)`, deliberately overwriting the spec's hooks from the bundled `defaults.json` on every launch so a user override cannot drop the `PreToolUse` security gate. That behavior is correct, but it means the bundled literal is the **only** place the path can be corrected: user config cannot override it, and any hand-edit of the generated spec is erased on the next start. `stub_wrapper.sh` is the second non-obvious one — kiro-cli strips env when spawning MCP subprocesses, so its `${KIROCREW_HOME:-…}` *fallback* is the branch that actually runs, making a wrong fallback a live writer rather than a dormant default.

**Change — the data-home literal only, at five sites.** Each site keeps exactly the `KIROCREW_HOME` handling it already had, using the repo's existing idiom (`"${KIROCREW_HOME:-$HOME/.kiro/crew}"` in shell, as in `cli.sh`, `install.sh`, `ensure-node.sh`, `ensure-python.sh`; `os.environ.get("KIROCREW_HOME", <default>)` in Python, as in `portability.py`). No new resolution behavior is introduced.

| Site | Before | After |
|---|---|---|
| `config/defaults.json` (audit hook) | `>> ~/.kirocrew/audit.log` | `>> "${KIROCREW_HOME:-$HOME/.kiro/crew}/audit.log"` |
| `mcp_gateway/stub_wrapper.sh` | `${KIROCREW_HOME:-$HOME/.kirocrew}/logs` | `${KIROCREW_HOME:-$HOME/.kiro/crew}/logs` |
| `scripts/install-demo-app.sh` | `$HOME/.kirocrew/apps/demo-app` | `${KIROCREW_HOME:-$HOME/.kiro/crew}/apps/demo-app` |
| `scripts/refresh-playwright-cookies.py` | `expanduser("~/.kirocrew/…")` ×2 | shared `_DATA_HOME` via `os.environ.get(…)` |
| `kirocrew-client-py/client.py` | `Path.home() / ".kirocrew"` ×2 | `Path.home() / ".kiro" / "crew"` |

**Deliberately out of scope:** references that exist on purpose — the migration itself (`home_migration.py`, `config/paths.py`), sensitive-path denylists (`security.py`, `sandbox.py`, `attach_backend.py`), legacy detection (`file_explorer/server.py`, `cloud/source.py`), and `dev-seed.sh`, which reads the pre-move home as a seed source. Also out of scope: *guidance text* naming the legacy path (the system prompt, MCP tool-schema descriptions, some skill docs and one `.tsx` string). Those misdirect an agent rather than writing a file themselves, they are a separate defect class needing their own guard roots, and they are catalogued for a follow-up.

## Tests

New `test/test_runtime_home_write_paths.py` — the write-path companion to the existing `test_skill_home_paths.py`, which covers skill *guidance* only and explicitly disclaims production modules. Six assertions over the four shapes that actually regressed:

1. `test_default_audit_hook_writes_to_the_current_data_home` — parses `defaults.json` and asserts the bundled hook is legacy-free. Locks the one site that regenerates itself on every launch.
2. `test_stub_wrapper_log_dir_targets_the_current_data_home` — asserts the wrapper's single `_LOG_DIR` fallback names the current home, because with env stripped the fallback is what runs.
3. `test_no_shell_home_default_points_at_the_legacy_home` — every `${KIROCREW_HOME:-…}` fallback across all 41 repo shell scripts.
4. `test_no_shell_script_uses_a_bare_legacy_home_path` — no executable shell line may name the legacy home. Comment lines are skipped (prose cannot create a directory); the two deliberate legacy *readers* are exempted by repo-relative path, compared via `as_posix()` so the Windows shard agrees.
5. `test_no_shipped_python_defaults_to_the_legacy_home` — shipped `KIROCREW_HOME` defaults, which is what made `_read_app_secret` fail open.
6. `test_no_python_expands_a_hardcoded_legacy_home` — no Python may `expanduser` a hardcoded legacy literal, scanned repo-wide excluding `test/`. This shape exists because the first three provably could not see the storage-state writer: it is not a `.sh` file, not in a shipped package, and never mentions `KIROCREW_HOME`.

Each assertion was negative-controlled by reintroducing its own regression and confirming only that assertion fails. `packages/kirocrew-client-py/tests/test_client.py` updated to assert the current home, with `monkeypatch.delenv("KIROCREW_HOME")` so it does not depend on the developer's ambient environment.

## Manual verification

N/A — unit coverage is sufficient. The assertions read the shipped files directly rather than a copy, so they verify the real bytes. The original defect was also observed live before the fix: the legacy home was recreated ~1s after gateway start, and both writers' files carried current timestamps.

## Screenshots

N/A — no user-visible UI surface. The change touches a config default, two shell scripts, a standalone utility, a client library path default, and tests.
