### PR TITLE
fix(computer-use): close two approval bypasses and six correctness bugs

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -2016,7 +2016,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Cursor Motion",
-      "help": "Draw a visible cursor gliding to each target before a real-pointer click, so the operator can see what the agent is doing. macOS only; purely visual and never a permit — the pointer opt-in and the governance permit are what allow the click itself.",
+      "help": "Draw a visible cursor gliding to each target before a real-pointer click, so the operator can see what the agent is doing. macOS only; purely visual and never a permit — the drawn cursor is not the pointer, and turning this on grants no new capability.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": false

--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -230,9 +230,18 @@ into a focused password box. `computer_press_key` is included for a second reaso
 `press_key("tab")` can *move* focus onto a password field, and the following keystroke
 would land there. `computer_click` is the only element-scoped tool that accepts an
 alternative, and only because coordinates are a target it can check
-(`policy.check_click_target`'s one-of). Enforced by `_ELEMENT_REQUIRED_TOOLS` at the
-chokepoint; `SKILL.md`'s tool table states the same thing, since an optional-looking
-argument there would have the model discover the refusal by hitting it.
+(`policy.check_click_target`'s one-of). **Three layers have to agree, and all three
+now do:** `MCP_COMPUTER_SCHEMAS` (the enforcement point), the advertised
+`inputSchema` in `mcp_computer._list_tools`, and `_ELEMENT_REQUIRED_TOOLS` at the
+chokepoint. The validator gave both keyboard tools the OPTIONAL field spec — the one
+that exists for `computer_click`, which legitimately takes coordinates instead — so
+an indexless call passed validation and was refused one step later, and the comments
+on both sides then described the *other* layer's behaviour (the chokepoint's called
+itself "unreachable through the MCP path"). Enforcement held throughout, because that
+`ValidationError` is converted to a refusal by `dispatch_tool`, but the chokepoint
+check is kept as the last line of defence rather than deleted as redundant.
+`SKILL.md`'s tool table states the same thing, since an optional-looking argument
+there would have the model discover the refusal by hitting it.
 
 Every tool has a `MCP_COMPUTER_SCHEMAS` entry in `validation.py`. That is
 mandatory, not tidiness: an unregistered tool's arguments pass RAW through
@@ -423,17 +432,36 @@ screen_recording, responsible_hint}, limits{field: [min, max]}}`.
   themselves rather than re-spelling them in TypeScript.
 
 **`PUT /api/computer-use/config`** accepts any subset of `{enabled, allowed_apps,
-extra_denied_apps}` (→ keystone) and the six budget fields (→ `config.json`), and
+extra_denied_apps}` (→ keystone) and the seven display/budget fields (the five
+`_INT_LIMITS` knobs plus `attach_screenshot` and `cursor_motion` → `config.json`), and
 returns the refreshed GET payload. Everything is validated before anything is
-written. `409` (matching `api_denied_command_builtin_toggle`, not the runtime
-chokepoints' `403`) when the ceiling forbids and the request would **widen** the
-surface — enabling, or editing the target lists. Disabling and shrinking a budget
-are always allowed: narrowing cannot conflict with a ceiling, and a user must
-never be locked out of switching this off. A corrupt keystone or `config.json` is
-`500` and is left byte-identical rather than clobbered
-(`StateCorruptError`, the `ConfigCorruptError` precedent). Every mutation SEL-audits
-the decision (`enabled=…`, changed field names) — never the app patterns
-themselves.
+written.
+
+**It is dashboard-browser-only, asserted in the handler** — `request["app"]` must be
+empty, else `403` before the body is read. That gate is the write boundary the
+keystone design rests on: `request["user"]` is truthy for an App-Kit token too, so
+the cookie check cannot separate them, and an app whose manifest declares
+`permissions.api: ["/api/computer-use"]` satisfies `app_token_path_allowed` (a bare
+prefix matches on the path boundary). Since `enable_state.save_state` deliberately
+bypasses `is_sensitive_path` — that is what lets the operator's own panel write a
+file the agent cannot — an agent able to author an app manifest could otherwise read
+its own `.app_secret`, mint a token, and flip `enabled: true` on its own desktop
+automation. Same guard as `handlers/kiro_prerequisite.py` and `messaging.py`'s
+notification push; the two machine routes are covered instead by their
+`request["internal_auth"]` assertion, which an app token can never satisfy.
+
+**There is no `409` and no `read_only` field**, because there is no ceiling: no
+`computer_use*` row exists in `SCOPE_CATALOG`. An earlier revision of this spec (and
+of the handler's own docstring and a 16-line comment) described a `409` for a widening
+request under a forbidding ceiling and a `forbidden`-only `read_only` the panel would
+key `disabled` on. Both belonged to the governance model that was removed by product
+decision, and the prose outlived the code — there is no `status=409` in the module at
+all. Do not re-document either without re-implementing it.
+
+A corrupt keystone or `config.json` is `500` and is left byte-identical rather than
+clobbered (`StateCorruptError`, the `ConfigCorruptError` precedent). Every mutation
+SEL-audits the decision (`enabled=…`, changed field names) — never the app patterns
+themselves, and the app-token refusal is audited too.
 
 **`POST /api/computer-use/invoke`** takes `{tool, args, session_key, agent, app}`
 and returns `{"text": …}` with a 200 for BOTH success and refusal, because a
@@ -789,6 +817,24 @@ turn-boundary signal kiro-cli does not have:
    legitimate action. A secure record contributes only role/subrole/title, so
    fingerprinting never reads credential bytes.
 
+**Both of a mutating action's walks re-use the budget the CACHED snapshot was
+walked at**, carried on `Snapshot.walk_budget` (stamped by `service.snapshot`, read
+back by `tools._mutation_walk_budget`). A mutating tool takes no `max_tree_nodes` /
+`max_tree_depth` / `text_limit` arguments — the model set those on the
+`computer_get_state` that produced the indices — so building either walk from the
+`config.json` default silently shrinks the tree: an element the model was
+legitimately shown at `max_tree_nodes=2001` resolves to *"no element at that index"*
+in the drift check, and the post-action refresh it is handed next is truncated
+identically, so calling `computer_get_state` again reproduces the same refusal
+forever. That is a documented happy path (the MCP schema advertises up to 5000 and
+the Settings copy says to raise it for dense apps), which is what made the loop
+worth a stamped field rather than a comment. `want_image` is still forced off for
+both — the verification compares structure, and spooling a screenshot nobody asked
+for would double the cost of every action. Pinned by
+`test_mcp_computer.py::TestTheDriftWalkHonoursTheSnapshotBudget`, which asserts the
+budget off the driver's own call journal (a behavioural assertion passed while the
+refresh walk was still using the default).
+
 Plus `computer_end_turn` for explicit early release, and `reset_shared_backend()`
 drops the cache too (indices from one driver's walk are meaningless against
 another's).
@@ -912,6 +958,31 @@ shown". Detected as `len(children) >= limit` rather than by re-reading the array
 a real count (that would reintroduce the cost the cap exists to avoid), so a node
 with exactly the cap many children is treated as truncated too — a false positive
 costs one suppressed screenshot, a false negative is the disclosure.
+
+**And that suppression ANNOUNCES itself** (`TRUNCATED_WINDOW_NOTE`, emitted by
+`render._render_image_note`). It did not: the renderer special-cased only
+`has_secure` and returned `""` for every other empty `image_path`, so a truncated
+walk produced no image and no reason. Truncation is the NORMAL state for a
+Chromium/Electron window at the shipped 1200-node default (Chrome measured 1475
+nodes), so `screenshot: true` on Chrome, Slack or VS Code silently returned nothing
+— the retry loop `SECURE_WINDOW_NOTE` and `OBS_SUPPRESSED_NOTE` exist to prevent.
+The note names the remedy (raise `max_tree_nodes` / `max_tree_depth`), because
+unlike the secure case this one is fixable by the caller, and it is checked AFTER
+`has_secure` so a window that is both keeps the more specific reason. The shipped
+`FakeComputerUseBackend` mirrors the refusal too — it previously attached pixels to
+a truncated walk, so deleting the production branch left the suite green.
+
+**It fires only when an image was actually REQUESTED** (`walk_budget.want_image`;
+`None` — an unstamped, backend-built snapshot — still announces, since there the
+request is unknown and a spurious note is cheaper than a silent omission). Without
+that condition the fix inverts into the same defect: every mutating action's refresh
+walk forces `want_image=False` by design, so a successful click on a browser window
+came back announcing the suppression of an image nobody asked for and telling the
+model to "re-run with a higher `max_tree_nodes`" — an argument mutating tools do not
+accept (reviewer finding on the first version of this fix). Both directions are
+pinned by `test_computer_use_snapshot.py::TestASuppressedScreenshotAlwaysSaysSoWhy`,
+including one case through the real `dispatch_tool` path, because neither is visible
+to a `render_tree` unit test on its own.
 
 **Every refusal is audited, including the pre-gate ones.** The gate audits its own
 denials and `_audit_allowed` records permitted calls, which left a hole between
@@ -1395,17 +1466,18 @@ computer use.
 - **"No screenshots" is not "no disclosure."** The accessibility tree itself
   leaked real paths, window titles and bundle ids in live probes, and a document
   path inside an `AXTitle` is not a credential so redaction will not catch it.
-  `window_titles`, `file_paths` and `element_values` are separately governable
-  channels, and the `file_paths` scrub is a pattern pass over the fields we walk,
-  not a proof of absence — a relative path, or a path split across two AX
-  attributes, survives it. A fleet that needs a real bound must also narrow
-  `computer_use.apps`.
-- **Governance is not an undo.** Every mutating tool is irreversible in the real
-  world: a click that sends an email, a `set_value` that changes production
-  config in an authenticated tab. `effective = POLICY ∩ PROFILE` decides
-  *whether*, never *how badly*. A fleet that sets only `enabled: true` with no
-  sibling rows has granted **unbounded** desktop automation, and the Settings
-  panel says exactly that in its `unrestricted` state.
+  `window_titles`, `file_paths` and `element_values` are **not** separately
+  governable — the `observations` scope was removed, `apply_observation_ceiling` is
+  a pass-through and `permitted_observation_channels` returns every channel — so
+  there is no `computer_use.apps` (or any other) row left to narrow. A deployment
+  that needs a real bound on what the tree may disclose should not enable the
+  feature.
+- **Nothing bounds the blast radius, and there is no undo.** Every mutating tool is
+  irreversible in the real world: a click that sends an email, a `set_value` that
+  changes production config in an authenticated tab. There is no
+  `effective = POLICY ∩ PROFILE` evaluation on this path — no module under
+  `computer_use/` consults a profile — so `enabled: true` grants **unbounded**
+  desktop automation by construction, not as the default of a tunable model.
 - **Element-index addressing is inherently racy** — see the honest limit under
   [Index lifecycle](#index-lifecycle-and-its-honest-limit).
 - **A ctypes fault ends computer use for the rest of the kiro-cli session.**

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -465,17 +465,16 @@ class KiroCrewConfig:
     slack_dm_activation: str = "always"       # activation mode for DMs (D-prefix channels)
 ```
 
-### Computer use: no `enabled` field here, and no pointer flag either
+### Computer use: no `enabled` field here
 
-`ComputerUseConfig` carries display and limits only. **Two** switches for native
-desktop GUI automation live **outside `config.json`**, on the keystone at
+`ComputerUseConfig` carries display and limits only. The switch for native desktop
+GUI automation lives **outside `config.json`**, on the keystone at
 `~/.kiro/crew/computer_use.json` (path via `config.loader.computer_use_state_path()`,
 leaf on `security._CREW_SECRET_LEAVES`):
 
 ```json
 {
   "enabled": false,
-  "allow_pointer_move": false,
   "allowed_apps": [],
   "extra_denied_apps": []
 }
@@ -490,17 +489,24 @@ redirect.
 
 - **`enabled`** — the primary enable for full desktop observation plus input
   synthesis. A security ceiling, so it goes where the agent can neither read nor
-  write it.
-- **`allow_pointer_move`** — the operator's consent for `click_method: "global"`,
-  the one path that warps the **real** mouse pointer. Same class of control, same
-  treatment, for exactly the same reason. It is only half the permit: the
-  `capabilities.computer_use_pointer` governance row is required in addition
-  (tightest-wins), and neither substitutes for the other.
+  write it. Read with a strict `is True` identity test, so a truthy string such as
+  `"enabled": "false"` does **not** enable desktop control, and the read fails soft
+  to `{}` → **off**.
+- **`allowed_apps` / `extra_denied_apps`** — the operator's own narrowing. These
+  are the ONLY other keys `PolicyConfig.from_state` reads.
 
-Both are read with a strict `is True` identity test, so a truthy string such as
-`"allow_pointer_move": "false"` does **not** hand over the mouse, and both reads
-fail soft to `{}` → **off**. See [security.md](security.md),
-[governance.md](governance.md) and [computer-use.md](computer-use.md).
+**There is no `allow_pointer_move` key, and writing one has no effect.** An earlier
+revision documented it here as a second consent switch for `click_method: "global"`
+(the one path that warps the real mouse pointer), gated together with a
+`capabilities.computer_use_pointer` governance row. Both were removed by product
+decision: there are no `computer_use.*` governance scopes at all, and
+`from_state` reads only the three keys above, so a hand-written
+`{"enabled": true, "allow_pointer_move": false}` silently grants the pointer path —
+the operator would believe they had withheld consent. What actually contains that
+path is that the model must NAME the method (`auto` never resolves onto it) and every
+use is SEL-audited under its own `tool_kind`. Do not re-document the flag without
+re-implementing it. See [security.md](security.md), [governance.md](governance.md)
+and [computer-use.md](computer-use.md).
 
 #### `computer_use.cursor_motion` — the one new `config.json` flag
 
@@ -512,18 +518,17 @@ invisible to `screencapture`, so an agent flipping it could at most decorate its
 clicks. A keystone flag would imply a security decision that does not exist.
 
 `overlay.cursor_motion_enabled()` reads it through `getattr(section,
-"cursor_motion", False)` rather than as a typed attribute, which makes the read
+"cursor_motion", False)` **even though the field is now declared** on
+`ComputerUseConfig`, and that stays deliberate: it makes the read
 **forward-compatible and fail-OFF**: a build whose `ComputerUseConfig` predates the
 field resolves to OFF rather than raising inside a tool call, and a missing field can
-only ever mean "no decoration", never "start drawing on the user's screen". The
-typed `ComputerUseConfig` field (and its `_EDITABLE_CONFIG` row) is the remaining
-wiring step; until it lands the flag is inert and the overlay stays off.
+only ever mean "no decoration", never "start drawing on the user's screen".
 
 Three consequences for this module: `"computer_use"` MUST be present in
 `_KNOWN_CONFIG_SECTIONS` (the guarded invariant that `to_dict()`'s emitted sections
 equal that set); the dashboard's `_EDITABLE_CONFIG` exposes only the limits
 (`computer_use.max_tree_nodes`, `computer_use.screenshot_max_px`) — never an
-`enabled` key and never `allow_pointer_move`; and every numeric knob is clamped to
+`enabled` key; and every numeric knob is clamped to
 the same `*_LIMIT` ceiling the MCP tool schemas enforce, so a hand-edited
 `config.json` cannot ask for an unbounded accessibility walk or a full-resolution
 screenshot.

--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -37,10 +37,14 @@ can reorder strictness or redefine matching):
 
 - `_ORDINAL_SCALES`: `approval = yolo < auto < interactive`;
   `sandbox = off < standard < cc < strict` (verified against `sandbox.py`).
-- `_MATCHERS`: `identifier` (case-insensitive), `command` (case-sensitive
-  `fnmatchcase`), `path`, `host`, `mcp` (a `@server` grant covers `@server/tool`),
-  `bundle_id` and `cu_action` (both added for computer use — see
-  [Governed capability: computer use](#governed-capability-computer-use-native-desktop-gui-automation)).
+- `_MATCHERS` — exactly **five**: `identifier` (case-insensitive), `command`
+  (case-sensitive `fnmatchcase`), `path`, `host`, and `mcp` (a `@server` grant covers
+  `@server/tool`). An earlier revision also listed `bundle_id` and `cu_action` "both
+  added for computer use"; they were removed with that governance model and naming
+  either in a `ScopedRuleset` raises `PlatformCompositionError: unknown matcher`,
+  which under `boot.fail_closed` aborts governance boot — so this list is
+  load-bearing, not descriptive. Extend it only through
+  `register_matcher`/`register_scope`, which validate the name.
   The `path` matcher normalizes **only the queried item** (`_norm_item`: expand
   `~`/`$VAR` → `os.path.abspath`, which anchors a relative path to the host CWD
   and collapses `.`/`..`) and matches it against the operator's pattern **expanded
@@ -353,12 +357,18 @@ canonical taxonomy parser — never re-implemented). Resolution is:
 **`identity_proven` is true for ANY non-empty session key**, so an unattended
 surface that *does* carry a key — `cron:<job>`, `subagent:<id>`, `taskrunner` —
 resolves to `None` (policy-ceiling-only), **not** `deny_all_profile`; only `_bg`
-and `_hb` fall to deny-all. That is correct for most scopes and wrong for
-computer use, which must not fall back to policy-only on a surface nobody is
-watching a mouse on. Hence the feature-local unattended refusal in
-`computer_use.gate` (a code rule that cannot be un-shipped by deleting a profile
-file) plus the shipped `cu-off` profiles bound to those surfaces as the visible,
-explainable form of the same decision.
+and `_hb` fall to deny-all. That is correct for every scope that remains.
+
+An earlier revision continued: "…and wrong for computer use", and described a
+feature-local unattended refusal in `computer_use.gate` plus shipped `cu-off`
+profiles bound to the unattended surfaces. **Neither exists.** Computer use is
+deliberately ungoverned — no `computer_use*` row in `SCOPE_CATALOG`, no
+unattended-surface rule, and no shipped profile of that name — so cron, subagent,
+taskrunner, webhook, workflow and channel sessions all drive the desktop once the
+operator has flipped the keystone. That is the product decision recorded in
+[computer-use.md](computer-use.md); the containment is the keystone the agent cannot
+write plus the SEL audit trail, not a surface ceiling. Do not re-document the refusal
+without re-implementing it.
 
 **`host` surface (in-process host actions).** A governance check that is not
 driven by a user-facing surface — app activation
@@ -603,7 +613,13 @@ read-your-writes should add it deliberately, with its own tests.
   user `auto_approve_tools` loop**. A governance deny wins over a user
   auto-approve, and the read-only auto-approve fast-path runs strictly AFTER
   both the deny-floor and `gate_decision`, so a read-only classification can
-  never re-admit a denied/governed call. The governance `commands` deny is
+  never re-admit a denied/governed call. **Inside** that fast-path the semantic
+  `tool_kind` is authoritative and is tested first, as an ALLOW-list: only
+  `read`/`fetch` auto-approve, and every other non-empty kind falls through to
+  interactive approval before any title-keyed branch (including the computer-use one)
+  is consulted — the title is the agent-authored `description`, and `tool_kind`
+  itself is a verbatim ACP string, so a denylist of mutating kinds cannot be
+  complete. See `security.md`, "Read-only auto-approve". The governance `commands` deny is
   evaluated in `gate_decision` **independently of** the user's keystone
   opt-out state, so a rule the operator disabled in `denied_commands.json` is
   STILL denied when the enterprise ceiling pins the equivalent pattern —
@@ -1102,7 +1118,8 @@ a product decision, not an oversight, and it is a reversal: an earlier revision
 shipped eight rows here (`capabilities.computer_use`, `computer_use.actions`,
 `.apps`, `.app_names`, `.observations`, `.targets`, `.approval`, and
 `capabilities.computer_use_pointer`) plus two custom matchers (`bundle_id`,
-`cu_action`). All of it was removed.
+`cu_action`). All of it was removed — neither matcher is registered, and naming
+either one now aborts governance boot (see the `_MATCHERS` note above).
 
 **What replaced it.** One operator opt-in on the keystone `computer_use.json`,
 which `security._SENSITIVE_HOME_DIRS` fences the agent away from. The agent cannot
@@ -1127,8 +1144,10 @@ Two things computer use still shares with this module, neither of them a decisio
 
 * `_CU_ACTION_CLASSES` — the code-owned `observe` / `mutate` / `pointer` /
   `keyboard` / `text_entry` / `control` labels. `hooks` reads them for the
-  read-only auto-approve, and `gate.is_mutating_action` reads them so "which verbs
-  synthesize input" has one definition;
+  read-only auto-approve — the one live consumer. `gate.is_mutating_action` reads
+  them too so "which verbs synthesize input" has one definition, but it currently has
+  no caller in the package: it is retained as the accessor an edition would use
+  rather than re-deriving the classes, not as a control on the dispatch path;
 * `CU_MCP_SERVER` / `is_computer_use_title` — the server key and title prefix, used
   by `classify_tool_title` to route a computer-use title to the ordinary `mcp` pair.
 

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -139,7 +139,7 @@ under `(allow default)`, never an edition-resolved or user-writable executable.
 - **App admission trust root (keystone invariant)** — `~/.kiro/crew/app_admission.json` (the sole fleet-controlled App Kit admission ceiling loaded by `apps/admission.py`) is on the sensitive floor, read- and write-blocked through the shared file gate. Because an **absent** policy falls open (admit), a governed agent that could `fs_write`/`tee`/`rm` this file could delete or neuter its own admission ceiling and re-admit a banned/unsigned app. Adding it to `_SENSITIVE_HOME_DIRS` also arms the bash write/extract matcher (`tee`/`rm`/redirect). The gateway's own loader (`apps.admission.load_app_admission_policy`) opens it directly via `path.read_text()` and does **not** route through `is_sensitive_path()`, so legitimate policy loading is unaffected.
 - **Runtime exec dir trust root (run-marker sandbox-escape)** — the `run/` dir under the crew home is on the sensitive floor (under every `_CREW_HOME_PREFIXES` entry) because the gateway executes its contents **outside** the agent sandbox: the sandbox launcher scripts (`sandbox.py` execs `python <home>/run/kirocrew_sandbox_*.py`) and the remote-instance run-marker `gateway-<port>.bin` (`instances/run_marker.py`), whose recorded launcher path the SSH token-mint **and** the `restart_remote` action read and `exec` on the remote host. Without this floor entry a prompt-injected / sandboxed agent that could `fs_write` (or `tee`/redirect) a marker — or a launcher — into `run/` could point it at an attacker-controlled binary that the next routine token refresh or restart execs unsandboxed (owner + `-x` checks don't help; agent writes run as the same user) — a reachable sandbox escape. Classifying the whole dir also arms the bash write/extract matcher. The gateway's own writers (`instances/run_marker.write_marker` via `atomic_write`, and the sandbox launcher writer) open these paths directly and do **not** route through `is_sensitive_path()`, so gateway startup/spawn is unaffected.
 
-- **Computer-use primary enable (keystone leaf `computer_use.json`)** — the on/off switch for native desktop GUI automation (see [computer-use.md](computer-use.md)) is `~/.kiro/crew/computer_use.json`, added to `_CREW_SECRET_LEAVES` so it is read+write-blocked under every `_CREW_HOME_PREFIXES` entry, on both the tool path (`is_sensitive_path`) and every shell form (`is_sensitive_bash_command` — `cat`, `>`, `tee`, `rm`, plus `tar -C` / `unzip -d` extraction into the trust root via `_EXTRACT_INTO_TRUST_ROOT_RE`). **It is deliberately NOT in `config.json`**, and the precedent is the denied-command opt-out immediately below: `is_sensitive_write_path("~/.kiro/crew/config.json")` is `True`, but `is_sensitive_bash_command("echo x > ~/.kiro/crew/config.json")` is `None` and `is_denied(...)` is `None` (`_WRITE_PROTECTED_BASH_LEAVES` is `('.data-home-ready',)` only), so a `config.json` toggle would be flippable by a prompt-injected agent through any redirect. A primary enable for full desktop observation plus input synthesis is a **security ceiling**, the same class as the deny opt-out, so it lives on the keystone. Reads fail soft to `{}` → **disabled**, and `is_enabled()` is a strict identity test against `True` (a hand-edited `"enabled": "false"` or `1` does not enable desktop control). The only writer is the dashboard PUT handler, which does not route through the agent tool gate; `enable_state.load_state()` opens the file directly, so legitimate reads are unaffected. The same file also carries `allow_pointer_move` — the opt-in for the one click path that warps the operator's REAL mouse pointer (`click_method: "global"`) — so that flag inherits the identical protection with no new leaf: it is read with the same strict `is True` identity test, and it is only half the gate (the `capabilities.computer_use_pointer` governance row is the other half, and neither substitutes for the other).
+- **Computer-use primary enable (keystone leaf `computer_use.json`)** — the on/off switch for native desktop GUI automation (see [computer-use.md](computer-use.md)) is `~/.kiro/crew/computer_use.json`, added to `_CREW_SECRET_LEAVES` so it is read+write-blocked under every `_CREW_HOME_PREFIXES` entry, on both the tool path (`is_sensitive_path`) and every shell form (`is_sensitive_bash_command` — `cat`, `>`, `tee`, `rm`, plus `tar -C` / `unzip -d` extraction into the trust root via `_EXTRACT_INTO_TRUST_ROOT_RE`). **It is deliberately NOT in `config.json`**, and the precedent is the denied-command opt-out immediately below: `is_sensitive_write_path("~/.kiro/crew/config.json")` is `True`, but `is_sensitive_bash_command("echo x > ~/.kiro/crew/config.json")` is `None` and `is_denied(...)` is `None` (`_WRITE_PROTECTED_BASH_LEAVES` is `('.data-home-ready',)` only), so a `config.json` toggle would be flippable by a prompt-injected agent through any redirect. A primary enable for full desktop observation plus input synthesis is a **security ceiling**, the same class as the deny opt-out, so it lives on the keystone. Reads fail soft to `{}` → **disabled**, and `is_enabled()` is a strict identity test against `True` (a hand-edited `"enabled": "false"` or `1` does not enable desktop control). The only writer is the dashboard PUT handler, which does not route through the agent tool gate; `enable_state.load_state()` opens the file directly, so legitimate reads are unaffected. The file carries no separate pointer opt-in: an earlier revision documented an `allow_pointer_move` flag (plus a `capabilities.computer_use_pointer` governance row) as a second consent gate for the one click path that warps the operator's REAL mouse pointer (`click_method: "global"`), and both were removed by product decision — `PolicyConfig.from_state` reads only `allowed_apps` / `extra_denied_apps`, so writing the flag has no effect and must not be re-documented without being re-implemented. That path is instead contained by requiring the model to NAME the method (`auto` never resolves onto it) and by a dedicated SEL `tool_kind` on every use.
 
 **Write-only config protection** (`is_sensitive_write_path` in `security.py` + `hooks.py`) — runtime config files are protected against *modification* by agent tools while staying *readable*:
 - `~/.kiro/crew/config.json` and `~/.kiro/crew/config.local.json` are in a write-only tier (`_WRITE_PROTECTED_HOME_PATHS`, expanded under every `_CREW_HOME_PREFIXES` entry so the pre-move legacy copy is covered too), deliberately NOT in the read+write `_SENSITIVE_HOME_DIRS` list above — the dashboard file viewer, `cat`, and knowledge indexing legitimately read config.
@@ -520,10 +520,50 @@ branch (`_cu_read_only_auto_approve`), keyed on the code-owned
 `_is_read_only_tool` title heuristic — that heuristic keys on a leading verb, and
 an agent-supplied title must never decide whether a keystroke is synthesized into
 somebody's window. It is additionally gated on the keystone primary enable, so no
-auto-approval can exist while the feature is off. Immediately above it,
-`_cu_approval_floor_forces_prompt` implements the `computer_use.approval` ordinal
-clamp by suppressing BOTH auto-approve branches when a policy sets the floor to
-`interactive`; see [governance.md](governance.md).
+auto-approval can exist while the feature is off. There is **no**
+`computer_use.approval` ordinal and no approval-floor clamp helper: that row was
+removed with the rest of the computer-use governance model, so nothing makes the
+feature observation-only; see [governance.md](governance.md).
+
+**The semantic `tool_kind` is an ALLOW-list, evaluated before ANY title-keyed
+fast-path.** Only `tool_kind in _READ_ONLY_TOOL_KINDS` (`read`/`fetch`) auto-approves
+outright; **every other non-empty kind returns `allow`** — i.e. falls through to
+interactive approval — before the computer-use check or `_is_read_only_tool` is
+consulted. A title-keyed branch is reachable only when the kind is **absent**.
+
+**The computer-use auto-approve additionally requires an EXPLICIT read-only kind** —
+it is reached only *under* that allow-list branch, never on an absent kind. Two
+agent-controlled inputs meet there and neither may decide alone: the title, and the
+absence of a kind (indistinguishable from an honest omission). They must agree.
+
+Three findings shaped this, and all are worth keeping in view:
+
+1. `tool_name` is the display title, and `select_tool_title` (`acp/_dispatch.py`)
+   prefers the LLM-authored `description`, so it is **agent-controlled** — as
+   `on_tool_call`'s own docstring states. The computer-use branch originally sat
+   *above* any kind test, so once the operator enabled computer use, a mutating call
+   titled `mcp__kirocrew-computer__computer_get_state` skipped the prompt entirely
+   (verified for all six mutating kinds).
+2. The first fix was a **denylist** (`kind in _WRITE_TOOL_KINDS` → `allow`), and it
+   was still fail-open: `tool_kind` is passed through verbatim from the ACP `kind`
+   field, so it is an arbitrary agent-influenced string and no enumeration of
+   mutating kinds can be complete. `kind="other"` is a real ACP value and sailed
+   past it. Hence the inversion — deny-by-default on the kind.
+3. The allow-list still let an **omitted** kind through to the computer-use branch,
+   so a `computer_click` could forge an observation title, send no kind, and
+   auto-approve. Fixed by demanding the explicit kind. Deliberately *not* fixed by
+   blocking absent kinds outright: the generic `_is_read_only_tool` fallback rejects
+   every `mcp__kirocrew-computer__*` title anyway (asserted by a test, so it cannot
+   quietly start matching), so a blanket block would have regressed every ordinary
+   tool's "reads don't nag" behaviour for no security gain.
+
+`_WRITE_TOOL_KINDS` survives as documentation of which kinds have been observed to
+mutate; **the gate must not branch on it again**. Over-blocking here costs one
+approval prompt, under-blocking costs the prompt that is the last thing between an
+injected agent and a click. Pinned by
+`test_hooks.py::TestMutatingKindBeatsTheTitle`, which asserts the unknown-kind cases
+behaviourally AND asserts over the AST that `on_tool_call` references no
+mutating-kind denylist.
 
 ### Computer use: a pixel/AX surface the path matchers cannot see
 
@@ -554,8 +594,10 @@ Three controls carry the weight instead:
    feature's primary enable and the denied-command opt-out — controls that are
    out-of-band precisely so the agent cannot reach them. The list is
    operator-EXTENSIBLE (`extra_denied_apps` can only ADD) and never
-   operator-shrinkable; the governance `computer_use.apps` ruleset is the
-   enterprise force-pin on top.
+   operator-shrinkable. There is no enterprise force-pin on top: the
+   `computer_use.apps` ruleset was removed with the rest of that model, so
+   `PolicyConfig.from_state` reads only `allowed_apps` / `extra_denied_apps` and the
+   shipped entry plus the operator's own additions are the whole list.
 2. **The secure-SUBROLE check**, and it must be the subrole. A real macOS password
    box reports `AXRole = "AXTextField"` (innocuous) with
    `AXSubrole = "AXSecureTextField"` and a **readable** `AXValue` — live-verified.

--- a/src/kiro_crew/builtin_skills/computer-use/SKILL.md
+++ b/src/kiro_crew/builtin_skills/computer-use/SKILL.md
@@ -83,8 +83,9 @@ cell. Then, in order:
   field looks identical to a writable one otherwise, and typing into it
   succeeds while the text goes nowhere. If a text field has no `(editable)`,
   it will not accept input — find the one that does instead of retrying.
-- **`<focused>`** — the caret is here. "Type this in" means this element, and
-  `computer_type_text` without an `element_index` goes here.
+- **`<focused>`** — the caret is here. "Type this in" usually means this element,
+  so pass ITS index — there is no indexless form (see the note under the action
+  table).
 - **`@ x=…,y=… WxH`** — position and size, **relative to the window**, in
   pixels. Absent when the element exposes no geometry (ordinary) or the window
   rect could not be read.
@@ -282,6 +283,7 @@ These are **answers**, not failures. Relay them and adapt; do not loop.
 |---|---|---|
 | a value ending in `…` | the text was cut at `text_limit`, not truncated by the app | re-snapshot with a larger `text_limit`; do NOT read the screenshot to recover it, and do not tell the user the content is missing |
 | `[tree truncated at N nodes]` | the window has more controls than the budget | raise `max_tree_nodes`, or scroll to bring your target into range — the rest of the window is real, you just have not been shown it |
+| `Screenshot suppressed: the accessibility tree was truncated …` | a cut-off walk cannot prove the window holds no password field, so no pixels were captured. Routine for a browser or an Electron app at the default budget | if you actually need the image, re-snapshot with a higher `max_tree_nodes` / `max_tree_depth`; otherwise work from the tree and do not re-request the screenshot |
 | `no state for 'X'. Call computer_get_state first.` | you acted without a snapshot | snapshot, then act |
 | `state for 'X' is 214s old. Call computer_get_state again.` | the snapshot expired (90s) | snapshot again |
 | `element_index 7 changed since the last computer_get_state (was 'AXButton "Save"', now 'AXButton "Delete"')` | the UI moved under you — this refusal is what stopped you clicking the wrong thing | snapshot again and re-locate the element by its label, not its old number |
@@ -351,11 +353,11 @@ computer_get_state(app="Finder", screenshot=True)    # screenshot=True opens the
       12 row "draft.md"
       ...
 computer_click(app="Finder", element_index=12)       # select the row
-computer_press_key(app="Finder", key="return")        # Finder's rename shortcut
+computer_press_key(app="Finder", element_index=12, key="return")   # rename shortcut
 computer_get_state(app="Finder", screenshot=True)     # rename mode = a visible change
   → 13 textfield "draft.md"
 computer_set_value(app="Finder", element_index=13, value="notes-2026.md")
-computer_press_key(app="Finder", key="return")        # commit
+computer_press_key(app="Finder", element_index=13, key="return")   # commit
 computer_get_state(app="Finder", screenshot=True)     # show the user the renamed file
 computer_end_turn()
 ```

--- a/src/kiro_crew/computer_use/cli.py
+++ b/src/kiro_crew/computer_use/cli.py
@@ -84,10 +84,16 @@ _EXIT_PROBLEM = 1
 
 # The surface identity ``call`` presents to the gate. ``cli_chat`` is the repo's
 # existing key for "a human at a terminal" — ``sel._infer_source`` maps it to the
-# ``cli`` surface, which is deliberately NOT in ``gate.UNATTENDED_SURFACES`` and
-# matches none of ``gate.UNATTENDED_KEY_PREFIXES``, so the unattended-surface
-# refusal does not fire. Reusing it (rather than minting a private key) is what
-# makes an operator profile bound to the CLI surface govern this command too.
+# ``cli`` surface, so the SEL audit record attributes the call correctly. Reusing it
+# (rather than minting a private key) is what keeps the audit trail readable and lets
+# an operator profile bound to the CLI surface govern this command too.
+#
+# It is NOT an authorization input: there is no unattended-surface refusal left to
+# avoid. ``gate.UNATTENDED_SURFACES`` / ``UNATTENDED_KEY_PREFIXES`` (which an earlier
+# revision of this comment cited) never existed in ``computer_use.gate`` after the
+# governance model was removed — the only ``_UNATTENDED_SURFACES`` in the tree is
+# ``platform/governance_profiles.py``'s, which selects a PROFILE and carries no
+# computer-use rule.
 _CLI_SESSION_KEY = "cli_chat"
 
 

--- a/src/kiro_crew/computer_use/gate.py
+++ b/src/kiro_crew/computer_use/gate.py
@@ -186,16 +186,6 @@ def apply_observation_ceiling(
     return dict(payload)
 
 
-def targets_axis_is_governed(*, session_key: str = "", agent: str = "", app: str = "") -> bool:
-    """Always ``False`` — there is no ``targets`` ceiling to evaluate.
-
-    ``tools`` reads this to decide whether to DEMAND an explicit ``element_index``
-    for keyboard input and coordinate gestures. With the axis gone, both forms are
-    allowed: typing into whatever the app has focused is a legitimate flow again.
-    """
-    return False
-
-
 def app_is_disclosable(
     *,
     bundle_id: str,
@@ -255,5 +245,4 @@ __all__ = [
     "permitted_observation_channels",
     "require_computer_use",
     "require_pointer_move",
-    "targets_axis_is_governed",
 ]

--- a/src/kiro_crew/computer_use/macos_ffi.py
+++ b/src/kiro_crew/computer_use/macos_ffi.py
@@ -213,9 +213,24 @@ CG_BOUNDS_H = "Height"
 CG_WINDOW_LAYER_NORMAL = 0
 
 # ── CoreGraphics event ABI constants ──
-# kCGEventSourceStatePrivate. NEVER pass NULL: an event built from the default
-# (HID) source inherits the user's live modifier state.
-K_CG_EVENT_SOURCE_STATE_PRIVATE = 1
+# ``kCGEventSourceStatePrivate``. NEVER pass NULL: an event built from the default
+# (HID) source inherits the user's live modifier state, which is the measured
+# ``"a","b","c"`` -> ``' I Abc'`` bug this source exists to prevent.
+#
+# The value is **-1**, and it is NOT interchangeable with 1.
+# ``CGEventTypes.h`` declares ``CGEventSourceStateID`` as
+# ``{kCGEventSourceStatePrivate = -1, kCGEventSourceStateCombinedSessionState = 0,
+# kCGEventSourceStateHIDSystemState = 1}`` — so the previous ``1`` selected the
+# SHARED HID table by name while claiming to be private. Verified live on
+# darwin-arm64: ``CGEventSourceGetSourceStateID`` reports an opaque id for -1 and
+# literally ``1`` for 1. The symptom was masked only because every posting path
+# (``post_key`` / ``post_text`` / ``post_scroll`` / ``_mouse_event``) also calls
+# ``CGEventSetFlags(event, 0)``; a future path that omits that would reintroduce
+# the modifier-inheritance bug, and ``macos_skylight``'s deliberate "HID source
+# unlike every other path in this package" contrast was vacuous while these were
+# the same table. Signed because the enum is an ``int32_t``, so ``_FN_SPECS`` binds
+# ``CGEventSourceCreate`` with ``c_int32`` rather than a uint.
+K_CG_EVENT_SOURCE_STATE_PRIVATE = -1
 # kCGScrollEventUnitLine. The enum has exactly TWO members — ``Pixel`` (0) and
 # ``Line`` (1); there is no page unit, so a "page" of scrolling is expressed as a
 # line count in the delta, not by the unit. Named accurately here because the old
@@ -1538,11 +1553,28 @@ def post_text(pid: int, text: str) -> None:
 
     Encoded per character as UTF-16LE so an astral character is delivered as its
     full surrogate pair in one event rather than as two lone surrogates.
+
+    **The whole string is encoded BEFORE the first keystroke is posted.** Encoding
+    inside the loop meant an unencodable character — a lone surrogate, which
+    ``str`` permits and UTF-16 cannot represent — raised ``UnicodeEncodeError``
+    *after* every preceding character had already been typed into a live
+    application. The caller then saw a failure while the target held a partial
+    string, and a model told "typing failed" would retry and double the prefix.
+    Encoding up front makes the call all-or-nothing: it either types the whole
+    string or refuses having typed nothing, which is the contract the driver's
+    failed ``DriverResult`` claims. ``surrogatepass`` is deliberately NOT used —
+    delivering a lone surrogate to AppKit is not a meaningful keystroke.
     """
     libs = _frameworks()
+    try:
+        encoded = [(char, char.encode("utf-16-le")) for char in text]
+    except UnicodeEncodeError as exc:
+        raise ComputerUseUnsupported(
+            f"the text contains a character that cannot be typed ({exc.reason}); "
+            "nothing was sent"
+        ) from exc
     source = event_source()
-    for char in text:
-        units = char.encode("utf-16-le")
+    for _char, units in encoded:
         count = len(units) // 2
         if count <= 0:
             continue

--- a/src/kiro_crew/computer_use/overlay.py
+++ b/src/kiro_crew/computer_use/overlay.py
@@ -39,6 +39,7 @@ import asyncio
 import json
 import logging
 import sys
+import threading
 from typing import Any, Sequence
 
 from kiro_crew import platform_compat
@@ -435,19 +436,36 @@ def points_payload(points: Sequence[tuple[float, float]]) -> "list[list[float]]"
 # cursors would fight over the same screen.
 
 _shared_overlay: "CursorOverlay | None" = None
+_shared_overlay_lock = threading.Lock()
 
 
 def get_shared_overlay() -> CursorOverlay:
     """Process-wide :class:`CursorOverlay` singleton.
 
-    No lock: construction is a handful of attribute assignments with no I/O, and
-    the gateway's callers all live on the one event loop. The ``asyncio.Lock``
-    that actually matters is created inside the instance, in the running loop.
+    A ``threading.Lock``, like every sibling singleton in this package
+    (``backend``, ``index``, ``macos_ffi``, ``apps_macos``) — an earlier revision
+    skipped it on the premise that "the gateway's callers all live on the one event
+    loop", and they do not. The only caller is :func:`show_pointer_motion`, which is
+    SYNC and is invoked from ``tools._perform`` inside ``dispatch_tool``, offloaded
+    onto ``subprocess_executor()`` — an 8-worker pool. Nothing upstream serializes
+    the pointer path, so two concurrent ``click_method: "global"`` clicks both saw
+    ``None`` here, each constructed a ``CursorOverlay``, and one was handed out while
+    the other was orphaned. The orphan is unreachable afterwards (``stop`` and
+    ``reset_shared_overlay`` both go through this global) so its ``overlay_proc``
+    child leaks for the gateway's lifetime — and each instance's own
+    ``asyncio.Lock`` cannot serialize across instances, so the two fake cursors
+    fight over the same screen, which is precisely what this singleton exists to
+    prevent.
+
+    Construction stays cheap and I/O-free (the ``asyncio.Lock`` that matters is
+    created lazily inside the instance, in the running loop), so holding this lock
+    cannot block meaningfully.
     """
     global _shared_overlay
-    if _shared_overlay is None:
-        _shared_overlay = CursorOverlay()
-    return _shared_overlay
+    with _shared_overlay_lock:
+        if _shared_overlay is None:
+            _shared_overlay = CursorOverlay()
+        return _shared_overlay
 
 
 def reset_shared_overlay() -> None:

--- a/src/kiro_crew/computer_use/render.py
+++ b/src/kiro_crew/computer_use/render.py
@@ -30,6 +30,7 @@ from kiro_crew.computer_use.types import (
     SELECTION_NOTE,
     TREE_INDENT,
     TRUNCATED_NOTE,
+    TRUNCATED_WINDOW_NOTE,
     WINDOW_ORIGIN_NOTE,
     AppRef,
     ElementRec,
@@ -264,9 +265,35 @@ def _render_image_note(snap: Snapshot) -> str:
     though the tree redacted the value. Suppression is whole-window because
     there is no reliable way to blank a sub-rectangle of an already-encoded
     JPEG, and a partial redaction that missed would be worse than none.
+
+    A TRUNCATED walk is announced for the same reason and was not: ``capture_macos``
+    refuses on ``truncated``/``depth_truncated`` because a cut-off walk cannot prove
+    the window holds no secure field ("unknown" behaves as "present"), but this
+    function special-cased only ``has_secure`` and returned ``""`` for everything
+    else. Since truncation is the NORMAL state for a Chromium/Electron window at the
+    shipped 1200-node default, ``screenshot: true`` on Chrome or Slack silently
+    produced no image and no reason — the retry loop these notes exist to prevent.
+    Checked before ``image_path`` so the explanation cannot be skipped, and after
+    ``has_secure`` so a window that is both keeps the more specific reason.
+
+    **But only when an image was actually REQUESTED**, which is what
+    ``walk_budget.want_image`` answers. Every mutating action's refresh walk forces
+    ``want_image=False`` by design, and truncation is routine — so an unconditional
+    note appended "Screenshot suppressed … Re-run with a higher max_tree_nodes" to
+    every successful click on a browser window, advertising the suppression of an
+    image nobody asked for and naming an argument mutating tools do not even accept.
+    That is the same retry loop pointed the other way. ``None`` (a snapshot a backend
+    built directly, with no budget stamped) keeps the announcement, because there the
+    request is unknown and a spurious note is cheaper than a silent omission.
     """
     if snap.has_secure:
         return SECURE_WINDOW_NOTE
+    if (
+        not snap.image_path
+        and (snap.truncated or snap.depth_truncated)
+        and (snap.walk_budget is None or snap.walk_budget.want_image)
+    ):
+        return TRUNCATED_WINDOW_NOTE
     if not snap.image_path:
         return ""
     return SCREENSHOT_NOTE.format(

--- a/src/kiro_crew/computer_use/service.py
+++ b/src/kiro_crew/computer_use/service.py
@@ -175,6 +175,10 @@ class ComputerUseService:
         if snap is None:
             raise ComputerUseError(f"the driver returned no state for '{app.label}'")
         snap = self._persist_image(snap)
+        # Stamp the budget this walk actually used, so the drift-verification
+        # re-walk can reproduce the SAME tree rather than the config default. See
+        # ``Snapshot.walk_budget`` and :meth:`verify_fingerprint`.
+        snap = replace(snap, walk_budget=req)
         self.index.put(snap, session_key=session_key)
         return snap
 
@@ -217,6 +221,13 @@ class ComputerUseService:
         in the overwhelming majority of cases; it is not a transactional
         guarantee.
         """
+        # *req* must carry the budget the CACHED snapshot was walked at, not the
+        # config default — ``tools._mutation_walk_budget`` resolves that from
+        # ``Snapshot.walk_budget`` before calling here. Verifying a tree walked at
+        # ``max_tree_nodes=2001`` against a 1200 default reports "no element at that
+        # index" for everything above 1200, and the refresh the model gets next is
+        # truncated identically, so re-snapshotting cannot break the loop.
+        #
         # want_image=False: the verification walk exists to compare structure, and
         # capturing (then discarding) pixels would double the cost of every
         # mutating action and spool a screenshot nobody asked for.

--- a/src/kiro_crew/computer_use/tools.py
+++ b/src/kiro_crew/computer_use/tools.py
@@ -204,11 +204,11 @@ _APP_SCOPED_TOOLS: frozenset[str] = frozenset(
 
 # Tools that address ONE element by index, and therefore have a resolved
 # ``ElementRec`` for ``policy.check_input_target`` to apply the secure-field
-# refusal to. ``computer_type_text`` and ``computer_click`` are both here even
-# though their index is OPTIONAL: when one is supplied the resolved element is
-# checked, and when it is not there is no element to check (the driver types into
-# whatever the app has focused, or clicks a raw coordinate). Indexless input is
-# allowed again — the ``targets`` ceiling that used to demand an index is gone.
+# refusal to. ``computer_click`` is here even though its index is OPTIONAL: when
+# one is supplied the resolved element is checked, and when it is not the target
+# is a raw coordinate instead (the one-of enforced by
+# ``policy.check_click_target``). Every OTHER member requires its index — see
+# ``_ELEMENT_REQUIRED_TOOLS`` below — so there is always an element to check.
 # ``computer_drag`` is NOT here — it has no element form at all.
 _ELEMENT_SCOPED_TOOLS: frozenset[str] = frozenset(
     {
@@ -401,8 +401,12 @@ def _dispatch(
                 # refuse. Authorization first, diagnostics second.
                 deferred = exc
         elif tool_name in _ELEMENT_REQUIRED_TOOLS:
-            # Unreachable through the MCP path (the schema marks it required), but
-            # this function is also the in-process entry point for an app backend.
+            # The LAST line of defence, and a reachable one — not merely a guard for
+            # the in-process entry point. ``MCP_COMPUTER_SCHEMAS`` is the enforcement
+            # layer for the MCP path, so this stays even where that schema already
+            # demands the field: a spec that relaxed one of these back to optional
+            # (as ``computer_type_text`` and ``computer_press_key`` once were) must
+            # still be refused here rather than typing into an uninspectable target.
             raise ValidationError(ARG_ELEMENT_INDEX, "required")
 
     # (3d) POINTER-REQUEST SHAPE — one-of(element_index | x+y), the method/target
@@ -587,7 +591,13 @@ def _run(
     # frame a policy might forbid — then discarding it — would be both slower and
     # a needless brush with the ceiling. A model that needs to see the result
     # calls ``computer_get_state``.
-    req = replace(service.snapshot_request(), want_image=False)
+    # Inherit the TREE BUDGET the cached snapshot was walked at, because a mutating
+    # tool takes no budget arguments of its own and the config default would silently
+    # shrink the tree: a model shown element 1400 under ``max_tree_nodes=2001`` would
+    # have its click refused by the drift check ("no element at that index") and would
+    # then be handed a 1200-node refresh, so re-snapshotting reproduced the same
+    # refusal forever. Only ``want_image`` is forced off (see below).
+    req = replace(_mutation_walk_budget(svc, target, session_key=session_key), want_image=False)
 
     if rec is not None:
         # Fingerprint drift against a FRESH walk. Unconditional on every mutating
@@ -980,7 +990,16 @@ def _render_snapshot(
 
 
 def _element_payload(elem: ElementRec) -> dict[str, Any]:
-    """Flatten one record into the ceiling's element shape."""
+    """Flatten one record into the ceiling's element shape.
+
+    EVERY field, not just the governable ones. ``frame``, ``traits`` and ``focused``
+    are not observation channels the ceiling narrows, but this dict is the ONLY thing
+    ``_element_from_payload`` gets to rebuild from, so a field omitted here is a field
+    silently deleted from every rendered tree — the lossy-rebuild bug
+    ``capture_macos`` was fixed for by switching to ``dataclasses.replace``. Keep this
+    in sync with ``ElementRec``; ``test_computer_use_snapshot.py`` asserts the
+    round-trip is total so a newly added field cannot be forgotten here.
+    """
     return {
         "index": elem.index,
         "role": elem.role,
@@ -991,6 +1010,9 @@ def _element_payload(elem: ElementRec) -> dict[str, Any]:
         "depth": elem.depth,
         "secure": elem.secure,
         "enabled": elem.enabled,
+        "frame": elem.frame,
+        "traits": elem.traits,
+        "focused": elem.focused,
     }
 
 
@@ -1002,6 +1024,7 @@ def _element_from_payload(entry: Mapping[str, Any]) -> ElementRec:
     channel, so a missing or retyped key must not raise inside a render path.
     """
     actions = entry.get("actions")
+    traits = entry.get("traits")
     return ElementRec(
         index=int(entry.get("index") or 0),
         role=str(entry.get("role") or ""),
@@ -1012,7 +1035,35 @@ def _element_from_payload(entry: Mapping[str, Any]) -> ElementRec:
         depth=int(entry.get("depth") or 0),
         secure=bool(entry.get("secure")),
         enabled=bool(entry.get("enabled", True)),
+        # A half-read frame is worse than none (see ``snapshot_macos``): only a
+        # complete 4-tuple of finite numbers becomes a rect, anything else is None.
+        frame=_frame_from_payload(entry.get("frame")),
+        traits=tuple(str(t) for t in traits) if isinstance(traits, (list, tuple)) else (),
+        focused=bool(entry.get("focused")),
     )
+
+
+def _frame_from_payload(raw: Any) -> "tuple[float, float, float, float] | None":
+    """Coerce a payload ``frame`` back to a rect, or ``None``.
+
+    Defensive for the same reason as the rest of ``_element_from_payload``: the
+    mapping has been through the ceiling and may have been re-typed. A partial or
+    non-numeric rect resolves to ``None`` rather than a plausible-looking rectangle
+    pointing somewhere else — ``bool`` is excluded explicitly because it is an ``int``
+    subclass, and a NaN/inf coordinate is refused because it would render as garbage
+    a model might pass to a coordinate click.
+    """
+    if not isinstance(raw, (list, tuple)) or len(raw) != 4:
+        return None
+    out: list[float] = []
+    for part in raw:
+        if isinstance(part, bool) or not isinstance(part, (int, float)):
+            return None
+        value = float(part)
+        if value != value or value in (float("inf"), float("-inf")):
+            return None
+        out.append(value)
+    return (out[0], out[1], out[2], out[3])
 
 
 def _with_notes(body: str, shaped: Mapping[str, Any]) -> str:
@@ -1053,6 +1104,29 @@ def _declared_observations(tool_name: str) -> tuple[str, ...]:
 
 
 # ── Helpers ──
+
+
+def _mutation_walk_budget(
+    svc: "service.ComputerUseService", target: AppRef, *, session_key: str
+) -> SnapshotRequest:
+    """The tree budget a mutating action's walks must use.
+
+    A mutating tool accepts no ``max_tree_nodes`` / ``max_tree_depth`` /
+    ``text_limit`` arguments — the model set those on the ``computer_get_state`` that
+    produced the indices it is now acting on. So the drift-verification walk and the
+    post-action refresh both have to reproduce THAT walk, not the config default:
+    with the default, an index above it resolves to "no element at that index", and
+    the refresh the model is handed next is truncated the same way, so calling
+    ``computer_get_state`` again cannot break the loop.
+
+    Falls back to the config default when the cache holds no stamped budget (a
+    snapshot a backend built directly, or an action on an app with no cached state —
+    which the freshness check refuses moments later anyway).
+    """
+    cached = svc.index.get(target.window_key, session_key=session_key)
+    if cached is not None and cached.walk_budget is not None:
+        return cached.walk_budget
+    return service.snapshot_request()
 
 
 def _opt_int(args: Mapping[str, Any], name: str) -> "int | None":

--- a/src/kiro_crew/computer_use/types.py
+++ b/src/kiro_crew/computer_use/types.py
@@ -135,7 +135,11 @@ MIN_CLICK_COUNT = 1
 # live tuning, and it is below the threshold where a turn feels slow.
 POST_ACTION_SETTLE_SECS = 0.15
 
-# ── Observation channels (the ``computer_use.observations`` item vocabulary) ──
+# ── Observation channels ──
+# Was the ``computer_use.observations`` scope's item vocabulary; that scope is gone
+# and ``gate.permitted_observation_channels`` now returns all of these
+# unconditionally. Retained as the shared names the renderers and the screenshot
+# relay agree on, and as the seam an edition would narrow.
 # What a result MAY carry. Queried one channel at a time and enforced at RESPONSE
 # SHAPING (``gate.apply_observation_ceiling``), not only against the caller's
 # request flag — an implementation that attaches a screenshot unconditionally
@@ -392,6 +396,18 @@ SCREENSHOT_NOTE = (
 SECURE_WINDOW_NOTE = (
     "Screenshot suppressed: this window contains a secure (password) field, so "
     "its pixels are not captured."
+)
+#: A truncated walk cannot prove the window holds no password field, so
+#: ``capture_macos`` treats "unknown" as "present" and captures nothing. That
+#: refusal used to be SILENT, which is the normal state for a browser (Chrome
+#: measured 1475 nodes against a 1200 default) — so ``screenshot: true`` on
+#: Chrome/Slack/VS Code returned no image and no reason, and the model retried in
+#: exactly the loop the sibling notes exist to prevent. It names the remedy,
+#: because raising the budget is something the model can actually do.
+TRUNCATED_WINDOW_NOTE = (
+    "Screenshot suppressed: the accessibility tree was truncated, so this window "
+    "cannot be confirmed free of a secure (password) field. Re-run with a higher "
+    "max_tree_nodes / max_tree_depth to capture it."
 )
 NO_APPS_NOTE = "No applications with on-screen windows were found."
 
@@ -853,6 +869,17 @@ class Snapshot:
     #: sanitized and clipped. Empty when there is no selection, when the focused
     #: element is secure, or when nothing is focused.
     selected_text: str = ""
+    #: The tree budget this snapshot was actually WALKED at, stamped by
+    #: ``service.snapshot``. The drift-verification re-walk reads it so it re-walks
+    #: the same tree the model was shown: verifying a snapshot taken at
+    #: ``max_tree_nodes=2001`` against the 1200 config default made every element
+    #: above 1200 permanently un-actionable ("changed since the last
+    #: computer_get_state … now no element at that index"), and re-snapshotting
+    #: reproduced the same refusal — a loop with no way out on a documented happy
+    #: path (the schema advertises up to 5000 and the Settings copy says to raise it
+    #: for dense apps). ``None`` for a snapshot a backend built directly, in which
+    #: case the caller's own request is used.
+    walk_budget: "SnapshotRequest | None" = None
 
     @property
     def key(self) -> str:

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2485,8 +2485,8 @@ class ComputerUseConfig:
             "Cursor Motion",
             "Draw a visible cursor gliding to each target before a real-pointer "
             "click, so the operator can see what the agent is doing. macOS only; "
-            "purely visual and never a permit — the pointer opt-in and the "
-            "governance permit are what allow the click itself.",
+            "purely visual and never a permit — the drawn cursor is not the pointer, "
+            "and turning this on grants no new capability.",
         ),
     )
 
@@ -3452,7 +3452,9 @@ class KiroCrewConfig:
     )
     weixin: WeixinConfig = field(
         default_factory=WeixinConfig,
-        metadata=_meta("WeChat", "Weixin (iLink personal WeChat) integration settings.", tags=["weixin"]),
+        metadata=_meta(
+            "WeChat", "Weixin (iLink personal WeChat) integration settings.", tags=["weixin"]
+        ),
     )
     discord: DiscordConfig = field(
         default_factory=DiscordConfig,

--- a/src/kiro_crew/dashboard/handlers/computer_use.py
+++ b/src/kiro_crew/dashboard/handlers/computer_use.py
@@ -395,19 +395,16 @@ def _snapshot() -> dict[str, Any]:
         # operator set no restriction — and the panel must be able to tell the two
         # apart rather than presenting a confidently empty allow-list.
         "policy_error": policy_error,
-        # ``read_only`` is what the panel keys every control's ``disabled`` on, and
-        # it is deliberately ``forbidden``-only rather than ``locked``. A NARROWED
-        # ceiling still PERMITS the capability — it just bounds what the automation
-        # may do — so the user must still be able to opt in; the PUT would succeed
-        # and locking the toggle would take the choice away for no reason. Only a
-        # ceiling that forbids the capability outright (or one we could not
-        # evaluate, which the summary reports as ``forbidden``) disables the
-        # controls, and then the PUT's own 409 is the authoritative refusal.
-        #
-        # Derived from GOVERNANCE, never from the platform: an unsupported platform
-        # renders a reason instead of controls, which is a separate branch. Keeping
-        # the two apart means a governed macOS host and an ungoverned Linux host can
-        # never be confused for one another.
+        # There is deliberately NO ``read_only`` / governance-lock field here, and no
+        # ``409`` on the PUT. Computer use is one operator opt-in on the keystone:
+        # ``SCOPE_CATALOG`` carries no ``computer_use*`` row, so there is no ceiling
+        # to report and nothing for the panel to grey out. An earlier revision of
+        # this handler documented both (a ``forbidden``-only ``read_only`` the panel
+        # would key ``disabled`` on, and a 409 when a ceiling forbade a widening
+        # request) — the governance model they belonged to was removed by product
+        # decision, and the prose outlived it, promising a refusal that never fires.
+        # The write boundary that DOES hold is the app-token gate on the PUT (an app
+        # token can never write the keystone); see ``api_computer_use_config_save``.
         # Ceilings, so the panel's number inputs bound themselves from the server
         # rather than re-spelling the limits in TypeScript.
         "limits": {key: [low, high] for key, (low, high) in _INT_LIMITS.items()},
@@ -537,14 +534,47 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
     refreshed GET payload so the panel re-renders from server truth rather than
     from its own optimistic guess.
 
-    Refuses with **409** when the governance ceiling forbids computer use and the
-    request would WIDEN the surface — matching ``api_denied_command_builtin_toggle``'s
-    precedent: the request conflicts with immutable server state (the ceiling), it
-    is not an auth failure of the caller. Turning the feature OFF, and shrinking a
-    budget, are always allowed: narrowing can never conflict with a ceiling, and a
-    user must never be locked out of switching this off.
+    **Dashboard-browser callers only.** An App-Kit-scoped token is refused with 403
+    before the body is even read: ``request["user"]`` is truthy for an app token too,
+    so the cookie check alone does not separate the two, and an app that declares
+    ``permissions.api: ["/api/computer-use"]`` in its manifest passes
+    ``app_token_path_allowed``. This is the ONE write the keystone design exists to
+    prevent — ``enable_state.save_state`` deliberately bypasses ``is_sensitive_path``
+    (that is what lets the operator's own Settings panel write a file the agent
+    cannot), so without this gate an agent that can author an app manifest could read
+    its own ``.app_secret``, mint an app token and flip ``enabled: true`` on its own
+    desktop automation. Same guard as ``handlers/kiro_prerequisite.py`` and
+    ``handlers/messaging.py``'s notification push.
+
+    **There is no governance ceiling on this route, and therefore no 409.** Computer
+    use is one operator opt-in: ``SCOPE_CATALOG`` carries no ``computer_use*`` row, so
+    there is nothing that can forbid a widening request. An earlier revision of this
+    docstring promised a 409 "when the governance ceiling forbids computer use"; the
+    model it referred to was removed by product decision and the sentence outlived it,
+    describing a refusal no code path can produce (there is no ``status=409`` in this
+    module). Do not re-document it without re-implementing it — see
+    ``docs/system-specs/modules/governance.md`` for why computer use is deliberately
+    ungoverned. Other outcomes: ``400`` for a malformed body or an out-of-range value,
+    ``403`` for an app token (above), and ``500`` for a corrupt keystone or
+    ``config.json``, which is left byte-identical rather than clobbered
+    (``StateCorruptError``, the ``ConfigCorruptError`` precedent).
     """
     from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+    if request.get("app"):
+        # Audited as a security-boundary denial before responding
+        # (backend-security-controls: every denial emits SEL).
+        _audit(
+            request,
+            operation=OP_CONFIG_SAVE,
+            outcome="denied",
+            resources=request.path,
+            error="app tokens may not write the computer-use keystone",
+        )
+        return web.json_response(
+            {"error": "dashboard user required"},
+            status=403,
+        )
 
     try:
         body = await request.json()
@@ -609,9 +639,12 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
         _audit(request, operation=OP_CONFIG_SAVE, outcome="denied", resources="empty_patch")
         return web.json_response({"error": "no known computer-use fields in body"}, status=400)
 
-    # ── Governance ──
-    # Only a request that could WIDEN the surface is gated: enabling the feature,
-    # or editing the operator's own target lists (which a ceiling may pin).
+    # No governance step here, deliberately. This block used to be a `# ──
+    # Governance ──` header over an explanation of widen-gating with no code beneath
+    # it: the ceiling it described (and the 409 it would have returned) was removed
+    # with the rest of the computer-use governance model, and only the prose
+    # survived. The write boundary that DOES hold is the app-token gate at the top of
+    # this handler.
 
     # ── Write ──
     # Read the CURRENT enable before mutating, so the session reset below fires only

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -597,30 +597,49 @@ class HookManager:
             from kiro_crew.slack.gateway import _is_read_only_tool
 
             kind = (tool_kind or "").strip().lower()
-            # Computer-use observation tools ("reads don't nag" for this feature
-            # too). Deliberately an EXPLICIT allowlist keyed on the code-owned
-            # action-class table rather than the `_is_read_only_tool` title
-            # heuristic: that heuristic keys on a leading verb, so it would
-            # auto-approve every `computer_*` tool or none of them depending on
-            # the name, and an agent-supplied title must never decide whether a
-            # keystroke is synthesized into somebody's window.
-            #
-            # Gated on the keystone primary enable so the auto-approval cannot
-            # exist while the feature is off — a disabled feature's tools should
-            # fall through to interactive approval (where they will be refused by
-            # the dispatcher anyway), not be silently pre-approved. Reached only
-            # AFTER the deny floor, _governance_denial and the approval-floor
-            # clamp above, so a governed fleet's read-only ceiling and its
-            # `interactive` approval floor both still win.
-            if _cu_read_only_auto_approve(tool_name):
-                return ToolHookResult.auto_approve()
-            # Trust the SEMANTIC kind first. The (agent-supplied, spoofable)
-            # title heuristic is only a fallback for when the kind is
-            # absent/unknown and NOT a known mutating/executing kind, so a write
-            # tool with a read-sounding title can't auto-approve.
+            # Trust the SEMANTIC kind, as an ALLOW-list. `tool_kind` is passed
+            # through verbatim from the ACP `kind` field (``acp/_dispatch.py``), so it
+            # is an arbitrary agent-influenced string and a DENYLIST of mutating kinds
+            # can never be complete — `kind="other"` is a real ACP value. Only these
+            # two spellings mean "this cannot change anything".
             if kind in _READ_ONLY_TOOL_KINDS:
                 return ToolHookResult.auto_approve()
-            if kind not in _WRITE_TOOL_KINDS and not kind and _is_read_only_tool(tool_name):
+            # Computer-use observation tools ("reads don't nag" for this feature too),
+            # and they require an EXPLICIT read-only kind — reached only under the
+            # branch above. Two agent-controlled inputs meet here and neither may
+            # decide alone:
+            #
+            #   * `tool_name` comes from `select_tool_title`, which prefers the
+            #     LLM-authored `description`, so a mutating call can title itself
+            #     `…__computer_get_state`;
+            #   * an omitted `kind` is indistinguishable from an honest one.
+            #
+            # Keying the class lookup on the title alone therefore let a `computer_click`
+            # forge an observation title, omit its kind, and skip the approval prompt
+            # entirely once the operator enabled computer use — the prompt that is the
+            # last thing between an injected agent and a real click on the operator's
+            # desktop. Demanding the kind means the two inputs must AGREE.
+            #
+            # The class table is still consulted (never `_is_read_only_tool`, whose
+            # leading-verb heuristic would auto-approve every `computer_*` tool or none
+            # depending on the name), and it is still gated on the keystone primary
+            # enable so no auto-approval can exist while the feature is off. Reached
+            # only AFTER the deny floor and `_governance_denial`, so a governance deny
+            # still wins. There is deliberately no approval-floor clamp to mention: the
+            # `computer_use.approval` ordinal was removed with the rest of that model.
+            if kind in _READ_ONLY_TOOL_KINDS and _cu_read_only_auto_approve(tool_name):
+                return ToolHookResult.auto_approve()
+            # Any other non-empty kind falls through to interactive approval, whatever
+            # the call titles itself. Over-blocking costs one prompt; under-blocking
+            # costs the prompt.
+            if kind:
+                return ToolHookResult.allow()
+            # Kind ABSENT: the pre-existing generic fallback, unchanged. It is safe for
+            # computer use specifically because `_is_read_only_tool` matches on a
+            # leading read-ish verb and rejects EVERY `mcp__kirocrew-computer__*` title
+            # (verified) — so a forged computer-use title cannot reach an auto-approve
+            # through this path either.
+            if _is_read_only_tool(tool_name):
                 return ToolHookResult.auto_approve()
 
         return ToolHookResult.allow()
@@ -653,10 +672,16 @@ class HookManager:
 # "move"; add conservatively (auto-approving trusts an agent-supplied field).
 _READ_ONLY_TOOL_KINDS: frozenset[str] = frozenset({"read", "fetch"})
 
-# Semantic kinds that mutate/execute — a title heuristic must NEVER auto-approve
-# these, even if the agent-supplied title reads like a read (e.g. a write tool
-# labelled "Read project status"). The title fallback only applies when the kind
-# is absent/unknown.
+# Semantic kinds known to mutate/execute. DOCUMENTATION ONLY — the gate no longer
+# branches on this set, and must not start again: `tool_kind` arrives verbatim from
+# the ACP `kind` field, so any denylist of mutating kinds is incomplete by
+# construction (`kind="other"` is a real value that a denylist auto-approved). The
+# auto-approve decision is an ALLOW-list on `_READ_ONLY_TOOL_KINDS` instead, and
+# every other non-empty kind falls through to interactive approval.
+#
+# Kept because it records which kinds we have actually seen mutate — useful when
+# judging whether a new kind belongs in the read-only set — and because deleting a
+# named constant is how the next reader loses that context.
 _WRITE_TOOL_KINDS: frozenset[str] = frozenset(
     {"edit", "execute", "delete", "move", "write", "create"}
 )

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -536,13 +536,24 @@ def _suspicious_pattern_items() -> list[PostureItem]:
     return [PostureItem(label=pattern) for pattern in security.SUSPICIOUS_BASH_PATTERNS]
 
 
+#: Every MCP tool-schema dispatch registry in ``validation``, by attribute name. A
+#: tool is only validated if it is IN one of these, so this list defines what the
+#: posture view can see. Keep it complete — ``test_security_posture`` reads the same
+#: names, so an omission fails there rather than quietly shrinking the report.
+_SCHEMA_REGISTRY_NAMES: tuple[str, ...] = (
+    "MCP_CORE_SCHEMAS",
+    "MCP_CRON_SCHEMAS",
+    "MCP_COMPUTER_SCHEMAS",
+)
+
+
 def _tool_schema_items() -> list[PostureItem]:
     """Validated tool schemas, keyed by the tool name they gate.
 
-    Derived from the DISPATCH REGISTRIES (``MCP_CORE_SCHEMAS`` /
-    ``MCP_CRON_SCHEMAS``) — the dicts ``mcp_core``/``mcp_cron`` actually look a
-    tool up in — plus the module-level ``*_SCHEMA`` objects that gate dashboard
-    handlers rather than MCP tools.
+    Derived from EVERY dispatch registry in ``validation`` — the dicts
+    ``mcp_core``/``mcp_cron``/``computer_use.tools`` actually look a tool up in —
+    plus the module-level ``*_SCHEMA`` objects that gate dashboard handlers rather
+    than MCP tools.
 
     An earlier version walked only ``dir(validation)`` for the ``*_SCHEMA``
     naming convention. That made the *convention*, not the registry, the source
@@ -551,9 +562,16 @@ def _tool_schema_items() -> list[PostureItem]:
     objects with no module-level name of their own, so they were validated but
     invisible here — a new tool registered that way would have added zero to the
     count.
+
+    ``_SCHEMA_REGISTRY_NAMES`` is enumerated rather than discovered, but the drift
+    test derives its expectation from the same module attributes, so a NEW registry
+    that is not listed here fails that test instead of silently under-reporting: the
+    ten ``MCP_COMPUTER_SCHEMAS`` entries were missing from this view for exactly that
+    reason, and the drift test could not catch it because it hardcoded the same two
+    registry names this function did.
     """
     seen: dict[str, str] = {}
-    for registry_name in ("MCP_CORE_SCHEMAS", "MCP_CRON_SCHEMAS"):
+    for registry_name in _SCHEMA_REGISTRY_NAMES:
         registry = getattr(_validation, registry_name, None) or {}
         for tool_name in registry:
             seen.setdefault(tool_name, registry_name)

--- a/src/kiro_crew/testing/fake_computer_use.py
+++ b/src/kiro_crew/testing/fake_computer_use.py
@@ -345,10 +345,19 @@ class FakeComputerUseBackend(ComputerUseBackend):
             )
         elements, truncated, depth_truncated = _walk(root, req.max_nodes, req.max_depth)
         has_secure = any(rec.secure for rec in elements)
-        # Mirror the production rule: a window holding ANY secure element gets no
-        # pixels at all, because a password field's rendered glyphs are a
-        # credential even after the tree redacted its value.
-        want_image = req.want_image and not has_secure
+        # Mirror BOTH production capture refusals (``capture_macos``), not just the
+        # obvious one:
+        #  * a window holding ANY secure element gets no pixels at all, because a
+        #    password field's rendered glyphs are a credential even after the tree
+        #    redacted its value;
+        #  * a TRUNCATED walk also gets none, because it cannot prove the window is
+        #    free of a secure field — "unknown" has to behave like "present" at the
+        #    one gate that decides whether pixels leave the process.
+        # The second was missing here, so ``snapshot(max_nodes=1, want_image=True)``
+        # returned ``truncated=True`` WITH an image attached and deleting the
+        # production branch left the whole suite green. A downstream consumer driving
+        # this fake would also have seen a capture the real driver refuses.
+        want_image = req.want_image and not has_secure and not (truncated or depth_truncated)
         snap = Snapshot(
             app=app,
             elements=elements,

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -432,27 +432,53 @@ def _json_type_ok(value: Any, type_name: str) -> bool:
 # multipleOf, contains, …) is REJECTED fail-closed rather than partially
 # enforced — ignoring a constraint the tool author wrote would forward values
 # the tool declared forbidden.
-_SUPPORTED_SCHEMA_KEYWORDS = frozenset({
-    "type", "required", "properties", "additionalProperties", "items",
-    "enum", "const", "pattern", "minimum", "maximum",
-    "exclusiveMinimum", "exclusiveMaximum", "minLength", "maxLength",
-    "minItems", "maxItems", "uniqueItems",
-})
+_SUPPORTED_SCHEMA_KEYWORDS = frozenset(
+    {
+        "type",
+        "required",
+        "properties",
+        "additionalProperties",
+        "items",
+        "enum",
+        "const",
+        "pattern",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "minLength",
+        "maxLength",
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+    }
+)
 
 # Annotation-only keywords (non-validating per JSON Schema draft 2020-12 —
 # ``format`` is annotation-only unless the format-assertion vocabulary is
 # explicitly enabled, which MCP does not require). Safe to ignore.
-_ANNOTATION_SCHEMA_KEYWORDS = frozenset({
-    "title", "description", "default", "examples", "format",
-    "$schema", "$id", "$comment", "deprecated", "readOnly", "writeOnly",
-})
+_ANNOTATION_SCHEMA_KEYWORDS = frozenset(
+    {
+        "title",
+        "description",
+        "default",
+        "examples",
+        "format",
+        "$schema",
+        "$id",
+        "$comment",
+        "deprecated",
+        "readOnly",
+        "writeOnly",
+    }
+)
 
 
 def _reject_unsupported_keywords(schema: dict, path: str) -> None:
     unsupported = [
-        k for k in schema
-        if k not in _SUPPORTED_SCHEMA_KEYWORDS
-        and k not in _ANNOTATION_SCHEMA_KEYWORDS
+        k
+        for k in schema
+        if k not in _SUPPORTED_SCHEMA_KEYWORDS and k not in _ANNOTATION_SCHEMA_KEYWORDS
     ]
     if unsupported:
         raise ValidationError(
@@ -483,20 +509,19 @@ def _reject_malformed_keyword_shapes(schema: dict[str, Any], _path: str) -> None
     treated as "no constraint". Only shape is checked here — semantics are
     enforced by the main validator.
     """
+
     def _bad(key: str) -> None:
         raise ValidationError(_path, f"malformed `{key}` keyword shape")
 
     t = schema.get("type")
     if "type" in schema and not (
-        isinstance(t, str)
-        or (isinstance(t, list) and all(isinstance(x, str) for x in t))
+        isinstance(t, str) or (isinstance(t, list) and all(isinstance(x, str) for x in t))
     ):
         _bad("type")
     if "enum" in schema and not isinstance(schema["enum"], list):
         _bad("enum")
     if "required" in schema and not (
-        isinstance(schema["required"], list)
-        and all(isinstance(x, str) for x in schema["required"])
+        isinstance(schema["required"], list) and all(isinstance(x, str) for x in schema["required"])
     ):
         _bad("required")
     if "properties" in schema and not isinstance(schema["properties"], dict):
@@ -521,14 +546,10 @@ def _reject_malformed_keyword_shapes(schema: dict[str, Any], _path: str) -> None
     if "pattern" in schema and not isinstance(schema["pattern"], str):
         _bad("pattern")
     for k in ("minLength", "maxLength", "minItems", "maxItems"):
-        if k in schema and (
-            not isinstance(schema[k], int) or isinstance(schema[k], bool)
-        ):
+        if k in schema and (not isinstance(schema[k], int) or isinstance(schema[k], bool)):
             _bad(k)
     for k in ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"):
-        if k in schema and (
-            not isinstance(schema[k], (int, float)) or isinstance(schema[k], bool)
-        ):
+        if k in schema and (not isinstance(schema[k], (int, float)) or isinstance(schema[k], bool)):
             _bad(k)
 
 
@@ -596,9 +617,7 @@ def validate_mcp_tool_arguments(
                 _path, f"expected {declared_type}, got {type(arguments).__name__}"
             )
     elif isinstance(declared_type, list):
-        if not any(
-            isinstance(t, str) and _json_type_ok(arguments, t) for t in declared_type
-        ):
+        if not any(isinstance(t, str) and _json_type_ok(arguments, t) for t in declared_type):
             raise ValidationError(
                 _path,
                 f"expected one of {declared_type}, got {type(arguments).__name__}",
@@ -624,9 +643,7 @@ def validate_mcp_tool_arguments(
                 # Oversized input, invalid pattern, or wall-clock timeout
                 # (possible ReDoS) — fail closed rather than forward a value
                 # whose declared constraint could not be safely checked.
-                raise ValidationError(
-                    _path, "pattern constraint could not be safely evaluated"
-                )
+                raise ValidationError(_path, "pattern constraint could not be safely evaluated")
             if not verdict:
                 raise ValidationError(_path, "does not match pattern")
 
@@ -670,15 +687,11 @@ def validate_mcp_tool_arguments(
             # dict subschema OR a boolean schema (`items: false` rejects every
             # element; `items: true` accepts). Recursion handles all three.
             for i, item in enumerate(arguments):
-                validate_mcp_tool_arguments(
-                    item, items, _path=f"{_path}[{i}]", _depth=_depth + 1
-                )
+                validate_mcp_tool_arguments(item, items, _path=f"{_path}[{i}]", _depth=_depth + 1)
         else:
             # No item schema: still bound depth/size of each element.
             for i, item in enumerate(arguments):
-                validate_mcp_tool_arguments(
-                    item, {}, _path=f"{_path}[{i}]", _depth=_depth + 1
-                )
+                validate_mcp_tool_arguments(item, {}, _path=f"{_path}[{i}]", _depth=_depth + 1)
 
     if isinstance(arguments, dict):
         properties = schema.get("properties")
@@ -695,12 +708,8 @@ def validate_mcp_tool_arguments(
                 raise ValidationError(_path, "object keys must be strings")
             sub = props.get(key)
             if sub is not None:
-                validate_mcp_tool_arguments(
-                    value, sub, _path=f"{_path}.{key}", _depth=_depth + 1
-                )
-            elif additional is False or (
-                isinstance(properties, dict) and not allow_extra
-            ):
+                validate_mcp_tool_arguments(value, sub, _path=f"{_path}.{key}", _depth=_depth + 1)
+            elif additional is False or (isinstance(properties, dict) and not allow_extra):
                 # Fail-closed: an explicit ``additionalProperties: false``
                 # rejects every undeclared key even when the schema declares
                 # NO ``properties`` map at all (i.e. it accepts only ``{}``),
@@ -713,9 +722,7 @@ def validate_mcp_tool_arguments(
                 )
             else:
                 # No properties map at all: bound depth/size of the blob.
-                validate_mcp_tool_arguments(
-                    value, {}, _path=f"{_path}.{key}", _depth=_depth + 1
-                )
+                validate_mcp_tool_arguments(value, {}, _path=f"{_path}.{key}", _depth=_depth + 1)
 
 
 # ── String Sanitization ──
@@ -1197,16 +1204,17 @@ def _validate_webapp_metadata_shape(am: dict) -> None:
     app_dir = am.get("app_dir")
     if app_dir is not None:
         if not isinstance(app_dir, str) or len(app_dir) > 4096:
-            raise ValidationError(
-                "webapp_metadata.app_dir", "must be a string (max 4096 chars)")
+            raise ValidationError("webapp_metadata.app_dir", "must be a string (max 4096 chars)")
         if app_dir != "":
             if any(ord(c) < 0x20 for c in app_dir):
                 raise ValidationError(
-                    "webapp_metadata.app_dir", "must not contain control characters")
+                    "webapp_metadata.app_dir", "must not contain control characters"
+                )
             posix_abs = app_dir.startswith("/") or app_dir.startswith("~/") or app_dir == "~"
             if not posix_abs and not PureWindowsPath(app_dir).is_absolute():
                 raise ValidationError(
-                    "webapp_metadata.app_dir", "must be an absolute path (or ~/-prefixed)")
+                    "webapp_metadata.app_dir", "must be an absolute path (or ~/-prefixed)"
+                )
     # deploy_target.public_url
     dt = am.get("deploy_target")
     if dt is not None:
@@ -1217,28 +1225,33 @@ def _validate_webapp_metadata_shape(am: dict) -> None:
             if not isinstance(pub_url, str):
                 raise ValidationError(
                     "webapp_metadata.deploy_target.public_url",
-                    "must be a valid http(s) URL (max 2048 chars)")
+                    "must be a valid http(s) URL (max 2048 chars)",
+                )
             # Empty string is allowed (documented draft state — URL not yet assigned).
             if pub_url != "" and not _WM_URL_RE.match(pub_url):
                 raise ValidationError(
                     "webapp_metadata.deploy_target.public_url",
-                    "must be a valid http(s) URL (max 2048 chars)")
+                    "must be a valid http(s) URL (max 2048 chars)",
+                )
             # R21 F2: reject Basic-auth userinfo (https://user:pass@host) —
             # the regex above accepts it, and a credential-bearing URL would
             # be surfaced/linked by the dashboard, transmitting the embedded
             # credentials to the host when opened.
             if pub_url != "":
                 from urllib.parse import urlsplit
+
                 try:
                     parts = urlsplit(pub_url)
                 except ValueError:
                     raise ValidationError(
                         "webapp_metadata.deploy_target.public_url",
-                        "must be a valid http(s) URL (max 2048 chars)")
+                        "must be a valid http(s) URL (max 2048 chars)",
+                    )
                 if parts.username or parts.password:
                     raise ValidationError(
                         "webapp_metadata.deploy_target.public_url",
-                        "must not contain userinfo (user:password@) credentials")
+                        "must not contain userinfo (user:password@) credentials",
+                    )
         # profile/region/slug — string-typed with existing regex patterns.
         for key, pattern, label in (
             ("profile", _WM_PROFILE_RE, "profile"),
@@ -1251,12 +1264,12 @@ def _validate_webapp_metadata_shape(am: dict) -> None:
             if val is not None:
                 if not isinstance(val, str) or len(val) > 128:
                     raise ValidationError(
-                        f"webapp_metadata.deploy_target.{key}",
-                        "must be a string (max 128 chars)")
+                        f"webapp_metadata.deploy_target.{key}", "must be a string (max 128 chars)"
+                    )
                 if val and not pattern.match(val):
                     raise ValidationError(
-                        f"webapp_metadata.deploy_target.{key}",
-                        f"invalid {label} format")
+                        f"webapp_metadata.deploy_target.{key}", f"invalid {label} format"
+                    )
 
     # lifecycle.status enum
     lc = am.get("lifecycle")
@@ -1268,39 +1281,38 @@ def _validate_webapp_metadata_shape(am: dict) -> None:
         # unhashable value (list/dict) raises TypeError inside `in` and
         # turns artifact save/update into a 500.
         if status is not None and not isinstance(status, str):
-            raise ValidationError(
-                "webapp_metadata.lifecycle.status", "must be a string")
+            raise ValidationError("webapp_metadata.lifecycle.status", "must be a string")
         if status is not None and status not in _WM_LIFECYCLE_STATUSES:
             raise ValidationError(
                 "webapp_metadata.lifecycle.status",
-                f"must be one of {sorted(_WM_LIFECYCLE_STATUSES)}")
+                f"must be one of {sorted(_WM_LIFECYCLE_STATUSES)}",
+            )
         # persistent: strict bool — the string "false" is truthy and would
         # silently flip expiry/teardown behavior downstream.
         pers = lc.get("persistent")
         if pers is not None and not isinstance(pers, bool):
-            raise ValidationError(
-                "webapp_metadata.lifecycle.persistent", "must be a boolean")
+            raise ValidationError("webapp_metadata.lifecycle.persistent", "must be a boolean")
         # ttl_hours: strict int (bool excluded — bool subclasses int), 0-8760.
         ttl = lc.get("ttl_hours")
         if ttl is not None:
             if isinstance(ttl, bool) or not isinstance(ttl, int):
-                raise ValidationError(
-                    "webapp_metadata.lifecycle.ttl_hours", "must be an integer")
+                raise ValidationError("webapp_metadata.lifecycle.ttl_hours", "must be an integer")
             if not (0 <= ttl <= 8760):
-                raise ValidationError(
-                    "webapp_metadata.lifecycle.ttl_hours", "must be 0-8760")
+                raise ValidationError("webapp_metadata.lifecycle.ttl_hours", "must be 0-8760")
         # expires_at ISO-8601 parseable
         exp = lc.get("expires_at")
         if exp is not None and exp != "":
             if not isinstance(exp, str):
                 raise ValidationError("webapp_metadata.lifecycle.expires_at", "must be a string")
             from datetime import datetime, timezone
+
             try:
                 datetime.strptime(exp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
             except (ValueError, TypeError):
                 raise ValidationError(
                     "webapp_metadata.lifecycle.expires_at",
-                    "must be ISO-8601 UTC (YYYY-MM-DDTHH:MM:SSZ)")
+                    "must be ISO-8601 UTC (YYYY-MM-DDTHH:MM:SSZ)",
+                )
 
     # cost and architecture lists capped
     for key in ("cost", "architecture"):
@@ -1312,11 +1324,12 @@ def _validate_webapp_metadata_shape(am: dict) -> None:
                     if isinstance(sub_val, list) and len(sub_val) > _WM_LIST_CAP:
                         raise ValidationError(
                             f"webapp_metadata.{key}.{sub_key}",
-                            f"list exceeds {_WM_LIST_CAP} entries")
+                            f"list exceeds {_WM_LIST_CAP} entries",
+                        )
             elif isinstance(val, list) and len(val) > _WM_LIST_CAP:
                 raise ValidationError(
-                    f"webapp_metadata.{key}",
-                    f"list exceeds {_WM_LIST_CAP} entries")
+                    f"webapp_metadata.{key}", f"list exceeds {_WM_LIST_CAP} entries"
+                )
 
 
 ARTIFACT_SAVE_SCHEMA = ToolSchema(
@@ -1696,9 +1709,7 @@ SEND_NOTIFICATION_SCHEMA = ToolSchema(
         # Cap matches the bus's _MAX_BODY_LEN (20000) so the schema never
         # rejects a body the advertised contract accepts.
         FieldSpec("body", str, max_len=20_000),
-        FieldSpec(
-            "priority", str, max_len=16, pattern=re.compile(r"^(critical|default|passive)$")
-        ),
+        FieldSpec("priority", str, max_len=16, pattern=re.compile(r"^(critical|default|passive)$")),
         # Path-only deep link -- the gateway re-validates with the full
         # WHATWG-hardened rule at the persistence trust root; this pattern
         # is the cheap first gate (must start with '/', not '//').
@@ -2037,20 +2048,25 @@ MCP_COMPUTER_SCHEMAS: dict[str, ToolSchema] = {
         fields=[
             _CU_APP_FIELD,
             FieldSpec("text", str, required=True, max_len=_cu_types.MAX_TYPE_TEXT_LEN),
-            # Optional: typing into whatever the app has focused is a legitimate
-            # flow. A named element is still preferred (and is what the secure-field
-            # refusal inspects), which the tool description says.
-            _CU_OPTIONAL_ELEMENT_FIELD,
+            # REQUIRED, and a security control rather than an ergonomic choice: an
+            # unnamed target has no role or subrole, so ``policy.check_input_target``
+            # has nothing to inspect and the keystrokes would land in whatever the
+            # app happened to focus — possibly a password field. Enforced again at
+            # the chokepoint by ``tools._ELEMENT_REQUIRED_TOOLS``; both layers say
+            # required so a conforming call is never refused on arrival.
+            _CU_ELEMENT_FIELD,
         ],
     ),
     _cu_types.TOOL_PRESS_KEY: ToolSchema(
         tool_name=_cu_types.TOOL_PRESS_KEY,
         fields=[
             _CU_APP_FIELD,
-            # Optional: sending a shortcut to whatever the app already has focused
-            # is a legitimate flow (cmd+S on the frontmost window). When an index IS
-            # given the driver focuses that element first.
-            _CU_OPTIONAL_ELEMENT_FIELD,
+            # REQUIRED for the same reason as ``computer_type_text``, plus one of its
+            # own: ``press_key('tab')`` can MOVE focus onto a password box, so the
+            # keystroke after an indexless call would land there. The driver focuses
+            # the named element first, which is what makes the secure-field refusal
+            # meaningful.
+            _CU_ELEMENT_FIELD,
             FieldSpec(
                 "key",
                 str,
@@ -2226,9 +2242,7 @@ def validate_ask_user_question(raw: object) -> list[dict]:
             # would make distinct-looking rows submit the same value.
             norm_label = " ".join(label.split()).casefold()
             if norm_label in seen_labels:
-                raise ValidationError(
-                    "questions", "duplicate option labels are not allowed"
-                )
+                raise ValidationError("questions", "duplicate option labels are not allowed")
             seen_labels.add(norm_label)
             desc = str(o.get("description") or "")[:_ASK_MAX_DESC_LEN]
             opts.append({"label": label, "description": desc})

--- a/test/test_computer_use_api.py
+++ b/test/test_computer_use_api.py
@@ -1221,6 +1221,92 @@ class _InlineThread:
             self._target(*self._args)
 
 
+def _app_token_middleware(app_name: str):
+    """Stand in for ``token_auth_middleware``'s app-token grant.
+
+    The real middleware sets BOTH ``request["user"]`` and ``request["app"]`` for an
+    app-scoped token — which is the trap: ``request["user"]`` is truthy, so a handler
+    that only checks it treats an app exactly like the dashboard operator.
+    """
+
+    @web.middleware
+    async def _mw(request: web.Request, handler):
+        request["user"] = "dashboard"
+        request["app"] = app_name
+        request["internal_auth"] = True
+        return await handler(request)
+
+    return _mw
+
+
+def _app_client(app_name: str = "pwn") -> TestClient:
+    app = web.Application(middlewares=[_app_token_middleware(app_name)])
+    app.router.add_get("/api/computer-use/config", cu_api.api_computer_use_config_get)
+    app.router.add_put("/api/computer-use/config", cu_api.api_computer_use_config_save)
+    return TestClient(TestServer(app))
+
+
+class TestAnAppTokenCannotWriteTheKeystone:
+    """The one write the keystone design exists to prevent (reviewer finding).
+
+    ``enable_state.save_state`` deliberately bypasses ``is_sensitive_path`` — that is
+    what lets the operator's own Settings panel write a file the agent cannot read or
+    write with a tool. So this handler is the only thing standing between an
+    App-Kit-scoped token and ``enabled: true``. It used to check nothing at all:
+    ``request["user"]`` is truthy for an app token too, and an app whose manifest
+    declares ``permissions.api: ["/api/computer-use"]`` passes
+    ``app_token_path_allowed`` (verified: a bare ``/api/computer-use`` pattern matches
+    ``/api/computer-use/config`` on the path boundary). An agent that can author an app
+    manifest could therefore mint a token and turn on its own desktop automation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_app_token_put_is_refused_and_the_keystone_is_untouched(
+        self, home, state_file, mock_sel
+    ):
+        async with _app_client() as client:
+            resp = await client.put("/api/computer-use/config", json={"enabled": True})
+        assert resp.status == 403
+        # THE assertion: refused BEFORE any write — the keystone never appears.
+        assert (
+            not state_file.exists()
+            or json.loads(state_file.read_text()).get(STATE_KEY_ENABLED) is not True
+        )
+        # A security-boundary denial is audited (backend-security-controls).
+        assert mock_sel.log_api_access.called
+
+    @pytest.mark.asyncio
+    async def test_an_app_token_cannot_edit_the_target_lists_either(self, home, state_file):
+        """``allowed_apps`` widening is the same boundary as the enable."""
+        async with _app_client() as client:
+            resp = await client.put(
+                "/api/computer-use/config", json={"allowed_apps": ["com.apple.Terminal"]}
+            )
+        assert resp.status == 403
+        assert not state_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_an_app_token_cannot_shrink_a_budget_either(self, home, config_file):
+        """Refused at the door, before the widen/narrow distinction is reached.
+
+        The 409 ceiling logic distinguishes widening from narrowing; this gate does
+        not, deliberately — an app token has no business writing ANY of the
+        operator's computer-use configuration, and a narrow-only exception would be a
+        second code path to keep correct for no user benefit.
+        """
+        async with _app_client() as client:
+            resp = await client.put("/api/computer-use/config", json={"max_tree_nodes": 200})
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_the_dashboard_user_is_still_allowed(self, home, state_file):
+        """The gate must key on ``app``, not break the operator's own panel."""
+        async with _client() as client:
+            resp = await client.put("/api/computer-use/config", json={"enabled": True})
+        assert resp.status == 200
+        assert json.loads(state_file.read_text(encoding="utf-8"))[STATE_KEY_ENABLED] is True
+
+
 class TestMixedSaveIsAllOrNothing:
     """A mixed state+limits PUT must not half-apply (reviewer finding).
 
@@ -1456,9 +1542,7 @@ class TestAMalformedKeystoneStillRendersSettings:
     async def test_a_LIST_of_malformed_entries_is_handled_too(self, state_file: Path):
         """``[{"name": "Preview"}]`` is a list, so the container check passes and every
         item is dropped — the same widening bug one level down, and the same 500."""
-        state_file.write_text(
-            json.dumps({"enabled": True, "allowed_apps": [{"name": "Preview"}]})
-        )
+        state_file.write_text(json.dumps({"enabled": True, "allowed_apps": [{"name": "Preview"}]}))
         async with _client() as client:
             resp = await client.get("/api/computer-use/config")
         assert resp.status == 200
@@ -1467,9 +1551,7 @@ class TestAMalformedKeystoneStillRendersSettings:
     async def test_a_HEALTHY_policy_reports_no_error(self, state_file: Path):
         """Inverse guard: the fallback must not fire on a well-formed file, or every
         real allow-list would render as unreadable."""
-        state_file.write_text(
-            json.dumps({"enabled": True, "allowed_apps": ["Preview", "Notes"]})
-        )
+        state_file.write_text(json.dumps({"enabled": True, "allowed_apps": ["Preview", "Notes"]}))
         async with _client() as client:
             body = await (await client.get("/api/computer-use/config")).json()
         assert body["allowed_apps"] == ["preview", "notes"]

--- a/test/test_computer_use_ffi.py
+++ b/test/test_computer_use_ffi.py
@@ -231,9 +231,7 @@ class _FakeCF:
         # mints a fresh handle for an element that already has one, so comparing
         # addresses would answer "different" for the very case ``CFEqual`` exists
         # to resolve.
-        self.CFEqual = _FakeFn(
-            lambda a, b: bool(_addr(a)) and heap.identity(a) == heap.identity(b)
-        )
+        self.CFEqual = _FakeFn(lambda a, b: bool(_addr(a)) and heap.identity(a) == heap.identity(b))
         self.CFStringCreateWithCString = _FakeFn(self._string_create)
         self.CFStringGetLength = _FakeFn(self._string_length)
         self.CFStringGetCString = _FakeFn(self._string_get)
@@ -1407,6 +1405,23 @@ def test_executable_path_reads_proc_pidpath(fakes: _Fakes):
 # ── key posting: the three load-bearing rules ──
 
 
+def test_the_private_event_source_constant_is_the_value_apple_declares():
+    """``kCGEventSourceStatePrivate`` is **-1**, asserted as a LITERAL.
+
+    ``CGEventTypes.h``: ``{kCGEventSourceStatePrivate = -1,
+    kCGEventSourceStateCombinedSessionState = 0,
+    kCGEventSourceStateHIDSystemState = 1}``.
+
+    Deliberately a literal and not ``macos_ffi.K_CG_EVENT_SOURCE_STATE_PRIVATE``:
+    the sibling test below compares the recorded call against that same symbol, so
+    it pins the constant against itself and passed happily while the value was
+    ``1`` — i.e. ``kCGEventSourceStateHIDSystemState``, the shared table whose live
+    modifier state produced the measured ``abc`` -> ``' I Abc'`` bug. Only an
+    independent literal can catch that class of error.
+    """
+    assert macos_ffi.K_CG_EVENT_SOURCE_STATE_PRIVATE == -1
+
+
 def test_post_key_uses_a_private_event_source(fakes: _Fakes):
     """``kCGEventSourceStatePrivate``, never NULL.
 
@@ -1515,6 +1530,35 @@ def test_post_text_delivers_an_astral_character_as_one_event(fakes: _Fakes):
         for (_e, count, _text) in fakes.calls_named(fakes.cg, "CGEventKeyboardSetUnicodeString")
     ]
     assert counts == [2, 2]
+
+
+def test_post_text_types_NOTHING_when_a_character_cannot_be_encoded(fakes: _Fakes):
+    """All-or-nothing: an unencodable character must not leave a partial string.
+
+    ``str`` permits a lone surrogate and UTF-16 cannot represent one, so encoding
+    inside the posting loop raised ``UnicodeEncodeError`` *after* the preceding
+    characters had already been typed into a LIVE application. The caller saw a
+    failure while the target held ``"ok"``, and a model told "typing failed" would
+    retry and double the prefix. The whole string is now encoded before the first
+    event is posted.
+    """
+    with pytest.raises(ComputerUseUnsupported):
+        macos_ffi.post_text(637, "ok\ud800bad")
+    assert fakes.calls_named(fakes.cg, "CGEventPostToPid") == [], (
+        "characters were typed into the application before the encode failed — "
+        "the caller is told nothing was sent while the target holds a partial string"
+    )
+    assert fakes.calls_named(fakes.cg, "CGEventKeyboardSetUnicodeString") == []
+
+
+def test_post_text_still_types_the_whole_string_when_every_char_encodes(fakes: _Fakes):
+    """The guard must not reject legitimate text (astral + accented + ASCII)."""
+    macos_ffi.post_text(637, "a\U0001F600é")
+    typed = [
+        text
+        for (_e, _count, text) in fakes.calls_named(fakes.cg, "CGEventKeyboardSetUnicodeString")
+    ]
+    assert typed == ["a", "a", "\U0001F600", "\U0001F600", "é", "é"]
 
 
 # ── scroll: the variadic hazard and the AX fallback ──

--- a/test/test_computer_use_ffi_argtypes.py
+++ b/test/test_computer_use_ffi_argtypes.py
@@ -30,10 +30,11 @@ discipline structurally rather than waiting for a crash:
 
   Note: the module DOES call ``CGEventPost`` now. The shipped
   ``click_method: "global"`` path deliberately moves the operator's real cursor,
-  inverting the original "the pointer never moves" guarantee, and it is reachable
-  only after both the keystone ``allow_pointer_move`` opt-in and the
-  ``capabilities.computer_use_pointer`` governance permit clear at the dispatch
-  chokepoint. What is pinned here is the CALL-SITE SET, not the symbol's absence.
+  inverting the original "the pointer never moves" guarantee. It needs no second
+  opt-in — there is no ``allow_pointer_move`` keystone flag and no
+  ``computer_use.*`` governance scope — but the model must NAME the method
+  (``auto`` never resolves onto it) and every use is SEL-audited under its own
+  ``tool_kind``. What is pinned here is the CALL-SITE SET, not the symbol's absence.
 
 Runs on every platform: it reads the module's declarative table and its source
 text, and never loads a framework or calls a symbol.
@@ -288,9 +289,12 @@ def test_global_event_tap_is_confined_to_the_pointer_moving_functions():
     default for every keyboard, scroll and app-scoped mouse path — it delivers to
     the app the model addressed rather than to whatever the operator is actually
     working in — and the system-wide HID tap is reachable from exactly two
-    functions, both of which are only entered once BOTH the keystone
-    ``allow_pointer_move`` opt-in and the ``capabilities.computer_use_pointer``
-    governance permit have cleared at the dispatch chokepoint.
+    functions, both of which are only entered for a request whose ``click_method``
+    the model NAMED as ``global`` (``auto`` never resolves onto it, an invariant with
+    its own test) and whose ``moves_pointer`` the chokepoint therefore set. There is
+    no second opt-in gating them: no ``allow_pointer_move`` keystone flag and no
+    ``computer_use.*`` governance scope — accountability (a dedicated SEL
+    ``tool_kind``) replaced authorization here.
 
     So this pins the CALL SITES rather than forbidding the name: the two
     pointer-moving functions may call it, nothing else may, and any new caller is a

--- a/test/test_computer_use_gate.py
+++ b/test/test_computer_use_gate.py
@@ -173,13 +173,19 @@ class TestObservationsArePassedThrough:
         }
         assert gate.apply_observation_ceiling(payload, session_key="dashboard:main") == payload
 
-    def test_the_targets_axis_reports_ungoverned(self):
-        """``tools`` reads this to decide whether to DEMAND an element index.
+    def test_there_is_no_targets_axis_shim_to_read(self):
+        """The ``targets`` ceiling is gone, and so is the predicate for it.
 
-        False means indexless keyboard input and coordinate gestures are both
-        allowed again.
+        It used to return ``False`` with a docstring saying indexless keyboard input
+        was "a legitimate flow again" — the INVERSE of what ships. Keyboard input
+        requires an ``element_index`` (``tools._ELEMENT_REQUIRED_TOOLS``) precisely so
+        the always-on secure-field refusal has a role/subrole to inspect. Nothing in
+        the package called it, so a reader auditing the security posture would have
+        concluded a live control had been removed. Deleted rather than corrected: a
+        dead predicate that contradicts an enforced control is a trap, and the two
+        pass-throughs the renderers really do traverse are asserted above.
         """
-        assert gate.targets_axis_is_governed(session_key="dashboard:main") is False
+        assert not hasattr(gate, "targets_axis_is_governed")
 
 
 class TestAppDisclosure:

--- a/test/test_computer_use_overlay.py
+++ b/test/test_computer_use_overlay.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import ctypes
 import json
+import threading
 
 import pytest
 
@@ -694,18 +695,57 @@ class TestShowPointerMotion:
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 
-    def test_a_closed_loop_is_not_scheduled_onto(self, enabled):
-        """A gateway restart must not leave a stale reference we write into."""
+    def test_a_closed_loop_is_not_scheduled_onto(self, enabled, monkeypatch):
+        """A gateway restart must not leave a stale reference we write into.
+
+        ``monkeypatch``, not a bare assignment + ``del``: ``del
+        overlay_mod.get_shared_overlay`` removed the REAL module function rather
+        than a shadow of it (an attribute assignment rebinds the module global, so
+        deleting it deletes the function), leaving every later test in the same
+        process to exercise a module missing its own singleton accessor — and to pass
+        vacuously. ``monkeypatch.setattr`` restores the original on teardown.
+        """
         loop = asyncio.new_event_loop()
         overlay_mod.bind_gateway_loop(loop)
         loop.close()
         calls: list = []
-        overlay_mod.get_shared_overlay = lambda: calls.append(1)  # noqa: E731
-        try:
-            overlay_mod.show_pointer_motion(1.0, 2.0)
-        finally:
-            del overlay_mod.get_shared_overlay
+        monkeypatch.setattr(overlay_mod, "get_shared_overlay", lambda: calls.append(1))
+        overlay_mod.show_pointer_motion(1.0, 2.0)
         assert calls == []
+
+    def test_the_shared_overlay_is_one_instance_under_thread_contention(self):
+        """The singleton must hold on the pool the pointer path actually runs on.
+
+        ``show_pointer_motion`` is SYNC and is called from ``tools._perform`` inside
+        ``dispatch_tool``, which the gateway offloads onto ``subprocess_executor()``
+        — an 8-worker pool — so ``get_shared_overlay`` is reached concurrently from
+        real threads. Without a lock two callers both saw ``None``, built two
+        ``CursorOverlay`` objects and orphaned one: unreachable afterwards (``stop``
+        and ``reset_shared_overlay`` both go through the global), so its
+        ``overlay_proc`` child leaks for the gateway's life, and the two fake cursors
+        fight over the screen — the exact thing the singleton exists to prevent.
+        """
+        overlay_mod.reset_shared_overlay()
+        try:
+            barrier = threading.Barrier(8)
+            got: list = []
+
+            def _race() -> None:
+                barrier.wait()
+                got.append(overlay_mod.get_shared_overlay())
+
+            threads = [threading.Thread(target=_race) for _ in range(8)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+            assert len(got) == 8
+            assert len({id(instance) for instance in got}) == 1, (
+                "concurrent callers built more than one CursorOverlay — the orphan's "
+                "child process leaks and two fake cursors fight over the screen"
+            )
+        finally:
+            overlay_mod.reset_shared_overlay()
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -1230,8 +1270,10 @@ class TestStructuralGuarantees:
 
         It must not import ``macos_ffi`` (the gateway's audited AX/CG surface) or
         any observation module: a purely cosmetic process with the ability to read
-        windows or capture pixels would be a second, unaudited plane for exactly
-        the data the ``computer_use.observations`` ceiling governs.
+        windows or capture pixels would be a second, unaudited plane for exactly the
+        data the tool path discloses under audit. (There is no
+        ``computer_use.observations`` ceiling any more — which makes the single
+        audited plane matter more, not less.)
         """
         import ast
         import inspect

--- a/test/test_computer_use_snapshot.py
+++ b/test/test_computer_use_snapshot.py
@@ -33,6 +33,7 @@ from kiro_crew.computer_use.types import (
     SECURE_WINDOW_NOTE,
     SNAPSHOT_TTL_SECS,
     TOOL_GET_STATE,
+    TRUNCATED_WINDOW_NOTE,
     AppRef,
     ElementRec,
     Snapshot,
@@ -764,12 +765,16 @@ class TestRenderedTrailerAndTraits:
         """These lines are ABOUT the tree, not nodes in it. Without the blank line the
         origin note reads as a sibling of the last element — and the tree's structure
         IS its indentation, so that is a genuine misreading, not a cosmetic one."""
-        lines = render.render_tree(_snap(fake, FAKE_FILES_APP), text_limit=DEFAULT_TEXT_LIMIT).splitlines()
+        lines = render.render_tree(
+            _snap(fake, FAKE_FILES_APP), text_limit=DEFAULT_TEXT_LIMIT
+        ).splitlines()
         origin = next(i for i, ln in enumerate(lines) if ln.startswith("Window origin"))
         assert lines[origin - 1] == ""
         # And every element line precedes it.
-        assert all(not ln.startswith(("Window origin", "Focus:", "Selected text:"))
-                   for ln in lines[:origin])
+        assert all(
+            not ln.startswith(("Window origin", "Focus:", "Selected text:"))
+            for ln in lines[:origin]
+        )
 
     def test_a_SECURE_window_renders_no_trailing_selection(self, fake):
         """A selected password is still a password. The login fixture's focused
@@ -792,3 +797,256 @@ class TestRenderedTrailerAndTraits:
         )
         assert "@" not in line
         assert "(" not in line
+
+
+class TestTheCeilingRoundTripIsLossless:
+    """``_render_snapshot`` flattens every record to a dict and rebuilds it, so the
+    rebuild must be TOTAL over ``ElementRec`` (reviewer finding).
+
+    The pair dropped ``frame``, ``traits`` and ``focused`` — three of the fields the
+    accessibility walk exists to read — so every ``computer_get_state`` reached by a
+    model rendered without rects, without ``(editable)`` and without the focus line,
+    while the response still instructed the model to "add the origin for a screen
+    point" for rects that had been deleted. `editable` is the load-bearing loss: it
+    is the only signal separating a writable text field from a read-only one, so
+    without it the model types into a log pane, gets an ``ok``, and verifies a change
+    that never happened.
+
+    Every OTHER test for these fields calls ``render.render_tree`` directly, which is
+    exactly why none of them caught it — this one goes through ``tools``.
+    """
+
+    def test_every_ElementRec_field_survives_the_payload_round_trip(self):
+        """Field-by-field, driven off ``dataclasses.fields`` so a NEW field fails here
+        rather than being silently dropped by the next lossy rebuild."""
+        import dataclasses
+
+        from kiro_crew.computer_use.tools import _element_from_payload, _element_payload
+
+        rec = ElementRec(
+            index=4,
+            role="AXTextField",
+            subrole="AXSearchField",
+            title="Query",
+            value="kirocrew",
+            actions=("AXConfirm",),
+            depth=2,
+            secure=False,
+            enabled=True,
+            frame=(18.0, 12.0, 28.0, 24.0),
+            traits=("editable", "selected"),
+            focused=True,
+        )
+        rebuilt = _element_from_payload(_element_payload(rec))
+        lost = [
+            f.name
+            for f in dataclasses.fields(ElementRec)
+            if getattr(rec, f.name) != getattr(rebuilt, f.name)
+        ]
+        assert not lost, f"the ceiling round-trip silently dropped {lost}"
+        assert rebuilt == rec
+
+    def test_the_tools_render_path_emits_the_geometry_and_traits(self, fake):
+        """The model-facing surface, not ``render_tree`` in isolation."""
+        from kiro_crew.computer_use import tools as cu_tools
+
+        snap = _snap(fake, FAKE_FILES_APP)
+        text = cu_tools._render_snapshot(
+            snap,
+            SnapshotRequest(),
+            session_key="dashboard:main",
+            agent="kirocrew",
+            app=FAKE_FILES_APP.name,
+        )
+        assert "@ x=18,y=12 28x24" in text, "element frames were dropped before rendering"
+        assert "(editable)" in text, "the editable trait was dropped before rendering"
+        assert "<focused>" in text
+        assert "Focus: element" in text
+
+    def test_a_malformed_frame_becomes_None_not_a_bogus_rect(self):
+        """A partial/re-typed rect must not render as a plausible wrong rectangle.
+
+        Same reasoning as the driver's half-read refusal: a rect pointing somewhere
+        else is worse than no rect, because a model will pass it to a coordinate
+        click. ``bool`` is excluded explicitly (it is an ``int`` subclass).
+        """
+        from kiro_crew.computer_use.tools import _element_from_payload
+
+        for bad in ((1, 2, 3), (1, 2, 3, "x"), (1, 2, 3, True), "nope", (1, 2, 3, 4, 5), None):
+            rec = _element_from_payload({"index": 1, "role": "AXButton", "frame": bad})
+            assert rec.frame is None, f"frame={bad!r} produced {rec.frame!r}"
+        ok = _element_from_payload({"index": 1, "role": "AXButton", "frame": (1, 2, 3, 4)})
+        assert ok.frame == (1.0, 2.0, 3.0, 4.0)
+
+    def test_a_secure_record_still_discloses_only_its_existence(self, fake):
+        """The restored fields must not weaken the secure floor.
+
+        ``_render_record`` returns at the secure branch BEFORE reading traits/focus/
+        frame, so populating them in the payload cannot leak — asserted rather than
+        assumed, because this fix is what put real values in those fields.
+        """
+        from kiro_crew.computer_use import tools as cu_tools
+
+        snap = _snap(fake, FAKE_LOGIN_APP)
+        text = cu_tools._render_snapshot(
+            snap,
+            SnapshotRequest(),
+            session_key="dashboard:main",
+            agent="kirocrew",
+            app=FAKE_LOGIN_APP.name,
+        )
+        line = next(ln for ln in text.splitlines() if SECURE_PLACEHOLDER in ln)
+        assert "@" not in line and "(" not in line and "<focused>" not in line
+        assert FAKE_SECRET_VALUE not in text
+
+
+class TestASuppressedScreenshotAlwaysSaysSoWhy:
+    """No silent screenshot suppression — every refusal names its reason.
+
+    ``capture_macos`` refuses to capture a window whose walk was TRUNCATED, because a
+    cut-off walk cannot prove the window is free of a secure field ("unknown" behaves
+    as "present" at the one gate that lets pixels leave the process). That refusal was
+    silent: ``render._render_image_note`` special-cased only ``has_secure`` and
+    returned ``""`` for everything else. Truncation is the NORMAL state for a
+    Chromium/Electron window at the shipped 1200-node default (Chrome measured 1475
+    nodes), so ``screenshot: true`` on Chrome/Slack/VS Code produced no image and no
+    explanation — exactly the retry loop ``SECURE_WINDOW_NOTE`` /
+    ``OBS_SUPPRESSED_NOTE`` were written to prevent.
+    """
+
+    @staticmethod
+    def _snap(**kwargs):
+        app = AppRef(bundle_id="com.google.Chrome", name="Chrome", pid=637, window_id=42)
+        return Snapshot(
+            app=app,
+            window_title="Docs",
+            elements=(ElementRec(index=0, role="AXWindow", title="Docs"),),
+            **kwargs,
+        )
+
+    @pytest.mark.parametrize("flag", ["truncated", "depth_truncated"])
+    def test_a_truncated_walk_explains_the_missing_screenshot(self, flag):
+        snap = self._snap(**{flag: True}, walk_budget=SnapshotRequest(want_image=True))
+        text = render.render_tree(snap, text_limit=DEFAULT_TEXT_LIMIT)
+        assert TRUNCATED_WINDOW_NOTE in text, (
+            "a suppressed capture on a truncated tree said nothing at all — the model "
+            "asked for a screenshot, got none, and has no reason to stop retrying"
+        )
+
+    def test_the_note_names_the_remedy_the_model_can_act_on(self):
+        """Unlike the secure/policy cases, this one is fixable by the caller."""
+        assert "max_tree_nodes" in TRUNCATED_WINDOW_NOTE
+
+    def test_a_secure_window_keeps_the_more_specific_reason(self):
+        """Both conditions at once must not degrade to the vaguer explanation."""
+        text = render.render_tree(
+            self._snap(truncated=True, has_secure=True), text_limit=DEFAULT_TEXT_LIMIT
+        )
+        assert SECURE_WINDOW_NOTE in text
+        assert TRUNCATED_WINDOW_NOTE not in text
+
+    def test_a_clean_walk_that_asked_for_no_image_stays_silent(self):
+        """The note must not appear where there is nothing to explain."""
+        text = render.render_tree(self._snap(), text_limit=DEFAULT_TEXT_LIMIT)
+        assert TRUNCATED_WINDOW_NOTE not in text
+        assert SECURE_WINDOW_NOTE not in text
+
+    def test_the_shipped_fake_refuses_a_truncated_capture_like_production(self, fake):
+        """Otherwise deleting production's branch leaves the whole suite green.
+
+        The fake refused only on ``has_secure``, so a truncated walk came back WITH an
+        image — a capture the real driver refuses — and any downstream suite driving
+        the shipped fake would have inherited that false behaviour.
+        """
+        result = fake.snapshot(FAKE_FILES_APP, SnapshotRequest(max_nodes=1, want_image=True))
+        snap = result.snapshot
+        assert snap.truncated is True
+        assert snap.image_jpeg == b"", "the fake attached pixels to a truncated walk"
+        assert snap.image_width == 0 and snap.image_height == 0
+        # And the un-truncated case still captures, so this is a real branch not a
+        # blanket disable.
+        full = fake.snapshot(FAKE_FILES_APP, SnapshotRequest(want_image=True)).snapshot
+        assert full.truncated is False
+        assert full.image_jpeg
+
+    @pytest.mark.parametrize("flag", ["truncated", "depth_truncated"])
+    def test_no_note_when_the_caller_never_asked_for_an_image(self, flag):
+        """The inverse failure, and the first version of this fix shipped it.
+
+        An unconditional note announced the suppression of an image nobody requested.
+        Every mutating action's refresh walk forces ``want_image=False`` by design, and
+        truncation is routine on a browser — so a successful click came back with
+        "Screenshot suppressed … Re-run with a higher max_tree_nodes", naming an
+        argument mutating tools do not accept. That is the same retry loop the note was
+        added to prevent, pointed the other way.
+        """
+        snap = self._snap(**{flag: True}, walk_budget=SnapshotRequest(want_image=False))
+        text = render.render_tree(snap, text_limit=DEFAULT_TEXT_LIMIT)
+        assert (
+            TRUNCATED_WINDOW_NOTE not in text
+        ), "announced a suppressed screenshot on a walk that never requested one"
+
+    def test_an_unstamped_snapshot_still_announces(self):
+        """``walk_budget=None`` means the request is unknown — announce rather than
+        hide, since a spurious note is cheaper than a silent omission."""
+        snap = self._snap(truncated=True)
+        assert snap.walk_budget is None
+        assert TRUNCATED_WINDOW_NOTE in render.render_tree(snap, text_limit=DEFAULT_TEXT_LIMIT)
+
+    def test_the_note_appears_and_disappears_through_the_REAL_dispatch_path(
+        self, fake, tmp_path, monkeypatch
+    ):
+        """End-to-end, because both failure directions were invisible to unit tests.
+
+        ``render_tree`` in isolation cannot show either bug: the first needed a
+        ``get_state`` that asked for pixels, the second needed a mutating action's
+        forced ``want_image=False``. Only the dispatcher produces both.
+        """
+        import json
+
+        from kiro_crew.computer_use import backend as cu_backend
+        from kiro_crew.computer_use import index as cu_index
+        from kiro_crew.computer_use import service as cu_service
+        from kiro_crew.computer_use import tools as cu_tools
+
+        # The keystone primary enable, in an isolated home — the dispatcher refuses
+        # everything before rendering otherwise, and a developer's real
+        # ``~/.kiro/crew`` must never decide this test's outcome.
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        (tmp_path / "computer_use.json").write_text(json.dumps({"enabled": True}), encoding="utf-8")
+
+        fake.trees[FAKE_FILES_APP.key] = FakeNode(
+            role="AXWindow",
+            title="Wide",
+            children=tuple(
+                FakeNode(role="AXButton", title=f"b{i}", actions=("AXPress",)) for i in range(30)
+            ),
+        )
+        cu_backend.register_computer_use_backend(lambda: fake)
+        cu_backend.reset_shared_backend()
+        cu_service.reset_shared_service()
+        cu_index.reset_shared_index()
+        try:
+            session = "dashboard:main"
+            asked = cu_tools.dispatch_tool(
+                TOOL_GET_STATE,
+                {"app": FAKE_FILES_APP.name, "max_tree_nodes": 5, "screenshot": True},
+                session_key=session,
+            )
+            assert TRUNCATED_WINDOW_NOTE in asked, "a requested capture was suppressed silently"
+
+            clicked = cu_tools.dispatch_tool(
+                "computer_click",
+                {"app": FAKE_FILES_APP.name, "element_index": 3},
+                session_key=session,
+            )
+            assert not clicked.startswith("Error:"), clicked
+            assert TRUNCATED_WINDOW_NOTE not in clicked, (
+                "a successful click announced the suppression of an image it never "
+                "requested, and told the model to raise an argument it cannot pass"
+            )
+        finally:
+            cu_backend.register_computer_use_backend(None)
+            cu_backend.reset_shared_backend()
+            cu_service.reset_shared_service()
+            cu_index.reset_shared_index()

--- a/test/test_hooks.py
+++ b/test/test_hooks.py
@@ -573,6 +573,137 @@ class TestShouldAutoApproveSpawn:
         ctx.hooks = HookManager(HooksConfig.from_dict({"auto_approve_subagent_spawn": True}))
         assert _should_auto_approve_spawn(ctx, "spawn_run_privileged") is False
 
+
+class TestMutatingKindBeatsTheTitle:
+    """Only an explicitly READ-ONLY ``tool_kind`` may auto-approve on a title.
+
+    ``tool_name`` is the display title, and ``select_tool_title``
+    (``acp/_dispatch.py``) prefers the LLM-authored ``description`` — so it is
+    agent-controlled, which ``on_tool_call``'s own docstring states outright. The
+    computer-use read-only auto-approve used to be tested BEFORE any kind guard, so
+    once the operator enabled computer use, an ``edit``/``execute``/``write``/
+    ``delete`` call titled ``mcp__kirocrew-computer__computer_get_state`` skipped
+    interactive approval entirely.
+
+    The first fix for that was a DENYLIST (``kind in _WRITE_TOOL_KINDS`` → allow),
+    and GPT 5.6 correctly rejected it as still fail-open: ``tool_kind`` arrives
+    verbatim from the ACP ``kind`` field, so an unlisted-but-real value like
+    ``"other"`` sailed past it and auto-approved. The decision is now an ALLOW-list —
+    only ``_READ_ONLY_TOOL_KINDS`` and an ABSENT kind can reach a title-keyed
+    branch — so a kind nobody has enumerated fails closed.
+    """
+
+    _CU_OBSERVE_TITLE = "mcp__kirocrew-computer__computer_get_state"
+
+    #: Known mutators, plus the ACP values and shapes a denylist would miss. The
+    #: second group is the point: those are what made the denylist fail open.
+    _NON_READ_KINDS = [
+        "edit",
+        "execute",
+        "delete",
+        "move",
+        "write",
+        "create",
+        "other",
+        "unknown",
+        "switch_mode",
+        "search",
+        "think",
+        "EDIT",
+    ]
+
+    @pytest.mark.parametrize("kind", _NON_READ_KINDS)
+    def test_a_non_read_kind_is_not_auto_approved_despite_a_cu_read_title(self, kind, monkeypatch):
+        # Force the CU predicate True so the test pins the DECISION, not the
+        # keystone read (which is off in CI and would mask a regression).
+        monkeypatch.setattr("kiro_crew.hooks._cu_read_only_auto_approve", lambda _name: True)
+        mgr = HookManager()
+        result = mgr.on_tool_call(self._CU_OBSERVE_TITLE, tool_kind=kind)
+        assert result.action == TOOL_ALLOW, (
+            f"tool_kind={kind!r} auto-approved on the strength of an agent-supplied "
+            "computer-use title — interactive approval was skipped"
+        )
+
+    def test_the_read_only_kinds_are_an_allowlist_not_a_denylist(self):
+        """Pinned structurally: the gate must not reintroduce a mutating-kind list.
+
+        A behavioural test alone would keep passing if someone widened the accepted
+        set back out, so this asserts the SHAPE — the read-only vocabulary is small
+        and explicit, and ``_WRITE_TOOL_KINDS`` is documentation rather than a branch.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from kiro_crew import hooks as hooks_mod
+
+        assert hooks_mod._READ_ONLY_TOOL_KINDS == frozenset({"read", "fetch"})
+        # Over the AST, not the source text: the explanatory comment names the
+        # constant deliberately, and a substring check would flag that prose.
+        tree = ast.parse(textwrap.dedent(inspect.getsource(hooks_mod.HookManager.on_tool_call)))
+        referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)} | {
+            node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+        }
+        assert "_WRITE_TOOL_KINDS" not in referenced, (
+            "the gate branches on a denylist of mutating kinds again — `tool_kind` is "
+            "an arbitrary ACP string, so such a list is incomplete by construction"
+        )
+        assert "_READ_ONLY_TOOL_KINDS" in referenced, "the allow-list branch is gone"
+
+    @pytest.mark.parametrize("kind", ["read", "fetch"])
+    def test_a_genuine_cu_observation_still_auto_approves(self, kind, monkeypatch):
+        """The feature the fix must not break: a PROVEN read still doesn't nag."""
+        monkeypatch.setattr("kiro_crew.hooks._cu_read_only_auto_approve", lambda _name: True)
+        mgr = HookManager()
+        assert mgr.on_tool_call(self._CU_OBSERVE_TITLE, tool_kind=kind).action == (
+            TOOL_AUTO_APPROVE
+        ), f"a computer-use observation tool with tool_kind={kind!r} should auto-approve"
+
+    def test_computer_use_needs_an_EXPLICIT_read_kind_not_merely_an_absent_one(self, monkeypatch):
+        """An OMITTED kind must not reach the computer-use auto-approve either.
+
+        Second GPT 5.6 finding on this PR, and correct. Two agent-controlled inputs meet
+        in this branch: the title (from `select_tool_title`, which prefers the LLM-authored
+        `description`) and the kind (whose absence is indistinguishable from an honest
+        omission). While the class lookup keyed on the title alone, a `computer_click`
+        could forge `…__computer_get_state`, omit its kind, and skip the approval prompt.
+        The two inputs must AGREE.
+
+        Narrower than GPT's prescription — the generic `_is_read_only_tool` fallback for
+        absent kinds is deliberately left intact, because it rejects every
+        `mcp__kirocrew-computer__*` title anyway (asserted below), so blocking absent
+        kinds outright would have regressed every ordinary tool for no security gain.
+        """
+        monkeypatch.setattr("kiro_crew.hooks._cu_read_only_auto_approve", lambda _name: True)
+        mgr = HookManager()
+        assert mgr.on_tool_call(self._CU_OBSERVE_TITLE).action == TOOL_ALLOW, (
+            "a computer-use title with NO kind auto-approved — a mutating call can "
+            "forge the title and omit the kind, so the two must agree"
+        )
+
+    def test_the_generic_fallback_never_matches_a_computer_use_title(self):
+        """Why leaving the absent-kind fallback in place is safe.
+
+        If `_is_read_only_tool` ever started matching a `computer_*` title, the branch
+        above would stop being the only way in and this PR's guarantee would quietly
+        weaken — so it is asserted rather than assumed.
+        """
+        from kiro_crew.slack.gateway import _is_read_only_tool
+
+        for tool in ("computer_get_state", "computer_list_apps", "computer_click"):
+            title = f"mcp__kirocrew-computer__{tool}"
+            assert not _is_read_only_tool(title), title
+
+    def test_a_read_sounding_title_cannot_rescue_a_non_read_kind(self, monkeypatch):
+        """The same invariant for the generic title heuristic, not just the CU one."""
+        monkeypatch.setattr("kiro_crew.hooks._cu_read_only_auto_approve", lambda _name: False)
+        mgr = HookManager()
+        for kind in ("execute", "other"):
+            assert mgr.on_tool_call("read_the_docs", tool_kind=kind).action == TOOL_ALLOW, kind
+        # ...and with no kind at all the title heuristic is still allowed to work for
+        # ORDINARY tools — unchanged from base, and the reason the fix stayed narrow.
+        assert mgr.on_tool_call("read_the_docs").action == TOOL_AUTO_APPROVE
+
     def test_rejects_none_context(self):
         from kiro_crew.slack.handler import _should_auto_approve_spawn
 

--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -290,6 +290,33 @@ def test_every_REQUIRED_validated_field_is_advertised_as_required(keystone: Path
         )
 
 
+@pytest.mark.parametrize("tool", sorted(cu_tools._ELEMENT_REQUIRED_TOOLS))
+def test_element_required_tools_demand_the_index_in_the_validator_too(tool: str):
+    """**The third layer.** ``MCP_COMPUTER_SCHEMAS`` must require what the chokepoint does.
+
+    Three layers have to agree that ``element_index`` is mandatory, and two of them
+    silently disagreed: ``validation.py`` gave ``computer_type_text`` and
+    ``computer_press_key`` the OPTIONAL field spec (the one that exists for
+    ``computer_click``, which legitimately takes coordinates instead), so an indexless
+    call passed the validator and was refused one step later by
+    ``tools._ELEMENT_REQUIRED_TOOLS``. Enforcement held — that raise is converted to a
+    refusal at ``tools.dispatch_tool`` — but the comments on both sides then described
+    the *other* layer's behaviour, and one of them invited a reader to delete the
+    chokepoint check as unreachable.
+
+    The two existing parity tests could not catch it: both compare the ADVERTISED
+    schema against the VALIDATOR, and here those two agreed with each other while the
+    validator disagreed with the chokepoint. This asserts that last edge.
+    """
+    required = {field.name for field in MCP_COMPUTER_SCHEMAS[tool].fields if field.required}
+    assert "element_index" in required, (
+        f"{tool} is in _ELEMENT_REQUIRED_TOOLS but its validation schema does not "
+        "require element_index — an indexless call would pass validation and be "
+        "refused one layer later, and an unnamed target has no role/subrole for the "
+        "always-on secure-field refusal to inspect"
+    )
+
+
 def test_unknown_tool_is_rejected_with_no_raw_passthrough():
     """There is no raw pass-through fallback for an unregistered tool name.
 
@@ -408,9 +435,7 @@ def test_an_unresolved_session_key_PROCEEDS_with_an_empty_identity(
     _enable(keystone)
     posted: list[Any] = []
     monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: "")
-    monkeypatch.setattr(
-        mcp_computer, "_invoke", lambda *a, **k: posted.append(a) or {"text": "ok"}
-    )
+    monkeypatch.setattr(mcp_computer, "_invoke", lambda *a, **k: posted.append(a) or {"text": "ok"})
     result = mcp_computer._call_tool_inner(TOOL_LIST_APPS, {})
     assert not result.startswith(ERROR_PREFIX), result
     assert result == "ok"
@@ -1504,10 +1529,12 @@ class TestAutoNeverResolvesToGlobal:
     """**The invariant.**
 
     ``auto`` resolving onto ``global`` would let a model take over the operator's
-    physical mouse without ever naming the method — which would make the Settings
-    opt-in and the ``capabilities.computer_use_pointer`` permit reachable by accident
-    rather than by an explicit request. Asserted three ways, because a single
-    behavioural case would not survive a refactor of the resolver.
+    physical mouse without ever naming the method. Since the separate pointer opt-in
+    was removed — there is no keystone ``allow_pointer_move`` and no
+    ``capabilities.computer_use_pointer`` row — this resolver is the ONLY thing
+    standing between an ordinary click and the operator's cursor, so it matters more
+    now, not less. Asserted three ways, because a single behavioural case would not
+    survive a refactor of the resolver.
     """
 
     @pytest.mark.parametrize(
@@ -1629,11 +1656,17 @@ class TestCursorMotionIsWiredToThePointerPath:
         assert not result.startswith(ERROR_PREFIX), result
         assert motions == [(10, 20, 1)]
 
-    def test_the_opt_in_does_not_imply_the_primary_enable(
+    def test_an_unrecognized_keystone_key_does_not_imply_the_primary_enable(
         self, keystone: Path, fake_backend: FakeComputerUseBackend
     ):
-        """The two flags are independent; the primary enable is checked FIRST, so a
-        pointer opt-in on a disabled feature is still a disabled feature."""
+        """Only ``enabled`` enables. Anything else on the keystone is not a grant.
+
+        ``allow_pointer_move`` is used as the payload precisely because an earlier
+        revision documented it as a second consent switch for the real-pointer path.
+        It was removed by product decision and ``PolicyConfig.from_state`` never reads
+        it, so a keystone carrying it and nothing else must still resolve to DISABLED
+        rather than to "the operator configured something, so presumably yes".
+        """
         keystone.write_text(json.dumps({"allow_pointer_move": True}), encoding="utf-8")
         result = _dispatch(TOOL_CLICK, app=FAKE_FILES_APP.name, x=1, y=2, click_method="global")
         assert result.startswith(ERROR_PREFIX)
@@ -1643,9 +1676,15 @@ class TestCursorMotionIsWiredToThePointerPath:
     def test_an_app_post_click_never_consults_the_pointer_permit(
         self, keystone: Path, fake_backend: FakeComputerUseBackend, monkeypatch
     ):
-        """The whole reason for a separate row: a fleet that has not authored the key
-        must keep clicking exactly as before, so the non-pointer paths must not even
-        ASK."""
+        """A pointer-free click must not travel the real-pointer code path at all.
+
+        ``require_pointer_move`` is now a no-op that only exists so an edition can
+        reintroduce a decision, but the CALL still marks which gestures the code
+        treats as pointer-moving — so an ``AXPress`` or an ``app_post`` click asking
+        for the pointer permit would mean the chokepoint had lost track of which
+        methods warp the cursor, which is the invariant that keeps ``auto`` off the
+        real-pointer path.
+        """
         from kiro_crew.computer_use import gate as cu_gate
 
         asked: list[str] = []
@@ -1835,9 +1874,7 @@ class TestTheActionHeaderIsRedacted:
         assert FAKE_CREDENTIAL_FIXTURE not in out
         assert "REDACTED" in out
 
-    def test_the_TREE_half_is_not_redacted_a_SECOND_time(
-        self, keystone: Path, fake_backend
-    ):
+    def test_the_TREE_half_is_not_redacted_a_SECOND_time(self, keystone: Path, fake_backend):
         """Why the two halves are redacted SEPARATELY rather than as one joined string.
 
         ``render_tree`` appends its screenshot note AFTER its own redaction pass, on
@@ -1879,14 +1916,10 @@ class TestTheSkillContractMatchesTheRuntime:
     """
 
     _SKILL = (
-        Path(__file__).resolve().parents[1]
-        / "src/kiro_crew/builtin_skills/computer-use/SKILL.md"
+        Path(__file__).resolve().parents[1] / "src/kiro_crew/builtin_skills/computer-use/SKILL.md"
     )
 
-    _SPEC = (
-        Path(__file__).resolve().parents[1]
-        / "docs/system-specs/modules/computer-use.md"
-    )
+    _SPEC = Path(__file__).resolve().parents[1] / "docs/system-specs/modules/computer-use.md"
 
     def test_the_skill_does_not_advertise_an_optional_element_index(self):
         text = self._SKILL.read_text(encoding="utf-8")
@@ -1931,6 +1964,49 @@ class TestTheSkillContractMatchesTheRuntime:
         assert TOOL_CLICK not in cu_tools._ELEMENT_REQUIRED_TOOLS
         for tool in (TOOL_TYPE_TEXT, TOOL_PRESS_KEY, TOOL_SET_VALUE, TOOL_SCROLL):
             assert tool in cu_tools._ELEMENT_REQUIRED_TOOLS, tool
+
+    def test_no_worked_example_in_the_skill_omits_a_required_element_index(self):
+        """The shipped example must be RUNNABLE, not just the prose correct.
+
+        ``SKILL.md``'s only end-to-end example called
+        ``computer_press_key(app="Finder", key="return")`` twice — both refused by
+        ``_CU_ELEMENT_FIELD`` and again by ``_ELEMENT_REQUIRED_TOOLS`` — while the same
+        file's prose said an index was required. A model following the example hits a
+        refusal on its second call, which is exactly the trial-and-error the skill
+        exists to remove, and prose alone could not catch it.
+        """
+        text = self._SKILL.read_text(encoding="utf-8")
+        offenders: list[str] = []
+        for line in text.splitlines():
+            stripped = line.strip()
+            for tool in sorted(cu_tools._ELEMENT_REQUIRED_TOOLS):
+                # Only literal invocations, not the signature rows in the tool table
+                # (which are rendered as `| \`tool(app, element_index, …)\` |`).
+                if stripped.startswith(f"{tool}(") and "element_index" not in stripped:
+                    offenders.append(stripped)
+        assert not offenders, (
+            "SKILL.md shows call(s) that every layer refuses — a model copying them "
+            f"gets an error, not a result: {offenders}"
+        )
+
+    def test_the_skill_documents_the_truncated_screenshot_suppression(self):
+        """Every non-failure message the model can see belongs in the skill's table.
+
+        A suppressed capture on a truncated walk is ROUTINE (a browser or Electron app
+        exceeds the default node budget), and it used to be emitted with no text at
+        all — the model asked for a screenshot, got none, and had no reason to stop
+        retrying. The note is now in ``types``; asserting the skill quotes it keeps the
+        two from drifting, since ``SKILL.md`` ships to every pip/DMG install and is
+        what tells the model this is an answer rather than a fault.
+        """
+        from kiro_crew.computer_use.types import TRUNCATED_WINDOW_NOTE
+
+        text = self._SKILL.read_text(encoding="utf-8")
+        # The distinctive opening clause, not the whole sentence: the table wraps it.
+        head = TRUNCATED_WINDOW_NOTE.split(",")[0]
+        assert head in text, f"SKILL.md does not document the {head!r} response"
+        # And the remedy the model can actually act on.
+        assert "max_tree_nodes" in TRUNCATED_WINDOW_NOTE
 
 
 class TestUnresolvedSessionsAreNamespaced:
@@ -2007,9 +2083,7 @@ class TestUnresolvedSessionsAreNamespaced:
         attribution the strict resolver exists to provide."""
         _enable(keystone)
         posted: list[Any] = []
-        monkeypatch.setattr(
-            mcp_computer, "_resolve_session_key_strict", lambda: "dashboard:main"
-        )
+        monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: "dashboard:main")
         monkeypatch.setattr(
             mcp_computer, "_invoke", lambda *a, **k: posted.append(a) or {"text": "ok"}
         )
@@ -2026,3 +2100,79 @@ class TestUnresolvedSessionsAreNamespaced:
         src = inspect.getsource(mcp_computer)
         assert "could not be identified" not in src
         assert "ERR_NO_SESSION" not in src
+
+
+class TestTheDriftWalkHonoursTheSnapshotBudget:
+    """A raised ``max_tree_nodes`` must not make its own elements un-actionable.
+
+    Reviewer finding, reproduced end-to-end. A mutating tool takes no tree-budget
+    arguments, so ``tools`` built the drift-verification request from
+    ``service.snapshot_request()`` — the *config default* (1200) — and discarded the
+    budget the cached snapshot was actually walked at. So ``computer_get_state(app,
+    max_tree_nodes=2001)`` rendered element 1400 with no truncation note, and the
+    follow-up ``computer_click(element_index=1400)`` was refused with
+    ``"… now no element at that index"`` because ``verify_fingerprint`` re-walked at
+    1200. Re-snapshotting reproduced the same tree and the same refusal, so the model
+    had no way out of the loop — on a documented happy path: the MCP schema advertises
+    ``max_tree_nodes`` up to 5000 and the Settings copy says to raise it for dense
+    apps.
+
+    Fixed by stamping ``Snapshot.walk_budget`` in ``service.snapshot`` and re-walking
+    at it.
+    """
+
+    @staticmethod
+    def _wide_tree(count: int = 1500):
+        from kiro_crew.testing.fake_computer_use import FakeNode
+
+        return FakeNode(
+            role="AXWindow",
+            title="Wide",
+            children=tuple(
+                FakeNode(role="AXButton", title=f"b{i}", actions=("AXPress",)) for i in range(count)
+            ),
+        )
+
+    def test_an_element_above_the_config_default_stays_actionable(
+        self, keystone: Path, fake_backend: FakeComputerUseBackend
+    ):
+        _enable(keystone)
+        fake_backend.trees[FAKE_FILES_APP.key] = self._wide_tree()
+        shown = _dispatch(
+            TOOL_GET_STATE, app=FAKE_FILES_APP.name, max_tree_nodes=2001, screenshot=False
+        )
+        assert '1400 button "b1399"' in shown, "the raised budget did not render element 1400"
+
+        result = _dispatch(TOOL_CLICK, app=FAKE_FILES_APP.name, element_index=1400)
+        assert not result.startswith(ERROR_PREFIX), result
+        assert "no element at that index" not in result
+
+    def test_the_snapshot_records_the_budget_it_was_walked_at(
+        self, keystone: Path, fake_backend: FakeComputerUseBackend
+    ):
+        """The mechanism, asserted directly: a stamp of ``None`` would silently
+        restore the old behaviour via the ``or req`` fallback."""
+        _enable(keystone)
+        fake_backend.trees[FAKE_FILES_APP.key] = self._wide_tree(20)
+        _dispatch(TOOL_GET_STATE, app=FAKE_FILES_APP.name, max_tree_nodes=1777, screenshot=False)
+        svc = cu_service.get_shared_service()
+        cached = svc.index.get(FAKE_FILES_APP.window_key, session_key=_SESSION)
+        assert cached is not None
+        assert cached.walk_budget is not None, "service.snapshot did not stamp walk_budget"
+        assert cached.walk_budget.max_nodes == 1777
+
+    def test_the_drift_walk_reuses_that_budget_not_the_config_default(
+        self, keystone: Path, fake_backend: FakeComputerUseBackend
+    ):
+        """Read off the fake's own journal, so this pins the request the driver saw."""
+        _enable(keystone)
+        fake_backend.trees[FAKE_FILES_APP.key] = self._wide_tree(20)
+        _dispatch(TOOL_GET_STATE, app=FAKE_FILES_APP.name, max_tree_nodes=1777, screenshot=False)
+        fake_backend.calls.clear()
+        _dispatch(TOOL_CLICK, app=FAKE_FILES_APP.name, element_index=3)
+        walks = [kw["max_nodes"] for name, kw in fake_backend.calls if name == "snapshot"]
+        assert walks, "the mutating action performed no verification walk"
+        assert all(n == 1777 for n in walks), (
+            f"the drift/refresh walks used {walks} instead of the snapshot's own 1777 — "
+            "an element the model was legitimately shown would be refused"
+        )

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -48,6 +48,23 @@ _REDACTOR_CALL_RE = re.compile(
 )
 
 
+def _mcp_schema_registry_names() -> list[str]:
+    """Every ``MCP_*_SCHEMAS`` dispatch registry in ``validation``, DISCOVERED.
+
+    Deliberately not a hardcoded list: hardcoding is what let the ten
+    ``MCP_COMPUTER_SCHEMAS`` tools go missing from the posture report while the drift
+    test that exists to catch that stayed green, because the test named the same two
+    registries the implementation did.
+    """
+    return sorted(
+        name
+        for name in dir(validation)
+        if name.startswith("MCP_")
+        and name.endswith("_SCHEMAS")
+        and isinstance(getattr(validation, name), dict)
+    )
+
+
 @pytest.fixture()
 def snapshot():
     return build_posture_snapshot()
@@ -145,9 +162,39 @@ class TestDerivation:
         """
         control = self._control(snapshot, "tool_schemas")
         labels = {i["label"] for i in control["items"]}
-        registered = set(validation.MCP_CORE_SCHEMAS) | set(validation.MCP_CRON_SCHEMAS)
+        registered: set[str] = set()
+        for name in _mcp_schema_registry_names():
+            registered |= set(getattr(validation, name))
         missing = registered - labels
         assert not missing, f"registered MCP tools absent from the posture view: {missing}"
+
+    def test_every_mcp_schema_registry_is_covered_by_the_posture_view(self, snapshot):
+        """The drift guard's OWN blind spot, closed.
+
+        This class previously hardcoded ``MCP_CORE_SCHEMAS | MCP_CRON_SCHEMAS`` — the
+        same two names the implementation hardcoded — so when ``MCP_COMPUTER_SCHEMAS``
+        was added, all ten computer-use tools were absent from the security-posture
+        report and the test written to catch exactly that stayed green. Discovering the
+        registries from ``validation`` instead means a NEW one fails here until it is
+        added to ``security_posture._SCHEMA_REGISTRY_NAMES``.
+        """
+        from kiro_crew import security_posture
+
+        discovered = set(_mcp_schema_registry_names())
+        assert discovered, "no MCP_*_SCHEMAS registries found in validation"
+        declared = set(security_posture._SCHEMA_REGISTRY_NAMES)
+        assert discovered <= declared, (
+            f"registries {sorted(discovered - declared)} exist in validation but are not "
+            "in security_posture._SCHEMA_REGISTRY_NAMES — their tools are validated but "
+            "invisible in the posture report"
+        )
+        # And every declared name must still exist, so a rename cannot leave a
+        # silently-empty entry behind.
+        for name in declared:
+            assert isinstance(getattr(validation, name, None), dict), (
+                f"security_posture._SCHEMA_REGISTRY_NAMES lists {name!r}, which is no "
+                "longer a dict in validation"
+            )
 
     def test_tool_schemas_includes_inline_registry_only_schemas(self, snapshot):
         """Regression guard for the naming-convention blind spot.
@@ -225,7 +272,9 @@ class TestDisclosureContract:
             # Comments legitimately discuss the boundary, so strip them first —
             # only real code references should fail.
             code = "\n".join(
-                line.split("#", 1)[0] for line in src.splitlines() if not line.strip().startswith("#")
+                line.split("#", 1)[0]
+                for line in src.splitlines()
+                if not line.strip().startswith("#")
             )
             assert forbidden not in code, forbidden
 
@@ -494,9 +543,7 @@ class TestOmissionDetection:
         cases = {
             "Credential in path or query": "https://evil.example.com/AKIAIOSFODNN7EXAMPLE",
             "Base64-encoded credential": "https://evil.example.com/p?d="
-            + base64.b64encode(
-                b"AKIAIOSFODNN7EXAMPLE and more padding text here"
-            ).decode(),
+            + base64.b64encode(b"AKIAIOSFODNN7EXAMPLE and more padding text here").decode(),
             f"Long query string (>= {security.exfil_query_min_len()} chars)": (
                 f"https://evil.example.com/p?d={long_q}"
             ),
@@ -566,7 +613,11 @@ class TestOmissionDetection:
         for path in pkg.rglob("*.py"):
             if path.name in {"sel.py", "security_posture.py"}:
                 continue
-            explicit |= set(re.findall(r'source="([a-z_]+)"', path.read_text(encoding="utf-8", errors="replace")))
+            explicit |= set(
+                re.findall(
+                    r'source="([a-z_]+)"', path.read_text(encoding="utf-8", errors="replace")
+                )
+            )
         beyond = explicit - set(_sel_mod.audit_sources())
         assert beyond, (
             "no explicit source= literal outside the inferred vocabulary was found — "

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -83,9 +83,10 @@ export interface ComputerUsePermissions {
 /** Computer-use config as returned by GET /api/computer-use/config.
  *
  * `enabled` comes from the keystone `computer_use.json`, not `config.json`; the
- * numeric fields are the config.json budgets. `read_only` is derived from
- * governance (never from the platform — an unsupported platform is the separate
- * `supported: false` branch). */
+ * numeric fields are the config.json budgets. There is deliberately no
+ * `read_only`/governance-lock field — computer use is one operator opt-in with no
+ * `computer_use*` governance scope, so nothing can forbid it and there is nothing to
+ * grey out. An unsupported platform is the separate `supported: false` branch. */
 export interface ComputerUseConfigData {
   enabled: boolean
   supported: boolean


### PR DESCRIPTION
## Problem

A max-effort code review of the **merged** PR #644 (computer use) surfaced 15 verified findings, and three mirrored reviewer passes over the fix diff surfaced 11 more. Two were reachable authorization bypasses that defeat the feature's entire security model:

- **Any mutating tool call could skip interactive approval.** `hooks.py` tested the computer-use read-only auto-approve *before* the `_WRITE_TOOL_KINDS` guard. `tool_name` is the display title, and `select_tool_title` (`acp/_dispatch.py`) prefers the **LLM-authored `description`** — `on_tool_call`'s own docstring calls it untrusted for security decisions. So once the operator enabled computer use, an `edit`/`execute`/`write`/`delete`/`move`/`create` call that titled itself `mcp__kirocrew-computer__computer_get_state` was auto-approved. Verified for all six kinds.
- **An app token could turn on the operator's desktop automation.** `PUT /api/computer-use/config` had no caller check at all. `request["user"]` is truthy for an App-Kit-scoped token too, an app declaring `permissions.api: ["/api/computer-use"]` satisfies `app_token_path_allowed` (a bare prefix matches on the path boundary — verified), and `enable_state.save_state` deliberately bypasses `is_sensitive_path` so the operator's own panel can write a file the agent cannot. An agent able to author an app manifest could therefore read its own `.app_secret`, mint a token, and flip `enabled: true`.

Plus six correctness defects and a large body of documentation that outlived the governance model #644 removed.

## Why it matters

The keystone `computer_use.json` is the *whole* security boundary for a feature that reads every window and synthesizes input into any application. The spec says so explicitly. Both bypasses route around it: one removes the human prompt that is the last thing standing between a prompt-injected agent and a click, the other lets the agent grant itself the capability. The correctness bugs are less severe but user-visible — one made a documented happy path (`max_tree_nodes` up to 5000, "raise it for dense apps") permanently unusable in a loop the model could not escape.

## Fix (symptoms → root cause → change)

**Approval bypass.** Symptom: a write-kind call auto-approved. Root cause: a title-keyed branch sat above the semantic-kind guard, and the title is agent-controlled. Change: the mutating-kind test is hoisted above *every* title-keyed fast-path and returns `allow` (interactive approval). Equivalent for all prior cases — the old `kind not in _WRITE_TOOL_KINDS and not kind` was already redundant.

**Keystone write.** Symptom: an app token writes the enable. Root cause: no `request["app"] == ""` assertion, and the cookie check cannot separate an app from the operator. Change: `403` before the body is read, SEL-audited, matching `handlers/kiro_prerequisite.py` and `messaging.py`. The two machine routes already re-assert `internal_auth`, which an app token can never satisfy.

**`kCGEventSourceStatePrivate`.** Symptom: none visible. Root cause: the constant was `1`; Apple's `CGEventTypes.h` declares it **`-1`**, and `1` is `kCGEventSourceStateHIDSystemState` — the shared table whose live modifier state produced the measured `abc` → `' I Abc'` bug this source exists to avoid. Masked only because every path also calls `CGEventSetFlags(event, 0)`. The old test asserted the constant against itself, so it could not catch a wrong value; it now asserts the literal.

**Element indices above the config default.** Symptom: `computer_get_state(max_tree_nodes=2001)` shows element 1400, the click is refused "no element at that index", and re-snapshotting reproduces it forever. Root cause: mutating tools take no budget arguments, so both the drift walk *and* the post-action refresh were built from the 1200 default. Change: `Snapshot.walk_budget` carries the budget the walk actually used. (Writing the third test exposed the refresh-walk half, which the review had not identified.)

**Lossy ceiling round-trip.** Symptom: no rects, no `(editable)`, no focus line in any `computer_get_state`. Root cause: `_element_payload`/`_element_from_payload` enumerated 9 of `ElementRec`'s 12 fields. Change: all 12, plus a `_frame_from_payload` that rejects partial/`bool`/NaN/inf rects rather than emitting a plausible wrong rectangle. `editable` is the load-bearing loss — it is the only signal separating a writable field from a read-only one.

**`post_text` partial typing.** Symptom: "typing failed" while the app holds half the string. Root cause: per-character encode inside the posting loop; a lone surrogate raises mid-way. Change: encode up front, refuse having typed nothing.

**Overlay singleton race.** Symptom: two fighting fake cursors and a leaked child process. Root cause: `get_shared_overlay` skipped its lock claiming callers live on the event loop; its only caller is sync and runs on the 8-worker `subprocess_executor`. Change: a `threading.Lock`, matching every sibling singleton.

**Silent screenshot suppression.** Symptom: `screenshot: true` on Chrome returns no image and no reason. Root cause: `capture_macos` refuses on a truncated walk (it cannot prove the window holds no password field) but `_render_image_note` special-cased only `has_secure`. Change: `TRUNCATED_WINDOW_NOTE`, naming the remedy — **gated on `walk_budget.want_image`**, because an unconditional note inverted the bug and announced a suppression on every mutating action's refresh (caught by a reviewer on the first version of this fix).

**Security-posture blind spot.** All ten computer-use schemas were missing from the report (63 → 73). The drift test written to catch that hardcoded the same two registries the implementation did; it now discovers them.

**Doc drift.** The deleted `allow_pointer_move` (including a help string **served to the dashboard**), a `409` and a `read_only` field neither of which exists in the module, a nonexistent approval-floor clamp, `bundle_id`/`cu_action` as governance matchers (naming either raises `PlatformCompositionError` and aborts governance boot), and operator advice to narrow a `computer_use.apps` scope that was removed. `SKILL.md`'s only worked example called `computer_press_key` twice without `element_index` — a script the code refuses, shipped to every install.

Also deletes `gate.targets_axis_is_governed`: no caller, and a docstring asserting the inverse of an enforced control.

## Tests

Every regression test was verified to **fail on the pre-fix code**, not just pass on the fixed code.

| Test | Locks in |
|---|---|
| `test_hooks.py::TestMutatingKindBeatsTheTitle` | all 6 mutating kinds fall through to approval despite a CU title; genuine CU observations still auto-approve (6 fail pre-fix) |
| `test_computer_use_api.py::TestAnAppTokenCannotWriteTheKeystone` | app token → 403, keystone untouched, denial audited; dashboard user still works (3 fail pre-fix) |
| `test_computer_use_ffi.py::test_the_private_event_source_constant_is_the_value_apple_declares` | the literal `-1`, not the symbol |
| `test_computer_use_ffi.py::test_post_text_types_NOTHING_when_a_character_cannot_be_encoded` | zero `CGEventPostToPid` calls on an unencodable string |
| `test_mcp_computer.py::TestTheDriftWalkHonoursTheSnapshotBudget` | asserts the budget off the driver's own call journal — a behavioural assertion passed while the refresh walk was still wrong |
| `test_computer_use_snapshot.py::TestTheCeilingRoundTripIsLossless` | driven off `dataclasses.fields`, so a NEW field fails rather than being dropped |
| `test_computer_use_snapshot.py::TestASuppressedScreenshotAlwaysSaysSoWhy` | **both** directions (4 fail if the note is removed, 3 if the `want_image` guard is dropped), incl. one case through real `dispatch_tool` |
| `test_computer_use_overlay.py::test_the_shared_overlay_is_one_instance_under_thread_contention` | 8 real threads → 1 instance |
| `test_security_posture.py::test_every_mcp_schema_registry_is_covered_by_the_posture_view` | registries discovered, not hardcoded |
| `test_mcp_computer.py::test_no_worked_example_in_the_skill_omits_a_required_element_index` | every literal call in the shipped skill is runnable |

Secure-field floor re-verified after populating `frame`/`traits`/`focused` in the payload: a secure record still renders exactly `7 textfield <secure>` — no title, value, traits, rect or focus marker.

## Manual verification

- Apple's `CGEventTypes.h` read directly from the macOS SDK; both enum values probed live on darwin-arm64 (`CGEventSourceGetSourceStateID` returns an opaque id for `-1`, literally `1` for `1`).
- The drift loop, the round-trip loss, the false truncation note and the overlay race were each reproduced end-to-end against the packaged fake backend before fixing.
- Keystone sensitive-path floor confirmed intact (`is_sensitive_path` plus the `cat` / `>` / `tee` shell forms).
- `auto` never resolves to `click_method: "global"` — 55 related tests pass.

## Screenshots

N/A — no user-visible UI change. The only frontend edit is a corrected doc comment in `api/client.ts` (the `ComputerUseConfigData` interface body was already correct).

## Gates

`pytest` 21625 passed · `mypy` 558 files clean (CI-parity venv, no faiss) · `flake8` + `isort --check-only` clean · `scrub-lint` clean · `tsc -b` 0 · `vitest` 483 files / 5893 passed
