### PR TITLE
fix(memory): serialize sqlite writes on the shared memory connection

### DIFF
--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -665,8 +665,14 @@ class VectorMemoryStore:
             self.db.commit()
 
         # 9. Retire conflicting episodic entries that reference the old value
-        # (outside the lock — _retire_stale_episodic does a blocking embed and
-        # re-locks its own FAISS search section).
+        # (called outside the lock — _retire_stale_episodic does a blocking embed
+        # first, then takes _db_lock itself for its db writes).
+        #
+        # Best-effort: the semantic row is already committed at this point, so a
+        # failure here must not propagate. Callers batch many keys per call
+        # (history consolidation writes N semantic + M episodic items in one
+        # thread), and an exception raised after a successful commit discarded
+        # every remaining item in the batch.
         if existing and not existing["is_deleted"]:
             old_val = existing["value_json"]
             try:
@@ -674,7 +680,14 @@ class VectorMemoryStore:
             except (json.JSONDecodeError, TypeError):
                 old_text = str(old_val)
             if isinstance(old_text, str) and len(old_text) >= 3:
-                self._retire_stale_episodic(key, old_text)
+                try:
+                    self._retire_stale_episodic(key, old_text)
+                except Exception:
+                    logger.warning(
+                        "Stale-episodic retirement failed for key %r (semantic write kept)",
+                        key,
+                        exc_info=True,
+                    )
 
         return None
 
@@ -684,11 +697,12 @@ class VectorMemoryStore:
         if not existing:
             return False
         now = _now_iso()
-        self.db.execute(
-            "UPDATE semantic_memory SET is_deleted = 1, updated_at = ? WHERE key = ?",
-            (now, key),
-        )
-        self.db.commit()
+        with self._db_lock:
+            self.db.execute(
+                "UPDATE semantic_memory SET is_deleted = 1, updated_at = ? WHERE key = ?",
+                (now, key),
+            )
+            self.db.commit()
         self._log_event("delete", "semantic", key, existing["value_json"], None, source)
         return True
 
@@ -704,47 +718,55 @@ class VectorMemoryStore:
         # Vector similarity: embed "key_suffix: old_value" and find similar episodic
         key_suffix = key.rsplit(".", 1)[-1].replace("_", " ")
         query = f"{key_suffix}: {old_value}"
+        # The embed is the one blocking call here, so it stays OUTSIDE the lock.
+        # Everything after it touches the shared sqlite connection and MUST be
+        # serialized on _db_lock: an unsynchronized DML statement races the
+        # implicit BEGIN of any concurrent writer (search_episodic's
+        # last_accessed_at write, another consolidation) and the loser raises
+        # "cannot start a transaction within a transaction".
         emb = self._try_embed(query)
-        if emb is not None:
-            results = self.search_episodic(query_embedding=emb, query_text="", limit=10)
-            for r in results:
-                if r.get("cosine_sim", 0) > 0.7 and r["id"] not in seen:
-                    seen.add(r["id"])
-                    self.db.execute(
-                        "UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (r["id"],)
-                    )
-                    self._log_event(
-                        "conflict_retire",
-                        "episodic",
-                        r["id"],
-                        r["text"][:200],
-                        None,
-                        "semantic_update",
-                    )
+        with self._db_lock:
+            if emb is not None:
+                results = self.search_episodic(query_embedding=emb, query_text="", limit=10)
+                for r in results:
+                    if r.get("cosine_sim", 0) > 0.7 and r["id"] not in seen:
+                        seen.add(r["id"])
+                        self.db.execute(
+                            "UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (r["id"],)
+                        )
+                        self._log_event(
+                            "conflict_retire",
+                            "episodic",
+                            r["id"],
+                            r["text"][:200],
+                            None,
+                            "semantic_update",
+                        )
 
-        # Text fallback: exact phrase matching
-        patterns = [f"%{key_suffix}: {old_value}%", f"%{key_suffix} {old_value}%"]
-        for pat in patterns:
-            for r in self.db.execute(
-                "SELECT id, text FROM episodic_memories WHERE is_deleted = 0 AND text LIKE ?",
-                (pat,),
-            ).fetchall():
-                if r["id"] not in seen:
-                    seen.add(r["id"])
-                    self.db.execute(
-                        "UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (r["id"],)
-                    )
-                    self._log_event(
-                        "conflict_retire",
-                        "episodic",
-                        r["id"],
-                        r["text"][:200],
-                        None,
-                        "semantic_update",
-                    )
+            # Text fallback: exact phrase matching
+            patterns = [f"%{key_suffix}: {old_value}%", f"%{key_suffix} {old_value}%"]
+            for pat in patterns:
+                for r in self.db.execute(
+                    "SELECT id, text FROM episodic_memories WHERE is_deleted = 0 AND text LIKE ?",
+                    (pat,),
+                ).fetchall():
+                    if r["id"] not in seen:
+                        seen.add(r["id"])
+                        self.db.execute(
+                            "UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (r["id"],)
+                        )
+                        self._log_event(
+                            "conflict_retire",
+                            "episodic",
+                            r["id"],
+                            r["text"][:200],
+                            None,
+                            "semantic_update",
+                        )
 
+            if seen:
+                self.db.commit()
         if seen:
-            self.db.commit()
             logger.info("Retired %d stale episodic entries for key %r", len(seen), key)
 
     def search_semantic(self, prefix: str) -> list[dict]:
@@ -856,12 +878,16 @@ class VectorMemoryStore:
     ) -> None:
         """Append to the audit trail."""
         try:
-            self.db.execute(
-                "INSERT INTO memory_events (event_type, memory_type, memory_key, "
-                "old_value, new_value, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (event_type, memory_type, key, old_value, new_value, source, _now_iso()),
-            )
-            self.db.commit()
+            # Every write path funnels through here, from both locked and
+            # unlocked callers, so serialize on the (reentrant) _db_lock: an
+            # unsynchronized INSERT races a concurrent writer's implicit BEGIN.
+            with self._db_lock:
+                self.db.execute(
+                    "INSERT INTO memory_events (event_type, memory_type, memory_key, "
+                    "old_value, new_value, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (event_type, memory_type, key, old_value, new_value, source, _now_iso()),
+                )
+                self.db.commit()
         except Exception:
             logger.debug("Failed to log memory event", exc_info=True)
 
@@ -875,16 +901,17 @@ class VectorMemoryStore:
 
     def rotate_events(self, max_rows: int = _MAX_EVENTS) -> int:
         """Delete oldest events if over limit. Returns count deleted."""
-        count = self.db.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
-        if count <= max_rows:
-            return 0
-        to_delete = count - max_rows
-        self.db.execute(
-            "DELETE FROM memory_events WHERE id IN "
-            "(SELECT id FROM memory_events ORDER BY id ASC LIMIT ?)",
-            (to_delete,),
-        )
-        self.db.commit()
+        with self._db_lock:
+            count = self.db.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
+            if count <= max_rows:
+                return 0
+            to_delete = count - max_rows
+            self.db.execute(
+                "DELETE FROM memory_events WHERE id IN "
+                "(SELECT id FROM memory_events ORDER BY id ASC LIMIT ?)",
+                (to_delete,),
+            )
+            self.db.commit()
         return to_delete
 
     # ── FAISS Index ──
@@ -1336,11 +1363,19 @@ class VectorMemoryStore:
         q = [x / norm for x in query_embedding] if norm > 0 else query_embedding
         q_len = len(q)
 
-        rows = self.db.execute(
-            "SELECT id, conversation_id, text, tags, importance, created_at, "
-            "last_accessed_at, embedding FROM episodic_memories "
-            "WHERE is_deleted = 0 AND embedding IS NOT NULL"
-        ).fetchall()
+        # The fetch is serialized with every other statement on this shared
+        # connection. sqlite3 caches prepared statements per connection, so two
+        # threads running a statement at the same time can corrupt each other's
+        # row iteration — observed as DatabaseError("another row available") and,
+        # on Windows CI, a NULL value for a column the WHERE clause excludes
+        # (`embedding IS NOT NULL` returning None, TypeError on len()). Only the
+        # fetch is locked: the scoring loop below works on materialized rows.
+        with self._db_lock:
+            rows = self.db.execute(
+                "SELECT id, conversation_id, text, tags, importance, created_at, "
+                "last_accessed_at, embedding FROM episodic_memories "
+                "WHERE is_deleted = 0 AND embedding IS NOT NULL"
+            ).fetchall()
 
         logger.debug(
             "Episodic SQLite vector search: query=%s… rows_with_emb=%d",
@@ -1379,13 +1414,21 @@ class VectorMemoryStore:
 
         candidates.sort(key=lambda x: x["score"], reverse=True)
         result = _mmr_rerank(candidates, limit=limit) if mmr else candidates[:limit]
-        for c in result:
-            self.db.execute(
-                "UPDATE episodic_memories SET last_accessed_at = ? WHERE id = ?",
-                (_now_iso(), c["id"]),
-            )
+        # Same lock discipline as the FAISS path in search_episodic. This UPDATE
+        # runs on every context assembly, so several threads reach it at once
+        # (parallel subagent spawns), and sqlite's implicit BEGIN is per
+        # connection: two unsynchronized writers can both observe autocommit=1
+        # and both issue BEGIN, and the loser raises "cannot start a transaction
+        # within a transaction". RLock is reentrant, so re-acquiring here is safe
+        # regardless of caller.
         if result:
-            self.db.commit()
+            with self._db_lock:
+                for c in result:
+                    self.db.execute(
+                        "UPDATE episodic_memories SET last_accessed_at = ? WHERE id = ?",
+                        (_now_iso(), c["id"]),
+                    )
+                self.db.commit()
         return result
 
     def get_episodic_list(
@@ -1413,8 +1456,9 @@ class VectorMemoryStore:
         existing = self._get_episodic(mem_id)
         if not existing:
             return False
-        self.db.execute("UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (mem_id,))
-        self.db.commit()
+        with self._db_lock:
+            self.db.execute("UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (mem_id,))
+            self.db.commit()
         self._log_event("delete", "episodic", mem_id, existing["text"][:200], None, source)
         return True
 
@@ -1503,27 +1547,29 @@ class VectorMemoryStore:
         return dict(row) if row else None
 
     def _delete_episodic_row(self, mem_id: str) -> None:
-        self.db.execute("UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (mem_id,))
-        self.db.commit()
+        with self._db_lock:
+            self.db.execute("UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (mem_id,))
+            self.db.commit()
 
     def _enforce_episodic_cap(self) -> None:
         """Tombstone lowest-importance oldest entries if over cap."""
-        count = self.db.execute(
-            "SELECT COUNT(*) FROM episodic_memories WHERE is_deleted = 0"
-        ).fetchone()[0]
-        if count < self._episodic_max:
-            return
-        excess = count - self._episodic_max + 1
-        rows = self.db.execute(
-            "SELECT id FROM episodic_memories WHERE is_deleted = 0 "
-            "ORDER BY importance ASC, created_at ASC LIMIT ?",
-            (excess,),
-        ).fetchall()
-        for row in rows:
-            self.db.execute(
-                "UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (row["id"],)
-            )
-        self.db.commit()
+        with self._db_lock:
+            count = self.db.execute(
+                "SELECT COUNT(*) FROM episodic_memories WHERE is_deleted = 0"
+            ).fetchone()[0]
+            if count < self._episodic_max:
+                return
+            excess = count - self._episodic_max + 1
+            rows = self.db.execute(
+                "SELECT id FROM episodic_memories WHERE is_deleted = 0 "
+                "ORDER BY importance ASC, created_at ASC LIMIT ?",
+                (excess,),
+            ).fetchall()
+            for row in rows:
+                self.db.execute(
+                    "UPDATE episodic_memories SET is_deleted = 1 WHERE id = ?", (row["id"],)
+                )
+            self.db.commit()
 
     # ── Lessons ──
 
@@ -1556,11 +1602,12 @@ class VectorMemoryStore:
 
         def _flush_backfills() -> None:
             if pending_backfills:
-                for blob, bk in pending_backfills:
-                    self.db.execute(
-                        "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (blob, bk)
-                    )
-                self.db.commit()
+                with self._db_lock:
+                    for blob, bk in pending_backfills:
+                        self.db.execute(
+                            "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (blob, bk)
+                        )
+                    self.db.commit()
 
         for existing in self.get_lessons():
             existing_val = str(json.loads(existing["value_json"]))
@@ -1636,10 +1683,11 @@ class VectorMemoryStore:
         err = self.set_semantic(key, value, confidence, source)
         if err is None and rule_emb:
             emb_blob = struct.pack(f"{len(rule_emb)}f", *rule_emb)
-            self.db.execute(
-                "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (emb_blob, key)
-            )
-            self.db.commit()
+            with self._db_lock:
+                self.db.execute(
+                    "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (emb_blob, key)
+                )
+                self.db.commit()
         return err is None
 
     @staticmethod
@@ -2094,12 +2142,15 @@ class VectorMemoryStore:
             tag_conds = " OR ".join(["tags LIKE ?" for _ in tag_filter])
             conditions = f"({conditions}) AND ({tag_conds})"
             params.extend(f'%"{t.lower()}"%' for t in tag_filter)
-        rows = self.db.execute(
-            f"SELECT id, conversation_id, text, tags, importance, created_at, last_accessed_at "
-            f"FROM episodic_memories WHERE is_deleted = 0 AND ({conditions}) "
-            f"ORDER BY created_at DESC LIMIT ?",
-            (*params, limit),
-        ).fetchall()
+        # Serialized for the same reason as the vector fallback above: this runs
+        # on the context-assembly path, concurrently with memory writes.
+        with self._db_lock:
+            rows = self.db.execute(
+                f"SELECT id, conversation_id, text, tags, importance, created_at, last_accessed_at "
+                f"FROM episodic_memories WHERE is_deleted = 0 AND ({conditions}) "
+                f"ORDER BY created_at DESC LIMIT ?",
+                (*params, limit),
+            ).fetchall()
         return [dict(r) for r in rows]
 
     # ── Episodic Promotion ──

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -1914,3 +1914,189 @@ class TestSearchLastAccessedLocking:
         # The locked, transactional UPDATE must not surface 'database is locked'
         # or interleave into a crash under concurrent search load.
         assert not errors, f"concurrent search-update raised: {errors!r}"
+
+
+class _TrackingLock:
+    """RLock wrapper that records, per thread, whether the lock is held."""
+
+    def __init__(self, inner: object) -> None:
+        self._inner = inner
+        self._local = threading.local()
+
+    @property
+    def held(self) -> bool:
+        return getattr(self._local, "depth", 0) > 0
+
+    def __enter__(self) -> "_TrackingLock":
+        self._inner.__enter__()  # type: ignore[attr-defined]
+        self._local.depth = getattr(self._local, "depth", 0) + 1
+        return self
+
+    def __exit__(self, *exc: object) -> object:
+        self._local.depth = getattr(self._local, "depth", 1) - 1
+        return self._inner.__exit__(*exc)  # type: ignore[attr-defined]
+
+
+class _AuditingConnection:
+    """sqlite connection proxy that flags statements issued without ``_db_lock``.
+
+    Python's sqlite3 emits an implicit ``BEGIN`` before INSERT/UPDATE/DELETE
+    when it observes ``sqlite3_get_autocommit() == 1``. Two threads writing on
+    the same connection can both pass that check and both issue ``BEGIN``, and
+    the loser raises ``OperationalError: cannot start a transaction within a
+    transaction``. Holding ``_db_lock`` across every DML statement is what
+    prevents it, so this proxy audits that discipline directly.
+
+    Reads are audited too, but only the two episodic-search fetches, which the
+    context-assembly path runs concurrently with memory writes. sqlite3 caches
+    prepared statements per connection, so a SELECT that overlaps another
+    statement can have its row iteration corrupted — that surfaced on Windows
+    CI as a NULL ``embedding`` from a query filtering ``embedding IS NOT NULL``,
+    raising ``TypeError`` on ``len()``. The other read methods are deliberately
+    NOT audited: they run unlocked by design and widening the audit to them
+    would assert an invariant this change does not establish.
+    """
+
+    _DML = ("INSERT", "UPDATE", "DELETE", "REPLACE", "BEGIN")
+    _GUARDED_READS = ("embedding IS NOT NULL", "text LIKE ?")
+
+    def __init__(self, inner: object, lock: _TrackingLock, violations: list[str]) -> None:
+        self._inner = inner
+        self._lock = lock
+        self._violations = violations
+
+    def _must_be_locked(self, sql: str) -> bool:
+        if sql.lstrip().upper().startswith(self._DML):
+            return True
+        return any(frag in sql for frag in self._GUARDED_READS)
+
+    def execute(self, sql: str, *args: object, **kwargs: object) -> object:
+        if self._must_be_locked(sql) and not self._lock.held:
+            self._violations.append(sql.strip()[:80])
+        return self._inner.execute(sql, *args, **kwargs)  # type: ignore[attr-defined]
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._inner, name)
+
+
+class TestSharedConnectionLockDiscipline:
+    """Every DML on the shared sqlite connection must hold ``_db_lock``."""
+
+    @staticmethod
+    def _fake_embed(dim: int):
+        def _embed(text: str) -> list[float]:
+            words = _tokenize(text)
+            vec = [0.0] * dim
+            for w in words:
+                vec[hash(w) % dim] += 1.0
+            return vec or [1.0] + [0.0] * (dim - 1)
+
+        return _embed
+
+    def _instrument(self, store: VectorMemoryStore) -> list[str]:
+        violations: list[str] = []
+        lock = _TrackingLock(store._db_lock)
+        store._db_lock = lock  # type: ignore[assignment]
+        store._db = _AuditingConnection(store._db, lock, violations)  # type: ignore[assignment]
+        return violations
+
+    def test_write_paths_hold_db_lock(self, tmp_path: Path) -> None:
+        dim = 16
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=dim)
+        store.init()
+        embed = self._fake_embed(dim)
+        store.embed_fn = embed
+        violations = self._instrument(store)
+
+        # Episodic writes + the two search fallbacks the context-assembly path
+        # uses when faiss is unavailable: the vector scan (which also updates
+        # last_accessed_at) and the LIKE fallback. Both fetches ran unlocked and
+        # raced consolidation.
+        store._faiss_index = None
+        for i in range(3):
+            text = f"the findings doc for topic alpha number {i} was written to disk"
+            assert store.write_episodic(text, embedding=embed(text)) is True
+        assert store.search_episodic(query_embedding=embed("findings doc"), limit=3)
+        assert store.search_episodic(query_text="findings doc", limit=3)
+
+        # Semantic write, then an overwrite so _retire_stale_episodic runs.
+        assert store.set_semantic("project.notes.findings_doc", "v1 draft", 0.9, "consolidation") is None
+        assert store.set_semantic("project.notes.findings_doc", "v2 final", 0.9, "consolidation") is None
+
+        # Remaining writers: lessons (incl. embedding backfill), deletes, rotation.
+        assert store.write_lesson("prefer explicit transactions over implicit ones") is True
+        store.delete_semantic("project.notes.findings_doc", "user_explicit")
+        rows = store.get_episodic_list(limit=1)
+        if rows:
+            store.delete_episodic(rows[0]["id"])
+        store.rotate_events(max_rows=1)
+
+        assert violations == [], f"statement issued without _db_lock held: {violations}"
+
+    def test_concurrent_search_and_semantic_write(self, tmp_path: Path) -> None:
+        """Consolidation-style writes must survive concurrent context assembly.
+
+        Reproduces the shape of the observed failure: several context-assembly
+        threads run the SQLite search fallback (which writes last_accessed_at)
+        while a consolidation thread overwrites semantic keys (which retires
+        stale episodic rows).
+        """
+        dim = 16
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=dim)
+        store.init()
+        embed = self._fake_embed(dim)
+        store.embed_fn = embed
+        store._faiss_index = None  # force the _sqlite_vector_search fallback
+        for i in range(12):
+            text = f"episodic entry {i} about the findings doc and topic alpha beta"
+            store.write_episodic(text, embedding=embed(text))
+
+        errors: list[BaseException] = []
+
+        def _searcher() -> None:
+            try:
+                for _ in range(25):
+                    store.search_episodic(query_embedding=embed("findings doc"), limit=5)
+            except BaseException as exc:  # noqa: BLE001 - capture any thread crash
+                errors.append(exc)
+
+        def _writer() -> None:
+            try:
+                for i in range(25):
+                    store.set_semantic(
+                        "project.notes.findings_doc", f"revision {i}", 0.9, "consolidation"
+                    )
+            except BaseException as exc:  # noqa: BLE001 - capture any thread crash
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_searcher) for _ in range(3)]
+        threads.append(threading.Thread(target=_writer))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent search/write raised: {errors!r}"
+        entry = store.get_semantic("project.notes.findings_doc")
+        assert entry is not None
+
+    def test_retire_failure_keeps_semantic_write(self, tmp_path: Path) -> None:
+        """A retirement failure must not discard the committed semantic write.
+
+        ``_write_semantic`` commits the row before retiring stale episodic
+        entries, so an exception raised in step 9 propagated out of
+        ``set_semantic`` and aborted the caller's whole batch — history
+        consolidation lost every remaining semantic and episodic item.
+        """
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        assert store.set_semantic("pref.editor", "vim", 0.9, "consolidation") is None
+
+        def _boom(key: str, old_value: str) -> None:
+            raise RuntimeError("cannot start a transaction within a transaction")
+
+        store._retire_stale_episodic = _boom  # type: ignore[assignment]
+        assert store.set_semantic("pref.editor", "emacs", 0.9, "consolidation") is None
+        entry = store.get_semantic("pref.editor")
+        assert entry is not None
+        assert entry["value_json"] == '"emacs"'


### PR DESCRIPTION
## Problem

Memory consolidation dies mid-batch with a sqlite transaction error:

```
ERROR kiro_crew.history: Consolidation failed for dashboard:chat-54-...
  File ".../vector_memory.py", line 713, in _retire_stale_episodic
    self.db.execute(
pysqlite3.dbapi2.OperationalError: cannot start a transaction within a transaction
```

It reproduces when several subagents spawn while a session consolidates: each
context assembly runs an episodic search, and consolidation overwrites semantic
keys at the same moment.

## Why it matters

The exception is raised **after** the semantic row is committed, so it unwinds
through `set_semantic` into `history._write_structured_memory` and aborts the
rest of that call. Every remaining semantic item and **all** episodic items for
that session are silently dropped — the user loses the memory the session was
supposed to produce, and the only trace is one ERROR line.

The same defect produces sibling corruption under load, all three reproduced
here: `OperationalError('cannot commit - no transaction is active')`,
`DatabaseError('another row available')`, and a `TypeError` from a NULL value in
a column the query explicitly filters out.

## Fix (symptom → root cause → change)

`VectorMemoryStore` shares one connection across the event loop and worker
threads (`check_same_thread=False`) in legacy transaction mode
(`isolation_level = ""`). Two separate consequences follow, and this PR closes
both.

**Writes.** In legacy mode python emits an implicit `BEGIN` before each
INSERT/UPDATE/DELETE, but only after it observes
`sqlite3_get_autocommit() == 1`. Two writers that do not hold `_db_lock` can
both pass that check, both issue `BEGIN`, and the loser raises. Both sides of
the observed collision were unlocked: `_sqlite_vector_search` wrote
`last_accessed_at` with no lock (its FAISS twin in `search_episodic` already
holds the lock with a comment describing exactly this hazard — the fallback
path was missed, and it is the path that runs whenever faiss is absent), and
`_retire_stale_episodic` wrote with no lock, deliberately, to avoid holding the
lock across its blocking embed. An AST audit of DML statements on that
connection counted **12 unlocked sites**.

**Reads.** sqlite3 caches prepared statements per connection, so a SELECT that
overlaps another statement can have its row iteration corrupted. Windows CI
caught this on the first push of this PR: the new concurrency test failed with
`TypeError: object of type 'NoneType' has no len()` from
`len(r["embedding"])`, inside a loop whose query filters
`embedding IS NOT NULL`. That is the same mechanism as the
`another row available` error reproduced on the pre-fix code.

This change:

1. Holds `_db_lock` across every DML + commit region on that connection:
   `_sqlite_vector_search`, `_retire_stale_episodic`, `_log_event`,
   `rotate_events`, `delete_semantic`, `delete_episodic`,
   `_delete_episodic_row`, `_enforce_episodic_cap`, and `write_lesson`'s two
   embedding writes. Unlocked DML sites go 12 → 1: the migration insert in
   `init()`, which runs before the store is shared. `_db_lock` is an `RLock`, so
   the nested re-acquisition through `search_episodic` and `_log_event` is safe.
2. Serializes the two episodic search **fetches** (`_sqlite_vector_search` and
   `_fts5_episodic_search`). Only the fetch is locked — the scoring loop works
   on materialized rows outside it.
3. Keeps the blocking embed in `_retire_stale_episodic` **outside** the lock, so
   the original reason for skipping the lock there still holds.
4. Makes step 9 of `_write_semantic` (stale-episodic retirement) best-effort.
   The row is already committed, so a retirement failure must not propagate and
   discard the caller's batch.

**Deliberately out of scope:** the remaining read-only methods
(`get_semantic`, `get_all_semantic`, `search_semantic`, `get_lessons`,
`get_events`, `get_episodic_list`, `_get_episodic`, `memory_stats`) still run
unlocked. They issue no DML, so they cannot produce the transaction error this
PR fixes. They remain a latent instance of the read-corruption class, and the
test audit is scoped to the two search fetches rather than asserting an
invariant this change does not establish.

## Tests

Three tests in `test/test_vector_memory.py::TestSharedConnectionLockDiscipline`.
All three fail on `main` and pass with this change:

* `test_write_paths_hold_db_lock` — wraps the connection in a proxy that flags
  any audited statement issued while `_db_lock` is not held by the current
  thread, then drives the real paths (episodic write, both search fallbacks,
  semantic overwrite with retirement, lesson write, deletes, event rotation).
  Audits all DML plus the two search fetches. On `main` it reports 15 unlocked
  statements; against the write-only fix it still reports the 2 unlocked
  SELECTs, so the read serialization has a deterministic check rather than
  relying on thread timing.
* `test_concurrent_search_and_semantic_write` — 3 searcher threads on the
  search fallback against 1 consolidation-style writer. Fails 4/4 runs on
  `main`; this is the test Windows CI used to surface the read corruption.
* `test_retire_failure_keeps_semantic_write` — a raising retirement must leave
  the committed semantic value in place instead of aborting the caller.

## Manual verification

N/A — unit coverage is sufficient. The failure is a thread-interleaving bug with
no UI surface, and the auditing proxy asserts the lock invariant directly rather
than waiting for a race to fire. Worth stating plainly: the read-corruption
mechanism was diagnosed from the Windows failure and the sqlite statement-cache
behaviour, **not** from a local reproduction — 15 attempts at 6 searchers × 60
iterations never triggered it on Linux.

Local gates: full backend suite 20116 passed, `isort` clean, `flake8` clean,
`mypy` 1.14.1 clean over 529 files. 22 suite failures are pre-existing on this
host (sandbox / hardlink / pid tests) — re-running those files with the change
reverted produces a superset, so none are attributable to this branch.
`tsc`/`vitest` not run: no frontend files touched.

## Screenshots

N/A — no user-visible UI change.
