### PR TITLE
fix(subagent): give queued spawns their real agent id

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -796,6 +796,15 @@ class SubagentInfo:
     task: str
     started: float = field(default_factory=time.time)
     done: bool = False
+    # True for the record returned by a spawn that hit the stagger/concurrency
+    # gate and was QUEUED instead of started. Such a record is not registered in
+    # ``_agents`` and carries no live state — but its ``id`` IS the id the agent
+    # will run under once ``_drain_queue`` starts it (pre-assigned at accept
+    # time), so callers may print it or hold on to it. This flag replaces the old
+    # ``q<n>`` id-prefix sentinel, which signalled "queued" by destroying the
+    # very identity it was reporting on: the drained spawn minted a fresh uuid,
+    # so the id the caller was told never matched the agent that ran.
+    queued: bool = False
     result: str = ""
     result_path: str = ""
     result_truncated: bool = False  # completion-event copy dropped content → summary+path
@@ -2265,6 +2274,7 @@ class SubagentManager:
         batch_id: str = "",
         batch_total: int = 0,
         _from_queue: bool = False,
+        _preassigned_id: str = "",
     ) -> SubagentInfo | None:
         """Spawn a subagent for *task*.
 
@@ -2308,6 +2318,16 @@ class SubagentManager:
         Returns:
             SubagentInfo | None: Agent metadata, or None if at capacity.
         """
+        # Identity is assigned ONCE, here, and used by every exit path — the
+        # queued return, each rejection, and the started record. That is what
+        # makes the id the caller is handed the id it will actually see again:
+        # ``spawn_run`` prints this id into its wave roster, and the dashboard
+        # resolves a wave by matching those printed ids against live per-agent
+        # events. A drained spawn passes the id it was queued under back in via
+        # ``_preassigned_id``, so a member that waits behind the stagger /
+        # concurrency gate keeps its identity across the round-trip instead of
+        # being announced under one id and starting under another.
+        agent_id: str = _preassigned_id or uuid.uuid4().hex[:8]
         # Submission accounting (Arbiter item 2): count this member as
         # submitted BEFORE any rejection or queue/registration branching. A
         # member refused below (empty task, low memory, bad cwd, governance)
@@ -2345,7 +2365,7 @@ class SubagentManager:
             except Exception:
                 logger.debug("SEL audit failed for empty-task rejection", exc_info=True)
             return self._announce_rejection(SubagentInfo(
-                id=uuid.uuid4().hex[:8],
+                id=agent_id,
                 task="",
                 agent=agent,
                 parent_session_key=parent_session_key,
@@ -2381,7 +2401,7 @@ class SubagentManager:
                 },
             )
             info = SubagentInfo(
-                id=uuid.uuid4().hex[:8],
+                id=agent_id,
                 task=_redacted_task,
                 agent=agent,
                 parent_session_key=parent_session_key,
@@ -2414,7 +2434,7 @@ class SubagentManager:
                     metadata={"cwd": cwd[:200], "reason": cwd_err, "task": _redacted_task[:120]},
                 )
                 info = SubagentInfo(
-                    id=uuid.uuid4().hex[:8],
+                    id=agent_id,
                     task=_redacted_task,
                     agent=agent,
                     parent_session_key=parent_session_key,
@@ -2442,7 +2462,7 @@ class SubagentManager:
                 metadata={"agent": agent, "task": _redacted_task[:120]},
             )
             return self._announce_rejection(SubagentInfo(
-                id=uuid.uuid4().hex[:8],
+                id=agent_id,
                 task=_redacted_task,
                 agent=agent,
                 parent_session_key=parent_session_key,
@@ -2455,6 +2475,17 @@ class SubagentManager:
         now = time.monotonic()
         should_queue, slot_free = self._should_stagger_queue(now)
         if should_queue:
+            # Carry this spawn's id (assigned at the top) in the queue entry so
+            # the drained spawn runs under it. The identity must survive the
+            # round-trip because it is the only handle the caller gets: spawn_run
+            # prints the id this call returns, and the inline SubagentRunCard
+            # resolves a wave by matching those printed ids against live
+            # per-agent events. Returning a throwaway sentinel (the old
+            # ``q<n>``) and minting a fresh uuid on drain meant every wave member
+            # after the first was announced under an id no agent ever had — with
+            # the default 2s stagger that is EVERY member after the first, so a
+            # 2-agent wave permanently rendered "1 agent running" while the
+            # sidebar and Subagents panel correctly showed 2.
             self._queue.append(
                 {
                     "task": task,
@@ -2469,6 +2500,7 @@ class SubagentManager:
                     "silent": silent,
                     "batch_id": batch_id,
                     "batch_total": batch_total,
+                    "_preassigned_id": agent_id,
                 }
             )
             logger.info(
@@ -2491,7 +2523,7 @@ class SubagentManager:
                 except RuntimeError:
                     pass  # no running loop (sync/test context)
             info = SubagentInfo(
-                id=f"q{len(self._queue)}", task=_redacted_task, agent=agent,
+                id=agent_id, task=_redacted_task, agent=agent, queued=True,
                 batch_id=batch_id, batch_total=max(0, int(batch_total)),
             )
             return info
@@ -2500,14 +2532,13 @@ class SubagentManager:
             agent, err = _validate_agent(agent)
             if err:
                 info = SubagentInfo(
-                    id=uuid.uuid4().hex[:8], task=_redacted_task, agent="",
+                    id=agent_id, task=_redacted_task, agent="",
                     parent_session_key=parent_session_key,
                     done=True, error=err,
                     batch_id=batch_id, batch_total=max(0, int(batch_total)),
                 )
                 return self._announce_rejection(info)
 
-        agent_id: str = uuid.uuid4().hex[:8]
         info = SubagentInfo(
             id=agent_id,
             task=_redacted_task,
@@ -2709,7 +2740,9 @@ class SubagentManager:
         # spawn() re-checks the gate; since elapsed >= stagger and a slot is
         # free, it starts immediately and updates _last_spawn_ts. Forward the FULL
         # kwarg set so approval_mode / silent / model / allowed_tools / bare survive
-        # the queue round-trip.
+        # the queue round-trip — including `_preassigned_id`, which makes the agent
+        # start under the id its caller was already told (and, if the gate re-queues
+        # it, keeps that id across the second round-trip too).
         self.spawn(**params, _from_queue=True)
         if self._queue and self._running_count < self._max_concurrent:
             try:

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -7,6 +7,7 @@ when configured, gating spawn execution behind user approval.
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -195,7 +196,13 @@ class TestSpawnWithoutApprovalCallback:
         # Assert
         assert first is not None
         assert second is not None  # queued, not rejected
-        assert second.id.startswith("q")  # queued ID prefix
+        assert second.queued is True  # queued, not started
+        # The queued member carries the REAL id it will run under, not a
+        # throwaway sentinel — spawn_run prints this id and the UI resolves the
+        # wave by it, so it must match the agent that eventually starts.
+        assert re.fullmatch(r"[0-9a-f]{8}", second.id)
+        assert manager._queue[0]["_preassigned_id"] == second.id
+        assert first.queued is False
 
 
 class TestSpawnWithApprovalCallback:

--- a/test/test_subagent_cwd.py
+++ b/test/test_subagent_cwd.py
@@ -279,13 +279,16 @@ class TestSpawnCwd:
             info = manager.spawn("t", cwd=str(project))
 
         assert info is not None
-        assert info.id.startswith("q"), "spawn at capacity should have returned a queued id"
+        assert info.queued is True, "spawn at capacity should have been queued"
         # Queue must carry the resolved cwd so dequeue can re-spawn correctly.
         # The queue stores the full spawn() kwarg dict (not a 5-tuple) so a
         # drained spawn preserves approval_mode / silent / model / allowed_tools.
         assert len(manager._queue) == 1
         queued = manager._queue[0]
         assert queued["cwd"] == os.path.realpath(str(project))
+        # ...and the pre-assigned id, so the drained agent runs under the id the
+        # caller was handed.
+        assert queued["_preassigned_id"] == info.id
 
     @pytest.mark.asyncio
     async def test_spawn_fails_closed_when_config_load_raises(

--- a/test/test_subagent_persistence.py
+++ b/test/test_subagent_persistence.py
@@ -353,12 +353,14 @@ class TestSpawnCreatesFolder:
             await manager._tasks[info1.id]
 
         assert info2 is not None
-        # Queued agent ID starts with 'q'
-        assert info2.id.startswith("q")
-        # No folder for queued agent
+        assert info2.queued is True
+        # No folder for a queued agent: the sandbox is created when the agent
+        # actually STARTS, not when it is accepted. Asserted against the queued
+        # member's real id — it no longer carries a `q<n>` name to filter on,
+        # because that sentinel destroyed the identity it was reporting on.
         folders = list(agent_root.iterdir()) if agent_root.exists() else []
-        queued_folders = [f for f in folders if f.name.startswith("q")]
-        assert len(queued_folders) == 0
+        assert not any(f.name == info2.id for f in folders)
+        assert not (agent_root / info2.id).exists()
 
 
 # ── Slice 3: Result streaming to agent folder ────────────────────────

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -400,7 +400,7 @@ class TestQueuedDepthWiring:
             m = _mgr(running=2, max_concurrent=2, last_ts=_t.monotonic())
             m._on_event = on_event
             info = m.spawn(task="x", parent_session_key="dashboard:s1")
-            assert info is not None and info.id.startswith("q")  # queued sentinel
+            assert info is not None and info.queued is True  # queued, not started
             assert len(m._queue) == 1  # actually appended
             await asyncio.sleep(0)
             await asyncio.sleep(0)
@@ -434,6 +434,102 @@ class TestQueuedDepthWiring:
 
         asyncio.run(run())
         assert ("dashboard:s1", 1) in events
+
+
+class TestQueuedIdentityRoundTrip:
+    """A queued member must START under the id its caller was handed.
+
+    Regression: spawn() used to return a throwaway ``q<n>`` sentinel for any
+    spawn that hit the stagger/concurrency gate, and _drain_queue minted a FRESH
+    uuid when it actually started the agent. With the default 2s stagger that is
+    every wave member after the first, so ``spawn_run``'s printed wave roster
+    listed one real id plus N placeholders no agent ever had — the inline
+    SubagentRunCard, which resolves a wave by matching those ids against live
+    per-agent events, could never observe more than one member and reported
+    "1 agent running" for a 2-agent wave the sidebar counted correctly.
+    """
+
+    def test_drained_spawn_reuses_the_announced_id(self, monkeypatch) -> None:
+        import re
+        import time as _t
+        from unittest.mock import MagicMock
+
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub, "_vet_spawn_governance", lambda *a, **k: None)
+
+        m = _mgr(running=1, max_concurrent=16, last_ts=_t.monotonic(), stagger=2.0)
+        info = m.spawn(task="x", parent_session_key="dashboard:s1")
+
+        assert info is not None and info.queued is True
+        assert re.fullmatch(r"[0-9a-f]{8}", info.id), "queued id must be a real agent id"
+
+        # Drain: the gate is open now (stagger elapsed, slot free), so the
+        # popped entry must be re-spawned under the SAME id.
+        m._last_spawn_ts = _t.monotonic() - 10.0
+        m.spawn = MagicMock()  # type: ignore[method-assign]
+        m._drain_queue()
+
+        assert m.spawn.call_count == 1
+        kwargs = m.spawn.call_args.kwargs
+        assert kwargs["_preassigned_id"] == info.id
+        assert kwargs["_from_queue"] is True
+
+    def test_requeue_preserves_the_id(self, monkeypatch) -> None:
+        """A drained spawn that hits the gate AGAIN keeps the same id."""
+        import time as _t
+
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub, "_vet_spawn_governance", lambda *a, **k: None)
+
+        m = _mgr(running=2, max_concurrent=2, last_ts=_t.monotonic(), stagger=2.0)
+        first = m.spawn(task="x", parent_session_key="dashboard:s1")
+        assert first is not None
+
+        # Re-enter spawn() with the id already assigned (what _drain_queue does)
+        # while the gate is still closed → queued a second time, id unchanged.
+        m._queue.clear()
+        again = m.spawn(
+            task="x",
+            parent_session_key="dashboard:s1",
+            _from_queue=True,
+            _preassigned_id=first.id,
+        )
+        assert again is not None and again.queued is True
+        assert again.id == first.id
+        assert m._queue[0]["_preassigned_id"] == first.id
+
+    def test_rejection_on_drain_uses_the_announced_id(self, monkeypatch) -> None:
+        """A member REJECTED when its queued spawn drains is announced under the
+        id its caller was handed, not a fresh one.
+
+        The guards that refuse a spawn (empty task, low memory, bad cwd,
+        governance, bad agent name) re-run on the drain pass, so a spawn accepted
+        at queue time can still be refused when it starts. Minting a fresh uuid
+        there would announce the failure under an id the caller never saw — the
+        same identity break this class of bug is about, just on the error path.
+        """
+        import time as _t
+
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub, "_vet_spawn_governance", lambda *a, **k: None)
+        # Refuse on memory so the guard fires ahead of the queue gate.
+        monkeypatch.setattr(sub, "check_memory_available", lambda min_gb=0: (False, 0.5))
+
+        m = _mgr(running=1, max_concurrent=16, last_ts=_t.monotonic(), stagger=2.0)
+        announced = "deadbeef"
+        info = m.spawn(
+            task="x",
+            parent_session_key="dashboard:s1",
+            _from_queue=True,
+            _preassigned_id=announced,
+        )
+
+        assert info is not None
+        assert info.done and "memory" in info.error
+        assert info.id == announced
 
 
 class TestCpuJiffiesParser:

--- a/website/src/pages/chat/SubagentRunCard.tsx
+++ b/website/src/pages/chat/SubagentRunCard.tsx
@@ -29,7 +29,9 @@ import { i18nT } from '../../i18n/t'
  *  `meta.output`, so historical messages render the card too. */
 const SPAWN_HEADER_RE = /^Spawned (\d+) subagent\(s\)\./m
 /** Agent ids are hex digests from SubagentManager; the agent name is optional
- *  (spawn_run omits the parenthetical when no agent was pinned). */
+ *  (spawn_run omits the parenthetical when no agent was pinned). Non-hex ids are
+ *  skipped, which is what excludes the `q<n>` queue sentinels in scrollback
+ *  persisted before SubagentManager pre-assigned queued members their real id. */
 const SPAWN_AGENT_LINE_RE = /^ {2}([0-9a-f]{4,32})(?: \(([^)]*)\))?: /gm
 
 export interface SpawnRunLaunch {
@@ -162,21 +164,22 @@ const SubagentRunCard = memo(function SubagentRunCard({
   // from the panel). Treat them as neither running nor terminal.
   //
   // The header count is authoritative for the wave size, not `ids.length`:
-  // spawn_run lists one line per accepted agent, and agents still behind the
-  // concurrency cap are listed under a placeholder id (`q1`, `q2` — see
-  // mcp_core.py) that the hex-id pattern deliberately does not match. Taking
-  // the total from `ids` made a 2-agent wave read "1 agent". Tasks that failed
-  // to start are reported in a separate section and never reach the header, so
-  // this does not over-count them.
+  // spawn_run lists one line per accepted agent, and in LEGACY scrollback the
+  // members that were queued behind the concurrency cap / spawn stagger are
+  // listed under a sentinel id (`q1`, `q2`) that the hex-id pattern does not
+  // match. Taking the total from `ids` made a 2-agent wave read "1 agent".
+  // Tasks that failed to start are reported in a separate section and never
+  // reach the header, so this does not over-count them.
   const total = launch.announced || launch.ids.length
   const settled = counts.done + counts.failed + counts.stopped
   // True only when every announced member is observable through `launch.ids`.
-  // It often is not: a wave whose members are queued behind the concurrency cap
-  // (or behind `subagent_spawn_stagger_secs`, which triggers on a 2-task wave in
-  // default config) is announced under placeholder ids `q1`/`q2`, and when those
-  // members actually start they are assigned FRESH ids that never appear in the
-  // launch text. So the card can permanently see fewer members than the header
-  // announced, and must not make a claim about the ones it cannot see.
+  // Waves launched by a current backend always are: SubagentManager pre-assigns
+  // each queued member's real id at accept time and the drained spawn starts
+  // under it, so every announced member appears in the launch text. Two cases
+  // still fall short and must not be claimed on — messages persisted before
+  // that fix (queued members recorded as `q1`/`q2`, with the agent that ran
+  // carrying an id found nowhere in the text), and ids the live slice has since
+  // dropped (history reload, "Dismiss done").
   const fullyObservable = launch.ids.length >= total && counts.unknown === 0
 
   const label = counts.running > 0

--- a/website/src/test/SubagentRunCard.test.tsx
+++ b/website/src/test/SubagentRunCard.test.tsx
@@ -92,11 +92,12 @@ describe('extractSpawnRunLaunch — MCP result envelope', () => {
 })
 
 describe('SubagentRunCard — wave total comes from the header count', () => {
-  // A wave whose members are still behind the concurrency cap (or the spawn
-  // stagger, which fires on a 2-task wave in default config) is announced under
-  // placeholder ids q1/q2 that the hex-id pattern skips, and those members get
-  // FRESH ids when they actually start — so they never become observable to the
-  // card. `ids.length` therefore understates the wave permanently.
+  // LEGACY scrollback only: waves persisted before SubagentManager pre-assigned
+  // queued members their real id recorded those members as `q1`/`q2` (skipped by
+  // the hex-id pattern), and the agents that eventually started carried FRESH
+  // ids absent from the launch text — so they can never become observable to the
+  // card and `ids.length` understates the wave permanently. Current waves list
+  // every member's real id; see the 'fixed backend' case below.
   it('reports the announced total, not the number of parseable ids', () => {
     const store = createTestStore({
       chat: {
@@ -136,6 +137,38 @@ describe('SubagentRunCard — wave total comes from the header count', () => {
     })
     renderWithProviders(<SubagentRunCard launch={{ ids: ['a1', 'a2'], announced: 2 }} slot={SLOT} />, { store })
     expect(screen.getByText('2 agents launched')).toBeTruthy()
+  })
+
+  it('counts every member of a staggered wave now that queued ids are real', () => {
+    // The reported bug, end to end. Observed launch text (chat-9, 02:19:18Z):
+    //   Spawned 2 subagent(s). …
+    //     4fbc9f4b (kirocrew): RESEARCH …
+    //     q1 (kirocrew): RESEARCH …
+    // The second member started 2.0s later (the default spawn stagger) under a
+    // fresh id, 8b2f1e3b, that appeared nowhere in the text — so the card saw one
+    // member and said "1 agent running" while the sidebar and Subagents panel
+    // both correctly said 2. SubagentManager now pre-assigns the queued member's
+    // real id at accept time, so both ids reach the launch text and the card
+    // agrees with the sidebar.
+    const output =
+      'Spawned 2 subagent(s). Results will arrive as completion events:\n' +
+      '  4fbc9f4b (kirocrew): RESEARCH: is react-i18next\u2019s <Trans> still current\n' +
+      '  8b2f1e3b (kirocrew): RESEARCH: what is the current React version\n'
+    const parsed = extractSpawnRunLaunch({
+      role: 'tool', content: '🔧 spawn_run', cls: '', meta: { output },
+    } as ChatMessage)
+    expect(parsed).toEqual({ ids: ['4fbc9f4b', '8b2f1e3b'], announced: 2 })
+
+    const store = createTestStore({
+      chat: {
+        activeSlot: SLOT,
+        subagents: { '4fbc9f4b': agent('4fbc9f4b', 'running'), '8b2f1e3b': agent('8b2f1e3b', 'tool') },
+        subagentQueued: {},
+      } as unknown as ChatState,
+    })
+    renderWithProviders(<SubagentRunCard launch={parsed!} slot={SLOT} />, { store })
+    expect(screen.getByText('2 agents running')).toBeTruthy()
+    expect(screen.queryByText('1 agent running')).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Problem

When two sub-agents are running in one chat, the sidebar row and the Subagents
panel both correctly say **2 agents running** while the inline `spawn_run` card in
the chat transcript says **1 agent running**. Reported from a live session; the
card also showed only one agent id, and clicking it always deep-linked to the same
first agent.

This is not an edge case. With the default `subagent_spawn_stagger_secs = 2.0`,
every wave member after the first is queued, so **every multi-agent wave** is
affected and the card can never report more than one running member.

## Why it matters

The card is the durable record of a wave in scrollback — the transient chip above
the composer drops when the wave ends, and the sidebar subtitle is per-session,
not per-wave. So the one surface that is supposed to tell you what a `spawn_run`
launched was systematically under-reporting it, and disagreeing with two other
surfaces on the same screen. A user watching a 9-agent fan-out saw "1 agent
running" and had no way to tell whether their spawn had actually taken.

## Fix (symptoms → root cause → change)

**Symptom.** Card says 1, sidebar says 2.

**Trace.** The two surfaces have different sources. The sidebar counts the slot's
whole live agent map (`chat.subagents`, fed by `subagent_spawn` WS events), so it
sees both agents. The card resolves *its own* wave by parsing the agent ids out of
the persisted `spawn_run` tool output and matching them against that same map — so
it can only ever count members whose ids appear in that text.

**Root cause.** They did not appear in that text. `SubagentManager.spawn()`
returned a throwaway sentinel id `q{n}` for any spawn that hit the
stagger/concurrency queue gate, and `_drain_queue()` minted a **fresh**
`uuid.uuid4().hex[:8]` when it later actually started that agent. A queued
member's identity was therefore never communicated to its caller. The launch text
from the reported session shows it exactly:

```
Spawned 2 subagent(s). Results will arrive as completion events:
  4fbc9f4b (kirocrew): RESEARCH: is react-i18next's <Trans> still current…
  q1 (kirocrew): RESEARCH: what is the current React version…
```

The second member started 2.0s later — one stagger interval — under `8b2f1e3b`, an
id that appears nowhere in the output. The card's hex-id pattern skips `q1`, so it
parsed one id, counted one running agent, and said so.

**Change.** `spawn()` now assigns the agent id **once**, at the top of the method,
and every exit path uses it: the queued return, each of the five refusal guards,
and the started record. A queued entry carries it as `_preassigned_id`, and the
drained `spawn(**params, _from_queue=True)` starts under it. Queued-ness is now
reported by a new `SubagentInfo.queued` flag instead of by mangling the id — the
old sentinel signalled "queued" by destroying the identity it was reporting on.

The single assignment also matters on the error path: the refusal guards (memory,
cwd, governance, agent name) **re-run on the drain pass**, so a member rejected
when its queued spawn drains used to be announced under an id its caller had never
seen either.

Fixing the backend also fixes, without any frontend logic change, the card's id
preview (it listed one id for an N-agent wave) and its click target (it could only
deep-link to the first member). The `.tsx` change here is comments only.

## Tests

- `test_subagent_sizing.py::TestQueuedIdentityRoundTrip::test_drained_spawn_reuses_the_announced_id`
  — a queued spawn returns a real 8-hex id, and `_drain_queue()` re-spawns it with
  that exact id via `_preassigned_id`. This is the regression.
- `…::test_requeue_preserves_the_id` — a drained spawn that hits the gate a second
  time keeps the same id rather than minting another.
- `…::test_rejection_on_drain_uses_the_announced_id` — a member refused *on the
  drain pass* (low memory) reports the announced id, not a fresh one.
- `SubagentRunCard.test.tsx` — "counts every member of a staggered wave now that
  queued ids are real": parses the real reported launch text with both ids present
  and asserts the card renders `2 agents running`, explicitly not `1 agent
  running`. The two existing legacy cases still pin the `q1` fallback for
  scrollback persisted before this fix.
- Four tests that asserted the `q` id prefix now assert `SubagentInfo.queued`.
  `test_subagent_persistence.py`'s "no folder for a queued agent" moved from
  filtering folder names by `q*` — which could pass vacuously — to an exact-id
  path assertion, so it now actually fails if the member starts.

## Manual verification

Backend-driven behavior change, verified by the unit tests above plus the
production evidence in the trace: the reported session's persisted `spawn_run`
output and the two agent `state.json` records (`4fbc9f4b` at 02:19:18Z,
`8b2f1e3b` at 02:19:20Z) confirm both the placeholder id and the 2.0s stagger
that produced it.

Still worth doing in a pod, since the surface is a rendered count: launch a
2-task `spawn_run` and confirm the inline card reads `2 agents running` in the
steady state, matching the sidebar. During the ~2s stagger ramp the card
legitimately reads `1 agent running` with a `1 waiting` chip — that state is
transient and true, unlike the previous permanent misreport.

Note this only affects **newly launched** waves. Messages already persisted with
`q1` in their launch text keep the legacy fallback ("N agents launched"), which is
retained deliberately and still covered by tests.
