### PR TITLE
feat(dashboard): move between sessions with Cmd+[ / Cmd+]

### DIFF
--- a/website/src/hooks/useKeyboardShortcuts.ts
+++ b/website/src/hooks/useKeyboardShortcuts.ts
@@ -41,6 +41,8 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
   { id: 'chat-9', key: '9', alt: !IS_MAC, ctrl: IS_MAC, label: 'Jump to chat 9', group: 'Chat Navigation' },
   { id: 'chat-prev', key: 'ArrowLeft', alt: true, label: 'Previous chat', group: 'Chat Navigation' },
   { id: 'chat-next', key: 'ArrowRight', alt: true, label: 'Next chat', group: 'Chat Navigation' },
+  { id: 'chat-prev-bracket', key: '[', meta: true, label: 'Previous chat', group: 'Chat Navigation' },
+  { id: 'chat-next-bracket', key: ']', meta: true, label: 'Next chat', group: 'Chat Navigation' },
   { id: 'chat-mru', key: '`', alt: true, label: 'Last visited chat (MRU)', group: 'Chat Navigation' },
   { id: 'chat-mru-back', key: '`', alt: true, shift: true, label: 'Walk back MRU history', group: 'Chat Navigation' },
   // Panel navigation
@@ -192,6 +194,57 @@ export function isSettingsChord(
   return mac ? (e.metaKey && !e.altKey) || altOnly : altOnly
 }
 
+/**
+ * Session-cycle chord: ⌘[ / ⌘] on macOS, Ctrl+[ / Ctrl+] on Windows-Linux —
+ * step one session backwards/forwards through the sidebar order.
+ *
+ * Keyed by KeyboardEvent.code, so the chord is POSITIONAL: on layouts where the
+ * bracket glyphs sit elsewhere (or need AltGr to type) the physical keys in the
+ * US-QWERTY bracket positions still work, matching how every other chord in
+ * this module is matched.
+ */
+const SESSION_STEP_BY_CODE: Record<string, number> = { BracketLeft: -1, BracketRight: 1 }
+
+/**
+ * The step this event asks for (-1 back, +1 forward), or 0 when it is not the
+ * session-cycle chord. Exactly ONE primary modifier and no Alt/Shift, so it
+ * cannot fire from ⌘⌥[ misses and cannot shadow Alt+arrow chat-nav, the Mac
+ * Ctrl+digit chat-jumps, or ⌘/Ctrl+digit remote-crew switching.
+ *
+ * `mac` is injectable for the same reason as isSettingsChord: IS_MAC is fixed
+ * at module load, so both platform behaviours would otherwise be untestable.
+ */
+export function sessionCycleStep(
+  e: Pick<KeyboardEvent, 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+  mac: boolean = IS_MAC,
+): number {
+  const primary = mac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+  if (!primary || e.altKey || e.shiftKey) return 0
+  return SESSION_STEP_BY_CODE[e.code] ?? 0
+}
+
+/**
+ * Neighbour of `curIdx` in a list of `len`, stepping by `step` and wrapping at
+ * both ends. Returns -1 for an empty list. With no current selection (-1) a
+ * backward step lands on the last entry and a forward step on the first —
+ * the behaviour both the Alt+arrow and the bracket chord want.
+ */
+export function wrapIndex(len: number, curIdx: number, step: number): number {
+  if (len === 0) return -1
+  if (curIdx < 0) return step < 0 ? len - 1 : 0
+  return (curIdx + step + len) % len
+}
+
+/**
+ * True when the keystroke came from inside an embedded terminal. Ctrl+[ is a
+ * real PTY keystroke there (it sends ESC — how vim users leave insert mode), so
+ * the session-cycle chord must let it through rather than swallow it.
+ */
+function isTerminalTarget(target: EventTarget | null): boolean {
+  const el = target as Element | null
+  return !!el && typeof el.closest === 'function' && !!el.closest('.xterm')
+}
+
 export function formatShortcut(def: ShortcutDef): string {
   const mac = isMac()
   const parts: string[] = []
@@ -292,6 +345,23 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
     if (code === 'Comma' && isSettingsChord(e)) {
       e.preventDefault()
       navigate('/settings')
+      return
+    }
+
+    // ⌘[ / ⌘] on macOS, Ctrl+[ / Ctrl+] on Windows-Linux: step to the
+    // previous/next session in sidebar order, wrapping at both ends — the same
+    // move as Alt+←/→, on a chord that survives being inside the composer
+    // (unlike Alt+arrow, which stays out of text fields to preserve word-jump;
+    // ⌘/Ctrl+bracket has no text-editing meaning). Handled BEFORE the Alt gate
+    // because the chord carries no Alt. Skipped when the keystroke came from a
+    // terminal, where Ctrl+[ is ESC and belongs to the PTY.
+    const step = sessionCycleStep(e)
+    if (step !== 0 && !isTerminalTarget(e.target)) {
+      if (!enabled || disabled) return
+      // Claim the keystroke: on macOS ⌘[ / ⌘] are the browser's Back/Forward.
+      e.preventDefault()
+      const nextIdx = wrapIndex(slots.length, activeSlot ? slots.findIndex(s => s.key === activeSlot) : -1, step)
+      if (nextIdx >= 0) { dispatch(switchSlot(slots[nextIdx].key)); navigate('/chat') }
       return
     }
 
@@ -399,11 +469,9 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
     // Alt+←/→: Previous/next chat (skip when in text input to preserve word-jump)
     if ((code === 'ArrowLeft' || code === 'ArrowRight') && !isInput) {
       e.preventDefault()
-      if (slots.length === 0) return
       const curIdx = activeSlot ? slots.findIndex(s => s.key === activeSlot) : -1
-      const nextIdx = code === 'ArrowLeft'
-        ? (curIdx <= 0 ? slots.length - 1 : curIdx - 1)
-        : (curIdx >= slots.length - 1 ? 0 : curIdx + 1)
+      const nextIdx = wrapIndex(slots.length, curIdx, code === 'ArrowLeft' ? -1 : 1)
+      if (nextIdx < 0) return
       dispatch(switchSlot(slots[nextIdx].key))
       navigate('/chat')
       return

--- a/website/src/test/useKeyboardShortcuts.test.tsx
+++ b/website/src/test/useKeyboardShortcuts.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, screen, act } from '@testing-library/react'
-import { DEFAULT_SHORTCUTS, formatShortcut, SHORTCUTS_ENABLED_KEY, SHORTCUTS_ENABLED_EVENT, useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
+import { DEFAULT_SHORTCUTS, formatShortcut, SHORTCUTS_ENABLED_KEY, SHORTCUTS_ENABLED_EVENT, useKeyboardShortcuts, sessionCycleStep, wrapIndex } from '../hooks/useKeyboardShortcuts'
 import { renderHookWithProviders, createTestStore, renderWithProviders } from './helpers'
 import ShortcutsModal from '../components/ShortcutsModal'
 import type { RootState } from '../store'
@@ -223,6 +223,167 @@ describe('ShortcutsModal', () => {
     renderWithProviders(<ShortcutsModal onClose={onClose} />)
     fireEvent.click(screen.getByRole('dialog'))
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('sessionCycleStep', () => {
+  const ev = (o: Partial<Record<'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey', unknown>>) =>
+    ({ code: 'BracketRight', metaKey: false, ctrlKey: false, altKey: false, shiftKey: false, ...o }) as Parameters<typeof sessionCycleStep>[0]
+
+  it('maps ⌘[ / ⌘] to -1 / +1 on macOS', () => {
+    expect(sessionCycleStep(ev({ code: 'BracketLeft', metaKey: true }), true)).toBe(-1)
+    expect(sessionCycleStep(ev({ code: 'BracketRight', metaKey: true }), true)).toBe(1)
+  })
+
+  it('maps Ctrl+[ / Ctrl+] to -1 / +1 on Windows/Linux', () => {
+    expect(sessionCycleStep(ev({ code: 'BracketLeft', ctrlKey: true }), false)).toBe(-1)
+    expect(sessionCycleStep(ev({ code: 'BracketRight', ctrlKey: true }), false)).toBe(1)
+  })
+
+  it('requires the platform primary modifier, not the other one', () => {
+    expect(sessionCycleStep(ev({ ctrlKey: true }), true)).toBe(0)   // Ctrl+] on Mac
+    expect(sessionCycleStep(ev({ metaKey: true }), false)).toBe(0)  // ⌘] on Win/Linux
+  })
+
+  it('rejects extra modifiers so it cannot fire from a near-miss chord', () => {
+    expect(sessionCycleStep(ev({ metaKey: true, altKey: true }), true)).toBe(0)
+    expect(sessionCycleStep(ev({ metaKey: true, shiftKey: true }), true)).toBe(0)
+    expect(sessionCycleStep(ev({ metaKey: true, ctrlKey: true }), true)).toBe(0)
+  })
+
+  it('returns 0 for any other key', () => {
+    expect(sessionCycleStep(ev({ code: 'KeyP', metaKey: true }), true)).toBe(0)
+    expect(sessionCycleStep(ev({ code: 'Backslash', metaKey: true }), true)).toBe(0)
+  })
+})
+
+describe('wrapIndex', () => {
+  it('steps and wraps at both ends', () => {
+    expect(wrapIndex(3, 1, 1)).toBe(2)
+    expect(wrapIndex(3, 2, 1)).toBe(0)
+    expect(wrapIndex(3, 1, -1)).toBe(0)
+    expect(wrapIndex(3, 0, -1)).toBe(2)
+  })
+  it('lands on an end when nothing is selected', () => {
+    expect(wrapIndex(3, -1, 1)).toBe(0)
+    expect(wrapIndex(3, -1, -1)).toBe(2)
+  })
+  it('reports -1 for an empty list', () => {
+    expect(wrapIndex(0, -1, 1)).toBe(-1)
+  })
+})
+
+describe('⌘/Ctrl+[ and ⌘/Ctrl+] session cycling', () => {
+  // The switchSlot thunk's pending reducer touches most of the chat slice, so
+  // preload from the slice's real initial state rather than a partial cast.
+  const chatState = (activeSlot: string | null) =>
+    ({ ...createTestStore().getState().chat, activeSlot, slotHistory: [] }) as RootState['chat']
+
+  const threeSlots = (active: string) => createTestStore({
+    dashboard: { slots: [
+      { key: 'slot-1', title: 'Chat 1', messages: 0, running: false },
+      { key: 'slot-2', title: 'Chat 2', messages: 0, running: false },
+      { key: 'slot-3', title: 'Chat 3', messages: 0, running: false },
+    ] } as unknown as RootState['dashboard'],
+    chat: chatState(active),
+  })
+
+  // jsdom reports a non-Mac platform, so the handler's primary modifier is Ctrl.
+  function mount(store: ReturnType<typeof createTestStore>, disabled?: boolean) {
+    renderHookWithProviders(
+      () => useKeyboardShortcuts({ onToggleShortcutsModal: vi.fn(), onNewChat: vi.fn(), disabled }),
+      { store },
+    )
+  }
+
+  const press = (code: string, target: EventTarget = document) => {
+    const event = new KeyboardEvent('keydown', { code, ctrlKey: true, cancelable: true, bubbles: true })
+    return !target.dispatchEvent(event) // true when preventDefault was called
+  }
+
+  it('] advances to the next session', () => {
+    const store = threeSlots('slot-2')
+    mount(store)
+    expect(press('BracketRight')).toBe(true)
+    expect(store.getState().chat.activeSlot).toBe('slot-3')
+  })
+
+  it('[ goes back to the previous session', () => {
+    const store = threeSlots('slot-2')
+    mount(store)
+    expect(press('BracketLeft')).toBe(true)
+    expect(store.getState().chat.activeSlot).toBe('slot-1')
+  })
+
+  it('wraps forward past the last session', () => {
+    const store = threeSlots('slot-3')
+    mount(store)
+    press('BracketRight')
+    expect(store.getState().chat.activeSlot).toBe('slot-1')
+  })
+
+  it('wraps backward past the first session', () => {
+    const store = threeSlots('slot-1')
+    mount(store)
+    press('BracketLeft')
+    expect(store.getState().chat.activeSlot).toBe('slot-3')
+  })
+
+  it('works from inside a text field (the chord has no editing meaning)', () => {
+    const store = threeSlots('slot-1')
+    mount(store)
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    expect(press('BracketRight', textarea)).toBe(true)
+    expect(store.getState().chat.activeSlot).toBe('slot-2')
+    textarea.remove()
+  })
+
+  it('leaves the keystroke to the PTY when it comes from a terminal', () => {
+    const store = threeSlots('slot-1')
+    mount(store)
+    const term = document.createElement('div')
+    term.className = 'xterm'
+    const inner = document.createElement('textarea')
+    term.appendChild(inner)
+    document.body.appendChild(term)
+    expect(press('BracketLeft', inner)).toBe(false) // not claimed → ESC reaches the PTY
+    expect(store.getState().chat.activeSlot).toBe('slot-1')
+    term.remove()
+  })
+
+  it('does not claim the keystroke when shortcuts are globally disabled', () => {
+    localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
+    const store = threeSlots('slot-1')
+    mount(store)
+    expect(press('BracketRight')).toBe(false) // browser Forward still works
+    expect(store.getState().chat.activeSlot).toBe('slot-1')
+  })
+
+  it('is suppressed while another surface owns the keyboard (disabled)', () => {
+    const store = threeSlots('slot-1')
+    mount(store, true)
+    press('BracketRight')
+    expect(store.getState().chat.activeSlot).toBe('slot-1')
+  })
+
+  it('does nothing with no sessions open', () => {
+    const store = createTestStore({
+      dashboard: { slots: [] } as unknown as RootState['dashboard'],
+      chat: chatState(null),
+    })
+    mount(store)
+    expect(press('BracketRight')).toBe(true) // still claimed, just nowhere to go
+    expect(store.getState().chat.activeSlot).toBe(null)
+  })
+
+  it('is advertised in the shortcuts registry as a ⌘/Ctrl chord', () => {
+    const prev = DEFAULT_SHORTCUTS.find(s => s.id === 'chat-prev-bracket')
+    const next = DEFAULT_SHORTCUTS.find(s => s.id === 'chat-next-bracket')
+    expect(prev).toMatchObject({ key: '[', meta: true, group: 'Chat Navigation' })
+    expect(next).toMatchObject({ key: ']', meta: true, group: 'Chat Navigation' })
+    expect(prev?.alt).toBeUndefined()
+    expect(next?.ctrl).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## What

Move between sessions with **⌘[ / ⌘]** on macOS (**Ctrl+[ / Ctrl+]** on Windows and Linux). The chord steps one session backwards or forwards through the sidebar order and wraps at both ends — the same move as the existing Alt+←/→, on the chord shape people already use for back/forward.

## Why

Alt+←/→ already cycles chats, but it deliberately does nothing inside a text field (it would eat word-jump), so you cannot switch sessions while the composer has focus — which is most of the time. ⌘/Ctrl+bracket has no text-editing meaning, so it works everywhere.

## How

- Matched on `KeyboardEvent.code` (`BracketLeft` / `BracketRight`), so the chord is **positional** and survives layouts where the bracket glyphs sit elsewhere — consistent with every other chord in this module.
- `sessionCycleStep` requires **exactly one** primary modifier (⌘ on Mac, Ctrl elsewhere) and no Alt/Shift, so it cannot fire from a ⌘⌥[ miss and cannot shadow Alt+arrow chat-nav, the Mac Ctrl+digit chat-jumps, or the ⌘/Ctrl+digit remote-crew switcher.
- Handled **before** the Alt gate, because the chord carries no Alt — same placement as the ⌘+, settings chord.
- Claims the keystroke with `preventDefault`, since ⌘[ / ⌘] are the browser's Back/Forward on macOS.
- **Terminal-safe:** skipped when the keystroke originates inside an `.xterm` surface, where Ctrl+[ is ESC and belongs to the PTY.
- Respects the global shortcuts toggle — with shortcuts off, the keystroke is left to the browser rather than swallowed.
- Advertised in the ⌥K shortcuts modal and Settings → Shortcuts (new `chat-prev-bracket` / `chat-next-bracket` registry entries).
- Alt+arrow now shares the new `wrapIndex` helper, so both bindings cycle identically (behaviour-preserving refactor, covered by the existing tests).

## Verification

Local gates, all green:

- `vitest run` — 5822 passed / 3 skipped, 478 files (24 new tests in `useKeyboardShortcuts.test.tsx`, revert-verified: dropping the terminal guard fails exactly the PTY test)
- `tsc -b`, `eslint` — clean

Verified live in a browser on an isolated worktree gateway (port 6899, its own `KIROCREW_HOME`):

1. Shortcuts modal lists the new chords under Chat Navigation (rendered as `Ctrl + [` / `Ctrl + ]` on this Linux host; a Mac renders `⌘[` / `⌘]`).
2. With three sessions open, Ctrl+] moved the selection one session forward (wrapping) and Ctrl+[ moved it back.

## Notes

Not Electron-gated, unlike the ⌘/Ctrl+digit remote-crew switcher: Chromium reserves ⌘/Ctrl+digit for tab switching and may never dispatch it, whereas ⌘[ / ⌘] are ordinary history accelerators the page can cancel. The macOS behaviour (⌘[ overriding browser Back) has not been exercised on real macOS hardware — this host is Linux — so that path rests on `preventDefault` semantics rather than a live check.
