### PR TITLE
fix(sidebar): hide the chat sessions vertical scrollbar

### DIFF
--- a/website/scripts/capture-folder-glyph.mjs
+++ b/website/scripts/capture-folder-glyph.mjs
@@ -16,15 +16,12 @@
 import { chromium } from 'playwright'
 import { mkdirSync } from 'node:fs'
 import { serveDist } from './lib/serve-dist.mjs'
+import { logPageProblems, stubDashboardApi } from './lib/stub-dashboard-api.mjs'
 
 const OUT = process.argv[2] || '../temp-screenshots/folder-glyph'
 const PREFIX = process.argv[3] || 'after'
 
 mkdirSync(OUT, { recursive: true })
-
-const json = (route, body, status = 200) => route.fulfill({
-  status, contentType: 'application/json', body: JSON.stringify(body),
-})
 
 // f1 carries a nested subtree (depth 2 and 3) so the "New chat in folder"
 // alignment can be judged at every indent level, not just the root folder.
@@ -66,43 +63,10 @@ async function main() {
   })
   const page = await context.newPage()
 
-  await page.routeWebSocket(/\/api\/ws/, () => {})
-
-  await page.route('**/api/**', async route => {
-    const path = new URL(route.request().url()).pathname
-    if (path === '/api/kiro-prerequisite') {
-      return json(route, {
-        platform: 'darwin', installed: true, authenticated: true, ready: true,
-        initial_setup_complete: true, can_auto_install: false, can_login: false,
-        repair_required: false, docs_url: '', setup_allowed: false,
-        operation: { kind: '', status: 'idle', message: '', detail: '', url: '', error: '' },
-      })
-    }
-    if (path === '/api/chat/folders') return json(route, folders)
-    if (path === '/api/chat/slots') return json(route, slots)
-    if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
-    if (path === '/api/status') return json(route, { sessions: slots.length, crons: 0, lessons: 0, uptime: 120, version: '0.5.0' })
-    if (path === '/api/notifications') return json(route, { notifications: [], unread: 0 })
-    if (path === '/api/auth/me') return json(route, { user: 'owner', app: '' })
-    if (path === '/api/themes') return json(route, { themes: [], installed: [] })
-    if (path === '/api/theme/boot') return json(route, { mode: 'dark', theme: '' })
-    if (path === '/api/dashboard/branding') return json(route, { bot_name: 'Kiro', avatar: '' })
-    if (path === '/api/recent-projects') return json(route, { dirs: [] })
-    if (path === '/api/dashboard/config') return json(route, { restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more' })
-    if (path === '/api/agents' || path === '/api/chat/agents') return json(route, [{ name: 'kirocrew', source: 'builtin' }, { name: 'oncall', source: 'aim' }])
-    const objectish = /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
-    if (objectish) return json(route, {})
-    return json(route, [])
-  })
-
-  page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 300)))
-  page.on('console', msg => { if (msg.type() === 'error') console.log('CONSOLE:', msg.text().slice(0, 300)) })
-
-  await page.addInitScript(() => {
-    localStorage.clear()
-    localStorage.setItem('mc-theme', 'dark')
-    localStorage.setItem('mc-onboarded', '1')
-  })
+  // Boot fixtures live in lib/stub-dashboard-api.mjs — shared by every
+  // harness so a new boot endpoint is one edit, not one per script.
+  await stubDashboardApi(page, { folders, slots })
+  logPageProblems(page)
 
   await page.goto(base + '/chat', { waitUntil: 'domcontentloaded' })
   await page.waitForTimeout(2600)

--- a/website/scripts/capture-sidebar-scrollbar.mjs
+++ b/website/scripts/capture-sidebar-scrollbar.mjs
@@ -1,0 +1,138 @@
+/**
+ * Screenshot + measurement harness for the chat sidebar's vertical scrollbar.
+ *
+ * Runs the REAL built SPA (website/dist) behind a tiny in-process static server
+ * and answers every /api/** call from fixtures via Playwright route interception
+ * (gateway-free — no kiro-cli, no live backend). Seeds enough root sessions to
+ * guarantee the session lane overflows, because the whole point of the change is
+ * only visible while the lane is scrollable.
+ *
+ * Screenshots alone are weak evidence here: the change REMOVES a 6px stripe, and
+ * "I don't see it" is not proof. Worse, they are NO evidence at all in headless
+ * — measured 2026-07-30, the before/after PNGs come out BYTE-IDENTICAL because
+ * headless Chromium uses macOS overlay scrollbars, which take no layout space
+ * and are not painted at rest. `--disable-features=OverlayScrollbar` does not
+ * change that. A real Electron/browser window does render the custom 6px bar
+ * from ::-webkit-scrollbar in index.css (see the 6px inset comment in
+ * ChatPage.tsx), so this harness under-reports the real UI.
+ *
+ * What it CAN prove, and what the probe below reports:
+ *   - the computed `scrollbar-width` on the exact lane element (auto -> none),
+ *   - that the lane is still genuinely scrollable (scrollHeight > clientHeight),
+ *     so a "hidden" result that came from killing the overflow cannot pass,
+ *   - that a driven scroll still moves it (scrollTop honoured).
+ * Treat the PNG as a layout confidence check only, never as the scrollbar verdict.
+ *
+ * Usage: node scripts/capture-sidebar-scrollbar.mjs [outDir] [prefix]
+ *   Run against the branch (after) and against a main build (before).
+ */
+import { chromium } from 'playwright'
+import { mkdirSync } from 'node:fs'
+import { serveDist } from './lib/serve-dist.mjs'
+import { logPageProblems, stubDashboardApi } from './lib/stub-dashboard-api.mjs'
+
+const OUT = process.argv[2] || '../temp-screenshots/sidebar-scrollbar'
+const PREFIX = process.argv[3] || 'after'
+
+mkdirSync(OUT, { recursive: true })
+
+// No folders: exercise the default single-lane layout, which is the surface the
+// report was about ("the chat sessions side bar").
+const folders = []
+
+const TITLES = [
+  'Sidebar scrollbar', 'Auto-update install flow', 'Tips Kit T1 analyzer',
+  'StyledSelect retirement', 'App Store revamp', 'Linux CDN links',
+  'Notification bridge RFC', 'Weixin QR render fix', 'i18n missing keys',
+  'Subagent resumability', 'Folder glyph collapse', 'ShipIt swap race',
+  'Model switch in place', 'Diagnostics collector', 'Release runbook SOP',
+  'Channel dispatch pipeline', 'Workspace mount', 'Memory governor',
+  'Notarize manifest', 'Nav animation polish', 'PEP 503 index', 'CLI installer',
+  'Cost formatting', 'Version bump lane', 'UX review lane', 'Frontend skill',
+]
+
+// 26 root sessions at ~34px a row overflows the lane at any sane window height.
+const slots = TITLES.map((title, i) => ({
+  key: `s${i + 1}`,
+  title,
+  messages: 4,
+  running: false,
+  agent: 'kirocrew',
+  created: '2026-07-20T01:00:00Z',
+  last_ts: new Date(Date.parse('2026-07-29T21:00:00Z') - i * 3600_000).toISOString(),
+  folder_id: '',
+}))
+
+async function main() {
+  const { srv, base } = await serveDist()
+  // Kept as a best-effort attempt to get classic, always-visible scrollbars in
+  // headless. Measured 2026-07-30: it does NOT work — the gutter stays 0 and the
+  // frames stay byte-identical. Left in (harmless) with this note so the next
+  // person does not spend the same hour rediscovering it; use the computed
+  // scrollbar-width from the probe as the verdict instead of the pixels.
+  const browser = await chromium.launch({ args: ['--disable-features=OverlayScrollbar'] })
+  const context = await browser.newContext({
+    viewport: { width: 1400, height: 900 },
+    deviceScaleFactor: 2, // 12-13px sidebar type renders soft at 1x on GitHub
+  })
+  const page = await context.newPage()
+
+  // Boot fixtures live in lib/stub-dashboard-api.mjs — shared by every
+  // harness so a new boot endpoint is one edit, not one per script.
+  await stubDashboardApi(page, { folders, slots })
+  logPageProblems(page)
+
+  await page.goto(base + '/chat', { waitUntil: 'domcontentloaded' })
+  await page.waitForTimeout(2600)
+
+  // The session lane is the nearest ancestor of a rendered session row whose
+  // COMPUTED overflow-y actually scrolls. Selecting on computed overflow rather
+  // than on a class keeps the probe independent of the classes under test — and
+  // rather than on "scrollHeight > clientHeight", which also matches an
+  // overflow-hidden wrapper that reports overflow but cannot scroll.
+  const probe = await page.evaluate(async () => {
+    const row = document.querySelector('[data-slot-key="s1"]')
+    if (!row) return { error: 'no session rows rendered' }
+    let lane = row.parentElement
+    while (lane) {
+      const oy = getComputedStyle(lane).overflowY
+      if ((oy === 'auto' || oy === 'scroll') && lane.scrollHeight > lane.clientHeight) break
+      lane = lane.parentElement
+    }
+    if (!lane) return { error: 'no scrollable ancestor found' }
+
+    const result = {
+      gutterPx: lane.offsetWidth - lane.clientWidth,
+      scrollable: lane.scrollHeight > lane.clientHeight,
+      scrollHeight: lane.scrollHeight,
+      clientHeight: lane.clientHeight,
+      computedScrollbarWidth: getComputedStyle(lane).scrollbarWidth,
+      laneClass: lane.className,
+    }
+
+    // Scrolling must still work — hiding the bar is cosmetic only.
+    lane.scrollTop = 200
+    await new Promise(r => requestAnimationFrame(r))
+    result.scrollTopAfterScroll = lane.scrollTop
+    lane.scrollTop = 0
+
+    lane.setAttribute('data-scrollbar-probe', '1')
+    return result
+  })
+  console.log(`PROBE ${PREFIX}`, JSON.stringify(probe))
+
+  const lane = page.locator('[data-scrollbar-probe="1"]')
+  const box = (await lane.count()) ? await lane.first().boundingBox() : null
+  // Frame the lane plus ~10px of slack on each side so the right edge — where
+  // the scrollbar track would sit — is unambiguously in shot.
+  const clip = box
+    ? { x: Math.max(0, box.x - 10), y: box.y, width: box.width + 20, height: Math.min(box.height, 760) }
+    : { x: 470, y: 118, width: 380, height: 760 }
+  await page.screenshot({ path: `${OUT}/${PREFIX}-01-session-lane.png`, clip })
+  console.log('wrote', `${OUT}/${PREFIX}-01-session-lane.png`)
+
+  await browser.close()
+  srv.close()
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/website/scripts/lib/serve-dist.mjs
+++ b/website/scripts/lib/serve-dist.mjs
@@ -8,7 +8,7 @@
  */
 import { readFileSync, existsSync, statSync } from 'node:fs'
 import { createServer } from 'node:http'
-import { join, extname } from 'node:path'
+import { join, extname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 // fileURLToPath, not URL.pathname: on Windows .pathname yields "/C:/…", which
@@ -26,16 +26,32 @@ export const MIME = {
  * @returns {Promise<{srv: import('node:http').Server, base: string}>}
  */
 export function serveDist(dist = DEFAULT_DIST) {
-  return new Promise(resolve => {
+  // Resolved once so the per-request containment test compares two absolute,
+  // normalized paths (a trailing-slash dist would otherwise fail the prefix).
+  const root = resolve(dist)
+  return new Promise(resolve_ => {
     const srv = createServer((req, res) => {
-      // new URL() normalizes away ".." segments before the join, so a crafted
-      // request cannot escape dist.
-      const rel = decodeURIComponent(new URL(req.url, 'http://x').pathname).replace(/^\/+/, '')
-      let file = join(dist, rel)
-      if (!rel || !existsSync(file) || statSync(file).isDirectory()) file = join(dist, 'index.html')
+      // Decode FIRST, then containment-check the resolved path. new URL()
+      // normalizes literal ".." segments, but it runs BEFORE decoding, so an
+      // encoded "%2e%2e%2f" survives normalization and only becomes "../" at
+      // decodeURIComponent — which is why normalization alone is not a defence.
+      // resolve() + a prefix test on the real dist root is.
+      let rel
+      try {
+        rel = decodeURIComponent(new URL(req.url, 'http://x').pathname).replace(/^\/+/, '')
+      } catch {
+        // Malformed percent-escapes throw; treat as a bad request rather than
+        // crashing the harness mid-capture.
+        res.writeHead(400); res.end('bad request'); return
+      }
+      let file = resolve(root, rel)
+      if (file !== root && !file.startsWith(root + sep)) {
+        res.writeHead(403); res.end('forbidden'); return
+      }
+      if (!rel || !existsSync(file) || statSync(file).isDirectory()) file = join(root, 'index.html')
       res.writeHead(200, { 'Content-Type': MIME[extname(file)] || 'application/octet-stream' })
       res.end(readFileSync(file))
     })
-    srv.listen(0, '127.0.0.1', () => resolve({ srv, base: `http://127.0.0.1:${srv.address().port}` }))
+    srv.listen(0, '127.0.0.1', () => resolve_({ srv, base: `http://127.0.0.1:${srv.address().port}` }))
   })
 }

--- a/website/scripts/lib/stub-dashboard-api.mjs
+++ b/website/scripts/lib/stub-dashboard-api.mjs
@@ -1,0 +1,99 @@
+/**
+ * Shared /api/** fixture stub for the screenshot harnesses in this folder.
+ *
+ * Every harness runs the REAL built SPA gateway-free, which means every harness
+ * needs the same ~25 endpoint stubs just to get the dashboard to boot: the
+ * prerequisite gate, theme/branding, auth, status, notifications. Only the
+ * folders and slots differ per harness, so keeping the boot fixtures here means
+ * one copy instead of one per capture script (jscpd flags the duplication, and
+ * more importantly a new endpoint added to the boot path had to be patched into
+ * every script by hand).
+ *
+ * `extra` lets a harness override or add a route without forking the whole map:
+ * it is consulted FIRST, and returning a truthy value from a handler marks the
+ * request handled.
+ */
+
+/** Fulfil a Playwright route with a JSON body. */
+export const json = (route, body, status = 200) => route.fulfill({
+  status, contentType: 'application/json', body: JSON.stringify(body),
+})
+
+/**
+ * Install the gateway-free API stub on a page.
+ *
+ * @param {import('playwright').Page} page
+ * @param {{
+ *   folders?: unknown[],
+ *   slots?: unknown[],
+ *   theme?: string,
+ *   botName?: string,
+ *   extra?: (path: string, route: import('playwright').Route) => unknown,
+ * }} opts
+ */
+export async function stubDashboardApi(page, opts = {}) {
+  const {
+    folders = [],
+    slots = [],
+    theme = 'dark',
+    botName = 'Kiro',
+    extra = null,
+  } = opts
+
+  // Swallow the dashboard's websocket so it does not retry-storm with no gateway.
+  await page.routeWebSocket(/\/api\/ws/, () => {})
+
+  await page.route('**/api/**', async route => {
+    const path = new URL(route.request().url()).pathname
+
+    if (extra && (await extra(path, route))) return
+
+    if (path === '/api/kiro-prerequisite') {
+      return json(route, {
+        platform: 'darwin', installed: true, authenticated: true, ready: true,
+        initial_setup_complete: true, can_auto_install: false, can_login: false,
+        repair_required: false, docs_url: '', setup_allowed: false,
+        operation: { kind: '', status: 'idle', message: '', detail: '', url: '', error: '' },
+      })
+    }
+    if (path === '/api/chat/folders') return json(route, folders)
+    if (path === '/api/chat/slots') return json(route, slots)
+    if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
+    if (path === '/api/status') {
+      return json(route, { sessions: slots.length, crons: 0, lessons: 0, uptime: 120, version: '0.5.0' })
+    }
+    if (path === '/api/notifications') return json(route, { notifications: [], unread: 0 })
+    if (path === '/api/auth/me') return json(route, { user: 'owner', app: '' })
+    if (path === '/api/themes') return json(route, { themes: [], installed: [] })
+    if (path === '/api/theme/boot') return json(route, { mode: theme, theme: '' })
+    if (path === '/api/dashboard/branding') return json(route, { bot_name: botName, avatar: '' })
+    if (path === '/api/recent-projects') return json(route, { dirs: [] })
+    if (path === '/api/dashboard/config') {
+      return json(route, {
+        restore_sessions: false, restore_window_minutes: 30,
+        merge_queued_messages: false, widget_density: 'more',
+      })
+    }
+    if (path === '/api/agents' || path === '/api/chat/agents') {
+      return json(route, [{ name: 'kirocrew', source: 'builtin' }, { name: 'oncall', source: 'aim' }])
+    }
+    // Endpoints not worth naming individually: anything object-shaped gets {},
+    // everything else gets []. Guessing wrong only costs an empty panel.
+    const objectish = /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
+    return json(route, objectish ? {} : [])
+  })
+
+  await page.addInitScript(([themeMode]) => {
+    localStorage.clear()
+    localStorage.setItem('mc-theme', themeMode)
+    localStorage.setItem('mc-onboarded', '1')
+  }, [theme])
+}
+
+/** Surface page errors + console errors on stdout so a broken capture is obvious. */
+export function logPageProblems(page) {
+  page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 300)))
+  page.on('console', msg => {
+    if (msg.type() === 'error') console.log('CONSOLE:', msg.text().slice(0, 300))
+  })
+}

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -3081,7 +3081,7 @@ function ChatSidebar({
           // tree, no DnD. Takes precedence over the tag-columns layout.
           // Inactive without folders (the toggle is hidden then too), so a
           // persisted flat preference can never strand the user.
-          <motion.div layoutScroll className="flex-1 min-h-0 overflow-y-auto p-2 flex flex-col" data-testid="flat-view-lane">
+          <motion.div layoutScroll className="flex-1 min-h-0 overflow-y-auto scrollbar-none p-2 flex flex-col" style={{ scrollbarWidth: 'none' }} data-testid="flat-view-lane">
             {(() => {
               // Date segments (Today / Yesterday / Last 7 Days / …) between
               // rows — resurrects the 9bb0f71 active-list pattern: only for
@@ -3129,7 +3129,14 @@ function ChatSidebar({
           </motion.div>
         ) : orderedColumns.length === 0 ? (
           // Legacy single-lane layout (identical to pre-columns behavior)
-          <motion.div layoutScroll className="flex-1 min-h-0 overflow-y-auto p-2 flex flex-col">
+          // Scrollbar hidden (scrollbar-none + inline scrollbarWidth covers
+          // Firefox, modern WebKit, and Safari <16) to match the app rail in
+          // App.tsx: on macOS with "always show scrollbars" this lane is
+          // permanently scrollable, so the 6px track was a fixed stripe down
+          // the sidebar rather than a transient hint. Scrolling itself is
+          // untouched — wheel, trackpad, keyboard, and drag-autoscroll all
+          // still work, and the list's own overflow is still the affordance.
+          <motion.div layoutScroll className="flex-1 min-h-0 overflow-y-auto scrollbar-none p-2 flex flex-col" style={{ scrollbarWidth: 'none' }}>
             {/* One DndContext owns folder reorder (sortable) + session drag-to-
              *  assign (draggable rows + droppable folder/root targets). */}
             <DndContext sensors={dndSensors} collisionDetection={sidebarCollision}
@@ -3358,7 +3365,7 @@ function ChatSidebar({
                     </div>,
                     document.body
                   )}
-                  <div className="flex-1 overflow-y-auto p-1.5 flex flex-col">
+                  <div className="flex-1 overflow-y-auto scrollbar-none p-1.5 flex flex-col" style={{ scrollbarWidth: 'none' }}>
                     {/* No onDrop here: folder assignment only changes via folder-header drop.
                         Cross-column drops are handled by the OUTER column onDrop
                         (which only mutates status tags, keeping folder_id intact). */}
@@ -3489,7 +3496,9 @@ function ChatSidebar({
                 )}
               </div>
             </div>
-            <div className="overflow-y-auto p-2 scroll-shadow" style={{ height: `${historyHeight}px` }}>
+            {/* scroll-shadow already fades the top/bottom edge as its
+             *  scrollability cue, so the bar itself is redundant here. */}
+            <div className="overflow-y-auto scrollbar-none p-2 scroll-shadow" style={{ height: `${historyHeight}px`, scrollbarWidth: 'none' }}>
               {(() => {
                 const filteredHistory = (historySearchResults ?? history).filter(s => {
                   if (!historyFilter) return true

--- a/website/src/test/ChatSidebar.scrollbar.test.tsx
+++ b/website/src/test/ChatSidebar.scrollbar.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * The chat sidebar's session lanes must not paint a vertical scrollbar.
+ *
+ * Why this is a test and not just a class in the JSX: the lane is permanently
+ * scrollable once a user has more than a screenful of sessions, so the 6px
+ * ::-webkit-scrollbar track from index.css reads as a fixed stripe down the
+ * sidebar rather than a transient hint. It is easy to lose the hiding again
+ * while editing that long className, and nothing else would fail.
+ *
+ * Both halves of the mechanism are asserted, because they cover different
+ * engines and only one of them is visible to jsdom:
+ *   - `scrollbar-none` (class)      -> ::-webkit-scrollbar{display:none}, WebKit
+ *   - inline `scrollbarWidth:none`  -> Firefox + Safari <16
+ * The class is checked by NAME rather than by computed style on purpose: jsdom
+ * does not load index.css, so a computed-style assertion here would be vacuous.
+ * Real rendering is verified separately by scripts/capture-sidebar-scrollbar.mjs.
+ *
+ * Lanes are located structurally — from a rendered session row up to its scroll
+ * parent — so the test cannot be satisfied by a scrollbar-none that landed on
+ * some unrelated container.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import type { ChatFolder } from '../types'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+// `style` must survive the strip — it carries the assertion under test.
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+// Legacy single-lane list (no tag columns) keeps the rows flat + easy to query.
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+const FOLDERS: ChatFolder[] = [{ id: 'f1', name: 'Alpha', order: 0 }]
+
+const mocks = vi.hoisted(() => ({ folders: [] as unknown[] }))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: (_t, p: string) => {
+      if (p === 'chatFolders') return vi.fn().mockImplementation(() => Promise.resolve(mocks.folders))
+      return vi.fn().mockResolvedValue([])
+    },
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+const SLOTS = [
+  { key: 'k-alpha', title: 'In Alpha', messages: 1, running: false, folder_id: 'f1', modified: 1000 },
+  { key: 'k-root', title: 'Unfoldered', messages: 1, running: false, modified: 2000 },
+]
+
+function renderSidebar() {
+  mocks.folders = FOLDERS
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots: SLOTS, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: { activeSlot: null, slotStatusDetail: {}, subagents: {}, slotActivity: {} } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], FOLDERS)
+  return render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={SLOTS as any} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+}
+
+/** Walk up from a session row to the lane that owns the vertical scroll. */
+function laneFor(row: Element | null): HTMLElement {
+  expect(row).toBeTruthy()
+  let el = row!.parentElement
+  while (el && !el.className.includes('overflow-y-auto')) el = el.parentElement
+  expect(el).toBeTruthy()
+  return el as HTMLElement
+}
+
+function expectScrollbarHidden(lane: HTMLElement) {
+  expect(lane.className).toContain('scrollbar-none')
+  expect(lane.style.scrollbarWidth).toBe('none')
+  // The lane must still SCROLL — hiding the bar is cosmetic, and removing the
+  // overflow would also "hide" it while breaking access to the list.
+  expect(lane.className).toContain('overflow-y-auto')
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('chat sidebar — vertical scrollbar is hidden', () => {
+  it('hides it on the default folder-tree lane', () => {
+    const { container } = renderSidebar()
+    expectScrollbarHidden(laneFor(container.querySelector('[data-slot-key="k-root"]')))
+  })
+
+  it('hides it on the flat view lane', () => {
+    const { getByTestId } = renderSidebar()
+    fireEvent.click(getByTestId('flat-view-toggle'))
+    const lane = getByTestId('flat-view-lane')
+    expectScrollbarHidden(lane)
+    // Confirm this really is the lane holding the rows, not an empty shell.
+    expect(lane.querySelectorAll('[data-slot-key]').length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Problem

The chat sessions sidebar shows a permanent vertical scrollbar. Once you have
more than a screenful of sessions the lane is *always* scrollable, so the 6px
`::-webkit-scrollbar` track from `index.css` is not a transient hint — it is a
fixed grey stripe running down the side of the session list for the entire time
the app is open.

## Why it matters

The sidebar is the most-looked-at surface in the dashboard, and this is the only
scrolling surface in the shell that still paints a bar. The app rail in `App.tsx`
and every issue-radar panel already hide theirs, so the session lanes read as an
unfinished edge next to them. It also steals 6px of width from session titles,
which are already truncated (`ChatPage.tsx` carries a comment compensating for
exactly this inset).

## Fix (symptom → root cause → change)

**Symptom:** a stripe down the sidebar.
**Root cause:** the sidebar's scroll containers were never opted out of the
global 6px scrollbar styling, unlike the sibling surfaces.
**Change:** apply the established two-part mechanism used by `App.tsx` — the
`scrollbar-none` class (`::-webkit-scrollbar{display:none}`, WebKit) plus an
inline `scrollbarWidth: 'none'` (Firefox and Safari <16) — to all four scroll
containers in the sidebar:

| Container | Notes |
|---|---|
| Folder-tree lane (default) | |
| Flat-view lane | |
| Per-column body | tag-columns layout |
| Older-sessions history panel | already fades its edges via `scroll-shadow`, so the bar was redundant |

`overflow-y-auto` stays on every lane, so scrolling is untouched: wheel,
trackpad, keyboard, and drag-autoscroll all still work.

### Also in this PR: a path traversal in the screenshot harnesses' static server

Surfaced by local review while adding a capture harness here, in the shared
`website/scripts/lib/serve-dist.mjs` used by ~11 existing harnesses. Its guard
reasoned that `new URL()` normalizes `..` away before the join. That is true, but
**normalization runs before `decodeURIComponent`**, so an encoded `%2e%2e%2f`
survives it and only becomes `../` after decoding.

Measured against the previous code:

| Request | Before | After |
|---|---|---|
| `/%2e%2e%2fpackage.json` | **200**, 5103 bytes — the real `website/package.json` | 403 |
| `/%2e%2e%2f%2e%2e%2fpackage.json` | 200 | 403 |
| `/%zz` (malformed escape) | unhandled `URIError`, harness dies mid-capture | 400 |
| `/` and `/settings` | 200 | 200 (unchanged) |

The path is now decoded first, then containment-checked against a `resolve()`d
dist root. Impact was bounded — loopback bind, ephemeral port, alive only while a
developer runs a capture script — but it was reachable and the fix is two lines.

## Tests

- `website/src/test/ChatSidebar.scrollbar.test.tsx` (new, 2 cases) locks the
  hidden-scrollbar contract on the folder-tree lane and the flat-view lane. It
  asserts **both** halves of the mechanism (class *and* inline style) because
  they cover different engines, locates each lane **structurally** — from a
  rendered session row up to its scroll parent — so it cannot be satisfied by a
  `scrollbar-none` that landed on an unrelated container, and asserts
  `overflow-y-auto` is still present so "hidden by removing the overflow" fails.
- The class is checked by name, not computed style, on purpose: jsdom does not
  load `index.css`, so a computed-style assertion would be vacuous. Noted in the
  file so nobody "upgrades" it into a false guarantee.
- Full frontend suite: **484 files, 5895 passed**, 3 pre-existing skips. `tsc -b`
  and the production build clean; eslint clean apart from pre-existing warnings
  in `ChatSidebar.tsx`.

## Manual verification

The traversal fix was verified by driving real requests at the server before and
after — the table above is measured output, not inference. No automated test
accompanies it: `website/scripts/**` is outside vitest's `include`
(`src/**`, `integration/**`), and a test placed under `src/` cannot import the
helper because vite rewrites `import.meta.url` to an `http` URL, so the module's
top-level `fileURLToPath` throws at import time. Bending the helper to suit the
test harness was not worth it for a dev-only script.

`scripts/capture-sidebar-scrollbar.mjs` (new) runs the real built SPA
gateway-free and reports, on the exact lane element: computed `scrollbar-width`
`auto` → `none`, the lane still scrollable (`scrollHeight` 1305 vs `clientHeight`
713), and a driven scroll still honoured (`scrollTop` 200).

## Screenshots

**Deliberately omitted, and this is worth reading rather than assuming an
oversight.** This change *removes* a 6px stripe, and I could not produce a frame
that shows it. Headless Chromium uses macOS overlay scrollbars: they occupy no
layout space and are not painted at rest, so the before and after captures came
out **byte-identical** (same SHA-1). `--disable-features=OverlayScrollbar` does
not change that; the gutter stays 0 either way. A real Electron window does paint
the custom bar, so the harness under-reports the actual UI.

Rather than attach two identical PNGs as if they demonstrated something, the
evidence here is the computed-style probe above. Both facts are recorded in the
harness header so the next person does not spend the same hour rediscovering
them. Reviewers wanting to see it should scroll the sidebar in a local build.
