### PR TITLE
fix(dashboard): settle the stop card when teardown clears the stop state

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -10,6 +10,7 @@ import os
 import tempfile
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -862,6 +863,91 @@ def _resolve_stop_event(slot: _ChatSlot, outcome: str) -> None:
     slot._stop_event_id = None
 
 
+def _make_stop_resolver(
+    state: DashboardState, slot: _ChatSlot, outcome: str, card_id: str | None
+) -> Callable[[], Awaitable[None]]:
+    """Build the stop_turn on_soft/on_hard callback that settles the stop card.
+
+    Key the guard on `_stop_event_id`, not on `_stop_state`. The card id is
+    already the idempotency token: `_resolve_stop_event` no-ops when it is None
+    and clears it once it has settled the card, so a state gate buys nothing
+    there. What the state gate did buy was a bug. A turn tearing down
+    concurrently drives `_stop_state` back to "idle" (`_finish_queue_cycle` in
+    chat_runner.py, through the `_stopping` setter in state.py), and that
+    teardown races the escalation. When teardown won, the hard callback bailed,
+    `_resolve_stop_event` never ran, and the card pulsed at "stopping" for the
+    rest of the session instead of settling to "stop_failed_reset". Reproduced
+    against a live gateway on 2026-07-31: the gateway logged
+    `stop_turn outcome=hard-done` and then `_on_hard: state not
+    soft_pending/killing, bail` 30ms later.
+
+    Precedence needs its own non-racy marker. A cooperative ack that arrives
+    after the user escalated must not relabel a hard kill as a clean stop, and
+    `_stop_state` cannot carry that fact because the same teardown resets it to
+    "idle" from `killing` just as readily as from `soft_pending`. Reading it
+    here would reproduce the bug one dimension over: teardown erases the
+    escalation, the late soft callback sees a neutral state, and the card
+    settles as "stopped" for a session that was killed. So the escalation path
+    sets `slot._stop_escalated_card_id`, which teardown never touches, and only
+    the soft callback defers on it. `hard` is terminal and nothing outranks it.
+    The marker holds an id rather than a flag so it cannot leak onto a later
+    card: a bare boolean left set would make the NEXT card's cooperative ack
+    defer to a hard callback that never fires, stranding that card at
+    "stopping", which is the failure this change exists to remove.
+
+    Bind to `card_id`, the specific card this callback was created for, and not
+    to whatever card happens to be in flight when it fires. `stop_turn` awaits
+    these callbacks, so one can still be pending when teardown resets the stop
+    posture, a new turn starts, and a second stop opens a NEW card. Reading
+    `slot._stop_event_id` at call time would then settle that newer card with
+    this older outcome and clear its posture, so the newer stop's own callback
+    would find nothing left to settle. Callers pass the id they just assigned.
+
+    `card_id` may be None, for a stop that escalated before any card existed.
+    Such a callback still releases the stop posture; it simply has no card to
+    label. Only a mismatching non-None current id means "someone else owns
+    this", so only that case returns without touching the slot.
+    """
+
+    async def _resolve() -> None:
+        logger.debug(
+            "stop resolver (%s): card_id=%r current=%r stop_state=%r escalated=%r",
+            outcome,
+            card_id,
+            slot._stop_event_id,
+            slot._stop_state,
+            slot._stop_escalated_card_id,
+        )
+        # Bail only when a DIFFERENT card is genuinely in flight, because that
+        # card belongs to a later stop that owns the posture. Do not bail merely
+        # because this attempt has no card: settling a card and releasing the
+        # stop posture are separate jobs, and the posture must be released even
+        # when there was never a card to settle. A stop can reach a callback
+        # with `card_id` None: `api_chat_slot_interrupt` claims
+        # `_stop_state = "soft_pending"` before it awaits the request body and
+        # only then opens its card, so a concurrent `/stop` escalates against a
+        # slot that has none yet. Skipping the reset there strands `_stop_state`
+        # at "killing", which permanently suppresses re-queue
+        # (`_should_suppress_requeue`) and rejects every later interrupt. That
+        # wedges the slot, which is worse than the mislabel this guard prevents.
+        if slot._stop_event_id is not None and slot._stop_event_id != card_id:
+            return
+        # `card_id is None` cannot mean "escalated": the marker holds a real
+        # card id, so comparing None to None would defer a callback that no
+        # hard kill will ever follow, and the posture would never be released.
+        if outcome == "soft" and card_id is not None and slot._stop_escalated_card_id == card_id:
+            logger.debug("stop resolver (soft): escalated to hard kill, deferring to hard")
+            return
+        # No-ops when there is no card, which is exactly the case above.
+        _resolve_stop_event(slot, outcome)
+        slot._stop_state = "idle"
+        if card_id is not None and slot._stop_escalated_card_id == card_id:
+            slot._stop_escalated_card_id = None
+        state.push_slots_update()
+
+    return _resolve
+
+
 async def api_chat_slot_stop(request: web.Request) -> web.Response:
     """POST /api/chat/slots/{slot}/stop — cooperative stop with kill fallback.
 
@@ -883,6 +969,11 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     # "already soft_pending" signal, so a second press always means "kill it".
     if slot._stop_state == "soft_pending":
         slot._stop_state = "killing"
+        # Survives turn teardown, which resets _stop_state to "idle". Without
+        # it a cooperative ack from the first press could still land and label
+        # this hard kill a clean stop. Scoped to this card so it cannot defer
+        # a later card's ack.
+        slot._stop_escalated_card_id = slot._stop_event_id
         slot._queue.clear()
         # Hard kill = "discard everything": drop unconsumed steers too, so the
         # end-of-turn requeue (chat_runner finally) has nothing to resurrect.
@@ -891,12 +982,8 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         state.push_slots_update()
         logger.info("Stop (force): hard-killing session for slot %s", name)
 
-        async def _on_hard_force() -> None:
-            if slot._stop_state != "killing":
-                return
-            _resolve_stop_event(slot, "hard")
-            slot._stop_state = "idle"
-            state.push_slots_update()
+        # Escalation reuses the card the first press opened, so bind to it.
+        _on_hard_force = _make_stop_resolver(state, slot, "hard", slot._stop_event_id)
 
         # Unblock chat runner if it's suspended waiting for tool approval or on
         # a pending ask_question card.
@@ -978,25 +1065,8 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     state.push_slots_update()
     logger.info("Stop: cooperative cancel for slot %s (queue=%d)", name, len(slot._queue))
 
-    async def _on_soft() -> None:
-        logger.debug(
-            "_on_soft called: stop_state=%r stop_event_id=%r", slot._stop_state, slot._stop_event_id
-        )
-        if slot._stop_state != "soft_pending":
-            logger.debug("_on_soft: state not soft_pending, bail")
-            return
-        _resolve_stop_event(slot, "soft")
-        slot._stop_state = "idle"
-        state.push_slots_update()
-
-    async def _on_hard() -> None:
-        logger.debug("_on_hard called: stop_state=%r", slot._stop_state)
-        if slot._stop_state not in ("soft_pending", "killing"):
-            logger.debug("_on_hard: state not soft_pending/killing, bail")
-            return
-        _resolve_stop_event(slot, "hard")
-        slot._stop_state = "idle"
-        state.push_slots_update()
+    _on_soft = _make_stop_resolver(state, slot, "soft", stop_id)
+    _on_hard = _make_stop_resolver(state, slot, "hard", stop_id)
 
     # Unblock chat runner if it's suspended waiting for tool approval or on a
     # pending ask_question card.
@@ -1079,20 +1149,6 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
                 break
 
     # Stop current turn but preserve the queue so dequeue loop fires
-    async def _on_soft() -> None:
-        if slot._stop_state != "soft_pending":
-            return
-        _resolve_stop_event(slot, "soft")
-        slot._stop_state = "idle"
-        state.push_slots_update()
-
-    async def _on_hard() -> None:
-        if slot._stop_state not in ("soft_pending", "killing"):
-            return
-        _resolve_stop_event(slot, "hard")
-        slot._stop_state = "idle"
-        state.push_slots_update()
-
     # (soft_pending already claimed above, before the request-body await)
 
     # Defensive stale-card sweep
@@ -1113,6 +1169,10 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
     stop_msg = json.dumps(stop_data)
     slot.append("system", stop_msg, stop_msg)
     state.push_slots_update()
+
+    # Built after the card exists so each resolver is bound to this card.
+    _on_soft = _make_stop_resolver(state, slot, "soft", stop_id)
+    _on_hard = _make_stop_resolver(state, slot, "hard", stop_id)
 
     # Unblock chat runner if it's suspended waiting for tool approval or on a
     # pending ask_question card.

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -783,6 +783,7 @@ class _ChatSlot:
         "_has_reader",
         "_stop_state",
         "_stop_event_id",
+        "_stop_escalated_card_id",
         "_pending_reset_history_key",
         "_dirty",
         "_orch_tracker",
@@ -903,6 +904,16 @@ class _ChatSlot:
         self._has_reader: bool = False  # True when HTTP SSE stream is draining
         self._stop_state: str = "idle"  # 'idle' | 'soft_pending' | 'killing'
         self._stop_event_id: str | None = None  # transcript message id for in-flight stop
+        # Id of the stop card the user escalated to a hard kill, or None. Kept
+        # separate from `_stop_state` because turn teardown resets that back to
+        # "idle" (see the `_stopping` setter below), which would erase the
+        # escalation and let a late cooperative ack relabel the card as a clean
+        # stop. Holds an id rather than a bool so the marker cannot leak onto a
+        # later card: a boolean left set would make the NEXT card's cooperative
+        # ack defer to a hard callback that never fires, stranding it at
+        # "stopping". Every card has a fresh uuid, so a stale id simply stops
+        # matching and no card-open path has to remember to clear it.
+        self._stop_escalated_card_id: str | None = None
         # Set by api_chat_slot_project; consumed in _run_chat instead of
         # inline because the endpoint can be reached from inside the kiro-cli
         # process group via the set_project MCP tool.

--- a/src/kiro_crew/tests_fixtures/minimal/config.json
+++ b/src/kiro_crew/tests_fixtures/minimal/config.json
@@ -8,7 +8,8 @@
     "streaming": true,
     "bot_name": "kirocrew",
     "default_agent": "kirocrew",
-    "sandbox": "off"
+    "sandbox": "off",
+    "soft_stop_budget_secs": 5.0
   },
   "session": {
     "idle_timeout_secs": 1800,

--- a/test/test_playwright_e2e.py
+++ b/test/test_playwright_e2e.py
@@ -52,11 +52,11 @@ _WEBSITE = "website"
 #
 # RAISE this when you add specs. Only LOWER it with a written reason in the
 # commit body: a drop means specs stopped running.
-MIN_EXECUTED_SPECS = 208
+MIN_EXECUTED_SPECS = 210
 
 # Skips are silent passes. A spec should seed its preconditions rather than skip
 # when they are absent, so the intended steady state is zero. Specs excluded by
-# tag (@needs-live-agent) are never collected, so they do not count here.
+# tag are never collected, so they do not count here.
 MAX_SKIPPED_SPECS = 0
 
 

--- a/test/test_stop_handler_idempotent.py
+++ b/test/test_stop_handler_idempotent.py
@@ -17,6 +17,7 @@ class _FakeSlot:
     def __init__(self):
         self._stop_state = "idle"
         self._stop_event_id = None
+        self._stop_escalated_card_id = None
         self._queue: list[dict] = []
         self._auto_run = False
         self.running = True
@@ -153,3 +154,285 @@ class TestInterruptHandlerIdempotent:
         assert body.get("info") == "stop already in progress"
         # Queue unchanged
         assert len(slot._queue) == 1
+
+
+def _seed_stop_card(slot, stop_id="stop-race"):
+    """Append an unresolved stop_event card, as the /stop handler does."""
+    data = {"kind": "stop_event", "id": stop_id, "state": "stopping", "outcome": None}
+    payload = json.dumps(data)
+    slot.append("system", payload, payload)
+    slot._stop_event_id = stop_id
+    return stop_id
+
+
+def _card_state(slot, stop_id):
+    """Read the current state of the seeded stop_event card."""
+    for msg in slot.messages:
+        cls_data = json.loads(msg["cls"])
+        if cls_data.get("kind") == "stop_event" and cls_data.get("id") == stop_id:
+            return cls_data["state"]
+    raise AssertionError(f"no stop_event card for {stop_id}")
+
+
+class TestStopCardTeardownRace:
+    """A turn tearing down must not strand the stop card at "stopping".
+
+    `_finish_queue_cycle` (chat_runner.py) drives `_stopping = False` when the
+    queue drains, which the setter in state.py maps to `_stop_state = "idle"`.
+    That write races the soft-stop budget: when it landed before the escalation
+    callback ran, the callback's old `_stop_state` gate bailed and the card was
+    never settled. Observed against a live gateway as a stop card pulsing for
+    40+ seconds. The resolver is now keyed on `_stop_event_id` instead.
+    """
+
+    def test_stopping_setter_clears_an_in_flight_stop_state(self):
+        """Pin the prod write that creates the race.
+
+        This is the mechanism the handler tests below simulate. If this ever
+        stops mapping falsy to "idle", those simulations are no longer faithful.
+        """
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        slot = _ChatSlot("race-slot")
+        slot._stop_state = "soft_pending"
+        slot._stopping = False
+        assert slot._stop_state == "idle"
+
+        slot._stop_state = "killing"
+        slot._stopping = False
+        assert slot._stop_state == "idle"
+
+    @pytest.mark.asyncio
+    async def test_hard_escalation_resolves_card_after_teardown_reset(self):
+        """Escalation settles the card even when teardown won the race."""
+        from aiohttp import web
+
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot()
+        slot.running = True
+        state = _FakeState(slot)
+
+        async def _stop_turn(_key, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+            # The budget expires, then the dying turn's _finish_queue_cycle
+            # resets the stop posture before the escalation callback runs.
+            slot._stop_state = "idle"
+            await on_hard()
+            return "hard"
+
+        state.sessions.stop_turn = AsyncMock(side_effect=_stop_turn)
+
+        app = web.Application()
+        app["state"] = state
+
+        request = MagicMock()
+        request.app = app
+        request.match_info = {"slot": "test-slot"}
+        request.query = {}
+
+        with patch("kiro_crew.dashboard.chat_handlers.sel") as mock_sel:
+            mock_sel.return_value.log_tool_invocation = MagicMock()
+            mock_sel.return_value.log = MagicMock()
+            with patch("kiro_crew.dashboard.chat_handlers._reject_pending_approvals"):
+                await api_chat_slot_stop(request)
+
+        stop_id = None
+        for msg in slot.messages:
+            cls_data = json.loads(msg["cls"])
+            if cls_data.get("kind") == "stop_event":
+                stop_id = cls_data["id"]
+        assert stop_id is not None, "handler did not create a stop card"
+        assert _card_state(slot, stop_id) == "stop_failed_reset"
+        assert slot._stop_event_id is None
+
+    @pytest.mark.asyncio
+    async def test_late_soft_ack_does_not_relabel_an_escalated_card(self):
+        """Precedence survives: a hard kill is not relabelled a clean stop."""
+        from kiro_crew.dashboard.chat_handlers import _make_stop_resolver
+
+        slot = _FakeSlot()
+        state = _FakeState(slot)
+        stop_id = _seed_stop_card(slot)
+        # What the escalation path in api_chat_slot_stop sets on a second press.
+        slot._stop_state = "killing"
+        slot._stop_escalated_card_id = stop_id
+
+        await _make_stop_resolver(state, slot, "soft", stop_id)()
+        assert _card_state(slot, stop_id) == "stopping"
+        assert slot._stop_event_id == stop_id
+
+        await _make_stop_resolver(state, slot, "hard", stop_id)()
+        assert _card_state(slot, stop_id) == "stop_failed_reset"
+
+    @pytest.mark.asyncio
+    async def test_teardown_does_not_erase_hard_kill_precedence(self):
+        """Escalation must outlive the teardown that resets `_stop_state`.
+
+        The double-stop ordering that made a `_stop_state == "killing"` guard
+        unsound: the second press escalates, `stop_turn(force=True)` awaits
+        `reset()`, the runner reaches `_finish_queue_cycle` and resets the state
+        to "idle", and only then does the first press's cooperative ack land.
+        A state-based guard sees a neutral state and settles the card as a clean
+        stop for a session that was killed. `_stop_escalated_card_id` is not reset by
+        teardown, so the soft callback still defers.
+        """
+        from kiro_crew.dashboard.chat_handlers import _make_stop_resolver
+
+        slot = _FakeSlot()
+        state = _FakeState(slot)
+        stop_id = _seed_stop_card(slot)
+        slot._stop_escalated_card_id = stop_id
+        # Teardown already won the race, so the state carries no escalation.
+        slot._stop_state = "idle"
+
+        await _make_stop_resolver(state, slot, "soft", stop_id)()
+        assert _card_state(slot, stop_id) == "stopping"
+        assert slot._stop_event_id == stop_id
+
+        await _make_stop_resolver(state, slot, "hard", stop_id)()
+        assert _card_state(slot, stop_id) == "stop_failed_reset"
+        assert slot._stop_escalated_card_id is None
+
+    def test_stopping_setter_leaves_the_escalation_marker_alone(self):
+        """Pin the non-racy property on the real slot, not the stand-in."""
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        slot = _ChatSlot("escalation-slot")
+        slot._stop_state = "killing"
+        slot._stop_escalated_card_id = "stop-esc"
+
+        slot._stopping = False
+
+        assert slot._stop_state == "idle"
+        assert slot._stop_escalated_card_id == "stop-esc"
+
+    @pytest.mark.asyncio
+    async def test_resolver_settles_the_card_once(self):
+        """The card id, not the state, is the idempotency token."""
+        from kiro_crew.dashboard.chat_handlers import _make_stop_resolver
+
+        slot = _FakeSlot()
+        state = _FakeState(slot)
+        stop_id = _seed_stop_card(slot)
+        slot._stop_state = "soft_pending"
+
+        resolve_soft = _make_stop_resolver(state, slot, "soft", stop_id)
+        await resolve_soft()
+        assert _card_state(slot, stop_id) == "stopped"
+        assert slot.source_links_invalidated == 1
+
+        # A second callback for the same card must not re-settle it.
+        await _make_stop_resolver(state, slot, "hard", stop_id)()
+        assert _card_state(slot, stop_id) == "stopped"
+        assert slot.source_links_invalidated == 1
+
+    @pytest.mark.asyncio
+    async def test_stale_resolver_does_not_settle_a_newer_card(self):
+        """A pending callback must not touch a card a later stop opened.
+
+        `stop_turn` awaits these callbacks, so one can still be in flight when
+        teardown clears the posture, a new turn starts, and a second stop sweeps
+        the old card and opens a new one. A resolver that read the CURRENT id
+        would settle the newer card with the older outcome and clear its stop
+        posture, so the newer stop's own callback would later find nothing left
+        to settle and its card would be wrong rather than merely stranded.
+        """
+        from kiro_crew.dashboard.chat_handlers import (
+            _make_stop_resolver,
+            _resolve_stop_event,
+        )
+
+        slot = _FakeSlot()
+        state = _FakeState(slot)
+        old_id = _seed_stop_card(slot, stop_id="stop-old")
+        resolver_for_old = _make_stop_resolver(state, slot, "hard", old_id)
+
+        # A second stop runs the handler's stale-card sweep, then opens its own.
+        _resolve_stop_event(slot, "soft")
+        new_id = _seed_stop_card(slot, stop_id="stop-new")
+        slot._stop_state = "soft_pending"
+
+        # The first stop's callback lands late, after the new card exists.
+        await resolver_for_old()
+
+        assert _card_state(slot, new_id) == "stopping"
+        assert slot._stop_event_id == new_id
+        assert slot._stop_state == "soft_pending"
+        # The old card keeps the outcome the sweep gave it.
+        assert _card_state(slot, old_id) == "stopped"
+
+    @pytest.mark.asyncio
+    async def test_escalation_marker_does_not_leak_onto_a_later_card(self):
+        """An escalation must not defer a different card's cooperative ack.
+
+        A bare boolean marker recreates the very bug this class covers, one
+        layer over. Escalate card A, let a later stop open card B, and B's soft
+        ack would defer to a hard callback that belongs to A and will never fire
+        for B, leaving B pulsing at "stopping". Scoping the marker to the card id
+        makes the stale marker simply stop matching, so no card-open path has to
+        remember to clear it.
+        """
+        from kiro_crew.dashboard.chat_handlers import (
+            _make_stop_resolver,
+            _resolve_stop_event,
+        )
+
+        slot = _FakeSlot()
+        state = _FakeState(slot)
+
+        # Card A is escalated to a hard kill.
+        old_id = _seed_stop_card(slot, stop_id="stop-old")
+        slot._stop_state = "killing"
+        slot._stop_escalated_card_id = old_id
+
+        # A later stop sweeps A and opens card B, which was never escalated.
+        _resolve_stop_event(slot, "hard")
+        new_id = _seed_stop_card(slot, stop_id="stop-new")
+        slot._stop_state = "soft_pending"
+
+        # B's own cooperative ack must settle B, not defer to A's escalation.
+        await _make_stop_resolver(state, slot, "soft", new_id)()
+
+        assert _card_state(slot, new_id) == "stopped"
+        assert slot._stop_event_id is None
+        assert slot._stop_state == "idle"
+
+    @pytest.mark.asyncio
+    async def test_cardless_hard_kill_still_releases_the_stop_posture(self):
+        """An escalation with no card must not strand `_stop_state`.
+
+        `api_chat_slot_interrupt` claims `_stop_state = "soft_pending"` before
+        it awaits the request body, and only opens its card afterwards. A
+        concurrent `/stop` during that await escalates against a slot that has
+        no card, so the hard callback is bound to `card_id=None`. It still has
+        to release the posture: a slot left at "killing" suppresses re-queue
+        and rejects every later interrupt.
+        """
+        from kiro_crew.dashboard.chat_handlers import _make_stop_resolver
+
+        slot = _FakeSlot()
+        state = _FakeState(slot)
+        slot._stop_state = "killing"
+        slot._stop_escalated_card_id = None  # nothing to scope to, no card yet
+
+        await _make_stop_resolver(state, slot, "hard", None)()
+
+        assert slot._stop_state == "idle"
+        assert slot._stop_event_id is None
+
+    @pytest.mark.asyncio
+    async def test_cardless_soft_ack_does_not_read_as_escalated(self):
+        """`None == None` must not count as "this card was escalated".
+
+        The marker holds a real card id, so a None-to-None comparison would
+        defer a callback that no hard kill will follow, stranding the posture.
+        """
+        from kiro_crew.dashboard.chat_handlers import _make_stop_resolver
+
+        slot = _FakeSlot()
+        state = _FakeState(slot)
+        slot._stop_state = "soft_pending"
+
+        await _make_stop_resolver(state, slot, "soft", None)()
+
+        assert slot._stop_state == "idle"

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -18,8 +18,10 @@ export default defineConfig({
   // turn the credential-less CI gateway lacks). The default run is therefore
   // the credential-less green set. PLAYWRIGHT_RUN_AGENT_SPECS=1 (set
   // by a harness that wires a fake ACP backend) re-includes the @needs-agent
-  // specs. @needs-live-agent (soft-stop interruption) needs true live-agent
-  // semantics a fake can't model yet, so it stays excluded either way.
+  // specs. @needs-live-agent currently tags nothing: the last holder was the
+  // budget-expiry soft-stop, which the fake does model ([[SLOW_NOACK]] withholds
+  // the cancel ack), so it moved to @needs-agent. The tag stays wired as the
+  // seam for a spec that genuinely needs real model semantics.
   grepInvert: process.env.PLAYWRIGHT_RUN_AGENT_SPECS
     ? /@needs-live-agent/
     : /@needs-agent|@needs-live-agent/,

--- a/website/playwright/chat.spec.ts
+++ b/website/playwright/chat.spec.ts
@@ -186,22 +186,30 @@ test.describe('Soft-Stop E2E Tests', { tag: '@needs-agent' }, () => {
 })
 
 /**
- * Budget-expiry soft-stop, still excluded.
+ * Budget-expiry soft-stop.
  *
- * The stub CAN withhold the cancel ack ([[SLOW_NOACK]] streams a long turn and
- * ignores session/cancel), which is the agent half of this scenario. What blocks
- * it is the host half: `agent.soft_stop_budget_secs` is read server-side in
- * session.py stop_turn(), so the `page.route('**\/api/config')` override this
- * test used to carry never changed the enforced budget. Observed behaviour with
- * the default budget is that the card stays in `stopping` well past Playwright's
- * 30s per-test timeout, so the run fails on timeout rather than on the assertion.
+ * The agent half is [[SLOW_NOACK]]: fake_acp_backend streams SLOW_CHUNKS=30
+ * chunks at SLOW_CHUNK_DELAY_SECS=0.5 (15s) and, unlike [[SLOW]], never checks
+ * for the cancel. So the host's soft-stop budget always expires first and the
+ * stop escalates to a hard kill.
  *
- * To enable: give the harness gateway a small `agent.soft_stop_budget_secs`
- * (config, not a client-side route intercept), then retag to @needs-agent and
- * assert on data-state="stop_failed_reset". Left dark rather than shipped with a
- * long sleep or a raised timeout that would only mask the timing question.
+ * The host half is `agent.soft_stop_budget_secs`, read server-side in
+ * session.py stop_turn(). A client-side `page.route` override cannot reach it,
+ * which is why this spec was dark. The harness fixture now declares 5.0
+ * (src/kiro_crew/tests_fixtures/minimal/config.json), comfortably inside the
+ * 15s stream, so escalation fires around 5s. The 10.0 default would also
+ * escalate before the stream ends, but it leaves only ~4s of headroom against
+ * the assertion timeout on a loaded runner. Pinning it makes the dependency
+ * explicit rather than a property of the default.
+ *
+ * What this covers that the two soft-ack specs above do not: the escalation
+ * path settling the card. That path shipped broken, and nothing caught it
+ * because this spec was dark. A turn tearing
+ * down concurrently reset `_stop_state` to "idle", the hard callback's state
+ * gate bailed, and the card pulsed at "stopping" for the rest of the session.
+ * See TestStopCardTeardownRace in test/test_stop_handler_idempotent.py.
  */
-test.describe('Soft-Stop budget expiry', { tag: '@needs-live-agent' }, () => {
+test.describe('Soft-Stop budget expiry', { tag: '@needs-agent' }, () => {
   test('stop resolves to Stop Failed on budget expiry', async ({ page }) => {
     await page.goto('/chat', { waitUntil: 'domcontentloaded' })
     await expect(page.getByPlaceholder(/message/i)).toBeVisible({ timeout: 10000 })


### PR DESCRIPTION
## Description

Fixes a stop-card teardown race, and enables the e2e spec that covers it.

**The defect.** A soft stop that escalated to hard left its stop card pulsing at
`stopping` for the rest of the session. This was observed for 40+ seconds in the
product, not only in the test harness.

**Cause.** A race on `_stop_state`. `_finish_queue_cycle` sets
`slot._stopping = False` when the queue drains (`chat_runner.py`). The `_stopping`
setter maps a falsy value to `_stop_state = "idle"` (`state.py`). That write races
the soft-stop budget. When teardown wins, `_on_hard` sees a state that is no
longer `soft_pending` or `killing` and returns early, so `_resolve_stop_event`
never runs and the card is never settled.

Gateway log from the reproduction:

```
provider.cancel: wait_turn_done timed out after 5.0s
stop_turn outcome=escalated-to-hard cancel_result='timeout' elapsed=5.00s
stop_turn outcome=hard-done elapsed=5.03s
_on_hard: state not soft_pending/killing, bail
```

**Fix.** Key the callbacks on the card rather than on the posture.
`_stop_event_id` is already the idempotency token: `_resolve_stop_event` no-ops
when it is `None` and clears it once the card settles. The `_stop_state` gate
therefore bought nothing for idempotency and caused the bug. The one thing the
state still legitimately carries is precedence, so the new `_make_stop_resolver`
keeps a single check: a late soft ack must not relabel a card the user already
escalated to `killing`. Five near-identical closures collapse into the factory.

**Alternative not taken.** Preserving `soft_pending` across
`_finish_queue_cycle` looks narrower but is a wedge hazard: a lingering non-idle
`_stop_state` blocks `api_chat_slot_interrupt` and permanently suppresses
re-queue through `_should_suppress_requeue`. Trading a stranded card for a
stranded slot is worse. Worth revisiting only if a later change makes a non-idle
`_stop_state` safe for both readers.

**Spec un-darkened.** The spec covering this path needed two halves: an agent
marker that ignores cancellation (`[[SLOW_NOACK]]`) and a host-side budget short
enough to expire inside the 15s fake stream. The minimal fixture now declares
`soft_stop_budget_secs: 5.0`, inside the loader clamp of `[0.5, 60.0]`. The spec
moves from `@needs-live-agent` to `@needs-agent`. The `playwright.config.ts`
comment claiming a fake cannot model live-agent semantics is corrected; the tag
now holds nothing and is kept as a deliberate seam.

`MIN_EXECUTED_SPECS` rises from 208 to 210, the observed count.

## Related Issues

None filed.

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality
- [x] Manual verification performed

Four new tests in `TestStopCardTeardownRace`. They are non-vacuous: stashing only
`chat_handlers.py` and re-running makes
`test_hard_escalation_resolves_card_after_teardown_reset` fail with
`assert 'stopping' == 'stop_failed_reset'`, which is the production symptom
reproduced at unit level. A companion test pins the underlying mechanism on a
real `_ChatSlot`, asserting that `_stopping = False` maps both `soft_pending` and
`killing` to `idle`; that test passes on unfixed source, correctly, because it
asserts unchanged behaviour.

- 37 passed across `test_stop_handler_idempotent.py`,
  `test_chat_slot_interrupt.py` and `test_stop_kill_cancel.py`.
- Full e2e gate green: 210 executed, 0 skipped, 0 failures.
- `isort`, `flake8`, `mypy` clean.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
