### PR TITLE
fix(dashboard): serve the SPA shell for /apps client routes, reach the knowledge onboarding state

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -406,8 +406,10 @@ _APPS_UI_BYPASS_RE = re.compile(r"^/apps/[a-z0-9][a-z0-9_-]*/ui/")
 #
 # NOTE: /apps/ is intentionally NOT in this tuple. /apps/ path handling is
 # governed solely by _APPS_SPA_EXCLUDED_RE in _is_spa_shell_request:
-#   - bare /apps/{name}           → SPA shell (browser refresh must work)
-#   - /apps/{name}/<sub-path>     → real server handler (proxy / static)
+#   - bare /apps/{name}              → SPA shell (browser refresh must work)
+#   - /apps/{name}/api|ui/...        → real server handler (proxy / static)
+#   - any other /apps/ path          → SPA shell (React Router owns it, e.g.
+#                                      /apps/detail/{name}, /apps/migrate/{name})
 # test_no_get_route_outside_shell_exclusions validates /apps/ routes against
 # _APPS_SPA_EXCLUDED_RE directly, not this tuple.
 SPA_FALLBACK_EXCLUDED_PREFIXES = (
@@ -422,11 +424,29 @@ SPA_FALLBACK_EXCLUDED_PREFIXES = (
     "/artifact-app/",
 )
 
-# Regex that matches /apps/{name} sub-namespace paths that have real server-side
-# handlers and must NOT be shadowed by the SPA shell. Bare /apps/{name} (no
-# further slash) is excluded from this pattern so those paths *do* get the SPA
-# shell on a browser refresh.
-_APPS_SPA_EXCLUDED_RE = re.compile(r"^/apps/[a-z0-9][a-z0-9_-]*/")
+# Regex that matches /apps/ paths with real server-side handlers, which must NOT
+# be shadowed by the SPA shell. apps/routes.py registers exactly two
+# sub-namespaces under /apps/{name}: /ui/ (the app's static bundle) and /api/
+# (the gateway-authenticated reverse proxy to the app backend). Every other
+# /apps/ path is a client-side React Router entry and needs the shell.
+#
+# Naming those two sub-namespaces is load-bearing. Matching any sub-path (the
+# earlier `^/apps/[a-z0-9][a-z0-9_-]*/`) read the FIRST segment as the app name,
+# so the router's own /apps/detail/{name} and /apps/migrate/{name} entries were
+# treated as server routes and returned 404 on direct navigation or refresh.
+# test_apps_router_subpaths_are_spa_shell locks that in, and
+# test_apps_server_routes_are_excluded_from_shell guards the other direction by
+# reading the live route literals out of apps/routes.py.
+#
+# The trailing slash is also load-bearing. Both handlers are registered with a
+# path segment after the sub-namespace (`/apps/{name}/ui/{path:.*}` and
+# `/apps/{name}/api/{path:.*}`), and no bare `/apps/{name}/ui` or
+# `/apps/{name}/api` route exists. An earlier `(?:/|$)` therefore excluded two
+# paths that no handler serves, and since the app name occupies the same segment
+# position as the router's `detail`/`migrate` verbs, an app named literally
+# "api" or "ui" got a 404 on /apps/detail/api. Requiring the slash costs no
+# real server route and resolves that collision toward the client route.
+_APPS_SPA_EXCLUDED_RE = re.compile(r"^/apps/[a-z0-9][a-z0-9_-]*/(?:api|ui)/")
 
 
 def _is_spa_shell_request(request: web.Request) -> bool:
@@ -437,10 +457,11 @@ def _is_spa_shell_request(request: web.Request) -> bool:
     dead-end 403 whose recovery JS never loads. Safe because the shell is
     static and secret-free and every data namespace is excluded.
 
-    Special case for ``/apps/``: bare ``/apps/{name}`` paths (no sub-path) are
-    React Router navigation entries that have no server-side route, so they must
-    fall through to the SPA shell.  Only ``/apps/{name}/<sub-path>`` URLs with
-    real handlers (``/api/``, ``/ui/``) are excluded.
+    Special case for ``/apps/``: only ``/apps/{name}/api/...`` and
+    ``/apps/{name}/ui/...`` have server-side handlers. Every other ``/apps/``
+    path is a React Router navigation entry with no server route -- bare
+    ``/apps/{name}``, plus ``/apps/detail/{name}`` and ``/apps/migrate/{name}``
+    -- so those must fall through to the SPA shell.
     """
     if request.method not in ("GET", "HEAD"):
         return False
@@ -448,9 +469,10 @@ def _is_spa_shell_request(request: web.Request) -> bool:
     # Fast-path: most paths don't start with /apps/
     if not path.startswith("/apps/"):
         return not path.startswith(SPA_FALLBACK_EXCLUDED_PREFIXES)
-    # /apps/ sub-namespace: only exclude paths that have real server-side
-    # handlers (i.e. the path has a sub-component after {name}/).
-    # Bare /apps/{name} with no trailing slash → SPA navigation → serve shell.
+    # /apps/ sub-namespace: exclude only the paths apps/routes.py actually
+    # serves (/apps/{name}/api/... and /apps/{name}/ui/...). Everything else
+    # under /apps/ belongs to React Router — bare /apps/{name} as well as
+    # /apps/detail/{name} and /apps/migrate/{name} — and gets the shell.
     return not _APPS_SPA_EXCLUDED_RE.match(path)
 
 

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -598,6 +598,72 @@ def test_apps_sub_paths_are_not_spa_shell(path: str) -> None:
 @pytest.mark.parametrize(
     "path",
     [
+        "/apps/detail/task-runner",
+        "/apps/detail/code-review-sage",
+        "/apps/migrate/legacy-app",
+        # An app whose name collides with a sub-namespace verb. The app name and
+        # the router's detail/migrate verbs share a segment position, so these
+        # are 3-segment client routes, not the 4-plus-segment server routes
+        # (/apps/{name}/api/{path}). An earlier `(?:/|$)` excluded them.
+        "/apps/detail/api",
+        "/apps/detail/ui",
+        "/apps/migrate/api",
+        "/apps/migrate/ui",
+    ],
+)
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
+def test_apps_router_subpaths_are_spa_shell(path: str, method: str) -> None:
+    """React Router owns /apps/detail/{name} and /apps/migrate/{name} (App.tsx).
+    Neither has a server-side route, so both must get the SPA shell.
+
+    Regression for: _APPS_SPA_EXCLUDED_RE matched any /apps/{seg}/ path, so it
+    read "detail" and "migrate" as the app name and excluded these from the
+    shell. Pasting /apps/detail/task-runner into the address bar (or refreshing
+    on it) returned 404; the routes worked only via in-app navigation.
+    """
+    import kiro_crew.dashboard.token_auth as ta
+
+    req = _make_request(path=path, method=method)
+    assert ta._is_spa_shell_request(req), (
+        f"{method} {path} should be a SPA shell request (React Router owns it, "
+        f"there is no server-side handler for this path)"
+    )
+
+
+def test_apps_server_routes_are_excluded_from_shell() -> None:
+    """Drift guard: every route apps/routes.py registers under /apps/ must be
+    excluded from the shell, or the SPA would shadow a real handler.
+
+    Reads the route literals from source so adding a third /apps/ sub-namespace
+    without extending _APPS_SPA_EXCLUDED_RE fails here.
+    """
+    import re as _re
+
+    import kiro_crew.apps.routes as ar
+    import kiro_crew.dashboard.token_auth as ta
+
+    source = open(ar.__file__, encoding="utf-8").read()
+    # add_get("/path", h) / add_route("*", "/path", h) / add_post("/path", h)
+    literals = _re.findall(r'add_(?:get|post|route)\(\s*(?:"[^"]*",\s*)?"([^"]+)"', source)
+    apps_routes = [p for p in literals if p.startswith("/apps/")]
+    assert apps_routes, "expected /apps/ route literals in apps/routes.py"
+
+    # Concretize aiohttp placeholders into a path the regex can be run against.
+    def concretize(p: str) -> str:
+        p = p.replace("{name}", "sample-app")
+        return _re.sub(r"\{[^}]+\}", "segment", p)
+
+    offenders = [p for p in apps_routes if not ta._APPS_SPA_EXCLUDED_RE.match(concretize(p))]
+    assert not offenders, (
+        f"/apps/ route(s) with a real handler are NOT excluded from the SPA "
+        f"shell and would be shadowed by index.html: {offenders}. Extend "
+        f"_APPS_SPA_EXCLUDED_RE in token_auth.py to cover their sub-namespace."
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "/app-assets/auto-research/icon.svg",
         "/app-assets/workflows/hero-light.svg",
         "/app-assets/auto-research/hero-dark.svg",

--- a/website/playwright/apps.spec.ts
+++ b/website/playwright/apps.spec.ts
@@ -15,10 +15,13 @@ import { test, expect, type APIRequestContext, type Page } from '@playwright/tes
  *
  * Tests assert the real harness state unconditionally. No conditional branches.
  *
- * FINDING: /apps/detail/:name is a client-side-only route — the server's SPA
- * fallback regex (_APPS_SPA_EXCLUDED_RE) treats "detail" as an app name and the
- * trailing segment as a sub-resource, returning 404 on direct navigation. Tests
- * navigate via the SPA shell rather than hitting the bare URL.
+ * Direct navigation to /apps/detail/:name works: the server's SPA fallback
+ * excludes only the two sub-namespaces apps/routes.py serves
+ * (/apps/{name}/api/ and /apps/{name}/ui/), so every other /apps/ path reaches
+ * React Router. It used to exclude any /apps/{seg}/ path, reading "detail" as
+ * the app name and 404ing the bare URL, which is why these tests previously
+ * navigated via pushState instead. gotoDetail() now hits the URL directly, so a
+ * regression re-appears here as a 404 rather than being routed around.
  */
 
 type AppEntry = {
@@ -77,15 +80,14 @@ async function gotoApps(page: Page) {
 }
 
 /**
- * Navigate to a detail page via client-side routing (avoids the server 404 on
- * direct /apps/detail/:name — see FINDING above).
+ * Navigate straight to /apps/detail/:name. Asserting on the HTTP status is the
+ * regression test for the SPA-fallback fix: before it, the gateway answered this
+ * URL with 404 instead of the shell, so the route worked only via in-app
+ * navigation.
  */
-async function gotoDetailViaRouter(page: Page, appName: string) {
-  await gotoApps(page)
-  await page.evaluate((name) => {
-    window.history.pushState({}, '', `/apps/detail/${name}`)
-    window.dispatchEvent(new PopStateEvent('popstate'))
-  }, appName)
+async function gotoDetail(page: Page, appName: string) {
+  const res = await page.goto(`/apps/detail/${appName}`, { waitUntil: 'domcontentloaded' })
+  expect(res?.status(), `GET /apps/detail/${appName} must be served the SPA shell, not 404`).toBe(200)
   // "Back to Apps" renders in both the found and not-found states.
   await expect(page.getByRole('button', { name: 'Back to Apps' })).toBeVisible({ timeout: 10000 })
 }
@@ -173,14 +175,14 @@ test.describe('Apps Page — /apps', () => {
 
 test.describe('App Detail Page — /apps/detail/:name', () => {
   test('renders detail view for Task Runner', async ({ page }) => {
-    await gotoDetailViaRouter(page, 'projects')
+    await gotoDetail(page, 'projects')
     // The detail page shows the display name
     await expect(page.locator('text=Task Runner').first()).toBeVisible({ timeout: 10000 })
     await expect(page.getByRole('button', { name: 'Back to Apps' })).toBeVisible()
   })
 
   test('shows "App Not Found" for a nonexistent app', async ({ page }) => {
-    await gotoDetailViaRouter(page, 'this-app-does-not-exist-zyx')
+    await gotoDetail(page, 'this-app-does-not-exist-zyx')
     await expect(page.locator('text=App Not Found')).toBeVisible({ timeout: 10000 })
     await expect(page.getByRole('button', { name: 'Back to Apps' })).toBeVisible()
   })
@@ -197,7 +199,7 @@ test.describe('App Detail Page — /apps/detail/:name', () => {
   })
 
   test('detail page shows Details metadata card', async ({ page }) => {
-    await gotoDetailViaRouter(page, 'projects')
+    await gotoDetail(page, 'projects')
     await expect(page.locator('text=Task Runner').first()).toBeVisible({ timeout: 10000 })
     // The Details card heading
     await expect(page.locator('text=Details').first()).toBeVisible({ timeout: 5000 })

--- a/website/playwright/knowledge.spec.ts
+++ b/website/playwright/knowledge.spec.ts
@@ -39,18 +39,59 @@ test.describe('Knowledge Page E2E Tests', () => {
     }
   })
 
-  test('renders list view with stats bar on fresh fixture', async ({ page }) => {
-    // The default statusFilter='active' prevents the onboarding empty-state from
-    // rendering (isEmpty requires !statusFilter which is false for 'active').
-    // The stats bar renders once /stats returns. With the minimal fixture there
-    // are 0 items and 0 entities, but sources may be >0 due to auto_ingest_artifacts.
-    await expect(page.getByText('Knowledge Library')).toBeVisible({ timeout: 10000 })
-    // Stats bar contains "{N} items" text — on fresh fixture items=0
+  test('renders the onboarding empty state and stats bar on fresh fixture', async ({ page }) => {
+    // Regression: isEmpty used to require `!statusFilter`, but statusFilter
+    // starts at 'active', so this block was unreachable for every user. The
+    // fresh fixture has 0 items and no filters applied, which is exactly the
+    // state the onboarding copy exists for.
+    await expect(page.getByTestId('knowledge-onboarding')).toBeVisible({ timeout: 10000 })
+    // exact: true — the onboarding heading also contains "Knowledge Library"
+    // ("Welcome to the Knowledge Library"), so a substring match resolves to two
+    // elements and trips strict mode.
+    await expect(page.getByText('Knowledge Library', { exact: true })).toBeVisible({ timeout: 10000 })
+    // The stats bar renders outside the empty-state branch, once /stats returns.
+    // With the minimal fixture items and entities are 0, but sources may be >0
+    // due to auto_ingest_artifacts.
     await expect(page.getByText('0 items')).toBeVisible({ timeout: 10000 })
     await expect(page.getByText('0 entities')).toBeVisible()
     await expect(page.getByText('0 relations')).toBeVisible()
-    // Verify the stats bar itself rendered (sources count may be >0 due to auto-ingest)
     await expect(page.getByText(/\d+ sources/)).toBeVisible()
+  })
+
+  test('a filter matching nothing shows the empty list, not the onboarding state', async ({ page, request }) => {
+    test.skip(
+      !HARNESS_GATEWAY,
+      'seeding knowledge items requires the ephemeral harness gateway: delete_item runs a global orphan-entity sweep (store.py:472)',
+    )
+    // The onboarding branch REPLACES the filter bar, so rendering it while a
+    // filter is applied would leave no control to clear that filter with. One
+    // seeded item plus a filter that matches nothing must keep the bar mounted.
+    const itemId = trackedId()
+    const importRes = await request.post('/api/knowledge/import', {
+      data: {
+        items: [{
+          id: itemId,
+          title: `Playwright_FilterGuard_${randomUUID().slice(0, 8)}`,
+          content: 'Content for the filter-vs-onboarding guard.',
+          item_type: 'document',
+          status: 'active',
+          namespace: 'default',
+        }],
+        entities: [],
+        relations: [],
+      },
+    })
+    expect(importRes.ok()).toBeTruthy()
+
+    await page.goto('/knowledge', { waitUntil: 'domcontentloaded' })
+    const typeSelect = page.getByLabel('Filter by type')
+    await expect(typeSelect).toBeVisible({ timeout: 10000 })
+    // 'policy' is a valid ITEM_TYPES value that the seeded 'document' item
+    // cannot match, so the list goes to 0 results with a filter applied.
+    await typeSelect.selectOption('policy')
+
+    await expect(page.getByTestId('knowledge-onboarding')).toHaveCount(0)
+    await expect(typeSelect).toBeVisible()
   })
 
   test('tabs switch between list, graph, and sources', async ({ page }) => {

--- a/website/src/pages/knowledge/helpers.ts
+++ b/website/src/pages/knowledge/helpers.ts
@@ -37,6 +37,9 @@ export function useCopy() {
 
 export const ITEM_TYPES = ['design_doc', 'runbook', 'meeting_notes', 'code_doc', 'presentation', 'report', 'policy', 'personal_notes', 'external_reference', 'document']
 export const STATUSES = ['active', 'archived']
+// Status the list view opens on. This is the default view, NOT user narrowing,
+// so the onboarding empty state treats this value as "no filter applied".
+export const DEFAULT_STATUS_FILTER = 'active'
 export const SUPPORTED_FORMATS = 'Markdown, Plain text, Code files (.py, .ts, .java, .go, .rs, etc.), HTML, JSON, YAML, CSV, DOCX'
 
 export const ONBOARDING = {

--- a/website/src/pages/knowledge/index.tsx
+++ b/website/src/pages/knowledge/index.tsx
@@ -4,7 +4,7 @@ import { Search, BookOpen, Network, FolderSync, HelpCircle, FileText, X, Copy } 
 import { Btn, SearchInput, Badge, EmptyState, ContentSkeleton } from '../../components/ui'
 import Clickable from '../../components/Clickable'
 import { knowledgeApi } from './api'
-import { useCopy, ITEM_TYPES, STATUSES, ONBOARDING } from './helpers'
+import { useCopy, ITEM_TYPES, STATUSES, DEFAULT_STATUS_FILTER, ONBOARDING } from './helpers'
 import DetailView from './DetailView'
 import SourcesList from './SourcesList'
 import { ItemCard } from './ItemCard'
@@ -143,7 +143,7 @@ export default function KnowledgePage() {
   const [query, setQuery] = useState('')
   const [searchInput, setSearchInput] = useState('')
   const [typeFilter, setTypeFilter] = useState('')
-  const [statusFilter, setStatusFilter] = useState('active')
+  const [statusFilter, setStatusFilter] = useState(DEFAULT_STATUS_FILTER)
   const [page, setPage] = useState(1)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [selectedEntity, setSelectedEntity] = useState<string | null>(null)
@@ -401,8 +401,60 @@ export default function KnowledgePage() {
     setShowAutocomplete(false)
   }, [])
 
-  const isEmpty = !loading && total === 0 && !query && !typeFilter && !statusFilter
+  // "The user has not narrowed anything" — every filter is still at its initial
+  // value. statusFilter starts at DEFAULT_STATUS_FILTER, so the earlier
+  // `!statusFilter` test could never be true and the onboarding block below was
+  // unreachable for every user since it was written.
+  //
+  // namespaceFilter is part of this test because fixing statusFilter exposes it:
+  // selecting a namespace that holds 0 items would otherwise render onboarding,
+  // and that branch replaces the filter bar, leaving no control to clear the
+  // filter with.
+  //
+  // Known gap: a library whose every item is archived also reports 0 active
+  // items, and both the list query and /namespaces are active-scoped, so it is
+  // indistinguishable from an empty library and shows onboarding. The Sources
+  // and Graph tabs stay mounted above this branch, so it is not a dead end.
+  const filtersPristine = !query && !typeFilter && !namespaceFilter && statusFilter === DEFAULT_STATUS_FILTER
+  const isEmpty = !loading && total === 0 && filtersPristine
   const totalPages = Math.ceil(total / limit)
+
+  // Extracted so the onboarding branch can render it too. Onboarding fires when
+  // total === 0 under pristine filters, which includes a library whose every
+  // item is archived. Replacing the filter bar in that state would strand the
+  // user: statusFilter defaults to active, so the only way back to their
+  // content is to change it. Keeping one definition avoids the bar drifting
+  // between the two render sites.
+  const listFilterBar = (
+    <div className="flex gap-2 mb-3 flex-wrap relative" ref={searchRef}>
+      <div className="relative flex-1 min-w-[200px]">
+        <SearchInput placeholder={i18nT('pages.knowledge.index.search_knowledge_press_enter_to_search')} value={searchInput}
+          onChange={e => { setSearchInput((e.target as HTMLInputElement).value); setShowAutocomplete(true) }}
+          onKeyDown={e => { if ((e as React.KeyboardEvent).key === 'Enter') { setQuery(searchInput); setPage(1) } }}
+          onFocus={() => setShowAutocomplete(true)}
+          onBlur={() => setTimeout(() => setShowAutocomplete(false), 200)}
+        />
+        {showAutocomplete && searchInput.length >= 2 && (
+          <EntityAutocomplete query={searchInput} onSelect={handleEntitySelect} />
+        )}
+      </div>
+      <select value={typeFilter} aria-label={i18nT('pages.knowledge.index.filter_by_type')} onChange={e => { setTypeFilter(e.target.value); setPage(1) }}
+        className="bg-bg-elevated border border-border rounded-md px-2 py-1.5 text-[13px] text-text outline-none">
+        <option value="">{i18nT('pages.knowledge.index.all_types')}</option>
+        {ITEM_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, ' ')}</option>)}
+      </select>
+      <select value={statusFilter} aria-label={i18nT('pages.knowledge.index.filter_by_status')} onChange={e => { setStatusFilter(e.target.value); setPage(1) }}
+        className="bg-bg-elevated border border-border rounded-md px-2 py-1.5 text-[13px] text-text outline-none">
+        <option value="">{i18nT('pages.knowledge.index.all_statuses')}</option>
+        {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+      </select>
+      <select value={namespaceFilter} aria-label={i18nT('pages.knowledge.index.filter_by_namespace')} onChange={e => { setNamespaceFilter(e.target.value); setPage(1) }}
+        className="bg-bg-elevated border border-border rounded-md px-2 py-1.5 text-[13px] text-text outline-none">
+        <option value="">{i18nT('pages.knowledge.index.all_namespaces')}</option>
+        {namespaces.map(ns => <option key={ns.name} value={ns.name}>{ns.name} ({ns.count})</option>)}
+      </select>
+    </div>
+  )
 
   return (
     <div className="flex flex-col h-full">
@@ -457,43 +509,19 @@ export default function KnowledgePage() {
       <div className={`flex-1 px-4 sm:px-6 py-4 min-h-0 ${tab === 'graph' ? 'flex flex-col' : 'overflow-y-auto'}`} ref={listContainerRef}>
         <EmbeddingStatus />
         {isEmpty && tab === 'list' ? (
-          <div className="flex flex-col items-center justify-center py-12 animate-rise">
-            <BookOpen size={48} className="text-muted/20 mb-4" />
-            <h3 className="text-lg font-bold text-text-strong mb-1">{ONBOARDING.title}</h3>
-            <p className="text-sm text-muted mb-4 text-center max-w-md">{ONBOARDING.description}</p>
-            <button onClick={() => setTab('sources')} className="px-4 py-2 bg-accent text-accent-fg rounded-md text-sm hover:bg-accent/80 cursor-pointer">{i18nT('pages.knowledge.index.go_to_sources_to_upload_files')}</button>
-          </div>
+          <>
+            {listFilterBar}
+            <div className="flex flex-col items-center justify-center py-12 animate-rise" data-testid="knowledge-onboarding">
+              <BookOpen size={48} className="text-muted/20 mb-4" />
+              <h3 className="text-lg font-bold text-text-strong mb-1">{ONBOARDING.title}</h3>
+              <p className="text-sm text-muted mb-4 text-center max-w-md">{ONBOARDING.description}</p>
+              <button onClick={() => setTab('sources')} className="px-4 py-2 bg-accent text-accent-fg rounded-md text-sm hover:bg-accent/80 cursor-pointer">{i18nT('pages.knowledge.index.go_to_sources_to_upload_files')}</button>
+            </div>
+          </>
         ) : tab === 'list' ? (
           selectedId ? <DetailView itemId={selectedId} onBack={() => setSelectedId(null)} onEntityClick={handleEntitySelect} /> : (
             <>
-              <div className="flex gap-2 mb-3 flex-wrap relative" ref={searchRef}>
-                <div className="relative flex-1 min-w-[200px]">
-                  <SearchInput placeholder={i18nT('pages.knowledge.index.search_knowledge_press_enter_to_search')} value={searchInput}
-                    onChange={e => { setSearchInput((e.target as HTMLInputElement).value); setShowAutocomplete(true) }}
-                    onKeyDown={e => { if ((e as React.KeyboardEvent).key === 'Enter') { setQuery(searchInput); setPage(1) } }}
-                    onFocus={() => setShowAutocomplete(true)}
-                    onBlur={() => setTimeout(() => setShowAutocomplete(false), 200)}
-                  />
-                  {showAutocomplete && searchInput.length >= 2 && (
-                    <EntityAutocomplete query={searchInput} onSelect={handleEntitySelect} />
-                  )}
-                </div>
-                <select value={typeFilter} aria-label={i18nT('pages.knowledge.index.filter_by_type')} onChange={e => { setTypeFilter(e.target.value); setPage(1) }}
-                  className="bg-bg-elevated border border-border rounded-md px-2 py-1.5 text-[13px] text-text outline-none">
-                  <option value="">{i18nT('pages.knowledge.index.all_types')}</option>
-                  {ITEM_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, ' ')}</option>)}
-                </select>
-                <select value={statusFilter} aria-label={i18nT('pages.knowledge.index.filter_by_status')} onChange={e => { setStatusFilter(e.target.value); setPage(1) }}
-                  className="bg-bg-elevated border border-border rounded-md px-2 py-1.5 text-[13px] text-text outline-none">
-                  <option value="">{i18nT('pages.knowledge.index.all_statuses')}</option>
-                  {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
-                </select>
-                <select value={namespaceFilter} aria-label={i18nT('pages.knowledge.index.filter_by_namespace')} onChange={e => { setNamespaceFilter(e.target.value); setPage(1) }}
-                  className="bg-bg-elevated border border-border rounded-md px-2 py-1.5 text-[13px] text-text outline-none">
-                  <option value="">{i18nT('pages.knowledge.index.all_namespaces')}</option>
-                  {namespaces.map(ns => <option key={ns.name} value={ns.name}>{ns.name} ({ns.count})</option>)}
-                </select>
-              </div>
+              {listFilterBar}
 
               {selectedItems.size > 0 && (
                 <BulkActions selectedIds={selectedItems} items={visibleItems} onDone={() => setSelectedItems(new Set())} />

--- a/website/src/test/EntityAutocomplete.test.tsx
+++ b/website/src/test/EntityAutocomplete.test.tsx
@@ -9,8 +9,22 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 // already provides the context.
 import { MemoryRouter } from 'react-router-dom'
 
-// Mock the knowledge API
-const mockKnowledgeApi = vi.fn().mockResolvedValue([])
+// Mock the knowledge API.
+//
+// /source-counts must report total > 0. With query === '' the page reads its
+// total from that endpoint (index.tsx:204), and a total of 0 with pristine
+// filters renders the onboarding empty state INSTEAD of the filter bar, so the
+// search input this test types into would never mount. A non-empty library is
+// the state a debounce test means to exercise anyway.
+const mockKnowledgeApi = vi.fn().mockImplementation((path: string) => {
+  if (path.startsWith('/source-counts')) {
+    return Promise.resolve({ counts: { 'src-1': 1 }, total: 1 })
+  }
+  if (path.startsWith('/items')) {
+    return Promise.resolve({ items: [], total: 1 })
+  }
+  return Promise.resolve([])
+})
 vi.mock('../pages/knowledge/api', () => ({
   knowledgeApi: (...args: unknown[]) => mockKnowledgeApi(...args),
 }))


### PR DESCRIPTION
## Description

Fixes two user-facing defects that the e2e de-quarantine campaign (#657, #719) surfaced and documented but never fixed. Both are independent, both have reproductions, and both are small.

### 1. `/apps/detail/{name}` and `/apps/migrate/{name}` 404 on direct navigation

`_APPS_SPA_EXCLUDED_RE` was `^/apps/[a-z0-9][a-z0-9_-]*/`, which matches any `/apps/{seg}/` path. It therefore read `detail` as the app name and excluded the URL from the SPA shell. Pasting `/apps/detail/task-runner` into the address bar, or refreshing on it, returned 404. Both routes worked only through in-app navigation.

`apps/routes.py` registers exactly two sub-namespaces under `/apps/{name}`: `/ui/` (static bundle) and `/api/` (reverse proxy). The regex now names them, so every other `/apps/` path reaches React Router.

The `_is_spa_shell_request` docstring already described this narrower rule ("Only `/apps/{name}/<sub-path>` URLs with real handlers (`/api/`, `/ui/`) are excluded"). Only the regex disagreed with it, which is why this reads as a defect rather than a deliberate policy.

### 2. The Knowledge onboarding empty state has never rendered for anyone

`isEmpty` required `!statusFilter`, and `statusFilter` is initialised to `'active'`. The condition could never be true, so the onboarding copy at `knowledge/index.tsx` was dead. The gate now compares against that default rather than testing for falsiness.

`namespaceFilter` joins the same test, because fixing `statusFilter` exposes it: selecting a namespace with 0 items would otherwise render onboarding, and that branch replaces the filter bar, leaving no control to clear the filter with.

**Known gap:** a library whose every item is archived also reports 0 active items. Both the list query and `/namespaces` are active-scoped, so that state is indistinguishable from an empty library and shows onboarding. The Sources and Graph tabs stay mounted above the branch, so it is not a dead end. Closing it needs an unfiltered count, which costs a request on every empty view.

**Rejected on (1):** allowlisting `/apps/detail` and `/apps/migrate`. That inverts the coupling, so every future client route under `/apps` would need a matching server edit and would reproduce this same 404. Worth revisiting if `apps/routes.py` ever serves an `/apps/` path that is not a fixed sub-namespace.

## Related Issues

None filed. Both defects were recorded as findings in the #657 / #719 spec comments, which this PR removes.

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality
- [x] Manual verification performed

New and changed tests:

- `test_apps_router_subpaths_are_spa_shell` covers both client routes, GET and HEAD.
- `test_apps_server_routes_are_excluded_from_shell` is a drift guard: it reads the route literals out of `apps/routes.py`, so adding a third `/apps/` sub-namespace fails without a regex update. Verified against a negative control (`/apps/{name}/data/...` is correctly reported as not excluded).
- `apps.spec.ts` `gotoDetail` now navigates directly and asserts status 200, replacing the `pushState` workaround that existed only to route around this 404. A regression now surfaces as a 404 rather than being worked around.
- `knowledge.spec.ts` asserts the onboarding state renders on the fresh fixture, and adds a test that a filter matching nothing keeps the filter bar mounted.
- `EntityAutocomplete.test.tsx` mocked every endpoint to `[]`, so total was 0 and fix (2) made the page render onboarding instead of the search input the test types into. Its mock now reports a non-empty library, which is the state a debounce test means to exercise. Confirmed against a clean baseline that the failure came from this change and not from load.

Suite results:

- `test/test_token_auth.py` + `test/test_dashboard_static_routes.py`: 223 passed.
- `setup.py test_e2e`: 18 passed, with `test_dashboard_playwright_suite` green, so the floor held at 208 executed and 0 skipped.
- `npx vitest run`: 478 files, 5804 passed, 3 skipped.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- Template placeholder retained: CLA wording is supplied by OSPO. -->
