### PR TITLE
chore(session-pid): stop logging a traceback for the expected orphan-probe race

### DIFF
--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -976,6 +976,16 @@ def _protected_pids() -> set[int]:
 _ORPHAN_SWEEP_MAX_KILLS = 30
 _ORPHAN_MIN_AGE_SECONDS = 120  # Never reap processes younger than this
 
+# A candidate PID can exit between the /proc (or ps) snapshot and the per-PID
+# probe. Linux surfaces that as FileNotFoundError/ProcessLookupError reading
+# /proc/<pid>/cmdline; macOS as a non-zero `ps -p <pid>` exit. All three mean
+# "already gone", which is the sweep's goal — not a failure worth a traceback.
+_PID_VANISHED_ERRORS = (
+    FileNotFoundError,
+    ProcessLookupError,
+    subprocess.CalledProcessError,
+)
+
 # Entrypoints that positively identify a KiroCrew-spawned MCP/worker process.
 # Each marker MUST be unique to a process KiroCrew itself launches — the sweep
 # SIGKILLs any user-owned orphan that matches, so a marker naming a server the
@@ -1187,6 +1197,13 @@ def find_orphan_mcp_candidates(active_pids: set[int]) -> list[int]:
                 fields = ps_out.split(None, 1)
                 pid_age = _parse_etime(fields[0].decode() if fields else "")
                 cmdline = fields[1] if len(fields) > 1 else b""
+        except _PID_VANISHED_ERRORS:
+            # Expected TOCTOU race: the PID was in the /proc (or ps) snapshot
+            # taken by _our_orphan_pids() and exited before this probe read it.
+            # That is the outcome the sweep wants, so log one line — a stack
+            # trace here would overstate a routine event.
+            logger.debug("Orphan candidate pid %s vanished before probe", pid)
+            continue
         except Exception:
             logger.debug(
                 "Orphan candidate probe failed for pid %s",

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -62,15 +62,30 @@ class TestTrackUntrack:
         _untrack_pid(999)  # should not crash
         assert "111" in pid_file.read_text(encoding="utf-8")
 
-    def test_untrack_session_pid(self, session_pid_file: Path) -> None:
+    @pytest.mark.parametrize("token", [None, "tok123"])
+    def test_untrack_session_pid(
+        self,
+        session_pid_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        token: str | None,
+    ) -> None:
+        """Untrack removes only the named PID's entry, in either record format.
+
+        Pin the start token instead of inheriting it from the host: PIDs 111
+        and 222 are live kernel threads on some machines (so _track writes the
+        3-field ``gw:pid:token``) and absent on others (2-field ``gw:pid``),
+        which would otherwise make the expected value host-dependent.
+        """
         from kiro_crew.session_pid import _track_session_pid, _untrack_session_pid
 
+        monkeypatch.setattr("kiro_crew.session_pid._pid_start_token", lambda p: token)
         _track_session_pid(111)
         _track_session_pid(222)
         _untrack_session_pid(111)
         gw = os.getpid()
+        suffix = f":{token}" if token else ""
         lines = session_pid_file.read_text(encoding="utf-8").strip().splitlines()
-        assert lines == [f"{gw}:222"]
+        assert lines == [f"{gw}:222{suffix}"]
 
     def test_untrack_session_pid_missing_file(self, session_pid_file: Path) -> None:
         from kiro_crew.session_pid import _untrack_session_pid
@@ -389,6 +404,81 @@ class TestFindOrphanMcpCandidates:
             result = find_orphan_mcp_candidates(active_pids={100, 200})
 
         assert result == []
+
+    def test_vanished_pid_logs_one_line_without_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A PID that exits between snapshot and probe logs no stack trace.
+
+        The candidate is already gone, which is what the sweep wants, so the
+        expected TOCTOU race must not emit exc_info.
+        """
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[22620]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(
+                Path,
+                "read_bytes",
+                side_effect=FileNotFoundError(2, "No such file or directory"),
+            ),
+            patch("os.getpid", return_value=1),
+            caplog.at_level("DEBUG", logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+        records = [r for r in caplog.records if "22620" in r.getMessage()]
+        assert len(records) == 1
+        assert records[0].exc_info is None
+        assert "vanished before probe" in records[0].getMessage()
+
+    def test_vanished_pid_on_macos_ps_exit_logs_no_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """`ps -p <dead-pid>` exits non-zero — same race, same quiet handling."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[9140]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch(
+                "kiro_crew.session_pid.subprocess.check_output",
+                side_effect=subprocess.CalledProcessError(1, "ps"),
+            ),
+            patch("os.getpid", return_value=1),
+            caplog.at_level("DEBUG", logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "darwin"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+        records = [r for r in caplog.records if "9140" in r.getMessage()]
+        assert len(records) == 1
+        assert records[0].exc_info is None
+
+    def test_unexpected_probe_error_keeps_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A genuinely unexpected probe failure still logs exc_info."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[555]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", side_effect=PermissionError(13, "denied")),
+            patch("os.getpid", return_value=1),
+            caplog.at_level("DEBUG", logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+        records = [r for r in caplog.records if "555" in r.getMessage()]
+        assert len(records) == 1
+        assert records[0].exc_info is not None
 
     def test_excludes_non_kirocrew_processes(self) -> None:
         """Orphans without known MCP entrypoint markers are skipped."""


### PR DESCRIPTION
## Problem

Every time the orphan-MCP sweep runs, a candidate PID that exits between the
process-table snapshot and the per-PID probe produces a 12-line
`FileNotFoundError` traceback in the gateway log:

```
19:48:41 DEBUG kiro_crew.session_pid: Orphan candidate probe failed for pid 22620
Traceback (most recent call last):
  File ".../kiro_crew/session_pid.py", line 1173, in find_orphan_mcp_candidates
    cmdline = Path(f"/proc/{pid}/cmdline").read_bytes()
  ...
FileNotFoundError: [Errno 2] No such file or directory: '/proc/22620/cmdline'
```

The PID being gone is exactly what the sweep wants. Nothing is broken, but the
log says "probe failed" and prints a stack trace.

## Why it matters

An operator reading the log sees a stack trace and has to spend time proving it
is benign — as happened here. Measured on a real gateway log this fires 10 times
in ~19.7 hours (~0.5/hour), costing 120 of 55,135 lines (0.22% of volume). So
this is a log-hygiene fix, not a volume fix: the traceback overstates the
severity of a routine event, which is the actual cost.

## Fix (symptom → root cause → change)

**Symptom:** a `FileNotFoundError` stack trace at DEBUG on every sweep that
happens to race a dying process.

**Root cause:** `find_orphan_mcp_candidates` wraps the whole per-PID probe in a
single `except Exception` that logs with `exc_info=True`. `_our_orphan_pids()`
takes a snapshot of same-UID PIDs parented to init/`systemd --user`, and the
probe then reads `/proc/<pid>/cmdline` (Linux) or shells out to `ps` (macOS).
A PID can exit in that window — an unavoidable TOCTOU race, and the sweep's
desired outcome — but the handler treats it identically to a genuine failure.

**Change:** add a `_PID_VANISHED_ERRORS` clause *ahead* of the generic handler
that logs one line with no `exc_info`:

```
20:48:41 DEBUG kiro_crew.session_pid: Orphan candidate pid 22620 vanished before probe
```

The tuple is `(FileNotFoundError, ProcessLookupError, subprocess.CalledProcessError)`.
The third member is load-bearing for macOS: `ps -p <dead-pid>` exits non-zero, so
`check_output` raises `CalledProcessError` for the identical race — without it,
macOS would keep printing tracebacks for the event Linux no longer prints.
`subprocess.TimeoutExpired` deliberately stays out of the tuple so a hung `ps`
still gets a traceback.

The generic `except Exception` is untouched, so anything genuinely unexpected
(e.g. `PermissionError`) keeps full `exc_info`. Both clauses `continue`, so
**which PIDs get killed is unchanged** — this is logging-only.

Also fixes `test_untrack_session_pid`, which failed on this machine and passed in
CI. Its expected record was host-dependent: `_track_session_pid` writes
`<gw>:<pid>:<start_token>` when a start token is available and the legacy
`<gw>:<pid>` otherwise, and PIDs 111/222 are live kernel threads on some hosts
(`cpuhp/20`, `migration/42`) and absent on others. The test now pins the token via
`monkeypatch` and is parameterized over both record formats, so the expectation no
longer depends on which low PIDs happen to be alive.

## Tests

`test/test_pid_lifecycle.py`, +94 lines:

- `test_vanished_pid_logs_one_line_without_traceback` — Linux path: asserts
  exactly one record for the PID, `exc_info is None`, and the new message.
- `test_vanished_pid_on_macos_ps_exit_logs_no_traceback` — non-Linux path:
  `check_output` raising `CalledProcessError` is quieted the same way.
- `test_unexpected_probe_error_keeps_traceback` — a `PermissionError` still
  carries `exc_info`. Guards against future over-broadening of the tuple.
- `test_untrack_session_pid[None]` / `[tok123]` — untrack removes only the named
  PID's entry, in both the legacy and token-bearing record formats.

RED-verified: with the source change stashed and the tests in place, the two
vanished tests fail on `exc_info` being populated, and pass after. The
`PermissionError` guard passes both before and after by design — it is a
characterization test, not a regression test.

## Manual verification

N/A — unit coverage is sufficient. The behavior under test is which log record
gets emitted for a given exception, which `caplog` observes directly; there is no
integration surface to exercise. The traceback in the Problem section is from a
real gateway log, and the quieted line is the one this change emits for it.

## Screenshots

N/A — no user-visible UI change. Backend logging only; no `website/**` files
touched.

## Notes for the reviewer

- Two pre-existing failures on `origin/main` (861cac27) are unrelated to this
  change and were confirmed by stashing it: `test_sandbox_argv.py` (9 failed / 91
  passed, byte-identical with and without) and the environmental set
  (`test_sandbox_cc_mode.py`, missing optional `qrcode`, source-provider install
  paths). `test_untrack_session_pid` was a third and **is** fixed here.
- Deliberately out of scope: no counter or metric for how often the race fires.
  If a durable record of the rate is wanted, DEBUG is the wrong level for it and a
  counter is the right mechanism — but that is new state, not this change.
