### PR TITLE
fix(mcp-apps): make rendered apps interactive — display mode, open-link, resize

### DIFF
--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -272,12 +272,49 @@ _APPS_RESOURCE_READ_TIMEOUT_SECS = 10.0
 
 
 def _mcp_apps_enabled() -> bool:
-    """Feature gate for MCP Apps capability injection (default OFF).
+    """Feature gate for MCP Apps: follows the operator's MCP-pooling opt-in.
 
-    Read per-call (not cached at import) so tests and the gateway can toggle
+    Resolution order:
+
+    1. ``KIROCREW_MCP_APPS`` set to ``0``/``false``/``no``/``off`` -> disabled
+       (explicit kill-switch, wins over everything).
+    2. ``KIROCREW_MCP_APPS`` set to ``1``/``true``/``yes`` -> enabled
+       (explicit override, e.g. tests and the e2e harness).
+    3. Unset -> follow ``mcp_gateway.enabled``, read LIVE from config.
+
+    Why config and not "am I running": an earlier version of this gate assumed
+    that executing inside gatewayd implied pooling was enabled. That invariant
+    is FALSE. A restarted gateway *adopts* a surviving daemon, and
+    ``GatewayManager._shutdown_locked`` deliberately refuses to terminate an
+    adopted daemon (ownership discipline -- it must not kill a process it did
+    not spawn, nor unlink a socket a live foreign daemon owns). So disabling
+    ``mcp_gateway`` leaves that survivor serving connected stubs. Keying on
+    "am I running" would have kept intercepting tool results, spooling app
+    payloads (which carry a ``callback_secret``), and rendering server HTML
+    *after the operator explicitly opted out*. Reading the config each call
+    means the survivor observes the opt-out and stands down.
+
+    Read per-call (``KiroCrewConfig.load`` is fingerprint-cached, so this is a
+    dict lookup in the common case) so the gateway reflects a config change
     without a daemon restart.
+
+    Fails CLOSED: if config cannot be read, the feature is disabled. An
+    unreadable config in gatewayd is an abnormal state, and silently disabling
+    an optional rendering feature is the low-harm outcome versus rendering
+    against an operator preference we could not confirm.
     """
-    return os.environ.get(MCP_APPS_ENV_FLAG, "").strip().lower() in ("1", "true", "yes")
+    raw = os.environ.get(MCP_APPS_ENV_FLAG, "").strip().lower()
+    if raw in ("0", "false", "no", "off"):
+        return False
+    if raw in ("1", "true", "yes"):
+        return True
+    try:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        return bool(KiroCrewConfig.load().mcp_gateway.enabled)
+    except Exception:  # pragma: no cover - defensive; fail closed
+        logger.debug("mcp-apps: config unreadable; treating feature as disabled", exc_info=True)
+        return False
 
 
 def _inject_client_extensions(msg: dict[str, Any]) -> dict[str, Any]:

--- a/test/test_mcp_apps_e2e.py
+++ b/test/test_mcp_apps_e2e.py
@@ -191,9 +191,10 @@ async def test_full_pipeline_marker_and_spool(apps_flag_on, spool_tmp):
 
 
 async def test_flag_off_is_a_noop(spool_tmp, monkeypatch):
-    """Flag off: no capability injection (server sees no ui extension), no
-    marker, no spool file — byte-identical passthrough."""
-    monkeypatch.delenv(MCP_APPS_ENV_FLAG, raising=False)
+    """Kill-switch set: no capability injection (server sees no ui extension),
+    no marker, no spool file — byte-identical passthrough. The gate defaults to
+    ON, so disabling requires an explicit falsy value."""
+    monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
     live = await _spawn_live_server()
     try:
         reply = await _handshake_and_draw(live)

--- a/test/test_mcp_gateway_apps_capability.py
+++ b/test/test_mcp_gateway_apps_capability.py
@@ -28,6 +28,15 @@ def _init_frame(capabilities=None):
     return {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": params}
 
 
+def _patch_pooling(monkeypatch, *, enabled: bool) -> None:
+    """Force ``mcp_gateway.enabled`` for the config-keyed gate."""
+    import kiro_crew.config.loader as loader
+
+    real = loader.KiroCrewConfig.load()
+    monkeypatch.setattr(real.mcp_gateway, "enabled", enabled, raising=False)
+    monkeypatch.setattr(loader.KiroCrewConfig, "load", staticmethod(lambda: real))
+
+
 @pytest.fixture
 def flag_on(monkeypatch):
     monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
@@ -35,7 +44,9 @@ def flag_on(monkeypatch):
 
 @pytest.fixture
 def flag_off(monkeypatch):
-    monkeypatch.delenv(MCP_APPS_ENV_FLAG, raising=False)
+    # The gate is a KILL-SWITCH (default ON), so "off" must be set explicitly.
+    # Unsetting the var now means ENABLED -- see test_default_unset_is_on.
+    monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
 
 
 class TestFlagOff:
@@ -46,11 +57,59 @@ class TestFlagOff:
         assert out is msg
         assert msg == before
 
-    def test_falsy_flag_values_stay_off(self, monkeypatch):
-        for value in ("", "0", "false", "no", "off"):
+    def test_explicit_falsy_values_disable(self, monkeypatch):
+        # NOTE: "" is deliberately absent -- an empty/unset value is the DEFAULT,
+        # which is now ON. Only an explicit falsy value disables the feature.
+        for value in ("0", "false", "no", "off", "OFF", " off "):
             monkeypatch.setenv(MCP_APPS_ENV_FLAG, value)
             msg = _init_frame(capabilities={})
-            assert _inject_client_extensions(msg) is msg
+            assert _inject_client_extensions(msg) is msg, value
+
+    def test_unset_follows_pooling_enabled(self, monkeypatch):
+        """Unset => follow ``mcp_gateway.enabled`` read live from config."""
+        monkeypatch.delenv(MCP_APPS_ENV_FLAG, raising=False)
+        _patch_pooling(monkeypatch, enabled=True)
+        out = _inject_client_extensions(_init_frame(capabilities={}))
+        ext = out["params"]["capabilities"]["extensions"]
+        assert ext[MCP_APPS_EXTENSION_KEY] == {"mimeTypes": [MCP_APPS_MIME_TYPE]}
+
+    def test_unset_respects_pooling_opt_out(self, monkeypatch):
+        """Pooling disabled => apps off, even with the env var unset.
+
+        This is the adopted-daemon case: ``_shutdown_locked`` refuses to
+        terminate a daemon it did not spawn, so a survivor keeps serving stubs
+        after the operator disables ``mcp_gateway``. Keying the gate on "am I
+        running" would keep intercepting results and spooling payloads (which
+        carry a callback_secret) after an explicit opt-out.
+        """
+        monkeypatch.delenv(MCP_APPS_ENV_FLAG, raising=False)
+        _patch_pooling(monkeypatch, enabled=False)
+        msg = _init_frame(capabilities={})
+        assert _inject_client_extensions(msg) is msg
+
+    def test_kill_switch_beats_pooling_enabled(self, monkeypatch):
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
+        _patch_pooling(monkeypatch, enabled=True)
+        msg = _init_frame(capabilities={})
+        assert _inject_client_extensions(msg) is msg
+
+    def test_explicit_on_beats_pooling_disabled(self, monkeypatch):
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+        _patch_pooling(monkeypatch, enabled=False)
+        out = _inject_client_extensions(_init_frame(capabilities={}))
+        assert MCP_APPS_EXTENSION_KEY in out["params"]["capabilities"]["extensions"]
+
+    def test_unreadable_config_fails_closed(self, monkeypatch):
+        """A config we cannot read must not enable the feature."""
+        monkeypatch.delenv(MCP_APPS_ENV_FLAG, raising=False)
+        import kiro_crew.config.loader as loader
+
+        def _boom():
+            raise OSError("config unreadable")
+
+        monkeypatch.setattr(loader.KiroCrewConfig, "load", staticmethod(_boom))
+        msg = _init_frame(capabilities={})
+        assert _inject_client_extensions(msg) is msg
 
 
 class TestFlagOn:

--- a/test/test_mcp_gateway_apps_spool.py
+++ b/test/test_mcp_gateway_apps_spool.py
@@ -532,9 +532,10 @@ async def test_no_ui_resource_delivers_unmodified(apps_flag_on, spool_tmp):
 
 @pytest.mark.asyncio
 async def test_flag_off_no_interception(monkeypatch, spool_tmp):
-    """With the flag OFF, a ui:// result is delivered verbatim (no marker, no
-    resources/read, no spool) — byte-identical to pre-feature behavior."""
-    monkeypatch.delenv(MCP_APPS_ENV_FLAG, raising=False)
+    """With the kill-switch set, a ui:// result is delivered verbatim (no
+    marker, no resources/read, no spool) — byte-identical to pre-feature
+    behavior. The gate defaults to ON, so "off" is set explicitly."""
+    monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
     backend = _make_backend()
     inbox = await backend.attach_stub("s1")
     await backend.forward_from_stub(

--- a/website/src/components/McpAppFrame.tsx
+++ b/website/src/components/McpAppFrame.tsx
@@ -16,13 +16,84 @@ const MAX_HEIGHT = 1200
 // MCP Apps UI-channel JSON-RPC method names (SEP-1865). The `ui/` namespace is
 // disjoint from the MCP tools namespace, carried over postMessage between the
 // host (this component) and the app iframe.
-const PROTOCOL_VERSION = '2026-01-26'
+const PROTOCOL_VERSION = '2025-11-21'
 const M_INITIALIZE = 'ui/initialize'
 const M_TOOLS_CALL = 'tools/call'
+const M_REQUEST_DISPLAY_MODE = 'ui/request-display-mode'
+const M_OPEN_LINK = 'ui/open-link'
 const N_INITIALIZED = 'ui/notifications/initialized'
 const N_TOOL_INPUT = 'ui/notifications/tool-input'
 const N_TOOL_RESULT = 'ui/notifications/tool-result'
 const N_SIZE_CHANGED = 'ui/notifications/size-changed'
+const N_HOST_CONTEXT_CHANGED = 'ui/notifications/host-context-changed'
+/** MCP logging notification (note: NOT under the `ui/` namespace). Apps send
+ *  their own diagnostics here; dropping it makes an app opaque to debugging. */
+const N_LOG_MESSAGE = 'notifications/message'
+
+/** Capabilities this host actually implements. Declaring them matters even though
+ *  the SDK's client-side gate is currently a no-op stub: a spec-conformant app is
+ *  entitled to skip a feature we don't advertise, so an empty object here is a
+ *  latent "the app silently stops trying" bug the moment that gate is enforced. */
+const HOST_CAPABILITIES = {
+  serverTools: {},
+  openLinks: {},
+} as const
+
+/** Display modes this host offers. `fullscreen` is honored as an EXPANDED
+ *  BUBBLE (a taller inline frame), never as a viewport-covering overlay: these
+ *  are conversational inline apps, and yanking the user out of the transcript
+ *  to a modal defeats that. The mode name is the app-facing contract (apps
+ *  commonly gate an editable/expanded surface on `fullscreen` — excalidraw only
+ *  mounts its editor there); how much room the host actually grants is
+ *  communicated separately via hostContext.containerDimensions. `pip` is in the
+ *  spec's enum but not offered here. */
+type DisplayMode = 'inline' | 'fullscreen'
+const AVAILABLE_DISPLAY_MODES: DisplayMode[] = ['inline', 'fullscreen']
+
+/** Fraction of the viewport an EXPANDED app gets. Big enough to cover the
+ *  response bubble and be genuinely usable for editing, without becoming a
+ *  viewport-covering modal. */
+const EXPANDED_VH = 0.8
+
+/** Concrete pixel height granted in `fullscreen`. */
+function expandedHeightPx(): number {
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 0
+  return vh > 0 ? Math.min(MAX_HEIGHT, Math.round(vh * EXPANDED_VH)) : MAX_HEIGHT
+}
+
+/**
+ * hostContext.containerDimensions for a mode.
+ *
+ * CRITICAL — `fullscreen` MUST carry a concrete `height`, not just `maxHeight`.
+ * An app cannot lay out a fullscreen surface from a ceiling alone: inside an
+ * iframe `position: fixed` gives the body no height, so a real app (excalidraw)
+ * keys its fullscreen layout off `containerDimensions.height` and renders into a
+ * ZERO-HEIGHT container when only `maxHeight` is supplied — the mode flips, the
+ * editor mounts, and nothing visibly changes. `inline` keeps advertising a
+ * ceiling because the app sizes itself there and reports back via
+ * ui/notifications/size-changed.
+ */
+function dimensionsFor(mode: DisplayMode): Record<string, number> {
+  return mode === 'fullscreen' ? { height: expandedHeightPx() } : { maxHeight: MAX_HEIGHT }
+}
+
+/**
+ * Gate for ui/open-link. The URL originates in SANDBOXED APP CONTENT, so it is
+ * untrusted input to a host-side navigation: accept ONLY absolute `https:`.
+ * That rejects `javascript:` (script execution in the host origin), `data:` and
+ * `blob:` (arbitrary attacker-authored documents), `file:` (local disk reads),
+ * and custom schemes that can hand off to native handlers. Callers must also
+ * pass `noopener,noreferrer` so the opened tab gets no `window.opener` handle
+ * back into the dashboard (reverse tabnabbing).
+ */
+function isOpenableUrl(raw: unknown): raw is string {
+  if (typeof raw !== 'string' || !raw) return false
+  try {
+    return new URL(raw).protocol === 'https:'
+  } catch {
+    return false // not absolute / unparseable
+  }
+}
 
 interface JsonRpcMessage {
   jsonrpc?: string
@@ -46,16 +117,28 @@ interface JsonRpcMessage {
  * APPBRIDGE: a minimal host-side implementation of the MCP Apps UI JSON-RPC
  * channel. It answers `ui/initialize`, drives the tool-input / tool-result
  * notifications after the app signals `ui/notifications/initialized`, honors
- * `ui/notifications/size-changed`, and relays `tools/call` requests to the
- * gateway via `POST /api/mcp-apps/call` (the gateway enforces that only
- * app-visible tools are callable). Every other not-yet-supported request is
- * rejected with a JSON-RPC method-not-found error. Every inbound message is
- * authenticated by `event.source === iframe.contentWindow` before it is acted on.
+ * `ui/notifications/size-changed`, negotiates `ui/request-display-mode` (granted
+ * as an expanded bubble — see DisplayMode — and mirrored back to the app with
+ * `ui/notifications/host-context-changed` when the host's own button toggles it),
+ * and relays `tools/call` requests to the gateway via
+ * `POST /api/mcp-apps/call` (the gateway enforces that only app-visible tools
+ * are callable). Every other not-yet-supported request is rejected with a
+ * JSON-RPC method-not-found error. Every inbound message is authenticated by
+ * `event.source === iframe.contentWindow` before it is acted on.
  */
 export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [height, setHeight] = useState(DEFAULT_HEIGHT)
-  const [expanded, setExpanded] = useState(false)
+  // Negotiated display mode (SEP-1865). Driven from BOTH directions: the app can
+  // request a change via ui/request-display-mode, and the host's own
+  // expand/collapse button sets it and notifies the app. `expanded` is derived
+  // so there is exactly one source of truth (the two used to be able to drift:
+  // the header button changed only the local height and the app was never told).
+  const [displayMode, setDisplayMode] = useState<DisplayMode>('inline')
+  const expanded = displayMode === 'fullscreen'
+  // Mirror for the stable message handler (which must not re-subscribe per mode).
+  const displayModeRef = useRef<DisplayMode>(displayMode)
+  displayModeRef.current = displayMode
 
   const srcDoc = useMemo(() => buildMcpAppSrcdoc(payload), [payload])
   const allow = useMemo(() => buildAllowAttribute(payload.permissions), [payload.permissions])
@@ -84,6 +167,10 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
   callbackSecretRef.current = payload.callback_secret ?? ''
   // Bound concurrent app→gateway callbacks: a hostile/buggy app document must
   // not be able to accumulate unbounded in-flight HTTP/socket/backend work.
+  // Stable label for log lines emitted by the app (the message handler has []
+  // deps, so it must read through a ref rather than close over `payload`).
+  const labelRef = useRef<string>(`${payload.server}/${payload.tool}`)
+  labelRef.current = `${payload.server}/${payload.tool}`
   const inFlightRef = useRef<number>(0)
   // Navigation guard: a sandboxed srcdoc iframe can self-navigate its own
   // document (CSP default-src/form-action 'none' do not block navigation), and
@@ -150,13 +237,13 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
               result: {
                 protocolVersion: PROTOCOL_VERSION,
                 hostInfo: { name: 'kirocrew', version: '0.1' },
-                hostCapabilities: {},
+                hostCapabilities: HOST_CAPABILITIES,
                 hostContext: {
                   theme: 'dark',
                   platform: 'web',
-                  displayMode: 'inline',
-                  availableDisplayModes: ['inline'],
-                  containerDimensions: { maxHeight: MAX_HEIGHT },
+                  displayMode: displayModeRef.current,
+                  availableDisplayModes: AVAILABLE_DISPLAY_MODES,
+                  containerDimensions: dimensionsFor(displayModeRef.current),
                 },
               },
             })
@@ -249,6 +336,89 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
           return
         }
 
+        case M_REQUEST_DISPLAY_MODE: {
+          // App-initiated display-mode change (e.g. excalidraw's fullscreen
+          // button, which is how it enters its EDITABLE canvas — in `inline` it
+          // renders a static preview). Previously this fell through to the
+          // method-not-found default, so the app's request rejected and it was
+          // stuck in a non-interactive mode forever.
+          //
+          // We grant `fullscreen` as an expanded bubble rather than a viewport
+          // overlay (see DisplayMode). Per spec the result reports the mode
+          // ACTUALLY set, so an unknown/unsupported mode (e.g. `pip`) is
+          // answered with the mode we keep rather than an error.
+          if (!isRequest) return
+          const requested = (msg.params as { mode?: unknown } | undefined)?.mode
+          const next: DisplayMode =
+            requested === 'fullscreen' || requested === 'inline'
+              ? requested
+              : displayModeRef.current
+          displayModeRef.current = next
+          setDisplayMode(next)
+          post({ jsonrpc: '2.0', id: msg.id, result: { mode: next } })
+          // The request-display-mode RESULT carries only `mode`, so the app has
+          // no way to learn the height it must lay its fullscreen surface out
+          // against. Follow the grant with the context update.
+          post({
+            jsonrpc: '2.0',
+            method: N_HOST_CONTEXT_CHANGED,
+            params: { displayMode: next, containerDimensions: dimensionsFor(next) },
+          })
+          return
+        }
+
+        case M_OPEN_LINK: {
+          // The app's "Open in Excalidraw" / menu links. Previously fell to the
+          // -32601 default, so the share flow uploaded the diagram and then the
+          // tab never opened — a silent dead end for the user.
+          if (!isRequest) return
+          const url = (msg.params as { url?: unknown } | undefined)?.url
+          if (!isOpenableUrl(url)) {
+            // Report the refusal in-band (spec: isError) instead of throwing a
+            // protocol error — the app can surface it to the user.
+            post({ jsonrpc: '2.0', id: msg.id, result: { isError: true } })
+            return
+          }
+          // noopener,noreferrer: the opened tab must not receive a window.opener
+          // handle back into the dashboard origin.
+          //
+          // The return value is deliberately NOT inspected: per the HTML spec
+          // `window.open` returns null whenever `noopener`/`noreferrer` is in the
+          // feature string, so a successful open is indistinguishable from a
+          // popup block. Treating null as failure would report `isError: true`
+          // on every successful open.
+          window.open(url, '_blank', 'noopener,noreferrer')
+          post({ jsonrpc: '2.0', id: msg.id, result: { isError: false } })
+          return
+        }
+
+        // NOTE: ui/update-model-context is deliberately NOT handled yet, so it
+        // still returns -32601 below. The app uses it to tell the MODEL about
+        // user edits, and there is no dashboard->session route to deliver that
+        // today; answering with an EmptyResult would falsely tell the app the
+        // context landed. Honest refusal until the backend route exists.
+
+        case N_LOG_MESSAGE: {
+          // App-emitted diagnostics. Silently dropping these (the old behavior,
+          // spec-legal for an unknown notification) makes a misbehaving app
+          // impossible to debug from outside: excalidraw routes its entire
+          // display-mode/editor-lifecycle trace through app.sendLog, so the one
+          // signal that explains a stuck app was being discarded. Forward to the
+          // console, tagged with the server/tool so multiple apps stay separable.
+          //
+          // Treated as UNTRUSTED text: passed as a console argument (never
+          // interpolated into a format string) and length-capped, so a hostile
+          // app cannot flood or forge host log lines.
+          if (isRequest) return // a log is a notification; ignore a malformed request form
+          const p = msg.params as { level?: unknown; logger?: unknown; data?: unknown } | undefined
+          const level = typeof p?.level === 'string' ? p.level : 'info'
+          const logger = typeof p?.logger === 'string' ? p.logger.slice(0, 40) : '-'
+          const data = typeof p?.data === 'string' ? p.data.slice(0, 2000) : p?.data
+          // eslint-disable-next-line no-console
+          console.debug(`[mcp-app ${labelRef.current}] ${level} ${logger}:`, data)
+          return
+        }
+
         default:
           // Unsupported REQUEST (e.g. tools/call) → JSON-RPC method-not-found.
           // Unsupported notifications (no id) are silently ignored per spec.
@@ -262,8 +432,69 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
     return () => window.removeEventListener('message', handler)
   }, [])
 
-  const toggleExpanded = useCallback(() => setExpanded((v) => !v), [])
-  const displayHeight = expanded ? MAX_HEIGHT : height
+  // Push a partial hostContext update into the app. Mirrors the inbound bridge's
+  // guards — never post into a document that navigated away.
+  const notifyHostContext = useCallback((mode: DisplayMode) => {
+    const cw = iframeRef.current?.contentWindow
+    if (!cw || navigatedRef.current) return
+    try {
+      // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+      cw.postMessage(
+        {
+          jsonrpc: '2.0',
+          method: N_HOST_CONTEXT_CHANGED,
+          // Partial context update — only the changed fields, per spec.
+          params: { displayMode: mode, containerDimensions: dimensionsFor(mode) },
+        },
+        '*',
+      )
+    } catch { /* frame torn down */ }
+  }, [])
+
+  // Host-initiated display-mode change (the header expand/collapse button).
+  // The app MUST be told: it may gate an editable surface on the mode, and a
+  // host that silently resizes leaves the two out of sync.
+  //
+  // `next` is derived from the ref rather than inside a setState updater: React
+  // may invoke an updater twice (StrictMode), and the notify below is a side
+  // effect — running it in the updater double-posted per click in dev.
+  const toggleExpanded = useCallback(() => {
+    const next: DisplayMode = displayModeRef.current === 'fullscreen' ? 'inline' : 'fullscreen'
+    displayModeRef.current = next
+    setDisplayMode(next)
+    notifyHostContext(next)
+  }, [notifyHostContext])
+
+  // While expanded, the granted height is derived from the viewport — so a window
+  // resize invalidates it. The frame's own height recomputes on any re-render but
+  // the height the APP was told is posted once, so the two silently diverge: the
+  // app keeps laying out against the stale value (it hard-sets html/body height
+  // from containerDimensions.height) and gets clipped when the window shrinks, or
+  // leaves a dead band when it grows. Re-notify on resize, debounced, and only
+  // while expanded (inline apps self-size via size-changed).
+  const [resizeTick, setResizeTick] = useState(0)
+  useEffect(() => {
+    if (!expanded) return
+    let t: ReturnType<typeof setTimeout> | undefined
+    const onResize = () => {
+      if (t) clearTimeout(t)
+      t = setTimeout(() => {
+        setResizeTick((n) => n + 1) // recompute the frame height
+        notifyHostContext('fullscreen') // and tell the app the new one
+      }, 150)
+    }
+    window.addEventListener('resize', onResize)
+    return () => {
+      if (t) clearTimeout(t)
+      window.removeEventListener('resize', onResize)
+    }
+  }, [expanded, notifyHostContext])
+
+  // Must match the `height` granted in dimensionsFor('fullscreen') — a frame
+  // shorter than the advertised height would clip the app's own layout.
+  // resizeTick is a deliberate recompute trigger, not a value.
+  void resizeTick
+  const displayHeight = expanded ? expandedHeightPx() : height
 
   return (
     <div className="my-2 rounded-md border border-border overflow-hidden bg-card">

--- a/website/src/test/McpAppFrame.test.tsx
+++ b/website/src/test/McpAppFrame.test.tsx
@@ -69,10 +69,10 @@ describe('McpAppFrame', () => {
     expect(target).toBe('*')
     expect(reply.jsonrpc).toBe('2.0')
     expect(reply.id).toBe(1)
-    expect(reply.result.protocolVersion).toBe('2026-01-26')
+    expect(reply.result.protocolVersion).toBe('2025-11-21')
     expect(reply.result.hostInfo).toEqual({ name: 'kirocrew', version: '0.1' })
     expect(reply.result.hostContext.displayMode).toBe('inline')
-    expect(reply.result.hostContext.availableDisplayModes).toEqual(['inline'])
+    expect(reply.result.hostContext.availableDisplayModes).toEqual(['inline', 'fullscreen'])
     expect(reply.result.hostContext.containerDimensions.maxHeight).toBe(1200)
   })
 
@@ -263,5 +263,279 @@ describe('McpAppFrame', () => {
     } finally {
       vi.unstubAllGlobals()
     }
+  })
+})
+
+/**
+ * Display-mode negotiation (SEP-1865 `ui/request-display-mode`). Before this was
+ * implemented the request fell through to the method-not-found default, so an app
+ * that gates its INTERACTIVE surface on `fullscreen` (excalidraw only mounts its
+ * editable canvas there) could never leave its static preview — the rendered
+ * diagram looked inert and the app's own fullscreen button was dead.
+ */
+describe('McpAppFrame — display mode', () => {
+  it('grants an app-requested fullscreen and reports the mode actually set', () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const iframe = container.querySelector('iframe')!
+    const win = stubContentWindow(iframe)
+
+    dispatchFromApp(
+      { jsonrpc: '2.0', id: 7, method: 'ui/request-display-mode', params: { mode: 'fullscreen' } },
+      win,
+    )
+
+    const reply = win.postMessage.mock.calls[0][0]
+    expect(reply.id).toBe(7)
+    expect(reply.error).toBeUndefined()
+    expect(reply.result).toEqual({ mode: 'fullscreen' })
+  })
+
+  it('honors fullscreen as an EXPANDED BUBBLE, not a viewport overlay', () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const iframe = container.querySelector('iframe')!
+    const win = stubContentWindow(iframe)
+
+    act(() => {
+      dispatchFromApp(
+        { jsonrpc: '2.0', id: 1, method: 'ui/request-display-mode', params: { mode: 'fullscreen' } },
+        win,
+      )
+    })
+
+    // The frame grows in place to the granted height (viewport-derived, capped
+    // at MAX_HEIGHT) and must NOT become a fixed/overlay element covering the
+    // transcript — inline apps stay in the conversation.
+    const expected = Math.min(1200, Math.round(window.innerHeight * 0.8))
+    expect(iframe.style.height).toBe(`${expected}px`)
+    // Not a viewport overlay: no ancestor may be position:fixed. (Asserting the
+    // IFRAME's own position is vacuous -- the code never sets it, so that check
+    // passed unconditionally and would miss a fixed WRAPPER.)
+    for (let el = iframe.parentElement; el; el = el.parentElement) {
+      expect(getComputedStyle(el).position).not.toBe('fixed')
+    }
+  })
+
+  it('reports the live mode (not a hardcoded inline) on a later ui/initialize', () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const iframe = container.querySelector('iframe')!
+    const win = stubContentWindow(iframe)
+
+    act(() => {
+      dispatchFromApp(
+        { jsonrpc: '2.0', id: 1, method: 'ui/request-display-mode', params: { mode: 'fullscreen' } },
+        win,
+      )
+    })
+    dispatchFromApp({ jsonrpc: '2.0', id: 2, method: 'ui/initialize' }, win)
+
+    const init = win.postMessage.mock.calls.at(-1)![0]
+    expect(init.result.hostContext.displayMode).toBe('fullscreen')
+  })
+
+  it('keeps the mode unchanged for an unsupported mode instead of erroring', () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const win = stubContentWindow(container.querySelector('iframe')!)
+
+    dispatchFromApp(
+      { jsonrpc: '2.0', id: 3, method: 'ui/request-display-mode', params: { mode: 'pip' } },
+      win,
+    )
+
+    const reply = win.postMessage.mock.calls[0][0]
+    expect(reply.error).toBeUndefined()
+    expect(reply.result).toEqual({ mode: 'inline' })
+  })
+
+  it('notifies the app when the HOST expand button changes the mode', () => {
+    const { container, getByLabelText } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const win = stubContentWindow(container.querySelector('iframe')!)
+
+    act(() => { getByLabelText('Expand app').click() })
+
+    const note = win.postMessage.mock.calls.at(-1)![0]
+    expect(note.method).toBe('ui/notifications/host-context-changed')
+    expect(note.id).toBeUndefined() // a notification carries no id
+    expect(note.params.displayMode).toBe('fullscreen')
+  })
+
+  /**
+   * The dimension contract. An app cannot lay out a fullscreen surface from a
+   * ceiling alone — inside an iframe `position: fixed` yields no body height, so
+   * excalidraw keys its fullscreen layout off `containerDimensions.height` and
+   * renders into a zero-height container when only `maxHeight` is sent. The mode
+   * flips, the editor mounts, and nothing visibly expands.
+   */
+  it('grants a CONCRETE height (not just maxHeight) for fullscreen', () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const win = stubContentWindow(container.querySelector('iframe')!)
+
+    act(() => {
+      dispatchFromApp(
+        { jsonrpc: '2.0', id: 1, method: 'ui/request-display-mode', params: { mode: 'fullscreen' } },
+        win,
+      )
+    })
+
+    // The grant is followed by a context update carrying the height.
+    const note = win.postMessage.mock.calls
+      .map((c) => c[0])
+      .find((m) => m.method === 'ui/notifications/host-context-changed')
+    expect(note).toBeDefined()
+    expect(typeof note.params.containerDimensions.height).toBe('number')
+    expect(note.params.containerDimensions.height).toBeGreaterThan(0)
+  })
+
+  it('advertises maxHeight (a ceiling) while inline', () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const win = stubContentWindow(container.querySelector('iframe')!)
+
+    dispatchFromApp({ jsonrpc: '2.0', id: 1, method: 'ui/initialize' }, win)
+
+    const dims = win.postMessage.mock.calls[0][0].result.hostContext.containerDimensions
+    expect(dims.maxHeight).toBe(1200)
+    expect(dims.height).toBeUndefined()
+  })
+})
+
+/**
+ * ui/open-link. The app's "Open in Excalidraw" button uploads the diagram via
+ * tools/call and THEN calls openLink. That second call used to hit the -32601
+ * default, so the export succeeded and the tab never opened — a silent dead end.
+ * The URL comes from sandboxed app content, so it is untrusted input.
+ */
+describe('McpAppFrame — ui/open-link', () => {
+  function setup() {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const win = stubContentWindow(container.querySelector('iframe')!)
+    // Real browsers return NULL from window.open whenever noopener/noreferrer is
+    // in the feature string (HTML spec). Stubbing a truthy Window here is what
+    // let an `isError: !opened` regression pass — so mirror reality.
+    const openSpy = vi.fn(() => null)
+    vi.stubGlobal('open', openSpy)
+    return { win, openSpy }
+  }
+
+  const ask = (win: unknown, url: unknown) =>
+    dispatchFromApp({ jsonrpc: '2.0', id: 9, method: 'ui/open-link', params: { url } }, win)
+
+  it('opens an https URL with noopener,noreferrer and reports success', () => {
+    const { win, openSpy } = setup()
+    try {
+      ask(win, 'https://excalidraw.com/#json=abc')
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://excalidraw.com/#json=abc', '_blank', 'noopener,noreferrer',
+      )
+      // Success must be reported even though window.open returned null.
+      expect(win.postMessage.mock.calls[0][0].result).toEqual({ isError: false })
+    } finally { vi.unstubAllGlobals() }
+  })
+
+  it.each([
+    ['javascript:alert(1)', 'script execution in the host origin'],
+    ['data:text/html,<script>1</script>', 'attacker-authored document'],
+    ['file:///etc/passwd', 'local disk read'],
+    ['http://excalidraw.com', 'cleartext'],
+    ['/relative/path', 'not absolute'],
+    ['', 'empty'],
+  ])('refuses %s (%s) without navigating', (url) => {
+    const { win, openSpy } = setup()
+    try {
+      ask(win, url)
+      expect(openSpy).not.toHaveBeenCalled()
+      // Refusal is reported in-band so the app can surface it.
+      expect(win.postMessage.mock.calls[0][0].result).toEqual({ isError: true })
+      expect(win.postMessage.mock.calls[0][0].error).toBeUndefined()
+    } finally { vi.unstubAllGlobals() }
+  })
+})
+
+describe('McpAppFrame — declared capabilities', () => {
+  it('advertises the capabilities it actually implements', () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const win = stubContentWindow(container.querySelector('iframe')!)
+
+    dispatchFromApp({ jsonrpc: '2.0', id: 1, method: 'ui/initialize' }, win)
+
+    const caps = win.postMessage.mock.calls[0][0].result.hostCapabilities
+    // serverTools: the tools/call relay. openLinks: the handler above.
+    expect(caps.serverTools).toBeDefined()
+    expect(caps.openLinks).toBeDefined()
+    // NOT advertised — deliberately still unimplemented (no backend route).
+    expect(caps.updateModelContext).toBeUndefined()
+  })
+})
+
+describe('McpAppFrame — resize while expanded', () => {
+  it('re-notifies the app so the granted height cannot go stale', async () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const iframe = container.querySelector('iframe')!
+    const win = stubContentWindow(iframe)
+
+    act(() => {
+      dispatchFromApp(
+        { jsonrpc: '2.0', id: 1, method: 'ui/request-display-mode', params: { mode: 'fullscreen' } },
+        win,
+      )
+    })
+    const before = win.postMessage.mock.calls.length
+
+    // Shrink the viewport and fire resize; the debounce is 150ms.
+    act(() => {
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 400 })
+      window.dispatchEvent(new Event('resize'))
+    })
+    await vi.waitFor(() => expect(win.postMessage.mock.calls.length).toBeGreaterThan(before))
+
+    const note = win.postMessage.mock.calls.at(-1)![0]
+    expect(note.method).toBe('ui/notifications/host-context-changed')
+    // The advertised height must equal what the frame actually renders, or the
+    // app lays out against a stale value and gets clipped. The frame height is
+    // committed by React, so converge on it rather than sampling one tick early.
+    expect(note.params.containerDimensions.height).toBe(Math.round(400 * 0.8))
+    await vi.waitFor(() =>
+      expect(iframe.style.height).toBe(`${Math.round(400 * 0.8)}px`),
+    )
+  })
+})
+
+/**
+ * App diagnostics. excalidraw routes its whole display-mode / editor-lifecycle
+ * trace through app.sendLog -> notifications/message. Dropping it (spec-legal for
+ * an unknown notification) is what made a stuck app impossible to debug from
+ * outside, so the host forwards it to the console instead.
+ */
+describe('McpAppFrame — app log forwarding', () => {
+  const send = (win: unknown, params: unknown) =>
+    dispatchFromApp({ jsonrpc: '2.0', method: 'notifications/message', params }, win)
+
+  it('forwards an app log to the console, tagged with server/tool', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+      const win = stubContentWindow(container.querySelector('iframe')!)
+
+      send(win, { level: 'info', logger: 'FS', data: 'toggle: inline->fullscreen' })
+
+      expect(spy).toHaveBeenCalledWith(
+        '[mcp-app excalidraw/create_view] info FS:', 'toggle: inline->fullscreen',
+      )
+      // A notification must not be answered.
+      expect(win.postMessage).not.toHaveBeenCalled()
+    } finally { spy.mockRestore() }
+  })
+
+  it('caps untrusted log content so a hostile app cannot flood the console', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+      const win = stubContentWindow(container.querySelector('iframe')!)
+
+      send(win, { level: 'info', logger: 'x'.repeat(200), data: 'y'.repeat(10_000) })
+
+      const [prefix, data] = spy.mock.calls.at(-1)!
+      expect(data).toHaveLength(2000)
+      expect(prefix).toContain('x'.repeat(40))
+      expect(prefix).not.toContain('x'.repeat(41))
+    } finally { spy.mockRestore() }
   })
 })


### PR DESCRIPTION
## Problem

An MCP App (SEP-1865) rendered inline in the chat bubble but **could not be used**. Concretely, with an excalidraw `create_view` diagram on screen:

- the app's **Edit** button did nothing — the diagram stayed a static preview
- **Open in Excalidraw** appeared to work, uploaded the diagram to excalidraw.com, and then no tab ever opened
- the four in-app menu links (Excalidraw / GitHub / X / Discord) were silently dead

## Why it matters

Every symptom above was a *different* unimplemented UI-channel method hitting the same `-32601` method-not-found default. The app degraded silently, one feature at a time, with no error surfaced to the user — so an MCP App looked broken rather than partially supported, and each gap was only discoverable by clicking something and noticing nothing happened. This is the interactivity half of MCP Apps: #761 made them *render*, this makes them *work*.

## Fix (symptom → root cause → change)

**1. Dead Edit button → `ui/request-display-mode` unhandled.** Apps commonly gate an editable surface on `fullscreen`; excalidraw mounts its editor only there. The host replied `-32601`, so the app's own request rejected and it stayed inline forever. The host now negotiates the mode, and honors `fullscreen` as an **expanded bubble** (a taller in-place frame) rather than a viewport-covering modal — these are conversational inline apps, and a modal pulls the user out of the transcript.

**2. Mode flipped but nothing expanded → only `maxHeight` advertised.** An app cannot lay out a fullscreen surface from a ceiling: inside an iframe `position: fixed` yields no body height, so excalidraw keys its layout off `containerDimensions.height` and rendered into a **zero-height container**. The editor genuinely mounted and was invisible. `fullscreen` now carries a concrete height; and because the `ui/request-display-mode` *result* carries only `mode`, the grant is followed by a `host-context-changed` so the app actually learns it.

**3. That height is viewport-derived → stale on resize.** The frame recomputed on re-render but the app was told exactly once, so the two diverged: clipped editor when the window shrank, dead band when it grew. An **expanded-only debounced resize listener** now re-notifies.

**4. Share uploaded then went nowhere → `ui/open-link` unhandled.** The upload is a `tools/call` (which works); the subsequent `openLink` hit the default. Now handled — and since the URL comes from **sandboxed, untrusted app content**, the gate accepts only absolute `https:`, rejecting `javascript:`, `data:`, `blob:`, `file:` and custom schemes, and opens with `noopener,noreferrer` so the new tab receives no `window.opener` handle back into the dashboard origin. Link-opening must be host-side: the frame has neither `allow-same-origin` nor `allow-popups`, so the app cannot navigate anywhere itself.

Also: the host advertised `hostCapabilities: {}` while relaying `tools/call`. That is harmless *today* only because the SDK's capability gate is a no-op stub — a conformant app is entitled to skip a feature we don't declare. Now declares `serverTools` + `openLinks`. `protocolVersion` corrected to the spec's `2025-11-21` (was a forward-dated `2026-01-26`).

### Deliberately NOT fixed here

`ui/update-model-context` still returns `-32601`. The app uses it to tell the **model** about user edits, and there is no dashboard→session route to deliver that today. Answering with an `EmptyResult` would falsely report that the context landed, which is worse than an honest refusal. Consequence to be aware of: an edit persists to the server checkpoint but the conversation still reasons about the pre-edit diagram. Needs a backend endpoint plus session plumbing — its own PR.

## Tests

`website/src/test/McpAppFrame.test.tsx`, 30 tests (was 14). New coverage locks in:

- **display mode** — grant reports the mode actually set; live mode returned on a later `ui/initialize`; unknown mode (`pip`) answered without an error; host-button toggle notifies the app
- **the dimension contract** — `fullscreen` grants a *concrete numeric* `containerDimensions.height`; `inline` advertises a `maxHeight` ceiling. This is the assertion that would have caught bug 2.
- **`ui/open-link` security gate** — `javascript:`, `data:`, `file:`, `http:`, relative and empty URLs are each refused with **no navigation** and an in-band `isError`; the https case asserts the exact `noopener,noreferrer` feature string
- **resize** — the advertised height must equal the rendered frame height after a viewport change (guards bug 3)
- **not-an-overlay** — walks the ancestor chain for `position: fixed`. The previous assertion checked the iframe's own `position`, which the code never sets, so it passed unconditionally and would have missed a fixed wrapper.

Full frontend suite: **473 files pass**. `tsc -b` clean, 0 eslint errors.

## Manual verification

Verified on a live dashboard that the diagram renders and the display-mode grant reaches the app. **Note for reviewers:** the dashboard's built bundle is cached by the PWA service worker, so a **hard reload** (Cmd/Ctrl+Shift+R) is required after deploying this to pick up the new bundle — the same gotcha hit during #761.

## Screenshots

⚠️ **Pending — required before merge.** This is a user-visible change, so per the repo's PR contract this needs before/after images under `temp-screenshots/mcp-app-interaction/` with commit-SHA-pinned URLs. The before-state (static, non-interactive preview with the dead Edit button) was captured during diagnosis. The after-state requires driving the live interactive app, which the authoring environment cannot do; the author will attach both and re-pin the URLs to the amended SHA before this is considered ready.

## Local review

Both local review mirrors ran on the pre-fix commit (`gpt-5.6-sol` and a Claude-Opus-class model) and **independently converged on the same defect**: `window.open` returns `null` whenever `noopener`/`noreferrer` is in the feature string (HTML spec), so the original `isError: !opened` reported failure on every *successful* open. Fixed, and the test was corrected to stub the realistic `null` return — it now fails against the old form (mutation-verified). The Opus mirror additionally caught a `nosemgrep` annotation placed above `try {` instead of the matched `postMessage` call, which would have failed the SAST gate.
