### PR TITLE
fix(gateway): name the process that actually holds gateway.lock

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -49,6 +49,7 @@ from kiro_crew.config.loader import (
 from kiro_crew.config.paths import _default_home, _legacy_home
 from kiro_crew.constants import env_flag_enabled
 from kiro_crew.crash_guard import install as _install_crash_guard
+from kiro_crew.dashboard.origin import parse_dashboard_url
 from kiro_crew.dashboard.state import set_build_info
 from kiro_crew.env import git_build_info
 from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
@@ -539,6 +540,29 @@ def _resolve_gateway_args(args: argparse.Namespace) -> dict:
         "approval_mode": approval,
         "test_mode": test_mode,
     }
+
+
+def _diagnostic_port(gw_kwargs: dict) -> int | None:
+    """The port a refused gateway would have bound, for lock-refusal diagnosis.
+
+    Mirrors the gateway's own resolution (``parse_dashboard_url`` on
+    ``dashboard.url``, with ``KIROCREW_PORT`` and then ``--port`` overriding it)
+    so the message can only ever name the port this process was about to bind.
+
+    ``None`` when there is no single answer -- ``--port auto`` picks an ephemeral
+    port and ``--slack-only`` binds nothing -- in which case the refusal message
+    omits every port claim rather than asserting one it cannot support.
+    """
+    if gw_kwargs.get("no_dashboard"):
+        return None
+    override = gw_kwargs.get("port_override")
+    if override is not None:
+        return None if str(override).lower() == "auto" else int(override)
+    try:
+        return parse_dashboard_url(KiroCrewConfig.load().dashboard.url)[1]
+    except Exception:
+        # Diagnosis only — never let it break the refusal path it decorates.
+        return None
 
 
 def _knowledge(args) -> None:
@@ -1841,9 +1865,12 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         _install_child_watcher()
         # Single-writer guard: refuse a second gateway bound to this
         # KIROCREW_HOME so two ConversationLog writers can never clobber the same
-        # session file. Held for the process lifetime; auto-released on death.
+        # session file. Held for the process lifetime; released by the kernel on
+        # death (POSIX record lock — see kiro_crew.gateway_lock). The port is
+        # passed for diagnosis only: on refusal it lets the error say whether the
+        # holder is answering on that port or is a wedged orphan squatting on it.
         try:
-            _gw_lock = GatewayLock(config_dir()).acquire()
+            _gw_lock = GatewayLock(config_dir(), port=_diagnostic_port(gw_kwargs)).acquire()
         except GatewayLockError as exc:
             print(f"👻 {exc}", file=sys.stderr)
             sys.exit(1)

--- a/src/kiro_crew/dashboard/port_reclaim.py
+++ b/src/kiro_crew/dashboard/port_reclaim.py
@@ -206,6 +206,28 @@ async def _terminate_pids(
     return await _wait_all_exited(pids, kill_wait, poll, _pid_exited)
 
 
+def _describe_holders(pids: list[int]) -> str:
+    """Render *pids* with their thread counts, for an actionable log line.
+
+    Thread count is what separates a running gateway (dozens of threads) from a
+    **wedged fork** of one -- a child forked before ``exec`` carries exactly the
+    one thread that called ``fork()``. By the time we get here the caller already
+    holds this home's ``gateway.lock``, so a single-threaded holder of the port
+    is provably an orphan of a dead gateway, and naming it is the whole
+    difference between a message a user can act on and one they cannot.
+    """
+    parts: list[str] = []
+    for pid in pids:
+        threads = platform_compat.process_thread_count(pid)
+        if threads is None:
+            parts.append(str(pid))
+        elif threads == 1:
+            parts.append(f"{pid} (1 thread — a wedged fork, not a gateway)")
+        else:
+            parts.append(f"{pid} ({threads} threads)")
+    return ", ".join(parts)
+
+
 async def reclaim_stale_gateway_port(
     port: int,
     *,
@@ -281,10 +303,10 @@ async def reclaim_stale_gateway_port(
 
     if not kiro_pids:
         log.error(
-            "Port %d is held by a non-KiroCrew process (pids %s) — refusing to "
+            "Port %d is held by a non-KiroCrew process (pid %s) — refusing to "
             "terminate it. Free the port or choose another with --port.",
             port,
-            listeners,
+            _describe_holders(listeners),
         )
         return FOREIGN_HOLDER
 
@@ -322,7 +344,7 @@ async def reclaim_stale_gateway_port(
         "Port %d is held by an unresponsive KiroCrew gateway (pid %s) left by an "
         "unclean exit — terminating it to reclaim the port.",
         port,
-        kiro_pids,
+        _describe_holders(kiro_pids),
     )
     ok = await terminate(kiro_pids)
     if ok:
@@ -330,8 +352,9 @@ async def reclaim_stale_gateway_port(
         return RECLAIMED
     log.error(
         "Failed to terminate stale gateway (pid %s) on port %d — you may need to "
-        "kill it manually (e.g. `sudo kirocrew stop`).",
-        kiro_pids,
+        "kill it manually: kill -9 %s",
+        _describe_holders(kiro_pids),
         port,
+        " ".join(str(p) for p in kiro_pids),
     )
     return RECLAIM_FAILED

--- a/src/kiro_crew/gateway_lock.py
+++ b/src/kiro_crew/gateway_lock.py
@@ -9,13 +9,33 @@ back newer on-disk content -- the dual-writer clobber that lost transcripts on
 This module enforces the single-writer invariant at the source: the gateway
 acquires an exclusive advisory ``flock`` on ``<home>/gateway.lock`` at startup
 and holds it for the process lifetime. A second gateway on the same home is
-refused with a message naming the incumbent pid.
+refused.
 
-``flock`` is the right primitive precisely because the kernel releases it when
-the holding process dies (clean exit, crash, or ``kill -9``). A crashed gateway
-therefore never wedges the home, and stale-lock reclaim is automatic -- there is
-no fragile pid-liveness check. The pid written into the file is purely
-informational, used only to name the holder in the refusal message.
+What ``flock`` does and does not guarantee
+-----------------------------------------
+``flock`` belongs to the open file *description*, so it is immune to a hazard
+that would otherwise be fatal here: an unrelated ``open()`` + ``close()`` of the
+lock path elsewhere in this process cannot release it. That matters because the
+gateway serves authenticated file reads over HTTP, and the lock file is inside
+the home those reads can reach. A POSIX record lock (``fcntl.lockf``) is keyed by
+(process, inode) instead, so one such read would silently drop this guard and let
+a second gateway start -- exactly the corruption this module exists to prevent.
+``flock`` is chosen deliberately for that reason.
+
+The cost of that choice is the other half of the same property. ``fork()`` shares
+one description between parent and child, so a forked child that inherits this fd
+keeps the lock alive after the parent dies. A child that wedges before ``exec``
+therefore pins the home: every later start is refused, and the pid recorded in
+the file names a process that no longer exists. That happened three times in two
+days, caused by ``preexec_fn`` forcing a plain ``fork()`` of the multi-threaded
+gateway in :mod:`kiro_crew.kiro_prerequisite`.
+
+The fix for that failure is to stop creating such children, not to weaken this
+guard -- see the removal of ``preexec_fn`` from ``_run_process``. What this
+module owes the operator meanwhile is an honest refusal: it resolves the process
+that ACTUALLY holds the lock from ``/proc/*/fd`` rather than quoting the pid in
+the file, reports what that process looks like, and names the reclaim command
+when the evidence points at an inherited fd. It never kills anything itself.
 
 Isolated homes (``--test-mode``/``--seed`` with a distinct ``KIROCREW_HOME``)
 resolve to a different lock file and are unaffected.
@@ -25,6 +45,7 @@ from __future__ import annotations
 
 import logging
 import os
+import socket
 from pathlib import Path
 
 from kiro_crew import platform_compat
@@ -35,11 +56,15 @@ LOCK_FILENAME = "gateway.lock"
 
 
 class GatewayLockError(RuntimeError):
-    """Raised when another live gateway already owns this ``KIROCREW_HOME``."""
+    """Raised when another process already owns this ``KIROCREW_HOME``."""
 
-    def __init__(self, home: Path, holder_pid: int | None) -> None:
+    def __init__(self, home: Path, holder_pid: int | None, diagnosis: str | None = None) -> None:
         self.home = home
         self.holder_pid = holder_pid
+        self.diagnosis = diagnosis
+        if diagnosis:
+            super().__init__(diagnosis)
+            return
         if holder_pid is not None:
             detail = f"another gateway (pid {holder_pid}) already owns {home}"
         else:
@@ -54,11 +79,16 @@ class GatewayLock:
     The lock is advisory (``flock``) and scoped to the lock file's inode, so it
     works across bind mounts (e.g. a jailed gateway) but not across hosts/NFS --
     matching the single-host scope of ``KIROCREW_HOME``.
+
+    *port* is diagnostic only. When given, a refusal reports whether the holder
+    also owns the dashboard port and whether that port answers, which is what
+    separates a running gateway from a wedged fork squatting on an inherited fd.
     """
 
-    def __init__(self, home: Path) -> None:
+    def __init__(self, home: Path, port: int | None = None) -> None:
         self._home = home
         self._path = home / LOCK_FILENAME
+        self._port = port
         self._fd: int | None = None
 
     @property
@@ -77,19 +107,14 @@ class GatewayLock:
         fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
         # platform_compat.try_acquire_lock: fcntl.flock LOCK_EX|LOCK_NB on
         # POSIX; msvcrt.locking LK_NBLCK on Windows. Returns True iff acquired.
-        # Both kernel primitives release automatically on process death, so a
-        # crashed gateway never wedges the home — the automatic stale-lock
-        # reclaim the docstring above depends on works uniformly on both
-        # platforms.
         if not platform_compat.try_acquire_lock(fd, exclusive=True):
-            # Held by a live process -- the kernel would have released a dead
-            # holder's lock. Read its pid for the message, then refuse.
-            holder = _read_pid(fd)
+            recorded = _read_pid(fd)
             os.close(fd)
-            raise GatewayLockError(self._home, holder)
+            holder, diagnosis = self._diagnose(recorded)
+            raise GatewayLockError(self._home, holder, diagnosis)
 
-        # We hold the lock. Any prior holder is gone (its flock was auto-released
-        # on death), so reclaim the file by stamping our pid over the stale one.
+        # We hold the lock. Stamp our pid over whatever was there so the file
+        # keeps naming the most recent acquirer.
         try:
             os.ftruncate(fd, 0)
             os.lseek(fd, 0, os.SEEK_SET)
@@ -120,6 +145,152 @@ class GatewayLock:
 
     def __exit__(self, *_exc: object) -> None:
         self.release()
+
+    # -- diagnostics ------------------------------------------------------
+
+    def _diagnose(self, recorded_pid: int | None) -> tuple[int | None, str | None]:
+        """Resolve who holds the lock, distinguishing owner from mere opener.
+
+        ``/proc/locks`` names the pid that ACQUIRED the flock, authoritatively.
+        That pid can be dead: an ``flock`` belongs to the open file description,
+        so it survives in a forked child while the kernel keeps reporting the
+        dead acquirer. In that case no ``/proc`` surface names the inheritor, so
+        we list the current openers as CANDIDATES and never as the owner.
+
+        Returns ``(pid, message)``. ``message`` is ``None`` when we learned
+        nothing, which leaves :class:`GatewayLockError` on its generic wording.
+        """
+        owner = platform_compat.flock_owner_pid(self._path)
+        openers = platform_compat.pids_holding_file(self._path)
+        if openers is not None:
+            openers = [pid for pid in openers if pid != os.getpid()]
+
+        if owner is not None and platform_compat.pid_exists(owner):
+            return owner, self._describe_live_owner(owner, recorded_pid)
+        if owner is not None:
+            return owner, self._describe_orphaned_lock(owner, openers)
+        # No /proc/locks (non-Linux, or unreadable): the recorded pid is all we
+        # have. Say that, rather than presenting it as the proven holder.
+        if recorded_pid is None:
+            return None, None
+        return recorded_pid, (
+            f"{self._path} is locked, but the holder could not be identified. "
+            f"The file records pid {recorded_pid}, which may be stale. "
+            "Stop the running gateway, or set KIROCREW_HOME to an isolated directory."
+        )
+
+    def _describe_live_owner(self, pid: int, recorded_pid: int | None) -> str:
+        """The ordinary case: a live process holds the lock, so name it."""
+        facts: list[str] = []
+        threads = platform_compat.process_thread_count(pid)
+        if threads is not None:
+            facts.append(f"{threads} thread{'s' if threads != 1 else ''}")
+        facts.extend(self._port_facts(pid))
+        detail = f" ({', '.join(facts)})" if facts else ""
+        message = (
+            f"{self._path} is held by pid {pid}{detail} -- another gateway already owns "
+            f"{self._home}; stop it first (kirocrew stop) or set KIROCREW_HOME to an "
+            "isolated directory"
+        )
+        if recorded_pid is not None and recorded_pid != pid:
+            message += f" (the lock file records pid {recorded_pid} -- stale)"
+        return message
+
+    def _describe_orphaned_lock(self, dead_owner: int, openers: list[int] | None) -> str:
+        """The wedge: the acquirer is gone but its flock lives on in an inheritor.
+
+        This is the state that cost three manual recoveries. It is worth naming
+        precisely, because the pid the operator would otherwise reach for -- the
+        one in the lock file, and the one ``/proc/locks`` reports -- is the dead
+        parent, and killing it does nothing.
+
+        The inheritor cannot be proven from ``/proc``: openers may include
+        processes that merely read the file. A reclaim command is therefore
+        offered only when THREE independent facts line up -- exactly one
+        candidate, that candidate's own parent is gone, and it is not serving
+        HTTP -- and the message states each one, so the operator is checking
+        evidence rather than trusting a verdict.
+
+        Any pid in a printed command is a snapshot, and the operator reads it
+        seconds later; that gap is unavoidable for any tool that names a process,
+        ``lsof`` included. The corroborating facts are what make the pid worth
+        acting on, so they are printed with it.
+        """
+        lines = [
+            f"{self._path} is locked, but the process that acquired it (pid {dead_owner}) "
+            "no longer exists. An flock belongs to the open file description, so it "
+            "survives in a process that inherited that descriptor -- typically a child "
+            "forked from the crashed gateway."
+        ]
+        if not openers:
+            lines.append(
+                "No current opener of the file could be identified, so the inheritor "
+                "cannot be named here. Find it with: lsof " + str(self._path)
+            )
+            return " ".join(lines)
+        described = []
+        for pid in openers:
+            threads = platform_compat.process_thread_count(pid)
+            bits = [f"{threads} thread{'s' if threads != 1 else ''}"] if threads else []
+            bits.extend(self._port_facts(pid))
+            described.append(f"pid {pid}" + (f" ({', '.join(bits)})" if bits else ""))
+        lines.append("The file is currently open in " + ", ".join(described) + ".")
+        if len(openers) > 1:
+            lines.append(
+                "More than one process has it open, so the inheritor is ambiguous -- "
+                "confirm which is a child of the dead gateway before killing anything."
+            )
+            return " ".join(lines)
+
+        candidate = openers[0]
+        ppid = platform_compat.parent_pid(candidate)
+        orphaned = ppid is not None and (ppid == 1 or not platform_compat.pid_exists(ppid))
+        serving = self._port is not None and _port_answers_http(self._port)
+        if orphaned and not serving:
+            lines.append(
+                f"Its parent (pid {ppid}) is gone too and it is not serving HTTP, so it is "
+                f"the likely inheritor; reclaim the home with: kill -9 {candidate}"
+            )
+        elif serving:
+            lines.append(
+                f"But pid {candidate} IS serving HTTP on port {self._port}, so it is a live "
+                "gateway, not a wedged leftover -- stop it with kirocrew stop instead."
+            )
+        else:
+            parent = "unknown" if ppid is None else f"pid {ppid}, still alive"
+            lines.append(
+                f"Its parent is {parent}, so it may be a healthy gateway that has just "
+                f"started and not yet bound its port. Confirm before killing it: ps -f -p "
+                f"{candidate}"
+            )
+        return " ".join(lines)
+
+    def _port_facts(self, pid: int) -> list[str]:
+        """Port ownership facts for *pid*, empty when no port was supplied."""
+        if self._port is None:
+            return []
+        if pid not in platform_compat.find_listening_pids(self._port):
+            return [f"does not hold port {self._port}"]
+        answering = "answering" if _port_answers_http(self._port) else "not answering"
+        return [f"holds port {self._port}, {answering} HTTP"]
+
+
+def _port_answers_http(port: int, timeout: float = 1.5) -> bool:
+    """True iff ``127.0.0.1:port`` returns an HTTP status line within *timeout*.
+
+    A plain connect is not enough: a wedged holder's kernel still completes the
+    handshake into the listen backlog even though nothing will ever ``accept()``,
+    so connect-success would misclassify an orphan as a live gateway. This
+    mirrors :func:`kiro_crew.dashboard.port_reclaim._probe_gateway_healthy` in a
+    synchronous form, because the lock is taken before the event loop exists.
+    """
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout) as sock:
+            sock.settimeout(timeout)
+            sock.sendall(b"GET / HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+            return sock.recv(5) == b"HTTP/"
+    except OSError:
+        return False
 
 
 def _read_pid(fd: int) -> int | None:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -1203,6 +1203,156 @@ def pid_exists(pid: int) -> bool:
         return False
 
 
+def process_thread_count(pid: int) -> int | None:
+    """Thread count of *pid*, or ``None`` when it cannot be determined.
+
+    Used to tell a *running* gateway (dozens of threads: the event loop, the
+    executor pool, watchdogs, MCP stdio readers) apart from a **wedged fork** of
+    one -- a child forked before ``exec`` inherits exactly one thread, the one
+    that called ``fork()``, and never gains another. That single-thread signature
+    is the decidable half of "this holder is an orphan, not a gateway".
+
+    Linux: ``Threads:`` in ``/proc/<pid>/status``. Everywhere else: ``None``, so
+    every caller must already handle "unknown" and degrade to a claim it can
+    support. Deliberately no ``ps`` fallback for macOS -- shelling out from this
+    low-level module would add an unrouted subprocess spawn (see
+    ``test_spawn_audit``) to a purely diagnostic path.
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        for ln in Path(f"/proc/{pid}/status").read_text().splitlines():
+            if ln.startswith("Threads:"):
+                return int(ln.split()[1])
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def flock_owner_pid(path: str | os.PathLike) -> int | None:
+    """PID recorded against an ``flock`` on *path*, via ``/proc/locks``.
+
+    This is the pid that ACQUIRED the lock, which is not always a live process:
+    an ``flock`` belongs to the open file description, so when the acquirer dies
+    and a forked child still holds the inherited fd, the kernel keeps reporting
+    the DEAD acquirer here. Verified on Linux 5.x -- an orphaned lock listed
+    ``FLOCK ADVISORY WRITE <dead parent pid>`` while the surviving child held the
+    fd. So a returned pid that is dead is positive evidence of an inherited fd,
+    and no ``/proc`` surface names the inheritor: use
+    :func:`pids_holding_file` for candidates and do not present them as owners.
+
+    Returns ``None`` on non-Linux, when ``/proc/locks`` is unreadable, or when no
+    ``FLOCK`` entry matches the file. Blocked waiters (``->`` rows) are skipped.
+
+    Matching is on the full ``major:minor:inode`` triple that ``/proc/locks``
+    prints, because inode numbers are only unique WITHIN a filesystem -- an
+    unrelated flock on another device can share this inode's number, and
+    accepting it would name a completely unrelated process. The device halves are
+    hex (``%02x``), the inode decimal (``%lu``). On filesystems whose ``s_dev``
+    differs from the ``st_dev`` that ``stat`` reports (btrfs subvolumes and
+    overlayfs use anonymous devices) the triple will not match and this returns
+    ``None``. That is the safe direction to fail: the caller degrades to its
+    "holder could not be identified" wording instead of naming a wrong process.
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        info = os.stat(path)
+    except OSError:
+        return None
+    want = (os.major(info.st_dev), os.minor(info.st_dev), info.st_ino)
+    try:
+        # Streamed, not slurped: /proc/locks is unbounded (one row per lock
+        # system-wide) and this runs on a startup failure path.
+        with open("/proc/locks", encoding="utf-8") as handle:
+            for row in handle:
+                fields = row.split()
+                # "23: FLOCK ADVISORY WRITE 39542 103:01:146872 0 EOF"; a blocked
+                # waiter is "23: -> FLOCK ..." and owns nothing.
+                if len(fields) < 6 or "->" in fields[:2] or fields[1] != "FLOCK":
+                    continue
+                try:
+                    pid = int(fields[4])
+                    major, minor, ino = fields[5].split(":")
+                    found = (int(major, 16), int(minor, 16), int(ino))
+                except (ValueError, IndexError):
+                    continue
+                if found == want:
+                    return pid
+    except OSError:
+        return None
+    return None
+
+
+def parent_pid(pid: int) -> int | None:
+    """PPID of *pid* from ``/proc/<pid>/stat``, or ``None`` if unknowable.
+
+    Used to corroborate that a candidate process really is orphaned: a child
+    reparented to init after its parent died reports ``1``. ``None`` means
+    "unknown", which callers must not read as either answer.
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        stat_data = Path(f"/proc/{pid}/stat").read_text()
+        # comm (field 2) may contain spaces/parens -- parse after the LAST ')'
+        close_paren = stat_data.rfind(")")
+        if close_paren < 0:
+            return None
+        return int(stat_data[close_paren + 2 :].split()[1])
+    except Exception:
+        return None
+
+
+def pids_holding_file(path: str | os.PathLike) -> list[int] | None:
+    """PIDs with an open fd on *path*, matched by inode via ``/proc/*/fd``.
+
+    These are CANDIDATE OPENERS, not lock owners. Any process may open the file
+    without locking it, and an inherited ``flock`` has no live owner to identify
+    (see :func:`flock_owner_pid`), so callers must not present a pid from here as
+    the holder. Answering "who has this file open" is still the only way to reach
+    the process that inherited a dead acquirer's descriptor.
+
+    Matching is by ``(st_dev, st_ino)`` rather than by link target so a bind
+    mount (a jailed gateway sees a different path for the same inode) still
+    resolves. PIDs whose ``/proc`` entry we cannot read are skipped: the result
+    is a best-effort lower bound.
+
+    Returns ``None`` on non-Linux, where there is no ``/proc`` to walk.
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        target = os.stat(path)
+    except OSError:
+        return None
+    key = (target.st_dev, target.st_ino)
+    holders: list[int] = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return None
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        fd_dir = f"/proc/{entry}/fd"
+        try:
+            fds = os.listdir(fd_dir)
+        except OSError:
+            # Dead between listdir and here, or another user's process.
+            continue
+        for fd_name in fds:
+            try:
+                st = os.stat(f"{fd_dir}/{fd_name}")
+            except OSError:
+                continue
+            if (st.st_dev, st.st_ino) == key:
+                holders.append(pid)
+                break
+    return holders
+
+
 def _raise_taskkill_error(pid: int, rc: int, stderr: bytes) -> None:
     """Translate a Windows taskkill non-zero rc into ProcessLookupError /
     PermissionError / OSError so callers' POSIX-style ``except`` guards

--- a/test/test_gateway_lock_diagnosis.py
+++ b/test/test_gateway_lock_diagnosis.py
@@ -1,0 +1,287 @@
+"""Tests for the gateway.lock refusal diagnosis.
+
+The point of the diagnosis is that the pid written INSIDE the lock file is not
+necessarily the pid holding it. ``flock`` survives in a forked child after its
+parent dies, so a crashed gateway can leave the home locked by a process the
+file never names. Three real incidents were recovered by hand for exactly that
+reason.
+
+``test_flock_is_held_by_a_fork_orphan`` pins that limitation deliberately. It is
+NOT a bug report against this module -- it documents the state the diagnosis
+exists to explain, and it will start failing if someone swaps the primitive for a
+POSIX record lock. That swap is unsafe here: record locks are keyed by
+(process, inode), so any unrelated ``open()``/``close()`` of the lock path inside
+the gateway -- including via its authenticated file-read endpoint -- would
+silently release the guard and let a second gateway start.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(os, "fork"), reason="fork-inheritance semantics are POSIX-only"
+)
+
+# Parent takes the lock, forks a child that wedges BEFORE exec while holding the
+# inherited fd, then dies immediately -- the crashed-gateway shape, minimised.
+# Run out-of-process so the parent's death is a real process death. The parent
+# writes the wedged child's pid to a FILE (argv[3]) so the test can reap that
+# exact process on every platform: a /proc sweep is Linux-only, and a stdout pipe
+# would not do either, because the wedged child inherits the pipe and reading it
+# would block for the child's whole lifetime instead of the parent's.
+_ORPHANING_HOLDER = """
+import os, sys, time
+sys.path[:0] = {syspath!r}
+from pathlib import Path
+from kiro_crew.gateway_lock import GatewayLock
+home, pid_file = Path(sys.argv[1]), sys.argv[2]
+GatewayLock(home).acquire()
+child = os.fork()
+if child == 0:
+    time.sleep(60)   # wedged pre-exec child, still holding the inherited fd
+    os._exit(0)
+with open(pid_file, "w") as fh:
+    fh.write(str(child))
+os._exit(0)          # the parent "crashes" while the child lives on
+"""
+
+
+@pytest.fixture
+def reap():
+    """Collects pids to SIGKILL at teardown, so no test leaks a wedged child."""
+    pids: list[int] = []
+    yield pids
+    for pid in pids:
+        try:
+            os.kill(pid, 9)
+        except OSError:
+            pass
+
+
+def _orphan_the_lock(home, reap: list[int]) -> int:
+    """Leave *home* locked by a forked child whose parent has died.
+
+    Returns (and registers for teardown) the wedged child's pid.
+    """
+    src = _ORPHANING_HOLDER.format(syspath=[p for p in sys.path if p])
+    pid_file = home / "holder.pid"
+    proc = subprocess.run(
+        [sys.executable, "-c", src, str(home), str(pid_file)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"lock holder exited {proc.returncode}"
+    pid = int(pid_file.read_text().strip())
+    reap.append(pid)
+    # The parent is reaped; the child keeps sleeping with the inherited fd.
+    time.sleep(0.5)
+    return pid
+
+
+def test_flock_is_held_by_a_fork_orphan(tmp_path, reap):
+    """The documented limitation: a dead parent's flock lives on in its child.
+
+    Fails if the primitive is swapped for a POSIX record lock -- which would
+    trade this loud, recoverable wedge for a silent loss of the guard.
+    """
+    from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
+
+    home = tmp_path / "home"
+    home.mkdir()
+    orphan = _orphan_the_lock(home, reap)
+
+    # Platform-neutral: the lock is still held, so startup is refused.
+    with pytest.raises(GatewayLockError) as excinfo:
+        GatewayLock(home).acquire()
+
+    # Identity claims need Linux /proc. On other platforms the diagnosis
+    # correctly degrades to the recorded pid, so asserting identity there would
+    # compare the dead parent against the surviving child and fail.
+    if sys.platform != "linux":
+        pytest.skip("holder identity needs /proc")
+    from kiro_crew import platform_compat
+
+    if platform_compat.pids_holding_file(home / "gateway.lock") is None:
+        pytest.skip("/proc/<pid>/fd not readable here")
+
+    # /proc/locks names the DEAD acquirer, never the inheritor -- that asymmetry
+    # is the whole reason the message has to be written carefully.
+    lock_path = home / "gateway.lock"
+    if not Path("/proc/locks").exists():
+        pytest.skip("/proc/locks unavailable")
+    acquirer = platform_compat.flock_owner_pid(lock_path)
+    # Asserted, NOT guarded: a None here means the owner lookup regressed, which
+    # is exactly the failure this test exists to catch. Guarding it would let the
+    # regression pass silently. (Filesystems with an anonymous s_dev, e.g. btrfs,
+    # legitimately return None -- so this pins the behaviour on the ext4/xfs
+    # tmp_path that CI and dev machines actually use.)
+    assert acquirer is not None
+    assert not platform_compat.pid_exists(acquirer)
+    assert acquirer != orphan
+    assert excinfo.value.holder_pid == acquirer
+    # And the orphan is offered as the likely inheritor, by pid -- it is
+    # single-threaded, reparented to init, and serving nothing.
+    assert platform_compat.parent_pid(orphan) == 1
+    assert f"kill -9 {orphan}" in str(excinfo.value)
+
+
+def test_pids_holding_file_finds_the_real_holder(tmp_path):
+    """Holder resolution comes from /proc, not from the pid inside the file."""
+    if sys.platform != "linux":
+        pytest.skip("/proc scanning is Linux-only")
+    from kiro_crew import platform_compat
+
+    path = tmp_path / "gateway.lock"
+    path.write_text("999999\n")  # a pid that is not us
+    fd = os.open(path, os.O_RDWR)
+    try:
+        if platform_compat.pids_holding_file(path) is None:
+            pytest.skip("/proc/<pid>/fd not readable here")
+        assert platform_compat.pids_holding_file(path) == [os.getpid()]
+    finally:
+        os.close(fd)
+    # fd closed -> no holders, while the file still names the stale pid.
+    assert platform_compat.pids_holding_file(path) == []
+    assert path.read_text().strip() == "999999"
+
+
+# --- refusal message rendering -------------------------------------------
+#
+# These drive the diagnosis directly (the lock is forced to appear taken) so the
+# wording is pinned without needing a real second holder. The message is the
+# whole point of the change: the old one named a pid that no longer existed.
+
+
+@pytest.fixture
+def refused_lock(monkeypatch, tmp_path):
+    """A home whose lock always appears held, plus a stale pid on disk."""
+    from kiro_crew import gateway_lock, platform_compat
+
+    (tmp_path / gateway_lock.LOCK_FILENAME).write_text("4242\n", encoding="utf-8")
+    monkeypatch.setattr(platform_compat, "try_acquire_lock", lambda *a, **k: False)
+    return tmp_path
+
+
+def _refusal(home, port=None):
+    from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
+
+    with pytest.raises(GatewayLockError) as excinfo:
+        GatewayLock(home, port=port).acquire()
+    return excinfo.value
+
+
+def test_refusal_names_the_live_acquirer_from_proc_locks(monkeypatch, refused_lock):
+    """A live acquirer is authoritative: name it, and never suggest killing it."""
+    from kiro_crew import gateway_lock, platform_compat
+
+    monkeypatch.setattr(platform_compat, "flock_owner_pid", lambda _p: 16968)
+    monkeypatch.setattr(platform_compat, "pid_exists", lambda _p: True)
+    monkeypatch.setattr(platform_compat, "pids_holding_file", lambda _p: [16968])
+    monkeypatch.setattr(platform_compat, "process_thread_count", lambda _p: 118)
+    monkeypatch.setattr(platform_compat, "find_listening_pids", lambda _p: [16968])
+    monkeypatch.setattr(gateway_lock, "_port_answers_http", lambda *_a, **_k: True)
+
+    err = _refusal(refused_lock, port=5477)
+    text = str(err)
+    assert err.holder_pid == 16968  # from /proc/locks, NOT the 4242 on disk
+    assert "118 threads" in text and "port 5477, answering HTTP" in text
+    assert "records pid 4242 -- stale" in text
+    assert "kill" not in text.lower()  # never offer up a live gateway
+
+
+def test_refusal_names_the_dead_acquirer_and_the_single_inheritor(monkeypatch, refused_lock):
+    """The wedge: acquirer dead, one opener, parent gone, serving nothing."""
+    from kiro_crew import gateway_lock, platform_compat
+
+    monkeypatch.setattr(platform_compat, "flock_owner_pid", lambda _p: 23184)
+    monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: False)
+    monkeypatch.setattr(platform_compat, "pids_holding_file", lambda _p: [23185])
+    monkeypatch.setattr(platform_compat, "process_thread_count", lambda _p: 1)
+    monkeypatch.setattr(platform_compat, "parent_pid", lambda _p: 1)
+    monkeypatch.setattr(platform_compat, "find_listening_pids", lambda _p: [23185])
+    monkeypatch.setattr(gateway_lock, "_port_answers_http", lambda *_a, **_k: False)
+
+    err = _refusal(refused_lock, port=5477)
+    text = str(err)
+    assert err.holder_pid == 23184  # the acquirer we can prove, even though dead
+    assert "pid 23184) no longer exists" in text
+    assert "inherited that descriptor" in text
+    assert "parent (pid 1) is gone" in text and "kill -9 23185" in text
+
+
+def test_refusal_withholds_kill_when_the_candidates_parent_is_alive(monkeypatch, refused_lock):
+    """A live parent means this may be a gateway that just started: do not kill it.
+
+    This is the shape a healthy starting gateway has -- one thread, no listener
+    yet -- so the parent is the fact that discriminates it from an orphan.
+    """
+    from kiro_crew import gateway_lock, platform_compat
+
+    monkeypatch.setattr(platform_compat, "flock_owner_pid", lambda _p: 23184)
+    monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: pid == 9001)
+    monkeypatch.setattr(platform_compat, "pids_holding_file", lambda _p: [23185])
+    monkeypatch.setattr(platform_compat, "process_thread_count", lambda _p: 1)
+    monkeypatch.setattr(platform_compat, "parent_pid", lambda _p: 9001)
+    monkeypatch.setattr(platform_compat, "find_listening_pids", lambda _p: [])
+    monkeypatch.setattr(gateway_lock, "_port_answers_http", lambda *_a, **_k: False)
+
+    text = str(_refusal(refused_lock, port=5477))
+    assert "parent is pid 9001, still alive" in text
+    assert "just started and not yet bound its port" in text
+    assert "kill -9" not in text
+
+
+def test_refusal_withholds_kill_from_a_candidate_that_is_serving_http(monkeypatch, refused_lock):
+    """Answering HTTP proves a live gateway, whatever /proc/locks says."""
+    from kiro_crew import gateway_lock, platform_compat
+
+    monkeypatch.setattr(platform_compat, "flock_owner_pid", lambda _p: 23184)
+    monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: False)
+    monkeypatch.setattr(platform_compat, "pids_holding_file", lambda _p: [23185])
+    monkeypatch.setattr(platform_compat, "process_thread_count", lambda _p: 1)
+    monkeypatch.setattr(platform_compat, "parent_pid", lambda _p: 1)
+    monkeypatch.setattr(platform_compat, "find_listening_pids", lambda _p: [23185])
+    monkeypatch.setattr(gateway_lock, "_port_answers_http", lambda *_a, **_k: True)
+
+    text = str(_refusal(refused_lock, port=5477))
+    assert "IS serving HTTP" in text and "kirocrew stop" in text
+    assert "kill -9" not in text
+
+
+def test_refusal_refuses_to_guess_between_multiple_openers(monkeypatch, refused_lock):
+    """Two openers -> ambiguous. Offer no kill command for either."""
+    from kiro_crew import platform_compat
+
+    monkeypatch.setattr(platform_compat, "flock_owner_pid", lambda _p: 23184)
+    monkeypatch.setattr(platform_compat, "pid_exists", lambda _p: False)
+    monkeypatch.setattr(platform_compat, "pids_holding_file", lambda _p: [23185, 30001])
+    monkeypatch.setattr(platform_compat, "process_thread_count", lambda _p: 1)
+    monkeypatch.setattr(platform_compat, "find_listening_pids", lambda _p: [])
+
+    text = str(_refusal(refused_lock, port=5477))
+    assert "pid 23185" in text and "pid 30001" in text
+    assert "ambiguous" in text
+    assert "kill -9" not in text  # an opener is not proof of ownership
+
+
+def test_refusal_degrades_honestly_without_proc_locks(monkeypatch, refused_lock):
+    """No /proc/locks (non-Linux): fall back to the recorded pid, say it may be stale."""
+    from kiro_crew import platform_compat
+
+    monkeypatch.setattr(platform_compat, "flock_owner_pid", lambda _p: None)
+    monkeypatch.setattr(platform_compat, "pids_holding_file", lambda _p: None)
+
+    err = _refusal(refused_lock, port=5477)
+    text = str(err)
+    assert err.holder_pid == 4242
+    assert "could not be identified" in text
+    assert "may be stale" in text
+    assert "kill" not in text.lower()  # we cannot name anyone -- do not guess


### PR DESCRIPTION
## Problem

A gateway crash left `$KIROCREW_HOME` locked, and every later start refused with:

```
another gateway (pid <DEAD PID>) already owns /home/me/.kiro/crew
```

That pid did not exist. The gateway would not start until someone found the real
holder by hand and killed it. Three unstartable gateways in two days on one
machine.

## Why it matters

The message actively misleads. It names a process the operator can verify is
gone, so the natural conclusion is that the lock file is stale and the guard is
broken. The pid that actually needs killing is never printed, so recovery means
knowing to reach for `lsof` on a lock file most users have never heard of.

## Fix (symptoms → root cause → change)

**Symptom:** the refusal names a dead pid.

**Root cause:** on failure the code reported the pid recorded *inside* the lock
file. That is whoever last stamped it. `flock` belongs to the open file
*description*, which `fork()` shares, so a child that inherits the lock fd keeps
the lock alive after its parent dies — and then the recorded pid is the dead
parent, never the child holding the fd.

The wedge itself came from `kiro_prerequisite._run_process` passing `preexec_fn=`,
which forces CPython onto a plain `fork()` of the multi-GB ~118-thread gateway and
runs Python in the child before `exec`. A lock another thread held at fork time is
unreleasable there, so the child deadlocked in a futex, never exec'd, and kept
every fd it inherited. **That fork window is removed in #814, which is the actual
cure. This PR fixes the message.**

**The finding that shaped the change.** Verified on Linux 5.x: `/proc/locks`
reports an flock against the pid that *acquired* it, and keeps reporting that pid
after it dies. A real orphan listed `FLOCK ADVISORY WRITE <dead parent>` while the
surviving child held the fd. So **no `/proc` surface names the inheritor**, and any
message presenting one pid as "the holder" is guessing.

**Change.** The diagnosis now keeps three claims apart instead of conflating them:

| Source | What it proves |
|---|---|
| `flock_owner_pid()` — `/proc/locks` | Who **acquired** the lock, and whether that process still exists. Authoritative. Matched on the full `major:minor:inode` triple, since inode numbers are unique only within a filesystem. |
| `pids_holding_file()` — `/proc/*/fd` | **Candidate openers only.** Any process may open the file without locking it, so these are never presented as owners. |

- **Live acquirer** → named, with thread count and port state. Never offered for killing.
- **Dead acquirer** → stated as dead, the inheritance explained, current openers listed. `kill -9` appears only when three independent facts agree: exactly one candidate, that candidate's own parent is gone, and it is not serving HTTP. Each fact is printed, so the operator checks evidence rather than trusting a verdict.
- **A live parent** → no command; that is also the shape of a gateway which just started and has not bound its port yet.
- **Candidate answering HTTP** → a live gateway; the message points at `kirocrew stop`.
- **No `/proc/locks`** (non-Linux) → falls back to the recorded pid and says it may be stale.

## Deliberately not changed: the lock primitive

An earlier revision of this PR swapped `flock` for a POSIX record lock
(`fcntl.lockf`), which *does* release on process death and would have made
reclaim automatic. **Reverted after review found a hole, reproduced empirically.**

Record locks are keyed by `(process, inode)`, so **any** `open()`+`close()` of the
lock path inside the gateway drops the guard. `hooks.validate_file_path` permits
`<home>/gateway.lock`, so a single authenticated `GET /api/file-read` released it,
and a second gateway then acquired the lock — the probe printed `SECOND GATEWAY
GOT THE LOCK`.

That trades a loud, recoverable wedge for silent dual-writer transcript
corruption, which is the exact harm the guard exists to prevent. A correctness
argument resting on "nothing else in this process ever opens this file" is not
one to own in a process whose job includes serving arbitrary file reads.

## Tests

`test/test_gateway_lock_diagnosis.py` covers every message path: live acquirer
(no kill offered), dead acquirer with one corroborated inheritor (named by pid),
candidate whose parent is still alive (no command), candidate answering HTTP
(points at `kirocrew stop`), several openers (refuses to guess), and no
`/proc/locks`.

The end-to-end test builds a **real fork orphan** and asserts that `/proc/locks`
names the dead acquirer, that the error reports that pid, and that the reclaim
command names the surviving child instead. That assertion is deliberately *not*
guarded behind a `None` check — a `None` from the owner lookup is the regression
the test exists to catch, so guarding it would let the regression pass silently.

`test_flock_is_held_by_a_fork_orphan` pins the inheritance limitation on purpose.
It is not a bug report against this module: it documents the state the diagnosis
exists to explain, and it fails if anyone swaps the primitive back to a record
lock.

## Manual verification

Reproduced the incident shape end-to-end: fork a child that inherits the lock fd,
let the parent exit, confirm the old code named the dead parent and the new code
names the surviving child. Also confirmed `/proc/locks` attributes the orphaned
lock to the dead parent (39542) while the child (39543) held the fd — the
observation the whole design rests on.

Full suite: 22 pre-existing failures, unchanged against a pristine `origin/main`
worktree (sandbox blocks `unshare`/`link()`, plus `KIROCREW_PORT` in the shell
env). `isort`, `flake8`, `mypy` clean.

## Screenshots

N/A — no user-visible UI change. The only surface is a CLI error message, quoted
above.
