### PR TITLE
fix(dashboard): stop a stray wheel event dragging the app shell

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -947,8 +947,17 @@
   *{box-sizing:border-box;margin:0;padding:0}
   html,body,#root{height:100%}
   body{font:400 0.875rem/1.55 var(--font-body);letter-spacing:normal;background:var(--bg);color:var(--text);
-    -webkit-font-smoothing:antialiased;overflow-x:hidden;overflow-y:auto;
+    -webkit-font-smoothing:antialiased;overflow-x:hidden;overflow-y:auto;overscroll-behavior-y:none;
     transition:background-color .25s ease,color .25s ease}
+  /* The dashboard shell is height-locked (h-screen + overflow-hidden), so the
+     document has no reason to scroll on those routes. Lock it. A third-party
+     node appended to <body> — browser extensions do this routinely — otherwise
+     leaves a few pixels of slack, and a wheel event that lands on the document
+     rather than on a pane drags the whole app through them. Containment on the
+     panes cannot cover that path because no chaining is involved.
+     Scoped with :has() so the onboarding and welcome views, which legitimately
+     grow past the viewport, keep their document scroll. */
+  body:has([data-testid="dashboard-shell"]){overflow:hidden}
   /* Global focus ring for keyboard navigation */
   /* TESTING: disabled to check scroll bug */
   /* :focus-visible{outline:2px solid var(--accent);outline-offset:2px} */

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3989,6 +3989,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
                 // This is more precise than item-level anchoring because
                 // it works at the DOM-element granularity.
                 overflowAnchor: 'auto',
+                // Keep wheel/touch momentum inside the message list. Without
+                // this, a delta that arrives at the top or bottom edge chains
+                // to the nearest scrollable ancestor — the document, which
+                // `body{overflow-y:auto}` leaves scrollable — and drags the
+                // whole app shell by however many pixels of slack exist
+                // (a browser-extension node parked past the shell is enough).
+                overscrollBehavior: 'contain',
               } as React.CSSProperties}
               aria-label={i18nT('pages.chatPage.chat_messages')}
               aria-live="polite"

--- a/website/src/test/ChatPage.responsivePanel.test.tsx
+++ b/website/src/test/ChatPage.responsivePanel.test.tsx
@@ -351,3 +351,27 @@ describe('ChatPage — activity toggle on mobile', () => {
     expect(screen.queryByLabelText('Window too narrow for the activity panel')).not.toBeInTheDocument()
   })
 })
+
+describe('ChatPage — message scroller contains its scroll', () => {
+  beforeEach(() => setWindowWidth(1400))
+
+  it('sets overscroll-behavior:contain so wheel deltas never chain to the document', async () => {
+    const store = createTestStore()
+    act(() => {
+      store.dispatch(switchSlot.pending('req-scroll', 'slot-scroll'))
+      store.dispatch(switchSlot.fulfilled({
+        key: 'slot-scroll',
+        messages: [{ role: 'assistant', content: 'hi', cls: '' }],
+        running: false, hasMore: false, total: 1, queue: [],
+      }, 'req-scroll', 'slot-scroll'))
+    })
+    renderChat(store)
+
+    const scroller = await screen.findByLabelText('Chat messages')
+    // Positive control: the list really is the scroll container under test.
+    expect(scroller.style.overflowY).toBe('auto')
+    // The guard: without containment, a delta at the top or bottom edge
+    // chains to the document and drags the whole app shell.
+    expect(scroller.style.overscrollBehavior).toBe('contain')
+  })
+})


### PR DESCRIPTION
## Problem

Scrolling inside the chat, or anywhere on the dashboard, drags the entire app shell — topbar, nav rail and all — up by a few pixels. It springs nothing back. The user has to scroll the other way to restore the layout.

Reproduced on a live gateway at 1320px viewport height: the document held exactly 13px of scrollable slack.

## Why it matters

The shell is meant to be fixed furniture. A topbar and nav rail that slide out of place on an ordinary wheel gesture read as a broken layout, and every pane in the dashboard can trigger it. The trigger is not under our control (see below), so any user running a common browser extension sees it.

## Fix (symptom → root cause → change)

The shell is already height-locked: `h-screen w-screen overflow-hidden` in `website/src/App.tsx`. So the document should have had nothing to scroll. Measuring in the browser found a stray body child:

```
<custom-tooltip style="position: absolute; opacity: 0; pointer-events: none; ...">
```

A **browser extension** appends that element to `document.body`. It is idle, invisible and 13px tall, and with no coordinates set it lands immediately after the last in-flow child — 13px past the bottom of the shell. `body { overflow-y: auto }` in `website/src/index.css` then made those 13px genuinely scrollable, and a wheel event landing on the document dragged the whole app through them.

The tag appears nowhere in this repo, and every body portal we render uses `position: fixed`, which cannot extend the document.

Three changes, ordered by what each one closes:

1. **Lock the document on dashboard routes.** `body:has([data-testid="dashboard-shell"]) { overflow: hidden }`. The shell has no legitimate reason to let the document scroll, so the slack becomes unreachable by any gesture, whatever a third party appends. Scoped with `:has()` deliberately — the onboarding and welcome views use `min-h-screen` and genuinely need document scroll, and they do not carry that test id.
2. **Contain the chat message scroller** (`overscroll-behavior: contain`). This closes the other route into the same slack: a wheel delta that reaches the list's top or bottom edge and chains outward to the document.
3. **Contain the document** (`overscroll-behavior-y: none`). Same protection for every other pane, including the embed and popout frames, which do not carry the shell test id and so are not covered by change 1.

Worth recording why all three are here: containment alone did **not** fix it. After deploying changes 2 and 3 to a live gateway, the drag persisted with `overscroll-behavior` confirmed active in the browser. That is what identified the direct-hit path — a wheel event landing on the document involves no chaining, so containment structurally cannot stop it. Change 1 is the fix; changes 2 and 3 close the chaining path and cover the frames change 1 misses.

## Tests

`website/src/test/ChatPage.responsivePanel.test.tsx` — new `describe` block asserting the chat scroller carries `overscroll-behavior: contain`, with `overflowY === 'auto'` as a positive control so the assertion fails loudly if the selector ever finds the wrong element.

Verified RED-first: with the `overscrollBehavior` line removed from `ChatPage.tsx`, the test fails with `expected '' to be 'contain'`. With it, the file passes 15/15.

The CSS rules carry no unit test. jsdom does not do layout, so a document-scroll assertion there would be theatre. Both were verified in a real browser instead — see below.

## Manual verification

On a live gateway, through the tunnel origin, hard-reloaded between steps:

1. Before: `document.documentElement.scrollHeight - clientHeight` → **13**, and the shell visibly dragged.
2. After changes 2 and 3 only: `overscroll-behavior-y: none` on body and `contain` on the scroller both confirmed via `getComputedStyle`. Slack still **13**, drag still present. This is the step that disproved the chaining hypothesis.
3. After change 1: slack **0**, drag gone. `document.querySelector('custom-tooltip')` still returns the element — it is still there, just clipped and unreachable.

Also confirmed the `dashboard-shell` test id survives the production build (present in the emitted bundle) and that the minifier preserves the rule as `body:has([data-testid=dashboard-shell]){overflow:hidden}`, so the selector really matches what ships.

Gates: `tsc --noEmit` clean, `eslint` 0 errors, `npm run build` clean, target test file 15/15.

## Screenshots

N/A — no visual change. The diff alters scroll behaviour only. Nothing moves, resizes, recolours or appears; the observable difference is that the shell stops moving when it should not have moved. A before/after screenshot pair would be pixel-identical.
