### PR TITLE
docs(rfc): amend channel RFC with the session address model decision

### DIFF
--- a/docs/request-for-change/rfc-channel-plugin-architecture.md
+++ b/docs/request-for-change/rfc-channel-plugin-architecture.md
@@ -119,3 +119,80 @@ Each PR lands green on the existing suites; no behavior change until ⑤.
 - **Channels as separate processes (MCP-style).** Real isolation, but adds IPC latency to typing-indicator lifecycles, complicates session/renderer state, and duplicates the app platform's trust story. Deferred as the isolation tier, not the foundation.
 - **Keep typed dataclass config.** Defensible in a monolith; incompatible with out-of-tree plugins (they cannot edit `loader.py`). Schema validation + contract tests replace the type safety, matching the manifest's existing trade.
 - **A channel-only plugin mechanism separate from apps.** Rejected: two discovery/trust/distribution systems to maintain, and the apps platform already solved loading, admission, and signing.
+
+## 9. Amendment: session address model (decided 2026-07-29)
+
+PR ③ introduces the channel registry and the host's control seams. Before it
+lands, the shape of a session address must be fixed — otherwise the control
+plane inherits the dashboard's slot-shaped addressing, which is exactly what
+makes channel sessions unmanageable today.
+
+### Motivation (measured)
+
+- The dashboard's stop/interrupt path (`/api/chat/slots/{slot}/stop`) resolves
+  its target via `state._slots.get(name)`. All cancellation state
+  (`_stop_state`, queue, pending steers, soft→hard escalation) lives on the
+  slot object. A channel conversation has no slot, so a stuck WeChat turn
+  cannot be observed or stopped from the dashboard — there is no address by
+  which to name it.
+- Cross-surface mirroring (`dashboard/chat_mirror.py`) is one-way (dashboard →
+  channel) and fires on turn completion — a hung turn never mirrors anything.
+- `InboundMessage` carries exactly two address levels (`conversation_id`,
+  `thread_id`); real topologies need more (Discord guild/channel/thread,
+  Feishu group/topic), and the shortfall has already degraded into key
+  string-munging (`session_map.py`'s `dashboard:dashboard_*` double-prefix
+  repair).
+
+### Options considered
+
+| | A: typed address object everywhere | B: opaque key + canonical grammar + single builder/parser | C: two-level ids (status quo) | D: URI scheme |
+|---|---|---|---|---|
+| Migration | every `sessions.*` call site | **zero — existing keys already fit** | zero | full rekey |
+| Arbitrary depth | yes | **yes (scope path)** | no — already proven insufficient | yes |
+| Fits a behavior-preserving PR ③ | no | **yes** | bakes in the wrong shape | no |
+| Matches existing code | no | **yes** (`_STATELESS_PREFIXES` routes on first segment; `build_dm_session_key` shared by 6 of 7 channels) | partial | no |
+
+**Decision: B.**
+
+### Rules
+
+1. **`session_key` is THE address** for every session (channel, dashboard,
+   cron, subagent). Control-plane operations (observe/steer/stop) are keyed by
+   session: `/api/sessions/{key}/…`, never `/api/chat/slots/{slot}/…`. A slot
+   is a dashboard-local alias resolved to a key at the dashboard edge.
+2. **Canonical conversational grammar** (blessing `build_dm_session_key`'s
+   existing shape): `{surface}:{agent}:{chat_type}:{scope…}[:genN]`. The first
+   segment is the surface and is the routing authority — the same convention
+   `_STATELESS_PREFIXES` already uses. `scope…` is one or more segments and is
+   where hierarchy depth lives.
+3. **Address ≠ organization.** The scope path encodes where a conversation
+   lives in the transport's own topology (immutable). Dashboard folders are
+   mutable UI metadata and stay out of the address: moving a session between
+   folders never changes its identity.
+4. **Exactly one builder/parser module** (extend `messaging/link.py` in PR ③).
+   Segments are colon-free, enforced at build time. The `session_map.py`
+   double-prefix repair moves into this parser and dies in one place.
+5. **The dispatch pipeline stays address-agnostic** — it passes keys through
+   verbatim and never parses them. Pinned in `messaging/dispatch.py`
+   docstrings by PR ①, contract-tested when the parser lands in PR ③.
+
+### Accepted debts
+
+- Slack and `dashboard:` keys predate the grammar. The parser must tolerate
+  them; migration is explicitly out of PR ③'s scope.
+- The app-platform `channel:{id}:{agent}` prefix collides with messaging
+  vocabulary. Noted, not renamed now. New code says `conversation_id` for
+  transport conversation identity (the legacy `channel_id=` kwarg survives
+  only at the `sessions.*` boundary).
+
+### Consequences for the migration plan
+
+- PR ③ keys the registry and any session-control surface by `session_key` and
+  ships the parser module with contract tests (including
+  `channel_type == first segment`).
+- PR ①'s `drive_turn` is the single seam through which every channel turn
+  passes; future cancellation checks attach there — one insertion point, not
+  seven.
+- The eventual dashboard-as-surface unification (dashboard = host + one
+  builtin surface with declared capabilities) builds on this address model; it
+  is deliberately out of scope for PRs ①–⑤.


### PR DESCRIPTION
# docs(rfc): amend channel RFC with the session address model decision

## Problem

PR ③ of the channel-plugin migration (#689) introduces the channel registry and the host's control seams. The shape of a session address is currently undecided, and the only existing control plane is slot-addressed: `/api/chat/slots/{slot}/stop` resolves via `state._slots.get(name)`, so a session with no dashboard slot (any channel conversation) cannot be observed or stopped at all. Without a recorded decision, PR ③ would inherit that slot shape.

## Why it matters

Channel sessions are today unobservable and unsteerable from the dashboard — a stuck WeChat turn cannot be stopped. The address model is the primitive that fixes this, and it is expensive to widen after PR ③ bakes it into the registry and API surface. Recording it now (with the options comparison) is what keeps PR ③ small.

## Fix (symptom → root cause → change)

Symptom: unmanageable channel sessions and string-munged keys (`session_map.py`'s `dashboard:dashboard_*` double-prefix repair). Root cause: no canonical session address — three coexisting key grammars and a two-level `InboundMessage` that cannot express real transport topologies. Change: a new **§9 Amendment** in `docs/request-for-change/rfc-channel-plugin-architecture.md` recording the decision:

- `session_key` is THE address; control-plane ops are `/api/sessions/{key}/…`; a slot is a dashboard-local alias.
- Canonical grammar `{surface}:{agent}:{chat_type}:{scope…}[:genN]` — blesses the existing `build_dm_session_key` shape (already used by 6 of 7 channels); first segment routes, matching `_STATELESS_PREFIXES`.
- Address ≠ organization: dashboard folders stay out of the address.
- One builder/parser module (extend `messaging/link.py` in PR ③), colon-free segments, contract tests.
- The dispatch pipeline stays address-agnostic (invariant pinned in PR ①'s docstrings).

Plus the four-way options comparison (typed object / opaque key + grammar / two-level ids / URI), accepted debts (legacy slack + dashboard keys tolerated by the parser; the app-platform `channel:` prefix collision), and consequences for PRs ①/③.

## Tests

N/A — docs only.

## Manual verification

Every measured claim in the amendment (slot-addressed stop path, one-way completion-time mirroring, two-level `InboundMessage`, double-prefix repair, `_STATELESS_PREFIXES` first-segment routing, `build_dm_session_key` adoption count) was verified against source at `5661dcb6` in the working session that produced this decision.

## Screenshots

N/A — docs only.

---

Related: #777 (PR ① of this migration) pins the pipeline-side invariants this amendment records — session-key opacity and `channel_type` = first key segment.
