### PR TITLE
fix(dashboard): make Auto selectable as the session model

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2561,9 +2561,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout }: { mode?:
     // satisfies the linter without re-creating this callback.
   }, [activeSlot, installedAgents, provider, queryClient, setAgentDropdown, setPendingAgent, setPendingModel])
   const switchModel = useCallback(async (modelName: string) => {
-    const val = modelName === 'auto' ? '' : modelName
-    if (!activeSlot) { setPendingModel(val); return }
-    await api.chatSlotModel(activeSlot, val)
+    // 'auto' is stored VERBATIM, not collapsed to ''. Both resolve to the same
+    // provider behaviour server-side, but '' is also the "never chosen" state,
+    // and every reader of an empty model re-resolves it to the agent template's
+    // model (the `resolvedModel` / `_initResolvedModel` queries below, and the
+    // backend's slot.model backfill). Writing '' therefore made an explicit Auto
+    // pick snap straight back to e.g. claude-opus-5 — Auto was unselectable.
+    // kiro-cli advertises `auto` as a real model id (and its default_model), and
+    // the ChatPane + Alt+Shift model-cycle paths already send it verbatim.
+    if (!activeSlot) { setPendingModel(modelName); return }
+    await api.chatSlotModel(activeSlot, modelName)
     // Keep the dropdown open after selecting — the user may switch models again
     // or drill into the reasoning-effort panel. Dismiss is via outside-click/Escape.
     // setPendingModel is a stable useState setter.

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1000,12 +1000,14 @@ function ChatSidebar({
   // (the backend leaves already-on-target slots as `unchanged`), minus running
   // slots when skipping. Keeps the "Switch N" label + disable guard honest.
   const bulkAffectedCount = useMemo(() => {
-    const target = bulkModel === 'auto' ? '' : bulkModel
-    return slots.filter(s => (s.model ?? '') !== target && (!bulkSkipRunning || !s.running)).length
+    return slots.filter(s => (s.model ?? '') !== bulkModel && (!bulkSkipRunning || !s.running)).length
   }, [slots, bulkModel, bulkSkipRunning])
   const bulkModelMutation = useMutation({
+    // 'auto' goes on the wire verbatim (not collapsed to ''): '' doubles as the
+    // "never chosen" state that every reader re-resolves to the agent template's
+    // model, so it cannot express an explicit Auto pick.
     mutationFn: ({ model, skipRunning }: { model: string; skipRunning: boolean }) =>
-      api.chatSlotsModel(model === 'auto' ? '' : model, skipRunning),
+      api.chatSlotsModel(model, skipRunning),
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: ['chat-slots'] })
       // Partial failure: the endpoint returns 200 with a non-empty `failed`

--- a/website/src/test/ChatPage.autoModel.test.tsx
+++ b/website/src/test/ChatPage.autoModel.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Regression test: "Auto" must be selectable as the session model.
+ *
+ * `switchModel` used to collapse the Auto pick to '' before sending it:
+ *   const val = modelName === 'auto' ? '' : modelName
+ * But '' is ALSO the "no model chosen yet" state, and every reader of an empty
+ * model re-resolves it to the agent template's model — ChatPage's
+ * `resolvedModel` query for existing slots, its `_initResolvedModel` effect for
+ * the not-yet-created slot, and the backend's `slot.model` backfill in
+ * chat_runner. So picking Auto snapped straight back to the agent's model (e.g.
+ * claude-opus-5) and Auto could never be selected.
+ *
+ * The fix sends 'auto' verbatim — the id kiro-cli actually advertises (and
+ * reports as its `default_model`), and the value the ChatPane and Alt+Shift
+ * model-cycle paths already used.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import { ThemeProvider } from '../hooks/useTheme'
+import type { RootState } from '../store'
+
+// The agent template pins a concrete model — this is what an empty slot.model
+// resolves to, and what used to clobber an explicit Auto pick. Repeated as a
+// literal inside the vi.mock factory below, which is hoisted above this const.
+const AGENT_MODEL = 'claude-opus-5'
+
+interface VirtuosoMockProps {
+  data?: unknown[]
+  itemContent: (index: number, item: unknown) => ReactNode
+}
+vi.mock('react-virtuoso', () => ({ Virtuoso: ({ data, itemContent }: VirtuosoMockProps) => <div data-testid="virtuoso">{data?.map((d: unknown, i: number) => <div key={i}>{itemContent(i, d)}</div>)}</div> }))
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0 }),
+    chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
+    models: vi.fn().mockResolvedValue([
+      { model_name: 'auto', description: 'Models chosen by task' },
+      { model_name: 'claude-opus-5', description: 'Claude Opus 5' },
+      { model_name: 'claude-sonnet-5', description: 'Claude Sonnet 5' },
+    ]),
+    agents: vi.fn().mockResolvedValue([]),
+    agentDetail: vi.fn().mockResolvedValue({ model: 'claude-opus-5' }),
+    chatSlotModel: vi.fn().mockResolvedValue({ ok: true }),
+    workspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    slackChannels: vi.fn().mockResolvedValue([]),
+    spawnList: vi.fn().mockResolvedValue({ agents: [] }),
+  },
+  SEARCH_MIN_CHARS: 2,
+}))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [{ name: 'kirocrew' }], defaultAgent: 'kirocrew' }) }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../components/DetailPanel', () => ({ default: () => null }))
+vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+})
+
+import ChatPage from '../pages/ChatPage'
+
+/** `model` is deliberately optional so a test can render the legacy "never
+ *  chosen" slot (no model key at all) as well as an explicit pick. */
+function makeStore(model?: string) {
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: {
+        status: null,
+        slots: [{ key: 'slot-a', messages: 0, running: false, mode: '', agent: 'kirocrew', model, pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }],
+        unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
+        subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      } as unknown as RootState['dashboard'],
+      chat: {
+        activeSlot: 'slot-a', messages: [],
+        slotRunning: false, slotStopping: false, slotState: 'idle',
+        history: [], historyHasMore: false, pendingInput: null,
+        subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools',
+        slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+        slotStatusDetail: {}, slotContextPct: {}, slotActivity: {}, slotHistory: [],
+        historyOffset: 0, _wsChunkedDuringFetch: false,
+        slotMessages: {}, slotLoading: false,
+      } as unknown as RootState['chat'],
+      notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+async function renderChat(model?: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await act(async () => {
+    render(
+      <QueryClientProvider client={qc}>
+        <Provider store={makeStore(model)}>
+          <ThemeProvider>
+            <MemoryRouter><ChatPage /></MemoryRouter>
+          </ThemeProvider>
+        </Provider>
+      </QueryClientProvider>,
+    )
+  })
+  await waitFor(() => expect(screen.getByLabelText('Message input')).toBeTruthy())
+}
+
+/** Open the model picker from the composer's model chip. */
+async function openModelPicker() {
+  const chip = await waitFor(() => screen.getByTitle(/^Model: /))
+  await act(async () => { fireEvent.click(chip) })
+  return chip
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('ChatPage — Auto model selection', { timeout: 15_000 }, () => {
+  it('sends the literal "auto" (not "") when Auto is picked', async () => {
+    const { api } = await import('../api/client')
+    await renderChat(AGENT_MODEL)
+    await openModelPicker()
+
+    const autoOption = await waitFor(() => screen.getByRole('option', { name: /auto/ }))
+    await act(async () => { fireEvent.click(autoOption) })
+
+    expect(api.chatSlotModel).toHaveBeenCalledWith('slot-a', 'auto')
+    // '' is the "never chosen" state; sending it made the pick un-stick.
+    expect(api.chatSlotModel).not.toHaveBeenCalledWith('slot-a', '')
+  })
+
+  it('shows Auto as the active model and does not re-resolve it to the agent model', async () => {
+    await renderChat('auto')
+    expect(await waitFor(() => screen.getByTitle('Model: auto'))).toBeTruthy()
+
+    await openModelPicker()
+    const autoOption = await waitFor(() => screen.getByRole('option', { name: /auto/ }))
+    expect(autoOption.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('still inherits the agent template model when no model was ever chosen', async () => {
+    // Unchanged behaviour for the legacy/never-chosen slot: an absent model
+    // resolves to the agent's own model rather than displaying Auto.
+    await renderChat(undefined)
+    expect(await waitFor(() => screen.getByTitle(`Model: ${AGENT_MODEL}`))).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Problem

Users can't select **Auto** as the model for a session. Clicking the `auto` row in the composer's model picker appears to do nothing — the chip snaps straight back to the agent template's model (e.g. `claude-opus-5`) and the picker keeps that model highlighted.

## Root cause

`ChatPage.switchModel` collapsed the pick to `''` before sending it:

```ts
const val = modelName === 'auto' ? '' : modelName
```

But `''` is *also* the "no model chosen yet" state, and every reader of an empty model re-resolves it to the agent template's model:

| Reader | Effect on `''` |
| --- | --- |
| `ChatPage` `resolvedModel` query | existing slot → agent template model |
| `ChatPage` `_initResolvedModel` effect | not-yet-created slot → agent template model |
| `chat_persistence` rehydrate (`elif slot.agent:`) | after restart → agent template model |
| `chat_runner` `if not slot.model` backfill | before a turn → provider's resolved model |

An explicit Auto was therefore indistinguishable from "unset" and was overwritten immediately.

## Fix

Send `auto` verbatim. This is not a new wire value:

- kiro-cli advertises `auto` as a real model id and reports it as its `default_model` (`chat --list-models`).
- The backend already accepts it — `_model_rejected_reason` passes `auto` explicitly, and `_wire_model_id` maps both `''` and `auto` to the provider default, switching a live session to the real `auto` id when the backend advertises it.
- `ChatPane`'s picker and the `Alt+Shift+S/X` model-cycle shortcut already sent it unmodified. The main composer was the outlier.

The same collapse is removed from the sidebar's bulk model switch.

A slot that never had a model chosen still inherits the agent template's model — unchanged.

## Verification

3 new tests in `website/src/test/ChatPage.autoModel.test.tsx`. The wire-value test revert-verifies (fails on the unfixed code).

Browser-verified on an isolated gateway (port 6877, own `KIROCREW_HOME`), same session and same click on both builds:

| | unfixed | fixed |
| --- | --- | --- |
| chip before pick | `claude-opus-5` | `claude-opus-5` |
| chip after picking Auto | `claude-opus-5` | `auto` |
| chip after reload | `claude-opus-5` | `auto` |
| highlighted picker row | `claude-opus-5` | `auto` |

Gates: `vitest` 5890 passed / 3 skipped (484 files), `tsc -b` clean, `eslint` 0 errors. No Python files touched.
