### PR TITLE
feat(dashboard): open the host's native folder dialog from the project picker

### DIFF
--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -117,6 +117,8 @@ from kiro_crew.dashboard.handlers.files import (  # noqa: E402, F401
     api_file_search,
     api_file_watch,
     api_file_write,
+    api_native_dir_dialog,
+    api_native_dir_dialog_probe,
     api_outbox_download,
     api_outbox_list,
     api_outbox_notify,

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -24,6 +24,8 @@ from aiohttp.multipart import BodyPartReader
 
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir
+from kiro_crew.dashboard import native_dialog
+from kiro_crew.dashboard.origin import is_direct_local_request
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.security import (
@@ -55,6 +57,14 @@ mimetypes.add_type(
 )
 
 _INLINE_DISPOSITION_PREFIXES = frozenset({"audio/", "video/", "image/", "application/pdf"})
+
+#: Single-flight guard for native folder dialogs. The dialog is modal on the
+#: host's screen, so a second one would stack behind the first with no way to
+#: attribute the answer; callers get 409 while one is open. A plain flag rather
+#: than an asyncio.Lock: the check-and-set below has no await between its two
+#: halves (so it is atomic on the event loop) and a flag carries no binding to
+#: the loop that first touched it.
+_NATIVE_DIALOG_STATE = {"busy": False}
 
 
 logger = logging.getLogger(__name__)
@@ -2082,6 +2092,105 @@ async def api_browse_dirs(request: web.Request) -> web.Response:
         pass
     _sel().log_api_access(caller=caller, operation="browse_dirs", outcome="allowed", resources=base)
     return web.json_response({"path": base, "parent": os.path.dirname(base), "dirs": dirs})
+
+
+def _last_project_dir() -> str:
+    """Most recent usable project directory, or ``""``.
+
+    Read from the gateway's own ``recent_projects.json`` rather than taken from
+    the caller, so the folder dialog's starting location carries no
+    request-supplied bytes. Blocking (file read) — call in a thread.
+    """
+    try:
+        raw = json.loads((config_dir() / "recent_projects.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return ""
+    if not isinstance(raw, list):
+        return ""
+    for entry in raw:
+        if not isinstance(entry, str) or not entry:
+            continue
+        resolved = os.path.realpath(os.path.expanduser(entry))
+        if os.path.isdir(resolved) and not is_sensitive_path(resolved):
+            return resolved
+    return ""
+
+
+async def api_native_dir_dialog_probe(request: web.Request) -> web.Response:
+    """GET /api/native-dir-dialog — can this host open a native folder dialog?
+
+    The dashboard asks before offering the affordance, so a browser tab on a
+    remote/headless gateway never shows a button that cannot work.
+    """
+    available = is_direct_local_request(request) and native_dialog.is_available()
+    return web.json_response({"available": available})
+
+
+async def api_native_dir_dialog(request: web.Request) -> web.Response:
+    """POST /api/native-dir-dialog — open the host's native folder chooser.
+
+    Returns ``{"path": "/abs/dir"}`` on a selection, ``{"cancelled": true}`` when
+    the user dismisses the dialog. The dialog draws on the gateway's own screen,
+    so the request must come from this machine; remote callers keep the
+    server-side directory browser instead.
+
+    Takes no input. The directory the chooser opens in is derived here from the
+    gateway's own recent-projects file, so no byte of the request reaches the
+    subprocess (see ``BENIGN_SPAWNS`` in ``test/test_spawn_audit.py``).
+    """
+    caller = request.get("user", "dashboard")
+    if not is_direct_local_request(request):
+        _sel().log_api_access(
+            caller=caller, operation="native_dir_dialog", outcome="denied",
+            resources="", error="not a direct local request")
+        return web.json_response(
+            {"error": "The folder dialog can only open on the machine running KiroCrew.",
+             "reason": "remote"}, status=403)
+    if not native_dialog.is_available():
+        return web.json_response(
+            {"error": "No native folder dialog is available on this host.",
+             "reason": "unavailable"}, status=503)
+    # Resolved before the guard below: check-and-set must have no await between
+    # its halves to stay atomic on the event loop, and this costs one small file
+    # read on the (rare) 409 path.
+    default_path = await asyncio.to_thread(_last_project_dir)
+    # One dialog at a time. Repeated clicks would otherwise stack modal panels
+    # on the host with no way to tell which one the eventual answer came from.
+    if _NATIVE_DIALOG_STATE["busy"]:
+        return web.json_response(
+            {"error": "A folder dialog is already open.", "reason": "busy"}, status=409)
+    _NATIVE_DIALOG_STATE["busy"] = True
+    # The flag's lifetime is the DIALOG's, not this request's. asyncio.to_thread
+    # cannot interrupt the worker, so a client that disconnects mid-dialog (tab
+    # closed, fetch aborted, proxy read timeout) leaves the OS panel on screen
+    # until a human answers it or DIALOG_TIMEOUT_SEC fires. Releasing the slot on
+    # request cancellation would admit a second stacked panel; a done-callback on
+    # the future plus a shielded await keeps it held until the thread finishes.
+    fut = asyncio.ensure_future(
+        asyncio.to_thread(native_dialog.choose_directory, default_path))
+    fut.add_done_callback(lambda _f: _NATIVE_DIALOG_STATE.__setitem__("busy", False))
+    try:
+        picked = await asyncio.shield(fut)
+    except native_dialog.DialogUnavailable as exc:
+        _sel().log_api_access(
+            caller=caller, operation="native_dir_dialog", outcome="denied",
+            resources="", error=str(exc))
+        return web.json_response({"error": str(exc), "reason": "failed"}, status=503)
+    if picked is None:
+        return web.json_response({"cancelled": True})
+    resolved = os.path.realpath(picked)
+    if not os.path.isdir(resolved):
+        return web.json_response({"error": "Not a directory", "path": resolved}, status=400)
+    # The same gate the server-side browser applies: a natively-picked path is
+    # still just a path, and ~/.ssh is no more selectable this way than that.
+    if is_sensitive_path(resolved):
+        _sel().log_api_access(
+            caller=caller, operation="native_dir_dialog", outcome="denied",
+            resources=resolved, error="sensitive path")
+        return web.json_response({"error": "Access denied", "reason": "sensitive"}, status=403)
+    _sel().log_api_access(
+        caller=caller, operation="native_dir_dialog", outcome="allowed", resources=resolved)
+    return web.json_response({"path": resolved})
 
 
 async def api_browse_files(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -6,8 +6,6 @@ import asyncio
 import json
 import logging
 import re
-import subprocess
-import sys
 import tempfile
 import zipfile
 from datetime import datetime
@@ -17,6 +15,7 @@ from aiohttp import web
 
 from kiro_crew.artifacts import get_default_store
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
+from kiro_crew.dashboard import native_dialog
 from kiro_crew.dashboard.handlers.files import _ZIP_CONTAINER_EXTS, _content_matches_ext
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.knowledge.agent_fetch import fetch_url_content
@@ -592,34 +591,27 @@ async def list_sources(request: web.Request) -> web.Response:
 
 
 # Max wall-clock the native folder dialog may stay open before we give up.
-_FOLDER_DIALOG_TIMEOUT = 180  # seconds
-
-
 def _folder_picker_available(request: web.Request) -> bool:
-    """The native folder picker is offered only on macOS (via osascript) and
-    only when the dashboard is local -- a dialog on a remote gateway would open
-    on the wrong screen."""
-    return sys.platform == "darwin" and bool(request.app.get("local_only", False))
+    """The native folder picker is offered only when the host has a chooser to
+    run (see ``native_dialog.detect_backend``) and only when the dashboard is
+    local -- a dialog on a remote gateway would open on the wrong screen."""
+    return native_dialog.is_available() and bool(request.app.get("local_only", False))
 
 
 def _run_folder_dialog() -> str | None:
-    """Open the macOS native folder chooser (blocking) and return the selected
+    """Open the host's native folder chooser (blocking) and return the selected
     absolute path, or None if the user cancelled or it failed to launch. Meant
-    to run off the event loop via an executor."""
-    cmd = [
-        "osascript", "-e",
-        'POSIX path of (choose folder with prompt '
-        '"Select a folder to add to your knowledge base")',
-    ]
+    to run off the event loop via an executor.
+
+    Thin adapter over the shared ``native_dialog`` module, which owns the
+    per-platform argv and the cancel-versus-failure reading. This surface feeds
+    the path back into a text field either way, so a failure collapses to the
+    same None as a cancel here.
+    """
     try:
-        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
-            cmd, capture_output=True, text=True, timeout=_FOLDER_DIALOG_TIMEOUT,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return native_dialog.choose_directory(prompt=native_dialog.PROMPT_KNOWLEDGE)
+    except native_dialog.DialogUnavailable:
         return None
-    # osascript exits non-zero (and prints nothing) when the user cancels.
-    path = proc.stdout.strip()
-    return path if proc.returncode == 0 and path else None
 
 
 async def pick_folder(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/native_dialog.py
+++ b/src/kiro_crew/dashboard/native_dialog.py
@@ -1,0 +1,238 @@
+"""Host-side native folder dialog.
+
+The dashboard renders in a browser (or an Electron webview), and the web
+platform deliberately withholds absolute filesystem paths from a page:
+``showDirectoryPicker()`` hands back a ``FileSystemDirectoryHandle`` whose only
+identifying field is the leaf name, and ``<input webkitdirectory>`` reports
+paths relative to the picked root. A project directory must be an absolute path
+the *gateway* can resolve, so neither is usable.
+
+The gateway itself runs on the machine whose directories the user is choosing,
+so it can ask the OS for its own folder dialog and read back a real path. That
+is what this module does: build an argv for the platform's native chooser, run
+it, and return the selected directory.
+
+Same-machine assumption: the caller (``handlers.files``) gates this on a direct
+local request, and the gateway already drives host GUI actions this way in
+``api_reveal_path`` (Finder reveal). When the gateway is genuinely remote — an
+``ssh -L`` forward, a headless host — the dialog either cannot start or opens on
+a screen nobody is watching, so every entry point here is timeout-bounded and
+the dashboard falls back to its server-side directory browser.
+
+Prompts are fixed literals rather than caller-supplied text: nothing user
+controlled is interpolated into an AppleScript or PowerShell program, and every
+subprocess runs argv-style with ``shell=False``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+
+from kiro_crew import platform_compat
+
+logger = logging.getLogger(__name__)
+
+#: Wall-clock ceiling for a dialog. Generous — the user is browsing their disk
+#: by hand — but bounded, so a dialog opened on an unwatched screen (remote
+#: gateway) eventually releases the single-flight slot instead of wedging it.
+DIALOG_TIMEOUT_SEC = 300
+
+#: Prompts, owned here rather than accepted from a request. Each is passed to
+#: the chooser as *data* (an argv element or env value), never spliced into
+#: program text, so the AppleScript/PowerShell bodies stay fixed literals.
+PROMPT_PROJECT = "Choose a project folder"
+PROMPT_KNOWLEDGE = "Select a folder to add to your knowledge base"
+
+#: Backend identifiers returned by :func:`detect_backend`.
+BACKEND_OSASCRIPT = "osascript"
+BACKEND_POWERSHELL = "powershell"
+BACKEND_ZENITY = "zenity"
+BACKEND_KDIALOG = "kdialog"
+
+#: Env vars carrying the prompt and default location into the PowerShell
+#: chooser. Passing them through the environment instead of the command text
+#: keeps the script a fixed literal (no quoting or injection surface).
+_WIN_DEFAULT_ENV = "KIROCREW_DIALOG_DEFAULT"
+_WIN_PROMPT_ENV = "KIROCREW_DIALOG_PROMPT"
+
+# AppleScript, one -e line per element. Prompt and default location arrive as
+# argv so the program text stays constant.
+#
+# `activate me` rather than `tell application "System Events" to activate`: the
+# panel still needs to come forward (otherwise it can open behind the browser),
+# but System Events is a faceless background app, so that Apple Event LAUNCHES
+# it and brings it frontmost before `choose folder` runs — routinely most of a
+# second on a cold call, which is felt as a slow-opening Finder panel.
+# `activate me` raises osascript's own process instead: same effect on window
+# order, no second process to start.
+_OSASCRIPT_LINES = (
+    "on run argv",
+    "set promptText to item 1 of argv",
+    "set loc to item 2 of argv",
+    "activate me",
+    "if loc is \"\" then",
+    "set f to choose folder with prompt promptText",
+    "else",
+    "set f to choose folder with prompt promptText default location (POSIX file loc)",
+    "end if",
+    "return POSIX path of f",
+    "end run",
+)
+
+# WinForms folder browser. -STA is mandatory: the dialog needs a
+# single-threaded apartment and silently fails without it.
+_POWERSHELL_SCRIPT = (
+    "Add-Type -AssemblyName System.Windows.Forms; "
+    "$d = New-Object System.Windows.Forms.FolderBrowserDialog; "
+    f"$d.Description = $env:{_WIN_PROMPT_ENV}; "
+    "$d.ShowNewFolderButton = $true; "
+    f"if ($env:{_WIN_DEFAULT_ENV}) {{ $d.SelectedPath = $env:{_WIN_DEFAULT_ENV} }}; "
+    "if ($d.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) "
+    "{ [Console]::Out.Write($d.SelectedPath) }"
+)
+
+
+class DialogUnavailable(RuntimeError):
+    """No native chooser can run on this host (no binary, or no GUI session)."""
+
+
+def _powershell() -> str | None:
+    """Absolute path to powershell.exe, or ``None`` when it isn't usable."""
+    system_root = os.environ.get("SystemRoot") or "C:\\Windows"
+    candidate = os.path.join(
+        system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe",
+    )
+    if platform_compat.is_executable_file(candidate):
+        return candidate
+    return shutil.which("powershell")
+
+
+def _has_display() -> bool:
+    """Return ``True`` when an X11/Wayland session is reachable.
+
+    Linux only. A gateway on a headless server has the chooser binaries
+    installed often enough that presence alone is a bad signal.
+    """
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def detect_backend() -> str | None:
+    """Return the native-chooser backend for this host, or ``None``.
+
+    ``None`` means the dashboard should keep using its server-side directory
+    browser: there is no chooser to run, or no session to draw it in.
+    """
+    if sys.platform == "darwin":
+        return BACKEND_OSASCRIPT if shutil.which("osascript") else None
+    if sys.platform == "win32":
+        return BACKEND_POWERSHELL if _powershell() else None
+    if not _has_display():
+        return None
+    for name, backend in (("zenity", BACKEND_ZENITY), ("kdialog", BACKEND_KDIALOG)):
+        if shutil.which(name):
+            return backend
+    return None
+
+
+def is_available() -> bool:
+    """Return ``True`` when a native folder dialog can be opened here."""
+    return detect_backend() is not None
+
+
+def build_command(
+    backend: str, default_path: str = "", prompt: str = PROMPT_PROJECT,
+) -> tuple[list[str], dict[str, str]]:
+    """Return ``(argv, extra_env)`` for *backend*.
+
+    *default_path* is the directory the chooser opens in; empty means "let the
+    OS decide". Neither it nor *prompt* is ever spliced into program text — each
+    travels as a separate argv element or env value.
+    """
+    if backend == BACKEND_OSASCRIPT:
+        argv = ["osascript"]
+        for line in _OSASCRIPT_LINES:
+            argv += ["-e", line]
+        # The `--` separator keeps a path that starts with "-" out of
+        # osascript's own option parsing.
+        return argv + ["--", prompt, default_path], {}
+    if backend == BACKEND_POWERSHELL:
+        exe = _powershell() or "powershell"
+        argv = [exe, "-NoProfile", "-NonInteractive", "-STA", "-Command", _POWERSHELL_SCRIPT]
+        env = {_WIN_PROMPT_ENV: prompt}
+        if default_path:
+            env[_WIN_DEFAULT_ENV] = default_path
+        return argv, env
+    if backend == BACKEND_ZENITY:
+        argv = ["zenity", "--file-selection", "--directory", f"--title={prompt}"]
+        if default_path:
+            # zenity treats a trailing separator as "start inside this dir".
+            argv.append(f"--filename={default_path.rstrip(os.sep)}{os.sep}")
+        return argv, {}
+    if backend == BACKEND_KDIALOG:
+        return ["kdialog", "--title", prompt,
+                "--getexistingdirectory", default_path or os.path.expanduser("~")], {}
+    raise DialogUnavailable(f"unknown dialog backend: {backend}")
+
+
+def _is_cancellation(backend: str, returncode: int, stderr: str) -> bool:
+    """Return ``True`` when a non-zero exit means "the user clicked Cancel".
+
+    Cancel and failure share an exit status on most of these tools, so each
+    backend needs its own reading. Guessing wrong in the cancel direction would
+    hide real breakage; guessing wrong the other way would show the user an
+    error for a normal dismissal.
+    """
+    if backend == BACKEND_OSASCRIPT:
+        # AppleScript reports a user cancel as error -128, printed as
+        # "execution error: User canceled. (-128)". Match the parenthesised
+        # token, not a bare "-128" substring, so a different negative code that
+        # merely contains those digits is not read as a dismissal. The numeric
+        # check carries this on non-English systems, where the message won't.
+        return "(-128)" in stderr or "user canceled" in stderr.lower()
+    if backend in (BACKEND_ZENITY, BACKEND_KDIALOG):
+        # Both exit 1 on dismissal and 255/-1 on real errors.
+        return returncode == 1
+    # PowerShell exits 0 whether or not the user picked something; a cancel is
+    # an empty stdout, handled by the caller.
+    return False
+
+
+def choose_directory(default_path: str = "", prompt: str = PROMPT_PROJECT) -> str | None:
+    """Open the host's native folder dialog. Blocking — call in a thread.
+
+    Returns the chosen absolute path, or ``None`` if the user cancelled.
+
+    Raises:
+        DialogUnavailable: no chooser on this host, the chooser could not
+            start, it failed, or it outran :data:`DIALOG_TIMEOUT_SEC`.
+    """
+    backend = detect_backend()
+    if backend is None:
+        raise DialogUnavailable("no native folder dialog on this host")
+    argv, extra_env = build_command(backend, default_path, prompt)
+    env = {**os.environ, **extra_env}
+    try:
+        proc = subprocess.run(
+            argv, capture_output=True, text=True,
+            timeout=DIALOG_TIMEOUT_SEC, env=env, check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DialogUnavailable("the folder dialog timed out") from exc
+    except OSError as exc:
+        raise DialogUnavailable(f"could not start the folder dialog: {exc}") from exc
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if proc.returncode != 0:
+        if _is_cancellation(backend, proc.returncode, stderr):
+            return None
+        logger.debug("native folder dialog failed (%s): rc=%s %s", backend, proc.returncode, stderr)
+        raise DialogUnavailable("the folder dialog could not be opened")
+    if not stdout:
+        return None  # dismissed without a selection
+    # osascript's `POSIX path of` appends a separator to directories; the
+    # dashboard stores project paths without one.
+    return stdout.rstrip("/") or "/"

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1804,6 +1804,8 @@ async def start_dashboard(
     app.router.add_get("/api/file-diff", handlers.api_file_diff)
     app.router.add_get("/api/file-search", handlers.api_file_search)
     app.router.add_get("/api/browse-dirs", handlers.api_browse_dirs)
+    app.router.add_get("/api/native-dir-dialog", handlers.api_native_dir_dialog_probe)
+    app.router.add_post("/api/native-dir-dialog", handlers.api_native_dir_dialog)
     app.router.add_get("/api/browse-files", handlers.api_browse_files)
     app.router.add_post("/api/upload", handlers.api_upload)
     app.router.add_post("/api/upload/file", handlers.api_upload_file)

--- a/test/test_knowledge_add_source.py
+++ b/test/test_knowledge_add_source.py
@@ -10,6 +10,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from kiro_crew.dashboard import native_dialog as nd
 from kiro_crew.dashboard.handlers.knowledge import (
     _folder_picker_available,
     _run_folder_dialog,
@@ -206,67 +207,70 @@ def _fake_request(local_only=True):
 
 
 class TestFolderPickerAvailable:
-    def test_available_on_mac_local(self, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+    def test_available_when_host_has_a_chooser_and_dashboard_is_local(self, monkeypatch):
+        monkeypatch.setattr(nd, "detect_backend", lambda: nd.BACKEND_OSASCRIPT)
         assert _folder_picker_available(_fake_request(local_only=True)) is True
 
-    def test_unavailable_off_mac(self, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "linux")
+    def test_unavailable_without_a_chooser(self, monkeypatch):
+        """A headless host has no dialog to draw, whatever its platform."""
+        monkeypatch.setattr(nd, "detect_backend", lambda: None)
         assert _folder_picker_available(_fake_request(local_only=True)) is False
 
+    def test_available_on_non_mac_hosts_with_a_chooser(self, monkeypatch):
+        monkeypatch.setattr(nd, "detect_backend", lambda: nd.BACKEND_ZENITY)
+        assert _folder_picker_available(_fake_request(local_only=True)) is True
+
     def test_unavailable_when_remote(self, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+        monkeypatch.setattr(nd, "detect_backend", lambda: nd.BACKEND_OSASCRIPT)
         assert _folder_picker_available(_fake_request(local_only=False)) is False
 
     def test_fail_closed_when_local_only_unset(self, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+        monkeypatch.setattr(nd, "detect_backend", lambda: nd.BACKEND_OSASCRIPT)
         assert _folder_picker_available(SimpleNamespace(app={})) is False
 
 
 class TestRunFolderDialog:
     def test_picked_returns_path(self, monkeypatch):
-        completed = MagicMock(returncode=0, stdout="/home/user/notes\n")
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.handlers.knowledge.subprocess.run",
-            lambda *a, **k: completed,
-        )
+        monkeypatch.setattr(nd, "choose_directory", lambda **kw: "/home/user/notes")
         assert _run_folder_dialog() == "/home/user/notes"
 
     def test_cancel_returns_none(self, monkeypatch):
-        completed = MagicMock(returncode=1, stdout="")
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.handlers.knowledge.subprocess.run",
-            lambda *a, **k: completed,
-        )
+        monkeypatch.setattr(nd, "choose_directory", lambda **kw: None)
         assert _run_folder_dialog() is None
 
     def test_launch_failure_returns_none(self, monkeypatch):
-        def boom(*a, **k):
-            raise FileNotFoundError()
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.handlers.knowledge.subprocess.run", boom,
-        )
+        """This surface feeds the path into a text field, so a failed dialog and
+        a cancelled one collapse to the same answer here."""
+        def boom(**kw):
+            raise nd.DialogUnavailable("no session")
+        monkeypatch.setattr(nd, "choose_directory", boom)
         assert _run_folder_dialog() is None
+
+    def test_uses_the_knowledge_prompt(self, monkeypatch):
+        seen = {}
+        monkeypatch.setattr(nd, "choose_directory", lambda **kw: seen.update(kw) or "/p")
+        _run_folder_dialog()
+        assert seen["prompt"] == nd.PROMPT_KNOWLEDGE
 
 
 class TestPickFolderHandler:
     @pytest.mark.asyncio
     async def test_blocked_when_not_local_only(self, store, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+        monkeypatch.setattr(nd, "detect_backend", lambda: nd.BACKEND_OSASCRIPT)
         async with TestClient(TestServer(_make_pick_app(store, local_only=False))) as client:
             resp = await client.post("/api/knowledge/pick-folder")
             assert resp.status == 403
 
     @pytest.mark.asyncio
-    async def test_blocked_when_not_mac(self, store, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "linux")
+    async def test_blocked_without_a_chooser(self, store, monkeypatch):
+        monkeypatch.setattr(nd, "detect_backend", lambda: None)
         async with TestClient(TestServer(_make_pick_app(store, local_only=True))) as client:
             resp = await client.post("/api/knowledge/pick-folder")
             assert resp.status == 403
 
     @pytest.mark.asyncio
     async def test_returns_picked_path(self, store, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+        monkeypatch.setattr(nd, "detect_backend", lambda: nd.BACKEND_OSASCRIPT)
         monkeypatch.setattr(
             "kiro_crew.dashboard.handlers.knowledge._run_folder_dialog",
             lambda: "/home/user/notes",
@@ -278,7 +282,7 @@ class TestPickFolderHandler:
 
     @pytest.mark.asyncio
     async def test_returns_null_on_cancel(self, store, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+        monkeypatch.setattr(nd, "detect_backend", lambda: nd.BACKEND_OSASCRIPT)
         monkeypatch.setattr(
             "kiro_crew.dashboard.handlers.knowledge._run_folder_dialog",
             lambda: None,
@@ -291,15 +295,15 @@ class TestPickFolderHandler:
 
 class TestConfigFolderPickerFlag:
     @pytest.mark.asyncio
-    async def test_reports_true_on_mac_local(self, store, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+    async def test_reports_true_when_local_with_a_chooser(self, store, monkeypatch):
+        monkeypatch.setattr(nd, "detect_backend", lambda: nd.BACKEND_OSASCRIPT)
         async with TestClient(TestServer(_make_pick_app(store, local_only=True))) as client:
             resp = await client.get("/api/knowledge/config")
             assert (await resp.json())["folder_picker"] is True
 
     @pytest.mark.asyncio
-    async def test_reports_false_off_mac(self, store, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "win32")
+    async def test_reports_false_without_a_chooser(self, store, monkeypatch):
+        monkeypatch.setattr(nd, "detect_backend", lambda: None)
         async with TestClient(TestServer(_make_pick_app(store, local_only=True))) as client:
             resp = await client.get("/api/knowledge/config")
             assert (await resp.json())["folder_picker"] is False

--- a/test/test_native_dialog.py
+++ b/test/test_native_dialog.py
@@ -1,0 +1,429 @@
+"""Tests for the host-side native folder dialog (module + /api/native-dir-dialog)."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import subprocess
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard import native_dialog as nd
+from kiro_crew.dashboard.handlers import api_native_dir_dialog, api_native_dir_dialog_probe
+from kiro_crew.dashboard.handlers import files as files_handlers
+
+
+def _make_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/api/native-dir-dialog", api_native_dir_dialog_probe)
+    app.router.add_post("/api/native-dir-dialog", api_native_dir_dialog)
+    return app
+
+
+@pytest.fixture()
+def mock_sel():
+    with patch("kiro_crew.dashboard.handlers.sel") as m:
+        m.return_value = MagicMock()
+        yield m.return_value
+
+
+@pytest.fixture(autouse=True)
+def _reset_busy():
+    files_handlers._NATIVE_DIALOG_STATE["busy"] = False
+    yield
+    files_handlers._NATIVE_DIALOG_STATE["busy"] = False
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["dialog"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestDetectBackend:
+    def test_macos_uses_osascript(self):
+        with patch.object(nd.sys, "platform", "darwin"), \
+             patch.object(nd.shutil, "which", return_value="/usr/bin/osascript"):
+            assert nd.detect_backend() == nd.BACKEND_OSASCRIPT
+
+    def test_macos_without_osascript_is_unavailable(self):
+        with patch.object(nd.sys, "platform", "darwin"), \
+             patch.object(nd.shutil, "which", return_value=None):
+            assert nd.detect_backend() is None
+
+    def test_windows_uses_powershell(self):
+        with patch.object(nd.sys, "platform", "win32"), \
+             patch.object(nd, "_powershell", return_value="C:\\powershell.exe"):
+            assert nd.detect_backend() == nd.BACKEND_POWERSHELL
+
+    def test_linux_without_display_is_unavailable(self):
+        """A headless gateway has zenity installed often enough that presence lies."""
+        with patch.object(nd.sys, "platform", "linux"), \
+             patch.dict(nd.os.environ, {}, clear=True), \
+             patch.object(nd.shutil, "which", return_value="/usr/bin/zenity"):
+            assert nd.detect_backend() is None
+
+    def test_linux_prefers_zenity_then_kdialog(self):
+        with patch.object(nd.sys, "platform", "linux"), \
+             patch.dict(nd.os.environ, {"DISPLAY": ":0"}):
+            with patch.object(nd.shutil, "which", side_effect=lambda n: "/usr/bin/zenity" if n == "zenity" else None):
+                assert nd.detect_backend() == nd.BACKEND_ZENITY
+            with patch.object(nd.shutil, "which", side_effect=lambda n: "/usr/bin/kdialog" if n == "kdialog" else None):
+                assert nd.detect_backend() == nd.BACKEND_KDIALOG
+            with patch.object(nd.shutil, "which", return_value=None):
+                assert nd.detect_backend() is None
+
+    def test_wayland_display_counts(self):
+        with patch.object(nd.sys, "platform", "linux"), \
+             patch.dict(nd.os.environ, {"WAYLAND_DISPLAY": "wayland-0"}, clear=True), \
+             patch.object(nd.shutil, "which", side_effect=lambda n: "/z" if n == "zenity" else None):
+            assert nd.detect_backend() == nd.BACKEND_ZENITY
+
+
+def _applescript(argv: list[str]) -> str:
+    """The -e lines only — i.e. the program text osascript will execute."""
+    return " ".join(a for a, prev in zip(argv, [""] + argv) if prev == "-e")
+
+
+class TestBuildCommand:
+    def test_osascript_passes_data_via_argv_not_program_text(self):
+        """The AppleScript body must stay a fixed literal — no interpolation."""
+        evil = '"; do shell script "touch /tmp/pwned"'
+        argv, env = nd.build_command(nd.BACKEND_OSASCRIPT, evil, evil)
+        assert argv[-3:] == ["--", evil, evil]
+        assert env == {}
+        script = _applescript(argv)
+        assert evil not in script
+        assert "choose folder" in script
+
+    def test_osascript_program_text_is_identical_for_any_input(self):
+        a, _ = nd.build_command(nd.BACKEND_OSASCRIPT, "/one", "Prompt one")
+        b, _ = nd.build_command(nd.BACKEND_OSASCRIPT, "/two", 'Prompt "two"')
+        assert _applescript(a) == _applescript(b)
+
+    def test_osascript_omits_default_location_when_empty(self):
+        argv, _ = nd.build_command(nd.BACKEND_OSASCRIPT, "")
+        assert argv[-3:] == ["--", nd.PROMPT_PROJECT, ""]
+        assert any("if loc is \"\" then" in a for a in argv)
+
+    def test_osascript_activates_itself_not_system_events(self):
+        """System Events is faceless: activating it launches a second process
+        before the panel can appear, which shows up as a slow-opening dialog."""
+        script = _applescript(nd.build_command(nd.BACKEND_OSASCRIPT, "")[0])
+        assert "activate me" in script
+        assert "System Events" not in script
+
+    def test_powershell_is_sta_and_uses_env_for_data(self):
+        argv, env = nd.build_command(nd.BACKEND_POWERSHELL, "C:\\proj", "Pick one")
+        assert "-STA" in argv          # WinForms dialogs need a single-threaded apartment
+        assert "-NoProfile" in argv
+        assert env == {nd._WIN_PROMPT_ENV: "Pick one", nd._WIN_DEFAULT_ENV: "C:\\proj"}
+        joined = " ".join(argv)
+        assert "C:\\proj" not in joined
+        assert "Pick one" not in joined
+
+    def test_powershell_no_default_env_without_default(self):
+        _, env = nd.build_command(nd.BACKEND_POWERSHELL, "")
+        assert nd._WIN_DEFAULT_ENV not in env
+
+    def test_prompt_reaches_each_backend_as_data(self):
+        argv, _ = nd.build_command(nd.BACKEND_ZENITY, "", nd.PROMPT_KNOWLEDGE)
+        assert f"--title={nd.PROMPT_KNOWLEDGE}" in argv
+        argv, _ = nd.build_command(nd.BACKEND_KDIALOG, "", nd.PROMPT_KNOWLEDGE)
+        assert argv[argv.index("--title") + 1] == nd.PROMPT_KNOWLEDGE
+
+    def test_zenity_directory_selection_with_trailing_separator(self):
+        argv, env = nd.build_command(nd.BACKEND_ZENITY, "/home/u/proj")
+        assert "--directory" in argv and "--file-selection" in argv
+        assert f"--filename=/home/u/proj{nd.os.sep}" in argv
+        assert env == {}
+
+    def test_kdialog_gets_existing_directory(self):
+        argv, _ = nd.build_command(nd.BACKEND_KDIALOG, "/home/u/proj")
+        assert "--getexistingdirectory" in argv
+        assert argv[-1] == "/home/u/proj"
+
+    def test_unknown_backend_raises(self):
+        with pytest.raises(nd.DialogUnavailable):
+            nd.build_command("telepathy")
+
+
+class TestChooseDirectory:
+    def test_returns_selection_without_trailing_slash(self):
+        """osascript's `POSIX path of` appends a separator; project paths don't carry one."""
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_OSASCRIPT), \
+             patch.object(nd.subprocess, "run", return_value=_completed(stdout="/home/u/proj/\n")):
+            assert nd.choose_directory() == "/home/u/proj"
+
+    def test_root_selection_survives_stripping(self):
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_OSASCRIPT), \
+             patch.object(nd.subprocess, "run", return_value=_completed(stdout="/\n")):
+            assert nd.choose_directory() == "/"
+
+    def test_osascript_cancel_is_none_not_error(self):
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_OSASCRIPT), \
+             patch.object(nd.subprocess, "run",
+                          return_value=_completed(1, stderr="execution error: User canceled. (-128)")):
+            assert nd.choose_directory() is None
+
+    def test_osascript_real_failure_raises(self):
+        """A non-cancel AppleScript error must not masquerade as a dismissal."""
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_OSASCRIPT), \
+             patch.object(nd.subprocess, "run",
+                          return_value=_completed(1, stderr="execution error: no user session (-1743)")):
+            with pytest.raises(nd.DialogUnavailable):
+                nd.choose_directory()
+
+    def test_osascript_code_is_matched_as_a_token(self):
+        """A different negative code that merely contains 128 is not a cancel."""
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_OSASCRIPT), \
+             patch.object(nd.subprocess, "run",
+                          return_value=_completed(1, stderr="execution error: boom (-1281)")):
+            with pytest.raises(nd.DialogUnavailable):
+                nd.choose_directory()
+
+    def test_zenity_cancel_is_none_other_codes_raise(self):
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_ZENITY):
+            with patch.object(nd.subprocess, "run", return_value=_completed(1)):
+                assert nd.choose_directory() is None
+            with patch.object(nd.subprocess, "run", return_value=_completed(255, stderr="cannot open display")):
+                with pytest.raises(nd.DialogUnavailable):
+                    nd.choose_directory()
+
+    def test_powershell_empty_stdout_is_cancel(self):
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_POWERSHELL), \
+             patch.object(nd.subprocess, "run", return_value=_completed(0, stdout="")):
+            assert nd.choose_directory() is None
+
+    def test_timeout_raises_unavailable(self):
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_ZENITY), \
+             patch.object(nd.subprocess, "run",
+                          side_effect=subprocess.TimeoutExpired(cmd="zenity", timeout=1)):
+            with pytest.raises(nd.DialogUnavailable):
+                nd.choose_directory()
+
+    def test_missing_binary_raises_unavailable(self):
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_ZENITY), \
+             patch.object(nd.subprocess, "run", side_effect=OSError("No such file")):
+            with pytest.raises(nd.DialogUnavailable):
+                nd.choose_directory()
+
+    def test_no_backend_raises_unavailable(self):
+        with patch.object(nd, "detect_backend", return_value=None):
+            with pytest.raises(nd.DialogUnavailable):
+                nd.choose_directory()
+
+    def test_default_path_reaches_the_command(self):
+        with patch.object(nd, "detect_backend", return_value=nd.BACKEND_ZENITY), \
+             patch.object(nd.subprocess, "run", return_value=_completed(stdout="/picked")) as run:
+            nd.choose_directory("/start/here")
+            assert any("--filename=/start/here" in a for a in run.call_args.args[0])
+
+
+class TestNativeDialogEndpoint:
+    @pytest.mark.asyncio
+    async def test_probe_reports_availability(self, mock_sel):
+        with patch.object(nd, "is_available", return_value=True):
+            async with TestClient(TestServer(_make_app())) as client:
+                assert (await (await client.get("/api/native-dir-dialog")).json()) == {"available": True}
+        with patch.object(nd, "is_available", return_value=False):
+            async with TestClient(TestServer(_make_app())) as client:
+                assert (await (await client.get("/api/native-dir-dialog")).json()) == {"available": False}
+
+    @pytest.mark.asyncio
+    async def test_probe_is_false_for_a_forwarded_request(self, mock_sel):
+        """A tunnelled browser is on another machine — hide the affordance."""
+        with patch.object(nd, "is_available", return_value=True):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get("/api/native-dir-dialog", headers={"X-Forwarded-For": "203.0.113.9"})
+                assert (await resp.json()) == {"available": False}
+
+    @pytest.mark.asyncio
+    async def test_returns_selected_path(self, tmp_path, mock_sel):
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value=str(tmp_path)):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={})
+                assert resp.status == 200
+                assert (await resp.json())["path"] == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_cancel_is_a_success_response(self, mock_sel):
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value=None):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={})
+                assert resp.status == 200
+                assert (await resp.json()) == {"cancelled": True}
+
+    @pytest.mark.asyncio
+    async def test_forwarded_request_is_refused(self, mock_sel):
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value="/tmp") as choose:
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={},
+                                         headers={"X-Forwarded-For": "203.0.113.9"})
+                assert resp.status == 403
+                assert (await resp.json())["reason"] == "remote"
+                choose.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_host_returns_503(self, mock_sel):
+        with patch.object(nd, "is_available", return_value=False):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={})
+                assert resp.status == 503
+                assert (await resp.json())["reason"] == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_dialog_failure_returns_503(self, mock_sel):
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", side_effect=nd.DialogUnavailable("no session")):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={})
+                assert resp.status == 503
+                assert (await resp.json())["reason"] == "failed"
+        # The slot must be released even when the dialog blew up.
+        assert files_handlers._NATIVE_DIALOG_STATE["busy"] is False
+
+    @pytest.mark.asyncio
+    async def test_second_dialog_is_refused_while_one_is_open(self, mock_sel):
+        files_handlers._NATIVE_DIALOG_STATE["busy"] = True
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value="/tmp") as choose:
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={})
+                assert resp.status == 409
+                assert (await resp.json())["reason"] == "busy"
+                choose.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sensitive_selection_is_denied(self, tmp_path, mock_sel):
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value=str(tmp_path)), \
+             patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=True):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={})
+                assert resp.status == 403
+                assert (await resp.json())["reason"] == "sensitive"
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_selection_is_rejected(self, mock_sel):
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value="/nonexistent_xyz_123"):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={})
+                assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_starting_directory_comes_from_recent_projects_not_the_request(
+        self, tmp_path, mock_sel, monkeypatch,
+    ):
+        """No request byte may reach the spawn (see BENIGN_SPAWNS justification)."""
+        recent = tmp_path / "recent"
+        recent.mkdir()
+        monkeypatch.setattr(files_handlers, "_last_project_dir", lambda: str(recent))
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value=str(tmp_path)) as choose:
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", json={"path": "/attacker/controlled"})
+                assert resp.status == 200
+                assert choose.call_args.args[0] == str(recent)
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_body_is_tolerated(self, tmp_path, mock_sel):
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value=str(tmp_path)):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.post("/api/native-dir-dialog", data="not json")
+                assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_selection_is_logged(self, tmp_path, mock_sel):
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", return_value=str(tmp_path)):
+            async with TestClient(TestServer(_make_app())) as client:
+                await client.post("/api/native-dir-dialog", json={})
+        assert mock_sel.log_api_access.call_args.kwargs["operation"] == "native_dir_dialog"
+        assert mock_sel.log_api_access.call_args.kwargs["outcome"] == "allowed"
+
+    @pytest.mark.asyncio
+    async def test_slot_stays_held_when_the_caller_disconnects_mid_dialog(self, mock_sel):
+        """A caller that walks away must not free the slot: the OS panel is still
+        on screen (to_thread cannot interrupt it), so releasing it here would let
+        a second request stack a second modal on the host.
+
+        Cancels the HANDLER task directly — an aiohttp client-side cancel does
+        not necessarily propagate to the server coroutine, so going through
+        TestClient would not exercise this path.
+        """
+        import asyncio as _asyncio
+
+        release = threading.Event()
+        entered = threading.Event()
+
+        def blocking_dialog(_default=""):
+            entered.set()
+            release.wait(5)
+            return "/tmp"
+
+        request = SimpleNamespace(
+            remote="127.0.0.1", headers={}, get=lambda key, default=None: default,
+        )
+        with patch.object(nd, "is_available", return_value=True), \
+             patch.object(nd, "choose_directory", side_effect=blocking_dialog):
+            task = _asyncio.ensure_future(api_native_dir_dialog(request))
+            await _asyncio.get_running_loop().run_in_executor(None, entered.wait, 5)
+            task.cancel()
+            with contextlib.suppress(_asyncio.CancelledError):
+                await task
+            # Dialog thread is still running — the slot must remain taken.
+            assert files_handlers._NATIVE_DIALOG_STATE["busy"] is True
+            release.set()
+            # Once the thread finishes, the done-callback frees the slot.
+            for _ in range(100):
+                if not files_handlers._NATIVE_DIALOG_STATE["busy"]:
+                    break
+                await _asyncio.sleep(0.02)
+            assert files_handlers._NATIVE_DIALOG_STATE["busy"] is False
+
+
+class TestLastProjectDir:
+    """Where the chooser opens is derived from the gateway's own state."""
+
+    def _write_recents(self, tmp_path, payload):
+        (tmp_path / "recent_projects.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_returns_first_existing_entry(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(files_handlers, "config_dir", lambda: tmp_path)
+        live = tmp_path / "live"
+        live.mkdir()
+        self._write_recents(tmp_path, ["/gone_xyz_123", str(live)])
+        assert files_handlers._last_project_dir() == str(live)
+
+    def test_skips_sensitive_entries(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(files_handlers, "config_dir", lambda: tmp_path)
+        secret = tmp_path / "secret"
+        secret.mkdir()
+        ok = tmp_path / "ok"
+        ok.mkdir()
+        self._write_recents(tmp_path, [str(secret), str(ok)])
+        monkeypatch.setattr(
+            files_handlers, "is_sensitive_path", lambda p: p == str(secret))
+        assert files_handlers._last_project_dir() == str(ok)
+
+    def test_missing_file_is_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(files_handlers, "config_dir", lambda: tmp_path)
+        assert files_handlers._last_project_dir() == ""
+
+    def test_corrupt_or_unexpected_json_is_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(files_handlers, "config_dir", lambda: tmp_path)
+        (tmp_path / "recent_projects.json").write_text("{not json", encoding="utf-8")
+        assert files_handlers._last_project_dir() == ""
+        self._write_recents(tmp_path, {"dirs": ["/x"]})
+        assert files_handlers._last_project_dir() == ""
+        self._write_recents(tmp_path, [None, 42, ""])
+        assert files_handlers._last_project_dir() == ""

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -215,7 +215,19 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "dashboard/handlers/files.py::api_reveal_path",
         "dashboard/handlers/files.py::api_screenshot",
         "dashboard/handlers/files.py::api_upload",
-        "dashboard/handlers/knowledge.py::_run_folder_dialog",
+        # Native folder chooser on the gateway's own screen (project picker and
+        # knowledge folder picker both route here). Fixed argv of a system
+        # binary — osascript / powershell -STA / zenity / kdialog — where the
+        # AppleScript and PowerShell bodies are module-owned literals and the
+        # only variable parts (prompt, starting directory) travel as argv
+        # elements or env values that the CALLERS derive server-side: the
+        # prompt is a module constant and the starting directory is read from
+        # the gateway's own recent_projects.json, so no request byte reaches
+        # the spawn. Sandboxing would defeat the feature rather than harden it:
+        # the chooser must reach the user's GUI session (scrubbed env drops
+        # DISPLAY/Aqua) and must see the whole filesystem to let the user pick
+        # any directory. Both entry points are gated on a direct-local request.
+        "dashboard/native_dialog.py::choose_directory",
         # Terminal live-cwd probe on hosts without /proc (macOS/BSD): fixed
         # `lsof -a -p <pid> -d cwd -Fn` list-argv (no shell=True) where <pid>
         # is the gateway's own PTY child pid (an int from asyncio.subprocess),

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -883,6 +883,15 @@ export const api = {
     }>,
   recentProjects: () => fetch('/api/recent-projects').then(j) as Promise<{ dirs: string[] }>,
   browseDirs: (path?: string) => fetch('/api/browse-dirs' + (path ? '?path=' + encodeURIComponent(path) : '')).then(j) as Promise<{ path: string; parent: string; dirs: { name: string; path: string }[] }>,
+  // Native folder dialog (opens on the machine running the gateway). The probe
+  // keeps the affordance hidden where it cannot work — remote or headless hosts.
+  // Takes no arguments: the gateway derives where the chooser opens from its own
+  // recent-projects file, so no request data reaches the spawned dialog.
+  // Non-2xx (403 remote / 409 busy / 503 unavailable) throws ApiError, so the
+  // caller's catch is the fall-back-to-browser path.
+  nativeDirDialogAvailable: () => fetch('/api/native-dir-dialog').then(j) as Promise<{ available: boolean }>,
+  openNativeDirDialog: () =>
+    post('/api/native-dir-dialog', {}).then(j) as Promise<{ path?: string; cancelled?: boolean }>,
   browseFiles: (path?: string) => fetch('/api/browse-files' + (path ? '?path=' + encodeURIComponent(path) : '')).then(j) as Promise<{ path: string; parent: string; dirs: { name: string; path: string; mtime: number }[]; files: { name: string; path: string; mtime: number }[] }>,
   workspaces: () => fetch('/api/workspaces').then(j),
   createWorkspace: (body: object) => post('/api/workspaces', body).then(j),

--- a/website/src/components/ProjectPicker.tsx
+++ b/website/src/components/ProjectPicker.tsx
@@ -5,6 +5,88 @@ import { api } from '../api/client'
 import { useListKeyboardNav } from '../hooks/useListKeyboardNav'
 
 import { i18nT } from '../i18n/t'
+
+/**
+ * Whether the host can open a native folder dialog, resolved once per page.
+ *
+ * The answer is a property of the machine running the gateway, not of this
+ * panel, so re-asking on every open only buys a round-trip — which is felt as
+ * lag when the dashboard is reached over a tunnel or a slow link.
+ */
+let nativeProbe: Promise<boolean> | null = null
+function probeNativeDialog(): Promise<boolean> {
+  if (!nativeProbe) {
+    // Defensive on two axes: the method may be absent (test fixtures mock the
+    // api module partially) and the call may throw synchronously rather than
+    // reject. Either way the answer is "no native dialog", which is the safe
+    // default — the server-side browser still works.
+    try {
+      nativeProbe = Promise.resolve(api.nativeDirDialogAvailable?.())
+        .then(d => !!d?.available)
+        .catch(() => false)
+    } catch {
+      nativeProbe = Promise.resolve(false)
+    }
+  }
+  return nativeProbe
+}
+/** Test seam: drop the cached answer so each case probes fresh. */
+export function __resetNativeProbeForTests(): void {
+  nativeProbe = null
+  warmedRecents = null
+  warmedBrowse = null
+  warmScheduled = false
+}
+
+/**
+ * Recents and the first directory listing, warmed after boot.
+ *
+ * The panel itself paints in ~40ms, but on the FIRST open its lists were empty
+ * until a round-trip completed — ~220ms at 80ms RTT, ~830ms at 400ms, and over
+ * a second on a loaded tunnel. Later opens were instant because the data stayed
+ * in component state, so the cost fell entirely on the first use.
+ *
+ * Warming happens on an idle callback AFTER mount rather than during boot: the
+ * boot path is already round-trip bound, and this data is not needed for first
+ * paint. By the time the user reaches for the button it is in hand, and if they
+ * click sooner the open still works — it just falls back to fetching, exactly as
+ * before.
+ */
+type WarmDirs = Awaited<ReturnType<typeof api.browseDirs>>
+let warmedRecents: Promise<string[]> | null = null
+let warmedBrowse: Promise<WarmDirs | null> | null = null
+let warmScheduled = false
+
+function warmRecents(): Promise<string[]> {
+  warmedRecents ??= Promise.resolve(api.recentProjects?.())
+    .then(d => d?.dirs || [])
+    .catch(() => [])
+  return warmedRecents
+}
+
+function warmBrowse(): Promise<WarmDirs | null> {
+  warmedBrowse ??= Promise.resolve(api.browseDirs?.())
+    .then(d => d ?? null)
+    .catch(() => null)
+  return warmedBrowse
+}
+
+/** Schedule the warm once per page, off the boot critical path. */
+function scheduleWarm(): void {
+  if (warmScheduled) return
+  warmScheduled = true
+  const run = () => {
+    void warmRecents()
+    // Only the server-side browser needs a directory listing; a host with a
+    // native dialog never renders the tree.
+    void probeNativeDialog().then(ok => { if (!ok) void warmBrowse() })
+  }
+  const idle = (globalThis as { requestIdleCallback?: (cb: () => void, o?: { timeout: number }) => void })
+    .requestIdleCallback
+  if (typeof idle === 'function') idle(run, { timeout: 3000 })
+  else setTimeout(run, 1500)
+}
+
 interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -22,6 +104,13 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
   const [recentDirs, setRecentDirs] = useState<string[]>([])
   const [recentQuery, setRecentQuery] = useState('')
   const [browseSel, setBrowseSel] = useState(0)
+  // Native folder dialog: `null` while the probe is in flight, then whether the
+  // host can open one. `nativeError` is set when a dialog that was supposed to
+  // work fails anyway (no GUI session behind an ssh -L forward, for instance) —
+  // that re-exposes the server-side Browse tab as the fallback.
+  const [nativeOk, setNativeOk] = useState<boolean | null>(null)
+  const [nativePending, setNativePending] = useState(false)
+  const [nativeError, setNativeError] = useState('')
   const btnRef = anchorRef
   const dropRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -36,24 +125,46 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
     return anchorRectRef.current
   }, [btnRef])
 
+  // Applying a listing is shared by the network path and the warmed cache, so
+  // both land the panel in exactly the same state.
+  const applyBrowse = useCallback((d: WarmDirs, preserveInput = false) => {
+    setBrowsePath(d.path); setBrowseParent(d.parent); setBrowseDirs(d.dirs); setBrowseSel(0)
+    if (!preserveInput) setInput(d.path)
+    // Keep the combobox input focused so arrow/Enter nav continues after a drill.
+    requestAnimationFrame(() => inputRef.current?.focus())
+  }, [])
+
   const browse = useCallback((path?: string, preserveInput = false) => {
-    api.browseDirs(path).then(d => {
-      setBrowsePath(d.path); setBrowseParent(d.parent); setBrowseDirs(d.dirs); setBrowseSel(0)
-      if (!preserveInput) setInput(d.path)
-      // Keep the combobox input focused so arrow/Enter nav continues after a drill.
-      requestAnimationFrame(() => inputRef.current?.focus())
-    }).catch(() => {})
+    api.browseDirs(path).then(d => applyBrowse(d, preserveInput)).catch(() => {})
+  }, [applyBrowse])
+
+  // Probe on MOUNT, not on open: the round-trip then overlaps with the user
+  // deciding to click, so the first open already knows which chrome to draw
+  // instead of rendering tabs and dropping them a moment later. The data warm
+  // rides along, so the first open's lists are populated too.
+  useEffect(() => {
+    probeNativeDialog().then(setNativeOk)
+    scheduleWarm()
   }, [])
 
   useEffect(() => {
     if (!open) return
     setRecentQuery('')
-    api.recentProjects().then(d => {
-      setRecentDirs(d.dirs || [])
-      setTab(d.dirs?.length ? 'recent' : 'browse')
-    }).catch(() => setTab('browse'))
-    browse()
-  }, [open, browse])
+    setNativeError('')
+    setNativePending(false)
+    // Warmed values resolve immediately when the idle callback already ran, so
+    // the list is populated in the same frame the panel paints.
+    warmRecents().then(dirs => {
+      setRecentDirs(dirs)
+      setTab(dirs.length ? 'recent' : 'browse')
+    })
+    probeNativeDialog().then(ok => {
+      setNativeOk(ok)
+      // The server-side tree is only shown when there is no native dialog, so
+      // listing it up front would be a round-trip nobody reads.
+      if (!ok) warmBrowse().then(d => { if (d) applyBrowse(d) })
+    })
+  }, [open, applyBrowse])
 
   useEffect(() => {
     if (!open) return
@@ -75,6 +186,32 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
   }, [open, onOpenChange, btnRef, getAnchorRect])
 
   const select = (path: string) => { onSelect(path); onOpenChange(false) }
+
+  // Ask the gateway to open the host's own folder dialog. The panel stays
+  // mounted while the OS dialog is up (the answer arrives on this request), and
+  // a failure degrades to the server-side browser rather than a dead end. Where
+  // the dialog opens is the gateway's decision, not ours.
+  const openNative = useCallback(() => {
+    setNativeError('')
+    setNativePending(true)
+    api.openNativeDirDialog()
+      .then(d => {
+        setNativePending(false)
+        if (d.path) select(d.path)
+      })
+      .catch(() => {
+        setNativePending(false)
+        setNativeOk(false)
+        setNativeError(i18nT('components.projectPicker.native_dialog_failed'))
+        setTab('browse')
+        // The tree was never listed (native mode skips it), so fetch it now
+        // that it is about to become the only way to pick a folder.
+        browse()
+      })
+    // `select` closes over onSelect/onOpenChange, both stable for a mounted panel.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [browse])
+
   const rq = recentQuery.trim().toLowerCase()
   const filteredRecent = rq ? recentDirs.filter(d => d.toLowerCase().includes(rq)) : recentDirs
 
@@ -123,6 +260,10 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
 
   const q = input.toLowerCase()
   const filteredBrowse = q && q !== browsePath.toLowerCase() ? browseDirs.filter(d => d.name.toLowerCase().includes(q.split('/').pop() || '') || d.path.toLowerCase().includes(q)) : browseDirs
+  // With a native dialog on hand there is only one way to browse, so the tab
+  // strip goes away and the panel is just: recents, plus "Choose folder…".
+  const showTabs = nativeOk !== true
+  const view = showTabs ? tab : 'recent'
 
   return createPortal(
     <div ref={dropRef} className="fixed z-[9999] bg-bg-elevated border border-border rounded-xl shadow-xl w-[400px] flex flex-col overflow-hidden animate-slide-up" style={(() => {
@@ -130,13 +271,23 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
       const spaceBelow = window.innerHeight - anchorR.bottom - 8
       const flipUp = spaceBelow < dropMinH || anchorR.bottom > window.innerHeight / 2
       const left = Math.max(8, Math.min(anchorR.right - 400, window.innerWidth - 408))
+      // With a native dialog and no recents there is nothing to scroll, so the
+      // panel sizes to its content instead of reserving a tall empty box.
+      const compact = nativeOk === true && recentDirs.length === 0
       if (flipUp) {
         const spaceAbove = anchorR.top - 8
-        return { bottom: window.innerHeight - anchorR.top + 4, left, height: Math.min(460, Math.max(200, spaceAbove)) }
+        const h = Math.min(460, Math.max(200, spaceAbove))
+        return compact
+          ? { bottom: window.innerHeight - anchorR.top + 4, left, maxHeight: h }
+          : { bottom: window.innerHeight - anchorR.top + 4, left, height: h }
       }
-      return { top: anchorR.bottom + 4, left, height: Math.min(460, Math.max(200, spaceBelow)) }
+      const h = Math.min(460, Math.max(200, spaceBelow))
+      return compact
+        ? { top: anchorR.bottom + 4, left, maxHeight: h }
+        : { top: anchorR.bottom + 4, left, height: h }
     })()}>
-      {/* Tabs */}
+      {/* Tabs — only when the server-side browser is the browsing surface. */}
+      {showTabs && (
       <div className="flex border-b border-border">
         <button className={`flex-1 px-3 py-2 text-[12px] font-medium flex items-center justify-center gap-1.5 transition-colors ${tab === 'recent' ? 'text-accent border-b-2 border-accent' : 'text-muted hover:text-text'}`} onMouseDown={e => { e.preventDefault(); setTab('recent') }}>
           <Clock size={12} /> {i18nT('components.projectPicker.recent')}
@@ -145,8 +296,19 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
           <FolderOpen size={12} /> {i18nT('components.projectPicker.browse')}
         </button>
       </div>
+      )}
+      {/* Native mode has no tab strip, so a heading takes its place: without it
+          the panel is two bare file paths and a button with no stated purpose. */}
+      {nativeOk === true && (
+        <div className="px-3 py-2 border-b border-border text-[12px] font-medium text-text">
+          {i18nT('components.projectPicker.open_a_project_folder')}
+        </div>
+      )}
+      {nativeError && (
+        <div className="px-3 py-2 text-[11px] text-warn border-b border-border">{nativeError}</div>
+      )}
 
-      {tab === 'recent' ? (
+      {view === 'recent' ? (
         <>
           {recentDirs.length > 0 && (
             <div className="p-2 border-b border-border">
@@ -168,7 +330,11 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
           )}
           <div id="pp-recent-list" role="listbox" aria-label={i18nT('components.projectPicker.recent_projects')} className="overflow-y-auto flex-1 min-h-0">
             {recentDirs.length === 0 ? (
-              <div className="px-3 py-6 text-[12px] text-muted text-center">{i18nT('components.projectPicker.no_recent_projects')}</div>
+              <div className="px-3 py-6 text-[12px] text-muted text-center">
+                {nativeOk === true
+                  ? i18nT('components.projectPicker.no_recent_projects_native')
+                  : i18nT('components.projectPicker.no_recent_projects')}
+              </div>
             ) : filteredRecent.length === 0 ? (
               <div className="px-3 py-6 text-[12px] text-muted text-center">{i18nT('components.projectPicker.no_matching_projects')}</div>
             ) : filteredRecent.map((d, i) => (
@@ -251,6 +417,22 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
             ))}
           </div>
         </>
+      )}
+
+      {nativeOk === true && (
+        <div className="border-t border-border p-2 shrink-0">
+          <button
+            type="button"
+            disabled={nativePending}
+            onClick={openNative}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded text-[12px] font-medium bg-accent/20 text-accent hover:bg-accent/30 disabled:opacity-60 disabled:cursor-wait transition-colors"
+          >
+            <FolderOpen size={13} className="shrink-0" />
+            {nativePending
+              ? i18nT('components.projectPicker.waiting_for_dialog')
+              : i18nT('components.projectPicker.choose_folder')}
+          </button>
+        </div>
       )}
     </div>,
     document.body

--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -1501,9 +1501,13 @@
     "projectPicker": {
       "back": "Back",
       "browse": "Browse",
+      "choose_folder": "Choose folder…",
+      "native_dialog_failed": "Couldn't open the folder window — choose a folder from the list below instead.",
       "no_matching_projects": "No matching projects",
       "no_recent_projects": "No recent projects",
+      "no_recent_projects_native": "No recent projects yet — choose a folder to get started.",
       "no_subdirectories": "No subdirectories",
+      "open_a_project_folder": "Open a project folder",
       "path_to_project": "/path/to/project",
       "project_directory_path": "Project directory path",
       "recent": "Recent",
@@ -1511,7 +1515,8 @@
       "search_recent_projects": "Search recent projects",
       "search_recent_projects_2": "Search recent projects…",
       "select": "Select",
-      "subdirectories": "Subdirectories"
+      "subdirectories": "Subdirectories",
+      "waiting_for_dialog": "A folder window opened — choose a folder there"
     },
     "publishHub": {
       "back": "Back",

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -1501,9 +1501,13 @@
     "projectPicker": {
       "back": "返回",
       "browse": "浏览",
+      "choose_folder": "选择文件夹…",
+      "native_dialog_failed": "无法打开文件夹窗口 — 请从下方列表中选择文件夹。",
       "no_matching_projects": "无匹配的项目",
       "no_recent_projects": "无最近项目",
+      "no_recent_projects_native": "还没有最近的项目 — 请选择一个文件夹开始。",
       "no_subdirectories": "无子目录",
+      "open_a_project_folder": "打开项目文件夹",
       "path_to_project": "/path/to/project",
       "project_directory_path": "项目目录路径",
       "recent": "最近",
@@ -1511,7 +1515,8 @@
       "search_recent_projects": "搜索最近项目",
       "search_recent_projects_2": "搜索最近项目…",
       "select": "选择",
-      "subdirectories": "子目录"
+      "subdirectories": "子目录",
+      "waiting_for_dialog": "已打开文件夹窗口 — 请在其中选择文件夹"
     },
     "publishHub": {
       "back": "返回",

--- a/website/src/test/ProjectPicker.test.tsx
+++ b/website/src/test/ProjectPicker.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
-import ProjectPicker from '../components/ProjectPicker'
+import ProjectPicker, { __resetNativeProbeForTests } from '../components/ProjectPicker'
 import { api } from '../api/client'
 import { useRef } from 'react'
 
@@ -11,8 +11,14 @@ const mockBrowseDirs = (path = '/home/u', dirs: { name: string; path: string }[]
   ({ path, parent: '/home', dirs })
 
 beforeEach(() => {
+  // The probe answer is cached for the page session in production; drop it so
+  // each case starts from an unknown host.
+  __resetNativeProbeForTests()
   vi.spyOn(api, 'recentProjects').mockResolvedValue({ dirs: ['/home/u/projA', '/home/u/projB'] })
   vi.spyOn(api, 'browseDirs').mockResolvedValue(mockBrowseDirs())
+  // Default to "no native dialog on this host" so the server-side browser is the
+  // surface under test; the native-dialog suite below opts in explicitly.
+  vi.spyOn(api, 'nativeDirDialogAvailable').mockResolvedValue({ available: false })
 })
 
 afterEach(() => {
@@ -471,6 +477,189 @@ describe('ProjectPicker', () => {
       fireEvent.change(input, { target: { value: '/home/u/' } })
       await act(async () => { await vi.advanceTimersByTimeAsync(300) })
       expect(browseSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('native folder dialog', () => {
+    const nativeAvailable = () => {
+      vi.mocked(api.nativeDirDialogAvailable).mockResolvedValue({ available: true })
+    }
+
+    it('replaces the Browse tab with a Choose folder action when the host can open one', async () => {
+      nativeAvailable()
+      const openSpy = vi.spyOn(api, 'openNativeDirDialog').mockResolvedValue({ cancelled: true })
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      expect(await screen.findByText('Choose folder…')).toBeInTheDocument()
+      // One browsing surface only — the tab strip is gone.
+      expect(screen.queryByText('Browse')).not.toBeInTheDocument()
+      expect(screen.queryByText('Recent')).not.toBeInTheDocument()
+      // Recents remain reachable: they are what a native dialog cannot offer.
+      expect(screen.getByText('/home/u/projA')).toBeInTheDocument()
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it('keeps the server-side browser when the host cannot open a dialog', async () => {
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      expect(await screen.findByText('Browse')).toBeInTheDocument()
+      expect(screen.queryByText('Choose folder…')).not.toBeInTheDocument()
+    })
+
+    it('selects the picked directory and closes', async () => {
+      nativeAvailable()
+      vi.spyOn(api, 'openNativeDirDialog').mockResolvedValue({ path: '/home/u/picked' })
+      const onSelect = vi.fn()
+      const onOpenChange = vi.fn()
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={onOpenChange} anchorRect={rect(100, 50)} onSelect={onSelect} />
+      )
+      fireEvent.click(await screen.findByText('Choose folder…'))
+      await waitFor(() => expect(onSelect).toHaveBeenCalledWith('/home/u/picked'))
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('sends no path — the gateway decides where the dialog opens', async () => {
+      nativeAvailable()
+      const openSpy = vi.spyOn(api, 'openNativeDirDialog').mockResolvedValue({ cancelled: true })
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      fireEvent.click(await screen.findByText('Choose folder…'))
+      await waitFor(() => expect(openSpy).toHaveBeenCalledWith())
+    })
+
+    it('shows a waiting state while the OS dialog is up', async () => {
+      nativeAvailable()
+      let resolve: (v: { cancelled: boolean }) => void = () => {}
+      vi.spyOn(api, 'openNativeDirDialog').mockReturnValue(
+        new Promise(r => { resolve = r as (v: { cancelled: boolean }) => void })
+      )
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      fireEvent.click(await screen.findByText('Choose folder…'))
+      const waiting = await screen.findByText('A folder window opened — choose a folder there')
+      expect(waiting.closest('button')).toBeDisabled()
+      await act(async () => { resolve({ cancelled: true }); await Promise.resolve() })
+      expect(await screen.findByText('Choose folder…')).toBeInTheDocument()
+    })
+
+    it('stays open on cancel without selecting anything', async () => {
+      nativeAvailable()
+      vi.spyOn(api, 'openNativeDirDialog').mockResolvedValue({ cancelled: true })
+      const onSelect = vi.fn()
+      const onOpenChange = vi.fn()
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={onOpenChange} anchorRect={rect(100, 50)} onSelect={onSelect} />
+      )
+      fireEvent.click(await screen.findByText('Choose folder…'))
+      await waitFor(() => expect(screen.getByText('Choose folder…')).toBeInTheDocument())
+      expect(onSelect).not.toHaveBeenCalled()
+      expect(onOpenChange).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the server-side browser when the dialog fails', async () => {
+      // A host that advertised a dialog can still fail to draw one (no GUI
+      // session behind an ssh -L forward) — the user must not be left stranded.
+      nativeAvailable()
+      vi.spyOn(api, 'openNativeDirDialog').mockRejectedValue(new Error('503'))
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      fireEvent.click(await screen.findByText('Choose folder…'))
+      expect(await screen.findByText(/Couldn't open the folder window/)).toBeInTheDocument()
+      expect(screen.getByText('Browse')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('/path/to/project')).toBeInTheDocument()
+      expect(screen.queryByText('Choose folder…')).not.toBeInTheDocument()
+    })
+
+    it('falls back when the availability probe itself fails', async () => {
+      vi.mocked(api.nativeDirDialogAvailable).mockRejectedValue(new Error('offline'))
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      expect(await screen.findByText('Browse')).toBeInTheDocument()
+      expect(screen.queryByText('Choose folder…')).not.toBeInTheDocument()
+    })
+
+    it('probes the host once per page, not once per open', async () => {
+      // Host capability cannot change under us; re-asking only costs a
+      // round-trip, which is what makes the panel feel slow over a tunnel.
+      nativeAvailable()
+      const probeSpy = vi.mocked(api.nativeDirDialogAvailable)
+      const { rerender } = renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      await screen.findByText('Choose folder…')
+      rerender(<ProjectPicker open={false} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />)
+      rerender(<ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />)
+      await screen.findByText('Choose folder…')
+      expect(probeSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not list the server-side tree that native mode never shows', async () => {
+      nativeAvailable()
+      const browseSpy = vi.mocked(api.browseDirs)
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      await screen.findByText('Choose folder…')
+      expect(browseSpy).not.toHaveBeenCalled()
+    })
+
+    it('lists the tree lazily once the dialog fails and the fallback appears', async () => {
+      nativeAvailable()
+      vi.spyOn(api, 'openNativeDirDialog').mockRejectedValue(new Error('503'))
+      const browseSpy = vi.mocked(api.browseDirs)
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      fireEvent.click(await screen.findByText('Choose folder…'))
+      await waitFor(() => expect(browseSpy).toHaveBeenCalled())
+      expect(await screen.findByPlaceholderText('/path/to/project')).toBeInTheDocument()
+    })
+  })
+
+  describe('warmed data', () => {
+    it('fetches recents and the tree once across repeated opens', async () => {
+      // The panel paints in ~40ms but its lists used to wait a full round-trip
+      // on the FIRST open — ~830ms at 400ms RTT. Warming once per page removes
+      // that from the perceived open latency.
+      const recentSpy = vi.mocked(api.recentProjects)
+      const browseSpy = vi.mocked(api.browseDirs)
+      const { rerender } = renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      await screen.findByText('/home/u/projA')
+      for (const open of [false, true, false, true]) {
+        rerender(<ProjectPicker open={open} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />)
+        await act(async () => { await Promise.resolve() })
+      }
+      await screen.findByText('/home/u/projA')
+      expect(recentSpy).toHaveBeenCalledTimes(1)
+      expect(browseSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('still populates when the warm has not run yet', async () => {
+      // Clicking before the idle callback fires must not show an empty panel.
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      expect(await screen.findByText('/home/u/projA')).toBeInTheDocument()
+    })
+
+    it('survives a failed warm without breaking the panel', async () => {
+      vi.mocked(api.recentProjects).mockRejectedValue(new Error('offline'))
+      vi.mocked(api.browseDirs).mockRejectedValue(new Error('offline'))
+      renderWithProviders(
+        <ProjectPicker open={true} onOpenChange={vi.fn()} anchorRect={rect(100, 50)} onSelect={vi.fn()} />
+      )
+      expect(await screen.findByText('Browse')).toBeInTheDocument()
+      // Empty recents means the panel opens on Browse, which still works.
+      expect(screen.getByPlaceholderText('/path/to/project')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Closes #742.

## The problem

The composer's folder picker is a custom HTML directory browser on every platform. macOS users expect NSOpenPanel — its sidebar, its ⌘⇧G path entry, its muscle memory. (File *attachments* already use a real `<input type="file">`, so only the folder half was non-native.)

## Why this is server-side and not an Electron bridge

The web platform deliberately withholds absolute paths from a page: `showDirectoryPicker()` returns a `FileSystemDirectoryHandle` whose only identifying field is the leaf name, and `<input webkitdirectory>` reports paths relative to the picked root. A project directory must be an absolute path the **gateway** can resolve, so neither is usable.

The gateway, however, runs on the machine whose directories the user is choosing. So it asks the OS for its own chooser and reads back a real path — which works in browser tabs *and* in the desktop app (which spawns its own local gateway), from one implementation. There is precedent: `api_reveal_path` already drives Finder from the gateway.

An Electron `dialog.showOpenDialog` bridge was considered and deliberately skipped: it would be a second implementation of a solved problem, and against a gateway forwarded over `ssh -L` it would confidently return a local path the gateway cannot see.

## What's here

**`src/kiro_crew/dashboard/native_dialog.py`** — per-platform chooser:

| Platform | Backend |
|---|---|
| macOS | `osascript` → `choose folder` (NSOpenPanel), raised inside a System Events `activate` so it can't open behind the browser |
| Windows | PowerShell `FolderBrowserDialog` with `-STA` (mandatory — the dialog silently fails without it) |
| Linux | `zenity --file-selection --directory`, falling back to `kdialog` |

Cancel-versus-failure is read per backend (osascript `(-128)`, zenity/kdialog exit 1, PowerShell empty stdout), so a host with no GUI session reports a failure instead of masquerading as a user dismissal. Bounded by a 300s timeout.

**`GET`/`POST /api/native-dir-dialog`** in `handlers/files.py`:

- Gated on `is_direct_local_request` — a dialog on a remote gateway would draw on a screen nobody is watching. The `GET` probe applies the same gate, so the affordance stays hidden where it cannot work.
- **Takes no input.** The directory the chooser opens in is derived from the gateway's own `recent_projects.json`, so no byte of the request reaches the subprocess. This is what makes the `BENIGN_SPAWNS` entry in `test_spawn_audit.py` honest rather than hand-waved.
- Single-flight, held for the **dialog thread's** lifetime, not the request's: `asyncio.to_thread` cannot interrupt a worker, so releasing the slot when a client disconnects would admit a second stacked modal on the host. Done-callback + `asyncio.shield`.
- The selected path is re-checked against `is_sensitive_path` — `~/.ssh` is no more selectable this way than through the server-side browser.

**Frontend** — where a native dialog exists the picker drops its Browse tab (one browsing surface, not two), keeps recents (the one thing a native dialog can't offer), and gains a "Choose folder…" action. A failed dialog re-exposes the server-side browser with an explanation rather than dead-ending. Host capability is probed once per page, and the directory listing native mode never renders is skipped.

**Knowledge base picker consolidated.** `handlers/knowledge.py` shipped its own macOS-only `osascript` chooser that treated *every* failure as a cancel. It now delegates to the shared module, gaining Windows/Linux support and honest failure reporting. Its dialog timeout rises from 180s to 300s as a side effect.

## Verification

- 20181 backend tests pass; 471 frontend files / 5697 tests pass; `tsc -b`, isort, flake8 clean; mypy clean on the whole package via a CI-parity venv (no faiss, mypy 1.14.1).
- 10 guards revert-verified — each fails when its protection is removed: remote refusal, single-flight, request-cancellation invariant, server-derived starting directory, sensitive-path skipping, cancel-vs-failure discrimination, prompt-as-data, the `(-128)` token match, probe caching, and the skipped listing.
- Five UI states captured against a live dev gateway (fallback tabs, native mode, first-run, waiting, failure-fallback) and reviewed by a new-user usability pass, whose findings are folded in: "folder dialog" → "folder window", a waiting state that says a window opened elsewhere, and a panel heading.

## Not verified — please read before approving

**No native dialog has actually opened.** This was built on Linux; every dialog in the tests is mocked at the subprocess boundary, and the screenshots force native mode via route interception. The argv construction, exit codes, and the `-STA` requirement come from documentation, not observation. **A run on real macOS and Windows is the missing evidence.** Opened as a draft for that reason.

Also deliberately out of scope: a **Cancel** button. Abandoning the request is exactly the cancellation path the single-flight fix addresses; a true cancel would have to terminate the chooser process, which is a larger change.
