### PR TITLE
fix(pod): stop worktrees and the global launcher hijacking each other

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -366,6 +366,40 @@ def _extra_mcp_scope_globals() -> list[Path]:
     return [s.global_json for s in scopes]
 
 
+def _in_linked_git_worktree(path: Path) -> bool:
+    """Whether *path* lives inside a git **linked worktree** (``git worktree add``).
+
+    A linked worktree's ``.git`` is a FILE holding
+    ``gitdir: <git-dir>/worktrees/<name>``; an ordinary clone's ``.git`` is a
+    DIRECTORY. Walks up from *path* and answers on the nearest repository marker,
+    so a linked worktree is distinguished from the main clone it belongs to.
+
+    The pointer is matched on the ``/worktrees/`` segment rather than
+    ``/.git/worktrees/``, because a **bare** repository's git dir *is* the repo
+    dir and carries no ``.git`` component — ``git -C myrepo.git worktree add``
+    writes ``gitdir: /…/myrepo.git/worktrees/<name>``, which a ``/.git/`` match
+    would miss, silently reopening the very bypass this guard exists to close.
+    ``/worktrees/`` stays precise: the only other producer of a ``gitdir:``
+    ``.git`` file is a submodule, which points into ``modules/`` instead.
+
+    Deliberately stdlib-only and subprocess-free: this runs on the gateway start
+    path, where shelling out to ``git`` would add latency and fail wherever git is
+    absent (notably the packaged desktop app).
+    """
+    for parent in (path, *path.parents):
+        marker = parent / ".git"
+        if marker.is_dir():
+            return False  # ordinary clone — nearest marker wins
+        if marker.is_file():
+            try:
+                head = marker.read_text(encoding="utf-8", errors="replace")[:4096]
+            except OSError:
+                return False
+            # Normalize separators so a Windows-style gitdir also matches.
+            return head.startswith("gitdir:") and "/worktrees/" in head.replace("\\", "/")
+    return False
+
+
 def ensure_kirocrew_on_path(bin_dir: Path | None = None) -> str | None:
     """Ensure a ``kirocrew`` launcher is reachable on the user's PATH.
 
@@ -388,6 +422,30 @@ def ensure_kirocrew_on_path(bin_dir: Path | None = None) -> str | None:
     target = _resolve_kirocrew_bin()
     # Nothing concrete to point at — bare "kirocrew" or a non-executable file.
     if not (os.path.isabs(target) and os.path.isfile(target) and os.access(target, os.X_OK)):
+        return None
+
+    # Never aim the user's machine-wide launcher at a linked git worktree. A
+    # worktree is ephemeral by construction: `git worktree remove` deletes its
+    # `.venv` along with the tree, and the shim is then a dangling symlink, so
+    # `kirocrew` stops working EVERYWHERE — not just in the tree that went away.
+    # Any process running out of a worktree's venv (a pod gateway, a dev run, a
+    # `kirocrew setup` invoked from that tree) resolves its own venv entrypoint
+    # here, so without this guard routine worktree work silently hijacks the
+    # global command. `instances/token_mint.py` documents the same hazard from
+    # the consuming side. Declining leaves whatever already worked in place.
+    #
+    # `.resolve()` first: the ancestry walk is LEXICAL, and the resolved target
+    # is frequently itself a symlink into a worktree (a PATH entry, or the very
+    # shim we are about to rewrite). Walking the symlink's own parents would find
+    # no `.git` marker and wave the worktree through — reopening this hole.
+    if _in_linked_git_worktree(Path(target).resolve()):
+        logger.info(
+            "Not installing a kirocrew launcher: %s is inside a linked git worktree, "
+            "which is ephemeral (removing the worktree would break `kirocrew` "
+            "machine-wide). Install from your primary clone, or link it yourself: "
+            "ln -sfn <clone>/.venv/bin/kirocrew ~/.local/bin/kirocrew",
+            target,
+        )
         return None
 
     # Already reachable on PATH as the same binary? Then there's nothing to do.

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1132,7 +1132,7 @@ Examples:
     )
     pod_sub = pod_parser.add_subparsers(
         dest="pod_action",
-        metavar="{up,down,ls,status,token,url,logs,provision,install}",
+        metavar="{up,down,ls,status,token,url,logs,exec,provision,install}",
     )
     pod_up = pod_sub.add_parser("up", help="Schedule an isolated pod for a worktree")
     pod_up.add_argument("name", help="Worktree name")
@@ -1159,6 +1159,19 @@ Examples:
     pod_logs = pod_sub.add_parser("logs", help="Tail a pod's journal")
     pod_logs.add_argument("name", help="Worktree name")
     pod_logs.add_argument("-n", "--lines", type=int, default=50, help="Lines to tail (default: 50)")
+    pod_exec = pod_sub.add_parser(
+        "exec",
+        help="Run a kirocrew command against a pod, using the pod's own binary and data",
+    )
+    pod_exec.add_argument("name", help="Worktree name")
+    # REMAINDER so the pod's own flags (--json, -n, --ttl …) reach the child
+    # instead of being claimed by this parser.
+    pod_exec.add_argument(
+        "argv",
+        nargs=argparse.REMAINDER,
+        metavar="-- ARGS",
+        help="Command to run in the pod, e.g. `-- status` or `-- cron list`",
+    )
     pod_prov = pod_sub.add_parser("provision", help="Build a worktree's venv + SPA dist")
     pod_prov.add_argument("name", help="Worktree name")
     pod_prov.add_argument(

--- a/src/kiro_crew/pod/cli.py
+++ b/src/kiro_crew/pod/cli.py
@@ -247,6 +247,25 @@ def _url(cfg: PodConfig, args: argparse.Namespace) -> None:
     print(f"http://127.0.0.1:{rt.derive_port(cfg, name)}")
 
 
+def _exec(cfg: PodConfig, args: argparse.Namespace) -> None:
+    name = rt.validate_name(args.name)
+    argv = list(args.argv or [])
+    if not argv:
+        _die("nothing to run — usage: kirocrew pod exec <name> -- <args…>")
+    # Validate BEFORE auditing: emitting "allowed" and then having the runtime
+    # refuse the verb would record the opposite of the decision actually taken,
+    # which is worse than no audit trail at all — SEL would attest that a denied
+    # `service uninstall` was permitted.
+    try:
+        rt.require_pod_safe_verb(argv, name)
+    except rt.PodError as exc:
+        _audit("pod.exec", "denied", f"name={name} argv={argv[0]}", error=str(exc))
+        _die(str(exc))
+    _audit("pod.exec", "allowed", f"name={name} argv={argv[0]}")
+    # execve replaces this process; on success nothing below runs.
+    sys.exit(rt.exec_in_pod(cfg, name, argv))
+
+
 def _logs(cfg: PodConfig, args: argparse.Namespace) -> None:
     name = rt.validate_name(args.name)
     subprocess.run(
@@ -316,13 +335,17 @@ _VERBS: dict[str, PodHandler] = {
     "provision": _provision,
     "_run": _run_internal,
     "_cleanup": _cleanup_internal,
+    "exec": _exec,
 }
 
 
 def dispatch(args: argparse.Namespace) -> None:
     action = getattr(args, "pod_action", None)
     if not action:
-        print("Usage: kirocrew pod {up|down|ls|status|token|url|logs|install|provision} …")
+        print(
+            "Usage: kirocrew pod "
+            "{up|down|ls|status|token|url|logs|exec|install|provision} …"
+        )
         sys.exit(2)
     cfg = PodConfig.load()
     handler = _VERBS.get(action)

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -370,7 +370,24 @@ def build_pod_env(cfg: PodConfig, home_dir: Path, port: int, checkout: Path) -> 
         "KIROCREW_HOME": str(home_dir),
         "KIROCREW_PORT": str(port),
         "KIROCREW_PROJECT_DIR": str(checkout),
-        "PATH": cfg.gateway_path,
+        # Give the pod its OWN workspace root. Without this, `workspace_root()`
+        # finds no `KIROCREW_WORKSPACE` and no `config_dir()/workspace_dir` file in
+        # a fresh pod home, so it falls through to the platform default under the
+        # REAL `HOME` — and every agent turn in the pod (a `chat`/`run`/`tui`
+        # through `pod exec`, and the pod gateway's own sessions) would read and
+        # WRITE the live workspace. `KIROCREW_WORKSPACE` is the documented override
+        # (config/loader.py:220, used as-is) and `eval/runner.py` already scopes a
+        # run the same way, so this is the existing mechanism rather than new
+        # resolution behaviour. Placing it inside the pod HOME means the
+        # zero-residue `ExecStopPost` teardown removes it with everything else.
+        "KIROCREW_WORKSPACE": str(home_dir / "workspace"),
+        # The pod's OWN venv leads PATH, ahead of cfg.gateway_path (which starts
+        # with ~/.local/bin). Without this a bare `kirocrew` inside a pod — an
+        # agent bash turn, a subprocess, `_kirocrew_bin()`'s "console-script on
+        # PATH" probe — resolves the machine-wide shim instead of the checkout
+        # under test, so the pod silently exercises the global install and stays
+        # coupled to a symlink it does not own.
+        "PATH": os.pathsep.join([str(checkout / ".venv" / "bin"), cfg.gateway_path]),
     }
     for key in [
         k
@@ -394,6 +411,9 @@ def write_pod_config(home_dir: Path, seed: str) -> None:
     """
     home_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(home_dir, stat.S_IRWXU)  # 0o700 owner-only (mkdir mode is umask-masked)
+    # The pod's own workspace root (see build_pod_env's KIROCREW_WORKSPACE).
+    # Created here so the gateway never falls back to the live workspace.
+    (home_dir / "workspace").mkdir(mode=0o700, exist_ok=True)
     dst_cfg = home_dir / "config.json"
     if dst_cfg.exists():
         return
@@ -425,6 +445,202 @@ def cleanup_home(cfg: PodConfig, name: str) -> int:
         return 2
     shutil.rmtree(target, ignore_errors=True)
     return 0
+
+
+def pod_context(cfg: PodConfig, name: str) -> tuple[Path, dict[str, str]]:
+    """Resolve pod *name* to ``(its own kirocrew binary, its isolated env)``.
+
+    The single seam every pod-scoped command goes through, so ``boot``,
+    :func:`exec_in_pod` and ``pod env`` cannot drift apart. Notably the env comes
+    from :func:`build_pod_env`, which means a command run against a pod inherits
+    the SAME messaging-credential scrubbing as the pod's own gateway — a
+    hand-rolled env here would silently let a throwaway instance act as the live
+    Slack / WeCom / Telegram identity.
+
+    Raises :class:`PodError` when the pod has no pinned checkout (never brought
+    up from inside a checkout) or that checkout has no provisioned venv.
+    """
+    validate_name(name)
+    checkout_str = read_env_file(cfg, name).get("CHECKOUT")
+    if not checkout_str:
+        raise PodError(
+            f"pod {name!r} has no pinned checkout — run `kirocrew pod up {name}` "
+            f"from inside a kirocrew checkout first"
+        )
+    checkout = Path(checkout_str).expanduser()
+    bin_path = checkout / ".venv" / "bin" / "kirocrew"
+    if not (bin_path.exists() and os.access(bin_path, os.X_OK)):
+        raise PodError(f"no kirocrew venv at {bin_path} (provision {name} first)")
+    env = build_pod_env(cfg, cfg.home_dir(name), derive_port(cfg, name), checkout)
+    return bin_path, env
+
+
+# `pod exec` forwards to a real kirocrew, so it inherits the WHOLE CLI — including
+# verbs that manage the HOST rather than any one instance. An earlier revision
+# denied the dangerous ones by name and that list was incomplete three times over
+# (`stop`, then `restart` for a second reason, then `service`), because the set of
+# host-scoped verbs is open-ended. So this is an ALLOWLIST: every verb below acts
+# only on `KIROCREW_HOME` state, which `pod exec` has already pointed at the pod.
+# Anything else — present or newly added — is refused until it is deliberately
+# listed, so the failure mode of drift is "temporarily unavailable" rather than
+# "silently operated on the user's live machine".
+#
+# Deliberately EXCLUDED, with the reason each is host-scoped, not pod-scoped:
+#   setup, update  — rewrite the install and the ~/.local/bin launcher
+#   app            — `apps/bridges.py` symlinks app agent JSONs into
+#                    `Path.home()/".kiro"/"agents"` and edits
+#                    `~/.kiro/settings/mcp.json` — the HOST registry, not
+#                    KIROCREW_HOME. A pod install/uninstall would replace or
+#                    delete symlinks the live gateway depends on, and point them
+#                    into a checkout that is about to be deleted: the same
+#                    dangling-symlink failure this PR exists to fix.
+#   stop, restart  — service-aware: `cli_server._stop` short-circuits to
+#                    systemctl when no explicit --port is passed, so they hit the
+#                    LIVE gateway; and `restart` additionally makes systemd run
+#                    the pod unit's ExecStopPost (erasing the pod HOME) while
+#                    leaving a DETACHED replacement `pod down` cannot stop
+#   service        — installs/removes the machine-wide systemd unit
+#   gateway        — would race a second gateway against the pod's own unit
+#   pod            — pod management from inside a pod (a nested `pod down` would
+#                    tear down its own supervisor)
+#   cloud          — provisions resources in the user's AWS account
+#   browse         — writes browser auth state outside KIROCREW_HOME
+#   manifest       — emits a Slack app manifest tied to the real identity
+#   run            — `task_reporter.save_progress` writes `TASK_PROGRESS.md`
+#                    "next to the spec file" (`Path(run.spec_path).parent`), so
+#                    `run /host/TASK.md` writes `/host/TASK_PROGRESS.md`. An
+#                    IMPLICIT write outside the pod, derived from a path the user
+#                    supplied as an input rather than a destination.
+#   snapshot       — its destination is CONFIGURABLE (`snapshot_dir`, or a
+#                    positional dir) and `--keep N` DELETES older archives beyond
+#                    N. `sanitized_seed_config` only forces tunnel/telegram/wecom
+#                    off, so a pod seeded from the live config inherits the user's
+#                    real backup directory — `snapshot --keep 1` from a pod would
+#                    prune live backups. Destructive and cross-plane.
+#   doctor         — NOT read-only: `cli_doctor.py:126` does
+#                    `atomic_write(agent_path, ...)` where `agent_path` is
+#                    `KIRO_AGENTS_DIR / AGENT_FILENAME` (line 405), i.e. under the
+#                    real HOME. It auto-adds missing MCP servers, so a pod
+#                    `doctor` rewrites the LIVE agent configuration.
+#   tui, chat      — `cli_chat._tui` resolves its port as
+#                    `getattr(args, "port", None) or cfg…get("port", 5476)` — the
+#                    CONFIG dashboard port, falling back to literal 5476, never
+#                    `KIROCREW_PORT`. A pod's config names no dashboard port, so it
+#                    lands on the LIVE gateway. `chat` is excluded too because
+#                    `chat --tui` branches straight into `_tui` (cli.py:1818), so
+#                    excluding only `tui` left the same hole open. Every OTHER
+#                    client verb (`status`, `logout`, and the credential verb) goes
+#                    through `cli_server.resolve_client_port`, which DOES honour
+#                    `KIROCREW_PORT` — so this hazard is confined to `_tui`.
+#   logs           — `cli_server._logs_cmd` runs `journalctl -u <SERVICE_NAME>`,
+#                    the HOST service unit, so inside a pod it would show the LIVE
+#                    gateway's journal while appearing to show the pod's. Wrong
+#                    answer rather than damage, but a confidently wrong one.
+#                    `kirocrew pod logs NAME` reads the pod's own unit.
+#   mcp-*          — stdio server entrypoints, not user-facing commands
+#
+# `agent` and `workspace` ARE listed: both dispatchers were checked and operate
+# only on `config_dir()` state (the config.json agents/workspaces maps), never on
+# `~/.kiro/agents`. `workspace` is safe specifically because it asserts every
+# source and destination `is_relative_to(config_dir())`; without that guard it
+# would belong with `snapshot`. `restore` is listed because although its SOURCE
+# archive path is arbitrary, that is a read — everything it writes lands in
+# `config_dir()`.
+#
+# The inclusion test, stated once so it does not have to be rediscovered. A verb
+# qualifies only if BOTH hold:
+#   (a) every path it writes IMPLICITLY — anywhere the user did not name as a
+#       destination — is inside `config_dir()`; and
+#   (b) it deletes nothing outside `config_dir()`.
+# An explicitly-named output destination is fine (`memory export -o FILE` writes
+# where the user pointed it, no differently from shell redirection). What fails is
+# an implicit write derived from an INPUT path (`run` → `TASK_PROGRESS.md` beside
+# the spec), a host registry (`app`), a host service (`service`, `stop`,
+# `restart`), a deletion driven by config (`snapshot --keep`), or a host-scoped
+# read that merely LOOKS pod-scoped (`logs`).
+_POD_SAFE_VERBS = frozenset(
+    {
+        "agent",
+        "artifact",
+        "config",
+        "consolidate",
+        "cron",
+        "eval",
+        "knowledge",
+        "learn",
+        "logout",
+        "memory",
+        "policy",
+        "restore",
+        "security",
+        "spawn",
+        "status",
+        "token",
+        "workspace",
+    }
+)
+
+# The pod-native equivalent to suggest for the verbs users are most likely to try.
+_POD_EQUIVALENT: dict[str, str] = {
+    "stop": "kirocrew pod down {name}",
+    "restart": "kirocrew pod down {name} && kirocrew pod up {name}",
+    "gateway": "kirocrew pod up {name}",
+    "logs": "kirocrew pod logs {name}",
+}
+
+
+def require_pod_safe_verb(argv: list[str], name: str) -> None:
+    """Raise :class:`PodError` unless ``argv[0]`` is a pod-scoped verb.
+
+    The verb must come FIRST. That is a deliberate constraint rather than a
+    limitation to work around: allowing global flags ahead of it reintroduces the
+    parsing ambiguity that made the previous denylist bypassable (``-v stop``, and
+    worse ``--log-level DEBUG stop``, where the flag's value is indistinguishable
+    from a verb). Flags AFTER the verb are untouched, so `-- status --json` works.
+    """
+    verb = argv[0] if argv else ""
+    if verb in _POD_SAFE_VERBS:
+        return
+    hint = ""
+    if verb in _POD_EQUIVALENT:
+        hint = f" Use `{_POD_EQUIVALENT[verb].format(name=name)}` instead."
+    elif verb.startswith("-"):
+        hint = " The verb must come first; put global flags after it."
+    else:
+        hint = (
+            " Only verbs that act on the pod's own data are allowed: "
+            + ", ".join(sorted(_POD_SAFE_VERBS))
+            + "."
+        )
+    raise PodError(f"refusing `{verb or '(nothing)'}` inside `pod exec`:{hint}")
+
+
+def exec_in_pod(cfg: PodConfig, name: str, argv: list[str]) -> int:
+    """``exec`` *argv* as the pod's own kirocrew, in the pod's isolated env.
+
+    Replaces the current process on success, so the child's exit status and its
+    stdio (including a TTY, which matters for ``chat`` / ``tui``) reach the caller
+    untouched. Returns an exit code only when the exec itself fails.
+    """
+    require_pod_safe_verb(argv, name)
+    bin_path, env = pod_context(cfg, name)
+    # Run INSIDE the pod's workspace, not the caller's cwd. Agent verbs resolve
+    # relative paths against the working directory, so inheriting the invoking
+    # shell's cwd (often the live checkout) would let `-- run ./TASK.md` or a file
+    # edit land outside the pod even with KIROCREW_WORKSPACE set correctly.
+    workspace = Path(env["KIROCREW_WORKSPACE"])
+    try:
+        workspace.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chdir(workspace)
+    except OSError as exc:
+        print(f"FATAL: could not enter the pod workspace {workspace}: {exc}")
+        return 70
+    try:
+        os.execve(str(bin_path), [str(bin_path), *argv], env)
+    except OSError as exc:  # pragma: no cover - exec failure is environmental
+        print(f"FATAL: could not exec {bin_path}: {exc}")
+        return 70
+    return 0  # unreachable on success
 
 
 # --------------------------------------------------------------------------- #

--- a/test/test_installer_shim_and_cleanup.py
+++ b/test/test_installer_shim_and_cleanup.py
@@ -382,6 +382,151 @@ def test_ensure_shim_noop_when_already_on_path(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------
+# ensure_kirocrew_on_path — never follow an ephemeral git worktree
+#
+# `git worktree remove` deletes the tree's .venv with it, so a shim pointing
+# there dangles and `kirocrew` breaks machine-wide, not just in that tree.
+# --------------------------------------------------------------------------
+def _checkout_with_kirocrew(root: Path, *, linked_worktree: bool, bare_parent: bool = False) -> Path:
+    """Build a fake checkout at *root* whose venv holds a `kirocrew` entrypoint.
+
+    ``linked_worktree`` chooses the repository marker: a ``.git`` FILE with a
+    ``gitdir:`` pointer (what `git worktree add` writes) versus a ``.git``
+    DIRECTORY (an ordinary clone). ``bare_parent`` selects the pointer shape a
+    **bare** repo produces — ``<repo>.git/worktrees/<name>``, with no ``.git``
+    path component — verified against real git, not assumed.
+    """
+    binary = root / ".venv" / "bin" / "kirocrew"
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(0o755)
+    if linked_worktree:
+        git_dir = (
+            f"{root.parent}/myrepo.git" if bare_parent else f"{root.parent}/main/.git"
+        )
+        (root / ".git").write_text(f"gitdir: {git_dir}/worktrees/{root.name}\n")
+    else:
+        (root / ".git").mkdir()
+    return binary
+
+
+def _resolve_to(monkeypatch, binary: Path) -> None:
+    """Make resolution land on *binary* and leave nothing else on PATH."""
+    monkeypatch.setattr(agent, "_KIROCREW_BIN", "", raising=False)
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.setattr(agent, "_resolve_kirocrew_bin", lambda: str(binary))
+    monkeypatch.setattr(agent.shutil, "which", lambda c, **kw: None)
+
+
+def test_in_linked_git_worktree_distinguishes_marker_kind(tmp_path):
+    """The detector answers on the nearest marker: `.git` file vs `.git` dir."""
+    wt = _checkout_with_kirocrew(tmp_path / "wt-feature", linked_worktree=True)
+    clone = _checkout_with_kirocrew(tmp_path / "clone", linked_worktree=False)
+
+    assert agent._in_linked_git_worktree(wt) is True
+    assert agent._in_linked_git_worktree(clone) is False
+    # Not a repository at all — nothing to decline.
+    assert agent._in_linked_git_worktree(tmp_path / "nowhere" / "bin" / "kirocrew") is False
+
+
+def test_in_linked_git_worktree_matches_a_bare_repo_pointer(tmp_path):
+    """A bare repo's git dir IS the repo dir, so its worktree pointer carries no
+    `.git` component (`/…/myrepo.git/worktrees/<name>`). Matching on `/.git/`
+    would miss it and reopen the bypass."""
+    wt = _checkout_with_kirocrew(
+        tmp_path / "wt-from-bare", linked_worktree=True, bare_parent=True
+    )
+    pointer = (tmp_path / "wt-from-bare" / ".git").read_text()
+    assert "/.git/worktrees/" not in pointer, "fixture must reproduce the bare shape"
+
+    assert agent._in_linked_git_worktree(wt) is True
+
+
+def test_in_linked_git_worktree_ignores_a_submodule_pointer(tmp_path):
+    """`/worktrees/` must not be so loose that a submodule matches: submodules
+    write `gitdir: ../.git/modules/<name>`, a different subtree."""
+    root = tmp_path / "sub"
+    binary = root / ".venv" / "bin" / "kirocrew"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(0o755)
+    (root / ".git").write_text("gitdir: ../.git/modules/sub\n")
+
+    assert agent._in_linked_git_worktree(binary) is False
+
+
+def test_ensure_shim_declines_a_worktree_target(tmp_path, monkeypatch):
+    """A venv inside a linked worktree must never become the global launcher."""
+    binary = _checkout_with_kirocrew(tmp_path / "wt-feature", linked_worktree=True)
+    _resolve_to(monkeypatch, binary)
+    bin_dir = tmp_path / "localbin"
+
+    assert agent.ensure_kirocrew_on_path(bin_dir=bin_dir) is None
+    assert not (bin_dir / "kirocrew").exists(), "worktree venv must not be linked"
+
+
+def test_ensure_shim_declines_a_symlink_pointing_into_a_worktree(tmp_path, monkeypatch):
+    """The ancestry walk is lexical, so a target that is ITSELF a symlink into a
+    worktree must be resolved first — otherwise its own parents carry no `.git`
+    marker and the worktree is waved through."""
+    real = _checkout_with_kirocrew(tmp_path / "wt-feature", linked_worktree=True)
+    # A PATH-style indirection outside any repo, pointing into the worktree.
+    link_dir = tmp_path / "elsewhere"
+    link_dir.mkdir()
+    link = link_dir / "kirocrew"
+    link.symlink_to(real)
+    assert agent._in_linked_git_worktree(link) is False, "lexical walk cannot see through it"
+
+    _resolve_to(monkeypatch, link)
+    bin_dir = tmp_path / "localbin"
+
+    assert agent.ensure_kirocrew_on_path(bin_dir=bin_dir) is None
+    assert not (bin_dir / "kirocrew").exists()
+
+
+def test_ensure_shim_declines_a_bare_repo_worktree_target(tmp_path, monkeypatch):
+    """Same refusal for a worktree of a bare repo — the shape that bypassed the
+    first version of this guard."""
+    binary = _checkout_with_kirocrew(
+        tmp_path / "wt-from-bare", linked_worktree=True, bare_parent=True
+    )
+    _resolve_to(monkeypatch, binary)
+    bin_dir = tmp_path / "localbin"
+
+    assert agent.ensure_kirocrew_on_path(bin_dir=bin_dir) is None
+    assert not (bin_dir / "kirocrew").exists()
+
+
+def test_ensure_shim_links_an_ordinary_clone_target(tmp_path, monkeypatch):
+    """Negative control: the same setup in a normal clone still gets linked, so
+    the guard rejects worktrees specifically rather than disabling the shim."""
+    binary = _checkout_with_kirocrew(tmp_path / "clone", linked_worktree=False)
+    _resolve_to(monkeypatch, binary)
+    bin_dir = tmp_path / "localbin"
+
+    created = agent.ensure_kirocrew_on_path(bin_dir=bin_dir)
+
+    assert created == str(bin_dir / "kirocrew")
+    assert os.path.realpath(bin_dir / "kirocrew") == os.path.realpath(binary)
+
+
+def test_ensure_shim_keeps_a_working_shim_when_target_is_a_worktree(tmp_path, monkeypatch):
+    """The regression that broke the machine: an existing, working shim must
+    survive a resolution that lands in a worktree — not be replaced by it."""
+    good = _checkout_with_kirocrew(tmp_path / "clone", linked_worktree=False)
+    bin_dir = tmp_path / "localbin"
+    bin_dir.mkdir()
+    (bin_dir / "kirocrew").symlink_to(good)
+
+    worktree_binary = _checkout_with_kirocrew(tmp_path / "wt-feature", linked_worktree=True)
+    _resolve_to(monkeypatch, worktree_binary)
+
+    assert agent.ensure_kirocrew_on_path(bin_dir=bin_dir) is None
+    assert os.path.realpath(bin_dir / "kirocrew") == os.path.realpath(good)
+    assert os.path.exists(bin_dir / "kirocrew"), "shim must not be left dangling"
+
+
+# --------------------------------------------------------------------------
 # clean_stale_managed_mcp — edge cases + command-based (playwright) purge
 # --------------------------------------------------------------------------
 def test_clean_stale_missing_file_returns_empty(tmp_path, monkeypatch):

--- a/test/test_pod_self_contained.py
+++ b/test/test_pod_self_contained.py
@@ -1,0 +1,425 @@
+"""A pod is self-contained: its own venv leads PATH, and pod-scoped commands run
+against the pod rather than the machine-wide install.
+
+The bug these guard: ``cfg.gateway_path`` begins with ``~/.local/bin``, so a bare
+``kirocrew`` inside a pod used to resolve the GLOBAL launcher shim — meaning a pod
+exercised the global install instead of the checkout under test, and its boot path
+depended on a symlink it does not own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.pod import runtime as rt
+from kiro_crew.pod.config import PodConfig
+
+
+def _pod_cfg(tmp_path: Path) -> PodConfig:
+    """A PodConfig rooted entirely under tmp_path, with the real default PATH shape
+    (``~/.local/bin`` first) so the ordering assertions are meaningful."""
+    return PodConfig(
+        pod_root=tmp_path / "pods",
+        pods_dir=tmp_path / "podenv",
+        artifacts_dir=tmp_path / "artifacts",
+        base_port=7810,
+        live_port=5476,
+        unit_prefix="kirocrew-pod@",
+        gateway_path=os.pathsep.join([str(tmp_path / ".local" / "bin"), "/usr/bin", "/bin"]),
+        repo_hint=None,
+        worktrees_root=None,
+    )
+
+
+def _provisioned_checkout(tmp_path: Path, name: str = "wt-feature") -> Path:
+    """A checkout with a provisioned venv entrypoint, as `pod provision` leaves it."""
+    checkout = tmp_path / name
+    binary = checkout / ".venv" / "bin" / "kirocrew"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(0o755)
+    return checkout
+
+
+# --------------------------------------------------------------------------- #
+# PATH ordering — the pod's own venv must win over the global shim dir
+# --------------------------------------------------------------------------- #
+def test_pod_env_puts_the_checkout_venv_ahead_of_the_global_shim_dir(tmp_path):
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+
+    env = rt.build_pod_env(cfg, tmp_path / "home", 7900, checkout)
+
+    entries = env["PATH"].split(os.pathsep)
+    venv_bin = str(checkout / ".venv" / "bin")
+    assert entries[0] == venv_bin, "the pod's own venv must lead PATH"
+    # The global shim dir is still reachable, just no longer first.
+    shim_dir = str(tmp_path / ".local" / "bin")
+    assert shim_dir in entries
+    assert entries.index(venv_bin) < entries.index(shim_dir)
+
+
+def test_pod_env_still_isolates_home_and_port(tmp_path):
+    """The PATH change must not disturb the existing isolation keys."""
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    home = tmp_path / "podhome"
+
+    env = rt.build_pod_env(cfg, home, 7900, checkout)
+
+    assert env["KIROCREW_HOME"] == str(home)
+    assert env["KIROCREW_PORT"] == "7900"
+    assert env["KIROCREW_PROJECT_DIR"] == str(checkout)
+
+
+def test_pod_env_scrubs_messaging_credentials(tmp_path, monkeypatch):
+    """Pinned because pod_context() hands this same env to arbitrary commands —
+    a regression here would let `pod exec` act as the live messaging identity."""
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-live")
+    monkeypatch.setenv("WECOM_SECRET", "live")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "live")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "keep-me")
+
+    env = rt.build_pod_env(cfg, tmp_path / "home", 7900, checkout)
+
+    assert "SLACK_BOT_TOKEN" not in env
+    assert "WECOM_SECRET" not in env
+    assert "TELEGRAM_BOT_TOKEN" not in env
+    assert env["AWS_SESSION_TOKEN"] == "keep-me", "AWS creds are kept on purpose"
+
+
+# --------------------------------------------------------------------------- #
+# pod_context — the single seam every pod-scoped command resolves through
+# --------------------------------------------------------------------------- #
+def test_pod_context_resolves_the_pods_own_binary_and_env(tmp_path, monkeypatch):
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    monkeypatch.setattr(rt, "read_env_file", lambda c, n: {"CHECKOUT": str(checkout)})
+
+    bin_path, env = rt.pod_context(cfg, "wt-feature")
+
+    assert bin_path == checkout / ".venv" / "bin" / "kirocrew"
+    assert env["KIROCREW_HOME"] == str(cfg.home_dir("wt-feature"))
+    assert env["PATH"].split(os.pathsep)[0] == str(checkout / ".venv" / "bin")
+
+
+def test_pod_context_errors_when_no_checkout_is_pinned(tmp_path, monkeypatch):
+    cfg = _pod_cfg(tmp_path)
+    monkeypatch.setattr(rt, "read_env_file", lambda c, n: {})
+
+    with pytest.raises(rt.PodError, match="no pinned checkout"):
+        rt.pod_context(cfg, "wt-feature")
+
+
+def test_pod_context_errors_when_the_venv_is_not_provisioned(tmp_path, monkeypatch):
+    cfg = _pod_cfg(tmp_path)
+    bare = tmp_path / "wt-bare"
+    bare.mkdir()
+    monkeypatch.setattr(rt, "read_env_file", lambda c, n: {"CHECKOUT": str(bare)})
+
+    with pytest.raises(rt.PodError, match="provision"):
+        rt.pod_context(cfg, "wt-feature")
+
+
+def test_exec_in_pod_execs_the_pods_binary_with_the_pod_env(tmp_path, monkeypatch):
+    """`pod exec` must exec the POD's binary (never the global one) and pass the
+    isolated env through, so the command hits the pod's data and port."""
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    monkeypatch.setattr(rt, "read_env_file", lambda c, n: {"CHECKOUT": str(checkout)})
+    seen: dict[str, object] = {}
+
+    def _fake_execve(path, argv, env):
+        seen.update(path=path, argv=argv, env=env)
+        raise SystemExit(0)  # stand in for "process replaced"
+
+    monkeypatch.setattr(rt.os, "execve", _fake_execve)
+
+    with pytest.raises(SystemExit):
+        rt.exec_in_pod(cfg, "wt-feature", ["cron", "list"])
+
+    expected = str(checkout / ".venv" / "bin" / "kirocrew")
+    assert seen["path"] == expected
+    assert seen["argv"] == [expected, "cron", "list"]
+    assert seen["env"]["KIROCREW_HOME"] == str(cfg.home_dir("wt-feature"))  # type: ignore[index]
+
+
+# --------------------------------------------------------------------------- #
+# `pod exec` accepts only POD-SCOPED verbs (allowlist), never host management.
+#
+# Denying by name was incomplete three times over — `stop`, then `restart` for a
+# second reason, then `service uninstall` — because the set of host-scoped verbs is
+# open-ended. An allowlist makes an unlisted verb (including a newly added one)
+# fail closed instead of silently operating on the user's live machine.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "verb",
+    [
+        "stop",
+        "restart",
+        "service",
+        "setup",
+        "update",
+        "gateway",
+        "cloud",
+        "browse",
+        "pod",
+        "app",
+        "logs",
+        "snapshot",
+        "run",
+        "doctor",
+        "tui",
+        "chat",
+    ],
+)
+def test_host_scoped_verbs_are_refused(verb):
+    with pytest.raises(rt.PodError, match=f"refusing `{verb}`"):
+        rt.require_pod_safe_verb([verb], "wt-feature")
+
+
+def test_app_is_refused_because_it_rewrites_the_host_agent_registry():
+    """`apps/bridges.py` symlinks app agents into `Path.home()/.kiro/agents` and
+    edits `~/.kiro/settings/mcp.json` — the HOST registry. A pod install/uninstall
+    would replace or delete symlinks the live gateway depends on."""
+    from kiro_crew.apps import bridges
+
+    assert bridges.KIRO_AGENTS_DIR == Path.home() / ".kiro" / "agents"
+    assert "app" not in rt._POD_SAFE_VERBS
+
+
+def test_service_uninstall_is_refused():
+    """The specific escalation an earlier denylist missed: it would stop the live
+    gateway AND delete its machine-wide service definition."""
+    with pytest.raises(rt.PodError, match="refusing `service`"):
+        rt.require_pod_safe_verb(["service", "uninstall"], "wt-feature")
+
+
+@pytest.mark.parametrize("verb", ["status", "cron", "artifact", "learn", "memory", "agent"])
+def test_pod_scoped_verbs_pass_through(verb):
+    assert rt.require_pod_safe_verb([verb], "wt-feature") is None
+
+
+def test_flags_after_the_verb_are_untouched():
+    assert rt.require_pod_safe_verb(["status", "--json"], "wt-feature") is None
+
+
+@pytest.mark.parametrize("argv", [["-v", "status"], ["--log-level", "DEBUG", "stop"], []])
+def test_a_leading_flag_or_empty_argv_is_refused(argv):
+    """The verb must come first. Allowing flags ahead of it is what made the old
+    denylist bypassable: a flag's VALUE is indistinguishable from a verb."""
+    with pytest.raises(rt.PodError):
+        rt.require_pod_safe_verb(list(argv), "wt-feature")
+
+
+def test_the_refusal_names_a_pod_native_equivalent_where_one_exists():
+    with pytest.raises(rt.PodError) as exc:
+        rt.require_pod_safe_verb(["restart"], "wt-feature")
+    assert "kirocrew pod down wt-feature" in str(exc.value)
+    assert "pod up wt-feature" in str(exc.value)
+
+
+def test_the_refusal_lists_the_allowed_verbs_otherwise():
+    with pytest.raises(rt.PodError) as exc:
+        rt.require_pod_safe_verb(["service"], "wt-feature")
+    assert "status" in str(exc.value) and "cron" in str(exc.value)
+
+
+def test_no_allowed_verb_is_host_scoped():
+    """Drift guard: the allowlist must never grow to include a verb that manages
+    the host rather than one instance."""
+    host_scoped = {
+        "setup",
+        "update",
+        "stop",
+        "restart",
+        "service",
+        "gateway",
+        "pod",
+        "cloud",
+        "browse",
+        "manifest",
+        "app",
+        "logs",
+        "snapshot",
+        "run",
+        "doctor",
+        "tui",
+        "chat",
+    }
+    assert not (rt._POD_SAFE_VERBS & host_scoped)
+
+
+# --------------------------------------------------------------------------- #
+# The audit trail must record the decision actually taken.
+#
+# Emitting "allowed" and then refusing the verb makes SEL attest the opposite of
+# what happened — worse than no entry, because it is trusted.
+# --------------------------------------------------------------------------- #
+def test_a_refused_exec_is_audited_as_denied_not_allowed(tmp_path, monkeypatch):
+    from kiro_crew.pod import cli as pod_cli
+
+    cfg = _pod_cfg(tmp_path)
+    seen: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        pod_cli,
+        "_audit",
+        lambda op, outcome, resources="", error="": seen.append((op, outcome)),
+    )
+    monkeypatch.setattr(pod_cli, "_die", lambda msg: (_ for _ in ()).throw(SystemExit(2)))
+
+    with pytest.raises(SystemExit):
+        pod_cli._exec(cfg, argparse.Namespace(name="wt-feature", argv=["service", "uninstall"]))
+
+    assert seen == [("pod.exec", "denied")], f"expected a single denied entry, got {seen}"
+
+
+def test_an_allowed_exec_is_audited_as_allowed(tmp_path, monkeypatch):
+    from kiro_crew.pod import cli as pod_cli
+
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    monkeypatch.setattr(rt, "read_env_file", lambda c, n: {"CHECKOUT": str(checkout)})
+    seen: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        pod_cli,
+        "_audit",
+        lambda op, outcome, resources="", error="": seen.append((op, outcome)),
+    )
+    monkeypatch.setattr(rt.os, "execve", lambda *a: (_ for _ in ()).throw(SystemExit(0)))
+
+    with pytest.raises(SystemExit):
+        pod_cli._exec(cfg, argparse.Namespace(name="wt-feature", argv=["status"]))
+
+    assert seen == [("pod.exec", "allowed")]
+
+
+def test_exec_in_pod_refuses_before_touching_the_pod(tmp_path, monkeypatch):
+    """The refusal must precede resolution, so it holds even for a pod that has
+    no pinned checkout — and must never reach execve."""
+    cfg = _pod_cfg(tmp_path)
+    monkeypatch.setattr(
+        rt.os, "execve", lambda *a: pytest.fail("execve must not be reached")
+    )
+
+    with pytest.raises(rt.PodError, match="refusing `service`"):
+        rt.exec_in_pod(cfg, "wt-feature", ["service", "uninstall"])
+
+
+def test_logs_is_refused_and_points_at_the_pod_journal():
+    """`cli_server._logs_cmd` runs `journalctl -u <host service unit>`, so inside a
+    pod it would confidently show the LIVE gateway's journal."""
+    with pytest.raises(rt.PodError) as exc:
+        rt.require_pod_safe_verb(["logs"], "wt-feature")
+    assert "kirocrew pod logs wt-feature" in str(exc.value)
+
+
+def test_snapshot_is_refused_because_its_destination_is_configurable():
+    """`snapshot_dir` is a config field and `--keep N` DELETES older archives, so a
+    pod seeded from the live config could prune the user's real backups —
+    `sanitized_seed_config` only forces tunnel/telegram/wecom off."""
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    assert hasattr(KiroCrewConfig, "__dataclass_fields__")
+    assert "snapshot_dir" in KiroCrewConfig.__dataclass_fields__
+    with pytest.raises(rt.PodError, match="refusing `snapshot`"):
+        rt.require_pod_safe_verb(["snapshot", "--keep", "1"], "wt-feature")
+
+
+# --------------------------------------------------------------------------- #
+# The pod must not inherit the LIVE workspace.
+#
+# workspace_root() falls through to a platform default under the real HOME when
+# neither KIROCREW_WORKSPACE nor config_dir()/workspace_dir is present — which a
+# fresh pod home has neither of. Every agent turn would then edit live files.
+# --------------------------------------------------------------------------- #
+def test_pod_env_scopes_the_workspace_into_the_pod_home(tmp_path):
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    home = cfg.home_dir("wt-feature")
+
+    env = rt.build_pod_env(cfg, home, 7900, checkout)
+
+    assert env["KIROCREW_WORKSPACE"] == str(home / "workspace")
+    # Inside the pod HOME, so zero-residue teardown removes it.
+    assert Path(env["KIROCREW_WORKSPACE"]).is_relative_to(home)
+
+
+def test_the_pod_workspace_is_not_the_live_workspace(tmp_path, monkeypatch):
+    """The concrete regression: with no override, resolution reaches a default
+    under the real HOME. The pod's value must not be that."""
+    from kiro_crew.config import loader
+
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    env = rt.build_pod_env(cfg, cfg.home_dir("wt-feature"), 7900, checkout)
+
+    monkeypatch.delenv("KIROCREW_WORKSPACE", raising=False)
+    live = loader.workspace_root()
+
+    assert Path(env["KIROCREW_WORKSPACE"]).resolve() != live.resolve()
+
+
+def test_the_override_actually_drives_workspace_root(tmp_path, monkeypatch):
+    """Pin that KIROCREW_WORKSPACE is the mechanism workspace_root() honours, so
+    the fix cannot silently stop working if resolution is reordered."""
+    from kiro_crew.config import loader
+
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    env = rt.build_pod_env(cfg, cfg.home_dir("wt-feature"), 7900, checkout)
+
+    monkeypatch.setenv("KIROCREW_WORKSPACE", env["KIROCREW_WORKSPACE"])
+
+    assert loader.workspace_root().resolve() == Path(env["KIROCREW_WORKSPACE"]).resolve()
+
+
+def test_exec_in_pod_runs_inside_the_pod_workspace(tmp_path, monkeypatch):
+    """Relative paths must resolve inside the pod, not the invoking shell's cwd."""
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+    monkeypatch.setattr(rt, "read_env_file", lambda c, n: {"CHECKOUT": str(checkout)})
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(rt.os, "chdir", lambda p: seen.update(cwd=str(p)))
+    monkeypatch.setattr(rt.os, "execve", lambda *a: (_ for _ in ()).throw(SystemExit(0)))
+
+    with pytest.raises(SystemExit):
+        rt.exec_in_pod(cfg, "wt-feature", ["status"])
+
+    assert seen["cwd"] == str(cfg.home_dir("wt-feature") / "workspace")
+
+
+def test_run_is_refused_because_it_writes_beside_the_spec():
+    """`task_reporter.save_progress` writes TASK_PROGRESS.md into
+    `Path(spec_path).parent`, so `run /host/TASK.md` writes outside the pod — an
+    implicit write derived from an INPUT path, which the inclusion test excludes."""
+    import inspect
+
+    from kiro_crew import task_reporter
+
+    src = inspect.getsource(task_reporter.save_progress)
+    assert "spec_path" in src and "parent" in src, "premise: progress goes beside the spec"
+    with pytest.raises(rt.PodError, match="refusing `run`"):
+        rt.require_pod_safe_verb(["run", "/host/TASK.md"], "wt-feature")
+
+
+def test_chat_is_refused_because_chat_tui_reaches_the_live_port():
+    """`cli_chat._tui` resolves the CONFIG dashboard port with a literal 5476
+    fallback and never reads KIROCREW_PORT, and `chat --tui` branches into it — so
+    excluding only `tui` left the hole open."""
+    import inspect
+
+    from kiro_crew import cli_chat
+
+    src = inspect.getsource(cli_chat)
+    assert "5476" in src, "premise: _tui carries a hardcoded live-port fallback"
+    assert "resolve_client_port" not in src, "premise: _tui bypasses the port resolver"
+    for verb in ("chat", "tui"):
+        with pytest.raises(rt.PodError, match=f"refusing `{verb}`"):
+            rt.require_pod_safe_verb([verb], "wt-feature")


### PR DESCRIPTION
## Problem

Two halves of one problem: a worktree could capture the machine-wide `kirocrew` launcher, and a pod could silently run the machine-wide install it exists to be isolated from.

**The launcher breaks after routine worktree work.** `kirocrew` dies with:

```
bash: /home/<user>/.local/bin/kirocrew: No such file or directory
```

because `~/.local/bin/kirocrew` had been repointed into a feature worktree's `.venv`, and that worktree was later removed. It is not confined to the tree that went away — the global command is gone, `kirocrew update` cannot run to repair it, and any systemd unit whose `ExecStart` was resolved from PATH now points at a path that no longer exists. This has happened more than once.

**A pod runs the wrong install.** A pod's `PATH` is built as `~/.local/bin:/usr/local/bin:/usr/bin:/bin` — it leads with the global shim directory. So a bare `kirocrew` inside a pod (an agent bash turn, a subprocess, `_kirocrew_bin()`'s "console-script on PATH" probe) resolves the *global* launcher, not the checkout under test. It is also circular: a pod's boot path depends on the very symlink a pod can hijack.

**And there is no way to drive a pod without the global install.** `pod url` / `token` / `logs` exist, but anything else means hand-assembling three facts — the pod's isolated home, its derived port, and its venv path.

## Why it matters

`git worktree remove` is normal and encouraged; this repo ships a pod system built on per-worktree checkouts, and `pod provision` gives each one its own venv. So the setup that breaks the global CLI *is* the sanctioned workflow, and it breaks after the work is done and the tree is cleaned up — exactly when nobody is looking for it. Recovery needs a manual `ln -sfn` against a path the user must work out themselves, and the one command that would normally repair an install is the one that is unavailable.

The pod half is worse than cosmetic: a pod whose contract is "never touch the live plane" was resolving the live plane's binary, so a test instance could exercise code that is not the code under test.

## Fix (symptoms → root cause → change)

**Symptom:** a dangling `~/.local/bin/kirocrew`; and `which kirocrew` inside a pod pointing outside the pod.

**Root cause (launcher):** `ensure_kirocrew_on_path()` links the shim to whatever `_resolve_kirocrew_bin()` returns, and that resolver deliberately prefers "the venv entrypoint for source-tree installs" — the venv of *the running process*. Any process out of a worktree's venv installs that ephemeral entrypoint as the global launcher, and `run_first_run_setup()` calls it on **every** gateway start, so one run from a worktree suffices. `instances/token_mint.py` already documents the downstream symptom ("points at an uninstalled worktree"); nothing prevented it at the source.

**Root cause (pod):** `build_pod_env()` passed `cfg.gateway_path` through unchanged, and that string starts with `~/.local/bin`.

**Changes:**

1. **The shim declines a linked-worktree target.** New `_in_linked_git_worktree()` walks up from the resolved binary and answers on the nearest repository marker: a linked worktree's `.git` is a **file** holding `gitdir: <git-dir>/worktrees/<name>`; an ordinary clone's is a **directory**. Matched on the `/worktrees/` segment, not `/.git/worktrees/`, because a **bare** repo's git dir *is* the repo dir and carries no `.git` component. The target is `.resolve()`d first, since the walk is lexical and the target is frequently itself a symlink into a worktree — including the very shim being rewritten. Stdlib-only and subprocess-free: this runs on the gateway start path, where shelling out to `git` would add latency and fail wherever git is absent (notably the packaged desktop app). The check precedes the existing-shim comparison, so a working shim is left alone rather than replaced by a doomed one, and the decline is logged at `info` naming the manual remedy so a worktree-primary user can discover why no launcher was installed.

2b. **A pod gets its own workspace root.** `workspace_root()` resolves `KIROCREW_WORKSPACE` then `config_dir()/workspace_dir` then a platform default under `HOME`. A fresh pod home has neither of the first two, and `build_pod_env` sets `HOME` to the REAL home, so resolution fell through to the LIVE workspace: every agent turn in a pod (and any `chat`/`run`/`tui` through `pod exec`) read and wrote the user's real workspace files. `build_pod_env` now sets `KIROCREW_WORKSPACE` to `<pod home>/workspace` — the documented override (`loader.py:220`, already used by `eval/runner.py`), placed inside the directory the unit's `ExecStopPost` deletes so zero-residue teardown still holds. `pod exec` also chdirs there, because agent verbs resolve relative paths against the cwd.

2. **A pod's own venv leads its PATH.** One line in `build_pod_env()`. A bare `kirocrew` inside a pod is now the pod's binary, for the gateway, its agent turns, and any subprocess.

3. **`kirocrew pod exec <name> -- <args…>`** runs any command as the pod's own binary against the pod's data and port, resolving through a new `pod_context()` seam that sources its environment from `build_pod_env()` — so a command run against a pod inherits the **same** messaging-credential scrubbing as the pod's own gateway rather than a hand-rolled environment.

4. **`pod exec` accepts only pod-scoped verbs (an allowlist).** It forwards to a real kirocrew, so it inherits the whole CLI — including verbs that manage the HOST rather than one instance. Denying the dangerous ones by name proved incomplete three times (`stop`, then `restart` for a second reason, then `service uninstall`), because that set is open-ended. Only verbs acting on `KIROCREW_HOME` state are allowed (`status`, `cron`, `artifact`, `learn`, `memory`, `agent`, `workspace`, `config`, `chat`, `tui`, `spawn`, `doctor`, `logout`, `restore`, `security`, `eval`, `policy`, `knowledge`, `consolidate`, and the dashboard-credential verb); anything else — present or newly added — is refused, so drift fails closed. Excluded with reasons in-code: `setup`/`update` rewrite the install and the launcher; `app` symlinks app agents into `Path.home()/.kiro/agents` and edits the host MCP settings, so a pod install/uninstall would break the live gateway; `stop`/`restart` are service-aware (`cli_server._stop` short-circuits to systemctl when no explicit `--port` is passed, hitting the LIVE gateway, and `restart` additionally makes systemd run the pod unit's `ExecStopPost`, erasing the pod HOME while a DETACHED replacement escapes `pod down`); `service` manages the machine-wide unit; `gateway` would race the pod's own unit; `pod` would let a nested `pod down` tear down its own supervisor; `cloud` provisions AWS resources; `browse` writes auth state outside `KIROCREW_HOME`; `manifest` emits a Slack manifest tied to the real identity; `logs` runs journalctl against the HOST service unit, so it would show the live gateway journal while appearing to show the pod (use `pod logs`); `snapshot` has a CONFIGURABLE destination and `--keep N` deletes older archives, so a seeded pod could prune the real backups; `run` writes TASK_PROGRESS.md beside the spec file, so a host spec path would be written outside the pod. The verb must be the FIRST token — permitting global flags ahead of it is what made the denylist bypassable, since a flag's value is indistinguishable from a verb (`--log-level DEBUG stop`). Flags after the verb are untouched. Refusals name the pod-native equivalent where one exists.

Scope notes: the shell installers (`install.sh`, `setup.sh`, `minimal_install.sh`, `cli.sh`) are untouched — those are run deliberately by a user against a tree they chose, whereas the guarded path fires unattended on every gateway start. A `pod env` verb (emitting exports for a pod-scoped shell) was implemented and then **removed** during review: it handed out a shell where pod scoping is advisory, silently ignored by exactly the two commands that can destroy the live plane, and with no argv to intercept there is no way to make it safe. `pod exec` covers the same need safely.

## Tests

`test/test_installer_shim_and_cleanup.py` extended in that file's existing `tmp_path` + `bin_dir=` idiom, with a shared `_checkout_with_kirocrew(root, linked_worktree=…, bare_parent=…)` helper where the marker shape is the single variable:

- detector: `.git` file → true, `.git` directory → false, no repository → false
- bare-repo pointer shape is matched (asserting the fixture reproduces the shape before asserting behaviour)
- a submodule pointer (`gitdir: ../.git/modules/sub`) is **not** matched — pins that `/worktrees/` is not too loose
- a worktree target is declined; **negative control:** the identical setup in an ordinary clone still *is* linked, proving the guard rejects worktrees specifically rather than disabling the shim
- a symlink pointing into a worktree is declined, asserting the lexical walk cannot see through it unaided
- the regression itself: an existing working shim survives a resolution that lands in a worktree, and is not left dangling

New `test/test_pod_self_contained.py`:

- the checkout venv leads PATH, ahead of the still-reachable global shim dir
- the existing isolation keys (`KIROCREW_HOME` / `PORT` / `PROJECT_DIR`) are undisturbed
- messaging credentials are still scrubbed while `AWS_SESSION_TOKEN` survives — pinned because `pod_context()` hands this env to arbitrary commands
- `pod_context()` resolves the pod's own binary, and errors clearly with no pinned checkout / no provisioned venv
- `exec_in_pod()` execs the pod's binary with the pod's env
- nine host-scoped verbs are refused (including `service uninstall` specifically); pod-scoped verbs pass; flags after the verb are untouched; a leading flag and empty argv are refused; the refusal names the pod-native equivalent where one exists and otherwise lists the allowed set; the refusal precedes pod resolution so `execve` is never reached; plus two drift guards — the allowlist and a host-scoped set must stay disjoint, and all 24 allowlisted verbs are asserted to be real top-level CLI verbs

Every behavioural fix was negative-controlled by reverting it: dropping `.resolve()` fails the symlink test, dropping the PATH prepend fails both pod PATH tests, restoring the `/.git/worktrees/` match fails both bare-repo tests, and adding `service` to the allowlist fails three cases including the drift guard.

## Manual verification

Reproduced and repaired on the machine that hit it: the dangling symlink was repointed at the stable clone and `kirocrew --version` worked again.

The git-layout claims were verified against real git rather than assumed — a `git worktree add` checkout has `.git` as a file (`gitdir: …/.git/worktrees/<name>`), a bare repo's worktree gives `…/myrepo.git/worktrees/<name>` with no `.git` component, and a submodule gives `…/.git/modules/<name>`.

New CLI surface exercised directly: `pod exec` appears in `kirocrew pod --help` (and `env` no longer does), `kirocrew pod exec <unknown>` fails with a clear message and no traceback, and `kirocrew pod exec <name> -- service uninstall` and `-- restart` both print refusals, the latter naming `kirocrew pod down <name> && kirocrew pod up <name>`.

Gates: `isort` clean, `flake8 -j 1` clean, `mypy` clean across 529 files, full backend suite 20,370 passed with only this host's known environment-dependent failures (sandbox/userns `EPERM`, pidfd child watcher, `gh` bin resolution, hardlinked-inode, source providers) — the same set `origin/main` fails here.

## Screenshots

N/A — no user-visible UI change. The new surface is CLI-only.






