### PR TITLE
docs: Add a short release process overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,10 @@ git push && git push --tags
 | `src/kiro_crew/__init__.py` | `__version__` (source of truth) |
 | `CHANGELOG.md` | New `## [X.Y.Z]` section |
 
+For the branch, channel, and RC model behind these steps — where the tag goes
+and how insider becomes stable — see
+**[docs/release-process.md](docs/release-process.md)**.
+
 ## Project Structure
 
 Key entry points:

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Credentials: `~/.kiro/crew/.env` — `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `KIRO
 | [docs/features.md](docs/features.md) | Complete feature reference |
 | [docs/project-architecture.md](docs/project-architecture.md) | System architecture with diagrams |
 | [docs/install.md](docs/install.md) | All build/install methods (source, wheel, desktop app) |
+| [docs/release-process.md](docs/release-process.md) | How releases are cut: branches, channels, versions |
 | [docs/security-deep-dive.md](docs/security-deep-dive.md) | Security architecture |
 | [docs/memory-architecture.md](docs/memory-architecture.md) | Memory system design |
 | [docs/mcp-architecture.md](docs/mcp-architecture.md) | MCP server management |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,56 @@
+# KiroCrew Release Process
+
+Deeper detail: [`release-process-design.md`](release-process-design.md).
+
+## The model
+
+- **`main` is always the latest (non-stable) code.** Nightly builds off `main` —
+  once a night, or several times a day on demand.
+- **Feature releases are cut as a release branch off `main`**, on 0.1
+  increments: `0.1.0` → `0.2.0` → `0.3.0`.
+- **Bug fixes go on the release branch**, not `main`. Each produces a new
+  insider RC (release candidate): `0.2.0.rc1`, `0.2.0.rc2`, …
+- **Stable is the last RC we judge stable enough** — promoted by tagging it, not
+  rebuilt. So `0.2.0.rc5` becomes stable `0.2.0`.
+- **Hot patches bump the patch digit** (`0.2.0` → `0.2.1`), cut from the release
+  branch. Small ones go straight to stable; larger ones go through an RC on
+  insider first.
+- **After each stable cut**, bump the version on `main` by 0.1 and merge the
+  branch's fixes back. Releasing stable `0.2.0` moves `main` to `0.3.0`.
+
+## Channels
+
+| Channel | Built from | Who |
+|---|---|---|
+| nightly | `main` | us and contributors |
+| insider | release branch, RC tags | power users testing ahead |
+| stable | the promoted insider | everyone (client default) |
+
+Nightly installs side by side as its own app; insider and stable are two update
+lanes of one production app, switchable in Settings.
+
+## Cutting a release
+
+1. Branch off `main` (`0.2.0`).
+2. Tag RCs on the branch as fixes land: `v0.2.0-rc.1`, `-rc.2`, … → insider.
+3. Tag the good RC's commit with a bare `v0.2.0` → stable.
+4. Bump `main` to `0.3.0`, merge the fixes back.
+5. Hot patch: fix on the branch, tag `v0.2.1`.
+
+## How builds are triggered
+
+- **Nightly** runs on a schedule every night, and can be kicked off on demand
+  any time.
+- **Insider and stable** are triggered by pushing a version tag — an RC tag
+  publishes to insider, a plain version tag publishes to stable.
+
+The release branch, RC numbering, promote decision, and back-merge are all
+human process; the pipeline only reacts to the tag.
+
+Each build ships a signed and notarized macOS app, a Linux AppImage, a CLI
+installer, a pip wheel, and a Docker image. The update feed for a channel is
+repointed last, after the artifacts are verified downloadable, and clients only
+install with the user's consent. Windows builds but is not yet signed or
+published.
+
+There is no rollback: we roll forward by cutting a new version.


### PR DESCRIPTION
## Problem

The release system is documented in two places and neither answers the basic
question. `docs/release-process-design.md` (531 lines) records design rationale;
`docs/release-automation.md` (579 lines) is ~440 lines of a superseded
beta-cut/promote/Feed-Lambda plan sitting under a short "As built" note. Neither
states the branch and channel model plainly, and nothing anywhere says how to
cut a release. `CONTRIBUTING.md` gives the version-bump and tag mechanics with
no context for which branch the tag belongs on.

## Why it matters

Anyone cutting a release — or just trying to understand what `nightly`,
`insider`, and `stable` mean — has to reverse-engineer it from a triggers table
or read 1,100 lines. A reader who lands mid-way through `release-automation.md`
reads a plan that was never built, with no visible warning.

## Fix

Adds `docs/release-process.md` (55 lines), a plain statement of the model:

- `main` is always the latest code and feeds nightly builds.
- Feature releases are cut as a release branch off `main`, on 0.1 increments.
- Bug fixes go on the release branch, each producing an insider release
  candidate (`0.2.0.rc1`, `0.2.0.rc2`, …).
- Stable is the last RC we judge stable enough, promoted by tagging it rather
  than rebuilt.
- Hot patches bump the patch digit; small ones go straight to stable, larger
  ones through an RC on insider first.
- After a stable cut, the version on `main` bumps by 0.1 and the branch's fixes
  are merged back.

It also covers how builds are triggered (nightly on a schedule or on demand;
insider and stable by pushing a version tag), what each build ships, and that
there is no rollback — we roll forward by cutting a new version.

Discoverability, which is the point of the change: linked from the README
documentation table and from CONTRIBUTING's "Releasing New Versions" section.

## Tests

N/A — documentation only, no code paths touched.

## Manual verification

Relative links checked: `docs/release-process.md` → `release-process-design.md`
resolves within `docs/`; README and CONTRIBUTING links resolve from the repo
root.

## Screenshots

N/A — no user-visible UI change.

## Note for reviewers

Two places where this doc disagrees with existing docs, left as-is rather than
silently reconciled:

- `release-process-design.md` lists "fast pullback" as product requirement P4
  and records a pullback being exercised once. This doc states roll-forward
  only. If that is the real policy, P4 should be retired there.
- `release-automation.md` describes a branch-cut model closer to this one than
  to what shipped. It may be worth reviving rather than deleting, but that is a
  separate change.
