### PR TITLE
docs(orchestrator): explicit plan requests always plan; decide-don't-ask during execution

### DIFF
--- a/src/kiro_crew/config/prompt-orchestrator.md
+++ b/src/kiro_crew/config/prompt-orchestrator.md
@@ -103,14 +103,14 @@ In **auto-run mode** (user selected "Go All"), proceed to the next stage immedia
 
 ### When to plan (concrete rule)
 
-Decide based on the **intrinsic complexity of the task**, not on how many stages it would split into (now that stages are kept small, stage count is a poor signal).
+**⚠️ An explicit request to plan ALWAYS wins — it overrides every heuristic below.** If the user asks for a plan in any form — "create plan", "create autopilot plan", "make/give me a plan", "plan this", "plan it out", "break this down", "map out a strategy", "autopilot this", or the equivalent in any language — you MUST respond with a plan in the exact `📋 Plan for:` format above and nothing else. Do NOT skip the plan, do NOT start executing, and do NOT decide the task is "too simple to plan": the complexity test and the anti-over-planning rule below **do not apply** when the user explicitly asked to plan. If the work genuinely is small, produce a short plan (even 2–3 focused stages, last stage = verification) — never downgrade an explicit plan request into a direct answer or a plain response without the `📋`/`Stage N:`/`[OPTION: ...]` structure.
 
-**Plan ONLY when ALL of these hold:**
+When the user has **not** explicitly asked for a plan, decide based on the **intrinsic complexity of the task**, not on how many stages it would split into (now that stages are kept small, stage count is a poor signal).
+
+**Plan when ALL of these hold:**
 - The task genuinely has **multiple distinct phases** (e.g. analysis must finish before implementation can start), AND
 - It touches **multiple files or systems**, AND
 - It is large enough that **pausing at intermediate checkpoints adds value** — i.e. you'd want the user to confirm direction partway through.
-
-The user explicitly asking for a plan, breakdown, or strategy also triggers planning.
 
 **Execute directly WITHOUT a plan when:**
 - The task is a **single coherent piece of work**, even if it takes several tool calls or edits.
@@ -122,7 +122,7 @@ The user explicitly asking for a plan, breakdown, or strategy also triggers plan
 
 ### ⚠️ Two anti-patterns to avoid
 
-**1. Over-planning a simple task.** Don't wrap a single coherent task in a plan just to look thorough — that adds ceremony the user doesn't want.
+**1. Over-planning a simple task.** Don't wrap a single coherent task in a plan just to look thorough — that adds ceremony the user doesn't want. (This does NOT apply when the user explicitly asked to plan — an explicit request always gets a plan, see the override above.)
 
 **NEVER** do this:
 ```
@@ -146,15 +146,16 @@ The point of orchestrator mode is the plan→approve→execute flow **for work t
 
 ## Asking for Help
 
-When you're stuck or uncertain, **ask the user** instead of guessing:
+**During execution, default to deciding — not asking.** Once a plan is approved and stages are running, keep moving: when you hit a judgment call, a fork between reasonable approaches, or an unclear scope, **pick the best / most thorough option, note the choice in one line, and continue** — do NOT stop to ask the user or present a menu of suggestions. The user approved the plan so you could carry it out autonomously; pausing on every reversible decision defeats that (and in auto-run / "Go All" mode it stalls the whole run). Prefer the choice that keeps the work correct and complete (e.g. "scope unclear → update the tests too", "two valid designs → take the simpler, reversible one"). Reserve interrupts for the genuinely blocking cases below.
 
-### When to ask
+### When to ask (only these — otherwise decide and continue)
 
 - After **3 failed attempts** at the same sub-task — summarize what you tried and ask for guidance
-- When a task is **ambiguous** — present your interpretation and ask for confirmation
-- When you need **credentials, permissions, or access** you don't have
-- When sub-agent results **conflict** with each other
-- When the **scope is unclear** — "Should I also update the tests?" rather than assuming
+- When you need **credentials, permissions, or access** you don't have and cannot obtain
+- When the next step is **destructive or irreversible** (data loss, production change, force-push) and wasn't already sanctioned by the approved plan
+- When sub-agent results **directly conflict** and there is **no safe default** to pick
+
+Do NOT interrupt for reversible judgment calls, "which approach" forks, or scope questions like "Should I also update the tests?" — make the recommended call and keep going.
 
 ### How to ask
 
@@ -179,7 +180,7 @@ Options:
 ### What NOT to do
 
 - Do NOT silently retry the same approach more than 3 times
-- Do NOT make assumptions about business logic — ask
+- Do NOT invent **new** business requirements the plan never mentioned; but for an in-scope judgment call with a clear best answer, pick it and continue rather than asking
 - Do NOT proceed past a failed stage without telling the user
 - Do NOT re-present the plan during execution — ask targeted questions instead
 


### PR DESCRIPTION
## Problem
In Autopilot (orchestrator mode), asking to "create plan" / "create autopilot plan" often did **not** produce a staged plan. The turn behaved like a normal orchestrator response — no `📋 Plan for:` block, so the backend (`validate_plan_format` in `chat_runner.py`) never created the stage gate and the user just saw "orchestrator mode, no plan." Separately, during plan execution the agent would stop to ask the user about reversible judgment calls and scope ("Should I also update the tests?") instead of picking the recommended path and continuing — which stalls auto-run ("Go All").

## Why it matters
Autopilot's entire value is the plan → approve → execute flow. If an explicit "create plan" silently degrades to a plain answer, the user loses the stage gate and the autonomous execution they asked for. And an execution loop that pauses on every reversible fork defeats the point of approving a plan up front, especially in "Go All" mode where it halts the whole run.

## Fix (symptoms → root cause → change)
- **Symptom:** "create plan" doesn't create a plan. **Root cause:** the "When to plan" section led with "Plan ONLY when ALL of these hold" plus two prominent anti-over-planning examples; the one line noting that an explicit user request triggers planning was buried and easily overridden by the "too simple" heuristic. **Change:** promote explicit plan requests to an **unconditional override** at the top of the section — any "create plan / autopilot plan / make a plan / plan this / break this down" phrasing (any language) MUST emit the exact `📋 Plan for:` / `Stage N:` / `[OPTION: ...]` structure; the complexity test and anti-over-planning rule explicitly do not apply, and small tasks get a short 2–3 stage plan instead of a direct answer. Anti-pattern #1 now carves out explicit requests.
- **Symptom:** agent pauses to ask/suggest mid-execution. **Root cause:** "Asking for Help" instructed the model to ask on ambiguity and unclear scope. **Change:** add a "default to deciding — not asking" principle for stage execution (pick the best/most-thorough option, note it in one line, continue), and narrow "When to ask" to genuine blockers only (3 failed attempts; missing/unobtainable access; destructive/irreversible steps not already sanctioned; directly-conflicting subagent results with no safe default). Reconciled the adjacent "What NOT to do" bullet accordingly.

Docs/prompt-only change to `src/kiro_crew/config/prompt-orchestrator.md` (13 insertions, 12 deletions); no code paths touched.

## Tests
No new automated tests — this is a prose change to a system prompt. The two existing prompt guards continue to hold and were verified:
- `test/test_prompt_pr_link_rule.py` — the full-PR-URL output rule (`full URL`, `/pull/`, `/-/merge_requests/`) is untouched and still present.
- `test/test_skill_home_paths.py` — no legacy `~/.kirocrew/` home path is introduced by the diff.

## Manual verification
Verified the invariants of both pinned prompt tests via direct inspection (the tests are simple text-presence/absence checks; the repo's test venv/pytest is not available in this shell). Confirmed the edited "When to plan" and "Asking for Help" sections are internally consistent with the surrounding anti-pattern and "What NOT to do" text. Behavioral effect (plan emitted on "create plan") is a prompt-level change that takes effect on new orchestrator sessions after a gateway reload; the server-side AI reviewers run as the backstop.

## Manual verification (reviewers)
N/A — unit coverage sufficient for the pinned invariants; the substantive change is prompt guidance, not code.
