### PR TITLE
fix(cli): verify the replacement gateway is serving before reporting success

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import logging
 import os
@@ -739,7 +740,7 @@ def _own_console_script() -> str | None:
     return str(path)
 
 
-def _spawn_detached_gateway(port: int | None = None) -> int:
+def _spawn_detached_gateway(port: int | None = None) -> subprocess.Popen[bytes]:
     """Spawn a detached ``kirocrew gateway`` so the calling shell returns.
 
     Used by :func:`_restart` when no platform service is active. The
@@ -770,7 +771,11 @@ def _spawn_detached_gateway(port: int | None = None) -> int:
     would bind 5476 while the parent polls 6776 and prints a 6776 URL. Naming
     the port explicitly removes the disagreement by construction.
 
-    Returns the new PID.
+    Returns the ``Popen`` handle, not just the pid: the caller must be able to
+    ask whether the replacement is still alive before it reports success, and
+    only the handle yields the child's **exit status** when it is not. A
+    replacement refused by the ``KIROCREW_HOME`` ownership guard exits 1 within
+    milliseconds, and that status is the whole diagnosis.
     """
     log_path = config_dir() / "gateway.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -808,16 +813,151 @@ def _spawn_detached_gateway(port: int | None = None) -> int:
         start_new_session=platform_compat.IS_POSIX,
         creationflags=(platform_compat.DETACHED_PROCESS | platform_compat.CREATE_NEW_PROCESS_GROUP),
     )
-    return proc.pid
+    return proc
 
 
 _RESTART_TOKEN_TTL = "20h"
 _RESTART_READY_TIMEOUT = 15  # seconds to wait for gateway to become ready
+# Gap between readiness probes while waiting for the replacement gateway. Short
+# enough that a fast boot is reported promptly, long enough not to hammer the
+# starting gateway's event loop while it restores sessions.
+_RESTART_READY_POLL_INTERVAL = 0.5
 # Seconds to wait for the incumbent gateway to exit before spawning its
 # replacement. Generous because a graceful shutdown reaps MCP servers and
 # kiro-cli children; the wait ends as soon as the pids are gone, so the common
 # case costs a fraction of a second.
 _RESTART_STOP_TIMEOUT = 30.0
+
+# Verdicts returned by :func:`_wait_gateway_ready`. The two failure modes are
+# kept apart because they need different operator action: a replacement that
+# DIED is a refused/broken startup (read the log), while one that never became
+# READY is still running and may simply be slow.
+_READY_OK = "ready"
+_READY_DIED = "died"
+_READY_TIMEOUT = "timeout"
+
+
+def _probe_gateway_ready(port: int, timeout: int = 3) -> int:
+    """HTTP status of ``GET /api/ready`` on the loopback gateway, ``0`` if unreachable.
+
+    Same contract as :func:`kiro_crew.pod.runtime.health` (the status code, or
+    ``0`` when the connection itself fails) but pointed at ``/api/ready`` rather
+    than ``/api/health``. That choice is the point of the probe: liveness only
+    proves a socket is bound, whereas readiness returns 503 until
+    ``DashboardState.ready`` is published *and* 503 again the moment shutdown is
+    requested — exactly the difference between "something answers this port" and
+    "the new gateway is serving". Both paths are in ``origin.PROBE_PATHS`` and
+    need no auth, so this hands no secret to whatever answers.
+
+    Every failure mode collapses to ``0`` (unreachable), including a listener
+    that answers the TCP handshake but does not speak HTTP. That case raises
+    ``http.client.HTTPException`` (``BadStatusLine`` and friends), which is NOT
+    an ``OSError`` or a ``URLError``, so it has to be caught explicitly -- and it
+    is exactly the case this probe exists to survive: a wedged fork holding the
+    port is the reason restart is being run at all, and it must produce a
+    "not ready" verdict, never an uncaught traceback out of the CLI.
+    """
+    url = f"http://{_CLI_LOOPBACK}:{port}/api/ready"
+    try:
+        # Loopback-only probe to our own gateway on 127.0.0.1; the URL is
+        # internally derived (never attacker-supplied), so the dynamic-URL SSRF
+        # audit rule is a false positive here.
+        with urllib.request.urlopen(url, timeout=timeout) as resp:  # nosemgrep
+            return int(resp.status)
+    except urllib.error.HTTPError as e:
+        return int(e.code)
+    except (urllib.error.URLError, OSError, http.client.HTTPException):
+        return 0
+
+
+def _replacement_is_serving(port: int, prior_pid: int | None) -> bool:
+    """True when the gateway now answering *port* is NOT the pre-restart one.
+
+    A bare port probe cannot tell a replacement from the incumbent — the old
+    gateway keeps answering until its socket closes, so a 200 taken during the
+    handover would report success for the process we just asked to die. The
+    discriminator is the run-marker pid: every dashboard-serving gateway records
+    its own pid in ``run/gateway-<port>.pid`` while wiring the dashboard, i.e.
+    *before* it publishes readiness, so a ready gateway's marker always names the
+    process that is serving. Waiting for that identity to CHANGE (rather than for
+    any 200) mirrors the ``_gateway_start_id`` handshake in the dev-fleet app.
+
+    On POSIX with a working listener lookup the marker claim is additionally
+    checked against reality via :func:`_gateway_owns_port` (recorded pid holds
+    the port, owned by us, looks like a gateway). That check denies outright on
+    Windows — and on any POSIX host without ``lsof``/``netstat`` it cannot
+    succeed either — so it is only applied where it can pass; elsewhere the
+    marker comparison alone stands, which keeps restart from reporting a false
+    failure on those hosts.
+
+    **No marker means not proven, never proven.** An absent marker is the state
+    the handover itself produces: ``clear_marker`` runs on graceful shutdown
+    BEFORE the outgoing gateway's ``_shutdown()``, so there is a window in which
+    the old gateway has erased its marker and its socket still answers. Treating
+    that as "the replacement is serving" would report the outgoing gateway's 200
+    as the new one's — precisely the confusion this function exists to prevent —
+    and on a host without a listener lookup nothing downstream would catch it.
+    So an unreadable marker returns ``False``: the caller keeps polling until a
+    marker appears or the deadline passes. The cost is a gateway whose marker
+    write failed (the write is best-effort, wrapped in ``except Exception``)
+    being reported as "not ready" while it is in fact serving. That is the right
+    way to be wrong here — a misleading timeout leaves a working gateway and an
+    accurate ``kirocrew token``, whereas a false success leaves the operator
+    believing a dead replacement is up.
+    """
+    recorded = run_marker.read_pid(port)
+    if recorded is None:
+        return False
+    if prior_pid is not None and recorded == prior_pid:
+        return False
+    if platform_compat.IS_POSIX and platform_compat.listening_pid_tool_available():
+        return _gateway_owns_port(port)
+    return True
+
+
+def _wait_gateway_ready(
+    proc: subprocess.Popen[bytes],
+    port: int,
+    prior_pid: int | None,
+    timeout: float,
+) -> tuple[str, int | None]:
+    """Poll until the spawned gateway actually serves *port*, or fail.
+
+    Returns ``(_READY_OK, None)`` once the replacement answers ``/api/ready``,
+    ``(_READY_DIED, exit_status)`` as soon as the child has exited, or
+    ``(_READY_TIMEOUT, None)`` when the deadline passes with it still up.
+
+    Two details earn their keep:
+
+    * **Early death short-circuits the wait.** A replacement refused by the
+      ``KIROCREW_HOME`` ownership guard exits within milliseconds; polling the
+      port for the full timeout would turn a instantly-knowable failure into a
+      15s stall with a worse message. ``proc.poll()`` is used rather than a pid
+      liveness probe because we are the child's parent, so it both detects the
+      exit and yields the status the operator needs. (Same shape as ``pod``'s
+      ``_wait_healthy`` bailing out on a dead unit instead of burning the wait.)
+    * **A zero timeout still probes once.** The deadline is checked *after* the
+      probe, so a collapsed timeout reports what is actually there instead of a
+      reflexive failure.
+    * **The child is re-polled before the timeout verdict.** A replacement that
+      exits DURING the last probe would otherwise be reported as "still running
+      but not ready", sending the operator to look for a live process that no
+      longer exists. The extra poll costs nothing and makes the two verdicts
+      mutually exclusive in fact, not just by intention.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        status = proc.poll()
+        if status is not None:
+            return _READY_DIED, status
+        if _probe_gateway_ready(port) == 200 and _replacement_is_serving(port, prior_pid):
+            return _READY_OK, None
+        if time.monotonic() >= deadline:
+            status = proc.poll()
+            if status is not None:
+                return _READY_DIED, status
+            return _READY_TIMEOUT, None
+        time.sleep(_RESTART_READY_POLL_INTERVAL)
 
 
 def _print_token_url(port: int) -> None:
@@ -862,7 +1002,11 @@ def _restart(cli_port: int | None = None) -> None:
        it (``systemctl restart`` / ``launchctl unload + load``).
     2. Otherwise, SIGTERM the foreground gateway via the existing
        lsof+SIGTERM path used by ``kirocrew stop``, then spawn a
-       detached replacement.
+       detached replacement and **verify it is serving** before reporting
+       success: a spawn only proves a pid was created, so the replacement is
+       polled on ``/api/ready`` until it answers. If it dies or never becomes
+       ready the command prints why and exits non-zero rather than claiming a
+       gateway that is not there.
 
     When ``cli_port is not None`` (user passed ``--port N``), branch (1) is
     bypassed: the systemd unit name is not bound to a specific port, so
@@ -899,6 +1043,13 @@ def _restart(cli_port: int | None = None) -> None:
     # kirocrew-process predicate so an unrelated listener on this port never
     # becomes something we block on. The entry condition below stays on the
     # UNFILTERED lookup so _stop() keeps emitting its existing diagnostics.
+    # Identity of the gateway we are about to replace, read BEFORE the stop: a
+    # graceful shutdown clears the run-marker, so afterwards there is nothing
+    # left to compare the replacement against. _replacement_is_serving() uses it
+    # so a 200 from the OUTGOING gateway can never be mistaken for the new one
+    # coming up. None (no marker, e.g. after a crash) simply means there is no
+    # old identity to exclude.
+    prior_marker_pid = run_marker.read_pid(port)
     listeners = platform_compat.find_listening_pids(port)
     incumbents = [p for p in listeners if _is_kirocrew_process(p)]
     if listeners or not platform_compat.listening_pid_tool_available():
@@ -935,7 +1086,45 @@ def _restart(cli_port: int | None = None) -> None:
             )
             sys.exit(1)
 
-    pid = _spawn_detached_gateway(port)
+    proc = _spawn_detached_gateway(port)
+    pid = proc.pid
+    # A pid is not a running gateway. The replacement can be refused by the
+    # ownership guard, crash on a bad config, or hang before it binds — all of
+    # which used to print the success line below and exit 0 with nothing serving.
+    # Report success only once the NEW gateway answers, and audit what happened.
+    verdict, exit_status = _wait_gateway_ready(proc, port, prior_marker_pid, _RESTART_READY_TIMEOUT)
+    if verdict != _READY_OK:
+        reason = (
+            f"replacement_died exit={exit_status}"
+            if verdict == _READY_DIED
+            else f"replacement_not_ready_within={int(_RESTART_READY_TIMEOUT)}s"
+        )
+        sel().log_api_access(
+            caller="cli",
+            operation="gateway_restart",
+            outcome="denied",
+            source="cli",
+            resources=f"port={port} via=fork pid={pid} reason={reason}",
+        )
+        if verdict == _READY_DIED:
+            print(
+                f"❌ Replacement gateway (pid {pid}) died immediately "
+                f"(exit status {exit_status}). Nothing is serving port {port}.\n"
+                f"   A replacement that exits at once is usually refused startup — "
+                f"another process still owning {config_dir()}, or a broken config.\n"
+                f"   To see why it exited, run: kirocrew logs -f"
+            )
+        else:
+            print(
+                f"❌ Replacement gateway (pid {pid}) did not become ready within "
+                f"{int(_RESTART_READY_TIMEOUT)}s. It is still running but not "
+                f"serving port {port}.\n"
+                f"   It may be slow to start or wedged during startup; nothing is "
+                f"serving the dashboard yet.\n"
+                f"   To follow its startup, run: kirocrew logs -f"
+            )
+        sys.exit(1)
+
     sel().log_api_access(
         caller="cli",
         operation="gateway_restart",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1826,7 +1826,7 @@ class TestRestart:
 
     @pytest.fixture(autouse=True)
     def _fast_restart_ready(self, monkeypatch):
-        """Collapse the post-spawn readiness poll so these tests don't spin.
+        """Collapse the post-spawn readiness work so these tests don't spin.
 
         These tests mock the gateway lifecycle (``_spawn_detached_gateway`` /
         ``restart_service``); with no real gateway, ``_print_token_url()``'s
@@ -1835,8 +1835,26 @@ class TestRestart:
         tests assert restart/spawn/stop dispatch, not token-URL readiness, so
         pin the timeout to 0 (loop is skipped, function returns immediately).
         Production default is unchanged.
+
+        For the same reason the post-spawn readiness VERDICT is pinned to
+        ``_READY_OK``: nothing here can actually become ready, so the real
+        verdict would (correctly) fail every dispatch test and mask what they
+        assert. The verdict itself is covered by
+        :class:`TestRestartReadinessVerdict` and :class:`TestWaitGatewayReady`,
+        which deliberately do NOT inherit this fixture.
         """
+        from kiro_crew import cli_server
+
         monkeypatch.setattr("kiro_crew.cli_server._RESTART_READY_TIMEOUT", 0)
+        monkeypatch.setattr(
+            "kiro_crew.cli_server._wait_gateway_ready",
+            lambda *a, **kw: (cli_server._READY_OK, None),
+        )
+
+    @staticmethod
+    def _fake_proc(pid: int) -> MagicMock:
+        """A ``Popen``-shaped stand-in: ``_restart`` reads ``.pid`` and polls it."""
+        return MagicMock(pid=pid, poll=MagicMock(return_value=None))
 
     @pytest.fixture(autouse=True)
     def _tool_available(self):
@@ -1891,7 +1909,10 @@ class TestRestart:
                 "kiro_crew.cli_server.platform_compat.find_listening_pids",
                 return_value=[],
             ),
-            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=4321) as mock_spawn,
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=self._fake_proc(4321),
+            ) as mock_spawn,
             patch("kiro_crew.cli_server._stop") as mock_stop,
         ):
             _restart(None)
@@ -1915,7 +1936,10 @@ class TestRestart:
                 return_value=[1234],
             ),
             patch("kiro_crew.cli_server._stop") as mock_stop,
-            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=5678) as mock_spawn,
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=self._fake_proc(5678),
+            ) as mock_spawn,
         ):
             _restart(None)
         # Order matters: stop first, then spawn — otherwise the new
@@ -1944,7 +1968,10 @@ class TestRestart:
                 return_value=[1234],
             ),
             patch("kiro_crew.cli_server._stop", side_effect=SystemExit(1)) as mock_stop,
-            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=9999) as mock_spawn,
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=self._fake_proc(9999),
+            ) as mock_spawn,
         ):
             _restart(None)
         mock_stop.assert_called_once_with(None)
@@ -1985,7 +2012,10 @@ class TestRestart:
             patch("kiro_crew.cli_server._stop"),
             patch("kiro_crew.cli_server._pid_exited", side_effect=fake_pid_exited),
             patch("kiro_crew.cli_server._print_token_url"),
-            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=5678) as mock_spawn,
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=self._fake_proc(5678),
+            ) as mock_spawn,
         ):
             cli_server._restart(None)
 
@@ -2051,7 +2081,10 @@ class TestRestart:
             patch("kiro_crew.cli_server._stop") as mock_stop,
             patch("kiro_crew.cli_server._pid_exited", return_value=False) as mock_exited,
             patch("kiro_crew.cli_server._print_token_url"),
-            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=5678) as mock_spawn,
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=self._fake_proc(5678),
+            ) as mock_spawn,
         ):
             cli_server._restart(None)
 
@@ -2099,7 +2132,10 @@ class TestRestart:
                 "kiro_crew.cli_server.platform_compat.listening_pid_tool_available",
                 return_value=True,
             ),
-            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=1234) as mock_spawn,
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=self._fake_proc(1234),
+            ) as mock_spawn,
             patch("kiro_crew.cli_server._print_token_url"),
         ):
             cli_server._restart(None)
@@ -2117,8 +2153,12 @@ class TestRestart:
             patch("shutil.which", return_value="/usr/local/bin/kirocrew"),
             patch("kiro_crew.cli_server.subprocess.Popen", return_value=proc) as mock_popen,
         ):
-            pid = _spawn_detached_gateway()
-        assert pid == 9999
+            spawned = _spawn_detached_gateway()
+        # The Popen HANDLE is returned, not a bare pid: restart must be able to
+        # poll the child for early death (and its exit status) before it reports
+        # success.
+        assert spawned is proc
+        assert spawned.pid == 9999
         argv = mock_popen.call_args.args[0]
         assert argv == ["/usr/local/bin/kirocrew", "gateway"]
         # Must detach from the controlling terminal — otherwise the detached
@@ -2258,7 +2298,10 @@ class TestRestart:
                 "kiro_crew.cli_server.service_controller.restart_service",
                 return_value=True,
             ) as mock_restart_service,
-            patch("kiro_crew.cli_server._spawn_detached_gateway", return_value=4321) as mock_spawn,
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=self._fake_proc(4321),
+            ) as mock_spawn,
             patch(
                 "kiro_crew.cli_server.platform_compat.find_listening_pids",
                 return_value=[],
@@ -2270,6 +2313,150 @@ class TestRestart:
         # And we should have fallen through to the spawn path.
         mock_spawn.assert_called_once()
         assert "Started detached gateway" in capsys.readouterr().out
+
+
+class TestRestartReadinessVerdict:
+    """`restart` must report success only once the REPLACEMENT is serving.
+
+    Deliberately a separate class from :class:`TestRestart`: that class's autouse
+    ``_fast_restart_ready`` fixture pins ``_wait_gateway_ready`` to ``ready`` (and
+    ``_RESTART_READY_TIMEOUT`` to 0) so its dispatch assertions don't need a live
+    gateway — which is exactly the behaviour under test here, so inheriting it
+    would mask every one of these tests.
+
+    Before this verdict existed, ``restart`` printed "✅ Started detached gateway
+    (pid N)" straight off the ``Popen`` pid and exited 0, so a replacement that
+    the ``KIROCREW_HOME`` ownership guard refused (exit 1, milliseconds later)
+    reported success with NO gateway running.
+    """
+
+    def _drive(self, *, poll, ready_status, marker_pid, timeout=None):
+        """Drive ``_restart``'s fork path with a scripted replacement gateway.
+
+        Returns ``(exit_code, mock_sel, mock_token_url)`` — ``exit_code`` is
+        ``None`` when ``_restart`` returned normally — so both the happy and the
+        failing path can assert the audited outcome.
+
+        Nothing here ever sleeps for real: the timeout is collapsed, and the wait
+        loop checks its deadline only AFTER probing, so every case resolves on the
+        first pass.
+        """
+        from kiro_crew import cli_server
+
+        mock_sel = MagicMock()
+        stack = [
+            patch("kiro_crew.cli_server.sel", return_value=mock_sel),
+            patch(
+                "kiro_crew.cli_server.service_controller.restart_service",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.cli_server.platform_compat.find_listening_pids",
+                return_value=[],
+            ),
+            patch(
+                "kiro_crew.cli_server.platform_compat.listening_pid_tool_available",
+                return_value=True,
+            ),
+            patch("kiro_crew.cli_server.run_marker.read_pid", side_effect=marker_pid),
+            patch("kiro_crew.cli_server._gateway_owns_port", return_value=True),
+            patch("kiro_crew.cli_server._probe_gateway_ready", return_value=ready_status),
+            patch(
+                "kiro_crew.cli_server._spawn_detached_gateway",
+                return_value=MagicMock(pid=4321, poll=MagicMock(return_value=poll)),
+            ),
+            patch("kiro_crew.cli_server._print_token_url"),
+            patch("kiro_crew.cli_server._RESTART_READY_TIMEOUT", 0 if timeout is None else timeout),
+        ]
+        with contextlib.ExitStack() as es:
+            patched = [es.enter_context(p) for p in stack]
+            code = None
+            try:
+                cli_server._restart(None)
+            except SystemExit as exc:
+                code = exc.code
+        return code, mock_sel, patched[-2]
+
+    @staticmethod
+    def _outcomes(mock_sel):
+        return [c.kwargs["outcome"] for c in mock_sel.log_api_access.call_args_list]
+
+    def test_replacement_that_dies_is_reported_as_a_failure(self, capsys):
+        """An immediately-exiting replacement must exit non-zero, not print ✅."""
+        code, mock_sel, mock_token_url = self._drive(
+            poll=1, ready_status=0, marker_pid=[None, None]
+        )
+
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "✅" not in out
+        assert "died immediately" in out
+        # The exit status is the diagnosis (1 == refused by the ownership guard),
+        # and the log is where the reason is.
+        assert "exit status 1" in out
+        assert "4321" in out
+        assert "kirocrew logs -f" in out
+        # The audit must record what actually happened, not an optimistic
+        # "allowed" logged before any verdict existed.
+        assert self._outcomes(mock_sel) == ["denied"]
+        resources = mock_sel.log_api_access.call_args.kwargs["resources"]
+        assert "reason=replacement_died exit=1" in resources
+        # No point chasing a token for a gateway that is not there.
+        mock_token_url.assert_not_called()
+
+    def test_replacement_that_never_becomes_ready_is_reported_as_a_failure(self, capsys):
+        """A live-but-not-serving replacement must exit non-zero with timeout wording."""
+        code, mock_sel, mock_token_url = self._drive(
+            poll=None, ready_status=503, marker_pid=[None, None]
+        )
+
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "✅" not in out
+        assert "did not become ready" in out
+        assert "4321" in out
+        assert self._outcomes(mock_sel) == ["denied"]
+        assert "reason=replacement_not_ready_within=" in (
+            mock_sel.log_api_access.call_args.kwargs["resources"]
+        )
+        mock_token_url.assert_not_called()
+
+    def test_ready_replacement_reports_success_and_audits_allowed(self, capsys):
+        """The success line survives verbatim — it just has to wait for the verdict."""
+        code, mock_sel, mock_token_url = self._drive(
+            poll=None,
+            ready_status=200,
+            # No marker before the stop; the replacement records pid 4321.
+            marker_pid=[None, 4321],
+        )
+
+        assert code is None
+        assert "✅ Started detached gateway (pid 4321)" in capsys.readouterr().out
+        assert self._outcomes(mock_sel) == ["allowed"]
+        mock_token_url.assert_called_once()
+
+    def test_old_gateway_answering_the_port_is_not_the_replacement(self, capsys):
+        """A 200 from the OUTGOING gateway must not be read as the new one.
+
+        The incumbent keeps serving until its socket closes, so during the
+        handover the port can answer 200 while the run-marker still names the old
+        pid. Accepting that would report success for the process we just asked to
+        die — the failure mode the ``_gateway_start_id`` handshake in dev-fleet
+        exists to avoid.
+        """
+        code, _mock_sel, mock_token_url = self._drive(
+            poll=None,
+            ready_status=200,
+            # 1234 before the stop AND still 1234 while polling: the marker never
+            # changed hands, so this is the old gateway.
+            marker_pid=[1234, 1234, 1234],
+        )
+
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "✅" not in out
+        assert "did not become ready" in out
+        mock_token_url.assert_not_called()
 
 
 class TestResolveClientPort:
@@ -3712,6 +3899,217 @@ class TestDoctorEmbeddings:
         out = capsys.readouterr().out
         assert "model url:   ❌ unreachable" in out
         assert "Check network connectivity" in out
+
+
+class TestWaitGatewayReady:
+    """Unit tests for the post-spawn readiness wait (`_wait_gateway_ready`).
+
+    The integration-level behaviour lives in
+    :class:`TestRestartReadinessVerdict`; this class pins the loop's own rules:
+    early-death short-circuit, the changed-marker-pid discriminator, and the
+    documented degradation on hosts where `_gateway_owns_port` cannot pass.
+    """
+
+    @staticmethod
+    def _proc(poll_values):
+        return MagicMock(pid=4321, poll=MagicMock(side_effect=list(poll_values)))
+
+    def test_dead_child_short_circuits_with_its_exit_status(self):
+        """A refused replacement must be reported at once, not waited out."""
+        from kiro_crew import cli_server
+
+        probe = MagicMock(return_value=0)
+        with (
+            patch("kiro_crew.cli_server._probe_gateway_ready", probe),
+            patch("kiro_crew.cli_server.time.sleep") as mock_sleep,
+        ):
+            verdict = cli_server._wait_gateway_ready(
+                self._proc([1]), 7777, None, timeout=999
+            )
+
+        assert verdict == (cli_server._READY_DIED, 1)
+        # Straight out of the loop: no probe, no sleep, no 999s stall.
+        probe.assert_not_called()
+        mock_sleep.assert_not_called()
+
+    def test_zero_timeout_still_probes_once(self):
+        """A collapsed timeout must report what is there, not a reflex failure."""
+        from kiro_crew import cli_server
+
+        probe = MagicMock(return_value=200)
+        with (
+            patch("kiro_crew.cli_server._probe_gateway_ready", probe),
+            patch("kiro_crew.cli_server._replacement_is_serving", return_value=True),
+        ):
+            verdict = cli_server._wait_gateway_ready(self._proc([None]), 7777, None, timeout=0)
+
+        assert verdict == (cli_server._READY_OK, None)
+        probe.assert_called_once_with(7777)
+
+    def test_not_ready_within_deadline_is_a_timeout(self):
+        from kiro_crew import cli_server
+
+        # Two polls: the loop's entry poll and the re-poll taken at the deadline
+        # before the timeout verdict. Alive for both, so the verdict is TIMEOUT.
+        with patch("kiro_crew.cli_server._probe_gateway_ready", return_value=503):
+            verdict = cli_server._wait_gateway_ready(
+                self._proc([None, None]), 7777, None, timeout=0
+            )
+
+        assert verdict == (cli_server._READY_TIMEOUT, None)
+
+    def test_polls_until_the_replacement_answers(self):
+        """A slow-booting gateway is waited for rather than failed."""
+        from kiro_crew import cli_server
+
+        with (
+            patch("kiro_crew.cli_server._probe_gateway_ready", side_effect=[0, 503, 200]),
+            patch("kiro_crew.cli_server._replacement_is_serving", return_value=True),
+            patch("kiro_crew.cli_server.time.sleep") as mock_sleep,
+        ):
+            verdict = cli_server._wait_gateway_ready(
+                self._proc([None, None, None]), 7777, None, timeout=999
+            )
+
+        assert verdict == (cli_server._READY_OK, None)
+        assert mock_sleep.call_count == 2
+
+    def test_probe_reports_zero_for_a_listener_that_does_not_speak_http(self):
+        """A wedged fork holding the port must yield "not ready", not a traceback.
+
+        ``http.client.BadStatusLine`` is neither an ``OSError`` nor a
+        ``URLError``, so it escapes the connection-failure handler unless caught
+        explicitly -- and a non-HTTP listener on the port is precisely the
+        situation restart is being run to clear.
+        """
+        import http.client
+
+        from kiro_crew import cli_server
+
+        with patch(
+            "kiro_crew.cli_server.urllib.request.urlopen",
+            side_effect=http.client.BadStatusLine("garbage"),
+        ):
+            assert cli_server._probe_gateway_ready(7777) == 0
+
+    def test_child_that_exits_during_the_last_probe_is_reported_as_died(self):
+        """Exiting on the final probe must not be reported as "still running".
+
+        Otherwise the operator is sent looking for a live process that no longer
+        exists, with no exit status to explain it.
+        """
+        from kiro_crew import cli_server
+
+        proc = MagicMock()
+        # Alive for the loop's entry poll, exited by the deadline re-poll.
+        proc.poll.side_effect = [None, 3]
+
+        with (
+            patch("kiro_crew.cli_server._probe_gateway_ready", return_value=503),
+            patch("kiro_crew.cli_server.time.monotonic", side_effect=[0.0, 100.0]),
+        ):
+            verdict, status = cli_server._wait_gateway_ready(proc, 7777, None, 0.0)
+
+        assert verdict == cli_server._READY_DIED
+        assert status == 3
+
+    def test_missing_marker_is_never_the_replacement(self):
+        """An absent marker is the handover's own state, not proof of a new gateway.
+
+        ``clear_marker`` runs on graceful shutdown before the outgoing gateway's
+        ``_shutdown()``, so mid-restart there is a window with no marker and the
+        old socket still answering. Accepting that as the replacement would
+        report the outgoing gateway's 200 as the new one's — and with no listener
+        lookup available, nothing downstream would catch it.
+        """
+        from kiro_crew import cli_server
+
+        with (
+            patch("kiro_crew.cli_server.run_marker.read_pid", return_value=None),
+            patch("kiro_crew.cli_server.platform_compat.IS_POSIX", False),
+        ):
+            assert cli_server._replacement_is_serving(7777, 1234) is False
+            # Also unproven when there was no prior identity to exclude.
+            assert cli_server._replacement_is_serving(7777, None) is False
+
+    def test_unchanged_marker_pid_is_the_old_gateway(self):
+        """The discriminator: same recorded pid as before the stop == not the new one."""
+        from kiro_crew import cli_server
+
+        with patch("kiro_crew.cli_server.run_marker.read_pid", return_value=1234):
+            assert cli_server._replacement_is_serving(7777, 1234) is False
+
+    def test_changed_marker_pid_that_owns_the_port_is_the_replacement(self):
+        from kiro_crew import cli_server
+
+        with (
+            patch("kiro_crew.cli_server.run_marker.read_pid", return_value=4321),
+            patch("kiro_crew.cli_server.platform_compat.IS_POSIX", True),
+            patch(
+                "kiro_crew.cli_server.platform_compat.listening_pid_tool_available",
+                return_value=True,
+            ),
+            patch("kiro_crew.cli_server._gateway_owns_port", return_value=True) as mock_owns,
+        ):
+            assert cli_server._replacement_is_serving(7777, 1234) is True
+        mock_owns.assert_called_once_with(7777)
+
+    def test_non_posix_degrades_to_the_marker_comparison(self):
+        """Windows must not fail restart: `_gateway_owns_port` denies outright there.
+
+        Requiring it would make every Windows restart report "never became ready"
+        for a perfectly healthy gateway, so the ownership proof is only applied
+        where it can pass and the marker comparison stands alone elsewhere.
+        """
+        from kiro_crew import cli_server
+
+        with (
+            patch("kiro_crew.cli_server.run_marker.read_pid", return_value=4321),
+            patch("kiro_crew.cli_server.platform_compat.IS_POSIX", False),
+            patch("kiro_crew.cli_server._gateway_owns_port", return_value=False) as mock_owns,
+        ):
+            assert cli_server._replacement_is_serving(7777, 1234) is True
+        mock_owns.assert_not_called()
+
+    def test_posix_without_a_listener_lookup_degrades_too(self):
+        """No lsof/netstat means `_gateway_owns_port` can never pass — degrade."""
+        from kiro_crew import cli_server
+
+        with (
+            patch("kiro_crew.cli_server.run_marker.read_pid", return_value=4321),
+            patch("kiro_crew.cli_server.platform_compat.IS_POSIX", True),
+            patch(
+                "kiro_crew.cli_server.platform_compat.listening_pid_tool_available",
+                return_value=False,
+            ),
+            patch("kiro_crew.cli_server._gateway_owns_port", return_value=False) as mock_owns,
+        ):
+            assert cli_server._replacement_is_serving(7777, None) is True
+        mock_owns.assert_not_called()
+
+    def test_probe_targets_api_ready_not_api_health(self):
+        """Readiness, not liveness: a bound socket is not a serving gateway."""
+        from kiro_crew import cli_server
+
+        resp = MagicMock(status=200)
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            assert cli_server._probe_gateway_ready(7777) == 200
+        assert mock_open.call_args.args[0] == "http://127.0.0.1:7777/api/ready"
+
+    def test_probe_reports_zero_when_unreachable(self):
+        from kiro_crew import cli_server
+
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("down")):
+            assert cli_server._probe_gateway_ready(7777) == 0
+
+    def test_probe_reports_the_http_status_of_a_not_ready_gateway(self):
+        from kiro_crew import cli_server
+
+        err = urllib.error.HTTPError("u", 503, "not ready", {}, None)
+        with patch("urllib.request.urlopen", side_effect=err):
+            assert cli_server._probe_gateway_ready(7777) == 503
 
 
 class TestPrintTokenUrl:


### PR DESCRIPTION
## Summary

`kirocrew restart` could exit 0 with no gateway running.

`_restart` printed its success line straight from the `Popen` pid and returned. A replacement refused by the `KIROCREW_HOME` ownership guard exits within milliseconds, and still produced `✅ Started detached gateway (pid N)` plus exit status 0. The only liveness signal was `_print_token_url`, whose failure degraded to `⚠️ Could not generate token (gateway still starting?)` — reporting a dead gateway as a slow one.

This polls the new gateway until it answers `GET /api/ready`, then reports success. Failure is loud and non-zero, and distinguishes *died* from *not ready yet* because they need different operator action.

Observed during an incident on 2026-07-28 22:31: replacement pid 14762 started 22:31:17, hit the ownership guard and exited immediately; the CLI reported success.

## Why readiness, not liveness

`/api/health` proves only that a socket is bound. `/api/ready` returns 503 until the dashboard publishes `ready`, and 503 again the moment shutdown is requested — which is exactly the difference between "something answers this port" and "the new gateway is serving". Both are in `origin.PROBE_PATHS` and need no auth, so the probe hands no secret to whatever answers.

## Two details that carry the correctness

**Telling the replacement apart from the incumbent.** A bare port probe cannot: the outgoing gateway keeps answering until its socket closes, so a 200 taken during handover would confirm the process we just asked to die. The run-marker pid is read *before* the stop (a graceful shutdown clears it) and the wait requires that identity to change — the same handshake shape as `_gateway_start_id` in the dev-fleet app, which waits for a *changed* id rather than any 200. On POSIX with a working listener lookup the marker claim is corroborated by `_gateway_owns_port`; elsewhere the marker comparison alone stands, so Windows and POSIX hosts without `lsof`/`netstat` do not report a false failure.

**Early death short-circuits the wait.** `proc.poll()` is used rather than a pid liveness probe: we are the child's parent, so it both detects the exit and yields the exit status, which is the whole diagnosis for a guard refusal. Polling the port for the full 15s would turn an instantly-knowable failure into a stall with a worse message. Same shape as `pod`'s `_wait_healthy` bailing out on a dead unit.

`_spawn_detached_gateway` now returns the `Popen` handle instead of the pid. It has exactly one caller.

## Scope

The **ordering** half of this defect (waiting for the incumbent to exit before spawning) landed separately in #707 and is untouched here.

## Tests

15 new tests across `TestRestart`, `TestWaitGatewayReady`, and the probe helpers:

- replacement dies immediately → non-zero exit, exit status reported
- replacement never becomes ready → non-zero exit, timeout wording
- ready replacement → success line, exit 0, SEL audit `allowed`
- an **old** gateway answering the port does not count as the replacement
- zero timeout still probes once; non-POSIX and no-listener-tool hosts degrade to the marker comparison
- probe targets `/api/ready` not `/api/health`; reports 0 when unreachable

The autouse `_fast_restart_ready` fixture pins `_RESTART_READY_TIMEOUT = 0`, which disables the readiness loop in every pre-existing restart test — the new tests opt out of it explicitly so the fix is not masked.

RED-first verified: reverting only the source leaves 15 failures; all pass with it.

The SEL audit previously asserted `outcome="allowed"` before any verdict existed. It now records the real outcome with a reason.

## Verification

- `pytest test/test_cli.py test/test_spawn_audit.py` → 228 passed, 1 skipped
- `flake8`, `mypy`, `isort` → clean on both touched files

One failure, `TestInstallPidfdChildWatcher::test_real_subprocess_works_after_install_on_linux`, is **pre-existing on clean `origin/main`** — confirmed by stashing the change and re-running.

Not verified: no live gateway restart was exercised. The behaviour is proven by tests, not by a reproduced incident.
