### PR TITLE
fix(chat): make a channel session and its dashboard tab one session

### DIFF
--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -8,37 +8,57 @@ in the sidebar's collapsed **History** pane, where the user had to search for
 one and resume it by hand.
 
 This module reconciles recent channel sessions INTO slots so they show up in
-the active chat list, seeded with the conversation so far and ready to continue.
+the active chat list, and binds each one as **one session with two surfaces**:
+the same conversation, readable and repliable from either the dashboard tab or
+the channel it started in.
 
 Design notes:
 
-* **One history key, no split.** The slot is an ordinary dashboard slot whose
-  key is derived from the channel session key
-  (``slack:1785370133.085469`` -> ``slack_1785370133.085469``), so everything
-  about it — turn persistence, replay, the ``closed`` flag, and both restore
-  paths — uses the single ``dashboard:<slot.key>`` history key.
+* **One session, one transcript — the channel's.** The slot's
+  ``shared_session_key`` is set to the channel session key, so the transcript is
+  READ, WRITTEN and RUN under that single key (see
+  :func:`~kiro_crew.dashboard.chat_utils.slot_transcript_key`). There is no
+  second ``dashboard:<slot.key>`` file to diverge from, and therefore no
+  mirroring or sync step: both surfaces append to the same file.
 
-  It deliberately does NOT set ``linked_session_key`` to the channel key.
-  ``_save_slot_to_history`` is hard-wired to ``_history_key_for(slot.key)``,
-  so binding the RUN path to the channel key while the SAVE path kept writing
-  ``dashboard:<slot.key>`` would split one conversation across two transcripts:
-  a dashboard reply would be invisible to the slot's own replay, and a tab the
-  user closed would have its ``closed`` flag written to a key the reconciler
-  never reads — so it would reopen on the next pass. Continuity with the live
-  channel session is not worth that; picking the conversation up with its full
-  history (which this does) is the point.
+  This replaces an earlier design in which the slot owned its own transcript and
+  was seeded with a COPY of the channel conversation. That copy was frozen at
+  the moment of surfacing — a thread that stayed live on the channel left the tab
+  showing only the turns that existed on the first reconcile pass, and a reply
+  typed into the tab answered from that stale window and never reached the
+  channel. The single-key binding is what removes both failures.
+
+* **Inbound channel replies run the slot's turn.** A surfaced Slack thread is
+  registered via :meth:`DashboardState.link_slack`, so
+  ``slack.handler.maybe_route_linked_thread`` hands an inbound reply to this
+  slot and runs it through the dashboard turn path instead of Slack's own. That
+  keeps ONE running turn per conversation, guarded by the single per-session
+  semaphore, and gives the channel the dashboard's streaming mirror for free.
+
+* **The window live-follows until the user takes over.** While a surfaced slot is
+  neither dirty nor running, every pass re-reads the shared transcript and
+  refreshes the in-memory window and the frozen-prefix counters
+  (:func:`resync_channel_slot`). This keeps the tab current for a conversation
+  still moving on the channel, and — critically — keeps ``_disk_older_count``
+  honest, since a stale count would make the next save rewrite the file from an
+  out-of-date snapshot and drop turns appended in the meantime.
+
 * **Recency-bounded.** Only sessions modified within the dashboard's configured
   ``restore_window_minutes`` become slots, so a long DM history does not turn
   into hundreds of tabs. Pinned and foldered sessions are exempt from the
   window, matching :func:`~kiro_crew.dashboard.chat_persistence.restore_recent_sessions`.
 * **Closed is sticky.** A session the user closed on the dashboard
   (``meta.closed``) is never re-surfaced — otherwise closing the tab would be
-  undone on the next reconcile pass.
+  undone on the next reconcile pass. Because the slot now writes ``closed`` to
+  the channel key, the two-key read below is load-bearing rather than defensive:
+  it also honors the legacy ``dashboard:``-keyed flag written by the old design.
 * **Ephemeral stays ephemeral.** ``incognito``/``temporary`` channel threads are
   skipped: the user asked for a conversation that leaves no trace, and a
   durable sidebar tab contradicts that.
-* **Idempotent.** Every pass is a no-op for sessions that already own a slot,
-  so it is safe to run on a timer.
+* **Idempotent.** Every pass re-asserts the binding for sessions that already
+  own a slot rather than creating a second one, so it is safe to run on a timer
+  and self-heals after a gateway restart (the ``_slack_to_slot`` index is
+  in-memory only).
 """
 
 from __future__ import annotations
@@ -86,11 +106,12 @@ _HYDRATE_LIMIT = 50
 
 
 class _Transcript(NamedTuple):
-    """A pending slot's seed transcript plus its on-disk line accounting.
+    """A slot's seed transcript plus the shared file's line accounting.
 
-    ``disk_older`` + ``disk_window`` always sum to the length of the slot's own
-    history file; the merged ``messages`` may be longer because it also carries
-    channel-side turns that file never held.
+    ``disk_older`` + ``disk_window`` always sum to the length of the CHANNEL
+    transcript — the file a surfaced slot shares and writes. The merged
+    ``messages`` may be longer because it also folds in turns left behind in a
+    legacy ``dashboard:``-keyed file by the previous copy-based design.
     """
 
     messages: list[dict[str, Any]]
@@ -115,12 +136,38 @@ def channel_slot_name(session_key: str) -> str:
 
 
 def slot_history_key(session_key: str) -> str:
-    """Return the history key the surfaced slot persists under.
+    """The LEGACY ``dashboard:``-keyed transcript for a channel session.
 
-    This is the ONLY key the slot reads or writes: turn persistence, replay, the
-    ``closed`` flag, and both restore paths all agree on it.
+    Under the current single-session design a surfaced slot reads and writes the
+    channel key itself, so this file is not written any more. It is still read on
+    two paths: the ``closed`` flag a tab dismissed under the old design wrote
+    here, and :func:`reconcile_channel_slots`' one-time merge of turns a
+    dashboard reply left in this file before the migration.
     """
     return _history_key_for(channel_slot_name(session_key))
+
+
+def channel_key_for_slot_name(slot_name: str, sessions: list[dict[str, Any]]) -> str:
+    """The channel session key whose slot name is *slot_name*, or ``""``.
+
+    An EXACT reverse lookup over *sessions* rather than a string transform:
+    ``_normalize_slot_key`` folds every non-word char to ``_``, so a key with
+    inner separators (``telegram:kirocrew:direct:9:gen3``) cannot be recovered
+    from its slot name by substitution. Comparing forward-normalized candidates
+    is lossless for every namespace, and cheap — the restore paths only reach
+    this when a slot has no legacy transcript of its own.
+
+    Accepts either key spelling ``list_sessions`` serves (``slack:1.1`` or the
+    ``slack_1.1`` filename stem); both fold to the same slot name, and both
+    resolve to the same transcript file via ``history._safe_key``.
+    """
+    if not slot_name:
+        return ""
+    for s in sessions:
+        key = s.get("key", "")
+        if key and is_channel_session_key(key) and channel_slot_name(key) == slot_name:
+            return key
+    return ""
 
 
 def _redact(text: str) -> str:
@@ -297,9 +344,9 @@ def surface_channel_session(
 
     *messages* is the merged transcript to seed the slot with, read by the caller
     so the disk IO stays off the event loop. *disk_older* and *disk_window* are
-    that caller's split of the slot's OWN on-disk lines into the frozen prefix
-    the window does not carry and the region it re-serializes — see
-    :func:`frozen_prefix_len` for why a save needs both.
+    that caller's split of the CHANNEL transcript — the file this slot now shares
+    — into the frozen prefix the window does not carry and the region it
+    re-serializes; see :func:`frozen_prefix_len` for why a save needs both.
     """
     session_key = session_info.get("key", "")
     if not session_key or not is_channel_session_key(session_key):
@@ -348,19 +395,108 @@ def surface_channel_session(
         )
     slot.drain()
     slot._resumed_count = len(slot.messages)
-    # The session file is frozen prefix + live window. Only the slot's OWN
-    # on-disk lines count toward either: the merged window also carries
-    # channel-side turns that were never in this file, and crediting those as
-    # persisted would let a trim fold unwritten turns into the frozen prefix.
+    # The shared session file is frozen prefix + live window, and the file the
+    # slot now writes IS the channel transcript — so both counts are measured
+    # against the CHANNEL side of the merge. Crediting legacy dashboard-keyed
+    # turns here would let a trim fold lines that are not in this file into its
+    # frozen prefix, and the next save would rewrite the file short.
     slot._disk_older_count = disk_older
     slot._disk_window_len = disk_window
+    # One session, two surfaces: read, write and run all resolve to the channel
+    # key from here on. This is what makes the tab a live view of the channel
+    # conversation rather than a copy of it.
+    slot.shared_session_key = session_key
     # Not dirty: a surfaced conversation the user never touches costs no write.
-    # The first real dashboard turn is what persists it under the slot key.
+    # The first real turn on either surface is what persists it.
     slot._dirty = False
     logger.info(
         "Surfaced %s session %s as slot %s", channel_label(session_key), session_key, slot_name
     )
     return slot
+
+
+def resync_channel_slot(
+    slot: "_ChatSlot",
+    messages: list[dict[str, Any]],
+    *,
+    disk_older: int,
+    disk_window: int,
+) -> bool:
+    """Refresh an already-surfaced slot's window from the shared transcript.
+
+    Returns ``True`` when the slot changed. A no-op when the slot is dirty or
+    running: the user (or a turn on either surface) owns the window then, and
+    replacing it would drop unsaved turns.
+
+    This is what keeps a tab current for a conversation still moving on the
+    channel — and it is also a correctness requirement, not just freshness. The
+    frozen-prefix counters are a snapshot of the shared file; if the channel side
+    appends while they go stale, the next save rewrites the file from
+    ``meta + frozen + window`` and silently drops everything appended past the
+    snapshot.
+    """
+    if slot._dirty or slot.running:
+        return False
+    window = hydrate_window(messages)
+    if len(window) == len(slot.messages) and all(
+        _identity(a) == _identity(b) for a, b in zip(window, slot.messages)
+    ):
+        # Already current — do not churn a broadcast every 30s.
+        slot._disk_older_count = disk_older
+        slot._disk_window_len = disk_window
+        return False
+    slot.messages.clear()
+    for msg in window:
+        role = msg.get("role", "assistant")
+        content = _redact(msg.get("content", ""))
+        slot.append(
+            role,
+            content,
+            f"msg msg-{'a' if role != 'user' else 'u'}",
+            ts=msg.get("ts", ""),
+            broadcast=False,
+        )
+    slot.drain()
+    slot._resumed_count = len(slot.messages)
+    slot._disk_older_count = disk_older
+    slot._disk_window_len = disk_window
+    slot._dirty = False
+    return True
+
+
+def _bind_slack_thread(state: "DashboardState", session_key: str, slot_name: str) -> None:
+    """Register a surfaced Slack slot so inbound thread replies run ITS turn.
+
+    ``slack.handler.maybe_route_linked_thread`` looks the slot up by the BARE
+    ``thread_ts`` in ``state._slack_to_slot``; once bound, an inbound reply is
+    appended to this slot and dispatched through the dashboard turn path instead
+    of Slack's own ``handle_message`` loop, so the conversation has exactly one
+    running turn and one transcript.
+
+    ``link_slack`` is reused verbatim rather than reimplemented: it owns evicting
+    a stale thread mapping, stealing the thread from a previous owner slot, and
+    persisting the binding to the session map. Called on every pass because
+    ``_slack_to_slot`` is in-memory and does not survive a gateway restart.
+    """
+    if channel_namespace_of(session_key) != "slack":
+        return
+    thread_ts = session_key.split(":", 1)[1] if ":" in session_key else ""
+    if not thread_ts:
+        return
+    slot = state._slots.get(slot_name)
+    if slot is not None and slot._slack_linked and slot._slack_thread_ts == thread_ts:
+        return  # already bound — link_slack would only re-broadcast
+    channel_id = ""
+    if state.sessions is not None:
+        try:
+            _ts, _chan = state.sessions.get_slack_link(session_key)
+            channel_id = _chan or ""
+        except Exception:
+            channel_id = ""
+    try:
+        state.link_slack(slot_name, thread_ts, channel_id)
+    except Exception:
+        logger.debug("channel reconcile: link_slack failed for %s", slot_name, exc_info=True)
 
 
 async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) -> int:
@@ -388,8 +524,9 @@ async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) 
 
     def _load_meta() -> dict[str, dict[str, Any]]:
         out: dict[str, dict[str, Any]] = {}
-        # Both the channel key and the slot key: the slot key is where a closed
-        # tab records `closed`, and skipping it would resurface it every pass.
+        # Both the channel key and the legacy slot key: a tab closed under the
+        # old design recorded `closed` on the latter, and skipping it would
+        # resurface it every pass.
         for s in candidates:
             for key in (s.get("key", ""), slot_history_key(s.get("key", ""))):
                 if not key or key in out:
@@ -402,51 +539,69 @@ async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) 
 
     metadata = await loop.run_in_executor(None, _load_meta)
     eligible = eligible_channel_sessions(candidates, metadata=metadata, cutoff=cutoff)
-    # Skip transcript reads for sessions that already own a slot — the steady state.
-    pending = [s for s in eligible if channel_slot_name(s.get("key", "")) not in state._slots]
-    if not pending:
+    if not eligible:
         return 0
 
     def _load_messages() -> dict[str, _Transcript]:
         out: dict[str, _Transcript] = {}
-        for s in pending:
+        for s in eligible:
             key = s.get("key", "")
-            try:
-                slot_msgs = log.read_messages(slot_history_key(key))
-            except Exception:
-                slot_msgs = []
             try:
                 chan_msgs = log.read_messages(key)
             except Exception:
                 chan_msgs = []
-            merged = merge_transcripts(slot_msgs, chan_msgs)
-            # Split the slot's own on-disk lines here, in the executor, while
-            # both sides are still separable — after the merge they are not.
-            older = frozen_prefix_len(slot_msgs, hydrate_window(merged))
-            out[key] = _Transcript(merged, older, max(0, len(slot_msgs) - older))
+            try:
+                legacy_msgs = log.read_messages(slot_history_key(key))
+            except Exception:
+                legacy_msgs = []
+            # The channel transcript is the slot's own file now; a legacy
+            # dashboard-keyed file only exists for conversations surfaced by the
+            # previous design, and its turns are folded in once so migrating
+            # loses nothing.
+            merged = merge_transcripts(legacy_msgs, chan_msgs)
+            older = frozen_prefix_len(chan_msgs, hydrate_window(merged))
+            out[key] = _Transcript(merged, older, max(0, len(chan_msgs) - older))
         return out
 
     transcripts = await loop.run_in_executor(None, _load_messages)
 
-    surfaced = 0
-    for s in pending:
+    changed = 0
+    for s in eligible:
         key = s.get("key", "")
         transcript = transcripts.get(key) or _Transcript([], 0, 0)
+        slot_name = channel_slot_name(key)
         try:
-            if surface_channel_session(
-                state,
-                s,
-                metadata.get(key) or {},
-                transcript.messages,
-                disk_older=transcript.disk_older,
-                disk_window=transcript.disk_window,
-            ):
-                surfaced += 1
+            existing = state._slots.get(slot_name)
+            if existing is None:
+                if surface_channel_session(
+                    state,
+                    s,
+                    metadata.get(key) or {},
+                    transcript.messages,
+                    disk_older=transcript.disk_older,
+                    disk_window=transcript.disk_window,
+                ):
+                    changed += 1
+            else:
+                # Self-heal a slot that predates this binding (or a restart that
+                # dropped it), then live-follow the shared transcript.
+                if not existing.shared_session_key:
+                    existing.shared_session_key = key
+                    changed += 1
+                if resync_channel_slot(
+                    existing,
+                    transcript.messages,
+                    disk_older=transcript.disk_older,
+                    disk_window=transcript.disk_window,
+                ):
+                    changed += 1
+            if slot_name in state._slots:
+                _bind_slack_thread(state, key, slot_name)
         except Exception:
-            logger.warning("channel reconcile: failed to surface %s", key, exc_info=True)
-    if surfaced:
+            logger.warning("channel reconcile: failed to reconcile %s", key, exc_info=True)
+    if changed:
         state.push_slots_update()
-    return surfaced
+    return changed
 
 
 async def channel_slot_reconciler(state: "DashboardState", window_minutes: int) -> None:

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -8,7 +8,11 @@ from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
-from kiro_crew.dashboard.chat_utils import _history_key_for, _sync_dashboard_slots
+from kiro_crew.dashboard.chat_utils import (
+    _history_key_for,
+    _sync_dashboard_slots,
+    slot_transcript_key,
+)
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -133,7 +137,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     async with slot._fork_lock:
         all_messages: list[dict] = []
         if state.conversation_log:
-            all_messages = state.conversation_log.read_messages_chained(_history_key_for(slot.key))
+            all_messages = state.conversation_log.read_messages_chained(slot_transcript_key(slot))
         if all_messages and slot._dirty:
             new_msgs = slot.messages[slot._resumed_count:]
             if new_msgs:

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -46,6 +46,8 @@ from kiro_crew.dashboard.chat_utils import (
     _redact_for_display,
     _remove_queued_by_id,
     _sync_dashboard_slots,
+    slot_session_key,
+    slot_transcript_key,
 )
 from kiro_crew.dashboard.state import (
     _MAX_PENDING_CONTEXT,
@@ -610,7 +612,7 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     if limit_raw is None and before is None:
         mem_msgs = list(slot.messages)
         if slot._disk_older_count > 0 and state.conversation_log:
-            history_key = _history_key_for(slot.key)
+            history_key = slot_transcript_key(slot)
             try:
                 disk_msgs = state.conversation_log.read_messages_chained(history_key)
             except Exception:
@@ -626,7 +628,7 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
         # Legacy pagination path (retained for programmatic callers).
         # Always reads from chained disk history; no in-memory offset math.
         limit = min(int(limit_raw or "200"), 500)
-        history_key = _history_key_for(slot.key)
+        history_key = slot_transcript_key(slot)
         try:
             all_msgs = (
                 state.conversation_log.read_messages_chained(history_key)
@@ -763,7 +765,7 @@ def _reject_pending_approvals(slot: _ChatSlot) -> None:
             if _mark_permission_resolved(slot.messages, aid, "rejected"):
                 slot._dirty = True
             sel().log_tool_invocation(
-                session_key=_history_key_for(slot.key),
+                session_key=slot_session_key(slot),
                 agent=getattr(slot, "agent", "") or "kirocrew",
                 source="dashboard",
                 tool_name=f"approval_reject:{aid}",
@@ -901,9 +903,11 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         # Unblock chat runner if it's suspended waiting for tool approval or on
         # a pending ask_question card.
         _unblock_pending_waits(state, slot)
-        await state.sessions.stop_turn(_history_key_for(name), force=True, on_hard=_on_hard_force)
+        await state.sessions.stop_turn(
+            slot_session_key(slot), force=True, on_hard=_on_hard_force
+        )
         sel().log_tool_invocation(
-            session_key=_history_key_for(name),
+            session_key=slot_session_key(slot),
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_stop",
@@ -923,7 +927,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         else:
             _info = "stop already in progress"
         sel().log_tool_invocation(
-            session_key=_history_key_for(name),
+            session_key=slot_session_key(slot),
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_stop",
@@ -1003,7 +1007,11 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     _unblock_pending_waits(state, slot)
 
     outcome = await state.sessions.stop_turn(
-        _history_key_for(name), force=False, preserve_queue=True, on_soft=_on_soft, on_hard=_on_hard
+        slot_session_key(slot),
+        force=False,
+        preserve_queue=True,
+        on_soft=_on_soft,
+        on_hard=_on_hard,
     )
     # Resolve orphaned card when provider reports no active turn
     if outcome == "idle" and slot._stop_event_id:
@@ -1011,7 +1019,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         slot._stop_state = "idle"
         state.push_slots_update()
     sel().log_tool_invocation(
-        session_key=_history_key_for(name),
+        session_key=slot_session_key(slot),
         agent=getattr(slot, "agent", "") or "kirocrew",
         source="dashboard",
         tool_name="dashboard_stop",
@@ -1044,7 +1052,7 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
     # (event id still None), and a compound condition would let it through.
     if slot._stop_state != "idle":
         sel().log_tool_invocation(
-            session_key=_history_key_for(name),
+            session_key=slot_session_key(slot),
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_interrupt",
@@ -1119,7 +1127,7 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
     _unblock_pending_waits(state, slot)
 
     outcome = await state.sessions.stop_turn(
-        _history_key_for(name),
+        slot_session_key(slot),
         force=False,
         preserve_queue=True,
         on_soft=_on_soft,
@@ -1131,7 +1139,7 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
         slot._stop_state = "idle"
         state.push_slots_update()
     sel().log_tool_invocation(
-        session_key=_history_key_for(name),
+        session_key=slot_session_key(slot),
         agent=getattr(slot, "agent", "") or "kirocrew",
         source="dashboard",
         tool_name="dashboard_interrupt",
@@ -1336,7 +1344,7 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
     else:
         state._restricted_keys.discard(f"dashboard:{name}")
     # Kill the per-tab session to free resources
-    await state.sessions.remove(_history_key_for(name))
+    await state.sessions.remove(slot_session_key(slot))
     _sync_dashboard_slots(state)
     state.push_slots_update()
     state.push_refresh("history")
@@ -1441,7 +1449,7 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
             state._restricted_keys.discard(f"dashboard:{name}")
         # Session cleanup is best-effort — history is already written
         try:
-            await state.sessions.remove(_history_key_for(name))
+            await state.sessions.remove(slot_session_key(removed))
         except Exception:
             logger.warning("Cleanup: session remove failed for %s", name, exc_info=True)
         archived.append(name)
@@ -1507,7 +1515,7 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
 
     # Reset session so next message uses the new agent
     logger.info("Slot %s agent switched to %r, resetting session", name, agent_name or "kirocrew")
-    await _reset_slot_session(state, slot, _history_key_for(name))
+    await _reset_slot_session(state, slot, slot_session_key(slot))
     # Persist the new agent so the session resumes under the correct agent
     # after a gateway restart.  Written after reset succeeds so we never
     # advertise an agent we couldn't actually switch to.
@@ -1519,7 +1527,7 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
             # chat/WS/heartbeat).
             await asyncio.to_thread(
                 state.conversation_log.update_metadata,
-                _history_key_for(name),
+                slot_transcript_key(slot),
                 {"agent": agent_name},
             )
         except Exception:
@@ -1696,7 +1704,7 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
     if slot.model == model_name:
         return web.json_response({"ok": True, "model": model_name})
     slot.model = model_name
-    session_key = _history_key_for(name)
+    session_key = slot_session_key(slot)
     provider = state.sessions.get_provider(session_key)
     if not await _try_live_model_switch(name, slot, provider, model_name):
         logger.info("Slot %s model switched to %r, resetting session", name, model_name or "auto")
@@ -1765,7 +1773,7 @@ async def api_chat_slots_model(request: web.Request) -> web.Response:
         # the new model with stale history (the model/history inconsistency), and a
         # single failure doesn't abort the whole bulk switch.
         try:
-            await _reset_slot_session(state, slot, _history_key_for(name))
+            await _reset_slot_session(state, slot, slot_session_key(slot))
         except Exception:
             logger.error("Bulk model switch: session reset failed for %s", name, exc_info=True)
             failed.append(name)
@@ -1833,7 +1841,7 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
     slot.reasoning_effort = effort
     logger.info("Slot %s reasoning_effort switched to %r", name, effort or "default")
 
-    session_key = _history_key_for(name)
+    session_key = slot_session_key(slot)
     provider = state.sessions.get_provider(session_key)
     _updated_live = False
     if isinstance(provider, AcpProvider) and provider.supports_effort():
@@ -1900,7 +1908,7 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
     slot.workspace = ws_name
     slot.project = default_project_dir(ws_name)
     logger.info("Slot %s workspace switched to %r, resetting session", name, ws_name)
-    await _reset_slot_session(state, slot, _history_key_for(name))
+    await _reset_slot_session(state, slot, slot_session_key(slot))
     state.push_slots_update()
     return web.json_response({"ok": True, "workspace": ws_name})
 
@@ -1956,7 +1964,7 @@ async def api_chat_slot_project(request: web.Request) -> web.Response:
     # from inside the kiro-cli process group (the set_project MCP tool); an
     # inline reset would killpg() the caller. Consumed in chat_runner.
     if project != old_project:
-        slot._pending_reset_history_key = _history_key_for(name)
+        slot._pending_reset_history_key = slot_session_key(slot)
     state.push_slots_update()
     return web.json_response({"ok": True, "project": project})
 
@@ -2184,7 +2192,7 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
     existing = state._slots.get(name)
     if not existing:
         for slot in state._slots.values():
-            if _history_key_for(slot.key) == canonical:
+            if _history_key_for(slot.key) == canonical or slot_session_key(slot) == history_key:
                 existing = slot
                 break
     if existing:

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -19,6 +19,7 @@ from kiro_crew.dashboard.chat_utils import (
     _history_key_for,
     _normalize_model,
     _sync_dashboard_slots,
+    slot_transcript_key,
 )
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _normalize_slot_key
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
@@ -389,6 +390,27 @@ def _rehydrate_slot_from_history(
         return state._slots[slot_name]
     history_key = _history_key_for(slot_name)
     meta = state.conversation_log.get_metadata(history_key)
+    # A channel-derived slot name (``slack_<ts>``) shares ONE session with the
+    # channel conversation, so its transcript lives under the channel key. Fall
+    # back to that key when the legacy ``dashboard:``-keyed file has no metadata,
+    # and remember it on the slot below so every later read/write agrees. Probing
+    # the legacy key first keeps a pre-migration slot restoring from the file it
+    # was actually written to.
+    shared_key = ""
+    if not meta:
+        # Local import: channel_slots -> state -> chat_persistence would be a
+        # module-level cycle. Same pattern as DashboardState.link_slack.
+        from kiro_crew.dashboard.channel_slots import channel_key_for_slot_name
+
+        try:
+            _sessions = state.conversation_log.list_sessions()
+        except Exception:
+            _sessions = []
+        candidate = channel_key_for_slot_name(slot_name, _sessions)
+        if candidate:
+            candidate_meta = state.conversation_log.get_metadata(candidate)
+            if candidate_meta:
+                history_key, meta, shared_key = candidate, candidate_meta, candidate
     # No metadata → session was never persisted. Don't create a phantom slot.
     if not meta:
         return None
@@ -482,6 +504,10 @@ def _rehydrate_slot_from_history(
         state._restricted_keys.add(f"dashboard:{slot_name}")
     if meta.get("forked_from") is not None:
         slot.forked_from = meta["forked_from"]
+    # Bind the shared session BEFORE the transcript read below, so every later
+    # read/write/run on this slot resolves to the same key the restore used.
+    if shared_key:
+        slot.shared_session_key = shared_key
     # Restore the persisted tab_id so cross-restart fork chaining survives.
     # get_or_create_slot (called by our caller) assigns a fresh random uuid to
     # slot._tab_id; if we don't overwrite it here, the next _flush_dirty_slots
@@ -1149,7 +1175,7 @@ def _save_slot_to_history(
         and not rewrite
     ):
         return
-    history_key = _history_key_for(slot.key)
+    history_key = slot_transcript_key(slot)
     try:
         # Hold the SAME per-session cross-process lock that ``append`` /
         # ``append_off_loop`` / rotate / rewrite / metadata mutations take, across

--- a/src/kiro_crew/dashboard/chat_rewind.py
+++ b/src/kiro_crew/dashboard/chat_rewind.py
@@ -27,7 +27,10 @@ from aiohttp import web
 
 from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
 from kiro_crew.dashboard.chat_runner import _run_chat
-from kiro_crew.dashboard.chat_utils import _history_key_for
+from kiro_crew.dashboard.chat_utils import (
+    slot_session_key,
+    slot_transcript_key,
+)
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -143,7 +146,7 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                 if disk_older > 0 and state.conversation_log is not None:
                     try:
                         chained = state.conversation_log.read_messages_chained(
-                            _history_key_for(slot.key)
+                            slot_transcript_key(slot)
                         )
                     except Exception:
                         logger.debug("rewind: chained scan for ts failed", exc_info=True)
@@ -188,7 +191,7 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
 
         # Capture orphan info before any mutation, so we can clean up the
         # kiro-cli session file even if the swap path errors out partway.
-        session_key = _history_key_for(slot.key)
+        session_key = slot_session_key(slot)
         orphan_kiro_session_id = ""
         if state.sessions is not None:
             try:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -59,7 +59,6 @@ from kiro_crew.dashboard.chat_utils import (
     _dequeue_next_message,
     _dequeue_next_system_message,
     _extract_bash_command,
-    _history_key_for,
     _maybe_consolidate,
     _maybe_inject_persona,
     _normalize_model,
@@ -68,6 +67,8 @@ from kiro_crew.dashboard.chat_utils import (
     _remove_queued_by_id,
     _validate_tool_name,
     is_system_injection,
+    slot_session_key,
+    slot_transcript_key,
 )
 from kiro_crew.dashboard.handlers import (
     MAX_PROMPT_BYTES,
@@ -2091,7 +2092,7 @@ async def _run_chat(
 ) -> None:
     """Stream LLM response into *slot*.  Survives browser disconnect."""
 
-    session_key = getattr(slot, "linked_session_key", "") or _history_key_for(slot.key)
+    session_key = slot_session_key(slot)
     sessions = getattr(state, "sessions", None)
 
     # Inherit Slack link: if this dashboard session mirrors a Slack thread,
@@ -2799,7 +2800,7 @@ async def _run_chat(
                     _last_stop_soft = True
                 break
             if not _last_stop_soft:
-                history_key = _history_key_for(slot.key)
+                history_key = slot_transcript_key(slot)
                 disk_count = 0
                 if state.conversation_log:
                     disk_count = len(state.conversation_log.read_messages(history_key))
@@ -3238,7 +3239,7 @@ async def _run_chat(
                     # the CANONICAL producing session on the spool. Pass it for
                     # the binding check or every real render is refused as a
                     # bare-vs-prefixed mismatch (silent no-render).
-                    producing_session_key=slot.linked_session_key or _history_key_for(slot.key),
+                    producing_session_key=slot_session_key(slot),
                 )
                 # Session directive (#755): a stateless session-bound tool
                 # (monitor_start / monitor_update / autonudge_stop / set_project

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -10,7 +10,7 @@ from aiohttp import web
 
 from kiro_crew.config.loader import config_dir
 from kiro_crew.context_management import extract_plan_metadata, rephrase_plan
-from kiro_crew.dashboard.chat_utils import _history_key_for
+from kiro_crew.dashboard.chat_utils import slot_transcript_key
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE, DashboardState, _ChatSlot
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -425,7 +425,7 @@ async def _persist_title(state: DashboardState, slot: _ChatSlot) -> None:
     """
 
     if state.conversation_log:
-        history_key = _history_key_for(slot.key)
+        history_key = slot_transcript_key(slot)
         try:
             await asyncio.to_thread(
                 state.conversation_log.set_title, history_key, slot.title

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -13,7 +13,7 @@ import logging
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from kiro_crew.providers.base import LLMEvent
@@ -373,6 +373,46 @@ def _history_key_for(slot_key: str) -> str:
     while slot_key.startswith("dashboard_"):
         slot_key = slot_key[len("dashboard_"):]
     return f"dashboard:{slot_key}"
+
+
+def slot_transcript_key(slot: Any) -> str:
+    """The session key a slot's transcript is READ from and WRITTEN to.
+
+    Ordinarily ``dashboard:<slot.key>``. A slot with ``shared_session_key`` set
+    is one half of a SINGLE session shared with a channel conversation (a Slack
+    thread and its dashboard tab), so its transcript lives under the channel's
+    own key and both surfaces append to that one file.
+
+    Every read, every write, and the ``closed`` flag must agree on this — a site
+    that keeps using ``_history_key_for(slot.key)`` while another uses this
+    helper splits the conversation across two transcripts, which is the exact
+    failure this indirection exists to prevent.
+
+    Note this is NOT ``linked_session_key``: that repoints only the run path and
+    is used by cron/workflow display-mirror slots which still own their own
+    transcript. See ``_ChatSlot.shared_session_key``.
+    """
+    return getattr(slot, "shared_session_key", "") or _history_key_for(slot.key)
+
+
+def slot_session_key(slot: Any) -> str:
+    """The runtime session key a slot's turns execute under.
+
+    Precedence: ``shared_session_key`` (one session shared with a channel) >
+    ``linked_session_key`` (cron/workflow run this slot mirrors) >
+    ``dashboard:<slot.key>``.
+
+    Use this wherever a slot is handed to :class:`SessionManager` — starting a
+    turn, stopping one, resetting or removing the session. A site that stops
+    ``dashboard:<slot.key>`` while the turn is running under the shared key
+    silently does nothing, because the semaphore and provider are registered
+    under the key the turn actually acquired.
+    """
+    return (
+        getattr(slot, "shared_session_key", "")
+        or getattr(slot, "linked_session_key", "")
+        or _history_key_for(slot.key)
+    )
 
 
 _INCOGNITO_PREFIX = (

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -833,6 +833,7 @@ class _ChatSlot:
         "_pending_rewrite",
         "_file_changes",
         "linked_session_key",
+        "shared_session_key",
         "_browse_mode",
         "_side",
         "_acp_client",
@@ -1026,6 +1027,19 @@ class _ChatSlot:
             []
         )  # [{path, content}] before-snapshots accumulated per turn for file-chip diffs
         self.linked_session_key: str = ""  # when set, _run_chat uses this as session key
+        # When set, this slot and a channel conversation ARE ONE session: the
+        # transcript is READ, WRITTEN and RUN under this key instead of
+        # ``dashboard:<slot.key>``. Set for slots surfaced from a channel
+        # (see :mod:`kiro_crew.dashboard.channel_slots`) so a Slack thread and
+        # its dashboard tab share a single transcript rather than diverging into
+        # two files.
+        #
+        # Deliberately SEPARATE from ``linked_session_key``, which repoints only
+        # the RUN path: cron/workflow slots set that one and still persist under
+        # their own key, because they are display mirrors of a run that owns its
+        # own transcript. Folding the two together would move those writes onto
+        # the cron key and double up with ``inject_cron_result_to_dashboard``.
+        self.shared_session_key: str = ""
         self._browse_mode: bool = False  # per-turn: True when user explicitly enables browser
         self._side: SideState | None = None
         # Live inner AcpClient for the in-flight turn, published by _run_chat at
@@ -1569,6 +1583,7 @@ class _ChatSlot:
             "memory_mode": self.memory_mode,
             "forked_from": self.forked_from,
             "linked_session_key": self.linked_session_key,
+            "shared_session_key": self.shared_session_key,
             "app": self._app,
         }
 

--- a/test/test_channel_slots.py
+++ b/test/test_channel_slots.py
@@ -211,19 +211,24 @@ class TestSurfaceChannelSession:
         assert slot.title == "Ship the thing"
         assert [m["content"] for m in slot.messages] == ["hi", "hello"]
 
-    def test_does_not_bind_to_the_channel_session_key(self, dashboard_state: Any) -> None:
-        """One history key only.
+    def test_binds_the_channel_key_as_the_shared_session(self, dashboard_state: Any) -> None:
+        """One session, two surfaces — the transcript key is the channel's.
 
-        `_save_slot_to_history` always writes `dashboard:<slot.key>`. Binding the
-        RUN path to the channel key would split the conversation across two
-        transcripts and send the `closed` flag to a key the reconciler never
-        reads, so a closed tab would reopen.
+        ``shared_session_key`` governs read, write AND run together, so the tab
+        and the channel thread append to a single file. It is deliberately NOT
+        ``linked_session_key``, which repoints only the run path and is owned by
+        cron/workflow display-mirror slots that still write their own transcript.
         """
         slot = channel_slots.surface_channel_session(
             dashboard_state, _session("slack:1.1"), {}, []
         )
         assert slot is not None
+        assert slot.shared_session_key == "slack:1.1"
         assert slot.linked_session_key == ""
+        from kiro_crew.dashboard.chat_utils import slot_session_key, slot_transcript_key
+
+        assert slot_transcript_key(slot) == "slack:1.1"
+        assert slot_session_key(slot) == "slack:1.1"
 
     def test_untitled_session_falls_back_to_the_channel_label(
         self, dashboard_state: Any
@@ -475,19 +480,20 @@ class TestFrozenPrefixAccounting:
     def test_empty_file_has_no_prefix(self) -> None:
         assert channel_slots.frozen_prefix_len([], [{"role": "user", "content": "x"}]) == 0
 
-    def test_seeded_slot_reports_the_prefix_and_only_its_own_disk_lines(
+    def test_seeded_slot_counts_the_prefix_against_the_shared_channel_file(
         self, dashboard_state: Any
     ) -> None:
-        """End-to-end: an over-long slot file plus later channel turns.
+        """End-to-end: a long legacy slot file plus the live channel transcript.
 
-        ``_disk_window_len`` must count the slot's OWN persisted lines only —
-        crediting the merged channel turns would let a trim fold turns that were
-        never written into the frozen prefix.
+        The slot now READS AND WRITES the channel key, so both counters describe
+        the CHANNEL file. Crediting legacy dashboard-keyed lines here would let a
+        trim fold lines that are not in the shared file into its frozen prefix,
+        and the next save would rewrite that file short.
         """
         over = 7
-        slot_msgs = self._slot_msgs(channel_slots._HYDRATE_LIMIT + over)
+        legacy_msgs = self._slot_msgs(channel_slots._HYDRATE_LIMIT + over)
         log = _FakeLog([_session("slack:1.1")], {})
-        log.transcripts["dashboard:slack_1.1"] = slot_msgs
+        log.transcripts["dashboard:slack_1.1"] = legacy_msgs
         log.transcripts["slack:1.1"] = [
             {"role": "user", "content": "said on slack after", "ts": "2026-07-30T23:00:00Z"}
         ]
@@ -496,13 +502,15 @@ class TestFrozenPrefixAccounting:
 
         assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
         slot = dashboard_state._slots["slack_1.1"]
-        # The channel turn is newest, so it takes the last window seat and one
-        # more slot line drops into the prefix.
-        assert slot._disk_older_count == over + 1
-        assert slot._disk_window_len == len(slot_msgs) - (over + 1)
-        assert slot._disk_older_count + slot._disk_window_len == len(slot_msgs)
+        # The lone channel line is the newest turn, so it survives into the
+        # window — nothing in the shared file is frozen.
+        assert slot._disk_older_count == 0
+        assert slot._disk_window_len == 1
+        assert slot._disk_older_count + slot._disk_window_len == len(log.transcripts["slack:1.1"])
+        # Seeding still folds the legacy turns in, so migrating loses nothing.
         assert len(slot.messages) == channel_slots._HYDRATE_LIMIT
         assert slot.messages[-1]["content"] == "said on slack after"
+        assert slot.shared_session_key == "slack:1.1"
 
     def test_empty_content_lines_are_not_seeded_but_still_counted(self) -> None:
         """A blank on-disk line is never appended, so it belongs to the prefix."""
@@ -548,19 +556,288 @@ class TestMergeTranscripts:
         assert channel_slots.merge_transcripts([], []) == []
 
 
-class TestReconcileMore:
+class TestSharedSessionBinding:
+    """The single-session contract: one transcript, both surfaces, no sync."""
 
-    def test_second_pass_is_a_no_op_and_reads_no_transcripts(
+    def _msgs(self, n: int, *, prefix: str = "m") -> list[dict[str, Any]]:
+        return [
+            {"role": "user", "content": f"{prefix}{i}", "ts": f"2026-07-30T00:{i:02d}:00Z"}
+            for i in range(n)
+        ]
+
+    def test_slot_name_lookup_round_trips_every_namespace(self) -> None:
+        """Exact reverse lookup — including keys with inner separators.
+
+        A string substitution cannot recover ``telegram:kirocrew:direct:9:gen3``
+        from ``telegram_kirocrew_direct_9_gen3``, which is why this resolves
+        against the session list instead.
+        """
+        keys = [
+            "slack:1785457986.925389",
+            "discord:123",
+            "telegram:kirocrew:direct:9:gen3",
+        ]
+        sessions = [_session(k) for k in keys]
+        for key in keys:
+            name = channel_slots.channel_slot_name(key)
+            assert channel_slots.channel_key_for_slot_name(name, sessions) == key
+
+    def test_slot_name_lookup_accepts_the_filename_stem_spelling(self) -> None:
+        """``list_sessions`` may serve either spelling; both fold to one slot."""
+        sessions = [_session("slack_1.1")]
+        assert channel_slots.channel_key_for_slot_name("slack_1.1", sessions) == "slack_1.1"
+
+    def test_slot_name_lookup_rejects_ordinary_dashboard_slots(self) -> None:
+        """A normal tab must never be mistaken for a channel session."""
+        sessions = [_session("slack:1.1"), _session("dashboard_chat-42-1785467660")]
+        assert channel_slots.channel_key_for_slot_name("chat-42-1785467660", sessions) == ""
+        assert channel_slots.channel_key_for_slot_name("", sessions) == ""
+        assert channel_slots.channel_key_for_slot_name("slack_9.9", sessions) == ""
+
+    def test_save_writes_the_channel_key_not_a_second_file(
+        self, dashboard_state: Any, tmp_path: Any
+    ) -> None:
+        """The regression that motivated this: two files meant a stale tab."""
+        from kiro_crew.dashboard.chat_utils import slot_transcript_key
+
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("slack:1.1"), {}, self._msgs(2)
+        )
+        assert slot is not None
+        assert slot_transcript_key(slot) == "slack:1.1"
+        # The legacy dashboard-keyed file is NOT the write target any more.
+        assert slot_transcript_key(slot) != "dashboard:slack_1.1"
+
+    def test_detail_serves_the_whole_shared_transcript(self, dashboard_state: Any) -> None:
+        """The reported bug: 62 messages on disk, 2 served.
+
+        With the counters measured against the shared file, the detail handler's
+        ``_disk_older_count > 0`` gate opens and the frozen prefix is read back,
+        so the tab shows every turn rather than the first reconcile's window.
+        """
+        total = channel_slots._HYDRATE_LIMIT + 12
+        log = _FakeLog([_session("slack:1.1")], {})
+        log.transcripts["slack:1.1"] = self._msgs(total)
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        slot = dashboard_state._slots["slack_1.1"]
+        assert slot._disk_older_count == 12
+        assert len(slot.messages) == channel_slots._HYDRATE_LIMIT
+        # Frozen prefix + live window reconstructs the full conversation, which
+        # is exactly what api_chat_slot_detail concatenates.
+        served = log.transcripts["slack:1.1"][: slot._disk_older_count] + list(slot.messages)
+        assert len(served) == total
+        assert [m["content"] for m in served] == [m["content"] for m in self._msgs(total)]
+
+    def test_resync_picks_up_turns_added_on_the_channel(self, dashboard_state: Any) -> None:
+        log = _FakeLog([_session("slack:1.1")], {})
+        log.transcripts["slack:1.1"] = self._msgs(2)
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        slot = dashboard_state._slots["slack_1.1"]
+        assert [m["content"] for m in slot.messages] == ["m0", "m1"]
+
+        log.transcripts["slack:1.1"] = self._msgs(2) + [
+            {"role": "assistant", "content": "later", "ts": "2026-07-30T23:00:00Z"}
+        ]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert [m["content"] for m in slot.messages] == ["m0", "m1", "later"]
+
+    def test_resync_leaves_a_dirty_slot_alone(self, dashboard_state: Any) -> None:
+        """The user owns the window once a turn has touched it."""
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("slack:1.1"), {}, self._msgs(2)
+        )
+        assert slot is not None
+        slot._dirty = True
+        changed = channel_slots.resync_channel_slot(
+            slot, self._msgs(5), disk_older=0, disk_window=5
+        )
+        assert changed is False
+        assert len(slot.messages) == 2
+
+    def test_resync_leaves_a_running_slot_alone(self, dashboard_state: Any) -> None:
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("slack:1.1"), {}, self._msgs(2)
+        )
+        assert slot is not None
+
+        async def _drive() -> None:
+            # `running` is derived from an unfinished task, so give it one.
+            async def _never() -> None:
+                await asyncio.sleep(3600)
+
+            slot.task = asyncio.create_task(_never())
+            try:
+                assert slot.running is True
+                assert (
+                    channel_slots.resync_channel_slot(
+                        slot, self._msgs(5), disk_older=0, disk_window=5
+                    )
+                    is False
+                )
+            finally:
+                slot.task.cancel()
+
+        asyncio.run(_drive())
+        assert len(slot.messages) == 2
+
+    def test_resync_refreshes_counters_even_when_the_window_is_current(
         self, dashboard_state: Any
     ) -> None:
+        """A stale count would make the next save rewrite the file short."""
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("slack:1.1"), {}, self._msgs(2)
+        )
+        assert slot is not None
+        assert (
+            channel_slots.resync_channel_slot(slot, self._msgs(2), disk_older=4, disk_window=2)
+            is False
+        )
+        assert slot._disk_older_count == 4
+        assert slot._disk_window_len == 2
+
+    def test_surfaced_slack_slot_is_bound_for_inbound_replies(
+        self, dashboard_state: Any
+    ) -> None:
+        """``maybe_route_linked_thread`` finds the slot by BARE thread_ts.
+
+        Without this the inbound Slack reply runs Slack's own turn loop against
+        the channel session and the dashboard tab never sees it.
+        """
+        log = _FakeLog([_session("slack:1785457986.925389")], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        slot = dashboard_state._slots["slack_1785457986.925389"]
+        assert slot._slack_linked is True
+        assert slot._slack_thread_ts == "1785457986.925389"
+        assert dashboard_state.get_linked_slot("1785457986.925389") is slot
+
+    def test_non_slack_channels_are_not_slack_bound(self, dashboard_state: Any) -> None:
+        log = _FakeLog([_session("discord:9.9")], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        slot = dashboard_state._slots["discord_9.9"]
+        assert slot.shared_session_key == "discord:9.9"
+        assert slot._slack_linked is False
+
+    def test_existing_slot_without_the_binding_is_self_healed(
+        self, dashboard_state: Any
+    ) -> None:
+        """Covers a slot surfaced before this change, and a gateway restart."""
         log = _FakeLog([_session("slack:1.1")], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        slot = dashboard_state.get_or_create_slot(name="slack_1.1", agent="")
+        assert slot.shared_session_key == ""
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) >= 1
+        assert slot.shared_session_key == "slack:1.1"
+
+    def test_title_persists_to_the_shared_session_not_a_second_file(
+        self, dashboard_state: Any
+    ) -> None:
+        """Metadata must ride in the transcript the slot actually writes.
+
+        Keyed off the slot's own name instead, an auto-title would land in a
+        ``dashboard:``-keyed file that otherwise does not exist — creating a
+        stray metadata-only transcript, and losing the title on restore, which
+        reads the shared key.
+        """
+        import asyncio as _asyncio
+
+        from kiro_crew.dashboard import chat_title
+
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("slack:1.1"), {}, self._msgs(2)
+        )
+        assert slot is not None
+        slot.title = "Ship the thing"
+
+        seen: list[str] = []
+
+        class _Log:
+            def set_title(self, key: str, title: str) -> None:
+                seen.append(key)
+
+        dashboard_state.conversation_log = _Log()
+        _asyncio.run(chat_title._persist_title(dashboard_state, slot))
+        assert seen == ["slack:1.1"]
+
+    def test_session_teardown_targets_the_shared_key(self, dashboard_state: Any) -> None:
+        """The provider and its semaphore are registered under the run key.
+
+        Removing ``dashboard:<slot.key>`` would leave the real session alive.
+        """
+        from kiro_crew.dashboard.chat_utils import slot_session_key
+
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("slack:1.1"), {}, self._msgs(2)
+        )
+        assert slot is not None
+        assert slot_session_key(slot) == "slack:1.1"
+        assert slot_session_key(slot) != "dashboard:slack_1.1"
+
+    def test_cron_style_linked_slot_keeps_its_own_transcript(
+        self, dashboard_state: Any
+    ) -> None:
+        """Guards the seam: linked_session_key must NOT move the transcript.
+
+        Cron/workflow slots are display mirrors of a run that owns its own
+        transcript. Folding them into the shared path would redirect their
+        writes onto the cron key and double up with the cron injector.
+        """
+        from kiro_crew.dashboard.chat_utils import slot_session_key, slot_transcript_key
+
+        slot = dashboard_state.get_or_create_slot(name="cron-abc", agent="")
+        slot.linked_session_key = "cron:abc"
+        assert slot_session_key(slot) == "cron:abc"
+        assert slot_transcript_key(slot) == "dashboard:cron-abc"
+
+    def test_surfaced_slot_takes_precedence_over_a_linked_key(
+        self, dashboard_state: Any
+    ) -> None:
+        from kiro_crew.dashboard.chat_utils import slot_session_key, slot_transcript_key
+
+        slot = channel_slots.surface_channel_session(
+            dashboard_state, _session("slack:1.1"), {}, []
+        )
+        assert slot is not None
+        slot.linked_session_key = "cron:abc"
+        assert slot_session_key(slot) == "slack:1.1"
+        assert slot_transcript_key(slot) == "slack:1.1"
+
+
+class TestReconcileMore:
+
+    def test_second_pass_reports_no_change_but_keeps_following(
+        self, dashboard_state: Any
+    ) -> None:
+        """Steady state reports 0 changes — but it DOES re-read the transcript.
+
+        The re-read is what makes the tab live-follow a conversation still moving
+        on the channel, and it keeps the frozen-prefix counters honest. Reporting
+        0 is what stops it broadcasting a slots update every 30s.
+        """
+        log = _FakeLog([_session("slack:1.1")], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "stable", "ts": "2026-07-30T00:00:00Z"}
+        ]
         dashboard_state.conversation_log = log
         dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
 
         assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
         log.message_reads.clear()
         assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
-        assert log.message_reads == [], "steady state must not re-read transcripts"
+        assert log.message_reads, "steady state must keep following the shared transcript"
 
     def test_works_on_stem_form_keys_as_served_by_list_sessions(
         self, dashboard_state: Any

--- a/test/test_history_locking_remediation.py
+++ b/test/test_history_locking_remediation.py
@@ -988,7 +988,7 @@ class TestOnLoopCallersOffload:
             real_set_title(*args, **kwargs)  # type: ignore[arg-type]
 
         log.set_title = _spy  # type: ignore[method-assign]
-        monkeypatch.setattr(chat_title, "_history_key_for", lambda _k: "dashboard:t")
+        monkeypatch.setattr(chat_title, "slot_transcript_key", lambda _s: "dashboard:t")
 
         state = MagicMock()
         state.conversation_log = log


### PR DESCRIPTION
## Problem

A conversation started on Slack shows up in the dashboard as a **stale tab**. Reported case: 62 messages on disk, 2 served to the dashboard, and the tab reporting nothing running while the thread was actively moving.

The dashboard was serving a **copy**, frozen at the moment the tab appeared:

```
--- served by dashboard ---            --- on disk ---
  total    = 2                          slack:<ts>          62 msgs
  has_more = False                       dashboard:slack_<ts>  MISSING
  running  = False
```

Four things stacked up:

1. **Two keys, two files.** A Slack thread persists under `slack:<ts>`. The reconciler surfaced it as slot `slack_<ts>`, whose transcript key was `dashboard:slack_<ts>` — a *different* file, which was never even created because the slot was seeded `_dirty=False`.
2. **The seed was one-shot and fired at turn 1.** `surface_channel_session` opened with `if slot_name in state._slots: return None`, and the reconciler runs every 30s — so the copy captured whatever existed ~30s in (2 messages) and every later pass was a deliberate no-op.
3. **Nothing carried later channel turns into the tab.** The only cross-surface plumbing (`_deliver_cross_surface_reply`, `dashboard_mirror_key`) runs dashboard → channel. There was no channel → dashboard direction.
4. **The read path could not recover.** `api_chat_slot_detail` only consults disk when `slot._disk_older_count > 0`; that count was computed from the slot's own (empty) file, so it was `0` and the handler returned in-memory messages only.

`running: False` was honest — turns were executing against the channel session, not the slot.

## Why it matters

The tab was not just stale, it was **lossy in both directions**:

- The user could not follow their own conversation from the dashboard.
- Replying in the tab ran under `dashboard:slack_<ts>` with 2 messages of context and created that file fresh — so the agent answered with no knowledge of the intervening turns, **and the reply never reached the Slack thread**. A silent fork with amnesia.
- Because `closed` was written to the slot key while the reconciler read the channel key too, dismissal semantics straddled two files.

This was flagged during the original review and deferred as *"surfaced tab is a copy not a live handoff."* It holds up if you surface a dormant thread and pick it up on the dashboard; it fails for a thread that stays live on the channel, which is the normal case.

## Fix (symptoms → root cause → change)

**Symptom** → tab shows the first turns only and can't be replied to safely.
**Root cause** → the slot's transcript identity was derived from its own slot key, so a channel conversation and its tab were two sessions that had to be *copied* between. Copying is what goes stale.
**Change** → make them **one session**. There is no sync step to keep correct because there is nothing to sync.

- **New `_ChatSlot.shared_session_key`** (`state.py`) — when set, the transcript is **read, written and run** under that key. Added to `__slots__` and the serialized payload.
- **Two resolvers in `chat_utils.py`** so no site can drift:
  - `slot_transcript_key(slot)` — read/write/`closed` (`shared` → else `dashboard:<key>`)
  - `slot_session_key(slot)` — the runtime key for `SessionManager` (`shared` → `linked` → `dashboard:<key>`)
- **Threaded through every site that decides identity**: the save path (`chat_persistence.py:1152`, the one the old design called out as hard-wired), both `api_chat_slot_detail` branches, the runner's disk-vs-memory comparison and subagent producing key, fork's transcript read, and rewind's archive scan + session reset.
- **Metadata follows the transcript.** `_persist_title` and the agent-switch `update_metadata` wrote to `dashboard:<slot.key>`. On a shared session that creates a stray metadata-only file the slot never otherwise touches, and the title is lost on restore because restore reads the shared key. Both now use `slot_transcript_key`.
- **Session teardown and provider lookup fixed.** `sessions.remove` (single + bulk close), all three `_reset_slot_session` calls, the live model / reasoning-effort `get_provider` lookups, and `_pending_reset_history_key` all keyed on `_history_key_for(name)` — a different key from the one the provider and its semaphore are registered under. They now use `slot_session_key`, as do the SEL audit labels beside them so the audit trail names the session that actually ran.
- **Stop/interrupt fixed** — all three `stop_turn` call sites had the same defect. On a shared session it silently no-ops: the stop button would do nothing.
- **Resume dedup accepts either spelling** so a caller naming the shared key still finds the slot owning that kiro-cli process, instead of starting a second one against the same session.
- **Inbound channel replies run the slot's turn.** Surfaced Slack slots register via the existing `DashboardState.link_slack`, so `slack.handler.maybe_route_linked_thread` hands the reply to this slot and dispatches it through the dashboard turn path instead of Slack's `handle_message` loop. One running turn per conversation under the single per-session semaphore, and the channel gets the dashboard's streaming mirror for free. Re-asserted every pass because `_slack_to_slot` is in-memory and does not survive a restart.
- **`resync_channel_slot`** — while a surfaced slot is neither dirty nor running, each pass refreshes the window and the frozen-prefix counters from the shared transcript. This is a correctness requirement, not just freshness: a stale `_disk_older_count` makes the next save rewrite the file from `meta + frozen + window` and **drop turns appended in the meantime**. It returns `False` when nothing changed so it does not broadcast every 30s.
- **Migration is lossless.** The reconciler still folds in any turns left in a legacy `dashboard:`-keyed file, and still reads `closed` from both keys, so a tab dismissed under the old design stays dismissed.
- **Restore recovers the binding** via `channel_key_for_slot_name`, an **exact reverse lookup over the session list** rather than a string transform — `_normalize_slot_key` folds every non-word char, so `telegram:kirocrew:direct:9:gen3` cannot be recovered from its slot name by substitution.

Deliberately **not** folded into `linked_session_key`: that repoints only the run path and belongs to cron/workflow display-mirror slots which still own their own transcript. Reusing it would move those writes onto the cron key and double up with `inject_cron_result_to_dashboard`.

## Tests

`test/test_channel_slots.py` — 69 pass (was 50).

Three existing tests asserted the old copy-based contract and were rewritten to the new one:

- `test_binds_the_channel_key_as_the_shared_session` (was `test_does_not_bind_to_the_channel_session_key`) — now asserts the shared binding, and still asserts `linked_session_key == ""` so the cron seam stays separate.
- `test_seeded_slot_counts_the_prefix_against_the_shared_channel_file` — counters now describe the channel file, not the slot's own.
- `test_second_pass_reports_no_change_but_keeps_following` — steady state reports 0 changes but *does* re-read, which is the live-follow guarantee.

New `TestSharedSessionBinding` covers:

| Test | Locks in |
|---|---|
| `test_detail_serves_the_whole_shared_transcript` | **The reported bug** — 62 on disk, 62 reconstructed, not 2 |
| `test_slot_name_lookup_round_trips_every_namespace` | Exact reverse lookup, including inner-separator telegram keys |
| `test_slot_name_lookup_accepts_the_filename_stem_spelling` | Both spellings `list_sessions` serves fold to one slot |
| `test_slot_name_lookup_rejects_ordinary_dashboard_slots` | A normal `chat-N` tab is never mistaken for a channel session |
| `test_save_writes_the_channel_key_not_a_second_file` | No second transcript to diverge from |
| `test_resync_picks_up_turns_added_on_the_channel` | Live follow |
| `test_resync_leaves_a_dirty_slot_alone` / `..._running_slot_alone` | The user/turn owns the window; no unsaved turns dropped |
| `test_resync_refreshes_counters_even_when_the_window_is_current` | Stale counters can't truncate the next save |
| `test_surfaced_slack_slot_is_bound_for_inbound_replies` | `get_linked_slot(bare_ts)` resolves, so Slack replies route in |
| `test_non_slack_channels_are_not_slack_bound` | Discord/Telegram get the shared key without a Slack link |
| `test_existing_slot_without_the_binding_is_self_healed` | Pre-change slots and post-restart slots recover |
| `test_title_persists_to_the_shared_session_not_a_second_file` | Metadata rides in the shared transcript, no stray file |
| `test_session_teardown_targets_the_shared_key` | Teardown can't leave the real session alive |
| `test_cron_style_linked_slot_keeps_its_own_transcript` | **Guards the seam** — `linked_session_key` must not move a cron slot's transcript |
| `test_surfaced_slot_takes_precedence_over_a_linked_key` | Precedence order is explicit |

`test/test_history_locking_remediation.py::test_persist_title_runs_set_title_off_loop` monkeypatched `chat_title._history_key_for`; retargeted to `slot_transcript_key`. Its actual assertion (the `_locked` write is dispatched off the event loop) is unchanged.

## Manual verification

Gates run in the worktree, all green:

| Gate | Result |
|---|---|
| `isort --check-only src/kiro_crew test` | clean |
| `flake8 src/kiro_crew test` | clean |
| `mypy src/kiro_crew/` | `Success: no issues found in 561 source files` |
| `pytest` (full backend) | **21981 passed**, 120 skipped, 5 xfailed |
| `npx tsc -b` | clean |
| `npx vitest run` | **6114 passed**, 3 skipped (499 files) |

18 backend failures on this host were confirmed **pre-existing**: stashing the change and re-running the same subset on clean `origin/main` reproduces them (25 in isolation). They are all host-environment cases — namespace/seatbelt sandbox probes, `gh` binary resolution, data-home beacon paths, `os.fork` under the agent sandbox — and none touch the changed modules.

The originating diagnosis was taken from the live gateway: `GET /api/chat/slots/slack_<ts>` returning `total: 2` against a 62-message on-disk transcript, with no `dashboard_slack_<ts>.jsonl` present at all.

## Screenshots

N/A — no user-visible visual change. This alters which session key a chat slot reads, writes and runs under; the rendered chat surface, components and styling are untouched. The observable difference is *message content* in an existing tab (all turns instead of the first few), not any change to layout or chrome.
