### PR TITLE
fix(pod): give systemctl --user a session bus so pods work from a service install

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -227,7 +227,18 @@ Every failure teaches the next step: no worktree → create one; no venv → aut
 no dist → build-or-`--provision`.
 
 - Playwright venv: controlled by env `KIROCREW_PW_PY`.
-  The FE phase skips gracefully if this interpreter is not executable.
+  If that interpreter is missing or not executable, the FE phase **fails** —
+  it does not skip. A run that captured zero screenshots must never report a
+  green summary. Set it up once, pinning the version that matches the chromium
+  build already on disk:
+
+  ```sh
+  python3 -m venv <path> && <path>/bin/pip install playwright==1.61.0
+  export KIROCREW_PW_PY=<path>/bin/python
+  ```
+
+  To skip the frontend phase deliberately, pass `--api-only` — that is the only
+  clean skip.
 - `--video` needs `ffmpeg` on PATH (or pointed to by `POD_E2E_FFMPEG` env).
   If absent, `.webm` is kept but no `.mp4` transcoding occurs. Recording
   finalization is time-capped (see `POD_E2E_TEARDOWN_TIMEOUT`), so `--video`

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
@@ -248,11 +248,23 @@ fi
 # ---------------------------------------------------------------- FE ------
 if [ "$RUN_FE" -eq 1 ] && [ "$HEALTHY" -eq 1 ]; then
   if [ -z "$PW_PY" ] || [ ! -x "$PW_PY" ]; then
-    log "SKIP: Playwright python not found (set KIROCREW_PW_PY)"
-    warn "playwright — skipped (no KIROCREW_PW_PY)"
+    # The frontend phase was REQUESTED (no --api-only) and cannot run, so it
+    # produced zero screenshots. Warning here made the run print a green
+    # summary with no evidence — which is how "capture is in flight" becomes a
+    # believable but false statement. Fail instead. Pin playwright==1.61.0: it
+    # pins chromium-1228, which the Node Playwright MCP server has already
+    # downloaded into ~/.cache/ms-playwright, so any other version triggers a
+    # fresh ~170MB browser download.
+    log "FAIL: Playwright python not found (set KIROCREW_PW_PY)"
+    log "  python3 -m venv <path> && <path>/bin/pip install playwright==1.61.0"
+    log "  export KIROCREW_PW_PY=<path>/bin/python"
+    log "  (or re-run with --api-only to skip the frontend phase deliberately)"
+    fail "playwright — no usable KIROCREW_PW_PY, so zero screenshots were captured (see fix above)"
   elif [ ! -f "$PW_RUNNER" ]; then
-    log "SKIP: pod-playwright.py not found at $PW_RUNNER"
-    warn "playwright — skipped (script missing)"
+    # Same false-green defect: the phase was requested, the driver is missing,
+    # no screenshots exist. A broken install must not report success.
+    log "FAIL: pod-playwright.py not found at $PW_RUNNER"
+    fail "playwright — driver missing at $PW_RUNNER, so zero screenshots were captured"
   else
     log "running Playwright FE check ..."
     # Token goes via env, not argv — process arguments are world-readable

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -238,6 +238,95 @@ def _doctor_data_home() -> None:
             print(f"  legacy:      ⏹ {legacy} still present (migration will retry on next cold start)")
 
 
+def _linger_enabled(user: str) -> bool | None:
+    """Whether ``user``'s systemd instance lingers past logout.
+
+    ``None`` when it cannot be determined (no ``loginctl``, unknown user, or an
+    unrecognised value) so the caller can stay quiet rather than guess.
+    """
+    if shutil.which("loginctl") is None:
+        return None
+    try:
+        res = subprocess.run(
+            ["loginctl", "show-user", user, "-p", "Linger", "--value"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if res.returncode != 0:
+        return None
+    val = res.stdout.strip().lower()
+    if val in ("yes", "true", "1"):
+        return True
+    if val in ("no", "false", "0"):
+        return False
+    return None
+
+
+def _doctor_pod_session_bus(issues: list[str]) -> None:
+    """Report whether pods have a reachable ``systemd --user`` session bus.
+
+    Pods are ``systemd --user`` units, so ``systemctl --user`` must be able to
+    reach the per-user systemd instance. A gateway started from a systemd SYSTEM
+    unit (``kirocrew service install``) inherits no login-session environment,
+    and if the per-user instance is not running at all there is nothing for
+    KiroCrew to point at — every pod verb then fails with "Failed to connect to
+    bus: No medium found". Diagnosing that belongs here.
+
+    Three outcomes: socket present → pass; absent → ❌ with the remediation;
+    present but ``Linger=no`` → warn, because pods work now and will die on
+    logout.
+
+    Advisory only (never appended to ``issues``, like the embedding-model URL
+    probe): a host with no per-user systemd instance — a container, a CI runner,
+    a headless server — is not a broken install, it is one where an optional dev
+    feature is unavailable. macOS and Windows already report that as "not
+    applicable" and block nothing, so blocking on Linux would be inconsistent as
+    well as a false alarm for everyone who never runs a pod.
+
+    Doctor only reports: enabling linger changes the user's login-session
+    lifetime and is theirs to choose, never a side effect of installing a
+    service.
+    """
+    del issues  # advisory-only diagnostic; keeps the call-site signature uniform
+    print("\nPods")
+    if not sys.platform.startswith("linux"):
+        print(
+            f"  session bus: ⏹ not applicable ({sys.platform} — pods are "
+            "Linux `systemd --user` only)"
+        )
+        return
+    if shutil.which("systemctl") is None:
+        print("  session bus: ⏹ not applicable (no `systemctl` on PATH)")
+        return
+
+    # Local import: keeps the pod package out of the CLI's import graph for
+    # every other command (circular-safe — pod.runtime imports no CLI module).
+    from kiro_crew.pod.runtime import has_session_bus, session_bus_socket
+
+    uid = getattr(os, "getuid", lambda: -1)()
+    user = os.environ.get("USER") or os.environ.get("LOGNAME") or str(uid)
+    sock = session_bus_socket()
+    if not has_session_bus():
+        print(f"  session bus: ❌ none for uid {uid} (looked for {sock})")
+        print("               Pods are systemd --user units, so `kirocrew pod` is")
+        print("               unavailable until one exists. Everything else works.")
+        print(f"               Fix: loginctl enable-linger {user}")
+        return
+    print(f"  session bus: ✅ {sock}")
+    if _linger_enabled(user) is False:
+        print(
+            "  linger:      ⚠️  disabled — the per-user systemd instance exits on "
+            "logout,"
+        )
+        print(
+            "               taking running pods with it. "
+            f"Fix: loginctl enable-linger {user}"
+        )
+
+
 def _doctor_model_url_reachable(issues: list[str]) -> None:
     """Light HTTPS-reachability probe of the resolved embedding-model URL.
 
@@ -465,6 +554,9 @@ def _doctor(platform_boot_error: "Exception | None" = None) -> None:
 
     # ── Data Home (+ leftover migration archive) ──
     _doctor_data_home()
+
+    # ── Pods (systemd --user session bus) ──
+    _doctor_pod_session_bus(issues)
 
     # ── MCP Tools ──
     print("\nMCP Tools")

--- a/src/kiro_crew/pod/README.md
+++ b/src/kiro_crew/pod/README.md
@@ -113,3 +113,19 @@ chokepoint plus the two siblings that shell out directly (`recent_journal` and
 `_logs`, which run `journalctl`). `pod url` is pure port arithmetic and works
 anywhere; `pod up` / `provision` fail earlier on their own preconditions
 (worktree resolution, venv/dist) before reaching systemd.
+
+### Session bus
+
+`systemctl --user` locates the per-user systemd instance through
+`XDG_RUNTIME_DIR` + `DBUS_SESSION_BUS_ADDRESS`. A process descended from a
+systemd **system** unit — which is how `kirocrew service install` runs the
+gateway — inherits no login-session environment and therefore neither variable,
+so pods used to fail with a bare `Failed to connect to bus: No medium found`.
+
+`runtime._systemctl_env()` backfills both when the socket
+(`$XDG_RUNTIME_DIR/bus`, else `/run/user/<uid>/bus`) actually exists; an
+explicitly-set value always wins. When the socket is genuinely absent — no login
+session and `Linger=no` — `require_systemd()` refuses with the fix
+(`loginctl enable-linger <user>`) instead of letting systemctl emit a message
+that names neither cause nor remedy. `kirocrew doctor` reports the same three
+states (present / absent / present-but-no-linger).

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -199,8 +199,62 @@ def pod_home(cfg: PodConfig, name: str) -> Path:
 # --------------------------------------------------------------------------- #
 # systemd --user helpers.
 # --------------------------------------------------------------------------- #
+def _session_runtime_dir() -> str:
+    """The per-user runtime directory ``systemctl --user`` resolves against.
+
+    ``XDG_RUNTIME_DIR`` when the caller has one, else systemd's conventional
+    ``/run/user/<uid>``. ``os.getuid`` is absent on Windows; pods are Linux-only
+    (:func:`require_systemd`) so that branch is unreachable at runtime, but the
+    ``getattr`` keeps this module importable there.
+    """
+    explicit = os.environ.get("XDG_RUNTIME_DIR")
+    if explicit:
+        return explicit
+    uid = getattr(os, "getuid", lambda: -1)()
+    return f"/run/user/{uid}"
+
+
+def session_bus_socket() -> str:
+    """Path of the D-Bus socket that fronts this user's systemd instance."""
+    return os.path.join(_session_runtime_dir(), "bus")
+
+
+def has_session_bus() -> bool:
+    """Whether ``systemctl --user`` can reach a per-user systemd instance.
+
+    An explicitly-set ``DBUS_SESSION_BUS_ADDRESS`` is taken at face value (the
+    caller has deliberately pointed somewhere, possibly not a filesystem path);
+    otherwise the conventional socket must actually exist.
+    """
+    if os.environ.get("DBUS_SESSION_BUS_ADDRESS"):
+        return True
+    return os.path.exists(session_bus_socket())
+
+
 def _systemctl_env() -> dict[str, str]:
-    return {**os.environ}
+    """Environment for ``systemctl --user``, with the session-bus pointers
+    backfilled when absent.
+
+    ``systemctl --user`` finds the per-user systemd instance through
+    ``XDG_RUNTIME_DIR`` + ``DBUS_SESSION_BUS_ADDRESS``. A process launched from
+    a systemd SYSTEM unit — which is how ``kirocrew service install`` runs the
+    gateway — inherits no login-session environment and therefore neither
+    variable, so every pod verb died with "Failed to connect to bus: No medium
+    found" even though the bus socket was present and the pod unit installed.
+
+    Only ever ADDS: an explicitly-set value always wins, so a caller that has
+    deliberately pointed at another bus is left untouched. The socket must
+    exist before we name it — if ``systemd --user`` genuinely is not running we
+    want systemctl's own diagnostic, not a failure against a path we invented.
+    """
+    env = {**os.environ}
+    runtime_dir = _session_runtime_dir()
+    if not env.get("DBUS_SESSION_BUS_ADDRESS"):
+        sock = os.path.join(runtime_dir, "bus")
+        if os.path.exists(sock):
+            env["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={sock}"
+    env.setdefault("XDG_RUNTIME_DIR", runtime_dir)
+    return env
 
 
 def _run(cmd: list[str], timeout: int = 15) -> subprocess.CompletedProcess:
@@ -218,6 +272,13 @@ def require_systemd() -> None:
     Windows instead of the documented "report the failure" one-liner. Checked
     here — the single chokepoint every systemd call funnels through — so no verb
     can forget it.
+
+    The third gate is the session bus. :func:`_systemctl_env` backfills the bus
+    pointers when the socket exists, but when ``systemd --user`` is genuinely
+    not running (no login session and ``Linger=no``) there is nothing to point
+    at and systemctl emits a raw "Failed to connect to bus: No medium found"
+    that names neither the cause nor the fix. Translate it here, keyed on the
+    socket's absence rather than on matching systemctl's stderr.
     """
     if not IS_LINUX:
         raise PodError(
@@ -227,6 +288,16 @@ def require_systemd() -> None:
     if shutil.which("systemctl") is None:
         raise PodError(
             "pods require `systemctl --user`, but no `systemctl` was found on PATH."
+        )
+    if not has_session_bus():
+        uid = getattr(os, "getuid", lambda: -1)()
+        user = os.environ.get("USER") or os.environ.get("LOGNAME") or str(uid)
+        raise PodError(
+            f"no `systemd --user` session bus for uid {uid} "
+            f"(looked for {session_bus_socket()}).\n"
+            "Pods are systemd --user units, so one is required.\n"
+            f"Fix: loginctl enable-linger {user}   "
+            "# keeps the per-user instance alive independently of login sessions"
         )
 
 

--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -99,6 +99,22 @@ def _current_group(user: str) -> str:
     return user
 
 
+def _current_uid(user: str) -> int | None:
+    """Numeric uid for ``user``, or ``None`` when it cannot be resolved.
+
+    Needed to point the unit at the per-user systemd runtime directory
+    (``/run/user/<uid>``). ``pwd`` is Unix-only and this module is imported on
+    Windows too, so the lookup is lazy and failure is non-fatal: the caller
+    omits the session-bus variables rather than baking in a guessed path.
+    """
+    try:
+        import pwd  # Unix-only; lazy so this module still imports on Windows.
+
+        return int(pwd.getpwnam(user).pw_uid)
+    except Exception:
+        return None
+
+
 def render_unit() -> str:
     """Render the systemd system-unit file contents.
 
@@ -106,23 +122,43 @@ def render_unit() -> str:
     has access to ``$HOME/.kiro/crew``, the user's config, etc. The PATH
     is set explicitly so subprocess invocations of git, node, etc.
     resolve the same way they would from an interactive shell.
+
+    A system unit inherits no login-session environment, so the per-user
+    systemd instance is also wired up explicitly — see the ``XDG_RUNTIME_DIR`` /
+    ``DBUS_SESSION_BUS_ADDRESS`` lines below.
     """
     bin_path = kirocrew_bin()
     user = _current_user()
     group = _current_group(user) if user else ""
     home = str(Path.home())
-    # USER is systemd-specific (launchd derives the user from the login
-    # session); everything else comes from the shared service_environment()
-    # so the two managers can never drift. Every value is double-quoted +
-    # escaped: a path or locale containing a space (e.g. an override under
-    # ``/opt/Kiro Crew/``) would otherwise be split on whitespace by systemd's
-    # tokenizer — ``ExecStart`` would try to exec the first word (203/EXEC) and
-    # an ``Environment=`` value would be truncated at the space.
     exec_start = f"{_sd_quote(bin_path)} gateway"
     env_lines = f"Environment={_sd_quote(f'USER={user}')}\n" + "".join(
         f"Environment={_sd_quote(f'{key}={value}')}\n"
         for key, value in service_environment(home).items()
     )
+    # The gateway spawns agent shells, MCP servers and crons that drive
+    # `systemctl --user` (pods). A system unit inherits no login-session
+    # environment, so without these the per-user systemd instance is
+    # unreachable and every pod command fails with "Failed to connect to bus:
+    # No medium found".
+    #
+    # Deliberately NOT in the shared service_environment(): `/run/user/<uid>` is
+    # a Linux/systemd path with no launchd equivalent, so baking it into the
+    # macOS plist would be meaningless. Same reason USER= is systemd-only above.
+    #
+    # A numeric uid is used rather than systemd's `%U` specifier: it has no
+    # specifier-expansion semantics to get wrong (and _sd_quote escapes `%` to
+    # `%%` anyway, which would defeat a specifier), and it matches how this
+    # generator already resolves user/group/home in Python.
+    uid = _current_uid(user) if user else None
+    if uid is not None:
+        env_lines += "".join(
+            f"Environment={_sd_quote(f'{key}={value}')}\n"
+            for key, value in (
+                ("XDG_RUNTIME_DIR", f"/run/user/{uid}"),
+                ("DBUS_SESSION_BUS_ADDRESS", f"unix:path=/run/user/{uid}/bus"),
+            )
+        )
     return (
         "[Unit]\n"
         "Description=Kiro Crew gateway (dashboard + Slack + cron)\n"

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -146,3 +146,142 @@ class TestDataHome:
         assert "legacy:" not in out
         assert "rollback copy" not in out
         assert "rm -rf" not in out
+
+
+class TestPodSessionBus:
+    """`kirocrew doctor` Pods section — the systemd --user session bus.
+
+    Pods are systemd --user units. A gateway started from a systemd SYSTEM unit
+    inherits no login-session environment, and if the per-user instance is not
+    running at all there is nothing to point at — every pod verb then fails with
+    "Failed to connect to bus: No medium found". Doctor reports the three states,
+    never gates its exit code on them (an absent bus means an optional dev
+    feature is unavailable, not a broken install), and never changes the user's
+    login-session lifetime itself.
+    """
+
+    @staticmethod
+    def _linux(monkeypatch, tmp_path: Path, *, bus: bool) -> Path:
+        monkeypatch.setattr(cli_doctor.sys, "platform", "linux")
+        monkeypatch.setattr(cli_doctor.shutil, "which", lambda n: f"/usr/bin/{n}")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        monkeypatch.setenv("USER", "tester")
+        sock = tmp_path / "bus"
+        if bus:
+            sock.touch()
+        return sock
+
+    def test_missing_bus_is_reported_but_never_blocks(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        # A container / CI runner / headless server has no per-user systemd
+        # instance. That is an unavailable optional feature, not a broken
+        # install, so it must NOT gate doctor's exit code — otherwise every
+        # such host is told its setup is broken (and `kirocrew doctor` starts
+        # exiting 1 in CI).
+        sock = self._linux(monkeypatch, tmp_path, bus=False)
+        issues: list[str] = ["pre-existing"]
+
+        cli_doctor._doctor_pod_session_bus(issues)
+
+        out = capsys.readouterr().out
+        assert "Pods" in out
+        assert str(sock) in out
+        assert "loginctl enable-linger tester" in out
+        assert "Everything else works" in out
+        assert issues == ["pre-existing"], "the missing bus must not add an issue"
+
+    def test_present_bus_passes_and_stays_quiet_when_lingering(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        sock = self._linux(monkeypatch, tmp_path, bus=True)
+        monkeypatch.setattr(cli_doctor, "_linger_enabled", lambda _u: True)
+        issues: list[str] = []
+
+        cli_doctor._doctor_pod_session_bus(issues)
+
+        out = capsys.readouterr().out
+        assert f"✅ {sock}" in out
+        assert "linger" not in out
+        assert issues == []
+
+    def test_present_bus_without_linger_warns_but_does_not_block(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        # Pods work right now and die on logout — a warning, not an issue.
+        self._linux(monkeypatch, tmp_path, bus=True)
+        monkeypatch.setattr(cli_doctor, "_linger_enabled", lambda _u: False)
+        issues: list[str] = []
+
+        cli_doctor._doctor_pod_session_bus(issues)
+
+        out = capsys.readouterr().out
+        assert "linger:" in out and "⚠️" in out
+        assert "loginctl enable-linger tester" in out
+        assert issues == []
+
+    def test_unknown_linger_stays_quiet(self, monkeypatch, tmp_path: Path, capsys) -> None:
+        # No loginctl / unparseable value → say nothing rather than guess.
+        self._linux(monkeypatch, tmp_path, bus=True)
+        monkeypatch.setattr(cli_doctor, "_linger_enabled", lambda _u: None)
+        issues: list[str] = []
+
+        cli_doctor._doctor_pod_session_bus(issues)
+
+        assert "linger:" not in capsys.readouterr().out
+        assert issues == []
+
+    def test_non_linux_is_not_applicable(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(cli_doctor.sys, "platform", "darwin")
+        issues: list[str] = []
+
+        cli_doctor._doctor_pod_session_bus(issues)
+
+        out = capsys.readouterr().out
+        assert "not applicable" in out
+        assert issues == []
+
+    def test_no_systemctl_is_not_applicable(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(cli_doctor.sys, "platform", "linux")
+        monkeypatch.setattr(cli_doctor.shutil, "which", lambda _n: None)
+        issues: list[str] = []
+
+        cli_doctor._doctor_pod_session_bus(issues)
+
+        out = capsys.readouterr().out
+        assert "not applicable" in out and "systemctl" in out
+        assert issues == []
+
+
+class TestLingerProbe:
+    """`loginctl show-user <u> -p Linger --value` → tri-state."""
+
+    def _run(self, monkeypatch, *, stdout: str, returncode: int = 0):
+        import subprocess
+
+        monkeypatch.setattr(cli_doctor.shutil, "which", lambda _n: "/usr/bin/loginctl")
+        monkeypatch.setattr(
+            cli_doctor.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                args=[], returncode=returncode, stdout=stdout, stderr=""
+            ),
+        )
+        return cli_doctor._linger_enabled("tester")
+
+    def test_yes_is_true(self, monkeypatch) -> None:
+        assert self._run(monkeypatch, stdout="yes\n") is True
+
+    def test_no_is_false(self, monkeypatch) -> None:
+        assert self._run(monkeypatch, stdout="no\n") is False
+
+    def test_unparseable_is_unknown(self, monkeypatch) -> None:
+        assert self._run(monkeypatch, stdout="wat\n") is None
+
+    def test_nonzero_exit_is_unknown(self, monkeypatch) -> None:
+        assert self._run(monkeypatch, stdout="", returncode=1) is None
+
+    def test_absent_loginctl_is_unknown(self, monkeypatch) -> None:
+        monkeypatch.setattr(cli_doctor.shutil, "which", lambda _n: None)
+        assert cli_doctor._linger_enabled("tester") is None

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -996,10 +996,14 @@ class TestPlatformGuard:
             rt.require_systemd()
 
     def test_require_systemd_passes_on_linux_with_systemctl(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.setattr(rt, "IS_LINUX", True)
         monkeypatch.setattr(rt.shutil, "which", lambda _n: "/usr/bin/systemctl")
+        # Third gate: a reachable session bus (see TestSessionBus).
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        (tmp_path / "bus").touch()
         rt.require_systemd()  # must not raise
 
     def test_systemctl_gated_before_spawn(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1040,3 +1044,166 @@ class TestPlatformGuard:
         with pytest.raises(rt.PodError):
             pod_cli._install(cfg, argparse.Namespace())
         assert wrote == []
+
+
+class TestSessionBus:
+    """``systemctl --user`` needs the per-user systemd instance's bus pointers.
+
+    A process descended from a systemd SYSTEM unit — how ``kirocrew service
+    install`` runs the gateway — inherits no login-session environment, so
+    neither ``XDG_RUNTIME_DIR`` nor ``DBUS_SESSION_BUS_ADDRESS`` is set and every
+    pod verb died with "Failed to connect to bus: No medium found" even though
+    the bus socket existed. ``_systemctl_env()`` backfills them; when the socket
+    is genuinely absent ``require_systemd()`` explains the fix instead.
+    """
+
+    @staticmethod
+    def _bus(monkeypatch: pytest.MonkeyPatch, runtime_dir: Path, *, exists: bool) -> Path:
+        """Point at *runtime_dir* as the session runtime dir, with no inherited bus."""
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        sock = runtime_dir / "bus"
+        if exists:
+            sock.touch()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        return sock
+
+    def test_backfills_both_when_socket_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        sock = self._bus(monkeypatch, tmp_path / "run", exists=True)
+        env = rt._systemctl_env()
+        assert env["XDG_RUNTIME_DIR"] == str(tmp_path / "run")
+        assert env["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={sock}"
+
+    def test_derives_runtime_dir_from_uid_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No ``XDG_RUNTIME_DIR`` → systemd's conventional ``/run/user/<uid>``."""
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        monkeypatch.setattr(rt.os, "getuid", lambda: 4242, raising=False)
+        assert rt._systemctl_env()["XDG_RUNTIME_DIR"] == "/run/user/4242"
+
+    def test_leaves_bus_unset_when_socket_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No socket → no invented address, so systemctl emits its own diagnostic
+        instead of failing against a path we made up."""
+        self._bus(monkeypatch, tmp_path / "run", exists=False)
+        env = rt._systemctl_env()
+        assert "DBUS_SESSION_BUS_ADDRESS" not in env
+        assert env["XDG_RUNTIME_DIR"] == str(tmp_path / "run")
+
+    def test_never_clobbers_an_explicit_bus(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A caller pointing at another bus is left alone — this only ever ADDS."""
+        self._bus(monkeypatch, tmp_path / "run", exists=True)
+        monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/elsewhere/bus")
+        assert rt._systemctl_env()["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/elsewhere/bus"
+
+    def test_never_clobbers_an_explicit_runtime_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._bus(monkeypatch, tmp_path / "run", exists=True)
+        assert rt._systemctl_env()["XDG_RUNTIME_DIR"] == str(tmp_path / "run")
+
+    def test_has_session_bus_trusts_an_explicit_address(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An explicit address may not be a filesystem path at all — take it as given."""
+        self._bus(monkeypatch, tmp_path / "run", exists=False)
+        monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "unix:abstract=/tmp/dbus-abc")
+        assert rt.has_session_bus() is True
+
+    def test_require_systemd_explains_a_missing_bus(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The raw systemctl message names neither cause nor fix — ours does."""
+        monkeypatch.setattr(rt, "IS_LINUX", True)
+        monkeypatch.setattr(rt.shutil, "which", lambda _n: "/usr/bin/systemctl")
+        sock = self._bus(monkeypatch, tmp_path / "run", exists=False)
+        monkeypatch.setenv("USER", "tester")
+        with pytest.raises(rt.PodError) as exc:
+            rt.require_systemd()
+        msg = str(exc.value)
+        assert str(sock) in msg
+        assert "loginctl enable-linger tester" in msg
+        # Keyed on the socket's absence, not on matching systemctl's stderr.
+        assert "No medium found" not in msg
+
+    def test_missing_bus_is_reported_before_any_spawn(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(rt, "IS_LINUX", True)
+        monkeypatch.setattr(rt.shutil, "which", lambda _n: "/usr/bin/systemctl")
+        self._bus(monkeypatch, tmp_path / "run", exists=False)
+        spawned: list[list[str]] = []
+        monkeypatch.setattr(rt, "_run", lambda cmd, **k: spawned.append(cmd))
+        with pytest.raises(rt.PodError):
+            rt.systemctl("list-units")
+        assert spawned == []
+
+    def test_systemctl_env_is_the_only_env_source_for_systemd_calls(self) -> None:
+        """Anti-regression: a future direct ``subprocess.run(["systemctl", ...])``
+        that forgets ``env=_systemctl_env()`` would silently reintroduce the bug,
+        so pin every systemd/journalctl spawn in the module to that one source.
+        """
+        import ast
+
+        src = Path(rt.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+
+        def _is_subprocess_run(node: ast.Call) -> bool:
+            fn = node.func
+            return (
+                isinstance(fn, ast.Attribute)
+                and fn.attr == "run"
+                and isinstance(fn.value, ast.Name)
+                and fn.value.id == "subprocess"
+            )
+
+        def _uses_systemctl_env(node: ast.Call) -> bool:
+            for kw in node.keywords:
+                if kw.arg != "env":
+                    continue
+                val = kw.value
+                return (
+                    isinstance(val, ast.Call)
+                    and isinstance(val.func, ast.Name)
+                    and val.func.id == "_systemctl_env"
+                )
+            return False
+
+        literal_systemd = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not _is_subprocess_run(node):
+                continue
+            argv = node.args[0] if node.args else None
+            if not isinstance(argv, ast.List):
+                continue
+            head = argv.elts[0] if argv.elts else None
+            if not isinstance(head, ast.Constant) or head.value not in (
+                "systemctl",
+                "journalctl",
+            ):
+                continue
+            literal_systemd += 1
+            assert _uses_systemctl_env(node), (
+                f"line {node.lineno}: {head.value} spawned without env=_systemctl_env()"
+            )
+
+        # journalctl in recent_journal is the one literal systemd spawn; if that
+        # drops to zero the scan above has stopped covering anything.
+        assert literal_systemd >= 1, "no literal systemd spawn found — scan is inert"
+        # The variable-argv chokepoint every systemctl() call funnels through.
+        chokepoint = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "_run"
+        )
+        assert any(
+            _is_subprocess_run(n) and _uses_systemctl_env(n)
+            for n in ast.walk(chokepoint)
+            if isinstance(n, ast.Call)
+        ), "_run no longer passes env=_systemctl_env()"

--- a/test/test_pod_e2e_video_guard.py
+++ b/test/test_pod_e2e_video_guard.py
@@ -561,3 +561,56 @@ def test_teardown_bail_row_matches_the_summary_grep(driver, tmp_path):
     assert re.search(pattern.group(1), line), (
         f"grep pattern {pattern.group(1)!r} no longer matches a teardown row"
     )
+
+
+def test_missing_playwright_interpreter_fails_the_run():
+    """A run that captured ZERO screenshots must not report a green summary.
+
+    The FE phase used to `warn` when KIROCREW_PW_PY was unset, so the summary
+    said "N passed, 0 failed" with no evidence on disk — which is how "capture
+    is in flight" becomes a believable but false statement. It must `fail`.
+    """
+    lines = _runner_text().splitlines()
+
+    def _index(needle: str):
+        return next((i for i, ln in enumerate(lines) if needle in ln), None)
+
+    fe_branch = _index('if [ "$RUN_FE" -eq 1 ]')
+    no_interp = _index('if [ -z "$PW_PY" ] || [ ! -x "$PW_PY" ]; then')
+    no_runner = _index('elif [ ! -f "$PW_RUNNER" ]; then')
+    assert fe_branch is not None and no_interp is not None and no_runner is not None
+    assert fe_branch < no_interp < no_runner
+
+    # Both zero-screenshot branches sit between the interpreter test and the
+    # `else` that launches the driver — neither may warn.
+    launch_else = next(
+        i for i, ln in enumerate(lines) if i > no_runner and ln.strip() == "else"
+    )
+    branch = "\n".join(lines[no_interp:launch_else])
+    assert "warn " not in branch, "a zero-screenshot branch still only warns"
+    assert branch.count("fail ") == 2, "both zero-screenshot branches must fail"
+    assert "KIROCREW_PW_PY" in branch
+
+
+def test_missing_playwright_message_names_the_pinned_version_and_the_opt_out():
+    """The fix must be copy-pasteable, and the pin must match the chromium build
+    the Node Playwright MCP server has already downloaded (1.61.0 → chromium-1228);
+    any other version triggers a fresh ~170MB download."""
+    body = _runner_text()
+    assert "playwright==1.61.0" in body
+    assert "export KIROCREW_PW_PY=" in body
+    # --api-only stays the one clean way to skip the frontend phase.
+    assert "--api-only" in body
+    assert "--api-only) RUN_FE=0 ;;" in body
+
+
+def test_api_only_skips_the_whole_fe_phase():
+    """`--api-only` sets RUN_FE=0, so the FE block (and its new failures) is
+    never entered — the graceful skip survives."""
+    lines = _runner_text().splitlines()
+    assert any("--api-only) RUN_FE=0 ;;" in ln for ln in lines)
+    fe_branch = next(i for i, ln in enumerate(lines) if 'if [ "$RUN_FE" -eq 1 ]' in ln)
+    no_interp = next(
+        i for i, ln in enumerate(lines) if 'if [ -z "$PW_PY" ] || [ ! -x "$PW_PY" ]' in ln
+    )
+    assert fe_branch < no_interp, "the interpreter check escaped the RUN_FE guard"

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -104,6 +104,77 @@ class TestLinuxUnitRendering:
         # by `systemctl --user`).
         assert "WantedBy=multi-user.target" in unit
 
+    def test_render_unit_carries_the_session_bus_environment(self, monkeypatch):
+        """A system unit inherits no login-session env, so pods (systemd --user
+        units) were unreachable from the service-installed gateway. The unit must
+        wire up the per-user systemd instance explicitly."""
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setenv("USER", "tester")
+        gid_result = MagicMock(returncode=0, stdout="staff\n", stderr="")
+        with patch(
+            "kiro_crew.service.common.shutil.which",
+            return_value="/usr/local/bin/kirocrew",
+        ), patch(
+            "kiro_crew.service.linux.subprocess.run", return_value=gid_result
+        ), patch.object(
+            svc_linux, "_current_uid", return_value=4242
+        ):
+            unit = svc_linux.render_unit()
+
+        assert 'Environment="XDG_RUNTIME_DIR=/run/user/4242"\n' in unit
+        assert (
+            'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/4242/bus"\n' in unit
+        )
+        # No reordering regression: the pre-existing Environment lines survive,
+        # still inside [Service] and still ahead of the new ones.
+        assert 'Environment="USER=tester"\n' in unit
+        assert 'Environment="HOME=' in unit
+        assert 'Environment="PATH=' in unit
+        service = unit.index("[Service]")
+        install = unit.index("[Install]")
+        for key in ("HOME", "USER", "PATH", "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS"):
+            at = unit.index(f'Environment="{key}=')
+            assert service < at < install, f"Environment={key} escaped [Service]"
+        assert unit.index('Environment="PATH=') < unit.index('Environment="XDG_RUNTIME_DIR=')
+
+    def test_render_unit_omits_session_bus_when_uid_unresolvable(self, monkeypatch):
+        """Rather than bake in a guessed uid, omit the pair — the pod runtime
+        backfills the same values at call time anyway."""
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setenv("USER", "tester")
+        gid_result = MagicMock(returncode=0, stdout="staff\n", stderr="")
+        with patch(
+            "kiro_crew.service.common.shutil.which",
+            return_value="/usr/local/bin/kirocrew",
+        ), patch(
+            "kiro_crew.service.linux.subprocess.run", return_value=gid_result
+        ), patch.object(
+            svc_linux, "_current_uid", return_value=None
+        ):
+            unit = svc_linux.render_unit()
+
+        assert "XDG_RUNTIME_DIR" not in unit
+        assert "DBUS_SESSION_BUS_ADDRESS" not in unit
+        # The rest of the unit is still well-formed.
+        assert 'Environment="PATH=' in unit
+        assert "[Install]" in unit
+
+    def test_session_bus_is_systemd_only_not_in_the_shared_environment(self):
+        """`/run/user/<uid>` is a Linux/systemd path with no launchd equivalent,
+        so it must NOT leak into the env shared with the macOS plist."""
+        from kiro_crew.service.common import service_environment
+
+        keys = set(service_environment("/home/tester"))
+        assert "XDG_RUNTIME_DIR" not in keys
+        assert "DBUS_SESSION_BUS_ADDRESS" not in keys
+
+    def test_current_uid_returns_none_for_an_unknown_user(self):
+        from kiro_crew.service import linux as svc_linux
+
+        assert svc_linux._current_uid("no-such-user-e2b9f1") is None
+
     def test_render_unit_falls_back_to_argv0_when_kirocrew_not_on_path(self, monkeypatch):
         from kiro_crew.service import linux as svc_linux
 

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -214,6 +214,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_commands.py::_cleanup_app_crons_from_scheduler",
         "cli_doctor.py::_doctor",
         "cli_doctor.py::_doctor_mcp_tools",
+        # Read-only diagnostic: `loginctl show-user <user> -p Linger --value`,
+        # a fixed argv whose only variable is the invoking account name taken
+        # from $USER/$LOGNAME (never agent-supplied). Same class as
+        # service/linux.py::_current_group — an identity/state query the doctor
+        # makes to tell the user whether pods survive logout. No shell, no
+        # agent-influenced argument, nothing written.
+        "cli_doctor.py::_linger_enabled",
         "cli_server.py::_logs_cmd",
         "cli_server.py::_spawn_detached_gateway",
         "cli_server.py::_update",


### PR DESCRIPTION
## Problem

`kirocrew pod up <wt>` fails immediately:

```
pod: systemctl start failed for <wt>: Failed to connect to bus: No medium found
```

Pods are `systemd --user` units, so the pod runtime shells out to
`systemctl --user`. That command locates the per-user systemd instance through
two environment variables, and **neither is set in any process descended from
the gateway** when the gateway was installed with `kirocrew service install`. So
every pod verb fails — not just `up`.

A second, quieter defect: when the frontend phase of `pod-e2e` cannot find its
Playwright interpreter it emitted a *warning* and the run still printed a green
summary, having captured **zero screenshots**.

## Why it matters

Pods are the only sanctioned way to run an isolated instance of a feature
worktree, and `kirocrew service install` is the documented install path. Together
that made an advertised feature — and the whole `pod-e2e` skill built on it —
structurally unreachable for anyone following the docs. The remaining fallback is
starting an ad-hoc gateway from the worktree, which is exactly the path with
known side effects on the shared agent home.

Verified on an AL2023 host running systemd 252: everything the feature needs was
already present (the per-user systemd instance was running, the bus socket
existed, the `kirocrew-pod@.service` template unit was installed). Only the two
pointers were missing.

The `pod-e2e` warning compounds it: a run that produced no evidence reported
success, which is how "screenshots are in flight" becomes a believable but false
statement.

## Fix (symptoms → root cause → change)

**Symptom** → `systemctl --user` cannot reach the per-user systemd instance from
anything the gateway spawns.

**Root cause** → `kirocrew service install` writes a systemd **system** unit,
which declares its entire environment by hand. A system unit inherits no
login-session environment, so `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS`
were simply absent. `pod/runtime.py` had the right seam for this —
`_systemctl_env()`, which every pod systemd call already funnels through — but it
was a pass-through stub returning `os.environ` unchanged.

**Change** — five parts, first is the primary fix:

1. **`_systemctl_env()` backfills the two pointers** when the bus socket exists.
   Because it is the single env source for every `systemctl --user` /
   `journalctl --user` call in the pod runtime, this fixes pods for *every*
   caller — service-installed gateway, ad-hoc gateway, agent shell, cron — with
   no root and no unit edit. It only ever **adds**: an explicitly-set value
   always wins, so a caller deliberately pointing at another bus is untouched.
   It also refuses to name a socket that does not exist, so a host with no
   per-user instance gets systemctl's own diagnostic rather than a failure
   against an invented path.

2. **The generated system unit carries them too**, so anything else the gateway
   spawns has a usable user bus and the unit is self-describing. These are added
   in `service/linux.py`, *not* the shared `service_environment()` — `/run/user/<uid>`
   is a Linux/systemd path with no launchd equivalent, so baking it into the
   macOS plist would be meaningless. A numeric uid is used rather than systemd's
   `%U` specifier: it has no specifier-expansion semantics to get wrong (and the
   unit quoter escapes `%` → `%%` anyway, which would defeat a specifier), and it
   matches how the generator already resolves user/group/home in Python. If the
   uid cannot be resolved the pair is omitted rather than guessed — part 1 still
   supplies the values at call time.

3. **An actionable error when there really is no bus.** If the per-user instance
   is genuinely not running (no login session and `Linger=no`), part 1 correctly
   declines to invent a bus. `require_systemd()` — the existing chokepoint that
   already gates off-Linux and missing-`systemctl` — now also refuses with the
   remediation (`loginctl enable-linger <user>`) instead of letting systemctl
   emit a message that names neither cause nor fix. Keyed on the socket's
   absence, not on string-matching systemctl's stderr.

4. **A `kirocrew doctor` check** reporting the three states: socket present →
   pass; absent → ❌ with the remediation; present but `Linger=no` → ⚠️ warn,
   because pods work now and die on logout. It is **advisory** — it never gates
   doctor's exit code, matching the embedding-model URL probe in the same file. A
   container, CI runner, or headless server has no per-user systemd instance;
   that is an unavailable optional feature, not a broken install, and macOS /
   Windows already report it as "not applicable" and block nothing. Doctor also
   never enables linger itself: changing a user's login-session lifetime is not a
   side effect an install should have.

5. **The `pod-e2e` screenshot phase fails instead of skipping** when its
   Playwright interpreter or driver is missing. `--api-only` (which sets
   `RUN_FE=0` and skips the whole phase) remains the one clean way to opt out.
   The failure message carries the copy-pasteable fix and pins
   `playwright==1.61.0` deliberately — that version pins `chromium-1228`, which
   the Node Playwright MCP server has already downloaded, so any other version
   triggers a fresh ~170MB browser download.

## Tests

35 new tests.

| Area | File | What it locks in |
|---|---|---|
| Backfill | `test/test_pod.py` (`TestSessionBus`) | Both vars appear when the socket is present; `DBUS_SESSION_BUS_ADDRESS` stays **absent** when it is not; a pre-set value and a pre-set `XDG_RUNTIME_DIR` are preserved verbatim; runtime dir derives from the uid when unset; `has_session_bus()` trusts a non-path address (`unix:abstract=…`) at face value |
| Actionable error | `test/test_pod.py` | The missing-socket path raises with the socket path and `loginctl enable-linger <user>`, does **not** contain systemctl's raw wording, and is raised **before** any subprocess is spawned |
| Anti-regression | `test/test_pod.py` | An AST scan asserts every literal `systemctl`/`journalctl` spawn in the pod runtime passes `env=_systemctl_env()`, and that the variable-argv chokepoint `_run` still does — so a future direct `subprocess.run(["systemctl", …])` cannot silently reintroduce the bug. Guarded against going inert by requiring at least one literal spawn to be found |
| Unit rendering | `test/test_service.py` | Both `Environment=` lines render with the numeric uid; HOME/USER/PATH survive unreordered and all stay inside `[Service]`; the pair is omitted when the uid is unresolvable; `_current_uid()` returns `None` for an unknown user; the vars are **not** in the shared `service_environment()` (launchd-drift guard) |
| Doctor | `test/test_cli_doctor.py` | pass / absent / linger-warn / linger-unknown / non-Linux / no-systemctl branches, plus an explicit assertion that the absent case adds **no** entry to `issues` |
| Linger probe | `test/test_cli_doctor.py` | `yes`→True, `no`→False, unparseable/non-zero-exit/absent-`loginctl`→None |
| pod-e2e | `test/test_pod_e2e_video_guard.py` | Both zero-screenshot branches call `fail` and neither calls `warn`; the message names the pinned version and the `--api-only` opt-out; the interpreter check stays inside the `RUN_FE` guard so `--api-only` still skips cleanly |
| Spawn audit | `test/test_spawn_audit.py` | The new `loginctl` read is allowlisted with a justification (fixed argv, only variable is the account name from `$USER`/`$LOGNAME`, nothing agent-supplied) |

Full backend suite: 21958 passed. The 52 failures on this host are
environment-specific (unprivileged user namespaces are unavailable, so
sandbox-routed spawns fail with `EPERM`); none are in the changed areas, and the
one in a file this PR touches
(`test_cli.py::TestInstallPidfdChildWatcher::test_real_subprocess_works_after_install_on_linux`)
fails identically on unmodified `main`.

Gates: `pytest`, `isort`, `flake8`, `mypy`, and the scrub lint all pass.
Backend-only change — no `tsc`/`vitest`, no dist rebuild.

## Manual verification

On an AL2023 host (systemd 252), with **both variables stripped from the
environment** to reproduce exactly what a system-unit-launched gateway sees:

1. `_systemctl_env()` returned `XDG_RUNTIME_DIR=/run/user/<uid>` and
   `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/<uid>/bus` from a parent process
   that had neither.

2. The call that used to fail now reaches the bus:

   ```
   before: Failed to connect to bus: No medium found
   after:  ○ kirocrew-pod@probe.service — … Active: inactive (dead)   [rc 3]
   ```

   `rc 3` / "inactive (dead)" is the *correct* answer for a unit that is not
   running — the bus was reached.

3. The rendered unit contains both `Environment=` lines with the resolved
   numeric uid, alongside the existing HOME/USER/PATH/locale entries.

4. `kirocrew doctor` printed the new `Pods` section: `session bus: ✅ /run/user/<uid>/bus`
   plus the `linger: ⚠️ disabled` warning — which matched the host's real state
   (`Linger=no`), and left the exit code alone.

5. With the runtime dir pointed at an empty directory (no bus at all), the
   actionable error rendered with the socket path and the `loginctl enable-linger`
   fix, and no subprocess was spawned.

## Screenshots

N/A — no user-visible UI surface changes. The only new user-facing output is CLI
text (`kirocrew doctor`'s `Pods` section and the pod error message), quoted
verbatim in **Manual verification** above.

## Related

- Depends on nothing; touches `service/linux.py`'s unit generator, which
  #849 refactored — rebased onto that and the session-bus vars are deliberately
  kept out of the shared `service_environment()` so the launchd plist cannot
  drift.
