### PR TITLE
perf(dashboard): lazy-load mermaid and trim redundant boot requests

### DIFF
--- a/website/src/api/queryClient.ts
+++ b/website/src/api/queryClient.ts
@@ -43,7 +43,13 @@ export const queryClient = new QueryClient({
     queries: {
       retry: retryPolicy,
       retryDelay: retryDelayPolicy,
-      staleTime: 30_000,
+      // Infinity: queries never go stale on their own. Freshness is driven
+      // exclusively by WebSocket push (invalidateQueries on server events).
+      // This eliminates the focus-refetch storm (refetchOnWindowFocus only
+      // fires on *stale* queries) without changing the safe default — the
+      // option stays true, so any query that sets a finite staleTime will
+      // still refetch on focus as React Query intends.
+      staleTime: Infinity,
     },
   },
 })

--- a/website/src/apps/code-review-sage/components/LearningRail.tsx
+++ b/website/src/apps/code-review-sage/components/LearningRail.tsx
@@ -26,6 +26,9 @@ export default function LearningRail() {
   const settingsQuery = useQuery({
     queryKey: ['code-review-sage', 'settings'],
     queryFn: () => sageApi.settings(),
+    // putSettings sends a replace-all PUT from this cache; finite staleTime
+    // lets focus-refetch fire here (global default is Infinity).
+    staleTime: 30_000,
   })
 
   const invalidate = () => {

--- a/website/src/apps/meetings/SettingsView.tsx
+++ b/website/src/apps/meetings/SettingsView.tsx
@@ -37,7 +37,10 @@ interface Props {
 
 export default function SettingsView({ onBack, notify }: Props) {
   const queryClient = useQueryClient()
-  const configQuery = useQuery({ queryKey: ['meetings', 'config'], queryFn: meetingsApi.config })
+  // `patch()` builds a full-replace PUT from this cache, so a backgrounded tab
+  // with stale cache would silently revert settings changed from another tab.
+  // Finite staleTime lets focus-refetch fire here (global default is Infinity).
+  const configQuery = useQuery({ queryKey: ['meetings', 'config'], queryFn: meetingsApi.config, staleTime: 30_000 })
   const dictionaryQuery = useQuery({
     queryKey: ['meetings', 'dictionary'],
     queryFn: meetingsApi.dictionary,

--- a/website/src/apps/ops-mission-control/SettingsPanel.tsx
+++ b/website/src/apps/ops-mission-control/SettingsPanel.tsx
@@ -1394,6 +1394,9 @@ export default function SettingsPanel() {
   const rotationQuery = useQuery({
     queryKey: ['ops-mission-control', 'rotation'],
     queryFn: () => opsApi.rotation(),
+    // settingsMutation sends a replace-all PUT from this cache; finite staleTime
+    // lets focus-refetch fire here (global default is Infinity).
+    staleTime: 30_000,
   })
 
   // Slack status rides on /state (it depends on live gateway state, not config

--- a/website/src/apps/papyrus/PapyrusPage.tsx
+++ b/website/src/apps/papyrus/PapyrusPage.tsx
@@ -159,6 +159,10 @@ export default function PapyrusPage() {
     queryFn: () => papyrusApi.getProject(project as string),
     enabled: !!project,
     retry: false,
+    // The deleted-in-another-tab detection below depends on this query
+    // re-running on window focus. Finite staleTime lets focus-refetch fire
+    // here (global default is Infinity).
+    staleTime: 30_000,
   })
   const detail = projectQuery.data
   const mainFile = detail?.main_file ?? ''

--- a/website/src/apps/personal-shopper/SitesTab.tsx
+++ b/website/src/apps/personal-shopper/SitesTab.tsx
@@ -51,6 +51,10 @@ export function SitesTab() {
   const { data, isLoading } = useQuery({
     queryKey: ['personal-shopper', 'sites'],
     queryFn: fetchSites,
+    // add/remove send a replace-all PUT built from this cache, so a stale cache
+    // would erase a site added from another tab. Finite staleTime lets
+    // focus-refetch fire here (global default is Infinity).
+    staleTime: 30_000,
   })
 
   const mutation = useMutation({

--- a/website/src/components/RegistryManager.tsx
+++ b/website/src/components/RegistryManager.tsx
@@ -75,6 +75,10 @@ export default function RegistryManager({ bare = false }: { bare?: boolean } = {
   const { data, isLoading } = useQuery({
     queryKey: ['registries'],
     queryFn: () => api.listRegistries(),
+    // handleAdd sends a REPLACE-ALL PUT built from this cached list, so a stale
+    // cache would silently erase a registry added from another tab. Use a finite
+    // staleTime so focus-refetch fires here (the global default is Infinity).
+    staleTime: 30_000,
   })
   const registries: Registry[] = data?.registries || []
 

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -473,8 +473,16 @@ export function useWebSocket() {
       }
       wasConnectedRef.current = true
       dispatch(sseConnected())
-      dispatch(fetchSlots())
       seedGoalLoops()
+      // FIRST connect only: App's mount effect already dispatched fetchSlots,
+      // and this handler fires strictly after it, so repeating it here is a
+      // redundant round-trip at the worst possible moment. The reconnect branch
+      // above still refetches — there it recovers state missed while the socket
+      // was down. fetchNotifications IS still dispatched here despite the
+      // mount-effect copy: syncPendingApprovals must only run after a
+      // notifications fetch has settled, because fetchNotifications.fulfilled
+      // replaces `items` wholesale and would wipe any approval notifications
+      // synced before it.
       dispatch(fetchNotifications()).then(() => syncPendingApprovals())
       syncPendingQuestions()
       // Eagerly subscribe to subagent events on first connect too.

--- a/website/src/test/MarkdownRenderer.mermaid.test.tsx
+++ b/website/src/test/MarkdownRenderer.mermaid.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from '@testing-library/react'
 
 vi.mock('mermaid', () => ({
@@ -10,6 +10,8 @@ vi.mock('mermaid', () => ({
 
 import mermaid from 'mermaid'
 import MarkdownRenderer from '../components/MarkdownRenderer'
+
+beforeEach(() => { vi.clearAllMocks() })
 
 describe('MarkdownRenderer mermaid config', () => {
   it('initializes mermaid with suppressErrorRendering so parse errors do not leak error SVGs into the DOM', async () => {
@@ -26,5 +28,19 @@ describe('MarkdownRenderer mermaid config', () => {
         expect.objectContaining({ suppressErrorRendering: true })
       )
     )
+  })
+
+  it('renders the diagram through the lazily-imported module', async () => {
+    render(<MarkdownRenderer content={'```mermaid\ngraph TD;A-->B\n```'} />)
+    await vi.waitFor(() => expect(mermaid.render).toHaveBeenCalled())
+  })
+
+  it('does NOT touch mermaid for content without a diagram', async () => {
+    // The point of the dynamic import: mermaid must not be pulled in — nor
+    // initialized — just because a chat message rendered.
+    render(<MarkdownRenderer content={'# Hello\n\nplain text and `code`'} />)
+    await new Promise(r => setTimeout(r, 50))
+    expect(mermaid.initialize).not.toHaveBeenCalled()
+    expect(mermaid.render).not.toHaveBeenCalled()
   })
 })

--- a/website/src/test/bootRequests.test.ts
+++ b/website/src/test/bootRequests.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { queryClient } from '../api/queryClient'
+
+/**
+ * Guards for the round-trip reductions in the dashboard's boot path. Each of
+ * these costs a full round-trip per occurrence when the dashboard is reached
+ * over a tunnel, so a regression here is a user-visible slowdown, not a style
+ * nit.
+ */
+
+describe('query defaults', () => {
+  it('uses Infinity staleTime so focus-refetch is effectively disabled globally', () => {
+    // Live data arrives by WebSocket push (invalidateQueries on server events).
+    // With staleTime: Infinity, queries never go stale on their own, so
+    // refetchOnWindowFocus (which only fires on stale queries) is a no-op for
+    // any query that doesn't explicitly override staleTime.
+    expect(queryClient.getDefaultOptions().queries?.staleTime).toBe(Infinity)
+  })
+
+  it('keeps refetchOnWindowFocus at the safe default (true/undefined)', () => {
+    // We do NOT set refetchOnWindowFocus: false. The safe default stays.
+    // Focus-refetch is neutralized via staleTime, not by disabling the option.
+    const val = queryClient.getDefaultOptions().queries?.refetchOnWindowFocus
+    expect(val === true || val === undefined).toBe(true)
+  })
+
+  it('keeps the retry policy', () => {
+    const q = queryClient.getDefaultOptions().queries
+    expect(q?.retry).toBeTypeOf('function')
+  })
+})
+
+describe('focus-refetch opt-ins via finite staleTime', () => {
+  // Surfaces where focus-refetch is load-bearing set a finite staleTime so the
+  // global Infinity doesn't prevent their focus-triggered refresh. Each either
+  // builds a REPLACE-ALL write from its query cache (stale = data loss) or
+  // documents behavior that depends on focus-triggered refetch.
+  const read = (rel: string) =>
+    readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
+
+  const optIns: Array<[string, string]> = [
+    ['../components/RegistryManager.tsx', 'replace-all PUT of registries'],
+    ['../apps/meetings/SettingsView.tsx', 'full-replace PUT of meetings config'],
+    ['../apps/personal-shopper/SitesTab.tsx', 'replace-all PUT of shopper sites'],
+    ['../apps/papyrus/PapyrusPage.tsx', 'project deleted-in-another-tab detection'],
+    ['../apps/code-review-sage/components/LearningRail.tsx', 'replace-all PUT of active namespaces'],
+    ['../apps/ops-mission-control/SettingsPanel.tsx', 'replace-all PUT of rotation settings'],
+  ]
+
+  it.each(optIns)('%s sets a finite staleTime (%s)', (rel) => {
+    const src = read(rel)
+    // Must have staleTime with a numeric value (not Infinity)
+    expect(src).toMatch(/staleTime:\s*\d+/)
+  })
+})


### PR DESCRIPTION
## Problem
Two classes of redundant round-trips slow the dashboard boot path — each one is a full round-trip when the dashboard is reached over a tunnel:

1. The WebSocket's FIRST-connect handler re-dispatched `fetchSlots()`, which App's mount effect had already issued strictly earlier.
2. `refetchOnWindowFocus` + `staleTime: 30_000` meant every window focus refetched every mounted query older than 30s — even though live data arrives by WebSocket push.

## Why it matters
Boot latency is user-visible on every dashboard load, and the focus-refetch churn is felt as lag on tunneled connections (triggers 429 rate limits on burst).

## Fix

- **First-connect refetch**: removed the redundant `fetchSlots()` from the WS first-connect handler (App mount already dispatched it). Kept `fetchNotifications()` there: `syncPendingApprovals()` must run after notifications settle to avoid the approval-hydration race.

- **Focus refetch storm**: changed `staleTime` from `30_000` to `Infinity`. Since `refetchOnWindowFocus` only fires on **stale** queries, and queries with `staleTime: Infinity` never go stale on their own, this effectively disables focus-refetch globally — without changing the `refetchOnWindowFocus` option itself (it stays at the safe React Query default of `true`). Freshness is driven exclusively by WebSocket push (`invalidateQueries` on server events).

  For the 4 surfaces whose caches feed replace-all PUTs (where stale data = silent data loss on write), a finite `staleTime: 30_000` is set per-query so focus-refetch still fires there:
  - `RegistryManager` — replace-all PUT of registries
  - `meetings/SettingsView` — full-replace PUT of config
  - `personal-shopper/SitesTab` — replace-all PUT of sites
  - `papyrus/PapyrusPage` — deleted-in-another-tab detection

### Dropped during rebase (superseded by main)
The branch predated ~1200 main commits. Two original changes landed independently:
- mermaid lazy-load — main has its own `loadMermaid`/`initMermaid` split.
- per-template agent-detail request dedup — main replaced per-slot `GET /api/agents/detail/<name>` with `GET /api/agents/resolved-model`.

## Tests
- `bootRequests.test.ts` (new): locks `staleTime: Infinity`, confirms `refetchOnWindowFocus` stays at safe default, and pins the 4 finite-staleTime opt-ins via source-level assertion.
- `MarkdownRenderer.mermaid.test.tsx`: regression tests remain valid against main's lazy-load.

no issue closed: perf follow-up to #765's boot audit.