### PR TITLE
feat(telemetry): report governance POSTURE in the usage beacon

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -353,6 +353,7 @@ shape cannot be widened from a call site.
 | `arch` | `arm64` | Architecture mix. |
 | `py` | `3.12` | **Minor only.** Answers "when can the floor move off 3.10". |
 | `dist` | `dmg` | Which install path users take. Clamped to a fixed set. |
+| `gov` | `verified` | Governance posture: `none` / `unsigned` / `signed` / `verified`. What share of DAU run under a Level-1 ceiling, and how many verify its signature. A STATE, never an identity — deliberately not the profile name (free-form stems) nor `identity.issuer` (names the signing org). |
 | `first_seen` | `1`/`0` | One bit → new-install and "launched once, never again" rate. |
 
 **Anti-fingerprinting is a design constraint, not a side effect.** Every value
@@ -467,7 +468,7 @@ absent/corrupt — so the id regenerates rather than merely not crashing. The
 Zero application code — the access log **is** the data product:
 
 ```
-client ──GET /b/1/<id>?v&os&arch&py&dist&first_seen──> CloudFront E1YM983XX3ASBM
+client ──GET /b/1/<id>?v&os&arch&py&dist&gov&first_seen──> CloudFront E1YM983XX3ASBM
                                      │ CloudFront Function returns 204 at the edge
                                      ▼
         standard logging v2 → s3://kirocrew-beacon-logs (PERMANENT, tiered)

--- a/src/kiro_crew/beacon.py
+++ b/src/kiro_crew/beacon.py
@@ -2,10 +2,11 @@
 
 Answers questions no local signal can: how many installations are actually
 RUNNING (Daily Active Instances), which VERSIONS they run, which
-OS/ARCH/Python they run on, which DISTRIBUTION CHANNEL they came from, and what
-share of installs are launched only once. Download counts cannot answer these —
-an install downloaded and never launched is indistinguishable from an active
-one, and self-hosted distribution links have no download telemetry at all.
+OS/ARCH/Python they run on, which DISTRIBUTION CHANNEL they came from, what share
+run under a governance ceiling (and how many of those verify its signature), and
+what share of installs are launched only once. Download counts cannot answer
+these — an install downloaded and never launched is indistinguishable from an
+active one, and self-hosted distribution links have no download telemetry.
 
 DELIBERATELY SEPARATE FROM ``kiro_crew.metrics`` (the OTEL trunk). Four reasons,
 each independently disqualifying:
@@ -43,7 +44,7 @@ PRIVACY:
   * Deliberately NOT ``handlers_system._get_owner_hash()``: that is
     ``HMAC(salt, hostname + ":" + username)``. It never leaves the host today,
     and sending it would change its character entirely.
-  * The payload is a fixed seven-key ALLOWLIST built by :func:`payload`. There
+  * The payload is a fixed eight-key ALLOWLIST built by :func:`payload`. There
     is no free-form field and no caller-supplied pass-through, so no prompt,
     path, repo name, credential, or model output can reach the wire — not by
     accident and not via a future call site.
@@ -134,6 +135,18 @@ _CI_ENV_VARS = (
 DIST_ENV = "KIROCREW_DISTRIBUTION"
 KNOWN_DISTRIBUTIONS = frozenset({"dmg", "appimage", "wheel", "source", "docker"})
 DEFAULT_DISTRIBUTION = "source"
+
+# Governance posture — a STATE, never an identity. Derived from the composed
+# ceiling (see :func:`governance_posture`), not from the environment, so unlike
+# ``dist`` there is nothing for a host to spoof. Four constants, so the field
+# stays low-cardinality by construction.
+POSTURE_NONE = "none"  # no Level-1 ceiling loaded
+POSTURE_UNSIGNED = "unsigned"  # ceiling enforced, integrity rests on file modes
+POSTURE_SIGNED = "signed"  # signature present but unproven / unchecked
+POSTURE_VERIFIED = "verified"  # signature verified against a trust key
+KNOWN_POSTURES = frozenset(
+    {POSTURE_NONE, POSTURE_UNSIGNED, POSTURE_SIGNED, POSTURE_VERIFIED}
+)
 
 # Fallback id when the data home is unwritable (read-only container, etc).
 # Process-local, so such a host contributes at most one count per process and
@@ -340,8 +353,63 @@ def _mark_sent() -> None:
         logger.debug("beacon stamp write failed: %s", exc)
 
 
+def governance_posture() -> str:
+    """Return this install's governance POSTURE, clamped to a fixed vocabulary.
+
+    Answers a question ``dist`` cannot: what share of Daily Active Instances run
+    under a Level-1 security ceiling at all, and of those, how many have a ceiling
+    whose signature actually VERIFIES. Today a governed enterprise fleet and an
+    ungoverned laptop are one undifferentiated number, so "is governance being
+    adopted, and is it being adopted correctly" has no answer.
+
+    Reports the POSTURE, never the identity. Deliberately NOT:
+
+      * the active PROFILE NAME — profile names are free-form file stems
+        (``governance_profiles`` derives them from ``path.stem``), so they are
+        unbounded operator-authored strings: exactly the cardinality bomb the
+        payload contract forbids, and they routinely encode an internal team,
+        app, or surface name.
+      * the ``identity.issuer`` — that names the ORGANIZATION that signed the
+        ceiling. Correlated with a stable install id it de-anonymizes the whole
+        row, which is the one thing this payload is built to prevent.
+
+    So the values are four constants that describe a STATE, and an outside
+    observer learns "some ceiling is present and verified", never whose:
+
+      * ``none``      — no ceiling loaded (the default standalone posture)
+      * ``unsigned``  — a ceiling is enforced, integrity rests on file permissions
+      * ``signed``    — a ceiling carries a signature that did NOT verify (or was
+                        never checked against a trust root) — advisory only
+      * ``verified``  — a ceiling whose signature verified against a trust key
+
+    Best-effort and import-cycle-safe: the context is read lazily inside the
+    function (``platform.context`` is a leaf that must not import this module's
+    dependents), and ANY failure reports ``none``. That fail direction is the
+    honest one — an install whose posture cannot be established is not evidence
+    of governance.
+    """
+    try:
+        from kiro_crew.platform.context import current_context
+
+        ceiling = getattr(current_context(), "governance", None)
+        if ceiling is None:
+            return POSTURE_NONE
+        state = getattr(ceiling, "signature_state", "")
+        if state == "verified":
+            return POSTURE_VERIFIED
+        if state == "unsigned":
+            return POSTURE_UNSIGNED
+        # "unverified" (present but unproven) and "unchecked" (parsed with no
+        # trust root) collapse to one bucket: both mean "a signature exists but
+        # nothing established it", and splitting them would report a distinction
+        # that carries no adoption meaning.
+        return POSTURE_SIGNED
+    except Exception:  # pragma: no cover - defensive; posture is never load-bearing
+        return POSTURE_NONE
+
+
 def payload(app_version: str) -> dict[str, str]:
-    """Build the exact seven-key allowlist that goes on the wire.
+    """Build the exact eight-key allowlist that goes on the wire.
 
     Every value is a random id, a low-cardinality platform constant, or a
     single bit. There is no caller-supplied field, so the payload shape is
@@ -354,6 +422,7 @@ def payload(app_version: str) -> dict[str, str]:
         "arch": platform.machine().lower(),
         "py": python_minor(),
         "dist": distribution(),
+        "gov": governance_posture(),
         "first_seen": "1" if is_first_send() else "0",
     }
 
@@ -423,7 +492,7 @@ def send(endpoint: str, app_version: str, *, enabled: bool) -> bool:
         return False
     try:
         req = urllib.request.Request(url, method="GET")
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- beacon_url enforces https:// and the payload is a fixed seven-key allowlist
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- beacon_url enforces https:// and the payload is a fixed eight-key allowlist
         with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECS):
             pass
         # Stamp only after a delivered request, so a failed send retries later

--- a/test/test_beacon.py
+++ b/test/test_beacon.py
@@ -142,9 +142,9 @@ class TestInstallId:
 
 
 class TestPayloadAllowlist:
-    EXPECTED_KEYS = {"id", "v", "os", "arch", "py", "dist", "first_seen"}
+    EXPECTED_KEYS = {"id", "v", "os", "arch", "py", "dist", "gov", "first_seen"}
 
-    def test_exactly_seven_keys(self, _isolated_home):
+    def test_exactly_eight_keys(self, _isolated_home):
         assert set(beacon.payload("1.2.3")) == self.EXPECTED_KEYS
 
     def test_no_value_leaks_identity_or_paths(self, _isolated_home, monkeypatch):
@@ -716,3 +716,111 @@ def _fake_urlopen(calls: list | None = None):
         return _Resp()
 
     return _open
+
+
+class TestGovernancePosture:
+    """``gov`` answers an adoption question, without leaking who is governed.
+
+    A governed enterprise fleet and an ungoverned laptop were previously one
+    undifferentiated DAU number, so "is governance being adopted, and correctly"
+    had no answer. The field reports a STATE from a four-value vocabulary.
+    """
+
+    def _ceiling(self, signature_state):
+        class _C:
+            pass
+
+        c = _C()
+        c.signature_state = signature_state
+        return c
+
+    def _with_context(self, monkeypatch, governance):
+        class _Ctx:
+            pass
+
+        ctx = _Ctx()
+        ctx.governance = governance
+        import kiro_crew.platform.context as pc
+
+        monkeypatch.setattr(pc, "current_context", lambda: ctx)
+
+    def test_no_ceiling_reports_none(self, _isolated_home, monkeypatch):
+        self._with_context(monkeypatch, None)
+        assert beacon.governance_posture() == beacon.POSTURE_NONE
+
+    @pytest.mark.parametrize(
+        "state,expected",
+        [
+            ("verified", beacon.POSTURE_VERIFIED),
+            ("unsigned", beacon.POSTURE_UNSIGNED),
+            # Both "present but unproven" states collapse to one bucket: the
+            # distinction carries no adoption meaning.
+            ("unverified", beacon.POSTURE_SIGNED),
+            ("unchecked", beacon.POSTURE_SIGNED),
+        ],
+    )
+    def test_signature_state_maps_to_posture(
+        self, _isolated_home, monkeypatch, state, expected
+    ):
+        self._with_context(monkeypatch, self._ceiling(state))
+        assert beacon.governance_posture() == expected
+
+    def test_posture_is_always_in_the_known_set(self, _isolated_home, monkeypatch):
+        """Low cardinality by construction — an unexpected state cannot widen it."""
+        for state in ("verified", "unsigned", "unverified", "unchecked", "", "wat", None):
+            self._with_context(monkeypatch, self._ceiling(state))
+            assert beacon.governance_posture() in beacon.KNOWN_POSTURES
+
+    def test_never_leaks_the_issuer(self, _isolated_home, monkeypatch):
+        """The issuer names the signing ORGANIZATION.
+
+        Correlated with a stable install id it de-anonymizes the row, which is the
+        one thing this payload exists to prevent — so a ceiling carrying an issuer
+        must contribute only the state word.
+        """
+        ceiling = self._ceiling("verified")
+        ceiling.identity_issuer = "Acme Corp Security Engineering"
+        ceiling.identity_signature = "deadbeefcafe" * 8
+        self._with_context(monkeypatch, ceiling)
+
+        blob = json.dumps(beacon.payload("1.2.3"))
+        assert "Acme" not in blob and "deadbeef" not in blob
+        assert beacon.payload("1.2.3")["gov"] == "verified"
+
+    def test_never_leaks_a_profile_name(self, _isolated_home, monkeypatch):
+        """Profile names are free-form file stems — unbounded, often internal.
+
+        Guards the deliberate choice not to report the ACTIVE PROFILE: stems are
+        operator-authored (``path.stem``) and routinely encode a team, app, or
+        surface name.
+        """
+        ceiling = self._ceiling("verified")
+        ceiling.profile_name = "internal-oncall-tier1"
+        ceiling.all_profiles = lambda: ["internal-oncall-tier1"]
+        self._with_context(monkeypatch, ceiling)
+        assert "oncall" not in json.dumps(beacon.payload("1.2.3"))
+
+    def test_broken_context_reports_none_not_a_crash(self, _isolated_home, monkeypatch):
+        """Fail direction is the honest one: unestablished posture is not governance.
+
+        The beacon runs in a detached boot thread, so a raising context must never
+        propagate — and must not be optimistically reported as governed either.
+        """
+        import kiro_crew.platform.context as pc
+
+        def boom():
+            raise RuntimeError("no context installed")
+
+        monkeypatch.setattr(pc, "current_context", boom)
+        assert beacon.governance_posture() == beacon.POSTURE_NONE
+
+    def test_posture_is_not_environment_spoofable(self, _isolated_home, monkeypatch):
+        """Unlike ``dist``, posture is derived from the composed ceiling.
+
+        A host cannot claim to be governed by exporting a variable, so the field
+        cannot be inflated the way a build-stamped channel could.
+        """
+        monkeypatch.setenv("KIROCREW_GOVERNANCE_POSTURE", "verified")
+        monkeypatch.setenv("KIROCREW_GOV", "verified")
+        self._with_context(monkeypatch, None)
+        assert beacon.governance_posture() == beacon.POSTURE_NONE


### PR DESCRIPTION
## Problem

The beacon can tell us how many installs run, on what, and from which
distribution channel — but not whether any of them are **governed**. A fleet
running under a Level-1 security ceiling and an ungoverned laptop are one
undifferentiated DAU number today, so two questions have no answer:

1. Is governance actually being **adopted**?
2. Of the installs that adopt it, how many **verify** their ceiling's signature
   rather than trusting filesystem permissions?

## Fix

Adds `gov` to the payload allowlist (now eight keys), from a four-value
vocabulary:

| value | meaning |
|---|---|
| `none` | no ceiling loaded (the default standalone posture) |
| `unsigned` | ceiling enforced, integrity rests on file permissions |
| `signed` | signature present but unproven, or never checked — advisory |
| `verified` | signature verified against a trust key |

`unverified` and `unchecked` collapse into `signed` deliberately: both mean "a
signature exists but nothing established it", and splitting them would report a
distinction with no adoption meaning.

## Why a posture, and not an identity

Two things are deliberately **not** sent, and tests pin both:

- **The active profile name.** `governance_profiles` derives names from
  `path.stem`, so they are unbounded operator-authored strings — exactly the
  cardinality bomb this payload's contract forbids, and they routinely encode an
  internal team, app, or surface name.
- **`identity.issuer`.** That names the *organization* that signed the ceiling.
  Correlated with a stable install id it de-anonymizes the entire row, which is
  the one property this payload exists to prevent.

So `gov` describes a **state**. An observer learns "some ceiling is present and
verified", never whose.

It is also **not environment-derived**: unlike `dist` (a build-time stamp),
posture is read from the composed ceiling, so a host cannot inflate it by
exporting a variable. Pinned by a test.

## Safety

Best-effort and import-cycle-safe: `platform.context` is imported lazily inside
the function (it is the leaf the rest of the platform imports, so a module-scope
import would close a cycle), and **any** failure reports `none`. That fail
direction is the honest one — an install whose posture cannot be established is
not evidence of governance — and the beacon runs in a detached boot thread where
a raising context must never propagate.

`kirocrew telemetry status` already prints the full payload preview, so the new
field is visible to users with no change to that command.

## Tests

`test/test_beacon.py` (+8), 73 pass:

- each `signature_state` maps to its posture, including the two-into-one collapse
- posture is always within `KNOWN_POSTURES`, even for an unexpected or `None` state
- a ceiling carrying an issuer **and** signature contributes only the state word
- a profile name never reaches the payload
- a raising context yields `none` rather than crashing
- the field is not spoofable from the environment

## Manual verification

Checked against a real composed enterprise ceiling (not a stub): it reports
`gov=unsigned` — governed, integrity resting on file permissions — which is both
honest and actionable, since it shows the remaining step to `verified` is signing
the policy document.
