### PR TITLE
feat(dashboard): collapse turn-recovery injections to a one-line card

### DIFF
--- a/test/test_recovery_card_parity.py
+++ b/test/test_recovery_card_parity.py
@@ -1,0 +1,50 @@
+"""The dashboard's RecoveryCard detects recovery rows by content prefix.
+
+Recovery continuations are appended as plain ``inject`` rows whose meta is a CSS
+class string, so the only signal the frontend has is the literal prefix text.
+If a prefix constant changes here without the TSX changing too, the card
+silently stops rendering and the raw machine-facing prompt reappears as a
+full-width bubble -- a regression with no test failure anywhere else.
+"""
+
+from pathlib import Path
+
+from kiro_crew.dashboard.state import (
+    REFUSAL_RECOVERY_PREFIX,
+    STALE_RECOVERY_PREFIX,
+    TOOL_STALL_RECOVERY_PREFIX,
+)
+
+_CARD = (
+    Path(__file__).resolve().parents[1]
+    / "website"
+    / "src"
+    / "pages"
+    / "chat"
+    / "RecoveryCard.tsx"
+)
+
+
+def test_recovery_prefixes_present_in_frontend_card() -> None:
+    source = _CARD.read_text(encoding="utf-8")
+    for prefix in (
+        REFUSAL_RECOVERY_PREFIX,
+        STALE_RECOVERY_PREFIX,
+        TOOL_STALL_RECOVERY_PREFIX,
+    ):
+        assert prefix in source, f"RecoveryCard.tsx is missing the prefix {prefix!r}"
+
+
+def test_refusal_body_shape_matches_card_parsing() -> None:
+    """The card counts blocked items by a ``- `` bullet and reads the deny
+    pattern out of ``Blocked by security policy: <pattern>``. Both come from
+    build_refusal_recovery_prompt plus the host gate's reason string, so pin the
+    shape the card relies on."""
+    from kiro_crew.dashboard.state import build_refusal_recovery_prompt
+
+    body = build_refusal_recovery_prompt(
+        [("Running: mypy src/…", "Blocked by security policy: .*env.*grep.*AWS.*")]
+    )
+    bullets = [ln for ln in body.splitlines() if ln.strip().startswith("- ")]
+    assert len(bullets) == 1
+    assert "Blocked by security policy: .*env.*grep.*AWS.*" in body

--- a/website/scripts/capture-recovery-card.mjs
+++ b/website/scripts/capture-recovery-card.mjs
@@ -1,0 +1,172 @@
+/**
+ * Screenshot harness for the in-transcript recovery card.
+ *
+ * Runs the REAL built SPA (website/dist) against a static file server with every
+ * /api/** call and the /api/ws websocket answered from fixtures. No gateway, no
+ * token, no agent. The client code is unmodified — only the network is stubbed —
+ * so the transcript, its virtualizer and the card render exactly as in
+ * production.
+ *
+ * The fixture transcript carries one row of each recovery kind (tool refusal,
+ * stalled turn, stalled tool) using the verbatim prefixes the gateway prepends,
+ * so the shots prove the prefix detection as well as the layout.
+ *
+ * Usage: node scripts/capture-recovery-card.mjs [outDir]
+ */
+import { chromium } from 'playwright'
+import { mkdirSync } from 'node:fs'
+import { serveDist } from './lib/serve-dist.mjs'
+import { json, makeFixedApi, handleBootRoute } from './lib/boot-api.mjs'
+
+const OUT = process.argv[2] || '../temp-screenshots/recovery-card'
+const SLOT = 'chat-recovery'
+const PROJECT = '/home/user/workspace/KiroCrew'
+
+mkdirSync(OUT, { recursive: true })
+
+const REFUSAL = '[Tool refusal — automatic recovery]'
+const STALLED = '[Stalled turn — automatic recovery]'
+const TOOL_STALL = '[Tool stall — automatic recovery]'
+
+const refusalBody = [
+  REFUSAL,
+  'One or more tool calls in your previous turn were blocked by a KiroCrew safety policy, which ended the turn early. This was NOT a user action — do not treat it as a cancellation or interruption by the user.',
+  '',
+  'Blocked:',
+  '  - Running: echo "== mypy =="; .venv/bin/mypy src/kiro_crew/config/loader.py src/kiro_crew/dashboard/handlers/core.py 2>&1 | tail -15; echo "== regenerate baseline =="; .venv/bin/python scripts/generate_config...: Blocked by security policy: .*env.*grep.*AWS.*',
+  '',
+  'Decide how to proceed: use an allowed alternative (for a shell command, a read-only variant), a different tool, or — if the block is correct and you genuinely cannot proceed — say so and stop. Otherwise continue the task where you left off.',
+].join('\n')
+
+const t0 = Date.now() / 1000 - 900
+const slots = [{
+  key: SLOT,
+  title: 'Verify the config loader change',
+  running: false,
+  last_message: 'Continuing the remaining verification.',
+  messages: 7,
+  agent: 'kirocrew',
+  memory_mode: 'persistent',
+  project: PROJECT,
+  modified: Math.floor(Date.now() / 1000),
+  source_links: [],
+  source_links_total: 0,
+}]
+
+const detail = {
+  running: false,
+  has_more: false,
+  total: 7,
+  queue: [],
+  project: PROJECT,
+  messages: [
+    { role: 'user', ts: t0, content: 'Run the backend gates on the changed modules and regenerate the config baseline.' },
+    { role: 'assistant', ts: t0 + 10, content: 'Running mypy on the changed modules, then regenerating the schema baseline.' },
+    { role: 'inject', ts: t0 + 40, content: refusalBody, meta: {} },
+    { role: 'assistant', ts: t0 + 55, content: 'That block was a false positive from a safety pattern — my command happened to combine `.venv`, `grep`, and an aws string in one line. Re-running without the pipe.' },
+    { role: 'inject', ts: t0 + 300, content: `${STALLED}\nYour previous turn was interrupted by a system stall and has been automatically recovered. This was NOT a user action — do not treat it as a cancellation or interruption by the user. The work you already completed is preserved in the conversation above. Continue from where you left off and finish the task; do not restart it or repeat steps that already succeeded.`, meta: {} },
+    { role: 'inject', ts: t0 + 600, content: `${TOOL_STALL}\nA tool call in your previous turn stopped producing output and was cancelled by the session watchdog. This was NOT a user action. The command redirected its output to build.log — inspect the tail of that file to see how far it got before re-running anything.`, meta: {} },
+    { role: 'assistant', ts: t0 + 620, content: 'Gates are green: mypy clean on both modules and the baseline regenerated with no diff.' },
+  ],
+}
+
+const FIXED_API = makeFixedApi(PROJECT)
+
+async function main() {
+  const { srv, base } = await serveDist()
+  const browser = await chromium.launch()
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 900 },
+    // The card is dense small type (11–13px); a 1x shot renders it soft.
+    deviceScaleFactor: 2,
+  })
+  const page = await context.newPage()
+  await page.routeWebSocket(/\/api\/ws/, () => {})
+
+  const scene = { theme: 'dark' }
+
+  await page.route('**/api/**', async route => {
+    const path = new URL(route.request().url()).pathname
+    if (path === '/api/chat/slots') return json(route, slots)
+    if (path.startsWith('/api/chat/slots/')) return json(route, detail)
+    return handleBootRoute(route, path, { project: PROJECT, theme: scene.theme, fixedApi: FIXED_API })
+  })
+
+  page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 300)))
+  page.on('console', msg => {
+    if (msg.type() === 'error') console.log('CONSOLE:', msg.text().slice(0, 300))
+  })
+
+  async function load(theme = 'dark') {
+    scene.theme = theme
+    await page.addInitScript(([t, slot]) => {
+      localStorage.clear()
+      localStorage.setItem('mc-theme', t)
+      localStorage.setItem('mc-onboarded', '1')
+      localStorage.setItem('mc-active-slot-chat', slot)
+    }, [theme, SLOT])
+    await page.goto(base + '/', { waitUntil: 'domcontentloaded' })
+    await page.waitForSelector('[data-testid="recovery-card"]', { timeout: 20000 })
+    await page.waitForTimeout(600)
+  }
+
+  /**
+   * Expand the turn's reasoning pane.
+   *
+   * `inject` rows are not in TurnBlock's always-visible set, so with
+   * collapse-reasoning on they sit inside the "Worked through N steps" pane —
+   * exactly where they sit today. Open it so the shots frame the card in the
+   * position a user reads it.
+   */
+  async function expandTurn() {
+    const toggle = page.getByRole('button', { name: /Worked through \d+ steps/ })
+    if (await toggle.count()) {
+      await toggle.first().evaluate(el => el.click())
+      await page.waitForTimeout(500)
+    }
+  }
+
+  async function shot(name) {
+    await page.screenshot({ path: `${OUT}/${name}.png` })
+    console.log('wrote', `${OUT}/${name}.png`)
+  }
+
+  /**
+   * Toggle the first recovery card.
+   *
+   * The transcript is virtualized: rows are absolutely positioned and a
+   * neighbouring row's box can sit over the card, so Playwright's hit-testing
+   * click times out. Dispatching the click on the node itself still runs the
+   * real React onClick — which is what is under test here — without depending
+   * on the virtualizer's stacking.
+   */
+  async function toggleFirstCard() {
+    await page.getByTestId('recovery-card-toggle').first().evaluate(el => {
+      el.scrollIntoView({ block: 'center' })
+      el.click()
+    })
+    await page.waitForTimeout(500)
+  }
+
+  await load('dark')
+  const cards = page.getByTestId('recovery-card')
+  console.log('cards rendered:', await cards.count())
+  console.log('kinds:', await cards.evaluateAll(els => els.map(e => e.dataset.kind)))
+  console.log('titles:', await cards.evaluateAll(els => els.map(e => e.innerText.replace(/\n/g, ' | ').slice(0, 90))))
+  await expandTurn()
+  await shot('collapsed-dark')
+
+  await toggleFirstCard()
+  await shot('expanded-dark')
+
+  await load('light')
+  await expandTurn()
+  await shot('collapsed-light')
+  await toggleFirstCard()
+  await shot('expanded-light')
+
+  await browser.close()
+  srv.close()
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/website/scripts/capture-subagent-cards.mjs
+++ b/website/scripts/capture-subagent-cards.mjs
@@ -19,6 +19,7 @@
  */
 import { chromium } from 'playwright'
 import { mkdirSync } from 'node:fs'
+import { json, makeFixedApi, handleBootRoute } from './lib/boot-api.mjs'
 
 const BASE = process.argv[2] || 'http://127.0.0.1:6803'
 const OUT = process.argv[3] || '../temp-screenshots/subagent-card-header'
@@ -90,20 +91,7 @@ const DONE_CARD = {
   tool_count: 22,
 }
 
-const FIXED_API = new Map([
-  ['/api/status', { sessions: 1, crons: 0, lessons: 0, uptime: 120, version: 'dev' }],
-  ['/api/notifications', { notifications: [], unread: 0 }],
-  ['/api/auth/me', { user: 'owner', app: '' }],
-  ['/api/models', { models: [], default: 'auto' }],
-  ['/api/themes', { themes: [], installed: [] }],
-  ['/api/dashboard/branding', { bot_name: 'Kiro', avatar: '' }],
-  ['/api/recent-projects', { dirs: [PROJECT] }],
-  ['/api/chat/nav/resolve-links', { summaries: [] }],
-])
-
-const json = (route, body, status = 200) => route.fulfill({
-  status, contentType: 'application/json', body: JSON.stringify(body),
-})
+const FIXED_API = makeFixedApi(PROJECT)
 
 async function main() {
   const browser = await chromium.launch()
@@ -123,28 +111,7 @@ async function main() {
     const path = new URL(route.request().url()).pathname
     if (path === '/api/chat/slots') return json(route, slots)
     if (path.startsWith('/api/chat/slots/')) return json(route, detail)
-    // The setup gate runs BEFORE the app shell: an array-shaped stub makes it
-    // read `.operation.status` off undefined and the whole shell error-boundaries
-    // out with nothing rendered.
-    if (path.startsWith('/api/kiro-prerequisite')) {
-      return json(route, {
-        platform: 'linux', installed: true, authenticated: true, ready: true,
-        initial_setup_complete: true, can_auto_install: false, can_login: false,
-        repair_required: false, docs_url: '', setup_allowed: true,
-        operation: { kind: '', status: 'idle', message: '', detail: '', url: '', error: '' },
-      })
-    }
-    // The app shell iterates this on boot; an object-shaped stub throws inside
-    // the ErrorBoundary and nothing renders at all.
-    if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
-    // These boot fixtures are static across every scene; keeping them in a map
-    // makes this harness's route contract explicit without cloning the long
-    // condition chain used by other screenshot harnesses.
-    if (FIXED_API.has(path)) return json(route, FIXED_API.get(path))
-    if (path === '/api/theme/boot') return json(route, { mode: scene.theme, theme: '' })
-    const objectish = /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
-    if (objectish) return json(route, {})
-    return json(route, [])
+    return handleBootRoute(route, path, { project: PROJECT, theme: scene.theme, fixedApi: FIXED_API })
   })
 
   page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 300)))

--- a/website/scripts/lib/boot-api.mjs
+++ b/website/scripts/lib/boot-api.mjs
@@ -1,0 +1,57 @@
+/**
+ * Shared boot-time API fixtures for the screenshot harnesses in this folder.
+ *
+ * Every harness runs the REAL built SPA with the network stubbed, so every one
+ * of them has to answer the same set of boot calls before any scene-specific
+ * route matters. Several of those answers are shape-sensitive in ways that are
+ * not obvious (see the comments below) — keeping one copy here means a harness
+ * that renders nothing is a bug in its own fixtures, not a re-discovery of
+ * these.
+ */
+
+/** Fulfil `route` with a JSON body. */
+export const json = (route, body, status = 200) => route.fulfill({
+  status, contentType: 'application/json', body: JSON.stringify(body),
+})
+
+/** Boot fixtures that are static across every scene, keyed by pathname. */
+export function makeFixedApi(project) {
+  return new Map([
+    ['/api/status', { sessions: 1, crons: 0, lessons: 0, uptime: 120, version: 'dev' }],
+    ['/api/notifications', { notifications: [], unread: 0 }],
+    ['/api/auth/me', { user: 'owner', app: '' }],
+    ['/api/models', { models: [], default: 'auto' }],
+    ['/api/themes', { themes: [], installed: [] }],
+    ['/api/dashboard/branding', { bot_name: 'Kiro', avatar: '' }],
+    ['/api/recent-projects', { dirs: [project] }],
+    ['/api/chat/nav/resolve-links', { summaries: [] }],
+  ])
+}
+
+/**
+ * Answer every boot call a harness does not handle itself.
+ *
+ * Call this as the LAST arm of a harness's `page.route('**\/api/**')` handler,
+ * after its scene-specific routes. It always fulfils, so the route never hangs.
+ */
+export function handleBootRoute(route, path, { project, theme = 'dark', fixedApi }) {
+  const fixed = fixedApi || makeFixedApi(project)
+  // The setup gate runs BEFORE the app shell: an array-shaped stub makes it read
+  // `.operation.status` off undefined and the whole shell error-boundaries out
+  // with nothing rendered.
+  if (path.startsWith('/api/kiro-prerequisite')) {
+    return json(route, {
+      platform: 'linux', installed: true, authenticated: true, ready: true,
+      initial_setup_complete: true, can_auto_install: false, can_login: false,
+      repair_required: false, docs_url: '', setup_allowed: true,
+      operation: { kind: '', status: 'idle', message: '', detail: '', url: '', error: '' },
+    })
+  }
+  // The app shell iterates this on boot; an object-shaped stub throws inside the
+  // ErrorBoundary and nothing renders at all.
+  if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
+  if (fixed.has(path)) return json(route, fixed.get(path))
+  if (path === '/api/theme/boot') return json(route, { mode: theme, theme: '' })
+  const objectish = /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
+  return json(route, objectish ? {} : [])
+}

--- a/website/src/i18n/locales/bn.json
+++ b/website/src/i18n/locales/bn.json
@@ -2665,6 +2665,16 @@
       "nudgeCard": {
         "loop": "লুপ"
       },
+      "recoveryCard": {
+        "tool_call_blocked": "টুল কল ব্লক করা হয়েছে",
+        "n_tool_calls_blocked": "{{count}}টি টুল কল ব্লক করা হয়েছে",
+        "safety_policy_continuing": "নিরাপত্তা নীতি · স্বয়ংক্রিয়ভাবে চলছে",
+        "n_patterns": "{{count}}টি প্যাটার্ন",
+        "turn_stalled": "টার্ন থেমে গেছে",
+        "recovered_continuing": "পুনরুদ্ধার হয়েছে · চলছে",
+        "tool_stopped_responding": "টুল সাড়া দেওয়া বন্ধ করেছে",
+        "cancelled_continuing": "বাতিল · চলছে"
+      },
       "sessionColorPicker": {
         "change_your_color_palette_in_display_settings": "ডিসপ্লে সেটিংসে আপনার রঙের প্যালেট পরিবর্তন করুন",
         "no_color": "কোনো রঙ নেই",

--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -2641,6 +2641,16 @@
       "nudgeCard": {
         "loop": "Loop"
       },
+      "recoveryCard": {
+        "tool_call_blocked": "Tool call blocked",
+        "n_tool_calls_blocked": "{{count}} tool calls blocked",
+        "safety_policy_continuing": "safety policy · continuing automatically",
+        "n_patterns": "{{count}} patterns",
+        "turn_stalled": "Turn stalled",
+        "recovered_continuing": "recovered · continuing",
+        "tool_stopped_responding": "Tool stopped responding",
+        "cancelled_continuing": "cancelled · continuing"
+      },
       "sessionColorPicker": {
         "change_your_color_palette_in_display_settings": "Change your color palette in Display settings",
         "no_color": "No color",

--- a/website/src/i18n/locales/es.json
+++ b/website/src/i18n/locales/es.json
@@ -2698,6 +2698,16 @@
       "nudgeCard": {
         "loop": "Bucle"
       },
+      "recoveryCard": {
+        "tool_call_blocked": "Llamada de herramienta bloqueada",
+        "n_tool_calls_blocked": "{{count}} llamadas de herramienta bloqueadas",
+        "safety_policy_continuing": "política de seguridad · continuando automáticamente",
+        "n_patterns": "{{count}} patrones",
+        "turn_stalled": "Turno estancado",
+        "recovered_continuing": "recuperado · continuando",
+        "tool_stopped_responding": "La herramienta dejó de responder",
+        "cancelled_continuing": "cancelado · continuando"
+      },
       "sessionColorPicker": {
         "change_your_color_palette_in_display_settings": "Cambia tu paleta de colores en los ajustes de Visualización",
         "no_color": "Sin color",

--- a/website/src/i18n/locales/fr.json
+++ b/website/src/i18n/locales/fr.json
@@ -2698,6 +2698,16 @@
       "nudgeCard": {
         "loop": "Boucle"
       },
+      "recoveryCard": {
+        "tool_call_blocked": "Appel d'outil bloqué",
+        "n_tool_calls_blocked": "{{count}} appels d'outil bloqués",
+        "safety_policy_continuing": "politique de sécurité · poursuite automatique",
+        "n_patterns": "{{count}} motifs",
+        "turn_stalled": "Tour bloqué",
+        "recovered_continuing": "récupéré · poursuite",
+        "tool_stopped_responding": "L'outil ne répond plus",
+        "cancelled_continuing": "annulé · poursuite"
+      },
       "sessionColorPicker": {
         "change_your_color_palette_in_display_settings": "Modifiez votre palette de couleurs dans les paramètres d'affichage",
         "no_color": "Aucune couleur",

--- a/website/src/i18n/locales/hi.json
+++ b/website/src/i18n/locales/hi.json
@@ -2665,6 +2665,16 @@
       "nudgeCard": {
         "loop": "लूप"
       },
+      "recoveryCard": {
+        "tool_call_blocked": "टूल कॉल अवरुद्ध",
+        "n_tool_calls_blocked": "{{count}} टूल कॉल अवरुद्ध",
+        "safety_policy_continuing": "सुरक्षा नीति · स्वतः जारी",
+        "n_patterns": "{{count}} पैटर्न",
+        "turn_stalled": "टर्न रुक गया",
+        "recovered_continuing": "पुनर्प्राप्त · जारी",
+        "tool_stopped_responding": "टूल ने प्रतिक्रिया देना बंद कर दिया",
+        "cancelled_continuing": "रद्द · जारी"
+      },
       "sessionColorPicker": {
         "change_your_color_palette_in_display_settings": "अपना रंग पैलेट प्रदर्शन सेटिंग्स में बदलें",
         "no_color": "कोई रंग नहीं",

--- a/website/src/i18n/locales/pt.json
+++ b/website/src/i18n/locales/pt.json
@@ -2698,6 +2698,16 @@
       "nudgeCard": {
         "loop": "Loop"
       },
+      "recoveryCard": {
+        "tool_call_blocked": "Chamada de ferramenta bloqueada",
+        "n_tool_calls_blocked": "{{count}} chamadas de ferramenta bloqueadas",
+        "safety_policy_continuing": "política de segurança · continuando automaticamente",
+        "n_patterns": "{{count}} padrões",
+        "turn_stalled": "Turno travado",
+        "recovered_continuing": "recuperado · continuando",
+        "tool_stopped_responding": "A ferramenta parou de responder",
+        "cancelled_continuing": "cancelado · continuando"
+      },
       "sessionColorPicker": {
         "change_your_color_palette_in_display_settings": "Altere sua paleta de cores nas configurações de Exibição",
         "no_color": "Sem cor",

--- a/website/src/i18n/locales/ru.json
+++ b/website/src/i18n/locales/ru.json
@@ -2731,6 +2731,16 @@
       "nudgeCard": {
         "loop": "Цикл"
       },
+      "recoveryCard": {
+        "tool_call_blocked": "Вызов инструмента заблокирован",
+        "n_tool_calls_blocked": "Заблокировано вызовов инструментов: {{count}}",
+        "safety_policy_continuing": "политика безопасности · продолжение автоматически",
+        "n_patterns": "шаблонов: {{count}}",
+        "turn_stalled": "Ход застопорился",
+        "recovered_continuing": "восстановлено · продолжение",
+        "tool_stopped_responding": "Инструмент перестал отвечать",
+        "cancelled_continuing": "отменено · продолжение"
+      },
       "sessionColorPicker": {
         "change_your_color_palette_in_display_settings": "Измените цветовую палитру в настройках отображения",
         "no_color": "Без цвета",

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -2632,6 +2632,16 @@
       "nudgeCard": {
         "loop": "循环"
       },
+      "recoveryCard": {
+        "tool_call_blocked": "工具调用被阻止",
+        "n_tool_calls_blocked": "{{count}} 个工具调用被阻止",
+        "safety_policy_continuing": "安全策略 · 正在自动继续",
+        "n_patterns": "{{count}} 条规则",
+        "turn_stalled": "回合停滞",
+        "recovered_continuing": "已恢复 · 继续中",
+        "tool_stopped_responding": "工具停止响应",
+        "cancelled_continuing": "已取消 · 继续中"
+      },
       "sessionColorPicker": {
         "change_your_color_palette_in_display_settings": "在“显示”设置中更改你的配色方案",
         "no_color": "无颜色",

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -148,6 +148,7 @@ import TurnBlock from './chat/TurnBlock'
 import Clickable from '../components/Clickable'
 import StopEventCard from './chat/StopEventCard'
 import NudgeCard, { nudgeMatchesLoop } from './chat/NudgeCard'
+import RecoveryCard, { parseRecoveryMessage } from './chat/RecoveryCard'
 import WorkflowProgressBar from './chat/WorkflowProgressBar'
 import { tryQuickSend } from '../lib/quickSend'
 import { rewindWithRollback } from '../lib/rewindCall'
@@ -3549,6 +3550,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
       return <NudgeCard key={key} message={m} onOpenLoop={ownLoop ? () => setAutoNudgeOpen(true) : undefined} />
     }
     if (m.kind === 'stop_event' || m.meta?.kind === 'stop_event') return <StopEventCard key={m.meta?.id as string ?? key} message={m} />
+    // A synthetic turn-recovery continuation (tool refusal / stalled turn /
+    // stalled tool) is machine-facing instruction text. It stays in the
+    // transcript for auditability, but as a one-line card that names the event
+    // and the deny pattern rather than a full-width bubble of prompt prose.
+    if (m.role === 'inject') {
+      const recovery = parseRecoveryMessage(m.content)
+      if (recovery) return <RecoveryCard key={key} parsed={recovery} />
+    }
     if (m.role === 'error') return <div key={key} className="bg-danger-subtle text-danger text-[13px] px-3 py-2 rounded-md border border-danger/15 self-center animate-scale-in">{m.content}</div>
     if (m.role === 'notice') return <div key={key} className="bg-card text-muted text-[13px] px-3 py-2 rounded-md border border-border self-center animate-scale-in">{m.content}</div>
     if (m.role === 'permission') return null

--- a/website/src/pages/chat/RecoveryCard.tsx
+++ b/website/src/pages/chat/RecoveryCard.tsx
@@ -1,0 +1,164 @@
+import { memo, useState } from 'react'
+import { ChevronRight, TriangleAlert } from 'lucide-react'
+
+import { i18nT } from '../../i18n/t'
+
+/**
+ * The three synthetic-continuation prefixes the gateway prepends when it
+ * recovers a turn that ended early. Kept in sync with the constants in
+ * `src/kiro_crew/dashboard/state.py` (REFUSAL_RECOVERY_PREFIX,
+ * STALE_RECOVERY_PREFIX, TOOL_STALL_RECOVERY_PREFIX).
+ *
+ * Detection is by content prefix rather than a meta flag on purpose: the rows
+ * are appended with a plain CSS-class meta ("msg msg-inject"), and matching the
+ * text means history-restored rows written by any gateway version render as a
+ * card too.
+ */
+export type RecoveryKind = 'refusal' | 'stalled' | 'tool_stall'
+
+const PREFIXES: ReadonlyArray<[RecoveryKind, string]> = [
+  ['refusal', '[Tool refusal — automatic recovery]'],
+  ['stalled', '[Stalled turn — automatic recovery]'],
+  ['tool_stall', '[Tool stall — automatic recovery]'],
+]
+
+/** `Blocked by security policy: <pattern>` — the deny pattern that fired. */
+const POLICY_RE = /Blocked by security policy:\s*(.+?)\s*$/gm
+/** A blocked-item bullet in the refusal body (`  - <tool>: <reason>`). */
+const BULLET_RE = /^\s*-\s+\S/
+
+export interface ParsedRecovery {
+  kind: RecoveryKind
+  /** What happened, stated as fact. Never claims the recovery succeeded. */
+  title: string
+  /** Cause plus the attempt, e.g. "safety policy · continuing automatically". */
+  detail: string
+  /** Trailing chip: the deny pattern, or a count when several distinct ones fired. */
+  chip: string
+  /** The verbatim injected prompt, minus the prefix line. */
+  body: string
+}
+
+/**
+ * Parse a recovery continuation into card fields, or null when `content` is not
+ * one.
+ *
+ * Titles deliberately describe the EVENT, not an outcome. At the moment the row
+ * renders, the continuation has only just been injected — the model may adapt,
+ * or may correctly decide it cannot proceed and stop. "Recovered" would claim a
+ * result that has not happened yet, so the attempt lives in `detail` instead.
+ */
+export function parseRecoveryMessage(content: string): ParsedRecovery | null {
+  const raw = content ?? ''
+  const found = PREFIXES.find(([, prefix]) => raw.startsWith(prefix))
+  if (!found) return null
+  const [kind, prefix] = found
+  const body = raw.slice(prefix.length).trim()
+
+  if (kind === 'stalled') {
+    return {
+      kind,
+      title: i18nT('pages.chat.recoveryCard.turn_stalled'),
+      detail: i18nT('pages.chat.recoveryCard.recovered_continuing'),
+      chip: '',
+      body,
+    }
+  }
+  if (kind === 'tool_stall') {
+    return {
+      kind,
+      title: i18nT('pages.chat.recoveryCard.tool_stopped_responding'),
+      detail: i18nT('pages.chat.recoveryCard.cancelled_continuing'),
+      chip: '',
+      body,
+    }
+  }
+
+  // Refusal: count the blocked-item bullets and collect the distinct deny
+  // patterns. A turn can refuse several calls, and they need not share a cause.
+  const blocked = body.split('\n').filter(line => BULLET_RE.test(line)).length
+  const patterns = new Set<string>()
+  for (const m of body.matchAll(POLICY_RE)) patterns.add(m[1])
+  const distinct = [...patterns]
+  return {
+    kind,
+    title:
+      blocked > 1
+        ? i18nT('pages.chat.recoveryCard.n_tool_calls_blocked', { count: blocked })
+        : i18nT('pages.chat.recoveryCard.tool_call_blocked'),
+    detail: i18nT('pages.chat.recoveryCard.safety_policy_continuing'),
+    chip:
+      distinct.length === 1
+        ? distinct[0]
+        : distinct.length > 1
+          ? i18nT('pages.chat.recoveryCard.n_patterns', { count: distinct.length })
+          : '',
+    body,
+  }
+}
+
+/**
+ * Compact one-line card for an automatic turn-recovery continuation.
+ *
+ * The injected text is machine-facing instruction ("decide how to proceed…") —
+ * it belongs in the transcript for auditability but does not deserve a
+ * full-width bubble every time a deny pattern fires. Collapsed it states what
+ * happened and which pattern fired, which is the part the user acts on;
+ * expanding reveals the prompt verbatim so nothing is hidden, only folded.
+ *
+ * Expansion is per-row local state and is not persisted: the transcript is
+ * virtualized, so a scrolled-away row remounts collapsed. Same behaviour as
+ * NudgeCard.
+ */
+export default memo(function RecoveryCard({ parsed }: { parsed: ParsedRecovery }) {
+  const [expanded, setExpanded] = useState(false)
+  const { kind, title, detail, chip, body } = parsed
+
+  return (
+    <div
+      className="self-center w-full max-w-full min-w-0 rounded-md border border-border bg-card text-muted animate-scale-in"
+      data-testid="recovery-card"
+      data-kind={kind}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded(v => !v)}
+        aria-expanded={expanded}
+        // Deliberately NO aria-label: it would REPLACE the accessible name, so
+        // assistive tech would announce only "Show recovery details" and never
+        // the title, detail or deny pattern this card exists to surface — the
+        // one thing a screen-reader user would otherwise have to expand the raw
+        // machine prose to learn. The inner text names the button (matching what
+        // sighted users read) and aria-expanded carries the toggle state.
+        className="w-full flex items-center gap-1.5 px-2.5 py-1.5 min-w-0 text-left text-[13px] hover:text-fg transition-colors"
+        data-testid="recovery-card-toggle"
+      >
+        <ChevronRight
+          size={13}
+          className={`lucide-inline shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+          aria-hidden="true"
+        />
+        <TriangleAlert size={13} className="lucide-inline shrink-0 text-warning" aria-hidden="true" />
+        <span className="font-medium text-fg shrink-0">{title}</span>
+        <span className="truncate text-[12px] opacity-75 min-w-0">{detail}</span>
+        {chip && (
+          <code
+            className="ml-auto shrink-0 max-w-[45%] truncate text-[11px] px-1.5 py-0.5 rounded border border-border bg-bg-elevated font-mono"
+            data-testid="recovery-card-chip"
+          >
+            {chip}
+          </code>
+        )}
+      </button>
+      {expanded && (
+        <div
+          className="px-2.5 pb-2.5 pt-2 text-[12px] font-mono leading-relaxed whitespace-pre-wrap overflow-hidden border-t border-border"
+          style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}
+          data-testid="recovery-card-body"
+        >
+          {body}
+        </div>
+      )}
+    </div>
+  )
+})

--- a/website/src/test/RecoveryCard.test.tsx
+++ b/website/src/test/RecoveryCard.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import RecoveryCard, { parseRecoveryMessage } from '../pages/chat/RecoveryCard'
+
+// Verbatim prefixes from src/kiro_crew/dashboard/state.py. The separator is an
+// em dash, not a hyphen — a mismatch is exactly the drift this suite guards.
+const REFUSAL = '[Tool refusal — automatic recovery]'
+const STALLED = '[Stalled turn — automatic recovery]'
+const TOOL_STALL = '[Tool stall — automatic recovery]'
+
+/** A refusal body shaped the way build_refusal_recovery_prompt() emits it. */
+function refusalBody(items: string[]): string {
+  return [
+    REFUSAL,
+    'One or more tool calls in your previous turn were blocked by a KiroCrew safety policy, which ended the turn early. This was NOT a user action — do not treat it as a cancellation or interruption by the user.',
+    '',
+    'Blocked:',
+    ...items.map(i => `  - ${i}`),
+    '',
+    'Decide how to proceed: use an allowed alternative (for a shell command, a read-only variant), a different tool, or — if the block is correct and you genuinely cannot proceed — say so and stop. Otherwise continue the task where you left off.',
+  ].join('\n')
+}
+
+describe('parseRecoveryMessage', () => {
+  it('returns null for ordinary injected content', () => {
+    expect(parseRecoveryMessage('Just some injected text')).toBeNull()
+    expect(parseRecoveryMessage('')).toBeNull()
+    // A hyphen instead of an em dash is NOT a recovery row.
+    expect(parseRecoveryMessage('[Tool refusal - automatic recovery]\nbody')).toBeNull()
+  })
+
+  it('titles a single refusal as the event, not as a completed recovery', () => {
+    const p = parseRecoveryMessage(
+      refusalBody(['Running: mypy src/…: Blocked by security policy: .*env.*grep.*AWS.*']),
+    )
+    expect(p?.kind).toBe('refusal')
+    expect(p?.title).toBe('Tool call blocked')
+    // The attempt is hedged in the detail line; the title never claims success.
+    expect(p?.title).not.toMatch(/recover/i)
+    expect(p?.detail).toBe('safety policy · continuing automatically')
+  })
+
+  it('surfaces the single deny pattern as the chip', () => {
+    const p = parseRecoveryMessage(
+      refusalBody(['Running: mypy src/…: Blocked by security policy: .*env.*grep.*AWS.*']),
+    )
+    expect(p?.chip).toBe('.*env.*grep.*AWS.*')
+  })
+
+  it('counts multiple blocked calls in the title', () => {
+    const p = parseRecoveryMessage(
+      refusalBody([
+        'Running: a: Blocked by security policy: .*env.*grep.*AWS.*',
+        'Running: b: Blocked by security policy: .*env.*grep.*AWS.*',
+        'Running: c: Blocked by security policy: .*env.*grep.*AWS.*',
+      ]),
+    )
+    expect(p?.title).toBe('3 tool calls blocked')
+    // One distinct pattern across three calls still shows the pattern itself.
+    expect(p?.chip).toBe('.*env.*grep.*AWS.*')
+  })
+
+  it('collapses several distinct patterns to a count', () => {
+    const p = parseRecoveryMessage(
+      refusalBody([
+        'Running: a: Blocked by security policy: .*env.*grep.*AWS.*',
+        'Running: b: Blocked by security policy: rm -rf /.*',
+      ]),
+    )
+    expect(p?.chip).toBe('2 patterns')
+  })
+
+  it('omits the chip when the refusal carries no policy pattern', () => {
+    // The read-only bash gate refuses without naming a deny pattern.
+    const p = parseRecoveryMessage(refusalBody(['Running: git push: read-only mode']))
+    expect(p?.chip).toBe('')
+    expect(p?.title).toBe('Tool call blocked')
+  })
+
+  it('labels a stalled turn and a stalled tool distinctly', () => {
+    const stalled = parseRecoveryMessage(`${STALLED}\nYour previous turn was interrupted…`)
+    expect(stalled?.kind).toBe('stalled')
+    expect(stalled?.title).toBe('Turn stalled')
+    expect(stalled?.chip).toBe('')
+
+    const tool = parseRecoveryMessage(`${TOOL_STALL}\nA tool call stopped producing output…`)
+    expect(tool?.kind).toBe('tool_stall')
+    expect(tool?.title).toBe('Tool stopped responding')
+  })
+
+  it('strips the prefix line from the body', () => {
+    const p = parseRecoveryMessage(`${STALLED}\nYour previous turn was interrupted.`)
+    expect(p?.body).toBe('Your previous turn was interrupted.')
+    expect(p?.body.startsWith('[')).toBe(false)
+  })
+})
+
+describe('RecoveryCard', () => {
+  const parsed = parseRecoveryMessage(
+    refusalBody(['Running: mypy src/…: Blocked by security policy: .*env.*grep.*AWS.*']),
+  )!
+
+  it('renders collapsed with the title, detail and pattern chip', () => {
+    render(<RecoveryCard parsed={parsed} />)
+    expect(screen.getByTestId('recovery-card')).toHaveAttribute('data-kind', 'refusal')
+    expect(screen.getByText('Tool call blocked')).toBeInTheDocument()
+    expect(screen.getByText('safety policy · continuing automatically')).toBeInTheDocument()
+    expect(screen.getByTestId('recovery-card-chip')).toHaveTextContent('.*env.*grep.*AWS.*')
+    // The machine-facing prose is folded away until asked for.
+    expect(screen.queryByTestId('recovery-card-body')).toBeNull()
+    expect(screen.getByTestId('recovery-card-toggle')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands to the verbatim injected prompt and collapses again', async () => {
+    const user = userEvent.setup()
+    render(<RecoveryCard parsed={parsed} />)
+    const toggle = screen.getByTestId('recovery-card-toggle')
+
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    const body = screen.getByTestId('recovery-card-body')
+    expect(body).toHaveTextContent('Decide how to proceed')
+    expect(body).toHaveTextContent('Blocked:')
+
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('recovery-card-body')).toBeNull()
+  })
+
+  it('names the toggle with the card content, not a generic label', () => {
+    // An aria-label here would REPLACE the accessible name, leaving AT users
+    // with "Show recovery details" and no way to learn what was blocked without
+    // expanding the raw machine prose. Pin the announced name to the digest.
+    render(<RecoveryCard parsed={parsed} />)
+    const toggle = screen.getByTestId('recovery-card-toggle')
+    expect(toggle).not.toHaveAttribute('aria-label')
+    const name = screen.getByRole('button', { name: /Tool call blocked/ })
+    expect(name).toBe(toggle)
+    expect(toggle).toHaveAccessibleName(/safety policy/)
+    expect(toggle).toHaveAccessibleName(/env/)
+  })
+
+  it('exposes the toggle as a keyboard-reachable button', async () => {
+    const user = userEvent.setup()
+    render(<RecoveryCard parsed={parsed} />)
+    const toggle = screen.getByRole('button', { name: /Tool call blocked/ })
+    await user.tab()
+    expect(toggle).toHaveFocus()
+    await user.keyboard('{Enter}')
+    expect(screen.getByTestId('recovery-card-body')).toBeInTheDocument()
+  })
+
+  it('drops the chip for kinds that have no deny pattern', () => {
+    const stalled = parseRecoveryMessage(`${STALLED}\nInterrupted by a system stall.`)!
+    render(<RecoveryCard parsed={stalled} />)
+    expect(screen.queryByTestId('recovery-card-chip')).toBeNull()
+    expect(screen.getByTestId('recovery-card')).toHaveAttribute('data-kind', 'stalled')
+  })
+})
+
+/**
+ * ChatPage's transcript is driven by the custom virtualizer, which mounts an
+ * empty window under jsdom (no layout engine), so a full-page render produces no
+ * message DOM. These are source-contract assertions in the same style as
+ * ChatPage.mcpOAuth.test.tsx: they lock in the wiring, while the card's own
+ * behaviour is covered above.
+ */
+describe('ChatPage – recovery card wiring', () => {
+  const src = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../pages/ChatPage.tsx'), 'utf8')
+
+  it('imports the card and its parser', () => {
+    expect(src).toMatch(
+      /import\s+RecoveryCard\s*,\s*\{\s*parseRecoveryMessage\s*\}\s*from\s*['"][^'"]*RecoveryCard['"]/,
+    )
+  })
+
+  it('routes recovery inject rows to the card', () => {
+    expect(src).toMatch(/parseRecoveryMessage\s*\(\s*m\.content\s*\)/)
+    expect(src).toMatch(/<RecoveryCard\s/)
+  })
+
+  it('checks for a recovery row BEFORE the generic inject bubble renders', () => {
+    // The generic `isInject` branch paints any injected text as a full-width
+    // warning bubble. If the recovery check lands after it, the card is dead
+    // code and the raw prompt reappears — the exact regression this fixes.
+    const card = src.indexOf('parseRecoveryMessage(m.content)')
+    const generic = src.indexOf("const isInject = m.role === 'inject'")
+    expect(card).toBeGreaterThanOrEqual(0)
+    expect(generic).toBeGreaterThanOrEqual(0)
+    expect(card).toBeLessThan(generic)
+  })
+})


### PR DESCRIPTION
## Problem

An automatic turn-recovery continuation was rendered by ChatPage's generic
`inject` branch as a full-width warning bubble containing the whole
machine-facing prompt — the "NOT a user action" framing, the blocked-item list,
and the "decide how to proceed" instructions. That text is written for the
model, not the reader, and it dominated the transcript every time a deny
pattern fired.

## Change

Three prefixes now render as a compact card (`RecoveryCard`), following the
`NudgeCard` precedent for machine-facing injected text:

| Prefix | Title | Detail |
|---|---|---|
| `[Tool refusal — automatic recovery]` | Tool call blocked | safety policy · continuing automatically |
| `[Stalled turn — automatic recovery]` | Turn stalled | recovered · continuing |
| `[Tool stall — automatic recovery]` | Tool stopped responding | cancelled · continuing |

Collapsed it is one line: what happened, the cause plus the attempt, and the
deny pattern that fired. Expanding reveals the injected prompt verbatim, so
nothing is hidden — only folded.

**Titles name the event, not an outcome.** At the moment the row renders the
continuation has only just been queued; the model may adapt, or may correctly
decide it cannot proceed and stop. "Auto-recovered" would claim a result that
has not happened, so the attempt is hedged in the secondary line and the title
stays factual.

Refusals with several blocked calls read `N tool calls blocked`; several
distinct patterns collapse the chip to `N patterns`; a refusal with no policy
pattern (the read-only bash gate) drops the chip entirely.

## Design decisions worth review

- **Prefix detection, not a meta flag.** Recovery rows are appended with only a
  CSS-class meta, so there is no structured signal to read. Matching the prefix
  also means history-restored rows written by any gateway version render as a
  card. `test/test_recovery_card_parity.py` pins the three constants against
  the TSX — without it, changing a prefix (or its em dash) would silently
  restore the raw bubble with nothing failing. Revert-verified.
- **Expansion is not persisted.** The transcript is virtualized, so a
  scrolled-away row remounts collapsed. Same behaviour as `NudgeCard`.
- **Frontend-only.** No backend change; the prompt text handed to the model is
  untouched.

## Known behaviour, unchanged by this PR

`inject` rows are not in `TurnBlock`'s always-visible set, so with
collapse-reasoning on a recovery row sits inside the "Worked through N steps"
pane. That is pre-existing and this PR does not change it — the screenshots
below open the pane the way a user does. Whether a policy block should always
surface inline is a separate question.

## Evidence

Screenshot harness `website/scripts/capture-recovery-card.mjs` runs the real
built SPA with the network stubbed and one row of each recovery kind, so the
shots prove prefix detection as well as layout. Attached in the review thread:
collapsed and expanded, dark and light.

<img width="2928" height="2058" alt="Screenshot 2026-07-30 at 12 46 11@2x" src="https://github.com/user-attachments/assets/7f57284e-bfc8-40c9-aaee-ac22f19fc592" />


## Verification

- `vitest run --coverage`: 484 files, 5902 passed / 3 skipped (15 new tests in
  `RecoveryCard.test.tsx`, covering parsing, all three kinds, multi-block
  counting, chip collapse, keyboard expand, and the ChatPage wiring + branch
  ordering)
- `tsc -b` clean; `eslint src` unchanged from base (1 pre-existing error in
  `src/vite-env.d.ts`)
- `jscpd` 0 clones — the harnesses' shared boot-API stub was extracted to
  `website/scripts/lib/boot-api.mjs` and `capture-subagent-cards.mjs`
  re-verified against it
- `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test`,
  `mypy src/kiro_crew/` (558 files) all clean

Not verified: rendering on a real macOS browser (captured under headless
Chromium on Linux).
