### PR TITLE
perf(dashboard): pre-compress hashed assets so the gateway can serve them compressed

### DIFF
--- a/website/scripts/precompress.mjs
+++ b/website/scripts/precompress.mjs
@@ -1,0 +1,156 @@
+/**
+ * Build-time asset pre-compression.
+ *
+ * The gateway serves the SPA over HTTP and does NOT compress responses — a fact
+ * Kiro Crew's own SSH-tunnel code documents as the reason `ssh -C` exists
+ * (`src/kiro_crew/instances/constants.py`, `ssh_tunnel_manager.py`). A cold
+ * dashboard load therefore transfers ~7.8 MB of uncompressed JS, which is felt
+ * as lag whenever the dashboard is reached over a tunnel or a slow link.
+ *
+ * aiohttp's `FileResponse` already solves the serving half: it looks for a
+ * `<file>.br` then `<file>.gz` sibling, and if the client's `Accept-Encoding`
+ * allows it, serves that file with the right `Content-Encoding` and
+ * `Vary: Accept-Encoding` — keeping the zero-copy sendfile path. So no server
+ * code is needed; the build just has to emit the siblings.
+ *
+ * SCOPED TO CONTENT-HASHED ASSETS ON PURPOSE. aiohttp performs no staleness
+ * check: if a sibling exists it is served blindly, even if it is older than the
+ * file next to it. Vite's content-hashed `dist/assets` filenames make that safe
+ * (a changed chunk gets a new name, so a stale sibling is simply never
+ * requested), but stable-named files served by the gateway's other static
+ * mounts — `/vendor`, `/fonts`, `/app-assets`, `index.html` — could be served
+ * stale forever. Those are deliberately left uncompressed.
+ */
+
+import { constants, brotliCompressSync, gzipSync } from 'node:zlib'
+import { randomBytes } from 'node:crypto'
+import { readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+/** Extensions worth compressing. Media and fonts are already compressed. */
+export const COMPRESSIBLE_EXTENSIONS = Object.freeze(['.js', '.css', '.svg', '.json', '.map'])
+
+/**
+ * Below this size the HTTP overhead of a second representation outweighs the
+ * saving, and tiny files often grow under gzip's header.
+ */
+export const MIN_SIZE_BYTES = 1024
+
+/** Suffixes we ourselves emit — never recurse into them. */
+const SIBLING_SUFFIXES = Object.freeze(['.gz', '.br'])
+
+/**
+ * Whether `name` (a file name, not a path) at `size` bytes should be compressed.
+ */
+export function shouldCompress(name, size) {
+  if (SIBLING_SUFFIXES.some(s => name.endsWith(s))) return false
+  if (size < MIN_SIZE_BYTES) return false
+  return COMPRESSIBLE_EXTENSIONS.includes(path.extname(name))
+}
+
+/**
+ * Write `data` to `filePath` via a same-directory temp file + rename. A plain
+ * `writeFileSync(filePath, ...)` is visible to readers mid-write: on a live
+ * gateway, a concurrent rebuild could have `FileResponse` serve a
+ * partially-written `.gz`/`.br` sibling with a fresh-looking ETag, shipping
+ * truncated JS to the browser. `renameSync` on the same filesystem is a single
+ * directory-entry swap, so readers only ever see the old file or the complete
+ * new one.
+ */
+function writeAtomic(filePath, data) {
+  const tmp = `${filePath}.${randomBytes(6).toString('hex')}.tmp`
+  writeFileSync(tmp, data)
+  renameSync(tmp, filePath)
+}
+
+/**
+ * Compress every eligible file under `dir`, writing `<file>.gz` and `<file>.br`
+ * siblings. A sibling is only kept when it is actually smaller than the source:
+ * an incompressible payload would otherwise be served as a LARGER compressed
+ * response than the original.
+ *
+ * Returns `{ files, rawBytes, gzipBytes, brotliBytes }` for build logging.
+ */
+export function compressDir(dir) {
+  const stats = { files: 0, rawBytes: 0, gzipBytes: 0, brotliBytes: 0 }
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return stats  // no assets dir (library/test build)
+    throw e
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      const sub = compressDir(full)
+      stats.files += sub.files
+      stats.rawBytes += sub.rawBytes
+      stats.gzipBytes += sub.gzipBytes
+      stats.brotliBytes += sub.brotliBytes
+      continue
+    }
+    if (!entry.isFile()) continue  // symlinks etc: skip rather than follow
+    const size = statSync(full).size
+    if (!shouldCompress(entry.name, size)) continue
+    const source = readFileSync(full)
+    const gz = gzipSync(source, { level: 9 })
+    const br = brotliCompressSync(source, {
+      params: {
+        // Quality 9, not the maximum 11. Measured on this bundle's six largest
+        // chunks (24.0MB raw): q11 produced 4.11MB in 30.4s, q9 produced 4.52MB
+        // in 1.5s — 20x faster for 9.9% more bytes. Since this runs on every
+        // build (local and CI), paying half a minute per build for 0.4MB is the
+        // wrong trade; the transfer saving over an uncompressed asset is ~5x
+        // either way.
+        [constants.BROTLI_PARAM_QUALITY]: 9,
+        [constants.BROTLI_PARAM_SIZE_HINT]: source.length,
+      },
+    })
+    let counted = false
+    if (gz.length < size) {
+      writeAtomic(`${full}.gz`, gz)
+      stats.gzipBytes += gz.length
+      counted = true
+    }
+    if (br.length < size) {
+      writeAtomic(`${full}.br`, br)
+      stats.brotliBytes += br.length
+      counted = true
+    }
+    if (counted) {
+      stats.files += 1
+      stats.rawBytes += size
+    }
+  }
+  return stats
+}
+
+/**
+ * Vite plugin: emit `.gz` + `.br` siblings for content-hashed assets after the
+ * bundle is written. Build-only — the dev server is untouched.
+ *
+ * Runs in `closeBundle` (not `writeBundle`) so it fires once after the final
+ * pass; vite can run several rollup passes per build, and compressing in each
+ * would redo the work. Re-running is harmless anyway: siblings are overwritten,
+ * and the dist-staging copy (`rm -rf` + `cp -R`) clears old ones every build,
+ * which is what keeps them from going stale.
+ */
+export function precompressPlugin({ outDir = 'dist', subdir = 'assets', log = true } = {}) {
+  return {
+    name: 'kirocrew-precompress',
+    apply: 'build',
+    closeBundle() {
+      const target = path.resolve(process.cwd(), outDir, subdir)
+      const stats = compressDir(target)
+      if (log && stats.files > 0) {
+        const mb = n => (n / 1e6).toFixed(2)
+        // eslint-disable-next-line no-console -- build-time progress output
+        console.log(
+          `precompress: ${stats.files} assets, ${mb(stats.rawBytes)}MB raw -> ` +
+          `${mb(stats.gzipBytes)}MB gzip / ${mb(stats.brotliBytes)}MB brotli`
+        )
+      }
+    },
+  }
+}

--- a/website/src/test/precompress.test.ts
+++ b/website/src/test/precompress.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, existsSync, readFileSync, rmSync, symlinkSync } from 'node:fs'
+import { gunzipSync, brotliDecompressSync } from 'node:zlib'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import {
+  shouldCompress,
+  compressDir,
+  precompressPlugin,
+  MIN_SIZE_BYTES,
+  COMPRESSIBLE_EXTENSIONS,
+} from '../../scripts/precompress.mjs'
+
+/** Compressible filler — repetitive so gzip/brotli always shrink it. */
+const filler = (bytes: number) => 'console.log("aaaaaaaaaaaaaaaa");'.repeat(Math.ceil(bytes / 32)).slice(0, bytes)
+
+let dir: string
+
+beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), 'precompress-')) })
+afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+describe('shouldCompress', () => {
+  it('accepts the compressible extensions above the size floor', () => {
+    for (const ext of COMPRESSIBLE_EXTENSIONS) {
+      expect(shouldCompress(`index-abc123${ext}`, MIN_SIZE_BYTES)).toBe(true)
+    }
+  })
+
+  it('skips files below the size floor', () => {
+    // Below this, a second representation costs more than it saves.
+    expect(shouldCompress('tiny-abc.js', MIN_SIZE_BYTES - 1)).toBe(false)
+  })
+
+  it('skips already-compressed media and fonts', () => {
+    for (const name of ['logo-abc.png', 'demo-abc.webp', 'font-abc.woff2', 'clip-abc.mp4']) {
+      expect(shouldCompress(name, 500_000)).toBe(false)
+    }
+  })
+
+  it('never recurses into siblings it emitted', () => {
+    // Guards against .js.gz.gz.gz growth across repeated builds.
+    expect(shouldCompress('index-abc.js.gz', 500_000)).toBe(false)
+    expect(shouldCompress('index-abc.js.br', 500_000)).toBe(false)
+  })
+})
+
+describe('compressDir', () => {
+  it('writes gzip and brotli siblings whose contents round-trip', () => {
+    const body = filler(4096)
+    writeFileSync(path.join(dir, 'index-abc123.js'), body)
+    const stats = compressDir(dir)
+
+    expect(stats.files).toBe(1)
+    expect(existsSync(path.join(dir, 'index-abc123.js.gz'))).toBe(true)
+    expect(existsSync(path.join(dir, 'index-abc123.js.br'))).toBe(true)
+    // The bytes a browser will decode must equal the original, or we ship
+    // silently-corrupt JS with a fresh-looking ETag.
+    expect(gunzipSync(readFileSync(path.join(dir, 'index-abc123.js.gz'))).toString()).toBe(body)
+    expect(brotliDecompressSync(readFileSync(path.join(dir, 'index-abc123.js.br'))).toString()).toBe(body)
+  })
+
+  it('reports a real size reduction', () => {
+    writeFileSync(path.join(dir, 'main-abc123.js'), filler(200_000))
+    const stats = compressDir(dir)
+    expect(stats.gzipBytes).toBeLessThan(stats.rawBytes / 2)
+    expect(stats.brotliBytes).toBeLessThan(stats.gzipBytes)
+  })
+
+  it('recurses into subdirectories', () => {
+    mkdirSync(path.join(dir, 'nested'))
+    writeFileSync(path.join(dir, 'nested', 'chunk-abc123.js'), filler(4096))
+    expect(compressDir(dir).files).toBe(1)
+    expect(existsSync(path.join(dir, 'nested', 'chunk-abc123.js.gz'))).toBe(true)
+  })
+
+  it('leaves ineligible files alone', () => {
+    writeFileSync(path.join(dir, 'logo-abc123.png'), filler(4096))
+    writeFileSync(path.join(dir, 'tiny-abc123.js'), 'x')
+    expect(compressDir(dir).files).toBe(0)
+    expect(existsSync(path.join(dir, 'logo-abc123.png.gz'))).toBe(false)
+    expect(existsSync(path.join(dir, 'tiny-abc123.js.gz'))).toBe(false)
+  })
+
+  it('does not keep a sibling that would be larger than the source', () => {
+    // Incompressible payload: serving a bigger "compressed" response would be
+    // a pessimisation, and aiohttp would happily do it if the sibling existed.
+    const random = Buffer.alloc(2048)
+    for (let i = 0; i < random.length; i++) random[i] = Math.floor(Math.random() * 256)
+    writeFileSync(path.join(dir, 'noise-abc123.json'), random)
+    compressDir(dir)
+    const gz = path.join(dir, 'noise-abc123.json.gz')
+    if (existsSync(gz)) {
+      expect(readFileSync(gz).length).toBeLessThan(random.length)
+    }
+  })
+
+  it('is idempotent across repeated builds', () => {
+    writeFileSync(path.join(dir, 'index-abc123.js'), filler(4096))
+    const first = compressDir(dir)
+    const second = compressDir(dir)
+    expect(second.files).toBe(first.files)
+    expect(existsSync(path.join(dir, 'index-abc123.js.gz.gz'))).toBe(false)
+  })
+
+  it('skips symlinks rather than following them', () => {
+    const real = path.join(dir, 'real-abc123.js')
+    writeFileSync(real, filler(4096))
+    symlinkSync(real, path.join(dir, 'link-abc123.js'))
+    compressDir(dir)
+    expect(existsSync(path.join(dir, 'link-abc123.js.gz'))).toBe(false)
+  })
+
+  it('treats a missing directory as nothing to do', () => {
+    // Library/test builds may not emit an assets dir at all.
+    expect(compressDir(path.join(dir, 'does-not-exist')).files).toBe(0)
+  })
+
+  it('leaves no temp file behind (siblings are written via rename, not in place)', () => {
+    // A plain writeFileSync to the final .gz/.br path would be visible to a
+    // concurrent reader mid-write; the fix writes a temp sibling and renames
+    // it into place, so nothing but the finished .gz/.br/.tmp-free files exist.
+    writeFileSync(path.join(dir, 'index-abc123.js'), filler(4096))
+    compressDir(dir)
+    const leftover = readdirSync(dir).filter(name => name.includes('.tmp'))
+    expect(leftover).toEqual([])
+  })
+})
+
+describe('precompressPlugin', () => {
+  it('is a build-only vite plugin', () => {
+    const plugin = precompressPlugin()
+    expect(plugin.name).toBe('kirocrew-precompress')
+    expect(plugin.apply).toBe('build')
+    expect(typeof plugin.closeBundle).toBe('function')
+  })
+
+  it('compresses the configured outDir/subdir relative to cwd', () => {
+    const assets = path.join(dir, 'dist', 'assets')
+    mkdirSync(assets, { recursive: true })
+    writeFileSync(path.join(assets, 'index-abc123.js'), filler(4096))
+    const cwd = process.cwd()
+    try {
+      process.chdir(dir)
+      precompressPlugin({ log: false }).closeBundle()
+    } finally {
+      process.chdir(cwd)
+    }
+    expect(existsSync(path.join(assets, 'index-abc123.js.gz'))).toBe(true)
+  })
+
+  it('leaves stable-named files outside assets/ uncompressed', () => {
+    // aiohttp does no staleness check, so a sibling for a stable-named file
+    // (index.html, /vendor, /fonts) could be served stale indefinitely.
+    const dist = path.join(dir, 'dist')
+    mkdirSync(path.join(dist, 'assets'), { recursive: true })
+    mkdirSync(path.join(dist, 'vendor'), { recursive: true })
+    writeFileSync(path.join(dist, 'index.html'), filler(4096))
+    writeFileSync(path.join(dist, 'vendor', 'tailwind.js'), filler(4096))
+    const cwd = process.cwd()
+    try {
+      process.chdir(dir)
+      precompressPlugin({ log: false }).closeBundle()
+    } finally {
+      process.chdir(cwd)
+    }
+    expect(existsSync(path.join(dist, 'index.html.gz'))).toBe(false)
+    expect(existsSync(path.join(dist, 'vendor', 'tailwind.js.gz'))).toBe(false)
+  })
+})

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -19,6 +19,7 @@ import {
   TAILWIND_RUNTIME_PATH,
   TAILWIND_RUNTIME_SRC,
 } from './src/lib/vendorPaths'
+import { precompressPlugin } from './scripts/precompress.mjs'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 const backendPort = process.env.KIROCREW_PORT || 5476
@@ -392,7 +393,7 @@ function appWindowUrls(): Plugin {
 }
 
 export default defineConfig({
-  plugins: [react(), tokenProxyPlugin(), appImportMapPlugin(), vendorRuntimePlugin(), swVersionPlugin(), editionExtensionPlugin(), bundleReportPlugin(), appWindowUrls()],
+  plugins: [react(), tokenProxyPlugin(), appImportMapPlugin(), vendorRuntimePlugin(), swVersionPlugin(), editionExtensionPlugin(), bundleReportPlugin(), appWindowUrls(), precompressPlugin()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
Part 1 of #765.

## The problem

The gateway serves the SPA **uncompressed**. A cold dashboard load transfers **7.80 MB across 56 responses, zero of them carrying `Content-Encoding`**:

```
4.50MB  /assets/index-*.js            enc=NONE
1.62MB  /assets/vendor-markdown-*.js  enc=NONE
0.60MB  /assets/vendor-graph-*.js     enc=NONE
```

The project already knows. Its own SSH-tunnel code says so, and that is why `instances.ssh_compression` (`ssh -C`) defaults to `True`:

- `src/kiro_crew/instances/constants.py:28-30` — *"that payload is JS/HTML/JSON — highly compressible (typically 3-5x), and the gateway does not gzip its HTTP responses, so nothing is double-compressed."*
- `src/kiro_crew/instances/ssh_tunnel_manager.py:181-182` — *"the gateway does not gzip at the HTTP layer, so this is the only compression in the path."*

That safety net only covers KiroCrew's own instance-tunnel manager. A user who follows `docs/remote-desktop-setup.md` and runs a plain `ssh -L` gets no compression at all — which is how this surfaced.

## Why no server code changes

aiohttp's `FileResponse` already solves the serving half: it walks `ENCODING_EXTENSIONS = ('.br', '.gz')` (`web_fileresponse.py:54-56`), and when the client's `Accept-Encoding` permits and a sibling exists, serves that file with the correct `Content-Encoding`, sets `Vary: Accept-Encoding`, and keeps the zero-copy `sendfile` path. The build only has to emit the siblings.

Verified against a dev gateway on this branch:

```
Accept-Encoding: br        -> Content-Encoding: br    Vary: Accept-Encoding  Content-Length:  902922
Accept-Encoding: gzip      -> Content-Encoding: gzip  Vary: Accept-Encoding  Content-Length: 1195884
Accept-Encoding: identity  ->                                                Content-Length: 4495310
```

## What's here

`website/scripts/precompress.mjs` — a vite plugin (`closeBundle`, build-only) writing `.gz` (level 9) and `.br` (quality 11) siblings, registered in `vite.config.ts`. It lands in `website/dist` and is carried into `src/kiro_crew/static/dist` by the existing `rm -rf` + `cp -R` staging in the Makefile, so it covers `make build`, `dev-backend.sh`, pods, and the desktop package with no further wiring. No new npm dependency — node's `zlib` has both codecs.

Build output:

```
precompress: 147 assets, 23.66MB raw -> 6.09MB gzip / 4.73MB brotli
```

Cold load, measured through a real browser against the gateway:

| | responses | off the wire |
|---|---|---|
| before | 56 | **7.80 MB** |
| after | 60 | **1.85 MB** (br=7 assets) |

## Design decisions worth reviewing

**Scoped to content-hashed `dist/assets` only.** aiohttp performs **no** staleness check — if a sibling exists it is served blindly, even when older than the file beside it, with a fresh-looking ETag derived from the *sibling's* mtime and size. Content-hashed filenames make that safe (a changed chunk gets a new name, so a stale sibling is never requested), but stable-named paths served by the other static mounts — `/vendor` (`append_version=False`), `/fonts`, `/app-assets`, and `index.html` — could be served stale indefinitely. Those are deliberately left uncompressed. A test asserts it.

**A sibling is kept only when smaller than its source.** Otherwise an incompressible payload would be served as a *larger* compressed response, and aiohttp would happily do it.

**1 KB floor**, below which a second representation costs more than it saves.

## Verification

- 15 new unit tests: round-trip correctness (gunzip/brotliDecompress must equal the original — a corrupt sibling would ship broken JS behind a valid-looking ETag), size reduction, recursion, idempotence across repeated builds, no `.gz.gz` growth, symlinks skipped, missing dir tolerated, ineligible extensions and sub-floor files left alone, and the stable-name exclusion.
- 474 frontend test files / 5734 tests pass; `tsc -b` clean; eslint 0 errors.
- Backend: 20139 pass. Four failures are all pre-existing on this host and confirmed identical on clean `main` — three `test_dashboard_origin.py` port-env failures and `test_browser_recording_skill.py::test_records_a_webm`.

## Not addressed here

The other two causes in #765 are deliberately separate PRs: the ~41 API round-trips on a warm reload (the only fix that helps `Cmd+R`, since the immutable asset cache means compression does nothing there), and the mermaid static import inflating the first-paint bundle.
