### PR TITLE
fix(build): pin the website bundle's V8 heap ceiling so macOS desktop builds stop OOMing

### DIFF
--- a/test/test_website_build_heap.py
+++ b/test/test_website_build_heap.py
@@ -1,0 +1,78 @@
+"""Regression guard for the production bundle's V8 heap ceiling.
+
+Background
+----------
+``website``'s production build (``tsc -b && vite build``) peaks around 2.8 GB of
+RSS, and rollup's chunk-rendering phase is where it spikes. Node picks a default
+old-space ceiling from total system memory, so the limit differs per runner: the
+16 GB ubuntu-22.04 runner gets ~4 GB and finishes, while the 7 GB macos-14 arm64
+runner gets less and dies with ``FATAL ERROR: Ineffective mark-compacts near heap
+limit`` in ``rendering chunks...``. The failure is platform-split and looks like a
+flake, which is how it survived several rounds of "re-run the job".
+
+Every packaging path (``make website``, ``make desktop`` via
+``packaging/build-desktop.sh``, build-wheel, build, ci, pages and docker-smoke
+workflows) shells out to ``npm run build``, so the ceiling belongs in that one
+script rather than in each caller's environment.
+
+Why the flag and not ``NODE_OPTIONS``
+------------------------------------
+An inline ``NODE_OPTIONS=...`` prefix inside an npm script is not portable to
+Windows ``cmd`` without a helper dependency, and exporting it in CI would leave
+local and packaged builds on the old default. Invoking vite's own bin through
+``node`` with the flag works identically on every platform. The ceiling is a cap,
+not a reservation, so a build that does not need the headroom does not pay for it.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_JSON = REPO_ROOT / "website" / "package.json"
+
+#: The observed peak is ~2.8 GB; this leaves headroom for growth while staying
+#: under the smallest runner's physical memory (macos-14 has 7 GB).
+MIN_HEAP_MB = 6144
+
+
+def _build_script() -> str:
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    return str(data["scripts"]["build"])
+
+
+def test_build_script_raises_the_heap_ceiling_explicitly():
+    script = _build_script()
+    match = re.search(r"--max-old-space-size=(\d+)", script)
+    assert match, (
+        "website's build script no longer pins a V8 heap ceiling; the macos-14 "
+        "runner will OOM in rollup's chunk-rendering phase"
+    )
+    assert int(match.group(1)) >= MIN_HEAP_MB, (
+        f"heap ceiling {match.group(1)} MB is below the {MIN_HEAP_MB} MB the bundle needs"
+    )
+
+
+def test_build_script_invokes_vite_through_node():
+    """The flag has to reach V8. `vite build` alone would ignore it, and an inline
+    NODE_OPTIONS prefix does not survive Windows cmd."""
+    script = _build_script()
+    assert "node --max-old-space-size" in script, (
+        "the heap flag is not passed to a node invocation"
+    )
+    assert "vite/bin/vite.js" in script, (
+        "the build no longer runs vite's bin directly, so the flag reaches nothing"
+    )
+    assert "NODE_OPTIONS" not in script, (
+        "an inline NODE_OPTIONS prefix is not portable to Windows cmd"
+    )
+
+
+def test_type_check_still_runs_before_the_bundle():
+    """`tsc -b` is the only thing that type-checks the app (the root tsconfig is
+    references-only), so it must stay ahead of the bundle step."""
+    script = _build_script()
+    assert script.index("tsc -b") < script.index("vite"), (
+        "the bundle is built before types are checked"
+    )

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "clean": "rm -rf dist && rm -rf node_modules",
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && node --max-old-space-size=6144 ./node_modules/vite/bin/vite.js build",
     "preview": "vite preview",
     "analyze": "vite build --mode analyze && node scripts/bundle-report.mjs",
     "test": "npm run test:website && npm run test:electron",


### PR DESCRIPTION
## Problem

`Build Desktop (macos-14)` fails during the website bundle:

```
transforming...
rendering chunks...
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
sh: line 1:  2864 Abort trap: 6           vite build
make: *** [desktop] Error 134
```

`Build Desktop (ubuntu-22.04)` succeeds on the same commit. This is reproducible on
**`main`**, not just on a feature branch — `ae704324` (#848) failed the identical way
at 18:24 UTC, and PR #518 failed it at 16:28 and again at 19:20.

## Why it matters

The macOS desktop artifact is not built at all when this trips, so every PR carries a
red required check and the DMG is unverified. Because the failure is platform-split
and clears on some re-runs, it reads like a flake — several PRs have already burned
re-run cycles on it, and one has been carrying it as "known runner OOM" for three
rounds.

## Fix (symptoms → root cause → change)

**Symptom:** OOM in rollup's `rendering chunks` phase, macOS only.

**Root cause:** Node derives its default old-space ceiling from total system memory.
The macos-14 arm64 runner has 7 GB (3 vCPU); ubuntu-22.04 has 16 GB and lands on the
~4 GB cap. Measured locally, the production bundle now peaks at **2.79 GB RSS** — the
chunk-rendering phase spikes past what macOS's smaller default allows, while the
Linux default absorbs it. Nothing in the repo pins a ceiling, so the build inherits
whichever default the runner happens to give it.

**Change:** pin the ceiling in `website/package.json`'s `build` script, invoking
vite's own bin through `node` so the flag actually reaches V8:

```
"build": "tsc -b && node --max-old-space-size=6144 ./node_modules/vite/bin/vite.js build"
```

One line, one place: `make website`, `make desktop` (via
`packaging/build-desktop.sh`), and the `build`, `build-wheel`, `ci`, `pages` and
`docker-smoke` workflows all shell out to `npm run build`, so none of them need their
own environment tweak.

Two alternatives rejected: an inline `NODE_OPTIONS=` prefix inside an npm script is
not portable to Windows `cmd` without adding a helper dependency, and setting
`NODE_OPTIONS` in CI only would leave local and packaged builds on the old default —
which is where a developer would next hit it. The flag is a cap, not a reservation,
so a build that does not need the headroom does not pay for it. 6144 MB leaves room
for bundle growth while staying under the 7 GB runner's physical memory.

## Tests

`test/test_website_build_heap.py` (3 tests, revert-verified — reverting the
`package.json` line fails two of them):

- the build script pins `--max-old-space-size` at ≥ 6144 MB
- the flag reaches V8: it is passed to a `node` invocation of `vite/bin/vite.js`, and
  is not an inline `NODE_OPTIONS` prefix
- `tsc -b` still runs before the bundle (the root tsconfig is references-only, so
  `tsc -b` is the only thing that type-checks the app)

## Manual verification

Ran `npm run build` with the patched script: clean build in 38.7 s. Confirmed the
flag lands, rather than assuming it: `node --max-old-space-size=6144 -e` reports a
6.19 GB `heap_size_limit` against 4.19 GB by default on this host.

Not verified: that the macos-14 runner passes. That needs this branch's own
`Build Desktop (macos-14)` run, which is the check to watch on this PR.

## Screenshots

N/A — build configuration only, no user-visible surface.
