### PR TITLE
fix(sweep): verify process identity before the orphan sweep kills a PID

### DIFF
--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -90,9 +90,16 @@ _SUBPROCESS_NO_WINDOW: int = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 #
 # Names only (no leading path): matched against a single path component so the
 # same set works for both os.walk dirname pruning and scandir entry filtering.
-TCC_PROTECTED_HOME_DIRS: frozenset[str] = frozenset({
-    "Downloads", "Documents", "Desktop", "Pictures", "Movies", "Music",
-})
+TCC_PROTECTED_HOME_DIRS: frozenset[str] = frozenset(
+    {
+        "Downloads",
+        "Documents",
+        "Desktop",
+        "Pictures",
+        "Movies",
+        "Music",
+    }
+)
 # Deliberately NOT included: ``Library``. It is not TCC-gated, so pruning it
 # removes zero prompts — while ``~/Library/CloudStorage/<Provider>/`` (modern
 # OneDrive / Google Drive / Dropbox mounts) and ``~/Library/Mobile Documents/``
@@ -391,6 +398,74 @@ def get_ppid(pid: int) -> int:
         except Exception:
             return -1
     return -1
+
+
+# macOS ``struct proc_bsdinfo`` (PROC_PIDTBSDINFO, 136 bytes) field offsets used
+# below. Verified empirically against ``ps -o lstart=`` on darwin: ``pbi_ppid``
+# at 16 (see get_ppid), ``pbi_start_tvsec`` at 120, ``pbi_start_tvusec`` at 128.
+_DARWIN_BSDINFO_SIZE = 136
+_DARWIN_OFF_START_TVSEC = 120
+_DARWIN_OFF_START_TVUSEC = 128
+
+
+def get_process_start_id(pid: int) -> str | None:
+    """Return a stable per-process start-time identity string, or ``None``.
+
+    Two processes that reuse the same PID at different times get DIFFERENT
+    values, so callers can tell "still the process I spawned" from "this PID was
+    recycled". The value is stable for the whole lifetime of a process and is
+    safe to persist and compare from a *different* process (unlike a builtin
+    ``hash()``, which is PYTHONHASHSEED-randomized per interpreter).
+
+    Never contains ``:``, so callers may embed it in colon-delimited records.
+
+    Implementation is deliberately **in-process and non-blocking** on every
+    platform — no ``subprocess``/fork — so it is safe to call directly from the
+    asyncio event loop (``AUTOSDE: no-blocking-call-on-event-loop``):
+
+    - Linux: ``/proc/<pid>/stat`` field 22 (starttime in clock ticks since boot).
+    - macOS: ``libproc.proc_pidinfo`` ``pbi_start_tvsec``/``pbi_start_tvusec``
+      (microsecond resolution, so processes spawned in the same second do not
+      alias — unlike ``ps -o lstart=``, which is 1-second granularity).
+    - Windows / any failure (including a process we may not introspect): ``None``,
+      meaning "identity unknown" — callers must not treat that as a mismatch.
+    """
+    if sys.platform == "linux":
+        try:
+            stat_data = Path(f"/proc/{pid}/stat").read_text()
+            # comm (field 2) may contain spaces/parens — parse after the LAST ')'
+            close_paren = stat_data.rfind(")")
+            if close_paren < 0:
+                return None
+            return stat_data[close_paren + 2 :].split()[19]
+        except Exception:
+            return None
+    if sys.platform == "darwin":
+        try:
+            path = ctypes.util.find_library("proc")
+            if path is None:
+                return None
+            lib = ctypes.CDLL(path)
+            lib.proc_pidinfo.argtypes = [
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.c_uint64,
+                ctypes.c_void_p,
+                ctypes.c_int,
+            ]
+            lib.proc_pidinfo.restype = ctypes.c_int
+            buf = ctypes.create_string_buffer(_DARWIN_BSDINFO_SIZE)
+            ret = lib.proc_pidinfo(pid, 3, 0, buf, _DARWIN_BSDINFO_SIZE)  # PROC_PIDTBSDINFO=3
+            if ret <= 0:
+                return None
+            sec = struct.unpack_from("<Q", buf.raw, _DARWIN_OFF_START_TVSEC)[0]
+            usec = struct.unpack_from("<Q", buf.raw, _DARWIN_OFF_START_TVUSEC)[0]
+            if sec == 0:
+                return None  # implausible — treat as unknown rather than a value
+            return f"{sec}.{usec:06d}"
+        except Exception:
+            return None
+    return None
 
 
 def _descendants_from_parent_map(root_pid: int, parent_map: dict[int, int]) -> list[int]:
@@ -1052,7 +1127,9 @@ def process_owner_uid(pid: int) -> int | None:
         if sys.platform == "darwin":
             out = subprocess.check_output(
                 ["ps", "-o", "uid=", "-p", str(int(pid))],
-                text=True, stderr=subprocess.DEVNULL, timeout=2,
+                text=True,
+                stderr=subprocess.DEVNULL,
+                timeout=2,
             )
             raw = out.strip()
             return int(raw) if raw.isdigit() else None

--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -48,12 +48,28 @@ def _pid_age_seconds(pid: int, proc_root: str = "/proc") -> float | None:
     boot). The comm field (field 2) can contain spaces and parentheses — split
     on the substring AFTER the LAST ')' in the line.
 
-    On non-Linux (no /proc): returns None (macOS has separate reaping paths).
+    On macOS (and other POSIX without /proc): derived from
+    ``platform_compat.get_process_start_id``, whose darwin value is the process
+    start time in epoch ``seconds.microseconds`` — so this needs no
+    ``subprocess`` and is safe on the event loop. Empirically required: the
+    startup sweep SIGKILL'd a live kiro-cli off a stale dead-gateway entry on
+    macOS (2026-07-29 repro) because the grace window silently did not apply
+    there.
+
+    On Windows: returns None (no grace — sweep behavior unchanged there).
 
     The *proc_root* parameter allows injection of a fake /proc tree for testing.
     """
-    if sys.platform != "linux":
+    if platform_compat.IS_WINDOWS:
         return None
+    if sys.platform != "linux":
+        start_id = platform_compat.get_process_start_id(pid)
+        if start_id is None:
+            return None
+        try:
+            return max(0.0, time.time() - float(start_id))
+        except ValueError:
+            return None
     try:
         stat_data = Path(f"{proc_root}/{pid}/stat").read_text()
         # Field 22 is starttime. Fields before it: pid (1), comm (2, in parens,
@@ -80,18 +96,39 @@ def _pid_age_seconds(pid: int, proc_root: str = "/proc") -> float | None:
 def _pid_in_spawn_grace(pid: int) -> bool:
     """Return True if the PID is within the spawn grace period and should be skipped.
 
-    - Non-Linux: returns False (grace not applicable — fall through to existing
-      kill behavior so the sweep remains functional on macOS/Windows).
-    - Linux + successful age read: True if age < SWEEP_SPAWN_GRACE_SECONDS.
-    - Linux + parse/read failure (age is None): True (treat as young — safe
+    - Windows: returns False (no age source — fall through to existing kill
+      behavior so the sweep remains functional there).
+    - POSIX (Linux via /proc, macOS via ``ps -o etime=``) + successful age
+      read: True if age < SWEEP_SPAWN_GRACE_SECONDS.
+    - POSIX + read failure (age is None): True (treat as young — safe
       direction; dead processes are already pruned by the earlier liveness check).
     """
-    if sys.platform != "linux":
+    if platform_compat.IS_WINDOWS:
         return False
     age = _pid_age_seconds(pid)
     if age is None:
         return True  # cannot determine age → treat as young (safe direction)
     return age < SWEEP_SPAWN_GRACE_SECONDS
+
+
+def _pid_start_token(pid: int) -> str | None:
+    """Stable, persistable identity token for a live PID (PID-recycle guard).
+
+    Thin delegate to ``platform_compat.get_process_start_id``, which is
+    in-process on every platform (``/proc`` read on Linux, ``libproc`` ctypes on
+    macOS) — deliberately NOT ``ps``, so this is safe to call from the asyncio
+    event loop via ``_track_session_pid`` at spawn time
+    (``AUTOSDE: no-blocking-call-on-event-loop``).
+
+    Returns ``None`` when identity cannot be determined (Windows, or a process
+    we may not introspect). Callers MUST treat ``None`` as "unknown", never as a
+    mismatch — see the sweep call sites.
+
+    Note this cannot reuse ``acp.client._get_start_time``: that hashes with
+    builtin ``hash()``, which is PYTHONHASHSEED-randomized per interpreter and
+    therefore meaningless once written to disk and compared by a later gateway.
+    """
+    return platform_compat.get_process_start_id(pid)
 
 
 def _pid_file_path() -> Path:
@@ -115,17 +152,25 @@ def _session_pid_file_lock():  # type: ignore[no-untyped-def]
 def _track_session_pid(pid: int) -> None:
     """Append a kiro-cli PID to the session tracking file (dedup).
 
-    Entries are written as ``<gateway_pid>:<child_pid>`` so each gateway
-    instance can identify and sweep only its own children.
+    Entries are written as ``<gateway_pid>:<child_pid>:<start_token>`` so each
+    gateway instance can identify and sweep only its own children, and so the
+    sweep can verify the PID still names the SAME process before killing
+    (PID-recycle guard — see ``_pid_start_token``). When no token is available
+    (Windows, ``ps`` failure) the legacy ``<gateway_pid>:<child_pid>`` form is
+    written and the sweep falls back to cmdline + spawn-grace checks only.
     """
-    entry = f"{os.getpid()}:{pid}"
+    token = _pid_start_token(pid)
+    prefix = f"{os.getpid()}:{pid}"
+    entry = f"{prefix}:{token}" if token else prefix
     with _session_pid_file_lock():
         path = _session_pid_file_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         if path.exists():
-            existing = set(path.read_text(encoding="utf-8").split())
-            if entry in existing:
-                return
+            # Dedup on the gw:pid prefix (not the full entry) so a re-track
+            # never duplicates a legacy 2-field line with a 3-field one.
+            for line in path.read_text(encoding="utf-8").split():
+                if line == prefix or line.startswith(prefix + ":"):
+                    return
         with open(path, "a", encoding="utf-8") as f:
             f.write(f"{entry}\n")
 
@@ -296,8 +341,15 @@ def _sweep_pid_entries(
         if not stripped:
             continue
         try:
+            recorded_token: str | None = None
             if ":" in stripped:
-                parts = stripped.split(":", 1)
+                # ``gw:pid`` (legacy) or ``gw:pid:start_token`` (recycle guard).
+                parts = stripped.split(":")
+                if len(parts) == 3:
+                    recorded_token = parts[2] or None
+                elif len(parts) != 2:
+                    killed_or_dead.add(stripped)
+                    continue
                 try:
                     gw_pid = int(parts[0])
                     pid = int(parts[1])
@@ -338,10 +390,33 @@ def _sweep_pid_entries(
             if not _is_managed_agent_process(pid):
                 killed_or_dead.add(stripped)
                 continue
+            # ── PID-recycle identity check ──────────────────────────
+            # The strongest guard: the entry recorded the child's start token
+            # at spawn. If the live process's token DIFFERS, this PID has been
+            # RECYCLED onto a different (agent) process — e.g. a fresh
+            # gateway's own just-spawned backend landing on a stale dead-
+            # gateway entry's PID (empirically reproduced on macOS
+            # 2026-07-29: sweep SIGKILL'd a live kiro-cli, surfacing as
+            # 'process exited (rc=None)'). Prune the stale entry, never kill.
+            #
+            # An UNREADABLE live token (None) is "identity unknown", NOT a
+            # mismatch: pruning there would untrack a live genuine orphan and
+            # leak it forever, since every sweep keys off this file (same
+            # fail-safe as _pid_gone_or_unmanaged — "any inconclusive result
+            # retains"). Keep the entry and fall through to the grace check;
+            # the next sweep retries.
+            if recorded_token is not None:
+                live_token = _pid_start_token(pid)
+                if live_token is not None and live_token != recorded_token:
+                    killed_or_dead.add(stripped)
+                    continue
+                if live_token is None:
+                    continue  # identity unknown — retain entry, retry next sweep
             # ── Spawn grace period (Fix A) ──────────────────────────
             # Skip live PIDs younger than SWEEP_SPAWN_GRACE_SECONDS.
-            # Non-Linux: grace not applicable (falls through to kill).
-            # Linux + parse failure: treat as young (safe direction).
+            # POSIX-wide (Linux /proc, macOS ps -o etime=); Windows: no age
+            # source, falls through to kill (behavior unchanged there).
+            # POSIX read failure: treat as young (safe direction).
             # A missed kill self-heals next cycle.
             if _pid_in_spawn_grace(pid):
                 continue
@@ -686,7 +761,17 @@ def cleanup_orphaned_session_roots() -> int:
         if not stripped or ":" not in stripped:
             continue
 
-        parts = stripped.split(":", 1)
+        # ``gw:pid`` (legacy) or ``gw:pid:start_token`` (recycle guard) — see
+        # _track_session_pid. A bare split(":", 1) would leave "pid:token" in
+        # parts[1] and int() it into a prune, silently discarding every
+        # token-bearing entry instead of sweeping it.
+        parts = stripped.split(":")
+        recorded_token: str | None = None
+        if len(parts) == 3:
+            recorded_token = parts[2] or None
+        elif len(parts) != 2:
+            entries_to_remove.add(stripped)
+            continue
         try:
             gw_pid = int(parts[0])
             child_pid = int(parts[1])
@@ -744,6 +829,20 @@ def cleanup_orphaned_session_roots() -> int:
             # PPid is something else entirely — PID was reused, prune
             entries_to_remove.add(stripped)
             continue
+
+        # Strongest PID-reuse guard: the entry recorded the child's start
+        # token at spawn (see _pid_start_token). A MISMATCH means this PID now
+        # names a DIFFERENT process — prune, never kill. An unreadable live
+        # token is "identity unknown", not a mismatch: retain the entry so a
+        # live genuine orphan is not untracked (and thus leaked forever) on one
+        # transient probe failure; the next sweep retries.
+        if recorded_token is not None:
+            live_token = _pid_start_token(child_pid)
+            if live_token is not None and live_token != recorded_token:
+                entries_to_remove.add(stripped)
+                continue
+            if live_token is None:
+                continue  # identity unknown — retain entry, retry next sweep
 
         # Confirmed orphan: kill the process tree
         total_killed, root_killed = _kill_pid_tree(child_pid)
@@ -826,13 +925,17 @@ def _untrack_session_pid(pid: int) -> None:
     orphan sweep doesn't race against legitimate still-running kiro-cli
     processes whose in-memory session entry has transiently gone away
     (e.g. during compaction/reset/replace)."""
-    entry = f"{os.getpid()}:{pid}"
+    prefix = f"{os.getpid()}:{pid}"
     with _session_pid_file_lock():
         path = _session_pid_file_path()
         if not path.exists():
             return
         lines = path.read_text(encoding="utf-8").splitlines()
-        lines = [ln for ln in lines if ln.strip() != entry]
+        # Match both the legacy ``gw:pid`` form and the token-bearing
+        # ``gw:pid:token`` form (see _track_session_pid).
+        lines = [
+            ln for ln in lines if ln.strip() != prefix and not ln.strip().startswith(prefix + ":")
+        ]
         path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
 
 

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -1283,3 +1283,369 @@ class TestSpawnedMarkerInjection:
                 f"{rel} no longer injects the KIROCREW_SPAWNED marker — "
                 "escaped MCP trees from this site become unsweepable"
             )
+
+
+# ── PID-recycle identity guard + cross-platform spawn grace ───────────
+# Regression cover for the quit->reopen race reproduced on macOS 2026-07-29:
+# a stale ``<dead_gw>:<pid>`` entry whose PID had been recycled onto a LIVE
+# kiro-cli was SIGKILL'd by the startup sweep (surfacing to the user as
+# "process exited (rc=None)"), because the file sweep verified only the
+# cmdline and the spawn-grace window was silently Linux-only.
+
+
+class TestPidStartTokenIdentityGuard:
+    def test_track_session_pid_records_start_token(
+        self, session_pid_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Entries carry ``gw:pid:token`` so the sweep can verify identity."""
+        from kiro_crew.session_pid import _track_session_pid
+
+        monkeypatch.setattr("kiro_crew.session_pid._pid_start_token", lambda p: "tok123")
+        _track_session_pid(4242)
+        assert session_pid_file.read_text(encoding="utf-8").strip() == f"{os.getpid()}:4242:tok123"
+
+    def test_track_session_pid_falls_back_when_token_unavailable(
+        self, session_pid_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No token (Windows / ps failure) → legacy 2-field entry."""
+        from kiro_crew.session_pid import _track_session_pid
+
+        monkeypatch.setattr("kiro_crew.session_pid._pid_start_token", lambda p: None)
+        _track_session_pid(4242)
+        assert session_pid_file.read_text(encoding="utf-8").strip() == f"{os.getpid()}:4242"
+
+    def test_track_session_pid_dedups_across_formats(
+        self, session_pid_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A legacy entry must not be duplicated by a token-bearing re-track."""
+        from kiro_crew.session_pid import _track_session_pid
+
+        session_pid_file.write_text(f"{os.getpid()}:4242\n")
+        monkeypatch.setattr("kiro_crew.session_pid._pid_start_token", lambda p: "tok123")
+        _track_session_pid(4242)
+        lines = session_pid_file.read_text(encoding="utf-8").strip().splitlines()
+        assert lines == [f"{os.getpid()}:4242"]
+
+    def test_untrack_session_pid_removes_token_entry(
+        self, session_pid_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Untrack matches the token-bearing form, not just the legacy one."""
+        from kiro_crew.session_pid import _track_session_pid, _untrack_session_pid
+
+        monkeypatch.setattr("kiro_crew.session_pid._pid_start_token", lambda p: "tok123")
+        _track_session_pid(4242)
+        _untrack_session_pid(4242)
+        assert session_pid_file.read_text(encoding="utf-8").strip() == ""
+
+    def test_recycled_pid_is_pruned_not_killed(self, session_pid_file: Path) -> None:
+        """THE regression: token mismatch → prune the stale entry, never kill.
+
+        The PID is live and its cmdline matches an agent, so every pre-existing
+        guard passes; only the start-token comparison catches the recycle.
+        """
+        from kiro_crew.session_pid import cleanup_orphaned_sessions
+
+        # Dead gateway (999999) : live child PID, recorded with an OLD token.
+        session_pid_file.write_text("999999:99998:oldtoken\n")
+        kills: list[tuple[int, int]] = []
+
+        with (
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            # Live process now reports a DIFFERENT token → PID was recycled.
+            patch("kiro_crew.session_pid._pid_start_token", return_value="newtoken"),
+            patch(
+                "kiro_crew.session_pid.platform_compat.pid_liveness",
+                return_value=platform_compat.PID_ALIVE,
+            ),
+            # The owning gateway (999999) must read as DEAD or _skip_tagged
+            # skips the entry and the test passes vacuously; the child is alive.
+            patch(
+                "kiro_crew.session_pid.platform_compat.pid_exists",
+                side_effect=lambda p: p != 999999,
+            ),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, s: kills.append((p, s)),
+            ),
+            # Grace disabled so the ONLY thing that can save the process is the
+            # identity check under test.
+            patch("kiro_crew.session_pid._pid_in_spawn_grace", return_value=False),
+            patch("kiro_crew.session_pid._cleanup_orphaned_mcp_servers", return_value=0),
+        ):
+            cleanup_orphaned_sessions()
+
+        assert kills == [], f"recycled PID was killed: {kills}"
+
+    def test_unreadable_token_retains_entry(self, session_pid_file: Path) -> None:
+        """Unknown identity must NOT prune: pruning would leak a live orphan.
+
+        Every sweep keys off this file, so untracking a live process on one
+        transient probe failure orphans it permanently (the fail-safe stated in
+        _pid_gone_or_unmanaged: "any inconclusive result retains").
+        """
+        from kiro_crew.session_pid import cleanup_orphaned_sessions
+
+        entry = "999999:99998:recorded-token"
+        session_pid_file.write_text(entry + "\n")
+        kills: list[tuple[int, int]] = []
+
+        with (
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            # Identity unreadable (probe failure) — neither match nor mismatch.
+            patch("kiro_crew.session_pid._pid_start_token", return_value=None),
+            patch(
+                "kiro_crew.session_pid.platform_compat.pid_liveness",
+                return_value=platform_compat.PID_ALIVE,
+            ),
+            patch(
+                "kiro_crew.session_pid.platform_compat.pid_exists",
+                side_effect=lambda p: p != 999999,
+            ),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, s: kills.append((p, s)),
+            ),
+            patch("kiro_crew.session_pid._pid_in_spawn_grace", return_value=False),
+            patch("kiro_crew.session_pid._cleanup_orphaned_mcp_servers", return_value=0),
+        ):
+            cleanup_orphaned_sessions()
+
+        assert kills == [], "killed a process whose identity could not be verified"
+
+    def test_session_roots_unreadable_token_retains_entry(self, session_pid_file: Path) -> None:
+        """Same fail-safe in the periodic root sweep: retain, don't kill or drop."""
+        from kiro_crew.session_pid import cleanup_orphaned_session_roots
+
+        entry = "999999:99998:recorded-token"
+        session_pid_file.write_text(entry + "\n")
+        kills: list[tuple[int, int]] = []
+
+        def fake_liveness(pid: int) -> str:
+            return platform_compat.PID_DEAD if pid == 999999 else platform_compat.PID_ALIVE
+
+        with (
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            patch("kiro_crew.session_pid._pid_start_token", return_value=None),
+            patch("kiro_crew.session_pid.platform_compat.pid_liveness", side_effect=fake_liveness),
+            patch("kiro_crew.session_pid.platform_compat.get_ppid", return_value=1),
+            patch("kiro_crew.session_pid.platform_compat.pid_exists", return_value=True),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, s: kills.append((p, s)),
+            ),
+        ):
+            cleanup_orphaned_session_roots()
+
+        assert kills == [], "killed a process whose identity could not be verified"
+        # Entry retained so the next sweep can retry.
+        assert entry in session_pid_file.read_text(encoding="utf-8")
+
+    def test_matching_token_still_killed(self, session_pid_file: Path) -> None:
+        """A genuine orphan (token matches) is still reaped — no regression."""
+        from kiro_crew.session_pid import cleanup_orphaned_sessions
+
+        session_pid_file.write_text("999999:99998:sametoken\n")
+        kills: list[tuple[int, int]] = []
+
+        with (
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            patch("kiro_crew.session_pid._pid_start_token", return_value="sametoken"),
+            patch(
+                "kiro_crew.session_pid.platform_compat.pid_liveness",
+                return_value=platform_compat.PID_ALIVE,
+            ),
+            # The owning gateway (999999) must read as DEAD or _skip_tagged
+            # skips the entry and the test passes vacuously; the child is alive.
+            patch(
+                "kiro_crew.session_pid.platform_compat.pid_exists",
+                side_effect=lambda p: p != 999999,
+            ),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, s: kills.append((p, s)),
+            ),
+            patch("kiro_crew.session_pid._pid_in_spawn_grace", return_value=False),
+            patch("kiro_crew.session_pid._cleanup_orphaned_mcp_servers", return_value=0),
+        ):
+            cleanup_orphaned_sessions()
+
+        assert (99998, platform_compat.SIGKILL) in kills
+
+    def test_legacy_entry_without_token_still_swept(self, session_pid_file: Path) -> None:
+        """Back-compat: a 2-field entry keeps its old cmdline+grace behavior."""
+        from kiro_crew.session_pid import cleanup_orphaned_sessions
+
+        session_pid_file.write_text("999999:99998\n")
+        kills: list[tuple[int, int]] = []
+
+        with (
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            patch(
+                "kiro_crew.session_pid.platform_compat.pid_liveness",
+                return_value=platform_compat.PID_ALIVE,
+            ),
+            # The owning gateway (999999) must read as DEAD or _skip_tagged
+            # skips the entry and the test passes vacuously; the child is alive.
+            patch(
+                "kiro_crew.session_pid.platform_compat.pid_exists",
+                side_effect=lambda p: p != 999999,
+            ),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, s: kills.append((p, s)),
+            ),
+            patch("kiro_crew.session_pid._pid_in_spawn_grace", return_value=False),
+            patch("kiro_crew.session_pid._cleanup_orphaned_mcp_servers", return_value=0),
+        ):
+            cleanup_orphaned_sessions()
+
+        assert (99998, platform_compat.SIGKILL) in kills
+
+    def test_session_roots_sweep_parses_token_entry(self, session_pid_file: Path) -> None:
+        """cleanup_orphaned_session_roots must not mis-prune 3-field entries.
+
+        A ``split(":", 1)`` parse would int("99998:tok") -> ValueError and prune
+        the entry, silently dropping every token-bearing line from the sweep.
+        """
+        from kiro_crew.session_pid import cleanup_orphaned_session_roots
+
+        session_pid_file.write_text("999999:99998:sametoken\n")
+        kills: list[tuple[int, int]] = []
+
+        def fake_liveness(pid: int) -> str:
+            # Owning gateway dead; child alive.
+            return platform_compat.PID_DEAD if pid == 999999 else platform_compat.PID_ALIVE
+
+        with (
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            patch("kiro_crew.session_pid._pid_start_token", return_value="sametoken"),
+            patch("kiro_crew.session_pid.platform_compat.pid_liveness", side_effect=fake_liveness),
+            patch("kiro_crew.session_pid.platform_compat.get_ppid", return_value=1),
+            patch("kiro_crew.session_pid.platform_compat.pid_exists", return_value=True),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, s: kills.append((p, s)),
+            ),
+        ):
+            cleanup_orphaned_session_roots()
+
+        assert (99998, platform_compat.SIGKILL) in kills
+
+    def test_session_roots_sweep_spares_recycled_pid(self, session_pid_file: Path) -> None:
+        """Token mismatch in the periodic root sweep → prune, never kill."""
+        from kiro_crew.session_pid import cleanup_orphaned_session_roots
+
+        session_pid_file.write_text("999999:99998:oldtoken\n")
+        kills: list[tuple[int, int]] = []
+
+        def fake_liveness(pid: int) -> str:
+            return platform_compat.PID_DEAD if pid == 999999 else platform_compat.PID_ALIVE
+
+        with (
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            patch("kiro_crew.session_pid._pid_start_token", return_value="newtoken"),
+            patch("kiro_crew.session_pid.platform_compat.pid_liveness", side_effect=fake_liveness),
+            patch("kiro_crew.session_pid.platform_compat.get_ppid", return_value=1),
+            patch("kiro_crew.session_pid.platform_compat.pid_exists", return_value=True),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, s: kills.append((p, s)),
+            ),
+        ):
+            cleanup_orphaned_session_roots()
+
+        assert kills == [], f"recycled PID was killed: {kills}"
+
+
+class TestSpawnGraceCrossPlatform:
+    def test_grace_applies_on_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression: the grace window was Linux-only, so macOS never got it."""
+        import kiro_crew.session_pid as sp
+
+        monkeypatch.setattr(sp.sys, "platform", "darwin")
+        monkeypatch.setattr(sp, "_pid_age_seconds", lambda p: 5.0)
+        assert sp._pid_in_spawn_grace(4242) is True
+
+    def test_old_process_not_in_grace_on_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import kiro_crew.session_pid as sp
+
+        monkeypatch.setattr(sp.sys, "platform", "darwin")
+        monkeypatch.setattr(sp, "_pid_age_seconds", lambda p: sp.SWEEP_SPAWN_GRACE_SECONDS + 1)
+        assert sp._pid_in_spawn_grace(4242) is False
+
+    def test_unknown_age_treated_as_young(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unreadable age → safe direction (skip the kill)."""
+        import kiro_crew.session_pid as sp
+
+        monkeypatch.setattr(sp.sys, "platform", "darwin")
+        monkeypatch.setattr(sp, "_pid_age_seconds", lambda p: None)
+        assert sp._pid_in_spawn_grace(4242) is True
+
+    def test_macos_age_derived_from_start_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """macOS age comes from the in-process start id — no subprocess/ps."""
+        import time as _time
+
+        import kiro_crew.session_pid as sp
+
+        monkeypatch.setattr(sp.sys, "platform", "darwin")
+        monkeypatch.setattr(sp.platform_compat, "IS_WINDOWS", False)
+        start = _time.time() - 90.0
+        monkeypatch.setattr(sp.platform_compat, "get_process_start_id", lambda p: f"{start:.6f}")
+        age = sp._pid_age_seconds(4242)
+        assert age is not None and 85.0 <= age <= 95.0
+
+    def test_macos_age_none_when_identity_unknown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import kiro_crew.session_pid as sp
+
+        monkeypatch.setattr(sp.sys, "platform", "darwin")
+        monkeypatch.setattr(sp.platform_compat, "IS_WINDOWS", False)
+        monkeypatch.setattr(sp.platform_compat, "get_process_start_id", lambda p: None)
+        assert sp._pid_age_seconds(4242) is None
+
+    def test_windows_has_no_grace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Windows keeps prior behavior (no age source, sweep stays functional)."""
+        import kiro_crew.session_pid as sp
+
+        monkeypatch.setattr(sp.platform_compat, "IS_WINDOWS", True)
+        assert sp._pid_in_spawn_grace(4242) is False
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX-only: relies on fork/exec + ps for identity"
+)
+class TestSweepSparesLiveProcess:
+    """End-to-end repro of the 2026-07-29 macOS incident with a REAL process.
+
+    The mock-based tests above pin the decision logic; this one proves the
+    whole sweep leaves an actually-running process alive. The victim is a
+    short-lived ``sleep`` renamed via ``_is_managed_agent_process`` patching,
+    so no kiro-cli is required and nothing user-owned is at risk.
+    """
+
+    def test_live_process_with_recycled_entry_survives(
+        self, session_pid_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.session_pid import cleanup_orphaned_sessions
+
+        monkeypatch.setattr("kiro_crew.session_pid.config_dir", lambda: tmp_path)
+        victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        try:
+            # Stale entry from a DEAD gateway naming the live PID, with a token
+            # that cannot match the live process (the recycle signature).
+            session_pid_file.write_text(f"999999:{victim.pid}:stale-token-does-not-match\n")
+
+            with (
+                # Cmdline check passes (as it did in the real incident).
+                patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+                # Grace disabled: isolate the identity check as the sole guard.
+                patch("kiro_crew.session_pid._pid_in_spawn_grace", return_value=False),
+                patch("kiro_crew.session_pid._cleanup_orphaned_mcp_servers", return_value=0),
+            ):
+                cleanup_orphaned_sessions()
+
+            assert victim.poll() is None, "sweep SIGKILLed a live process (the bug)"
+            # And the stale entry is pruned so it can't re-trigger next boot.
+            assert str(victim.pid) not in session_pid_file.read_text(encoding="utf-8")
+        finally:
+            victim.kill()
+            victim.wait()

--- a/test/test_pid_sweep_helpers.py
+++ b/test/test_pid_sweep_helpers.py
@@ -683,11 +683,25 @@ class TestPidAgeSeconds:
 class TestPidInSpawnGrace:
     """Tests for _pid_in_spawn_grace helper."""
 
-    def test_non_linux_returns_false(self) -> None:
-        """Non-Linux: grace not applicable, returns False (sweep proceeds)."""
+    def test_macos_young_pid_returns_true(self) -> None:
+        """macOS: grace DOES apply (regression — it was silently Linux-only).
+
+        The startup sweep SIGKILLed a live kiro-cli on macOS because this
+        returned False unconditionally off-Linux (2026-07-29 repro).
+        """
         from kiro_crew.session_pid import _pid_in_spawn_grace
 
-        with patch("kiro_crew.session_pid.sys.platform", "darwin"):
+        with (
+            patch("kiro_crew.session_pid.sys.platform", "darwin"),
+            patch("kiro_crew.session_pid._pid_age_seconds", return_value=30.0),
+        ):
+            assert _pid_in_spawn_grace(12345) is True
+
+    def test_windows_returns_false(self) -> None:
+        """Windows: no age source — grace not applicable, sweep proceeds."""
+        from kiro_crew.session_pid import _pid_in_spawn_grace
+
+        with patch("kiro_crew.session_pid.platform_compat.IS_WINDOWS", True):
             assert _pid_in_spawn_grace(12345) is False
 
     @_linux_only
@@ -768,14 +782,20 @@ class TestSweepGraceIntegration:
         assert 99999 not in candidates
 
     def test_non_linux_old_orphan_still_killed(self, session_pid_file: Path) -> None:
-        """On non-Linux, grace is not applied — old orphans are still killed."""
+        """On macOS, an orphan OLDER than the grace window is still killed.
+
+        Grace now applies cross-platform, so the age must be stubbed old —
+        previously non-Linux skipped grace entirely, which is the defect that
+        let the sweep kill freshly-spawned backends.
+        """
         from kiro_crew.session_pid import _sweep_pid_entries
 
         with (
             patch("os.kill"),  # alive
             patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
-            # _pid_in_spawn_grace returns False on non-linux
             patch("kiro_crew.session_pid.sys.platform", "darwin"),
+            # Older than SWEEP_SPAWN_GRACE_SECONDS → grace does not protect it.
+            patch("kiro_crew.session_pid._pid_age_seconds", return_value=9999.0),
             patch("kiro_crew.acp.client._get_child_pids", return_value=[]),
         ):
             killed, dead, _ = _sweep_pid_entries(
@@ -786,3 +806,23 @@ class TestSweepGraceIntegration:
 
         assert killed == 1
         assert "1:99999" in dead
+
+    def test_non_linux_young_orphan_spared(self, session_pid_file: Path) -> None:
+        """Regression: on macOS a YOUNG live agent PID must NOT be killed."""
+        from kiro_crew.session_pid import _sweep_pid_entries
+
+        with (
+            patch("os.kill"),  # alive
+            patch("kiro_crew.session_pid._is_managed_agent_process", return_value=True),
+            patch("kiro_crew.session_pid.sys.platform", "darwin"),
+            patch("kiro_crew.session_pid._pid_age_seconds", return_value=5.0),
+            patch("kiro_crew.acp.client._get_child_pids", return_value=[]),
+        ):
+            killed, dead, _ = _sweep_pid_entries(
+                ["1:99999"],
+                should_skip_tagged=lambda gw, p: False,
+                should_skip_bare=lambda p: False,
+            )
+
+        assert killed == 0
+        assert "1:99999" not in dead


### PR DESCRIPTION
## Problem

Users hit repeated `process exited (rc=None)` errors in chat — every message failed, with no working backend. A reporter found a reliable trigger:

1. Quit the app, then immediately reopen it → "backend port occupied" error
2. Kill the gateway, reopen → every message returns `process exited (rc=None)`

The orphan-process sweep was SIGKILLing a **live, healthy** kiro-cli backend.

## Why it matters

Chat is completely non-functional for the affected session — every turn dies instantly with an opaque error that names no cause, so users can't self-diagnose or work around it. The trigger (quit → reopen) is ordinary app usage, and because the PID file is shared across gateway instances under one config dir, one messy shutdown can poison later launches.

## Fix (symptoms → root cause → change)

**Symptom:** a live kiro-cli dies immediately, repeatedly.

**Root cause:** `kiro_session_pids.txt` records `<gateway_pid>:<child_pid>` entries. A hard-killed gateway leaves its entry behind (deliberately — surviving processes are handed to the next boot to reap). On the next launch the startup sweep reaps entries whose owning gateway is dead, guarded only by a **cmdline check** (`kiro-cli`/`claude` in the process name) plus a 120s spawn-grace window. Two gaps combined:

- The cmdline check cannot distinguish "the orphan I recorded" from "a *different* agent process that has since been assigned that PID". After PID recycling, a healthy backend matches the check.
- The spawn-grace window that would otherwise spare a young process was **silently Linux-only** — `_pid_age_seconds` returned `None` off-Linux, so `_pid_in_spawn_grace` returned `False` and the sweep fell straight through to the kill. macOS had no protection at all.

Reproduced locally: a stale `<dead_gw>:<pid>` entry pointing at a live `kiro-cli acp` → `cleanup_orphaned_sessions()` → **SIGKILL, rc=-9**.

**Change:**

1. **Identity check before any kill.** `_track_session_pid` now records the child's process start time as a third field (`<gw_pid>:<child_pid>:<start_marker>`). Both sweeps — `_sweep_pid_entries` (startup/periodic) and `cleanup_orphaned_session_roots` — compare the recorded marker against the live process. A **mismatch** means the PID was recycled: prune the stale entry, **never kill**. A genuine orphan still matches and is still reaped.
2. **New `platform_compat.get_process_start_id()`**, next to the existing `get_ppid`. Fully in-process on every platform — `/proc/<pid>/stat` field 22 on Linux, ctypes `libproc.proc_pidinfo` (`PROC_PIDTBSDINFO`) on macOS, `None` on Windows. Deliberately **not** `ps`: `_track_session_pid` is called inline from the async spawn paths (`AcpClient._spawn`, `AcpRuntime._spawn`), so a forking call there would block the event loop (`AUTOSDE: no-blocking-call-on-event-loop`). macOS reads `pbi_start_tvsec`/`pbi_start_tvusec`, giving **microsecond** resolution, so processes started within the same second cannot alias — which `ps -o lstart=` (1-second granularity) could not guarantee.
3. **Spawn grace now applies cross-platform.** `_pid_age_seconds` derives macOS age from that same epoch-based start id (no subprocess), so the 120s window protects freshly-spawned backends on macOS too. Windows keeps prior behavior (no age source → no grace), so the sweep stays functional there.

Fail directions are deliberate and match the module's existing `_pid_gone_or_unmanaged` contract ("any inconclusive result retains"):

| Situation | Action |
|---|---|
| Marker mismatch (recycled PID) | prune entry, no kill |
| Marker unreadable (probe failed) | **retain** entry, no kill — retry next sweep |
| Marker matches, owner dead | kill (genuine orphan) |
| Legacy 2-field entry (pre-upgrade) | prior behavior: cmdline + PPid + grace |

Not reused: `acp/client.py`'s `_get_start_time`, which hashes with builtin `hash()` — `PYTHONHASHSEED`-randomized per interpreter, so it is meaningless once written to disk and compared by a later gateway process. The docstring records why.

Note this fixes the **kill**; it does not change shutdown. A hard quit still leaves an orphan entry by design, and the next launch now reaps it correctly instead of shooting a live process.

## Tests

`test/test_pid_lifecycle.py` — new coverage:
- **`test_recycled_pid_is_pruned_not_killed`** — the core regression: PID live, cmdline matches, owner dead, grace disabled, so the identity check is the *only* guard; asserts no kill.
- **`test_unreadable_token_retains_entry`** / **`test_session_roots_unreadable_token_retains_entry`** — unknown identity must not kill *or* drop the entry (dropping would untrack a live orphan and leak it permanently).
- **`test_matching_token_still_killed`** / **`test_legacy_entry_without_token_still_swept`** — genuine orphans are still reaped; legacy entries don't regress.
- **`test_session_roots_sweep_parses_token_entry`** / **`test_session_roots_sweep_spares_recycled_pid`** — the periodic root sweep handles the 3-field format (a `split(":", 1)` parse would `int("pid:marker")` and silently prune every new entry).
- Marker recorded / fallback-when-unavailable / prefix dedup / untrack-matches-both-formats.
- **`TestSweepSparesLiveProcess`** — end-to-end with a **real** spawned process: a stale entry naming its live PID must leave it running and prune the entry.
- **`TestSpawnGraceCrossPlatform`** — macOS grace applies, old process still swept, unknown age treated as young, age derived from the start id, Windows unchanged.

`test/test_pid_sweep_helpers.py` — **two pre-existing tests were rewritten**, called out explicitly for review: `test_non_linux_returns_false` asserted `darwin → False`, which *is* the defect, so it could not survive; its real intent (no age source → no grace) is now carried by `test_windows_returns_false`. The non-Linux old-orphan integration test needed an age stub since darwin now has a real age source; its assertions are unchanged, and a young-orphan-spared case was added.

446 tests pass; mypy, flake8, isort, black clean.

## Manual verification

- **Reproduced the bug** before fixing: stale dead-gateway entry + live `kiro-cli acp` → sweep SIGKILLed it (`rc=-9`).
- **Verified the macOS struct offsets empirically** rather than trusting a header layout: cross-checked `pbi_start_tvsec` (offset 120) / `pbi_start_tvusec` (128) against `ps -o lstart=` across multiple processes; a root-owned PID returns `<=0` from `proc_pidinfo` and degrades to `None`.
- **Confirmed same-second disambiguation**: two children spawned inside the same second produce different markers (microseconds differ).
- **Confirmed marker properties on a real process**: stable across repeated reads, contains no `:` (so the colon-delimited record stays unambiguous), differs per process, and returns `None` once the process is reaped.

No user-visible UI change, so no screenshots.
