### PR TITLE
feat(dashboard): surface channel-originated sessions in the chat list

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -3658,6 +3658,7 @@
         "url": "",
         "restore_sessions": false,
         "restore_window_minutes": 30,
+        "surface_channel_sessions": true,
         "bot_name": "",
         "avatar": "",
         "merge_queued_messages": false,
@@ -3727,10 +3728,24 @@
       "sensitive": false,
       "tags": [],
       "label": "Restore Window Minutes",
-      "help": "Time window (minutes) for session restoration (0-1440). 0 = restore all.",
+      "help": "Time window (minutes) for session restoration, and for surfacing channel conversations in the chat list (0-1440). 0 = no limit.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 30
+    },
+    {
+      "path": "dashboard.surface_channel_sessions",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Show Channel Conversations In Chat List",
+      "help": "Show recently active Slack/Discord/Teams (etc.) conversations in the dashboard's chat list instead of only under History. Uses the same recency window as session restoration.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": true
     },
     {
       "path": "dashboard.bot_name",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1410,7 +1410,17 @@ class DashboardConfig:
         default=30,
         metadata=_meta(
             "Restore Window Minutes",
-            "Time window (minutes) for session restoration (0-1440). 0 = restore all.",
+            "Time window (minutes) for session restoration, and for surfacing "
+            "channel conversations in the chat list (0-1440). 0 = no limit.",
+        ),
+    )
+    surface_channel_sessions: bool = field(
+        default=True,
+        metadata=_meta(
+            "Show Channel Conversations In Chat List",
+            "Show recently active Slack/Discord/Teams (etc.) conversations in the "
+            "dashboard's chat list instead of only under History. Uses the same "
+            "recency window as session restoration.",
         ),
     )
     bot_name: str = field(
@@ -4093,6 +4103,7 @@ class KiroCrewConfig:
                 url=dashboard_data.get("url", ""),
                 restore_sessions=dashboard_data.get("restore_sessions", False),
                 restore_window_minutes=dashboard_data.get("restore_window_minutes", 30),
+                surface_channel_sessions=dashboard_data.get("surface_channel_sessions", True),
                 bot_name=dashboard_data.get("bot_name", ""),
                 avatar=dashboard_data.get("avatar", ""),
                 merge_queued_messages=dashboard_data.get("merge_queued_messages", False),

--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -1,0 +1,465 @@
+"""Surface channel-originated sessions in the dashboard's active chat list.
+
+A conversation started on Slack (or Discord/Telegram/Teams/…) persists under a
+channel-namespaced session key such as ``slack:<thread_ts>``. The dashboard's
+slot restore paths only ever built slots for ``dashboard:``-prefixed keys, so
+those conversations existed on disk but had no chat slot — they only appeared
+in the sidebar's collapsed **History** pane, where the user had to search for
+one and resume it by hand.
+
+This module reconciles recent channel sessions INTO slots so they show up in
+the active chat list, seeded with the conversation so far and ready to continue.
+
+Design notes:
+
+* **One history key, no split.** The slot is an ordinary dashboard slot whose
+  key is derived from the channel session key
+  (``slack:1785370133.085469`` -> ``slack_1785370133.085469``), so everything
+  about it — turn persistence, replay, the ``closed`` flag, and both restore
+  paths — uses the single ``dashboard:<slot.key>`` history key.
+
+  It deliberately does NOT set ``linked_session_key`` to the channel key.
+  ``_save_slot_to_history`` is hard-wired to ``_history_key_for(slot.key)``,
+  so binding the RUN path to the channel key while the SAVE path kept writing
+  ``dashboard:<slot.key>`` would split one conversation across two transcripts:
+  a dashboard reply would be invisible to the slot's own replay, and a tab the
+  user closed would have its ``closed`` flag written to a key the reconciler
+  never reads — so it would reopen on the next pass. Continuity with the live
+  channel session is not worth that; picking the conversation up with its full
+  history (which this does) is the point.
+* **Recency-bounded.** Only sessions modified within the dashboard's configured
+  ``restore_window_minutes`` become slots, so a long DM history does not turn
+  into hundreds of tabs. Pinned and foldered sessions are exempt from the
+  window, matching :func:`~kiro_crew.dashboard.chat_persistence.restore_recent_sessions`.
+* **Closed is sticky.** A session the user closed on the dashboard
+  (``meta.closed``) is never re-surfaced — otherwise closing the tab would be
+  undone on the next reconcile pass.
+* **Ephemeral stays ephemeral.** ``incognito``/``temporary`` channel threads are
+  skipped: the user asked for a conversation that leaves no trace, and a
+  durable sidebar tab contradicts that.
+* **Idempotent.** Every pass is a no-op for sessions that already own a slot,
+  so it is safe to run on a timer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+from kiro_crew.dashboard.chat_utils import _history_key_for
+from kiro_crew.dashboard.state import _normalize_slot_key
+from kiro_crew.messaging.link import channel_namespace_of, is_channel_session_key
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+logger = logging.getLogger(__name__)
+
+#: How often the background reconciler runs. Not user-configurable: it only
+#: bounds how stale the sidebar can be for a channel conversation started while
+#: the dashboard is already open, and each pass is a cheap metadata scan.
+RECONCILE_INTERVAL_SECS = 30
+
+#: Memory modes whose sessions must never be surfaced as a durable slot.
+_EPHEMERAL_MEMORY_MODES = frozenset({"incognito", "temporary"})
+
+#: Human-facing label per channel namespace, used only when a session has no
+#: title of its own yet (first turn still in flight).
+_CHANNEL_LABELS: dict[str, str] = {
+    "slack": "Slack",
+    "discord": "Discord",
+    "telegram": "Telegram",
+    "whatsapp": "WhatsApp",
+    "webex": "Webex",
+    "wecom": "WeCom",
+    "teams": "Teams",
+    "weixin": "Weixin",
+    "unified": "Direct message",
+}
+
+#: Messages hydrated into a newly surfaced slot. Matches the cron inject path.
+_HYDRATE_LIMIT = 50
+
+
+class _Transcript(NamedTuple):
+    """A pending slot's seed transcript plus its on-disk line accounting.
+
+    ``disk_older`` + ``disk_window`` always sum to the length of the slot's own
+    history file; the merged ``messages`` may be longer because it also carries
+    channel-side turns that file never held.
+    """
+
+    messages: list[dict[str, Any]]
+    disk_older: int
+    disk_window: int
+
+
+def channel_label(session_key: str) -> str:
+    """Return the display label for *session_key*'s channel (``"Slack"``, …)."""
+    ns = channel_namespace_of(session_key)
+    return _CHANNEL_LABELS.get(ns, ns.capitalize() if ns else "Channel")
+
+
+def channel_slot_name(session_key: str) -> str:
+    """Return the dashboard slot key for a channel session key.
+
+    Deterministic and idempotent — the same channel session always maps to the
+    same slot, which is what makes repeat reconcile passes no-ops and lets the
+    key itself carry the conversation's provenance.
+    """
+    return _normalize_slot_key(session_key)
+
+
+def slot_history_key(session_key: str) -> str:
+    """Return the history key the surfaced slot persists under.
+
+    This is the ONLY key the slot reads or writes: turn persistence, replay, the
+    ``closed`` flag, and both restore paths all agree on it.
+    """
+    return _history_key_for(channel_slot_name(session_key))
+
+
+def _redact(text: str) -> str:
+    text, _ = redact_exfiltration_urls(text)
+    text, _ = redact_credentials(text)
+    return text
+
+
+def eligible_channel_sessions(
+    sessions: list[dict[str, Any]],
+    *,
+    metadata: dict[str, dict[str, Any]],
+    cutoff: float | None,
+) -> list[dict[str, Any]]:
+    """Filter a ``list_sessions()`` result down to channel sessions to surface.
+
+    *metadata* maps session key -> ``get_metadata()`` result, and must contain an
+    entry for BOTH the channel key and its ``dashboard:``-prefixed slot key (see
+    :func:`slot_history_key`) — closing a tab writes ``closed`` to the slot key,
+    so reading only the channel key would let a closed tab reopen on the next
+    pass. *cutoff* is a unix timestamp; sessions older than it are dropped unless
+    pinned or foldered. ``None`` disables the recency filter (mirrors
+    ``restore_window_minutes=0``).
+
+    Pure and side-effect free so the eligibility rules are directly testable.
+    """
+    out: list[dict[str, Any]] = []
+    for s in sessions:
+        key = s.get("key", "")
+        if not key or not is_channel_session_key(key):
+            continue
+        meta = metadata.get(key) or {}
+        slot_meta = metadata.get(slot_history_key(key)) or {}
+        # Either side having been closed means the user dismissed this
+        # conversation; never resurface it.
+        if meta.get("closed") or slot_meta.get("closed"):
+            continue
+        modes = (
+            str(meta.get("memory_mode", "")).lower(),
+            str(slot_meta.get("memory_mode", "")).lower(),
+            str(s.get("memory_mode", "")).lower(),
+        )
+        if any(m in _EPHEMERAL_MEMORY_MODES for m in modes):
+            continue
+        exempt = (
+            bool(meta.get("pinned"))
+            or bool(meta.get("folder_id"))
+            or bool(slot_meta.get("pinned"))
+            or bool(slot_meta.get("folder_id"))
+        )
+        if not exempt and cutoff is not None and float(s.get("modified", 0) or 0) < cutoff:
+            continue
+        out.append(s)
+    return out
+
+
+def _identity(msg: dict[str, Any]) -> tuple[str, str, str]:
+    """Match/dedupe identity for one transcript message.
+
+    Used both to drop the channel turns already copied into the slot and to
+    locate a slot's on-disk lines inside the hydrate window.
+    """
+    return (
+        str(msg.get("role", "")),
+        str(msg.get("content", "")),
+        str(msg.get("ts", "")),
+    )
+
+
+def _ts_sort_key(msg: dict[str, Any]) -> tuple[int, float, str]:
+    """Chronological sort key for one transcript message.
+
+    The two sides of a merge are written by different code paths and nothing
+    makes them agree on timezone: the dashboard writes an ISO-8601 UTC string,
+    while a channel turn can land as a naive local-time one. Comparing those
+    lexicographically interleaves them wrongly by the host's UTC offset on any
+    machine that is not on UTC, so parse to an absolute instant first.
+
+    Buckets keep the fallbacks out of the ordered region: ``0`` parseable
+    (ordered by epoch seconds), ``1`` present but unparseable (lexicographic),
+    ``2`` absent (stable-sorted last, preserving relative order).
+    """
+    raw = str(msg.get("ts", "") or "")
+    if not raw:
+        return (2, 0.0, "")
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return (1, 0.0, raw)
+    if parsed.tzinfo is None:
+        # Naive means host-local — that is what a writer using datetime.now()
+        # emits. Reading it as UTC would shift the turn by the host's offset.
+        parsed = parsed.astimezone()
+    return (0, parsed.timestamp(), "")
+
+
+def merge_transcripts(
+    slot_messages: list[dict[str, Any]],
+    channel_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge a slot's own transcript with its channel transcript, by timestamp.
+
+    Neither side is a superset of the other. The slot transcript holds any
+    dashboard replies; the channel transcript holds anything the user said on
+    the channel AFTER the conversation was first surfaced. Re-surfacing (e.g.
+    after a restart with ``restore_sessions`` off) must seed the tab with both.
+
+    Ordering is by the ``ts`` field, normalized to an absolute instant by
+    :func:`_ts_sort_key` so a naive local-time channel turn cannot interleave
+    wrongly with a UTC dashboard turn. Duplicates — the channel turns already
+    copied into the slot — are dropped on :func:`_identity`.
+    """
+    seen: set[tuple[str, str, str]] = set()
+    merged: list[dict[str, Any]] = []
+    for m in list(slot_messages) + list(channel_messages):
+        ident = _identity(m)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        merged.append(m)
+    return sorted(merged, key=_ts_sort_key)
+
+
+def hydrate_window(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The tail of *messages* a newly surfaced slot is actually seeded with.
+
+    One function so the seeding loop and the frozen-prefix arithmetic that has
+    to agree with it cannot drift: empty-content lines are dropped first (they
+    are never appended), then the tail is capped at :data:`_HYDRATE_LIMIT`.
+    """
+    return [m for m in messages if m.get("content")][-_HYDRATE_LIMIT:]
+
+
+def frozen_prefix_len(
+    slot_messages: list[dict[str, Any]],
+    window: list[dict[str, Any]],
+) -> int:
+    """Count the slot's on-disk lines that *window* does not re-serialize.
+
+    ``_save_slot_to_history`` models a session file as **frozen prefix + live
+    window**: it copies the first ``slot._disk_older_count`` on-disk lines
+    verbatim, then writes ``serialize(window)`` after them. Seeding a slot with
+    only the tail of a long transcript while leaving that count at ``0`` tells
+    the next save the file has no prefix, so the older lines are re-emitted
+    after newer ones — the transcript loses chronological order.
+
+    The boundary is positional: every slot line before the first one the window
+    carries. Because the window is the chronological tail of the merge, every
+    later slot line is in it too, so nothing between the boundary and the end
+    of the file is stranded.
+    """
+    if not slot_messages:
+        return 0
+    carried = {_identity(m) for m in window}
+    for i, msg in enumerate(slot_messages):
+        if _identity(msg) in carried:
+            return i
+    return len(slot_messages)
+
+
+def surface_channel_session(
+    state: "DashboardState",
+    session_info: dict[str, Any],
+    meta: dict[str, Any],
+    messages: list[dict[str, Any]],
+    *,
+    disk_older: int = 0,
+    disk_window: int = 0,
+) -> "_ChatSlot | None":
+    """Create the dashboard slot for one channel session.
+
+    Returns the slot when this call newly surfaced it, else ``None`` (already
+    present — the common steady-state case).
+
+    *messages* is the merged transcript to seed the slot with, read by the caller
+    so the disk IO stays off the event loop. *disk_older* and *disk_window* are
+    that caller's split of the slot's OWN on-disk lines into the frozen prefix
+    the window does not carry and the region it re-serializes — see
+    :func:`frozen_prefix_len` for why a save needs both.
+    """
+    session_key = session_info.get("key", "")
+    if not session_key or not is_channel_session_key(session_key):
+        return None
+
+    # The slot key is derived from the channel session key, deterministically and
+    # idempotently, so it IS the record of where the conversation started — the
+    # sidebar reads provenance straight off it, and every restore path preserves
+    # it for free because the key is the slot's identity.
+    slot_name = channel_slot_name(session_key)
+    if slot_name in state._slots:
+        return None
+    try:
+        slot = state.get_or_create_slot(name=slot_name, agent=meta.get("agent", "") or "")
+    except ValueError:
+        # A slot with this name exists under a conflicting memory_mode. Leave it
+        # alone rather than fighting over the key.
+        logger.debug("channel slot %s exists with a conflicting memory_mode", slot_name)
+        return None
+
+    raw_title = session_info.get("title") or meta.get("title") or ""
+    slot.title = _redact(raw_title) if raw_title else channel_label(session_key)
+    slot._titled = bool(raw_title)
+    if meta.get("created_at"):
+        slot.created_at = meta["created_at"]
+    if meta.get("model"):
+        slot.model = meta["model"]
+    if meta.get("workspace"):
+        slot.workspace = meta["workspace"]
+    if meta.get("project"):
+        slot.project = meta["project"]
+    if meta.get("folder_id"):
+        slot.folder_id = meta["folder_id"]
+    if meta.get("pinned"):
+        slot.pinned = True
+
+    for msg in hydrate_window(messages):
+        role = msg.get("role", "assistant")
+        content = _redact(msg.get("content", ""))
+        slot.append(
+            role,
+            content,
+            f"msg msg-{'a' if role != 'user' else 'u'}",
+            ts=msg.get("ts", ""),
+            broadcast=False,
+        )
+    slot.drain()
+    slot._resumed_count = len(slot.messages)
+    # The session file is frozen prefix + live window. Only the slot's OWN
+    # on-disk lines count toward either: the merged window also carries
+    # channel-side turns that were never in this file, and crediting those as
+    # persisted would let a trim fold unwritten turns into the frozen prefix.
+    slot._disk_older_count = disk_older
+    slot._disk_window_len = disk_window
+    # Not dirty: a surfaced conversation the user never touches costs no write.
+    # The first real dashboard turn is what persists it under the slot key.
+    slot._dirty = False
+    logger.info(
+        "Surfaced %s session %s as slot %s", channel_label(session_key), session_key, slot_name
+    )
+    return slot
+
+
+async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) -> int:
+    """One reconcile pass. Returns the number of slots surfaced or re-bound.
+
+    Safe to call on the event loop: every filesystem read is offloaded, and only
+    the in-memory slot mutations run on the loop (so ``state._slots`` is never
+    touched from a worker thread).
+    """
+    log = state.conversation_log
+    if log is None:
+        return 0
+    loop = asyncio.get_running_loop()
+    cutoff = time.time() - (window_minutes * 60) if window_minutes > 0 else None
+
+    try:
+        sessions = await loop.run_in_executor(None, log.list_sessions)
+    except Exception:
+        logger.debug("channel reconcile: list_sessions failed", exc_info=True)
+        return 0
+
+    candidates = [s for s in sessions if is_channel_session_key(s.get("key", ""))]
+    if not candidates:
+        return 0
+
+    def _load_meta() -> dict[str, dict[str, Any]]:
+        out: dict[str, dict[str, Any]] = {}
+        # Both the channel key and the slot key: the slot key is where a closed
+        # tab records `closed`, and skipping it would resurface it every pass.
+        for s in candidates:
+            for key in (s.get("key", ""), slot_history_key(s.get("key", ""))):
+                if not key or key in out:
+                    continue
+                try:
+                    out[key] = log.get_metadata(key)
+                except Exception:
+                    out[key] = {}
+        return out
+
+    metadata = await loop.run_in_executor(None, _load_meta)
+    eligible = eligible_channel_sessions(candidates, metadata=metadata, cutoff=cutoff)
+    # Skip transcript reads for sessions that already own a slot — the steady state.
+    pending = [s for s in eligible if channel_slot_name(s.get("key", "")) not in state._slots]
+    if not pending:
+        return 0
+
+    def _load_messages() -> dict[str, _Transcript]:
+        out: dict[str, _Transcript] = {}
+        for s in pending:
+            key = s.get("key", "")
+            try:
+                slot_msgs = log.read_messages(slot_history_key(key))
+            except Exception:
+                slot_msgs = []
+            try:
+                chan_msgs = log.read_messages(key)
+            except Exception:
+                chan_msgs = []
+            merged = merge_transcripts(slot_msgs, chan_msgs)
+            # Split the slot's own on-disk lines here, in the executor, while
+            # both sides are still separable — after the merge they are not.
+            older = frozen_prefix_len(slot_msgs, hydrate_window(merged))
+            out[key] = _Transcript(merged, older, max(0, len(slot_msgs) - older))
+        return out
+
+    transcripts = await loop.run_in_executor(None, _load_messages)
+
+    surfaced = 0
+    for s in pending:
+        key = s.get("key", "")
+        transcript = transcripts.get(key) or _Transcript([], 0, 0)
+        try:
+            if surface_channel_session(
+                state,
+                s,
+                metadata.get(key) or {},
+                transcript.messages,
+                disk_older=transcript.disk_older,
+                disk_window=transcript.disk_window,
+            ):
+                surfaced += 1
+        except Exception:
+            logger.warning("channel reconcile: failed to surface %s", key, exc_info=True)
+    if surfaced:
+        state.push_slots_update()
+    return surfaced
+
+
+async def channel_slot_reconciler(state: "DashboardState", window_minutes: int) -> None:
+    """Background task: reconcile now, then every ``RECONCILE_INTERVAL_SECS``.
+
+    Runs for the gateway's lifetime. Every iteration is guarded so a transient
+    filesystem error can never kill the loop.
+    """
+    while True:
+        try:
+            await reconcile_channel_slots(state, window_minutes)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("channel slot reconciler pass failed", exc_info=True)
+        await asyncio.sleep(RECONCILE_INTERVAL_SECS)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -31,6 +31,7 @@ from kiro_crew.config import config_dir
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.constants import env_flag_enabled
 from kiro_crew.dashboard import (
+    channel_slots,
     chat,
     handlers,
     handlers_channel,
@@ -2556,6 +2557,18 @@ async def start_dashboard(
     # Reseed it past the highest restored index so the next new chat can't
     # re-mint a colliding low index (which scrambles the tab -> session map).
     state.reseed_slot_counter()
+
+    # Surface conversations started on Slack/Discord/Teams (etc.) in the chat
+    # list. These persist under channel-namespaced keys (``slack:<ts>``), which
+    # neither restore path above builds slots for — without this they exist only
+    # in the sidebar's collapsed History pane. Runs immediately, then on a timer
+    # so a channel conversation started while the dashboard is open still shows
+    # up without a restart.
+    if cfg.dashboard.surface_channel_sessions:
+        _chan_reconciler = asyncio.create_task(
+            channel_slots.channel_slot_reconciler(state, cfg.dashboard.restore_window_minutes)
+        )
+        state._channel_slot_reconciler = _chan_reconciler  # prevent GC
 
     # Relaunch agents in non-archived channels
     from kiro_crew.channel import ChannelManager, run_channel_agent

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1676,6 +1676,9 @@ class DashboardState:
         self._terminal_sessions: dict[str, Any] = {}  # PTY sessions for CLI panel
         self._terminal_reaper: asyncio.Task | None = None  # type: ignore[type-arg]
         self._terminal_title_poller: asyncio.Task | None = None  # type: ignore[type-arg]
+        # Background reconciler that surfaces channel-originated sessions
+        # (slack:<ts>, discord:…) as chat slots. Held to prevent GC.
+        self._channel_slot_reconciler: asyncio.Task | None = None  # type: ignore[type-arg]
         self._loop_heartbeat: asyncio.Task | None = None  # type: ignore[type-arg]
         # Off-loop event-loop stall watchdog; armed under the real gateway
         # entrypoint (faulthandler enabled) and stopped on shutdown. Annotated

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -20,6 +20,62 @@ _SLACK_TS_RE = re.compile(r"\d+\.\d+")
 
 SLACK_NAMESPACE = "slack"
 
+#: Session-key namespaces owned by a messaging channel, i.e. every prefix a
+#: conversation started OUTSIDE the dashboard can carry. Slack keys are
+#: ``slack:<thread_ts>``; every other transport uses
+#: ``{channel}:{agent}:{chatType}:{user}[:genN]`` (see
+#: :func:`build_dm_session_key`), plus the ``unified:`` bucket that
+#: ``dm_scope="unified"`` collapses direct DMs into.
+#:
+#: Deliberately excludes the non-channel namespaces that also contain a colon
+#: (``dashboard:``, ``cron:``, ``hook:``, ``subagent:``, ``channel:``) — those
+#: are surfaced by their own owners, not by the channel-session reconciler.
+#:
+#: NOTE: ``autonudge._CHANNEL_KEY_PREFIXES`` is a deliberately NARROWER set —
+#: only the transports that support unattended nudge fires. Do not merge them.
+CHANNEL_SESSION_NAMESPACES: tuple[str, ...] = (
+    SLACK_NAMESPACE,
+    "discord",
+    "telegram",
+    "whatsapp",
+    "webex",
+    "wecom",
+    "teams",
+    "weixin",
+    "unified",
+)
+
+#: Both separators a namespace can be followed by. A live session key uses ``:``;
+#: ``ConversationLog.list_sessions()`` reports the persisted FILENAME STEM, where
+#: ``history._safe_key`` has folded ``:`` to ``_`` — so a caller reading the
+#: session index sees ``slack_1785370133.085469``. Callers must accept both, the
+#: same way the dashboard restore path accepts ``dashboard:`` and ``dashboard_``.
+_CHANNEL_SESSION_PREFIXES: tuple[str, ...] = tuple(
+    f"{ns}{sep}" for ns in CHANNEL_SESSION_NAMESPACES for sep in (":", "_")
+)
+
+
+def is_channel_session_key(key: str) -> bool:
+    """True when *key* is a session started on a messaging channel.
+
+    Accepts both the live ``slack:<ts>`` form and the persisted ``slack_<ts>``
+    filename stem (see :data:`_CHANNEL_SESSION_PREFIXES`).
+
+    Used by the dashboard to decide which persisted sessions deserve a chat slot
+    of their own. Unlike :func:`kiro_crew.autonudge.is_channel_key` (which
+    answers "can this session be nudged?"), this covers EVERY channel transport,
+    including the reply-token-bound ones.
+    """
+    return key.startswith(_CHANNEL_SESSION_PREFIXES)
+
+
+def channel_namespace_of(key: str) -> str:
+    """Return the channel namespace of *key*, or ``""`` if it is not a channel key."""
+    for ns in CHANNEL_SESSION_NAMESPACES:
+        if key.startswith((f"{ns}:", f"{ns}_")):
+            return ns
+    return ""
+
 
 @dataclass
 class ChannelLink:

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -130,6 +130,13 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "to the browser.",
     ),
     (
+        "Channel session surfacing",
+        "dashboard/channel_slots.py",
+        "Titles and hydrated transcript of a Slack/Discord/Teams conversation as it is "
+        "surfaced into a dashboard chat slot — the channel transport is a separate "
+        "egress boundary, so its content is re-scanned before reaching the browser.",
+    ),
+    (
         "Session history (JSONL)",
         "history.py",
         "Redacted before persistence, so a leaked credential is not written to disk "

--- a/test/test_channel_slots.py
+++ b/test/test_channel_slots.py
@@ -1,0 +1,606 @@
+"""Tests for surfacing channel-originated sessions as dashboard chat slots.
+
+Covers the eligibility rules (recency window, closed, ephemeral memory modes,
+pin/folder exemption), the slot-creation/binding behaviour, and the async
+reconcile pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import channel_slots
+from kiro_crew.messaging.link import (
+    channel_namespace_of,
+    is_channel_session_key,
+)
+
+NOW = time.time()
+
+
+@pytest.fixture
+def dashboard_state(tmp_path: Any) -> Any:
+    """DashboardState with mocked services and a real (empty) ConversationLog."""
+    return _make_state(tmp_path)
+
+
+def _session(key: str, *, modified: float | None = None, **extra: Any) -> dict[str, Any]:
+    return {"key": key, "title": "", "modified": modified if modified is not None else NOW, **extra}
+
+
+class TestChannelKeyPredicates:
+    def test_recognizes_every_channel_namespace(self) -> None:
+        for key in (
+            "slack:1785370133.085469",
+            "discord:kirocrew:direct:U1",
+            "telegram:kirocrew:direct:U1",
+            "whatsapp:kirocrew:direct:U1",
+            "webex:kirocrew:direct:U1",
+            "wecom:kirocrew:direct:U1",
+            "teams:kirocrew:direct:U1",
+            "weixin:kirocrew:direct:U1",
+            "unified:kirocrew",
+        ):
+            assert is_channel_session_key(key), key
+
+    def test_recognizes_the_persisted_filename_stem_form(self) -> None:
+        """list_sessions() reports the stem, where _safe_key folded ':' -> '_'.
+
+        Missing this is why the reconciler saw zero channel sessions in a real
+        instance while every synthetic ``slack:`` fixture passed.
+        """
+        assert is_channel_session_key("slack_1785370133.085469")
+        assert is_channel_session_key("discord_kirocrew_direct_U1")
+        assert is_channel_session_key("unified_kirocrew")
+        assert channel_namespace_of("slack_1.1") == "slack"
+        assert channel_slots.channel_label("slack_1.1") == "Slack"
+
+    def test_rejects_non_channel_namespaces(self) -> None:
+        for key in (
+            "dashboard:chat-1-123",
+            "cron:abc123",
+            "hook:default:1",
+            "subagent:xyz",
+            "channel:general",
+            "dashboard_chat-1-123",
+            "cron_abc123",
+            "",
+            "slackish:1.2",
+            "slackish_1.2",
+        ):
+            assert not is_channel_session_key(key), key
+
+    def test_namespace_of(self) -> None:
+        assert channel_namespace_of("slack:1.2") == "slack"
+        assert channel_namespace_of("teams:a:direct:b") == "teams"
+        assert channel_namespace_of("cron:x") == ""
+
+    def test_labels(self) -> None:
+        assert channel_slots.channel_label("slack:1.2") == "Slack"
+        assert channel_slots.channel_label("wecom:a:direct:b") == "WeCom"
+        assert channel_slots.channel_label("dashboard:chat-1") == "Channel"
+
+
+class TestEligibility:
+    def test_dashboard_and_cron_sessions_are_never_eligible(self) -> None:
+        sessions = [_session("dashboard:chat-1-1"), _session("cron:abc")]
+        out = channel_slots.eligible_channel_sessions(sessions, metadata={}, cutoff=None)
+        assert out == []
+
+    def test_recent_channel_session_is_eligible(self) -> None:
+        sessions = [_session("slack:1785370133.085469")]
+        out = channel_slots.eligible_channel_sessions(
+            sessions, metadata={}, cutoff=NOW - 1800
+        )
+        assert [s["key"] for s in out] == ["slack:1785370133.085469"]
+
+    def test_stale_channel_session_is_filtered(self) -> None:
+        sessions = [_session("slack:1.1", modified=NOW - 7200)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions, metadata={}, cutoff=NOW - 1800
+        )
+        assert out == []
+
+    def test_zero_window_disables_recency_filter(self) -> None:
+        sessions = [_session("slack:1.1", modified=NOW - 999999)]
+        out = channel_slots.eligible_channel_sessions(sessions, metadata={}, cutoff=None)
+        assert len(out) == 1
+
+    def test_pinned_survives_the_window(self) -> None:
+        sessions = [_session("slack:1.1", modified=NOW - 7200)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions, metadata={"slack:1.1": {"pinned": True}}, cutoff=NOW - 1800
+        )
+        assert len(out) == 1
+
+    def test_foldered_survives_the_window(self) -> None:
+        sessions = [_session("slack:1.1", modified=NOW - 7200)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions, metadata={"slack:1.1": {"folder_id": "f1"}}, cutoff=NOW - 1800
+        )
+        assert len(out) == 1
+
+    def test_closed_on_the_channel_key_is_never_resurfaced(self) -> None:
+        """Closing the tab must stick — otherwise the next pass undoes it."""
+        sessions = [_session("slack:1.1")]
+        out = channel_slots.eligible_channel_sessions(
+            sessions, metadata={"slack:1.1": {"closed": True}}, cutoff=NOW - 1800
+        )
+        assert out == []
+
+    def test_closed_on_the_slot_key_is_never_resurfaced(self) -> None:
+        """Closing the TAB writes `closed` to the slot key, not the channel key.
+
+        Reading only the channel key is why a closed tab would reopen on the
+        next 30s pass — the exact defect this asserts against.
+        """
+        sessions = [_session("slack:1.1")]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"closed": True}},
+            cutoff=NOW - 1800,
+        )
+        assert out == []
+
+    def test_pinned_on_the_slot_key_survives_the_window(self) -> None:
+        sessions = [_session("slack:1.1", modified=NOW - 7200)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"pinned": True}},
+            cutoff=NOW - 1800,
+        )
+        assert len(out) == 1
+
+    def test_ephemeral_on_the_slot_key_is_skipped(self) -> None:
+        sessions = [_session("slack:1.1")]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"memory_mode": "incognito"}},
+            cutoff=None,
+        )
+        assert out == []
+
+    def test_slot_history_key_derivation(self) -> None:
+        assert channel_slots.channel_slot_name("slack:1.1") == "slack_1.1"
+        assert channel_slots.slot_history_key("slack:1.1") == "dashboard:slack_1.1"
+
+    def test_closed_beats_pinned(self) -> None:
+        sessions = [_session("slack:1.1")]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"slack:1.1": {"closed": True, "pinned": True}},
+            cutoff=None,
+        )
+        assert out == []
+
+    @pytest.mark.parametrize("mode", ["incognito", "temporary", "INCOGNITO"])
+    def test_ephemeral_threads_are_skipped(self, mode: str) -> None:
+        sessions = [_session("slack:1.1")]
+        out = channel_slots.eligible_channel_sessions(
+            sessions, metadata={"slack:1.1": {"memory_mode": mode}}, cutoff=None
+        )
+        assert out == []
+
+    @pytest.mark.parametrize("mode", ["incognito", "temporary"])
+    def test_ephemeral_detected_from_listing_too(self, mode: str) -> None:
+        """The listing carries memory_mode as well; either source disqualifies."""
+        sessions = [_session("slack:1.1", memory_mode=mode)]
+        out = channel_slots.eligible_channel_sessions(sessions, metadata={}, cutoff=None)
+        assert out == []
+
+
+class TestSurfaceChannelSession:
+    def test_creates_slot_seeded_with_the_conversation(self, dashboard_state: Any) -> None:
+        slot = channel_slots.surface_channel_session(
+            dashboard_state,
+            _session("slack:1785370133.085469", title="Ship the thing"),
+            {},
+            [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}],
+        )
+        assert slot is not None
+        # Deterministic name = the session key folded to the filename charset.
+        assert slot.key == "slack_1785370133.085469"
+        assert slot.title == "Ship the thing"
+        assert [m["content"] for m in slot.messages] == ["hi", "hello"]
+
+    def test_does_not_bind_to_the_channel_session_key(self, dashboard_state: Any) -> None:
+        """One history key only.
+
+        `_save_slot_to_history` always writes `dashboard:<slot.key>`. Binding the
+        RUN path to the channel key would split the conversation across two
+        transcripts and send the `closed` flag to a key the reconciler never
+        reads, so a closed tab would reopen.
+        """
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("slack:1.1"), {}, []
+        )
+        assert slot is not None
+        assert slot.linked_session_key == ""
+
+    def test_untitled_session_falls_back_to_the_channel_label(
+        self, dashboard_state: Any
+    ) -> None:
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("teams:a:direct:b"), {}, []
+        )
+        assert slot is not None
+        assert slot.title == "Teams"
+        assert slot._titled is False
+
+    def test_is_idempotent(self, dashboard_state: Any) -> None:
+        info = _session("slack:1.1", title="T")
+        first = channel_slots.surface_channel_session(dashboard_state, info, {}, [])
+        second = channel_slots.surface_channel_session(dashboard_state, info, {}, [])
+        assert first is not None
+        assert second is None, "second pass must be a no-op"
+        assert len(dashboard_state._slots) == 1
+
+    def test_leaves_an_existing_slot_untouched(self, dashboard_state: Any) -> None:
+        """A slot restored from open_slots.json already owns its transcript —
+        re-hydrating would duplicate messages on top of it."""
+        existing = dashboard_state.get_or_create_slot(name="slack_1.1")
+        existing.append("user", "already here", "msg msg-u", broadcast=False)
+        existing.drain()
+        assert (
+            channel_slots.surface_channel_session(
+                dashboard_state,
+                _session("slack:1.1"),
+                {},
+                [{"role": "user", "content": "should not be duplicated"}],
+            )
+            is None
+        )
+        assert [m["content"] for m in existing.messages] == ["already here"]
+
+    def test_ignores_non_channel_keys(self, dashboard_state: Any) -> None:
+        assert (
+            channel_slots.surface_channel_session(
+                dashboard_state, _session("dashboard:chat-1-1"), {}, []
+            )
+            is None
+        )
+        assert dashboard_state._slots == {}
+
+    def test_applies_metadata(self, dashboard_state: Any) -> None:
+        slot = channel_slots.surface_channel_session(
+            dashboard_state,
+            _session("slack:1.1"),
+            {
+                "agent": "kirocrew",
+                "model": "claude-opus-5",
+                "workspace": "default",
+                "project": "p1",
+                "folder_id": "f1",
+                "pinned": True,
+                "created_at": "2026-07-30T00:00:00Z",
+            },
+            [],
+        )
+        assert slot is not None
+        assert slot.agent == "kirocrew"
+        assert slot.model == "claude-opus-5"
+        assert slot.project == "p1"
+        assert slot.folder_id == "f1"
+        assert slot.pinned is True
+        assert slot.created_at == "2026-07-30T00:00:00Z"
+
+    def test_redacts_titles_and_messages(self, dashboard_state: Any) -> None:
+        slot = channel_slots.surface_channel_session(
+            dashboard_state,
+            _session("slack:1.1", title="key AKIAIOSFODNN7EXAMPLE"),
+            {},
+            [{"role": "assistant", "content": "token AKIAIOSFODNN7EXAMPLE"}],
+        )
+        assert slot is not None
+        assert "AKIAIOSFODNN7EXAMPLE" not in slot.title
+        assert "AKIAIOSFODNN7EXAMPLE" not in slot.messages[0]["content"]
+
+
+class _FakeLog:
+    def __init__(self, sessions: list[dict[str, Any]], meta: dict[str, dict[str, Any]]) -> None:
+        self._sessions = sessions
+        self._meta = meta
+        self.message_reads: list[str] = []
+        #: key -> transcript. Unset keys read empty, so the reconciler's
+        #: slot-key-then-channel-key preference order is observable.
+        self.transcripts: dict[str, list[dict[str, Any]]] = {
+            s["key"]: [{"role": "user", "content": f"msg for {s['key']}"}] for s in sessions
+        }
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        return list(self._sessions)
+
+    def get_metadata(self, key: str) -> dict[str, Any]:
+        return dict(self._meta.get(key, {}))
+
+    def read_messages(self, key: str) -> list[dict[str, Any]]:
+        self.message_reads.append(key)
+        return list(self.transcripts.get(key, []))
+
+
+class TestReconcilePass:
+    def test_surfaces_eligible_and_pushes_once(self, dashboard_state: Any) -> None:
+        dashboard_state.conversation_log = _FakeLog(
+            [
+                _session("slack:1.1"),
+                _session("discord:a:direct:b"),
+                _session("dashboard:chat-1-1"),
+                _session("slack:2.2", modified=NOW - 99999),
+            ],
+            {},
+        )
+        pushes: list[int] = []
+        dashboard_state.push_slots_update = lambda: pushes.append(1)  # type: ignore[method-assign]
+
+        n = asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert n == 2
+        assert set(dashboard_state._slots) == {"slack_1.1", "discord_a_direct_b"}
+        # get_or_create_slot broadcasts on create; the pass adds a final push so
+        # a rebind-only pass (no create) still reaches connected clients.
+        assert pushes, "the pass must broadcast the new slots"
+
+    def test_a_closed_tab_is_not_reopened_by_the_next_pass(
+        self, dashboard_state: Any
+    ) -> None:
+        """End-to-end guard for the reopen defect: `closed` lives on the SLOT key."""
+        dashboard_state.conversation_log = _FakeLog(
+            [_session("slack:1.1")], {"dashboard:slack_1.1": {"closed": True}}
+        )
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
+        assert dashboard_state._slots == {}
+
+    def test_seeds_from_both_transcripts_merged(self, dashboard_state: Any) -> None:
+        """Neither side is a superset: the slot holds dashboard replies, the channel
+        holds anything said on the channel after surfacing. Re-surfacing needs both."""
+        log = _FakeLog([_session("slack:1.1")], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "on slack first", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "user", "content": "on slack later", "ts": "2026-07-30T00:03:00Z"},
+        ]
+        log.transcripts["dashboard:slack_1.1"] = [
+            {"role": "user", "content": "on slack first", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "user", "content": "from the dashboard", "ts": "2026-07-30T00:01:00Z"},
+        ]
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert [m["content"] for m in dashboard_state._slots["slack_1.1"].messages] == [
+            "on slack first",
+            "from the dashboard",
+            "on slack later",
+        ]
+
+
+@contextmanager
+def _tz(name: str) -> Iterator[None]:
+    """Run the block with the process's local timezone set to *name*.
+
+    ``datetime.astimezone()`` on a naive value reads the process zone, which is
+    precisely what makes an un-suffixed channel timestamp ambiguous.
+    """
+    prev = os.environ.get("TZ")
+    os.environ["TZ"] = name
+    time.tzset()
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = prev
+        time.tzset()
+
+
+#: ``time.tzset`` is Unix-only, and CI also runs the backend suite on Windows.
+_needs_tzset = pytest.mark.skipif(not hasattr(time, "tzset"), reason="time.tzset() is Unix-only")
+
+
+class TestMergeTranscriptTimezones:
+    """The two sides of a merge do not agree on timezone.
+
+    The dashboard writes ISO-8601 UTC; a channel turn can arrive as a naive
+    local-time string. Comparing those as text interleaves them wrongly by the
+    host's UTC offset, so ordering has to run on absolute instants.
+    """
+
+    @_needs_tzset
+    def test_naive_local_and_utc_interleave_chronologically(self) -> None:
+        # 12:30 in a UTC-07:00 zone is 19:30Z — later than 19:00Z, even though
+        # "2026-07-30T12:30:00" sorts BEFORE "2026-07-30T19:00:00+00:00".
+        slot = [{"role": "assistant", "content": "utc reply", "ts": "2026-07-30T19:00:00+00:00"}]
+        chan = [{"role": "user", "content": "naive local", "ts": "2026-07-30T12:30:00"}]
+        with _tz("US/Pacific"):
+            out = channel_slots.merge_transcripts(slot, chan)
+        assert [m["content"] for m in out] == ["utc reply", "naive local"]
+
+    def test_lexicographic_order_would_have_been_wrong(self) -> None:
+        """Pin the regression: text order disagrees with chronological order."""
+        naive, utc = "2026-07-30T12:30:00", "2026-07-30T19:00:00+00:00"
+        assert naive < utc, "if this stops holding the test above proves nothing"
+
+    def test_zulu_and_offset_spellings_of_one_instant_are_ordered_together(self) -> None:
+        slot = [{"role": "user", "content": "second", "ts": "2026-07-30T00:00:01+00:00"}]
+        chan = [{"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}]
+        out = channel_slots.merge_transcripts(slot, chan)
+        assert [m["content"] for m in out] == ["first", "second"]
+
+    def test_unparseable_timestamps_sort_before_untimestamped_and_keep_order(self) -> None:
+        chan = [
+            {"role": "user", "content": "none"},
+            {"role": "user", "content": "junk-b", "ts": "not-a-date-b"},
+            {"role": "user", "content": "real", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "user", "content": "junk-a", "ts": "not-a-date-a"},
+        ]
+        out = channel_slots.merge_transcripts([], chan)
+        assert [m["content"] for m in out] == ["real", "junk-a", "junk-b", "none"]
+
+
+class TestFrozenPrefixAccounting:
+    """A seeded slot must declare how much of its history file it did NOT load.
+
+    ``_save_slot_to_history`` writes ``frozen prefix + serialize(window)``. Left
+    at 0, the first save re-emits the omitted older lines AFTER the newer ones.
+    """
+
+    def _slot_msgs(self, n: int) -> list[dict[str, Any]]:
+        return [
+            {"role": "user", "content": f"m{i}", "ts": f"2026-07-30T00:{i:02d}:00Z"}
+            for i in range(n)
+        ]
+
+    def test_short_transcript_has_no_prefix(self) -> None:
+        msgs = self._slot_msgs(3)
+        assert channel_slots.frozen_prefix_len(msgs, channel_slots.hydrate_window(msgs)) == 0
+
+    def test_counts_only_the_lines_the_window_omits(self) -> None:
+        msgs = self._slot_msgs(channel_slots._HYDRATE_LIMIT + 12)
+        window = channel_slots.hydrate_window(msgs)
+        assert len(window) == channel_slots._HYDRATE_LIMIT
+        assert channel_slots.frozen_prefix_len(msgs, window) == 12
+
+    def test_channel_only_window_freezes_the_whole_file(self) -> None:
+        """No slot line survived into the window → every one of them is prefix."""
+        msgs = self._slot_msgs(4)
+        assert channel_slots.frozen_prefix_len(msgs, [{"role": "user", "content": "x"}]) == 4
+
+    def test_empty_file_has_no_prefix(self) -> None:
+        assert channel_slots.frozen_prefix_len([], [{"role": "user", "content": "x"}]) == 0
+
+    def test_seeded_slot_reports_the_prefix_and_only_its_own_disk_lines(
+        self, dashboard_state: Any
+    ) -> None:
+        """End-to-end: an over-long slot file plus later channel turns.
+
+        ``_disk_window_len`` must count the slot's OWN persisted lines only —
+        crediting the merged channel turns would let a trim fold turns that were
+        never written into the frozen prefix.
+        """
+        over = 7
+        slot_msgs = self._slot_msgs(channel_slots._HYDRATE_LIMIT + over)
+        log = _FakeLog([_session("slack:1.1")], {})
+        log.transcripts["dashboard:slack_1.1"] = slot_msgs
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "said on slack after", "ts": "2026-07-30T23:00:00Z"}
+        ]
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        slot = dashboard_state._slots["slack_1.1"]
+        # The channel turn is newest, so it takes the last window seat and one
+        # more slot line drops into the prefix.
+        assert slot._disk_older_count == over + 1
+        assert slot._disk_window_len == len(slot_msgs) - (over + 1)
+        assert slot._disk_older_count + slot._disk_window_len == len(slot_msgs)
+        assert len(slot.messages) == channel_slots._HYDRATE_LIMIT
+        assert slot.messages[-1]["content"] == "said on slack after"
+
+    def test_empty_content_lines_are_not_seeded_but_still_counted(self) -> None:
+        """A blank on-disk line is never appended, so it belongs to the prefix."""
+        msgs = [
+            {"role": "user", "content": "", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "user", "content": "kept", "ts": "2026-07-30T00:01:00Z"},
+        ]
+        window = channel_slots.hydrate_window(msgs)
+        assert [m["content"] for m in window] == ["kept"]
+        assert channel_slots.frozen_prefix_len(msgs, window) == 1
+
+
+class TestMergeTranscripts:
+    def test_orders_by_timestamp_across_sources(self) -> None:
+        slot = [{"role": "user", "content": "b", "ts": "2026-07-30T00:02:00Z"}]
+        chan = [
+            {"role": "user", "content": "a", "ts": "2026-07-30T00:01:00Z"},
+            {"role": "user", "content": "c", "ts": "2026-07-30T00:03:00Z"},
+        ]
+        out = channel_slots.merge_transcripts(slot, chan)
+        assert [m["content"] for m in out] == ["a", "b", "c"]
+
+    def test_drops_duplicates_already_copied_into_the_slot(self) -> None:
+        msg = {"role": "user", "content": "same", "ts": "2026-07-30T00:01:00Z"}
+        out = channel_slots.merge_transcripts([dict(msg)], [dict(msg)])
+        assert len(out) == 1
+
+    def test_keeps_same_text_at_different_times(self) -> None:
+        out = channel_slots.merge_transcripts(
+            [{"role": "user", "content": "ping", "ts": "2026-07-30T00:01:00Z"}],
+            [{"role": "user", "content": "ping", "ts": "2026-07-30T00:09:00Z"}],
+        )
+        assert len(out) == 2
+
+    def test_untimestamped_messages_sort_last_and_keep_order(self) -> None:
+        out = channel_slots.merge_transcripts(
+            [{"role": "user", "content": "no ts 1"}, {"role": "user", "content": "no ts 2"}],
+            [{"role": "user", "content": "has ts", "ts": "2026-07-30T00:01:00Z"}],
+        )
+        assert [m["content"] for m in out] == ["has ts", "no ts 1", "no ts 2"]
+
+    def test_empty_sources(self) -> None:
+        assert channel_slots.merge_transcripts([], []) == []
+
+
+class TestReconcileMore:
+
+    def test_second_pass_is_a_no_op_and_reads_no_transcripts(
+        self, dashboard_state: Any
+    ) -> None:
+        log = _FakeLog([_session("slack:1.1")], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        log.message_reads.clear()
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
+        assert log.message_reads == [], "steady state must not re-read transcripts"
+
+    def test_works_on_stem_form_keys_as_served_by_list_sessions(
+        self, dashboard_state: Any
+    ) -> None:
+        dashboard_state.conversation_log = _FakeLog(
+            [_session("slack_1785370133.085469"), _session("dashboard_chat-1-1")], {}
+        )
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        slot = dashboard_state._slots["slack_1785370133.085469"]
+        assert slot.linked_session_key == "", "one history key only"
+
+    def test_no_conversation_log_is_a_no_op(self, dashboard_state: Any) -> None:
+        dashboard_state.conversation_log = None
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
+
+    def test_list_sessions_failure_is_swallowed(self, dashboard_state: Any) -> None:
+        class Boom:
+            def list_sessions(self) -> list[dict[str, Any]]:
+                raise OSError("disk gone")
+
+        dashboard_state.conversation_log = Boom()
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
+
+    def test_one_bad_session_does_not_block_the_others(
+        self, dashboard_state: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dashboard_state.conversation_log = _FakeLog(
+            [_session("slack:1.1"), _session("slack:2.2")], {}
+        )
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        real = channel_slots.surface_channel_session
+
+        def flaky(
+            state: Any, info: dict[str, Any], meta: Any, msgs: Any, **kw: Any
+        ) -> Any:
+            if info["key"] == "slack:1.1":
+                raise RuntimeError("boom")
+            return real(state, info, meta, msgs, **kw)
+
+        monkeypatch.setattr(channel_slots, "surface_channel_session", flaky)
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert "slack_2.2" in dashboard_state._slots

--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -2796,6 +2796,8 @@
       "include_untagged_sessions": "Include untagged sessions",
       "incognito_no_memory_writes": "Incognito — no memory writes",
       "linked_to_slack": "Linked to Slack",
+      "copied_from_channel": "Copied from {{channel}} — replies stay here",
+      "copied_from_direct_message": "Copied from a direct message — replies stay here",
       "load_more": "Load more…",
       "manage_tags": "Manage tags…",
       "manage_tags_2": "Manage Tags",

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -2807,6 +2807,8 @@
       "include_untagged_sessions": "包含无标签的会话",
       "incognito_no_memory_writes": "隐身 — 不写入记忆",
       "linked_to_slack": "已关联 Slack",
+      "copied_from_channel": "已从 {{channel}} 复制 — 回复将保留在此处",
+      "copied_from_direct_message": "已从私信复制 — 回复将保留在此处",
       "load_more": "加载更多…",
       "manage_tags": "管理标签…",
       "manage_tags_2": "管理标签",

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -22,6 +22,7 @@ import { computeReorderedFolders } from '../utils/reorderFolders'
 import { computeRecentRank, recencyTintShadow, clampTintCount } from '../utils/recencyTint'
 import { computeActiveSubtree, folderIsHidden, folderOffersHide } from '../utils/folderVisibility'
 import { groupHistoryByFolder } from '../utils/groupHistoryByFolder'
+import { slotChannelLabel, slotChannelNamespace } from '../utils/channelOrigin'
 import { SearchInput, Input, Btn, IconButton, IconButtonGroup } from '../components/ui'
 import { useProvider } from '../providers'
 import ModelDropdownList from '../components/ModelDropdownList'
@@ -1941,6 +1942,19 @@ function ChatSidebar({
                 <motion.span key={agentName || 'empty'} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.15 }} className="truncate">{agentName || '\u00A0'}</motion.span>
               </AnimatePresence>
               {isOut && <span className="text-accent" title={i18nT('pages.chatSidebar.popped_out_to_a_separate_window')}><ExternalLink size={10} /></span>}
+              {slotChannelNamespace(s.key) && (() => {
+                // Distinct from the `Link` glyph above (`linked_to_slack`), which
+                // means live two-way mirroring. This one is a one-time copy: the
+                // conversation started on that channel, replies stay here.
+                //
+                // `unified` gets its own key rather than an interpolated label:
+                // it has no proper noun, and an English article fragment inside
+                // a translated sentence is not something a locale can repair.
+                const label = slotChannelNamespace(s.key) === 'unified'
+                  ? i18nT('pages.chatSidebar.copied_from_direct_message')
+                  : i18nT('pages.chatSidebar.copied_from_channel', { channel: slotChannelLabel(s.key) })
+                return <span className="text-muted shrink-0" title={label} aria-label={label}><MessageSquare size={10} /></span>
+              })()}
               {s.slack_linked && <span className="text-[10px]" title={i18nT('pages.chatSidebar.linked_to_slack')}><Link size={10} /></span>}
               {s.clean_mode
                 ? <span className="text-accent" title={i18nT('pages.chatSidebar.clean_agent_only_no_kirocrew_context_or_mcp')}><Droplet size={10} /></span>

--- a/website/src/utils/channelOrigin.test.ts
+++ b/website/src/utils/channelOrigin.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { slotChannelLabel, slotChannelNamespace } from './channelOrigin'
+
+describe('slotChannelLabel', () => {
+  it('labels every channel namespace', () => {
+    expect(slotChannelLabel('slack:1785370133.085469')).toBe('Slack')
+    expect(slotChannelLabel('discord:kirocrew:direct:U1')).toBe('Discord')
+    expect(slotChannelLabel('telegram:kirocrew:direct:U1')).toBe('Telegram')
+    expect(slotChannelLabel('whatsapp:kirocrew:direct:U1')).toBe('WhatsApp')
+    expect(slotChannelLabel('webex:kirocrew:direct:U1')).toBe('Webex')
+    expect(slotChannelLabel('wecom:kirocrew:direct:U1')).toBe('WeCom')
+    expect(slotChannelLabel('teams:kirocrew:direct:U1')).toBe('Teams')
+    expect(slotChannelLabel('weixin:kirocrew:direct:U1')).toBe('Weixin')
+    expect(slotChannelLabel('unified:kirocrew')).toBe('Direct message')
+  })
+
+  it('labels the persisted filename-stem form too', () => {
+    // list_sessions() reports the stem, where history._safe_key folded ':' -> '_'.
+    expect(slotChannelLabel('slack_1785370133.085469')).toBe('Slack')
+    expect(slotChannelLabel('discord_kirocrew_direct_U1')).toBe('Discord')
+    expect(slotChannelLabel('unified_kirocrew')).toBe('Direct message')
+  })
+
+  it('returns empty for non-channel producers so no glyph renders', () => {
+    expect(slotChannelLabel('cron:abc123')).toBe('')
+    expect(slotChannelLabel('cron_abc123')).toBe('')
+    expect(slotChannelLabel('hook:default:1')).toBe('')
+    expect(slotChannelLabel('subagent:xyz')).toBe('')
+    expect(slotChannelLabel('dashboard:chat-1-1')).toBe('')
+    expect(slotChannelLabel('dashboard_chat-1-1')).toBe('')
+    expect(slotChannelLabel('channel:general')).toBe('')
+  })
+
+  it('returns empty for an unlinked slot', () => {
+    expect(slotChannelLabel(undefined)).toBe('')
+    expect(slotChannelLabel('')).toBe('')
+  })
+
+  it('does not match a namespace by prefix alone', () => {
+    expect(slotChannelLabel('slackish:1.2')).toBe('')
+  })
+
+  it('is case-sensitive so a user-titled session is not mislabelled', () => {
+    // A title-derived slot name like "Slack thread triage" folds to
+    // "Slack_thread_triage" — capital S, so it is NOT channel-origin.
+    expect(slotChannelLabel('Slack_thread_triage')).toBe('')
+    expect(slotChannelLabel('Teams_sync_notes')).toBe('')
+  })
+})
+
+describe('slotChannelNamespace', () => {
+  it('returns the namespace for both key separators', () => {
+    expect(slotChannelNamespace('slack:1785370133.085469')).toBe('slack')
+    expect(slotChannelNamespace('slack_1785370133.085469')).toBe('slack')
+    expect(slotChannelNamespace('discord:bot:direct:u1')).toBe('discord')
+  })
+
+  it('singles out unified, which has no proper-noun label to interpolate', () => {
+    // The tooltip routes this namespace to its own locale key so a translated
+    // sentence never has to embed the English article form.
+    expect(slotChannelNamespace('unified:kirocrew')).toBe('unified')
+    expect(slotChannelNamespace('unified_kirocrew')).toBe('unified')
+  })
+
+  it('returns empty for dashboard sessions and non-channel keys', () => {
+    expect(slotChannelNamespace('dashboard:chat-1-1')).toBe('')
+    expect(slotChannelNamespace('slackish:1.2')).toBe('')
+    expect(slotChannelNamespace('Slack_thread_triage')).toBe('')
+    expect(slotChannelNamespace(undefined)).toBe('')
+    expect(slotChannelNamespace('')).toBe('')
+  })
+
+  it('agrees with slotChannelLabel on what counts as channel-origin', () => {
+    for (const key of ['slack:1.1', 'unified_kirocrew', 'dashboard:chat-1', 'Slack_x', '']) {
+      expect(Boolean(slotChannelNamespace(key))).toBe(Boolean(slotChannelLabel(key)))
+    }
+  })
+})

--- a/website/src/utils/channelOrigin.ts
+++ b/website/src/utils/channelOrigin.ts
@@ -1,0 +1,61 @@
+/**
+ * Channel-origin helpers for chat slots.
+ *
+ * When the backend surfaces a conversation that started on Slack/Discord/Teams
+ * (etc.), it mints the slot key FROM that channel's session key
+ * (`slack:1785370133.085469` -> `slack_1785370133.085469`), deterministically.
+ * The key is therefore the record of where the conversation started, and it
+ * survives every restore path for free because it is the slot's identity — no
+ * extra payload field is needed.
+ *
+ * Mirrors `CHANNEL_SESSION_NAMESPACES` in `src/kiro_crew/messaging/link.py`.
+ * Keep the two lists in sync.
+ */
+
+/** Display label per channel namespace. */
+const CHANNEL_LABELS: Record<string, string> = {
+  slack: 'Slack',
+  discord: 'Discord',
+  telegram: 'Telegram',
+  whatsapp: 'WhatsApp',
+  webex: 'Webex',
+  wecom: 'WeCom',
+  teams: 'Teams',
+  weixin: 'Weixin',
+  unified: 'Direct message',
+}
+
+/**
+ * Return the channel namespace a slot originated from, or `''` for an ordinary
+ * dashboard session.
+ *
+ * Callers that need to vary a SENTENCE by channel want this rather than the
+ * label: `unified` has no proper noun to interpolate, and an English fragment
+ * injected into a translated string cannot be fixed by the translation.
+ */
+export function slotChannelNamespace(slotKey?: string): string {
+  if (!slotKey) return ''
+  for (const ns of Object.keys(CHANNEL_LABELS)) {
+    if (slotKey.startsWith(`${ns}:`) || slotKey.startsWith(`${ns}_`)) {
+      return ns
+    }
+  }
+  return ''
+}
+
+/**
+ * Return the display label of the channel a slot originated from, or `''` for an
+ * ordinary dashboard session.
+ *
+ * Match is case-sensitive on purpose: the backend always mints these keys
+ * lowercase, so a user-titled session like `Slack_thread_triage` (capital S,
+ * from the title-derived slot name) is correctly NOT labelled as channel-origin.
+ *
+ * Accepts both separators — a live session key uses `slack:<ts>` while a slot
+ * key and the persisted session index use `slack_<ts>` (the history layer folds
+ * `:` to `_`).
+ */
+export function slotChannelLabel(slotKey?: string): string {
+  const ns = slotChannelNamespace(slotKey)
+  return ns ? CHANNEL_LABELS[ns] : ''
+}


### PR DESCRIPTION
## Problem

A conversation you start with the agent from Slack (or Discord/Telegram/Teams/Webex/WeCom/Weixin) never shows up in the dashboard's chat list. It persists fine — under a channel-namespaced session key like `slack:1785370133.085469` — but the only way to reach it from the dashboard is to expand the sidebar's collapsed **History** pane, search for it, and resume it by hand.

Both slot-restore paths ignore those sessions outright. `restore_recent_sessions` skips any key that is not `dashboard:`/`dashboard_`-prefixed, and `restore_open_slots` only replays keys already in `open_slots.json`. So a channel conversation can never enter the active chat list on its own, no matter how recent it is.

## Why it matters

Slack is a first-class entry point for the agent, but the work you start there is second-class once you sit down at the dashboard: it's buried in history, indistinguishable from months-old archived sessions, and easy to lose track of entirely. The natural workflow — kick something off from your phone in Slack, then pick it up on the dashboard with a real editor and a full transcript — requires you to know the session exists and go digging for it.

## Fix (symptoms → root cause → change)

**Symptom:** channel conversations are absent from the chat list and only reachable via History search.

**Root cause:** nothing in the dashboard ever creates a slot for a channel-namespaced session. The two restore paths are both keyed on the `dashboard:` namespace, and no channel transport asks the dashboard to make one (unlike cron, which calls `inject_cron_result_to_dashboard` to build a `cron-<id>` slot bound to `cron:<id>`).

**Change** — a reconciler that gives channel sessions the same treatment cron already gets:

- **New `dashboard/channel_slots.py`.** `reconcile_channel_slots()` walks the session index, filters to channel sessions worth surfacing, and creates a slot per session hydrated from its transcript. `channel_slot_reconciler()` runs it at gateway startup and every 30s after, so a thread started while the dashboard is already open appears without a restart. Every filesystem read is offloaded to an executor; only the in-memory slot mutations run on the loop, so `state._slots` is never touched from a worker thread.
- **One history key, no split.** The slot is an ordinary dashboard slot whose key is derived from the channel session key (`slack:1785370133.085469` -> `slack_1785370133.085469`), so everything about it — turn persistence, replay, the `closed` flag, and both restore paths — agrees on the single `dashboard:<slot.key>` history key. It deliberately does **not** set `linked_session_key` to the channel key: `_save_slot_to_history` is hard-wired to `_history_key_for(slot.key)`, so binding the run path to the channel key while the save path kept writing `dashboard:<slot.key>` would split one conversation across two transcripts *and* send a closed tab's `closed` flag to a key the reconciler never reads — so the tab would reopen 30s later. (Caught by GPT 5.6 review on rev 1; see the disposition comment.)
- **Eligibility rules** (pure + directly tested in `eligible_channel_sessions`): recency-bounded by the existing `dashboard.restore_window_minutes` so a long DM history doesn't become hundreds of tabs; pinned/foldered exempt from the window; `incognito`/`temporary` threads skipped, because a durable sidebar tab contradicts an ephemeral conversation. `closed`, `pinned` and `memory_mode` are read from **both** the channel key and the slot key, since closing a tab records `closed` against the slot key.
- **Idempotent + restart-safe.** Slot names are the deterministic folded key, so repeat passes are no-ops and an already-present slot is never re-hydrated on top of its own transcript. Re-surfacing seeds from **both** transcripts merged by timestamp (`merge_transcripts`, deduped on `(role, content, ts)`) — neither side is a superset: the slot holds dashboard replies, the channel holds anything said on the channel after the conversation was first surfaced.
- **Persistence accounting for a seeded slot** (added in rev 3, from two blocking GPT 5.6 findings). `_save_slot_to_history` models a session file as *frozen prefix + live window*: it copies the first `_disk_older_count` on-disk lines verbatim, then re-serializes the window after them. Seeding only the last 50 messages of a longer transcript while leaving that count at `0` told the next save the file had no prefix, so the omitted older lines were re-emitted **after** newer ones. `frozen_prefix_len()` now derives the boundary positionally — every slot line before the first one the window carries — and `hydrate_window()` is the single definition of what gets seeded (empty-content filter, then the tail cap) so the arithmetic cannot drift from the loop it has to match. `_disk_window_len` was wrong in the same place and is fixed with it: it counted merged channel turns that were never in this slot's file, and since it is the watermark that licenses a trim to fold a leading window message into the frozen prefix, over-counting it would let a trim credit turns that are not on disk.
- **Timestamp ordering is normalized, not lexicographic** (second blocking GPT 5.6 finding). The two sides of a merge are written by different code paths and nothing makes them agree on timezone — the dashboard writes ISO-8601 UTC, a channel turn can land naive local. `_ts_sort_key()` parses to an absolute instant (naive read as host-local, since that is what `datetime.now()` emits), with parse failures and missing values bucketed so they cannot pollute the ordered region.
- **`messaging/link.py`** gains `CHANNEL_SESSION_NAMESPACES` / `is_channel_session_key()` / `channel_namespace_of()` as the single definition of "this session came from a channel". These accept both the live `slack:<ts>` form and the persisted `slack_<ts>` filename stem. `autonudge._CHANNEL_KEY_PREFIXES` is left alone and commented as a deliberately narrower set (only nudge-capable transports).
- **New `dashboard.surface_channel_sessions` config flag** (default `true`) to turn the behaviour off. Note it is independent of `restore_sessions`: that flag governs restoring *tabs at startup*, while this governs whether channel conversations are represented at all. `restore_window_minutes` now also gates channel surfacing, so its help string says so and `config-baseline.json` is regenerated (the baseline pins help text and `test_config_baseline.py` compares against it).
- **Sidebar (`ChatSidebar.tsx`)** renders a small `MessageSquare` glyph with a "Started on Slack" tooltip on channel-originated rows, reusing the exact visual language the History pane already uses, so a surfaced Slack thread is not indistinguishable from a dashboard chat. The tooltip is localized in en + zh-CN and worded to state the actual contract — "Copied from Slack — replies stay here" — so it cannot be read as the live two-way mirroring that the neighbouring `Link` glyph means. It uses **two** locale keys, not one interpolated string: `copied_from_channel` takes a proper-noun `{{channel}}`, while the `unified` (direct-message) namespace routes to its own fully translated `copied_from_direct_message` — an English article fragment injected into a translated sentence is not something a locale can repair. Routing needs the namespace rather than the label, so `slotChannelNamespace()` is the exported primitive and `slotChannelLabel()` is implemented on top of it, one prefix-matching loop, so the two cannot disagree about what counts as channel-origin. Provenance is read straight off `slot.key` — the reconciler mints that key *from* the channel session key, so the key **is** the provenance record and survives every restore path for free. No new payload field, no new persisted metadata. The match is case-sensitive so a title-derived slot name like `Slack_thread_triage` is correctly not labelled.
- **`security_posture.py`** registers the new module as a redaction sink. The channel transport is a separate egress boundary, so titles and hydrated transcript content are re-scanned before reaching the browser. (The registry's drift guard catches this — see Tests.)

## Tests

- **`test/test_channel_slots.py` — 50 new tests.**
  - Key predicates: all nine channel namespaces recognised in both `:` and `_` form; `dashboard:`/`cron:`/`hook:`/`subagent:`/`channel:` and prefix-only lookalikes (`slackish:`) rejected.
  - Eligibility: recent surfaces, stale filtered, `window=0` disables the filter, pinned/foldered survive the window, `closed` wins over pinned, `incognito`/`temporary` skipped from either metadata or listing.
  - Eligibility, slot-key side: `closed` / `pinned` / `incognito` honoured on the **slot** key too, plus the `channel_slot_name` / `slot_history_key` derivation.
  - Slot creation: correct deterministic key + title + seeded transcript; **no** channel binding is set (the rev-1 defect, asserted directly); untitled sessions fall back to the channel label; metadata applied; titles and messages redacted; idempotent on the second pass; non-channel keys ignored; an existing slot left untouched rather than re-hydrated.
  - `merge_transcripts`: cross-source timestamp ordering, duplicates dropped, same text at different times kept, untimestamped messages sorted last with stable order, empty sources.
  - Timezone normalization: a naive `12:30` in `US/Pacific` (= `19:30Z`) must sort **after** `19:00+00:00`, which is the exact pair the old lexicographic key got backwards — plus a second assertion pinning that text and chronological order genuinely disagree, so the first test cannot silently stop proving anything. `Z` and `+00:00` spellings of one instant order together; unparseable values keep their own bucket. (`time.tzset()` is Unix-only, so that one case skips on the Windows leg.)
  - Frozen-prefix accounting: short transcripts have no prefix; an over-long one counts exactly the omitted lines; a window carrying no slot line freezes the whole file; empty file; a blank on-disk line is not seeded but still counted. Plus an end-to-end reconcile asserting `disk_older + disk_window == len(slot file)` when a later channel turn takes the last window seat.
  - Reconcile pass: surfaces eligible only, broadcasts once per pass, **a closed tab is not reopened by the next pass** (end-to-end guard for the rev-1 defect), seeds from both transcripts merged, steady state re-reads no transcripts, works on stem-form keys as actually served, no-op without a conversation log, `list_sessions` failure swallowed, one bad session does not block the others.
- **`website/src/utils/channelOrigin.test.ts` — 10 new tests** covering both key forms, non-channel producers, the unlinked case, case-sensitivity, the `unified` namespace that routes to its own locale key, and a guard that `slotChannelNamespace()` and `slotChannelLabel()` always agree on what counts as channel-origin.
- **`test_security_posture.py`** (41 tests) is the pre-existing drift guard that *forced* the sink registration above — a new redactor call site cannot ship unclassified.

Local gates green on the final revision (targeted suites, isort, flake8, mypy, `tsc --noEmit`, vitest), and **all 44 CI checks pass** — every backend shard on 3.10/3.12/Windows, frontend, E2E, coverage, and all five AI reviewers.

Two failures seen along the way were pre-existing flakes in the shared suite, neither in code this diff touches, both green on re-run:
- `test_platform_compat.py::test_self_cmdline_mentions_python` — fails on `main` itself (run `30513396342`, commit `4d56815d`, same assertion), where `process_command_line(os.getpid())` returns `""`.
- `test_pid_lifecycle.py::test_untrack_session_pid` — hardcodes fake PIDs 111/222 and asserts the legacy two-field entry form, which only holds when those PIDs do not exist on the host. On one runner PID 222 *was* a live process, so the start-time identifier resolved and the three-field form was written instead. Environment-dependent, and worth a separate fix.

## Manual verification

Ran the worktree against an isolated `dev-backend.sh` gateway (own `KIROCREW_HOME`, port 6777, `restore_sessions: false` so the result is attributable to the reconciler alone), seeded two Slack threads and one Discord DM through the real `ConversationLog` API, and read back `GET /api/chat/slots`:

```
count 3
 - slack_1785370133.085469   | 'Surface Slack sessions on the dashboard' | linked= 'slack_1785370133.085469' | msgs= 2
 - slack_1785361002.114820   | 'Pipeline promotion blocked on alarm'     | linked= 'slack_1785361002.114820' | msgs= 2
 - discord_kirocrew_direct_U04LT9K2A | 'Weekend release notes'          | linked= 'discord_kirocrew_direct_U04LT9K2A' | msgs= 2
```

All three surfaced with their real titles and transcripts; the co-resident `dashboard_*` session was correctly left to the normal restore path. (Captured on rev 1, when the payload still carried a `linked_session_key`; rev 2 removes that field's use — the rows, titles and transcripts are unchanged.)

This run also caught a genuine bug that every synthetic fixture had hidden: `list_sessions()` returns the persisted **filename stem** (`slack_<ts>`), not the live `slack:<ts>` key, so the original colon-only predicate matched nothing in a real instance. Both key forms are now accepted and explicitly tested.

## Screenshots

**Not captured — stated honestly rather than approximated.** The dashboard render of the new sidebar rows is not included: the isolated dev gateway would not complete a browser auth exchange in this environment (the SPA held a terminal `/api/auth/refresh` backoff and never set an access cookie), so no authenticated dashboard frame could be produced. I did not want to substitute a mock or a hand-built page for real evidence.

What the visible change is backed by instead:
- The `/api/chat/slots` payload above is the exact data the sidebar renders — the rows, their titles, and their channel bindings are proven live.
- The only new pixels are one conditional 10px glyph plus tooltip on an existing row, gated entirely by the unit-tested pure helper `slotChannelLabel()`, and reusing the `MessageSquare` glyph the History pane already renders for these same sessions.

Happy to add a captured frame if a reviewer can point at a working local-auth path for a dev-backend instance.

