### PR TITLE
test(e2e): declare the locale and tint-bound dependencies

### DIFF
--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -25,6 +25,15 @@ export default defineConfig({
     : /@needs-agent|@needs-live-agent/,
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5476',
+    // Pin the browser locale. Most specs assert English prose, and the app
+    // resolves its language from `navigator.languages` when no explicit choice
+    // is stored (src/i18n/detect.ts precedence: config `dashboard.language`
+    // mirrored to localStorage `mc-lang`, then the browser tags, then `en`).
+    // The harness storage state carries no `mc-lang`, so the browser tags
+    // decide, and a zh-* runner would render the zh-CN catalog and fail those
+    // assertions. Declaring en-US here makes that an explicit dependency
+    // instead of an accident of the runner's environment.
+    locale: 'en-US',
     trace: 'on-first-retry',
     video: process.env.PLAYWRIGHT_VIDEO === '1' ? 'on' : 'off',
     navigationTimeout: 10000, // 10 second navigation timeout

--- a/website/playwright/settings.spec.ts
+++ b/website/playwright/settings.spec.ts
@@ -1,8 +1,13 @@
 import { test, expect } from '@playwright/test'
+import { MAX_RECENT_TINT_COUNT } from '../src/utils/recencyTint'
 
-// Mirrors MAX_RECENT_TINT_COUNT (website/src/utils/recencyTint.ts:13). Specs
-// cannot import from src/, so this is duplicated deliberately.
-const MAX_TINT = 50
+// The stepper's upper bound comes from the source of truth rather than a copy,
+// so raising or lowering it there cannot leave this spec asserting a stale
+// bound. Playwright transpiles specs with its own pipeline, so importing across
+// the playwright/ and src/ boundary resolves even though src/ is a separate
+// tsconfig project. recencyTint.ts is a dependency-free module of pure helpers,
+// so this pulls in no component or DOM code.
+const MAX_TINT = MAX_RECENT_TINT_COUNT
 
 /**
  * Settings page (/settings) — route-level Playwright coverage.
@@ -80,12 +85,13 @@ test.describe('Settings Page', () => {
     await expect(field).toBeVisible({ timeout: 10000 })
 
     // Step in whichever direction is actually available. clampTintCount
-    // (recencyTint.ts:21) floors the value into [0, MAX_RECENT_TINT_COUNT=50],
-    // and DisplayPanel passes no `disabled` prop, so at 50 the Increase button
-    // is still clickable but the persisted value stays 50 -- an assertion of
-    // originalCount + 1 would then poll for 51 until it times out. The harness
-    // always starts at the 0 default so increment is the normal path, but a
-    // developer running this against a live gateway may sit at either bound.
+    // (recencyTint.ts:21) floors the value into [0, MAX_RECENT_TINT_COUNT],
+    // and DisplayPanel passes no `disabled` prop, so at the maximum the
+    // Increase button is still clickable but the persisted value stays at the
+    // bound -- an assertion of originalCount + 1 would then poll for a value
+    // one past the bound until it times out. The harness always starts at the 0
+    // default so increment is the normal path, but a developer running this
+    // against a live gateway may sit at either bound.
     const atMax = originalCount >= MAX_TINT
     const delta = atMax ? -1 : 1
     const btn = field.getByRole('button', { name: atMax ? 'Decrease' : 'Increase' })


### PR DESCRIPTION
## Description

Two Playwright dependencies were implicit. Both are now declared, so neither can pass by accident. No production code changes.

### 1. The suite depended on the runner's language without saying so

Nineteen spec files assert English prose, and the app resolves its language from `navigator.languages` when no explicit choice is stored. The precedence in `src/i18n/detect.ts` is config `dashboard.language` (mirrored to localStorage `mc-lang` for a synchronous first paint), then the browser tags, then `en`.

The harness storage state carries six `mc-*` keys but no `mc-lang`, so the browser tags decide. `detect.ts` maps any `zh-*` tag, including a bare `zh` and `zh-Hans`, to the zh-CN catalog. Those nineteen files therefore pass only because the runner happens to be English, and a contributor on a Chinese-locale machine would see them fail for a reason unrelated to their change.

`locale: 'en-US'` in the `use:` block makes that dependency explicit. This is worth doing now rather than later because i18n architecture work is in flight.

### 2. The stepper's upper bound was a hand-copied constant

`settings.spec.ts` hard-coded `50` while the source of truth is `MAX_RECENT_TINT_COUNT` in `src/utils/recencyTint.ts`, linked only by a comment. Changing the constant there would leave the spec asserting a stale bound with nothing to catch it. The spec now imports the constant. A comment further down also hard-coded `50` and `51`, so it now refers to the bound instead of restating its value.

The comment I removed claimed specs cannot import from `src/`. That is not true. Playwright transpiles specs with its own pipeline rather than through `tsconfig.app.json`, whose `include` covers only `src`. I verified the import resolves and all 197 specs still collect. `recencyTint.ts` declares no imports, so this pulls in no component or DOM code.

**Rejected:** a drift guard that parses the constant out of the source file and asserts the copy matches, which is the pattern `test/test_token_auth.py` already uses for route literals. A direct import deletes the duplicate rather than detecting its drift, so a guard would have nothing left to protect. Worth revisiting only if `recencyTint.ts` gains a dependency that cannot load in the Playwright context, which would force the copy back.

## Related Issues

None filed. Both items were recorded as test-infra debt during the e2e de-quarantine campaign (#657, #719).

## Testing

- [x] Existing tests pass
- [ ] New tests added for new functionality (none: both changes harden existing tests rather than add coverage)
- [x] Manual verification performed

The locale pin changes browser behaviour for every spec, so it needed the full suite rather than the settings spec alone:

- `python setup.py test_e2e`: 18 passed. `test_dashboard_playwright_suite` carries the `executed >= 208 / skipped <= 0` floor and asserts the Playwright exit code, so its pass covers every spec, not just the floor.
- `npx playwright test --list`: 197 tests in 24 files collect, which is the real parse and import-resolution check for `playwright/` since `tsc -b` does not cover that directory.
- The settings stepper assertion using the imported bound executed as part of the suite.

Backend lint and type gates were not run because the diff contains no Python.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) (not applicable)
- [x] No secrets, credentials, or internal references in the diff
