### PR TITLE
docs: fix Windows install gaps (sandbox config, workspace env var, CONTRIBUTING mismatch)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,9 @@ we welcome issues and pull requests.
 
 ## Prerequisites
 
-- macOS or Linux (Windows is not supported by the `kiro-cli` backend)
+- macOS, Linux, or Windows (native source install — see
+  [docs/windows-install.md](docs/windows-install.md) for Windows-specific
+  prerequisites, the `venv` activation step, and per-feature parity notes)
 - Python ≥ 3.9
 - Node.js ≥ 18 and npm (for the frontend)
 - The `kiro-cli` agent on your `PATH`, logged in (`kiro-cli login`) — it is the

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -65,6 +65,25 @@ Then:
 
 ```powershell
 kirocrew setup
+```
+
+Windows has no OS-level sandbox backend (no Linux user namespaces, no macOS
+`sandbox-exec` equivalent), so `kirocrew doctor` fails to probe the built-in
+`@kirocrew-cron` / `@kirocrew-core` MCP servers until you explicitly opt in to
+running the agent subprocess without that isolation layer:
+
+```powershell
+kirocrew config set agent.sandbox_allow_unsandboxed_exec true
+```
+
+This is a real security tradeoff, not a cosmetic warning: without an OS
+sandbox, the agent subprocess runs with your full user permissions and can
+read anything your account can read (e.g. `~/.aws`, `~/.ssh`), with only the
+app-level `security.py` checks (bypassable) standing in. Run `kirocrew doctor`
+again to confirm `@kirocrew-cron` / `@kirocrew-core` now report their tool
+counts instead of a sandbox error, then start the gateway:
+
+```powershell
 kirocrew gateway
 ```
 
@@ -75,6 +94,22 @@ PowerShell installer; if it is signed out, choose **Sign in to Kiro** and
 complete the device-code flow in the browser. The dashboard opens automatically
 after `kiro-cli whoami` succeeds. This setup runs on the gateway machine, which
 may be different from the computer running the browser.
+
+If your default drive is low on space, redirect KiroCrew's config/data home and
+workspace before running `setup`:
+
+```powershell
+$env:KIROCREW_HOME = "D:\kiro-crew-home"
+$env:KIROCREW_WORKSPACE = "D:\kirocrew-workspace"
+kirocrew setup
+```
+
+Note: the `kirocrew setup` workspace-path prompt does not read
+`KIROCREW_WORKSPACE` when computing its *displayed default* — pressing Enter
+on that prompt still falls back to the platform default under your home
+directory. Type the desired path explicitly at the prompt (or pass it via
+`KIROCREW_WORKSPACE` and confirm it matches before accepting). The env var is
+otherwise honored everywhere else at runtime.
 
 `kirocrew` / `kirocrew-browse` land in `.venv\Scripts\`. If a launched (non-shell)
 gateway can't find the built-in `kirocrew-cron` / `kirocrew-core` MCP servers,


### PR DESCRIPTION
## Summary

Found these gaps while doing a native Windows source install this week, following docs/windows-install.md end to end.

- **CONTRIBUTING.md** prerequisites say Windows is not supported by the kiro-cli backend. That directly contradicts README.md (\Windows (native)\) and the existing docs/windows-install.md. Updated it to point at the Windows doc instead of asserting the opposite.
- **docs/windows-install.md** Quick Start is missing a required step: on Windows there is no OS-level sandbox backend, so \kirocrew doctor\ fails to probe \@kirocrew-cron\ / \@kirocrew-core\ until you run \kirocrew config set agent.sandbox_allow_unsandboxed_exec true\. The doc's own feature-status table lists core gateway/chat/cron/dashboard as working, but that only holds once this flag is set. Added the step plus an explicit note on what it actually trades away (no OS isolation for the agent subprocess).
- Documented \KIROCREW_HOME\ / \KIROCREW_WORKSPACE\ for redirecting KiroCrew off a full system drive, since the doc didn't mention either var. Also noted a real quirk: the \kirocrew setup\ workspace-path prompt doesn't read \KIROCREW_WORKSPACE\ when computing its *displayed default* — pressing Enter still falls back to the platform default under the home directory, so the env var has to be typed explicitly at the prompt. (Might be worth a follow-up code fix separately; flagging here since it's easy to trip on silently.)

## Testing

Docs-only change. Verified by walking through the corrected steps on a fresh native Windows install (Python 3.13, Node 22): \kirocrew doctor\ failed with the sandbox probe error before setting the flag, and passed cleanly after.

No code changes, so no new tests.