### PR TITLE
fix(chat): keep the subagent wave chip above theme overlays

### DIFF
--- a/website/src/pages/chat/SubagentProgressBar.tsx
+++ b/website/src/pages/chat/SubagentProgressBar.tsx
@@ -109,7 +109,14 @@ const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: 
   }, [hasActive, slot, dispatch])
   if (!hasActive) return null
   return (
-    <div className="px-5 mx-auto w-full" style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>
+    // `relative z-[46]` lifts the wave chip above every theme-experience
+    // overlay: those are clamped to OVERLAY_Z_MAX=45 in ThemeExperienceLayer,
+    // so 46 is the minimal value that no theme (built-in or custom, present or
+    // future) can paint over — while staying below the mute button (z=50) and
+    // consent modal (z=120), and under modal backdrops (z-[46], later in DOM).
+    // Without this the chip sits at auto z-index and a fullscreen overlay (e.g.
+    // an activate-time transition wipe) covers it for the overlay's lifetime.
+    <div className="px-5 mx-auto w-full relative z-[46]" style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>
       <div className="mb-1 rounded-md bg-accent/10 border border-accent/20 animate-slide-up overflow-hidden">
         <div className="flex items-center gap-2 px-3 py-1.5 text-[13px] font-mono">
           <Bot size={14} className="text-accent shrink-0" />

--- a/website/src/test/SubagentProgressBar.test.tsx
+++ b/website/src/test/SubagentProgressBar.test.tsx
@@ -134,6 +134,20 @@ describe('SubagentProgressBar — queued / waiting count', () => {
   })
 })
 
+describe('SubagentProgressBar — overlay stacking', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  // Theme-experience overlays are clamped to OVERLAY_Z_MAX=45 (ThemeExperienceLayer).
+  // The chip wrapper must sit strictly above that band so no theme can paint over
+  // an active wave; z-[46] is the minimal clearance (below mute z=50 / consent z=120).
+  it('elevates the wave chip above the theme-overlay ceiling (relative + z-[46])', () => {
+    const { container } = renderBar(makeStore(['a1']))
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper).toHaveClass('relative')
+    expect(wrapper).toHaveClass('z-[46]')
+  })
+})
+
 describe('sseSubagentQueued reducer', () => {
   function freshStore() {
     const store = configureStore({


### PR DESCRIPTION
## Problem
When an L2 "experience" theme is active (e.g. Bikini Bottom), the subagent **wave chip** (`SubagentProgressBar`) appears to vanish right after a theme switch and only returns "after a while."

## Why it matters
The chip is the user's only inline signal that a subagent wave is running (running / queued / done / failed counts + stop/retry controls). If a decorative theme overlay hides it, the user loses visibility into active work and the ability to stop or retry agents — a functional regression, not just cosmetic.

## Fix (symptom → root cause → change)
- **Symptom:** chip disappears on theme switch, reappears seconds later.
- **Root cause:** theme-experience overlays are clamped to `OVERLAY_Z_MAX = 45` (`ThemeExperienceLayer.tsx`), but the chip wrapper rendered at **auto z-index**. Any fullscreen overlay — e.g. Bikini's `bubbles-transition` activate-time wipe, which stays mounted up to `ACTIVATE_ONCE_MS = 8000` — paints over the chip for the overlay's lifetime. (The chip's own colors were never the issue: `:root` in `index.css` assigns the full palette incl. `--accent`, so `color-mix()` always resolves.)
- **Change:** elevate the chip wrapper to `relative z-[46]` — one tick above the overlay ceiling, and deliberately **below** the mute button (`z=50`) and consent modal (`z=120`), and at the same `z-[46]` tier as modal backdrops (which sit later in DOM, so a modal still correctly dims the chip). This is theme-agnostic: because *every* overlay from *every* theme (present or future) is clamped to ≤45, `46` is provably immune.

## Tests
- Added `SubagentProgressBar — overlay stacking` unit test asserting the chip wrapper carries `relative` + `z-[46]`, locking in the elevation so a future refactor can't silently drop it below the overlay band.
- Existing chip unit (13) + integration (12) suites still green; `tsc -b` clean.

## Manual verification
Recommended (not run here — sandbox cannot stage a live themed session): switch to an L2 overlay theme (Bikini Bottom) with a subagent wave active and confirm `[data-testid="subagent-histogram"]` stays visible through and after the switch.

## Screenshots
N/A to capture in this environment — reproducing requires a live gateway with an L2 overlay theme **and** an active subagent wave, which the sandbox cannot stage (token-mint capture blockers, noted in prior sessions). The change is a single stacking-context bump; visual behavior is: chip remains visible above the drifting-bubbles / transition-wipe overlays instead of being covered.
