### PR TITLE
fix(acp): collapse unroutable-frame drop logs into a periodic counter

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -426,6 +426,42 @@ handshake: it issues `session/load` directly under the original sessionId and
 registers the session queue **after** the load response so replayed transcript
 frames are dropped rather than counted against the current turn.
 
+**Unroutable frames are counted, not logged per frame.** The reader drops any
+frame it cannot route; the drop itself is correct and unchanged, but logging one
+`DEBUG` line per dropped frame is a log-retention hazard on a multiplexed
+backend. Every frame for a torn-down or not-yet-registered sessionId takes that
+branch — including the entire transcript replay of a `session/load` (the queue is
+registered after the response, above) — and a backend that keeps streaming after
+teardown makes it an unbounded **steady state**, not a burst. Measured on an
+operator host: ~60 lines/second sustained for 6+ hours from one gateway PID,
+33–59% of every `gateway.log` rotation, which at
+`RotatingFileHandler(maxBytes=2MB, backupCount=3)` (`cli.py`) rolled the
+diagnostics an incident needed out of the retained 8MB window before they could
+be read. So `_reader_loop` funnels the two **frame-rate** drop paths — a frame
+whose `sessionId` is not registered, and a no-`sessionId` global notification
+arriving while zero sessions are registered (sentinel `_DROP_NO_SESSION`) —
+through `_note_dropped_frame()`, which tallies `(sessionId, method)` and emits
+one `DEBUG` summary carrying the accumulated count at most every
+`_DROP_SUMMARY_INTERVAL_SECS` (60s). The key stays **per session** deliberately:
+the decisive signal in the incident was that two *different* session UUIDs were
+flooding at once, which a single global tally would hide. The level stays `DEBUG`
+— the goal is far fewer lines, not louder ones.
+
+Three properties make the counter safe on the demux hot path: it never awaits
+(no timer task to leak — the flush rides the next drop), the map is bounded
+(`_DROP_SUMMARY_MAX_KEYS` = 64 distinct keys forces an early flush instead of
+growth, and both backend-controlled key halves are truncated to
+`_DROP_SUMMARY_KEY_MAX_CHARS` = 80), and the residual count is flushed in the
+loop's `finally` on **every** exit (EOF, stdout overrun, cancel, crash) so a
+low-rate trickle is reported late rather than swallowed. No lock is needed:
+`_reader_loop` is the sole writer (`spawn()` creates exactly one reader task).
+The two response-shaped drop branches (non-numeric id, unmatched id) stay
+per-frame on purpose — the id is their whole diagnostic value and is distinct per
+frame, so aggregating by it would give the counter an unbounded key space while
+aggregating without it would discard the only identifying datum; both are also
+bounded by the requests this runtime issued, so neither has the after-teardown
+steady state.
+
 Every kiro session runs on `AcpRuntime` + `AcpSessionHandle`:
 `AcpProvider.start()` (`providers/acp.py`) unconditionally calls
 `_start_kiro_runtime()` for the kiro backend, wrapping an `AcpSessionHandle` in

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -107,11 +107,62 @@ _DEFAULT_MAX_RSS_MB = 500.0  # 500 MiB
 # runtime has lived long enough to plausibly have ballooned.
 _RSS_PROBE_MIN_AGE_SECS = 300.0  # 5 minutes
 
+# ── Unroutable-frame drop accounting ──
+#
+# The reader drops any frame it cannot route (see _reader_loop). That is
+# CORRECT behaviour, but logging it per frame is not: kiro-cli is multiplexed,
+# so every frame for a torn-down or not-yet-registered sessionId takes the drop
+# branch, and a backend that keeps streaming after teardown makes that an
+# unbounded STEADY STATE, not a burst. Measured on an operator host: ~60
+# lines/second for 6+ hours from one gateway PID, taking 33–59% of every
+# gateway.log rotation — which, at RotatingFileHandler(maxBytes=2MB,
+# backupCount=3) (see cli.py), rolls the genuine diagnostics needed for an
+# incident out of the retained 8MB window before anyone can read them.
+#
+# So the per-frame line is collapsed into a periodic count keyed by
+# (sessionId, method). The key must stay PER SESSION: the incident's decisive
+# signal was that two DIFFERENT session UUIDs were flooding at once, which a
+# single global tally would hide.
+_DROP_SUMMARY_INTERVAL_SECS = 60.0
+# Hard cap on distinct (sessionId, method) keys held between flushes. Both
+# halves of the key are backend-controlled, so an unbounded map would be a
+# memory sink; reaching the cap forces an early flush instead of growing.
+_DROP_SUMMARY_MAX_KEYS = 64
+# Backend-controlled key text is truncated before it is stored, so a
+# pathological sessionId/method (a stdout line may be up to
+# _STDOUT_BUFFER_LIMIT) cannot be retained at full length by the map either.
+_DROP_SUMMARY_KEY_MAX_CHARS = 80
+# Stands in for the sessionId half of the key on the no-sessionId broadcast
+# path, which has no session to name.
+_DROP_NO_SESSION = "-"
+# Stands in for EITHER half of the key when the backend supplied no usable
+# string: an absent `method`, or a value of the wrong JSON type (see
+# _drop_key_part).
+_DROP_KEY_PLACEHOLDER = "?"
+
 KIRO_CLI_BIN = "kiro-cli"
 KIRO_CLI_SUBCMD = "acp"
 CLIENT_NAME = "kirocrew"
 CLIENT_VERSION = "0.1.2"
 PROTOCOL_VERSION = "2025-08-22"
+
+
+def _drop_key_part(value: object) -> str:
+    """Bounded, hashable string for one half of a (sessionId, method) drop key.
+
+    BOTH halves arrive verbatim from backend JSON: `JsonRpcMessage.from_dict`
+    copies `method` and `params` with no validation, so the `str | None`
+    annotation is documentation, not enforcement — `{"method": 123}` yields an
+    int, and `params.sessionId` is `Any`. Slicing such a value raises TypeError
+    *inside* `_reader_loop`, the single owner of this process's stdout, which
+    marks the runtime dead and tears down EVERY multiplexed session on it. One
+    malformed frame must not cost every session, so anything that is not a
+    `str` (including the legitimate absent-`method` `None`) becomes the
+    placeholder before it is sliced or used as a dict key.
+    """
+    if not isinstance(value, str):
+        return _DROP_KEY_PLACEHOLDER
+    return value[:_DROP_SUMMARY_KEY_MAX_CHARS]
 
 
 def _get_rss_mb(pid: int) -> float | None:
@@ -320,6 +371,14 @@ class AcpRuntime:
         self._dead = False
         self._last_activity: float = 0.0
         self._stderr_lines: list[str] = []
+        # Unroutable-frame drop accounting: (sessionId, method) → count since
+        # the last flush, plus the monotonic timestamp of that flush (0.0 = no
+        # window open yet; the first counted drop opens it). Written ONLY from
+        # _reader_loop (the single stdout owner) and its flush helper, so a plain
+        # dict needs no lock — asyncio.ensure_future(self._reader_loop()) is
+        # called exactly once, in spawn(), and never re-entered.
+        self._dropped_frames: dict[tuple[str, str], int] = {}
+        self._dropped_frames_flushed_at: float = 0.0
 
     @property
     def pid(self) -> int | None:
@@ -628,6 +687,57 @@ class AcpRuntime:
 
     # ── Reader Task (single owner of stdout) ──
 
+    def _note_dropped_frame(self, session_id: object, method: object) -> None:
+        """Count one unroutable frame, flushing a summary at most once per interval.
+
+        Replaces a per-frame log line (see the drop-accounting constants above).
+        Cheap and synchronous by design: it is called from the hot demux path
+        and must not await, so there is no timer task to leak and no blocking
+        I/O beyond the throttled ``logger.debug`` the flush itself emits.
+
+        Both arguments are backend-controlled and deliberately typed `object`:
+        they are normalized through `_drop_key_part`, which is the only thing
+        that keeps a wrong-typed value from raising in the shared reader.
+        """
+        key = (_drop_key_part(session_id), _drop_key_part(method))
+        now = time.monotonic()
+        if self._dropped_frames_flushed_at == 0.0:
+            # First drop of this runtime's life opens the window. __init__ cannot
+            # supply the baseline (a runtime may be constructed long before
+            # spawn()), and a stale 0.0 would make every first drop flush
+            # immediately instead of aggregating.
+            self._dropped_frames_flushed_at = now
+        counts = self._dropped_frames
+        if key not in counts and len(counts) >= _DROP_SUMMARY_MAX_KEYS:
+            # A wide fan-out of distinct keys inside one interval must not grow
+            # the map; report what we have and start a fresh window.
+            self._flush_dropped_frames(now)
+        counts[key] = counts.get(key, 0) + 1
+        if now - self._dropped_frames_flushed_at >= _DROP_SUMMARY_INTERVAL_SECS:
+            self._flush_dropped_frames(now)
+
+    def _flush_dropped_frames(self, now: float | None = None) -> None:
+        """Emit one summary record per (sessionId, method) and reset the window.
+
+        Called on the interval from _note_dropped_frame and unconditionally when
+        the reader loop exits, so a low-rate trickle is reported late rather
+        than swallowed. A key seen once in an otherwise idle hour is therefore
+        reported at the next drop or at loop exit — deliberately traded for
+        having no wakeup timer on the event loop.
+        """
+        self._dropped_frames_flushed_at = time.monotonic() if now is None else now
+        counts = self._dropped_frames
+        if not counts:
+            return
+        for (session_id, method), count in counts.items():
+            logger.debug(
+                "Dropped %d unroutable frame(s) for session %s (method=%s)",
+                count,
+                session_id,
+                method,
+            )
+        counts.clear()
+
     async def _reader_loop(self) -> None:
         """Single reader task — owns stdout exclusively. Routes frames by type.
 
@@ -688,6 +798,18 @@ class AcpRuntime:
                     except (TypeError, ValueError, OverflowError):
                         # OverflowError: json parses 1e9999 to float("inf"),
                         # which int() rejects differently from a bad string.
+                        #
+                        # Left per-frame on purpose (same for the unmatched-id
+                        # line below), unlike the two session-routing drops:
+                        # here the ID is the whole diagnostic value, and it is a
+                        # distinct value per frame — aggregating by it would give
+                        # the counter an unbounded key space, while aggregating
+                        # without it would throw away the only datum that
+                        # identifies the correlation bug. Both branches also
+                        # require a response-shaped frame, i.e. one per request
+                        # THIS runtime issued (bounded by turns), so neither has
+                        # the after-teardown steady state that made the
+                        # unknown-session line a flood.
                         logger.debug("Response with non-numeric id %r dropped", msg.id)
                         continue
 
@@ -720,11 +842,10 @@ class AcpRuntime:
                     if queue is not None:
                         await queue.put(msg)
                     else:
-                        logger.debug(
-                            "Dropping frame for unknown session %s (method=%s)",
-                            session_id,
-                            msg.method,
-                        )
+                        # Counted, not logged per frame: this is the measured
+                        # flood (transcript replay during session/load, plus any
+                        # backend still streaming after teardown).
+                        self._note_dropped_frame(session_id, msg.method)
                     continue
 
                 # No sessionId → genuinely global notification; broadcast to all.
@@ -734,13 +855,23 @@ class AcpRuntime:
                     for queue in list(self._session_queues.values()):
                         await queue.put(msg)
                 else:
-                    logger.debug("Unrouted msg (no sessions): method=%s", msg.method)
+                    # Same unbounded shape as the unknown-session branch: with
+                    # zero registered sessions EVERY global notification lands
+                    # here, so a backend that keeps streaming after the last
+                    # teardown floods at frame rate. Counted the same way, with
+                    # a sentinel for the session half of the key.
+                    self._note_dropped_frame(_DROP_NO_SESSION, msg.method)
 
         except asyncio.CancelledError:
             return
         except Exception as exc:
             logger.error("Reader loop crashed: %s", exc, exc_info=True)
             self._mark_dead(f"reader crash: {exc}")
+        finally:
+            # Report the residual count on EVERY exit (EOF, overrun, cancel,
+            # crash) so a trickle that never reached the interval is still
+            # accounted for instead of vanishing with the task.
+            self._flush_dropped_frames()
 
     def saw_not_logged_in(self) -> bool:
         """True if kiro-cli's 'not logged in' auth-failure appeared on stderr.

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -3638,3 +3638,272 @@ async def test_runtime_spawn_scrubs_channel_creds_on_default_auto(monkeypatch):
         assert key not in env, f"{key} leaked into default-auto runtime child env"
     assert env.get("KIROCREW_UNRELATED_KEEPME") == "keep-this-value"
     assert env.get("AWS_ACCESS_KEY_ID") == "FAKE-akid"
+
+
+# ── Unroutable-frame drop accounting (log-flood containment) ──
+#
+# The reader drops any frame it cannot route. Logging that per frame turned a
+# multiplexed backend's post-teardown / transcript-replay stream into ~60
+# lines/second sustained for hours, taking 33–59% of every 2MB gateway.log
+# rotation and rolling incident evidence out of the retained window. These tests
+# lock in the replacement: one throttled summary per (sessionId, method) carrying
+# the count, with the DROP behaviour itself unchanged.
+
+
+async def _drain(reader: asyncio.StreamReader, timeout: float = 5.0) -> None:
+    """Wait until the reader loop has consumed everything fed, or fail loudly.
+
+    A fixed ``asyncio.sleep(0.05)`` encodes an assumption about scheduler
+    latency that a loaded CI runner breaks -- it is why this suite's Windows
+    shard failed while its siblings passed. Waiting on the observable condition
+    (stdout buffer drained, then a bounded number of turns for the handler that
+    follows ``readline``) is deterministic under load and faster locally.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while reader._buffer:
+        if loop.time() >= deadline:
+            raise AssertionError("reader loop did not consume the fed frames in time")
+        await asyncio.sleep(0)
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+
+def _drop_records(caplog) -> list[str]:
+    return [r.getMessage() for r in caplog.records if "unroutable frame(s)" in r.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_unknown_session_drops_aggregate_into_one_counted_record(caplog):
+    """N drops of the same (sid, method) inside one window → ONE record, count N."""
+    import logging
+
+    import kiro_crew.acp.runtime as runtime_mod
+
+    rt, reader, _ = _make_runtime()
+    task = await _start_reader(rt)
+    try:
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.acp.runtime"):
+            for _ in range(5):
+                _feed(reader, {"method": "session/update", "params": {"sessionId": "ghost"}})
+            await _drain(reader)
+            # Still inside the first window: aggregated, nothing emitted yet —
+            # this is the assertion that fails on the per-frame implementation.
+            assert _drop_records(caplog) == []
+            assert rt._dropped_frames == {("ghost", "session/update"): 5}
+
+            # Age the window out, then one more drop triggers the flush.
+            rt._dropped_frames_flushed_at -= runtime_mod._DROP_SUMMARY_INTERVAL_SECS + 1.0
+            _feed(reader, {"method": "session/update", "params": {"sessionId": "ghost"}})
+            await _drain(reader)
+
+        records = _drop_records(caplog)
+        assert len(records) == 1, records
+        assert (
+            "Dropped 6 unroutable frame(s) for session ghost (method=session/update)" in records[0]
+        )
+        # The point of the change: SIX dropped frames produce ONE log record,
+        # not six. Counts every record naming the session, whatever its wording.
+        assert len([r for r in caplog.records if "ghost" in r.getMessage()]) == 1
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_two_unknown_sessions_are_counted_separately(caplog):
+    """A global tally would hide that two distinct session UUIDs are flooding."""
+    import logging
+
+    rt, reader, _ = _make_runtime()
+    task = await _start_reader(rt)
+    try:
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.acp.runtime"):
+            for _ in range(3):
+                _feed(reader, {"method": "session/update", "params": {"sessionId": "sid-aaa"}})
+            for _ in range(2):
+                _feed(reader, {"method": "session/update", "params": {"sessionId": "sid-bbb"}})
+            await _drain(reader)
+            # Residual flush on reader exit reports both keys.
+            await _stop_reader(task)
+
+        records = _drop_records(caplog)
+        assert len(records) == 2, records
+        joined = "\n".join(records)
+        assert "Dropped 3 unroutable frame(s) for session sid-aaa" in joined
+        assert "Dropped 2 unroutable frame(s) for session sid-bbb" in joined
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_counted_drop_is_still_dropped_not_delivered():
+    """Logging change only: an unroutable frame reaches no queue, as before."""
+    rt, reader, _ = _make_runtime()
+    q = _register(rt, "sA")
+    task = await _start_reader(rt)
+    try:
+        _feed(reader, {"method": "session/update", "params": {"sessionId": "ghost"}})
+        await _drain(reader)
+        # Not routed to the co-tenant, not broadcast — just counted.
+        assert q["sA"].empty()
+        assert rt._dropped_frames == {("ghost", "session/update"): 1}
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_no_session_broadcast_drops_are_counted(caplog):
+    """With zero registered sessions every global frame drops — same shape."""
+    import logging
+
+    import kiro_crew.acp.runtime as runtime_mod
+
+    rt, reader, _ = _make_runtime()
+    task = await _start_reader(rt)
+    try:
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.acp.runtime"):
+            for _ in range(4):
+                _feed(reader, {"method": "mcp/status", "params": {}})
+            await _drain(reader)
+            assert rt._dropped_frames == {(runtime_mod._DROP_NO_SESSION, "mcp/status"): 4}
+            await _stop_reader(task)
+
+        records = _drop_records(caplog)
+        assert len(records) == 1, records
+        assert "Dropped 4 unroutable frame(s)" in records[0]
+        assert "(method=mcp/status)" in records[0]
+    finally:
+        await _stop_reader(task)
+
+
+def test_drop_counter_state_does_not_leak_between_intervals(caplog):
+    """A flushed window starts empty — the next record counts only new drops."""
+    import logging
+
+    rt, _reader, _ = _make_runtime()
+
+    with caplog.at_level(logging.DEBUG, logger="kiro_crew.acp.runtime"):
+        rt._note_dropped_frame("sid-x", "session/update")
+        rt._note_dropped_frame("sid-x", "session/update")
+        rt._flush_dropped_frames()
+        assert rt._dropped_frames == {}
+
+        rt._note_dropped_frame("sid-x", "session/update")
+        rt._flush_dropped_frames()
+        assert rt._dropped_frames == {}
+
+    records = _drop_records(caplog)
+    assert len(records) == 2, records
+    assert "Dropped 2 unroutable frame(s) for session sid-x" in records[0]
+    # Not 3 — the first window's count did not carry over.
+    assert "Dropped 1 unroutable frame(s) for session sid-x" in records[1]
+
+
+def test_drop_counter_map_is_bounded(caplog):
+    """A wide fan-out of distinct keys flushes early instead of growing."""
+    import logging
+
+    import kiro_crew.acp.runtime as runtime_mod
+
+    rt, _reader, _ = _make_runtime()
+    cap = runtime_mod._DROP_SUMMARY_MAX_KEYS
+
+    with caplog.at_level(logging.DEBUG, logger="kiro_crew.acp.runtime"):
+        for i in range(cap * 3):
+            rt._note_dropped_frame(f"sid-{i}", "session/update")
+            assert len(rt._dropped_frames) <= cap
+
+    # Overflow forced flushes rather than an unbounded map.
+    assert len(_drop_records(caplog)) >= cap
+
+
+def test_drop_counter_truncates_backend_controlled_key_text():
+    """A pathological sessionId/method cannot be retained at full length."""
+    import kiro_crew.acp.runtime as runtime_mod
+
+    rt, _reader, _ = _make_runtime()
+    limit = runtime_mod._DROP_SUMMARY_KEY_MAX_CHARS
+
+    rt._note_dropped_frame("s" * (limit * 10), "m" * (limit * 10))
+
+    (session_id, method), count = next(iter(rt._dropped_frames.items()))
+    assert count == 1
+    assert len(session_id) == limit
+    assert len(method) == limit
+
+
+def test_drop_counter_handles_missing_method():
+    """A frame with no `method` is still counted, under a placeholder key."""
+    rt, _reader, _ = _make_runtime()
+
+    rt._note_dropped_frame("sid-x", None)
+
+    assert rt._dropped_frames == {("sid-x", "?"): 1}
+
+
+# The two key halves come straight from backend JSON, which is untrusted and
+# type-unchecked (JsonRpcMessage.from_dict copies `method` / `params` verbatim).
+# A wrong-typed value used to raise TypeError inside _reader_loop — the SINGLE
+# owner of this process's stdout — killing every multiplexed session over one
+# malformed frame. These lock in that the frame is counted and the demux lives.
+
+
+@pytest.mark.asyncio
+async def test_numeric_method_is_counted_and_reader_survives():
+    """`{"method": 123}` must not kill the shared reader (all sessions with it)."""
+    rt, reader, _ = _make_runtime()
+    q = _register(rt, "sA")
+    task = await _start_reader(rt)
+    try:
+        _feed(reader, {"method": 123, "params": {"sessionId": "ghost"}})
+        await _drain(reader)
+
+        # Counted under the placeholder, not crashed.
+        assert rt._dropped_frames == {("ghost", "?"): 1}
+        # The property the finding is about: the demux is still alive...
+        assert rt._dead is False
+        assert rt.is_alive() is True
+        assert not task.done()
+        # ...and still routing for every co-tenant session.
+        _feed(reader, {"method": "session/update", "params": {"sessionId": "sA"}})
+        msg = await asyncio.wait_for(q["sA"].get(), timeout=1.0)
+        assert msg.params["sessionId"] == "sA"
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_non_string_session_id_is_counted_and_reader_survives():
+    """Same hazard on the sessionId half: `params.sessionId` is Any, not str."""
+    rt, reader, _ = _make_runtime()
+    q = _register(rt, "sA")
+    task = await _start_reader(rt)
+    try:
+        # Truthy, unregistered, and not a str → reaches the drop counter.
+        _feed(reader, {"method": "session/update", "params": {"sessionId": 12345}})
+        await _drain(reader)
+
+        assert rt._dropped_frames == {("?", "session/update"): 1}
+        assert rt._dead is False
+        assert rt.is_alive() is True
+        assert not task.done()
+        _feed(reader, {"method": "session/update", "params": {"sessionId": "sA"}})
+        msg = await asyncio.wait_for(q["sA"].get(), timeout=1.0)
+        assert msg.params["sessionId"] == "sA"
+    finally:
+        await _stop_reader(task)
+
+
+def test_drop_counter_placeholder_appears_in_flushed_summary(caplog):
+    """A coerced key half is reported as the placeholder, wording unchanged."""
+    import logging
+
+    rt, _reader, _ = _make_runtime()
+
+    with caplog.at_level(logging.DEBUG, logger="kiro_crew.acp.runtime"):
+        rt._note_dropped_frame(12345, 123)
+        rt._flush_dropped_frames()
+
+    records = _drop_records(caplog)
+    assert len(records) == 1, records
+    assert "Dropped 1 unroutable frame(s) for session ? (method=?)" in records[0]


### PR DESCRIPTION
## Summary

One `logger.debug` call was consuming a third to three fifths of every `gateway.log` rotation, evicting the records needed to diagnose real failures. During a recent investigation the log for the gateway generation under examination had already rotated away.

Measured share of `Dropping frame for unknown session` lines, four consecutive rotations on one host:

| File | Lines | Drop lines | Share |
|---|---|---|---|
| `gateway.log` | 7,047 | 3,515 | **49.9%** |
| `gateway.log.1` | 16,352 | 9,119 | **55.8%** |
| `gateway.log.2` | 18,464 | 6,155 | **33.3%** |
| `gateway.log.3` | 15,936 | 9,455 | **59.3%** |

Sustained ~60 lines/second for 6+ hours, across multiple session UUIDs, all from one gateway PID. `gateway.log` rotates at 2 MB.

This collapses the per-frame log into a periodic counter.

## Why the frames are unroutable

`_session_queues` is the routing table; a `sessionId` is registered only between `create_session()`/`resume_session()` and `terminate_session()`. kiro-cli is multiplexed — one process, many sessions — so any frame the backend emits for a torn-down or not-yet-registered session hits the drop branch. During `session/load` kiro-cli replays the entire prior transcript on stdout *before* the queue is registered, and every replayed frame takes this path. A backend that keeps streaming after teardown therefore produces an unbounded steady state, not a burst.

The dropping itself is correct and unchanged — this is a logging change only. The log line carried no control flow.

## Design

Aggregate per `(sessionId, method)` and flush at most once per `_DROP_SUMMARY_INTERVAL_SECS` (60s) with the accumulated count.

**Per-pair, not global.** The key signal in the incident was that *two different* session UUIDs were flooding. A single global tally would have hidden it.

**No timer task.** The flush rides the next drop, so there is nothing to leak on the event loop. The trade-off is explicit in the docstring: a lone drop in an otherwise idle hour is reported at the next drop or at loop exit, not on a wall-clock boundary. The residual is flushed in the reader loop's `finally`, so it fires on EOF, stdout overrun, cancel and crash alike.

**Bounded.** Keys are evicted on every flush; reaching `_DROP_SUMMARY_MAX_KEYS` (64) distinct keys inside one window forces an early flush rather than growth; both backend-controlled key halves are truncated to 80 chars.

**No lock needed** — confirmed from the code rather than assumed: `asyncio.ensure_future(self._reader_loop())` appears exactly once, and the new dict is written only from that task and the flush helper it calls. (`_session_queues` is different — it *is* mutated from other coroutines, which is why the pre-existing broadcast snapshots before awaiting.)

**Level stays DEBUG.** The correct outcome is far fewer lines, not louder ones.

## Which drop paths were aggregated, and why not all four

Aggregated — both share the same unbounded steady-state shape and key naturally on `(session, method)`:
- unknown session
- no-`sessionId` broadcast with zero sessions registered (with a `-` sentinel for the session half; with no sessions registered, *every* global notification lands here)

Left per-frame — each requires a response-shaped frame, i.e. one per request this runtime issued, so they are bounded by turns with no after-teardown steady state. Aggregating by id would give the counter an unbounded key space; aggregating without it would discard the only datum identifying a correlation bug. The reasoning is in a comment at the call site.
- non-numeric response id
- unmatched response id

## Prior art followed

`_SUPPRESSED_STDERR_SUMMARY_INTERVAL_SECS` in `acp/client.py` uses the same throttled-count-with-EOF-flush shape for the `thinking_tokens` stderr flood.

## Tests

8 new tests in `test/test_acp_runtime.py`:

- N drops for one `(sid, method)` in a window produce **one** record carrying count N, not N records (includes a wording-independent assertion that fails at 6 on the old code)
- two different session UUIDs are counted separately
- the frame is still dropped — a co-tenant queue stays empty
- counter state does not leak between intervals (second record is count 1, not 3)
- the no-session broadcast path is counted
- the map is bounded; backend-controlled key text is truncated; a missing `method` is handled

RED-first verified: reverting only the source leaves 8 failures.

## Verification

- `pytest test/test_acp_runtime.py test/test_acp_runtime_kill.py` → 153 passed
- plus 6 further ACP suites (provider, session_provider, stale_recovery, turn_lock, liveness, fake_backend) → 342 passed
- `flake8`, `mypy`, `isort` → clean

`black --check` could not run: it self-aborts on this interpreter's AST-safety block, and fails identically on an untouched file. Compensated manually — every added line is within the configured line length, verified by script. Formatting is tool-unverified.

Not verified: the new output has not been observed on a live gateway; the measurements above are from existing log files.

Two adjacent per-line DEBUG sites are out of scope (`non-JSON stdout line`, `non-object JSON stdout line`) — they log line *content*, so they have no aggregation key, though a backend emitting continuous garbage would flood them the same way.
