### PR TITLE
fix(setup): apply subprocess rlimits after exec, not via preexec_fn

### DIFF
--- a/src/kiro_crew/_process_group_supervisor.py
+++ b/src/kiro_crew/_process_group_supervisor.py
@@ -1,4 +1,14 @@
-"""Keep a POSIX setup subprocess group anchored until all descendants exit."""
+"""Keep a POSIX setup subprocess group anchored until all descendants exit.
+
+Also applies the caller's resource limits. This runs AFTER ``exec``, in a
+single-threaded process, which is the whole point: applying them via
+``preexec_fn`` instead forced CPython to ``fork()`` the multi-GB, ~118-thread
+gateway and run Python in the child before ``exec``. Locks other threads held at
+fork time are unreleasable there, so the child deadlocked in a futex, never
+exec'd, and never exited -- while pinning every fd it inherited (see the
+gateway.lock reclaim fix). Limits set here are inherited by the exec'd child and
+all of its descendants, so coverage is unchanged.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +18,65 @@ import sys
 import time
 from pathlib import Path
 
+try:
+    import resource as _resource
+except ImportError:  # pragma: no cover - Windows has no POSIX rlimits
+    _resource = None  # type: ignore[assignment]
+
 _POLL_SECONDS = 0.05
+_RLIMIT_FLAG = "--rlimits="
+
+
+def _apply_rlimits(spec: str) -> None:
+    """Apply ``RLIMIT_NAME:value`` pairs from *spec* to this process.
+
+    Mirrors ``kiro_crew.security.apply_resource_limits``'s clamp rules -- take
+    the min of the request and the inherited hard limit, set soft AND hard so the
+    child cannot raise its own ceiling back up, and skip anything the kernel or
+    platform rejects rather than failing the spawn. Duplicated rather than
+    imported on purpose: this file is executed as an immutable ``python -I -c``
+    source string, so it must stay stdlib-only.
+
+    The ``resource`` import is guarded because this module is also imported
+    directly by the test suite, including on Windows, where the supervisor itself
+    is never spawned.
+    """
+    if _resource is None:
+        return
+    res = _resource
+    for item in spec.split(","):
+        name, _, raw = item.partition(":")
+        try:
+            res_id = getattr(res, name)
+            requested = int(raw)
+        except (AttributeError, ValueError):
+            continue
+        try:
+            _soft, hard = res.getrlimit(res_id)
+            if hard != res.RLIM_INFINITY:
+                requested = min(requested, hard)
+            res.setrlimit(res_id, (requested, requested))
+        except (ValueError, OSError):
+            continue
+
+
+def _bias_oom_score() -> None:
+    """Bias the OOM killer toward this process tree (inherited by descendants).
+
+    Mirrors ``kiro_crew.security._bias_child_oom_score``: a memory-ballooning
+    tool subprocess should be killed before the cgroup ceiling takes out the
+    whole agent scope. Linux-only, unprivileged, best-effort.
+    """
+    if sys.platform != "linux":
+        return
+    try:
+        fd = os.open("/proc/self/oom_score_adj", os.O_WRONLY)
+        try:
+            os.write(fd, b"1000")
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
 
 
 def _proc_stat_group_member(text: str, pgid: int) -> bool:
@@ -98,6 +166,17 @@ def _exit_code(status: int) -> int:
 
 def main() -> None:
     argv = sys.argv[1:]
+    # Bias the OOM killer FIRST and unconditionally. It is an independent control
+    # from the rlimits -- ``preexec_fn`` applied it on every spawn -- so gating it
+    # on the presence of ``--rlimits=`` would silently drop it for an operator who
+    # disables every limit. Inherited by the exec'd child and its descendants.
+    _bias_oom_score()
+    # Optional leading --rlimits=NAME:value,... from the spawning gateway. Applied
+    # before the fork below so the exec'd child and every descendant inherit the
+    # ceiling, matching what preexec_fn used to cover.
+    if argv and argv[0].startswith(_RLIMIT_FLAG):
+        _apply_rlimits(argv[0][len(_RLIMIT_FLAG):])
+        argv = argv[1:]
     if not argv or not Path(argv[0]).is_absolute():
         raise SystemExit(127)
 

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -45,7 +45,7 @@ from kiro_crew.kiro_cli import (
     find_kiro_cli_candidates,
     known_kiro_cli_dirs,
 )
-from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
+from kiro_crew.sandbox import resource_limit_supervisor_argv, sandboxed_spawn_argv
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -1174,11 +1174,20 @@ async def _run_process(
             # two parent wait loops depend on each other; loading it from a
             # mutable package path would also let a same-UID agent replace code
             # immediately before an owner-triggered install.
+            #
+            # It also carries the resource limits (``--rlimits=``) that used to
+            # ride on ``preexec_fn``. See resource_limit_supervisor_argv: a
+            # preexec_fn forces a plain fork() of this multi-threaded gateway and
+            # runs Python in the child before exec, which is how a child wedged
+            # in a futex and pinned the fds it had inherited. The supervisor
+            # applies the same setrlimits after exec, single-threaded, and the
+            # exec'd child inherits them.
             spawn_argv = [
                 sys.executable,
                 "-I",
                 "-c",
                 _PROCESS_GROUP_SUPERVISOR_CODE,
+                *resource_limit_supervisor_argv(),
                 *spawn_argv,
             ]
         proc = await asyncio.create_subprocess_exec(
@@ -1187,7 +1196,6 @@ async def _run_process(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=spawn_env,
-            preexec_fn=resource_limit_preexec(),
             start_new_session=platform_compat.IS_POSIX,
             creationflags=creationflags,
         )

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2572,6 +2572,45 @@ def resource_limit_preexec() -> "Callable[[], None] | None":
     return _RESOURCE_PREEXEC  # type: ignore[return-value]
 
 
+# Cached ``--rlimits=`` argv fragment for the process-group supervisor. Same
+# policy as ``resource_limit_preexec``, delivered post-exec instead of post-fork.
+_RESOURCE_SUPERVISOR_ARGV: object = _UNSET
+
+
+def resource_limit_supervisor_argv() -> "tuple[str, ...]":
+    """Return the supervisor's ``--rlimits=`` argv fragment (empty if none apply).
+
+    The alternative to :func:`resource_limit_preexec` for the one spawn that
+    already prepends ``_process_group_supervisor.py``. Passing ``preexec_fn=``
+    forces CPython to ``fork()`` the multi-GB, ~118-thread gateway and run Python
+    in the child before ``exec``; a lock another thread held at fork time is
+    unreleasable there, and that is how a child deadlocked in a futex, never
+    exec'd, and pinned every fd it had inherited. Handing the limits to the
+    supervisor moves the same ``setrlimit`` calls after ``exec``, where the
+    process is single-threaded, and the exec'd child inherits them either way.
+
+    The values are policy numbers, not secrets, so argv (world-readable via
+    ``ps``) is a fine channel.
+    """
+    global _RESOURCE_SUPERVISOR_ARGV
+    if _RESOURCE_SUPERVISOR_ARGV is _UNSET:
+        if os.name != "posix":
+            _RESOURCE_SUPERVISOR_ARGV = ()
+            return ()
+        from kiro_crew.security import resource_limit_spec
+
+        cfg: dict | None = None
+        try:
+            from kiro_crew.config.loader import _raw_config
+
+            cfg = _raw_config()
+        except Exception:
+            logger.debug("resource_limit_supervisor_argv: config unavailable, using defaults")
+        spec = ",".join(f"{name}:{value}" for name, value in resource_limit_spec(cfg))
+        _RESOURCE_SUPERVISOR_ARGV = (f"--rlimits={spec}",) if spec else ()
+    return _RESOURCE_SUPERVISOR_ARGV  # type: ignore[return-value]
+
+
 # ---------------------------------------------------------------------------
 # Session host preexec — the inverse of resource_limit_preexec.
 # ---------------------------------------------------------------------------

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5041,6 +5041,43 @@ def _bias_child_oom_score() -> None:
         pass
 
 
+def resource_limit_spec(config: dict | None = None) -> list[tuple[str, int]]:
+    """Resolve the configured rlimits as ``(RLIMIT_* name, value)`` pairs.
+
+    Split out of :func:`apply_resource_limits` so one policy reader serves both
+    ways of applying the limits:
+
+    * **post-fork**, as the ``preexec_fn`` :func:`apply_resource_limits` builds;
+    * **post-exec**, by the process-group supervisor
+      (``_process_group_supervisor.py``), which receives these pairs on its argv
+      because it cannot import this module -- it runs under ``python -I -c`` from
+      an immutable gateway-captured source string, and that is deliberate: a
+      mutable package path would let a same-UID agent swap the code out.
+
+    Names, not ``resource`` constants: the consumer resolves them with
+    ``getattr`` and skips any its platform lacks. A value of ``0`` means "leave
+    inherited" and is dropped here.
+    """
+    limits = dict(_RLIMIT_DEFAULTS)
+    if config and isinstance(config.get("resource_limits"), dict):
+        rl_config = config["resource_limits"]
+        for key in _RLIMIT_DEFAULTS:
+            val = rl_config.get(key)
+            # Accept 0 (explicit disable) and positive ints; ignore junk.
+            if isinstance(val, (int, float)) and not isinstance(val, bool) and val >= 0:
+                limits[key] = int(val)
+
+    # (rlimit name, requested soft/hard value in the rlimit's native unit).
+    max_memory_bytes = limits["max_memory_mb"] * 1024 * 1024
+    specs = [
+        ("RLIMIT_NPROC", limits["max_processes"]),
+        ("RLIMIT_NOFILE", limits["max_open_files"]),
+        ("RLIMIT_CPU", limits["max_cpu_seconds"]),
+        ("RLIMIT_AS", max_memory_bytes),
+    ]
+    return [(name, value) for name, value in specs if value > 0]
+
+
 def apply_resource_limits(config: dict | None = None) -> "Callable[[], None]":
     """Return a preexec_fn that applies POSIX resource limits to a child process.
 
@@ -5083,28 +5120,12 @@ def apply_resource_limits(config: dict | None = None) -> "Callable[[], None]":
     # type (closures don't inherit the guard's narrowing of the module global).
     res = _resource
 
-    limits = dict(_RLIMIT_DEFAULTS)
-    if config and isinstance(config.get("resource_limits"), dict):
-        rl_config = config["resource_limits"]
-        for key in _RLIMIT_DEFAULTS:
-            val = rl_config.get(key)
-            # Accept 0 (explicit disable) and positive ints; ignore junk.
-            if isinstance(val, (int, float)) and not isinstance(val, bool) and val >= 0:
-                limits[key] = int(val)
-
-    # (rlimit constant, requested soft/hard value in the rlimit's native unit).
-    # A value of 0 means "leave inherited" and is skipped below.
-    max_memory_bytes = limits["max_memory_mb"] * 1024 * 1024
-    specs = [
-        ("RLIMIT_NPROC", limits["max_processes"]),
-        ("RLIMIT_NOFILE", limits["max_open_files"]),
-        ("RLIMIT_CPU", limits["max_cpu_seconds"]),
-        ("RLIMIT_AS", max_memory_bytes),
-    ]
     # Resolve the rlimit constants once in the parent (cheap, keeps the
     # post-fork callable minimal). Skip any this platform lacks.
     resolved = [
-        (getattr(res, name), value) for name, value in specs if value > 0 and hasattr(res, name)
+        (getattr(res, name), value)
+        for name, value in resource_limit_spec(config)
+        if hasattr(res, name)
     ]
 
     def _set_limits() -> None:

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import os
 import sqlite3
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -597,6 +598,75 @@ class TestKiroPrerequisiteHelpers:
             42,
             999,
         ) == {100}
+
+    def test_supervisor_rlimit_spec_ignores_junk(self) -> None:
+        """A malformed --rlimits= entry must never fail the spawn.
+
+        Safe to run in-process precisely because nothing here resolves to a real
+        rlimit, so no setrlimit call touches this test process.
+        """
+        supervisor._apply_rlimits("RLIMIT_DOES_NOT_EXIST:1")
+        supervisor._apply_rlimits("RLIMIT_NOFILE:not-an-int")
+        supervisor._apply_rlimits("")
+        supervisor._apply_rlimits("garbage")
+
+    @pytest.mark.skipif(
+        platform_compat.IS_WINDOWS, reason="POSIX resource limits"
+    )
+    def test_supervisor_applies_rlimits_and_child_inherits_them(self) -> None:
+        """The post-exec replacement for preexec_fn actually enforces a ceiling.
+
+        Runs the real supervisor the way ``_run_process`` does -- including
+        ``start_new_session=True``, without which the supervisor waits on the
+        caller's own process group and never exits -- and reads the limit from
+        the exec'd grandchild, which is what the ceiling has to cover.
+        """
+        code = Path(supervisor.__file__).read_text(encoding="utf-8")
+        probe = "import resource;print(resource.getrlimit(resource.RLIMIT_NOFILE)[0])"
+        real_python = os.path.realpath(sys.executable)
+
+        def run(*extra: str) -> str:
+            done = subprocess.run(  # noqa: S603 - fixed argv, test-local
+                [sys.executable, "-I", "-c", code, *extra, real_python, "-c", probe],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                start_new_session=True,
+            )
+            assert done.returncode == 0, done.stderr
+            return done.stdout.strip()
+
+        inherited = int(run())
+        capped = int(run("--rlimits=RLIMIT_NOFILE:64"))
+        assert capped == 64
+        assert inherited != capped  # the cap came from the flag, not the host
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="oom_score_adj is Linux-only")
+    def test_supervisor_biases_oom_score_without_any_rlimit_flag(self) -> None:
+        """The OOM bias is independent of the rlimits and must not be gated on them.
+
+        ``preexec_fn`` applied it on every spawn. Gating it on ``--rlimits=``
+        would silently drop it for an operator who disables every limit.
+        """
+        code = Path(supervisor.__file__).read_text(encoding="utf-8")
+        probe = "print(open('/proc/self/oom_score_adj').read().strip())"
+        done = subprocess.run(  # noqa: S603 - fixed argv, test-local
+            [
+                sys.executable,
+                "-I",
+                "-c",
+                code,
+                os.path.realpath(sys.executable),
+                "-c",
+                probe,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            start_new_session=True,
+        )
+        assert done.returncode == 0, done.stderr
+        assert done.stdout.strip() == "1000"
 
     def test_posix_candidates_are_discoverable_on_windows_host(
         self,
@@ -2412,6 +2482,8 @@ class TestKiroPrerequisiteWorkflow:
             "-I",
             "-c",
             prerequisite_module._PROCESS_GROUP_SUPERVISOR_CODE,
+            # Resource limits ride on the supervisor's argv, not preexec_fn.
+            *prerequisite_module.resource_limit_supervisor_argv(),
             "/sandbox/launcher",
             "/usr/bin/env",
             "/tmp/agent-writable/kiro-cli",
@@ -2499,7 +2571,10 @@ class TestKiroPrerequisiteWorkflow:
         )
 
         assert result.ok is True
-        assert captured["spawn_argv"][4] == f"/usr/bin/{wrapper}"
+        # 4 supervisor items (python, -I, -c, code) plus the optional --rlimits=
+        # fragment, then the resolved sandbox wrapper.
+        wrapper_index = 4 + len(prerequisite_module.resource_limit_supervisor_argv())
+        assert captured["spawn_argv"][wrapper_index] == f"/usr/bin/{wrapper}"
 
     @pytest.mark.skipif(
         platform_compat.IS_WINDOWS,

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -95,7 +95,24 @@ _PREEXEC_TOKENS = ("resource_limit_preexec", "session_host_preexec")
 # agent-influenced code — a resource ceiling adds nothing. Keyed by
 # ``<relpath>::<function>`` with a justification, same discipline as
 # ``BENIGN_SPAWNS``.
-PREEXEC_EXEMPT: frozenset[str] = frozenset(set())
+PREEXEC_EXEMPT: frozenset[str] = frozenset(
+    {
+        # Applies the SAME limits post-exec instead of post-fork. This spawn
+        # already prepends the immutable process-group supervisor
+        # (`python -I -c <supervisor>`), so it hands the resolved rlimits to that
+        # supervisor as `--rlimits=NAME:value,...` (see
+        # sandbox.resource_limit_supervisor_argv) and the supervisor calls
+        # setrlimit before forking the real child, which inherits the ceiling.
+        # The limits are therefore NOT dropped; only the delivery point moved.
+        # Why it had to move: `preexec_fn` forces CPython off posix_spawn/vfork
+        # onto a plain fork() of the multi-GB, ~118-thread gateway and runs
+        # Python in the child before exec. A lock another thread held at fork
+        # time is unreleasable there, and a child so wedged deadlocked in a
+        # futex, never exec'd, never exited, and pinned every fd it inherited --
+        # including gateway.lock and the dashboard listener.
+        "kiro_prerequisite.py::_run_process",
+    }
+)
 
 # Benign spawns: command/args/cwd are fixed or operator-controlled, NOT
 # influenced by the agent, a hostile MCP-config entry, or an agent-selected


### PR DESCRIPTION
## Problem

A gateway crash left a deadlocked orphan process that had forked from the
gateway and never reached `exec`. It held the fds it inherited — `gateway.lock`
and the dashboard listening socket — so the gateway became unstartable and only
a manual `kill -9` recovered it. Three times in two days on one machine.

Observed orphans: pid 23184 (3.7 GB RSS, 1 thread) and pid 16968 (10.8 GB, 1
thread). Both PPID 1, both carrying the parent gateway's PGID, both blocked in
syscall 202 (futex).

Evidence for the fork site is a loop-stall crash dump under
`logs/crash-dumps/`, whose main-thread stack is
`api_kiro_prerequisite_status -> snapshot -> _probe -> _audited_probe ->
_run_process -> create_subprocess_exec -> subprocess.py _execute_child`.

## Why it matters

This is the mechanism that produces the wedge, so it is the change that stops
orphans existing at all. `_run_process` runs on the gateway's own event loop
during a routine prerequisite probe, so any user can hit it without doing
anything unusual.

## Fix (symptoms -> root cause -> change)

**Symptom:** a child of the gateway deadlocks before `exec` and never exits.

**Root cause:** `_run_process` passed `preexec_fn=resource_limit_preexec()`.
A `preexec_fn` forces CPython off `posix_spawn`/`vfork` onto a plain `fork()`
**and then runs Python in the child before `exec`**. The gateway is multi-GB and
~118 threads; a lock another thread held at fork time is unreleasable in the
child, so the child deadlocked in a futex, never exec'd, and never exited.

**Change:** the limits are not dropped — only their delivery point moves, from
post-fork to post-exec.

This spawn already prepends the immutable, gateway-captured process-group
supervisor (`python -I -c <supervisor source>`), which is the outermost process
and is single-threaded after `exec`. The resolved rlimits now ride on that
supervisor's argv as `--rlimits=NAME:value,...`, and the supervisor calls
`setrlimit` before forking the real child. rlimits are inherited across `fork`
and `exec`, so the exec'd child and every descendant carry the same ceiling.

- `security`: `resource_limit_spec()` split out of `apply_resource_limits()`, so
  one policy reader serves both delivery paths. It returns rlimit *names*, not
  `resource` constants, because the consumer cannot import this module — the
  supervisor runs from an immutable source string under `-I` deliberately, since
  a mutable package path would let a same-UID agent swap the enforcement code
  out immediately before an owner-triggered install.
- `sandbox`: `resource_limit_supervisor_argv()`, the post-exec counterpart to
  `resource_limit_preexec()`. Cached identically; returns `()` on Windows and
  when every limit is disabled.
- `_process_group_supervisor`: accepts a leading `--rlimits=` and applies it
  before the fork. The clamp rules (min against the inherited hard limit, set
  soft **and** hard so the child cannot raise its own ceiling) are duplicated
  rather than imported — the stdlib-only constraint forces that — and both
  copies cross-reference each other.
- `_process_group_supervisor`: `import resource` is guarded. The test suite
  imports this module directly, including on Windows, where the supervisor is
  never spawned; an unguarded import would fail collection for the whole file.
- `_process_group_supervisor`: the `oom_score_adj` bias is applied first and
  **unconditionally**, not gated on `--rlimits=` being present. It is an
  independent control that `preexec_fn` applied on every spawn, so gating it
  would silently drop it for an operator who disables every rlimit.
- `kiro_prerequisite._run_process`: drops `preexec_fn`, passes the fragment.

**What is claimed and what is not.** The child no longer runs any Python between
fork and exec, which is what made the deadlock possible — that is structural.
Whether CPython additionally selects `vfork` or `posix_spawn` for this spawn
depends on the interpreter version and the other `create_subprocess_exec`
arguments, and this PR does not claim it.

**Scope.** This is the one spawn that has a supervisor to carry the limits and
the one with a crash dump proving it wedged. `resource_limit_preexec()` is
unchanged and still used by `cron_script`, `git_coord`, `hooks` and
`mcp_discovery`, which have the same fork-before-exec shape and no supervisor.
Those need their own mechanism and their own review — a follow-up, not silently
ignored.

**Behaviour difference worth naming:** the supervisor's own interpreter startup
now runs before the caps apply. It is a fixed, gateway-owned Python that
allocates far less than the child it guards.

## Tests

- `test_supervisor_applies_rlimits_and_child_inherits_them` — runs the real
  supervisor the way `_run_process` does and reads `RLIMIT_NOFILE` from the
  **exec'd grandchild**, which is what the ceiling has to cover. Includes
  `start_new_session=True`; without it the supervisor waits on the caller's own
  process group and never exits (this cost a 60-second timeout to learn).
- `test_supervisor_biases_oom_score_without_any_rlimit_flag` — pins the
  decoupling above: no flag at all, and the grandchild still reports
  `oom_score_adj` of 1000. Checked against a negative control (removing the
  call yields 0), so it is not vacuous.
- `test_supervisor_rlimit_spec_ignores_junk` — a malformed or hostile
  `--rlimits=` fragment can never fail a spawn.
- The two existing argv assertions now derive the supervisor prefix from
  `resource_limit_supervisor_argv()` instead of hardcoding an index, so they
  stay correct whether or not any limit is configured.
- `test_spawn_audit.py`'s resource-limit tripwire gets its first ever
  `PREEXEC_EXEMPT` entry. The justification records that the limits moved rather
  than vanished, names the delivery mechanism, and explains why it had to move,
  so a future reader can re-derive the decision instead of trusting it.

## Manual verification

Ran the supervisor directly: with `--rlimits=RLIMIT_NOFILE:512` the exec'd child
reports `(512, 512)`; without the flag it reports the inherited `(65535, 65535)`;
with a malformed spec it reports the inherited value and still exits 0. Confirmed
the module imports cleanly with the `resource` module made unavailable, and that
`_apply_rlimits` is then a no-op rather than a crash.

Full backend suite on this branch: 20169 passed, 27 failed. All 27 reproduce on a
pristine `origin/main` worktree except one ACP deferral test, which passes in
isolation on this branch and is a load flake under the parallel run. The
sandbox-related failures are this host's environment (`unshare` EPERM, `link()`
denied).

## Screenshots

N/A — no user-visible UI change.
