### PR TITLE
fix(dashboard): use Cmd+, for Open settings on macOS

### DIFF
--- a/website/src/hooks/useKeyboardShortcuts.ts
+++ b/website/src/hooks/useKeyboardShortcuts.ts
@@ -53,7 +53,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
   { id: 'new-chat', key: 'n', alt: true, shift: true, label: 'New chat', group: 'Actions' },
   { id: 'close-chat', key: 'w', alt: true, shift: true, label: 'Close session', group: 'Actions' },
   { id: 'shortcuts-modal', key: 'k', alt: true, label: 'Open shortcuts help', group: 'Actions' },
-  { id: 'open-settings', key: ',', alt: true, label: 'Open settings', group: 'Actions' },
+  { id: 'open-settings', key: ',', alt: !IS_MAC, meta: IS_MAC, label: 'Open settings', group: 'Actions' },
   { id: 'cycle-agent', key: 'a', alt: true, shift: true, label: 'Cycle agent', group: 'Actions' },
   { id: 'cycle-prev-agent', key: 'z', alt: true, shift: true, label: 'Previous agent', group: 'Actions' },
   { id: 'cycle-reasoning', key: 'd', alt: true, shift: true, label: 'Cycle reasoning effort', group: 'Actions' },
@@ -112,7 +112,7 @@ export const CORE_PANEL_MAP: Record<string, string> = {
 export const RESERVED_PANEL_CODES: ReadonlySet<string> = new Set<string>([
   ...Object.keys(CORE_PANEL_MAP),
   'KeyK', // shortcuts modal (Alt+K)
-  'Comma', // settings (Alt+,)
+  'Comma', // settings (Cmd+, on macOS, Alt+, elsewhere; Alt+, stays bound on Mac)
   'Enter', // focus text input (Alt+Enter)
   'Backquote', // MRU toggle (Alt+`)
   'ArrowLeft',
@@ -165,6 +165,32 @@ export function registerPanelShortcut(entry: { code: string; path: string; label
 }
 
 const isMac = () => typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
+
+/**
+ * True when `e` is the platform's "open Settings" chord.
+ *
+ * macOS uses ⌘+, — the OS-standard Preferences chord, and the same one the
+ * desktop app's "Settings…" menu item advertises (electron/app-menu.js binds
+ * `CmdOrCtrl+,`). Windows/Linux uses Alt+,, matching every other in-page
+ * shortcut there.
+ *
+ * Option+, remains accepted on macOS, unadvertised: a Mac browser can claim
+ * ⌘+, as its own Preferences accelerator before the page ever sees the keydown,
+ * so dropping the Option chord would leave those users with no keyboard route
+ * to Settings. Exactly one primary modifier is required either way, so the
+ * chord can't fire from ⌘⌥, or ⌃, misses.
+ *
+ * `mac` is injectable so both platform behaviours are testable without
+ * reloading the module (IS_MAC is fixed at module load).
+ */
+export function isSettingsChord(
+  e: Pick<KeyboardEvent, 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+  mac: boolean = IS_MAC,
+): boolean {
+  if (e.code !== 'Comma' || e.shiftKey || e.ctrlKey) return false
+  const altOnly = e.altKey && !e.metaKey
+  return mac ? (e.metaKey && !e.altKey) || altOnly : altOnly
+}
 
 export function formatShortcut(def: ShortcutDef): string {
   const mac = isMac()
@@ -257,6 +283,18 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
       return
     }
 
+    // Settings — ⌘+, on macOS, Alt+, on Windows/Linux (see isSettingsChord for
+    // why, and for the Option+, fallback Mac browsers still need). Handled
+    // BEFORE the Alt gate below because the Mac chord carries no Alt. Fires
+    // even when shortcuts are globally disabled, so the user can always reach
+    // the toggle that re-enables them. The `code` test is the cheap fast path
+    // that keeps the predicate off the hot keystroke path.
+    if (code === 'Comma' && isSettingsChord(e)) {
+      e.preventDefault()
+      navigate('/settings')
+      return
+    }
+
     // All other shortcuts use Alt (Option on Mac)
     if (!e.altKey || e.ctrlKey || e.metaKey) return
 
@@ -264,13 +302,6 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
     if (code === 'KeyK' && !e.shiftKey) {
       e.preventDefault()
       onToggleShortcutsModal()
-      return
-    }
-
-    // Alt+,: Settings — always works so user can re-enable shortcuts
-    if (code === 'Comma' && !e.shiftKey) {
-      e.preventDefault()
-      navigate('/settings')
       return
     }
 

--- a/website/src/test/settingsShortcut.test.tsx
+++ b/website/src/test/settingsShortcut.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * The "Open settings" chord: ⌘+, on macOS, Alt+, on Windows/Linux.
+ *
+ * macOS reserves ⌘+, for Preferences — the desktop app's own "Settings…" menu
+ * item already binds `CmdOrCtrl+,` (electron/app-menu.js) — so the in-page
+ * binding and the shortcuts reference must advertise ⌘+, there, not Option+,.
+ *
+ * `isSettingsChord` takes the platform as an injectable argument, so both
+ * behaviours are asserted without reloading the module (IS_MAC is fixed at
+ * module load, and this file runs in a non-Mac jsdom).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent } from '@testing-library/react'
+
+const navigateSpy = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateSpy }
+})
+
+import {
+  DEFAULT_SHORTCUTS,
+  IS_MAC,
+  RESERVED_PANEL_CODES,
+  SHORTCUTS_ENABLED_KEY,
+  formatShortcut,
+  isSettingsChord,
+  useKeyboardShortcuts,
+} from '../hooks/useKeyboardShortcuts'
+import { createTestStore, renderHookWithProviders } from './helpers'
+import type { RootState } from '../store'
+
+type Chord = Pick<KeyboardEvent, 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>
+
+const chord = (over: Partial<Chord> = {}): Chord => ({
+  code: 'Comma',
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  ...over,
+})
+
+const setPlatform = (val: string) =>
+  Object.defineProperty(navigator, 'platform', { value: val, configurable: true })
+
+describe('isSettingsChord — macOS', () => {
+  it('accepts ⌘+,', () => {
+    expect(isSettingsChord(chord({ metaKey: true }), true)).toBe(true)
+  })
+  it('still accepts Option+, (unadvertised fallback for Mac browsers that eat ⌘+,)', () => {
+    expect(isSettingsChord(chord({ altKey: true }), true)).toBe(true)
+  })
+  it('rejects ⌘⌥+, — exactly one primary modifier', () => {
+    expect(isSettingsChord(chord({ metaKey: true, altKey: true }), true)).toBe(false)
+  })
+  it('rejects ⌃+, and ⌘⌃+,', () => {
+    expect(isSettingsChord(chord({ ctrlKey: true }), true)).toBe(false)
+    expect(isSettingsChord(chord({ metaKey: true, ctrlKey: true }), true)).toBe(false)
+  })
+  it('rejects the shifted form (⌘⇧+, is a different chord)', () => {
+    expect(isSettingsChord(chord({ metaKey: true, shiftKey: true }), true)).toBe(false)
+  })
+  it('rejects a non-comma key', () => {
+    expect(isSettingsChord(chord({ code: 'KeyK', metaKey: true }), true)).toBe(false)
+  })
+})
+
+describe('isSettingsChord — Windows/Linux', () => {
+  it('accepts Alt+,', () => {
+    expect(isSettingsChord(chord({ altKey: true }), false)).toBe(true)
+  })
+  it('rejects Ctrl+, / Meta+, (the shell menu owns CmdOrCtrl+, there)', () => {
+    expect(isSettingsChord(chord({ ctrlKey: true }), false)).toBe(false)
+    expect(isSettingsChord(chord({ metaKey: true }), false)).toBe(false)
+  })
+  it('rejects a bare comma', () => {
+    expect(isSettingsChord(chord(), false)).toBe(false)
+  })
+})
+
+describe('open-settings registry entry', () => {
+  const def = DEFAULT_SHORTCUTS.find(s => s.id === 'open-settings')!
+
+  it('binds the platform primary modifier, never both', () => {
+    expect(def.key).toBe(',')
+    expect(!!def.meta).toBe(IS_MAC)
+    expect(!!def.alt).toBe(!IS_MAC)
+    expect(def.shift).toBeUndefined()
+  })
+
+  it('renders as ⌘, on Mac and Alt + , elsewhere', () => {
+    setPlatform('MacIntel')
+    expect(formatShortcut({ ...def, alt: false, meta: true })).toBe('\u2318,')
+    setPlatform('Win32')
+    expect(formatShortcut({ ...def, alt: true, meta: false })).toBe('Alt + ,')
+  })
+
+  it('keeps Comma reserved against downstream panel registration', () => {
+    // Still consumed before panel routing on both platforms (Option+, remains
+    // bound on Mac), so a downstream panel on Comma would be unreachable.
+    expect(RESERVED_PANEL_CODES.has('Comma')).toBe(true)
+  })
+})
+
+describe('useKeyboardShortcuts — settings navigation', () => {
+  function setup(opts: { enabled?: boolean; disabled?: boolean } = {}) {
+    if (opts.enabled === false) localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
+    const store = createTestStore({
+      dashboard: { slots: [] } as unknown as RootState['dashboard'],
+      chat: { activeSlot: null, slotHistory: [] } as unknown as RootState['chat'],
+    })
+    renderHookWithProviders(
+      () => useKeyboardShortcuts({ onToggleShortcutsModal: () => {}, onNewChat: () => {}, disabled: opts.disabled }),
+      { store },
+    )
+  }
+
+  beforeEach(() => {
+    localStorage.clear()
+    navigateSpy.mockClear()
+  })
+
+  it('runs in a non-Mac jsdom, so Alt+, is the live chord here', () => {
+    expect(IS_MAC).toBe(false)
+  })
+
+  it('Alt+, navigates to /settings', () => {
+    setup()
+    fireEvent.keyDown(document, { code: 'Comma', altKey: true })
+    expect(navigateSpy).toHaveBeenCalledWith('/settings')
+  })
+
+  it('Alt+, still navigates when shortcuts are globally disabled', () => {
+    // The escape hatch: Settings holds the toggle that re-enables shortcuts.
+    setup({ enabled: false })
+    fireEvent.keyDown(document, { code: 'Comma', altKey: true })
+    expect(navigateSpy).toHaveBeenCalledWith('/settings')
+  })
+
+  it('Meta+, does not navigate on a non-Mac platform', () => {
+    setup()
+    fireEvent.keyDown(document, { code: 'Comma', metaKey: true })
+    expect(navigateSpy).not.toHaveBeenCalled()
+  })
+
+  it('Alt+Shift+, does not navigate', () => {
+    setup()
+    fireEvent.keyDown(document, { code: 'Comma', altKey: true, shiftKey: true })
+    expect(navigateSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

The dashboard's in-page "Open settings" chord was `Alt+,` on every platform. On macOS that renders as `⌥,` in the shortcuts modal and Settings → Shortcuts, while `⌘,` — the OS-standard Preferences chord — did nothing in the page. The desktop shell already disagrees with that: `website/electron/app-menu.js` binds `CmdOrCtrl+,` on its "Settings…" item, so the menu and the in-page reference advertised two different chords for the same action.

## Change

- macOS: binding and advertised chord are now `⌘,` (`meta`), matching the OS and the app menu.
- Windows/Linux: unchanged `Alt+,` (the shell menu owns `Ctrl+,` there, and the in-page chords are Alt-based).
- macOS keeps `⌥,` accepted but unadvertised. Mac browsers (Chrome, Safari, Firefox) can claim `⌘,` as their own Preferences accelerator before the page sees the keydown; removing the Option chord would leave those users with no keyboard route to Settings.
- The chord test is extracted as `isSettingsChord(e, mac = IS_MAC)`, a pure predicate. `IS_MAC` is fixed at module load and the test env is not a Mac, so injecting the platform is what makes both behaviours assertable without reloading the module graph.
- Dispatch moved ahead of the Alt gate (`if (!e.altKey || ...) return`) because the Mac chord carries no Alt. It stays ahead of the `enabled` / `disabled` gates, preserving the existing property that Settings — which holds the shortcuts toggle — is reachable even when shortcuts are globally off.
- `Comma` stays in `RESERVED_PANEL_CODES`: it is still consumed before panel routing on both platforms, so a downstream panel registered on it would be unreachable. The `extensionSeams` drift guard still parses the branch (hence the `code === 'Comma'` fast-path test kept inline).

Exactly one primary modifier is required, so `⌘⌥,`, `⌃,` and `⌘⇧,` do not fire.

## Testing

- 17 new tests in `website/src/test/settingsShortcut.test.tsx`: predicate matrix for both platforms, registry entry shape, `formatShortcut` rendering (`⌘,` vs `Alt + ,`), and integration tests that `Alt+,` navigates (including when shortcuts are disabled) while `Meta+,` does not on non-Mac.
- Revert-verified: restoring the old always-Alt predicate fails `accepts ⌘+,`.
- `vitest run` 5721 pass / 473 files, `tsc -b` clean, `eslint` clean. No Python surface touched.

## Not verified

No macOS screenshot: this was built on Linux, where the affected row still renders `Alt + ,`. The display surfaces (shortcuts modal, Settings → Shortcuts) both derive the glyph from `formatShortcut`, which is unit-covered for both platforms, but the `⌘,` cap has not been seen rendered on a real Mac.
