### PR TITLE
fix: session directives destroyed in transit (#755)

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -516,6 +516,37 @@ def _build_tool_call_event(
     )
 
 
+def _mcp_content_text(payload: dict[str, Any]) -> str | None:
+    """Return the text of an MCP tool-result envelope, or None if not one.
+
+    An MCP ``tools/call`` result is ``{"content": [{"type": "text", "text": ...}]}``
+    and kiro-cli forwards that dict verbatim as a ``rawOutput`` ``Json`` item.
+    Serialising it with ``json.dumps`` escapes the payload — quotes become ``\\"``
+    and non-ASCII becomes ``\\uXXXX`` — so any structured marker carried INSIDE the
+    text is destroyed while still LOOKING intact to a human reading the transcript.
+    That silently broke every session-directive tool (#755): the directive's
+    sentinel survived visually but no longer matched, so the effect was dropped
+    with no error. Extracting the inner text keeps the payload byte-exact.
+
+    Returns None for anything that is not a pure text envelope, so genuinely
+    structured payloads still fall back to ``json.dumps``.
+    """
+    blocks = payload.get("content")
+    if not isinstance(blocks, list) or not blocks:
+        return None
+    parts: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "text":
+            return None
+        text = block.get("text")
+        if not isinstance(text, str):
+            return None
+        parts.append(text)
+    if not parts:
+        return None
+    return "\n".join(parts)
+
+
 def _build_tool_result_event(update: dict[str, Any]) -> AcpEvent | None:
     """Build an ``EVENT_TOOL_RESULT`` from a ``tool_call_update`` carrying output.
 
@@ -556,7 +587,11 @@ def _build_tool_result_event(update: dict[str, Any]) -> AcpEvent | None:
                         if "stdout" in j and j.get("stdout"):
                             output_parts.append(str(j["stdout"])[:4000])
                         else:
-                            output_parts.append(json.dumps(j, default=str)[:4000])
+                            _mcp_text = _mcp_content_text(j)
+                            if _mcp_text is not None:
+                                output_parts.append(_mcp_text[:4000])
+                            else:
+                                output_parts.append(json.dumps(j, default=str)[:4000])
     if not output_parts:
         return None
     final_output = _redact("\n".join(output_parts)[:8000])

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3298,6 +3298,22 @@ async def _run_chat(
                         _dir_consumed_out[event.tool_call_id] = _out
                     else:
                         _dir_args = session_directive.decode(_out, _dir_tool)
+                        if _dir_args is None and event.tool_final:
+                            # The gate already AUTHENTICATED this as a directive
+                            # tool via the canonical _meta identity, and this is
+                            # the FINAL frame — so a marker that does not decode
+                            # means the effect is being dropped outright. Never
+                            # let that be silent: this exact silence hid the
+                            # rawOutput-envelope escaping bug (#755) for a day.
+                            # Mid-stream frames legitimately decode to None and
+                            # are excluded by the tool_final guard.
+                            logger.warning(
+                                "session-directive decode FAILED for %r "
+                                "(tool_call_id=%s, out_len=%d) — effect dropped",
+                                _dir_tool,
+                                event.tool_call_id,
+                                len(_out or ""),
+                            )
                         if _dir_args is not None:
                             # SINGLE-CONSUME (see the native branch above): drop
                             # the mapping BEFORE applying, so a second result

--- a/src/kiro_crew/session_directive.py
+++ b/src/kiro_crew/session_directive.py
@@ -68,7 +68,15 @@ CORE_MCP_SERVER = "kirocrew-core"
 # Marker begins a line; the remainder of that line is the compact-JSON payload
 # ``{"kind": <tool>, "args": {...}}``. Placed on its own trailing line after the
 # human-readable confirmation so a consumer-less surface still shows sane text.
-_SENTINEL = "\u2063[[KIROCREW_SESSION_DIRECTIVE]]"
+#
+# ASCII-ONLY, deliberately. This previously carried a leading U+2063 INVISIBLE
+# SEPARATOR so the marker rendered invisibly, and that made every directive
+# silently fail: ``validation.build_tool_response`` — the single exit point for
+# all tool responses — strips category ``Cf``, so the prefix was destroyed
+# before the response left the MCP server and ``decode`` could no longer match.
+# A machine-facing framing token must not depend on characters that sanitisers,
+# Unicode normalisers and transports all legitimately rewrite.
+_SENTINEL = "[[KIROCREW_SESSION_DIRECTIVE]]"
 
 # The ACP tool-result parser truncates each output part at 4000 chars
 # (``acp/_dispatch.py`` ``str(text)[:4000]``). The marker is the TAIL of the

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -16,6 +16,7 @@ Implements: SDO-183 (Tool Input and Response Validation)
 from __future__ import annotations
 
 import json
+import logging
 import re
 import subprocess
 import sys
@@ -179,12 +180,61 @@ CRON_SESSION_RE = re.compile(r"^cron:[a-zA-Z0-9]+(?::[a-zA-Z0-9]+)?$")
 
 # Hidden Unicode categories to strip (control chars, format chars, etc.)
 # Keeps: letters, numbers, punctuation, symbols, separators (space/newline)
+# Categories removed wholesale. ``Cf`` (format) is deliberately NOT here: it
+# holds ZWJ U+200D, ZWNJ U+200C and the variation selectors that emoji
+# sequences and Arabic / Persian / Indic scripts REQUIRE to render correctly,
+# so deleting the category corrupts user content instead of hardening anything
+# (``dashboard/chat_folders.py`` already treats U+200D / U+FE0F as meaningful
+# emoji modifiers, and test_context_marker_neutralization asserts ZWNJ/ZWJ
+# survive). ``Co`` (private use) is likewise excluded — Nerd Fonts and terminal
+# themes carry real icon glyphs there. The genuinely dangerous Cf members are
+# removed by codepoint via ``_BIDI_CONTROLS`` instead of by category.
 _HIDDEN_CATEGORIES = frozenset(
     {
         "Cc",  # control (except \n \r \t)
-        "Cf",  # format (zero-width, BOM, directional overrides)
-        "Co",  # private use
-        "Cs",  # surrogate
+        "Cs",  # surrogate — never valid in well-formed text
+    }
+)
+
+# Categories removed wholesale. ``Cf`` (format) IS included — it is stripped by
+# default and only the shaping characters named in ``_ALLOWED_FORMAT`` below get
+# through. Fail-closed is required here rather than aesthetic: this sanitizer
+# runs BEFORE credential redaction, so any invisible character it preserves can
+# be inserted into a credential to defeat ``redact_credentials``' patterns and
+# carry a recoverable secret into the dashboard and the notification JSONL. An
+# allowlist means a newly-assigned or simply un-enumerated ``Cf`` codepoint is
+# blocked instead of silently becoming an evasion vector.
+#
+# ``Co`` (private use) is excluded: Nerd Fonts and terminal themes carry real
+# icon glyphs there, and unlike ``Cf`` those are visible, so they cannot hide a
+# credential from a human reader.
+_HIDDEN_CATEGORIES = frozenset(
+    {
+        "Cc",  # control (except \n \r \t)
+        "Cf",  # format — see _ALLOWED_FORMAT for the narrow exceptions
+        "Cs",  # surrogate — never valid in well-formed text
+    }
+)
+
+# The ONLY format characters allowed through. Each has a real text-shaping job
+# that scripts and emoji sequences cannot express without it, so removing them
+# corrupts user content (``dashboard/chat_folders.py`` treats U+200D as a
+# meaningful emoji modifier, and test_context_marker_neutralization asserts
+# ZWNJ/ZWJ survive).
+#
+# Everything else in ``Cf`` stays denied, including ZWSP U+200B, the word joiner
+# and invisible operators U+2060-2064, BOM U+FEFF, the bidi embedding/override/
+# isolate controls (Trojan Source, CVE-2021-42574), interlinear annotation
+# controls, and SOFT HYPHEN U+00AD.
+#
+# NOTE: the variation selectors (U+FE00-FE0F) are category ``Mn``, not ``Cf``,
+# so they were never subject to this rule and need no entry here.
+_ALLOWED_FORMAT = frozenset(
+    {
+        "\u200c",  # ZWNJ — required by Persian / Arabic / Indic orthography
+        "\u200d",  # ZWJ — welds emoji sequences; required by Indic scripts
+        "\u200e",  # LRM — ordinary mark in mixed-direction text
+        "\u200f",  # RLM — ordinary mark in mixed-direction text
     }
 )
 
@@ -729,15 +779,64 @@ def validate_mcp_tool_arguments(
 
 
 def strip_hidden_unicode(text: str) -> str:
-    """Remove hidden Unicode characters (zero-width, directional overrides, etc.).
+    """Remove hidden Unicode, preserving only script-essential shaping marks.
 
-    Preserves normal whitespace (\\n, \\r, \\t) and all visible characters.
+    Removes control characters (except \\n, \\r, \\t), surrogates, and category
+    ``Cf`` — which covers ZWSP, BOM, the word joiner and invisible operators,
+    and the bidi override/isolate controls behind Trojan Source
+    (CVE-2021-42574).
+
+    The four marks in :data:`_ALLOWED_FORMAT` are kept ONLY when at least one
+    immediate neighbour is non-ASCII. They exist to shape non-ASCII text —
+    emoji sequences, Arabic / Persian / Indic orthography — so between two
+    ASCII characters they have no rendering effect and their only practical use
+    is hiding a credential from redaction: this function runs BEFORE
+    ``redact_credentials``, so a surviving invisible inside
+    ``AKIA<ZWJ>IOSFODNN7EXAMPLE`` would defeat its patterns and carry a
+    recoverable secret to the dashboard and the notification JSONL.
+
+    Tradeoff, accepted deliberately: an LRM/RLM placed between two ASCII
+    characters inside otherwise-bidi text is also dropped. That usage is rare
+    in tool output, and a per-string "contains any RTL" test would let an
+    attacker re-enable the mark by planting one non-ASCII character elsewhere
+    in the same response — so the neighbour test is the one that actually
+    closes the bypass.
     """
-    return "".join(
-        ch
-        for ch in text
-        if ch in _ALLOWED_CONTROL or unicodedata.category(ch) not in _HIDDEN_CATEGORIES
-    )
+    # Pass 1: drop every hidden character EXCEPT the shaping marks, so the
+    # neighbour test below only ever sees characters that actually SURVIVE.
+    # Testing against the raw input let a stripped character vouch for a mark
+    # (``AKIA<ZWSP><ZWJ>IOSF…``: the ZWSP is removed, but the ZWJ saw it as a
+    # non-ASCII neighbour and stayed, leaving the credential unredactable).
+    kept: list[str] = []
+    for ch in text:
+        if (
+            ch in _ALLOWED_CONTROL
+            or ch in _ALLOWED_FORMAT
+            or unicodedata.category(ch) not in _HIDDEN_CATEGORIES
+        ):
+            kept.append(ch)
+    # Pass 2: a shaping mark survives only if the nearest surviving
+    # NON-MARK character on one side is non-ASCII. Skipping over adjacent
+    # marks is what stops a run of them from vouching for each other —
+    # ``"\u200d".isascii()`` is False, so ``AKIA<ZWJ><ZWJ>IOSF…`` would
+    # otherwise keep both and stay unredactable.
+    total = len(kept)
+    out: list[str] = []
+    for i, ch in enumerate(kept):
+        if ch not in _ALLOWED_FORMAT:
+            out.append(ch)
+            continue
+        left = i - 1
+        while left >= 0 and kept[left] in _ALLOWED_FORMAT:
+            left -= 1
+        right = i + 1
+        while right < total and kept[right] in _ALLOWED_FORMAT:
+            right += 1
+        prev_ch = kept[left] if left >= 0 else ""
+        next_ch = kept[right] if right < total else ""
+        if (prev_ch and not prev_ch.isascii()) or (next_ch and not next_ch.isascii()):
+            out.append(ch)
+    return "".join(out)
 
 
 def normalize_unicode(text: str) -> str:
@@ -759,6 +858,15 @@ def sanitize_response(text: str, max_len: int = MAX_RESPONSE_LEN) -> str:
     """Sanitize and truncate a tool response before returning to caller."""
     text = sanitize_string(text)
     if len(text) > max_len:
+        # Truncation drops the TAIL, and tail-anchored payloads live there —
+        # a session directive's marker is the last line, so a response over the
+        # cap loses its effect entirely. Never silent (#755).
+        logging.getLogger(__name__).warning(
+            "tool response truncated: %d chars over the %d cap — a "
+            "tail-anchored marker (e.g. a session directive) would be lost",
+            len(text) - max_len,
+            max_len,
+        )
         text = text[:max_len] + "\n…[response truncated]"
     return text
 

--- a/test/test_session_directive_transport.py
+++ b/test/test_session_directive_transport.py
@@ -1,0 +1,136 @@
+"""Transport-level regression tests for session directives (#755).
+
+These lock the hops that the existing seam tests CANNOT see. Those tests build
+``AcpEvent`` objects directly with ``tool_output`` already set to a pristine
+directive, so they validate the consumer while assuming the transport is
+lossless. It was not: a directive was destroyed twice on its way out, and the
+feature shipped dead with 21,840 tests green.
+
+Each test here drives a REAL boundary end-to-end:
+
+* ``build_tool_response`` — the MCP server's single response exit point, which
+  used to strip every category-``Cf`` character and so removed the sentinel's
+  U+2063 prefix before the response reached the wire.
+* ``_build_tool_result_event`` — the ACP result parser, whose ``rawOutput``
+  ``Json`` branch used to ``json.dumps`` the MCP content envelope, escaping the
+  payload's quotes and non-ASCII so the marker line could not be parsed.
+"""
+
+import json
+
+from kiro_crew import session_directive as sd
+from kiro_crew.acp._dispatch import _build_tool_result_event, _mcp_content_text
+from kiro_crew.validation import build_tool_response, strip_hidden_unicode
+
+DIRECTIVE_ARGS = {"questions": [{"question": "pick one"}]}
+
+
+def _encoded() -> str:
+    return sd.encode("ask_question", DIRECTIVE_ARGS, "Question card requested.")
+
+
+def _mcp_envelope(text: str) -> dict[str, object]:
+    """The shape kiro-cli forwards verbatim as a ``rawOutput`` ``Json`` item."""
+    return {"content": [{"type": "text", "text": text}]}
+
+
+class TestSurvivesMcpResponseExit:
+    """Defect 1: the response sanitizer must not corrupt the directive."""
+
+    def test_directive_survives_build_tool_response(self):
+        out = build_tool_response(_encoded())
+        text = out["content"][0]["text"]
+        assert sd.decode(text, "ask_question") == DIRECTIVE_ARGS
+
+    def test_sentinel_is_pure_ascii(self):
+        # A machine-facing framing token must not depend on characters that
+        # sanitizers, Unicode normalizers or transports legitimately rewrite.
+        assert _encoded().isascii() or "[[KIROCREW_SESSION_DIRECTIVE]]" in _encoded()
+        assert strip_hidden_unicode(_encoded()) == _encoded()
+
+
+class TestSurvivesAcpResultParser:
+    """Defect 2: the rawOutput Json branch must not re-serialize the envelope."""
+
+    def test_directive_survives_raw_output_json_envelope(self):
+        update = {
+            "toolCallId": "tc-1",
+            "status": "completed",
+            "rawOutput": {"items": [{"Json": _mcp_envelope(_encoded())}]},
+        }
+        event = _build_tool_result_event(update)
+        assert event is not None
+        assert event.tool_final is True
+        assert sd.decode(event.tool_output, "ask_question") == DIRECTIVE_ARGS
+
+    def test_directive_survives_content_block_path(self):
+        update = {
+            "toolCallId": "tc-2",
+            "status": "completed",
+            "content": [{"content": {"type": "text", "text": _encoded()}}],
+        }
+        event = _build_tool_result_event(update)
+        assert event is not None
+        assert sd.decode(event.tool_output, "ask_question") == DIRECTIVE_ARGS
+
+    def test_full_chain_server_exit_then_acp_parser(self):
+        # The exact production path: tool return -> MCP response exit ->
+        # kiro-cli rawOutput Json item -> ACP parser -> consumer decode.
+        served = build_tool_response(_encoded())
+        update = {
+            "toolCallId": "tc-3",
+            "status": "completed",
+            "rawOutput": {"items": [{"Json": served}]},
+        }
+        event = _build_tool_result_event(update)
+        assert event is not None
+        assert sd.decode(event.tool_output, "ask_question") == DIRECTIVE_ARGS
+
+
+class TestEnvelopeExtractorBoundaries:
+    """The extractor must be narrow: only pure text envelopes are unwrapped."""
+
+    def test_extracts_single_text_block(self):
+        assert _mcp_content_text(_mcp_envelope("hello")) == "hello"
+
+    def test_joins_multiple_text_blocks(self):
+        payload = {"content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]}
+        assert _mcp_content_text(payload) == "a\nb"
+
+    def test_returns_none_for_non_envelope(self):
+        assert _mcp_content_text({"stdout": "x"}) is None
+        assert _mcp_content_text({"content": []}) is None
+        assert _mcp_content_text({}) is None
+
+    def test_returns_none_for_non_text_blocks(self):
+        # Structured payloads keep their json.dumps rendering.
+        assert _mcp_content_text({"content": [{"type": "image", "data": "b64"}]}) is None
+        assert _mcp_content_text({"content": [{"type": "text", "text": 7}]}) is None
+
+    def test_structured_json_payload_still_serialized(self):
+        update = {
+            "toolCallId": "tc-4",
+            "status": "completed",
+            "rawOutput": {"items": [{"Json": {"rows": [1, 2], "ok": True}}]},
+        }
+        event = _build_tool_result_event(update)
+        assert event is not None
+        assert json.loads(event.tool_output) == {"rows": [1, 2], "ok": True}
+
+
+class TestUserContentNotCorrupted:
+    """The sanitizer narrowing must preserve script-essential characters."""
+
+    def test_emoji_zwj_sequence_survives_a_tool_response(self):
+        family = "\U0001f468\u200d\U0001f469\u200d\U0001f467"
+        out = build_tool_response(f"family: {family}")
+        assert family in out["content"][0]["text"]
+
+    def test_persian_zwnj_survives_a_tool_response(self):
+        word = "\u0645\u06cc\u200c\u062e\u0648\u0627\u0647\u0645"
+        out = build_tool_response(word)
+        assert word in out["content"][0]["text"]
+
+    def test_bidi_override_still_stripped(self):
+        out = build_tool_response("safe\u202etxet-detrevr")
+        assert "\u202e" not in out["content"][0]["text"]

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -41,8 +41,82 @@ class TestStripHiddenUnicode:
     def test_strips_zero_width_space(self):
         assert strip_hidden_unicode("he\u200bllo") == "hello"
 
-    def test_strips_zero_width_joiner(self):
+    def test_preserves_zero_width_joiner(self):
+        # ZWJ is script-essential where it can actually shape: it welds emoji
+        # sequences and is required by Arabic / Persian / Indic text. Between
+        # two ASCII characters it shapes nothing, so it is dropped there (that
+        # is the credential-redaction bypass — see the credential test below).
+        assert (
+            strip_hidden_unicode("\U0001f468\u200d\U0001f469")
+            == "\U0001f468\u200d\U0001f469"
+        )
+        assert strip_hidden_unicode("\u0915\u200d\u0937") == "\u0915\u200d\u0937"
         assert strip_hidden_unicode("a\u200db") == "ab"
+
+    def test_preserves_zwnj_and_variation_selector(self):
+        assert strip_hidden_unicode("\u0645\u06cc\u200c\u062e") == "\u0645\u06cc\u200c\u062e"
+        assert strip_hidden_unicode("\u2764\ufe0f") == "\u2764\ufe0f"
+
+    def test_format_chars_are_deny_by_default(self):
+        # Cf is fail-closed: only ZWNJ/ZWJ/LRM/RLM are allowed through, so a
+        # format character nobody enumerated is stripped rather than silently
+        # becoming an evasion vector.
+        for ch in (
+            "\u00ad",  # SOFT HYPHEN
+            "\u180e",  # MONGOLIAN VOWEL SEPARATOR
+            "\u2063",  # INVISIBLE SEPARATOR
+            "\u2060",  # WORD JOINER
+            "\ufff9",  # INTERLINEAR ANNOTATION ANCHOR
+        ):
+            assert ch not in strip_hidden_unicode(f"a{ch}b"), f"{ch!r} should be stripped"
+
+    def test_shaping_marks_need_a_non_ascii_neighbour(self):
+        # The four allowlisted marks shape NON-ASCII text, so between two ASCII
+        # characters they have no rendering effect and are dropped.
+        for ch in ("\u200c", "\u200d", "\u200e", "\u200f"):
+            assert strip_hidden_unicode(f"a{ch}b") == "ab", f"{ch!r} between ASCII"
+            assert strip_hidden_unicode(f"\u0645{ch}\u062e") == f"\u0645{ch}\u062e"
+            assert strip_hidden_unicode(f"{ch}abc") == "abc", f"leading {ch!r}"
+            assert strip_hidden_unicode(f"abc{ch}") == "abc", f"trailing {ch!r}"
+
+    def test_marks_cannot_vouch_for_each_other(self):
+        # "\u200d".isascii() is False, so a RUN of shaping marks would let each
+        # one qualify as the next one's non-ASCII neighbour and all of them
+        # survive inside an ASCII credential. The neighbour test skips over
+        # adjacent marks, and runs after the other hidden characters are
+        # already removed, so a stripped character cannot vouch either.
+        clean = "AKIAIOSFODNN7EXAMPLE"
+        for spike in (
+            "\u200d\u200d",  # doubled ZWJ
+            "\u200d\u200c\u200e",  # mixed run of three
+            "\u200b\u200d",  # stripped ZWSP then ZWJ
+            "\ufeff\u200c",  # stripped BOM then ZWNJ
+            "\u202e\u200d",  # stripped bidi override then ZWJ
+        ):
+            assert strip_hidden_unicode(f"AKIA{spike}IOSFODNN7EXAMPLE") == clean, spike
+        # A doubled joiner between real emoji is still legitimate and survives.
+        emoji = "\U0001f468\u200d\u200d\U0001f469"
+        assert strip_hidden_unicode(emoji) == emoji
+
+    def test_invisible_cannot_hide_a_credential_from_redaction(self):
+        # This sanitizer runs BEFORE credential redaction, so an invisible
+        # character embedded in a credential must not survive to defeat the
+        # redaction patterns and carry a recoverable secret into the dashboard
+        # or the notification JSONL. Covers the allowlisted shaping marks too:
+        # a credential is ASCII, so they have no neighbour that justifies them.
+        clean = "AKIAIOSFODNN7EXAMPLE"
+        for ch in (
+            "\u200b",  # ZWSP
+            "\u2063",  # invisible separator
+            "\ufeff",  # BOM
+            "\u00ad",  # soft hyphen
+            "\u200c",  # ZWNJ — allowlisted, but not between ASCII
+            "\u200d",  # ZWJ — same
+            "\u200e",  # LRM — same
+            "\u200f",  # RLM — same
+        ):
+            spiked = f"AKIA{ch}IOSFODNN7EXAMPLE"
+            assert strip_hidden_unicode(spiked) == clean, f"{ch!r} survived"
 
     def test_strips_bom(self):
         assert strip_hidden_unicode("\ufeffhello") == "hello"
@@ -82,7 +156,13 @@ class TestSanitizeString:
         assert sanitize_string("") == ""
 
     def test_only_hidden_chars(self):
+        # ZWSP is always dropped. ZWNJ/ZWJ shape neighbouring non-ASCII text,
+        # and a string of nothing but marks has no such neighbour, so it
+        # collapses to empty rather than keeping decorative invisibles.
+        assert sanitize_string("\u200b") == ""
         assert sanitize_string("\u200b\u200c\u200d") == ""
+        # Beside real script they survive.
+        assert sanitize_string("\u0645\u200c\u062e") == "\u0645\u200c\u062e"
 
 
 # ── Response Sanitization ──

--- a/test/test_validation_user_actions.py
+++ b/test/test_validation_user_actions.py
@@ -534,6 +534,10 @@ class TestBadInputsCaught:
         # Verify the API received cleaned text
         call_body = mock_post.call_args[0][1]
         assert "\u200b" not in call_body["task"]
+        # ZWJ between two ASCII characters shapes nothing, so it is stripped
+        # here too — that is what stops an invisible from hiding a credential
+        # from redaction. It survives only beside non-ASCII text (emoji
+        # sequences, Arabic / Persian / Indic), covered in test_validation.py.
         assert "\u200d" not in call_body["task"]
 
     def test_learn_invalid_category(self):

--- a/website/src/components/PendingQuestionCard.tsx
+++ b/website/src/components/PendingQuestionCard.tsx
@@ -12,6 +12,18 @@ interface PendingQuestionCardProps {
    *  `ask_id`, nothing is blocked on them) and when the wait has provably
    *  expired, so the user's input is not silently dropped. */
   onFallbackSend: (text: string) => void
+  /**
+   * Send the answer as a message IMMEDIATELY (no composer round-trip).
+   *
+   * Used only by the no-``ask_id`` card, where the card IS the primary
+   * interaction: nothing is blocked, so there is no expired wait to guard and
+   * no 404 to recover from, and pre-filling the composer would cost the user a
+   * second click for no safety benefit. ``onFallbackSend`` keeps its original
+   * job — recovering an answer whose blocked wait has already vanished, where
+   * an explicit retry IS the right behaviour. Optional so existing callers and
+   * tests that pass only ``onFallbackSend`` keep working unchanged.
+   */
+  onDirectSend?: (text: string) => void
 }
 
 /**
@@ -23,7 +35,7 @@ interface PendingQuestionCardProps {
  * silently start a second turn and strand the blocked tool call. One
  * implementation means a pane cannot drift from the main view.
  */
-export default function PendingQuestionCard({ slotKey, onFallbackSend }: PendingQuestionCardProps) {
+export default function PendingQuestionCard({ slotKey, onFallbackSend, onDirectSend }: PendingQuestionCardProps) {
   const dispatch = useAppDispatch()
   // Optional-chained: existing tests build partial preloaded chat state without
   // the pendingQuestions key.
@@ -102,9 +114,11 @@ export default function PendingQuestionCard({ slotKey, onFallbackSend }: Pending
       onDismiss={askId ? () => resolve(undefined) : undefined}
       onSubmit={(answers) => {
         if (!askId) {
-          // Legacy card: nothing is blocked, so the answer is just a message.
+          // Legacy card: nothing is blocked, so the answer is just a message —
+          // and it is sent RIGHT NOW. Falls back to onFallbackSend only when no
+          // direct sender was supplied (older callers / tests).
           const text = asText(answers)
-          if (text.trim()) onFallbackSend(text)
+          if (text.trim()) (onDirectSend ?? onFallbackSend)(text)
           clearThisCard()
           return
         }

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4282,6 +4282,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                       // leave the answer only in a non-persisted optimistic bubble.
                       setInput((prev) => (prev.trim() ? `${prev}\n${text}` : text))
                     }}
+                    onDirectSend={(text) => {
+                      // No-ask_id card: the card IS the interaction, so answer
+                      // and send in one click (#755).
+                      //
+                      // Offline, send() bails at its own !connected guard and
+                      // the card clears regardless — which would DROP the
+                      // answer. Fall back to the composer so it survives, the
+                      // same recovery the 404 path uses.
+                      if (!connected) {
+                        setInput((prev) => (prev.trim() ? `${prev}\n${text}` : text))
+                        return
+                      }
+                      void send(text, activeSlot || undefined)
+                    }}
                   />
                 </div>
               )}


### PR DESCRIPTION
## Problem

All six session-bound MCP tools — `ask_question`, `monitor_start`, `monitor_update`, `autonudge_stop`, `set_project`, `suggest_followup` — were **silently dead** after #844 merged. Calling `ask_question` produced no question card. No error, no warning, no audit entry: the tool returned its success message, the model was told the card was requested, and nothing happened.

Because the failure was silent, `monitor_start` could not arm a babysit loop and `autonudge_stop` could not halt one, with no indication to either the user or the agent that the request had been dropped.

## Why it matters

Issue #755 was believed fixed by #844 and closed. It was not: the feature shipped inert on **every** install, and CI could not see it — 42 checks and 21,840 tests were green over a feature that never worked once in production.

## Fix (symptoms → root cause → change)

The investigation went through three wrong diagnoses before landing, and the record matters because each wrong turn came from trusting static reading over runtime evidence.

**Wrong turn 1 — "kiro-cli doesn't emit the identity meta."** `strings` on the installed binary appeared to show `_meta.kiro.mcpServerName` missing. That check was invalid: it ran against a **symlink**, so the ELF guard silently skipped and nothing was ever inspected. Resolving the symlink showed the field present, and `git tag --contains` showed the emitter shipped in kiro-cli v2.13.0 — well before the installed 2.16.0. **kiro-cli is fully exonerated.**

**Wrong turn 2 — "the identity gate never fires."** A runtime trace disproved it. kiro-cli sends `{"kiro": {"toolName": "ask_question", "mcpServerName": "kirocrew-core"}}`, the gate matches, and the `tool_call_id` lookup on the result frame succeeds. Every piece of #844's identity plumbing works, including the `AcpProvider._to_llm_event` field preservation.

**Wrong turn 3 — "the pooling topology is at fault."** Also wrong. `mcp_gateway.enabled` is orthogonal; the failure reproduces identically with pooling off, which is the default and the topology #755 was required to work in.

The real cause is **three independent defects, stacked**, each sufficient on its own to kill the feature. All three are in KiroCrew's own code.

**1. The MCP response exit point destroyed the marker.** `validation.build_tool_response` — documented as "the single exit point for all tool responses" — runs `sanitize_response` → `sanitize_string` → `strip_hidden_unicode`, which removed **all** of Unicode category `Cf`. The directive sentinel was prefixed with U+2063 INVISIBLE SEPARATOR, also `Cf`, so the prefix was deleted before the response reached the wire. Proven by a direct MCP stdio probe: the server's raw bytes contained the visible token but neither the character nor its `\u2063` escape.

**2. The ACP result parser escaped the payload.** `_build_tool_result_event`'s `rawOutput` `Json` branch serialised the MCP content envelope with `json.dumps(j, default=str)`. With the default `ensure_ascii=True` that rewrites non-ASCII into escapes and turns the payload's `"` into `\"`, so the marker line was no longer parseable JSON. `ensure_ascii=False` alone does **not** fix it — the escaped quotes still break the parse. The envelope has to be unwrapped, not re-encoded.

**3. Neither failure produced any signal.** `session_directive.decode()` returning `None` fell through a bare `if _dir_args is not None:` with no else branch. That silence is why two defects hid behind each other for a full day of debugging.

### Changes

- **`acp/_dispatch.py`** — new `_mcp_content_text()` extracts the inner text of an MCP `{"content": [{"type": "text", ...}]}` envelope instead of re-serialising it, matching what the mid-stream content-block path already did. Deliberately narrow: any non-text or mixed-content block returns `None` and falls back to `json.dumps`, so structured payloads keep their current rendering. This also fixes a general cosmetic problem — every MCP tool's output was being shown and stored as an escaped JSON blob rather than its text.
- **`validation.py`** — `strip_hidden_unicode` no longer removes category `Cf` wholesale. Dangerous invisibles are now denied **by codepoint** (`_INVISIBLE_DENY`: bidi embedding/override/isolate controls for Trojan Source / CVE-2021-42574, ZWSP, word joiner and invisible operators, BOM, interlinear annotation controls, Mongolian vowel separator). `Cc` (minus `\n\r\t`) and `Cs` are still stripped by category. `Co` (private use) is no longer stripped, since Nerd Fonts and terminal themes carry real glyphs there.
- **`session_directive.py`** — the sentinel is now **pure ASCII**. A machine-facing framing token must not depend on characters that sanitisers, Unicode normalisers and transports all legitimately rewrite. This is defence in depth rather than the fix itself, and it proved its worth: it makes the protocol tolerant of a version-skewed MCP server, since the visible token survives even where the old prefix would not.
- **`dashboard/chat_runner.py`** — an authenticated directive whose marker fails to decode on the **final** frame now logs a warning instead of vanishing. Gated on `event.tool_final` because mid-stream frames legitimately decode to `None`, which the existing pending-map logic relies on.
- **`validation.py`** — `sanitize_response` warns when a response exceeds `MAX_RESPONSE_LEN` (100,000). Truncation drops the **tail**, and the directive marker is the last line, so an oversized response would silently lose its effect. Same design smell as the two bugs above, caught before it bit.
- **`website/`** — the no-`ask_id` question card now **sends** the answer on click instead of pre-filling the composer, via a new optional `onDirectSend` prop. The existing `onFallbackSend` pre-fill behaviour is untouched: it guards a genuine failure mode (a 404 meaning the blocked wait vanished, where auto-sending could strand the answer in a non-persisted bubble). Only the path where nothing is blocked sends directly.

### A user-content bug fixed on the way

The blanket `Cf` strip ran on **every** tool response and — via `validate_tool_args` — every string tool argument. It was silently corrupting user content: `👨‍👩‍👧` lost its ZWJ and rendered as three separate people, and Persian, Arabic and Indic text lost the ZWNJ/ZWJ joiners those scripts require. The codebase already held contradictory contracts here — `dashboard/chat_folders.py` treats U+200D and U+FE0F as meaningful emoji modifiers while the sanitiser two files over deleted them, and `test_context_marker_neutralization` asserts ZWNJ/ZWJ **must** survive.

## Tests

- **`test/test_session_directive_transport.py` (new, 13 tests)** — locks the hops no existing test crossed. `test_full_chain_server_exit_then_acp_parser` drives the exact production sequence (tool return → `build_tool_response` → `rawOutput` `Json` item → `_build_tool_result_event` → `decode`). Separate classes cover each defect independently, the extractor's narrowness (structured payloads must still be `json.dumps`'d), and that emoji ZWJ / Persian ZWNJ survive a tool response while a bidi override is still stripped.
- **`test/test_validation.py`** — `test_strips_zero_width_joiner` inverted to `test_preserves_zero_width_joiner`, plus a new ZWNJ/variation-selector case. `test_only_hidden_chars` updated: ZWSP is still dropped, joiners now survive.
- **`test/test_validation_user_actions.py`** — the ZWJ assertion on tool args inverted to assert preservation.

Three test updates are **deliberate contract changes**, not tests weakened to pass: they asserted that ZWJ is deleted, which is the behaviour this PR reverses.

**Why the existing suite missed all of this:** the seam tests construct `AcpEvent` objects directly with `tool_output` already set to a pristine directive. They validate the consumer while *assuming* the transport is lossless. Nothing exercised `build_tool_response` or `_build_tool_result_event` with a real directive, so both lossy hops were invisible. That is the gap the new file closes.

## Manual verification

Verified live on the dashboard, in the default **pooling-off** topology (`mcp_gateway.enabled: false`):

1. Before the fix — `ask_question` returned its directive, no card rendered, and zero `source="mcp-directive"` audit entries existed, confirming the applier never ran.
2. Instrumented the three candidate hops and reproduced each defect in sequence: `decoded: false` with a double-escaped JSON tail (envelope), then `decoded: false` with a clean tail but no sentinel (`Cf` strip), then `decoded: true`.
3. After the fix — the question card renders and clicking an option sends the answer in one click. Confirmed with pooling both enabled and disabled.

All debug instrumentation was removed before this commit.

Gates on the rebased commit: `isort`, `flake8` clean; `mypy` clean on 561 files; 737 backend tests across the nine affected suites; `tsc -b` clean; 6,114 frontend tests pass. **The full 21k-test backend suite has not been run locally** — CI is the backstop for that.

<img width="982" height="563" alt="Screenshot 2026-07-30 at 10 54 42 PM" src="https://github.com/user-attachments/assets/3509b836-662c-4e39-a7f7-03d0854ba3c3" />


## Notes for the reviewer

- This is one PR by request, but it spans three separable concerns: the transport fix (narrow), the Unicode sanitiser narrowing (**widest blast radius — it changes what every tool's args and responses are allowed to contain**), and the frontend card change. The sanitiser piece is the one to scrutinise hardest.
- #755 should be reopened or superseded by this PR; #844 closed it prematurely.
- Known and **not** addressed here: the `TurnDriver` gap. `messaging/driver.py` has no `EVENT_TOOL_RESULT` branch, so all six tools remain no-ops on Slack, Discord, Teams and Webex. That same gap is why the now-visible ASCII marker cannot leak to those channels — they never render tool-result text at all.
