### PR TITLE
fix(tunnel): stop the tunnel on gateway shutdown

### DIFF
--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -462,7 +462,33 @@ delegates to that same global. Wired sites:
   deny gate in `tunnel/setup.py` is evaluated BEFORE the manager is constructed or
   `start()` reached, so a companion tunnel cannot start without dashboard token
   auth; the connect/disconnect callbacks and `/api/tunnel/status` stay wrapped
-  AROUND the provider. Import direction: `tunnel/` imports
+  AROUND the provider. **Teardown is wired at
+  `dashboard/server.py::_wire_tunnel_shutdown`** — an `app.on_cleanup` hook that
+  reads `state.tunnel_manager` lazily (the manager is assigned later, by
+  `setup_tunnel`). It covers BOTH start paths, because a live tunnel does not
+  imply a manager: with a manager it calls `TunnelManager.stop()`; with
+  `state.tunnel_manager` still `None` — the on-demand link path
+  (`slack.use_tunnel_url` → `ensure_available()`) provisions and starts a tunnel
+  straight on the provider and never constructs a manager — it stops
+  `current_context().tunnel` directly. Exactly one path runs per shutdown (the
+  manager delegates to the same provider), so nothing is stopped twice, and both
+  are idempotent, so a shutdown path that runs twice is harmless. Both paths go
+  through one guard: bounded by `_TUNNEL_STOP_TIMEOUT_SECS`, every failure logged
+  and swallowed — including a fail-closed `current_context()` lookup, which is
+  evaluated INSIDE the guard — so a hanging or raising provider cannot block or
+  abort the remaining `on_cleanup` handlers. **Registration order is
+  load-bearing:** the hook is appended immediately after the `web.Application` is
+  created, ahead of every other cleanup registration and well before
+  `runner.setup()` freezes the signal lists. aiohttp dispatches `on_cleanup` in
+  registration order under a hard shutdown deadline, so a tunnel hook queued
+  behind the other subsystems can be starved (instances cleanup waiting on SSH
+  children that ignore SIGTERM eats the deadline, the gateway force-exits, and
+  the tunnel is never stopped); the lazy `state.tunnel_manager` read is what makes
+  the early registration safe. Because the manager is edition-neutral, one hook
+  tears down EVERY provider (the Default's `stop()` is a no-op).
+  `start_api_server` (the `--slack-only`/headless path) never calls
+  `setup_tunnel`, so it needs no hook.
+  Import direction: `tunnel/` imports
   `kiro_crew.platform.context`; `platform/` keeps zero imports of `kiro_crew.tunnel`.
 - `dashboard/server.py` — tunnel enable-gate
   ORs in `current_context().tunnel.enabled()`. **Dashboard contributor (wave 3):**

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -436,6 +436,13 @@ _IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 # request headers.
 _MAX_HEADER_FIELD_SIZE = 32 * 1024
 
+# Upper bound on the tunnel teardown at shutdown. The provider behind the
+# ``TunnelProvider`` seam may talk to a remote control plane (or supervise a
+# child process), so an unbounded await here could hang ``runner.cleanup()``
+# forever and wedge the whole gateway exit. 5s is generous for a local
+# teardown and still well inside the desktop app's shutdown window.
+_TUNNEL_STOP_TIMEOUT_SECS = 5.0
+
 
 def _extra_frame_ancestors(
     request: "web.Request | None", app: "web.Application | None" = None
@@ -1232,6 +1239,79 @@ def _wire_status_delta_sink(app: web.Application, state: DashboardState) -> None
     app.on_cleanup.append(_status_sink_shutdown)
 
 
+def _wire_tunnel_shutdown(app: web.Application, state: DashboardState) -> None:
+    """Register the tunnel teardown hook on ``app``'s shutdown path.
+
+    Without this the tunnel is started (``tunnel/setup.py`` → ``TunnelManager.start()``)
+    and then NEVER stopped: ``TunnelManager.stop()`` had no production caller, so
+    whatever the active ``TunnelProvider`` brought up outlived the gateway — even
+    on a clean Ctrl+C. A companion provider that supervises a child process
+    leaked it (reparented to PID 1) and the next gateway start collided on the
+    same tunnel name. The manager is edition-neutral, so stopping it here tears
+    down EVERY provider (the public Default's ``stop()`` is a no-op).
+
+    Registered like the other long-lived subsystems (``_watchdog_shutdown``,
+    ``_register_instances_hooks``): the hook is appended BEFORE ``runner.setup()``
+    freezes the app's signal lists, and reads ``state.tunnel_manager`` lazily —
+    the manager is only assigned later, after ``setup_tunnel`` runs, and this
+    hook fires at shutdown, long after that assignment. That lazy read is also
+    what lets the REGISTRATION sit first in ``start_dashboard``: ``on_cleanup``
+    handlers are dispatched in registration order under a hard shutdown
+    deadline, so a tunnel hook queued behind the other subsystems can be starved
+    (instances cleanup waiting on SSH children that ignore SIGTERM eats the
+    deadline, the gateway force-exits, and the tunnel is never stopped).
+
+    Two teardown paths, because a live tunnel does not imply a manager:
+    ``setup_tunnel`` builds a ``TunnelManager`` and the hook stops that, but the
+    on-demand link path (``slack.use_tunnel_url`` →
+    ``current_context().tunnel.ensure_available()`` in ``slack/allowlist.py``)
+    provisions and starts a tunnel straight on the provider and never constructs
+    a manager. With ``state.tunnel_manager`` still None, bailing out left exactly
+    the orphan this hook exists to prevent, so the no-manager path stops
+    ``current_context().tunnel`` directly. Only one path runs per shutdown — the
+    manager delegates to the same provider — so nothing is stopped twice.
+
+    Failure containment: ``on_cleanup`` handlers run in sequence and a raise
+    aborts the remaining ones, so a tunnel teardown must never propagate. BOTH
+    paths go through ``_stop_bounded``: the stop is bounded by
+    ``_TUNNEL_STOP_TIMEOUT_SECS`` and every exception is logged and swallowed, so
+    neither a hanging nor a raising provider — nor a fail-closed
+    ``current_context()`` — can block or crash the rest of gateway shutdown.
+    ``TunnelManager.stop()`` is itself idempotent (it re-delegates and, on
+    failure, simply declines to pin STOPPED) and a provider ``stop()`` is
+    expected to be too, so a shutdown path that runs twice is harmless on either
+    path.
+    """
+
+    async def _stop_bounded(stop: Callable[[], Awaitable[None]], what: str) -> None:
+        """Await *stop* under the shared bound, logging and swallowing everything.
+
+        *stop* is INVOKED inside the guard, so a synchronous raise — including a
+        fail-closed ``current_context()`` lookup — is contained as well.
+        """
+        try:
+            await asyncio.wait_for(stop(), timeout=_TUNNEL_STOP_TIMEOUT_SECS)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "%s did not finish within %.0fs — continuing shutdown",
+                what,
+                _TUNNEL_STOP_TIMEOUT_SECS,
+            )
+        except Exception:
+            logger.warning("%s failed during shutdown", what, exc_info=True)
+
+    async def _tunnel_shutdown(_app: web.Application) -> None:
+        mgr = getattr(state, "tunnel_manager", None)
+        if mgr is not None:
+            await _stop_bounded(mgr.stop, "Tunnel stop")
+            return
+        # No manager, but the provider may still own a running tunnel (the
+        # on-demand ``ensure_available()`` path never builds one).
+        await _stop_bounded(lambda: current_context().tunnel.stop(), "Tunnel provider stop")
+
+    app.on_cleanup.append(_tunnel_shutdown)
+
+
 async def start_dashboard(
     sessions: SessionManager,
     crons: CronService,
@@ -1493,6 +1573,16 @@ async def start_dashboard(
         client_max_size=60 * 1024 * 1024
     )  # 60 MB: covers 50 MB upload + multipart overhead
     app["state"] = state
+    # ── Tunnel teardown (FIRST cleanup hook, deliberately) ───────────────────
+    # aiohttp dispatches ``on_cleanup`` in registration order and gateway
+    # shutdown has a hard deadline, so this is registered ahead of every other
+    # cleanup hook: behind them it can be starved — instances cleanup waiting on
+    # SSH children that ignore SIGTERM eats the deadline, the gateway
+    # force-exits, and the tunnel is never stopped. Safe this early: the hook
+    # only reads ``state.tunnel_manager`` lazily at shutdown, long after
+    # ``setup_tunnel`` assigns it further below, and this is still well before
+    # ``runner.setup()`` freezes the signal lists. See ``_wire_tunnel_shutdown``.
+    _wire_tunnel_shutdown(app, state)
     from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
 
     app["kiro_prerequisite_service"] = await asyncio.to_thread(

--- a/test/test_tunnel_manager.py
+++ b/test/test_tunnel_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -579,3 +580,346 @@ class TestSetupTunnelThroughProvider:
 
         assert result is None
         assert provider.started == 0
+
+
+# ── Shutdown wiring: the dashboard must tear the tunnel down on exit ──
+
+
+_CLEANUP_REGISTRARS = (
+    "_wire_tunnel_shutdown(app",
+    "_wire_status_delta_sink(app",
+    "_register_instances_hooks(app",
+    "app.on_cleanup.append(",
+)
+
+
+def _cleanup_registration_order() -> list[str]:
+    """Every ``on_cleanup`` registration in ``start_dashboard``, in source order.
+
+    Read out of the production function itself rather than hardcoded, so moving a
+    registration in ``server.py`` moves it here too — which is what lets the
+    ordering test replay the REAL sequence instead of one the test invented. Only
+    call forms are matched (``name(app``), so the surrounding prose that names the
+    same helpers in backticks is not picked up.
+    """
+    import inspect
+
+    from kiro_crew.dashboard import server
+
+    src = inspect.getsource(server.start_dashboard)
+    hits: list[tuple[int, str]] = []
+    for token in _CLEANUP_REGISTRARS:
+        start = 0
+        while (idx := src.find(token, start)) != -1:
+            hits.append((idx, token))
+            start = idx + 1
+    return [token for _, token in sorted(hits)]
+
+
+class TestTunnelShutdownWiring:
+    """``TunnelManager.stop()`` MUST be reached from the gateway shutdown path.
+
+    Regression for a production-wiring gap: ``stop()`` existed but had ZERO
+    production callers, so a started tunnel outlived its gateway even on a clean
+    Ctrl+C — a companion provider's supervised child reparented to PID 1 and the
+    next start collided on the tunnel name. These tests drive the real wiring
+    helper (``dashboard.server._wire_tunnel_shutdown``) rather than the manager
+    in isolation, so they fail if the hook is dropped again.
+    """
+
+    @staticmethod
+    def _state(tunnel_manager=None):
+        from kiro_crew.dashboard.state import DashboardState
+
+        state = DashboardState(
+            sessions=MagicMock(), crons=MagicMock(), lessons=MagicMock(), start_time=0.0
+        )
+        state.tunnel_manager = tunnel_manager
+        return state
+
+    @staticmethod
+    def _frozen_app(state, extra_cleanup=None):
+        """Wire the shutdown hook onto a frozen app, mirroring start_dashboard.
+
+        ``_wire_tunnel_shutdown`` is called before ``runner.setup()``; freezing
+        here reproduces that freeze so ``on_cleanup.send()`` runs the hooks with
+        real aiohttp signal semantics (sequential, abort-on-raise).
+        """
+        from aiohttp import web
+
+        from kiro_crew.dashboard import server
+
+        app = web.Application()
+        server._wire_tunnel_shutdown(app, state)
+        if extra_cleanup is not None:
+            app.on_cleanup.append(extra_cleanup)
+        app.freeze()
+        return app
+
+    @pytest.mark.asyncio
+    async def test_shutdown_stops_tunnel_exactly_once(self):
+        """App shutdown drives the manager's stop through to the provider once."""
+        provider = _install_tunnel_provider(_FakeTunnelProvider())
+        mgr = TunnelManager(port=5476)
+        await mgr.start()
+        app = self._frozen_app(self._state(mgr))
+
+        await app.on_cleanup.send(app)
+
+        assert provider.stopped == 1
+
+    @pytest.mark.asyncio
+    async def test_shutdown_pins_status_stopped(self):
+        """On the success path the tunnel reports STOPPED with no public URL."""
+        _install_tunnel_provider(_FakeTunnelProvider())
+        mgr = TunnelManager(port=5476)
+        await mgr.start()
+        assert mgr.status.state == TunnelState.CONNECTED
+        app = self._frozen_app(self._state(mgr))
+
+        await app.on_cleanup.send(app)
+
+        assert mgr.status.state == TunnelState.STOPPED
+        assert mgr.public_url == ""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_without_tunnel_manager_does_not_raise(self):
+        """Tunnel disabled / never started (``tunnel_manager is None``) is a no-op."""
+        app = self._frozen_app(self._state(None))
+
+        await app.on_cleanup.send(app)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_raising_stop_does_not_abort_remaining_shutdown(self):
+        """A manager whose stop() raises must not skip later cleanup hooks.
+
+        aiohttp runs ``on_cleanup`` handlers in sequence and a propagating
+        exception aborts the rest, so the tunnel teardown has to swallow its own
+        failures — otherwise one broken provider strands every subsystem
+        registered after it.
+        """
+        ran = []
+
+        async def _later_hook(_app):
+            ran.append("later")
+
+        mgr = MagicMock()
+        mgr.stop = AsyncMock(side_effect=RuntimeError("provider stop boom"))
+        app = self._frozen_app(self._state(mgr), extra_cleanup=_later_hook)
+
+        await app.on_cleanup.send(app)
+
+        mgr.stop.assert_awaited_once()
+        assert ran == ["later"]
+
+    @staticmethod
+    def _never_completing():
+        """A stop coroutine factory that parks until the test releases it.
+
+        The hang is driven by an event the TEST owns, not a wall-clock sleep, so
+        the bounded-teardown assertions never depend on runner speed. Callers
+        release the event afterwards so nothing is left parked at loop close.
+        """
+        release = asyncio.Event()
+
+        async def _stop() -> None:
+            await release.wait()
+
+        return _stop, release
+
+    @pytest.mark.asyncio
+    async def test_hanging_stop_does_not_block_remaining_shutdown(self):
+        """A provider that never returns is abandoned at the bounded timeout.
+
+        The bound is patched to ``0``, which takes ``asyncio.wait_for``'s
+        cancel-and-await branch: same timeout path, zero wall-clock dependence
+        (no slow-runner race), and the abandoned awaitable is awaited to
+        completion rather than left pending.
+        """
+        from kiro_crew.dashboard import server
+
+        ran = []
+
+        async def _later_hook(_app):
+            ran.append("later")
+
+        stop, release = self._never_completing()
+        mgr = MagicMock()
+        mgr.stop = MagicMock(side_effect=stop)
+        app = self._frozen_app(self._state(mgr), extra_cleanup=_later_hook)
+
+        try:
+            with patch.object(server, "_TUNNEL_STOP_TIMEOUT_SECS", 0):
+                await app.on_cleanup.send(app)
+        finally:
+            release.set()
+
+        assert ran == ["later"]
+
+    @pytest.mark.asyncio
+    async def test_second_shutdown_is_harmless(self):
+        """Shutdown paths can run twice; the repeat stop must not raise or unpin."""
+        _install_tunnel_provider(_FakeTunnelProvider())
+        mgr = TunnelManager(port=5476)
+        await mgr.start()
+        app = self._frozen_app(self._state(mgr))
+
+        await app.on_cleanup.send(app)
+        await app.on_cleanup.send(app)
+
+        assert mgr.status.state == TunnelState.STOPPED
+        assert mgr.public_url == ""
+
+    # ── No-manager path: the on-demand tunnel must be torn down too ──────────
+
+    @pytest.mark.asyncio
+    async def test_shutdown_stops_context_tunnel_when_no_manager(self):
+        """No manager does NOT mean no tunnel — the provider still has to be stopped.
+
+        The on-demand link path (``slack.use_tunnel_url`` →
+        ``current_context().tunnel.ensure_available()`` in ``slack/allowlist.py``)
+        provisions and starts a tunnel straight on the provider and never
+        constructs a ``TunnelManager``, so ``state.tunnel_manager`` stays None
+        while the provider owns a running tunnel. Bailing out on ``mgr is None``
+        left exactly the orphan this hook exists to prevent.
+        """
+        provider = _install_tunnel_provider(_FakeTunnelProvider())
+        app = self._frozen_app(self._state(None))
+
+        await app.on_cleanup.send(app)
+
+        assert provider.stopped == 1
+
+    @pytest.mark.asyncio
+    async def test_second_shutdown_without_manager_is_harmless(self):
+        """Firing the no-manager path twice must not raise (provider stop is idempotent)."""
+        provider = _install_tunnel_provider(_FakeTunnelProvider())
+        app = self._frozen_app(self._state(None))
+
+        await app.on_cleanup.send(app)
+        await app.on_cleanup.send(app)
+
+        assert provider.stopped == 2
+
+    @pytest.mark.asyncio
+    async def test_raising_context_tunnel_does_not_abort_remaining_shutdown(self):
+        """The no-manager path gets the SAME swallow-all containment as the manager path."""
+        ran = []
+
+        async def _later_hook(_app):
+            ran.append("later")
+
+        class _BoomProvider(_FakeTunnelProvider):
+            async def stop(self) -> None:
+                self.stopped += 1
+                raise RuntimeError("provider stop boom")
+
+        provider = _install_tunnel_provider(_BoomProvider())
+        app = self._frozen_app(self._state(None), extra_cleanup=_later_hook)
+
+        await app.on_cleanup.send(app)
+
+        assert provider.stopped == 1
+        assert ran == ["later"]
+
+    @pytest.mark.asyncio
+    async def test_unavailable_context_does_not_abort_remaining_shutdown(self):
+        """A fail-closed ``current_context()`` is contained, not propagated.
+
+        The provider lookup happens INSIDE the guard, so a composition failure at
+        shutdown cannot abort the remaining ``on_cleanup`` handlers either.
+        """
+        from kiro_crew.dashboard import server
+
+        ran = []
+
+        async def _later_hook(_app):
+            ran.append("later")
+
+        app = self._frozen_app(self._state(None), extra_cleanup=_later_hook)
+
+        with patch.object(
+            server, "current_context", side_effect=RuntimeError("no platform context")
+        ) as ctx:
+            await app.on_cleanup.send(app)
+
+        ctx.assert_called_once()
+        assert ran == ["later"]
+
+    @pytest.mark.asyncio
+    async def test_hanging_context_tunnel_does_not_block_remaining_shutdown(self):
+        """The no-manager path is bounded by the same ``_TUNNEL_STOP_TIMEOUT_SECS``."""
+        from kiro_crew.dashboard import server
+
+        ran = []
+
+        async def _later_hook(_app):
+            ran.append("later")
+
+        stop, release = self._never_completing()
+
+        class _HangProvider(_FakeTunnelProvider):
+            # Sync def returning the awaitable so the "was asked to stop" count
+            # is recorded at call time — with the bound at 0 the coroutine is
+            # cancelled before its first step, so counting inside it would be
+            # unobservable (same shape as the manager-path hang test's MagicMock).
+            def stop(self):  # type: ignore[override]
+                self.stopped += 1
+                return stop()
+
+        provider = _install_tunnel_provider(_HangProvider())
+        app = self._frozen_app(self._state(None), extra_cleanup=_later_hook)
+
+        try:
+            with patch.object(server, "_TUNNEL_STOP_TIMEOUT_SECS", 0):
+                await app.on_cleanup.send(app)
+        finally:
+            release.set()
+
+        assert provider.stopped == 1
+        assert ran == ["later"]
+
+    # ── Dispatch ordering ────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_tunnel_teardown_dispatches_before_other_cleanup_hooks(self):
+        """The tunnel hook must FIRE first, not merely be registered somewhere.
+
+        aiohttp dispatches ``on_cleanup`` in registration order and gateway
+        shutdown has a hard deadline, so a tunnel hook queued behind the other
+        subsystems can be starved: instances cleanup waiting on SSH children that
+        ignore SIGTERM eats the deadline, the gateway force-exits, and the tunnel
+        is never stopped. Replay ``start_dashboard``'s real registration order
+        onto a live frozen app and assert the recorded dispatch order, so this
+        fails if the registration slides back down the function.
+        """
+        from aiohttp import web
+
+        from kiro_crew.dashboard import server
+
+        order = _cleanup_registration_order()
+        assert len(order) > 1, "expected several on_cleanup registrations to order against"
+
+        ran: list[str] = []
+        mgr = MagicMock()
+        mgr.stop = AsyncMock(side_effect=lambda: ran.append("tunnel"))
+
+        def _recorder(label: str):
+            async def _hook(_app) -> None:
+                ran.append(label)
+
+            return _hook
+
+        app = web.Application()
+        for position, token in enumerate(order):
+            if token.startswith("_wire_tunnel_shutdown"):
+                server._wire_tunnel_shutdown(app, self._state(mgr))
+            else:
+                app.on_cleanup.append(_recorder(f"other-{position}"))
+        app.freeze()
+
+        await app.on_cleanup.send(app)
+
+        assert ran, "no cleanup hook ran"
+        assert ran[0] == "tunnel", f"tunnel teardown must dispatch first, got {ran}"
+        assert len(ran) == len(order)


### PR DESCRIPTION
## Summary

`TunnelManager.stop()` has **zero production callers**. The tunnel is started (`tunnel/setup.py` → `TunnelManager.start()`) and then never stopped, so whatever the active `TunnelProvider` brought up outlives the gateway — including on a clean Ctrl+C, not just SIGHUP or SIGKILL.

`state.tunnel_manager` is assigned once at `dashboard/server.py:2741` and read in exactly one place, `dashboard/handlers/tunnel.py:16-19`, which reads `.status` only. The only `.stop()` callers are six sites in `test/test_tunnel_manager.py`.

This registers the missing teardown hook.

## Operator consequence

Tunnel children outlive their gateway and then collide on the tunnel name, leaving the registry with no entry while several local clients each believe they are serving it. Two orphaned trees were observed live on one host — each a `tunnel create …` wrapper plus a `node …/cli.mjs create …` grandchild — one reparented to PID 1 and three days old.

## Scope — deliberately just the lifecycle call

The child spawn is **not in this repo**. `DefaultTunnelProvider` (`platform/defaults.py:354-387`) is all no-ops with `enabled()` returning `False`, and there are zero `Popen`/`create_subprocess_*` calls anywhere under `tunnel/` or `platform/`. The real spawn lives behind the `TunnelProvider` seam in a downstream companion package.

So this PR does not invent a process-group kill or `PR_SET_PDEATHSIG` — there is no process here to signal. It fixes the seam: because `TunnelManager` is edition-neutral, wiring `stop()` into shutdown tears down **every** provider. Spawn hardening belongs downstream, where the spawn is.

## Pattern followed

`_watchdog_shutdown` (`dashboard/server.py:2433-2443`) and `_register_instances_hooks` (`:1116-1180`): a module-level wiring helper appends an `app.on_cleanup` hook **before** `runner.setup()` freezes the app's signal lists, and reads the subsystem off `DashboardState` with a lazy `getattr` because the object is created later. `_wire_tunnel_shutdown` mirrors that exactly, registered at `:2501` right after `_register_instances_hooks` and before `runner.setup()` at `:2513`. The manager is assigned after setup, which is fine — the hook only fires at shutdown.

`app.on_cleanup` is reached on both relevant paths: standalone `runner.cleanup()`, and the gateway's `_shutdown()`, which gathers `self._dashboard_runner.cleanup()` (`slack/gateway.py:4922`).

## Failure containment

`on_cleanup` handlers run in sequence and a raise aborts the remaining ones, so a tunnel teardown must never propagate. The stop is bounded by `_TUNNEL_STOP_TIMEOUT_SECS` (5s) and every exception is logged and swallowed, so neither a hanging nor a raising provider can block or crash the rest of gateway shutdown. The bound matters because a provider may talk to a remote control plane or supervise a child.

`stop()` is already idempotent — it re-delegates and, on failure, simply declines to pin `STOPPED` — so a shutdown path that runs twice is harmless.

## Scope checks

- **slack-only gateway**: `slack/gateway.py` has zero `tunnel` references. `no_dashboard=True` routes to `start_api_server`, which never calls `setup_tunnel`, so `state.tunnel_manager` stays `None`. No hook added — it would be dead code. Noted in the spec.
- **second registration site**: `setup_tunnel` is called from exactly one place (`server.py:2732`). The duplicate-looking blocks near 1544/2878 are `/api/health|live|ready` probe-parity routes in `start_api_server`, not a second tunnel setup.

## Tests

6 new tests in `TestTunnelShutdownWiring`. They drive the real wiring helper on a **frozen** `web.Application` and fire `app.on_cleanup.send(app)`, so they exercise aiohttp's real signal semantics — sequential, abort-on-raise — rather than mocking them:

- shutdown calls `stop()` exactly once
- status is pinned `STOPPED` and the URL cleared
- `tunnel_manager=None` does not raise
- a raising `stop()` does not abort a later `on_cleanup` hook
- a hanging `stop()` is abandoned at the timeout and a later hook still runs
- firing cleanup twice is harmless

RED-first verified: reverting only `server.py` leaves 6 failures.

## Verification

- `pytest test/test_tunnel_manager.py` → 38 passed
- regression sweep of neighbouring suites (dashboard, dashboard_state_ws, instances, platform_context) → 264 passed
- `flake8`, `mypy`, `isort` → clean

`black --check` could not run in this environment (self-aborts on the interpreter's AST-safety block). Re-checked under a different interpreter: the added code is clean; the one hunk black wants to reformat is pre-existing on `origin/main`, confirmed against `git show origin/main:…`.

Not verified: no gateway was booted and interrupted. The call chain was traced by reading; the tests prove `stop()` is now reached. The actual child teardown is not observable here because the public provider is a no-op. The 5s timeout is a judgement call, not a measurement.

Spec updated: `docs/system-specs/modules/platform-context.md`.
