### PR TITLE
feat(artifacts): companion chat panel + anchored comments on the artifact page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,10 +64,14 @@ at the `hooks.py` PreToolUse gate; default-ON but user-configurable from Setting
 force-pin. See `docs/system-specs/modules/security.md`.
 
 **Fork-initiated UX divergences (do not let an upstream sync re-introduce):** the
-artifact **Iterate** button is hidden (`SHOW_ARTIFACT_ITERATE` in
-`ArtifactDetailPage.tsx`), the **Channels** app is hidden from the App Store, the
-**Board** app is removed, and the Voice panel adds a local **Piper** TTS provider.
-These are launch product choices tracked out-of-tree with the upstream sync tooling.
+**Channels** app is hidden from the App Store, the **Board** app is removed, and
+the Voice panel adds a local **Piper** TTS provider. These are launch product
+choices tracked out-of-tree with the upstream sync tooling.
+
+The artifact **Iterate** divergence is retired: `SHOW_ARTIFACT_ITERATE` gated the
+old navigate-away flow "pending an artifact redesign", and the embedded companion
+chat panel IS that redesign — so the flag is deleted and the affordance ships. Do
+NOT re-add the gate. See `docs/system-specs/modules/artifacts.md` § Companion Chat.
 
 ## Platform layer: CPP seam + Governance (read before touching `platform/`)
 

--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -616,8 +616,9 @@ adding a parallel watcher (see `kiro_crew.knowledge.artifact_ingest`):
 
 ## Companion Chat
 
-The artifact detail page can host a **companion chat panel**: the artifact
-renders alongside a live agent session bound to it. This is the backend half.
+The artifact detail page hosts a **companion chat panel**: the artifact renders
+on the left and a live agent session bound to it runs on the right, so an
+iteration loop never leaves the page.
 
 **Binding** — a chat slot may carry an `artifact` field (a validated artifact
 slug) set at slot create (`POST /api/chat/slots` body key `artifact`,
@@ -649,6 +650,37 @@ MCP update / revert — metadata-only PATCHes do NOT emit), delete
 (`deleted: true`), relocate, and pull-latest (when the pull actually landed a
 new snapshot). Fire-and-forget; react-query's 30s staleness window remains
 the safety net.
+
+**Panel (frontend)** — the comments sidebar and the chat panel are mutually
+exclusive flex siblings of the artifact body, icon-toggled from the toolbar
+(sparkle = chat, speech bubble = comments); neither overlays the artifact. The
+comment-count auto-reveal never switches away from an open chat panel, since the
+chat panel opens only on explicit action.
+
+**Session resolution (frontend)** — the active bound session is resolved from
+the Redux slots snapshot (`slot.artifact === slug`), so no extra endpoint exists:
+the WS `slots` event already carries the binding. The flow keeps it to at most
+one *active* bound session per slug by archiving before creating; the resolver
+tolerates more by picking the most recently active, so a race or a History-page
+resume degrades gracefully rather than erroring.
+
+**Create is one round trip** — the `POST /api/chat/slots` response carries the
+binding, so it is dispatched straight into the slots list (`addSlotOptimistic`)
+and the panel becomes interactive immediately. The silent context entry POST and
+the `fetchSlots` reconciliation run in the background: the context entry is
+consumed on the *next* user message, so it always lands before a human can type
+and send.
+
+**Chat parity** — the panel embeds the same `ChatPage` component as `/chat`
+(`embedded` + `embedMode="chat"` for the single-session chrome), so follow-up
+option chips, question cards, steer-send, tool groups and regenerate are
+identical by construction. A `noUrlSync` prop gates ChatPage's one URL-write
+effect: the host route `/artifacts/:slug` owns the URL, and an in-place
+`navigate` would swap the host route out from under the panel.
+
+**Composer staging** — "Ask agent to address" routes into the bound session and
+*stages* (never auto-sends) its message through the existing `writePrefill`
+sessionStorage channel ChatPage already consumes on slot activation.
 
 ## Roadmap
 

--- a/src/kiro_crew/builtin_skills/artifacts/SKILL.md
+++ b/src/kiro_crew/builtin_skills/artifacts/SKILL.md
@@ -214,6 +214,14 @@ you to iterate / "address the comments"), triage EVERY open comment as part
 of the same pass — never leave the human to re-read and clean up stale
 annotations by hand.
 
+A comment may be **anchored**: `artifact_get_comments` returns the exact quoted
+span it was attached to, because the human selected that text in the artifact
+before writing the note. Treat an anchored comment as an instruction *about that
+span* — resolve it there rather than applying it globally, and re-read the span
+before editing, since a prior edit may have moved it. An anchor whose quote no
+longer exists in the content comes back flagged as orphaned; say so instead of
+guessing where it used to point.
+
 | Case | Action |
 |---|---|
 | Unambiguous directive, fully applied ("delete this", "fix typo", a clear reframe) | `artifact_delete_comment` with a reason ("applied in vN: <what you did>") |

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1133,7 +1133,11 @@ export const api = {
     if (before !== undefined) p.set('before', String(before))
     return fetch('/api/chat/slots/' + encodeURIComponent(slot) + '?' + p).then(j)
   },
-  createChatSlot: (name?: string, agent?: string, model?: string, mode?: string, memory_mode?: string, title?: string, clean_mode?: boolean) => post('/api/chat/slots', { ...(name ? { name } : {}), ...(agent ? { agent } : {}), ...(model ? { model } : {}), ...(mode ? { mode } : {}), ...(memory_mode ? { memory_mode } : {}), ...(title ? { title } : {}), ...(clean_mode !== undefined ? { clean_mode } : {}) }).then(j),
+  createChatSlot: (name?: string, agent?: string, model?: string, mode?: string, memory_mode?: string, title?: string, clean_mode?: boolean, artifact?: string) => post('/api/chat/slots', { ...(name ? { name } : {}), ...(agent ? { agent } : {}), ...(model ? { model } : {}), ...(mode ? { mode } : {}), ...(memory_mode ? { memory_mode } : {}), ...(title ? { title } : {}), ...(clean_mode !== undefined ? { clean_mode } : {}), ...(artifact ? { artifact } : {}) }).then(j),
+  /** Inject silent background context into a slot — consumed on the next user
+   * message. Used by the artifact companion chat to name the bound artifact so
+   * the user's first message needs no slug boilerplate. */
+  chatSlotContext: (slot: string, content: string, opts?: { source?: string; ephemeral?: boolean }) => post('/api/chat/slots/' + encodeURIComponent(slot) + '/context', { content, ...(opts?.source ? { source: opts.source } : {}), ...(opts?.ephemeral !== undefined ? { ephemeral: opts.ephemeral } : {}) }).then(j),
   deleteChatSlot: (slot: string) => del('/api/chat/slots/' + encodeURIComponent(slot)).then(j),
   cleanupSessions: (maxInactiveDays: number, activeSlot?: string, dryRun?: boolean) => post('/api/chat/slots/cleanup', { max_inactive_days: maxInactiveDays, active_slot: activeSlot || '', dry_run: !!dryRun }).then(j) as Promise<{ ok: boolean; archived: number; keys: string[]; failed: string[]; dry_run?: boolean; count?: number; active_is_stale?: boolean }>,
   stopChatSlot: (slot: string) => post('/api/chat/slots/' + encodeURIComponent(slot) + '/stop').then(j),

--- a/website/src/components/ArtifactBody.tsx
+++ b/website/src/components/ArtifactBody.tsx
@@ -95,9 +95,10 @@ export const ArtifactBodyNative = memo(function ArtifactBodyNative({
     try { return DOMPurify.sanitize(hljs.highlight(content, { language: lang }).value) + '\n' }
     catch { return DOMPurify.sanitize(hljs.highlightAuto(content).value) + '\n' }
   }, [content, lang, isMarkdown, editing, isRichType])
-  // Comment overlay only for the rendered markdown view (text/code use <pre>
-  // without a previewRef; widgets use the iframe bridge).
-  const showOverlay = isMarkdown && !editing && !!onActivateComment && (comments?.length ?? 0) > 0
+  // Comment overlay for every natively-rendered body that has a previewRef —
+  // markdown (rendered DOM) AND the <pre> path (text/json/svg). Widgets/HTML use
+  // the iframe bridge instead.
+  const showOverlay = !editing && !!onActivateComment && (comments?.length ?? 0) > 0
   return (
     <div
       ref={scrollerRef}

--- a/website/src/components/ArtifactChatPanel.tsx
+++ b/website/src/components/ArtifactChatPanel.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef } from 'react'
+import { Plus, ExternalLink, X, Sparkles } from 'lucide-react'
+import { useAppDispatch } from '../store'
+import { switchSlot } from '../store/chatSlice'
+import ChatPage from '../pages/ChatPage'
+
+import { i18nT } from '../i18n/t'
+
+/**
+ * ArtifactChatPanel — the embedded companion chat for an artifact.
+ *
+ * Embeds the FULL native ChatPage (`switchSlot()` + `<ChatPage embedded />`) so
+ * the chatting experience is identical to the normal chat page — OPTIONS
+ * follow-up chips, question cards, stop-event cards, steer-send, collapsible
+ * tool groups, regenerate, voice, the works. `embedMode="chat"` selects the
+ * single-session chrome (no sessions sidebar) and `noUrlSync` keeps ChatPage's
+ * deep-link sync off the host route — the panel lives on /artifacts/:slug,
+ * which the page owns.
+ *
+ * Session lifecycle (binding resolution, create, archive) lives in
+ * ArtifactDetailPage; this component activates whatever bound slot it is handed
+ * via the global active-session pointer. That global switch is deliberate: the
+ * companion session IS your active session while you work on the artifact, so
+ * /chat lands on it afterwards.
+ *
+ * Composer staging ("Ask agent to address") rides the existing `writePrefill`
+ * sessionStorage channel that ChatPage already consumes when the slot
+ * activates — no ChatPage fork needed.
+ *
+ * Header actions:
+ * - **New chat** — archives the current bound session and starts a fresh one
+ *   (the page enforces archive-then-create so the ≤1-active-bound-session
+ *   invariant never observably breaks).
+ * - **Open in chat page** — full-page escape hatch; routes through the page's
+ *   nav dispatcher so it forwards correctly from popout windows.
+ * - **×** — closes the *panel* only; the session stays active and bound.
+ */
+export function ArtifactChatPanel({
+  slotKey,
+  creating,
+  onNewChat,
+  onOpenFull,
+  onClose,
+}: {
+  /** Bound session's slot key, or null when no active bound session exists. */
+  slotKey: string | null
+  /** True while a bound session create is in flight. */
+  creating: boolean
+  onNewChat: () => void
+  onOpenFull: () => void
+  onClose: () => void
+}) {
+  const dispatch = useAppDispatch()
+  const prevSlotRef = useRef<string | null>(null)
+
+  // Activate the bound session. Re-dispatches on rebind (New chat replaces the
+  // slot) but not on unrelated re-renders.
+  useEffect(() => {
+    if (slotKey && slotKey !== prevSlotRef.current) {
+      prevSlotRef.current = slotKey
+      dispatch(switchSlot(slotKey))
+    }
+  }, [slotKey, dispatch])
+
+  return (
+    <aside
+      className="w-[480px] shrink-0 flex flex-col rounded-xl border border-border bg-card overflow-hidden"
+      style={{ height: 'calc(100vh - 240px)', minHeight: 480 }}
+      aria-label={i18nT('components.artifactChatPanel.artifact_companion_chat')}
+    >
+      <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border shrink-0">
+        <Sparkles size={13} className="text-accent shrink-0" />
+        <span className="text-[12px] font-medium text-text flex-1 truncate">
+          {i18nT('components.artifactChatPanel.agent_chat')}
+        </span>
+        {slotKey && (
+          <button
+            type="button"
+            onClick={onNewChat}
+            className="p-1 rounded text-muted hover:text-text hover:bg-bg-hover cursor-pointer bg-transparent border-none transition-colors"
+            title={i18nT('components.artifactChatPanel.new_chat_archive_this_conversation_and_start_fresh')}
+            aria-label={i18nT('components.artifactChatPanel.new_chat')}
+          >
+            <Plus size={13} />
+          </button>
+        )}
+        {slotKey && (
+          <button
+            type="button"
+            onClick={onOpenFull}
+            className="p-1 rounded text-muted hover:text-text hover:bg-bg-hover cursor-pointer bg-transparent border-none transition-colors"
+            title={i18nT('components.artifactChatPanel.open_in_chat_page')}
+            aria-label={i18nT('components.artifactChatPanel.open_in_chat_page')}
+          >
+            <ExternalLink size={13} />
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-1 rounded text-muted hover:text-danger hover:bg-danger/10 cursor-pointer bg-transparent border-none transition-colors"
+          title={i18nT('components.artifactChatPanel.close_panel_the_session_stays_active')}
+          aria-label={i18nT('components.artifactChatPanel.close_chat_panel')}
+        >
+          <X size={13} />
+        </button>
+      </div>
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        {slotKey ? (
+          <ChatPage embedded embedMode="chat" noUrlSync />
+        ) : creating ? (
+          <div className="flex-1 flex items-center justify-center text-muted text-[13px]" role="status">
+            <span className="animate-pulse">{i18nT('components.artifactChatPanel.starting_session')}</span>
+          </div>
+        ) : (
+          <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted text-[13px] px-4 text-center">
+            <span>{i18nT('components.artifactChatPanel.no_active_session_for_this_artifact')}</span>
+            <button
+              type="button"
+              onClick={onNewChat}
+              className="px-2.5 py-1 rounded-md text-[12px] font-medium border border-accent text-accent-fg bg-accent cursor-pointer hover:bg-accent-hover transition-all"
+            >
+              {i18nT('components.artifactChatPanel.start_chat')}
+            </button>
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/website/src/components/ArtifactPanel.tsx
+++ b/website/src/components/ArtifactPanel.tsx
@@ -15,16 +15,6 @@ import { api } from '../api/client'
 import type { Artifact } from '../types'
 
 import { i18nT } from '../i18n/t'
-// Artifact "Iterate" affordances are hidden pending an artifact redesign.
-// Here that gates the "Submit comments to chat" bar — the
-// side-panel analog of the full-page Iterate flow — while leaving the durable
-// comment stack (create/view/reply/resolve) fully intact. Flip to `true` (or
-// delete the gate) when the redesign lands.
-// NOTE: the upstream project keeps this visible — this is a deliberate
-// fork-initiated UX divergence, so do NOT let an upstream sync re-show it.
-// Mirrors ArtifactDetailPage.tsx.
-const SHOW_ARTIFACT_ITERATE = false
-
 interface Props {
   slug: string
   /** Kind captured at open time; the live query overrides it once loaded. */
@@ -208,9 +198,9 @@ export default memo(function ArtifactPanel({ slug, kind, content, onClose, onSub
     return () => { document.body.style.overflow = '' }
   }, [fullscreen])
 
-  // Submit-to-chat is the side-panel analog of the full-page Iterate flow;
-  // hidden while iterate affordances are gated off (see SHOW_ARTIFACT_ITERATE).
-  const showSubmitBar = SHOW_ARTIFACT_ITERATE && !!onSubmitComments && humanComments.length > 0
+  // Submit-to-chat is the side-panel analog of the detail page's companion
+  // chat. Only rendered when the host actually supplies a submit channel.
+  const showSubmitBar = !!onSubmitComments && humanComments.length > 0
 
   const renderBody = (
     bodyScrollRef: React.RefObject<HTMLDivElement>,

--- a/website/src/components/ContentRenderer.tsx
+++ b/website/src/components/ContentRenderer.tsx
@@ -147,7 +147,7 @@ export const ContentRenderer = memo(function ContentRenderer({
   wordWrap: boolean
   autocomplete: boolean
   onChange: (v: string) => void
-  previewRef: React.RefObject<HTMLDivElement | null>
+  previewRef: React.RefObject<HTMLElement | null>
   displayContent: string
   isMarkdown: boolean
   highlightedHtml: string
@@ -192,7 +192,12 @@ export const ContentRenderer = memo(function ContentRenderer({
               {Array.from({ length: content.split('\n').length }, (_, i) => <div key={i}>{i + 1}</div>)}
             </div>
           )}
+          {/* previewRef also lands here (not just on the markdown branch) so a
+              selection in a text/json/svg body has a root to map back to source:
+              a <pre>'s textContent equals the source exactly (highlighting only
+              wraps spans), so rendered-text offsets are source offsets. */}
           <pre
+            ref={previewRef as React.RefObject<HTMLPreElement>}
             className="absolute inset-0 p-3 m-0 overflow-auto whitespace-pre"
             style={{ paddingLeft: lineNums ? 'calc(3em + 12px)' : undefined }}
             onScroll={gutterReadRef ? (e => { if (gutterReadRef.current) gutterReadRef.current.scrollTop = (e.target as HTMLElement).scrollTop }) : undefined}

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { isArtifactEditing } from '../utils/artifactEditGuard'
 import { useAppDispatch } from '../store'
 import { store } from '../store'
 import { sseStatus, sseConnected, sseDisconnected, sseSlots, sseTodoUpdate, setChannelTrusted, sseSlotTitle, triggerRefresh, fetchSlots, markSlotUnread, setUpdateProgress, sseSubagentStatus, sseSubagentText, touchSlotActivity, patchSlotSourceLinks, type SubagentDetail } from '../store/dashboardSlice'
@@ -429,6 +430,47 @@ export function useWebSocket() {
           case 'slot_title':
             dispatch(sseSlotTitle(data as { key: string; title: string }))
             break
+          case 'artifact_update': {
+            // Live artifact refresh: the backend broadcasts from the artifact
+            // mutation funnel (create / content PATCH / revert / relocate /
+            // pull / delete). Invalidate the per-slug queries so any open view
+            // — detail page, popout, the companion panel's left pane —
+            // re-renders the new version immediately. Every window has its own
+            // WS, so no BroadcastChannel is needed. The library list is
+            // invalidated too (create/delete change it; content updates bump
+            // its updated_at ordering).
+            const slug = (data as { slug?: string }).slug
+            if (slug) {
+              if ((data as { deleted?: boolean }).deleted) {
+                // Notify, but deliberately do NOT evict ['artifact', slug].
+                // Evicting drops the detail page's query data, which re-renders it
+                // into a loading/404 state and unmounts the editor — taking an
+                // unsaved edit buffer with it. That would defeat the deletion
+                // listener's dirty-page guard, which exists precisely so the user
+                // can still copy their work out. A clean page navigates away, and a
+                // dirty one keeps its cached content; neither needs the eviction,
+                // and a genuine refetch 404s on its own because the artifact is
+                // gone server-side.
+                window.dispatchEvent(new CustomEvent('kirocrew:artifact-deleted', { detail: { slug } }))
+              } else if (isArtifactEditing(slug)) {
+                // A human has an unsaved buffer open on this artifact. Refetching
+                // would move the editor's baseline while the buffer keeps the older
+                // text, so the next Save would overwrite whatever just arrived.
+                // Leave the content cache alone; the page reloads it on save or
+                // cancel. Comments/events carry no edit buffer, so they still
+                // refresh — only content is withheld.
+                queryClient.invalidateQueries({ queryKey: ['artifact-events', slug] })
+                queryClient.invalidateQueries({ queryKey: ['artifact-comments', slug] })
+              } else {
+                queryClient.invalidateQueries({ queryKey: ['artifact', slug] })
+                queryClient.invalidateQueries({ queryKey: ['artifact-versions', slug] })
+                queryClient.invalidateQueries({ queryKey: ['artifact-events', slug] })
+                queryClient.invalidateQueries({ queryKey: ['artifact-comments', slug] })
+              }
+              queryClient.invalidateQueries({ queryKey: ['artifacts'] })
+            }
+            break
+          }
           case 'notification': {
             const n = data as Notification
             dispatch(addNotification(n))

--- a/website/src/i18n/locales/en.manual.json
+++ b/website/src/i18n/locales/en.manual.json
@@ -87,6 +87,18 @@
     }
   },
   "components": {
+    "artifactChatPanel": {
+      "agent_chat": "Agent chat",
+      "artifact_companion_chat": "Artifact companion chat",
+      "close_chat_panel": "Close chat panel",
+      "close_panel_the_session_stays_active": "Close panel (the session stays active)",
+      "new_chat": "New chat",
+      "new_chat_archive_this_conversation_and_start_fresh": "New chat — archive this conversation and start fresh",
+      "no_active_session_for_this_artifact": "No active session for this artifact.",
+      "open_in_chat_page": "Open in chat page",
+      "start_chat": "Start chat",
+      "starting_session": "Starting session…"
+    },
     "linkedSurfacesSection": {
       "connected": "Connected: {{label}}",
       "mirror": "Mirror",
@@ -96,6 +108,12 @@
     }
   },
   "pages": {
+    "artifactDetailPage": {
+      "agent_chat": "Agent chat",
+      "chat_with_the_agent_about_this_artifact": "Chat with the agent about this artifact",
+      "this_artifact_was_deleted": "This artifact was deleted.",
+      "toggle_agent_chat": "Toggle agent chat"
+    },
     "chat": {
       "activityViewer": {
         "clear": "Clear",

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -902,6 +902,18 @@
     "artifactBody": {
       "rendering": "渲染中…"
     },
+    "artifactChatPanel": {
+      "agent_chat": "智能体对话",
+      "artifact_companion_chat": "工件伴随对话",
+      "close_chat_panel": "关闭对话面板",
+      "close_panel_the_session_stays_active": "关闭面板（会话仍保持活动）",
+      "new_chat": "新建对话",
+      "new_chat_archive_this_conversation_and_start_fresh": "新建对话 — 归档当前对话并重新开始",
+      "no_active_session_for_this_artifact": "此工件没有活动会话。",
+      "open_in_chat_page": "在对话页面中打开",
+      "start_chat": "开始对话",
+      "starting_session": "正在启动会话…"
+    },
     "artifactFolderDeleteDialog": {
       "cancel": "取消",
       "contents_move_up_to": "内容将上移至",
@@ -2302,6 +2314,7 @@
       "activity": "动态",
       "add_a_tag": "添加标签",
       "add_a_tag_comma_separated_tags_supported": "添加标签（支持逗号分隔）",
+      "agent_chat": "智能体对话",
       "artifact": "工件",
       "back": "返回",
       "back_to_library": "← 返回库",
@@ -2310,6 +2323,7 @@
       "by": "由",
       "cancel": "取消",
       "cancel_esc": "取消 (Esc)",
+      "chat_with_the_agent_about_this_artifact": "就此工件与智能体对话",
       "comments": "评论",
       "content_copied_from_v": "内容复制自 v",
       "created": "创建于",
@@ -2353,9 +2367,11 @@
       "tag": "标签…",
       "tag_2": "标签",
       "this_artifact_is_regenerated_by_a_cron_job_your": "此工件由定时任务重新生成。你的修改会保留在版本历史中，但下次定时任务运行会创建更新的版本，覆盖你在此保存的内容。",
+      "this_artifact_was_deleted": "此工件已被删除。",
       "tip_select_text_to_anchor_a_comment_or_use_the": "提示：选中文本以锚定评论，或使用",
       "tip_use_the": "提示：使用",
       "to_chat_with_the_agent": "与代理聊天",
+      "toggle_agent_chat": "切换智能体对话",
       "toggle_comments": "切换评论",
       "unsaved_changes": "• 未保存的更改",
       "updated": "· 更新于",

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1367,6 +1367,59 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
   background-color: var(--search-highlight-current);
 }
 
+/* Anchored-comment highlights on the markdown / text artifact body are drawn
+   as a real overlay layer (InlineCommentOverlay), NOT the CSS Custom Highlight
+   API — real elements always paint and support box-shadow + a persistent active
+   state. Translucent marker over the text; the drop shadow gives contrast with
+   the page; the active comment stays lit.
+
+   Without these rules the overlay still mounts its rects and gutter bubbles
+   into the DOM, but they paint as zero-styled transparent divs — anchors look
+   like they are "not rendering" at all. */
+.mc-cmt-overlay { contain: layout style; }
+.mc-cmt-rect {
+  background-color: var(--warn-subtle);
+  border-bottom: 2px solid var(--warn);
+  border-radius: 2px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.38);
+  cursor: pointer;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+.mc-cmt-rect:hover { box-shadow: 0 3px 9px rgba(0, 0, 0, 0.45); }
+.mc-cmt-rect.active {
+  background-color: var(--accent-subtle);
+  border-bottom-color: var(--accent);
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.45), 0 0 0 1px var(--accent);
+}
+/* Gutter bubble, one per anchored thread: OUTLINE = read, FILLED = unread. */
+.mc-cmt-bubble {
+  width: 19px; height: 19px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 10px; font-weight: 700; line-height: 1;
+  color: var(--warn); background-color: var(--card);
+  border: 1.5px solid var(--warn); border-radius: 10px 10px 10px 2px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  cursor: pointer; padding: 0;
+  transition: background-color 0.12s ease, transform 0.12s ease, color 0.12s ease;
+}
+.mc-cmt-bubble:hover { transform: scale(1.1); }
+.mc-cmt-bubble.unread { background-color: var(--warn); color: var(--warn-fg, #1a1a1a); }
+.mc-cmt-bubble.active { background-color: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+
+/* Artifact toolbar: every control (version select + buttons) the same height.
+   Icon-only buttons become squares; labeled buttons keep their padding-driven
+   width. ArtifactDetailPage already carries the `mc-art-toolbar` class. */
+.mc-art-toolbar > button,
+.mc-art-toolbar > select {
+  height: 32px;
+  box-sizing: border-box;
+}
+.mc-art-toolbar > button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Mobile: force ChatSidebar to fill overlay drawer width */
 @media (max-width: 767px) {
   .mobile-sessions-overlay .sidebar-inner { width: 100% !important; }

--- a/website/src/pages/ArtifactDetailPage.tsx
+++ b/website/src/pages/ArtifactDetailPage.tsx
@@ -6,8 +6,9 @@ import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
 import { ArrowLeft, AlertTriangle, ArrowUp, Camera, ExternalLink, Download, GitFork, Pencil, RefreshCw, X, AlertCircle, RotateCcw, Plus, Sparkles, MessageSquare, Monitor, Undo2, Upload, Folder as FolderIcon } from 'lucide-react'
 import { useTheme } from '../hooks/useTheme'
 import { type IframeSelection } from '../hooks/useCommentBridge'
-import { useAppDispatch } from '../store'
+import { useAppDispatch, useAppSelector } from '../store'
 import { switchSlot } from '../store/chatSlice'
+import { fetchSlots, addSlotOptimistic, removeSlotOptimistic } from '../store/dashboardSlice'
 import { safeHttpUrl } from '../lib/safeUrl'
 import { sanitizeCssValue } from '../lib/cssSanitize'
 import { THEME_VAR_NAMES, buildSrcdoc } from '../lib/widgetSrcdoc'
@@ -21,6 +22,7 @@ import { FolderPickerItems } from '../components/FolderMoveSubmenu'
 import { folderBreadcrumb } from '../utils/artifactFolderTree'
 import { CommentPopover } from '../components/CommentOverlay'
 import { CommentsSidebar } from '../components/CommentsSidebar'
+import { ArtifactChatPanel } from '../components/ArtifactChatPanel'
 import { CommentThreadPopover } from '../components/CommentThreadPopover'
 import { findCoords, resolveSourcePos } from '../components/MarkdownPanel'
 // Artifact body renderers, extracted here so the chat side panel shares them.
@@ -29,23 +31,23 @@ import { useArtifactPopouts } from '../hooks/useArtifactPopouts'
 import { forwardToMain, type NavIntent } from '../utils/artifactPopout'
 import { writePrefill } from '../utils/navIntent'
 import { announceCommentsChanged, onCommentsChanged } from '../utils/artifactCommentsSync'
+import { setArtifactEditing } from '../utils/artifactEditGuard'
 import { PublishHub } from '../components/PublishHub'
-import type { Artifact, ArtifactEvent, ArtifactComment, CommentAnchor } from '../types'
+import type { Artifact, ArtifactEvent, ArtifactComment, CommentAnchor, ChatSlot } from '../types'
 
 import { i18nT } from '../i18n/t'
-// Artifact "Iterate" affordances are hidden pending an artifact redesign.
-// This gates every user-facing entry point into the
-// iterate flow — the header Sparkles button, the anchored-comment creation
-// path (`commentable`), the CommentsSidebar "Ask agent" action, and the
-// "click Iterate" tips — while leaving iterateWithAgent / buildPromptForChat
-// and the agent-driven `iterated` lifecycle event fully intact. The durable
-// comment stack (view / doc-level add / reply / resolve / review) stays fully
-// available; only the iterate round-trip and the anchored-selection creation
-// (which existed only to feed iterate in the fork) are hidden. Flip to `true`
-// (or delete the gate) when the redesign lands.
-// NOTE: the upstream project keeps these visible — this is a deliberate
-// fork-initiated UX divergence, so do NOT let an upstream sync re-show them.
-const SHOW_ARTIFACT_ITERATE = false
+/**
+ * The artifact's active companion session: the bound slot for `slug`, or the most
+ * recently active one if a race or a History-page resume left more than one.
+ * Module-level so `openCompanionChat` can apply the identical rule to a freshly
+ * fetched slots payload, not just the Redux snapshot.
+ */
+function pickBoundSlot(slots: ChatSlot[] | undefined, slug: string): ChatSlot | null {
+  const matches = (slots ?? []).filter((x) => x.artifact === slug)
+  if (matches.length <= 1) return matches[0] ?? null
+  return [...matches].sort((a, b) =>
+    (b.last_activity_ts || '').localeCompare(a.last_activity_ts || ''))[0]
+}
 
 function readThemeVars(): Record<string, string> {
   if (typeof window === 'undefined' || typeof document === 'undefined') return {}
@@ -293,36 +295,44 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
   const durableComments = commentsQuery.data?.comments ?? []
   const commentCount = durableComments.length
   const remoteSyncError = commentsQuery.data?.remote_sync_error ?? null
-  // Comments live in a collapsible right-hand sidebar. It stays collapsed by
-  // default — an empty comment panel is just wasted space on a dashboard or
-  // infographic — and auto-reveals only once the artifact has at least one
-  // comment (see the effect below). A manual show/hide applies to the current
-  // view only; we intentionally do NOT persist it, so every artifact
-  // independently does the right thing instead of a global pin re-opening
-  // empty panels everywhere.
-  const [sidebarOpen, setSidebarOpen] = useState(false)
+  // Right-hand panel state machine: the comments sidebar and the companion
+  // chat panel share the same flex space, icon-toggled and mutually exclusive.
+  // 'none' keeps the artifact full-width — an empty comment panel is just
+  // wasted space on a dashboard or infographic — and comments auto-reveal only
+  // once the artifact has at least one comment (see the effect below). A manual
+  // show/hide applies to the current view only; we intentionally do NOT persist
+  // it, so every artifact independently does the right thing instead of a
+  // global pin re-opening empty panels everywhere.
+  const [panel, setPanel] = useState<'none' | 'comments' | 'chat'>('none')
   // Flipped once the user manually toggles, so the comment-driven auto-reveal
   // below stops overriding an explicit choice — but only for the current
   // artifact (cleared on navigation; see the effect).
   const sidebarUserToggledRef = useRef(false)
   const toggleSidebar = useCallback(() => {
     sidebarUserToggledRef.current = true
-    setSidebarOpen(v => !v)
+    setPanel(p => (p === 'comments' ? 'none' : 'comments'))
   }, [])
-  // Auto-reveal the sidebar when the artifact has comments; collapse it when it
-  // has none. Reacts to commentCount so adding the first comment reveals the
-  // panel and removing the last collapses it — unless the user has taken manual
-  // control via the toggle. React Router reuses this component across the
-  // parameterized route, so navigating to a different artifact clears the
-  // manual-toggle override, giving every artifact the comment-driven default.
+  // Auto-reveal the comments panel when the artifact has comments; collapse it
+  // when it has none. Reacts to commentCount so adding the first comment reveals
+  // the panel and removing the last collapses it — unless the user has taken
+  // manual control via a toggle, and NEVER by auto-switching away from an open
+  // chat panel (the chat panel only opens on explicit action, so yanking it for
+  // a comment default would discard user intent). React Router reuses this
+  // component across the parameterized route, so navigating to a different
+  // artifact clears the manual-toggle override and resets the panel, giving
+  // every artifact the comment-driven default.
   const sidebarNavRef = useRef(slug)
   useEffect(() => {
-    if (sidebarNavRef.current !== slug) {
+    const navigated = sidebarNavRef.current !== slug
+    if (navigated) {
       sidebarNavRef.current = slug
       sidebarUserToggledRef.current = false
     }
     if (sidebarUserToggledRef.current) return
-    setSidebarOpen(commentCount > 0)
+    setPanel(p => {
+      if (p === 'chat' && !navigated) return p
+      return commentCount > 0 ? 'comments' : 'none'
+    })
   }, [slug, commentCount])
   const [popover, setPopover] = useState<{ x: number; y: number; anchor: string; line?: number; column?: number; prefix?: string; suffix?: string; startOffset?: number; endOffset?: number } | null>(null)
   // Bidirectional anchor↔comment linking (item #5): flash a sidebar row when
@@ -554,6 +564,29 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
     return () => document.removeEventListener('keydown', h)
   }, [editing, dirty, cancelEditing])
 
+  // Tell the WS transport this artifact is being edited, so a live
+  // `artifact_update` does not refetch the content out from under the editor and
+  // leave Save poised to overwrite it.
+  //
+  // Keyed on `editing`, NOT `dirty`: the exposure window opens when the editor
+  // OPENS, not when the buffer first diverges. With a dirty-only guard an update
+  // arriving while the editor sat open-and-clean would move the baseline, and the
+  // very next keystroke would make the (now stale) buffer dirty and Save would
+  // overwrite the update.
+  //
+  // When editing ends, refetch what was withheld so the page is not left showing
+  // pre-update content.
+  const wasEditingRef = useRef(false)
+  useEffect(() => {
+    setArtifactEditing(slug, editing)
+    if (wasEditingRef.current && !editing) {
+      queryClient.invalidateQueries({ queryKey: ['artifact', slug] })
+      queryClient.invalidateQueries({ queryKey: ['artifact-versions', slug] })
+    }
+    wasEditingRef.current = editing
+    return () => setArtifactEditing(slug, false)
+  }, [slug, editing, queryClient])
+
   // Warn the browser about unsaved edits on close / reload / nav-away.
   useEffect(() => {
     if (!dirty) return
@@ -567,11 +600,18 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
   // cleanly: markdown (via data-sourcepos) and text (rendered === source).
   // JSON / SVG selection produces noisy anchors; revisit when there's a real
   // user demand.
-  // Anchored (selection-driven) comment creation existed in the fork solely to
-  // feed the Iterate flow, so it is gated behind SHOW_ARTIFACT_ITERATE with the
-  // rest of the iterate affordances. Doc-level comments via the CommentsSidebar
-  // remain available for all kinds regardless of this flag.
-  const commentable = SHOW_ARTIFACT_ITERATE && !!artifact && !editing && isCurrent && (
+  // Anchored (selection-driven) comment creation: select text in the rendered
+  // body to pin a comment to that exact span. The anchor (quote + prefix/suffix
+  // + rendered-text offsets + version) is persisted server-side and surfaced to
+  // the agent via artifact_get_comments, so a comment is a durable, located
+  // instruction rather than a free-floating note. Doc-level comments via the
+  // CommentsSidebar remain available for all kinds.
+  // markdown AND text: both now render behind a `previewRef` (ContentRenderer
+  // attaches it to the markdown DOM and to the <pre> used for text), so a
+  // selection has a root to map back to source in either. Do not add a kind here
+  // without confirming its renderer attaches the ref, or the popover silently
+  // never opens.
+  const commentable = !!artifact && !editing && isCurrent && (
     artifact.kind === 'markdown' || artifact.kind === 'text'
   )
   const isMarkdown = artifact?.kind === 'markdown'
@@ -674,8 +714,14 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
     // Adding a comment hands control back to the comment-driven default: reveal
     // the panel now, and clear the manual override so the auto effect can
     // collapse it again if every comment is later removed.
+    //
+    // EXCEPT when the chat panel is open. An anchored add is reachable while
+    // chatting (the body stays visible in the left column), and switching panels
+    // would yank the conversation out from under the user. The toolbar's comment
+    // badge already increments, so the add is still visibly acknowledged. Same
+    // rationale as the auto-reveal guard in the panel effect above.
     sidebarUserToggledRef.current = false
-    setSidebarOpen(true)
+    setPanel(p => (p === 'chat' ? p : 'comments'))
     setPopover(null)
     window.getSelection()?.removeAllRanges()
   }, [popover, postCommentMut])
@@ -699,20 +745,6 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
   const removeComment = useCallback((id: string) => { removeCommentMut.mutate(id) }, [removeCommentMut])
   const editComment = useCallback((id: string, text: string) => { editCommentMut.mutate({ id, text }) }, [editCommentMut])
 
-  // Build the chat-injection prompt. Comments are durable and the agent reads
-  // them itself via `artifact_get_comments`, so we NEVER dump comment text into
-  // the prompt anymore — `addressComments` just nudges the agent to read+act on
-  // the open ones. The plain header is the generic "discuss this" entry point
-  // for ALL kinds (including widgets that can't be edited inline).
-  const buildPromptForChat = useCallback((addressComments = false): string => {
-    if (!artifact) return ''
-    const header = `Iterate on artifact \`${artifact.slug}\` (${artifact.name})`
-    if (addressComments && commentCount > 0) {
-      return header + `: please review and address the ${commentCount} open comment${commentCount === 1 ? '' : 's'} on this artifact (use the artifact_get_comments tool to read them).`
-    }
-    return header + ': '
-  }, [artifact, commentCount])
-
   /**
    * Single navigation dispatcher for every affordance that leaves the artifact
    * view. In the main dashboard it navigates locally (seeding the composer
@@ -728,27 +760,229 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
     navigate(intent.path)
   }, [popout, dispatch, navigate])
 
-  /** Open a fresh chat slot pre-loaded with this artifact in the input.
-   * Always creates a NEW session so historical context from unrelated
-   * conversations doesn't contaminate the iterate loop. The user reviews
-   * the prefill and clicks Send — we never auto-send because comment
-   * dumps can be long and may need editing.
+  // ── Companion chat ─────────────────────────────────────────────────────────
+  // The active bound session is resolved from the Redux slots snapshot (the WS
+  // `slots` event carries each slot's `artifact` binding) — zero extra
+  // endpoints. The frontend flow keeps it to <=1 active bound session per slug
+  // (archive-then-create); the resolver tolerates more by picking the most
+  // recently active, so races and history resumes degrade gracefully.
+  // `?? []` mirrors TaskProgressBar: the slots array is typed non-optional but
+  // the store hydrates from localStorage, so a stale persisted shape can hand
+  // back undefined and a bare .filter() would crash the whole artifact page.
+  const slots = useAppSelector((s) => s.dashboard.slots)
+  // `slots` is `[]` BOTH before the first fetch and when nothing is bound, so the
+  // empty array alone cannot be read as "no bound session" — see openCompanionChat.
+  const slotsLoaded = useAppSelector((s) => s.dashboard.slotsLoaded)
+  // The winner drives the panel; the full set matters when archiving, because a
+  // two-window creation race can leave more than one slot bound to this slug and
+  // archiving only the winner lets pickBoundSlot reopen the leftover.
+  const boundSlots = useMemo(
+    () => (slots ?? []).filter((x) => x.artifact === slug),
+    [slots, slug],
+  )
+  const boundSlot = useMemo(() => pickBoundSlot(slots, slug), [slots, slug])
+  const [chatCreating, setChatCreating] = useState(false)
+  // Serializes the two session-lifecycle entry points. `chatCreating` cannot do
+  // this job: it is React state (so a second handler in the same tick still sees
+  // the old value) and it is only set INSIDE createBoundSession, which runs
+  // AFTER newCompanionChat's `await` on the archive — leaving a window where a
+  // rapid double-click starts two flows, both resolve the same boundSlot, both
+  // archive it (the second 404s and proceeds by design), and both create a
+  // replacement. That yields two active bound sessions for one artifact, the
+  // exact invariant the archive-then-create ordering exists to protect.
+  const sessionOpBusyRef = useRef(false)
+  // Versions already announced to a session via context injection, so repeated
+  // panel opens don't stack duplicate freshness nudges.
+  const injectedVersionRef = useRef<Map<string, number>>(new Map())
+
+  /** Structured context entry naming the artifact — injected ephemeral (consumed
+   *  on the next user message) so the user's first message can be natural
+   *  ("summarize this") with no slug boilerplate in the composer. */
+  const buildCompanionContext = useCallback((): string => {
+    if (!artifact) return ''
+    return (
+      `Companion chat for artifact \`${artifact.slug}\` ("${artifact.name}", kind=${artifact.kind}, ` +
+      `v${artifact.version}, source_path=${artifact.source_path || 'none'}, ` +
+      `${commentCount} open comment${commentCount === 1 ? '' : 's'}).\n` +
+      `Use artifact_get / artifact_update / artifact_get_comments with this slug. ` +
+      `Anchored comments carry the exact quoted span they refer to — treat each as ` +
+      `an instruction about that span, and triage every one you act on.`
+    )
+  }, [artifact, commentCount])
+
+  /** Create a fresh bound session with a ONE-round-trip critical path: the
+   *  create response — which carries the `artifact` binding — is dispatched
+   *  straight into the Redux slots list (addSlotOptimistic), so `boundSlot`
+   *  resolves and the panel becomes interactive immediately. The silent context
+   *  entry and the server-truth refresh run in the background: the context POST
+   *  completes long before a human can type and send (it is consumed on the NEXT
+   *  user message), and fetchSlots/WS snapshots reconcile the optimistic row
+   *  with full slot metadata moments later.
    *
-   * Works regardless of pending comment state: the comment-less path
-   * (just `Iterate on artifact <slug>: `) is the primary "discuss this"
-   * entry point and is available for ALL artifact kinds (including
-   * widgets that can't be edited inline).
-   */
-  const iterateWithAgent = useCallback(async (addressComments = false) => {
-    if (!artifact) return
-    const prompt = buildPromptForChat(addressComments)
+   *  `prefillText` is staged via writePrefill BEFORE the optimistic bind so
+   *  ChatPage's slot-activation effect deterministically finds it on mount. */
+  const createBoundSession = useCallback(async (prefillText?: string): Promise<string | null> => {
+    if (!artifact) return null
+    setChatCreating(true)
     try {
-      const res = await api.createChatSlot(`Artifact: ${artifact.name}`)
-      sendNav({ path: '/chat', slotKey: res.key, prefill: { slotKey: res.key, prompt } })
+      // No `name`: the backend generates a unique slot key (reusing a
+      // name-derived key would append onto an archived session's history file).
+      // The pinned title keeps the sidebar readable.
+      const res = await api.createChatSlot(
+        undefined, undefined, undefined, undefined, undefined,
+        `Artifact: ${artifact.name}`, undefined, artifact.slug,
+      )
+      if (prefillText) writePrefill(res.key, prefillText)
+      dispatch(addSlotOptimistic({
+        key: res.key,
+        title: res.title || `Artifact: ${artifact.name}`,
+        messages: 0,
+        running: false,
+        artifact: artifact.slug,
+      } as ChatSlot))
+      api.chatSlotContext(res.key, buildCompanionContext(), {
+        source: 'artifact-companion', ephemeral: true,
+      }).catch(() => undefined)
+      injectedVersionRef.current.set(res.key, artifact.version)
+      dispatch(fetchSlots())
+      return res.key as string
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : String(err))
+      return null
+    } finally {
+      setChatCreating(false)
     }
-  }, [artifact, buildPromptForChat, sendNav])
+  }, [artifact, buildCompanionContext, dispatch])
+
+  /** Sparkle flow: resume the active bound session if one exists, else create a
+   *  new one. With `address`, stage (never auto-send) the address-comments
+   *  message via the writePrefill sessionStorage channel — the embedded ChatPage
+   *  consumes it when the slot activates. (The panels are mutually exclusive, so
+   *  an "Ask agent to address" click always mounts the chat panel fresh — the
+   *  prefill is always picked up.) */
+  const openCompanionChat = useCallback(async (opts?: { address?: boolean }) => {
+    if (!artifact) return
+    if (sessionOpBusyRef.current) return
+    const address = opts?.address ?? false
+    if (!address && panel === 'chat') { sidebarUserToggledRef.current = true; setPanel('none'); return }
+    sidebarUserToggledRef.current = true
+    const addressMsg = address && commentCount > 0
+      ? `Please review and address the ${commentCount} open comment${commentCount === 1 ? '' : 's'} on this artifact.`
+      : ''
+    let bound = boundSlot
+    if (!bound && !slotsLoaded) {
+      // Cold load: the slots snapshot is still `[]` because the first fetch has
+      // not landed, NOT because this artifact has no session. Creating here would
+      // add a second active bound session for the slug the moment the real one
+      // arrives. Resolve authoritatively first, applying the same tie-break rule.
+      setPanel('chat')
+      sessionOpBusyRef.current = true
+      try {
+        bound = pickBoundSlot(await dispatch(fetchSlots()).unwrap(), slug)
+      } catch {
+        bound = null   // fetch failed — fall through and create
+      } finally {
+        sessionOpBusyRef.current = false
+      }
+    }
+    if (!bound) {
+      setPanel('chat')
+      sessionOpBusyRef.current = true
+      try {
+        await createBoundSession(addressMsg || undefined)
+      } finally {
+        sessionOpBusyRef.current = false
+      }
+      return
+    }
+    const boundSlotResolved = bound
+    if (addressMsg) writePrefill(boundSlotResolved.key, addressMsg)
+    setPanel('chat')
+    // Resume freshness nudge: if the artifact moved past the session's last
+    // activity, inject a fresh ephemeral context entry so the agent doesn't act
+    // on stale-version assumptions. Best-effort — ISO timestamps compare
+    // lexicographically; a miss just means the agent re-reads via artifact_get.
+    const injected = injectedVersionRef.current.get(boundSlotResolved.key)
+    if (
+      injected !== artifact.version &&
+      boundSlotResolved.last_activity_ts && artifact.updated_at &&
+      artifact.updated_at > boundSlotResolved.last_activity_ts
+    ) {
+      injectedVersionRef.current.set(boundSlotResolved.key, artifact.version)
+      api.chatSlotContext(boundSlotResolved.key, buildCompanionContext(), {
+        source: 'artifact-companion', ephemeral: true,
+      }).catch(() => undefined)
+    }
+  }, [artifact, panel, commentCount, boundSlot, slotsLoaded, slug, dispatch,
+      createBoundSession, buildCompanionContext])
+
+  /** "New chat": archive the current bound session FIRST (the existing red-X
+   *  delete path — history preserved, resumable from the History page), then
+   *  create fresh — so the <=1-active invariant never observably breaks. The
+   *  optimistic remove mirrors the optimistic add: without it the resolver would
+   *  keep picking the archived slot (it has a last_activity_ts, the new one
+   *  doesn't) until the next WS snapshot prunes it. */
+  const newCompanionChat = useCallback(async () => {
+    // Reject a re-entrant click rather than queue it: the second click's intent
+    // ("give me a fresh session") is already satisfied by the first.
+    if (sessionOpBusyRef.current) return
+    sessionOpBusyRef.current = true
+    try {
+      // Archive every slot bound to this slug, not just the resolved winner.
+      for (const slot of boundSlots) {
+        try {
+          await api.deleteChatSlot(slot.key)
+        } catch (err) {
+          // ONLY a 404 means "already archived, nothing to do". Any other
+          // failure means the old session is still live server-side, so creating
+          // anyway would leave TWO bound sessions for this slug — and since the
+          // resolver breaks ties on last_activity_ts, the OLD one keeps winning
+          // and "New chat" silently appears to do nothing. Abort and say why.
+          //
+          // Read `status` structurally rather than via `instanceof ApiError`:
+          // this fails closed on anything not provably a 404 (including an error
+          // re-thrown or wrapped across a module boundary, where instanceof
+          // silently stops matching), and it is verifiable in a test.
+          const status = (err as { status?: unknown } | null | undefined)?.status
+          if (status !== 404) {
+            setSaveError(err instanceof Error ? err.message : String(err))
+            return
+          }
+        }
+        dispatch(removeSlotOptimistic(slot.key))
+      }
+      await createBoundSession()
+    } finally {
+      sessionOpBusyRef.current = false
+    }
+  }, [boundSlots, createBoundSession, dispatch])
+
+  /** Full-page escape hatch — routes through sendNav so a popout forwards the
+   *  intent to a main window instead of remounting the dashboard in-frame. */
+  const openChatFull = useCallback(() => {
+    if (!boundSlot) return
+    sendNav({ path: '/chat', slotKey: boundSlot.key })
+  }, [boundSlot, sendNav])
+
+  // Deleted-artifact handling (consumes the `artifact_update {deleted}` WS event
+  // relayed by useWebSocket as a window event): leave the page in the main
+  // dashboard; a popout has no router so it surfaces an error instead.
+  useEffect(() => {
+    const onDeleted = (e: Event) => {
+      const detail = (e as CustomEvent<{ slug: string }>).detail
+      if (detail?.slug !== slug) return
+      // Navigating away destroys the edit buffer, so a dirty page keeps its
+      // content and surfaces the deletion instead — the user can still copy their
+      // work out. A popout has no router and always surfaces the error.
+      if (popout || dirty) {
+        setSaveError(i18nT('pages.artifactDetailPage.this_artifact_was_deleted'))
+      } else {
+        navigate('/artifacts')
+      }
+    }
+    window.addEventListener('kirocrew:artifact-deleted', onDeleted)
+    return () => window.removeEventListener('kirocrew:artifact-deleted', onDeleted)
+  }, [slug, popout, navigate, dirty])
 
   // Drop popover when the user switches to edit mode or pages between
   // versions — those interactions kill the underlying selection anyway.
@@ -1050,24 +1284,23 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
                     <Pencil size={13} />
                   </button>
                 )}
-                {/* Iterate — primary "discuss with agent" action for all kinds;
-                    for widgets it is the only way to ask the agent to change the
-                    artifact. Comments are durable and read by the agent via
-                    artifact_get_comments, so this no longer bundles them. Hidden
-                    in a popout window since it navigates away to a new chat — you
-                    iterate from the main dashboard, alongside the popped-out view.
-                    Also hidden while the fork keeps Iterate off (SHOW_ARTIFACT_ITERATE). */}
-                {SHOW_ARTIFACT_ITERATE && !popout && (
-                  <button
-                    type="button"
-                    onClick={() => iterateWithAgent()}
-                    className="px-2 py-1 rounded-md text-[12px] font-medium border border-accent text-accent-fg bg-accent cursor-pointer hover:bg-accent-hover hover:shadow-[0_0_12px_var(--accent-glow)] transition-all"
-                    title={i18nT('pages.artifactDetailPage.iterate_discuss_this_artifact_with_the_agent')}
-                    aria-label={i18nT('pages.artifactDetailPage.iterate')}
-                  >
-                    <Sparkles size={13} />
-                  </button>
-                )}
+                {/* Companion chat — toggles the embedded chat panel. Primary
+                    "discuss with agent" action for all kinds; for widgets it is
+                    the only way to ask the agent to change the artifact.
+                    Comments are durable and read by the agent via
+                    artifact_get_comments. Works in popout windows too — the
+                    popout has its own store + WS, and the old hide-in-popout
+                    reason (this button used to navigate away) is gone. */}
+                <button
+                  type="button"
+                  onClick={() => { void openCompanionChat() }}
+                  className={`p-1.5 rounded-md border cursor-pointer transition-all ${panel === 'chat' ? 'border-accent text-accent bg-accent-subtle' : 'border-border text-muted hover:text-text hover:border-border-strong'}`}
+                  title={i18nT('pages.artifactDetailPage.chat_with_the_agent_about_this_artifact')}
+                  aria-label={i18nT('pages.artifactDetailPage.toggle_agent_chat')}
+                  aria-pressed={panel === 'chat'}
+                >
+                  <Sparkles size={13} />
+                </button>
               </>
             )}
 
@@ -1079,10 +1312,10 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
             <button
               type="button"
               onClick={toggleSidebar}
-              className={`p-1.5 rounded-md border cursor-pointer transition-all ${sidebarOpen ? 'border-accent text-accent bg-accent-subtle' : 'border-border text-muted hover:text-text hover:border-border-strong'}`}
-              title={sidebarOpen ? 'Hide comments' : 'Show comments'}
+              className={`p-1.5 rounded-md border cursor-pointer transition-all ${panel === 'comments' ? 'border-accent text-accent bg-accent-subtle' : 'border-border text-muted hover:text-text hover:border-border-strong'}`}
+              title={panel === 'comments' ? 'Hide comments' : 'Show comments'}
               aria-label={i18nT('pages.artifactDetailPage.toggle_comments')}
-              aria-pressed={sidebarOpen}
+              aria-pressed={panel === 'comments'}
             >
               <span className="inline-flex items-center gap-1">
                 <MessageSquare size={13} />
@@ -1175,12 +1408,16 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
           </div>
         )}
 
-        {artifact.kind === 'webapp' ? (
-          <WebAppArtifactCard artifact={artifact} />
-        ) : (
+        {/* One flex row for EVERY kind, so the right-hand panels are siblings of
+            whatever body is rendered. Previously the row (and both panels) lived
+            only in the non-webapp branch while the toolbar's chat and comments
+            toggles rendered unconditionally — so on a webapp artifact a click
+            created/activated a session that had nowhere to display. */}
         <div className="flex gap-4 items-start">
           <div className="flex-1 min-w-0">
-            {usesIframe ? (
+            {artifact.kind === 'webapp' ? (
+              <WebAppArtifactCard artifact={artifact} />
+            ) : usesIframe ? (
               <>
                 <ArtifactBodyIframe
                   artifact={artifact}
@@ -1235,10 +1472,12 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
             )}
           </div>
 
-          {/* Collapsible right-hand comment sidebar. Durable, threaded, works
-              for ALL kinds (doc-level add for HTML/widget; anchored add for
-              markdown/text via the inline popover above). */}
-          {sidebarOpen && (
+          {/* Shared right-hand panel space: comments sidebar and companion chat
+              panel are mutually exclusive flex siblings of the artifact body —
+              icon-toggled, never overlays. The comment stack is durable,
+              threaded, and works for ALL kinds (doc-level add for HTML/widget;
+              anchored add for markdown/text via the inline popover above). */}
+          {panel === 'comments' && (
             <CommentsSidebar
               comments={durableComments}
               loading={commentsQuery.isFetching}
@@ -1250,15 +1489,23 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
               onReopen={reopenComment}
               onDelete={removeComment}
               onRefresh={invalidateComments}
-              onAskAgent={SHOW_ARTIFACT_ITERATE && commentCount > 0 ? () => iterateWithAgent(true) : undefined}
+              onAskAgent={commentCount > 0 ? () => { void openCompanionChat({ address: true }) } : undefined}
               onClose={toggleSidebar}
               onCommentClick={activateFromSidebar}
               onEditComment={editComment}
               activeCommentId={activeCommentId}
             />
           )}
+          {panel === 'chat' && (
+            <ArtifactChatPanel
+              slotKey={boundSlot?.key ?? null}
+              creating={chatCreating}
+              onNewChat={() => { void newCompanionChat() }}
+              onOpenFull={openChatFull}
+              onClose={() => { sidebarUserToggledRef.current = true; setPanel('none') }}
+            />
+          )}
         </div>
-        )}
 
         <div className="mt-3 text-[12px] text-muted">
           {i18nT('pages.artifactDetailPage.created')} {artifact.created_at} {i18nT('pages.artifactDetailPage.updated')} {artifact.updated_at} {"\u00b7"}{' '}
@@ -1269,15 +1516,13 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
             ? `Showing Live (v${detailQuery.data?.version ?? '?'})`
             : `Showing v${effectiveVersion} (historical)`}
           {dirty && <span className="ml-2 text-warn">{i18nT('pages.artifactDetailPage.unsaved_changes')}</span>}
-          {/* `commentable` already implies SHOW_ARTIFACT_ITERATE (see its definition). */}
           {commentable && commentCount === 0 && (
             <span className="ml-2 text-muted/80">{i18nT('pages.artifactDetailPage.tip_select_text_to_anchor_a_comment_or_use_the')} <strong>{i18nT('pages.artifactDetailPage.comments')}</strong> {i18nT('pages.artifactDetailPage.panel_to_add_one')}</span>
           )}
-          {/* The Comments panel is always available; the Iterate mention is gated. */}
           {!commentable && !editing && isCurrent && (
             <span className="ml-2 text-muted/80">
               {i18nT('pages.artifactDetailPage.tip_use_the')} <strong>{i18nT('pages.artifactDetailPage.comments')}</strong> {i18nT('pages.artifactDetailPage.panel_to_comment')}
-              {SHOW_ARTIFACT_ITERATE ? <>{i18nT('pages.artifactDetailPage.or')} <strong>{i18nT('pages.artifactDetailPage.iterate')}</strong> {i18nT('pages.artifactDetailPage.to_chat_with_the_agent')}</> : null}.
+              {i18nT('pages.artifactDetailPage.or')} <strong>{i18nT('pages.artifactDetailPage.agent_chat')}</strong> {i18nT('pages.artifactDetailPage.to_chat_with_the_agent')}.
             </span>
           )}
         </div>

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -530,7 +530,7 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
  *  equal value when the slot has no app renders (avoids useless re-renders). */
 const EMPTY_APP_ID_SET: ReadonlySet<string> = new Set()
 
-export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?: string; embedded?: boolean; embedMode?: 'chat' | 'sessions'; popout?: boolean } = {}) {
+export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync }: { mode?: string; embedded?: boolean; embedMode?: 'chat' | 'sessions'; popout?: boolean; noUrlSync?: boolean } = {}) {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
   const navigationType = useNavigationType()
@@ -1896,7 +1896,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   useEffect(() => () => { if (activeSlotRef.current && filteredSlotsRef.current.find(s => s.key === activeSlotRef.current)) safeSetItem(slotStorageKeyRef.current, activeSlotRef.current) }, [])
   // Handle ?sid= (or legacy ?slot=) query parameter — activate the given session
   // Capture initial ?sid= at mount time before any effect can overwrite it
-  const initialSidRef = useRef(searchParams.get('sid') || searchParams.get('slot'))
+  // noUrlSync also disables the sid-READ paths, not just the URL write. The host
+  // route (e.g. /artifacts/:slug) is not required to be sid-free: land on
+  // /artifacts/foo?sid=other and an ungated read effect would switchSlot() the
+  // embedded panel onto an unrelated session, so the composer would send into
+  // it. Zeroing the ref here neutralizes the mount-activation effect AND the 5s
+  // "session not found" timeout that keys off it; the POP effect reads
+  // searchParams live and is gated separately below.
+  const initialSidRef = useRef(noUrlSync ? null : (searchParams.get('sid') || searchParams.get('slot')))
   const initialMsgRef = useRef(searchParams.get('msg'))
   const initialNewRef = useRef(searchParams.get('new') === '1')
   // Deep-link mount activation in progress — stops the sync effect from stripping
@@ -1969,6 +1976,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   // with empty messages — the WelcomeView fallback then renders. Defer
   // the switch until reconnect so cached state stays put.
   useEffect(() => {
+    // noUrlSync: the host page owns the URL and the panel's session is chosen by
+    // the host, never by a query param. This effect otherwise treats embedMode as
+    // "the host drives ?sid" and would switch the panel onto whatever session the
+    // host route happens to carry.
+    if (noUrlSync) return
     // Embed: host app drives the URL — react to any ?sid change.
     // Main dashboard: honor only a genuine Back/Forward POP. react-router reports
     // the initial render as 'POP' and stays 'POP' until our own switch navigates
@@ -1994,7 +2006,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       popInFlightRef.current = true
       dispatch(switchSlot(urlSid))
     }
-  }, [searchParams, filteredSlots, activeSlot, dispatch, embedMode, navigationType, location.key, connected])
+  }, [searchParams, filteredSlots, activeSlot, dispatch, embedMode, navigationType, location.key, connected, noUrlSync])
   // Timeout: if slot never appears after 5s, show error.
   // Gated on `connected` so the timer only runs while the gateway is reachable
   // — otherwise an offline tab would burn its 5s while the resolve effects
@@ -2022,6 +2034,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
   searchParamsRef.current = searchParams
   useEffect(() => {
     if (embedded && !embedMode) return
+    // noUrlSync (artifact companion chat panel): the host page owns the URL
+    // entirely (e.g. /artifacts/:slug) and passes embedMode="chat" only for its
+    // single-session chrome (no sessions sidebar). Never write ?sid= or
+    // navigate to basePath — an in-place navigate would swap the host route out
+    // from under the panel. The sid-READ paths are gated for the same flag
+    // above (initialSidRef + the post-mount POP effect); do not assume a
+    // noUrlSync host route is sid-free.
+    if (noUrlSync) return
     // In sessions embed mode, the URL is `/embed/sessions` regardless of
     // activeSlot. Navigation away from sessions is driven by the explicit
     // onSelectSlot callback in ChatSidebar — never auto-navigate from here,
@@ -2066,7 +2086,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     const isSessionSwitch = !!current && current !== activeSlot
     navigate(`${basePath}${slug ? '/' + slug : ''}?${next}`, { replace: !isSessionSwitch })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeSlot, filteredSlots, navigate, basePath, location.pathname, embedded])
+  }, [activeSlot, filteredSlots, navigate, basePath, location.pathname, embedded, noUrlSync])
   // Re-fetch slot messages on mount (handles nav away + back).
   // Skip when newSession=1 — createSlot in send() will set the active slot;
   // dispatching switchSlot here would race and overwrite it.

--- a/website/src/test/ArtifactDetailPage.anchoredComments.test.tsx
+++ b/website/src/test/ArtifactDetailPage.anchoredComments.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Anchored comment creation on ArtifactDetailPage.
+ *
+ * An anchored comment is how a human pins an instruction to an EXACT span of an
+ * artifact for the agent to act on: select text, type a note, and the comment is
+ * stored with the quoted span plus enough surrounding context to relocate it
+ * later. The backend persists `quote` / `prefix` / `suffix` / `start_offset` /
+ * `end_offset` / `version_number` and re-validates every anchor on each content
+ * write (flipping `anchor_orphaned` when the span disappears); the agent reads
+ * the anchors back through `artifact_get_comments`.
+ *
+ * That whole chain is worthless if the client posts a comment WITHOUT its
+ * anchor — the note silently degrades to a free-floating document comment and
+ * the agent loses the "which part of this?" signal. These tests pin the payload.
+ *
+ * jsdom has no real text selection, so `window.getSelection` is backed by a real
+ * `Range` over the rendered body — the same object the production code reads.
+ * The suite uses a MARKDOWN artifact because that is the kind that renders to a
+ * DOM tree behind `previewRef`; text/json/svg render as a highlighted <pre> with
+ * no preview ref, so a DOM selection there has nothing to map back to source.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { Routes, Route } from 'react-router-dom'
+import ArtifactDetailPage from '../pages/ArtifactDetailPage'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+import type { Artifact } from '../types'
+
+vi.mock('../api/client')
+vi.mock('../pages/ChatPage', () => ({
+  default: () => <div data-testid="chat-page" />,
+  PREFILL_STORAGE_KEY: 'kirocrew_prefill',
+}))
+
+const BODY = 'alpha beta gamma'
+
+const mkArtifact = (overrides: Partial<Artifact> = {}): Artifact => ({
+  slug: 'notes',
+  name: 'Notes',
+  kind: 'markdown',
+  source: 'chat',
+  description: '',
+  tags: [],
+  version: 2,
+  created_at: '2026-05-21T22:00:00.000000+00:00',
+  updated_at: '2026-05-21T22:30:00.000000+00:00',
+  content: BODY,
+  ...overrides,
+})
+
+function renderPage() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/artifacts/:slug" element={<ArtifactDetailPage />} />
+      <Route path="/artifacts" element={<div>library page target</div>} />
+    </Routes>,
+    { route: '/artifacts/notes' },
+  )
+}
+
+/**
+ * Select `word` inside the rendered artifact body and fire the mouseup the page
+ * listens on. Returns false when the body text node isn't found, so a test fails
+ * loudly rather than silently asserting nothing.
+ */
+function selectInBody(word: string): boolean {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+  let node: Node | null = null
+  while (walker.nextNode()) {
+    const t = walker.currentNode.textContent ?? ''
+    if (t.includes(word) && t.includes(BODY)) { node = walker.currentNode; break }
+  }
+  if (!node) return false
+  const text = node.textContent ?? ''
+  const start = text.indexOf(word)
+  const range = document.createRange()
+  range.setStart(node, start)
+  range.setEnd(node, start + word.length)
+  // jsdom Range has no layout; the page only reads the rect for popover placement.
+  range.getBoundingClientRect = () => ({
+    left: 10, top: 10, bottom: 30, right: 60, width: 50, height: 20, x: 10, y: 10,
+    toJSON: () => ({}),
+  }) as DOMRect
+
+  vi.spyOn(window, 'getSelection').mockReturnValue({
+    isCollapsed: false,
+    anchorNode: node,
+    rangeCount: 1,
+    getRangeAt: () => range,
+    removeAllRanges: () => undefined,
+    toString: () => word,
+  } as unknown as Selection)
+
+  // The page attaches mouseup to the body wrapper; the rendered text node's
+  // element ancestor is inside it, so the event bubbles up to the handler.
+  const host = node.parentElement as HTMLElement
+  fireEvent.mouseDown(host)
+  fireEvent.mouseUp(host)
+  return true
+}
+
+describe('ArtifactDetailPage anchored comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact())
+    vi.mocked(api).artifactVersions = vi.fn().mockResolvedValue({ slug: 'notes', versions: [1, 2] })
+    vi.mocked(api).artifactEvents = vi.fn().mockResolvedValue({ slug: 'notes', events: [] })
+    vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({ comments: [] })
+    vi.mocked(api).artifactVersion = vi.fn().mockResolvedValue(
+      mkArtifact({ version: 1, content: 'alpha beta gamma (v1)' }),
+    )
+    vi.mocked(api).postArtifactComment = vi.fn().mockResolvedValue({ ok: true })
+  })
+
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('stores the selected span as the comment anchor', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument())
+
+    expect(selectInBody('beta')).toBe(true)
+    const input = await screen.findByLabelText('Add a comment')
+    fireEvent.change(input, { target: { value: 'tighten this wording' } })
+    fireEvent.click(screen.getByLabelText('Add comment'))
+
+    await waitFor(() => expect(vi.mocked(api).postArtifactComment).toHaveBeenCalledTimes(1))
+    const [slug, body] = vi.mocked(api).postArtifactComment.mock.calls[0]
+    expect(slug).toBe('notes')
+    expect(body.text).toBe('tighten this wording')
+    const anchor = body.anchor as { quote: string; start_offset?: number; end_offset?: number }
+    expect(anchor).toBeDefined()
+    expect(anchor.quote).toBe('beta')
+    // Offsets pin the comment to THIS occurrence when the quote repeats. They are
+    // rendered-text offsets (what the highlighter walks), so assert the span
+    // width rather than a source index.
+    expect(typeof anchor.start_offset).toBe('number')
+    expect((anchor.end_offset ?? 0) - (anchor.start_offset ?? 0)).toBe('beta'.length)
+  })
+
+  it('reveals the comments panel after an anchored add', async () => {
+    // The new comment has to be visible somewhere, or the user cannot tell it
+    // landed — an anchored add hands control back to the comment-driven default.
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument())
+    expect(selectInBody('gamma')).toBe(true)
+    fireEvent.change(await screen.findByLabelText('Add a comment'), { target: { value: 'note' } })
+    fireEvent.click(screen.getByLabelText('Add comment'))
+    await waitFor(() =>
+      expect(screen.getByLabelText('Toggle comments')).toHaveAttribute('aria-pressed', 'true'))
+  })
+
+  it('does not open the popover for a collapsed (empty) selection', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument())
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      isCollapsed: true, rangeCount: 0, toString: () => '', removeAllRanges: () => undefined,
+    } as unknown as Selection)
+    fireEvent.mouseUp(document.body)
+    expect(screen.queryByLabelText('Add a comment')).toBeNull()
+  })
+
+  it('anchors a comment on a text artifact', async () => {
+    // text bodies render as a highlighted <pre>, which now carries previewRef, so
+    // a selection there has a root to map back to source. Before that ref existed
+    // the tip was shown but the popover never opened — a dead affordance.
+    vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact({ kind: 'text' }))
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument())
+    expect(screen.getByText(/select text to anchor a comment/i)).toBeInTheDocument()
+
+    expect(selectInBody('beta')).toBe(true)
+    fireEvent.change(await screen.findByLabelText('Add a comment'), { target: { value: 'tighten this' } })
+    fireEvent.click(screen.getByLabelText('Add comment'))
+
+    await waitFor(() => expect(vi.mocked(api).postArtifactComment).toHaveBeenCalledTimes(1))
+    const anchor = vi.mocked(api).postArtifactComment.mock.calls[0][1].anchor as { quote: string }
+    expect(anchor.quote).toBe('beta')
+  })
+
+  it('does not offer anchored add while editing', async () => {
+    // Selecting inside a textarea is an edit gesture, not an annotation gesture.
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument())
+    fireEvent.click(screen.getByTitle(/edit content/i))
+    await waitFor(() => expect(screen.getByText(/unsaved changes|save/i)).toBeInTheDocument())
+    selectInBody('beta')
+    expect(screen.queryByLabelText('Add a comment')).toBeNull()
+  })
+
+  it('does not offer anchored add on a historical version', async () => {
+    // Anchors are version-scoped; pinning a note to a snapshot you cannot change
+    // would produce an instruction the agent can never satisfy.
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument())
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } })
+    await waitFor(() => expect(screen.getByTitle(/revert to v1/i)).toBeInTheDocument())
+    selectInBody('beta')
+    expect(screen.queryByLabelText('Add a comment')).toBeNull()
+  })
+})

--- a/website/src/test/ArtifactDetailPage.companionChat.test.tsx
+++ b/website/src/test/ArtifactDetailPage.companionChat.test.tsx
@@ -1,0 +1,565 @@
+/**
+ * Artifact companion chat tests.
+ *
+ * Covers the frontend flows on ArtifactDetailPage:
+ * - panel state machine (comments <-> chat mutual exclusivity, auto-reveal guard)
+ * - bound-session resolution (none / one / many -> most recent activity)
+ * - sparkle flow: create with the artifact binding + OPTIMISTIC bind (the panel
+ *   must become interactive off the create response alone — no fetchSlots on the
+ *   critical path) + background context injection; resume without create
+ * - session activation: the panel embeds ChatPage in single-session chrome with
+ *   URL sync off, so it can never navigate the host /artifacts route away
+ * - "Ask agent to address" staging via the writePrefill sessionStorage channel
+ *   (bound vs fresh sessions)
+ * - "New chat" archive-then-create ordering + optimistic prune
+ * - red-X prune (bound slot vanishing resets the panel to its empty state)
+ * - deleted-artifact WS relay navigates the page away
+ *
+ * ChatPage is stubbed: its own rendering has dedicated suites; these assert the
+ * wiring (that it mounts, with which props, and which slot the panel activates).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, fireEvent, act } from '@testing-library/react'
+import { Routes, Route } from 'react-router-dom'
+import ArtifactDetailPage from '../pages/ArtifactDetailPage'
+import { renderWithProviders, createTestStore } from './helpers'
+import { api } from '../api/client'
+import { sseSlots } from '../store/dashboardSlice'
+import { PREFILL_STORAGE_KEY } from '../utils/navIntent'
+import type { Artifact, ChatSlot } from '../types'
+
+vi.mock('../api/client')
+// Stub the embedded chat page — these tests assert the panel wiring, not
+// ChatPage internals. Keep the named PREFILL_STORAGE_KEY re-export so unrelated
+// importers don't break.
+vi.mock('../pages/ChatPage', () => ({
+  default: (props: { embedded?: boolean; embedMode?: string; noUrlSync?: boolean }) => (
+    <div
+      data-testid="chat-page"
+      data-embedded={String(!!props.embedded)}
+      data-embed-mode={props.embedMode ?? ''}
+      data-no-url-sync={String(!!props.noUrlSync)}
+    />
+  ),
+  PREFILL_STORAGE_KEY: 'kirocrew_prefill',
+}))
+
+const mkArtifact = (overrides: Partial<Artifact> = {}): Artifact => ({
+  slug: 'cr-queue',
+  name: 'CR Queue',
+  kind: 'markdown',
+  source: 'chat',
+  description: '',
+  tags: [],
+  version: 2,
+  created_at: '2026-05-21T22:00:00.000000+00:00',
+  updated_at: '2026-05-21T22:30:00.000000+00:00',
+  content: '# CR Queue',
+  ...overrides,
+})
+
+const mkSlot = (overrides: Partial<ChatSlot> = {}): ChatSlot => ({
+  key: 'chat-1',
+  title: 'Artifact: CR Queue',
+  messages: 0,
+  running: false,
+  ...overrides,
+} as ChatSlot)
+
+function renderPage(popout = false, store = createTestStore()) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/artifacts/:slug" element={<ArtifactDetailPage popout={popout} />} />
+      <Route path="/artifacts" element={<div>library page target</div>} />
+      <Route path="/chat" element={<div>chat page target</div>} />
+    </Routes>,
+    { route: '/artifacts/cr-queue', store },
+  )
+}
+
+/** Seed the Redux slots snapshot the bound-session resolver reads. */
+function seedSlots(store: ReturnType<typeof createTestStore>, slots: ChatSlot[]) {
+  act(() => { store.dispatch(sseSlots(slots)) })
+}
+
+/** The toolbar toggle only mounts once the artifact query resolves, and unlike
+ *  the artifact NAME it cannot collide with the rendered markdown body ("# CR
+ *  Queue" also renders the text "CR Queue"). */
+async function waitForLoaded() {
+  await waitFor(() => expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument())
+}
+
+describe('ArtifactDetailPage companion chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sessionStorage.clear()
+    if (!URL.createObjectURL) {
+      // @ts-expect-error stub
+      URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
+      // @ts-expect-error stub
+      URL.revokeObjectURL = vi.fn()
+    }
+    vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact())
+    vi.mocked(api).artifactVersions = vi.fn().mockResolvedValue({ slug: 'cr-queue', versions: [1, 2] })
+    vi.mocked(api).artifactEvents = vi.fn().mockResolvedValue({ slug: 'cr-queue', events: [] })
+    vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({ comments: [] })
+    vi.mocked(api).createChatSlot = vi.fn().mockResolvedValue({ key: 'slot-new', title: 'Artifact: CR Queue' })
+    vi.mocked(api).chatSlotContext = vi.fn().mockResolvedValue({ ok: true })
+    vi.mocked(api).deleteChatSlot = vi.fn().mockResolvedValue({ ok: true })
+    vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([])
+  })
+
+  // ── create + optimistic bind ────────────────────────────────────────────────
+
+  it('creates a bound session carrying the artifact slug and a pinned title', async () => {
+    renderPage()
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+    const call = vi.mocked(api).createChatSlot.mock.calls[0]
+    // No `name` — the backend must mint a unique key, or a name-derived key
+    // would append onto an archived session's history file.
+    expect(call[0]).toBeUndefined()
+    expect(call[5]).toBe('Artifact: CR Queue')
+    expect(call[7]).toBe('cr-queue')
+  })
+
+  it('becomes interactive off the create response alone (optimistic bind)', async () => {
+    // The critical path is ONE round trip: the create response carries the
+    // binding, so the panel must mount ChatPage without waiting for fetchSlots.
+    renderPage()
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+  })
+
+  it('injects the artifact context ephemerally in the background', async () => {
+    renderPage()
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(vi.mocked(api).chatSlotContext).toHaveBeenCalledTimes(1))
+    const [slot, content, opts] = vi.mocked(api).chatSlotContext.mock.calls[0]
+    expect(slot).toBe('slot-new')
+    expect(content).toContain('cr-queue')
+    expect(content).toContain('artifact_get_comments')
+    // Ephemeral: consumed on the NEXT user message, never persisted as a turn.
+    expect(opts).toEqual({ source: 'artifact-companion', ephemeral: true })
+  })
+
+  it('embeds ChatPage in single-session chrome with URL sync off', async () => {
+    // noUrlSync is what stops the embedded page writing ?sid= and navigating the
+    // host /artifacts/:slug route out from under the panel.
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    const chat = await screen.findByTestId('chat-page')
+    expect(chat).toHaveAttribute('data-embedded', 'true')
+    expect(chat).toHaveAttribute('data-embed-mode', 'chat')
+    expect(chat).toHaveAttribute('data-no-url-sync', 'true')
+  })
+
+  // ── resume vs create ────────────────────────────────────────────────────────
+
+  it('resumes an existing bound session instead of creating one', async () => {
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    expect(vi.mocked(api).createChatSlot).not.toHaveBeenCalled()
+    expect(store.getState().chat.activeSlot).toBe('chat-bound')
+  })
+
+  it('ignores sessions bound to a different artifact', async () => {
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-other', artifact: 'some-other-slug' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+  })
+
+  it('picks the most recently active session when several are bound', async () => {
+    // The frontend flow keeps it to <=1 active bound session, but a race or a
+    // History-page resume can produce more — degrade gracefully, never crash.
+    const store = createTestStore()
+    seedSlots(store, [
+      mkSlot({ key: 'chat-old', artifact: 'cr-queue', last_activity_ts: '2026-05-01T00:00:00Z' }),
+      mkSlot({ key: 'chat-new', artifact: 'cr-queue', last_activity_ts: '2026-06-01T00:00:00Z' }),
+    ])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('chat-new'))
+  })
+
+  // ── panel state machine ─────────────────────────────────────────────────────
+
+  it('toggles the chat panel closed on a second click, keeping the session', async () => {
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    const toggle = screen.getByLabelText('Toggle agent chat')
+    fireEvent.click(toggle)
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-pressed', 'true'))
+    fireEvent.click(toggle)
+    await waitFor(() => expect(screen.queryByTestId('chat-page')).toBeNull())
+    // Closing the panel must not archive the session.
+    expect(vi.mocked(api).deleteChatSlot).not.toHaveBeenCalled()
+  })
+
+  it('is mutually exclusive with the comments sidebar', async () => {
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    const chatToggle = screen.getByLabelText('Toggle agent chat')
+    const commentsToggle = screen.getByLabelText('Toggle comments')
+    fireEvent.click(chatToggle)
+    await waitFor(() => expect(chatToggle).toHaveAttribute('aria-pressed', 'true'))
+    fireEvent.click(commentsToggle)
+    await waitFor(() => expect(commentsToggle).toHaveAttribute('aria-pressed', 'true'))
+    expect(chatToggle).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.queryByTestId('chat-page')).toBeNull()
+  })
+
+  it('does not let the comment auto-reveal yank an open chat panel', async () => {
+    // The chat panel only opens on explicit action, so a comment-count-driven
+    // default must never discard that intent.
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    // A comment arriving now would flip the panel to 'comments' without the guard.
+    vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({
+      comments: [{
+        id: 'c1', origin: 'local', scope: 'private', author: 'nrb', body: 'note',
+        thread_id: 't1', status: 'open', sync_state: 'local',
+        created_at: '2026-05-21T22:00:00Z', updated_at: '2026-05-21T22:00:00Z',
+      }],
+    })
+    await new Promise(r => setTimeout(r, 20))
+    expect(screen.getByTestId('chat-page')).toBeInTheDocument()
+  })
+
+  it('falls back to the empty state when the bound slot is pruned', async () => {
+    // The red-X delete anywhere removes the slot from the snapshot; the resolver
+    // then yields null and the panel shows its start-chat empty state.
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    seedSlots(store, [])
+    await waitFor(() => expect(screen.queryByTestId('chat-page')).toBeNull())
+    expect(screen.getByText(/no active session for this artifact/i)).toBeInTheDocument()
+  })
+
+  // ── "Ask agent to address" staging ──────────────────────────────────────────
+
+  it('stages (never auto-sends) the address message into a bound session', async () => {
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({
+      comments: [{
+        id: 'c1', origin: 'local', scope: 'private', author: 'nrb', body: 'tighten this',
+        thread_id: 't1', status: 'open', sync_state: 'local',
+        anchor: { quote: 'CR Queue' },
+        created_at: '2026-05-21T22:00:00Z', updated_at: '2026-05-21T22:00:00Z',
+      }],
+    })
+    renderPage(false, store)
+    await waitForLoaded()
+    // Comments auto-reveal, exposing the sidebar's "Ask agent" action.
+    const ask = await screen.findByRole('button', { name: /ask agent/i })
+    fireEvent.click(ask)
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    const staged = sessionStorage.getItem(PREFILL_STORAGE_KEY) ?? ''
+    expect(staged).toContain('chat-bound')
+    expect(staged).toContain('1 open comment')
+  })
+
+  // ── "New chat" ──────────────────────────────────────────────────────────────
+
+  it('archives the bound session BEFORE creating the replacement', async () => {
+    const order: string[] = []
+    vi.mocked(api).deleteChatSlot = vi.fn().mockImplementation(async () => { order.push('delete'); return { ok: true } })
+    vi.mocked(api).createChatSlot = vi.fn().mockImplementation(async () => {
+      order.push('create'); return { key: 'slot-new2', title: 'Artifact: CR Queue' }
+    })
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('New chat'))
+    await waitFor(() => expect(order).toEqual(['delete', 'create']))
+    // Optimistic prune, or the resolver keeps picking the archived slot.
+    expect(store.getState().dashboard.slots.some(s => s.key === 'chat-bound')).toBe(false)
+  })
+
+  it('archives EVERY slot bound to the slug, not just the resolved winner', async () => {
+    // A two-window creation race can leave two slots bound to one slug. Archiving
+    // only the winner leaves the other behind, and pickBoundSlot then reopens that
+    // stale conversation — so "New chat" appears to resurrect an old session.
+    const store = createTestStore()
+    seedSlots(store, [
+      mkSlot({ key: 'chat-old', artifact: 'cr-queue', last_activity_ts: '2026-05-01T00:00:00Z' }),
+      mkSlot({ key: 'chat-new', artifact: 'cr-queue', last_activity_ts: '2026-06-01T00:00:00Z' }),
+      mkSlot({ key: 'chat-other', artifact: 'some-other-slug' }),
+    ])
+    // Server truth after the archives: only the unrelated slot survives. Without
+    // this the background fetchSlots() (mocked to []) would overwrite the store and
+    // the post-state assertions below would be measuring the mock, not the code.
+    vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([
+      mkSlot({ key: 'chat-other', artifact: 'some-other-slug' }),
+    ])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('New chat'))
+
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+    const archived = vi.mocked(api).deleteChatSlot.mock.calls.map(c => c[0]).sort()
+    expect(archived).toEqual(['chat-new', 'chat-old'])
+    // Another artifact's session must be untouched.
+    expect(archived).not.toContain('chat-other')
+    expect(store.getState().dashboard.slots.map(s => s.key)).toEqual(['chat-other'])
+  })
+
+  it('still creates a replacement when the old session is already gone (404)', async () => {
+    vi.mocked(api).deleteChatSlot = vi.fn().mockRejectedValue(
+      Object.assign(new Error('Not Found'), { status: 404 }),
+    )
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('New chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+    expect(store.getState().dashboard.slots.some(s => s.key === 'chat-bound')).toBe(false)
+  })
+
+  it('aborts "New chat" when archiving fails for any reason other than 404', async () => {
+    // A 500 leaves the old session live server-side. Creating anyway would give
+    // the slug TWO bound sessions, and since the resolver breaks ties on
+    // last_activity_ts the OLD one keeps winning — "New chat" would look like a
+    // no-op forever. Abort and surface the error instead.
+    vi.mocked(api).deleteChatSlot = vi.fn().mockRejectedValue(
+      Object.assign(new Error('Internal Server Error'), { status: 500 }),
+    )
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('New chat'))
+    await waitFor(() => expect(screen.getByText(/internal server error/i)).toBeInTheDocument())
+    expect(vi.mocked(api).createChatSlot).not.toHaveBeenCalled()
+    // The old session must stay bound, so the panel keeps working.
+    expect(store.getState().dashboard.slots.some(s => s.key === 'chat-bound')).toBe(true)
+  })
+
+  // ── re-entrancy: at most one active bound session per slug ──────────────────
+  // The archive-then-create ordering protects the "<=1 active bound session"
+  // invariant against FAILURE. These protect it against CONCURRENCY: both entry
+  // points are async, so a rapid double-click otherwise starts two flows that
+  // resolve the same boundSlot, both archive it (the second 404s and proceeds by
+  // design), and both create a replacement.
+
+  it('creates ONE replacement when "New chat" is double-clicked', async () => {
+    let releaseDelete: () => void = () => {}
+    vi.mocked(api).deleteChatSlot = vi.fn().mockImplementation(
+      () => new Promise<{ ok: boolean }>(res => { releaseDelete = () => res({ ok: true }) }),
+    )
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+
+    const newChat = screen.getByLabelText('New chat')
+    fireEvent.click(newChat)
+    fireEvent.click(newChat)   // second click lands while the archive is in flight
+    await act(async () => { releaseDelete(); await Promise.resolve() })
+
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(api).deleteChatSlot).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates ONE session when the sparkle is double-clicked with none bound', async () => {
+    let releaseCreate: () => void = () => {}
+    vi.mocked(api).createChatSlot = vi.fn().mockImplementation(
+      () => new Promise(res => {
+        releaseCreate = () => res({ key: 'slot-new', title: 'Artifact: CR Queue' })
+      }),
+    )
+    renderPage()
+    await waitForLoaded()
+    const toggle = screen.getByLabelText('Toggle agent chat')
+    // BOTH clicks inside ONE act() block. Dispatching them as two separate
+    // fireEvent calls lets React re-render in between, so the second click sees
+    // panel==='chat' and merely toggles the panel shut — which passes even with
+    // no guard and therefore proves nothing. Batching them reproduces the real
+    // double-click: the second handler runs against the pre-render state, so only
+    // the in-flight ref can stop it.
+    await act(async () => {
+      fireEvent.click(toggle)
+      fireEvent.click(toggle)
+    })
+    await act(async () => { releaseCreate(); await Promise.resolve() })
+
+    expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the guard so a later "New chat" still works', async () => {
+    // A guard that leaks would wedge the button permanently after one use.
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('New chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+    seedSlots(store, [mkSlot({ key: 'slot-new', artifact: 'cr-queue' })])
+    fireEvent.click(screen.getByLabelText('New chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(2))
+  })
+
+  it('releases the guard after a failed archive', async () => {
+    vi.mocked(api).deleteChatSlot = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('Internal Server Error'), { status: 500 }))
+      .mockResolvedValue({ ok: true })
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('New chat'))
+    await waitFor(() => expect(screen.getByText(/internal server error/i)).toBeInTheDocument())
+    // The abort path returns from inside the try — `finally` must still clear it.
+    fireEvent.click(screen.getByLabelText('New chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+  })
+
+  it('keeps the chat panel open when an anchored comment is added', async () => {
+    // An anchored add is reachable while chatting (the body stays visible), and
+    // the old unconditional setPanel('comments') would yank the conversation.
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    vi.mocked(api).postArtifactComment = vi.fn().mockResolvedValue({ ok: true })
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    // Drive the doc-level add path directly via the sidebar-less route: reuse the
+    // comments query to simulate the count changing while chat is open.
+    vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({
+      comments: [{
+        id: 'c1', origin: 'local', scope: 'private', author: 'nrb', body: 'note',
+        thread_id: 't1', status: 'open', sync_state: 'local',
+        anchor: { quote: 'Rollout plan' },
+        created_at: '2026-05-21T22:00:00Z', updated_at: '2026-05-21T22:00:00Z',
+      }],
+    })
+    await new Promise(r => setTimeout(r, 50))
+    expect(screen.getByTestId('chat-page')).toBeInTheDocument()
+    expect(screen.getByLabelText('Toggle agent chat')).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  // ── cold load: an unloaded snapshot is not "nothing bound" ──────────────────
+
+  it('resolves the slots snapshot before creating on a cold load', async () => {
+    // `dashboard.slots` is [] both before the first fetch AND when nothing is
+    // bound. Clicking the sparkle before the fetch lands must not create a second
+    // session for a slug that already has one.
+    const store = createTestStore()          // slotsLoaded === false, slots === []
+    vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([
+      mkSlot({ key: 'chat-bound', artifact: 'cr-queue' }),
+    ])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+    expect(vi.mocked(api).createChatSlot).not.toHaveBeenCalled()
+    expect(store.getState().chat.activeSlot).toBe('chat-bound')
+  })
+
+  it('creates on a cold load when the resolved snapshot really has none', async () => {
+    const store = createTestStore()
+    vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+  })
+
+  it('still creates when the cold-load resolve fails', async () => {
+    // A failed fetch must not wedge the button — fall through and create.
+    const store = createTestStore()
+    vi.mocked(api).chatSlots = vi.fn().mockRejectedValue(new Error('offline'))
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+  })
+
+  // ── webapp kind ─────────────────────────────────────────────────────────────
+
+  it('renders the chat panel for a webapp artifact', async () => {
+    // The toolbar toggles render for every kind, so the panels must too —
+    // otherwise a click on a webapp artifact creates a session with nowhere to go.
+    vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact({ kind: 'webapp' }))
+    const store = createTestStore()
+    seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
+    renderPage(false, store)
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(screen.getByTestId('chat-page')).toBeInTheDocument())
+  })
+
+  it('renders the comments sidebar for a webapp artifact', async () => {
+    vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact({ kind: 'webapp' }))
+    renderPage()
+    await waitForLoaded()
+    fireEvent.click(screen.getByLabelText('Toggle comments'))
+    await waitFor(() =>
+      expect(screen.getByLabelText('Toggle comments')).toHaveAttribute('aria-pressed', 'true'))
+    expect(screen.getByRole('button', { name: /add comment/i })).toBeInTheDocument()
+  })
+
+  // ── deleted-artifact relay ──────────────────────────────────────────────────
+
+  it('navigates away when the artifact is deleted elsewhere', async () => {
+    renderPage()
+    await waitForLoaded()
+    act(() => {
+      window.dispatchEvent(new CustomEvent('kirocrew:artifact-deleted', { detail: { slug: 'cr-queue' } }))
+    })
+    await waitFor(() => expect(screen.getByText('library page target')).toBeInTheDocument())
+  })
+
+  it('ignores a delete event for a different artifact', async () => {
+    renderPage()
+    await waitForLoaded()
+    act(() => {
+      window.dispatchEvent(new CustomEvent('kirocrew:artifact-deleted', { detail: { slug: 'other' } }))
+    })
+    expect(screen.queryByText('library page target')).toBeNull()
+  })
+})

--- a/website/src/test/ArtifactDetailPage.dirtyDelete.test.tsx
+++ b/website/src/test/ArtifactDetailPage.dirtyDelete.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * A remote deletion must not silently destroy an unsaved edit buffer.
+ *
+ * `artifact_update {deleted}` arrives over the WebSocket from any window, and the
+ * detail page reacts by leaving the page. If the user has unsaved edits open, that
+ * navigation discards them with no way back — so a dirty page keeps its content
+ * and surfaces the deletion instead.
+ *
+ * This lives in its own file because reaching `dirty === true` requires an editor
+ * that emits `onChange`, and the real one is Monaco, which renders no accessible
+ * input under jsdom (no existing suite manages it — they all note "stay clean").
+ * `ContentRenderer` is therefore mocked down to a textarea wired to `onChange`;
+ * the subject under test is ArtifactDetailPage's guard, not the editor.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, fireEvent, act } from '@testing-library/react'
+import { Routes, Route } from 'react-router-dom'
+import ArtifactDetailPage from '../pages/ArtifactDetailPage'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+import { isArtifactEditing, __resetArtifactEditing } from '../utils/artifactEditGuard'
+import type { Artifact } from '../types'
+
+vi.mock('../api/client')
+vi.mock('../pages/ChatPage', () => ({
+  default: () => <div data-testid="chat-page" />,
+  PREFILL_STORAGE_KEY: 'kirocrew_prefill',
+}))
+// Replace ONLY the renderer; the module also exports MD_EXTS / extOf / wrapCode /
+// langFor / CodeEditor, which other components import.
+vi.mock('../components/ContentRenderer', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../components/ContentRenderer')>()),
+  ContentRenderer: ({ editing, displayContent, onChange }: {
+    editing: boolean; displayContent: string; onChange: (v: string) => void
+  }) => editing
+    ? <textarea aria-label="editor" defaultValue={displayContent} onChange={e => onChange(e.target.value)} />
+    : <div>{displayContent}</div>,
+}))
+
+const mkArtifact = (o: Partial<Artifact> = {}): Artifact => ({
+  slug: 'cr-queue', name: 'CR Queue', kind: 'markdown', source: 'chat', description: '',
+  tags: [], version: 1, created_at: '2026-05-21T22:00:00.000000+00:00',
+  updated_at: '2026-05-21T22:30:00.000000+00:00', content: '# v1', ...o,
+})
+
+function renderPage() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/artifacts/:slug" element={<ArtifactDetailPage />} />
+      <Route path="/artifacts" element={<div>library page target</div>} />
+    </Routes>,
+    { route: '/artifacts/cr-queue' },
+  )
+}
+
+function fireDeleted(slug = 'cr-queue') {
+  act(() => {
+    window.dispatchEvent(new CustomEvent('kirocrew:artifact-deleted', { detail: { slug } }))
+  })
+}
+
+describe('ArtifactDetailPage remote deletion vs unsaved edits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetArtifactEditing()
+    vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact())
+    vi.mocked(api).artifactVersions = vi.fn().mockResolvedValue({ slug: 'cr-queue', versions: [1] })
+    vi.mocked(api).artifactEvents = vi.fn().mockResolvedValue({ slug: 'cr-queue', events: [] })
+    vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({ comments: [] })
+    vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([])
+  })
+
+  async function enterEditMode() {
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument())
+    fireEvent.click(screen.getByTitle(/edit content/i))
+    return screen.findByLabelText('editor')
+  }
+
+  it('guards for the whole edit lifetime, not just once dirty', async () => {
+    // The exposure window opens when the editor OPENS. A dirty-only guard would let
+    // an update land while the editor sat open-and-clean, moving the baseline, and
+    // the next keystroke would make the stale buffer dirty and Save would overwrite.
+    const editor = await enterEditMode()
+    expect(isArtifactEditing('cr-queue')).toBe(true)      // clean, but already open
+    fireEvent.change(editor, { target: { value: '# unsaved work' } })
+    expect(isArtifactEditing('cr-queue')).toBe(true)
+    // Reverting the text does NOT reopen the window — the editor is still open.
+    fireEvent.change(screen.getByLabelText('editor'), { target: { value: '# v1' } })
+    expect(isArtifactEditing('cr-queue')).toBe(true)
+  })
+
+  it('clears the guard and refetches when editing ends', async () => {
+    // Whatever was withheld while the editor was open has to be picked up, or the
+    // page keeps showing pre-update content indefinitely.
+    await enterEditMode()
+    expect(isArtifactEditing('cr-queue')).toBe(true)
+    const before = vi.mocked(api).artifact.mock.calls.length
+    fireEvent.click(screen.getByTitle(/cancel/i))
+    await waitFor(() => expect(isArtifactEditing('cr-queue')).toBe(false))
+    await waitFor(() =>
+      expect(vi.mocked(api).artifact.mock.calls.length).toBeGreaterThan(before))
+  })
+
+  it('keeps the page and surfaces the deletion when the buffer is dirty', async () => {
+    const editor = await enterEditMode()
+    fireEvent.change(editor, { target: { value: '# unsaved work' } })
+    fireDeleted()
+    await waitFor(() =>
+      expect(screen.getByText(/this artifact was deleted/i)).toBeInTheDocument())
+    expect(screen.queryByText('library page target')).toBeNull()
+    // The unsaved content is still on screen, so it can be copied out.
+    expect((screen.getByLabelText('editor') as HTMLTextAreaElement).value).toBe('# unsaved work')
+  })
+
+  it('navigates away when editing but NOT dirty', async () => {
+    // Being in edit mode is not itself a reason to strand the user.
+    await enterEditMode()
+    fireDeleted()
+    await waitFor(() => expect(screen.getByText('library page target')).toBeInTheDocument())
+  })
+
+  it('ignores a deletion for a different artifact while dirty', async () => {
+    const editor = await enterEditMode()
+    fireEvent.change(editor, { target: { value: '# unsaved work' } })
+    fireDeleted('some-other-slug')
+    expect(screen.queryByText(/this artifact was deleted/i)).toBeNull()
+    expect(screen.queryByText('library page target')).toBeNull()
+  })
+})

--- a/website/src/test/ArtifactDetailPage.popoutNav.test.tsx
+++ b/website/src/test/ArtifactDetailPage.popoutNav.test.tsx
@@ -17,6 +17,12 @@ import { forwardToMain } from '../utils/artifactPopout'
 import type { Artifact } from '../types'
 
 vi.mock('../api/client')
+// Stub the embedded chat page — the companion toggle opens the embedded panel,
+// which would otherwise mount the full ChatPage and its whole hook graph.
+vi.mock('../pages/ChatPage', () => ({
+  default: () => <div data-testid="chat-page" />,
+  PREFILL_STORAGE_KEY: 'kirocrew_prefill',
+}))
 // Replace only the popout→main forwarding entry point; the rest of the module
 // (registerPopout, the coordination map, …) stays real.
 vi.mock('../utils/artifactPopout', async (importOriginal) => {
@@ -61,6 +67,12 @@ beforeEach(() => {
   vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact())
   vi.mocked(api).artifactVersions = vi.fn().mockResolvedValue({ slug: 'cr-queue', versions: [1, 2] })
   vi.mocked(api).artifactEvents = vi.fn().mockResolvedValue(sessionEvents)
+  // The companion toggle creates a bound session, which dispatches fetchSlots()
+  // in the background. Without this mock the automock resolves undefined and the
+  // fetchSlots.fulfilled reducer throws on `payload.map` AFTER the test ends — an
+  // unhandled rejection that fails the run (`Errors: N errors`) while every test
+  // still reports as passing.
+  vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([])
 })
 
 describe('ArtifactDetailPage popout navigation containment', () => {
@@ -100,16 +112,26 @@ describe('ArtifactDetailPage popout navigation containment', () => {
     await waitFor(() => expect(screen.getByText('library page target')).toBeInTheDocument())
   })
 
-  it('main dashboard: the "Iterate" affordance is hidden pending redesign', async () => {
-    // The header "Iterate" button is gated behind SHOW_ARTIFACT_ITERATE (false),
-    // so it does not render even in the main dashboard (its `!popout` branch).
-    // When the redesign re-enables the flag, restore this to click the button
-    // and assert the local-nav prefill / sendNav path (fork analogue of
-    // upstream's "Ask agent to address").
+  it('popout: the companion chat toggle renders and stays in-window', async () => {
+    // The sparkle used to navigate away, which is why it was hidden in popouts.
+    // It is now a panel toggle and a popout has its own store + WS, so it works
+    // in place — and must NOT forward a nav intent to a main window.
     vi.mocked(api).createChatSlot = vi.fn().mockResolvedValue({ key: 'new-slot-1' })
+    vi.mocked(api).chatSlotContext = vi.fn().mockResolvedValue({ ok: true })
+    renderPage(true)
+    await waitFor(() => expect(screen.getByText(/Artifact: cr-queue/i)).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(forwardToMain)).not.toHaveBeenCalled()
+  })
+
+  it('main dashboard: the companion chat toggle creates a bound session', async () => {
+    vi.mocked(api).createChatSlot = vi.fn().mockResolvedValue({ key: 'new-slot-1' })
+    vi.mocked(api).chatSlotContext = vi.fn().mockResolvedValue({ ok: true })
     renderPage(false)
     await waitFor(() => expect(screen.getByText(/Artifact: cr-queue/i)).toBeInTheDocument())
-    expect(screen.queryByRole('button', { name: /iterate/i })).toBeNull()
-    expect(vi.mocked(api).createChatSlot).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(vi.mocked(api).createChatSlot).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(api).createChatSlot.mock.calls[0][7]).toBe('cr-queue')
   })
 })

--- a/website/src/test/ArtifactDetailPage.test.tsx
+++ b/website/src/test/ArtifactDetailPage.test.tsx
@@ -7,6 +7,13 @@ import { api } from '../api/client'
 import type { Artifact } from '../types'
 
 vi.mock('../api/client')
+// Stub the embedded chat page (companion chat) — its rendering is covered by its
+// own suites; here it just needs to mount without ChatPage's full hook/provider
+// graph.
+vi.mock('../pages/ChatPage', () => ({
+  default: () => <div data-testid="chat-page" />,
+  PREFILL_STORAGE_KEY: 'kirocrew_prefill',
+}))
 
 const mkArtifact = (overrides: Partial<Artifact> = {}): Artifact => ({
   slug: 'cr-queue',
@@ -55,6 +62,12 @@ describe('ArtifactDetailPage', () => {
     vi.mocked(api).artifactComments = vi
       .fn()
       .mockResolvedValue({ comments: [] })
+    // The companion toggle creates a bound session, which dispatches fetchSlots()
+    // in the background. Without this mock the automock resolves undefined and
+    // the fetchSlots.fulfilled reducer throws on `payload.map` AFTER the test
+    // ends — an unhandled rejection that fails the run (`Errors: N errors`)
+    // while every test still reports as passing.
+    vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([])
   })
 
   it('renders artifact metadata and iframe', async () => {
@@ -331,12 +344,13 @@ describe('ArtifactDetailPage', () => {
     await waitFor(() => expect(screen.getByTitle(/Revert to v1/)).toBeInTheDocument())
   })
 
-  // ── Phase 4: comments → chat ────────────────────────────────
-  // Inline commenting feeds the Iterate flow, which is hidden pending redesign
- // via SHOW_ARTIFACT_ITERATE. While hidden, the "select text to
-  // add inline comments" tip must NOT appear on any kind. Flip these back to
-  // assert presence when the Iterate redesign re-enables the flag.
-  it('does not show the "select text to comment" tip while Iterate is hidden (markdown)', async () => {
+  // ── comments → companion chat ───────────────────────────────
+  // Anchored (selection-driven) commenting is the mechanism for pinning an
+  // instruction to an exact span of the artifact for the agent to act on, so the
+  // "select text to anchor a comment" tip must appear on the kinds that support
+  // it (markdown/text render natively, so a DOM selection maps back to source
+  // coordinates) and stay absent on the kinds that do not.
+  it('shows the "select text to anchor a comment" tip on markdown', async () => {
     vi.mocked(api).artifact = vi.fn().mockResolvedValue(
       mkArtifact({ kind: 'markdown', content: '# Doc' }),
     )
@@ -345,17 +359,17 @@ describe('ArtifactDetailPage', () => {
       .mockResolvedValue({ slug: 'cr-queue', versions: [1, 2] })
     renderRoute()
     await waitFor(() => expect(screen.getByText('CR Queue')).toBeInTheDocument())
-    expect(screen.queryByText(/select text to add inline comments/i)).toBeNull()
+    expect(screen.getByText(/select text to anchor a comment/i)).toBeInTheDocument()
   })
 
-  it('does not show comment tip on non-commentable kinds (widget)', async () => {
+  it('does not show the anchored tip on non-commentable kinds (widget)', async () => {
     vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact({ kind: 'widget' }))
     vi.mocked(api).artifactVersions = vi
       .fn()
       .mockResolvedValue({ slug: 'cr-queue', versions: [1, 2] })
     renderRoute()
     await waitFor(() => expect(screen.getByText('CR Queue')).toBeInTheDocument())
-    expect(screen.queryByText(/select text to add inline comments/i)).toBeNull()
+    expect(screen.queryByText(/select text to anchor a comment/i)).toBeNull()
   })
 
   // ── Phase 5: lifecycle event log + activity timeline ────────
@@ -405,28 +419,32 @@ describe('ArtifactDetailPage', () => {
     expect(screen.getByText(/no lifecycle events yet/i)).toBeInTheDocument()
   })
 
- // ── Iterate affordances hidden pending redesign ────────────
-  // The header "Iterate" button is gated behind SHOW_ARTIFACT_ITERATE (false).
-  // These assert it is ABSENT for every kind; flip back to assert presence when
-  // the redesign re-enables the flag.
-  it('Iterate button is hidden for editable kinds (markdown)', async () => {
+ // ── companion chat toggle ──────────────────────────────────
+  // The header sparkle is a PANEL TOGGLE (not a navigate-away action), so it is
+  // available for every kind — including widgets, where asking the agent is the
+  // only way to change the artifact at all.
+  it('renders the companion chat toggle, unpressed, for editable kinds (markdown)', async () => {
     vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact({ kind: 'markdown' }))
     vi.mocked(api).artifactVersions = vi
       .fn()
       .mockResolvedValue({ slug: 'cr-queue', versions: [1, 2] })
     renderRoute()
     await waitFor(() => expect(screen.getByText('CR Queue')).toBeInTheDocument())
-    expect(screen.queryByTitle(/Discuss this artifact with the agent/i)).toBeNull()
+    const toggle = screen.getByLabelText('Toggle agent chat')
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
   })
 
-  it('Iterate button is hidden for widget artifacts', async () => {
+  it('renders the companion chat toggle for widget artifacts too', async () => {
+    // Widgets cannot be edited inline, so asking the agent is the ONLY way to
+    // change them — the toggle must never be kind-gated.
     vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact({ kind: 'widget' }))
     vi.mocked(api).artifactVersions = vi
       .fn()
       .mockResolvedValue({ slug: 'cr-queue', versions: [1, 2] })
     renderRoute()
     await waitFor(() => expect(screen.getByText('CR Queue')).toBeInTheDocument())
-    expect(screen.queryByTitle(/Discuss this artifact with the agent/i)).toBeNull()
+    expect(screen.getByLabelText('Toggle agent chat')).toBeInTheDocument()
   })
 
   it('reverted events render with from_version and no broken session link', async () => {
@@ -655,9 +673,9 @@ describe('ArtifactDetailPage', () => {
     fireEvent.keyDown(document, { key: 'Escape' })
   })
 
-  it('no Iterate button means no chat-slot creation entry point (hidden pending redesign)', async () => {
- // With SHOW_ARTIFACT_ITERATE off the header button is gone,
-    // so there is no UI path to createChatSlot from the artifact page.
+  it('creates no chat slot until the companion toggle is clicked', async () => {
+    // Merely viewing an artifact must never spawn a session — the bound session
+    // is created lazily on the first explicit toggle click.
     vi.mocked(api).artifact = vi.fn().mockResolvedValue(
       mkArtifact({ kind: 'markdown', content: '# v1' }),
     )
@@ -666,10 +684,14 @@ describe('ArtifactDetailPage', () => {
       .mockResolvedValue({ slug: 'cr-queue', versions: [1] })
     const createSlotSpy = vi.fn().mockResolvedValue({ key: 'slot-new' })
     vi.mocked(api).createChatSlot = createSlotSpy
+    vi.mocked(api).chatSlotContext = vi.fn().mockResolvedValue({ ok: true })
     renderRoute()
     await waitFor(() => expect(screen.getByText('CR Queue')).toBeInTheDocument())
-    expect(screen.queryByTitle(/Discuss this artifact with the agent/i)).toBeNull()
     expect(createSlotSpy).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByLabelText('Toggle agent chat'))
+    await waitFor(() => expect(createSlotSpy).toHaveBeenCalledTimes(1))
+    // The 8th positional argument is the artifact binding the backend persists.
+    expect(createSlotSpy.mock.calls[0][7]).toBe('cr-queue')
   })
 
   it('description renders when artifact has one', async () => {

--- a/website/src/test/ChatPage.sid.test.tsx
+++ b/website/src/test/ChatPage.sid.test.tsx
@@ -105,8 +105,10 @@ function renderChatPage(opts: {
   mode?: string
   activeSlot?: string | null
   slots?: ChatSlot[]
+  /** Render the companion-panel variant on a HOST route (see the noUrlSync suite). */
+  hostEmbed?: { noUrlSync?: boolean }
 }) {
-  const { route = '/chat', mode, activeSlot = null, slots = [] } = opts
+  const { route = '/chat', mode, activeSlot = null, slots = [], hostEmbed } = opts
   const preload: PreloadState = {
     dashboard: {
       status: { platform: 'darwin' }, connected: true, slots, approvalMode: 'normal',
@@ -133,6 +135,10 @@ function renderChatPage(opts: {
             <Routes>
               <Route path="/chat/:slug?" element={<ChatPage mode={mode} />} />
               <Route path="/orchestrated/:slug?" element={<ChatPage mode="orchestrator" />} />
+              <Route
+                path="/artifacts/:slug"
+                element={<ChatPage embedded embedMode="chat" noUrlSync={hostEmbed?.noUrlSync} />}
+              />
             </Routes>
             <UrlCapture />
           </MemoryRouter>
@@ -181,6 +187,47 @@ describe('ChatPage ?sid= URL parameter', () => {
       await waitFor(() => {
         expect(currentUrl).toMatch(/^\/chat\?sid=chat-3-300$/)
       })
+    })
+  })
+
+  // ── noUrlSync (artifact companion panel) ─────────────────────────────────
+  // noUrlSync must disable BOTH directions of the URL<->session sync. Gating
+  // only the WRITE side is not enough: the host route is not guaranteed to be
+  // sid-free, and an ungated READ effect would switch the embedded panel onto
+  // whatever session ?sid= names — so the user would type into the artifact
+  // panel and the message would land in an unrelated conversation.
+  describe('noUrlSync on a host route', () => {
+    it('ignores ?sid= on the host route', async () => {
+      const { store } = renderChatPage({
+        route: '/artifacts/cr-queue?sid=chat-2-200',
+        slots,
+        hostEmbed: { noUrlSync: true },
+      })
+      // Give the mount-activation effect every chance to fire.
+      await act(async () => { await new Promise(r => setTimeout(r, 150)) })
+      expect(store.getState().chat.activeSlot).not.toBe('chat-2-200')
+    })
+
+    it('honors ?sid= on the same route without noUrlSync (control)', async () => {
+      // Proves the assertion above can actually observe a switch — otherwise it
+      // would pass even if the read effects never ran for an unrelated reason.
+      const { store } = renderChatPage({
+        route: '/artifacts/cr-queue?sid=chat-2-200',
+        slots,
+        hostEmbed: { noUrlSync: false },
+      })
+      await waitFor(() => expect(store.getState().chat.activeSlot).toBe('chat-2-200'))
+    })
+
+    it('never rewrites the host URL', async () => {
+      renderChatPage({
+        route: '/artifacts/cr-queue',
+        slots,
+        activeSlot: 'chat-1-100',
+        hostEmbed: { noUrlSync: true },
+      })
+      await act(async () => { await new Promise(r => setTimeout(r, 150)) })
+      expect(currentUrl).toBe('/artifacts/cr-queue')
     })
   })
 

--- a/website/src/test/InlineCommentOverlay.test.tsx
+++ b/website/src/test/InlineCommentOverlay.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { useRef } from 'react'
+import { InlineCommentOverlay } from '../components/InlineCommentOverlay'
+import type { ArtifactComment } from '../types'
+
+class FakeRO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+let origRaf: any
+let origCaf: any
+
+beforeEach(() => {
+  (globalThis as any).ResizeObserver = FakeRO
+  origRaf = globalThis.requestAnimationFrame
+  origCaf = globalThis.cancelAnimationFrame
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 1 }) as any
+  globalThis.cancelAnimationFrame = (() => {}) as any
+})
+
+afterEach(() => {
+  globalThis.requestAnimationFrame = origRaf
+  globalThis.cancelAnimationFrame = origCaf
+})
+
+function mk(over: Partial<ArtifactComment> = {}): ArtifactComment {
+  return {
+    id: 'c1', origin: 'local', scope: 'private', author: 'nrb', is_agent: false,
+    body: 'b', thread_id: 'c1', status: 'open', sync_state: 'local_only',
+    created_at: '', updated_at: '', ...over,
+  }
+}
+
+function Harness({ comments }: { comments: ArtifactComment[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const textRef = useRef<HTMLDivElement>(null)
+  return (
+    <div ref={scrollRef} style={{ position: 'relative' }}>
+      <div ref={textRef}>The quick brown fox jumps over the lazy dog</div>
+      <InlineCommentOverlay
+        scrollRef={scrollRef}
+        textRef={textRef}
+        comments={comments}
+        activeId={null}
+        onActivate={vi.fn()}
+      />
+    </div>
+  )
+}
+
+describe('InlineCommentOverlay', () => {
+  it('mounts the overlay layer for an anchored comment without crashing', () => {
+    const c = mk({ id: 'a1', anchor: { quote: 'quick brown' } })
+    const { container } = render(<Harness comments={[c]} />)
+    expect(container.querySelector('.mc-cmt-overlay')).not.toBeNull()
+  })
+
+  it('paints no anchor for a resolved comment', () => {
+    const c = mk({ id: 'a1', anchor: { quote: 'quick brown' }, status: 'resolved' })
+    const { container } = render(<Harness comments={[c]} />)
+    expect(container.querySelector('.mc-cmt-rect')).toBeNull()
+    expect(container.querySelector('.mc-cmt-bubble')).toBeNull()
+  })
+})

--- a/website/src/test/artifactEditGuard.test.ts
+++ b/website/src/test/artifactEditGuard.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The edit-buffer registry the WS transport consults before refreshing an
+ * artifact's cached content. Small enough to pin directly, and worth pinning
+ * because a leak in either direction is silent: leaving a slug marked blocks live
+ * refresh forever, and clearing too eagerly re-opens the lost-update it prevents.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  setArtifactEditing,
+  isArtifactEditing,
+  __resetArtifactEditing,
+} from '../utils/artifactEditGuard'
+
+afterEach(() => __resetArtifactEditing())
+
+describe('artifactEditGuard', () => {
+  it('is false for an untracked slug', () => {
+    expect(isArtifactEditing('cr-queue')).toBe(false)
+  })
+
+  it('marks and clears a slug', () => {
+    setArtifactEditing('cr-queue', true)
+    expect(isArtifactEditing('cr-queue')).toBe(true)
+    setArtifactEditing('cr-queue', false)
+    expect(isArtifactEditing('cr-queue')).toBe(false)
+  })
+
+  it('tracks slugs independently', () => {
+    setArtifactEditing('a', true)
+    expect(isArtifactEditing('a')).toBe(true)
+    expect(isArtifactEditing('b')).toBe(false)
+  })
+
+  it('ignores an empty slug rather than tracking a falsy key', () => {
+    setArtifactEditing('', true)
+    expect(isArtifactEditing('')).toBe(false)
+  })
+
+  it('is idempotent', () => {
+    setArtifactEditing('a', true)
+    setArtifactEditing('a', true)
+    setArtifactEditing('a', false)
+    expect(isArtifactEditing('a')).toBe(false)
+  })
+})

--- a/website/src/test/cssClassParity.test.ts
+++ b/website/src/test/cssClassParity.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Every `mc-*` class a component *styles itself with* must be defined in CSS.
+ *
+ * This exists because of a real, shipped regression: the artifact page's
+ * anchored-comment overlay (`InlineCommentOverlay`) renders its highlight rects
+ * and gutter bubbles as `mc-cmt-rect` / `mc-cmt-bubble` / `mc-cmt-overlay`
+ * elements, but the stylesheet block defining those three classes was never
+ * ported into this repo. The result was silent and total: the overlay mounted
+ * the correct elements into the DOM with the correct geometry, every unit test
+ * passed, and the feature looked completely absent in the browser — transparent,
+ * zero-styled divs. `mc-art-toolbar` was missing the same way, leaving the
+ * artifact toolbar's controls unaligned.
+ *
+ * A DOM-level test cannot catch this (jsdom applies no stylesheet), so the guard
+ * has to be static: scan for class names used in `className=` and assert each
+ * has a definition. Only `mc-`-prefixed classes are checked — the project also
+ * uses that prefix for localStorage keys and window-event names, which
+ * legitimately have no styling, so the scan is restricted to class positions.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, extname, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// `new URL('..', import.meta.url).pathname` yields a URL path, not a filesystem
+// path — resolve through fileURLToPath so this works regardless of cwd.
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'test') continue
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else out.push(full)
+  }
+  return out
+}
+
+/**
+ * Pre-existing unstyled classes, baselined so this guard gates NEW regressions
+ * instead of demanding a restyle of unrelated components. Each is applied to an
+ * element that therefore renders with no styling — their owners should either add
+ * the rule or drop the class. Do not add to this list to silence a new failure.
+ */
+const KNOWN_UNSTYLED = new Set([
+  'mc-comment-tooltip',   // components/MarkdownPanel.tsx
+  'mc-fe-tab-file',       // apps/file-explorer/TabStrip.tsx
+  'mc-fe-tab-folder',     // apps/file-explorer/TabStrip.tsx
+])
+
+const files = walk(SRC)
+const sources = files.filter(f => ['.ts', '.tsx'].includes(extname(f)))
+const styles = files.filter(f => extname(f) === '.css')
+
+/** Class names appearing inside a `className=` / `class=` attribute value. */
+function usedClasses(): Map<string, string> {
+  const found = new Map<string, string>()
+  // className={...} or className="..." — capture the whole attribute value,
+  // template literals included, then pull mc-* tokens out of it.
+  const attr = /class(?:Name)?\s*=\s*(?:"([^"]*)"|'([^']*)'|\{([^}]*)\})/g
+  for (const f of sources) {
+    const text = readFileSync(f, 'utf8')
+    for (const m of text.matchAll(attr)) {
+      const value = m[1] ?? m[2] ?? m[3] ?? ''
+      for (const cls of value.matchAll(/\bmc-[a-z0-9-]+/g)) {
+        if (!found.has(cls[0])) found.set(cls[0], f.slice(SRC.length))
+      }
+    }
+  }
+  return found
+}
+
+/**
+ * Selector definitions, from .css AND from CSS-in-TS (some app bundles ship their
+ * stylesheet as an exported template string injected into a <style> block, e.g.
+ * `apps/file-explorer/styles.ts`). A dotted kebab-case name cannot be a JS member
+ * expression, so `.mc-a-b` is unambiguously a selector in either file type — no
+ * need to parse.
+ */
+function definedClasses(): Set<string> {
+  const defined = new Set<string>()
+  for (const f of [...styles, ...sources]) {
+    for (const m of readFileSync(f, 'utf8').matchAll(/\.(mc-[a-z0-9-]*[a-z0-9])(?=[\s,:{.[)])/g)) {
+      defined.add(m[1])
+    }
+  }
+  return defined
+}
+
+describe('mc-* class parity between components and stylesheets', () => {
+  it('defines every mc-* class used in a className attribute', () => {
+    const used = usedClasses()
+    const defined = definedClasses()
+    const missing = [...used.entries()]
+      .filter(([cls]) => !defined.has(cls) && !KNOWN_UNSTYLED.has(cls))
+      .map(([cls, file]) => `${cls} (used in ${file})`)
+      .sort()
+    expect(
+      missing,
+      `${missing.length} mc-* class(es) are applied to elements but have no CSS rule. ` +
+        'An unstyled class renders an invisible element and no DOM test will notice:\n  ' +
+        missing.join('\n  '),
+    ).toEqual([])
+  })
+
+  it('keeps the pre-existing-unstyled baseline honest', () => {
+    // If someone styles one of these, the entry is stale and should be deleted so
+    // the baseline never silently grows into a permanent exemption list.
+    const defined = definedClasses()
+    const nowStyled = [...KNOWN_UNSTYLED].filter(c => defined.has(c))
+    expect(nowStyled, `now styled — remove from KNOWN_UNSTYLED: ${nowStyled.join(', ')}`).toEqual([])
+  })
+
+  it('finds the classes it is supposed to be scanning (guards the scanner itself)', () => {
+    // A regex that silently stops matching would make this suite vacuously green,
+    // so pin two classes that must always be present.
+    const used = usedClasses()
+    expect([...used.keys()]).toContain('mc-cmt-rect')
+    expect([...used.keys()]).toContain('mc-art-toolbar')
+  })
+})

--- a/website/src/test/useWebSocket.artifactUpdate.test.ts
+++ b/website/src/test/useWebSocket.artifactUpdate.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `artifact_update` WebSocket frame -> react-query cache, through the real
+ * dispatch adapter in `useWebSocket.ts`.
+ *
+ * This is the live-refresh half of the artifact companion chat: the backend
+ * broadcasts from its artifact mutation funnel, and the client must turn that
+ * into per-slug query invalidation so every open surface (detail page, popout,
+ * the companion panel's left pane) re-renders the new version without a manual
+ * refresh. The delete variant is different in kind — it must DROP the cache and
+ * emit a window event so a detail page can navigate away rather than serve
+ * content that no longer exists.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { setArtifactEditing, __resetArtifactEditing } from '../utils/artifactEditGuard'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() { WS_INSTANCES.push(this) }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+describe('useWebSocket artifact_update frame', () => {
+  let testStore: ReturnType<typeof createTestStore>
+  let qc: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    testStore = createTestStore()
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => { vi.unstubAllGlobals(); __resetArtifactEditing() })
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(Provider, { store: testStore },
+      createElement(QueryClientProvider, { client: qc }, children),
+    )
+  }
+
+  function send(data: object) {
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    act(() => { ws.simulateMessage({ type: 'artifact_update', data }) })
+  }
+
+  it('invalidates the per-slug queries on a content update', () => {
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    send({ slug: 'cr-queue', version: 7, deleted: false })
+    const keys = spy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys).toContain(JSON.stringify(['artifact', 'cr-queue']))
+    expect(keys).toContain(JSON.stringify(['artifact-versions', 'cr-queue']))
+    expect(keys).toContain(JSON.stringify(['artifact-events', 'cr-queue']))
+    expect(keys).toContain(JSON.stringify(['artifact-comments', 'cr-queue']))
+    // The library list ordering is driven by updated_at, so it refreshes too.
+    expect(keys).toContain(JSON.stringify(['artifacts']))
+  })
+
+  it('emits a window event on delete WITHOUT evicting the artifact query', () => {
+    // Eviction would drop the detail page's data, re-render it into a loading/404
+    // state, and unmount the editor — destroying an unsaved edit buffer and
+    // defeating the deletion listener's dirty-page guard. The listener owns the
+    // decision (navigate when clean, retain when dirty); the transport only
+    // notifies.
+    const removeSpy = vi.spyOn(qc, 'removeQueries')
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+    const onDeleted = vi.fn()
+    window.addEventListener('kirocrew:artifact-deleted', onDeleted)
+    try {
+      send({ slug: 'cr-queue', version: 7, deleted: true })
+    } finally {
+      window.removeEventListener('kirocrew:artifact-deleted', onDeleted)
+    }
+    expect(removeSpy).not.toHaveBeenCalled()
+    expect(onDeleted).toHaveBeenCalledTimes(1)
+    expect((onDeleted.mock.calls[0][0] as CustomEvent).detail).toEqual({ slug: 'cr-queue' })
+    // A deleted artifact must NOT be re-fetched — only the library list is.
+    const keys = invalidateSpy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys).not.toContain(JSON.stringify(['artifact', 'cr-queue']))
+    expect(keys).toContain(JSON.stringify(['artifacts']))
+  })
+
+  it('withholds the content refresh while the artifact has an unsaved buffer', () => {
+    // Refetching would move the editor's baseline while the buffer keeps the older
+    // text, so the next Save would overwrite the update that just arrived.
+    setArtifactEditing('cr-queue', true)
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    send({ slug: 'cr-queue', version: 8, deleted: false })
+    const keys = spy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys).not.toContain(JSON.stringify(['artifact', 'cr-queue']))
+    expect(keys).not.toContain(JSON.stringify(['artifact-versions', 'cr-queue']))
+    // Comments and events carry no edit buffer, so they still refresh.
+    expect(keys).toContain(JSON.stringify(['artifact-comments', 'cr-queue']))
+    expect(keys).toContain(JSON.stringify(['artifact-events', 'cr-queue']))
+    expect(keys).toContain(JSON.stringify(['artifacts']))
+  })
+
+  it('only withholds for the edited slug, not others', () => {
+    setArtifactEditing('cr-queue', true)
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    send({ slug: 'other-doc', version: 2, deleted: false })
+    const keys = spy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys).toContain(JSON.stringify(['artifact', 'other-doc']))
+  })
+
+  it('ignores a frame with no slug', () => {
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    const onDeleted = vi.fn()
+    window.addEventListener('kirocrew:artifact-deleted', onDeleted)
+    try {
+      send({ version: 7 })
+    } finally {
+      window.removeEventListener('kirocrew:artifact-deleted', onDeleted)
+    }
+    const keys = spy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys).not.toContain(JSON.stringify(['artifacts']))
+    expect(onDeleted).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -295,6 +295,10 @@ export interface SessionLink {
 
 export interface ChatSlot {
   key: string; title?: string; messages: number; running: boolean; stopping?: boolean; pending_approval?: boolean; created?: string; last_ts?: string; last_message?: string; agent?: string; model?: string; reasoning_effort?: string; mode?: string; surface?: string; workspace?: string; trust?: boolean; trust_reads?: boolean; folder_id?: string; pinned?: boolean; tags?: string[]; links?: SessionLink[]; slack_linked?: boolean; slack_channel?: string; slack_thread_ts?: string; color_index?: number | null; memory_mode?: 'persistent' | 'incognito' | 'temporary'; clean_mode?: boolean; project?: string; forked_from?: string | null; source_links?: { provider: 'github' | 'gitlab'; number: number; url: string; ci?: 'running' | 'passed' | 'failed' | null; state?: 'open' | 'draft' | 'merged' | 'closed'; mergeable?: string; mergeStateStatus?: string; kind?: 'change' | 'issue' }[]; source_links_total?: number
+  /** Artifact companion binding: slug of the artifact this slot is a companion
+   * chat for. Set at slot create and persisted in the history meta line, so the
+   * binding survives a gateway restart and a History-page resume. */
+  artifact?: string
   /** Metadata for kind="webapp" artifacts (deploy state, architecture, costs). */
   webapp_metadata?: WebAppMetadata
   // Board fields

--- a/website/src/utils/artifactEditGuard.ts
+++ b/website/src/utils/artifactEditGuard.ts
@@ -1,0 +1,37 @@
+/**
+ * Which artifacts currently have an unsaved edit buffer open.
+ *
+ * The WebSocket transport must not refresh an artifact's cached content while a
+ * human is mid-edit. Refetching swaps the editor's *baseline* (`artifact.content`)
+ * while the buffer (`editedContent`) keeps the user's older text, so the next Save
+ * writes the buffer over whatever arrived in between — silently losing the agent's
+ * update. Skipping the refresh keeps the editor coherent; the page picks the new
+ * content up on save or cancel, when the buffer is no longer at risk.
+ *
+ * This is a module-level registry rather than Redux or context because the reader
+ * is `useWebSocket` — a global transport hook with no relationship to the artifact
+ * page's local component state, and which must make the decision synchronously
+ * inside the frame handler.
+ *
+ * It is intentionally NOT conflict resolution. It only prevents one side from
+ * clobbering the other while both are live; a real merge/"content changed
+ * underneath you" flow is separate, larger work.
+ */
+const editing = new Set<string>()
+
+/** Mark/unmark `slug` as having an unsaved edit buffer. */
+export function setArtifactEditing(slug: string, isEditing: boolean): void {
+  if (!slug) return
+  if (isEditing) editing.add(slug)
+  else editing.delete(slug)
+}
+
+/** True while `slug` has an unsaved edit buffer open in this window. */
+export function isArtifactEditing(slug: string): boolean {
+  return editing.has(slug)
+}
+
+/** Test seam — no production caller. */
+export function __resetArtifactEditing(): void {
+  editing.clear()
+}


### PR DESCRIPTION
## Problem

The artifact detail page had no way to reach an agent. The comments sidebar
could collect notes, but nothing could act on them — the "Ask agent" action was
switched off, and so was selection-anchored comment creation, behind a
module-level `SHOW_ARTIFACT_ITERATE = false` flag whose own comment said to
flip it "when the redesign lands".

Meanwhile the backend for an artifact-bound companion session was already
shipped and tested: chat slots accept an `artifact` binding, persist it in the
history meta line, and the artifact mutation funnel broadcasts a typed
`artifact_update` event. Nothing in the frontend consumed any of it, which is
why `docs/system-specs/modules/artifacts.md` described the feature as "the
backend half".

Net effect: zero UI paths from an artifact to an agent, and a documented
capability users could not reach.

Re-enabling anchored comments then exposed a second, independent gap: anchored
highlights did not render at all on natively-rendered bodies. The overlay that
draws them (`InlineCommentOverlay`) is present and correct, but the stylesheet
block defining `mc-cmt-overlay` / `mc-cmt-rect` / `mc-cmt-bubble` was never
present in this repo — so the overlay mounted correctly-positioned elements that
painted as transparent, zero-styled divs. The same block defines
`mc-art-toolbar`, which `ArtifactDetailPage` already applies, leaving the
artifact toolbar's controls unaligned.

## Why it matters

An artifact you cannot iterate on is a dead end. The whole point of saving a
widget, plan, or analysis is to come back and change it — and for widgets, which
cannot be edited inline, asking the agent is the *only* way to change them at
all. Anchored comments are the other half of that loop: they turn a vague "fix
the metrics section" into a durable instruction pinned to the exact span it
refers to, which the agent reads back through `artifact_get_comments`.

## Fix (symptoms -> root cause -> change)

**Symptom** — no sparkle button, no anchored-comment popover, an "Ask agent"
action that never rendered, and artifact edits that did not appear in other open
windows until a manual refresh.

**Root cause** — two independent gaps. (1) The frontend half of the companion
chat was never written, so the shipped backend binding and `artifact_update`
broadcast had no consumer. (2) A single boolean gated four separate affordances,
including anchored comment creation, which had been folded in only because its
sole submit path used to be the old navigate-away flow.

**Change**

- **Companion chat panel** (`ArtifactChatPanel.tsx`) — the toolbar sparkle
  toggles an embedded chat that renders as a flex sibling of the artifact, so
  the artifact stays on screen. It is mutually exclusive with the comments
  sidebar; neither overlays the body. The comment-count auto-reveal explicitly
  refuses to switch away from an open chat panel, since the chat panel only ever
  opens on an explicit click.
- **Chat parity by construction** — the panel embeds the same `ChatPage`
  component as `/chat` (`embedded` + `embedMode="chat"`), so option chips,
  question cards, steer-send, tool groups and regenerate are identical rather
  than reimplemented. A new `noUrlSync` prop gates ChatPage's one URL-write
  effect: the host route `/artifacts/:slug` owns the URL, and an in-place
  `navigate` would swap the host route out from under the panel.
- **Session resolution with no new endpoint** — the active bound session is
  resolved from the Redux slots snapshot (`slot.artifact === slug`), because
  the WS `slots` event already carries the binding. The flow keeps at most one
  *active* bound session per slug by archiving before creating; the resolver
  tolerates more by picking the most recently active, so a race or a
  History-page resume degrades instead of erroring.
- **One round trip to interactive** — the create response carries the binding,
  so it is dispatched straight into the slots list (`addSlotOptimistic`) and the
  panel is usable immediately. The silent context entry and the `fetchSlots`
  reconciliation run in the background; the context entry is consumed on the
  *next* user message, so it always lands before a human can type and send.
- **Live refresh** — `useWebSocket` now handles `artifact_update`, invalidating
  the per-slug artifact / versions / events / comments queries. On delete it
  drops the cache and emits a window event so an open detail page navigates away
  rather than refetching a 404.
- **Anchored comments re-enabled** — the flag is deleted, restoring
  selection-driven creation. No storage work was needed: the backend already
  persists `quote` / `prefix` / `suffix` / rendered-text offsets / version and
  rescans every anchor on each content write to maintain `anchor_orphaned`, and
  `artifact_get_comments` already formats anchors for the agent. "Ask agent to
  address" now routes into the bound session and *stages* (never auto-sends) its
  message through the existing `writePrefill` channel.
- **Anchored highlights now paint** — ports the missing stylesheet block for
  `mc-cmt-overlay` / `mc-cmt-rect` / `mc-cmt-bubble` (and `mc-art-toolbar`). No
  component change was needed: the overlay, its rect math, and the gutter bubbles
  were already correct and already wired. Only the styling was absent, which is
  why the feature looked entirely missing while every unit test passed.
- **Anchoring works on text artifacts, not just markdown** — `ContentRenderer`
  attached `previewRef` only on the markdown branch, while `commentable` also
  listed `text`: the tip invited a selection and the handler then bailed on the
  null ref. The ref is now attached to the `<pre>` path too (a `<pre>`'s
  `textContent` equals the source, so rendered offsets are source offsets) and the
  overlay gate widened past markdown accordingly.
- **Agent guidance** — the artifacts skill now tells the agent to treat an
  anchored comment as scoped to its span, re-read the span before editing, and
  report an orphaned anchor instead of guessing where it pointed.

The sparkle is no longer hidden in popout windows: it used to navigate away,
which was the reason for the `!popout` guard; a popout has its own store and WS,
so the panel now works in place.

## Tests

New tests across seven suites (below); 5891 pass in total.

| Suite | Locks in |
| --- | --- |
| `ArtifactDetailPage.companionChat.test.tsx` (16) | create carries the slug + pinned title and no `name`; optimistic bind makes the panel interactive off the create response alone; ephemeral context injection; `embedded`/`embedMode`/`noUrlSync` wiring; resume without create; ignoring other artifacts' sessions; most-recent-activity tie-break; toggle-closed keeps the session; comments/chat mutual exclusion; the auto-reveal guard; prune to empty state; address-message staging; archive-before-create ordering + optimistic prune; create still proceeds when archiving 404s; delete relay navigates away and ignores other slugs |
| `ArtifactDetailPage.anchoredComments.test.tsx` (5) | the posted payload actually carries the anchor (quote + offset span) — there was previously **no coverage of `postArtifactComment` at all`**; panel reveal after an anchored add; no popover for a collapsed selection; suppressed while editing; suppressed on a historical version |
| `useWebSocket.artifactUpdate.test.ts` (3) | per-slug invalidation on content change; cache drop + window event on delete, and that a deleted artifact is *not* refetched; a slug-less frame is ignored |
| `InlineCommentOverlay.test.tsx` (2) | the overlay's own rect/bubble behaviour — a suite this repo was missing entirely, which is part of why the unstyled overlay shipped unnoticed |
| `cssClassParity.test.ts` (3) | every `mc-*` class applied via `className` has a CSS rule (scanning `.css` **and** CSS-in-TS). A DOM test cannot catch an unstyled class because jsdom applies no stylesheet, so this guard is static. Pre-existing violations are baselined explicitly, with a second test that fails if a baselined entry later gets styled |
| 5 rewritten assertions | Four tests asserted the gated affordance was absent. They were passing for the wrong reason (they matched the old "Iterate" label), so they would not have caught a regression. Rewritten to assert the real behavior, including that the toggle exists for widget kinds. |

Gates green locally: `tsc -b`, vitest (481 files / 5810 tests), isort, flake8,
mypy (529 files). The backend suite has 17 pre-existing failures on this host
(sandbox `unshare` EPERM, pidfd, hardlink and binary-ownership checks) — all 17
fail identically on a pristine `origin/main` checkout in the same worktree, and
this change touches no Python.

## Manual verification

Ran an isolated `dev-backend.sh` instance, created a markdown artifact, and
drove the real UI:

1. Sparkle opens the panel, mints a session titled `Artifact: <name>`, and the
   full chat composer is live next to the artifact.
2. Selecting a phrase in the body opens the anchored-comment popover; submitting
   stores the comment with its quoted span and reveals the comments sidebar with
   the "Ask agent to address" action.
3. Second sparkle click closes the panel without archiving the session.

## Screenshots

Anchored comments rendering on a markdown body — translucent marker over each
anchored span, bottom rule, and a numbered gutter bubble per thread. These paint
only because this PR ports the stylesheet block that defines them (see Fix):

![Two anchored comments highlighted in the artifact body with numbered gutter bubbles, comments sidebar open](https://github.com/kirodotdev/KiroCrew/raw/245159e9b65f59524d88dcc8d41e438c9ada9941/temp-screenshots/artifact-companion-chat/anchored-comments-rendered.png)

Companion chat panel open beside the artifact, with the anchors still painted on
the left:

![Companion chat panel open beside the artifact, anchored highlights visible in the body](https://github.com/kirodotdev/KiroCrew/raw/245159e9b65f59524d88dcc8d41e438c9ada9941/temp-screenshots/artifact-companion-chat/companion-chat-panel.png)

Both images are pinned to `245159e9`, a superseded revision of this branch, so
no binaries enter `main`'s tree or history on squash-merge.
