### PR TITLE
feat(dashboard): show goal-loop cycle progress in the chat sidebar

### DIFF
--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1134,6 +1134,10 @@ export const api = {
   // never polls, so a refresh is always an explicit user action.
   fetchIssueSource: (url: string, refresh = false) => post('/api/source/issue', { url, refresh }).then(j) as Promise<IssueSource>,
   chatSlots: () => fetch('/api/chat/slots').then(j),
+  /** All goal loops across sessions. Returns `{enabled:false, loops:[]}` when
+   *  the auto-nudge feature flag is off, so callers need no flag check. */
+  autonudgeList: (): Promise<{ enabled: boolean; loops: { slot_key: string; active?: boolean; cycle_count?: number; max_cycles?: number }[] }> =>
+    fetch('/api/autonudge').then(j),
   chatSlotDetail: (slot: string, limit?: number, before?: number) => {
     const p = new URLSearchParams()
     if (limit) p.set('limit', String(limit))

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -7,7 +7,7 @@ import { sseStatus, sseConnected, sseDisconnected, sseSlots, sseTodoUpdate, setC
 import { addNotification, ackNotificationByTs, unackNotificationByTs, removeNotificationByTs, fetchNotifications } from '../store/notificationsSlice'
 import { MC_NOTIFICATION_EVENT, TURN_DONE_KIND, shouldChimeOnTurnDone, type McNotificationDetail } from './notificationEvent'
 import { emitThemeSound } from './themeSound'
-import { fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentQueued, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentSnapshot, sseSubagentBatchUpdate, sseSubagentBatchChunks, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, appendSlotMessage, setQuestionCard, resolveQuestionCard, setFollowupCard, sseMcpAppRender } from '../store/chatSlice'
+import { fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentQueued, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentSnapshot, sseSubagentBatchUpdate, sseSubagentBatchChunks, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, appendSlotMessage, setQuestionCard, resolveQuestionCard, setFollowupCard, sseMcpAppRender, setGoalLoops, sseGoalLoop } from '../store/chatSlice'
 import { api } from '../api/client'
 import { sanitizeLlmOutput } from '../utils/sanitize'
 import { applyStatusDelta, parseStatusDelta } from '../utils/pullRequestStatusDelta'
@@ -181,6 +181,42 @@ export function useWebSocket() {
     })
   }, [dispatch])
 
+  /** Bumped by every `autonudge_state` frame. A seed captures this before its
+   *  fetch and discards the response if a frame landed while it was in flight:
+   *  the seed's full-replace would otherwise resurrect a loop whose `removed`
+   *  frame we had already applied, and because frames fire only on CHANGE
+   *  nothing would ever correct it — leaving a phantom "Loop N/M" that
+   *  suppresses that row's unread dot until the next reconnect. */
+  const goalLoopGenRef = useRef(0)
+
+  /** Cold-seed the sidebar's goal-loop map. `autonudge_state` only fires on
+   *  change, so a loop armed before this client connected would show no progress
+   *  until its next cycle fired — which can be minutes. Runs on first connect
+   *  and on every reconnect. Silent on failure and on the feature being
+   *  disabled (the endpoint answers `{enabled:false, loops:[]}`). */
+  const seedGoalLoops = useCallback(() => {
+    const gen = goalLoopGenRef.current
+    // Fully best-effort, including SYNCHRONOUS failure. This runs early in the
+    // connect handler, ahead of notification sync and the subagent subscribe, so
+    // an exception escaping here would silently strand those — a cosmetic seed
+    // must never be able to do that.
+    try {
+      api.autonudgeList()
+        .then(res => {
+          // A live frame superseded this snapshot — it is now stale, so drop it
+          // rather than replacing fresher state with older state.
+          if (goalLoopGenRef.current !== gen) return
+          dispatch(setGoalLoops((res?.loops || []).map(loop => ({
+            slot: loop.slot_key,
+            active: loop.active === true,
+            cycle_count: Number(loop.cycle_count) || 0,
+            max_cycles: Number(loop.max_cycles) || 0,
+          }))))
+        })
+        .catch(() => {})
+    } catch { /* seed is cosmetic — never break the connect path */ }
+  }, [dispatch])
+
   const syncPendingApprovals = useCallback(async () => {
     try {
       const approvals = await api.approvals()
@@ -351,6 +387,7 @@ export function useWebSocket() {
         chunkBufRef.current.clear()  // drop pre-disconnect partial chunks; refreshSlot recovers state
         dispatch(sseConnected())
         dispatch(fetchSlots()).finally(() => { reconnectingRef.current = false })
+        seedGoalLoops()
         dispatch(fetchNotifications()).then(() => syncPendingApprovals())
       syncPendingQuestions()
         // Re-fetch active slot messages to recover from missed chunks
@@ -367,6 +404,7 @@ export function useWebSocket() {
       wasConnectedRef.current = true
       dispatch(sseConnected())
       dispatch(fetchSlots())
+      seedGoalLoops()
       dispatch(fetchNotifications()).then(() => syncPendingApprovals())
       syncPendingQuestions()
       // Eagerly subscribe to subagent events on first connect too.
@@ -884,10 +922,35 @@ export function useWebSocket() {
               api.voiceConfig().then(c => { autoSpeakRef.current = !!c.autoSpeak }).catch(() => {})
             }
             break
-          case 'autonudge_state':
+          case 'autonudge_state': {
             // Broadcast for ChatPage to refresh its autonudge loop state.
             window.dispatchEvent(new CustomEvent('autonudge_state', { detail: data }))
+            // Mirror into the store as well, so the sidebar can show progress on
+            // EVERY looping row instead of only the active slot (ChatPage's
+            // listener filters to `activeSlot`). The service emits one event per
+            // fired cycle, which is what makes the cycle counter tick live.
+            const nudge = data as unknown as {
+              event?: string
+              slot?: string
+              loop?: { active?: boolean; cycle_count?: number; max_cycles?: number }
+            }
+            if (nudge.slot) {
+              // Bump BEFORE dispatching so an in-flight seed is invalidated even
+              // if its .then() runs immediately after this frame is handled.
+              goalLoopGenRef.current++
+              dispatch(sseGoalLoop({
+                slot: nudge.slot,
+                // `removed` still carries the loop object (the gateway observer
+                // only fires when `loop is not None`), and its `active` flag is
+                // whatever it was at removal — so the event name, not the flag,
+                // decides a removal.
+                active: nudge.event !== 'removed' && nudge.loop?.active === true,
+                cycle_count: Number(nudge.loop?.cycle_count) || 0,
+                max_cycles: Number(nudge.loop?.max_cycles) || 0,
+              }))
+            }
             break
+          }
           case 'voice_chunk': {
             if (voiceMutedRef.current) break
             if (data.slot !== store.getState().chat.activeSlot) break
@@ -1020,7 +1083,7 @@ export function useWebSocket() {
     }
 
     ws.onerror = () => { /* onclose will fire */ }
-  }, [dispatch, flushChunks, scheduleChunkFlush, playNextVoiceChunk, queryClient, stopVoice, syncPendingApprovals, syncPendingQuestions, recordResolvedAskId])
+  }, [dispatch, flushChunks, scheduleChunkFlush, playNextVoiceChunk, queryClient, stopVoice, syncPendingApprovals, syncPendingQuestions, seedGoalLoops, recordResolvedAskId])
 
   /**
    * Force an immediate reconnect: cancels any pending backoff timer, closes

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -708,6 +708,8 @@ function ChatSidebar({
   // loaded" from "data loaded and genuinely empty".
   const slotsLoaded = useAppSelector(s => s.dashboard.slotsLoaded)
   const slotStatusDetail = useAppSelector(s => s.chat.slotStatusDetail)
+  // Presence in this map means "this session is in an active goal loop".
+  const goalLoops = useAppSelector(s => s.chat.goalLoops)
   // Live subagent activity per slot, for the sidebar row's "N agents running"
   // subtitle. Mirrors SubagentProgressBar's source of truth: chatSlice.subagents
   // for the store's active slot, slotActivity[slot].subagents for background
@@ -1984,6 +1986,35 @@ function ChatSidebar({
       ? '1 sub-agent needs approval'
       : `${subagentAwaiting} sub-agents need approval`
     const wfActive = workflowActive[s.key]
+    // Goal loop (auto-nudge). A loop is a MODE, not a turn state, so it is not
+    // gated on `s.running` — a looping session spends most of its life mid-turn,
+    // and hiding the indicator then would hide it almost always.
+    // Own-property read only. The store normalizes writes through `safeKey`
+    // (`__proto__`/`constructor`/`prototype` are rerouted to an inert key), so a
+    // bare `goalLoops[s.key]` would disagree with it — returning a truthy
+    // `Object.prototype` for such a key and rendering "Loop · undefined" while
+    // suppressing the row's unread dot.
+    const goalLoop = Object.prototype.hasOwnProperty.call(goalLoops ?? {}, s.key)
+      ? goalLoops[s.key]
+      : undefined
+    // `max_cycles === 0` means unlimited (autonudge.py NudgeLoop default), so
+    // there is no denominator to show — fall back to a bare count.
+    const goalLoopLabel = !goalLoop
+      ? ''
+      : goalLoop.max_cycles > 0
+        ? `Loop ${goalLoop.cycle_count}/${goalLoop.max_cycles}`
+        : `Loop · ${goalLoop.cycle_count}`
+    // Whatever this row would have said if no loop were running, reused as the
+    // loop line's trailing detail. This is why the loop branch can outrank the
+    // working signals below without swallowing them: live workflow/subagent/tool
+    // status still shows, and between cycles it falls back to the last message.
+    const goalLoopDetail = wfActive
+      ? wfActive.label
+      : subagentCount > 0
+        ? subagentLabel
+        : s.running
+          ? (slotStatusDetail[s.key]?.text || 'Thinking…')
+          : (s.last_message || '')
     const ci = s.color_index != null && s.color_index >= 0 && s.color_index < paletteColors.length ? s.color_index : null
     const rowColor = ci != null ? paletteColors[ci] : null
     const boostStyle: Record<string, string> = {}
@@ -2062,7 +2093,7 @@ function ChatSidebar({
             dispatch(switchSlot(s.key))
             onSelectSlot?.(s.key)
           }}>
-          {s.unread && !s.running && !s.pending_approval && !subagentAwaiting && (
+          {s.unread && !s.running && !s.pending_approval && !subagentAwaiting && !goalLoop && (
             // Blue dot = "your turn": the agent finished its turn (not running)
             // and you haven't opened the session since (unread). Redefined from
             // the old "any unseen output" trigger so it no longer lights
@@ -2070,6 +2101,9 @@ function ChatSidebar({
             // treatment instead (including a sub-agent's spawn approval, which
             // leaves the parent turn idle and would otherwise read as a plain
             // unread reply).
+            // A goal loop suppresses it too: the loop appends a turn every cycle,
+            // so the dot would light permanently and stop meaning "your turn".
+            // The "Loop N/M" subtitle carries the state instead.
             <span className="absolute right-1.5 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full pointer-events-none" style={{ background: 'var(--accent)' }} title={i18nT('pages.chatSidebar.agent_finished_your_turn')} />
           )}
           <div className="flex-1 min-w-0 overflow-hidden">
@@ -2161,6 +2195,16 @@ function ChatSidebar({
               <div className="text-[12px] leading-snug mt-0.5 flex items-center gap-1.5 min-w-0" title={subagentApprovalLabel}>
                 <Bot size={11} className="shrink-0" style={{ color: 'var(--warn)' }} aria-hidden />
                 <span className="truncate font-medium" style={{ color: 'var(--warn)' }}>{subagentApprovalLabel}</span>
+              </div>
+            ) : goalLoop ? (
+              // An active goal loop outranks every "working" signal below it but
+              // stays under both approval branches: an owed decision must never
+              // read as unattended progress. Nothing is lost by ranking it high
+              // — `goalLoopDetail` carries whatever the lower branch would have
+              // shown, so this line reads "Loop 7/24 · 3 agents running".
+              <div className="text-[12px] leading-snug mt-0.5 flex items-center gap-1.5 min-w-0" title={goalLoop.max_cycles > 0 ? `Goal loop · cycle ${goalLoop.cycle_count} of ${goalLoop.max_cycles}` : `Goal loop · cycle ${goalLoop.cycle_count} (no cap)`}>
+                <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse shrink-0" aria-hidden />
+                <span className="truncate"><span className="font-medium text-accent">{goalLoopLabel}</span>{goalLoopDetail ? <span className="text-muted"> · {goalLoopDetail}</span> : null}</span>
               </div>
             ) : wfActive ? (
               // A dynamic-workflow run launched from this session is still

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -222,6 +222,18 @@ interface ChatState {
    *  by slot name so it survives active-slot switches without the subagents
    *  map's active/non-active split. Populated by `subagent_queued` WS events. */
   subagentQueued: Record<string, number>
+  /** Live goal-loop (auto-nudge) progress per slot, keyed by the BARE slot key
+   *  the sidebar renders — `binding_key_for` strips the `dashboard:` prefix, so
+   *  these match `Slot.key` directly. Channel loops (`slack:`/`discord:` keys)
+   *  land here too and simply match no sidebar row.
+   *  Only ACTIVE loops are held: a loop that hit `max_cycles` stays in the
+   *  service registry with `active=false`, and a stopped loop must not keep
+   *  showing progress, so presence in this map IS "looping".
+   *  Cold-seeded from `GET /api/autonudge`, then kept live by `autonudge_state`
+   *  WS events — the service emits one per fired cycle (autonudge.py
+   *  `_emit("fired", …)` right after the `cycle_count` bump), which is what
+   *  makes the counter tick without rebroadcasting the whole slots list. */
+  goalLoops: Record<string, { cycle_count: number; max_cycles: number }>
   /** Agent id the user picked from the chip — the Activity Subagents tab
    *  scrolls to, expands, and auto-loads this card (1-click transcript). */
   selectedSubagentId: string | null
@@ -299,6 +311,7 @@ const initialState: ChatState = {
   voiceAudio: null,
   subagents: {},
   subagentQueued: {},
+  goalLoops: {},
   selectedSubagentId: null,
   toolLog: [],
   workflowRuns: {},
@@ -1183,6 +1196,33 @@ const chatSlice = createSlice({
       state.subagentQueued ??= {}
       if (n === 0) delete state.subagentQueued[safeKey(action.payload.slot)]
       else state.subagentQueued[safeKey(action.payload.slot)] = n
+    },
+    /** Replace the whole goal-loop map from a cold `GET /api/autonudge` seed.
+     *  A full replace (not a merge) is correct here: the response is the
+     *  service's complete registry, so a loop this client still holds but the
+     *  server no longer reports has ended and must disappear. */
+    setGoalLoops(state, action: PayloadAction<{ slot: string; active: boolean; cycle_count: number; max_cycles: number }[]>) {
+      const next: Record<string, { cycle_count: number; max_cycles: number }> = {}
+      for (const loop of action.payload) {
+        if (!loop.active || isUnsafeKey(loop.slot)) continue
+        next[safeKey(loop.slot)] = {
+          cycle_count: Math.max(0, Math.floor(Number(loop.cycle_count) || 0)),
+          max_cycles: Math.max(0, Math.floor(Number(loop.max_cycles) || 0)),
+        }
+      }
+      state.goalLoops = next
+    },
+    /** Upsert (or drop) one loop from an `autonudge_state` WS event. */
+    sseGoalLoop(state, action: PayloadAction<{ slot: string; active: boolean; cycle_count: number; max_cycles: number }>) {
+      const { slot, active } = action.payload
+      if (isUnsafeKey(slot)) return
+      // Same partial-preloaded-state tolerance as subagentQueued above.
+      state.goalLoops ??= {}
+      if (!active) { delete state.goalLoops[safeKey(slot)]; return }
+      state.goalLoops[safeKey(slot)] = {
+        cycle_count: Math.max(0, Math.floor(Number(action.payload.cycle_count) || 0)),
+        max_cycles: Math.max(0, Math.floor(Number(action.payload.max_cycles) || 0)),
+      }
     },
     sseSubagentPending(state, action: PayloadAction<{ slot: string; id: string; task: string; approval_id: string }>) {
       if (isUnsafeKey(action.payload.slot) || isUnsafeKey(action.payload.id)) return
@@ -2218,6 +2258,7 @@ export const {
   sseContextUsage, setVoicePlaying, setVoiceAudio,
   toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, clearSubagentsForSnapshot, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentQueued,
   sseSubagentBatchUpdate, sseSubagentBatchChunks, selectSubagent, clearTerminalSubagents,
+  setGoalLoops, sseGoalLoop,
   sseSubagentSnapshot, sseToolActivity, sseToolResult, sseActivityEvent,
   sseMcpAppRender,
   sseWorkflowEvent, clearWorkflowRun,

--- a/website/src/test/ChatSidebar.goalLoop.test.tsx
+++ b/website/src/test/ChatSidebar.goalLoop.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Chat sidebar goal-loop ("Loop N/M") subtitle:
+ * a session in an active auto-nudge loop shows its cycle progress composed with
+ * whatever the row would otherwise have said, and gives up the blue "your turn"
+ * dot — a loop appends a turn every cycle, so that dot would light permanently
+ * and stop meaning anything.
+ *
+ * Progress comes from chat.goalLoops, keyed by the BARE slot key (autonudge.py
+ * `binding_key_for` strips the `dashboard:` prefix). Presence in the map IS
+ * "looping": inactive loops are dropped on the way into the store, so a loop
+ * that hit max_cycles leaves no residue here.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+// Legacy single-lane list (no tag columns) keeps the rows flat + easy to query.
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: () => vi.fn().mockResolvedValue([]),
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+const UNREAD_DOT_TITLE = 'Agent finished — your turn'
+
+/** Minimal SubagentActivity — subagentCounts only reads `.status`. */
+const sa = (status: string) => ({ id: `id-${status}-${Math.random()}`, status } as any)
+
+function renderSidebar(
+  slots: any[],
+  chat: Record<string, unknown>,
+  { activeSlotProp = null, unreadSlots = [] }: { activeSlotProp?: string | null; unreadSlots?: string[] } = {},
+) {
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots, updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: { activeSlot: null, slotStatusDetail: {}, subagents: {}, slotActivity: {}, goalLoops: {}, ...chat } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  return render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={activeSlotProp} unreadSlots={unreadSlots}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('chat sidebar — goal-loop progress subtitle', () => {
+  it('shows bounded cycle progress composed with the last message', () => {
+    const slots = [{ key: 'k', title: 'loop', running: false, messages: 5, last_message: 'pulled 24/24 halves' }]
+    const { getByText } = renderSidebar(slots, { goalLoops: { k: { cycle_count: 7, max_cycles: 24 } } })
+    expect(getByText('Loop 7/24')).toBeTruthy()
+    // Composed, not replaced — the last message survives beside the progress.
+    expect(getByText(/pulled 24\/24 halves/)).toBeTruthy()
+  })
+
+  it('drops the denominator for an unlimited loop (max_cycles === 0)', () => {
+    const slots = [{ key: 'k', title: 'loop', running: false, messages: 5 }]
+    const { getByText, queryByText } = renderSidebar(slots, { goalLoops: { k: { cycle_count: 31, max_cycles: 0 } } })
+    expect(getByText('Loop · 31')).toBeTruthy()
+    expect(queryByText(/Loop 31\/0/)).toBeNull()
+  })
+
+  it('is NOT gated on running — a mid-turn loop still shows progress, carrying the live tool status', () => {
+    // The case the feature exists for: a looping session is mid-turn most of the
+    // time, so gating on !running would hide the indicator almost always.
+    const slots = [{ key: 'k', title: 'loop', running: true, messages: 5, last_message: 'stale' }]
+    const { getByText, queryByText } = renderSidebar(
+      slots,
+      { activeSlot: 'k', goalLoops: { k: { cycle_count: 3, max_cycles: 24 } }, slotStatusDetail: { k: { text: 'Reading gateway.log' } } },
+      { activeSlotProp: 'k' },
+    )
+    expect(getByText('Loop 3/24')).toBeTruthy()
+    expect(getByText(/Reading gateway\.log/)).toBeTruthy()
+    expect(queryByText(/stale/)).toBeNull() // live detail wins over last_message
+  })
+
+  it('carries the subagent label as its detail when a wave is running', () => {
+    const slots = [{ key: 'k', title: 'loop', running: false, messages: 5 }]
+    const { getByText } = renderSidebar(slots, {
+      goalLoops: { k: { cycle_count: 9, max_cycles: 24 } },
+      slotActivity: { k: { toolLog: [], subagents: { a: sa('running'), b: sa('running') } } },
+    })
+    expect(getByText('Loop 9/24')).toBeTruthy()
+    expect(getByText(/2 agents running/)).toBeTruthy()
+  })
+
+  it('is outranked by a pending approval — an owed decision must not read as unattended progress', () => {
+    const slots = [{ key: 'k', title: 'loop', running: false, messages: 5, pending_approval: true }]
+    const { getByText, queryByText } = renderSidebar(slots, { goalLoops: { k: { cycle_count: 7, max_cycles: 24 } } })
+    expect(getByText('Needs approval')).toBeTruthy()
+    expect(queryByText('Loop 7/24')).toBeNull()
+  })
+
+  it('suppresses the blue "your turn" dot while looping', () => {
+    const slots = [{ key: 'k', title: 'loop', running: false, messages: 5, last_message: 'cycle output' }]
+    const { queryByTitle } = renderSidebar(
+      slots,
+      { goalLoops: { k: { cycle_count: 7, max_cycles: 24 } } },
+      { unreadSlots: ['k'] },
+    )
+    expect(queryByTitle(UNREAD_DOT_TITLE)).toBeNull()
+  })
+
+  it('keeps the dot and the plain last message when no loop is active', () => {
+    // Guards the suppression against over-reach: an unread, idle, loop-free row
+    // is exactly the case the dot was built for.
+    const slots = [{ key: 'k', title: 'plain', running: false, messages: 5, last_message: 'final answer' }]
+    const { getByText, queryByTitle, queryByText } = renderSidebar(slots, {}, { unreadSlots: ['k'] })
+    expect(queryByTitle(UNREAD_DOT_TITLE)).toBeTruthy()
+    expect(getByText('final answer')).toBeTruthy()
+    expect(queryByText(/^Loop/)).toBeNull()
+  })
+})

--- a/website/src/test/useWebSocketGoalLoopSeed.test.ts
+++ b/website/src/test/useWebSocketGoalLoopSeed.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression: the goal-loop cold seed (`GET /api/autonudge`, fired on every WS
+ * connect) does a FULL REPLACE of `chat.goalLoops`, because loops that ended
+ * while this client was disconnected must disappear.
+ *
+ * The trap this pins: that full replace races the live `autonudge_state` stream.
+ * If a loop's `removed` frame is handled while the seed request is still in
+ * flight, the seed's older snapshot resurrects the dead loop — and because
+ * frames fire only on CHANGE, nothing ever corrects it. The row keeps a phantom
+ * "Loop N/M" subtitle and its unread dot stays suppressed until the next
+ * reconnect. So a seed response must be discarded when a frame landed while it
+ * was in flight.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+
+/** Resolved by hand inside the test so the in-flight window is controllable. */
+let seedDeferred: { resolve: (v: unknown) => void; promise: Promise<unknown> }
+const newDeferred = () => {
+  let resolve!: (v: unknown) => void
+  const promise = new Promise(res => { resolve = res })
+  return { resolve, promise }
+}
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+    autonudgeList: vi.fn(() => seedDeferred.promise),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() { WS_INSTANCES.push(this) }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+const LOOP = { id: 'lp1', slot_key: 'chat-1-1721', message: 'go', idle_secs: 60, max_cycles: 24, cycle_count: 7, active: true, last_fire_ts: 0 }
+
+describe('useWebSocket goal-loop seed vs live frames', () => {
+  let testStore: ReturnType<typeof createTestStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    seedDeferred = newDeferred()
+    testStore = createTestStore({})
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return createElement(Provider, { store: testStore },
+      createElement(QueryClientProvider, { client: qc }, children),
+    )
+  }
+
+  const loops = () => testStore.getState().chat.goalLoops
+
+  it('seeds the map when no frame arrives while the request is in flight', async () => {
+    renderHook(() => useWebSocket(), { wrapper })
+    act(() => { WS_INSTANCES[0].simulateOpen() })
+
+    await act(async () => {
+      seedDeferred.resolve({ enabled: true, loops: [LOOP] })
+      await seedDeferred.promise
+    })
+    expect(loops()['chat-1-1721']).toEqual({ cycle_count: 7, max_cycles: 24 })
+  })
+
+  it('discards a seed response that a `removed` frame superseded mid-flight', async () => {
+    renderHook(() => useWebSocket(), { wrapper })
+    act(() => { WS_INSTANCES[0].simulateOpen() })
+
+    // The loop ends while the seed request is still open.
+    act(() => {
+      WS_INSTANCES[0].simulateMessage({
+        type: 'autonudge_state', data: { event: 'removed', slot: 'chat-1-1721', loop: LOOP },
+      })
+    })
+    expect(loops()['chat-1-1721']).toBeUndefined()
+
+    // The stale snapshot resolves afterwards and must NOT resurrect it.
+    await act(async () => {
+      seedDeferred.resolve({ enabled: true, loops: [LOOP] })
+      await seedDeferred.promise
+    })
+    expect(loops()['chat-1-1721']).toBeUndefined()
+  })
+
+  it('keeps a live `fired` frame rather than reverting it to the seed snapshot', async () => {
+    renderHook(() => useWebSocket(), { wrapper })
+    act(() => { WS_INSTANCES[0].simulateOpen() })
+
+    act(() => {
+      WS_INSTANCES[0].simulateMessage({
+        type: 'autonudge_state',
+        data: { event: 'fired', slot: 'chat-1-1721', loop: { ...LOOP, cycle_count: 9 } },
+      })
+    })
+    await act(async () => {
+      seedDeferred.resolve({ enabled: true, loops: [LOOP] })  // stale cycle_count 7
+      await seedDeferred.promise
+    })
+    expect(loops()['chat-1-1721']).toEqual({ cycle_count: 9, max_cycles: 24 })
+  })
+
+  it('ignores an inactive loop in the seed payload', async () => {
+    renderHook(() => useWebSocket(), { wrapper })
+    act(() => { WS_INSTANCES[0].simulateOpen() })
+
+    await act(async () => {
+      seedDeferred.resolve({ enabled: true, loops: [{ ...LOOP, active: false }] })
+      await seedDeferred.promise
+    })
+    expect(loops()['chat-1-1721']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

A session running a goal loop (`monitor_start` / auto-nudge) appends a turn on
every cycle. That kept the sidebar's blue "your turn" dot permanently lit, so the
dot stopped distinguishing "the agent is waiting on you" from "this session is
grinding away on its own" — and the sidebar gave no way to tell how far through
its cycle budget a loop was without opening the session and the 🎯 popover.

## Why it matters

The blue dot is the sidebar's only "needs you" signal. One looping session
devalues it across every row: users learn to ignore it, and then miss a real
handoff on a different session. Loop progress (`cycle 7/24`) was already tracked
server-side and streamed to the client, but nothing surfaced it per-row.

## Fix (symptom → root cause → change)

**Symptom:** permanently-lit unread dot, no visible loop progress.

**Root cause:** the sidebar had no per-session knowledge of goal loops at all.
`ChatPage` fetched `/api/autonudge/slot/{key}` for the **active slot only**, and
`GET /api/autonudge` (list-all) had no consumer. Meanwhile `AutoNudgeService`
already emitted `_emit("fired", loop)` immediately after each `cycle_count` bump
(`src/kiro_crew/autonudge.py`), and the gateway observer already broadcast
`cycle_count` + `max_cycles` on the `autonudge_state` WS frame. The data was
flowing; only the sidebar was blind to it.

**Change** (frontend-only — no backend edit was needed):

- `chat.goalLoops`: a new Redux map keyed by the **bare** slot key (matching
  `binding_key_for`, which strips the `dashboard:` prefix). Presence in the map
  *is* "looping" — inactive loops are dropped on the way in, so a loop that hit
  `max_cycles` leaves no stale progress behind.
- Cold-seeded from `GET /api/autonudge` on connect **and** reconnect (frames only
  fire on change, so a loop armed before this client connected would otherwise
  show nothing until its next cycle), then kept live by `autonudge_state` frames.
- `ChatSidebar` renders a `Loop N/M` subtitle and suppresses the unread dot while
  a loop is active.

Three judgement calls worth flagging for review:

1. **The loop line is not gated on `running`.** A loop is a *mode*, not a turn
   state, and a looping session is mid-turn most of the time — gating it would
   hide the indicator almost always.
2. **It composes rather than replaces.** `goalLoopDetail` is whatever the row
   *would* have shown, so the line reads `Loop 7/24 · 3 agents running`,
   `Loop 7/24 · Reading gateway.log`, or `Loop 7/24 · <last message>` between
   cycles. This is why the branch can outrank the working signals without
   swallowing them.
3. **Both approval branches still outrank it.** An owed decision must never read
   as unattended progress.

`max_cycles = 0` means unlimited (the `NudgeLoop` default), so there is no
denominator — that case renders `Loop · 31`.

### Two defects found by local review and fixed in this commit

- **Seed/WS ordering race** (`useWebSocket.ts`). The seed does a full replace. If
  a loop's `removed` frame was handled while the seed request was in flight, the
  older snapshot resurrected the dead loop — and because frames fire only on
  change, nothing ever corrected it: a phantom `Loop N/M` suppressing that row's
  unread dot until the next reconnect. Fixed with a generation counter bumped by
  every frame; a seed discards its response if the generation moved.
- **Connect-path fragility** (`useWebSocket.ts`). `seedGoalLoops` runs ahead of
  notification sync and the subagent subscribe, so a throwing `api.autonudgeList`
  stranded both. The seed is now fully best-effort including synchronous throw.

## Tests

- `website/src/test/ChatSidebar.goalLoop.test.tsx` (7) — bounded progress
  composed with the last message; the unlimited (`max_cycles = 0`) form; not
  gated on `running` (carries live tool status); composes the subagent label;
  outranked by a pending approval; suppresses the unread dot; and a negative
  control proving an unread loop-free row keeps its dot and plain last message.
- `website/src/test/useWebSocketGoalLoopSeed.test.ts` (4) — seeds when
  uncontended; **discards a seed superseded mid-flight by a `removed` frame**;
  keeps a live `fired` frame rather than reverting to the stale snapshot; ignores
  an inactive loop in the seed payload.

RED-first verified for both: reverting the sidebar render fails 5 of 7 (the 2 that
pass are the negative controls), and removing the generation guard fails 2 of 4.

## Manual verification

**Not done — flagging it rather than claiming it.** The rendered pixels have not
been observed. The subtitle reuses the exact classes and compose structure of the
`pending_approval` branch a few lines above it in the same ternary, so the visual
risk is low, but low is not verified. Seeing it live needs a pod with
`KIROCREW_AUTONUDGE` set and a loop armed long enough to tick a cycle.

## Screenshots

None — see above. Happy to add them if a reviewer wants the surface confirmed
before merge.

## Out of scope (pre-existing, noted not fixed)

The sibling `workflowActive[s.key]` and `subagentCounts[s.key]` lookups in
`ChatSidebar` read a plain object with a raw slot key, so a `constructor`-shaped
key would resolve to `Object.prototype`. That exists on `main` and is untouched
here; this change's own `goalLoops` read is guarded to stay consistent with the
store's documented `safeKey` convention.

## Note on the earlier zh-CN catalog fixes (now dropped)

An earlier revision of this PR carried nine `zh-CN.json` edits to unblock
`Frontend Tests`, which was failing on three pre-existing catalog guards
(`zhStyle` glossary, `destructiveConfirm` missing verb form, `catalogParity`
plural leftovers). Those failures were reproduced with this branch's own changes
reverted, so they were never caused by this PR.

`main` has since fixed all three itself in #876, which regenerated the catalog:
the glossary keys now read `轮次`, `pages.schedulePage.type_verb_to_confirm`
exists, and the five stray pre-plural keys are gone. After rebasing onto that,
my edits were fully redundant, so they have been **dropped**. This PR is back to
its original scope: six files, all sidebar/store/transport plus two new tests,
and **no i18n or locale file is touched**.
