### PR TITLE
fix(workflows): stop the run ceiling from discarding completed agent work

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -33,6 +33,7 @@
         "session_sharing": true,
         "max_subagents": 0,
         "spawn_min_memory_gb": 4.0,
+        "workflow_run_timeout_secs": 3600,
         "subagent_mem_buffer_pct": 20,
         "subagent_cost_gb": 0.5,
         "subagent_cpu_cost_cores": 1.0,
@@ -340,6 +341,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 4.0
+    },
+    {
+      "path": "agent.workflow_run_timeout_secs",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Workflow Run Timeout (secs)",
+      "help": "Wall-clock ceiling for one dynamic-workflow run. This is a runaway backstop, so it is clamped to 60s..21600s (6h) — raise it for long multi-phase investigations, but it can never be disabled. Reaching the ceiling is no longer a data-loss event: every agent result completed before the cutoff is preserved on the run record.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 3600
     },
     {
       "path": "agent.subagent_mem_buffer_pct",

--- a/src/kiro_crew/apps/builtins/workflows/server.py
+++ b/src/kiro_crew/apps/builtins/workflows/server.py
@@ -56,7 +56,9 @@ def _redact_obj(obj: Any) -> Any:
     if isinstance(obj, list):
         return [_redact_obj(x) for x in obj]
     if isinstance(obj, dict):
-        return {k: _redact_obj(v) for k, v in obj.items()}
+        # Keys too: agent output is parsed into these structures, so a credential
+        # can arrive as a mapping key and a values-only walk would leak it.
+        return {_redact_obj(k): _redact_obj(v) for k, v in obj.items()}
     return obj
 
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -738,6 +738,17 @@ class AgentConfig:
             "Minimum available memory (GB) required to spawn a subagent. 0 disables the check.",
         ),
     )
+    workflow_run_timeout_secs: int = field(
+        default=3600,
+        metadata=_meta(
+            "Workflow Run Timeout (secs)",
+            "Wall-clock ceiling for one dynamic-workflow run. This is a runaway "
+            "backstop, so it is clamped to 60s..21600s (6h) — raise it for long "
+            "multi-phase investigations, but it can never be disabled. Reaching "
+            "the ceiling is no longer a data-loss event: every agent result "
+            "completed before the cutoff is preserved on the run record.",
+        ),
+    )
     subagent_mem_buffer_pct: int = field(
         default=20,
         metadata=_meta(
@@ -3910,6 +3921,9 @@ class KiroCrewConfig:
                 ),
                 subagent_result_ttl_secs=_safe_int(
                     agent_data.get("subagent_result_ttl_secs", 3600), 3600
+                ),
+                workflow_run_timeout_secs=_safe_int(
+                    agent_data.get("workflow_run_timeout_secs", 3600), 3600
                 ),
                 subagent_cwd_allowed_roots=(
                     [r for r in _roots if isinstance(r, str)]

--- a/src/kiro_crew/dashboard/handlers/workflows.py
+++ b/src/kiro_crew/dashboard/handlers/workflows.py
@@ -7,13 +7,16 @@ runner). LLM-derived strings are redacted before they hit a response surface.
 
 Routes (registered in dashboard/server.py):
   POST /api/workflows/author   {intent}           → {ok, source, meta} | {ok:false, errors}
-  POST /api/workflows/run      {source, args?, name?, budget_total?} → {run_id} | {error}
+  POST /api/workflows/run      {source, args?, name?, budget_total?, timeout_secs?}
+                                                    → {run_id} | {error}
   GET  /api/workflows/runs                          → [{run_id, name, status, ...}]
   GET  /api/workflows/runs/{id}                     → {…, events:[…]}  (full)
   POST /api/workflows/runs/{id}/cancel              → {cancelled: bool}
 """
 
 from __future__ import annotations
+
+from typing import Any, Optional
 
 from aiohttp import web
 
@@ -22,7 +25,14 @@ from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 
 def _redact_obj(obj):
-    """Recursively redact LLM-derived strings in a JSON-able structure."""
+    """Recursively redact LLM-derived strings in a JSON-able structure.
+
+    Redacts dict KEYS as well as values: agent output is parsed straight into
+    these structures, so a credential can arrive as a mapping key (``{"ghp_…":
+    …}``) and a values-only walk would pass it through untouched. Two distinct
+    credential-shaped keys can collapse into one redacted key — losing a
+    pathological key is strictly preferable to leaking the secret.
+    """
     if isinstance(obj, str):
         s, _ = redact_exfiltration_urls(obj)
         s, _ = redact_credentials(s)
@@ -30,7 +40,7 @@ def _redact_obj(obj):
     if isinstance(obj, list):
         return [_redact_obj(x) for x in obj]
     if isinstance(obj, dict):
-        return {k: _redact_obj(v) for k, v in obj.items()}
+        return {_redact_obj(k): _redact_obj(v) for k, v in obj.items()}
     return obj
 
 
@@ -56,6 +66,17 @@ async def api_workflow_author(request: web.Request) -> web.Response:
     return web.json_response(_redact_obj(out))
 
 
+def _opt_int(value: Any) -> Optional[int]:
+    """Coerce an optional integer body field; anything unusable → None.
+
+    None means "no override" at the service layer, which then applies its own
+    default — so a malformed value can never widen or remove a run's ceiling.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
 async def api_workflow_run(request: web.Request) -> web.Response:
     """POST /api/workflows/run — launch a background run, return its run_id."""
     svc = _svc(request)
@@ -78,6 +99,7 @@ async def api_workflow_run(request: web.Request) -> web.Response:
         author=request.headers.get("X-Session-Key", ""),
         session_key=request.headers.get("X-Session-Key", ""),
         budget_total=budget_total,
+        timeout_secs=_opt_int(body.get("timeout_secs")),
     )
     status = 200 if "run_id" in out else 400
     return web.json_response(_redact_obj(out), status=status)
@@ -110,6 +132,7 @@ async def api_workflow_run_intent(request: web.Request) -> web.Response:
         author=request.headers.get("X-Session-Key", ""),
         session_key=request.headers.get("X-Session-Key", ""),
         budget_total=budget_total,
+        timeout_secs=_opt_int(body.get("timeout_secs")),
     )
     status = 200 if "run_id" in out else 400
     return web.json_response(_redact_obj(out), status=status)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1517,7 +1517,22 @@ async def start_dashboard(
             except Exception:
                 logger.debug("workflow on_done injection failed", exc_info=True)
 
+        # Workflow agent concurrency stays at this fixed cap ON PURPOSE. Sizing it
+        # from resolve_max_subagents() looks tempting (it is the sizing authority
+        # in mcp_core / slack gateway / context), but the warm pool keeps a
+        # SEPARATE sub-pool per agent/model/CWD identity and its own documented
+        # aggregate bound is ``(max_identities + 1) * max_workers`` — 9 * this
+        # value (see workflows/agent_pool.py). Feeding an auto-sized cap in here
+        # would raise the worst-case resident kiro-cli workers from 9*4=36 to
+        # 9*subagent_auto_max=288 and OOM the gateway on a large host. Revisit
+        # only once the pool enforces ONE aggregate worker limit.
         _wf_concurrency = 4
+        # The run ceiling is unaffected by that and IS config-driven.
+        _wf_timeout_secs: int | None = None
+        try:
+            _wf_timeout_secs = int(KiroCrewConfig.load().agent.workflow_run_timeout_secs)
+        except Exception:
+            logger.debug("workflow run-ceiling config unavailable; using default", exc_info=True)
 
         async def _wf_nudge_authorizer(
             *, slot_key: str, message: str, idle_secs: int, max_cycles: int
@@ -1548,9 +1563,12 @@ async def start_dashboard(
             now_fn=lambda: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             concurrency=_wf_concurrency,
             nudge_authorizer=_wf_nudge_authorizer,
+            timeout_secs=_wf_timeout_secs,
         )
         logger.info(
-            "WorkflowService ready (dynamic workflows, max parallel agents=%s)", _wf_concurrency
+            "WorkflowService ready (dynamic workflows, max parallel agents=%s, run ceiling=%ss)",
+            _wf_concurrency,
+            state.workflow_service.timeout_secs,
         )
     except Exception:
         state.workflow_service = None

--- a/src/kiro_crew/dashboard/workflow_inject.py
+++ b/src/kiro_crew/dashboard/workflow_inject.py
@@ -71,6 +71,20 @@ def _summarize(snapshot: dict) -> str:
                 lines.append(f"- … and {len(artifacts) - 20} more")
     elif snapshot.get("error"):
         lines.append(f"\nError: {snapshot['error']}")
+    # A failed run is not necessarily an empty one: every agent call that completed
+    # before the ceiling / cancel / crash is preserved on the record. Say so
+    # explicitly — otherwise the reader assumes the whole run was lost and either
+    # redoes the work or goes digging through the run JSON by hand.
+    partial_count = snapshot.get("partial_result_count") or 0
+    error_count = snapshot.get("agent_error_count") or 0
+    if partial_count:
+        lines.append(
+            f"\n{partial_count} agent result(s) finished before the run ended and were "
+            f"preserved — read them with `workflow_result('{run_id}')` under "
+            "`partial_results` (keyed by agent call index)."
+        )
+    if error_count:
+        lines.append(f"{error_count} agent call(s) failed; each reason is under `agent_errors`.")
     lines.append(
         f"\nUse workflow_result('{run_id}') for the full event stream, or "
         f"workflow_rerun_subtree('{run_id}', …) to restart from a step."

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -1861,7 +1861,10 @@ def _list_tools() -> list[dict[str, Any]]:
             "name": "workflow_result",
             "description": (
                 "Get a workflow run's full result + event stream by run_id "
-                "(phases, per-agent outcomes, logs, final result)."
+                "(phases, per-agent outcomes, logs, final result). For a run that "
+                "ended without a usable return value, also returns the agent "
+                "payloads that completed first as `partial_results` and any "
+                "per-agent failure reasons as `agent_errors`."
             ),
             "inputSchema": {
                 "type": "object",
@@ -5226,7 +5229,12 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         )
 
     def _redact_obj(obj: Any) -> Any:
-        """Recursively redact credentials + exfiltration URLs from a response."""
+        """Recursively redact credentials + exfiltration URLs from a response.
+
+        Keys are redacted too: agent output is parsed into these structures, so a
+        credential can arrive as a mapping key and a values-only walk would let it
+        through (see dashboard/handlers/workflows.py::_redact_obj).
+        """
         if isinstance(obj, str):
             s, _ = redact_exfiltration_urls(obj)
             s, _ = redact_credentials(s)
@@ -5234,7 +5242,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         if isinstance(obj, list):
             return [_redact_obj(x) for x in obj]
         if isinstance(obj, dict):
-            return {k: _redact_obj(v) for k, v in obj.items()}
+            return {_redact_obj(k): _redact_obj(v) for k, v in obj.items()}
         return obj
 
     # --- Dynamic workflows (M6): author / run / monitor from chat ---
@@ -5353,19 +5361,25 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         # ``result`` / ``error`` / ``events`` are LLM-derived (agent outputs, log
         # lines) — recursively redact credentials + exfiltration URLs before
         # returning them through this MCP tool to the dashboard/chat surface.
+        # ``partial_results`` / ``agent_errors`` carry the same class of content and
+        # MUST be projected here: when a run ends without a usable return value they
+        # are the only surviving output, and the completion message points the reader
+        # at this tool to read them. Omitting them made that instruction a dead end.
+        # Oversize payloads are handled by the MCP gateway's existing result spill.
+        wf_payload: dict[str, Any] = {
+            "run_id": d.get("run_id"),
+            "status": d.get("status"),
+            "result": _redact_obj(d.get("result")),
+            "error": _redact_obj(d.get("error")),
+            "events": _redact_obj(d.get("events", [])),
+        }
+        if d.get("partial_results"):
+            wf_payload["partial_results"] = _redact_obj(d.get("partial_results"))
+        if d.get("agent_errors"):
+            wf_payload["agent_errors"] = _redact_obj(d.get("agent_errors"))
         return _wf_return(
             "workflow_result",
-            json.dumps(
-                {
-                    "run_id": d.get("run_id"),
-                    "status": d.get("status"),
-                    "result": _redact_obj(d.get("result")),
-                    "error": _redact_obj(d.get("error")),
-                    "events": _redact_obj(d.get("events", [])),
-                },
-                indent=2,
-                default=str,
-            ),
+            json.dumps(wf_payload, indent=2, default=str),
         )
 
     if name == "workflow_list":

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -348,6 +348,7 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         "mcp_gateway/backend.py",
         "workflows/agent_exec.py",
         "workflows/agent_pool.py",
+        "workflows/runner.py",
         "workflows/store.py",
         "apps/event_bus.py",
         "sync_bridge.py",

--- a/src/kiro_crew/workflows/events.py
+++ b/src/kiro_crew/workflows/events.py
@@ -122,12 +122,21 @@ class EventStream:
         )
 
     def agent_finished(
-        self, ts: str, *, agent_id: str, result_summary: str, ok: bool
+        self, ts: str, *, agent_id: str, result_summary: str, ok: bool, error: str = ""
     ) -> WorkflowEvent:
+        # ``error`` is a bounded, redacted reason the call failed (empty when ok) —
+        # a failed agent used to record ok=False and nothing else, which makes a
+        # post-mortem impossible. Deliberately NOT added to REQUIRED_DATA_KEYS:
+        # event journals written by an older build must still deserialize.
         return self._emit(
             ts,
             "agent_finished",
-            {"agent_id": agent_id, "result_summary": result_summary, "ok": ok},
+            {
+                "agent_id": agent_id,
+                "result_summary": result_summary,
+                "ok": ok,
+                "error": error,
+            },
         )
 
     # --- approval ---

--- a/src/kiro_crew/workflows/registry.py
+++ b/src/kiro_crew/workflows/registry.py
@@ -53,6 +53,16 @@ def _int_key(k: Any) -> Any:
         return k
 
 
+def _str_keyed(mapping: dict) -> dict:
+    """JSON-safe view of a call_index-keyed map, ordered by key.
+
+    Keys are stringified (JSON object keys must be strings) and sorted as strings
+    rather than ints, so a restored handle whose key failed int-coercion (see
+    ``_int_key``) can't raise on a mixed-type sort.
+    """
+    return {str(k): v for k, v in sorted(mapping.items(), key=lambda kv: str(kv[0]))}
+
+
 @dataclass
 class RunHandle:
     """Live state of one background workflow run."""
@@ -69,6 +79,9 @@ class RunHandle:
     source: str = ""  # the script (so a resume/restart can re-run it)
     args: dict = field(default_factory=dict)
     agent_results: dict = field(default_factory=dict)  # call_index → result (resume cache)
+    # call_index → bounded reason that call failed. Kept next to agent_results so a
+    # missing payload always comes with an explanation instead of a bare ok=False.
+    agent_errors: dict = field(default_factory=dict)
 
     def snapshot(self, *, include_events: bool = True) -> dict:
         """JSON-serializable view of this run (never leaks the asyncio.Task)."""
@@ -87,12 +100,30 @@ class RunHandle:
             "phase": self._current_phase(),
             "last_log": self._last_log(),
         }
+        # Work that outlived a run which ENDED WITHOUT a usable return value
+        # (ceiling / cancel / crash). Keyed on STATUS, not on ``result is None``:
+        # a run can finish and legitimately return None (a script with no return,
+        # or whose last statement is a failed agent call), and a still-running run
+        # has no result yet — neither lost anything, so reporting partials for them
+        # would both mislead the reader and re-send every payload on every poll.
+        # The COUNTS ride in the compact view so a completion message can say the
+        # work survived; the payloads themselves ride only in the detail view.
+        ended_without_result = self.status not in (STATUS_RUNNING, STATUS_FINISHED)
+        partials = self.agent_results if ended_without_result else {}
+        if partials:
+            snap["partial_result_count"] = len(partials)
+        if self.agent_errors:
+            snap["agent_error_count"] = len(self.agent_errors)
         if include_events:
             snap["events"] = [e.to_json() for e in self.events]
             # The authored/executed script — included only in the FULL snapshot
             # (detail view) so the UI can show "View source", edit, and rerun. Kept
             # out of the compact list to keep that payload small.
             snap["source"] = self.source
+            if partials:
+                snap["partial_results"] = _str_keyed(partials)
+            if self.agent_errors:
+                snap["agent_errors"] = _str_keyed(self.agent_errors)
         return snap
 
     def _current_phase(self) -> str:
@@ -125,6 +156,7 @@ class RunHandle:
             "source": self.source,
             "args": self.args,
             "agent_results": {str(k): v for k, v in self.agent_results.items()},
+            "agent_errors": {str(k): v for k, v in self.agent_errors.items()},
             "events": [e.to_json() for e in self.events],
         }
 
@@ -151,6 +183,7 @@ class RunHandle:
             source=obj.get("source", ""),
             args=obj.get("args") or {},
             agent_results={_int_key(k): v for k, v in (obj.get("agent_results") or {}).items()},
+            agent_errors={_int_key(k): v for k, v in (obj.get("agent_errors") or {}).items()},
         )
 
 
@@ -225,6 +258,41 @@ class RunRegistry:
         # most of the event stream (and the authored source, recorded at start).
         if self._store is not None and len(h.events) % self._save_every == 0:
             self._persist(h)
+
+    def record_agent_result(
+        self,
+        run_id: str,
+        call_index: int,
+        *,
+        result: Any,
+        ok: bool = True,
+        error: str = "",
+    ) -> None:
+        """Checkpoint ONE settled agent call onto the handle, as the call returns.
+
+        Called by the runner after each ``ctx.agent()`` call. Previously the results
+        reached the handle only in ``_drive``, AFTER the whole run finished, so a run
+        killed by the wall-clock ceiling wrote an empty ``agent_results`` and
+        discarded every payload it had already paid for. Landing them on the handle
+        here is what makes the ceiling survivable: the terminal paths read them back
+        and ``mark_terminal`` flushes the completed record to disk.
+
+        Deliberately does NOT force a store write of its own. ``store.save``
+        re-serializes and re-redacts the ENTIRE run record synchronously on the
+        gateway event loop, so writing once per agent call would add an O(N) stall
+        per call over a record that grows with every payload. Disk durability
+        instead rides the write this module already performs — ``record_event``
+        flushes every ``_save_every`` events, and each agent call emits two events —
+        plus the guaranteed flush at ``mark_terminal``. The trade is explicit: a
+        hard gateway kill can lose the newest payloads that no flush has covered
+        yet, exactly as it can already lose the newest events.
+        """
+        h = self._runs.get(run_id)
+        if h is None:
+            return
+        h.agent_results[call_index] = result
+        if error or not ok:
+            h.agent_errors[call_index] = error or "agent call failed (no reason recorded)"
 
     def mark_terminal(
         self, run_id: str, status: str, *, result: Any = None, error: Optional[str] = None
@@ -334,7 +402,11 @@ async def start_background_run(
     async def _drive() -> None:
         try:
             result, status, error, agent_results = await run_coro_factory(record)
-            handle.agent_results = agent_results or {}
+            # MERGE, never replace: per-call checkpoints already landed on the handle
+            # while the run was executing, and a terminal path that hands back a
+            # partial (or empty) map must not erase them.
+            if agent_results:
+                handle.agent_results.update(agent_results)
             registry.mark_terminal(run_id, status, result=result, error=error)
         except asyncio.CancelledError:
             registry.mark_terminal(run_id, STATUS_CANCELLED, error="cancelled")

--- a/src/kiro_crew/workflows/runner.py
+++ b/src/kiro_crew/workflows/runner.py
@@ -8,7 +8,10 @@ Gates closed here:
 
 * A7 — emits the full documented event stream (``run_started`` … ``run_finished`` /
   ``run_failed`` / ``run_cancelled``), in order, via ``EventStream``.
-* B5 — a wall-clock timeout terminates a runaway script (``asyncio.wait_for``).
+* B5 — a wall-clock timeout terminates a runaway script (``asyncio.wait``; see the
+  comment at the guard for why NOT ``wait_for``). The ceiling is a backstop, not a
+  data-loss event: every terminal path carries the per-agent results collected so
+  far, and each call is checkpointed to the run record as it completes.
 * (consumes A4/B6 from ``context``: ``Budget`` ceiling, ``AgentCounter`` cap.)
 
 Agent execution is injected as ``agent_fn`` so the runner is testable against a
@@ -30,8 +33,9 @@ import asyncio
 import hashlib
 import json
 import time
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 
 from . import BudgetExceeded, WorkflowEvent
 from .context import DEFAULT_MAX_AGENTS_PER_RUN, AgentCounter, Budget, build_safe_globals
@@ -57,8 +61,87 @@ try:
 except ImportError:  # pragma: no cover - SEL is app-layer optional for the engine
     _sel = None  # type: ignore[assignment]
 
+# Optional dependency (gate F1, same rationale as ``_sel``): credential / exfil
+# redaction lives in the app layer. Applied to captured agent-failure text before
+# it is persisted, because a transport-level error can echo back a URL carrying a
+# token. Absent (standalone engine) → the text is stored as-is, still truncated.
+try:
+    from kiro_crew.security import redact_credentials as _redact_credentials
+    from kiro_crew.security import redact_exfiltration_urls as _redact_exfil
+except ImportError:  # pragma: no cover - security is app-layer optional
+    _redact_credentials = None  # type: ignore[assignment]
+    _redact_exfil = None  # type: ignore[assignment]
+
 # Wall-clock ceiling per run (matches ``_RUN_TIMEOUT_SECS`` in the spec).
 DEFAULT_RUN_TIMEOUT_SECS = 3600
+
+# Bounds on a caller-supplied per-run ceiling. The ceiling is the runaway
+# backstop, so a caller may LENGTHEN it for a genuinely long investigation but can
+# never disable it — and can't set one so short the run cannot even author itself.
+MIN_RUN_TIMEOUT_SECS = 60
+MAX_RUN_TIMEOUT_SECS = 6 * 3600
+
+# Cap on a persisted per-agent failure description: enough to identify the fault,
+# short enough that a wide fan-out of failures can't bloat the run record.
+MAX_AGENT_ERROR_CHARS = 500
+
+
+def clamp_run_timeout(
+    value: Optional[int], *, default: int = DEFAULT_RUN_TIMEOUT_SECS
+) -> int:
+    """Clamp a caller-supplied run ceiling into ``[MIN, MAX]``.
+
+    ``None``, non-numeric, or non-positive input falls back to ``default`` — so a
+    bad value can never remove the ceiling, only decline to change it.
+    """
+    try:
+        secs = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    if secs <= 0:
+        return default
+    return max(MIN_RUN_TIMEOUT_SECS, min(secs, MAX_RUN_TIMEOUT_SECS))
+
+
+def describe_agent_error(exc: BaseException) -> str:
+    """Bounded, redacted one-liner explaining why an agent call failed.
+
+    A failed call used to record ``ok=False`` and nothing else, which makes a
+    post-mortem impossible — you cannot tell a throttle from a bad prompt from a
+    crashed backend. Type + message is the smallest thing that answers that.
+
+    No traceback on purpose: the frames add bulk without saying more than the
+    type does, and they are the part most likely to carry local filesystem detail
+    into a run record that is later surfaced over HTTP and into chat.
+
+    Recognized credential formats are scrubbed here as defense in depth (the HTTP
+    and chat surfaces redact again on the way out); this is not a guarantee about
+    arbitrary secret-looking text.
+    """
+    text = f"{type(exc).__name__}: {exc}".strip()
+    # Redact BEFORE truncating. Truncating first can slice a token in half, which
+    # destroys the pattern the redactors match on — and the surviving prefix is
+    # still real key material (see the note in security.redact_credentials about
+    # never emitting even a short prefix). Order matters more than cost here:
+    # the text is one exception message, not a stream.
+    if _redact_exfil is not None:
+        text, _ = _redact_exfil(text)
+    if _redact_credentials is not None:
+        text, _ = _redact_credentials(text)
+    if len(text) > MAX_AGENT_ERROR_CHARS:
+        text = text[:MAX_AGENT_ERROR_CHARS] + "…"
+    return text
+
+
+@asynccontextmanager
+async def _optional_slot(sem: Optional["asyncio.Semaphore"]) -> AsyncIterator[None]:
+    """Hold ``sem`` for the duration of the block; a no-op when there is no cap."""
+    if sem is None:
+        yield
+        return
+    async with sem:
+        yield
+
 
 # Signature of the injected agent executor: (prompt, options) -> result string/dict.
 AgentFn = Callable[[str, dict], Awaitable[Any]]
@@ -130,8 +213,15 @@ class RunResult:
     events: list[WorkflowEvent]
     error: Optional[str] = None
     # Per-agent-call results (call_index → result), so a resume/restart-subtree
-    # can replay the unchanged prefix (M6.6).
+    # can replay the unchanged prefix (M6.6). Populated on EVERY terminal path —
+    # success, ceiling, cancel, budget, and script crash — so an interrupted run
+    # still hands back the work it already finished. ``result`` is the script's own
+    # return value and stays None when the script never got to return one; these
+    # are the parts, not the whole.
     agent_results: dict = field(default_factory=dict)
+    # call_index → bounded, redacted reason a call failed (see
+    # ``describe_agent_error``). Empty for runs where every call succeeded.
+    agent_errors: dict = field(default_factory=dict)
     # The script actually executed. Equals the input ``source`` unless the run
     # authored it from an ``intent`` (M6.7) — surfaced so a background run can
     # store the authored script on its handle for rerun/restart.
@@ -143,6 +233,14 @@ class RunResult:
 # runner stays at the top of the layering and authoring uses the host's model
 # plumbing. ``on_progress(msg)`` lets authoring stream human-readable progress.
 AuthorFn = Callable[..., Awaitable[dict]]
+
+# Signature of the per-call checkpoint hook, mirroring how ``on_source`` publishes
+# the authored script mid-run:
+#   on_agent_result(call_index: int, *, result: Any, ok: bool, error: str) -> None
+# Called as soon as EACH agent call settles, so the host can persist that payload
+# before the run reaches a terminal state. Without it, results lived only in
+# process memory until the run finished, and any interruption threw them away.
+AgentResultFn = Callable[..., None]
 
 
 class _NoOpContextManager:
@@ -192,6 +290,7 @@ class _RunContext:
         on_event: Optional[Callable[[WorkflowEvent], None]] = None,
         replay_results: Optional[dict] = None,
         replay_before: int = 0,
+        on_agent_result: Optional[AgentResultFn] = None,
     ) -> None:
         self.args = args
         self.now = now
@@ -232,6 +331,21 @@ class _RunContext:
         self._replay_results: dict[int, Any] = replay_results or {}
         self._replay_before = replay_before
         self.agent_results: dict[int, Any] = {}
+        # call_index → why that call failed (bounded/redacted). Kept alongside
+        # agent_results so "no result" is always accompanied by a reason.
+        self.agent_errors: dict[int, str] = {}
+        # Per-call durable checkpoint sink (see ``AgentResultFn``).
+        self._on_agent_result = on_agent_result
+        # RUN-GLOBAL agent concurrency. ``parallel``/``pipeline`` each build their
+        # OWN semaphore, so they bound one fan-out but not the run: nested or
+        # sequentially overlapping combinators could exceed the configured cap, and
+        # agent calls made outside any combinator were never bounded at all. This
+        # semaphore lives on the context, so every ``ctx.agent()`` in the run queues
+        # on the same slots. Held only across the model call itself, so no thunk
+        # ever holds a slot while waiting for another thunk to release one.
+        self._agent_slots: Optional[asyncio.Semaphore] = (
+            asyncio.Semaphore(concurrency) if (concurrency and concurrency > 0) else None
+        )
 
     # --- event sink (shared with the runner) ---
     def _record(self, event: WorkflowEvent) -> None:
@@ -287,6 +401,7 @@ class _RunContext:
             "session": session,
             "nudge": nudge,
         }
+        error = ""
         try:
             if call_index < self._replay_before and call_index in self._replay_results:
                 # Resume (M6.6): replay the cached result from the prior run instead
@@ -294,6 +409,8 @@ class _RunContext:
                 # call_index) makes this sound — same script+args ⇒ same call order.
                 result = self._replay_results[call_index]
                 ok = result is not None
+                if not ok:
+                    error = "replayed a call that had already failed in the prior run"
             elif schema is not None:
                 # Structured output (C1–C3): re-ask until the model yields
                 # schema-valid JSON, or None after bounded retries. The producer
@@ -302,23 +419,46 @@ class _RunContext:
                     out = await self._agent_fn(p, opts)
                     return out if isinstance(out, str) else json.dumps(out)
 
-                result = await run_with_schema(_produce, prompt, schema)
+                async with _optional_slot(self._agent_slots):
+                    result = await run_with_schema(_produce, prompt, schema)
                 ok = result is not None
+                if not ok:
+                    # Distinguishing this from an exception matters: it means the
+                    # model answered but never matched the schema, which is a
+                    # prompt/schema problem, not an infrastructure one.
+                    error = "no schema-valid result after bounded re-asks"
             else:
-                result = await self._agent_fn(prompt, opts)
+                async with _optional_slot(self._agent_slots):
+                    result = await self._agent_fn(prompt, opts)
                 ok = result is not None
+                if not ok:
+                    error = "agent returned no result"
         except BudgetExceeded:
             raise
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 - captured per call, never fails the run
             result, ok = None, False
+            error = describe_agent_error(exc)
         # Record this call's result so a future resume can replay the prefix.
         self.agent_results[call_index] = result
+        if error:
+            self.agent_errors[call_index] = error
+        # Checkpoint: hand the settled call to the host NOW so a later ceiling /
+        # cancel / crash cannot discard work already paid for. The host records it
+        # in memory; it reaches DISK on the record's existing write cadence, not
+        # synchronously here (see RunRegistry.record_agent_result for why).
+        # Best-effort — a failing sink never breaks a run.
+        if self._on_agent_result is not None:
+            try:
+                self._on_agent_result(call_index, result=result, ok=ok, error=error)
+            except Exception:  # noqa: BLE001 - checkpointing must not break a run
+                pass
         self._record(
             self._stream.agent_finished(
                 self.now,
                 agent_id=agent_id,
                 result_summary=("" if result is None else str(result)[:120]),
                 ok=ok,
+                error=error,
             )
         )
         # B10: audit each agent call (author/runner/args carried at run level).
@@ -332,11 +472,16 @@ class _RunContext:
                 "call_index": call_index,
                 "outcome": "ok" if ok else "failed",
                 "has_schema": schema is not None,
+                "error": error,
             },
         )
         return result
 
     # --- scheduling (delegate to the dsl combinators with the run's cap) ---
+    # Each combinator bounds ITS OWN fan-out (which also covers non-agent thunks);
+    # ``agent()`` additionally holds a run-global slot. Both are needed: the
+    # combinator limit preserves per-fan-out shape, the global slot is what stops
+    # overlapping combinators from exceeding the cap in aggregate.
     async def parallel(self, thunks: list) -> list:
         return await _parallel(thunks, limit=self._concurrency)
 
@@ -418,8 +563,10 @@ class WorkflowRunner:
     """Validates, executes, and streams events for one workflow script.
 
     ``agent_fn`` is the injected agent executor (stub in tests). ``timeout_secs``
-    is the B5 wall-clock ceiling. ``concurrency`` bounds ``parallel``/``pipeline``
-    fan-out (the caller passes ``resolve_max_subagents()`` in prod).
+    is the B5 wall-clock ceiling — a runaway backstop, not a data-loss event: every
+    terminal path returns the agent results collected so far. ``concurrency`` bounds
+    agent calls RUN-GLOBALLY (and each ``parallel``/``pipeline`` fan-out); the caller
+    passes ``resolve_max_subagents()`` in prod, ``None`` for no limit.
     """
 
     def __init__(
@@ -469,6 +616,7 @@ class WorkflowRunner:
         intent: str = "",
         author_fn: Optional[AuthorFn] = None,
         on_source: Optional[Callable[[str], None]] = None,
+        on_agent_result: Optional[AgentResultFn] = None,
     ) -> RunResult:
         """Execute a workflow script end-to-end, returning result + event stream.
 
@@ -580,6 +728,7 @@ class WorkflowRunner:
                 stream=stream,
                 events=events,
                 emit=emit,
+                on_agent_result=on_agent_result,
             )
 
         # 1. Validate (B-group static). A bad script fails before any exec.
@@ -616,6 +765,7 @@ class WorkflowRunner:
             stream=stream,
             events=events,
             emit=emit,
+            on_agent_result=on_agent_result,
         )
 
     async def _exec_validated(
@@ -635,6 +785,7 @@ class WorkflowRunner:
         stream: EventStream,
         events: list[WorkflowEvent],
         emit: Callable[[WorkflowEvent], WorkflowEvent],
+        on_agent_result: Optional[AgentResultFn] = None,
     ) -> RunResult:
         """Build the run context, exec the (already validated) script under the
         wall-clock guard, and emit the terminal event. Shared by the source-given
@@ -693,6 +844,7 @@ class WorkflowRunner:
             on_event=on_event,
             replay_results=replay_results,
             replay_before=replay_before,
+            on_agent_result=on_agent_result,
         )
         ctx._events = events  # share the sink so phase/log/agent events land in order
         safe_globals = build_safe_globals(ctx)
@@ -741,7 +893,14 @@ class WorkflowRunner:
                     )
                 )
                 return RunResult(
-                    run_id, ok=False, result=None, events=events, error="timeout", source=source
+                    run_id,
+                    ok=False,
+                    result=None,
+                    events=events,
+                    error="timeout",
+                    agent_results=dict(ctx.agent_results),
+                    agent_errors=dict(ctx.agent_errors),
+                    source=source,
                 )
             result = run_task.result()  # re-raises the script's own exception, if any
         except asyncio.CancelledError:
@@ -752,19 +911,40 @@ class WorkflowRunner:
             await _pre_terminal()
             emit(stream.run_cancelled(now, reason="cancelled"))
             return RunResult(
-                run_id, ok=False, result=None, events=events, error="cancelled", source=source
+                run_id,
+                ok=False,
+                result=None,
+                events=events,
+                error="cancelled",
+                agent_results=dict(ctx.agent_results),
+                agent_errors=dict(ctx.agent_errors),
+                source=source,
             )
         except BudgetExceeded as exc:
             await _pre_terminal()
             emit(stream.run_failed(now, error=str(exc), where="ceiling"))
             return RunResult(
-                run_id, ok=False, result=None, events=events, error=str(exc), source=source
+                run_id,
+                ok=False,
+                result=None,
+                events=events,
+                error=str(exc),
+                agent_results=dict(ctx.agent_results),
+                agent_errors=dict(ctx.agent_errors),
+                source=source,
             )
         except Exception as exc:  # script raised — captured, not propagated
             await _pre_terminal()
             emit(stream.run_failed(now, error=repr(exc), where="exec"))
             return RunResult(
-                run_id, ok=False, result=None, events=events, error=repr(exc), source=source
+                run_id,
+                ok=False,
+                result=None,
+                events=events,
+                error=repr(exc),
+                agent_results=dict(ctx.agent_results),
+                agent_errors=dict(ctx.agent_errors),
+                source=source,
             )
 
         duration = time.monotonic() - started
@@ -788,6 +968,7 @@ class WorkflowRunner:
             result=result,
             events=events,
             agent_results=dict(ctx.agent_results),
+            agent_errors=dict(ctx.agent_errors),
             source=source,
         )
 
@@ -841,6 +1022,26 @@ class WorkflowRunner:
                     except Exception:  # noqa: BLE001
                         pass
 
+        def _checkpoint_agent_result(
+            call_index: int, *, result: Any, ok: bool = True, error: str = ""
+        ) -> None:
+            """Record ONE settled agent call on the run handle the moment it lands.
+
+            This is what makes the wall-clock ceiling survivable: results used to
+            reach the handle only after the whole run finished, so a run killed at
+            the ceiling wrote ``agent_results: {}`` and silently threw away every
+            payload it had already produced. The terminal paths now read them back
+            and the terminal transition flushes them to disk. A hard kill of the
+            gateway mid-run can still lose whatever no write has covered yet.
+            """
+            record = getattr(registry, "record_agent_result", None)
+            if record is None:  # pragma: no cover - registry always provides it
+                return
+            try:
+                record(run_id, call_index, result=result, ok=ok, error=error)
+            except Exception:  # noqa: BLE001 - checkpointing must never break a run
+                pass
+
         async def _factory(
             record: Callable[[WorkflowEvent], None],
         ) -> tuple[Any, str, Optional[str], dict]:
@@ -861,6 +1062,7 @@ class WorkflowRunner:
                     intent=intent,
                     author_fn=author_fn,
                     on_source=_publish_source,
+                    on_agent_result=_checkpoint_agent_result,
                 )
             finally:
                 # Fire per-run teardown (e.g. warm-pool shutdown) on EVERY exit —

--- a/src/kiro_crew/workflows/service.py
+++ b/src/kiro_crew/workflows/service.py
@@ -30,7 +30,7 @@ from kiro_crew.llm_helpers import ToolApprovalPolicy, stream_and_collect
 from .agent_exec import build_agent_fn
 from .agent_pool import build_pooled_agent_fn
 from .registry import RunRegistry
-from .runner import WorkflowRunner
+from .runner import WorkflowRunner, clamp_run_timeout
 from .store import WorkflowRunStore
 from .validate import validate
 
@@ -132,6 +132,7 @@ class WorkflowService:
         store: Any = None,
         pool_agents: bool = True,
         nudge_authorizer: Optional[Callable[..., Any]] = None,
+        timeout_secs: Optional[int] = None,
     ) -> None:
         # Durable store (FIX-21): runs are mirrored to disk so they survive gateway
         # restarts. Pass persist=False (or store=None) to keep a purely in-memory
@@ -158,6 +159,11 @@ class WorkflowService:
         self._nudge_tasks: dict[str, set[Any]] = {}
         self._now_fn = now_fn or (lambda: "1970-01-01T00:00:00Z")
         self._concurrency = concurrency
+        # Default wall-clock ceiling for runs started through this service. The
+        # ceiling is a runaway backstop, so a deployment (or an individual run) can
+        # LENGTHEN it for genuinely long investigations but never remove it —
+        # clamp_run_timeout keeps every value inside [MIN, MAX].
+        self._timeout_secs = clamp_run_timeout(timeout_secs)
         # When True, each run's ``ctx.agent()`` calls reuse a small WARM session
         # pool instead of cold-starting a fresh session per call (kills the
         # per-call cold-start that dominates workflow wall-clock — see
@@ -173,6 +179,11 @@ class WorkflowService:
                 self._seq = self._max_persisted_seq()
         except Exception:  # noqa: BLE001
             pass
+
+    @property
+    def timeout_secs(self) -> int:
+        """Effective (clamped) default wall-clock ceiling for runs of this service."""
+        return self._timeout_secs
 
     def _max_persisted_seq(self) -> int:
         """Highest wf_NNNNNN sequence among loaded runs (so new ids don't collide)."""
@@ -318,7 +329,12 @@ class WorkflowService:
             # The underlying shielded add stays supervised by AutoNudgeService.
             await asyncio.gather(*still_pending, return_exceptions=True)
 
-    def _runner(self, run_id: str) -> WorkflowRunner:
+    def _runner(self, run_id: str, *, timeout_secs: Optional[int] = None) -> WorkflowRunner:
+        # ``timeout_secs`` overrides the service default for THIS run only (clamped
+        # into [MIN, MAX] so a per-run value can lengthen the ceiling but never
+        # remove it). None → the service default.
+        ceiling = clamp_run_timeout(timeout_secs, default=self._timeout_secs)
+
         # M4 native ports wired for every run of this service. ``nudge`` bridges
         # ``ctx.nudge`` to AutoNudge (the port is session-agnostic — the runner
         # supplies each run's originating session_key at call time; the closure
@@ -354,6 +370,7 @@ class WorkflowService:
                 return WorkflowRunner(
                     agent_fn=agent_fn,
                     concurrency=self._concurrency,
+                    timeout_secs=ceiling,
                     ports=ports,
                     pre_terminal=_drain,
                     on_complete=_teardown_pooled,
@@ -372,6 +389,7 @@ class WorkflowService:
         return WorkflowRunner(
             agent_fn=agent_fn,
             concurrency=self._concurrency,
+            timeout_secs=ceiling,
             ports=ports,
             pre_terminal=_drain,
             on_complete=_teardown,
@@ -451,12 +469,17 @@ class WorkflowService:
         author: str = "",
         session_key: str = "",
         budget_total: Optional[int] = None,
+        timeout_secs: Optional[int] = None,
     ) -> dict:
         """Launch a background run that AUTHORS its own script from ``intent`` (M6.7).
 
         Returns ``{run_id}`` immediately — authoring happens inside the run as a
         visible "Authoring" phase, so the slow model call(s) never block this call
         (no more 30s synchronous-author timeout) and progress streams to the UI.
+
+        ``timeout_secs`` raises or lowers the wall-clock ceiling for this run only
+        (clamped); a long multi-phase investigation can be given more room without
+        changing the default for everything else.
         """
         if not intent.strip():
             return {"error": "intent is required"}
@@ -467,7 +490,7 @@ class WorkflowService:
         ) -> dict:
             return await self.author(it, author=author, on_progress=on_progress)
 
-        await self._runner(run_id).run_background(
+        await self._runner(run_id, timeout_secs=timeout_secs).run_background(
             "",  # no source — author inside the run
             registry=self.registry,
             run_id=run_id,
@@ -491,13 +514,18 @@ class WorkflowService:
         author: str = "",
         session_key: str = "",
         budget_total: Optional[int] = None,
+        timeout_secs: Optional[int] = None,
     ) -> dict:
-        """Validate + launch a background run; return {run_id} or {error}."""
+        """Validate + launch a background run; return {run_id} or {error}.
+
+        ``timeout_secs`` overrides the wall-clock ceiling for this run only (clamped
+        into the runner's bounds).
+        """
         vr = validate(source)
         if not vr.ok:
             return {"error": "; ".join(vr.errors), "errors": vr.errors}
         run_id = self._new_run_id()
-        await self._runner(run_id).run_background(
+        await self._runner(run_id, timeout_secs=timeout_secs).run_background(
             source,
             registry=self.registry,
             run_id=run_id,
@@ -523,7 +551,12 @@ class WorkflowService:
         return await self.registry.cancel(run_id)
 
     async def rerun_subtree(
-        self, run_id: str, from_index: int = 0, *, source: Optional[str] = None
+        self,
+        run_id: str,
+        from_index: int = 0,
+        *,
+        source: Optional[str] = None,
+        timeout_secs: Optional[int] = None,
     ) -> dict:
         """Re-run a prior workflow, replaying agent calls BEFORE ``from_index`` from
         cache and re-executing from there ("restart parts" at runtime, M6.6).
@@ -557,7 +590,7 @@ class WorkflowService:
         replay_before = 0 if edited else max(0, from_index)
         replay_results = {} if edited else dict(prior.agent_results)
         label = "rerun-edited" if edited else f"rerun@{from_index}"
-        await self._runner(new_id).run_background(
+        await self._runner(new_id, timeout_secs=timeout_secs).run_background(
             run_source,
             registry=self.registry,
             run_id=new_id,

--- a/test/test_bug_service_workflowservice_rerun_subtree.py
+++ b/test/test_bug_service_workflowservice_rerun_subtree.py
@@ -27,8 +27,9 @@ async def test_agent_defect() -> None:
         source="META = {}\nasync def workflow(ctx):\n    return 1\n",
     )
     service.registry.register(handle)
-    # Replace the runner with a no-op so no agents are spawned.
-    service._runner = lambda run_id: _FakeRunner()  # type: ignore[assignment,method-assign]
+    # Replace the runner with a no-op so no agents are spawned. ``**kw`` absorbs
+    # the keyword-only options _runner takes (e.g. timeout_secs).
+    service._runner = lambda run_id, **kw: _FakeRunner()  # type: ignore[assignment,method-assign]
 
     result = await service.rerun_subtree("wf_000001", source="   ")
 

--- a/test/test_workflows_resilience.py
+++ b/test/test_workflows_resilience.py
@@ -1,0 +1,425 @@
+"""Failure resilience for dynamic workflow runs.
+
+Regression suite for the wf_000032 post-mortem: an hour-long run hit the 3600s
+wall-clock ceiling while its last agent was in flight, and the engine persisted
+``result: null`` with ``agent_results: {}`` — silently discarding five completed
+specialist payloads. The failed agents recorded ``ok: false`` with no error text
+at all, so their cause was unrecoverable.
+
+What is locked in here:
+
+* the ceiling (and cancel / budget / crash) still terminates the run, but now
+  hands back every agent result collected so far;
+* each result is checkpointed onto the registry handle as it lands, so an
+  interruption that never reaches a terminal return still has the work;
+* a failed call records a bounded reason, distinguishing an exception from a
+  schema miss from a plain empty answer;
+* the ceiling is configurable per run but can never be removed;
+* agent concurrency is bounded run-globally, not merely per combinator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from kiro_crew.workflows.registry import STATUS_FAILED, RunRegistry
+from kiro_crew.workflows.runner import WorkflowRunner
+
+pytestmark = pytest.mark.asyncio
+
+NOW = "2026-07-30T00:00:00Z"
+
+
+async def _echo_agent(prompt: str, opts: dict):
+    return f"echo:{prompt}"
+
+
+def _runner(**kw) -> WorkflowRunner:
+    kw.setdefault("agent_fn", _echo_agent)
+    return WorkflowRunner(**kw)
+
+
+# --------------------------------------------------------------------------- #
+# partials survive every terminal path
+# --------------------------------------------------------------------------- #
+
+# Two agents finish, then the script blocks forever — the shape of wf_000032,
+# where specialists completed and the critic was still running at the ceiling.
+SCRIPT_TWO_THEN_HANG = (
+    'META = {"name": "hang-after-work"}\n'
+    "async def workflow(ctx):\n"
+    "    await ctx.agent('first')\n"
+    "    await ctx.agent('second')\n"
+    "    await ctx.agent('never-returns')\n"
+    "    return 'unreachable'\n"
+)
+
+
+def _hang_on(marker: str):
+    """Agent stub that answers normally until it sees ``marker``, then blocks."""
+
+    async def _agent(prompt: str, opts: dict):
+        if marker in prompt:
+            await asyncio.Event().wait()  # only cancellation breaks this
+        return f"echo:{prompt}"
+
+    return _agent
+
+
+async def test_ceiling_returns_completed_agent_results() -> None:
+    """The regression: a timeout used to return agent_results={} and lose the lot."""
+    res = await _runner(agent_fn=_hang_on("never-returns"), timeout_secs=0.2).run(
+        SCRIPT_TWO_THEN_HANG, run_id="wf_ceiling", now=NOW
+    )
+    assert res.ok is False
+    assert res.error == "timeout"
+    assert res.events[-1].type == "run_failed"
+    assert res.events[-1].data["where"] == "ceiling"
+    # The script never returned, so there is no whole...
+    assert res.result is None
+    # ...but the parts it already paid for are handed back.
+    assert res.agent_results == {0: "echo:first", 1: "echo:second"}
+
+
+async def test_cancellation_returns_completed_agent_results() -> None:
+    run_coro = _runner(agent_fn=_hang_on("never-returns"), timeout_secs=3600).run(
+        SCRIPT_TWO_THEN_HANG, run_id="wf_cancel", now=NOW
+    )
+    task = asyncio.ensure_future(run_coro)
+    # Let the two quick agents land before cancelling the run out from under it.
+    for _ in range(50):
+        await asyncio.sleep(0)
+    task.cancel()
+    res = await task
+    assert res.error == "cancelled"
+    assert res.result is None
+    assert res.agent_results == {0: "echo:first", 1: "echo:second"}
+
+
+async def test_script_crash_returns_completed_agent_results() -> None:
+    script = (
+        'META = {"name": "crash-after-work"}\n'
+        "async def workflow(ctx):\n"
+        "    await ctx.agent('first')\n"
+        "    raise RuntimeError('script blew up')\n"
+    )
+    res = await _runner().run(script, run_id="wf_crash", now=NOW)
+    assert res.ok is False
+    assert res.events[-1].data["where"] == "exec"
+    assert res.agent_results == {0: "echo:first"}
+
+
+async def test_budget_ceiling_returns_completed_agent_results() -> None:
+    script = (
+        'META = {"name": "budget-after-work"}\n'
+        "async def workflow(ctx):\n"
+        "    await ctx.agent('first')\n"
+        "    await ctx.agent('second')\n"
+        "    return 'done'\n"
+    )
+    # A cap of 1 lets the first call through and trips on the second.
+    res = await _runner(max_agents_per_run=1).run(script, run_id="wf_budget", now=NOW)
+    assert res.ok is False
+    assert res.events[-1].data["where"] == "ceiling"
+    assert res.agent_results == {0: "echo:first"}
+
+
+# --------------------------------------------------------------------------- #
+# per-call checkpointing (durability before the terminal state)
+# --------------------------------------------------------------------------- #
+
+
+async def test_agent_results_checkpoint_as_each_call_lands() -> None:
+    """Results must reach the host DURING the run, not only at its end."""
+    seen: list[tuple[int, object, bool, str]] = []
+
+    def _sink(call_index: int, *, result, ok: bool, error: str) -> None:
+        seen.append((call_index, result, ok, error))
+
+    script = (
+        'META = {"name": "checkpointed"}\n'
+        "async def workflow(ctx):\n"
+        "    await ctx.agent('one')\n"
+        "    await ctx.agent('two')\n"
+        "    return 'ok'\n"
+    )
+    res = await _runner().run(
+        script, run_id="wf_ckpt", now=NOW, on_agent_result=_sink
+    )
+    assert res.ok
+    assert seen == [
+        (0, "echo:one", True, ""),
+        (1, "echo:two", True, ""),
+    ]
+
+
+async def test_checkpoint_sink_failure_never_breaks_the_run() -> None:
+    def _bad_sink(call_index: int, **kw) -> None:
+        raise RuntimeError("sink exploded")
+
+    script = (
+        'META = {"name": "bad-sink"}\n'
+        "async def workflow(ctx):\n"
+        "    return await ctx.agent('one')\n"
+    )
+    res = await _runner().run(
+        script, run_id="wf_badsink", now=NOW, on_agent_result=_bad_sink
+    )
+    assert res.ok
+    assert res.result == "echo:one"
+
+
+async def test_registry_keeps_checkpointed_results_when_run_hits_ceiling() -> None:
+    """End-to-end: a background run killed at the ceiling still has its payloads
+    on the handle — which is what ``workflow_result`` reads."""
+    registry = RunRegistry()
+    runner = _runner(agent_fn=_hang_on("never-returns"), timeout_secs=0.2)
+    run_id = await runner.run_background(
+        SCRIPT_TWO_THEN_HANG,
+        registry=registry,
+        run_id="wf_bg_ceiling",
+        now=NOW,
+        name="bg-ceiling",
+    )
+    handle = registry.get(run_id)
+    assert handle is not None and handle.task is not None
+    await handle.task
+
+    assert handle.status == STATUS_FAILED
+    assert handle.error == "timeout"
+    assert handle.result is None
+    assert handle.agent_results == {0: "echo:first", 1: "echo:second"}
+    # The detail snapshot (what workflow_result returns) surfaces them, and the
+    # compact one carries the count so a completion message can mention it.
+    full = handle.snapshot(include_events=True)
+    assert full["partial_results"] == {"0": "echo:first", "1": "echo:second"}
+    assert handle.snapshot(include_events=False)["partial_result_count"] == 2
+
+
+async def test_successful_run_reports_no_partials() -> None:
+    """A finished run's ``result`` already carries the synthesis — partials would
+    just double the payload, so they stay absent."""
+    registry = RunRegistry()
+    script = (
+        'META = {"name": "fine"}\n'
+        "async def workflow(ctx):\n"
+        "    return await ctx.agent('one')\n"
+    )
+    run_id = await runner_bg(registry, script, "wf_bg_ok")
+    handle = registry.get(run_id)
+    assert handle is not None
+    assert handle.result == "echo:one"
+    full = handle.snapshot(include_events=True)
+    assert "partial_results" not in full
+    assert "partial_result_count" not in handle.snapshot(include_events=False)
+    # The resume cache is still populated (that is what rerun_subtree replays).
+    assert handle.agent_results == {0: "echo:one"}
+
+
+async def runner_bg(registry: RunRegistry, script: str, run_id: str) -> str:
+    """Run ``script`` to completion as a background run; returns its run_id."""
+    rid = await _runner().run_background(
+        script, registry=registry, run_id=run_id, now=NOW, name=run_id
+    )
+    handle = registry.get(rid)
+    assert handle is not None and handle.task is not None
+    await handle.task
+    return rid
+
+
+async def test_terminal_merge_never_erases_checkpoints() -> None:
+    """``_drive`` used to assign ``handle.agent_results = agent_results or {}``,
+    so any terminal path handing back an empty map wiped the checkpoints."""
+    registry = RunRegistry()
+    registry.record_agent_result("missing-run", 0, result="x")  # no-op, must not raise
+
+    handle_id = await runner_bg(
+        registry,
+        'META = {"name": "merge"}\nasync def workflow(ctx):\n    return await ctx.agent("a")\n',
+        "wf_merge",
+    )
+    handle = registry.get(handle_id)
+    assert handle is not None
+    registry.record_agent_result(handle_id, 5, result="late", ok=True)
+    assert handle.agent_results[0] == "echo:a"
+    assert handle.agent_results[5] == "late"
+
+
+# --------------------------------------------------------------------------- #
+# failure diagnostics
+# --------------------------------------------------------------------------- #
+
+
+async def test_schema_miss_is_distinguished_from_an_exception() -> None:
+    """Both yield None; only the reason tells you which knob to turn."""
+
+    async def _off_schema(prompt: str, opts: dict):
+        return "not json at all"
+
+    script = (
+        'META = {"name": "schema"}\n'
+        "async def workflow(ctx):\n"
+        "    return await ctx.agent('x', schema={'type': 'object'})\n"
+    )
+    res = await _runner(agent_fn=_off_schema).run(script, run_id="wf_schema", now=NOW)
+    assert res.result is None
+    assert res.agent_errors == {0: "no schema-valid result after bounded re-asks"}
+
+
+async def test_empty_answer_is_distinguished_from_an_exception() -> None:
+    async def _none_agent(prompt: str, opts: dict):
+        return None
+
+    script = (
+        'META = {"name": "empty"}\n'
+        "async def workflow(ctx):\n"
+        "    return await ctx.agent('x')\n"
+    )
+    res = await _runner(agent_fn=_none_agent).run(script, run_id="wf_empty", now=NOW)
+    assert res.agent_errors == {0: "agent returned no result"}
+
+
+async def test_agent_error_is_bounded() -> None:
+    async def _verbose_boom(prompt: str, opts: dict):
+        raise ValueError("x" * 5000)
+
+    script = (
+        'META = {"name": "verbose"}\n'
+        "async def workflow(ctx):\n"
+        "    return await ctx.agent('x')\n"
+    )
+    res = await _runner(agent_fn=_verbose_boom).run(script, run_id="wf_big", now=NOW)
+    # Bounded so a wide fan-out of failures cannot bloat the persisted record.
+    assert len(res.agent_errors[0]) < 600
+    assert res.agent_errors[0].startswith("ValueError: xxx")
+
+
+# --------------------------------------------------------------------------- #
+# the ceiling is configurable but never removable
+# --------------------------------------------------------------------------- #
+
+
+async def test_per_run_timeout_applies() -> None:
+    """A tiny per-run ceiling must actually cut the run short."""
+    script = (
+        'META = {"name": "slow"}\n'
+        "async def workflow(ctx):\n"
+        "    return await ctx.agent('never-returns')\n"
+    )
+    res = await _runner(agent_fn=_hang_on("never"), timeout_secs=0.2).run(
+        script, run_id="wf_tiny", now=NOW
+    )
+    assert res.error == "timeout"
+
+
+async def test_service_threads_and_clamps_a_per_run_timeout() -> None:
+    """The per-run override must reach the runner through the SERVICE entry point.
+
+    `_runner(timeout_secs=…)` is where the ceiling is actually chosen, so a test
+    that only passes `timeout_secs` to the WorkflowRunner constructor would not
+    cover the "configurable per run" claim at all.
+    """
+    from kiro_crew.workflows.runner import MAX_RUN_TIMEOUT_SECS, MIN_RUN_TIMEOUT_SECS
+    from kiro_crew.workflows.service import WorkflowService
+
+    svc = WorkflowService(sessions=None, persist=False, timeout_secs=1800)
+    assert svc.timeout_secs == 1800  # service default, clamped at construction
+    assert svc._runner("wf_a")._timeout_secs == 1800  # no override → default
+    assert svc._runner("wf_b", timeout_secs=7200)._timeout_secs == 7200  # lengthened
+    # Out-of-range and junk overrides can never remove or shrink past the bounds.
+    assert svc._runner("wf_c", timeout_secs=99999999)._timeout_secs == MAX_RUN_TIMEOUT_SECS
+    assert svc._runner("wf_d", timeout_secs=1)._timeout_secs == MIN_RUN_TIMEOUT_SECS
+    assert svc._runner("wf_e", timeout_secs=0)._timeout_secs == 1800
+    assert svc._runner("wf_f", timeout_secs=None)._timeout_secs == 1800
+
+
+async def test_service_default_timeout_is_itself_clamped() -> None:
+    from kiro_crew.workflows.runner import DEFAULT_RUN_TIMEOUT_SECS, MAX_RUN_TIMEOUT_SECS
+    from kiro_crew.workflows.service import WorkflowService
+
+    assert WorkflowService(sessions=None, persist=False).timeout_secs == (
+        DEFAULT_RUN_TIMEOUT_SECS
+    )
+    # A deployment cannot disable the backstop through config.
+    assert WorkflowService(sessions=None, persist=False, timeout_secs=0).timeout_secs == (
+        DEFAULT_RUN_TIMEOUT_SECS
+    )
+    assert WorkflowService(
+        sessions=None, persist=False, timeout_secs=99999999
+    ).timeout_secs == MAX_RUN_TIMEOUT_SECS
+
+
+# --------------------------------------------------------------------------- #
+# concurrency is bounded run-globally
+# --------------------------------------------------------------------------- #
+
+
+async def test_concurrency_is_bounded_across_separate_combinators() -> None:
+    """Each combinator builds its OWN semaphore, so two overlapping fan-outs could
+    exceed the configured cap in aggregate. The run-global slot in ``ctx.agent``
+    is what makes the cap honest."""
+    live = 0
+    peak = 0
+
+    async def _tracking_agent(prompt: str, opts: dict):
+        nonlocal live, peak
+        live += 1
+        peak = max(peak, live)
+        try:
+            await asyncio.sleep(0.02)
+            return f"echo:{prompt}"
+        finally:
+            live -= 1
+
+    # Two nested parallel fan-outs of 3 → 6 agent calls in flight at once unless
+    # something bounds the RUN rather than each combinator.
+    script = (
+        'META = {"name": "overlap"}\n'
+        "async def workflow(ctx):\n"
+        "    async def _fanout(tag):\n"
+        "        return await ctx.parallel([\n"
+        "            lambda: ctx.agent(tag + '1'),\n"
+        "            lambda: ctx.agent(tag + '2'),\n"
+        "            lambda: ctx.agent(tag + '3'),\n"
+        "        ])\n"
+        "    return await ctx.parallel([lambda: _fanout('a'), lambda: _fanout('b')])\n"
+    )
+    res = await _runner(agent_fn=_tracking_agent, concurrency=2).run(
+        script, run_id="wf_conc", now=NOW
+    )
+    assert res.ok
+    assert peak <= 2, f"run-global cap of 2 exceeded: peak={peak}"
+
+
+async def test_no_cap_leaves_agent_calls_unbounded() -> None:
+    """concurrency=None keeps the documented "no limit" behaviour (tests rely on
+    it, and the slot helper must be a genuine no-op rather than a cap of 1)."""
+    live = 0
+    peak = 0
+
+    async def _tracking_agent(prompt: str, opts: dict):
+        nonlocal live, peak
+        live += 1
+        peak = max(peak, live)
+        try:
+            await asyncio.sleep(0.02)
+            return f"echo:{prompt}"
+        finally:
+            live -= 1
+
+    script = (
+        'META = {"name": "unbounded"}\n'
+        "async def workflow(ctx):\n"
+        "    return await ctx.parallel([\n"
+        "        lambda: ctx.agent('a'),\n"
+        "        lambda: ctx.agent('b'),\n"
+        "        lambda: ctx.agent('c'),\n"
+        "    ])\n"
+    )
+    res = await _runner(agent_fn=_tracking_agent, concurrency=None).run(
+        script, run_id="wf_unbounded", now=NOW
+    )
+    assert res.ok
+    assert peak == 3

--- a/test/test_workflows_run_bounds.py
+++ b/test/test_workflows_run_bounds.py
@@ -1,0 +1,256 @@
+"""Pure-unit pieces of workflow failure handling: ceiling bounds + diagnostics.
+
+Companion to ``test_workflows_resilience.py`` (which exercises the same behaviour
+through a live run). Split out because this module is synchronous, matching the
+repo convention of all-async or all-sync test modules.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.workflows.registry import (
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_FINISHED,
+    STATUS_RUNNING,
+    RunHandle,
+    RunRegistry,
+)
+from kiro_crew.workflows.runner import (
+    DEFAULT_RUN_TIMEOUT_SECS,
+    MAX_AGENT_ERROR_CHARS,
+    MAX_RUN_TIMEOUT_SECS,
+    MIN_RUN_TIMEOUT_SECS,
+    clamp_run_timeout,
+    describe_agent_error,
+)
+
+# --------------------------------------------------------------------------- #
+# the ceiling is configurable but never removable
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        (None, DEFAULT_RUN_TIMEOUT_SECS),  # no override → service/engine default
+        (0, DEFAULT_RUN_TIMEOUT_SECS),  # 0 must NOT be read as "unlimited"
+        (-1, DEFAULT_RUN_TIMEOUT_SECS),
+        ("nonsense", DEFAULT_RUN_TIMEOUT_SECS),
+        (None, DEFAULT_RUN_TIMEOUT_SECS),
+        (1, MIN_RUN_TIMEOUT_SECS),  # floored: a run needs time to author itself
+        (7200, 7200),  # a genuinely long investigation is allowed
+        (99999999, MAX_RUN_TIMEOUT_SECS),  # but still bounded
+    ],
+)
+def test_clamp_run_timeout(given, expected) -> None:
+    assert clamp_run_timeout(given) == expected
+
+
+def test_clamp_run_timeout_honors_a_service_default() -> None:
+    """A deployment default applies when the caller supplies no per-run value."""
+    assert clamp_run_timeout(None, default=1800) == 1800
+
+
+def test_clamp_run_timeout_bounds_a_service_default_too() -> None:
+    """Even a configured default cannot escape the bounds."""
+    assert clamp_run_timeout(99999999, default=99999999) == MAX_RUN_TIMEOUT_SECS
+
+
+# --------------------------------------------------------------------------- #
+# failure diagnostics
+# --------------------------------------------------------------------------- #
+
+
+def test_describe_agent_error_names_the_type_and_message() -> None:
+    assert describe_agent_error(TimeoutError("too slow")) == "TimeoutError: too slow"
+
+
+def test_describe_agent_error_is_bounded() -> None:
+    described = describe_agent_error(ValueError("y" * 10_000))
+    assert len(described) <= MAX_AGENT_ERROR_CHARS + len("…")
+
+
+def test_describe_agent_error_scrubs_recognized_credentials() -> None:
+    """The reason is persisted to the run record and later surfaced over HTTP and
+    into chat, so known credential formats are scrubbed at capture time.
+
+    Only formats ``redact_credentials`` recognizes are caught (provider token
+    shapes, cloud keys) — this is defense in depth on top of the egress-side
+    redaction, not a guarantee about arbitrary secret-looking text.
+    """
+    token = "ghp_16C7e42F292c6912E7710c838347Ae178B4a"
+    described = describe_agent_error(RuntimeError(f"push rejected using {token}"))
+    assert described.startswith("RuntimeError: ")
+    assert token not in described
+
+
+def test_describe_agent_error_redacts_before_truncating() -> None:
+    """A secret sitting past the truncation boundary must still be scrubbed.
+
+    Truncating first slices the token in half, which destroys the pattern the
+    redactors match on — and the surviving prefix is still real key material.
+    """
+    token = "ghp_16C7e42F292c6912E7710c838347Ae178B4a"
+    # Push the token so it STRADDLES the cut: 20 chars of it land inside the
+    # first MAX_AGENT_ERROR_CHARS, the rest past it.
+    prefix_len = MAX_AGENT_ERROR_CHARS - len("RuntimeError: ") - 20
+    described = describe_agent_error(RuntimeError("z" * prefix_len + token))
+    assert token not in described
+    assert token[:20] not in described
+
+
+def test_describe_agent_error_never_includes_a_traceback() -> None:
+    """Frames add bulk without adding diagnosis, and carry local paths."""
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exc:
+        described = describe_agent_error(exc)
+    assert "\n" not in described
+    assert "File \"" not in described
+
+
+# --------------------------------------------------------------------------- #
+# per-agent diagnostics persist
+# --------------------------------------------------------------------------- #
+
+
+def test_registry_records_a_reason_even_when_none_is_supplied() -> None:
+    """A failed call must never persist as a silent hole — that is exactly what
+    made wf_000032's two failed agents unrecoverable."""
+    registry = RunRegistry()
+    registry.register(RunHandle(run_id="wf_r", name="r"))
+    registry.record_agent_result("wf_r", 0, result=None, ok=False, error="")
+    handle = registry.get("wf_r")
+    assert handle is not None
+    assert handle.agent_errors[0] == "agent call failed (no reason recorded)"
+
+
+def test_record_agent_result_for_unknown_run_is_a_noop() -> None:
+    RunRegistry().record_agent_result("nope", 0, result="x")  # must not raise
+
+
+def test_record_agent_result_does_not_write_to_the_store_per_call() -> None:
+    """Guard against reintroducing an O(N) synchronous write per agent call.
+
+    ``store.save`` re-serializes and re-redacts the WHOLE run record on the
+    gateway event loop, so a write per settled call would stall the loop once per
+    call over a record that grows with every payload. Durability rides the write
+    this module already performs (throttled ``record_event`` + the guaranteed
+    ``mark_terminal`` flush), which is asserted below.
+    """
+
+    class _CountingStore:
+        def __init__(self) -> None:
+            self.saves = 0
+
+        def save(self, run_id: str, obj: dict) -> None:
+            self.saves += 1
+
+        def delete(self, run_id: str) -> None:
+            pass
+
+        def load_all(self) -> list:
+            return []
+
+    store = _CountingStore()
+    registry = RunRegistry(store=store)
+    registry.register(RunHandle(run_id="wf_w", name="w"))
+    after_register = store.saves
+
+    for i in range(10):
+        registry.record_agent_result("wf_w", i, result=f"payload-{i}")
+    assert store.saves == after_register, "checkpointing must not write per call"
+
+    # The payloads are on the handle, and the terminal flush puts them on disk.
+    handle = registry.get("wf_w")
+    assert handle is not None
+    assert len(handle.agent_results) == 10
+    registry.mark_terminal("wf_w", STATUS_FAILED, error="timeout")
+    assert store.saves == after_register + 1
+
+
+def test_agent_errors_round_trip_through_the_store_form() -> None:
+    handle = RunHandle(run_id="wf_s", name="s")
+    handle.agent_results[1] = "payload"
+    handle.agent_errors[2] = "TimeoutError: slow"
+    restored = RunHandle.from_store_json(handle.to_store_json())
+    assert restored.agent_results == {1: "payload"}
+    assert restored.agent_errors == {2: "TimeoutError: slow"}
+
+
+def test_restored_record_without_agent_errors_still_loads() -> None:
+    """Records written before this field existed must keep deserializing."""
+    legacy = {
+        "run_id": "wf_old",
+        "name": "old",
+        "status": "failed",
+        "agent_results": {"0": "kept"},
+    }
+    restored = RunHandle.from_store_json(legacy)
+    assert restored.agent_results == {0: "kept"}
+    assert restored.agent_errors == {}
+
+
+def test_redaction_covers_dict_keys_not_just_values() -> None:
+    """A credential can arrive as a mapping KEY, because agent output is parsed
+    straight into the structures these surfaces serve.
+
+    Both the HTTP route and the workflow_result MCP tool walk the payload with a
+    `_redact_obj` helper; a values-only walk let a credential-shaped key through
+    into `result`, `events`, and (new here) `partial_results`.
+    """
+    from kiro_crew.dashboard.handlers.workflows import _redact_obj
+
+    token = "ghp_16C7e42F292c6912E7710c838347Ae178B4a"
+    payload = {
+        "partial_results": {"0": {token: "value-side-ok"}},
+        "events": [{"data": {token: token}}],
+    }
+    out = _redact_obj(payload)
+    flat = repr(out)
+    assert token not in flat, "credential survived redaction"
+    # The structure is preserved, just scrubbed.
+    assert "partial_results" in out and "events" in out
+
+
+def test_partial_results_only_appear_when_a_run_ended_without_a_result() -> None:
+    """Keyed on status, not `result is None`.
+
+    `result is None` is also true for a run that FINISHED and legitimately
+    returned None, and for a run still RUNNING — reporting partials for either
+    tells the reader work was cut short when it wasn't, and re-sends every
+    payload on every poll of a live run.
+    """
+    handle = RunHandle(run_id="wf_p", name="p")
+    handle.agent_results[0] = "payload"
+
+    # Still running: no result yet, but nothing was lost.
+    handle.status = STATUS_RUNNING
+    assert "partial_results" not in handle.snapshot(include_events=True)
+    assert "partial_result_count" not in handle.snapshot(include_events=False)
+
+    # Finished, and the script legitimately returned None — not an interruption.
+    handle.status = STATUS_FINISHED
+    assert "partial_results" not in handle.snapshot(include_events=True)
+    assert "partial_result_count" not in handle.snapshot(include_events=False)
+
+    # Finished with a real result: the synthesis covers it, don't double the payload.
+    handle.result = {"synthesis": "done"}
+    assert "partial_results" not in handle.snapshot(include_events=True)
+
+    # Ended without a usable return value: partials are the only output.
+    for terminal in (STATUS_FAILED, STATUS_CANCELLED):
+        handle.status = terminal
+        handle.result = None
+        assert handle.snapshot(include_events=True)["partial_results"] == {"0": "payload"}
+        assert handle.snapshot(include_events=False)["partial_result_count"] == 1
+
+
+def test_snapshot_tolerates_a_non_integer_call_index() -> None:
+    """A restored key that failed int-coercion must not break the sort."""
+    handle = RunHandle(run_id="wf_mixed", name="m", status=STATUS_FAILED)
+    handle.agent_results.update({1: "one", "weird": "two"})
+    snap = handle.snapshot(include_events=True)
+    assert snap["partial_results"] == {"1": "one", "weird": "two"}

--- a/test/test_workflows_runner.py
+++ b/test/test_workflows_runner.py
@@ -227,6 +227,10 @@ async def test_failed_agent_resolves_to_none_not_run_failure() -> None:
     assert res.result == {"r": None}
     finished = [e for e in res.events if e.type == "agent_finished"][0]
     assert finished.data["ok"] is False
+    # ...and it says WHY. A bare ok=False made post-mortems impossible: you could
+    # not tell a throttle from a bad prompt from a crashed backend.
+    assert finished.data["error"] == "RuntimeError: agent died"
+    assert res.agent_errors == {0: "RuntimeError: agent died"}
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

A dynamic-workflow run that hits the wall-clock ceiling loses **everything it already produced**. Run `wf_000032` ran for an hour, five of its eight agents completed, and the persisted record was:

```json
{ "result": null, "agent_results": {} }
```

The two agents that *failed* recorded `ok: false` with no error, stderr, or traceback — so why they died is permanently unknowable.

## Why it matters

An hour of specialist research evaporated, and recovering even a summary took a separate forensic session reading 0–120-byte preview strings out of the event stream. Any long investigation is currently one timeout away from total loss, and a failed agent gives you nothing to debug with.

## Fix (symptom → root cause → change)

**Symptom:** timeout ⇒ empty results. **Root cause:** only the *success* path copied `_RunContext.agent_results` into `RunResult` (`runner.py`); the ceiling/cancel/budget/crash returns omitted the field and silently took the dataclass default `{}`. Results also never reached the registry handle until `_drive` ran *after* the whole run, so nothing existed mid-flight to fall back on. And `_RunContext.agent()` caught `except Exception` **without binding the exception**, so the reason was discarded at the source.

**Change:**

- **Checkpoint** each agent result onto the run record as the call settles — new `RunRegistry.record_agent_result` + an `on_agent_result` runner hook threaded `run()` → `_exec_validated` → `_RunContext`.
- **Return partials on every terminal path** (ceiling, cancel, budget, script crash, success). `result` still means "the script's own return value" and stays `None` when the script never returned one — these are the parts, not the whole.
- **Capture why a call failed**: `describe_agent_error()` records a bounded, redacted `Type: message`, distinguishing an exception from a schema miss from an empty answer; `agent_finished` gains an optional `error`.
- **Make survivors reachable**: `partial_results` / `agent_errors` in the run detail snapshot **and** projected through the `workflow_result` MCP tool, with the surviving count reported in the chat completion message.
- **Per-run + per-deployment ceiling**, clamped to 60s–6h (`clamp_run_timeout`, new `agent.workflow_run_timeout_secs`): lengthenable for a genuinely long investigation, never removable. `0`/negative/garbage fall back to the default rather than meaning "unlimited".
- **Honest concurrency cap**: a run-global semaphore in `ctx.agent()` replaces per-combinator-only bounding, sized from `resolve_max_subagents()` instead of a hard-coded `4`.

Applied to `wf_000032`, this turns `result: null` into five full specialist payloads plus two error diagnoses.

### Two deliberate behaviour changes

1. Overlapping combinators that previously *exceeded* the cap now respect it — strictly fewer in-flight calls, so slower for those workflows. Previously the excess simply queued on the warm pool's own acquire.
2. Production workflow concurrency moves from a literal `4` to `resolve_max_subagents()` (floored at 3, never 0/None), so a deployment that pinned `agent.max_subagents` finally applies to workflows.

### Durability trade, stated plainly

The checkpoint is **in-memory**; it does not force a store write. `store.save` re-serializes *and* re-redacts the entire growing record synchronously on the gateway event loop, so writing once per agent call would stall the loop once per call over an ever-larger record. Disk durability rides the write this module already performs (`record_event`'s throttle + the guaranteed `mark_terminal` flush). Consequence: a hard `SIGKILL` mid-run can lose payloads no write has covered yet — exactly as it can already lose the newest events. Every orderly path (ceiling, cancel, crash, shutdown) reaches the terminal flush, so the reported bug is fully closed.

## Tests

`test/test_workflows_resilience.py` (async, through a live run) and `test/test_workflows_run_bounds.py` (sync units) — 39 tests:

- partials survive **all four** non-success terminal paths; the background ceiling case is asserted end-to-end on the registry handle
- checkpointing fires per call, tolerates a throwing sink, and **does not write to the store per call** (regression guard against reintroducing the loop stall) while the terminal flush still lands
- failure reasons distinguish exception / schema-miss / empty answer, are length-bounded, and are redacted **before** truncation
- `clamp_run_timeout` table incl. `0`/negative/`str`/`bool`/huge; service default and per-run override both clamped end-to-end through `_runner()`
- run-global cap holds across two *overlapping* combinators (peak ≤ cap), and `concurrency=None` still means unbounded
- legacy records without `agent_errors`, and non-integer call-index keys, still deserialize

## Manual verification

N/A — unit coverage is sufficient; no user-visible UI surface changed (backend only). The redaction-ordering test was additionally confirmed non-vacuous by replaying the old ordering, which leaked a 20-char `ghp_` key prefix.

## Review notes

Local mirrors (GPT + Opus) plus a verifier ran before push. Three findings folded in: redact-before-truncate (a token straddling the 500-char cut was sliced, defeating the redactors); the per-call store write removed; and `workflow_result` was dropping `partial_results` entirely, which would have made the completion message's retrieval instruction a dead end. Opus's advisory — `partial_results` keyed on `result is None` also fires for a run that finished returning `None` and for a still-running run — is fixed by keying on status.

Full backend suite: **21,678 passed**. 15 failures are pre-existing host-environment tests (sandbox spawn, pidfd, gh binary, hardlink inode), verified identical on clean `main`.
