### PR TITLE
fix(computer-use): make the Open System Settings shortcuts work

### DIFF
--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -1256,6 +1256,81 @@ re-signing anything in the chain can void a grant — the same mechanism that
 permanently broke the reference bundle's Accessibility 3/3 times — so
 `packaging/resign-macos-libs.sh` is a known hazard for this feature.
 
+### The grant shortcuts MUST use `window.open`, not `location.href`
+
+Each non-granted permission row offers an **Open System Settings** button that
+targets a macOS System Settings deep link (`SETTINGS_URL_*` in `permissions.py`;
+the frontend mirrors the two constants). It must be handed off with
+`window.open(pane, '_blank', 'noopener,noreferrer')` —
+`openSystemSettings()` in `ComputerUsePanel.tsx` — never by assigning
+`window.location.href`.
+
+The reason is CSP, and it is invisible in a browser tab: the dashboard renders
+inside an **instance `<iframe>`** (`InstancesViewport`), and a *frame* navigation
+is governed by the `frame-src` directive — declared explicitly in `_BASE_CSP`
+(`dashboard/server.py`) as `frame-src 'self' blob: https://*.cloudfront.net …`,
+a loopback/cloudfront allowlist that names no custom scheme.
+Assigning `location.href` to an
+`x-apple.systempreferences:` URL is therefore refused with
+`ERR_BLOCKED_BY_CSP` before it ever reaches LaunchServices, so the button is a
+**dead click in the packaged desktop app** while working fine from a top-level
+page. `window.open` is a new top-level request instead, which is not subject to
+`frame-src`.
+
+In Electron that `window.open` arrives at the main process's
+`setWindowOpenHandler`. That handler used to allow any **same-origin** URL in-app,
+forward cross-origin `http:`/`https:` to the browser, and silently deny
+everything else — so the deep link died there too.
+`electron/external-scheme.js` owns that decision now:
+`classifyNavigation()` returns `allow` (same-origin, in-app), `external`
+(cross-origin web + an **allowlisted** non-web URL → `shell.openExternal`), or
+`block`.
+
+The non-web allowlist (`EXTERNAL_URLS`) matches **whole URLs, exactly** — the two
+`SETTINGS_URL_*` panes — not the `x-apple.systempreferences:` scheme. A
+scheme-granular rule would admit unbounded attacker-chosen payloads into
+LaunchServices, and that is reachable rather than theoretical: LLM-authored widget
+and artifact content renders in iframes carrying
+`sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"`, no CSP
+directive constrains a `window.open` target's scheme, and remote-instance frames
+share this same handler — so model-generated JS could otherwise pop *any* pane
+(Sharing → Remote Login, Configuration Profiles) beside agent-authored text
+telling the user to enable it. Exact matching also removes a parser-differential
+class: the verdict is computed from `new URL(...)` (WHATWG lowercases the scheme,
+strips tabs/newlines inside it, resolves `..`) while the **raw** string is what
+`shell.openExternal` re-parses with NSURL/CFURL; requiring raw equality means the
+validated and forwarded values cannot diverge. Because it is exact-match, the
+constant must stay byte-identical to `permissions.py` and the panel's `PANE_*`
+mirrors — `external-scheme.test.js` reads both real files and asserts agreement,
+since a drift is a silent dead button.
+
+`file:` is excluded by construction (handing an arbitrary local path to the OS is
+a disclosure/execution vector, not a navigation), an unparseable URL fails closed
+to `block`, and an unusable app origin never *promotes* a cross-origin URL to
+same-origin — including an **opaque** one, where `new URL()` succeeds and reports
+the literal origin `"null"` that would otherwise compare equal to a foreign
+opaque origin. `shell.openExternal` returns a **rejecting** Promise when the OS
+has no handler, so the hand-off swallows the throw, the rejection, *and* a
+throwing log sink; the handler body is guarded end-to-end and fails closed to
+`deny`, because a dead grant shortcut must never take the main process down.
+
+That handler is the single gate for **every** `window.open` in the dashboard, not
+just this button, so it checks **same-origin before protocol** — the ordering the
+inline handler it replaced used. This matters for `blob:`, which *inherits* the
+creating page's origin: `WidgetFrame`'s "Open in new tab" opens a
+`URL.createObjectURL` wrapper document and needs a real window object, so a
+same-origin blob must classify as `allow`. A protocol-first ordering demoted it to
+`block` and turned that button into a dead click — the same silent-failure shape
+as the bug above. Origin-inheriting schemes are checked for same-origin ONLY and
+never appear in the external allowlist, so `blob:` can never reach
+`shell.openExternal`. `external-scheme.test.js` pins this with a parity table
+asserting that every pre-existing URL shape keeps its old verdict and that the
+System Settings deep link is the *only* changed one.
+
+Both halves are pinned by tests (`ComputerUsePanel.test.tsx`,
+`electron/test/external-scheme.test.js`) because the failure mode is a silent
+dead button that only reproduces in a packaged build.
+
 ---
 
 ## The CLI (`kirocrew computer`) — and what is deliberately not ported

--- a/website/electron/external-scheme.js
+++ b/website/electron/external-scheme.js
@@ -1,0 +1,216 @@
+// External-scheme hand-off for the KiroCrew Electron app.
+//
+// Why this exists: Settings -> Computer Use offers "Open System Settings"
+// shortcuts that target macOS System Settings deep links
+// (`x-apple.systempreferences:…`). In the packaged desktop app those buttons
+// were dead clicks, for two compounding reasons:
+//
+//  1. The dashboard renders as a FRAME (InstancesViewport mounts each instance's
+//     dashboard in an <iframe>). A frame navigation is governed by the CSP
+//     `frame-src` directive, which the dashboard declares explicitly as
+//     `frame-src 'self' blob: https://*.cloudfront.net …` (server.py `_BASE_CSP`)
+//     — a loopback/cloudfront allowlist that names no custom scheme. So
+//     assigning `window.location.href = 'x-apple…'` inside the pane is refused
+//     with ERR_BLOCKED_BY_CSP before it ever reaches the OS. (The same
+//     assignment works from a TOP-LEVEL page, which is why this survived
+//     browser-tab testing.)
+//  2. Routing it through `window.open()` instead makes it a new top-level
+//     request, which DOES reach `setWindowOpenHandler` — but that handler allowed
+//     any SAME-ORIGIN URL in-app, forwarded cross-origin `http:`/`https:` to the
+//     browser, and silently denied every other scheme, so the deep link died
+//     there too.
+//
+// This module owns the scheme decision so it is unit-testable without a live
+// Electron process, mirroring display-media.js. The renderer half of the fix
+// (window.open instead of location.href) lives in ComputerUsePanel.tsx.
+"use strict";
+
+// Non-web URLs handed to the OS. Deliberately an EXACT-MATCH allowlist of whole
+// URLs, not a scheme allowlist: the string comes from the renderer and reaches
+// shell.openExternal, which launches an external application.
+//
+// Whole-URL matching, because the product needs exactly these two targets and a
+// scheme-granular rule would admit unbounded attacker-chosen payloads into
+// LaunchServices. That is reachable, not theoretical: LLM-authored widget and
+// artifact content renders in iframes carrying
+// `sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"`
+// (WidgetFrame, ArtifactBody, ArtifactsPage), no CSP directive constrains a
+// `window.open` target's scheme, and remote-instance dashboard frames share this
+// same handler. A scheme-only rule would let model-generated JS pop ANY System
+// Settings pane — e.g. Sharing -> Remote Login, or Configuration Profiles — next
+// to agent-authored text telling the user to enable it.
+//
+// Matching the raw string also removes a parser-differential class: the verdict
+// is computed from `new URL(...)` (WHATWG: lowercases the scheme, strips tabs and
+// newlines inside it, resolves `..`) while the RAW string is what gets forwarded
+// and re-parsed by NSURL/CFURL. Requiring raw equality means validated and
+// forwarded values cannot diverge.
+//
+// `file:` is absent by construction — handing an arbitrary local path to the OS
+// is a local-file disclosure/execution vector, not a navigation. Web schemes are
+// handled separately (see classifyNavigation) because they may also be
+// same-origin, which stays in-app.
+//
+// MUST stay byte-identical to the backend's SETTINGS_URL_* constants
+// (`computer_use/permissions.py`) and their frontend mirrors
+// (`PANE_*` in ComputerUsePanel.tsx). A drift here is a dead button, not a
+// security hole — the panel's own test pins the frontend pair.
+const EXTERNAL_URLS = Object.freeze([
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+]);
+
+// Web schemes the dashboard itself may navigate to.
+const WEB_SCHEMES = Object.freeze(["http:", "https:"]);
+
+// Schemes that INHERIT the creating page's origin, so a same-origin check is
+// meaningful for them. `blob:` is the load-bearing case: WidgetFrame's "Open in
+// new tab" builds a wrapper document with URL.createObjectURL and opens it, and
+// `new URL('blob:http://host/uuid').origin` is `http://host` — the inner origin.
+// Such a URL must stay IN-APP (it is the dashboard's own content and needs a real
+// window object); it must never be handed to the OS, which is why these are
+// checked for same-origin only and never appear in EXTERNAL_SCHEMES.
+const ORIGIN_INHERITING_SCHEMES = Object.freeze(["blob:"]);
+
+/**
+ * Classify a URL the renderer asked to open.
+ *
+ * Returns one of:
+ *  - "allow"    — same-origin: let the WebContents handle it in-app.
+ *  - "external" — hand to the OS / default browser.
+ *  - "block"    — deny, and do nothing (unknown or unsafe scheme).
+ *
+ * SAME-ORIGIN IS CHECKED FIRST, deliberately. The handler this replaced tested
+ * origin before protocol, and `blob:` inherits the creating page's origin — so a
+ * protocol-first ordering would demote the dashboard's own blob popouts
+ * (WidgetFrame "Open in new tab") from `allow` to `block` and make that button a
+ * dead click in the packaged app. Only schemes that genuinely carry an inner
+ * origin participate; a same-origin verdict can only ever be `allow`, so this
+ * never widens what reaches `shell.openExternal`.
+ *
+ * Fails closed: an unparseable URL is "block".
+ *
+ * @param {string} url the requested target
+ * @param {string} appOrigin the dashboard's own origin (e.g. http://127.0.0.1:6777)
+ * @returns {"allow"|"external"|"block"}
+ */
+function classifyNavigation(url, appOrigin) {
+  let target;
+  try {
+    target = new URL(url);
+  } catch {
+    return "block";
+  }
+  const isWeb = WEB_SCHEMES.includes(target.protocol);
+  if (isWeb || ORIGIN_INHERITING_SCHEMES.includes(target.protocol)) {
+    let sameOrigin = false;
+    try {
+      const appOriginValue = new URL(appOrigin).origin;
+      // Reject OPAQUE origins before comparing. `new URL()` succeeds for any
+      // non-special scheme (`file:`, `data:`, `blob:null/…`) and yields the
+      // literal string "null", which compares EQUAL to an opaque target origin —
+      // so the catch below never fires and a foreign document would be treated
+      // as same-origin. Not reachable today (getAppOrigin is always
+      // `http://localhost:<port>`), but the invariant must hold for any caller.
+      sameOrigin = appOriginValue !== "null" && target.origin === appOriginValue;
+    } catch {
+      // An unusable appOrigin must never PROMOTE a cross-origin URL to
+      // same-origin (that would open it in-app); treat it as external instead.
+      sameOrigin = false;
+    }
+    if (sameOrigin) return "allow";
+    // Cross-origin web URLs open in the real browser. A cross-origin
+    // origin-inheriting URL (a blob from some other origin) is NOT ours and is
+    // not an OS hand-off either — block it.
+    return isWeb ? "external" : "block";
+  }
+  // Non-web: exact whole-URL match only. Compared against the RAW string, so the
+  // value validated here is byte-identical to the one forwarded to the OS.
+  return EXTERNAL_URLS.includes(url) ? "external" : "block";
+}
+
+/**
+ * Hand a URL to the OS, swallowing both failure shapes.
+ *
+ * `shell.openExternal` returns a Promise that REJECTS when the OS has no
+ * handler for the scheme, so a bare call would surface as an unhandledRejection
+ * rather than being caught by a synchronous try/catch. A failed hand-off is a
+ * cosmetic problem — never a reason to disturb the main process.
+ *
+ * @param {(url: string) => Promise<void>|void} openExternal shell.openExternal
+ * @param {string} url the target
+ * @param {(msg: string) => void} log diagnostic sink
+ */
+function openExternalSafely(openExternal, url, log) {
+  // A throwing sink must not become the failure. In the async branch below it
+  // would otherwise surface as an unhandledRejection — the very thing this
+  // helper exists to prevent.
+  const note = (msg) => {
+    try {
+      if (log) log(msg);
+    } catch {
+      /* a diagnostic must never be load-bearing */
+    }
+  };
+  try {
+    const pending = openExternal(url);
+    if (pending && typeof pending.catch === "function") {
+      pending.catch((err) =>
+        note(`openExternal rejected: ${err && err.message ? err.message : err}`),
+      );
+    }
+  } catch (err) {
+    note(`openExternal threw: ${err && err.message ? err.message : err}`);
+  }
+}
+
+/**
+ * Build the `setWindowOpenHandler` callback.
+ *
+ * Same-origin targets open in-app; allowlisted external schemes and
+ * cross-origin web URLs are handed to the OS and the in-app window is denied
+ * (so no blank popup is left behind); everything else is denied outright.
+ *
+ * @param {object} deps
+ * @param {(url: string) => Promise<void>|void} deps.openExternal shell.openExternal (REQUIRED)
+ * @param {() => string} deps.getAppOrigin resolves the dashboard origin (REQUIRED)
+ * @param {(msg: string) => void} [deps.log] diagnostic sink
+ * @returns {(details: {url: string}) => {action: "allow"|"deny"}}
+ */
+function createWindowOpenHandler(deps) {
+  if (!deps || typeof deps.openExternal !== "function") {
+    throw new Error("openExternal is required");
+  }
+  if (typeof deps.getAppOrigin !== "function") {
+    throw new Error("getAppOrigin is required");
+  }
+  const log = deps.log || (() => {});
+
+  // The WHOLE body is guarded, not just the classification: a throwing `log`
+  // sink (a closed stdout / EPIPE) or a hostile `url` getter would otherwise
+  // escape into Electron's setWindowOpenHandler. Fail closed to `deny`.
+  return function handleWindowOpen(details) {
+    try {
+      const url = details && details.url;
+      const verdict = classifyNavigation(url, deps.getAppOrigin());
+      if (verdict === "allow") return { action: "allow" };
+      if (verdict === "external") {
+        openExternalSafely(deps.openExternal, url, log);
+      } else {
+        log(`denied window.open for unsupported target: ${String(url).slice(0, 60)}`);
+      }
+    } catch {
+      /* fall through to deny */
+    }
+    return { action: "deny" };
+  };
+}
+
+module.exports = {
+  EXTERNAL_URLS,
+  ORIGIN_INHERITING_SCHEMES,
+  WEB_SCHEMES,
+  classifyNavigation,
+  createWindowOpenHandler,
+  openExternalSafely,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -46,6 +46,7 @@ const { findConfiguredDashboardPort } = require("./data-home");
 const { createTokenRetryHandler } = require("./token-retry");
 const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
 const { createDisplayMediaHandler } = require("./display-media");
+const { createWindowOpenHandler } = require("./external-scheme");
 const { initAutoUpdate } = require("./auto-update");
 const {
   classifyBundleLocation,
@@ -913,18 +914,19 @@ function setupWindowContents(win, backendUrl) {
   // Sync native tab bar to dashboard dark/light mode on focus (process-global setting)
   win.on("focus", () => syncNativeTheme(view, win));
 
-  view.webContents.setWindowOpenHandler(({ url }) => {
-    try {
-      const u = new URL(url);
-      if (u.origin === new URL(backendUrl).origin) {
-        return { action: 'allow' };
-      }
-      if (u.protocol === 'http:' || u.protocol === 'https:') {
-        shell.openExternal(url);
-      }
-    } catch {}
-    return { action: 'deny' };
-  });
+  // Same-origin opens in-app; cross-origin http(s) and allowlisted non-web
+  // schemes are handed to the OS. The non-web branch is what makes the
+  // Settings -> Computer Use "Open System Settings" shortcuts work: the
+  // dashboard renders inside an instance <iframe>, where a `location.href`
+  // assignment to a custom scheme is refused by CSP `frame-src`, so the panel
+  // routes through `window.open` — which arrives here. See external-scheme.js.
+  view.webContents.setWindowOpenHandler(
+    createWindowOpenHandler({
+      openExternal: (url) => shell.openExternal(url),
+      getAppOrigin: () => backendUrl,
+      log: glog,
+    }),
+  );
 
   view.webContents.session.webRequest.onBeforeSendHeaders((details, callback) => {
     delete details.requestHeaders["Referer"];

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -74,6 +74,7 @@
       "remote-token.js",
       "token-retry.js",
       "display-media.js",
+      "external-scheme.js",
       "validation.js",
       "context-menu.js",
       "preload.js",

--- a/website/electron/test/external-scheme.test.js
+++ b/website/electron/test/external-scheme.test.js
@@ -1,0 +1,377 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  EXTERNAL_URLS,
+  classifyNavigation,
+  createWindowOpenHandler,
+  openExternalSafely,
+} = require("../external-scheme");
+
+const ORIGIN = "http://127.0.0.1:6777";
+const PANE_ACCESSIBILITY =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
+const PANE_SCREEN =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture";
+
+/* The allowlist is now exact-match on whole URLs, so it is only correct while it
+ * stays byte-identical to the pane constants the backend publishes and the panel
+ * sends. A drift in either direction silently re-creates the dead button this
+ * change fixed, so pin it against the real sources rather than a restated copy. */
+describe("pane constants agree across backend, panel and this allowlist", () => {
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const PANE_RE = /x-apple\.systempreferences:com\.apple\.[^'"`\s]+/g;
+
+  function panesIn(relPath) {
+    const text = fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+    return [...new Set(text.match(PANE_RE) || [])].sort();
+  }
+
+  it("matches src/kiro_crew/computer_use/permissions.py", () => {
+    assert.deepEqual(panesIn("src/kiro_crew/computer_use/permissions.py"), [...EXTERNAL_URLS].sort());
+  });
+
+  it("matches website/src/pages/settings/ComputerUsePanel.tsx", () => {
+    assert.deepEqual(
+      panesIn("website/src/pages/settings/ComputerUsePanel.tsx"),
+      [...EXTERNAL_URLS].sort(),
+    );
+  });
+});
+
+describe("classifyNavigation", () => {
+  it("keeps same-origin web URLs in-app", () => {
+    assert.equal(classifyNavigation(`${ORIGIN}/settings`, ORIGIN), "allow");
+    assert.equal(classifyNavigation(`${ORIGIN}/`, `${ORIGIN}/some/path`), "allow");
+  });
+
+  it("sends cross-origin web URLs to the OS browser", () => {
+    assert.equal(classifyNavigation("https://example.com/docs", ORIGIN), "external");
+    // A different loopback PORT is a different origin.
+    assert.equal(classifyNavigation("http://127.0.0.1:6778/", ORIGIN), "external");
+  });
+
+  it("sends the System Settings deep links to the OS", () => {
+    assert.equal(classifyNavigation(PANE_ACCESSIBILITY, ORIGIN), "external");
+    assert.equal(classifyNavigation(PANE_SCREEN, ORIGIN), "external");
+  });
+
+  it("blocks file: — handing a local path to the OS is a disclosure vector", () => {
+    assert.equal(classifyNavigation("file:///etc/passwd", ORIGIN), "block");
+    assert.equal(classifyNavigation("file:///Users/me/.ssh/id_rsa", ORIGIN), "block");
+  });
+
+  it("blocks other non-web schemes rather than defaulting them open", () => {
+    for (const url of [
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "vscode://file/etc/hosts",
+      "smb://attacker/share",
+      "ftp://example.com/x",
+      "chrome://settings",
+      "about:blank",
+    ]) {
+      assert.equal(classifyNavigation(url, ORIGIN), "block", url);
+    }
+  });
+
+  // Regression guard: `blob:` INHERITS the creating page's origin, and the
+  // handler this replaced checked origin BEFORE protocol. WidgetFrame's "Open in
+  // new tab" builds a wrapper document with URL.createObjectURL and opens it, so
+  // classifying same-origin blobs as anything but `allow` turns that button into
+  // a dead click in the packaged app (it needs a real window object).
+  it("keeps a same-origin blob: in-app — WidgetFrame's popout depends on it", () => {
+    assert.equal(classifyNavigation(`blob:${ORIGIN}/0388b437-dead-beef`, ORIGIN), "allow");
+  });
+
+  it("blocks a cross-origin blob: — not ours, and never an OS hand-off", () => {
+    assert.equal(classifyNavigation("blob:https://evil.example/abc", ORIGIN), "block");
+  });
+
+  it("never hands an origin-inheriting scheme to the OS", () => {
+    // A same-origin verdict can only be "allow", so blob: must never be able to
+    // reach shell.openExternal by any path.
+    for (const origin of [ORIGIN, "http://localhost:3000", "not-an-origin", ""]) {
+      assert.notEqual(classifyNavigation(`blob:${ORIGIN}/x`, origin), "external");
+    }
+  });
+
+  it("fails closed on an unparseable URL", () => {
+    assert.equal(classifyNavigation("not a url", ORIGIN), "block");
+    assert.equal(classifyNavigation("", ORIGIN), "block");
+    assert.equal(classifyNavigation(undefined, ORIGIN), "block");
+    assert.equal(classifyNavigation(null, ORIGIN), "block");
+  });
+
+  it("never promotes a cross-origin URL to same-origin when appOrigin is unusable", () => {
+    // A broken appOrigin must not make an arbitrary URL open IN-APP.
+    assert.equal(classifyNavigation("https://evil.example/", "not-an-origin"), "external");
+    assert.equal(classifyNavigation("https://evil.example/", ""), "external");
+  });
+
+  it("allowlists exactly the two panes the product needs", () => {
+    assert.deepEqual(EXTERNAL_URLS, [PANE_ACCESSIBILITY, PANE_SCREEN]);
+  });
+
+  /* The allowlist is whole-URL, not scheme-granular. This is reachable, not
+   * theoretical: LLM-authored widget/artifact content renders in iframes with
+   * `allow-popups-to-escape-sandbox`, and no CSP directive constrains a
+   * window.open target's scheme — so a scheme-only rule would let model-generated
+   * JS pop ANY System Settings pane next to text telling the user to enable it. */
+  it("blocks every other pane in the permitted scheme", () => {
+    for (const url of [
+      "x-apple.systempreferences:com.apple.preferences.sharing?Services_RemoteLogin",
+      "x-apple.systempreferences:com.apple.preferences.configurationprofiles",
+      "x-apple.systempreferences:com.apple.preference.security?FDE",
+      "x-apple.systempreferences:/Users/victim/Downloads/evil.prefPane",
+      "x-apple.systempreferences:anything-at-all",
+      "x-apple.systempreferences:",
+    ]) {
+      assert.equal(classifyNavigation(url, ORIGIN), "block", url);
+    }
+  });
+
+  // The verdict is computed from `new URL(...)` but the RAW string is what gets
+  // forwarded and re-parsed by NSURL/CFURL. Exact raw matching is what stops the
+  // validated and forwarded values from diverging.
+  it("rejects near-miss variants of an allowlisted pane", () => {
+    for (const url of [
+      `${PANE_ACCESSIBILITY}&extra=1`,
+      `${PANE_ACCESSIBILITY}#frag`,
+      ` ${PANE_ACCESSIBILITY}`,
+      `\t${PANE_ACCESSIBILITY}`,
+      "X-Apple.SystemPreferences:com.apple.preference.security?Privacy_Accessibility",
+      "x-apple.systempreferences:com.apple.preference.security?privacy_accessibility",
+    ]) {
+      assert.equal(classifyNavigation(url, ORIGIN), "block", JSON.stringify(url));
+    }
+  });
+
+  /* `new URL()` SUCCEEDS for any non-special scheme and reports the literal
+   * origin "null", which compares equal to an opaque target origin — so the
+   * catch never fires and a foreign document would read as same-origin. */
+  it("treats an opaque appOrigin as never-same-origin", () => {
+    for (const appOrigin of ["file:///x", "data:text/plain,x", "blob:null/y", "mailto:a@b"]) {
+      assert.notEqual(classifyNavigation("blob:null/attacker", appOrigin), "allow");
+    }
+  });
+});
+
+/* Parity with the inline handler this module replaced.
+ *
+ * That handler governed EVERY window.open() in the dashboard — popouts, widget
+ * blob popouts, external links — so the only intended behaviour change is that
+ * an allowlisted non-web scheme now reaches the OS. Anything else that differs
+ * is a regression in a feature this change was not about, which is exactly how
+ * the blob: popout broke once already. */
+describe("parity with the previous inline handler", () => {
+  // Verbatim transcription of the pre-change handler (main.js, before the fix).
+  function legacyVerdict(url, appOrigin) {
+    try {
+      const u = new URL(url);
+      if (u.origin === new URL(appOrigin).origin) return "allow";
+      if (u.protocol === "http:" || u.protocol === "https:") return "external";
+    } catch {
+      /* fall through */
+    }
+    return "deny";
+  }
+
+  // Every URL shape the dashboard's window.open call sites actually produce.
+  const SHAPES = [
+    `${ORIGIN}/popout/chat/x?sid=slot1`, // chatPopout
+    `${ORIGIN}/popout/artifact/slug`, // artifactPopout
+    `${ORIGIN}/worlds-popout`, // usePopoutSync
+    `${ORIGIN}/apps/detail/thing`, // AppsPage cmd-click
+    `${ORIGIN}/api/file-raw?path=/tmp/a.pdf`, // FileRenderers
+    `blob:${ORIGIN}/0388b437`, // WidgetFrame popout
+    "https://kiro.dev/", // footer link
+    "https://github.com/owner/repo", // RegistryManager
+    "https://d123.cloudfront.net/index.html", // deployed artifact
+    "http://localhost:3000/", // another loopback port
+    "http://mypod.localhost:6777/app", // tunnel URL
+    "about:blank", // DevFleetPage shim
+    "blob:https://evil.example/x",
+    "data:text/html,<b>x</b>",
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "not a url",
+  ];
+
+  it("matches the legacy verdict for every pre-existing URL shape", () => {
+    for (const url of SHAPES) {
+      const legacy = legacyVerdict(url, ORIGIN);
+      const now = classifyNavigation(url, ORIGIN);
+      // "deny" and "block" are the same outcome under different names: the
+      // handler denies the popup and shells out to nothing.
+      const normalized = now === "block" ? "deny" : now;
+      assert.equal(normalized, legacy, `${url} — legacy ${legacy}, now ${now}`);
+    }
+  });
+
+  it("changes exactly one verdict: the System Settings deep link", () => {
+    assert.equal(legacyVerdict(PANE_ACCESSIBILITY, ORIGIN), "deny");
+    assert.equal(classifyNavigation(PANE_ACCESSIBILITY, ORIGIN), "external");
+  });
+});
+
+describe("createWindowOpenHandler", () => {
+  function harness(overrides = {}) {
+    const opened = [];
+    const logged = [];
+    const handler = createWindowOpenHandler({
+      openExternal: (url) => {
+        opened.push(url);
+      },
+      getAppOrigin: () => ORIGIN,
+      log: (m) => logged.push(m),
+      ...overrides,
+    });
+    return { handler, opened, logged };
+  }
+
+  it("requires its Electron glue", () => {
+    assert.throws(() => createWindowOpenHandler(), /openExternal is required/);
+    assert.throws(() => createWindowOpenHandler({}), /openExternal is required/);
+    assert.throws(
+      () => createWindowOpenHandler({ openExternal: () => {} }),
+      /getAppOrigin is required/,
+    );
+  });
+
+  it("allows a same-origin popup without shelling out", () => {
+    const { handler, opened } = harness();
+    assert.deepEqual(handler({ url: `${ORIGIN}/artifacts/1` }), { action: "allow" });
+    assert.deepEqual(opened, []);
+  });
+
+  it("hands a System Settings deep link to the OS and denies the popup", () => {
+    // The regression under test: this used to fall through to a bare deny, so
+    // the grant shortcut was a dead click in the packaged app.
+    const { handler, opened } = harness();
+    assert.deepEqual(handler({ url: PANE_ACCESSIBILITY }), { action: "deny" });
+    assert.deepEqual(opened, [PANE_ACCESSIBILITY]);
+  });
+
+  it("hands a cross-origin web URL to the OS and denies the popup", () => {
+    const { handler, opened } = harness();
+    assert.deepEqual(handler({ url: "https://example.com" }), { action: "deny" });
+    assert.deepEqual(opened, ["https://example.com"]);
+  });
+
+  it("denies a blocked scheme without shelling out, and says why", () => {
+    const { handler, opened, logged } = harness();
+    assert.deepEqual(handler({ url: "file:///etc/passwd" }), { action: "deny" });
+    assert.deepEqual(opened, []);
+    assert.match(logged.join("\n"), /unsupported target/);
+  });
+
+  it("denies (and never throws) when the URL is missing or malformed", () => {
+    const { handler, opened } = harness();
+    assert.deepEqual(handler({}), { action: "deny" });
+    assert.deepEqual(handler({ url: "://" }), { action: "deny" });
+    assert.deepEqual(handler(undefined), { action: "deny" });
+    assert.deepEqual(opened, []);
+  });
+
+  it("denies rather than escaping when the log sink throws", () => {
+    // A throwing sink (closed stdout / EPIPE) must not propagate out of the
+    // handler into Electron's setWindowOpenHandler.
+    const { handler } = harness({
+      log: () => {
+        throw new Error("EPIPE");
+      },
+    });
+    assert.deepEqual(handler({ url: "file:///etc/passwd" }), { action: "deny" });
+  });
+
+  it("denies rather than escaping when reading details.url throws", () => {
+    const { handler } = harness();
+    const hostile = {
+      get url() {
+        throw new Error("hostile getter");
+      },
+    };
+    assert.deepEqual(handler(hostile), { action: "deny" });
+  });
+
+  it("denies when resolving the app origin throws", () => {
+    const { handler, opened } = harness({
+      getAppOrigin: () => {
+        throw new Error("no window");
+      },
+    });
+    assert.deepEqual(handler({ url: PANE_ACCESSIBILITY }), { action: "deny" });
+    assert.deepEqual(opened, []);
+  });
+
+  it("survives a throwing openExternal", () => {
+    const { handler, logged } = harness({
+      openExternal: () => {
+        throw new Error("LaunchServices unavailable");
+      },
+    });
+    assert.deepEqual(handler({ url: PANE_ACCESSIBILITY }), { action: "deny" });
+    assert.match(logged.join("\n"), /openExternal threw: LaunchServices unavailable/);
+  });
+
+  it("survives a REJECTING openExternal without an unhandled rejection", async () => {
+    // shell.openExternal returns a Promise that rejects when the OS has no
+    // handler for the scheme; unhandled, that would crash the main process.
+    const logged = [];
+    const handler = createWindowOpenHandler({
+      openExternal: () => Promise.reject(new Error("no handler")),
+      getAppOrigin: () => ORIGIN,
+      log: (m) => logged.push(m),
+    });
+    assert.deepEqual(handler({ url: PANE_ACCESSIBILITY }), { action: "deny" });
+    await new Promise((r) => setImmediate(r));
+    assert.match(logged.join("\n"), /openExternal rejected: no handler/);
+  });
+});
+
+describe("openExternalSafely", () => {
+  it("tolerates a void-returning openExternal (no .catch on the result)", () => {
+    let seen = "";
+    assert.doesNotThrow(() =>
+      openExternalSafely((url) => {
+        seen = url;
+      }, PANE_SCREEN, () => {}),
+    );
+    assert.equal(seen, PANE_SCREEN);
+  });
+
+  it("tolerates a missing log sink", () => {
+    assert.doesNotThrow(() =>
+      openExternalSafely(() => {
+        throw new Error("boom");
+      }, PANE_SCREEN),
+    );
+  });
+
+  it("tolerates a THROWING log sink on the sync path", () => {
+    assert.doesNotThrow(() =>
+      openExternalSafely(
+        () => {
+          throw new Error("boom");
+        },
+        PANE_SCREEN,
+        () => {
+          throw new Error("EPIPE");
+        },
+      ),
+    );
+  });
+
+  it("tolerates a THROWING log sink on the async path", async () => {
+    // Without the guard this surfaces as an unhandledRejection — the exact
+    // failure this helper exists to prevent.
+    assert.doesNotThrow(() =>
+      openExternalSafely(() => Promise.reject(new Error("no handler")), PANE_SCREEN, () => {
+        throw new Error("EPIPE");
+      }),
+    );
+    await new Promise((r) => setImmediate(r));
+  });
+});

--- a/website/src/pages/settings/ComputerUsePanel.test.tsx
+++ b/website/src/pages/settings/ComputerUsePanel.test.tsx
@@ -15,7 +15,12 @@ vi.mock('../../api/client', () => ({
 }))
 
 import { api } from '../../api/client'
-import { ComputerUsePanel, commitNumericDraft, permissionPollInterval } from './ComputerUsePanel'
+import {
+  ComputerUsePanel,
+  commitNumericDraft,
+  openSystemSettings,
+  permissionPollInterval,
+} from './ComputerUsePanel'
 
 const ENABLE_LABEL = /enable computer use/i
 
@@ -108,6 +113,67 @@ describe('ComputerUsePanel', () => {
       screen.getByRole('button', { name: /open system settings for accessibility/i }),
     ).toBeInTheDocument()
     expect(screen.getByText('Grant them to Terminal')).toBeInTheDocument()
+  })
+
+  /* ── the grant shortcut's delivery mechanism ──────────────────────────────
+   * Pinned deliberately, because the failure is invisible in a browser tab: the
+   * dashboard renders inside an instance <iframe>, where a FRAME navigation is
+   * governed by CSP `frame-src` (a loopback/cloudfront allowlist that names no
+   * custom scheme), so
+   * `window.location.href = 'x-apple.systempreferences:…'` is refused with
+   * ERR_BLOCKED_BY_CSP and the button does nothing in the packaged desktop app.
+   * `window.open` is a new top-level request, which the OS/Electron main process
+   * handles. A regression back to `location.href` must fail here rather than
+   * ship as a dead button. */
+  it('hands the grant shortcut to the OS via window.open, never a frame navigation', async () => {
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+    try {
+      await renderPanel(
+        snapshot({
+          permissions: {
+            accessibility: 'missing',
+            screen_recording: 'missing',
+            responsible_hint: '',
+          },
+        }),
+      )
+      fireEvent.click(
+        await screen.findByRole('button', { name: /open system settings for accessibility/i }),
+      )
+      expect(open).toHaveBeenCalledWith(
+        'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility',
+        '_blank',
+        expect.stringContaining('noopener'),
+      )
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /open system settings for screen recording/i }),
+      )
+      expect(open).toHaveBeenLastCalledWith(
+        'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+        '_blank',
+        expect.stringContaining('noopener'),
+      )
+
+    } finally {
+      open.mockRestore()
+    }
+  })
+
+  describe('openSystemSettings', () => {
+    it('opens the pane in a new top-level context with noopener', () => {
+      const open = vi.spyOn(window, 'open').mockReturnValue(null)
+      try {
+        openSystemSettings('x-apple.systempreferences:com.apple.preference.sound')
+        expect(open).toHaveBeenCalledWith(
+          'x-apple.systempreferences:com.apple.preference.sound',
+          '_blank',
+          'noopener,noreferrer',
+        )
+      } finally {
+        open.mockRestore()
+      }
+    })
   })
 
   it('renders only the reason and no toggle when the platform is unsupported', async () => {

--- a/website/src/pages/settings/ComputerUsePanel.tsx
+++ b/website/src/pages/settings/ComputerUsePanel.tsx
@@ -92,6 +92,29 @@ const RESTARTED = 'Your chat sessions were restarted so this takes effect right 
  *  warning here would leave the operator unsure whether the feature is safe to use. */
 const POLICY_UNREADABLE = 'The app lists in computer_use.json could not be read, so they are shown empty here. The agent still refuses every action that depends on them until the file is valid JSON.'
 
+/** Hand a System Settings deep link to the OS.
+ *
+ *  MUST be `window.open`, not `window.location.href`. The dashboard renders
+ *  inside an instance <iframe> (InstancesViewport), and a FRAME navigation is
+ *  governed by the CSP `frame-src` directive, which the dashboard declares as a
+ *  loopback/cloudfront allowlist naming no custom scheme — so assigning
+ *  `location.href` to an
+ *  `x-apple.systempreferences:` URL is refused with ERR_BLOCKED_BY_CSP and the
+ *  button is a dead click in the desktop app. `window.open` is a new top-level
+ *  request instead: the browser hands it to the OS, and in Electron it reaches
+ *  the main process's `setWindowOpenHandler` (see electron/external-scheme.js),
+ *  which forwards the allowlisted scheme to `shell.openExternal`.
+ *
+ *  Exported so the delivery mechanism is asserted directly — a regression back
+ *  to `location.href` would otherwise only show up as a dead button in a
+ *  packaged build, which is exactly how this shipped broken.
+ */
+export function openSystemSettings(pane: string): void {
+  // `noopener` keeps the opened context from retaining a handle on the
+  // dashboard window; nothing needs the returned reference.
+  window.open(pane, '_blank', 'noopener,noreferrer')
+}
+
 /** One advisory permission row: name, state badge, and a grant shortcut.
  *  Local to this panel rather than shared with SecurityPanel's StatusRow — the
  *  two carry different semantics (a permission hint is never a security state)
@@ -104,7 +127,7 @@ function PermRow({ label, state, pane }: { label: string; state: string; pane: s
       <span className="flex items-center gap-2">
         <Badge variant={variant}>{PERM_LABELS[state] ?? state}</Badge>
         {state !== GRANTED && (
-          <Btn onClick={() => { window.location.href = pane }} aria-label={`Open System Settings for ${label}`}>
+          <Btn onClick={() => openSystemSettings(pane)} aria-label={`Open System Settings for ${label}`}>
             Open System Settings <ExternalLink className="lucide-inline" />
           </Btn>
         )}


### PR DESCRIPTION
## Problem

In **Settings → Computer Use**, the **Open System Settings** button next to each
non-granted permission row (Accessibility, Screen Recording) did nothing in the
packaged desktop app. No System Settings window, no error dialog, no console
message — a completely silent dead click. Since these buttons are the only
in-app path to granting the two TCC permissions computer use depends on, a user
who followed the UI had no way to complete setup.

Reproduced on the real app: clicking the Accessibility row's button leaves
System Settings closed (verified with a clean baseline and the button visibly
hover-highlighted, so the click landed on the target).

## Why it matters

Computer use is unusable until Accessibility is granted, and this button is the
affordance the panel offers to grant it. The failure is also the worst shape a
UI bug can take: it looks like nothing happened, so it reads as "the feature is
broken" rather than "this button is broken", and it is invisible during
browser-tab development.

## Fix (symptoms → root cause → change)

**Symptom:** the button does nothing, only in the packaged app.

**Root cause — CSP, in a frame.** The dashboard renders inside an instance
`<iframe>` (`InstancesViewport`). Assigning `window.location.href` is therefore
a *frame* navigation, governed by the CSP `frame-src` directive — declared in
`_BASE_CSP` as a loopback/cloudfront allowlist that names no custom scheme. So
Chromium refuses the `x-apple.systempreferences:` URL with
`ERR_BLOCKED_BY_CSP` before it ever reaches LaunchServices. The identical
assignment works from a *top-level* page, which is exactly why this shipped and
why it never reproduced in a browser tab.

A second, compounding cause sat behind it: routing through `window.open` makes
the request top-level (not `frame-src` governed) and it reaches Electron's
`setWindowOpenHandler` — but that handler allowed any same-origin URL in-app,
forwarded cross-origin `http(s)` to the browser, and **silently denied every
other scheme**, so the hand-off died there too.

**Change — both halves:**

1. `ComputerUsePanel` calls `window.open(pane, '_blank', 'noopener,noreferrer')`
   via a small exported `openSystemSettings()`.
2. New `website/electron/external-scheme.js` owns the scheme/URL decision, and
   `setWindowOpenHandler` forwards allowlisted non-web URLs to
   `shell.openExternal`. The logic is a pure function with the Electron glue
   injected, so it is unit-testable without a live Electron process (mirroring
   the existing `display-media.js` pattern).

**The allowlist is whole-URL exact-match, not scheme-granular.** It holds only
the two `SETTINGS_URL_*` panes. A scheme-level rule would admit unbounded
attacker-chosen payloads into LaunchServices, and that is reachable rather than
theoretical: LLM-authored widget/artifact content renders in iframes carrying
`sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"`, no CSP
directive constrains a `window.open` target's scheme, and remote-instance frames
share this same handler — so model-generated JS could otherwise pop *any* pane
(Sharing → Remote Login, Configuration Profiles) next to agent-authored text
telling the user to enable it. Exact matching additionally removes a
parser-differential class: the verdict is computed from `new URL(...)` (WHATWG
lowercases the scheme, strips tabs/newlines inside it, resolves `..`) while the
**raw** string is what `shell.openExternal` re-parses with NSURL/CFURL.

Fail-closed behavior: `file:` is excluded by construction (handing an arbitrary
local path to the OS is a disclosure/execution vector), an unparseable URL
blocks, an unusable app origin never *promotes* a cross-origin URL to
same-origin — including an **opaque** origin, where `new URL()` succeeds and
reports the literal string `"null"` that would otherwise compare equal to a
foreign opaque origin. `shell.openExternal` rejects when the OS has no handler,
so the hand-off swallows the throw, the rejection, *and* a throwing log sink;
the handler body is guarded end-to-end and fails closed to `deny`.

**Preserving every other caller.** That handler gates *every* `window.open` in
the dashboard, not just this button, so it keeps the previous
same-origin-before-protocol ordering. `blob:` inherits the creating page's
origin, and `WidgetFrame`'s "Open in new tab" opens a `createObjectURL` wrapper
that needs a real window object — a protocol-first check demoted it to `block`
and would have made *that* button a dead click in exactly the same silent way.
Origin-inheriting schemes are same-origin-checked only and never join the
external allowlist, so `blob:` can never reach `shell.openExternal`.

## Tests

- `website/electron/test/external-scheme.test.js` (new, 33 cases):
  - **Legacy parity table** — every URL shape the dashboard's `window.open` call
    sites actually produce (popouts, widget blob, footer/registry/cloudfront
    links, tunnel URLs, `about:blank`, `data:`, `file:`, garbage) keeps its
    pre-change verdict, and asserts the System Settings pane is the **only**
    changed one. This is the guard that would have caught the `blob:` regression.
  - **Cross-layer constant pin** — reads `permissions.py` and
    `ComputerUsePanel.tsx` and asserts the panes still agree byte-for-byte with
    the allowlist, since exact-match makes a drift a silent dead button.
  - Payload rejection within the permitted scheme, near-miss variants
    (case/whitespace/fragment/extra-param), opaque-origin handling, `blob:`
    same-origin vs cross-origin, throwing/rejecting `openExternal`, throwing log
    sink, hostile `url` getter.
- `ComputerUsePanel.test.tsx` — asserts the grant shortcut is delivered via
  `window.open` with `noopener`, for both rows. Pins the *mechanism*, because a
  regression to `location.href` would otherwise only surface as a dead button in
  a packaged build.
- Both suites verified **non-vacuous**: reverting the fix fails them (2 panel
  failures; 5 handler failures), and re-introducing the protocol-first ordering
  fails the parity test specifically.

## Manual verification

Verified in real Electron against the exact failing configuration
(`WebContentsView` + iframe + the live dashboard CSP header captured from the
running gateway):

- **Before:** `ERR_BLOCKED_BY_CSP`, System Settings stays closed.
- **After:** System Settings opens on **Privacy → Accessibility**, and the SPA
  frame is left intact (no navigation away).
- **`blob:` popout after the change:** still receives a real window object and
  never shells out.
- Also confirmed the top-level (non-frame) case was never broken, which is why
  browser-tab testing missed this.

Full gates: 406/406 electron tests, 5895 frontend tests, `tsc -b` clean, eslint
0 errors, jscpd 0 clones. No Python changed.

## Screenshots

**N/A — no visual change.** The diff alters only the button's click handler; the
markup, label, `aria-label`, and `lucide-react` icon are untouched (see the
`ComputerUsePanel.tsx` diff — the rendered `<Btn>` is byte-identical apart from
`onClick`). The user-visible difference is behavioral: the button now opens
System Settings instead of doing nothing.

## Note on the manifest change

`website/electron/package.json` adds `external-scheme.js` to electron-builder's
`build.files` — **no dependency added or removed**. Without it the new module
would be missing from the packaged DMG; the repo's own
`packaging.test.js` ("includes every local require() from main.js") caught that.
