### PR TITLE
refactor(messaging): extract the shared channel turn pipeline

### DIFF
--- a/src/kiro_crew/messaging/dispatch.py
+++ b/src/kiro_crew/messaging/dispatch.py
@@ -1,0 +1,252 @@
+"""Shared channel turn pipeline — one copy of the dispatch skeleton.
+
+Every non-Slack channel dispatcher repeated the same sequence around
+:class:`TurnDriver`. Measured on main before this extraction: 7
+``transport_dispatch.py`` files totalling 3,796 lines, of which roughly
+two-thirds was identical after normalizing channel names (weixin vs wecom
+differed on 248 of ~760 combined lines). This module owns that skeleton:
+
+    governance gate
+    -> renderer.on_turn_start()          (typing indicator before cold start)
+    -> sessions.get_or_create + set_channel
+    -> publish_turn_identity
+    -> ctx_builder.build_message         (off-loop, embeds block)
+    -> TurnDriver.run                    (shared redaction + approval ladder)
+    -> post-turn: record_success, persist, threshold notice, SEL audit
+                                         (each guarded independently)
+    -> finally: renderer.close() + release (release gated on acquire)
+
+What stays per-channel is what actually differs between them: the wire
+protocol, event normalization, ``authorize()`` semantics, rendering, command
+vocabulary, and the ack strings. Channels inject those through
+:class:`ChannelTurn` rather than subclassing, so a capability this protocol
+lacks widens the protocol once instead of forking the pipeline.
+
+Dependency direction is ``<channel> -> messaging`` (never the reverse), so this
+module must not import any channel package.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+from kiro_crew.executors import run_in_embed_pool
+from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
+from kiro_crew.messaging.driver import TurnDriver
+from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
+from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChannelTurn:
+    """Everything the pipeline needs that varies per channel.
+
+    ``persist`` runs in a worker thread (it does blocking history I/O), so it
+    must be a plain sync callable. ``notice`` and ``renderer`` are async.
+    """
+
+    channel_type: str
+    """Governance member name, e.g. ``"weixin"``. Gates every inbound message.
+
+    Invariant: this MUST equal the first ``:``-segment of ``session_key`` —
+    the surface name is the routing authority for governance and (future)
+    control-plane operations. Holds by construction today because every
+    adopter builds its key via ``build_dm_session_key(channel_type, ...)``.
+    """
+
+    session_key: str
+    """The session address. OPAQUE to this pipeline: it is passed through to
+    ``sessions.*`` verbatim and never parsed, split, or rebuilt here. Keys are
+    constructed channel-side via :func:`kiro_crew.messaging.link.build_dm_session_key`
+    (``{surface}:{agent}:{chat_type}:{scope}[:genN]``). Keeping the pipeline
+    address-agnostic is what lets the address grammar evolve (deeper scope
+    paths, new surfaces) without touching dispatch.
+    """
+
+    conversation_id: str
+    """Stable identity of the conversation on its transport (e.g.
+    ``"weixin:{user_id}"``), used for session attribution/UI. Feeds the
+    legacy ``channel_id=`` kwarg of ``sessions.get_or_create`` /
+    ``set_channel`` — the old name survives at that API boundary only.
+    Distinct from BOTH ``channel_type`` (the transport) and the app-platform
+    ``channel:`` concept.
+    """
+
+    agent: str
+    user_text: str
+    renderer: Any
+    """A :class:`kiro_crew.messaging.renderer.Renderer`."""
+
+    approval_mode: str
+    decider: Optional[Any] = None
+    """``None`` for channels with no interactive buttons (deny-by-default for
+    INTERACTIVE mode; ``auto``/``trust`` still work)."""
+
+    persist: Optional[Callable[[str, str, bool], None]] = None
+    """``(user_text, reply_text, is_new) -> None``, called off the event loop."""
+
+    notice: Optional[Callable[[str, Any], Awaitable[None]]] = None
+    """``(session_key, provider) -> None`` post-turn threshold handling."""
+
+    audit_caller: str = ""
+    """SEL audit caller label; defaults to ``<channel_type>:unknown``."""
+
+
+async def inbound_permitted(channel_type: str) -> bool:
+    """Per-message governance gate.
+
+    Rechecked on every message (not just at connect) so a host-profile deny
+    added while the transport is live stops dispatch without a restart. The
+    pipeline calls this itself, so a channel cannot forget it.
+    """
+    if await channel_inbound_permitted(channel_type):
+        return True
+    logger.info("%s inbound dropped: denied by channels governance policy", channel_type)
+    return False
+
+
+def build_tool_gate(ctx_builder: Any, *, session_key: str, agent: str) -> Callable[[Any], str]:
+    """PreToolUse security gate, channel-neutral (off ``ctx_builder.hooks``).
+
+    Sensitive-path keystone + governance ceiling + deny-list. Returns ``"deny"``
+    (un-overridable), ``"auto_approve"``, or ``""`` (passthrough). Built here so
+    no channel package needs to import ``kiro_crew.slack``.
+    """
+
+    def _tool_gate(event: Any) -> str:
+        result = ctx_builder.hooks.on_tool_call(
+            getattr(event, "title", "") or "",
+            session_key=session_key,
+            agent=agent,
+            tool_kind=getattr(event, "tool_kind", "") or "",
+            raw_params=getattr(event, "raw_tool_params", None),
+            command=getattr(event, "shell_command", None),
+            is_shell=bool(getattr(event, "is_shell", False)),
+        )
+        if result.action == TOOL_DENY:
+            return "deny"
+        if result.action == TOOL_AUTO_APPROVE:
+            return "auto_approve"
+        return ""
+
+    return _tool_gate
+
+
+def build_auto_approve(ctx_builder: Any) -> Callable[[str], bool]:
+    """Preserve the ``auto_approve_subagent_spawn`` hook for ``spawn_run``."""
+
+    def _auto_approve(title: str) -> bool:
+        return bool(
+            ctx_builder
+            and ctx_builder.hooks
+            and ctx_builder.hooks.auto_approve_subagent_spawn
+            and title == "spawn_run"
+        )
+
+    return _auto_approve
+
+
+async def drive_turn(turn: ChannelTurn, *, sessions: Any, ctx_builder: Any) -> None:
+    """Run one authorized inbound message end to end.
+
+    Everything acquire-dependent runs INSIDE the try so ``finally`` always
+    finalizes the turn (``renderer.close``), even when ``get_or_create`` raises
+    on a cold-start failure. ``release()`` is gated on ``_acquired`` so a
+    semaphore that was never held is never released.
+    """
+    renderer = turn.renderer
+    session_key = turn.session_key
+    _acquired = False
+    # Enforced governance backstop. Channels SHOULD gate earlier (before any
+    # side effect such as a command ack or a generation bump — see the weixin
+    # dispatcher, which checks before parse_command), but the pipeline rechecks
+    # so an adopter that forgets cannot execute a policy-denied turn. Denied
+    # messages are dropped silently, before the typing indicator and before any
+    # session is acquired.
+    if not await inbound_permitted(turn.channel_type):
+        return
+    try:
+        # Typing indicator first (before the potentially slow cold start);
+        # on_turn_start is idempotent so the driver's later call no-ops.
+        await renderer.on_turn_start()
+        provider, is_new, resumed = await sessions.get_or_create(
+            session_key, agent=turn.agent, channel_id=turn.conversation_id
+        )
+        _acquired = True
+        if is_new:
+            await sessions.set_channel(session_key, turn.conversation_id)
+        # Publish this turn's session identity so managed MCP tools resolve
+        # X-Session-Key; one shared writer lives in messaging.identity.
+        await publish_turn_identity(sessions, session_key)
+        # Off-loop: build_message embeds the episodic query (blocking urllib).
+        full_message, _ = await run_in_embed_pool(
+            ctx_builder.build_message,
+            turn.user_text,
+            is_new,
+            session_key,
+            channel_id=turn.conversation_id,
+            agent=turn.agent,
+            resumed=resumed,
+        )
+
+        driver = TurnDriver(
+            provider,
+            renderer,
+            approval_mode=turn.approval_mode,
+            decider=turn.decider,
+            auto_approve_tool=build_auto_approve(ctx_builder),
+            tool_gate=build_tool_gate(ctx_builder, session_key=session_key, agent=turn.agent),
+        )
+        accumulated = await driver.run(full_message)
+
+        # ── Post-turn bookkeeping. Each step is guarded independently so a
+        # failure here cannot fall through to the except and re-record a turn
+        # that actually succeeded. ──
+        try:
+            sessions.record_success(session_key)
+        except Exception:
+            logger.warning(
+                "%s: record_success failed session=%s",
+                turn.channel_type, session_key, exc_info=True,
+            )
+        if turn.persist is not None:
+            try:
+                await asyncio.to_thread(turn.persist, turn.user_text, accumulated, is_new)
+            except Exception:
+                logger.warning(
+                    "%s: persist_turn failed session=%s",
+                    turn.channel_type, session_key, exc_info=True,
+                )
+        if turn.notice is not None:
+            try:
+                await turn.notice(session_key, provider)
+            except Exception:
+                logger.warning(
+                    "%s: maybe_notice failed session=%s",
+                    turn.channel_type, session_key, exc_info=True,
+                )
+        try:
+            sel().log_api_access(
+                caller=turn.audit_caller or f"{turn.channel_type}:unknown",
+                operation="transport_dispatch.handle",
+                outcome="success",
+                source=turn.channel_type,
+                resources=f"session={session_key}",
+            )
+        except Exception:
+            logger.debug("%s: success audit failed", turn.channel_type, exc_info=True)
+    except Exception:
+        logger.exception("%s transport_dispatch: error handling message", turn.channel_type)
+        if _acquired:
+            await sessions.record_failure(session_key)
+    finally:
+        # Always finalize the turn, even if get_or_create raised before the
+        # semaphore was held. Only release if we actually acquired it.
+        await renderer.close()
+        if _acquired:
+            sessions.release(session_key)

--- a/src/kiro_crew/weixin/transport_dispatch.py
+++ b/src/kiro_crew/weixin/transport_dispatch.py
@@ -26,19 +26,15 @@ Dependency direction is ``weixin -> messaging`` (allowed).
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.executors import run_in_embed_pool
-from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
-from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
-from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
+from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 from kiro_crew.messaging.transport import InboundMessage
-from kiro_crew.sel import sel
 from kiro_crew.weixin.commands import ConversationState, parse_command
 from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
 from kiro_crew.weixin.turn_renderer import WeixinRenderer
@@ -100,8 +96,7 @@ class WeixinDispatcher:
         # Inbound channels-governance gate (off-loop) — recheck per message so a
         # host-profile deny added after connect stops dispatch without a restart
         # (the startup gate only blocks CONNECTING). Silently drop on deny.
-        if not await channel_inbound_permitted("weixin"):
-            logger.info("weixin inbound dropped: denied by channels governance policy")
+        if not await inbound_permitted("weixin"):
             return
         user_id = inbound.user_id
         text = inbound.text
@@ -133,7 +128,7 @@ class WeixinDispatcher:
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
         )
         session_key = self._session_key(user_id)
-        channel_id = f"weixin:{user_id}"
+        conversation_id = f"weixin:{user_id}"
         agent = self._resolve_agent()
 
         renderer = WeixinRenderer(
@@ -146,108 +141,28 @@ class WeixinDispatcher:
             session_key=session_key,
         )
 
-        # Everything acquire-dependent runs INSIDE the try so the finally always
-        # finalizes the turn (renderer.close), even if get_or_create raises on a
-        # cold-start failure. release() is gated on _acquired so we never release
-        # a semaphore we didn't hold.
-        _acquired = False
-        try:
-            # Typing indicator first (before the potentially slow cold start);
-            # on_turn_start is idempotent so the driver's later call no-ops.
-            await renderer.on_turn_start()
-            provider, is_new, resumed = await self.sessions.get_or_create(
-                session_key, agent=agent, channel_id=channel_id
-            )
-            _acquired = True
-            if is_new:
-                await self.sessions.set_channel(session_key, channel_id)
-            # Publish this turn's session identity so managed MCP tools resolve
-            # X-Session-Key; one shared writer lives in messaging.identity.
-            await publish_turn_identity(self.sessions, session_key)
-            # Off-loop: build_message embeds the episodic query (blocking urllib).
-            full_message, _ = await run_in_embed_pool(
-                self.ctx_builder.build_message,
-                text,
-                is_new,
-                session_key,
-                channel_id=channel_id,
+        # The turn skeleton (acquire -> identity -> context -> TurnDriver ->
+        # guarded post-turn -> finally close/release) lives once in
+        # messaging.dispatch. Only the weixin-specific pieces are injected.
+        await drive_turn(
+            ChannelTurn(
+                channel_type="weixin",
+                session_key=session_key,
+                conversation_id=conversation_id,
                 agent=agent,
-                resumed=resumed,
-            )
-
-            # PreToolUse security gate (channel-neutral, off ctx_builder.hooks):
-            # sensitive-path keystone + governance ceiling + deny-list. Returns
-            # "deny" (un-overridable), "auto_approve", or "" (passthrough).
-            def _tool_gate(event: Any) -> str:
-                result = self.ctx_builder.hooks.on_tool_call(
-                    getattr(event, "title", "") or "",
-                    session_key=session_key,
-                    agent=agent,
-                    tool_kind=getattr(event, "tool_kind", "") or "",
-                    raw_params=getattr(event, "raw_tool_params", None),
-                    command=getattr(event, "shell_command", None),
-                    is_shell=bool(getattr(event, "is_shell", False)),
-                )
-                if result.action == TOOL_DENY:
-                    return "deny"
-                if result.action == TOOL_AUTO_APPROVE:
-                    return "auto_approve"
-                return ""
-
-            driver = TurnDriver(
-                provider,
-                renderer,
+                user_text=text,
+                renderer=renderer,
                 approval_mode=self.approval_mode,
                 decider=None,  # iLink can't render approve/deny buttons
-                # Preserve the auto_approve_subagent_spawn hook for spawn_run
-                # (replicated inline to avoid a weixin -> slack import).
-                auto_approve_tool=lambda title: bool(
-                    self.ctx_builder
-                    and self.ctx_builder.hooks
-                    and self.ctx_builder.hooks.auto_approve_subagent_spawn
-                    and title == "spawn_run"
+                persist=lambda user_text, reply, is_new: self._persist_turn(
+                    session_key, user_text, reply, is_new
                 ),
-                tool_gate=_tool_gate,
-            )
-            accumulated = await driver.run(full_message)
-
-            # ── Post-turn bookkeeping (each guarded so a failure here can't
-            # fall through to the except and re-record the successful turn). ──
-            self.sessions.record_success(session_key)
-            try:
-                await asyncio.to_thread(
-                    self._persist_turn, session_key, text, accumulated, is_new
-                )
-            except Exception:
-                logger.warning(
-                    "weixin: persist_turn failed session=%s", session_key, exc_info=True
-                )
-            try:
-                await self._maybe_notice(user_id, session_key, provider)
-            except Exception:
-                logger.warning(
-                    "weixin: maybe_notice failed session=%s", session_key, exc_info=True
-                )
-            try:
-                sel().log_api_access(
-                    caller=f"weixin:{user_id}",
-                    operation="transport_dispatch.handle",
-                    outcome="success",
-                    source="weixin",
-                    resources=f"session={session_key}",
-                )
-            except Exception:
-                logger.debug("weixin: success audit failed", exc_info=True)
-        except Exception:
-            logger.exception("weixin transport_dispatch: error handling message")
-            if _acquired:
-                await self.sessions.record_failure(session_key)
-        finally:
-            # Always finalize the turn, even if get_or_create raised before the
-            # semaphore was held. Only release if we actually acquired it.
-            await renderer.close()
-            if _acquired:
-                self.sessions.release(session_key)
+                notice=lambda sk, provider: self._maybe_notice(user_id, sk, provider),
+                audit_caller=f"weixin:{user_id}",
+            ),
+            sessions=self.sessions,
+            ctx_builder=self.ctx_builder,
+        )
 
     async def _handle_busy(self, inbound: InboundMessage, session_key: str) -> None:
         """Mid-turn message: fold into the running turn via steer.

--- a/test/test_identity_topology.py
+++ b/test/test_identity_topology.py
@@ -544,15 +544,29 @@ def test_every_channel_transport_dispatch_publishes_identity() -> None:
         "no */transport_dispatch.py surfaces discovered — the channel dispatch "
         "layout changed; update this guard so it keeps covering every surface."
     )
-    missing = [
-        str(p.relative_to(src))
-        for p in dispatchers
-        if "publish_turn_identity" not in p.read_text(encoding="utf-8")
-    ]
+    # A surface satisfies the contract either by calling the shared publisher
+    # directly, or by delegating its turn to the shared pipeline
+    # (messaging.dispatch.drive_turn), which publishes on the channel's behalf.
+    # The delegation branch is only sound while the pipeline itself publishes,
+    # so that is asserted first — otherwise "calls drive_turn" would become a
+    # loophole that silently reintroduces the #232 gap for every adopter at once.
+    pipeline = src / "messaging" / "dispatch.py"
+    assert "publish_turn_identity" in pipeline.read_text(encoding="utf-8"), (
+        "messaging/dispatch.py no longer publishes per-turn session identity. "
+        "Every channel delegating to drive_turn depends on it, so removing the "
+        "call reintroduces the #232 'missing X-Session-Key' gap for ALL of them."
+    )
+    missing = []
+    for p in dispatchers:
+        text = p.read_text(encoding="utf-8")
+        if "publish_turn_identity" in text or "drive_turn" in text:
+            continue
+        missing.append(str(p.relative_to(src)))
     assert not missing, (
         "channel transport-dispatch surface(s) run a turn without publishing "
         f"per-turn session identity: {missing}. Every channel turn must call "
-        "messaging.identity.publish_turn_identity so managed MCP tools resolve "
+        "messaging.identity.publish_turn_identity — directly, or by delegating "
+        "to messaging.dispatch.drive_turn — so managed MCP tools resolve "
         "X-Session-Key; otherwise they fail with HTTP 400 'missing "
         "X-Session-Key' from that channel (#232)."
     )

--- a/test/test_weixin_dispatch.py
+++ b/test/test_weixin_dispatch.py
@@ -454,7 +454,7 @@ def test_governance_deny_drops_the_message_before_any_turn(tmp_path, monkeypatch
     The startup gate only blocks CONNECTING, so without this per-message recheck
     an inbound DM would drive an unauthorized turn until the gateway restarted.
     """
-    import kiro_crew.weixin.transport_dispatch as mod
+    import kiro_crew.messaging.dispatch as mod
 
     provider = FakeProvider()
     d, client, sessions = _make(tmp_path, provider=provider)
@@ -471,7 +471,7 @@ def test_governance_deny_drops_the_message_before_any_turn(tmp_path, monkeypatch
 
 
 def test_governance_permit_allows_the_turn(tmp_path, monkeypatch):
-    import kiro_crew.weixin.transport_dispatch as mod
+    import kiro_crew.messaging.dispatch as mod
 
     provider = FakeProvider("allowed")
     d, client, _ = _make(tmp_path, provider=provider)
@@ -482,6 +482,57 @@ def test_governance_permit_allows_the_turn(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "channel_inbound_permitted", permit)
     asyncio.run(d.handle_message(_msg("go")))
     assert [s["text"] for s in client.sent] == ["allowed"]
+
+
+def test_pipeline_enforces_the_gate_even_if_a_channel_forgets(tmp_path, monkeypatch):
+    """drive_turn itself denies — an adopter cannot bypass governance.
+
+    The channel-side check is a fail-fast (it must run before command acks and
+    generation bumps, which are side effects a denied sender must not cause).
+    This pins the pipeline's own backstop: calling drive_turn directly with a
+    denied channel_type must not start the renderer or acquire a session, so a
+    future channel that forgets its early check still cannot run a turn.
+    """
+    import kiro_crew.messaging.dispatch as mod
+
+    provider = FakeProvider()
+    d, client, sessions = _make(tmp_path, provider=provider)
+
+    async def deny(_channel_type):
+        return False
+
+    monkeypatch.setattr(mod, "channel_inbound_permitted", deny)
+
+    started: list[str] = []
+
+    class SpyRenderer:
+        capabilities = WEIXIN_CAPABILITIES
+
+        async def on_turn_start(self):
+            started.append("start")
+
+        async def close(self):
+            started.append("close")
+
+    asyncio.run(
+        mod.drive_turn(
+            mod.ChannelTurn(
+                channel_type="weixin",
+                session_key="weixin:kirocrew:direct:u1",
+                conversation_id="weixin:u1",
+                agent="kirocrew",
+                user_text="should never run",
+                renderer=SpyRenderer(),
+                approval_mode=APPROVAL_AUTO,
+            ),
+            sessions=sessions,
+            ctx_builder=d.ctx_builder,
+        )
+    )
+
+    assert started == []  # no typing indicator, no close -> returned before try
+    assert provider.prompts == []  # no turn ran
+    assert sessions.successes == 0
 
 
 def test_soft_threshold_notice_fires_once(tmp_path):
@@ -520,7 +571,7 @@ def test_tool_gate_denies_when_hooks_deny(tmp_path):
     # assert the closure maps the hook result onto the driver's contract.
     captured: dict[str, Any] = {}
 
-    import kiro_crew.weixin.transport_dispatch as mod
+    import kiro_crew.messaging.dispatch as mod
 
     real_driver = mod.TurnDriver
 


### PR DESCRIPTION
# refactor(messaging): extract the shared channel turn pipeline

PR ① of the channel-plugin RFC (#689) migration plan.

## Problem

Every messaging channel carries a hand-copied clone of the same turn-dispatch skeleton — 7 dispatchers, 3,796 lines, ~⅔ identical after channel-name normalization (weixin↔wecom differ on 248 of ~760 combined lines). Each new channel copies the skeleton again (an 8th copy was pending for Feishu), so every solved bug class must be re-fixed per copy. Two such classes were still live in the clone, and this PR closes both (see Fix).

## Why it matters

The duplication grows ~380 lines per channel and turns every cross-cutting fix (release-semaphore safety, post-turn failure isolation, the governance gate, audit) into seven parallel edits. The RFC's endpoint — channels as plugins — is unreachable while the turn lifecycle lives inside each channel package.

## Fix (symptom → root cause → change)

Symptom: N copies of one dispatch skeleton, drifting. Root cause: no shared home for the channel-neutral turn lifecycle — `messaging/` owned the transport contract but not the pipeline. Change: extract the skeleton **verbatim** from the weixin dispatcher (smallest, freshest tests) into `src/kiro_crew/messaging/dispatch.py`, and have weixin call it (377 → 292 lines):

- `inbound_permitted()` — the channels-governance gate.
- `build_tool_gate()` / `build_auto_approve()` — PreToolUse gating off `ctx_builder.hooks`; lives here so no channel package imports `kiro_crew.slack`.
- `ChannelTurn` — the per-channel variation surface. Names the transport conversation identity `conversation_id` (the legacy `channel_id=` kwarg survives only at the `sessions.*` boundary), and documents two invariants for PR ③: the session key is **opaque** to the pipeline, and `channel_type` equals the key's first segment.
- `drive_turn()` — the skeleton, invariants preserved verbatim: `on_turn_start` before `get_or_create` (typing indicator before a slow cold start), `_acquired`-gated `release()` (a semaphore never held is never released, including when `get_or_create` raises), `renderer.close()` first in `finally`, `persist` via `asyncio.to_thread`, episodic embed via `run_in_embed_pool`.

Two hardenings on top of the verbatim lift. Both were pre-existing in the clone dispatchers — **neither is a regression from this move**, and both are exactly the class of bug that only gets fixed once now that there is one copy:

1. **`drive_turn()` performs the governance check itself**, so an adopter that forgets cannot execute a policy-denied turn. Channels keep their earlier fail-fast: weixin gates before `parse_command`, because a command ack and a generation bump are side effects a denied sender must not cause, and the pipeline runs after those. The pipeline check is the enforced backstop, not a replacement — deliberately not de-duplicated. The check returns **before** the `try`, so no typing indicator fires, no session is acquired, and `renderer.close()` does not run on the deny path (`close()` would emit `on_done(stop_reason="error")` and send a message to the denied sender).
2. **`record_success()` is now guarded** like the other post-turn steps. It was the only unguarded one, sitting under a comment claiming all were guarded, so a raise there fell through to the `except` and re-recorded a successful turn as failed — advancing the circuit breaker toward a session reset.

Deliberately left channel-side: command intercept and busy/steer handling (ack strings are per-channel — weixin's are Chinese). They generalize in PR ② once three more adopters show what is genuinely shared.

## Tests

- 3 existing tests' monkeypatch targets repointed from `kiro_crew.weixin.transport_dispatch` to `kiro_crew.messaging.dispatch` — the seams moved by design, and coverage is now stronger: those tests pin the gate for every future adopter, not just weixin.
- New `test_pipeline_enforces_the_gate_even_if_a_channel_forgets` calls `drive_turn` directly with a denied `channel_type` and asserts no typing indicator, no session acquisition, no turn — locking hardening (1) against future adopters.
- Full gate green: 91 weixin tests (`test_weixin_dispatch.py` + `test_weixin.py` + `test_weixin_qr.py`), `flake8`, `isort`, `mypy` (528 files).

## Manual verification

N/A — behavior-preserving extraction with unit coverage over every moved seam (governance deny drops the message, tool-gate deny/auto-approve mapping, conversation id set on new sessions, release-on-failure). The weixin channel's live end-to-end path (QR login → chat turn) was verified against this dispatcher lineage in #627 / #711.

## Screenshots

N/A — backend-only.

## Accepted, not fixed

- **Double governance evaluation (LOW):** a permitted message now walks the ProfileStore twice — once channel-side, once in `drive_turn`. That is the cost of an enforced backstop; the fix if it ever shows under burst load is a memoized per-message result, which is speculative at current load.
- **Policy-flip window:** if a deny lands between the two evaluations, the message drops after `maybe_rotate` already advanced the idle/daily generation. Recoverable local state, no data loss.
