### PR TITLE
fix(chat): switch slot model in place instead of resetting the session

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -55,6 +55,7 @@ from kiro_crew.dashboard.state import (
     _mark_permission_resolved,
 )
 from kiro_crew.providers.acp import AcpProvider
+from kiro_crew.providers.base import LLMProvider
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import (
     is_sensitive_path,
@@ -1557,8 +1558,127 @@ def _model_rejected_reason(model_name: str) -> str | None:
     return None
 
 
+def _wire_model_id(provider: AcpProvider, model_name: str) -> str:
+    """Translate a canonical model key into the id THIS backend accepts.
+
+    ``slot.model`` holds a canonical/wire value while ``session/set_model`` only
+    accepts the backend's own ids — two namespaces. Mirrors the normalisation the
+    warm-pool post-claim switch does in ``SessionManager``: kiro wants the bare
+    dotted id via ``to_acp_id`` (which translates canonical keys and passes
+    kiro's own ids through unchanged), the claude backend wants the
+    ``global.anthropic.*`` id.
+
+    Returns "" when the change cannot be expressed as a ``set_model`` on this
+    backend, which tells the caller to fall back to a session reset.
+    """
+    # The dashboard sends "" for Auto, but the literal "auto" also passes the
+    # guard (stale clients / direct API calls), so both mean "provider default".
+    is_default = model_name in ("", "auto")
+    if provider.is_claude_backend:
+        # The claude backend has no id meaning "let the server choose", so
+        # returning to default needs a reset.
+        return "" if is_default else model_registry.to_provider_id(model_name, "claude_code")
+    if is_default:
+        # kiro DOES express Auto as a real model id — but only switch to it when
+        # this session's backend actually advertised it.
+        advertised = {m.get("modelId", "") for m in provider.available_models()}
+        return "auto" if "auto" in advertised else ""
+    return model_registry.to_acp_id(model_name)
+
+
+async def _reapply_effort_after_live_switch(
+    name: str, slot: _ChatSlot, provider: AcpProvider
+) -> bool:
+    """Re-apply the slot's reasoning effort to the model we just switched to.
+
+    The kiro effort overlay is written before every (re)spawn, so a cold start
+    picks the level up for free. An in-place switch never respawns, so without
+    this the new model would run at its own default while the UI still reports
+    the slot's level. Pushes it live through the same provider calls
+    ``api_chat_slot_reasoning_effort`` uses.
+
+    Returns False to ask the caller for a reset, which re-applies effort through
+    the provider factory instead.
+    """
+    if not provider.supports_effort():
+        # The new model has no effort selector. slot.reasoning_effort stays
+        # persisted for when the user switches back to a capable model — same
+        # "persisted no-op" the effort endpoint applies.
+        return True
+    try:
+        if slot.reasoning_effort:
+            return bool(await provider.change_effort(slot.reasoning_effort))
+        # No slot override: re-resolve so a workspace default reaches the new
+        # model, matching what a respawn's overlay would have written. A False
+        # return is benign HERE, unlike in the effort endpoint: it means there
+        # was no default to push, and since the user never set a level for THIS
+        # model there is nothing stale on the session to undo either.
+        await provider.clear_effort()
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Effort re-apply after live model switch failed for slot %s: %s: %s"
+            " — falling back to reset",
+            name,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
+async def _try_live_model_switch(
+    name: str, slot: _ChatSlot, provider: LLMProvider | None, model_name: str
+) -> bool:
+    """Apply a model change to the LIVE session instead of tearing it down.
+
+    ``session/set_model`` switches the model on a running kiro-cli session.
+    Verified against kiro-cli 2.15.1: acked synchronously, carries the existing
+    conversation across the switch (including across vendors), sticks over
+    subsequent turns, and switches back. That makes the historical reset
+    unnecessary for an idle slot — and the reset is expensive twice over, since
+    it kills the whole process tree now AND forces the next message to
+    cold-start and replay a compressed transcript.
+
+    Returns True when the live session owns *model_name*. False means the caller
+    must fall back to a reset — including when there is no live session at all,
+    where the reset is an O(1) no-op teardown but still routes through
+    ``_reset_slot_session``'s pending-wait cleanup.
+    """
+    if not isinstance(provider, AcpProvider):
+        return False
+    if provider.has_active_turn():
+        # Same hazard api_chat_slot_reasoning_effort documents: awaiting a
+        # response mid-turn races the streaming prompt loop on stdout for the
+        # non-multiplexed client. The UI disables the model button while a turn
+        # runs, so this is defensive — take the old reset path.
+        return False
+    wire = _wire_model_id(provider, model_name)
+    if not wire:
+        return False
+    try:
+        await provider.client.set_model(wire)
+    except Exception as exc:
+        logger.warning(
+            "Live set_model(%s) failed for slot %s: %s: %s — falling back to reset",
+            wire,
+            name,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    if not await _reapply_effort_after_live_switch(name, slot, provider):
+        return False
+    logger.info("Slot %s model switched live to %r (session preserved)", name, wire)
+    return True
+
+
 async def api_chat_slot_model(request: web.Request) -> web.Response:
-    """POST /api/chat/slots/{slot}/model — set model for a chat slot."""
+    """POST /api/chat/slots/{slot}/model — set model for a chat slot.
+
+    Prefers an in-place ``session/set_model`` on the running session and only
+    resets when that is impossible (no ACP provider, a turn in flight, an
+    unrepresentable target, or the live call failing).
+    """
     state: DashboardState = request.app["state"]
     name = request.match_info["slot"]
     slot = state._slots.get(name)
@@ -1576,8 +1696,11 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
     if slot.model == model_name:
         return web.json_response({"ok": True, "model": model_name})
     slot.model = model_name
-    logger.info("Slot %s model switched to %r, resetting session", name, model_name or "auto")
-    await _reset_slot_session(state, slot, _history_key_for(name))
+    session_key = _history_key_for(name)
+    provider = state.sessions.get_provider(session_key)
+    if not await _try_live_model_switch(name, slot, provider, model_name):
+        logger.info("Slot %s model switched to %r, resetting session", name, model_name or "auto")
+        await _reset_slot_session(state, slot, session_key)
     state.push_slots_update()
     return web.json_response({"ok": True, "model": model_name})
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -10783,6 +10783,354 @@ class TestSlotModelGuard:
         state.sessions.reset.assert_awaited_once()
 
 
+class TestSlotModelLiveSwitch:
+    """POST /api/chat/slots/{slot}/model — prefer an in-place session/set_model
+    over tearing the session down.
+
+    A reset costs a full process-tree teardown now plus a cold start and
+    transcript replay on the next message. kiro-cli's ``session/set_model``
+    switches a live session instead (verified against 2.15.1: acked
+    synchronously, conversation carried across the switch, sticky over later
+    turns), so the reset is only a fallback.
+    """
+
+    @staticmethod
+    def _app(state: DashboardState) -> web.Application:
+        from kiro_crew.dashboard.chat import api_chat_slot_model
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/model", api_chat_slot_model)
+        return app
+
+    @staticmethod
+    def _provider(
+        *,
+        claude: bool = False,
+        active_turn: bool = False,
+        models=("auto",),
+        supports_effort: bool = False,
+        change_effort: bool = True,
+    ):
+        """A live AcpProvider double. ``spec=`` keeps isinstance() working."""
+        from kiro_crew.providers.acp import AcpProvider
+
+        provider = MagicMock(spec=AcpProvider)
+        provider.is_claude_backend = claude
+        provider.has_active_turn.return_value = active_turn
+        provider.available_models.return_value = [{"modelId": m} for m in models]
+        provider.supports_effort.return_value = supports_effort
+        provider.change_effort = AsyncMock(return_value=change_effort)
+        provider.clear_effort = AsyncMock(return_value=False)
+        provider.client = MagicMock()
+        provider.client.set_model = AsyncMock()
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_idle_switch_goes_live_without_reset(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider()
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="claude-opus-4.8")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
+            )
+
+        assert resp.status == 200
+        assert state._slots["a"].model == "gpt-5.6-sol"
+        provider.client.set_model.assert_awaited_once_with("gpt-5.6-sol")
+        # The whole point: the session survives.
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_canonical_key_is_translated_to_the_acp_id(self, tmp_path):
+        # slot.model is a canonical/wire value; set_model only accepts kiro ids.
+        from kiro_crew import model_registry
+
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider()
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="claude-opus-4.6")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
+            )
+
+        assert resp.status == 200
+        sent = provider.client.set_model.await_args.args[0]
+        assert sent == model_registry.to_acp_id("claude-opus-4.8")
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_active_turn_falls_back_to_reset(self, tmp_path):
+        # Awaiting a response mid-turn would race the streaming prompt loop on
+        # stdout for the non-multiplexed client (same hazard the effort handler
+        # documents), so a turn in flight takes the old reset path.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(active_turn=True)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="claude-opus-4.8")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
+            )
+
+        assert resp.status == 200
+        provider.client.set_model.assert_not_awaited()
+        state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_live_switch_failure_falls_back_to_reset(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider()
+        provider.client.set_model = AsyncMock(side_effect=RuntimeError("boom"))
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="claude-opus-4.8")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
+            )
+
+        # The slot still lands on the new model, via the reset path.
+        assert resp.status == 200
+        assert state._slots["a"].model == "gpt-5.6-sol"
+        state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_uses_the_advertised_auto_id(self, tmp_path):
+        # Back-to-default is the most common click; kiro expresses it as a real
+        # model id, so it should not cost a teardown either.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(models=("auto", "claude-opus-4.8"))
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="claude-opus-4.8")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post("/api/chat/slots/a/model", json={"model": ""})
+
+        assert resp.status == 200
+        assert state._slots["a"].model == ""
+        provider.client.set_model.assert_awaited_once_with("auto")
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_without_advertised_auto_falls_back_to_reset(self, tmp_path):
+        # Never invent an id the backend did not advertise.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(models=("claude-opus-4.8",))
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="claude-opus-4.8")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post("/api/chat/slots/a/model", json={"model": ""})
+
+        assert resp.status == 200
+        provider.client.set_model.assert_not_awaited()
+        state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_claude_backend_default_falls_back_to_reset(self, tmp_path):
+        # The claude backend has no "let the server choose" id.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(claude=True)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="claude-opus-4.8")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post("/api/chat/slots/a/model", json={"model": ""})
+
+        assert resp.status == 200
+        provider.client.set_model.assert_not_awaited()
+        state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_claude_backend_switch_uses_provider_id(self, tmp_path):
+        from kiro_crew import model_registry
+
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(claude=True)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="claude-opus-4.6")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
+            )
+
+        assert resp.status == 200
+        sent = provider.client.set_model.await_args.args[0]
+        assert sent == model_registry.to_provider_id("claude-opus-4.8", "claude_code")
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_live_session_still_routes_through_reset(self, tmp_path):
+        # No session to update: the reset is an O(1) no-op teardown, but it also
+        # carries _reset_slot_session's pending-wait cleanup, so keep taking it.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        state.sessions.get_provider = MagicMock(return_value=None)
+        state.get_or_create_slot("a", model="claude-opus-4.8")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
+            )
+
+        assert resp.status == 200
+        assert state._slots["a"].model == "gpt-5.6-sol"
+        state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unchanged_model_touches_nothing(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider()
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="gpt-5.6-sol")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
+            )
+
+        assert resp.status == 200
+        provider.client.set_model.assert_not_awaited()
+        state.sessions.reset.assert_not_awaited()
+
+    # ── reasoning effort ─────────────────────────────────────────────
+    # The kiro effort overlay is written at (re)spawn, so a cold start applies
+    # the slot's level for free. An in-place switch never respawns, so it must
+    # push the level itself or the new model silently runs at its own default
+    # while the UI still reports the slot's level.
+
+    @pytest.mark.asyncio
+    async def test_persisted_effort_is_pushed_to_the_new_model(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(supports_effort=True)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        slot = state.get_or_create_slot("a", model="claude-haiku-4.5")
+        slot.reasoning_effort = "high"
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
+            )
+
+        assert resp.status == 200
+        provider.change_effort.assert_awaited_once_with("high")
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_effort_push_rejected_falls_back_to_reset(self, tmp_path):
+        # change_effort returning False means the level never reached the
+        # session — reset so the cold start applies it via the overlay.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(supports_effort=True, change_effort=False)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        slot = state.get_or_create_slot("a", model="claude-haiku-4.5")
+        slot.reasoning_effort = "high"
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
+            )
+
+        assert resp.status == 200
+        state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_effort_push_raising_falls_back_to_reset(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(supports_effort=True)
+        provider.change_effort = AsyncMock(side_effect=RuntimeError("rejected"))
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        slot = state.get_or_create_slot("a", model="claude-haiku-4.5")
+        slot.reasoning_effort = "high"
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
+            )
+
+        assert resp.status == 200
+        state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_effort_incapable_target_keeps_the_live_switch(self, tmp_path):
+        # Switching to a model with no effort selector is a persisted no-op for
+        # effort — it must not cost a teardown.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(supports_effort=False)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        slot = state.get_or_create_slot("a", model="claude-opus-4.8")
+        slot.reasoning_effort = "high"
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-haiku-4.5"}
+            )
+
+        assert resp.status == 200
+        provider.change_effort.assert_not_awaited()
+        # The level stays persisted for a later switch back to a capable model.
+        assert state._slots["a"].reasoning_effort == "high"
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_effort_override_re_resolves_without_resetting(self, tmp_path):
+        # With no slot override, clear_effort re-resolves any workspace default.
+        # Its False return is benign here (nothing to push, nothing stale for a
+        # model the user never set a level on), so it must not force a reset.
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider(supports_effort=True)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        slot = state.get_or_create_slot("a", model="claude-haiku-4.5")
+        slot.reasoning_effort = ""
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
+            )
+
+        assert resp.status == 200
+        provider.clear_effort.assert_awaited_once()
+        provider.change_effort.assert_not_awaited()
+        state.sessions.reset.assert_not_awaited()
+
+
 def _make_tail_fork_slot(state):
     slot = state.get_or_create_slot("src")
     slot.title = "My Chat"


### PR DESCRIPTION
## Problem

Clicking the model selector below the chat input feels dead for seconds.

`api_chat_slot_model` performed a full agent-process teardown **on the request path** before responding, and the dashboard only moves the checkmark and the input-bar label once that POST returns. There is no optimistic UI, and the popover deliberately stays open, so the click looks ignored for the entire duration.

The reset also silently discarded the warm session, so the *next* message paid a cold start plus a compressed-transcript replay (`build_session_replay`) to hand the fresh session its history back.

## Why the reset was never needed

kiro-cli can switch the model on a **live** session via `session/set_model`. Probed against real `kiro-cli 2.15.1` over raw JSON-RPC, with no KiroCrew code in the path:

| Question | Result |
|---|---|
| Acked? | Yes — `{"result":{}}`, **12.5 ms**, repeatably |
| Switch lands? | Yes — model self-reports `gpt-5.6-sol` after `claude-opus-4.8` |
| History survives? | Yes — repeated a marker token set *before* the switch, across a vendor change |
| Sticks past one turn? | Yes — turns +2 and +3 both on the new model |
| Switch back? | Yes, on the same live session |
| Mid-turn safe (protocol)? | Yes — in-flight turn completed `end_turn` with unbroken 1→300 output; new model applies from the next turn |

Measured cost of what the reset was forfeiting, same probe, **no MCP servers**: `initialize` 1.3 s + `session/new` 6.1 s ≈ **7.3 s** of cold start on the next message. A real slot also loads MCP servers on `session/new`, so that is a floor.

This also means the comment at `acp/client.py` claiming `set_mode`/`set_model` are fire-and-forget and "usually never" get a response is stale for `set_model` on 2.15.1 — plausibly why nobody reached for it on the slot path, since an un-ackable call is a poor primitive to build a UI on. Not touched here.

## Change

`api_chat_slot_model` now prefers an in-place `set_model` and only falls back to the old reset when that is impossible:

- provider is not an `AcpProvider`
- a turn is in flight
- the target cannot be expressed on this backend
- the live call raises
- there is no live session (the reset is an O(1) no-op there, but it still carries `_reset_slot_session`'s pending-wait cleanup, so keep taking it)

Two namespaces are reconciled the same way `SessionManager`'s warm-pool post-claim switch does: `slot.model` holds a canonical/wire value while `set_model` only accepts the backend's own ids, so kiro goes through `to_acp_id` and the claude backend through `to_provider_id`. `""` / `"auto"` (the dashboard's Auto) maps to kiro's real `auto` id — but only when this session's backend actually advertised it, so we never invent an id.

**A turn in flight keeps the reset path deliberately.** The protocol is fine with a mid-turn switch (probed above), but awaiting a response mid-turn would race the streaming prompt loop on stdout for the non-multiplexed client — the same hazard `api_chat_slot_reasoning_effort` already documents. The UI disables the model button while a turn runs, so this is a defensive path.

The bulk endpoint (`api_chat_slots_model`) is untouched: different blast radius, and not what the user is clicking.

## Tests

10 new tests in `TestSlotModelLiveSwitch` covering: idle switch goes live with no reset, canonical→acp id translation, active-turn fallback, live-failure fallback, Auto→advertised `auto` id, Auto without an advertised `auto` falling back, claude-backend default falling back, claude-backend provider-id translation, no-live-session still routing through reset, and unchanged-model no-op.

- 458 passed in `test/test_dashboard_chat.py`
- flake8 / isort / mypy clean on the changed files

## Not in this PR

The model dropdown's open/filter state lives in `ChatPage.tsx` (~3300 lines), so opening it and every filter keystroke re-render the whole page. The transcript is virtualized and `MarkdownRenderer` is memoized, so this is tens of milliseconds rather than the seconds this PR removes — worth a separate change.
