### PR TITLE
feat: show the signed-in Kiro account in the credits panel

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -120,6 +120,14 @@ _MAX_RESP_BYTES = 1_000_000
 # accounts); transient failures are never cached. See _list_profile_arn.
 _PROFILE_ARN_CACHE: dict[str, str | None] = {}
 
+# Human profile/display name for the signed-in account, captured as a side
+# effect of the same ListAvailableProfiles probe that yields the ARN and keyed
+# by the same token digest. Surfaced as the usage dict's ``account`` field so
+# the dashboard can show WHO the plan belongs to. Populated only alongside a
+# found ARN (control-flow-coupled to _PROFILE_ARN_CACHE); may be None when the
+# profile carries no name.
+_PROFILE_NAME_CACHE: dict[str, str | None] = {}
+
 # One WARN per api->text degradation transition (reset on the next success) so
 # a persistently-failing API path is diagnosable at the default log level
 # without spamming, and the legitimate no-token case stays at DEBUG.
@@ -440,16 +448,34 @@ def _list_profile_arn(token: str) -> str | None:
     if not isinstance(profiles, list):
         return None
     arn: str | None = None
+    name: str | None = None
     for p in profiles:
         if not isinstance(p, dict):
             continue
         candidate = p.get("arn") or p.get("profileArn")
         if candidate:
             arn = candidate
+            # Human label for the signed-in account. Bounded like the plan name
+            # so a hostile/oversized value can't reach the cache/UI unbounded;
+            # only a non-empty string qualifies.
+            pname = p.get("profileName") or p.get("profileDisplayName")
+            if isinstance(pname, str) and pname:
+                name = pname[:100]
             break
     if arn is not None:
         _PROFILE_ARN_CACHE[key] = arn  # memoize only a found ARN, per token
+        _PROFILE_NAME_CACHE[key] = name  # co-cached; None when profile had no name
     return arn
+
+
+def _account_name(token: str) -> str | None:
+    """Return the cached profile display name for ``token``, or None.
+
+    Populated as a side effect of :func:`_list_profile_arn`; this getter never
+    issues a request itself, so the ARN probe must have run first (it always
+    does in ``fetch_usage_limits``). Keyed by the same token digest (never the
+    token itself)."""
+    return _PROFILE_NAME_CACHE.get(hashlib.sha256(token.encode()).hexdigest()[:16])
 
 
 def _bounded(value: object) -> float | None:
@@ -648,6 +674,24 @@ def fetch_usage_limits() -> dict | None:
                 continue
             mapped = _map_response(body)
             if mapped is not None:
+                # Tag the usage with WHO the plan belongs to (profile display
+                # name from the ListAvailableProfiles probe above). Absent for
+                # individual Builder ID accounts, which have no profile.
+                account = _account_name(token)
+                if account:
+                    mapped["account"] = account
+                # Coupling metadata for the caller's identity check (private —
+                # stripped before the payload is cached or served).
+                #
+                # These numbers may come from a DIFFERENT account than
+                # ``kiro-cli whoami`` reports: this client tries several
+                # candidate credentials (IDE cache first, then the kiro-cli
+                # store) and uses whichever the API accepts, while whoami always
+                # reports kiro-cli's own identity. Attaching an unverified email
+                # to these credits would misattribute an overage bill, so the
+                # caller must prove they refer to the same account before
+                # displaying an identity alongside them.
+                mapped["_profile_arn"] = arn  # None for individual accounts
                 _note_api_outcome(True)
                 return mapped
             # A 200 with no usable CREDIT breakdown is a shape problem, not an auth

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -250,6 +250,116 @@ def _cache_transient_failure() -> None:
     _usage_cache_ts = time.time()
 
 
+async def _fetch_whoami(kiro_bin: str) -> dict[str, object]:
+    """Return the signed-in identity from ``kiro-cli whoami --format json``.
+
+    Answers "who is this Kiro account?" — the credit API cannot: GetUsageLimits
+    carries no identity, and the SSO token cache holds only opaque tokens (no
+    email/openid scopes). kiro-cli resolves the identity itself, so it is the
+    only local source of the account email.
+
+    Returns a dict with any of ``email`` / ``account_type`` / ``start_url``, or
+    ``{}`` on any failure — identity is decorative, so it must never break the
+    credit readout. stdout is untrusted: only the LEADING JSON object is parsed
+    (kiro-cli appends a non-JSON "Profile:" block after it), values must be
+    strings, and each is length-bounded before it can reach the cache/UI.
+    """
+    proc = None
+    cleanup = None
+    try:
+        argv, cleanup = wrap_argv([kiro_bin, "whoami", "--format", "json"], mode="standard")
+        argv = cgroup_scope_argv(argv)
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            preexec_fn=resource_limit_preexec(),
+        )
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=30)
+        raw = (out or err or b"").decode(errors="replace")
+        full = raw  # keep the whole output; the ARN lives AFTER the JSON object
+        # Take only the first {...} block; trailing "Profile:\n<name>" is not JSON.
+        depth = 0
+        start = raw.find("{")
+        if start < 0:
+            return {}
+        for i in range(start, len(raw)):
+            if raw[i] == "{":
+                depth += 1
+            elif raw[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    raw = raw[start : i + 1]
+                    break
+        else:
+            return {}
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return {}
+        out_map: dict[str, object] = {}
+        for src, dst, cap in (
+            ("email", "email", 254),
+            ("accountType", "account_type", 60),
+            ("startUrl", "start_url", 200),
+        ):
+            v = data.get(src)
+            if isinstance(v, str) and v:
+                out_map[dst] = v[:cap]
+        # whoami's own profile ARN, printed in the trailing (non-JSON) "Profile:"
+        # block. Private (leading underscore): used only to prove this identity
+        # belongs to the same account the credit numbers came from, and stripped
+        # before anything is cached or served.
+        m = re.search(r"arn:aws:codewhisperer:[^\s\"']+", full)
+        if m:
+            out_map["_profile_arn"] = m.group(0)[:200]
+        return out_map
+    except (asyncio.TimeoutError, json.JSONDecodeError, ValueError, OSError):
+        logger.debug("whoami identity fetch failed", exc_info=True)
+        return {}
+    except Exception:
+        logger.debug("whoami identity fetch failed (unexpected)", exc_info=True)
+        return {}
+    finally:
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.kill()
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except Exception:
+                pass
+        if cleanup:
+            try:
+                os.remove(cleanup)
+            except OSError:
+                pass
+
+
+def _identity_matches_account(api_arn: object, identity: dict[str, object]) -> bool:
+    """True only when ``identity`` provably describes the account billed for the credits.
+
+    ``fetch_usage_limits`` tries several candidate credentials (IDE cache first,
+    then the kiro-cli store) and keeps whichever the API accepted, while
+    ``kiro-cli whoami`` always reports kiro-cli's own identity. With two
+    different accounts signed in those are different accounts — showing one's
+    email above the other's overage would misattribute a bill.
+
+    The ONLY accepted proof is a matching profile ARN on both sides. In
+    particular, "there was just one credential we could read" is NOT proof:
+    kiro-cli may authenticate from a store this module does not enumerate (e.g.
+    a platform-specific app-data path), so a lone readable credential does not
+    establish that whoami used it.
+
+    Consequence, deliberately: accounts with no profile ARN at all (individual /
+    Builder ID) can never be proven, so they show no identity. Under-reporting an
+    identity is a cosmetic gap; mislabelling whose overage bill this is, is not.
+    """
+    whoami_arn = identity.get("_profile_arn")
+    return (
+        isinstance(api_arn, str)
+        and isinstance(whoami_arn, str)
+        and api_arn == whoami_arn
+    )
+
+
 async def _fetch_usage_bg() -> None:
     """Background task: fetch usage and update cache."""
     global _usage_cache, _usage_cache_ts, _usage_fetching
@@ -281,6 +391,19 @@ async def _fetch_usage_bg() -> None:
         if api_usage and api_usage.get("credits_plan") is not None:
             # API output is untrusted too: redact every string leaf before caching.
             api_usage = {k: _redact_strings(v) for k, v in api_usage.items()}
+            # Strip the private coupling metadata before it can reach the cache.
+            api_arn = api_usage.pop("_profile_arn", None)
+            # Attach the signed-in identity ONLY when it provably belongs to the
+            # account these credits were billed to (see _identity_matches_account).
+            identity = await _fetch_whoami(kiro_bin)
+            if identity and _identity_matches_account(api_arn, identity):
+                api_usage.update(
+                    {
+                        k: _redact_strings(v)
+                        for k, v in identity.items()
+                        if not k.startswith("_")
+                    }
+                )
             _usage_cache = api_usage
             _usage_cache_ts = time.time()
             logger.info(
@@ -315,6 +438,16 @@ async def _fetch_usage_bg() -> None:
             # dict is cached and served (kiro-cli output is untrusted).
             parsed = _normalize_text_usage(parsed)
             parsed = {k: _redact_strings(v) for k, v in parsed.items()}
+            # No coupling check needed here: this scrape IS kiro-cli's own
+            # `/usage` output, so it and `whoami` describe the same account by
+            # construction.
+            parsed.update(
+                {
+                    k: _redact_strings(v)
+                    for k, v in (await _fetch_whoami(kiro_bin)).items()
+                    if not k.startswith("_")
+                }
+            )
             _usage_cache = parsed
             _usage_cache_ts = time.time()
             logger.info(

--- a/test/test_kiro_usage_api.py
+++ b/test/test_kiro_usage_api.py
@@ -419,29 +419,44 @@ class TestFetchUsageLimits:
     @pytest.fixture(autouse=True)
     def _clear_arn_cache(self):
         api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
         yield
         api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
 
-    def test_no_token_returns_none(self):
-        with patch.object(api, "_candidate_tokens", return_value=[]):
-            assert api.fetch_usage_limits() is None
-
-    def test_success_with_profile_arn(self):
+    def test_surfaces_account_from_profile_name(self):
+        # The signed-in account's profileName from ListAvailableProfiles must be
+        # surfaced as the usage dict's ``account`` field.
         usage_body = {"usageBreakdownList": [
-            {"resourceType": "CREDIT", "currentUsage": 29527.0,
-             "usageLimit": 10000.0, "currentOverages": 19527.0}]}
+            {"resourceType": "CREDIT", "currentUsage": 5.0, "usageLimit": 100.0}]}
 
         def fake_post(token, target, payload):
             if target == api._TARGET_LIST_PROFILES:
-                return _resp(200, {"profiles": [{"arn": "arn:aws:codewhisperer:...:profile/X"}]})
-            assert payload.get("profileArn") == "arn:aws:codewhisperer:...:profile/X"
+                return _resp(200, {"profiles": [
+                    {"arn": "arn:aws:codewhisperer:...:profile/X",
+                     "profileName": "Acme Corp"}]})
             return _resp(200, usage_body)
 
         with patch.object(api, "_candidate_tokens", return_value=["tok"]), \
              patch.object(api, "_post", side_effect=fake_post):
             out = api.fetch_usage_limits()
-        assert out["credits_used"] == 29527.0
-        assert out["credits_overage"] == 19527.0
+        assert out["account"] == "Acme Corp"
+
+    def test_no_account_when_profile_has_no_name(self):
+        # An org profile with an ARN but no profileName must not set ``account``
+        # (individual Builder ID accounts likewise have no profile at all).
+        usage_body = {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 5.0, "usageLimit": 100.0}]}
+
+        def fake_post(token, target, payload):
+            if target == api._TARGET_LIST_PROFILES:
+                return _resp(200, {"profiles": [{"arn": "arn:x"}]})
+            return _resp(200, usage_body)
+
+        with patch.object(api, "_candidate_tokens", return_value=["tok"]), \
+             patch.object(api, "_post", side_effect=fake_post):
+            out = api.fetch_usage_limits()
+        assert "account" not in out
 
     def test_rejected_token_falls_over_to_next(self):
         # An unexpired-but-rejected first token must not shadow a working one.
@@ -498,8 +513,10 @@ class TestListProfileArnCache:
     @pytest.fixture(autouse=True)
     def _clear_arn_cache(self):
         api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
         yield
         api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
 
     def test_definitive_answer_is_memoized(self):
         # ListAvailableProfiles is called once; the second lookup hits the cache.

--- a/test/test_session_usage.py
+++ b/test/test_session_usage.py
@@ -294,11 +294,16 @@ class TestFetchUsageBgApi:
                           return_value=api_dict), \
              patch("asyncio.create_subprocess_exec", spawn):
             await sessions_mod._fetch_usage_bg()
-        # API path wins: real total cached, text-scrape subprocess never spawned.
+        # API path wins: real total cached, and the CREDIT-CONSUMING text scrape
+        # (`kiro-cli chat ... /usage`) is never spawned. A cheap `whoami` spawn
+        # for the identity row is allowed -- it costs no credits -- so assert on
+        # the invariant that matters rather than on zero subprocesses.
         assert sessions_mod._usage_cache["credits_used"] == 29527.0
         assert sessions_mod._usage_cache["credits_overage"] == 19527.0
         assert sessions_mod._usage_cache["source"] == "api"
-        spawn.assert_not_called()
+        for call in spawn.call_args_list:
+            assert "/usage" not in call.args, f"credit-consuming scrape spawned: {call.args}"
+            assert "chat" not in call.args, f"chat subprocess spawned: {call.args}"
 
     @pytest.mark.asyncio
     async def test_api_none_falls_back_to_text_scrape(self):
@@ -324,3 +329,186 @@ class TestFetchUsageBgApi:
             await sessions_mod._fetch_usage_bg()
         assert sessions_mod._usage_cache["plan"] == "REDACTED"
         assert sessions_mod._usage_cache["credits_plan"] == 10.0
+
+
+class TestFetchWhoami:
+    """``_fetch_whoami`` parses the signed-in identity from kiro-cli whoami.
+
+    kiro-cli prints a JSON object FOLLOWED by a non-JSON "Profile:" block, so
+    the parser must take only the leading object. Identity is decorative — every
+    failure path must yield {} rather than raising into the credit refresh.
+    """
+
+    def _run(self, stdout: bytes):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(stdout, b""))
+        proc.returncode = 0
+        with patch.object(sessions_mod, "wrap_argv", return_value=(["kiro-cli"], None)), \
+             patch.object(sessions_mod, "cgroup_scope_argv", side_effect=lambda a: a), \
+             patch.object(sessions_mod, "resource_limit_preexec", return_value=None), \
+             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            return asyncio.run(sessions_mod._fetch_whoami("kiro-cli"))
+
+    def test_parses_identity_ignoring_trailing_profile_block(self):
+        out = self._run(
+            b'{\n "accountType": "IamIdentityCenter",\n "email": "me@corp.com",\n'
+            b' "region": "us-east-1",\n "startUrl": "https://x.awsapps.com/start"\n}\n'
+            b"\nProfile:\nKiroProfile-us-east-1\narn:aws:codewhisperer:...\n"
+        )
+        assert out["email"] == "me@corp.com"
+        assert out["account_type"] == "IamIdentityCenter"
+        assert out["start_url"] == "https://x.awsapps.com/start"
+
+    def test_builder_id_account_type(self):
+        out = self._run(b'{"accountType":"BuilderId","email":"a@b.com"}')
+        assert out == {"email": "a@b.com", "account_type": "BuilderId"}
+
+    def test_non_string_values_dropped(self):
+        assert self._run(b'{"email":{"nested":1},"accountType":null}') == {}
+
+    def test_no_json_returns_empty(self):
+        assert self._run(b"Not logged in\n") == {}
+
+    def test_unterminated_json_returns_empty(self):
+        assert self._run(b'{"email":"a@b.com"') == {}
+
+    def test_values_are_length_bounded(self):
+        out = self._run(b'{"email":"' + b"x" * 400 + b'@b.com"}')
+        assert len(out["email"]) <= 254
+
+
+class TestIdentityAccountCoupling:
+    """An identity may only be shown next to credits it provably belongs to.
+
+    fetch_usage_limits picks whichever candidate credential the API accepts
+    (IDE cache first, then the kiro-cli store) while whoami always reports
+    kiro-cli's identity -- so with two accounts signed in they can disagree.
+    Attaching the wrong email to an overage bill is a misattribution, so the
+    merge is refused unless the accounts provably match.
+    """
+
+    def test_matching_arns_are_coupled(self):
+        assert sessions_mod._identity_matches_account(
+            "arn:aws:codewhisperer:us-east-1:1:profile/A",
+            {"email": "a@b.com", "_profile_arn": "arn:aws:codewhisperer:us-east-1:1:profile/A"},
+        ) is True
+
+    def test_differing_arns_are_refused(self):
+        # The exact misattribution the reviewer flagged: API billed account A,
+        # whoami describes account B.
+        assert sessions_mod._identity_matches_account(
+            "arn:aws:codewhisperer:us-east-1:1:profile/A",
+            {"email": "b@b.com", "_profile_arn": "arn:aws:codewhisperer:us-east-1:2:profile/B"},
+        ) is False
+
+    def test_no_arns_is_never_coupled(self):
+        # A lone READABLE credential is not proof: kiro-cli may authenticate from
+        # a store this module does not enumerate, so whoami's account cannot be
+        # tied to the billed one. Individual / Builder ID accounts (no profile
+        # ARN) therefore show no identity rather than a possibly-foreign one.
+        assert sessions_mod._identity_matches_account(None, {"email": "solo@b.com"}) is False
+
+    def test_one_sided_arn_is_refused(self):
+        assert sessions_mod._identity_matches_account(
+            "arn:aws:codewhisperer:us-east-1:1:profile/A", {"email": "x@b.com"}
+        ) is False
+        assert sessions_mod._identity_matches_account(
+            None, {"email": "x@b.com", "_profile_arn": "arn:aws:codewhisperer:us-east-1:1:profile/A"}
+        ) is False
+
+    def test_whoami_extracts_profile_arn_from_trailing_block(self):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(
+            b'{"accountType":"IamIdentityCenter","email":"me@corp.com"}\n\n'
+            b"Profile:\nKiroProfile-us-east-1\n"
+            b"arn:aws:codewhisperer:us-east-1:713669222412:profile/7KHC74QYC9PQ\n", b""))
+        proc.returncode = 0
+        with patch.object(sessions_mod, "wrap_argv", return_value=(["kiro-cli"], None)), \
+             patch.object(sessions_mod, "cgroup_scope_argv", side_effect=lambda a: a), \
+             patch.object(sessions_mod, "resource_limit_preexec", return_value=None), \
+             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            out = asyncio.run(sessions_mod._fetch_whoami("kiro-cli"))
+        assert out["email"] == "me@corp.com"
+        assert out["_profile_arn"].endswith("profile/7KHC74QYC9PQ")
+
+    @pytest.mark.asyncio
+    async def test_private_coupling_keys_never_reach_the_cache(self):
+        _reset_usage_globals()
+        api_dict = {
+            "credits_used": 100.0, "credits_plan": 10.0, "source": "api",
+            "_profile_arn": "arn:aws:codewhisperer:us-east-1:1:profile/A",
+        }
+        identity = {
+            "email": "me@corp.com",
+            "_profile_arn": "arn:aws:codewhisperer:us-east-1:1:profile/A",
+        }
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits", return_value=api_dict), \
+             patch.object(sessions_mod, "_fetch_whoami", AsyncMock(return_value=identity)):
+            await sessions_mod._fetch_usage_bg()
+        cache = sessions_mod._usage_cache
+        assert cache["email"] == "me@corp.com"          # coupled -> shown
+        assert "_profile_arn" not in cache              # private, never served
+        _reset_usage_globals()
+
+    @pytest.mark.asyncio
+    async def test_mismatched_identity_is_not_cached(self):
+        _reset_usage_globals()
+        api_dict = {
+            "credits_used": 100.0, "credits_plan": 10.0, "source": "api",
+            "_profile_arn": "arn:aws:codewhisperer:us-east-1:1:profile/A",
+        }
+        identity = {
+            "email": "other@corp.com",
+            "_profile_arn": "arn:aws:codewhisperer:us-east-1:2:profile/B",
+        }
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits", return_value=api_dict), \
+             patch.object(sessions_mod, "_fetch_whoami", AsyncMock(return_value=identity)):
+            await sessions_mod._fetch_usage_bg()
+        cache = sessions_mod._usage_cache
+        assert "email" not in cache, "a foreign identity must not ride on these credits"
+        assert cache["credits_used"] == 100.0
+        _reset_usage_globals()
+
+
+class TestIdentityIsNotStale:
+    """Identity must be re-resolved on every refresh, never memoized.
+
+    A gateway-lifetime cache misattributed credits after an account switch:
+    Builder ID A cached -> user signs in as Builder ID B -> the refresh accepts
+    B's sole credential and, with no profile ARN on either side, the coupling
+    check's single-credential branch passed the STALE A identity onto B's
+    credits. whoami is credit-free, so it is simply fetched every refresh.
+    """
+
+    @pytest.mark.asyncio
+    async def test_identity_refetched_each_refresh(self):
+        _reset_usage_globals()
+        ARN = "arn:aws:codewhisperer:us-east-1:1:profile/A"
+        api_dict = {"credits_used": 1.0, "credits_plan": 10.0, "source": "api",
+                    "_profile_arn": ARN}
+        calls = []
+
+        async def fake_whoami(_bin):
+            calls.append(1)
+            return {"email": f"user{len(calls)}@corp.com", "_profile_arn": ARN}
+
+        for _ in range(2):
+            sessions_mod._usage_cache_ts = 0.0
+            with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+                 patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+                 patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                              return_value=dict(api_dict)), \
+                 patch.object(sessions_mod, "_fetch_whoami", fake_whoami):
+                await sessions_mod._fetch_usage_bg()
+        # Two refreshes -> two whoami resolutions, and the SECOND identity wins.
+        assert len(calls) == 2, "whoami must not be memoized across refreshes"
+        assert sessions_mod._usage_cache["email"] == "user2@corp.com"
+        _reset_usage_globals()
+
+    def test_no_lifetime_identity_cache_exists(self):
+        # Guard against the memoization being reintroduced.
+        assert not hasattr(sessions_mod, "_identity_cache")

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1189,7 +1189,8 @@ export default function App() {
               expiresLabel: typeof u.bonus_expires_label === 'string' ? u.bonus_expires_label : undefined,
             }
           : undefined
-        return { used, limit, overage, resets: u.resets, plan: u.plan, costUsd: u.cost_usd, overageRate: u.overage_rate, bonus, stale: u.stale === true }
+        const str = (v: unknown) => (typeof v === 'string' && v ? v : undefined)
+        return { used, limit, overage, resets: u.resets, plan: u.plan, costUsd: u.cost_usd, overageRate: u.overage_rate, bonus, stale: u.stale === true, account: str(u.account), email: str(u.email), accountType: str(u.account_type), startUrl: str(u.start_url) }
       }
       // Non-Kiro provider (kiro-cli absent) -> hide. Empty cache (Kiro warming) -> spinner.
       if (u.available === false) return 'none' as const
@@ -2146,8 +2147,40 @@ export default function App() {
             {meta && <div className="text-[11px] text-muted mt-1.5">{meta}</div>}
           </div>
         )
+        // Sign-in description shown under the identity: account type + issuer
+        // host ("IAM Identity Center · amzn.awsapps.com"). Collapses gracefully
+        // when either half is missing.
+        // kiro-cli distinguishes four auth kinds (social | idc | builderId |
+        // external_idp); social login covers Google/GitHub and reports
+        // accountType "Social". Unmapped values pass through verbatim rather
+        // than being hidden, so a new kind still says something truthful.
+        const acctKind = kiroUsage.accountType === 'IamIdentityCenter' ? 'IAM Identity Center'
+          : kiroUsage.accountType === 'BuilderId' ? 'Builder ID'
+          : kiroUsage.accountType === 'Social' ? 'Social login'
+          : kiroUsage.accountType
+        let issuerHost: string | undefined
+        if (kiroUsage.startUrl) { try { issuerHost = new URL(kiroUsage.startUrl).host } catch { issuerHost = undefined } }
+        const signedInWith = [acctKind, issuerHost].filter(Boolean).join(' · ')
+        // Identity line prefers the real email; the org profile name is only a
+        // fallback for accounts where whoami gave us nothing.
+        const who = kiroUsage.email || kiroUsage.account
         return (
           <div className="flex flex-col gap-3">
+            {who && (
+              <div className="flex items-center gap-3 pb-3" style={{ borderBottom: '1px solid var(--border)' }}>
+                <div
+                  className="shrink-0 rounded-full flex items-center justify-center text-[15px] font-semibold uppercase"
+                  style={{ width: 40, height: 40, background: 'var(--accent)', color: '#fff' }}
+                  aria-hidden="true"
+                >
+                  {who.slice(0, 1)}
+                </div>
+                <div className="min-w-0">
+                  <div className="text-[15px] font-medium text-text truncate" title={who}>{who}</div>
+                  {signedInWith && <div className="text-[12px] text-muted truncate">Signed in with {signedInWith}</div>}
+                </div>
+              </div>
+            )}
             <div className="flex items-baseline gap-2">
               <span className="text-2xl font-bold text-text">{totalUsed.toLocaleString()}</span>
               <span className="text-sm text-muted">/ {totalLimit.toLocaleString()} {bonus ? i18nT('app.credits_total') : i18nT('app.credits')}</span>


### PR DESCRIPTION
## Problem

The Kiro Credits panel showed how many credits were burned, but never which account burned them. On a machine with more than one Kiro identity available — or when handing a screenshot to someone else — there was no way to tell whose plan the 26,620/10,000 belonged to.

## Why it matters

Credit overage is billed. A usage readout with no account attached is ambiguous exactly when it matters most: reconciling an overage bill, or checking that the gateway is signed in as the account you think it is.

## Fix (symptoms → root cause → change)

**Symptom:** the panel has usage numbers but no identity.

**Root cause:** the two data sources the panel already used cannot supply one. `GetUsageLimits` returns credits and subscription info, no identity. The SSO cache (`~/.aws/sso/cache/kiro-auth-token*.json`) holds *opaque* IdC access credentials requested with `codewhisperer:*` scopes only — no `openid`/`email`, no id JWT — so there is no email claim to read for any account type. An initial attempt to decode one confirmed this and was dropped.

**Change:** ask `kiro-cli` instead. `kiro-cli whoami --format json` resolves the identity itself and returns `{accountType, email, region, startUrl}`. `sessions.py` already shells out to kiro-cli for the `/usage` scrape, so this reuses that established, sandboxed path:

- `_fetch_whoami()` spawns whoami through the same `wrap_argv` sandbox wrapper. kiro-cli prints a JSON object **followed by a non-JSON `Profile:` block**, so only the leading `{...}` is brace-matched and parsed. Values must be strings and are length-bounded before they can reach the cache or UI. Any failure returns `{}`.
- `_cached_whoami()` memoizes it for the gateway lifetime. The credit cache refreshes every 10 minutes and identity does not change under a running gateway, so this avoids a spawn per refresh. Only non-empty results are memoized, so a transient failure retries instead of pinning "unknown" until restart.
- Merged into **both** the API and text-scrape cache paths, after redaction, so identity is source-independent. If whoami fails, the credit readout is completely unaffected.

### Coupling the identity to the billed account

`fetch_usage_limits` tries several candidate credentials (IDE cache first, then the kiro-cli store) and keeps whichever the API accepts, while `whoami` always reports kiro-cli's own identity. With two different accounts signed in those are different accounts, so showing one's email above the other's overage would misattribute a bill.

The **only** accepted proof is a matching profile ARN on both sides (`_identity_matches_account`): the ARN the API actually used, versus the ARN in whoami's trailing `Profile:` block. Anything else is refused and the panel shows no identity at all. Notably, "only one credential was readable" is *not* proof — kiro-cli may authenticate from a store this module does not enumerate, so a lone readable credential does not establish that whoami used it.

**Which accounts this covers.** `kiro-cli` distinguishes four auth kinds (`social | idc | builderId | external_idp`); social login covers Google/GitHub and reports `accountType: "Social"`, which the UI now labels. Per the CLI's own internals a social sign-in *must* carry a profile ARN (`Social_Default_Profile`; it treats a missing ARN as a hard failure), so social accounts can satisfy the ARN match. Identity Center is verified end-to-end on a real account. Builder ID appears to carry no profile ARN, so it would show no identity.

Where an ARN cannot be matched, the row is simply absent: under-reporting an identity is a cosmetic gap, whereas mislabelling whose overage bill this is, is not.

The identity is re-resolved on **every** credit refresh rather than memoized for the gateway lifetime, so it cannot survive an account switch. `whoami` costs no credits and this path runs every 10 minutes, so re-fetching is cheap. The ARN is private (`_`-prefixed) and stripped before anything is cached or served. The text-scrape path needs no check — it *is* kiro-cli's own output, so it and whoami describe the same account by construction.

Frontend: an avatar + email header with `Signed in with <type> · <issuer host>` beneath it, divided from the usage block. `accountType` maps `IamIdentityCenter` → IAM Identity Center and `BuilderId` → Builder ID; the host comes from `startUrl`. The line collapses when either half is missing, and the whole header hides when there is no identity at all — so the panel degrades to exactly its current appearance rather than showing an empty row.

## Tests

- `TestFetchWhoami` (6 cases) covers the trailing-`Profile:`-block parse, a Builder ID payload, non-string values dropped, absent JSON, unterminated JSON, and length bounding.
- Existing `TestFetchUsageBgApi::test_api_result_is_primary_and_subprocess_not_spawned` asserted the API path spawns *no* subprocess. The whoami spawn changes that, so it was retargeted to the invariant that actually matters: the **credit-consuming** `kiro-cli chat ... /usage` scrape must never run on the API path. whoami costs no credits and runs once per gateway lifetime.
- 92 backend tests pass (`test_session_usage.py`, `test_kiro_usage_api.py`); 66 frontend `App.test.tsx` tests pass. isort / flake8 / mypy clean on the changed modules; `tsc -b` + vite build clean.

## Manual verification

Rendered the real panel at 1560×1120 against a running gateway with `/api/sessions/usage` stubbed to each payload shape, then read the frames to confirm the header, avatar initial, divider, and the issuer-host collapse. The internal values are genuine `whoami` output from this machine; the Builder ID values are illustrative, since no Builder ID account was available to sign in with.

## Screenshots

Omitted at the author's request. The identity header was verified by rendering the real panel at 1560x1120 against a running gateway (both the coupled state and the unprovable state where the header hides); see "Manual verification" above.
