### PR TITLE
fix(dashboard): reclaim 8px of dead space under the top header

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1815,7 +1815,7 @@ export default function App() {
         animate={isMobile ? { width: 220, x: 0 } : { x: 0 }}
         exit={{ x: -240 }}
         transition={isMobile ? { duration: 0.25, ease: [0.32, 0.72, 0, 1] } : undefined}
-        className={`bg-bg-elevated border border-border rounded-xl flex flex-col m-2 shadow-sm z-50 overflow-hidden ${isMobile ? 'fixed top-0 left-0 bottom-0' : ''}`}
+        className={`bg-bg-elevated border border-border rounded-xl flex flex-col mx-2 mt-0 mb-2 shadow-sm z-50 overflow-hidden ${isMobile ? 'fixed top-0 left-0 bottom-0' : ''}`}
         style={isMobile ? undefined : { gridArea: 'nav', width: 'auto' }}
         role="navigation"
         aria-label={i18nT('app.main_navigation')}

--- a/website/src/components/OverlayDrawer.tsx
+++ b/website/src/components/OverlayDrawer.tsx
@@ -37,7 +37,7 @@ export default function OverlayDrawer({ open, width, dragging, morph, className,
                 ? { width: { duration: 0.32, ease: EASE }, opacity: { duration: 0.12, ease: EASE } }
                 : settle
           }
-          className={`shrink-0 py-2 overflow-hidden ${className || ''}`}
+          className={`shrink-0 pb-2 overflow-hidden ${className || ''}`}
         >
           {children}
         </motion.div>

--- a/website/src/components/SidePanelLayout.tsx
+++ b/website/src/components/SidePanelLayout.tsx
@@ -71,7 +71,7 @@ export default function SidePanelLayout({ title, tabs, defaultTab, footer, heade
           {footer && <div className="pt-2 pb-2">{footer}</div>}
         </div>
       ) : (
-        <nav className="w-[200px] shrink-0 border-r border-border bg-bg overflow-y-auto py-3 px-3 flex flex-col gap-0.5">
+        <nav className="w-[200px] shrink-0 border-r border-border bg-bg overflow-y-auto pt-1 pb-3 px-3 flex flex-col gap-0.5">
           <div className="text-lg font-bold text-text-strong px-2.5 py-2 mb-1">{title}</div>
           {tabs.map((t, i) => (
             <React.Fragment key={t.key}>
@@ -103,7 +103,7 @@ export default function SidePanelLayout({ title, tabs, defaultTab, footer, heade
 
       <div className={`flex-1 min-w-0 min-h-0 flex flex-col ${fixedContent ? 'overflow-hidden' : 'overflow-y-auto'}`}>
         {!isMobile && (
-        <div className="flex items-end justify-between gap-4 px-6 pt-4 pb-3 shrink-0">
+        <div className="flex items-end justify-between gap-4 px-6 pt-2 pb-3 shrink-0">
           <div>
             <div className="text-2xl font-bold tracking-tight text-text-strong">{meta?.label || ''}</div>
             {meta?.description && <div className="text-muted text-sm mt-1">{meta.description}</div>}

--- a/website/src/components/ui.tsx
+++ b/website/src/components/ui.tsx
@@ -252,7 +252,7 @@ export function EmptyState({ icon, title, subtitle }: { icon: React.ReactNode; t
 
 export function PageHeader({ title, subtitle, actions }: { title: string; subtitle?: string; actions?: React.ReactNode }) {
   return (
-    <div className="flex items-end justify-between gap-4 px-6 pt-4 pb-3">
+    <div className="flex items-end justify-between gap-4 px-6 pt-2 pb-3">
       <div>
         <div className="text-2xl font-bold tracking-tight text-text-strong">{title}</div>
         {subtitle && <div className="text-muted text-sm mt-1">{subtitle}</div>}

--- a/website/src/pages/ArtifactDeployPage.tsx
+++ b/website/src/pages/ArtifactDeployPage.tsx
@@ -213,7 +213,7 @@ export default function ArtifactDeployPage() {
     <>
       {/* Deploy is a sub-surface of Artifacts (Joe R1): always give the way
           back to the gallery so the console never feels like a dead end. */}
-      <div className="px-6 pt-4">
+      <div className="px-6 pt-2">
         <button
           type="button"
           onClick={() => navigate('/artifacts')}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3722,8 +3722,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
           Desktop, non-embed, with sessions only. */}
       {!isMobile && embedMode !== 'chat' && embedMode !== 'sessions' && filteredSlots.length > 0 && (() => {
         const RADIUS = 12 // same as the panel's rounded-xl — constant through the morph
-        const PANEL = { top: 8, left: 0, width: sidebarWidth, height: Math.max(0, containerH - 16), borderRadius: RADIUS, opacity: 1 }
-        const BTN = { top: 20, left: 8, width: 34, height: 34, borderRadius: RADIUS, opacity: 1 }
+        const PANEL = { top: 0, left: 0, width: sidebarWidth, height: Math.max(0, containerH - 8), borderRadius: RADIUS, opacity: 1 }
+        const BTN = { top: 12, left: 8, width: 34, height: 34, borderRadius: RADIUS, opacity: 1 }
         const MORPH = { duration: 0.32, ease: [0.32, 0.72, 0, 1] as const }
         return (
           <>
@@ -3743,7 +3743,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
             <button
               type="button"
               onClick={() => window.dispatchEvent(new CustomEvent('toggle-pin-chat-sidebar'))}
-              className="absolute top-[20px] left-2 z-[61] w-[34px] h-[34px] rounded-xl flex items-center justify-center cursor-pointer text-muted hover:text-text transition-colors bg-transparent border-none"
+              className="absolute top-[12px] left-2 z-[61] w-[34px] h-[34px] rounded-xl flex items-center justify-center cursor-pointer text-muted hover:text-text transition-colors bg-transparent border-none"
               title={sidebarOpen ? 'Hide sessions' : 'Show sessions'}
               aria-label={sidebarOpen ? 'Hide sessions sidebar' : 'Show sessions sidebar'}
             >
@@ -3843,7 +3843,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
                 in index.css) so the overlay never paints over the scroller's scrollbar
                 track — otherwise the thumb is hidden/un-grabbable when scrolled to top. */}
             <div className="absolute top-0 left-0 right-1.5 z-10 pointer-events-none" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
-              <div className={`pr-5 pt-3 pb-2 flex items-center gap-2 bg-bg pointer-events-none ${!sidebarOpen && !isMobile ? 'pl-14' : 'pl-5'}`}>
+              <div className={`pr-5 pt-1 pb-2 flex items-center gap-2 bg-bg pointer-events-none ${!sidebarOpen && !isMobile ? 'pl-14' : 'pl-5'}`}>
                 {embedMode !== 'chat' && isMobile && (
                   <button className="p-1 rounded-md text-muted hover:text-text cursor-pointer bg-transparent border-none pointer-events-auto" onClick={() => setMobileSessions(p => !p)} aria-label={i18nT('pages.chatPage.toggle_sessions')}>
                     {effectiveMode === 'orchestrator' ? <MessageSquareDot size={16} /> : <MessageSquare size={16} />}

--- a/website/src/pages/WorldsPage.tsx
+++ b/website/src/pages/WorldsPage.tsx
@@ -41,7 +41,7 @@ export default function WorldsPage() {
         {...(collapsed ? { inert: '' } : {})}
       >
         <div style={{ overflow: 'hidden' }}>
-        <div className="px-5 pt-4 pb-2">
+        <div className="px-5 pt-2 pb-2">
           <div className="text-lg font-semibold text-text-strong"><Sparkles className="lucide-inline" /> {i18nT('pages.worldsPage.agent_worlds')}</div>
           <div className="text-sm text-muted">
             {agents.length} {i18nT('pages.worldsPage.agent')}{agents.length !== 1 ? 's' : ''} {i18nT('pages.worldsPage.present')}{' '}

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -314,7 +314,7 @@ export default function SidePanel({
   }, [menuOpen])
 
   return (
-    <div className="shrink-0 min-h-0 my-2 flex flex-col bg-bg overflow-hidden relative border-l border-t border-b border-border rounded-l-xl" style={{ width: effectiveWidth, maxWidth: '100vw' }}>
+    <div className="shrink-0 min-h-0 mt-0 mb-2 flex flex-col bg-bg overflow-hidden relative border-l border-t border-b border-border rounded-l-xl" style={{ width: effectiveWidth, maxWidth: '100vw' }}>
       {/* Left-edge resize handle */}
       {fillWidth == null && <div role="separator" aria-orientation="vertical" aria-label={i18nT('pages.chat.sidePanel.resize_panel')} className="absolute left-0 top-0 bottom-0 w-[6px] cursor-col-resize z-30 group/drag" style={{ touchAction: 'none' }} {...panelResize}>
         <div className="absolute left-0 top-0 bottom-0 w-[2px] transition-colors duration-200 bg-transparent group-hover/drag:bg-accent resize-accent" />

--- a/website/src/pages/knowledge/index.tsx
+++ b/website/src/pages/knowledge/index.tsx
@@ -406,7 +406,7 @@ export default function KnowledgePage() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-start sm:items-end justify-between gap-3 sm:gap-4 px-4 sm:px-6 pt-4 pb-3">
+      <div className="flex items-start sm:items-end justify-between gap-3 sm:gap-4 px-4 sm:px-6 pt-2 pb-3">
         <div className="min-w-0">
           <div className="text-xl sm:text-2xl font-bold tracking-tight text-text-strong flex items-center gap-2">
             <BookOpen size={22} className="shrink-0" /> {i18nT('pages.knowledge.index.knowledge_library')}


### PR DESCRIPTION
# Problem

Every region below the 42px dashboard top bar started 8px lower than it needed to, leaving a visible empty band running the full width of the window. It reads as a seam between the header and the app rather than as intentional spacing, and it costs 8px of vertical room on every single screen.

# Why it matters

This is the most-looked-at pixel band in the product — it is on screen in every session, on every route. The dead band makes the shell look loosely assembled, and on short laptop displays it spends scarce vertical space on nothing. Reclaiming it tightens the whole dashboard for free.

# Fix (symptom → root cause → change)

**Symptom:** an empty ~8px band immediately under the top bar, above the left nav card and the sessions panel.

**Root cause:** there was no single offending rule — four independent containers each reserved their own top offset, and they happened to sum to the same visible gap:

- the left nav card used a symmetric `m-2`, so its top margin pushed it 8px below the header
- the sessions `OverlayDrawer` used a symmetric `py-2`
- the chat `SidePanel` used a symmetric `my-2`
- the content panes carried a 16px header inset (`PageHeader` `pt-4` and friends), which visually aligned with the cards' 8px margin + 8px inner padding

Because they were symmetric shorthands, nobody could shrink the top gap without also shrinking the bottom.

**Change:** drop the top offset in the three card containers and shift the content panes up by the same 8px, so all four regions move together and nothing loses alignment:

| region | before | after |
|---|---|---|
| left nav card | `m-2` | `mx-2 mt-0 mb-2` |
| sessions drawer | `py-2` | `pb-2` |
| chat side panel | `my-2` | `mt-0 mb-2` |
| shared `PageHeader` | `pt-4` | `pt-2` |
| chat title row | `pt-3` | `pt-1` |
| `SidePanelLayout` header / side nav | `pt-4` / `py-3` | `pt-2` / `pt-1 pb-3` |
| Knowledge, Worlds, ArtifactDeploy headers | `pt-4` | `pt-2` |

The sessions collapse/expand **morph geometry moved with it** — `PANEL` top `8→0` and height `containerH - 16 → containerH - 8` (matching the drawer's new top inset 0 / bottom inset 8), `BTN` top `20→12`, and the static collapse button `top-[20px] → top-[12px]`. `BTN.top` keeps the same +12 offset from the panel's top edge, so the icon still lands centred on the box the morph settles into.

Only the top offsets changed. Bottom margins, widths, radii, and the `px-6 pb-8 overflow-y-auto flex-1 min-h-0` scroll-container recipe are all untouched.

## Blast radius of the two shared components

- **`OverlayDrawer`** has exactly **one** consumer (`ChatPage.tsx`), so `py-2 → pb-2` cannot regress another surface. That call site passes `!py-0` on mobile, which still wins over `pb-2`, so the mobile drawer is unaffected.
- **`PageHeader`** is consumed by ~20 pages plus the `kirocrew-ui` re-export. Every one shifts up 8px uniformly — that is the point of the change. No consumer compensated for the old `pt-4` with a negative margin or offset, so nothing lands double-shifted.

# Tests

No new tests. This is a pure spacing change with no new branch or state, and the repo has no vertical-rhythm assertions to extend — a unit test asserting a Tailwind class string would restate the diff rather than lock in behaviour. What the existing suites do cover is that nothing regressed: the shell/layout tests (`layout`, `App`, `sidePanelReserve`, `ChatPage.responsivePanel`) exercise the changed containers and pass, alongside the full `vitest` suite and 362 electron tests.

The real verification for this change is dimensional, and it is below.

# Manual verification

Measured on **two real built bundles** (`origin/main` vs this branch), served from `website/dist` with fixtured `/api/**`, reading `getBoundingClientRect()` in a headless Chromium at 1520×1000:

| element | before | after | Δ |
|---|---|---|---|
| top bar bottom edge | 42 | 42 | **0** (unchanged) |
| left nav card top | 50 | 42 | **−8** |
| sessions panel card top | 50 | 42 | **−8** |
| sessions "Sessions" title | 69 | 61 | **−8** |
| settings side-nav first item | 104 | 96 | **−8** |
| settings content h1 | 58 | 50 | **−8** |

Uniform −8px across all four regions with the header itself unmoved — which is exactly the intent, and confirms the content panes did not drift out of alignment with the cards.

Also verified after rebasing onto current `main`: `tsc -b` clean, `npm run build` clean, full `npm test` green, `lint:theme-colors` exits 0, and `eslint src` reports no new errors (the single `vite-env.d.ts` parse error is pre-existing and byte-identical on `main`).

# Screenshots

Before/after top-strip crops were captured for four surfaces — Sessions (left nav + sessions panel), Settings (side nav + content header), and Schedule and Artifacts (both on the shared `PageHeader`) — plus full-frame context shots. They confirm visually what the table above measures: on Settings in particular, the side nav and the "Overview" content header move up *together*, which was the main alignment risk.

Those images are **deliberately not committed to this branch.** An earlier revision of this PR did commit them under `temp-screenshots/header-gap/` (~900KB of PNGs) so the body could hot-link raw commit URLs, and the Arbiter correctly flagged that as a one-way door: git history is append-only, so merging would bake the binaries into every clone permanently, and a later `git rm` would clean the working tree but not the history. They have been removed. The dimensional table is the load-bearing evidence here, and it is reproducible; the frames can be attached to this conversation on request.

# Note for a follow-up (not in this PR)

`LAYOUT.TOPBAR_HEIGHT` in `website/src/components/layout.ts` is `52`, while the top bar this change measures against is `42px` (`grid-rows-[42px_...]` in `App.tsx`). That constant is stale and unreferenced by the bar's actual height. Consolidating the header inset into a single shared constant next to it — so the `pt-2` / `mt-0` values now spread across the touched files become one edit — is the natural cleanup. Left out here to keep this PR to one concern; the Design reviewer and Arbiter both agreed it is a reasonable follow-up rather than a blocker.
