### PR TITLE
fix(chat): show empty state on Changes tab when session has no PR

### DIFF
--- a/website/src/i18n/locales/bn.json
+++ b/website/src/i18n/locales/bn.json
@@ -2552,6 +2552,7 @@
         "loading": "লোড হচ্ছে…",
         "no_files_changed_yet": "এখনও কোনো ফাইল পরিবর্তিত হয়নি",
         "no_matches": "কোনো মিল নেই",
+        "no_pull_requests_yet": "এই সেশনে এখনও কোনো পুল রিকোয়েস্ট নেই",
         "no_subagents_running": "কোনো সাবএজেন্ট চলছে না",
         "no_workflow_runs": "কোনো ওয়ার্কফ্লো রান নেই",
         "output": "আউটপুট",

--- a/website/src/i18n/locales/de.json
+++ b/website/src/i18n/locales/de.json
@@ -2552,6 +2552,7 @@
         "loading": "Wird geladen…",
         "no_files_changed_yet": "Noch keine Dateien geändert",
         "no_matches": "Keine Treffer",
+        "no_pull_requests_yet": "Noch keine Pull Requests in dieser Sitzung",
         "no_subagents_running": "Keine Subagenten laufen",
         "no_workflow_runs": "Keine Workflow-Ausführungen",
         "output": "Ausgabe",

--- a/website/src/i18n/locales/en.manual.json
+++ b/website/src/i18n/locales/en.manual.json
@@ -123,6 +123,7 @@
       "activityViewer": {
         "clear": "Clear",
         "no_matches": "No matches",
+        "no_pull_requests_yet": "No pull requests in this session yet",
         "resource_type_issue": "Issue",
         "resource_type_link": "Link",
         "resource_type_pr": "PR",

--- a/website/src/i18n/locales/es.json
+++ b/website/src/i18n/locales/es.json
@@ -2584,6 +2584,7 @@
         "loading": "Cargando…",
         "no_files_changed_yet": "Aún no hay archivos modificados",
         "no_matches": "Sin coincidencias",
+        "no_pull_requests_yet": "Aún no hay pull requests en esta sesión",
         "no_subagents_running": "No hay subagentes en ejecución",
         "no_workflow_runs": "No hay ejecuciones de flujos de trabajo",
         "output": "Salida",

--- a/website/src/i18n/locales/fr.json
+++ b/website/src/i18n/locales/fr.json
@@ -2584,6 +2584,7 @@
         "loading": "Chargement…",
         "no_files_changed_yet": "Aucun fichier modifié pour l'instant",
         "no_matches": "Aucun résultat",
+        "no_pull_requests_yet": "Aucune pull request dans cette session pour l'instant",
         "no_subagents_running": "Aucun sous-agent en cours",
         "no_workflow_runs": "Aucune exécution de workflow",
         "output": "Sortie",

--- a/website/src/i18n/locales/hi.json
+++ b/website/src/i18n/locales/hi.json
@@ -2552,6 +2552,7 @@
         "loading": "लोड हो रहा है…",
         "no_files_changed_yet": "अभी कोई फ़ाइल नहीं बदली",
         "no_matches": "कोई मेल नहीं",
+        "no_pull_requests_yet": "इस सत्र में अभी तक कोई पुल रिक्वेस्ट नहीं है",
         "no_subagents_running": "कोई सबएजेंट नहीं चल रहा",
         "no_workflow_runs": "कोई वर्कफ़्लो रन नहीं",
         "output": "आउटपुट",

--- a/website/src/i18n/locales/it.json
+++ b/website/src/i18n/locales/it.json
@@ -2584,6 +2584,7 @@
         "loading": "Caricamento…",
         "no_files_changed_yet": "Ancora nessun file modificato",
         "no_matches": "Nessuna corrispondenza",
+        "no_pull_requests_yet": "Ancora nessuna pull request in questa sessione",
         "no_subagents_running": "Nessun subagente in esecuzione",
         "no_workflow_runs": "Nessuna esecuzione di workflow",
         "output": "Output",

--- a/website/src/i18n/locales/pt.json
+++ b/website/src/i18n/locales/pt.json
@@ -2584,6 +2584,7 @@
         "loading": "Carregando…",
         "no_files_changed_yet": "Nenhum arquivo alterado ainda",
         "no_matches": "Nenhum resultado",
+        "no_pull_requests_yet": "Ainda não há pull requests nesta sessão",
         "no_subagents_running": "Nenhum subagente em execução",
         "no_workflow_runs": "Nenhuma execução de fluxo de trabalho",
         "output": "Saída",

--- a/website/src/i18n/locales/ru.json
+++ b/website/src/i18n/locales/ru.json
@@ -2616,6 +2616,7 @@
         "loading": "Загрузка…",
         "no_files_changed_yet": "Изменённых файлов пока нет",
         "no_matches": "Нет совпадений",
+        "no_pull_requests_yet": "В этом сеансе пока нет пул-реквестов",
         "no_subagents_running": "Нет запущенных субагентов",
         "no_workflow_runs": "Нет запусков рабочих процессов",
         "output": "Вывод",

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -2520,6 +2520,7 @@
         "loading": "加载中…",
         "no_files_changed_yet": "尚无文件更改",
         "no_matches": "无匹配项",
+        "no_pull_requests_yet": "此会话中还没有拉取请求",
         "no_subagents_running": "没有运行中的子代理",
         "no_workflow_runs": "无工作流运行",
         "output": "输出",

--- a/website/src/pages/chat/ActivityViewer.tsx
+++ b/website/src/pages/chat/ActivityViewer.tsx
@@ -989,13 +989,14 @@ export default function ActivityViewer({ subagents, toolLog, open, onToggle, slo
   // When a `view` prop is supplied, SidePanel owns the tab strip — render only
   // that view and skip the internal SegmentedControl.
   const requestedTab = view ?? tab
-  // `changes` is a PINNED view, so its tab exists even with nothing to show and
-  // falling back to Files is the long-standing behaviour. `issues` is NOT
-  // pinned: it only appears once the session mentions an issue, or when the user
-  // opens it from the + menu. In that second case there is no auto-removal, so
-  // falling back would render the Files list under an "Issues" label. Keep the
-  // requested view and let it render its own empty state instead.
-  const effectiveTab = requestedTab === 'changes' && !hasSources ? 'files' : requestedTab
+  // In the internal SegmentedControl (`!view`) the Changes segment only exists
+  // when there are sources, so a stale `changes` selection with none left must
+  // fall back to Files. But under `view` mode Changes is a PINNED tab that is
+  // ALWAYS present — falling back there would render the touched-files list
+  // under a "Changes" header (confusing, and wrong when files were touched with
+  // no PR). Keep it on `changes` and let it render its own PR empty state,
+  // mirroring how the (unpinned) Issues view already owns its empty state.
+  const effectiveTab = requestedTab === 'changes' && !hasSources && !view ? 'files' : requestedTab
 
   const TABS: { key: typeof tab; label: string; icon: ReactNode; count?: number }[] = [
     ...(hasSources ? [{ key: 'changes' as const, label: 'Changes', icon: <GitPullRequest size={13} />, count: sources!.length }] : []),
@@ -1027,14 +1028,20 @@ export default function ActivityViewer({ subagents, toolLog, open, onToggle, slo
       )}
 
       {/* Changes (pull request sources) view */}
-      {effectiveTab === 'changes' && hasSources && (
+      {effectiveTab === 'changes' && (
         <div className="flex-1 min-h-0 overflow-hidden">
-          <PullRequestPanel
-            sources={sources!}
-            selectedUrl={selectedSourceUrl || ''}
-            onSelect={onSelectSource || (() => {})}
-            onAddToChat={onAddToChat || (() => {})}
-          />
+          {hasSources ? (
+            <PullRequestPanel
+              sources={sources!}
+              selectedUrl={selectedSourceUrl || ''}
+              onSelect={onSelectSource || (() => {})}
+              onAddToChat={onAddToChat || (() => {})}
+            />
+          ) : (
+            <div className="text-muted text-[13px] pt-8 px-6 text-center">
+              {i18nT('pages.chat.activityViewer.no_pull_requests_yet')}
+            </div>
+          )}
         </div>
       )}
 

--- a/website/src/test/ActivityViewer.test.tsx
+++ b/website/src/test/ActivityViewer.test.tsx
@@ -105,6 +105,25 @@ describe('ActivityViewer', () => {
     expect(screen.getByText('Loading source provider…')).toBeInTheDocument()
   })
 
+  it('shows an empty state, not the Files view, when Changes is opened with no PR', () => {
+    // Changes is a PINNED view (always present under `view` mode), so with no
+    // sources it must NOT fall back to the touched-files list under a "Changes"
+    // header — it owns its own PR empty state instead. Even with touched files
+    // present, the Changes view stays empty.
+    render(
+      <ActivityViewer
+        {...baseProps}
+        view="changes"
+        sources={[]}
+        files={[{ path: '/proj/foo.ts', ts: 1, source: 'tool' }]}
+      />,
+      { wrapper },
+    )
+    expect(screen.queryByText('No files changed yet')).toBeNull()
+    expect(screen.queryByText('/proj/foo.ts')).toBeNull()
+    expect(screen.getByText(/No pull requests in this session yet/)).toBeInTheDocument()
+  })
+
   it('Resources hides links present in the Changes tab (sources) and keeps the rest', () => {
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const store = configureStore({


### PR DESCRIPTION
## Problem
Opening the pinned **Changes** tab in the chat side panel for a session that has **no pull request** showed the touched/working-tree **Files** list (or the Files "No files changed yet" empty state) rendered under a **Changes** header. The tab silently fell back to a different view, which is confusing and, when files had been touched, plainly wrong (working-tree changes shown as if they were "Changes"/PR content).

## Why it matters
The Changes tab is a pinned, always-present view. Its silent fallback made the panel misrepresent session state — users saw file changes under a "Changes" label with no PR, blurring the distinction between "files touched this session" (the Files tab) and "pull requests in this session" (the Changes tab).

## Fix (symptom → root cause → change)
- **Symptom:** Changes tab with no PR shows the Files list / "No files changed yet".
- **Root cause:** `effectiveTab = requestedTab === 'changes' && !hasSources ? 'files' : requestedTab` unconditionally redirected the Changes view to Files whenever there were no PR sources — including under `view` mode, where Changes is a pinned tab that is always rendered.
- **Change:**
  - Gate the fallback with `&& !view` so it only applies to the internal `SegmentedControl` path (where the Changes segment genuinely does not exist without sources). Under `view` mode (the pinned side-panel tab), the view stays on `changes`.
  - Give the Changes view its own top-aligned empty state — `No pull requests in this session yet` — mirroring how the (unpinned) Issues view already owns its empty state.
  - Localize the new string via `i18nT` across all 10 shipped catalogs (`en.manual` + `zh-CN, hi, es, fr, bn, pt, ru, de, it`).

## Tests
- `website/src/test/ActivityViewer.test.tsx`: new case asserts that opening Changes with `sources=[]` (even with touched `files`) renders the `No pull requests in this session yet` empty state and does **not** render the Files list ("No files changed yet") or any file row.
- Existing `ActivityViewer` suite (27) still passes; `catalogParity` + `englishIdentity` green (the new key is present at the correct path in every locale).

## Manual verification
Open a chat session that has never mentioned a PR link, open the side panel, and select the pinned **Changes** tab. It now shows the top-aligned "No pull requests in this session yet" message instead of the touched-files list. Mentioning a GitHub/GitLab PR link still populates the `PullRequestPanel` as before.

## Screenshots
The change is a text-only empty state (a single centered/top-aligned `<div>` with the localized string) — no new layout, component, or theming surface. Reaching the live state requires an interactive session (open panel → Changes tab with no PR), which is not scriptable in this environment without the interactive-browser toggle; the exact rendered copy and placement are asserted by the added unit test. Flagging for a reviewer to eyeball if desired.
