### PR TITLE
feat(i18n): carry translator context into the translation shards

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -129,6 +129,14 @@ hand-assemble a catalog: `join`'s fail-closed check is what stops English text
 shipping disguised as a translation. Keep shard dirs OUTSIDE the worktree (Rule
 9 — a dirty tree blocks worktree pruning).
 
+`split` also writes `shard-NN.context.json` beside each shard, carrying the
+translator context from `src/i18n/en.context.json` for the keys in that shard.
+**Read it before translating the shard** — it is the only thing that tells you
+`KB` is kilobytes and not "knowledge base", that `K` is a keyboard key you must
+leave alone, and that `Run` is the verb. `join` ignores those files. If a short
+or ambiguous string has no entry, add one there rather than guessing twice.
+`split` warns and emits no context files if the sidecar is not present.
+
 **Don't pin a test fixture to a language you might later ship.** Assertions like
 "`fr` is unsupported, so it falls back" silently invert the moment French ships.
 This has now bitten twice — `fr` when French shipped, then `de-DE` in
@@ -202,7 +210,8 @@ its own key-parity, placeholder-preservation, and no-empty-value tests. Miss one
 of the three edits and CI fails naming the gap; it can't silently ship as
 English. To seed a catalog for translation, `node scripts/i18n-shard.mjs split
 <dir>` writes flat key→value shards and `join <dir> <tag>` reassembles them,
-refusing to write a partial result.
+refusing to write a partial result. Each shard gets a `shard-NN.context.json`
+sibling holding the translator context for its keys — read it first.
 
 Guard tests that must stay green: `catalogParity.test.ts` (cross-language key
 parity), `englishIdentity.test.ts` (catalog holds real prose — no encoded HTML

--- a/website/scripts/i18n-shard.mjs
+++ b/website/scripts/i18n-shard.mjs
@@ -34,6 +34,22 @@ const EN_FILES = [
   path.join(ROOT, 'src/i18n/locales/en.manual.json'),
 ]
 
+/**
+ * Translator context, keyed the same way as the catalog. Carried into the shard
+ * directory as `shard-NN.context.json` so a translator filling shards sees why
+ * `KB` is kilobytes and not "knowledge base", and that `K` is a keyboard key.
+ * See `src/i18n/en.context.json` for what belongs in it.
+ *
+ * Absent-tolerant on purpose. The sidecar is a separate change, and a translation
+ * run must not hard-fail because context has not landed yet — but it warns rather
+ * than falling silent, because silently shipping context-free shards is the exact
+ * failure the sidecar exists to prevent.
+ */
+const CONTEXT_FILE = path.join(ROOT, 'src/i18n/en.context.json')
+const CONTEXT = fs.existsSync(CONTEXT_FILE)
+  ? JSON.parse(fs.readFileSync(CONTEXT_FILE, 'utf-8')).entries
+  : {}
+
 function flatten(obj, prefix = '') {
   const out = {}
   for (const [k, v] of Object.entries(obj)) {
@@ -89,22 +105,53 @@ for (const file of EN_FILES) {
 
 if (cmd === 'split') {
   const size = Number(arg) || 400
+  if (!fs.existsSync(CONTEXT_FILE)) {
+    console.warn(
+      'warning: src/i18n/en.context.json is missing, so shards carry no translator '
+      + 'context. Short and ambiguous strings (`KB`, `K`, `Run`) will be guessed at.',
+    )
+  }
   fs.mkdirSync(dir, { recursive: true })
+
+  // Clear previously generated context sidecars before rewriting. `split` into an
+  // existing directory otherwise leaves a stale one behind whenever a shard's keys
+  // lose all their context -- the write below is conditional, so nothing overwrites
+  // it -- and stale guidance is worse than none: a translator would follow it.
+  // Only the sidecars, never `shard-NN.json`: those are filled in place by a
+  // translator, so deleting one would destroy work.
+  for (const f of fs.readdirSync(dir)) {
+    if (/^shard-\d+\.context\.json$/.test(f)) fs.unlinkSync(path.join(dir, f))
+  }
+
   const keys = Object.keys(flat).sort()
   let shard = 0
+  let described = 0
   for (let i = 0; i < keys.length; i += size) {
     const chunk = {}
     for (const k of keys.slice(i, i + size)) chunk[k] = flat[k]
-    const file = path.join(dir, `shard-${String(++shard).padStart(2, '0')}.json`)
+    const stem = `shard-${String(++shard).padStart(2, '0')}`
+    const file = path.join(dir, `${stem}.json`)
     fs.writeFileSync(file, JSON.stringify(chunk, null, 2) + '\n')
-    console.log(`${file}  (${Object.keys(chunk).length} keys)`)
+
+    // Translator context, as a SIBLING file rather than inside the shard: the
+    // shard is filled in place, so a description living in it would either be
+    // overwritten or arrive back as a translation. `join` skips `*.context.json`.
+    // Without this the sidecar is inert — a translator working the documented
+    // workflow would never learn that `KB` is kilobytes and not "knowledge base".
+    const ctx = {}
+    for (const k of Object.keys(chunk)) if (CONTEXT[k]) ctx[k] = CONTEXT[k]
+    if (Object.keys(ctx).length) {
+      fs.writeFileSync(path.join(dir, `${stem}.context.json`), JSON.stringify(ctx, null, 2) + '\n')
+      described += Object.keys(ctx).length
+    }
+    console.log(`${file}  (${Object.keys(chunk).length} keys${Object.keys(ctx).length ? `, ${Object.keys(ctx).length} with context` : ''})`)
   }
-  console.log(`\n${shard} shards, ${keys.length} keys total`)
+  console.log(`\n${shard} shards, ${keys.length} keys total, ${described} carrying translator context`)
 } else if (cmd === 'join') {
   const locale = arg
   if (!locale) throw new Error('join requires a locale, e.g. zh-CN')
   const merged = {}
-  for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.json')).sort()) {
+  for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.json') && !f.endsWith('.context.json')).sort()) {
     Object.assign(merged, JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')))
   }
 


### PR DESCRIPTION
Replaces #919 (same change, plus the GPT review fix; force-push was unavailable in my environment so
the corrected single commit landed on a fresh branch).

## What

`i18n-shard.mjs split` now writes a `shard-NN.context.json` sibling next to each shard, holding the
translator context for that shard's keys. `join` skips `*.context.json`. Both of `AGENTS.md`'s
descriptions of the translation workflow now say to read it first.

## Why

`split` is the documented path a translator walks, and it carries the key and the English value and
nothing else. So a translator — human or LLM — has no way to learn that:

- `KB` is **kilobytes**, not "knowledge base" (a real feature in this product sharing the abbreviation)
- `K` names a **physical keyboard key** and must be left alone
- `Run` is the **verb**, not the noun — different words in several locales

Nine languages are currently guessing at that class of string. This is the finding
[#914](https://github.com/kirodotdev/KiroCrew/pull/914)'s design review raised: the sidecar is inert
until something delivers it, and the reviewer suggested exactly this as a small follow-up.

## Design

**A sibling file, not a field inside the shard.** Shards are *filled in place* — a description living
inside one would either be overwritten by the translation or come back as one. Keeping it beside the
shard also means `join`'s fail-closed coverage check still sees exactly the corpus it split from, which
is the check that stops English text shipping disguised as a translation.

**Stale sidecars are cleared before writing** (the GPT review finding on #919). The context write is
conditional — a shard with no described keys gets no file — so `split` into an existing directory would
otherwise leave an obsolete sidecar that nothing overwrites, and stale guidance is worse than none
because a translator would follow it. Only `shard-*.context.json` is removed, never `shard-NN.json`:
those are filled in place, so deleting one would destroy work.

**Absent-tolerant, so this does not stack.** A missing `src/i18n/en.context.json` warns and emits no
context files rather than aborting a translation run. That lets this land independently of #914 instead
of stacking — stacking is what killed #903, where the base fell behind `main` while the head was rebased
forward and the PR ended up carrying 10 commits against a one-commit-per-PR rule. It warns rather than
falling silent because silently shipping context-free shards is the exact failure the sidecar prevents.

## Verification

Both paths exercised in a `node:20-bookworm` container:

| scenario | result |
|---|---|
| sidecar **absent** (this branch on `main`) | warns; 11 shards, 4048 keys, **0** carrying context, 0 context files |
| sidecar **present** (copied from #914) | no warning; 11 shards, 4048 keys, **85** carrying context, 10 context files |
| `join`'s file filter | reads **11** shard files / **4048** keys — the full corpus, so its exact-coverage check still passes with 10 context files in the same directory |
| **stale sidecar** — 10 generated files plus a planted `shard-99.context.json`, then re-split with the sidecar removed | **0** context files remain |

`eslint scripts/i18n-shard.mjs` clean. `join` was deliberately **not** invoked end-to-end: it writes
`src/i18n/locales/<locale>.json` into the repo, so the filter arithmetic was checked directly rather
than polluting the tree with a throwaway locale.

**Pre-existing hazard, noted not fixed:** re-running `split` into a directory whose shards a translator
has already filled overwrites those shards with fresh English. That is true on `main` today and is out
of scope here; `AGENTS.md` already says to keep shard dirs outside the worktree, but the overwrite is
worth a guard in its own change.

## Progress map — where this PR sits in the plan

Plan: `knowledge/i18n-architecture-audit-and-plan.md` §5. A **follow-up to Phase 0 item 10**, not a
numbered item of its own.

| phase | status |
|---|---|
| **0** Guards + the writing that unblocks everything | **in progress** — #898, #911, #913, #914 cover items 1–12; this PR closes the review finding on 10b |
| **0.5** i18next 26 + react-i18next 17 | not started |
| **1** Remove visible English (~690 sites) | not started |
| **2** Script & layout correctness | not started |
| **3** De-fragment (D1, D2) | not started |
| **4** Locale-aware formatting | not started |
| **5** Render-time gate | not started |
| **6** Structural cleanup | not started |
| **7** Contributor-facing quality machinery | not started — this is a down payment: the shard workflow is what a community translator actually uses |
| **Track B** Backend boundary (D14-c) | unblocked by #913 |
| **Track C** RTL | not started |

Phase 0, item by item:

| # | item | status |
|---|---|---|
| 1–6, 8, 11, 12 | catalog QA, source-string checks, allowlists, `ci.yml` job, `no-literal-string` at `mode:'all'`, concatenation rule, literal-key rule, D11 `memo()` test, scanners demoted | done — #898 |
| 7 | `en-XA` pseudolocale, dev-only | done — #898 |
| 9 | `code` on non-2xx JSON bodies, as a ratchet | #913 |
| 10a | per-language style guides + DNT glossary | #911 |
| 10b | `en.context.json` translator-context sidecar | #914 |
| 10b-hook | **shards deliver the context to the translator** | **⬅ this PR** |

Stack: independent of #898, #911, #913 and #914. Two files changed, none added.
