### PR TITLE
docs(agents): clarify routing metadata tooltip + Orchestrator Mode

### DIFF
--- a/website/src/pages/AgentsPage.tsx
+++ b/website/src/pages/AgentsPage.tsx
@@ -88,7 +88,7 @@ function AgentMetadataEditor({ name }: { name: string }) {
     <div className="mb-3">
       <div className="flex items-center gap-2 mb-1">
         <span className="text-[12px] text-muted font-medium uppercase tracking-wider">{i18nT('pages.agentsPage.routing_metadata')}</span>
-        <InfoTip text="Describes when to delegate tasks to this agent. Used by the conductor skill to route tasks to the right specialist. Markdown format." />
+        <InfoTip text="Routing hints for the conductor skill: describe the tasks and triggering conditions where this agent should be picked (e.g. 'Use for frontend/React UI work' or 'Handle DB migrations'). An incoming task is matched against this text to delegate to the right specialist. These hints only take effect once Orchestrator Mode is enabled in Config (Developer → Config → Orchestrator Mode); otherwise they're ignored. Markdown format." />
       </div>
       <textarea aria-label={i18nT('pages.agentsPage.routing_metadata_2')} className="w-full bg-bg-elevated border border-border rounded-md p-2.5 text-text font-mono text-[12px] outline-none resize-y leading-relaxed transition-colors focus-ring" rows={4} value={content} onChange={e => setContent(e.target.value)} placeholder={i18nT('pages.agentsPage.describe_when_to_use_this_agent')} />
       <div className="flex items-center gap-2 mt-1">


### PR DESCRIPTION
## Problem
In Developer → Config, the agent template exposes a **routing metadata** field with a `?` tooltip even when Orchestrator Mode is off. The tooltip ("Describes when to delegate tasks to this agent. Used by the conductor skill to route tasks to the right specialist. Markdown format.") doesn't tell users *what to write* (the triggering conditions), and doesn't mention that the field is inert until Orchestrator Mode is enabled.

## Why it matters
Users fill in (or ignore) the field without knowing it only matters for multi-agent orchestration, and without a concrete idea of the content that actually drives routing — so the feature is discoverable but not usable from the tooltip alone.

## Fix (symptom → root cause → change)
- Symptom: tooltip is vague and gives no actionable guidance or enablement path.
- Root cause: the help copy only described the field abstractly.
- Change: rewrote the `InfoTip` text on the routing-metadata field in `website/src/pages/AgentsPage.tsx` to (1) say what to write — the tasks and triggering conditions that make the conductor pick this agent, with examples, and (2) note the hints only take effect once **Orchestrator Mode** is enabled (Developer → Config → Orchestrator Mode). Copy-only; no logic or component structure changed.

Before:
> Describes when to delegate tasks to this agent. Used by the conductor skill to route tasks to the right specialist. Markdown format.

After:
> Routing hints for the conductor skill: describe the tasks and triggering conditions where this agent should be picked (e.g. 'Use for frontend/React UI work' or 'Handle DB migrations'). An incoming task is matched against this text to delegate to the right specialist. These hints only take effect once Orchestrator Mode is enabled in Config (Developer → Config → Orchestrator Mode); otherwise they're ignored. Markdown format.

## Tests
N/A — no test asserts on this tooltip copy; `tsc -b` passes. Change is a static string literal.

## Manual verification
`npx tsc -b` clean. The tooltip renders via the existing `InfoTip` component (unchanged); only the `text` prop string differs.

## Screenshots
N/A — text-only tooltip copy change routed through the unchanged `InfoTip` component; no new/changed panels, layout, or theme. The exact rendered string is visible in the diff (before/after above).