### PR TITLE
fix(desktop): scale & reposition splash ghosts on window resize

### DIFF
--- a/website/electron/loading.html
+++ b/website/electron/loading.html
@@ -181,6 +181,17 @@
     ];
     var BASE_ROT = { top: 180, left: 90, right: -90, bottom: 0, free: 0 };
 
+    // The GH sizes above were tuned against the default window (see main.js:994).
+    // Scaling the whole composition by the viewport-vs-baseline ratio keeps ghosts
+    // proportioned at any window size — so edge ghosts stay clipped by the same
+    // fraction instead of drifting when a fixed-size ghost meets a bigger viewport.
+    var REF_W = 1280, REF_H = 860;
+    function viewScale() {
+      // Uniform (min-ratio) scale preserves the layout's proportions; clamp keeps
+      // it sane on extreme window shapes.
+      return Math.max(0.55, Math.min(Math.min(W / REF_W, H / REF_H), 2.4));
+    }
+
     var MIN_FLOOR_MS = 1600;   // never hand off before this (no sub-second flash)
     var MIN_GHOSTS   = 5;
     var STAGGER_MS   = 210;
@@ -201,13 +212,22 @@
 
     function rnd(a, b) { return a + Math.random() * (b - a); }
 
+    // Lay out a ghost against the CURRENT viewport: both its size (scaled to the
+    // window) and its position (ax/ay are viewport fractions). Must re-run on any
+    // W/H change (resize / maximise) — otherwise ghosts keep the initial
+    // small-window size + coordinates, clustering in a corner with clipped edges.
+    function layoutGhost(g) {
+      var cfg = g.cfg, s = viewScale();
+      var w = cfg.size * s, h = w * 1.31;
+      g.el.style.width  = w + "px";
+      g.el.style.height = h + "px";
+      g.el.style.left = (cfg.ax * W - w / 2) + "px";
+      g.el.style.top  = (cfg.ay * H - h / 2) + "px";
+    }
+
     function makeGhost(cfg) {
       var el = document.createElement("div");
       el.className = "ghost";
-      el.style.width = cfg.size + "px";
-      el.style.height = (cfg.size * 1.31) + "px";
-      el.style.left = (cfg.ax * W - cfg.size / 2) + "px";
-      el.style.top  = (cfg.ay * H - cfg.size * 1.31 / 2) + "px";
       el.style.filter = cfg.depth >= .9
         ? "drop-shadow(0 7px 14px rgba(20,8,50,0.32))"
         : "drop-shadow(0 5px 10px rgba(20,8,50,0.26)) blur(" + (1 - cfg.depth) * 2.6 + "px)";
@@ -221,12 +241,25 @@
         eyes: el.querySelector(".g-eyes"),
         visible: false
       };
+      layoutGhost(g);
       var rot = BASE_ROT[cfg.edge] + rnd(-9, 9);
       g.tilt.style.transform = "rotate(" + rot + "deg)" + (cfg.flip ? " scaleX(-1)" : "");
       g.floatEl.style.animationDuration = rnd(2.4, 4.3).toFixed(2) + "s";
       g.floatEl.style.animationDelay = (-rnd(0, 3)).toFixed(2) + "s";
       return g;
     }
+
+    // Keep the composition anchored + proportioned to the viewport as it resizes.
+    // rAF-coalesced so a burst of resize events costs at most one relayout/frame.
+    var resizeRAF = 0;
+    window.addEventListener("resize", function () {
+      if (resizeRAF) return;
+      resizeRAF = requestAnimationFrame(function () {
+        resizeRAF = 0;
+        W = window.innerWidth; H = window.innerHeight;
+        for (var i = 0; i < ghosts.length; i++) layoutGhost(ghosts[i]);
+      });
+    });
 
     function popIn(g) { g.pop.classList.remove("popIn", "popOut"); void g.pop.offsetWidth; g.pop.classList.add("popIn"); }
     function showGhost(g) { g.el.style.opacity = String(g.cfg.depth); g.visible = true; popIn(g); }


### PR DESCRIPTION
## Problem
The KiroCrew desktop app opens with a small window, and the gateway-wait splash (`website/electron/loading.html`) renders its floating "ghosts" laid out for that small size. When the user maximizes / resizes the window before the gateway is ready, the ghosts stay pinned to the original small-window coordinates and size — clustered in one corner with a large empty center, and the edge ghosts (meant to be half-clipped at the border) clipped by the wrong proportion.

## Why it matters
This is the very first thing a user sees on every launch. On any display larger than the initial window (i.e. essentially always, once maximized) the intro animation looks broken and off-center, which reads as a low-quality or half-loaded app during the most impressionable moment of the session.

## Fix (symptoms → root cause → change)
- **Symptom:** after expanding the window, ghosts are small, corner-clustered, and edge ghosts are mis-clipped.
- **Root cause:** the splash captured `window.innerWidth/innerHeight` once at startup (`var W = ...`) and `makeGhost()` baked each ghost's `width/height` and `left/top` into fixed pixels from those initial dimensions. There was **no `resize` listener**, so the layout never recomputed when the window changed.
- **Change** (all in `loading.html`):
  - `viewScale()` derives a clamped uniform scale from the **live** `W/H` against a design baseline (`1280×860`, the default window per `main.js`), so the whole composition scales as one unit rather than each ghost staying a fixed size.
  - `layoutGhost(g)` applies both the scaled size **and** the fractional (`ax/ay`) position from the current viewport; `makeGhost()` no longer writes fixed dimensions.
  - A `requestAnimationFrame`-coalesced `window` `resize` handler re-reads `innerWidth/innerHeight` and relays out every ghost, so the composition tracks continuously at any size and during drag. Because both center (viewport fraction) and size (× scale) track the viewport together, edge ghosts stay clipped by the same proportion at every size.

This is a fully dynamic solution — no size is hardcoded; `1280×860` is only the denominator that makes scale `1.0` reproduce the original design.

## Tests
N/A — `loading.html` is a static, un-bundled Electron asset with no existing test harness (the adjacent unit-tested logic lives in `gateway-wait.js`, which is untouched). The change is layout-only vanilla JS driven by `window.resize`.

## Manual verification
Verified in a browser by serving `loading.html?ready=99999`, loading at 640×460, then resizing to 1680×982: pre-fix build left the ghosts corner-clustered and clipped; post-fix build re-scales and re-centers the whole composition to fill the enlarged window and keeps edge ghosts clipped by the same proportion. Author will re-confirm in a real rebuilt desktop app.

## Screenshots
Omitted at the author's request (will validate in the rebuilt app). The change is to the launch splash only.
