### PR TITLE
fix(sessions): classify every transport instead of falling back to Slack

### DIFF
--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -43,6 +43,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from dataclasses import fields as fields_of
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Iterator
 from typing import List as _List
@@ -108,12 +109,9 @@ ALLOWED_KINDS = frozenset(
     }
 )
 
-#: Allowed source markers (provenance).
-ALLOWED_SOURCES = frozenset(
+#: Provenance/creation buckets that predate the unified session taxonomy.
+_LEGACY_SOURCES = frozenset(
     {
-        # Provenance/creation buckets (back-compat) + actual session origins from
-        # ``infer_use_case`` so an artifact's source can reflect WHERE the saving
-        # session came from rather than a generic "manual".
         "chat",
         "cron",
         "subagent",
@@ -126,6 +124,27 @@ ALLOWED_SOURCES = frozenset(
         "unknown",
     }
 )
+
+
+@lru_cache(maxsize=1)
+def allowed_sources() -> frozenset[str]:
+    """Allowed source markers (provenance).
+
+    The legacy creation buckets above, PLUS every source the canonical session
+    classifier can report -- derived from ``session_kind.all_sources()`` rather
+    than restated. ``infer_use_case`` stamps those, and :func:`_validate_source`
+    rejects anything absent, so a transport registered in ``messaging.link`` but
+    missing here would turn an artifact save into a 400.
+
+    Read on first use rather than at import: the classifier reaches the transport
+    registry through ``messaging``, which imports ``acp.runtime`` -> ``validation``
+    -> back into this module. ``validation`` needs only ``MAX_CONTENT_BYTES`` from
+    here, so deferring keeps that partial import satisfiable.
+    """
+    from kiro_crew.session_kind import all_sources
+
+    return _LEGACY_SOURCES | all_sources()
+
 
 #: Allowed lifecycle event types. ``referenced`` is reserved for chat-mention
 #: scanning (added in a follow-up CR); the in-line save/update path emits
@@ -550,9 +569,9 @@ def _markdown_misclassification_reason(content: str, source_path: str) -> str | 
 
 
 def _validate_source(source: str) -> str:
-    if source not in ALLOWED_SOURCES:
+    if source not in allowed_sources():
         raise ArtifactValidationError(
-            f"invalid source {source!r}: must be one of {sorted(ALLOWED_SOURCES)}"
+            f"invalid source {source!r}: must be one of {sorted(allowed_sources())}"
         )
     return source
 

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -579,7 +579,16 @@ _RUNTIME_DISPLAY = {
     "taskrunner": "KiroCrew task runner",
     "background": "KiroCrew background",
     "cli": "CLI terminal",
+    "heartbeat": "KiroCrew heartbeat",
     "slack": "Slack",
+    "discord": "Discord",
+    "telegram": "Telegram",
+    "teams": "Teams",
+    "webex": "Webex",
+    "wecom": "WeCom",
+    "weixin": "Weixin",
+    "whatsapp": "WhatsApp",
+    "unified": "direct message",
 }
 
 
@@ -589,20 +598,9 @@ def _runtime_display_name(session_key: str) -> str:
     Uses the same prefix heuristic as ``sel.py:_infer_source()`` so both
     SEL audit logs and LLM context agree on the runtime.
     """
-    if session_key.startswith("dashboard:") or session_key.startswith("dashboard_"):
-        source = "dashboard"
-    elif session_key.startswith("cron:") or session_key.startswith("cron_"):
-        source = "cron"
-    elif session_key.startswith("subagent:"):
-        source = "subagent"
-    elif session_key.startswith("taskrunner"):
-        source = "taskrunner"
-    elif session_key == "_bg":
-        source = "background"
-    elif session_key == "cli_chat":
-        source = "cli"
-    else:
-        source = "slack"
+    from kiro_crew.session_kind import source_of
+
+    source = source_of(session_key)
     return _RUNTIME_DISPLAY.get(source, source)
 
 

--- a/src/kiro_crew/dashboard/handlers_instances.py
+++ b/src/kiro_crew/dashboard/handlers_instances.py
@@ -53,17 +53,24 @@ def _audit(operation: str, outcome: str, *, request_id: str = "", error: str = "
         logger.debug("SEL audit failed for instances_%s", operation, exc_info=True)
 
 
-def _is_slack_origin(request: web.Request) -> bool:
-    """True if the request arrived via the Slack path (X-Session-Key 'slack:*')."""
-    sk = request.headers.get("X-Session-Key", "")
-    return sk.startswith("slack:")
+def _is_channel_origin(request: web.Request) -> bool:
+    """True if the request arrived from a messaging channel, not the dashboard.
+
+    Covers EVERY transport, not just Slack. This gate previously tested
+    ``sk.startswith("slack:")``, so a request whose ``X-Session-Key`` named any
+    other channel — Discord, Telegram, Teams, Webex, WeCom, Weixin — passed the
+    owner-only check that an identical Slack request was denied.
+    """
+    from kiro_crew.messaging.link import is_channel_session_key
+
+    return is_channel_session_key(request.headers.get("X-Session-Key", ""))
 
 
 def _guard(request: web.Request, operation: str) -> web.Response | None:
     """Shared gate: enabled-check + owner-only (non-Slack). Returns a denial
     Response to short-circuit, or None to proceed. Audits every denial."""
-    if _is_slack_origin(request):
-        _audit(operation, "denied", error="slack-origin rejected")
+    if _is_channel_origin(request):
+        _audit(operation, "denied", error="channel-origin rejected")
         return web.json_response(
             {"error": "instances control plane is owner-only (not reachable via Slack)"},
             status=403,

--- a/src/kiro_crew/mcp_gateway/claim.py
+++ b/src/kiro_crew/mcp_gateway/claim.py
@@ -45,16 +45,25 @@ _CLAIM_TIMEOUT_SECS = 5.0
 
 
 def classify_session_type(session_key: str) -> str:
-    """Session-type label for a caller block. Mirrors ``stub._build_caller_block``."""
-    if session_key.startswith("cron:"):
-        return "cron"
-    if session_key.startswith("hook:"):
-        return "hook"
-    if session_key.startswith("dashboard:"):
-        return "dashboard"
-    if session_key:
-        return "slack-thread"
-    return "unknown"
+    """Session-type label for a caller block. THE single implementation.
+
+    ``stub._build_caller_block`` calls this rather than keeping its own copy —
+    the two used to be hand-mirrored prefix chains, and both ended in a terminal
+    ``else`` that labelled every non-cron/hook/dashboard key ``slack-thread``,
+    so a Discord or Telegram caller was reported as a Slack thread.
+
+    ``slack-thread`` is preserved verbatim for actual Slack keys: the value goes
+    out on the claim wire, so this is a bug fix for the other transports, not a
+    rename of the existing one.
+    """
+    from kiro_crew.session_kind import KIND_CHANNEL, KIND_UNKNOWN, classify
+
+    kind = classify(session_key)
+    if kind.kind == KIND_CHANNEL:
+        return "slack-thread" if kind.channel == "slack" else kind.channel
+    if kind.kind == KIND_UNKNOWN:
+        return "unknown"
+    return kind.source
 
 
 def build_claim_frame(pid: int, session_key: str, channel_id: Optional[str]) -> dict:

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -288,16 +288,11 @@ def _build_caller_block(channel_id: Optional[str]) -> dict[str, str]:
     principal = (
         os.environ.get("KIROCREW_PRINCIPAL") or os.environ.get("USER") or ""
     )
-    if session_key.startswith("cron:"):
-        session_type = "cron"
-    elif session_key.startswith("hook:"):
-        session_type = "hook"
-    elif session_key.startswith("dashboard:"):
-        session_type = "dashboard"
-    elif session_key:
-        session_type = "slack-thread"
-    else:
-        session_type = "unknown"
+    # One implementation, shared with the claim path so both ends of the wire
+    # cannot drift (they were hand-mirrored copies before).
+    from kiro_crew.mcp_gateway.claim import classify_session_type
+
+    session_type = classify_session_type(session_key)
     return {
         "session_key": session_key,
         "session_type": session_type,

--- a/src/kiro_crew/platform/governance_profiles.py
+++ b/src/kiro_crew/platform/governance_profiles.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
+from kiro_crew import session_kind
 from kiro_crew.config.paths import config_dir
 from kiro_crew.platform.context import PlatformCompositionError
 from kiro_crew.platform.governance import (
@@ -187,7 +188,19 @@ def audit_governance_degraded(
 # such a surface has no explicitly-bound profile AND its identity is unproven,
 # it resolves to deny-all rather than the (permissive) no-profile path — these
 # are the high-blast-radius surfaces the profile layer exists to contain.
-_UNATTENDED_SURFACES = frozenset({"cron", "subagent", "background", "heartbeat", "taskrunner"})
+#
+# DERIVED, not restated: the taxonomy owns which kinds are unattended, so a new
+# unattended kind is contained here the moment it is registered.  The previous
+# hand-typed set had already drifted narrower than the taxonomy's (it omitted
+# ``hook``/``side``/``channel-agent``/``wf-pool``) — the exact duplication this
+# module's unification exists to remove.
+#
+# Widening to the taxonomy's full set is behaviour-preserving: the branch below
+# is reachable only when identity is UNPROVEN, which is true solely for an empty
+# key and the ``_bg``/``_hb`` sentinels.  Every added member (``hook:``, ``side:``,
+# ``channel-agent:``, ``wf-pool:``) is always carried by a non-empty key, so it
+# proves identity and never reaches the deny-all path.
+_UNATTENDED_SURFACES = session_kind.UNATTENDED_KINDS
 
 # Session-key sentinel for an in-process HOST action that is not driven by any
 # user-facing surface (app activation, Slack workspace admission).  Classifies to
@@ -209,15 +222,73 @@ def _profiles_dir() -> Path:
     return config_dir() / "profiles"
 
 
+#: Surfaces the pre-unification ``sel._infer_source`` returned DIRECTLY. Every
+#: other key hit its terminal ``else -> "slack"``, so anything outside this set
+#: must keep binding to ``"slack"`` — see ``_infer_surface``. Deliberately an
+#: allowlist: a new session kind defaults to the conservative pin rather than
+#: escaping to the policy ceiling.
+_PRE_UNIFICATION_SURFACES = frozenset(
+    {
+        "host",
+        "dashboard",
+        "cron",
+        "subagent",
+        "taskrunner",
+        "background",
+        "heartbeat",
+        "cli",
+    }
+)
+
+#: Key forms ``classify()`` recognises that the pre-unification parser did NOT:
+#: the filename-folded ``dashboard_`` / ``cron_`` / ``subagent_`` variants, the
+#: bare ``chat-`` slot form, and ``cli_chat:`` (the old parser matched only the
+#: exact ``cli_chat`` sentinel). All of these hit the old terminal ``-> "slack"``,
+#: so they stay pinned even though the classifier can now name them properly.
+_POST_UNIFICATION_ONLY_PREFIXES: tuple[str, ...] = (
+    "dashboard_",
+    "cron_",
+    "subagent_",
+    "chat-",
+    "cli_chat:",
+)
+
+
 def _infer_surface(session_key: str) -> str:
-    """Classify a session key to its surface.
+    """Classify a session key to the surface its governance profile binds to.
 
-    Delegates to ``sel._infer_source`` — the single canonical classifier — so
-    governance never grows a 4th, drifting copy of the taxonomy parser.
+    Delegates to the canonical classifier so governance never grows a drifting
+    copy of the taxonomy parser.
+
+    ONE deliberate divergence: any surface the pre-unification classifier did NOT
+    recognise binds to ``"slack"``. The classifier itself reports the true origin
+    (a Discord session reads ``"discord"``, a webhook session ``"hook"``), which is
+    correct for audit and display — but the value returned HERE selects which
+    policy profile applies, and a profile is bound by surface name. Adopting the
+    true origin would move such a session off any ``slack``-bound profile and onto
+    the policy ceiling alone (see the no-bound-profile branch in
+    ``profile_for_session``) -- a RELAXATION for anyone who has bound a Slack
+    profile expecting it to cover these sessions.
+
+    Stated as an allowlist of what the old parser returned DIRECTLY rather than a
+    list of what pins to Slack, so the conservative pin is the default: a kind
+    added to the classifier later cannot silently escape to the ceiling without
+    someone editing this set on purpose.
+
+    Splitting the collapse is a policy decision (does a Slack-bound profile govern
+    Discord? a webhook?) that needs an owner and a migration note, not a side
+    effect of fixing the labels.
     """
-    from kiro_crew.sel import _infer_source
+    from kiro_crew.session_kind import classify
 
-    return _infer_source(session_key)
+    if not session_key:
+        # The empty key is the documented ungoverned opt-out and classified to
+        # "unknown" before unification too.
+        return "unknown"
+    if session_key.startswith(_POST_UNIFICATION_ONLY_PREFIXES):
+        return "slack"
+    surface = classify(session_key).source
+    return surface if surface in _PRE_UNIFICATION_SURFACES else "slack"
 
 
 def _salvage_bind(data: object) -> Optional[Bind]:

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -640,6 +640,18 @@ _AUDIT_SURFACE_DETAIL: dict[str, str] = {
     "cli": "Terminal chat sessions",
     "host": "In-process governance checks not driven by a user-facing surface",
     "unknown": "Events that carry no surface signal (classified rather than misattributed)",
+    "discord": "Discord messages, approvals, and owner-authorization decisions",
+    "telegram": "Telegram messages, approvals, and owner-authorization decisions",
+    "teams": "Microsoft Teams messages and owner-authorization decisions",
+    "webex": "Webex messages and owner-authorization decisions",
+    "wecom": "WeCom messages (inbound-bound replies only)",
+    "weixin": "Weixin messages and owner-authorization decisions",
+    "whatsapp": "WhatsApp messages and owner-authorization decisions",
+    "unified": "Cross-transport direct messages under a unified DM scope",
+    "hook": "Inbound webhook-triggered sessions",
+    "side": "Sidecar question-and-answer sessions",
+    "channel-agent": "Channel-scoped agent sessions with reduced tool access",
+    "wf-pool": "Pooled workflow-execution sessions",
 }
 
 

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -28,6 +28,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from pathlib import Path
 
 from kiro_crew import platform_compat
@@ -867,28 +868,14 @@ def _infer_source(session_key: str) -> str:
     honest bind target (``bind: {type: surface, id: host}``) instead of the
     accidental ``slack`` an empty key used to classify to.
     """
-    if not session_key:
-        return "unknown"
-    if session_key == "_host":
-        return "host"
-    if session_key.startswith("dashboard:"):
-        return "dashboard"
-    if session_key.startswith("cron:"):
-        return "cron"
-    if session_key.startswith("subagent:"):
-        return "subagent"
-    if session_key.startswith("taskrunner"):
-        return "taskrunner"
-    if session_key == "_bg":
-        return "background"
-    if session_key == "_hb":
-        return "heartbeat"
-    if session_key == "cli_chat":
-        return "cli"
-    return "slack"
+    from kiro_crew.session_kind import source_of
+
+    return source_of(session_key)
 
 
-_AUDIT_SOURCES: tuple[str, ...] = (
+#: Preferred display order for the surfaces that existed before the session
+#: taxonomy was unified. Ordering only -- membership is NOT decided here.
+_AUDIT_SOURCE_ORDER: tuple[str, ...] = (
     "unknown",
     "host",
     "dashboard",
@@ -902,6 +889,25 @@ _AUDIT_SOURCES: tuple[str, ...] = (
 )
 
 
+@lru_cache(maxsize=1)
+def _audit_sources() -> tuple[str, ...]:
+    """Every ``source`` :func:`_infer_source` can stamp.
+
+    DERIVED from the canonical classifier's own vocabulary, not restated: any
+    transport registered in ``messaging.link`` must be stampable or its events
+    cannot be audited at all. Hand-typing this list is how ``whatsapp`` was
+    omitted on the first cut of the unified taxonomy -- it was a registered
+    transport that the classifier reported and this tuple denied.
+
+    Computed on first use rather than at import: ``session_kind`` reaches the
+    transport registry through ``messaging.link``, which imports ``acp`` ->
+    ``security`` -> back into this module. Deferring the read breaks that cycle.
+    """
+    from kiro_crew.session_kind import all_sources
+
+    return _AUDIT_SOURCE_ORDER + tuple(sorted(all_sources() - set(_AUDIT_SOURCE_ORDER)))
+
+
 def audit_sources() -> tuple[str, ...]:
     """Every ``source`` value :func:`_infer_source` can stamp on an event.
 
@@ -912,7 +918,7 @@ def audit_sources() -> tuple[str, ...]:
     ``_infer_source``'s actual branches, so adding a surface there without adding
     it here fails CI.
     """
-    return _AUDIT_SOURCES
+    return _audit_sources()
 
 
 def sel() -> SecurityEventLog:

--- a/src/kiro_crew/session_kind.py
+++ b/src/kiro_crew/session_kind.py
@@ -1,0 +1,259 @@
+"""The one place that answers "what kind of session is this key?".
+
+A session key currently encodes where the session was born — ``dashboard:chat-7``,
+``slack:1785457986.925389``, ``cron:abc``, ``telegram:kirocrew:direct:9:gen3``. Four
+independent parsers grew up reading that prefix, each with its own vocabulary and
+each ending in a terminal ``else`` that guessed **Slack**:
+
+* ``sel._infer_source`` — the SEL audit log's ``source`` field
+* ``context._runtime_display_name`` — the runtime name shown to the model
+* ``validation.infer_use_case`` — persisted provenance (``Artifact.source``, metrics)
+* ``sync_bridge`` — the session list's source badge
+
+plus two more copies of a narrower variant in ``mcp_gateway.claim`` and
+``mcp_gateway.stub``. Six parsers, one taxonomy, and every one of them labelled a
+Discord, Telegram, Teams, Webex, WeCom or Weixin session as *Slack* — because Slack
+was the fallback rather than a match.
+
+This module owns the taxonomy. The callers above keep their own public vocabulary
+(``Artifact.source`` is persisted data and the SEL ``source`` field is queried, so
+neither can be renamed) but they now all derive it from one classification instead
+of six prefix chains.
+
+Deliberately NOT in scope here: which *surface* a session's governance profile binds
+to. That reads the same taxonomy but changing it changes which policy applies, so
+``governance_profiles._infer_surface`` pins its current behaviour explicitly rather
+than inheriting a relabelling by accident — see the note there.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _link() -> object:
+    """The transport registry module, imported on first use.
+
+    ``messaging.link`` lives under a package whose ``__init__`` pulls in the
+    transport driver and ``acp``, so importing it at module scope would make this
+    low-level taxonomy module drag the whole stack in -- and several of those
+    modules import back into callers of this one. Keeping this module a LEAF means
+    anything can ``import session_kind`` at module scope safely.
+    """
+    from kiro_crew.messaging import link
+
+    return link
+
+
+def _is_channel_session_key(session_key: str) -> bool:
+    return bool(_link().is_channel_session_key(session_key))  # type: ignore[attr-defined]
+
+
+def _channel_namespace_of(session_key: str) -> str:
+    return str(_link().channel_namespace_of(session_key))  # type: ignore[attr-defined]
+
+
+#: Legacy Slack session keys that predate the ``slack:`` namespace: a bare thread
+#: timestamp, or a Slack channel-id composite. Matched only after the namespaced
+#: forms so a real ``slack:<ts>`` never reaches here.
+_LEGACY_SLACK_TS_RE = re.compile(r"^\d+\.\d+$")
+_SLACK_COMPOSITE_RE = re.compile(r"^[CDG][A-Z0-9]+:.+$")
+
+#: A conversation a human is present for. Everything else runs unattended.
+KIND_DASHBOARD = "dashboard"
+KIND_CHANNEL = "channel"
+KIND_CLI = "cli"
+
+#: Unattended / machine-driven origins.
+KIND_CRON = "cron"
+KIND_SUBAGENT = "subagent"
+KIND_TASKRUNNER = "taskrunner"
+KIND_BACKGROUND = "background"
+KIND_HEARTBEAT = "heartbeat"
+KIND_HOOK = "hook"
+KIND_SIDE = "side"
+KIND_CHANNEL_AGENT = "channel-agent"
+KIND_WORKFLOW_POOL = "wf-pool"
+KIND_HOST = "host"
+KIND_UNKNOWN = "unknown"
+
+#: Kinds with no human on the other end. Mirrors the intent of
+#: ``governance_profiles._UNATTENDED_SURFACES``, stated once here.
+UNATTENDED_KINDS = frozenset(
+    {
+        KIND_CRON,
+        KIND_SUBAGENT,
+        KIND_TASKRUNNER,
+        KIND_BACKGROUND,
+        KIND_HEARTBEAT,
+        KIND_HOOK,
+        KIND_SIDE,
+        KIND_CHANNEL_AGENT,
+        KIND_WORKFLOW_POOL,
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def channel_sources() -> frozenset[str]:
+    """Every transport that can appear as a ``source``.
+
+    Read from the ONE registry in ``messaging.link`` rather than restated, so
+    adding a transport there flows to every consumer automatically.
+    """
+    return frozenset(_link().CHANNEL_SESSION_NAMESPACES)  # type: ignore[attr-defined]
+
+
+@lru_cache(maxsize=1)
+def all_sources() -> frozenset[str]:
+    """Every value ``SessionKind.source`` can return.
+
+    Consumers that must keep their own vocabulary -- a persisted enum, an audit
+    field, a display map -- derive it from this instead of hand-typing transports.
+    A hand-typed list is how ``whatsapp`` was omitted on the first cut of this
+    module: it is registered in ``messaging.link`` but was missing from three
+    separate lists, which turned a working artifact save into a 400.
+
+    ``KIND_CHANNEL`` is deliberately absent -- ``source`` never returns it, it
+    collapses to the transport name.
+    """
+    return channel_sources() | {
+        KIND_DASHBOARD,
+        KIND_CLI,
+        KIND_CRON,
+        KIND_SUBAGENT,
+        KIND_TASKRUNNER,
+        KIND_BACKGROUND,
+        KIND_HEARTBEAT,
+        KIND_HOOK,
+        KIND_SIDE,
+        KIND_CHANNEL_AGENT,
+        KIND_WORKFLOW_POOL,
+        KIND_HOST,
+        KIND_UNKNOWN,
+    }
+
+
+#: Literal sentinel keys, matched before any prefix.
+_SENTINELS: dict[str, str] = {
+    "_host": KIND_HOST,
+    "_bg": KIND_BACKGROUND,
+    "_hb": KIND_HEARTBEAT,
+    "cli_chat": KIND_CLI,
+}
+
+#: ``prefix -> kind``. Both separators are listed because a session key that has
+#: round-tripped through a filename carries ``_`` where it started with ``:``
+#: (``history._safe_key`` folds every non-word character).
+_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("dashboard:", KIND_DASHBOARD),
+    ("dashboard_", KIND_DASHBOARD),
+    ("chat-", KIND_DASHBOARD),
+    ("cron:", KIND_CRON),
+    ("cron_", KIND_CRON),
+    ("subagent:", KIND_SUBAGENT),
+    ("subagent_", KIND_SUBAGENT),
+    # Separator-less on purpose: the previous classifier matched
+    # ``startswith("taskrunner")``, so a bare "taskrunner" key must keep
+    # classifying rather than falling through to unknown.
+    ("taskrunner", KIND_TASKRUNNER),
+    ("hook:", KIND_HOOK),
+    ("hook_", KIND_HOOK),
+    ("side:", KIND_SIDE),
+    ("side_", KIND_SIDE),
+    ("channel:", KIND_CHANNEL_AGENT),
+    ("wf-pool:", KIND_WORKFLOW_POOL),
+    ("cli_chat:", KIND_CLI),
+)
+
+
+@dataclass(frozen=True)
+class SessionKind:
+    """What a session key says about its own origin.
+
+    ``kind`` is one of the ``KIND_*`` constants. ``channel`` is the transport
+    namespace (``"slack"``, ``"discord"``, …) when ``kind == KIND_CHANNEL``, and
+    ``""`` otherwise — so a caller that needs the transport reads it directly
+    instead of re-parsing the key.
+    """
+
+    kind: str
+    channel: str = ""
+
+    @property
+    def attended(self) -> bool:
+        """True when a human is on some surface of this session.
+
+        ``KIND_UNKNOWN`` counts as attended: an empty or unrecognised key is the
+        documented opt-out for the governance gate, and treating it as unattended
+        would turn every ungoverned caller into a deny-all.
+        """
+        return self.kind not in UNATTENDED_KINDS
+
+    @property
+    def source(self) -> str:
+        """The flat label callers persist or display.
+
+        Collapses ``KIND_CHANNEL`` to its transport, so a Slack session reads
+        ``"slack"`` and a Discord session reads ``"discord"`` — rather than both
+        reading ``"slack"`` because Slack was the fallback.
+        """
+        if self.kind == KIND_CHANNEL and self.channel:
+            return self.channel
+        return self.kind
+
+
+def classify(session_key: str) -> SessionKind:
+    """Classify *session_key*. Never raises; unrecognised keys are ``KIND_UNKNOWN``.
+
+    Order matters: sentinels, then channel namespaces, then prefixes. Channels are
+    checked before the prefix table because a channel key's namespace is data
+    (``messaging.link.CHANNEL_SESSION_NAMESPACES``) rather than a literal here —
+    keeping one registry instead of a second list that drifts from it.
+    """
+    if not session_key:
+        return SessionKind(KIND_UNKNOWN)
+    sentinel = _SENTINELS.get(session_key)
+    if sentinel is not None:
+        return SessionKind(sentinel)
+    if _is_channel_session_key(session_key):
+        return SessionKind(KIND_CHANNEL, _channel_namespace_of(session_key))
+    if _LEGACY_SLACK_TS_RE.match(session_key) or _SLACK_COMPOSITE_RE.match(session_key):
+        # Pre-namespace Slack shapes, still present in old transcripts and in the
+        # notification jump-to-source path: a bare thread ts ("1785457986.925389")
+        # and a channel-id composite ("C08HZAWV4TP:thread123").
+        return SessionKind(KIND_CHANNEL, "slack")
+    for prefix, kind in _PREFIXES:
+        if session_key.startswith(prefix):
+            return SessionKind(kind)
+    return SessionKind(KIND_UNKNOWN)
+
+
+def source_of(session_key: str) -> str:
+    """Shorthand for ``classify(session_key).source``."""
+    return classify(session_key).source
+
+
+def is_attended(session_key: str) -> bool:
+    """Shorthand for ``classify(session_key).attended``."""
+    return classify(session_key).attended
+
+
+def is_slack_channel_composite(session_key: str) -> bool:
+    """True for the ONE key shape that carries a real Slack ``<channel-id>:<ts>``.
+
+    Callers that want to reconstruct a Slack URL need both halves of that pair.
+    Every other namespaced key -- ``slack:<ts>`` (no channel), ``discord:<id>``,
+    ``cron:``, ``hook:``, ``wf-pool:`` -- has a colon but no channel id, so
+    splitting it on the colon fabricates a link to a conversation that does not
+    exist.
+
+    Deliberately an ALLOWLIST keyed on the channel-id shape rather than a list of
+    prefixes to skip: a denylist has to be extended every time a session kind is
+    registered, and the one it replaced had already fallen behind (it let
+    unrecognised uppercase keys through). A new kind is now excluded by default.
+    """
+    return bool(_SLACK_COMPOSITE_RE.match(session_key))

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -3054,7 +3054,18 @@ class GatewayOrchestrator:
             return None
         if parent_key.startswith("dashboard:"):
             return {"slot": parent_key.removeprefix("dashboard:")}
-        if ":" in parent_key and not parent_key.startswith(("cron:", "subagent:", "hook:")):
+        # A permalink needs a real "<channel-id>:<ts>" pair. Testing only for a
+        # colon meant every other namespaced key minted a bogus Slack URL: a
+        # ``slack:<ts>`` session key yielded channel "slack" (a dead link), and a
+        # ``discord:``/``telegram:`` key produced a fabricated Slack permalink for
+        # a conversation that never happened on Slack.
+        #
+        # Allowlist on the channel-id shape, not a denylist of prefixes to skip:
+        # the taxonomy owns session-key shapes, so registering a new kind can
+        # never leak back into this branch.
+        from kiro_crew.session_kind import is_slack_channel_composite
+
+        if is_slack_channel_composite(parent_key):
             chan, ts = parent_key.split(":", 1)
             return {
                 "slack_link": f"https://amzn-aws.slack.com/archives/{chan}/p{ts.replace('.', '')}"

--- a/src/kiro_crew/slack/sessions_view.py
+++ b/src/kiro_crew/slack/sessions_view.py
@@ -83,6 +83,13 @@ def _default_session_title(key: str, kind: str) -> str:
             return f"Task Runner {key.split(':', 2)[-1]}"
         if "_" in key:
             return f"Task Runner {key.split('_', 2)[-1]}"
+    # A channel-born session used to fall through to `return key`, rendering the
+    # raw session key (e.g. "slack_1785457986.925389") as its user-visible title.
+    from kiro_crew.session_kind import KIND_CHANNEL, classify
+
+    classified = classify(key)
+    if classified.kind == KIND_CHANNEL and classified.channel:
+        return f"{classified.channel.capitalize()} conversation"
     return key
 
 

--- a/src/kiro_crew/sync_bridge.py
+++ b/src/kiro_crew/sync_bridge.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from kiro_crew.history import ConversationLog
     from kiro_crew.slack.client import SlackClientOps
 
+from kiro_crew.session_kind import source_of
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,12 +35,7 @@ def list_recent_sessions(
         key = s.get("key", "")
         if not key:
             continue
-        if key.startswith("dashboard:") or key.startswith("dashboard_"):
-            source = "dashboard"
-        elif key.startswith("cron:") or key.startswith("cron_"):
-            source = "cron"
-        else:
-            source = "slack"
+        source = source_of(key)
         result.append(
             {
                 "key": key,

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -141,23 +141,28 @@ def infer_use_case(session_key: str) -> str:
     invocations into one session each. Both can be fixed in a follow-up
     by appending a ``:<uuid>`` suffix at the entry point.
     """
-    if not session_key:
-        return "unknown"
-    if session_key.startswith("cron:") or session_key.startswith("cron_"):
-        return "cron"
-    if session_key.startswith("subagent:") or session_key.startswith("subagent_"):
-        return "subagent"
-    if session_key == "_bg":
-        return "subagent"
-    if session_key.startswith("taskrunner_") or session_key.startswith("taskrunner:"):
-        return "task-runner"
-    if session_key.startswith("dashboard:") or session_key.startswith("chat-"):
-        return "dashboard"
-    if session_key == "cli_chat" or session_key.startswith("cli_chat:"):
-        return "cli"
-    if SLACK_THREAD_TS_RE.match(session_key):
+    from kiro_crew.session_kind import (
+        KIND_BACKGROUND,
+        KIND_TASKRUNNER,
+        KIND_UNKNOWN,
+        classify,
+    )
+
+    if SLACK_THREAD_TS_RE.match(session_key or ""):
+        # A bare Slack thread ts predates the namespaced form; the classifier
+        # only recognises `slack:<ts>`, so keep honouring the legacy shape.
         return "slack"
-    return "unknown"
+    kind = classify(session_key)
+    # This function's vocabulary is persisted (``Artifact.source``) and emitted as
+    # a metric attribute, so two labels stay pinned to their historical spelling
+    # rather than adopting the canonical constants.
+    if kind.kind == KIND_TASKRUNNER:
+        return "task-runner"
+    if kind.kind == KIND_BACKGROUND:
+        return "subagent"
+    if kind.kind == KIND_UNKNOWN:
+        return "unknown"
+    return kind.source
 
 
 # Valid Jira project key pattern (e.g. PROJ, TEAM_X)

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -564,10 +564,17 @@ class TestOmissionDetection:
         """The audited-surface list must track ``sel._infer_source``'s branches.
 
         Guards the drift the previous hand-typed 8-tuple had already suffered.
+
+        The transport probes are GENERATED from ``messaging.link``'s registry
+        rather than typed out. A hand-typed probe set is what let ``whatsapp``
+        through: it was a registered transport absent from both the vocabulary and
+        this guard, so the two agreed with each other and disagreed with reality.
         """
         from kiro_crew import sel as sel_mod
+        from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES
 
-        # Every source _infer_source can return must be in the published tuple...
+        # Non-channel origins: one literal probe each, since their key shapes are
+        # sentinels and prefixes rather than registry entries.
         probes = {
             "": "unknown",
             "_host": "host",
@@ -578,8 +585,16 @@ class TestOmissionDetection:
             "_bg": "background",
             "_hb": "heartbeat",
             "cli_chat": "cli",
-            "C123:456.789": "slack",
+            "hook:abc": "hook",
+            "side:chat-1": "side",
+            "channel:C123": "channel-agent",
+            "wf-pool:run1": "wf-pool",
         }
+        # One probe per REGISTERED transport, generated so a transport added to
+        # the registry is exercised here without editing this test.
+        for namespace in sorted(CHANNEL_SESSION_NAMESPACES):
+            probes[f"{namespace}:kirocrew:direct:probe"] = namespace
+
         for key, expected in probes.items():
             assert sel_mod._infer_source(key) == expected, key
         assert set(probes.values()) == set(sel_mod.audit_sources()), (

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -350,7 +350,17 @@ class TestInferSource:
         ("_bg", "background"),
         ("cli_chat", "cli"),
         ("C08HZAWV4TP:thread123", "slack"),
-        ("random_key", "slack"),
+        # Every other messaging transport is now identified rather than being
+        # swept into "slack" by a terminal fallback.
+        ("slack:1785457986.925389", "slack"),
+        ("discord:kirocrew:direct:9:gen3", "discord"),
+        ("telegram:kirocrew:forum:22:gen1", "telegram"),
+        ("teams:kirocrew:direct:a@b.com", "teams"),
+        # An unrecognised key carries no surface signal → "unknown", NOT "slack".
+        # Guessing Slack here mislabelled every non-Slack transport in the audit
+        # log; the governance bind target keeps its historical value separately
+        # (see governance_profiles._infer_surface).
+        ("random_key", "unknown"),
         # An empty key carries no surface signal → "unknown", NOT "slack"
         # (an app-activation governance degrade passes no session_key).
         ("", "unknown"),

--- a/test/test_session_kind.py
+++ b/test/test_session_kind.py
@@ -1,0 +1,494 @@
+"""The canonical session-key classifier.
+
+Locks in the taxonomy itself, and — more importantly — the specific
+mislabellings that six independent prefix parsers used to produce by guessing
+Slack whenever nothing else matched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from kiro_crew.session_kind import (
+    KIND_BACKGROUND,
+    KIND_CHANNEL,
+    KIND_CHANNEL_AGENT,
+    KIND_CLI,
+    KIND_CRON,
+    KIND_DASHBOARD,
+    KIND_HEARTBEAT,
+    KIND_HOOK,
+    KIND_HOST,
+    KIND_SIDE,
+    KIND_SUBAGENT,
+    KIND_TASKRUNNER,
+    KIND_UNKNOWN,
+    KIND_WORKFLOW_POOL,
+    classify,
+    is_attended,
+    source_of,
+)
+
+
+class TestKinds:
+    @pytest.mark.parametrize(
+        "key,kind",
+        [
+            ("dashboard:chat-7", KIND_DASHBOARD),
+            ("dashboard_chat-7", KIND_DASHBOARD),
+            ("chat-3-1785467660", KIND_DASHBOARD),
+            ("cron:abc", KIND_CRON),
+            ("cron_abc", KIND_CRON),
+            ("subagent:x1", KIND_SUBAGENT),
+            ("taskrunner:run_9", KIND_TASKRUNNER),
+            ("taskrunner", KIND_TASKRUNNER),
+            ("hook:h1", KIND_HOOK),
+            ("side:chat-1", KIND_SIDE),
+            ("channel:C123", KIND_CHANNEL_AGENT),
+            ("wf-pool:r1", KIND_WORKFLOW_POOL),
+            ("_bg", KIND_BACKGROUND),
+            ("_hb", KIND_HEARTBEAT),
+            ("_host", KIND_HOST),
+            ("cli_chat", KIND_CLI),
+            ("cli_chat:1", KIND_CLI),
+        ],
+    )
+    def test_non_channel_kinds(self, key: str, kind: str) -> None:
+        assert classify(key).kind == kind
+
+    def test_empty_key_is_unknown_not_slack(self) -> None:
+        """An empty key is the documented ungoverned opt-out, not a Slack session."""
+        assert classify("").kind == KIND_UNKNOWN
+        assert classify("").channel == ""
+
+    def test_unrecognised_key_is_unknown_not_slack(self) -> None:
+        """The bug this module exists to remove.
+
+        Six parsers ended in a terminal ``else`` that returned Slack, so any key
+        they did not recognise was recorded as having come from Slack.
+        """
+        assert classify("random_key").kind == KIND_UNKNOWN
+        assert source_of("random_key") == "unknown"
+
+
+class TestChannels:
+    @pytest.mark.parametrize(
+        "key,channel",
+        [
+            ("slack:1785457986.925389", "slack"),
+            ("discord:kirocrew:direct:9:gen3", "discord"),
+            ("telegram:kirocrew:forum:22:gen1", "telegram"),
+            ("teams:kirocrew:direct:a@b.com", "teams"),
+            ("webex:kirocrew:direct:a@b.com", "webex"),
+            ("wecom:kirocrew:direct:u1", "wecom"),
+            ("weixin:kirocrew:direct:u1", "weixin"),
+            ("unified:kirocrew", "unified"),
+        ],
+    )
+    def test_every_transport_is_identified(self, key: str, channel: str) -> None:
+        """Each transport reports itself — none of them collapses to Slack."""
+        kind = classify(key)
+        assert kind.kind == KIND_CHANNEL
+        assert kind.channel == channel
+        assert kind.source == channel
+
+    def test_filename_stem_form_is_recognised(self) -> None:
+        """``history._safe_key`` folds ``:`` to ``_``, so both spellings arrive."""
+        assert classify("slack_1785457986.925389").channel == "slack"
+        assert classify("discord_kirocrew_direct_9").channel == "discord"
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "1785457986.925389",  # bare thread ts, pre-namespace
+            "C08HZAWV4TP:thread123",  # Slack channel-id composite
+            "C123:456.789",
+        ],
+    )
+    def test_legacy_slack_shapes_still_classify(self, key: str) -> None:
+        """Old transcripts and the jump-to-source path still carry these."""
+        kind = classify(key)
+        assert kind.kind == KIND_CHANNEL
+        assert kind.channel == "slack"
+
+    def test_namespaced_key_wins_over_the_legacy_pattern(self) -> None:
+        """A real ``slack:<ts>`` must not be re-parsed as a channel-id composite."""
+        assert classify("slack:1785457986.925389").channel == "slack"
+
+
+class TestAttended:
+    @pytest.mark.parametrize(
+        "key", ["dashboard:chat-1", "slack:1.1", "discord:a:direct:1", "cli_chat", "_host"]
+    )
+    def test_attended(self, key: str) -> None:
+        assert is_attended(key) is True
+
+    @pytest.mark.parametrize(
+        "key", ["cron:a", "subagent:a", "taskrunner:a", "_bg", "_hb", "hook:a", "side:a"]
+    )
+    def test_unattended(self, key: str) -> None:
+        assert is_attended(key) is False
+
+    def test_unknown_counts_as_attended(self) -> None:
+        """Treating an unrecognised key as unattended would turn the governance
+        gate's documented no-op into deny-all for every ungoverned caller."""
+        assert is_attended("") is True
+        assert is_attended("random_key") is True
+
+
+class TestConsumersAgree:
+    """The adapters keep their own public vocabulary but one classification."""
+
+    def test_sel_audit_source_reports_the_true_transport(self) -> None:
+        from kiro_crew.sel import _infer_source
+
+        assert _infer_source("discord:kirocrew:direct:9:gen1") == "discord"
+        assert _infer_source("slack:1785.1") == "slack"
+        assert _infer_source("random_key") == "unknown"
+
+    def test_governance_binding_is_deliberately_unchanged(self) -> None:
+        """Every transport still binds to the ``slack`` surface.
+
+        The classifier reports the true transport, but the governance bind target
+        is pinned: adopting it would move an existing Discord/Telegram/Teams
+        session off a Slack-bound profile onto the policy ceiling alone, which
+        RELAXES policy for anyone relying on that profile. Splitting it needs an
+        owner and a migration note, so it is not a side effect of fixing labels.
+        """
+        from kiro_crew.platform.governance_profiles import _infer_surface
+
+        assert _infer_surface("discord:kirocrew:direct:9:gen1") == "slack"
+        assert _infer_surface("telegram:kirocrew:direct:9:gen1") == "slack"
+        assert _infer_surface("random_key") == "slack"
+        # The empty key keeps its ungoverned opt-out.
+        assert _infer_surface("") == "unknown"
+        # Non-channel kinds are untouched.
+        assert _infer_surface("cron:job") == "cron"
+        assert _infer_surface("dashboard:chat-1") == "dashboard"
+
+    def test_use_case_keeps_its_persisted_spellings(self) -> None:
+        """``Artifact.source`` and a metric attribute read these values."""
+        from kiro_crew.validation import infer_use_case
+
+        assert infer_use_case("taskrunner:run1") == "task-runner"
+        assert infer_use_case("_bg") == "subagent"
+        assert infer_use_case("1785457986.925389") == "slack"
+        assert infer_use_case("discord:a:direct:1") == "discord"
+        assert infer_use_case("") == "unknown"
+
+    def test_every_use_case_value_is_an_allowed_artifact_source(self) -> None:
+        """A source the classifier can emit must pass artifact validation."""
+        from kiro_crew.artifacts import allowed_sources
+        from kiro_crew.validation import infer_use_case
+
+        for key in (
+            "dashboard:chat-1",
+            "slack:1.1",
+            "discord:a:direct:1",
+            "telegram:a:direct:1",
+            "teams:a:direct:b@c.com",
+            "webex:a:direct:b@c.com",
+            "wecom:a:direct:u",
+            "weixin:a:direct:u",
+            "unified:a",
+            "cron:j",
+            "subagent:s",
+            "taskrunner:r",
+            "hook:h",
+            "side:s",
+            "channel:C1",
+            "wf-pool:w",
+            "cli_chat",
+            "_bg",
+            "_hb",
+            "_host",
+            "",
+        ):
+            assert infer_use_case(key) in allowed_sources(), key
+
+    def test_mcp_session_type_is_one_implementation(self) -> None:
+        """The claim and stub paths shared a hand-mirrored copy that guessed Slack."""
+        from kiro_crew.mcp_gateway.claim import classify_session_type
+
+        # The existing wire value for Slack is preserved verbatim.
+        assert classify_session_type("slack:1785.1") == "slack-thread"
+        assert classify_session_type("1785457986.925389") == "slack-thread"
+        # Other transports are no longer reported as Slack threads.
+        assert classify_session_type("discord:a:direct:1:gen1") == "discord"
+        assert classify_session_type("telegram:a:direct:1:gen1") == "telegram"
+        assert classify_session_type("cron:j") == "cron"
+        assert classify_session_type("hook:h") == "hook"
+        assert classify_session_type("dashboard:chat-1") == "dashboard"
+        assert classify_session_type("") == "unknown"
+
+    def test_runtime_display_name_covers_every_transport(self) -> None:
+        from kiro_crew.context import _runtime_display_name
+
+        assert _runtime_display_name("slack:1.1") == "Slack"
+        assert _runtime_display_name("discord:a:direct:1") == "Discord"
+        assert _runtime_display_name("teams:a:direct:b@c.com") == "Teams"
+        assert _runtime_display_name("dashboard:chat-1") == "KiroCrew dashboard"
+
+
+class TestNoImportCycle:
+    """``session_kind`` must not create a startup import cycle.
+
+    The first revision imported ``session_kind`` at ``artifacts`` module scope.
+    That reached the transport registry through ``messaging``, whose package
+    ``__init__`` imports ``acp.runtime`` -> ``validation`` -> back into a partially
+    initialized ``artifacts``, so ``import kiro_crew.mcp_core`` raised ImportError
+    and the MCP server could not start. The whole test suite stayed green because
+    pytest imports these modules in a different order.
+
+    Each module is imported in a COLD interpreter, which is the only way to catch
+    an ordering cycle -- inside this process the modules are already loaded.
+    """
+
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "kiro_crew.mcp_core",
+            "kiro_crew.artifacts",
+            "kiro_crew.validation",
+            "kiro_crew.sel",
+            "kiro_crew.session_kind",
+            "kiro_crew.context",
+            "kiro_crew.security_posture",
+            "kiro_crew.platform.governance_profiles",
+        ],
+    )
+    def test_module_imports_standalone(self, module: str) -> None:
+        proc = subprocess.run(
+            [sys.executable, "-c", f"import {module}"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, (
+            f"cold import of {module} failed — likely an import cycle:\n{proc.stderr[-2000:]}"
+        )
+
+    def test_session_kind_is_a_leaf_module(self) -> None:
+        """Importing it must not drag in the transport or ACP stack.
+
+        This is what keeps it safe to import from module scope anywhere. If it
+        starts pulling ``messaging`` in eagerly, the cycle above comes back.
+        """
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; import kiro_crew.session_kind; "
+                "heavy=[m for m in ('kiro_crew.messaging','kiro_crew.acp') if m in sys.modules]; "
+                "print(','.join(heavy))",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr[-2000:]
+        assert proc.stdout.strip() == "", (
+            f"session_kind eagerly imported: {proc.stdout.strip()} — keep it a leaf"
+        )
+
+
+class TestVocabulariesAreDerivedNotHandTyped:
+    """Every consumer vocabulary is derived from the ONE transport registry.
+
+    The first cut of this module hand-typed the transport list into three separate
+    places and omitted ``whatsapp`` -- a registered transport. The classifier
+    reported ``"whatsapp"``, the artifact allowlist rejected it, and every artifact
+    save from a WhatsApp session began returning 400. These tests iterate the
+    registry itself so the probe set cannot drift out of sync with it again.
+    """
+
+    def test_every_registered_transport_is_a_reportable_source(self) -> None:
+        from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES
+        from kiro_crew.session_kind import all_sources
+
+        missing = set(CHANNEL_SESSION_NAMESPACES) - all_sources()
+        assert not missing, f"transports registered but not reportable: {missing}"
+
+    def test_governance_unattended_set_is_the_taxonomy_set(self) -> None:
+        """Governance must not keep its own copy of "which kinds are unattended".
+
+        It did, and the copy had already drifted narrower -- it omitted ``hook``,
+        ``side``, ``channel-agent`` and ``wf-pool`` -- so the first consumer of
+        ``is_attended`` would have disagreed with the governance containment check
+        about the same session.
+        """
+        from kiro_crew.platform.governance_profiles import _UNATTENDED_SURFACES
+        from kiro_crew.session_kind import UNATTENDED_KINDS
+
+        assert _UNATTENDED_SURFACES is UNATTENDED_KINDS
+
+    def test_widening_the_unattended_set_kept_the_deny_all_path_identical(self) -> None:
+        """Deriving the set widened it; that must not deny anything new.
+
+        The deny-all branch is reachable only on UNPROVEN identity, which is true
+        solely for an empty key and the ``_bg``/``_hb`` sentinels. Every newly
+        included kind always arrives on a non-empty key, so it proves identity and
+        resolves to the no-profile path exactly as before.
+        """
+        from kiro_crew.platform.governance_profiles import resolve_active_scope
+        from kiro_crew.session_kind import UNATTENDED_KINDS
+
+        newly_included = UNATTENDED_KINDS - {
+            "cron",
+            "subagent",
+            "background",
+            "heartbeat",
+            "taskrunner",
+        }
+        assert newly_included, "test is vacuous if the set did not widen"
+        for kind in sorted(newly_included):
+            assert resolve_active_scope(f"{kind}:conv", agent=None) is None
+
+    def test_slack_permalink_shape_is_an_allowlist_not_a_prefix_denylist(self) -> None:
+        """Only a real ``<channel-id>:<ts>`` pair may become a Slack permalink.
+
+        The denylist this replaced had to name every non-Slack prefix, so any kind
+        registered later would have started minting fabricated links again.
+        """
+        from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES
+        from kiro_crew.session_kind import all_sources, is_slack_channel_composite
+
+        assert is_slack_channel_composite("C08HZAWV4TP:1785457986.925389")
+        assert is_slack_channel_composite("D01ABCDEF:1.2")
+        # No namespaced session key carries a channel id, so none may build a link.
+        for ns in sorted(set(CHANNEL_SESSION_NAMESPACES) | all_sources()):
+            assert not is_slack_channel_composite(f"{ns}:conv"), ns
+        # A bare thread ts has no channel half to split off.
+        assert not is_slack_channel_composite("1785457986.925389")
+
+    def test_every_source_is_a_stampable_audit_source(self) -> None:
+        from kiro_crew.sel import audit_sources
+        from kiro_crew.session_kind import all_sources
+
+        missing = all_sources() - set(audit_sources())
+        assert not missing, f"sources SEL cannot stamp: {missing}"
+
+    def test_every_source_is_an_allowed_artifact_source(self) -> None:
+        from kiro_crew.artifacts import allowed_sources
+        from kiro_crew.session_kind import all_sources
+
+        missing = all_sources() - allowed_sources()
+        assert not missing, f"sources that would 400 an artifact save: {missing}"
+
+    def test_every_audit_source_has_a_posture_gloss(self) -> None:
+        from kiro_crew.security_posture import _AUDIT_SURFACE_DETAIL
+        from kiro_crew.sel import audit_sources
+
+        missing = set(audit_sources()) - set(_AUDIT_SURFACE_DETAIL)
+        assert not missing, f"audited surfaces with no operator-facing gloss: {missing}"
+
+    def test_every_registered_transport_saves_an_artifact(self) -> None:
+        """The end-to-end shape of the WhatsApp regression, per transport."""
+        from kiro_crew.artifacts import _validate_source
+        from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES
+        from kiro_crew.validation import infer_use_case
+
+        for ns in sorted(CHANNEL_SESSION_NAMESPACES):
+            _validate_source(infer_use_case(f"{ns}:some-conversation-id"))
+
+    def test_every_registered_transport_has_a_runtime_display_name(self) -> None:
+        from kiro_crew.context import _RUNTIME_DISPLAY
+        from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES
+
+        missing = set(CHANNEL_SESSION_NAMESPACES) - set(_RUNTIME_DISPLAY)
+        assert not missing, f"transports the model would see as a raw key: {missing}"
+
+
+class TestGovernanceBindingIsPinned:
+    """``_infer_surface`` must be behaviour-identical to the pre-unification parser.
+
+    Relabelling is correct for audit and display but NOT for policy: a profile is
+    bound by surface name, so renaming a session's surface moves it off a
+    Slack-bound profile onto the policy ceiling -- a relaxation. The first cut
+    pinned only channel and unrecognised keys, leaving ``hook:``, ``side:``,
+    ``channel:`` and ``wf-pool:`` free to escape.
+    """
+
+    @staticmethod
+    def _pre_unification_surface(key: str) -> str:
+        """Verbatim transcription of the parser this PR replaced."""
+        if not key:
+            return "unknown"
+        if key == "_host":
+            return "host"
+        if key.startswith("dashboard:"):
+            return "dashboard"
+        if key.startswith("cron:"):
+            return "cron"
+        if key.startswith("subagent:"):
+            return "subagent"
+        if key.startswith("taskrunner"):
+            return "taskrunner"
+        if key == "_bg":
+            return "background"
+        if key == "_hb":
+            return "heartbeat"
+        if key == "cli_chat":
+            return "cli"
+        return "slack"
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "",
+            "_host",
+            "_bg",
+            "_hb",
+            "cli_chat",
+            "cli_chat:x",
+            "dashboard:chat-1",
+            "dashboard_chat-1",
+            "chat-7",
+            "cron:abc",
+            "cron_abc",
+            "subagent:x",
+            "subagent_x",
+            "taskrunner",
+            "taskrunner:1",
+            # The four the first cut let escape to the policy ceiling.
+            "hook:abc",
+            "side:q",
+            "channel:agent1",
+            "wf-pool:7",
+            "hook_abc",
+            "side_q",
+            # Legacy Slack shapes.
+            "1785457986.925389",
+            "C08HZAWV4TP:thread123",
+            "random_key",
+        ],
+    )
+    def test_matches_the_parser_it_replaced(self, key: str) -> None:
+        from kiro_crew.platform.governance_profiles import _infer_surface
+
+        assert _infer_surface(key) == self._pre_unification_surface(key)
+
+    def test_every_registered_transport_still_binds_to_slack(self) -> None:
+        from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES
+        from kiro_crew.platform.governance_profiles import _infer_surface
+
+        for ns in sorted(CHANNEL_SESSION_NAMESPACES):
+            assert _infer_surface(f"{ns}:conv") == "slack"
+
+    def test_an_unpinned_new_kind_defaults_to_slack_not_the_ceiling(self) -> None:
+        """The allowlist shape is what makes this safe by default.
+
+        A kind added to the classifier later must fall to the conservative pin
+        rather than silently escaping onto the policy ceiling. Asserted through a
+        source name that is deliberately absent from the allowlist.
+        """
+        from kiro_crew.platform.governance_profiles import (
+            _PRE_UNIFICATION_SURFACES,
+            _infer_surface,
+        )
+
+        assert "wf-pool" not in _PRE_UNIFICATION_SURFACES
+        assert _infer_surface("wf-pool:new-kind") == "slack"

--- a/test/test_sync_bridge.py
+++ b/test/test_sync_bridge.py
@@ -28,7 +28,7 @@ class TestListRecentSessions:
     def test_returns_sessions_with_source(self, tmp_path):
         log = ConversationLog(base_dir=tmp_path)
         log.append("dashboard_chat-1-100", "user", "hello")
-        log.append("thread-slack-1", "user", "hi from slack")
+        log.append("slack_1785457986.925389", "user", "hi from slack")
         log.append("cron_job-1", "user", "cron msg")
         result = list_recent_sessions(log, limit=10)
         sources = {s["source"] for s in result}


### PR DESCRIPTION
## Problem

Six independent parsers read a session key's prefix to decide what kind of session it is. Each grew its own vocabulary, and each ended in a terminal `else` that guessed **Slack**:

| Parser | What it feeds |
|---|---|
| `sel._infer_source` | the SEL audit log's `source` field |
| `context._runtime_display_name` | the runtime name shown to the model |
| `validation.infer_use_case` | persisted provenance (`Artifact.source`) and the turn-duration metric |
| `sync_bridge` | the session list's source badge |
| `mcp_gateway.claim` | MCP claim attribution |
| `mcp_gateway.stub` | MCP stub attribution |

Because Slack was the fallback rather than a match, **any session born on Discord, Telegram, Teams, Webex, WeCom, Weixin or WhatsApp was labelled Slack** — in the audit log, in the model's own view of where it is running, in persisted artifact provenance, and in the session list.

Two of those mislabels are security-relevant:

- **Wrong security profile.** `governance_profiles._infer_surface` delegates to `sel._infer_source` (its docstring calls it "the single canonical classifier"). A Discord session therefore resolved to surface `slack` and bound to a Slack-scoped governance profile.
- **Owner-only gate bypassed.** `_is_slack_origin` recognised only the `slack:` namespace, so a Discord/Telegram/Teams channel origin passed an owner-only instance operation that a Slack origin is denied.

Three lesser defects found in the same code:

- `slack/gateway.py` minted a **Slack permalink from any colon-key** — a dead link for a `slack:` key and a fabricated URL for a Discord or Telegram one.
- `slack/sessions_view.py` rendered a **raw session key as a session title** when no title was stored.
- `validation.infer_use_case` missed the `dashboard_` filename form, so `"unknown"` leaked into `Artifact.source` and into the `kirocrew.turn.duration` metric for filename-round-tripped keys.

## Why it matters

The audit log is the record you consult after an incident. If it attributes a Discord action to Slack, the record is wrong in the one place that has to be right. The governance binding is worse than cosmetic: an operator who configures a Slack profile has been silently applying it to every other transport too.

This is also the first step of the larger session-naming work — the prefix is doing identity work it should not. Collapsing six parsers into one taxonomy is the prerequisite for treating all surfaces equally, and it is independently a bug fix.

## Fix

**Symptoms** → a Discord session reads as Slack everywhere; an owner-only gate lets non-Slack channels through; permalinks point nowhere or somewhere wrong.

**Root cause** → the taxonomy had no owner. Six copies each re-derived it from string prefixes, and a terminal `else → "slack"` in five of them converted "I don't recognise this" into "this is Slack".

**Change** → adds `src/kiro_crew/session_kind.py` as the single owner of the taxonomy and rewires all six parsers to derive from it:

- `classify(key) -> SessionKind` with `kind` plus, for channel sessions, the transport `channel`. Unrecognised keys classify as `unknown`, never as Slack.
- `ALL_SOURCES` / `CHANNEL_SOURCES` publish the complete vocabulary, with the transport half read from `messaging.link`'s `CHANNEL_SESSION_NAMESPACES` — the one registry.
- Legacy pre-namespace Slack shapes (bare thread ts, channel-id composite) still classify as Slack — they appear in old transcripts and in the notification jump-to-source path.
- `attended` / `UNATTENDED_KINDS` states once which origins have no human on them, and governance reads that set rather than keeping its own. `unknown` counts as attended, because treating an unrecognised key as unattended would turn every ungoverned caller into a deny-all.

**Consumer vocabularies are derived, not restated.** The artifact source allowlist, the SEL audit sources, the posture gloss map, the runtime display map, and the drift guard's own probe set all read the registry. Each caller keeps its own **public** spelling — `Artifact.source` is persisted data and the SEL `source` field is queried, so neither can be renamed — but membership is decided in one place. Registering a transport in `messaging.link` now reaches every consumer with no second list to update.

**`session_kind` is a leaf module.** It reaches the registry through a cached lazy accessor rather than a
module-scope import, and consumers read `all_sources()` / `allowed_sources()` on first use. This is load-bearing,
not style: `messaging`'s package `__init__` imports `acp.runtime` → `validation`, and `validation` imports back
into `artifacts`. An earlier revision of this PR imported `session_kind` at `artifacts` module scope and broke
`import kiro_crew.mcp_core` outright — the MCP server could not start, while the whole test suite stayed green
because pytest imports those modules in a different order.

**Two duplications the first revision left behind.** Design review caught both. They are the same disease this PR exists to cure, so they are fixed here rather than deferred:

- `governance_profiles._UNATTENDED_SURFACES` was a *second* hand-typed unattended set, and it had already drifted **narrower** than the taxonomy's — it omitted `hook`, `side`, `channel-agent` and `wf-pool`. The first consumer of `is_attended` would therefore have disagreed with the governance containment check about the same session. It is now the taxonomy's set. Widening it denies nothing new: that branch is reachable only on *unproven* identity, which is true solely for an empty key and the `_bg`/`_hb` sentinels, and every added kind always arrives on a non-empty key.
- the permalink fix had replaced "any colon-key" with a hand-typed **denylist** of seven prefixes to skip — which would have needed extending for every kind registered later. It is now an **allowlist** on the Slack channel-id shape (`is_slack_channel_composite`), so a newly registered kind is excluded by default. Strictly narrower than the denylist it replaces: it also stops an unrecognised uppercase key from minting a fabricated link.

**Governance binding is pinned and proved equivalent.** `_infer_surface` keeps its pre-unification behaviour exactly. Relabelling is right for audit and display but not for policy: a profile is bound by surface name, so renaming a session's surface moves it off a Slack-bound profile and onto the policy ceiling — a *relaxation* for anyone who has one configured. The pin is stated as an **allowlist of what the old parser returned directly**, so a session kind added later falls to the conservative pin rather than silently escaping. Whether a Slack-bound profile should govern Discord (or a webhook) is a policy decision with an owner and a migration note, not a side effect of fixing labels.

## Tests

`test/test_session_kind.py` — new. Covers every key shape (namespaced, filename-folded, legacy Slack, sentinel, empty, unrecognised), the attended/unattended split, and one test per bug above.

Two classes specifically guard the two review findings this PR went through:

- **`TestVocabulariesAreDerivedNotHandTyped`** — iterates `CHANNEL_SESSION_NAMESPACES` to assert every registered transport is reportable, stampable in SEL, accepted by the artifact allowlist, glossed in the posture view, and displayable to the model. Includes an end-to-end `infer_use_case → _validate_source` round trip per transport, which is the exact shape of the WhatsApp failure. Also asserts that governance's unattended set **is** the taxonomy's object rather than merely equal to it, that the widening denied nothing new (`resolve_active_scope` still returns `None` for each newly included kind), and that no namespaced key of any registered transport or source can produce a Slack permalink.
- **`TestNoImportCycle`** — cold-interpreter import of each entry-point module (`mcp_core`, `artifacts`,
  `validation`, `sel`, `context`, `security_posture`, `governance_profiles`), plus an assertion that importing
  `session_kind` does not pull in `messaging` or `acp`. A same-process test cannot catch an ordering cycle, which
  is exactly why the suite missed the one above.
- **`TestGovernanceBindingIsPinned`** — transcribes the parser this PR replaced and asserts `_infer_surface` matches it across 23 key shapes, including the `hook:` / `side:` / `channel:` / `wf-pool:` forms; plus a test that an unpinned new kind defaults to `slack` rather than the ceiling.

Updated: `test_sel.py`, `test_security_posture.py`, `test_sync_bridge.py` — three assertions encoded the old `else → slack` fallback and now assert the true transport. The posture drift guard's transport probes are now **generated** from the registry; they were hand-typed, which is what let a registered transport be absent from both the vocabulary and the guard, so the two agreed with each other and disagreed with reality.

**Gates:** isort, flake8, mypy (564 files) clean. 22410 backend tests pass; `tsc -b` clean. A cold-interpreter `import kiro_crew.mcp_core` is checked on every revision, since that is the failure the suite cannot see. The ~20 backend failures on this host (sandbox namespace, `os.fork`, `gh` binary resolution, beacon data-home, source-provider install paths) are environmental: they all descend from `unshare(CLONE_NEWUSER)` returning `EPERM` here, and CI's Linux backend shards are green on the same tree.

## Manual verification

- Ran an equivalence harness comparing `_infer_surface` against a transcription of the parser it replaced across 33 key shapes: zero divergence, including the four namespaces the first revision let escape.
- Confirmed `whatsapp` is now both stampable in SEL and accepted by the artifact allowlist, by resolving it through the live objects rather than reading the lists.
- Confirmed `_AUDIT_SURFACE_DETAIL` has no duplicate entries after rebasing over #830, which touched the same file (a different section of it).

## Screenshots

The one user-visible surface is the **source badge in the session list**: a Discord-born session previously showed `slack` and now shows `discord`. There is no layout or component change — only the string the existing badge renders, which is asserted in `test_sync_bridge.py`.

No dashboard screenshot attached: this agent cannot authenticate to the dashboard in this environment (same limitation noted on #884). Happy to add one if a reviewer wants it captured.

