### PR TITLE
fix(weixin): stop declaring file support the transport does not have

### DIFF
--- a/src/kiro_crew/weixin/transport.py
+++ b/src/kiro_crew/weixin/transport.py
@@ -49,13 +49,17 @@ logger = logging.getLogger(__name__)
 
 DispatchFn = Callable[[InboundMessage], Awaitable[None]]
 
-# iLink renders Markdown natively; DM-only; no threads. Files flagged True so
-# the renderer keeps attachments once media support lands.
+# iLink renders Markdown natively; DM-only; no threads. ``files`` is False
+# because this transport has NO media path: send_message carries text only, and
+# inbound media (image/voice/file/video) is not decrypted or cached (see the
+# module docstring). Flip it to True in the same change that lands the media
+# support -- declaring a capability the transport cannot perform makes the
+# contract lie to every future capability-aware caller.
 WEIXIN_CAPABILITIES = TransportCapabilities(
     streaming=False,
     edit=False,
     reactions=False,
-    files=True,
+    files=False,
     rich_blocks=False,
     threads=False,
     max_message_chars=WEIXIN_CHUNK_LIMIT,

--- a/test/test_weixin.py
+++ b/test/test_weixin.py
@@ -38,6 +38,20 @@ from kiro_crew.weixin.transport import WeixinTransport
 
 
 # ── protocol headers ──────────────────────────────────────────────────────────
+def test_declared_capabilities_do_not_promise_files_without_a_media_path():
+    """``files`` must stay False while the transport has no media path.
+
+    The flag is a contract read by capability-aware callers (and, per the
+    channel-plugin RFC, eventually by the agent's own tool surface). iLink's
+    send path carries text only and inbound media is never decrypted or cached,
+    so declaring files=True advertises a capability the transport cannot
+    perform. Flip this together with the media implementation, not before.
+    """
+    from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
+
+    assert WEIXIN_CAPABILITIES.files is False
+
+
 def test_headers_carry_required_ilink_fields():
     h = _headers("abc123", '{"k":1}')
     assert h["AuthorizationType"] == "ilink_bot_token"


### PR DESCRIPTION
# fix(weixin): stop declaring file support the transport does not have

## Problem

`WEIXIN_CAPABILITIES` declares `files=True`, with the comment *"Files flagged True so the renderer keeps attachments once media support lands."* Media support never landed — #627 removed the AES-128-ECB CDN envelope path (unreachable, and it tripped CodeQL weak-crypto), and `src/kiro_crew/weixin/transport.py` still states *"Text only for now — media (voice/file/image/video) is not supported yet."*

So the capability contract advertises something `send_message` cannot do.

## Why it matters

There is **no live misbehavior today**, and that is the point: `capabilities.files` currently has **zero read sites** across the codebase (as do `reactions`, `streaming`, `edit`, `rich_blocks`, and `threads`), which is why this drift went unnoticed for a full release.

The channel-plugin RFC (#689, amended in #778) makes this flag load-bearing — capability-aware delivery, and eventually gating the agent's own tool surface so it does not offer `file_send` on a text-only channel. The first consumer of `capabilities.files` would silently do the wrong thing for WeChat. A flag that lies is worse than a flag that is absent, so it is cheaper to correct before anything depends on it than after.

## Fix (symptom → root cause → change)

Symptom: a declared capability with no implementation behind it. Root cause: the flag was set aspirationally for a media path that was later deleted, and nothing reads the flag so no test caught the divergence. Change: `files=False`, plus a comment stating the flag must flip **in the same change** that lands media support — not before.

## Tests

`test_declared_capabilities_do_not_promise_files_without_a_media_path` pins `files is False` with the rationale, so the flag cannot drift back aspirationally again. Nothing previously asserted `files=True`, so no existing expectation changes.

Gate green: 92 weixin tests (`test_weixin.py` + `test_weixin_dispatch.py` + `test_weixin_qr.py`), `flake8`, `isort`, `mypy` (558 files).

## Manual verification

N/A — a declaration change with unit coverage. No runtime path reads the flag today, which is verifiable by grep: `capabilities.files` has no consumers.

## Screenshots

N/A — backend-only.
