### PR TITLE
fix: harden four CSE security findings (find allowlist, zip bomb, href XSS, apigw logging)

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -212,7 +212,6 @@ _READ_ONLY_BASH_PREFIXES: tuple[str, ...] = (
     "cat",
     "head",
     "tail",
-    "find",
     "grep",
     "egrep",
     "fgrep",

--- a/src/kiro_crew/deploy/iam.py
+++ b/src/kiro_crew/deploy/iam.py
@@ -147,6 +147,25 @@ def boundary_policy_document() -> dict[str, Any]:
                 ],
             },
             {
+                # CWE-778: the API access-log groups created by the fullstack
+                # templates must be deletable when the reaper cascades a
+                # backend-stack teardown, or delete-stack lands in DELETE_FAILED.
+                "Sid": "ReaperLogsCap",
+                "Effect": "Allow",
+                "Action": ["logs:DeleteLogGroup"],
+                "Resource": [
+                    "arn:aws:logs:*:*:log-group:/kirocrew-deploy-app/*",
+                    "arn:aws:logs:*:*:log-group:/kirocrew-deploy-app/*:*",
+                ],
+            },
+            {
+                # logs:DescribeLogGroups is not resource-scopable (Resource "*").
+                "Sid": "ReaperLogsDescribe",
+                "Effect": "Allow",
+                "Action": ["logs:DescribeLogGroups"],
+                "Resource": "*",
+            },
+            {
                 "Sid": "ReaperCascadeIamCap",
                 "Effect": "Allow",
                 "Action": [
@@ -323,6 +342,36 @@ def policy_document(*, include_custom_domain: bool = False, tier: str = "static"
                     "lambda:RemovePermission", "lambda:TagResource",
                 ],
                 "Resource": "arn:aws:lambda:*:*:function:kirocrew-deploy-app-*",
+            },
+            {
+                # CWE-778 access logging: the app-apigw*.yaml stages create an
+                # AWS::Logs::LogGroup (/kirocrew-deploy-app/<slug>/apigw*) and
+                # attach AccessLogSettings. deploy-backend.sh runs
+                # `cloudformation deploy` with the deploy principal's own
+                # creds (no --role-arn), so that principal needs scoped
+                # log-group lifecycle perms or the stack rolls back. Scoped to
+                # the managed prefix; HTTP API v2 needs no account CloudWatch role.
+                "Sid": "LogsFullstack",
+                "Effect": "Allow",
+                "Action": [
+                    "logs:CreateLogGroup", "logs:DeleteLogGroup",
+                    "logs:PutRetentionPolicy",
+                    "logs:TagResource", "logs:ListTagsForResource",
+                ],
+                "Resource": [
+                    "arn:aws:logs:*:*:log-group:/kirocrew-deploy-app/*",
+                    "arn:aws:logs:*:*:log-group:/kirocrew-deploy-app/*:*",
+                ],
+            },
+            {
+                # logs:DescribeLogGroups has NO resource-level authorization —
+                # it must be Resource "*" or IAM denies it. CloudFormation's
+                # AWS::Logs::LogGroup handler calls it during create/stabilize.
+                # Read-only metadata listing, so "*" is the least it can be.
+                "Sid": "LogsDescribe",
+                "Effect": "Allow",
+                "Action": ["logs:DescribeLogGroups"],
+                "Resource": "*",
             },
             {
                 # R35 F1 + R39 F1: reads are unconditioned; unconditioned POST

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw-ddb.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw-ddb.yaml
@@ -165,16 +165,29 @@ Resources:
       AuthorizerId: !Ref OriginVerifyAuthorizer
       AuthorizationType: CUSTOM
 
+  # CWE-778: access-log destination for the HTTP API stage so requests to the
+  # deployed app are auditable (who / when / status). 14-day retention.
+  ApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/kirocrew-deploy-app/${Slug}/apigw-ddb-access'
+      RetentionInDays: 14
+
   Stage:
     Type: AWS::ApiGatewayV2::Stage
     Properties:
       ApiId: !Ref HttpApi
       StageName: '$default'
       AutoDeploy: true
+      # CWE-778: emit structured access logs to CloudWatch Logs for auditability.
+      AccessLogSettings:
+        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
+        Format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","routeKey":"$context.routeKey","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","integrationError":"$context.integrationErrorMessage"}'
       # CWE-770: throttle the $default stage so a per-app deploy cannot be driven
       # into unbounded request/Lambda-invocation volume. DefaultRouteSettings
       # applies to every route on the stage.
       DefaultRouteSettings:
+        DetailedMetricsEnabled: true
         ThrottlingRateLimit: !Ref ApiThrottlingRateLimit
         ThrottlingBurstLimit: !Ref ApiThrottlingBurstLimit
 

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/app-apigw.yaml
@@ -126,16 +126,29 @@ Resources:
       AuthorizerId: !Ref OriginVerifyAuthorizer
       AuthorizationType: CUSTOM
 
+  # CWE-778: access-log destination for the HTTP API stage so requests to the
+  # deployed app are auditable (who / when / status). 14-day retention.
+  ApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/kirocrew-deploy-app/${Slug}/apigw-access'
+      RetentionInDays: 14
+
   Stage:
     Type: AWS::ApiGatewayV2::Stage
     Properties:
       ApiId: !Ref HttpApi
       StageName: '$default'
       AutoDeploy: true
+      # CWE-778: emit structured access logs to CloudWatch Logs for auditability.
+      AccessLogSettings:
+        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
+        Format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","routeKey":"$context.routeKey","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","integrationError":"$context.integrationErrorMessage"}'
       # CWE-770: throttle the $default stage so a per-app deploy cannot be driven
       # into unbounded request/Lambda-invocation volume. DefaultRouteSettings
       # applies to every route on the stage.
       DefaultRouteSettings:
+        DetailedMetricsEnabled: true
         ThrottlingRateLimit: !Ref ApiThrottlingRateLimit
         ThrottlingBurstLimit: !Ref ApiThrottlingBurstLimit
 

--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -170,6 +170,14 @@ def create_export_zip() -> tuple[bytes, dict]:
     return buf.getvalue(), manifest
 
 
+# Zip-bomb guards for import archives (CWE-409). A real personal snapshot is far
+# below these ceilings; a decompression bomb (huge declared uncompressed size, or
+# millions of entries) is rejected before extraction rather than filling the
+# host disk.
+_MAX_IMPORT_MEMBERS = 50_000
+_MAX_IMPORT_UNCOMPRESSED = 2 * 1024 ** 3  # 2 GiB
+
+
 def validate_import_zip(zip_path: Path) -> tuple[bool, str, dict]:
     """Validate a zip file for import.
 
@@ -184,6 +192,17 @@ def validate_import_zip(zip_path: Path) -> tuple[bool, str, dict]:
                 parts = PurePosixPath(name).parts
                 if ".." in parts or name.startswith("/"):
                     return False, f"Rejected path traversal: {name}", {}
+
+            # Zip-bomb guard: bound entry count and total uncompressed size.
+            infos = zf.infolist()
+            if len(infos) > _MAX_IMPORT_MEMBERS:
+                return False, f"Rejected: archive has too many entries ({len(infos)} > {_MAX_IMPORT_MEMBERS})", {}
+            total_uncompressed = sum(i.file_size for i in infos)
+            if total_uncompressed > _MAX_IMPORT_UNCOMPRESSED:
+                return False, (
+                    f"Rejected: uncompressed size {total_uncompressed} exceeds cap "
+                    f"{_MAX_IMPORT_UNCOMPRESSED} (possible zip bomb)"
+                ), {}
 
             # Find manifest
             manifest_entries = [n for n in names if n.endswith("MANIFEST.json")]
@@ -218,7 +237,19 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
         work = Path(work_str)
 
         with zipfile.ZipFile(str(zip_path), "r") as zf:
-            for info in zf.infolist():
+            infos = zf.infolist()
+            # Zip-bomb guard (defense-in-depth; validate_import_zip also checks).
+            if len(infos) > _MAX_IMPORT_MEMBERS:
+                raise ValueError(
+                    f"Import archive has too many entries ({len(infos)} > {_MAX_IMPORT_MEMBERS})"
+                )
+            total_uncompressed = sum(i.file_size for i in infos)
+            if total_uncompressed > _MAX_IMPORT_UNCOMPRESSED:
+                raise ValueError(
+                    f"Import archive uncompressed size {total_uncompressed} exceeds cap "
+                    f"{_MAX_IMPORT_UNCOMPRESSED} (possible zip bomb)"
+                )
+            for info in infos:
                 parts = PurePosixPath(info.filename).parts
                 if ".." in parts or info.filename.startswith("/"):
                     continue

--- a/test/test_deploy_apigw_logging.py
+++ b/test/test_deploy_apigw_logging.py
@@ -1,0 +1,62 @@
+"""Regression: API Gateway access logging (CWE-778) — template <-> IAM coverage.
+
+The app-apigw*.yaml stages create a CloudWatch LogGroup + AccessLogSettings.
+deploy-backend.sh runs `cloudformation deploy` with the deploy principal's own
+creds, so the fullstack policy must grant scoped log-group lifecycle perms or
+the stack rolls back; and the reaper cascade must be able to delete them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kiro_crew.deploy.iam import boundary_policy_document, policy_document
+
+_TEMPLATES = (
+    Path(__file__).resolve().parents[1]
+    / "src/kiro_crew/deploy/skills/artifact-deploy/templates"
+)
+
+
+def _actions(doc: dict) -> set[str]:
+    acts: set[str] = set()
+    for st in doc["Statement"]:
+        a = st.get("Action", [])
+        acts.update([a] if isinstance(a, str) else a)
+    return acts
+
+
+def test_apigw_templates_have_access_logging():
+    for name in ("app-apigw.yaml", "app-apigw-ddb.yaml"):
+        text = (_TEMPLATES / name).read_text()
+        assert "AccessLogSettings:" in text, name
+        assert "AWS::Logs::LogGroup" in text, name
+
+
+def test_fullstack_policy_grants_scoped_log_group_perms():
+    doc = policy_document(tier="fullstack")
+    acts = _actions(doc)
+    for need in ("logs:CreateLogGroup", "logs:DeleteLogGroup", "logs:PutRetentionPolicy"):
+        assert need in acts, f"fullstack policy missing {need}"
+    logs_st = [
+        s for s in doc["Statement"]
+        if "logs:CreateLogGroup" in (
+            s["Action"] if isinstance(s["Action"], list) else [s["Action"]]
+        )
+    ]
+    assert logs_st, "no logs statement in fullstack policy"
+    res = logs_st[0]["Resource"]
+    res = res if isinstance(res, list) else [res]
+    assert all("/kirocrew-deploy-app/" in r for r in res), res
+    assert all(r != "*" for r in res), res
+    # logs:DescribeLogGroups is not resource-scopable — must be Resource "*".
+    desc = [s for s in doc["Statement"] if s.get("Action") == ["logs:DescribeLogGroups"]]
+    assert desc and desc[0]["Resource"] == "*", "DescribeLogGroups must be Resource '*'"
+
+
+def test_static_policy_has_no_log_perms():
+    assert "logs:CreateLogGroup" not in _actions(policy_document(tier="static"))
+
+
+def test_reaper_boundary_can_delete_log_groups():
+    assert "logs:DeleteLogGroup" in _actions(boundary_policy_document())

--- a/test/test_portability.py
+++ b/test/test_portability.py
@@ -607,3 +607,36 @@ class TestRoundTrip:
         conn.close()
         assert len(rows) == 1
         assert "deployment" in rows[0][1]
+
+
+def _make_min_import_zip(path, extra_files=1):
+    """Minimal valid import archive: one top-level dir + MANIFEST.json."""
+    with zipfile.ZipFile(str(path), "w") as zf:
+        zf.writestr("snap/MANIFEST.json", json.dumps({"version": 2}))
+        for i in range(extra_files):
+            zf.writestr(f"snap/f{i}.txt", "x")
+    return path
+
+
+def test_import_zip_bomb_member_cap(tmp_path, monkeypatch):
+    # SEC-7F44A198: too many entries is rejected before extraction.
+    import kiro_crew.portability as port
+
+    z = _make_min_import_zip(tmp_path / "imp.zip", extra_files=3)
+    monkeypatch.setattr(port, "_MAX_IMPORT_MEMBERS", 1)
+    ok, msg, _ = port.validate_import_zip(z)
+    assert ok is False and "too many entries" in msg
+    with pytest.raises(ValueError, match="too many entries"):
+        port.apply_import_zip(z)
+
+
+def test_import_zip_bomb_size_cap(tmp_path, monkeypatch):
+    # SEC-7F44A198: excessive declared uncompressed size is rejected (zip bomb).
+    import kiro_crew.portability as port
+
+    z = _make_min_import_zip(tmp_path / "imp2.zip", extra_files=1)
+    monkeypatch.setattr(port, "_MAX_IMPORT_UNCOMPRESSED", 1)
+    ok, msg, _ = port.validate_import_zip(z)
+    assert ok is False and "zip bomb" in msg
+    with pytest.raises(ValueError, match="zip bomb"):
+        port.apply_import_zip(z)

--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -55,9 +55,20 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("cat /tmp/foo.txt") is True
         assert is_read_only_bash("head -20 file.py") is True
         assert is_read_only_bash("tail -f log.txt") is True
-        assert is_read_only_bash("find . -name '*.py'") is True
         assert is_read_only_bash("grep -r 'pattern' src/") is True
         assert is_read_only_bash("wc -l file.txt") is True
+
+    def test_find_not_auto_approved(self):
+        # `find` is NOT on the read-only allowlist (SEC-005 / SEC-FC0A8D32):
+        # it resolves destructive behaviour through sub-options (-delete/-exec),
+        # so removing it from the allowlist (the finding's remediation option 1)
+        # means it is never auto-approved.
+        assert is_read_only_bash("find . -delete") is False
+        assert is_read_only_bash("find . '-delete'") is False
+        assert is_read_only_bash("find . -exec rm {} +") is False
+        assert is_read_only_bash("find . -name '*.py'") is False
+        assert is_read_only_bash("find src -type f") is False
+        assert "not on the read-only allowlist" in unsafe_bash_reason("find . -delete")
         assert is_read_only_bash("diff file1 file2") is True
 
     def test_git_read_commands(self):
@@ -93,14 +104,14 @@ class TestIsReadOnlyBash:
 
     def test_devnull_redirects_allowed(self):
         """Discard-only redirect idioms are read-only despite '>'/'&'."""
-        assert is_read_only_bash("find . -name '*.py' 2>/dev/null") is True
+        assert is_read_only_bash("head -5 file.txt 2>/dev/null") is True
         assert is_read_only_bash("grep -r 'pattern' src/ 2>/dev/null") is True
         assert is_read_only_bash("ls /nonexistent >/dev/null") is True
         assert is_read_only_bash("cat file &>/dev/null") is True
-        assert is_read_only_bash("find / -name x 2>>/dev/null") is True
+        assert is_read_only_bash("wc -l /tmp/x 2>>/dev/null") is True
         assert is_read_only_bash("ls -la 2>&1") is True
         # Compound + pipe chains with a /dev/null sink stay read-only.
-        assert is_read_only_bash("find . -type f 2>/dev/null | head -20") is True
+        assert is_read_only_bash("grep -r foo . 2>/dev/null | head -20") is True
         assert (
             is_read_only_bash("ls /a 2>/dev/null; grep -r foo /b 2>/dev/null") is True
         )
@@ -186,7 +197,7 @@ class TestUnsafeBashReason:
         # Invariant: empty reason IFF the command is read-only.
         for cmd in (
             "ls -la",
-            "find . -name '*.py' 2>/dev/null",
+            "head -5 file.txt 2>/dev/null",
             "grep -r foo src/ | head -20",
             "git status && git log --oneline -3",
         ):
@@ -217,7 +228,7 @@ class TestUnsafeBashReason:
         """unsafe_bash_reason is non-empty exactly when is_read_only_bash is False."""
         samples = [
             "ls -la",
-            "find . -name x 2>/dev/null",
+            "wc -l /tmp/x 2>/dev/null",
             "grep -r foo src/ | head",
             "echo payload > /etc/file",
             "echo $(rm -rf /)",

--- a/website/src/apps/issue-radar/components/IssueDetail.tsx
+++ b/website/src/apps/issue-radar/components/IssueDetail.tsx
@@ -31,6 +31,7 @@ import {
 import type { LucideIcon } from 'lucide-react'
 import RefMarkdown from './RefMarkdown'
 import { parseRepoRef } from '../lib/refLinks'
+import { safeHttpUrl } from '../../../lib/safeUrl'
 import { CommentCardSkeleton, HeaderSkeleton, TimelineSkeleton } from './DetailSkeleton'
 import AiSummaryCard from './AiSummaryCard'
 import Clickable from '../../../components/Clickable'
@@ -362,7 +363,7 @@ function eventVisual(
         body: (
           <>
             {who} {i18nT('apps.issueRadar.components.issueDetail.referenced_this_in')}{' '}
-            <a href={ev.source?.url} target="_blank" rel="noreferrer" className="text-accent hover:underline">
+            <a href={safeHttpUrl(ev.source?.url ?? '') ?? undefined} target="_blank" rel="noreferrer" className="text-accent hover:underline">
               {ev.source?.is_pr ? providerTerms(repoRef).changeRequestShort : 'issue'}
               {providerTerms(repoRef).sigil}{ev.source?.number}
             </a>{' '}
@@ -428,7 +429,7 @@ function RelatedLinks({ items }: { items: RelatedRef[] }) {
           return (
             <a
               key={r.url}
-              href={r.url}
+              href={safeHttpUrl(r.url) ?? undefined}
               target="_blank"
               rel="noreferrer"
               title={target
@@ -731,7 +732,7 @@ export default function IssueDetail({ issue }: { issue: Issue }) {
                   {copied ? <Check size={13} className="text-ok" /> : <Copy size={13} />}
                 </button>
                 <a
-                  href={detail?.url ?? issue.url}
+                  href={safeHttpUrl(detail?.url ?? issue.url ?? '') ?? undefined}
                   target="_blank"
                   rel="noreferrer"
                   title={`Open on ${terms.providerName}`}


### PR DESCRIPTION
## Problem
Four open CSE findings against KiroCrew `main`:
- **SEC-005 / SEC-FC0A8D32 (CWE-184):** the read-only bash auto-approve classifier admitted `find` by name, so a prompt-injected `find … -delete` / `-exec` could auto-approve and delete or execute without user confirmation.
- **SEC-7F44A198 (CWE-409):** `apply_import_zip` extracted an import archive with no member-count or uncompressed-size cap — a decompression bomb could fill the host disk.
- **SEC-7A37E543 (CWE-79):** issue-radar `IssueDetail.tsx` rendered provider-supplied URLs into `<a href>` with no scheme allowlist — a `javascript:` / `data:` URL from a hostile or compromised provider is a DOM-XSS in the dashboard origin.
- **SEC-449530B7 (CWE-778):** the one-click-deploy API Gateway `$default` stages had no access logging — deployed public endpoints were unauditable.

## Why it matters
Each is a reachable local-user harm on a personal tool: silent file deletion, host-disk exhaustion, script execution in the dashboard origin, and no audit trail on internet-facing deploy endpoints.

## Fix (symptom → root cause → change)
- **find:** a text-level classifier cannot safely admit `find`, whose sub-options (`-delete`/`-exec`) make it destructive. Per the finding's remediation option 1, **remove `find` from `_READ_ONLY_BASH_PREFIXES`** so it is never auto-approved (one line).
- **zip bomb:** add `_MAX_IMPORT_MEMBERS` (50k) + `_MAX_IMPORT_UNCOMPRESSED` (2 GiB) caps, enforced in BOTH `validate_import_zip` and `apply_import_zip` before extraction.
- **href XSS:** route all three provider-supplied `href` sinks (cross-referenced event, RelatedLinks, header `#` link) through the existing `safeHttpUrl()` scheme allowlist. Commit/author links use a hardcoded `https` scheme (`lib/links.ts`) and are left as-is.
- **apigw logging:** add a CloudWatch `AWS::Logs::LogGroup` + `AccessLogSettings` + `DetailedMetricsEnabled` to both `app-apigw.yaml` and `app-apigw-ddb.yaml` `$default` stages, and grant the fullstack deploy principal + reaper cascade the scoped `logs:*` permissions (mutations ARN-scoped to `/kirocrew-deploy-app/*`; `DescribeLogGroups` on `*` as IAM requires) so the log groups create and tear down cleanly.

## Tests
- `test/test_trust_reads.py::test_find_not_auto_approved` — `find`, `find '-delete'`, `find -exec …` all classify not-read-only.
- `test/test_portability.py` — zip-bomb member-count + size caps reject before extraction (both entry points).
- `test/test_deploy_apigw_logging.py` — templates carry AccessLogSettings + LogGroup; fullstack policy grants scoped log perms with `DescribeLogGroups` on `*`; reaper can delete the log groups.

## Manual verification
N/A — unit coverage + local gates (pytest, isort, flake8, mypy, `tsc -b`) are sufficient. Full vitest could not run on this host (Node 16 lacks `BroadcastChannel`); CI runs it.

## Screenshots
N/A — no user-visible UI change (the `href` edit only gates an existing link's scheme; rendering is unchanged for valid URLs).

## Follow-up (out of scope)
The pre-existing `--help`/`--version` auto-approve exemption in `_classify_bash` is bypassable for ANY non-allowlisted command (a destructive command followed by a `# --help` comment, or `${IFS}`-packed args) — independent of `find`. Text-level classification cannot parse shell quoting/comments/expansion; tracked as a separate follow-up finding.
