### PR TITLE
fix(embeddings): run llama.cpp inference on one owned thread

### DIFF
--- a/src/kiro_crew/embeddings.py
+++ b/src/kiro_crew/embeddings.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import platform
+import queue
 import shutil
 import ssl
 import sys
@@ -80,6 +81,10 @@ _N_CTX = 2048
 # n_ctx after clipping (dense CJK/code) fail the embed call and return None.
 _MAX_EMBED_CHARS = 6_000
 _LLM_LOAD_RETRY_SECS = 300.0  # re-attempt a failed model load after this long
+# How long close() waits for the inference thread to finish its current job and
+# exit. Bounded so an unload never wedges a shutdown; the thread is a daemon, so
+# a straggler cannot hold the interpreter open either.
+_INFER_STOP_TIMEOUT_SECS = 30.0
 
 # ── Download constants ──
 
@@ -266,6 +271,19 @@ class EmbeddingBackend(abc.ABC):
 # ── In-process llama.cpp backend ──
 
 
+class _InferJob:
+    """One ``create_embedding`` call handed to the embedder's worker thread."""
+
+    __slots__ = ("llm", "texts", "result", "error", "done")
+
+    def __init__(self, llm: object, texts: "list[str]") -> None:
+        self.llm = llm
+        self.texts = texts
+        self.result: object | None = None
+        self.error: BaseException | None = None
+        self.done = threading.Event()
+
+
 class LlamaCppEmbedder(EmbeddingBackend):
     """Serialized in-process embedder over the vendored llama.cpp runtime.
 
@@ -273,6 +291,18 @@ class LlamaCppEmbedder(EmbeddingBackend):
     inference call is serialized behind ``_lock``. All failures return
     ``None`` (graceful degradation) — callers already treat ``None`` as
     "no embedding available".
+
+    Inference does not run on the caller's thread. llama.cpp builds a compute
+    thread pool (``n_threads_batch``, which defaults to the CPU count) the
+    first time a GIVEN thread runs inference, and that pool lives as long as
+    its calling thread does. Embed calls arrive on long-lived executor threads
+    (``mc-embed``, asyncio's default executor, cron, maintenance), so calling
+    inference inline accumulated one CPU-count-sized pool per caller thread —
+    measured at 31 pools / ~1,460 threads in one gateway after an hour, still
+    climbing. Every call is therefore forwarded to ONE owned daemon thread
+    (``kc-embed-infer``), so the process holds exactly one compute pool no
+    matter how many threads embed. ``_lock`` already serialized inference, so
+    the hand-off adds no queueing that was not there before.
     """
 
     def __init__(
@@ -289,6 +319,9 @@ class LlamaCppEmbedder(EmbeddingBackend):
         self._lock = threading.Lock()  # serializes inference (Llama is not thread-safe)
         self._load_lock = threading.Lock()  # guards loader-thread spawn state
         self._load_thread: threading.Thread | None = None
+        # Single owned inference thread + its job queue (see the class docstring).
+        self._jobs: "queue.SimpleQueue[_InferJob | None]" = queue.SimpleQueue()
+        self._infer_thread: threading.Thread | None = None
 
     @property
     def model_path(self) -> Path:
@@ -364,6 +397,56 @@ class LlamaCppEmbedder(EmbeddingBackend):
             self._load_failed_at = time.monotonic()
             self._llm = None
 
+    def _infer_loop(self, jobs: "queue.SimpleQueue[_InferJob | None]") -> None:
+        """Worker body: run queued ``create_embedding`` calls, one at a time.
+
+        ``jobs`` is passed in rather than read from ``self`` so this worker is
+        bound for life to the queue it was started with. That is what makes a
+        straggler harmless: it can only ever drain — and exit on the sentinel
+        from — its own queue, never one feeding a later worker.
+
+        Every job is completed even on failure, so a caller can never be left
+        waiting on ``job.done``. ``None`` is the shutdown sentinel from
+        :meth:`close`; exiting the thread is what releases llama.cpp's compute
+        pool.
+        """
+        while True:
+            job = jobs.get()
+            if job is None:
+                return
+            try:
+                job.result = job.llm.create_embedding(job.texts)  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: BLE001 - relayed to the caller verbatim
+                job.error = exc
+            finally:
+                job.done.set()
+
+    def _create_embedding(self, llm: object, texts: "list[str]") -> object:
+        """Run one ``create_embedding`` on the owned thread; re-raise its error.
+
+        Caller must hold ``_lock``, which keeps at most one job in flight.
+        The wait is unbounded, matching the previous inline call — a wedged
+        native inference blocked the caller then too.
+        """
+        thread = self._infer_thread
+        if thread is None or not thread.is_alive():
+            # New worker, new queue. A straggler left behind by a timed-out
+            # close() join keeps draining its OWN queue, so it can neither
+            # consume this worker's jobs nor eat this worker's future sentinel.
+            self._jobs = queue.SimpleQueue()
+            thread = threading.Thread(
+                target=self._infer_loop, args=(self._jobs,), name="kc-embed-infer", daemon=True
+            )
+            self._infer_thread = thread
+            thread.start()
+        jobs = self._jobs
+        job = _InferJob(llm, texts)
+        jobs.put(job)
+        job.done.wait()
+        if job.error is not None:
+            raise job.error
+        return job.result
+
     def embed(self, text: str) -> list[float] | None:
         """Embed a single text. Returns None on any failure."""
         result = self.embed_batch([text])
@@ -390,8 +473,8 @@ class LlamaCppEmbedder(EmbeddingBackend):
             clipped.append(t)
         with self._lock:
             try:
-                resp = llm.create_embedding(clipped)  # type: ignore[attr-defined]
-                vectors = [item["embedding"] for item in resp["data"]]
+                resp = self._create_embedding(llm, clipped)
+                vectors = [item["embedding"] for item in resp["data"]]  # type: ignore[index]
             except Exception:
                 logger.debug("In-process embed failed", exc_info=True)
                 return None
@@ -429,11 +512,24 @@ class LlamaCppEmbedder(EmbeddingBackend):
         return self.is_ready()
 
     def close(self) -> None:
-        """Unload the model (frees ~700MB RSS). Safe to call repeatedly."""
+        """Unload the model (frees ~700MB RSS). Safe to call repeatedly.
+
+        Also stops the inference thread: llama.cpp's compute pool is owned by
+        that thread, so it is only released when the thread exits.
+        """
         with self._lock, self._load_lock:
             self._llm = None
             self._load_failed_at = 0.0
             self._load_thread = None
+            thread, self._infer_thread = self._infer_thread, None
+            if thread is not None and thread.is_alive():
+                # Holding _lock means no job can be queued behind this sentinel.
+                # If the join times out, the straggler stays parked on THIS
+                # queue, which the next worker will not share (see
+                # _create_embedding), so the sentinel it eventually consumes is
+                # still its own.
+                self._jobs.put(None)
+                thread.join(_INFER_STOP_TIMEOUT_SECS)
 
 
 _shared_embedder: EmbeddingBackend | None = None

--- a/test/test_embeddings.py
+++ b/test/test_embeddings.py
@@ -342,6 +342,112 @@ class TestLlamaCppEmbedder:
         # The model loaded exactly once despite the concurrent first calls.
         assert len(fake_cls.instances) == 1
 
+    def test_inference_runs_on_one_owned_thread(self, tmp_path: Path, monkeypatch) -> None:
+        """Inference never runs on the caller's thread, and always on the same one.
+
+        llama.cpp builds a compute thread pool (n_threads_batch, = CPU count)
+        the first time a given thread runs inference, and that pool lives as
+        long as its calling thread. Embeds arrive on long-lived executor
+        threads, so running inference inline leaked one pool per caller.
+        """
+        fake_cls = _make_fake_llama_class()
+        monkeypatch.setattr("kiro_crew.embeddings._load_llama_class", lambda: fake_cls)
+        emb = self._embedder(tmp_path)
+        assert emb.wait_ready(timeout=5)
+        llm = fake_cls.instances[0]
+        inference_threads: list[threading.Thread] = []
+        caller_threads: list[threading.Thread] = []
+        worker_results: list[list[float] | None] = []
+        real_create = llm.create_embedding
+
+        def _recording(texts):
+            inference_threads.append(threading.current_thread())
+            return real_create(texts)
+
+        llm.create_embedding = _recording
+
+        def _work(i: int) -> None:
+            caller_threads.append(threading.current_thread())
+            worker_results.append(emb.embed(f"text {i}"))
+
+        threads = [threading.Thread(target=_work, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # Assert on THIS thread: an assert inside _work would be swallowed by
+        # threading and could not fail the test.
+        assert all(r is not None and len(r) == _DIM for r in worker_results)
+        assert emb.embed("from the test thread") is not None  # main thread too
+
+        assert len(inference_threads) == 5
+        assert len(set(inference_threads)) == 1, "inference must not follow the caller"
+        worker = inference_threads[0]
+        assert worker is not threading.current_thread()
+        assert worker not in caller_threads
+        assert worker.daemon
+
+    def test_close_stops_the_inference_thread(self, tmp_path: Path, monkeypatch) -> None:
+        """close() releases the compute pool, which means ending its owner thread."""
+        fake_cls = _make_fake_llama_class()
+        monkeypatch.setattr("kiro_crew.embeddings._load_llama_class", lambda: fake_cls)
+        emb = self._embedder(tmp_path)
+        assert emb.wait_ready(timeout=5)
+        assert emb.embed("hello") is not None
+        worker = emb._infer_thread
+        assert worker is not None and worker.is_alive()
+
+        emb.close()
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+        assert emb._infer_thread is None
+
+        # A later embed brings up a fresh worker rather than wedging.
+        assert emb.wait_ready(timeout=5)
+        assert emb.embed("hello again") is not None
+        assert emb._infer_thread is not None and emb._infer_thread is not worker
+
+    def test_worker_is_bound_to_its_own_queue(self, tmp_path: Path, monkeypatch) -> None:
+        """A straggler from a timed-out close() cannot serve or starve the next worker.
+
+        With the stop timeout at zero the join always "times out", so close()
+        leaves the previous worker alive. Each worker owns the queue it was
+        started with, so the straggler drains only its own — it can neither
+        consume the next worker's jobs nor eat that worker's future sentinel.
+        """
+        fake_cls = _make_fake_llama_class()
+        monkeypatch.setattr("kiro_crew.embeddings._load_llama_class", lambda: fake_cls)
+        monkeypatch.setattr("kiro_crew.embeddings._INFER_STOP_TIMEOUT_SECS", 0.0)
+        emb = self._embedder(tmp_path)
+        assert emb.wait_ready(timeout=5)
+        assert emb.embed("first") is not None
+        first_worker, first_queue = emb._infer_thread, emb._jobs
+        assert first_worker is not None
+
+        emb.close()  # join(0.0) — may or may not have reaped the worker yet
+        assert emb._infer_thread is None
+
+        assert emb.wait_ready(timeout=5)
+        assert emb.embed("after close") is not None, "job was orphaned"
+        assert emb._infer_thread is not None and emb._infer_thread is not first_worker
+        assert emb._jobs is not first_queue
+        # The old worker exits on the sentinel left on its own queue.
+        first_worker.join(timeout=5)
+        assert not first_worker.is_alive()
+
+    def test_inference_error_propagates_from_the_worker(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A failure raised on the worker thread still degrades to None, not a hang."""
+        fake_cls = _make_fake_llama_class()
+        monkeypatch.setattr("kiro_crew.embeddings._load_llama_class", lambda: fake_cls)
+        emb = self._embedder(tmp_path)
+        assert emb.wait_ready(timeout=5)
+        fake_cls.embed_error = RuntimeError("ggml exploded")
+        assert emb.embed("boom") is None
+        fake_cls.embed_error = None
+        assert emb.embed("recovered") is not None
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # ModelDownloadManager


### PR DESCRIPTION
## Problem

The gateway accumulates OS threads and RSS for as long as it runs. On a 48-core
host, one hour after start:

```
Threads:  1559 -> 1702      (measured 18 minutes apart, same process)
VmRSS:    4.4 GB
VmSize:   28 GB
%CPU:     206 (steady)
```

Grouping the live threads by consecutive tid + creation time shows **31 cohorts
of exactly 47 threads** (= `nproc - 1`), created between 19:36 and 20:31, each
cohort's threads holding near-identical CPU time (e.g. 47 × 8.26s ± 0.05 — the
signature of one synchronized worker team), none ever reclaimed. Every
`create_subprocess_exec` the event loop performs forks that thread count.

## Why it matters

Nothing bounds this within a session. The ceiling is the number of long-lived
worker threads that ever embed — `mc-embed` (8) plus asyncio's default executor
(32) plus the cron / maintenance / governance / discovery / subprocess pools —
so roughly 60 callers × 47 ≈ 2,800 threads and matching stack + arena RSS. A
long-running gateway pays for it in memory, in fork latency on the event loop
(every kiro-cli spawn forks this process), and eventually in host thread
pressure. The only mitigation today is restarting the gateway.

## Fix (symptoms -> root cause -> change)

- **Symptom:** cohorts of exactly 47 threads appear at context-build times and
  never go away; only one `Loaded embedding model` line is ever logged, so it is
  not duplicate model loads.
- **Root cause:** llama.cpp builds a compute thread pool sized by
  `n_threads_batch` (which defaults to the CPU count) the **first time a given
  thread runs inference**, and that pool lives as long as its calling thread
  does. Reproduced in isolation: first embed on a thread `+47` threads,
  subsequent embeds on the same thread `+0`, first embed on a *new* thread `+47`
  again, and the pool disappears when that thread exits. `LlamaCppEmbedder`
  called `create_embedding` inline on whatever thread asked for a vector, and
  those are pool threads that never exit.
- **Change:** forward every `create_embedding` to **one owned daemon thread**
  (`kc-embed-infer`) via a `queue.SimpleQueue` of jobs. `_lock` already
  serialized all inference, so the hand-off adds no queueing that was not
  already there, and the process now holds exactly one compute pool no matter
  how many threads embed. `close()` additionally stops that thread — the pool is
  owned by the thread, so dropping the `Llama` reference alone would leave it
  running, which would have made `close()`'s "frees ~700MB RSS" contract only
  half true. Each worker is **passed the queue it drains at construction**, so a
  straggler left behind by a timed-out `close()` join can only drain (and exit
  on the sentinel from) its own queue, never one feeding a later worker.

Rejected alternative: bounding `n_threads` / `n_threads_batch` on the `Llama`
constructor. It shrinks the pools but costs real latency, measured on a 2 KB
text — default (24/48): 0.8–1.3s; `n_threads=4`: 3.3s; `n_threads=2`: 6.2s.
Embeds sit on the critical path of every new session and subagent context build
and already serialize, so tripling per-embed latency to bound threads is the
wrong trade. `OMP_NUM_THREADS` is not a lever either: 4/8/16 only cap the
load-time pool and leave the 47-thread compute pool untouched.

## Tests

`test/test_embeddings.py`:

- `test_inference_runs_on_one_owned_thread` — records
  `threading.current_thread()` inside `create_embedding` while four caller
  threads plus the test thread embed; asserts all five inferences ran on **one**
  thread, that it is none of the callers, and that it is a daemon. **RED on
  `main`** for the substantive reason: `AssertionError: inference must not
  follow the caller / assert 5 == 1`.
- `test_close_stops_the_inference_thread` — `close()` ends the worker and
  `_infer_thread` is cleared; a later embed brings up a fresh worker instead of
  wedging. **RED on `main`** (`AttributeError: no attribute '_infer_thread'`).
- `test_inference_error_propagates_from_the_worker` — a failure raised on the
  worker still degrades to `None` (never a hang), and the next embed recovers.
- `test_worker_is_bound_to_its_own_queue` — with `_INFER_STOP_TIMEOUT_SECS`
  monkeypatched to `0.0` the `close()` join always "times out", so the previous
  worker is still alive; asserts the next embed is served (no orphaned job), that
  the new worker and its queue are both fresh objects, and that the straggler
  exits on the sentinel left on its own queue.

## Manual verification

Loaded the real `qwen3-embedding-0.6b.gguf` against an isolated
`KIROCREW_HOME` (symlinked model, no writes to the live home) and embedded from
16 distinct caller threads, then exercised `close()` and a reload:

```
loaded + first embed:   threads=  96 rss=1099MB
8 fresh caller threads: threads=  96 rss=1357MB
8 fresh caller threads: threads=  96 rss=1357MB
after close():          threads=  48 rss= 123MB
reload embed ok: True   threads=  96
workers alive: ['kc-embed-infer']
```

Thread count flat at 96 across every embed; on `main` the same workload lands at
roughly 96 + 15×47 ≈ 800. Latency unchanged (8 concurrent embeds in 8.0–13.6s,
matching the pre-change 6-in-11.0s measurement). `close()` returns both the pool
and the model, and the reload runs on exactly one worker.

Local gates: full backend suite **21,750 passed**, 21 failed — every one of those
21 is inside a set already proven to fail identically with both changed files
reverted to `origin/main` on this same host (23 failed / 1 passed for the same
ids on both sides), and all of them are sandbox/seatbelt, source-provider
ownership, pid-lifecycle and dashboard-URL tests that touch nothing in this diff.
Their membership shifts run to run within the sandbox/no-isolation family, which
is what an order-dependent host flake looks like. `isort` clean, `flake8` clean,
`mypy 1.14.1` (matching the `pyproject.toml` pin, no faiss installed) reports no
issues in 558 source files.

One gap stated plainly: the timed-out-join race that motivated the per-worker
queue is timing-dependent and cannot be forced deterministically with the fake
Llama harness (`close()` cannot even run while a job is in flight, since it needs
`_lock`). The fix removes it by construction — a worker's queue is immutable for
its lifetime — rather than by test; `test_worker_is_bound_to_its_own_queue`
covers the reachable straggler path.

## Screenshots

N/A — no user-visible UI surface changes; the diff is backend-only
(`src/kiro_crew/embeddings.py`) plus tests.

## Known follow-up (out of scope)

48 threads survive `close()`, i.e. the model **load-time** pool is not tied to
the loader thread. It is a constant, not a leak, so it is left alone here.
