### PR TITLE
fix(dashboard): stop the startup restore from crash-looping the gateway

### DIFF
--- a/src/kiro_crew/dashboard/chat.py
+++ b/src/kiro_crew/dashboard/chat.py
@@ -88,7 +88,9 @@ from kiro_crew.dashboard.chat_persistence import (  # noqa: F401
     _rehydrate_slot_from_history,
     _save_slot_to_history,
     restore_open_slots,
+    restore_open_slots_async,
     restore_recent_sessions,
+    restore_recent_sessions_async,
     save_all_slots_to_history,
 )
 from kiro_crew.dashboard.chat_regenerate import (  # noqa: F401

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -9,6 +9,7 @@ import re
 import time
 import uuid
 from collections import deque
+from collections.abc import Iterator
 
 from kiro_crew import model_registry
 from kiro_crew.agent import KIRO_AGENTS_DIR
@@ -174,39 +175,57 @@ def save_all_slots_to_history(state: DashboardState) -> None:
         logger.debug("Shutdown: open_slots snapshot failed", exc_info=True)
 
 
-def restore_open_slots(state: DashboardState) -> int:
-    """Restore the tabs the user had open at the previous shutdown.
+def _build_kiro_model_map() -> dict[str, str]:
+    """Map kiro-agent name/stem -> configured model, for legacy sessions.
 
-    Reads ``<config_dir>/open_slots.json`` (written by
-    ``DashboardState._persist_open_slots`` on every flush) and rehydrates
-    each listed key from on-disk session metadata so it shows up in the
-    Sessions sidebar exactly as it did before the restart — independent of
-    the ``restore_window_minutes`` mtime cutoff used by
-    ``restore_recent_sessions``.
+    Sessions persisted before ``model`` was written into their metadata resolve
+    their model by agent name instead, so both restore paths need this map.
+    Factored out of ``_rehydrate_slot_from_history`` and
+    ``restore_recent_sessions`` because the former rebuilt it *per restored
+    slot* — re-globbing and re-parsing every agent JSON on each of N tabs to
+    produce a byte-identical dict. Callers restoring many slots should build it
+    once and pass it down (see ``kiro_model_map`` params below).
+    """
+    out: dict[str, str] = {}
+    try:
+        for f in KIRO_AGENTS_DIR.glob("*.json"):
+            try:
+                data = json.loads(f.read_text(encoding="utf-8"))
+                model = data.get("model", "")
+                if data.get("name"):
+                    out[data["name"]] = model
+                out[f.stem] = model
+            except (json.JSONDecodeError, OSError):
+                continue
+    except Exception:
+        logger.debug("Failed to build kiro model map", exc_info=True)
+    return out
 
-    Path resolves through ``config_dir()`` (honors ``KIROCREW_HOME``) so
-    dev/test instances with non-default homes don't read the production
-    ``~/.kiro/crew`` snapshot.
 
-    Returns the number of slots restored. Missing / malformed file is a
-    no-op (returns 0). Sessions that have been explicitly closed
-    (``meta.closed``) are skipped via _rehydrate_slot_from_history's own
-    guard, so closing a tab and then restarting still loses the tab.
+def _restore_open_slots_steps(state: DashboardState) -> "Iterator[int]":
+    """Drive the open-tab restore one tab at a time, yielding the running count.
+
+    Exposed as a generator so the same logic serves both a plain synchronous
+    caller (:func:`restore_open_slots`) and an event-loop-friendly one
+    (:func:`restore_open_slots_async`) that awaits between tabs. See
+    :func:`restore_open_slots` for the behavioural contract.
     """
     if not state.conversation_log:
-        return 0
+        return
     path = config_dir() / "open_slots.json"
     if not path.exists():
-        return 0
+        return
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         logger.debug("open_slots.json unreadable; skipping", exc_info=True)
-        return 0
+        return
     keys = data.get("keys") if isinstance(data, dict) else None
     if not isinstance(keys, list):
-        return 0
+        return
     restored = 0
+    # Built once and shared across every tab — it is identical per slot.
+    kiro_model_map = _build_kiro_model_map()
     for raw in keys:
         if not isinstance(raw, str) or not raw:
             continue
@@ -231,7 +250,7 @@ def restore_open_slots(state: DashboardState) -> int:
         if raw in state._slots:
             continue
         try:
-            slot = _rehydrate_slot_from_history(state, raw)
+            slot = _rehydrate_slot_from_history(state, raw, kiro_model_map=kiro_model_map)
         except Exception:
             logger.debug("restore_open_slots: rehydrate failed for %s", raw, exc_info=True)
             # Roll back any partial slot leaked by _rehydrate_slot_from_history.
@@ -253,8 +272,72 @@ def restore_open_slots(state: DashboardState) -> int:
             continue
         if slot is not None:
             restored += 1
+        # One yield point per tab. The async driver turns this into a real event-loop
+        # yield; the sync driver just spins through it.
+        yield restored
     if restored:
         logger.info("Restored %d open tab(s) from open_slots.json", restored)
+
+
+def restore_open_slots(state: DashboardState) -> int:
+    """Restore the tabs the user had open at the previous shutdown.
+
+    Reads ``<config_dir>/open_slots.json`` (written by
+    ``DashboardState._persist_open_slots`` on every flush) and rehydrates
+    each listed key from on-disk session metadata so it shows up in the
+    Sessions sidebar exactly as it did before the restart — independent of
+    the ``restore_window_minutes`` mtime cutoff used by
+    ``restore_recent_sessions``.
+
+    Path resolves through ``config_dir()`` (honors ``KIROCREW_HOME``) so
+    dev/test instances with non-default homes don't read the production
+    ``~/.kiro/crew`` snapshot.
+
+    Returns the number of slots restored. Missing / malformed file is a
+    no-op (returns 0). Sessions that have been explicitly closed
+    (``meta.closed``) are skipped via _rehydrate_slot_from_history's own
+    guard, so closing a tab and then restarting still loses the tab.
+
+    Blocking: restores every tab without yielding. Startup on the event loop must
+    use :func:`restore_open_slots_async` instead — see the note there.
+    """
+    restored = 0
+    for restored in _restore_open_slots_steps(state):
+        pass
+    return restored
+
+
+async def restore_open_slots_async(state: DashboardState) -> int:
+    """:func:`restore_open_slots`, yielding to the event loop between tabs.
+
+    Restoring a tab reads and redacts a transcript, so a user with many large
+    tabs can spend tens of seconds in here. Doing that synchronously monopolizes
+    the event loop — and because ``_loop_heartbeat`` pets the
+    ``LoopStallWatchdog`` *from a coroutine*, a blocked loop cannot pet it. The
+    watchdog's 25s ``exit_after`` timer then fires, dumps thread stacks and
+    ``_exit``s the gateway, which is exactly the observed startup crash-loop: the
+    app never finished booting. Yielding per tab lets the heartbeat run, so a slow
+    restore degrades into "the sidebar fills in progressively" rather than "the
+    gateway dies".
+
+    Stays ON the loop rather than moving to a worker thread because creating a
+    slot broadcasts via ``asyncio.Queue.put_nowait`` / ``asyncio.Event.set``,
+    neither of which is thread-safe.
+
+    Because we now yield, the 5s periodic flush (already running by this point)
+    can interleave — so ``restoring_open_slots`` is held for the duration to stop
+    it snapshotting a half-restored slot set over open_slots.json.
+    """
+    restored = 0
+    state.restoring_open_slots = True
+    try:
+        for restored in _restore_open_slots_steps(state):
+            # sleep(0) yields to the ready queue without adding wall-clock delay.
+            await asyncio.sleep(0)
+    finally:
+        # Always clear, even if a rehydrate raises — a stuck flag would silently
+        # disable open-tab persistence for the rest of the process's life.
+        state.restoring_open_slots = False
     return restored
 
 
@@ -272,8 +355,17 @@ def _attach_variants(slot: _ChatSlot, m: dict) -> None:
         slot.messages[-1]["variant_idx"] = m.get("variant_idx", 0)
 
 
-def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _ChatSlot | None:
+def _rehydrate_slot_from_history(
+    state: DashboardState,
+    slot_name: str,
+    *,
+    kiro_model_map: dict[str, str] | None = None,
+) -> _ChatSlot | None:
     """Rehydrate a single dashboard slot from persisted history.
+
+    *kiro_model_map* lets a bulk caller build the agent→model map once and share
+    it across every slot instead of paying a fresh directory glob + JSON parse
+    per tab; omit it and one is built on demand for single-slot callers.
 
     Unlike ``state.get_or_create_slot`` (which creates a fresh, empty slot with
     default ``memory_mode='persistent'``), this helper reads the session's
@@ -306,39 +398,38 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
         _restore_cfg = KiroCrewConfig.load()
     except Exception:
         _restore_cfg = None
-    # Build the same kiro-agent model map as restore_recent_sessions so
-    # legacy sessions without persisted `model` still resolve correctly.
-    kiro_model_map: dict[str, str] = {}
-    try:
-        for f in KIRO_AGENTS_DIR.glob("*.json"):
-            try:
-                data = json.loads(f.read_text(encoding="utf-8"))
-                model = data.get("model", "")
-                if data.get("name"):
-                    kiro_model_map[data["name"]] = model
-                kiro_model_map[f.stem] = model
-            except (json.JSONDecodeError, OSError):
-                continue
-    except Exception:
-        logger.debug("Failed to build kiro model map", exc_info=True)
+    # Same kiro-agent model map as restore_recent_sessions so legacy sessions
+    # without a persisted `model` still resolve correctly. Reuse the caller's
+    # when bulk-restoring — it is identical for every slot.
+    if kiro_model_map is None:
+        kiro_model_map = _build_kiro_model_map()
     slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
-    # Pull display fields from session listing for title parity with bulk restore.
-    sessions = state.conversation_log.list_sessions()
-    session_info = next(
-        (s for s in sessions if s.get("key") == history_key),
-        {},
-    )
+    # Title comes from the metadata line we already read above. We deliberately
+    # do NOT consult ``list_sessions()`` here: that call globbed + stat'd + read
+    # the first line of EVERY session file in the history dir (O(all sessions))
+    # to look up one title, and it ran once per restored slot — so a boot with N
+    # open tabs did N full directory scans. With 77 tabs over 455 session files
+    # that measured ~13s of pure event-loop block, which alone can trip the
+    # 25s LoopStallWatchdog and crash-loop the gateway before it ever serves.
+    #
+    # It was also dead code: ``list_sessions()`` keys are FILENAME STEMS
+    # (``dashboard_chat-1-...``, because history's ``_safe_key()`` folds ``:``
+    # to ``_``), while ``history_key`` here is the canonical colon form
+    # (``dashboard:chat-1-...``). The two never compared equal, so the lookup
+    # always yielded ``{}`` and the title always fell through to ``meta``.
+    # Dropping it is therefore behaviour-identical as well as O(N) cheaper.
+    #
     # Titles may have been auto-generated by an LLM (_generate_title_via_kiro)
     # and are surfaced on the dashboard, so apply the same redaction passes
     # used on assistant content before setting. Defence-in-depth — the title
     # author is trusted-ish (our own kiro process), but the generation input
     # is user content, so a prompt injection could craft a title with an
     # exfiltration URL or leaked credential.
-    raw_title = session_info.get("title") or meta.get("title") or slot_name
+    raw_title = meta.get("title") or slot_name
     raw_title, _ = redact_exfiltration_urls(raw_title)
     raw_title, _ = redact_credentials(raw_title)
     slot.title = raw_title
-    slot._titled = bool(session_info.get("title") or meta.get("title"))
+    slot._titled = bool(meta.get("title"))
     if meta.get("created_at"):
         slot.created_at = meta["created_at"]
     if meta.get("agent"):
@@ -446,29 +537,22 @@ def _rehydrate_slot_from_history(state: DashboardState, slot_name: str) -> _Chat
     return slot
 
 
-def restore_recent_sessions(
+def _restore_recent_sessions_steps(
     state: DashboardState, window_minutes: int = 30, *, folders_only: bool = False
-) -> int:
-    """Restore sessions as chat slots."""
+) -> "Iterator[int]":
+    """Drive :func:`restore_recent_sessions` one session at a time.
+
+    Generator for the same reason as :func:`_restore_open_slots_steps`: it lets
+    the startup path yield to the event loop between sessions. This path restores
+    every folder'd/pinned session regardless of the mtime window, so it can be
+    just as slow as the open-tab restore — measured at 13.6s for 76 sessions.
+    """
     if not state.conversation_log:
-        return 0
+        return
     cutoff = time.time() - (window_minutes * 60) if window_minutes > 0 else None
     restored = 0
 
-    kiro_model_map: dict[str, str] = {}
-    try:
-
-        for f in KIRO_AGENTS_DIR.glob("*.json"):
-            try:
-                data = json.loads(f.read_text(encoding="utf-8"))
-                model = data.get("model", "")
-                if data.get("name"):
-                    kiro_model_map[data["name"]] = model
-                kiro_model_map[f.stem] = model
-            except (json.JSONDecodeError, OSError):
-                continue
-    except Exception:
-        logger.debug("Failed to build kiro model map", exc_info=True)
+    kiro_model_map = _build_kiro_model_map()
     try:
         _restore_cfg = KiroCrewConfig.load()
     except Exception:
@@ -595,7 +679,45 @@ def restore_recent_sessions(
         slot._dirty = False
         restored += 1
         logger.info("Restored session %s (%s)", slot_name, slot.title)
+        # One yield point per restored session (see _restore_open_slots_steps).
+        yield restored
     _sync_dashboard_slots(state)
+
+
+def restore_recent_sessions(
+    state: DashboardState, window_minutes: int = 30, *, folders_only: bool = False
+) -> int:
+    """Restore sessions as chat slots.
+
+    Blocking: see :func:`restore_recent_sessions_async` for the startup path.
+    """
+    restored = 0
+    for restored in _restore_recent_sessions_steps(
+        state, window_minutes, folders_only=folders_only
+    ):
+        pass
+    return restored
+
+
+async def restore_recent_sessions_async(
+    state: DashboardState, window_minutes: int = 30, *, folders_only: bool = False
+) -> int:
+    """:func:`restore_recent_sessions`, yielding to the event loop per session.
+
+    Same rationale as :func:`restore_open_slots_async` — keeps the stall-watchdog
+    heartbeat alive while a large restore proceeds, and holds
+    ``restoring_open_slots`` so an interleaved flush cannot snapshot a partial
+    slot set (this path adds slots to the same sidebar).
+    """
+    restored = 0
+    state.restoring_open_slots = True
+    try:
+        for restored in _restore_recent_sessions_steps(
+            state, window_minutes, folders_only=folders_only
+        ):
+            await asyncio.sleep(0)
+    finally:
+        state.restoring_open_slots = False
     return restored
 
 

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2615,20 +2615,32 @@ async def start_dashboard(
     # fall off into History on every gateway restart. Closed tabs (meta.closed)
     # are still excluded by the rehydrate guard. restore_open_slots() logs
     # its own info line on success, so no caller-side log here.
-    chat.restore_open_slots(state)
-    restored = chat.restore_recent_sessions(
-        state,
-        cfg.dashboard.restore_window_minutes if cfg.dashboard.restore_sessions else 0,
-        folders_only=not cfg.dashboard.restore_sessions,
-    )
-    if restored:
-        logger.info("Restored %d session(s)", restored)
+    # Awaited (not called bare) so the restore yields to the loop between tabs and
+    # the stall watchdog keeps getting its heartbeat — a user with many large tabs
+    # used to block here long enough to trip the 25s watchdog and crash-loop the
+    # gateway before it finished starting.
+    #
+    # Both restores run inside suspend_slots_push() so the per-slot broadcasts
+    # coalesce into one at the end: get_or_create_slot() pushes the whole slot list
+    # on every call, which made bulk restore O(N²) in serialization work for
+    # intermediate states no client renders. Reseeding happens inside the block too
+    # — it must complete before the single broadcast so clients never see slots
+    # under a counter that could still re-mint a colliding index.
+    with state.suspend_slots_push():
+        await chat.restore_open_slots_async(state)
+        restored = await chat.restore_recent_sessions_async(
+            state,
+            cfg.dashboard.restore_window_minutes if cfg.dashboard.restore_sessions else 0,
+            folders_only=not cfg.dashboard.restore_sessions,
+        )
+        if restored:
+            logger.info("Restored %d session(s)", restored)
 
-    # Both restore paths above rehydrate tabs under their original
-    # "chat-<N>-<ts>" keys but leave _slot_counter at its boot value of 0.
-    # Reseed it past the highest restored index so the next new chat can't
-    # re-mint a colliding low index (which scrambles the tab -> session map).
-    state.reseed_slot_counter()
+        # Both restore paths above rehydrate tabs under their original
+        # "chat-<N>-<ts>" keys but leave _slot_counter at its boot value of 0.
+        # Reseed it past the highest restored index so the next new chat can't
+        # re-mint a colliding low index (which scrambles the tab -> session map).
+        state.reseed_slot_counter()
 
     # Surface conversations started on Slack/Discord/Teams (etc.) in the chat
     # list. These persist under channel-namespaced keys (``slack:<ts>``), which

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import json
 import logging
 import math
@@ -13,7 +14,7 @@ import tempfile
 import time
 import traceback
 import uuid
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
@@ -1575,6 +1576,17 @@ class _ChatSlot:
 class DashboardState:
     """Shared state injected into all handlers via ``app["state"]``."""
 
+    # Class-level defaults, NOT just __init__ assignments. push_slots_update and
+    # _persist_open_slots read these on every call, and a partially-constructed
+    # state built with DashboardState.__new__(DashboardState) — the pattern used
+    # by several endpoint test suites, which set only the attributes the handler
+    # under test touches — never runs __init__. Without a class default those
+    # reads raise AttributeError. __init__ still assigns per-instance values
+    # below; these only supply the "nothing suspended, not restoring" baseline.
+    _slots_push_suspend: int = 0
+    _slots_push_pending: bool = False
+    restoring_open_slots: bool = False
+
     def __init__(
         self,
         sessions: SessionManager,
@@ -1693,6 +1705,14 @@ class DashboardState:
         # Broadcast: each SSE client gets its own queue; _notify_event wakes all
         self._sse_queues: list[asyncio.Queue[dict[str, Any]]] = []
         self._notify_event = asyncio.Event()
+        # Depth + pending flag for suspend_slots_push(); see that method.
+        self._slots_push_suspend = 0
+        self._slots_push_pending = False
+        # True while the startup open-tab restore is in flight. Suppresses the
+        # open_slots.json snapshot so a periodic flush cannot overwrite the file
+        # being restored from with a half-populated slot set — see
+        # _persist_open_slots.
+        self.restoring_open_slots = False
         self._notification_log: list[dict[str, Any]] = _load_notifications()
         self._unread_count: int = 0
         # Notification bus (schema v2) — notify() adapts legacy calls onto it;
@@ -2265,7 +2285,18 @@ class DashboardState:
         Failures are logged at debug level — losing the snapshot only
         degrades restore behaviour back to the legacy 30-min mtime window,
         it never breaks the gateway.
+
+        NO-OP while ``restoring_open_slots`` is set. The startup restore yields to
+        the event loop between tabs, and ``start_flush_loop()`` is already running
+        by then (every 5s), so without this guard a flush lands mid-restore and
+        snapshots a PARTIAL slot set over the very file being restored from —
+        measured 77 tabs collapsing to 70. A kill in that window would drop the
+        un-restored tabs from the sidebar permanently. Whatever is on disk is
+        already the authoritative set we are loading, so skipping is always safe.
         """
+        if self.restoring_open_slots:
+            logger.debug("open_slots snapshot skipped: restore in progress")
+            return
         try:
             path = config_dir() / "open_slots.json"
             # Only snapshot persistent-memory slots. Incognito/temporary tabs
@@ -3088,11 +3119,39 @@ class DashboardState:
             out.append(d)
         return out
 
+    @contextlib.contextmanager
+    def suspend_slots_push(self) -> "Iterator[None]":
+        """Coalesce every ``push_slots_update()`` inside the block into one at exit.
+
+        ``get_or_create_slot`` broadcasts the FULL slot list on each call, so a bulk
+        restore of N tabs serializes 1+2+…+N slots — O(N²) ``to_dict``/redaction
+        work for intermediate states no client will ever render (measured ~1.3s at
+        N=77, and it grows quadratically). Wrap the restore, emit one broadcast.
+
+        Depth-counted so nested use is safe (an inner block must not flush early),
+        and ``@contextmanager``'s try/finally unwinds the depth even if the body
+        raises. Only flushes if something actually asked to push.
+        """
+        self._slots_push_suspend += 1
+        try:
+            yield
+        finally:
+            self._slots_push_suspend -= 1
+            if self._slots_push_suspend == 0 and self._slots_push_pending:
+                self._slots_push_pending = False
+                self.push_slots_update()
+
     def push_slots_update(self) -> None:
         """Push slots, keeping provider status confined to owner websockets."""
         from kiro_crew.dashboard.handlers.source_providers import (
             gitlab_hosts_generation,
         )
+
+        if self._slots_push_suspend:
+            # Inside suspend_slots_push(); remember that a push is owed and let the
+            # outermost block emit a single coalesced broadcast on exit.
+            self._slots_push_pending = True
+            return
 
         yolo_active = self.is_yolo_active()  # expire first if needed
         slots_data = self.serialize_slots()

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -2185,7 +2185,17 @@ class ConversationLog:
         cached = self._meta_cache.get(key)
         if cached and cached[0] == mtime:
             return cached[1]
-        first = path.read_text(encoding="utf-8").split("\n", 1)[0].strip()
+        # Read ONLY the first line. The previous form slurped the entire file via
+        # read_text() and then threw all but the first line away — on a 26 MB
+        # transcript that is ~10ms and ~26 MB of transient allocation to obtain a
+        # few hundred bytes (measured ~32x slower than readline()). Startup
+        # restore calls this once per tab, so the waste scaled with both tab count
+        # and transcript size, pushing the event loop toward the stall watchdog.
+        try:
+            with open(path, encoding="utf-8") as fh:
+                first = fh.readline().strip()
+        except OSError:
+            return {}
         if not first:
             return {}
         try:

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -25,13 +25,20 @@ These tests cover:
 
 from __future__ import annotations
 
+import asyncio
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
 from chat_test_helpers import _make_state
 
-from kiro_crew.dashboard.chat_persistence import restore_open_slots
+from kiro_crew.dashboard.chat_persistence import (
+    _rehydrate_slot_from_history,
+    restore_open_slots,
+    restore_open_slots_async,
+)
 from kiro_crew.dashboard.chat_utils import _history_key_for
+from kiro_crew.dashboard.state import DashboardState
 
 
 def _seed_session(state, slot_key: str, *, closed: bool = False) -> None:
@@ -702,3 +709,309 @@ def test_reseed_skips_unicode_digit_key_without_crashing(tmp_path, monkeypatch):
     state.reseed_slot_counter()  # must not raise
 
     assert state._slot_counter == 4
+
+
+# ── Startup must not block the event loop (stall-watchdog crash-loop) ──
+#
+# Regression cover for the gateway crash-loop: restoring many large tabs ran
+# synchronously on the event loop, so the LoopStallWatchdog heartbeat (which pets
+# the watchdog FROM A COROUTINE) never got a turn. After exit_after=25s the
+# watchdog dumped thread stacks and _exit()ed, so the app never finished starting.
+
+
+def test_restore_open_slots_async_yields_between_tabs(tmp_path, monkeypatch):
+    """The async restore must hand the loop back per tab so the heartbeat can run.
+
+    Pins the actual crash mechanism: a coroutine running concurrently with the
+    restore has to get scheduled. If restore ever goes back to blocking straight
+    through, the ticker records no ticks and this fails.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    for i in range(6):
+        _seed_session(state, f"chat-{i}-yield")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": [f"chat-{i}-yield" for i in range(6)], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    ticks = 0
+
+    async def _drive():
+        stop = False
+
+        async def ticker():
+            nonlocal ticks
+            while not stop:
+                ticks += 1
+                await asyncio.sleep(0)
+
+        t = asyncio.create_task(ticker())
+        await asyncio.sleep(0)  # let the ticker reach its first await
+        restored = await restore_open_slots_async(state2)
+        stop = True
+        t.cancel()
+        return restored
+
+    restored = asyncio.run(_drive())
+    assert restored == 6
+    # One yield per tab at minimum; the ticker interleaves on each.
+    assert ticks >= 6, f"restore starved the loop (ticks={ticks})"
+
+
+def test_restore_open_slots_async_matches_sync_result(tmp_path, monkeypatch):
+    """The async and sync drivers must restore the same slots.
+
+    They share one generator, so this guards the two thin wrappers from drifting.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-same")
+    _seed_session(state, "chat-2-same")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-same", "chat-2-same"], "ts": 0.0})
+    )
+
+    sync_state = _make_state(tmp_path / "sessions")
+    async_state = _make_state(tmp_path / "sessions")
+    assert restore_open_slots(sync_state) == asyncio.run(
+        restore_open_slots_async(async_state)
+    )
+    assert set(sync_state._slots) == set(async_state._slots) == {"chat-1-same", "chat-2-same"}
+
+
+def test_rehydrate_does_not_scan_the_whole_session_dir(tmp_path, monkeypatch):
+    """Rehydrating one tab must not call list_sessions().
+
+    list_sessions() stats + reads the first line of EVERY session file. It used to
+    run once per restored tab purely to look up one title (which it never actually
+    found — its keys are filename stems, ``dashboard_x``, while the lookup used the
+    canonical ``dashboard:x``), making restore O(tabs x all sessions). That was ~13s
+    of the stall on a real 77-tab home.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-noscan")
+    state.conversation_log.update_metadata(
+        _history_key_for("chat-1-noscan"), {"title": "Kept Title"}
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    with patch.object(
+        type(state2.conversation_log),
+        "list_sessions",
+        side_effect=AssertionError("list_sessions() must not be called per slot"),
+    ):
+        slot = _rehydrate_slot_from_history(state2, "chat-1-noscan")
+
+    assert slot is not None
+    # Title still comes through, from the metadata line we already read.
+    assert slot.title == "Kept Title"
+    assert slot._titled is True
+
+
+def test_bulk_restore_emits_one_slots_broadcast(tmp_path, monkeypatch):
+    """suspend_slots_push() coalesces the per-slot broadcasts into one.
+
+    get_or_create_slot() broadcasts the FULL slot list every call, so restoring N
+    tabs serialized 1+2+...+N slots — quadratic redaction work for intermediate
+    states no client ever renders.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    for i in range(5):
+        _seed_session(state, f"chat-{i}-bcast")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": [f"chat-{i}-bcast" for i in range(5)], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    seen: list[str] = []
+    state2._broadcast = lambda note: seen.append(note.get("_type"))  # type: ignore[method-assign]
+
+    with state2.suspend_slots_push():
+        restored = restore_open_slots(state2)
+
+    assert restored == 5
+    assert seen.count("slots") == 1, f"expected 1 coalesced slots push, got {seen.count('slots')}"
+
+
+def test_suspend_slots_push_unwinds_and_flushes_on_exception(tmp_path, monkeypatch):
+    """The suspend depth must unwind (and the owed push fire) even if the body raises.
+
+    Otherwise one failed restore would leave the gateway permanently unable to
+    broadcast slot updates.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    seen: list[str] = []
+    state._broadcast = lambda note: seen.append(note.get("_type"))  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        with state.suspend_slots_push():
+            state.push_slots_update()
+            raise RuntimeError("boom")
+
+    assert state._slots_push_suspend == 0
+    assert seen.count("slots") == 1
+
+
+def test_suspend_slots_push_nested_does_not_flush_early(tmp_path, monkeypatch):
+    """Only the OUTERMOST suspend block flushes — nested users must not push early."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    seen: list[str] = []
+    state._broadcast = lambda note: seen.append(note.get("_type"))  # type: ignore[method-assign]
+
+    with state.suspend_slots_push():
+        with state.suspend_slots_push():
+            state.push_slots_update()
+        assert seen.count("slots") == 0, "inner exit flushed early"
+    assert seen.count("slots") == 1
+
+
+def test_suspend_slots_push_no_push_means_no_broadcast(tmp_path, monkeypatch):
+    """An empty suspend block must not synthesize a broadcast nobody asked for."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    seen: list[str] = []
+    state._broadcast = lambda note: seen.append(note.get("_type"))  # type: ignore[method-assign]
+
+    with state.suspend_slots_push():
+        pass
+
+    assert seen.count("slots") == 0
+
+
+# ── The deferred restore must not let a flush truncate the snapshot ──
+#
+# start_flush_loop() is running (every 5s) BEFORE the startup restore. While the
+# restore was synchronous it starved that timer, so a flush could never land
+# mid-restore. Now that the restore yields per tab, one can — and
+# _flush_dirty_slots calls _persist_open_slots, which would overwrite the very
+# file being restored FROM with a half-populated slot set. Reproduced at real
+# scale before the guard: 77 tabs collapsed to 70.
+
+
+def test_flush_during_async_restore_does_not_truncate_snapshot(tmp_path, monkeypatch):
+    """A flush landing mid-restore must not shrink open_slots.json."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-flush" for i in range(8)]
+    for k in keys:
+        _seed_session(state, k)
+    snapshot = tmp_path / "open_slots.json"
+    snapshot.write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+
+    # Fire the flush deterministically at the restore's own yield point — that is
+    # exactly where the real 5s flush timer gets to run — rather than racing a
+    # second task (which the scheduler may not interleave at all).
+    real_sleep = asyncio.sleep
+    observed: list[int] = []
+
+    async def flushing_sleep(delay, *a, **kw):
+        if delay == 0:
+            state2._persist_open_slots()
+            # Record what a crash at THIS instant would leave on disk.
+            observed.append(len(json.loads(snapshot.read_text())["keys"]))
+        return await real_sleep(delay, *a, **kw)
+
+    with patch(
+        "kiro_crew.dashboard.chat_persistence.asyncio.sleep", side_effect=flushing_sleep
+    ):
+        restored = asyncio.run(restore_open_slots_async(state2))
+
+    assert restored == 8
+    assert observed, "flush never landed mid-restore — test would not detect the bug"
+    # Assert on the INTERMEDIATE states, not just the final one. Without the guard
+    # the file transiently reads 1, 2, 3 … tabs; it only ends up complete because
+    # the restore happens to finish. A kill in that window is what loses tabs.
+    assert all(n == len(keys) for n in observed), (
+        f"snapshot was truncated mid-restore: sizes {observed} (expected all {len(keys)})"
+    )
+    assert set(json.loads(snapshot.read_text())["keys"]) == set(keys)
+
+
+def test_restoring_flag_clears_and_reenables_persistence(tmp_path, monkeypatch):
+    """The guard must be released after the restore so snapshots resume."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-flag")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-flag"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    assert state2.restoring_open_slots is False
+    asyncio.run(restore_open_slots_async(state2))
+    assert state2.restoring_open_slots is False
+
+    # A normal flush after restore writes the live set again.
+    state2.get_or_create_slot("chat-9-postrestore")
+    state2._persist_open_slots()
+    assert set(json.loads((tmp_path / "open_slots.json").read_text())["keys"]) == {
+        "chat-1-flag",
+        "chat-9-postrestore",
+    }
+
+
+def test_restoring_flag_cleared_even_if_restore_raises(tmp_path, monkeypatch):
+    """A crash mid-restore must not leave open-tab persistence disabled forever."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-boom")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-boom"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    with patch(
+        "kiro_crew.dashboard.chat_persistence._build_kiro_model_map",
+        side_effect=RuntimeError("boom"),
+    ):
+        with pytest.raises(RuntimeError):
+            asyncio.run(restore_open_slots_async(state2))
+
+    assert state2.restoring_open_slots is False
+
+
+def test_push_slots_update_survives_a_partially_constructed_state():
+    """A state built with __new__ (no __init__) must still be able to broadcast.
+
+    Several endpoint suites build their fixture as
+    ``DashboardState.__new__(DashboardState)`` and then set only the attributes
+    the handler under test touches — they never run __init__. push_slots_update
+    reads the suspend counter on EVERY call, so keeping that counter as an
+    __init__-only assignment made all of those suites raise AttributeError
+    (19 failures across test_queue_cancel/edit/reorder in CI). The counter and
+    its companions are therefore class-level defaults; this test pins that so a
+    future __init__-only attribute added to the same read path cannot silently
+    reintroduce the break.
+    """
+    bare = DashboardState.__new__(DashboardState)
+    # Only what push_slots_update itself needs — deliberately NOT the new flags.
+    # `_yolo` is intentionally omitted: it is a property whose setter mutates the
+    # process-global safety-override singleton, and push_slots_update reads YOLO
+    # state from that global rather than from the instance.
+    bare._slots = {}
+    bare._ws_clients = []
+    bare._sse_queues = []
+    bare._notify_event = MagicMock()
+    bare.channel_manager = None
+
+    # Readable without __init__, at their documented baseline.
+    assert bare._slots_push_suspend == 0
+    assert bare._slots_push_pending is False
+    assert bare.restoring_open_slots is False
+
+    # And the read path actually runs rather than raising AttributeError.
+    bare.push_slots_update()
+
+    # The context manager also works on a bare state, and leaves no residue.
+    with bare.suspend_slots_push():
+        bare.push_slots_update()
+        assert bare._slots_push_suspend == 1
+    assert bare._slots_push_suspend == 0
+    assert bare._slots_push_pending is False


### PR DESCRIPTION
## Problem

The gateway never finishes booting on a data home with many open tabs. It crash-loops with `gateway child exited code=1`, so the app is unusable — not degraded, dead.

Reproduced on a real home: 458 session files, ~250 live dashboard sessions, 68–77 restored tabs (~125–160 MB of transcripts), **39 consecutive failed launches** across three separate crash-loop episodes.

Closes #833.

## Why it matters

This is a hard-fail on startup with no user-side workaround. Trimming `open_slots.json` does not help: folder'd/pinned sessions bypass the mtime window entirely (`has_folder`/`has_pin` short-circuit the cutoff), so trimming to 20 open tabs still restored 56 sessions for a 23.7s total — still inside the danger zone. No config avoids it either — `restore_sessions=false` → `folders_only=True` loads every folder'd session; `restore_sessions=true` applies the mtime window but folder'd still bypass it. ~16.4s either way.

It is also the **third** instance of one failure class: #99 (blocking `copytree` on the loop) and #323 (sync KB re-embed on the loop). Blocking work on the event loop during startup trips the watchdog.

## Fix (symptom → root cause → change)

**Symptom.** `LoopStallWatchdog` dumps thread stacks and `_exit()`s the process ~25s into boot.

**Root cause.** `_loop_heartbeat` pets the watchdog **from a coroutine**. A blocked loop cannot run that coroutine, so it cannot pet the watchdog — the watchdog fires against a process that is working correctly, just synchronously. Both restores ran synchronously on the loop (`server.py`), so any startup work over ~20–25s was fatal. The real budget is `exit_after − (time since last beat)`, so ~20s suffices.

Four changes, descending by measured impact:

1. **Drop the per-slot `list_sessions()` call** in `_rehydrate_slot_from_history`. It globbed + stat'd + read the first line of *every* session file to look up one title, once per restored tab — O(tabs × all sessions), measured 0.19–0.36s per tab (~92% of that path's cost; 77 tabs ≈ 27s). It was also **dead code**: `list_sessions()` keys are filename stems (`dashboard_chat-1-…`, because history's `_safe_key()` folds `:` to `_`) while the lookup compared the canonical colon form from `_history_key_for()` (`dashboard:chat-1-…`). Never equal → `session_info` was always `{}` → the title always fell through to the `meta` already read. Verified byte-identical over all 429 dashboard sessions on that corpus. Secondary: it also thrashed the `_meta_cache` LRU (cap 256, 458 files), evicting the entry `get_metadata()` had just warmed.

2. **Yield to the loop between tabs.** Both paths are now generators with thin sync + async drivers; startup awaits the async ones. Worst uninterrupted block ~30s → **1.26s**, so what the watchdog measures no longer scales with tab count or transcript size. Stays **on** the loop rather than moving to a thread because slot creation broadcasts through `asyncio.Queue.put_nowait` / `asyncio.Event.set`, neither thread-safe. The SPA already snapshots on connect *and* listens for later `slots` broadcasts, so a slow restore fills the sidebar progressively instead of ending the process.

3. **Coalesce the broadcast storm** via a depth-counted `DashboardState.suspend_slots_push()`. `get_or_create_slot()` ends in `push_slots_update()`, which serializes **every** slot (`serialize_slots` → `to_dict` → `_redact`), so restoring N slots did 1+2+…+N serializations — every intermediate payload discarded, since no client is connected during boot. Profiled: **68 slots in 13.8s**, of which `redact_credentials` was 11.5s cumulative and `_redact_meta_for_role` 9.2s, across 2,346 `to_dict()` calls to produce one useful payload. Reseeding runs inside the block so clients never observe slots under a counter that could still re-mint a colliding index.

4. **`_read_metadata` reads one line.** The old form `read_text().split("\n", 1)[0]` read an entire 26 MB transcript and discarded all but the first line — ~32x slower than `readline()` (10.7ms vs 0.3ms) plus 26 MB of transient allocation, once per tab.

### Plus: a data-loss window that change 2 opens

Making the restore yield re-enables a writer the blocking version starved. `start_flush_loop()` is already running (every 5s) and `_flush_dirty_slots` calls `_persist_open_slots()`, so a flush can now land mid-restore and overwrite the very `open_slots.json` being restored **from** with a partial slot set. Reproduced at scale: the on-disk snapshot transiently read 1, 2, 3 … and landed at **70 of 77**. It only self-heals because the restore finishes — an abrupt exit inside that window permanently drops the un-restored tabs from the sidebar.

`DashboardState.restoring_open_slots` is held across both async restore paths in `try`/`finally` (a stuck flag would silently disable open-tab persistence for the life of the process) and makes `_persist_open_slots` a no-op while set. Safe because whatever is on disk is already the authoritative set being loaded.

Also hoists the per-slot `kiro_model_map` rebuild into a shared `_build_kiro_model_map()` — it re-globbed and re-parsed every agent JSON per tab to produce a byte-identical dict.

Redaction is deliberately left on the read path: idempotent and a no-op for dashboard transcripts (0 changes across 24,432 messages, since the write path already redacts), but it remains the defence for tampered history files.

## Open design question for reviewers — please weigh in

**Change 2 is not a speedup.** It makes the long operation *interruptible* so total duration stops being what the watchdog measures; wall-clock is unchanged. Changes 1, 3 and 4 are real reductions; change 2 manages the symptom, and the `restoring_open_slots` guard exists *only* because change 2 yields.

The deeper issue is that boot materializes a **full slot** — `read_messages_chained()` (reads the whole transcript) plus a 500-message replay with three redaction passes each — for sessions that only need a **sidebar row**. Rows need title/folder/pinned/agent/mtime, all of which are in the metadata line. The blocker is that `_ChatSlot.to_dict()` derives `last_msg`, `options`, `prompt_preview` and `last_activity_ts` by reverse-scanning in-memory messages, so a row currently cannot render without its transcript loaded.

The cheap primitives already exist and are already used by `GET /api/sessions`: `list_sessions()` reads only the first line per file behind an mtime-keyed cache, and `last_message_preview()` does a bounded backward tail seek — explicitly "cheap even on large sessions" — paginated and run in `run_in_executor`.

So the arguably correct fix is: boot reads metadata only, materialize the slot on tab activation, and changes 2 and the flush guard become unnecessary. That needs three seams handled deliberately — `state._slots.get(name)` is the addressing gate for the whole control plane; `_restricted_keys` is currently populated *by* the restore (skipping it would let a restricted session pass the consolidation gate — a privacy regression, not a perf one); and `reseed_slot_counter()` would derive the next index from the metadata key list.

I'd like reviewer opinion on whether to land this as-is to stop a live field crash and follow up with lazy materialization, or hold for the larger change. Filing the follow-up either way.

## Tests

10 regression tests in `test/test_open_slots_persistence.py`, each confirmed to fail against the old code:

- `test_restore_open_slots_async_yields_between_tabs` — a ticker coroutine must observe ≥1 tick per tab; this is the assertion that fails if the restore starves the loop again.
- `test_restore_open_slots_async_matches_sync_result` — async driver is equivalent to sync.
- `test_rehydrate_does_not_scan_the_whole_session_dir` — locks in the deleted `list_sessions()` call so it cannot be reintroduced.
- `test_bulk_restore_emits_one_slots_broadcast` — N pushes → 1.
- `test_suspend_slots_push_unwinds_and_flushes_on_exception`, `…_nested_does_not_flush_early`, `…_no_push_means_no_broadcast` — depth counting, exception unwind, and no spurious broadcast.
- `test_flush_during_async_restore_does_not_truncate_snapshot` — asserts on the **intermediate** snapshot sizes, not just the final state. Its first cut passed with the guard removed, because the file happens to be complete once the restore ends; it now fails with `sizes [1, 2, 3, 4, 5, 6, 7, 8] (expected all 8)` when the guard is gone.
- `test_restoring_flag_clears_and_reenables_persistence`, `test_restoring_flag_cleared_even_if_restore_raises` — the `finally` contract.

Local gates green on `8d06fd59`: 619 passed across the affected suites, `mypy` clean (558 files), `isort` and `flake8` clean. Backend-only, so no `tsc`/vitest.

## Manual verification

Verified end to end against an isolated 77-tab home (not a fixture): 76 tabs restored, the `open_slots.json` snapshot stays at 77 across boot, no loop-stall dump, no lag warning, the watchdog never fires, dashboard serves HTTP 200.

## Screenshots

N/A — backend-only change (event-loop scheduling, file IO, broadcast coalescing). No user-visible surface changed. The observable difference is that the gateway boots at all; the sidebar now populates progressively rather than appearing all at once.

## Reviewer notes (found by the local review gate, disclosed rather than left to be discovered)

- `restoring_open_slots` is **read** on an executor thread (`_persist_open_slots` runs via `run_in_executor`) but set/cleared on the loop — a genuinely cross-thread flag. Assessed immaterial: the flag is set within ~ms while the flush loop's first tick is 5s out, the check-then-write gap is a single bytecode boundary, and the next 5s flush rewrites the full set unconditionally so nothing is permanently lost. Flagging it explicitly rather than letting it look accidental.
- `push_slots_update`'s new early return skips `is_yolo_active()`. Not an auto-approve leak: YOLO expiry is enforced independently at approval time.
- `_read_metadata`'s new `except OSError: return {}` diverges from the old propagate-on-`read_text`. Safe in `_rehydrate_slot_from_history` (`if not meta: return None`); in `_restore_recent_sessions_steps` an empty `meta` would fall through to a `persistent` default. Reaching it needs `stat()` to succeed while `open()` fails on a same-UID file, and that condition previously crashed startup outright.
- `_sync_dashboard_slots()` and the open-slots `logger.info` sit after the generators' loops, so they run on normal exhaustion in both drivers but are skipped if a generator is abandoned mid-iteration. The only such path is `CancelledError` at `await asyncio.sleep(0)` — shutdown during boot.
