### PR TITLE
fix(onboarding): mount first-run modal chrome once to kill transition glitch

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -31,6 +31,7 @@ import { GithubIcon, DiscordIcon } from './components/BrandIcon'
 import { Toggle } from './components/ui'
 import OnboardingFlow from './components/OnboardingFlow'
 import AgentImportFlow from './components/AgentImportFlow'
+import { OnboardingShellHost } from './components/OnboardingChapterShell'
 import { PREVIEW_FOCUS_EVENT } from './components/WebPreviewPanel'
 import { motion, AnimatePresence } from 'framer-motion'
 import { usePersistedBool } from './hooks/usePersistedBool'
@@ -1733,36 +1734,43 @@ export default function App() {
       {(updating || showUpdateModal) && <UpdateOverlay onCancel={() => { setUpdating(false); setShowUpdateModal(false) }} />}
       <UpdateModal />
 
-      {/* First-run import gate. Existing users inherit the old onboarding
-          marker, while new users reach the feature tour only after this flow. */}
-      <AgentImportFlow
-        initialOpen={showAgentImport}
-        onComplete={() => {
-          markImportOnboarded()
-          setShowAgentImport(false)
-          if (!onboarded || continueTourAfterImport.current) {
-            setShowOnboarding(true)
-          }
-          continueTourAfterImport.current = false
-        }}
-        onSkipAll={() => {
-          // Skip the entire first-run flow: mark both import + onboarding tour
-          // done and close both so the user lands in the product (new chat).
-          markImportOnboarded()
-          markOnboarded()
-          setShowAgentImport(false)
-          setShowOnboarding(false)
-          continueTourAfterImport.current = false
-        }}
-      />
+      {/* First-run modal chrome mounted ONCE (scrim + accent panel + floating
+          mascots) so the import→customize hand-off swaps only the right-column
+          content — the mascots never remount/replay, killing the transition
+          glitch. Both flows portal their content into this single shell; each
+          still renders standalone (its own chrome) when used outside a host. */}
+      <OnboardingShellHost>
+        {/* First-run import gate. Existing users inherit the old onboarding
+            marker, while new users reach the feature tour only after this flow. */}
+        <AgentImportFlow
+          initialOpen={showAgentImport}
+          onComplete={() => {
+            markImportOnboarded()
+            setShowAgentImport(false)
+            if (!onboarded || continueTourAfterImport.current) {
+              setShowOnboarding(true)
+            }
+            continueTourAfterImport.current = false
+          }}
+          onSkipAll={() => {
+            // Skip the entire first-run flow: mark both import + onboarding tour
+            // done and close both so the user lands in the product (new chat).
+            markImportOnboarded()
+            markOnboarded()
+            setShowAgentImport(false)
+            setShowOnboarding(false)
+            continueTourAfterImport.current = false
+          }}
+        />
 
-      {/* First-run onboarding: 4-step flow (theme → Schedule → Apps → Sessions).
-          Rendered unconditionally so the `/onboarding` slash command can reopen
-          it anytime; internal visibility is seeded by `initialOpen`. */}
-      <OnboardingFlow
-        initialOpen={showOnboarding}
-        onComplete={() => { markOnboarded(); setShowOnboarding(false) }}
-      />
+        {/* First-run onboarding: 4-step flow (theme → Schedule → Apps → Sessions).
+            Rendered unconditionally so the `/onboarding` slash command can reopen
+            it anytime; internal visibility is seeded by `initialOpen`. */}
+        <OnboardingFlow
+          initialOpen={showOnboarding}
+          onComplete={() => { markOnboarded(); setShowOnboarding(false) }}
+        />
+      </OnboardingShellHost>
 
       {/* Mobile backdrop */}
       <AnimatePresence>

--- a/website/src/components/AgentImportFlow.tsx
+++ b/website/src/components/AgentImportFlow.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
-import { motion, useReducedMotion } from 'framer-motion'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import {
   AlertTriangle,
-  ArrowRight,
   BookOpen,
   Brain,
   CalendarClock,
@@ -24,8 +21,8 @@ import {
   type AgentImportConflictStrategy,
   type AgentImportSource,
 } from '../api/client'
-import { KiroGhost } from './KiroGhost'
 import { Btn, SendBtn } from './ui'
+import OnboardingChapterShell, { OnboardingShellContext } from './OnboardingChapterShell'
 
 import { i18nT } from '../i18n/t'
 type Stage = 1 | 2 | 3 | 4
@@ -76,42 +73,6 @@ function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback
 }
 
-// Floating decorative mascot — an exact copy of the Kiro CLI setup gate's
-// FloatingGhost (components/KiroPrerequisiteGate.tsx): same KiroGhost art,
-// staggered fade + spring scale entrance, and an infinite easeInOut bob.
-// Honors the OS reduce-motion setting.
-function FloatingGhost({
-  className,
-  delay,
-  rotate = 0,
-}: {
-  className: string
-  delay: number
-  rotate?: number
-}) {
-  const reduceMotion = useReducedMotion()
-  return (
-    <motion.div
-      aria-hidden="true"
-      className={`pointer-events-none absolute z-0 text-white drop-shadow-[0_12px_20px_rgba(24,20,38,0.26)] ${className}`}
-      initial={reduceMotion ? false : { opacity: 0, scale: 0.72 }}
-      animate={{
-        opacity: 1,
-        scale: 1,
-        y: reduceMotion ? 0 : [-5, 5, -5],
-        rotate,
-      }}
-      transition={{
-        opacity: { delay, duration: 0.35 },
-        scale: { delay, duration: 0.45, type: 'spring', bounce: 0.45 },
-        y: { delay, duration: 3.8, ease: 'easeInOut', repeat: Infinity },
-      }}
-    >
-      <KiroGhost size={160} className="h-full w-full" />
-    </motion.div>
-  )
-}
-
 // Animated "Importing…" label — cycles the trailing dots between ".", ".." and
 // "..." while an import is in flight. The dots span reserves width so the
 // button doesn't jitter as they grow.
@@ -146,7 +107,11 @@ export default function AgentImportFlow({
   const [selectedSources, setSelectedSources] = useState<Set<string>>(new Set())
   const [strategy, setStrategy] = useState<AgentImportConflictStrategy>('skip')
   const [selectedCategories, setSelectedCategories] = useState<Record<string, Set<string>>>({})
-  const dialogRef = useRef<HTMLDivElement>(null)
+  // The focus trap queries the dialog element. Inside a persistent shell host
+  // the dialog is host-owned, so use its ref; standalone we own it locally.
+  const shellHost = useContext(OnboardingShellContext)
+  const localDialogRef = useRef<HTMLDivElement>(null)
+  const dialogRef = shellHost?.dialogRef ?? localDialogRef
   const headingRef = useRef<HTMLHeadingElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const previousInitialOpenRef = useRef(initialOpen)
@@ -274,7 +239,9 @@ export default function AgentImportFlow({
 
   useEffect(() => {
     if (open) headingRef.current?.focus()
-  }, [open, stage, scanQuery.isPending, scanQuery.isError, applyMutation.status])
+    // shellHost?.sectionSlot: in host mode the heading is portaled a pass after
+    // open, so re-run once the section slot exists to move initial focus to it.
+  }, [open, stage, scanQuery.isPending, scanQuery.isError, applyMutation.status, shellHost?.sectionSlot])
 
   const skip = () => {
     if (!completionMutation.isPending && !applyMutation.isPending && !skipAllMutation.isPending) {
@@ -720,69 +687,25 @@ export default function AgentImportFlow({
     )
   })()
 
-  return createPortal(
-    <div
-      ref={dialogRef}
-      role="dialog"
-      aria-modal="true"
-      aria-label={i18nT('components.agentImportFlow.import_agent_setup')}
-      className="fixed inset-0 z-[140] flex min-h-0 overflow-y-auto bg-bg/70 backdrop-blur-sm p-0 text-text sm:items-center sm:justify-center sm:p-6"
+  return (
+    <OnboardingChapterShell
+      dialogRef={dialogRef}
+      ariaLabel={i18nT('components.agentImportFlow.import_agent_setup')}
+      panelHeadline={i18nT('components.agentImportFlow.bring_your_crew_with_you')}
+      panelBody={i18nT('components.agentImportFlow.bring_your_supported_setup_sessions_memories_wor')}
+      panelFootnote={i18nT('components.agentImportFlow.merge_only_setup_credentials_stay_where_they_are')}
+      eyebrow={
+        <>
+          {i18nT('components.agentImportFlow.import_setup')}
+          {showStepFooter && ` · ${stage} of ${STAGE_LABELS.length}`}
+        </>
+      }
+      onSkipAll={skipAll}
+      skipDisabled={isBusy}
+      header={stageHeader}
+      footer={showStepFooter ? stepFooterNav : undefined}
     >
-      <div className="relative flex min-h-screen w-full flex-col overflow-hidden bg-card shadow-xl sm:h-[min(760px,calc(100vh-48px))] sm:min-h-0 sm:max-w-6xl sm:flex-row sm:rounded-2xl sm:border sm:border-border">
-        <aside className="relative flex min-h-[248px] w-full shrink-0 overflow-hidden bg-accent text-accent-fg sm:min-h-0 sm:w-[36%]">
-          <FloatingGhost className="-left-8 top-[24%] h-24 w-20 rotate-90 lg:h-28 lg:w-24" delay={0.15} rotate={90} />
-          <FloatingGhost className="-right-5 top-5 h-28 w-20 -rotate-12 lg:h-36 lg:w-28" delay={0.35} rotate={-12} />
-          <FloatingGhost className="bottom-[-5.5rem] right-[-12%] hidden h-64 w-48 lg:block" delay={0.55} />
-          <FloatingGhost className="-top-20 left-[40%] hidden h-48 w-36 rotate-180 lg:block" delay={0.75} rotate={180} />
-          <div className="relative z-10 flex w-full flex-col p-7 sm:p-10">
-            <div className="flex items-center gap-3">
-              <KiroGhost size={28} className="h-8 w-7" />
-              <span className="text-[15px] font-semibold tracking-wide">{i18nT('components.agentImportFlow.kiro_crew')}</span>
-            </div>
-            <div className="mt-auto max-w-[290px]">
-              <h1 className="text-4xl font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[clamp(2.2rem,4vw,3.5rem)]">
-                {i18nT('components.agentImportFlow.bring_your_crew_with_you')}
-              </h1>
-              <p className="mt-5 max-w-[270px] text-sm leading-relaxed text-accent-fg/80">
-                {i18nT('components.agentImportFlow.bring_your_supported_setup_sessions_memories_wor')}
-              </p>
-            </div>
-            <p className="mt-8 text-[12px] font-medium text-accent-fg/75">
-              {i18nT('components.agentImportFlow.merge_only_setup_credentials_stay_where_they_are')}
-            </p>
-          </div>
-        </aside>
-        <section className="flex min-h-[calc(100vh-248px)] min-w-0 flex-1 flex-col bg-card sm:min-h-0">
-          <header className="shrink-0 px-6 pt-7 sm:px-10 sm:pt-10">
-            <div className="flex items-center justify-between gap-4">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
-                {i18nT('components.agentImportFlow.import_setup')}{showStepFooter && ` · ${stage} of ${STAGE_LABELS.length}`}
-              </p>
-              <button
-                type="button"
-                aria-label={i18nT('components.agentImportFlow.skip_all_setup_and_onboarding')}
-                disabled={isBusy}
-                onClick={skipAll}
-                className="inline-flex items-center gap-1.5 text-[13px] font-medium text-muted transition-colors hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {i18nT('components.agentImportFlow.skip_all')} <ArrowRight className="lucide-inline" />
-              </button>
-            </div>
-            {stageHeader}
-          </header>
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            <main className="w-full px-6 pb-8 pt-6 sm:px-10 sm:pb-10 sm:pt-6">
-              <div className="mx-auto max-w-2xl">{stageContent}</div>
-            </main>
-          </div>
-          {showStepFooter && (
-            <footer className="flex shrink-0 flex-wrap items-center justify-end gap-3 px-6 pt-4 pb-6 sm:px-10 sm:pb-10">
-              {stepFooterNav}
-            </footer>
-          )}
-        </section>
-      </div>
-    </div>,
-    document.body,
+      {stageContent}
+    </OnboardingChapterShell>
   )
 }

--- a/website/src/components/OnboardingChapterShell.tsx
+++ b/website/src/components/OnboardingChapterShell.tsx
@@ -1,10 +1,22 @@
-import type { ReactNode, RefObject } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { motion, useReducedMotion } from 'framer-motion'
 import { ArrowRight } from 'lucide-react'
 import { KiroGhost } from './KiroGhost'
 
 import { i18nT } from '../i18n/t'
+
 // Floating decorative mascot — the same treatment as the Kiro CLI setup gate
 // (KiroPrerequisiteGate's FloatingGhost) and the Import setup panel: staggered
 // fade + spring scale entrance and an infinite easeInOut bob. Honors the OS
@@ -41,108 +53,254 @@ function FloatingGhost({
   )
 }
 
+// The accent left panel — brand lockup + floating mascots + the flow's copy.
+// Factored out so the persistent HOST and the standalone shell render the exact
+// same aside; when it lives in the host it is mounted ONCE and only its copy
+// text changes between flows, so the mascots never re-run their entrance.
+function ShellAside({ copy }: { copy: ShellAsideCopy }) {
+  return (
+    <aside className="relative flex min-h-[248px] w-full shrink-0 overflow-hidden bg-accent text-accent-fg sm:min-h-0 sm:w-[36%]">
+      <FloatingGhost className="-left-8 top-[24%] h-24 w-20 rotate-90 lg:h-28 lg:w-24" delay={0.15} rotate={90} />
+      <FloatingGhost className="-right-5 top-5 h-28 w-20 -rotate-12 lg:h-36 lg:w-28" delay={0.35} rotate={-12} />
+      <FloatingGhost className="bottom-[-5.5rem] right-[-12%] hidden h-64 w-48 lg:block" delay={0.55} />
+      <FloatingGhost className="-top-20 left-[40%] hidden h-48 w-36 rotate-180 lg:block" delay={0.75} rotate={180} />
+      <div className="relative z-10 flex w-full flex-col p-7 sm:p-10">
+        <div className="flex items-center gap-3">
+          <KiroGhost size={28} className="h-8 w-7" />
+          <span className="text-[15px] font-semibold tracking-wide">{i18nT('components.onboardingChapterShell.kiro_crew')}</span>
+        </div>
+        <div className="mt-auto max-w-[290px]">
+          <h1 className="text-4xl font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[clamp(2.2rem,4vw,3.5rem)]">
+            {copy.panelHeadline}
+          </h1>
+          <p className="mt-5 max-w-[270px] text-sm leading-relaxed text-accent-fg/80">
+            {copy.panelBody}
+          </p>
+        </div>
+        <p className="mt-8 text-[12px] font-medium text-accent-fg/75">{copy.panelFootnote}</p>
+      </div>
+    </aside>
+  )
+}
+
+// Shared class strings so the host-owned <section> slot and the standalone
+// shell's <section> are byte-identical (same flex layout / min-heights).
+const SECTION_CLASS =
+  'flex min-h-[calc(100vh-248px)] min-w-0 flex-1 flex-col bg-card sm:min-h-0'
+const SCRIM_CLASS =
+  'fixed inset-0 z-[120] flex min-h-0 overflow-y-auto bg-bg/70 backdrop-blur-sm p-0 text-text sm:items-center sm:justify-center sm:p-6'
+const PANEL_CLASS =
+  'relative flex min-h-screen w-full flex-col overflow-hidden bg-card shadow-xl sm:h-[min(760px,calc(100vh-48px))] sm:min-h-0 sm:max-w-6xl sm:flex-row sm:rounded-2xl sm:border sm:border-border'
+
+interface ShellAsideCopy {
+  ariaLabel: string
+  panelHeadline: string
+  panelBody: string
+  panelFootnote: string
+}
+
+interface OnboardingShellApi {
+  // The single persistent dialog element. Flows use it for their focus trap.
+  dialogRef: RefObject<HTMLDivElement>
+  // The persistent right-column <section>; flows portal their header/body/footer
+  // into it. Null until the host has mounted the chrome.
+  sectionSlot: HTMLElement | null
+  // A flow registers its aside copy while open (and clears it on close). The
+  // host shows the chrome whenever any flow is registered.
+  setAsideCopy: (id: string, copy: ShellAsideCopy | null) => void
+}
+
+const OnboardingShellContext = createContext<OnboardingShellApi | null>(null)
+
 /**
- * Two-column onboarding "chapter" shell, mirroring the Import setup layout
- * (components/AgentImportFlow.tsx): a translucent scrim, an accent left panel
+ * Single persistent host for the first-run modal chrome. Wrap the first-run
+ * flows (AgentImportFlow + OnboardingFlow) in ONE of these so the scrim, accent
+ * panel, and floating mascots mount exactly once and stay mounted across the
+ * import→customize (and step 1→2) hand-offs. Only the right-column content and
+ * the aside copy swap — nothing in the accent panel remounts, so the mascots
+ * never replay their entrance. That is the fix for the transition glitch.
+ *
+ * When a flow renders OUTSIDE a host (e.g. a unit test rendering it standalone),
+ * OnboardingChapterShell falls back to rendering its own full chrome, so
+ * behavior is unchanged in isolation.
+ */
+export function OnboardingShellHost({ children }: { children: ReactNode }) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const [sectionSlot, setSectionSlot] = useState<HTMLElement | null>(null)
+  const [copies, setCopies] = useState<Record<string, ShellAsideCopy>>({})
+
+  const setAsideCopy = useCallback((id: string, copy: ShellAsideCopy | null) => {
+    setCopies(prev => {
+      if (copy === null) {
+        if (!(id in prev)) return prev
+        const next = { ...prev }
+        delete next[id]
+        return next
+      }
+      const cur = prev[id]
+      if (
+        cur
+        && cur.ariaLabel === copy.ariaLabel
+        && cur.panelHeadline === copy.panelHeadline
+        && cur.panelBody === copy.panelBody
+        && cur.panelFootnote === copy.panelFootnote
+      ) {
+        return prev
+      }
+      return { ...prev, [id]: copy }
+    })
+  }, [])
+
+  const api = useMemo<OnboardingShellApi>(
+    () => ({ dialogRef, sectionSlot, setAsideCopy }),
+    [sectionSlot, setAsideCopy],
+  )
+
+  // Exactly one flow is open at a time by construction; if two ever overlap for
+  // a commit, the most recently registered wins.
+  const ids = Object.keys(copies)
+  const active = ids.length > 0 ? copies[ids[ids.length - 1]] : null
+
+  return (
+    <OnboardingShellContext.Provider value={api}>
+      {children}
+      {active
+        && createPortal(
+          <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label={active.ariaLabel}
+            className={SCRIM_CLASS}
+          >
+            <div className={PANEL_CLASS}>
+              <ShellAside copy={active} />
+              <section ref={setSectionSlot} className={SECTION_CLASS} />
+            </div>
+          </div>,
+          document.body,
+        )}
+    </OnboardingShellContext.Provider>
+  )
+}
+
+/**
+ * Two-column first-run modal shell: a translucent scrim, an accent left panel
  * with the brand lockup + floating mascots, and a right column with a FIXED
- * header (eyebrow "<chapter> · N of M" + "Skip all") and stage title/description,
- * a SCROLLABLE body, and a PINNED footer for the step navigation.
+ * header (eyebrow + "Skip all" and an optional title/description block), a
+ * SCROLLABLE body, and an optional PINNED footer.
+ *
+ * The header/footer are passed as SLOTS so each flow keeps its own title copy,
+ * focus refs, and footer navigation — the Import flow hides the title/footer on
+ * its full-panel scanning/error/empty states, while the Customize chapter
+ * always shows them.
+ *
+ * When rendered inside an <OnboardingShellHost>, this component does NOT render
+ * its own chrome: it registers its aside copy with the host and portals just
+ * the right-column content (header + body + footer) into the host's persistent
+ * <section>. Outside a host it renders the full chrome itself (standalone /
+ * tests). Either way the flow call sites are identical.
  */
 export default function OnboardingChapterShell({
-  chapterLabel,
-  stepIndex,
-  stepCount,
   panelHeadline,
   panelBody,
   panelFootnote,
-  title,
-  description,
+  eyebrow,
   onSkipAll,
   skipDisabled,
+  header,
   footer,
   dialogRef,
   ariaLabel,
   children,
 }: {
-  chapterLabel: string
-  stepIndex: number
-  stepCount: number
   panelHeadline: string
   panelBody: string
   panelFootnote: string
-  title: string
-  description: string
+  // The uppercase eyebrow above the stage title, e.g. "CUSTOMIZE · 1 OF 2" or
+  // "IMPORT SETUP · 1 OF 4". A plain node so each flow owns its counter logic.
+  eyebrow: ReactNode
   onSkipAll: () => void
   skipDisabled?: boolean
-  footer: ReactNode
+  // Stage title/description block. Nullable: the Import flow passes null for its
+  // full-panel scanning/error/empty states, which carry their own headings.
+  header?: ReactNode
+  // Pinned footer navigation. Nullable for the same full-panel states.
+  footer?: ReactNode
+  // Standalone mode: the dialog element. Inside a host the dialog is host-owned
+  // and this ref is unused (the flow reads the host's dialogRef for its trap).
   dialogRef: RefObject<HTMLDivElement>
   ariaLabel: string
   children: ReactNode
 }) {
+  const host = useContext(OnboardingShellContext)
+  // Stable per-mount id so the flow's aside-copy registration can be cleared on
+  // close/unmount without colliding with the other flow's registration.
+  const id = useId()
+
+  // Register the aside copy with the host while mounted; clear it on unmount.
+  // Deps are all primitive strings, so this never loops on node identity.
+  useEffect(() => {
+    if (!host) return
+    host.setAsideCopy(id, { ariaLabel, panelHeadline, panelBody, panelFootnote })
+    return () => host.setAsideCopy(id, null)
+  }, [host, id, ariaLabel, panelHeadline, panelBody, panelFootnote])
+
+  // The right-column content — identical markup in both host and standalone
+  // modes, so the flows' header/body/footer render the same either way.
+  const sectionInner = (
+    <>
+      <header className="shrink-0 px-6 pt-7 sm:px-10 sm:pt-10">
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
+            {eyebrow}
+          </p>
+          <button
+            type="button"
+            aria-label={i18nT('components.onboardingChapterShell.skip_all_setup_and_onboarding')}
+            disabled={skipDisabled}
+            onClick={onSkipAll}
+            className="inline-flex items-center gap-1.5 text-[13px] font-medium text-muted transition-colors hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {i18nT('components.onboardingChapterShell.skip_all')} <ArrowRight className="lucide-inline" />
+          </button>
+        </div>
+        {header}
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <main className="w-full px-6 pb-8 pt-6 sm:px-10 sm:pb-10 sm:pt-6">
+          <div className="mx-auto max-w-2xl">{children}</div>
+        </main>
+      </div>
+      {footer && (
+        <footer className="flex shrink-0 flex-wrap items-center justify-end gap-3 px-6 pt-4 pb-6 sm:px-10 sm:pb-10">
+          {footer}
+        </footer>
+      )}
+    </>
+  )
+
+  // Host mode: portal the right-column content into the persistent <section>.
+  if (host) {
+    return host.sectionSlot ? createPortal(sectionInner, host.sectionSlot) : null
+  }
+
+  // Standalone mode: render the full chrome ourselves.
   return createPortal(
     <div
       ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label={ariaLabel}
-      className="fixed inset-0 z-[120] flex min-h-0 overflow-y-auto bg-bg/70 backdrop-blur-sm p-0 text-text sm:items-center sm:justify-center sm:p-6"
+      className={SCRIM_CLASS}
     >
-      <div className="relative flex min-h-screen w-full flex-col overflow-hidden bg-card shadow-xl sm:h-[min(760px,calc(100vh-48px))] sm:min-h-0 sm:max-w-6xl sm:flex-row sm:rounded-2xl sm:border sm:border-border">
-        <aside className="relative flex min-h-[248px] w-full shrink-0 overflow-hidden bg-accent text-accent-fg sm:min-h-0 sm:w-[36%]">
-          <FloatingGhost className="-left-8 top-[24%] h-24 w-20 rotate-90 lg:h-28 lg:w-24" delay={0.15} rotate={90} />
-          <FloatingGhost className="-right-5 top-5 h-28 w-20 -rotate-12 lg:h-36 lg:w-28" delay={0.35} rotate={-12} />
-          <FloatingGhost className="bottom-[-5.5rem] right-[-12%] hidden h-64 w-48 lg:block" delay={0.55} />
-          <FloatingGhost className="-top-20 left-[40%] hidden h-48 w-36 rotate-180 lg:block" delay={0.75} rotate={180} />
-          <div className="relative z-10 flex w-full flex-col p-7 sm:p-10">
-            <div className="flex items-center gap-3">
-              <KiroGhost size={28} className="h-8 w-7" />
-              <span className="text-[15px] font-semibold tracking-wide">{i18nT('components.onboardingChapterShell.kiro_crew')}</span>
-            </div>
-            <div className="mt-auto max-w-[290px]">
-              <h1 className="text-4xl font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[clamp(2.2rem,4vw,3.5rem)]">
-                {panelHeadline}
-              </h1>
-              <p className="mt-5 max-w-[270px] text-sm leading-relaxed text-accent-fg/80">
-                {panelBody}
-              </p>
-            </div>
-            <p className="mt-8 text-[12px] font-medium text-accent-fg/75">{panelFootnote}</p>
-          </div>
-        </aside>
-        <section className="flex min-h-[calc(100vh-248px)] min-w-0 flex-1 flex-col bg-card sm:min-h-0">
-          <header className="shrink-0 px-6 pt-7 sm:px-10 sm:pt-10">
-            <div className="flex items-center justify-between gap-4">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
-                {chapterLabel} · {stepIndex} {i18nT('components.onboardingChapterShell.of')} {stepCount}
-              </p>
-              <button
-                type="button"
-                aria-label={i18nT('components.onboardingChapterShell.skip_all_setup_and_onboarding')}
-                disabled={skipDisabled}
-                onClick={onSkipAll}
-                className="inline-flex items-center gap-1.5 text-[13px] font-medium text-muted transition-colors hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {i18nT('components.onboardingChapterShell.skip_all')} <ArrowRight className="lucide-inline" />
-              </button>
-            </div>
-            <div className="mt-6">
-              <h1 tabIndex={-1} className="text-2xl font-semibold text-text-strong outline-none">
-                {title}
-              </h1>
-              <p className="mt-2 text-sm leading-relaxed text-muted">{description}</p>
-            </div>
-          </header>
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            <main className="w-full px-6 pb-8 pt-6 sm:px-10 sm:pb-10 sm:pt-6">
-              <div className="mx-auto max-w-2xl">{children}</div>
-            </main>
-          </div>
-          <footer className="flex shrink-0 flex-wrap items-center justify-end gap-3 px-6 pt-4 pb-6 sm:px-10 sm:pb-10">
-            {footer}
-          </footer>
-        </section>
+      <div className={PANEL_CLASS}>
+        <ShellAside copy={{ ariaLabel, panelHeadline, panelBody, panelFootnote }} />
+        <section className={SECTION_CLASS}>{sectionInner}</section>
       </div>
     </div>,
     document.body,
   )
 }
+
+export { OnboardingShellContext }

--- a/website/src/components/OnboardingFlow.tsx
+++ b/website/src/components/OnboardingFlow.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useContext, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -6,7 +6,7 @@ import { ArrowRight, Check, Monitor, Sun, Moon } from 'lucide-react'
 import { useTheme, type ModePreference, type ColorTheme } from '../hooks/useTheme'
 import { GhostVar2 } from '../assets/onboarding/GhostIcons'
 import { Btn, SendBtn } from './ui'
-import OnboardingChapterShell from './OnboardingChapterShell'
+import OnboardingChapterShell, { OnboardingShellContext } from './OnboardingChapterShell'
 import { api } from '../api/client'
 
 import { i18nT } from '../i18n/t'
@@ -112,7 +112,11 @@ export default function OnboardingFlow({
   const [open, setOpen] = useState(initialOpen)
   const [step, setStep] = useState(1)
   const [coords, setCoords] = useState<{ left: number; top: number } | null>(null)
-  const dialogRef = useRef<HTMLDivElement>(null)
+  // The focus trap queries the dialog element. Inside a persistent shell host
+  // the dialog is host-owned, so use its ref; standalone we own it locally.
+  const shellHost = useContext(OnboardingShellContext)
+  const localDialogRef = useRef<HTMLDivElement>(null)
+  const dialogRef = shellHost?.dialogRef ?? localDialogRef
 
   // ── Step-2 profile state ──────────────────────────────────────────────────
   const [role, setRole] = useState('')
@@ -330,7 +334,9 @@ export default function OnboardingFlow({
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [open, step, finish, savingProfile])
+    // shellHost?.sectionSlot: in host mode the dialog mounts a pass after the
+    // flow opens, so re-run once it exists to install the trap + initial focus.
+  }, [open, step, finish, savingProfile, dialogRef, shellHost?.sectionSlot])
 
   if (!open) return null
 
@@ -357,15 +363,21 @@ export default function OnboardingFlow({
   if (step === 1) {
     return (
       <OnboardingChapterShell
-        chapterLabel="Customize"
-        stepIndex={1}
-        stepCount={2}
+        eyebrow={`Customize · 1 ${i18nT('components.onboardingChapterShell.of')} 2`}
         ariaLabel={i18nT('components.onboardingFlow.customize_kirocrew')}
         panelHeadline="Make it yours."
         panelBody="Set your look and tell Kiro about you so responses fit the way you work."
         panelFootnote="Change anything later in Settings."
-        title={i18nT('components.onboardingFlow.pick_your_look')}
-        description={i18nT('components.onboardingFlow.choose_a_color_theme_and_mode_you_can_change_it')}
+        header={
+          <div className="mt-6">
+            <h1 tabIndex={-1} className="text-2xl font-semibold text-text-strong outline-none">
+              {i18nT('components.onboardingFlow.pick_your_look')}
+            </h1>
+            <p className="mt-2 text-sm leading-relaxed text-muted">
+              {i18nT('components.onboardingFlow.choose_a_color_theme_and_mode_you_can_change_it')}
+            </p>
+          </div>
+        }
         onSkipAll={finish}
         dialogRef={dialogRef}
         footer={<SendBtn type="button" onClick={next}>{i18nT('components.onboardingFlow.continue')}</SendBtn>}
@@ -427,15 +439,21 @@ export default function OnboardingFlow({
     }
     return (
       <OnboardingChapterShell
-        chapterLabel="Customize"
-        stepIndex={2}
-        stepCount={2}
+        eyebrow={`Customize · 2 ${i18nT('components.onboardingChapterShell.of')} 2`}
         ariaLabel={i18nT('components.onboardingFlow.customize_kirocrew')}
         panelHeadline="Make it yours."
         panelBody="Set your look and tell Kiro about you so responses fit the way you work."
         panelFootnote="Change anything later in Settings."
-        title={i18nT('components.onboardingFlow.tell_kiro_about_you')}
-        description={i18nT('components.onboardingFlow.answers_set_how_kiro_explains_things_plain_langu')}
+        header={
+          <div className="mt-6">
+            <h1 tabIndex={-1} className="text-2xl font-semibold text-text-strong outline-none">
+              {i18nT('components.onboardingFlow.tell_kiro_about_you')}
+            </h1>
+            <p className="mt-2 text-sm leading-relaxed text-muted">
+              {i18nT('components.onboardingFlow.answers_set_how_kiro_explains_things_plain_langu')}
+            </p>
+          </div>
+        }
         onSkipAll={finish}
         skipDisabled={savingProfile}
         dialogRef={dialogRef}


### PR DESCRIPTION
## Problem

During first-run onboarding, the modal visibly **glitched** at the hand-off from
the **Import setup** flow to the **Customize** chapter: the accent panel and its
floating ghost mascots flashed / replayed their entrance animation for a frame,
even though the two screens look nearly identical.

## Why it matters

This is the very first thing a brand-new user sees. A janky flash on the opening
screen undercuts the polish of the whole first-run experience and reads as a bug.

## Fix (symptom → root cause → change)

- **Symptom:** mascots re-animate / the panel flashes when moving from Import
  setup to Customize (and between customize steps).
- **Root cause:** `AgentImportFlow` and `OnboardingFlow` (steps 1–2) each
  rendered their **own** `createPortal` modal with a byte-for-byte copy of the
  scrim + accent panel + mascots. At the hand-off `App` unmounted one portal and
  mounted the other, so the accent panel (and its framer-motion mascots)
  **remounted** and replayed the entrance — a real DOM teardown, not just a
  repaint.
- **Change:** introduce **`OnboardingShellHost`**, a single persistent host that
  owns the scrim + accent panel + mascots and mounts them **exactly once**. Both
  flows still call `OnboardingChapterShell`, which now detects the host via React
  context and portals only its **right-column content** (header / body / footer)
  into the host's persistent `<section>`, registering just its aside copy
  (headline / body / footnote + `aria-label`) as scalar state. Across the
  import→customize and step 1→2 hand-offs nothing in the accent panel remounts,
  so the mascots keep their animation state and never replay. Outside a host
  (unit tests) the shell still renders its own full chrome, so isolated behavior
  is unchanged. Each flow resolves its focus-trap dialog ref from the host when
  present, and its focus effect re-runs once the host dialog/section mounts
  (the host portal mounts a commit after the flow opens).

Net effect on `AgentImportFlow.tsx` is a large deletion: its duplicated
container markup and local `FloatingGhost` are removed in favor of the shared
shell.

## Tests

- `website/src/components/AgentImportFlow.test.tsx` (14) and
  `website/src/test/OnboardingFlow.test.tsx` (12) — all pass. These render each
  flow **standalone** (no host), which exercises the fallback path and locks in
  that the shell still renders its own dialog, headings, footer nav, focus trap
  (Tab/Shift+Tab wrap, Escape), and the profile-persistence / import-apply
  behavior unchanged.
- No new tests were added: the change is a structural refactor of the modal
  container with no new user-facing behavior; the existing suites already cover
  both flows' contracts, and the persistent-host path is composed only in `App`.

## Manual verification

- `tsc -b`, `eslint`, and the two vitest suites (26 tests) are green locally.
- Local AI-reviewer mirror pass (GPT + Opus/AUTOSDE contracts): no AUTOSDE
  blocking-rule hits; the one substantive finding (focus effects not re-running
  when the host dialog mounts a pass later) is fixed by adding host
  section-slot readiness to both flows' focus-effect deps.

## Screenshots

This is a **motion/transition** fix: the two screens are visually unchanged at
rest, so a still frame cannot show the delta — the fix is that the accent panel
no longer remounts (mascots don't replay) during the import→customize hand-off.
The meaningful evidence is a recording of that transition; the automated Design/UX
review gates assess the rendered result. The affected surfaces (Import setup and
Customize) are otherwise identical to `main`.
