### PR TITLE
feat(i18n): commit the translation prompt and a 9-locale translation driver

### DIFF
--- a/website/scripts/i18n-translate.mjs
+++ b/website/scripts/i18n-translate.mjs
@@ -1,0 +1,661 @@
+#!/usr/bin/env node
+/**
+ * Translation driver: renders the committed prompt per (locale, shard), validates
+ * filled shards, and drives `i18n-shard.mjs join` across every shipped locale.
+ *
+ * `i18n-shard.mjs` is deliberately single-locale — `join <dir> <tag>` writes one
+ * catalog per invocation. That is the right shape for the primitive and the wrong
+ * shape for the job: Phase 1 adds ~1767 keys, and `catalogParity.test.ts` demands
+ * every one of them in all 9 non-English catalogs in the SAME commit, so a
+ * translation run is inherently a 9-way fan-out. Doing that by hand is nine
+ * chances to skip a locale and discover it as a red `Frontend Tests`.
+ *
+ * This script does NOT call a model. It renders the prompt and checks the answer;
+ * sending it is the caller's job (an agent, a contributor, whatever). That split is
+ * deliberate — it keeps the pipeline reproducible and testable with no network, no
+ * credentials, and no vendor pinned into the repo.
+ *
+ * Usage:
+ *   node scripts/i18n-translate.mjs plan [pathPrefix]        # what needs translating
+ *   node scripts/i18n-translate.mjs emit <baseDir> [--locales a,b]
+ *   node scripts/i18n-translate.mjs verify <baseDir> --locale <tag>
+ *   node scripts/i18n-translate.mjs merge <baseDir>          # ADD keys (Phase 1)
+ *   node scripts/i18n-translate.mjs join-all <baseDir>       # rewrite whole catalogs
+ *
+ * Use `merge`, not `join-all`, when adding keys. `i18n-shard.mjs join` rewrites the
+ * catalog from the shards, and the shards are keyed off the ENGLISH corpus — so any
+ * form the locale has and English does not is silently dropped. Measured: a join
+ * round-trip removes 108 lines from `ru.json` and 45 keys from each of es/fr/pt/it,
+ * all of them `_few`/`_many` CLDR plural forms. `merge` is additive and cannot.
+ *
+ * Layout under <baseDir> (keep it OUTSIDE the worktree — a dirty tree blocks
+ * worktree pruning, see website/AGENTS.md Rule 9):
+ *   en/       shard-NN.json + shard-NN.context.json   <- `i18n-shard.mjs split` output
+ *   prompts/  <locale>/shard-NN.prompt.md             <- `emit` writes these
+ *   <locale>/ shard-NN.json                           <- filled translations
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+const SRC = path.join(ROOT, 'src/i18n')
+
+const PROMPT_FILE = path.join(SRC, 'TRANSLATION-PROMPT.md')
+const GLOSSARY_FILE = path.join(SRC, 'glossary.json')
+const CONTEXT_FILE = path.join(SRC, 'en.context.json')
+const STYLE_DIR = path.join(SRC, 'style')
+const LANGUAGES_FILE = path.join(SRC, 'languages.ts')
+const BASELINE_FILE = path.join(SRC, 'untranslated-baseline.json')
+const PLURAL_KEYS_FILE = path.join(SRC, 'pluralKeys.json')
+const LOCALES_DIR = path.join(SRC, 'locales')
+
+/**
+ * Categories `check-i18n-strings.mjs` assigns that Phase 1 owns. The other three
+ * — `template`, `object-prop`, `array` — need a change of shape rather than a
+ * local edit, so they belong to Phase 6 and must not inflate a Phase 1 estimate.
+ */
+export const PHASE1_CATEGORIES = ['expression', 'prose', 'attribute', 'status-call']
+export const PHASE6_CATEGORIES = ['template', 'object-prop', 'array']
+
+/**
+ * Parse the shipped locales out of `languages.ts` rather than duplicating them.
+ * A second hardcoded list is a second thing to forget when language #11 ships;
+ * `translateDriver.test.ts` asserts this parse against the real
+ * `SUPPORTED_LANGUAGES` so a format change here fails loudly instead of silently
+ * translating eight languages out of nine.
+ */
+export function parseLanguages(source) {
+  const block = source.match(/SUPPORTED_LANGUAGES[^=]*=\s*\[([\s\S]*?)\n\]/)
+  if (!block) throw new Error('could not locate SUPPORTED_LANGUAGES in languages.ts')
+  const out = []
+  for (const m of block[1].matchAll(/\{\s*code:\s*'([^']+)'\s*,\s*label:\s*'([^']+)'([^}]*)\}/g)) {
+    if (/devOnly:\s*true/.test(m[3])) continue
+    out.push({ code: m[1], label: m[2] })
+  }
+  if (out.length === 0) throw new Error('parsed zero languages from languages.ts')
+  return out
+}
+
+const ALL_LANGUAGES = parseLanguages(fs.readFileSync(LANGUAGES_FILE, 'utf-8'))
+const DEFAULT_LANGUAGE = 'en'
+const TARGET_LANGUAGES = ALL_LANGUAGES.filter(l => l.code !== DEFAULT_LANGUAGE)
+
+// ---------------------------------------------------------------------------
+// pure helpers (exported for the test suite)
+// ---------------------------------------------------------------------------
+
+export function flatten(obj, prefix = '') {
+  const out = {}
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k
+    if (v && typeof v === 'object' && !Array.isArray(v)) Object.assign(out, flatten(v, key))
+    else out[key] = v
+  }
+  return out
+}
+
+/** i18next interpolation, tags, and `$t()` nesting — the things that are code. */
+export function placeholders(value) {
+  return [
+    ...String(value).matchAll(/\{\{[^}]*\}\}/g),
+    ...String(value).matchAll(/<\/?[^>]+>/g),
+    ...String(value).matchAll(/\$t\([^)]*\)/g),
+  ].map(m => m[0]).sort()
+}
+
+/**
+ * Every rule `verify` can decide mechanically. Ordered so the cheapest and most
+ * certain failures report first.
+ *
+ * `dnt` is word-boundary, matching `glossary.test.ts` — a substring check would
+ * flag any word that merely contains `Git`, and a term absent from the English
+ * is not required to appear in the translation.
+ */
+export function checkValue({ key, en, tr, dnt = [], categories = null, pluralBases = null }) {
+  const findings = []
+  const push = (rule, detail) => findings.push({ key, rule, detail })
+
+  if (typeof tr !== 'string') return [{ key, rule: 'not-a-string', detail: typeof tr }]
+  if (tr.trim() === '') return [{ key, rule: 'empty', detail: 'value is empty or whitespace' }]
+
+  const ph = { en: placeholders(en), tr: placeholders(tr) }
+  if (ph.en.join('|') !== ph.tr.join('|')) {
+    push('placeholder-parity', `en=[${ph.en.join(' ')}] tr=[${ph.tr.join(' ')}]`)
+  }
+
+  const nl = s => (String(s).match(/\n/g) ?? []).length
+  if (nl(en) !== nl(tr)) push('newline-count', `en=${nl(en)} tr=${nl(tr)}`)
+
+  for (const term of dnt) {
+    const re = new RegExp(`(?<![\\p{L}\\p{N}])${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\p{L}\\p{N}])`, 'u')
+    if (re.test(en) && !re.test(tr)) push('dnt-missing', `"${term}" is in the English but not the translation`)
+  }
+
+  // The next three rules are RELATIVE to the English, not absolute. Measured
+  // against the shipped catalogs, absolute forms produced 142 findings on
+  // already-approved translations — and every one was inherited: the English
+  // itself carries 77 doubled spaces (JSX text extraction kept the source
+  // indentation) and 64 unbalanced brackets (the D1 fragment keys, `'Findings ('`
+  // + N + `')'`). Those are SOURCE defects that Phase 3 repairs by de-fragmenting
+  // the key; reporting them against the translator is noise that would get this
+  // whole check switched off. Fire only on a defect the translation introduces.
+  if (tr !== tr.trim() && en === String(en).trim()) {
+    push('edge-whitespace', 'leading or trailing whitespace the English does not have')
+  }
+  if (/ {2}/.test(tr) && !/ {2}/.test(String(en))) {
+    push('doubled-space', 'two consecutive spaces the English does not have')
+  }
+
+  // Full-width LETTERS and DIGITS only. The whole U+FF01-FF5E block would also
+  // catch full-width punctuation, which is correct CJK typography and is what the
+  // style guides ask for — flagging `（` here would fight the rule it implements.
+  // Absolute rather than relative: English never contains these.
+  if (/[\uFF10-\uFF19\uFF21-\uFF3A\uFF41-\uFF5A]/.test(tr)) {
+    push('fullwidth-latin', 'full-width Latin letter or digit')
+  }
+
+  // Bracket balance, pooled across widths, as a DELTA against the English. Two
+  // separate calibrations are baked in here, both measured against the shipped
+  // catalogs:
+  //
+  //  - DELTA, not balance: the D1 fragment keys (`'Findings ('` + N + `')'`) are
+  //    deliberately unbalanced in the source, so demanding balance reported 64
+  //    findings against already-approved translations.
+  //  - POOLED across widths, not per width: zh-CN correctly rewrites `(` as `（`,
+  //    which its own style guide asks for. Comparing per width called all 60 of
+  //    those a defect.
+  //
+  // What remains a defect is MIXING the widths inside one value — `发现 (3）`, the
+  // failure `qa.test.ts` exists for — which pooling would otherwise hide, so that
+  // is checked separately below.
+  const strip = s => String(s).replace(/\{\{[^}]*\}\}/g, '').replace(/<\/?[^>]+>/g, '')
+  const delta = (s, opens, closes) => {
+    const chars = [...strip(s)]
+    return chars.filter(c => opens.includes(c)).length - chars.filter(c => closes.includes(c)).length
+  }
+  const FAMILIES = [
+    { name: 'round', opens: '(（', closes: ')）' },
+    { name: 'square', opens: '[【', closes: ']】' },
+    { name: 'curly', opens: '{', closes: '}' },
+  ]
+  for (const { name, opens, closes } of FAMILIES) {
+    const dEn = delta(en, opens, closes)
+    const dTr = delta(tr, opens, closes)
+    if (dEn !== dTr) {
+      push('unbalanced-bracket', `${name} bracket balance ${dTr >= 0 ? '+' : ''}${dTr}, English is ${dEn >= 0 ? '+' : ''}${dEn}`)
+    }
+    // Consistent conversion is fine; using both widths of one family in a single
+    // value is the mixed-width pair the QA suite rejects.
+    const chars = [...strip(tr)]
+    const ascii = chars.some(c => c === opens[0] || c === closes[0])
+    const wide = opens.length > 1 && chars.some(c => c === opens[1] || c === closes[1])
+    if (ascii && wide) push('mixed-width-bracket', `${name} brackets use both ASCII and full-width forms`)
+  }
+
+  // A key is a plural form only if its BASE is in `pluralKeys.json`. Shape alone is
+  // not enough: the slug generator ends a key with the sentence's last word, so
+  // `"…to add one"` becomes `..._add_one` and looked like an impossible `_one` form
+  // in three approved zh-CN values. With no registry supplied, stay silent rather
+  // than guess — a false blocker here costs more than a missed one.
+  if (categories && pluralBases) {
+    const m = key.match(/^(.*)_(zero|one|two|few|many|other)$/)
+    if (m && pluralBases.includes(m[1]) && !categories.includes(m[2])) {
+      push('impossible-plural', `_${m[2]} is not a CLDR category for this locale (${categories.join(', ')})`)
+    }
+  }
+
+  return findings
+}
+
+/**
+ * English passthrough is reported separately from `checkValue`'s findings because
+ * it is not always wrong — a proper noun or a symbol legitimately survives
+ * translation — but a shard where most values match English is a shard nobody
+ * translated, and that is worth a hard failure.
+ */
+export function passthroughRatio(en, tr) {
+  const keys = Object.keys(en)
+  if (keys.length === 0) return 0
+  return keys.filter(k => tr[k] === en[k]).length / keys.length
+}
+
+export function renderPrompt(template, slots) {
+  let out = template
+  for (const [name, value] of Object.entries(slots)) {
+    out = out.split(`{{${name}}}`).join(value)
+  }
+  const leftover = out.match(/\{\{[A-Z_]+\}\}/g)
+  if (leftover) throw new Error(`unfilled prompt slot(s): ${[...new Set(leftover)].join(', ')}`)
+  return out
+}
+
+/** The prompt body between the two markers — the doc's prose is not part of it. */
+export function extractPromptBody(doc) {
+  const m = doc.match(/^## PROMPT BEGIN\s*$([\s\S]*?)^## PROMPT END\s*$/m)
+  if (!m) throw new Error('TRANSLATION-PROMPT.md is missing its "## PROMPT BEGIN" / "## PROMPT END" markers')
+  return m[1].trim()
+}
+
+// ---------------------------------------------------------------------------
+// absent-tolerant inputs
+// ---------------------------------------------------------------------------
+
+/**
+ * The glossary, style guides and context sidecar each land in their own PR, so a
+ * translation run must not hard-fail because one has not merged yet. Same
+ * contract `i18n-shard.mjs` uses for the sidecar: degrade, but say so loudly —
+ * silently producing context-free, glossary-free output is the exact failure
+ * these files exist to prevent.
+ */
+function readOptional(file, what) {
+  if (fs.existsSync(file)) return fs.readFileSync(file, 'utf-8')
+  console.warn(`warning: ${path.relative(ROOT, file)} is missing, so ${what}`)
+  return null
+}
+
+function dntTerms() {
+  const raw = readOptional(GLOSSARY_FILE, 'do-not-translate terms cannot be enforced')
+  return raw ? (JSON.parse(raw).dnt ?? []) : []
+}
+
+function pluralCategories(code) {
+  try {
+    return new Intl.PluralRules(code).resolvedOptions().pluralCategories
+  } catch {
+    return ['other']
+  }
+}
+
+// ---------------------------------------------------------------------------
+// subcommands
+// ---------------------------------------------------------------------------
+
+function cmdPlan(prefix) {
+  if (!fs.existsSync(BASELINE_FILE)) {
+    console.error(
+      `${path.relative(ROOT, BASELINE_FILE)} does not exist.\n`
+      + 'It is generated by `node scripts/check-i18n-strings.mjs --update` and is the\n'
+      + 'Phase 1 worklist. Without it there is nothing to plan against.',
+    )
+    process.exit(2)
+  }
+  const { files } = JSON.parse(fs.readFileSync(BASELINE_FILE, 'utf-8'))
+  const rows = Object.entries(files)
+    .filter(([f]) => !prefix || f.startsWith(prefix))
+    .map(([f, cats]) => ({
+      file: f,
+      phase1: PHASE1_CATEGORIES.reduce((n, c) => n + (cats[c] ?? 0), 0),
+      phase6: PHASE6_CATEGORIES.reduce((n, c) => n + (cats[c] ?? 0), 0),
+      cats,
+    }))
+    .filter(r => r.phase1 > 0)
+    .sort((a, b) => b.phase1 - a.phase1)
+
+  const p1 = rows.reduce((n, r) => n + r.phase1, 0)
+  const p6 = rows.reduce((n, r) => n + r.phase6, 0)
+  console.log(`${rows.length} file(s)${prefix ? ` under ${prefix}` : ''} with Phase 1 work`)
+  console.log(`  Phase 1 (this phase):    ${p1}`)
+  console.log(`  Phase 6 (deferred):      ${p6}`)
+  console.log(`  x ${TARGET_LANGUAGES.length} locales:          ${p1 * TARGET_LANGUAGES.length} translated values\n`)
+  for (const r of rows.slice(0, 40)) {
+    const detail = Object.entries(r.cats)
+      .filter(([c]) => c !== 'total')
+      .map(([c, n]) => `${c}:${n}`)
+      .join(' ')
+    console.log(`  ${String(r.phase1).padStart(4)} p1  ${String(r.phase6).padStart(4)} p6  ${r.file}`)
+    console.log(`             ${detail}`)
+  }
+  if (rows.length > 40) console.log(`  … and ${rows.length - 40} more`)
+}
+
+function cmdEmit(baseDir, locales) {
+  const enDir = path.join(baseDir, 'en')
+  if (!fs.existsSync(enDir)) {
+    console.error(
+      `${enDir} does not exist.\n`
+      + `Run \`node scripts/i18n-shard.mjs split ${enDir}\` first — that is what produces\n`
+      + 'the English shards and their translator-context sidecars.',
+    )
+    process.exit(2)
+  }
+  const template = extractPromptBody(fs.readFileSync(PROMPT_FILE, 'utf-8'))
+  const dnt = dntTerms()
+  const shards = fs.readdirSync(enDir)
+    .filter(f => /^shard-\d+\.json$/.test(f))
+    .sort()
+  if (shards.length === 0) {
+    console.error(`no shard-NN.json found in ${enDir}`)
+    process.exit(2)
+  }
+
+  let written = 0
+  for (const { code, label } of locales) {
+    const style = readOptional(path.join(STYLE_DIR, `${code}.md`), `${code} has no style guide to follow`)
+    const existing = fs.existsSync(path.join(LOCALES_DIR, `${code}.json`))
+      ? flatten(JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, `${code}.json`), 'utf-8')))
+      : {}
+    const examples = Object.entries(existing)
+      .filter(([, v]) => typeof v === 'string' && v.length > 2 && v.length < 60)
+      .slice(0, 12)
+    const outDir = path.join(baseDir, 'prompts', code)
+    fs.mkdirSync(outDir, { recursive: true })
+
+    for (const shard of shards) {
+      const stem = shard.replace(/\.json$/, '')
+      const ctxFile = path.join(enDir, `${stem}.context.json`)
+      const ctx = fs.existsSync(ctxFile) ? fs.readFileSync(ctxFile, 'utf-8') : null
+      const body = renderPrompt(template, {
+        LOCALE: code,
+        LANGUAGE_LABEL: label,
+        PLURAL_CATEGORIES: pluralCategories(code).join(', '),
+        STYLE_GUIDE: style ?? '_(no style guide has landed for this locale yet — apply the general rules above.)_',
+        DNT_TERMS: dnt.length
+          ? dnt.map(t => `- \`${t}\``).join('\n')
+          : '_(no glossary has landed yet — keep product names and proper nouns in Latin script.)_',
+        CONTEXT: ctx
+          ? `\`\`\`json\n${ctx.trim()}\n\`\`\``
+          : '_(no context entries apply to this shard.)_',
+        SHARD_JSON: `\`\`\`json\n${fs.readFileSync(path.join(enDir, shard), 'utf-8').trim()}\n\`\`\``,
+        EXAMPLES: examples.length
+          ? `\`\`\`json\n${JSON.stringify(Object.fromEntries(examples), null, 2)}\n\`\`\``
+          : '_(this locale has no catalog yet — you are establishing the terminology.)_',
+      })
+      fs.writeFileSync(path.join(outDir, `${stem}.prompt.md`), `${body}\n`)
+      written += 1
+    }
+    console.log(`${code}: ${shards.length} prompt(s) -> ${path.relative(process.cwd(), outDir)}`)
+  }
+  console.log(`\n${written} prompt(s) for ${locales.length} locale(s). Answers go in <baseDir>/<locale>/shard-NN.json.`)
+}
+
+/**
+ * Keys a locale is not expected to carry, because the English plural form has no
+ * counterpart in this locale's CLDR categories. `en.json` holds `x_one` + `x_other`;
+ * zh-CN has only `other`, so `x_one` is legitimately absent and demanding it would
+ * report 45 phantom missing keys against the approved catalog.
+ *
+ * Mirrors how `catalogParity.test.ts` builds `EN_SINGULAR_KEYS` — the registry is
+ * the source of truth for which keys are counted, so a plural-shaped key that is
+ * NOT registered stays mandatory.
+ */
+export function expectedAbsent(enKeys, pluralBases, categories) {
+  const bases = new Set(pluralBases)
+  const cats = new Set(categories)
+  return new Set(enKeys.filter(k => {
+    const m = k.match(/^(.*)_(zero|one|two|few|many|other)$/)
+    return m !== null && bases.has(m[1]) && !cats.has(m[2])
+  }))
+}
+
+function cmdVerify(baseDir, code) {
+  const enDir = path.join(baseDir, 'en')
+  const trDir = path.join(baseDir, code)
+  for (const [dir, hint] of [[enDir, 'run `i18n-shard.mjs split` first'], [trDir, 'no filled shards for this locale']]) {
+    if (!fs.existsSync(dir)) {
+      console.error(`${dir} does not exist — ${hint}.`)
+      process.exit(2)
+    }
+  }
+  const dnt = dntTerms()
+  const categories = pluralCategories(code)
+  const pluralBases = fs.existsSync(PLURAL_KEYS_FILE)
+    ? JSON.parse(fs.readFileSync(PLURAL_KEYS_FILE, 'utf-8'))
+    : []
+  const read = d => Object.assign(
+    {},
+    ...fs.readdirSync(d)
+      .filter(f => /^shard-\d+\.json$/.test(f))
+      .sort()
+      .map(f => JSON.parse(fs.readFileSync(path.join(d, f), 'utf-8'))),
+  )
+  const en = read(enDir)
+  const tr = read(trDir)
+  const absentOk = expectedAbsent(Object.keys(en), pluralBases, categories)
+
+  const findings = []
+  const missing = Object.keys(en).filter(k => !(k in tr) && !absentOk.has(k))
+  const extra = Object.keys(tr).filter(k => !(k in en))
+  for (const k of missing) findings.push({ key: k, rule: 'missing-key', detail: 'absent from the filled shards' })
+  for (const k of extra) findings.push({ key: k, rule: 'unknown-key', detail: 'not in the English corpus' })
+  for (const k of Object.keys(en)) {
+    if (k in tr) findings.push(...checkValue({ key: k, en: en[k], tr: tr[k], dnt, categories, pluralBases }))
+  }
+
+  const comparable = Object.fromEntries(Object.entries(en).filter(([k]) => k in tr))
+  const ratio = passthroughRatio(comparable, tr)
+  const PASSTHROUGH_LIMIT = 0.5
+  const ratioFailed = ratio > PASSTHROUGH_LIMIT
+
+  console.log(
+    `[${code}] ${Object.keys(en).length} key(s)`
+    + `${absentOk.size ? `, ${absentOk.size} plural form(s) not applicable to this locale` : ''}`
+    + `, ${findings.length} finding(s), ${(ratio * 100).toFixed(1)}% identical to English`,
+  )
+  if (findings.length) {
+    const byRule = {}
+    for (const f of findings) (byRule[f.rule] ??= []).push(f)
+    for (const [rule, items] of Object.entries(byRule).sort((a, b) => b[1].length - a[1].length)) {
+      console.error(`\n  ${rule} (${items.length})`)
+      for (const it of items.slice(0, 8)) console.error(`    ${it.key}: ${it.detail}`)
+      if (items.length > 8) console.error(`    … and ${items.length - 8} more`)
+    }
+  }
+  if (ratioFailed) {
+    console.error(
+      `\n  passthrough: ${(ratio * 100).toFixed(1)}% of values are byte-identical to English, above the `
+      + `${PASSTHROUGH_LIMIT * 100}% limit.\n  That is the shape of a shard nobody translated.`,
+    )
+  }
+  if (findings.length || ratioFailed) process.exit(1)
+  console.log(`OK: ${code} is ready to join.`)
+}
+
+/**
+ * Additive merge of translated keys into an existing catalog.
+ *
+ * `i18n-shard.mjs join` writes the whole catalog from the shards, which is right
+ * for a full re-translation and WRONG for Phase 1. Measured on the shipped
+ * catalogs: a join round-trip drops 108 lines from `ru.json` and 45 keys from each
+ * of es/fr/pt/it, because those are locale-specific CLDR plural forms (`_few`,
+ * `_many`) that the English corpus does not contain and so no shard can carry. The
+ * documented split/join workflow silently deletes them.
+ *
+ * Phase 1 ADDS keys. So merge instead: existing values win nothing and lose
+ * nothing, new values land, and every form the locale already had survives.
+ */
+export function mergeCatalog(existing, additions) {
+  const out = structuredClone(existing)
+  for (const [key, value] of Object.entries(additions)) {
+    const parts = key.split('.')
+    const leaf = parts.pop()
+    let node = out
+    for (const p of parts) {
+      if (p === '__proto__' || p === 'constructor' || p === 'prototype') {
+        throw new Error(`Refusing to nest key '${key}': unsafe object-key segment.`)
+      }
+      if (typeof node[p] !== 'object' || node[p] === null || Array.isArray(node[p])) node[p] = {}
+      node = node[p]
+    }
+    if (leaf === '__proto__' || leaf === 'constructor' || leaf === 'prototype') {
+      throw new Error(`Refusing to nest key '${key}': unsafe object-key segment.`)
+    }
+    node[leaf] = value
+  }
+  return out
+}
+
+export function sortDeep(obj) {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) return obj
+  return Object.fromEntries(Object.keys(obj).sort().map(k => [k, sortDeep(obj[k])]))
+}
+
+function cmdMerge(baseDir, locales) {
+  const results = []
+  for (const { code } of locales) {
+    const dir = path.join(baseDir, code)
+    const target = path.join(LOCALES_DIR, `${code}.json`)
+    if (!fs.existsSync(dir)) {
+      results.push({ code, ok: false, why: 'no shard directory' })
+      continue
+    }
+    if (!fs.existsSync(target)) {
+      results.push({ code, ok: false, why: `${path.relative(ROOT, target)} does not exist` })
+      continue
+    }
+    const additions = Object.assign(
+      {},
+      ...fs.readdirSync(dir)
+        .filter(f => f.endsWith('.json') && !f.endsWith('.context.json'))
+        .sort()
+        .map(f => flatten(JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')))),
+    )
+    const empty = Object.entries(additions).filter(([, v]) => typeof v !== 'string' || !v.trim())
+    if (empty.length) {
+      // Fail closed, exactly as `join` does. A blank value merged into a catalog
+      // renders as nothing at all, which is worse than the English fallback it
+      // replaces — and `returnEmptyString: false` makes it invisible in review.
+      results.push({ code, ok: false, why: `${empty.length} empty value(s), e.g. ${empty[0][0]}` })
+      continue
+    }
+    const before = JSON.parse(fs.readFileSync(target, 'utf-8'))
+    const beforeCount = Object.keys(flatten(before)).length
+    const merged = sortDeep(mergeCatalog(before, additions))
+    const afterCount = Object.keys(flatten(merged)).length
+    fs.writeFileSync(target, `${JSON.stringify(merged, null, 2)}\n`)
+    results.push({
+      code,
+      ok: true,
+      why: `${Object.keys(additions).length} key(s) merged, ${beforeCount} -> ${afterCount}`,
+    })
+  }
+
+  for (const r of results) console.log(`${r.ok ? 'ok  ' : 'FAIL'} ${r.code.padEnd(6)} ${r.why}`)
+  const failed = results.filter(r => !r.ok)
+  console.log(`\n${results.length - failed.length}/${results.length} locale(s) merged.`)
+  if (failed.length) {
+    console.error(
+      `\n${failed.length} locale(s) did not merge: ${failed.map(r => r.code).join(', ')}.\n`
+      + 'catalogParity.test.ts requires every locale, so this commit is not shippable yet.',
+    )
+    process.exit(1)
+  }
+}
+
+function cmdJoinAll(baseDir, locales) {
+  const results = []
+  for (const { code } of locales) {
+    const dir = path.join(baseDir, code)
+    if (!fs.existsSync(dir)) {
+      results.push({ code, ok: false, why: 'no shard directory' })
+      continue
+    }
+    try {
+      const out = execFileSync(
+        process.execPath,
+        [path.join(__dirname, 'i18n-shard.mjs'), 'join', dir, code],
+        { cwd: ROOT, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+      )
+      results.push({ code, ok: true, why: out.trim().split('\n').pop() ?? 'joined' })
+    } catch (err) {
+      const why = `${err.stderr ?? ''}${err.stdout ?? ''}`.trim().split('\n').filter(Boolean).pop()
+      results.push({ code, ok: false, why: why ?? 'join failed' })
+    }
+  }
+
+  for (const r of results) console.log(`${r.ok ? 'ok  ' : 'FAIL'} ${r.code.padEnd(6)} ${r.why}`)
+  const failed = results.filter(r => !r.ok)
+  console.log(`\n${results.length - failed.length}/${results.length} locale(s) joined.`)
+  if (failed.length) {
+    // Fail closed on a partial run. A catalog written for 7 of 9 locales still
+    // fails `catalogParity.test.ts` for the other 2, and reporting that here is
+    // cheaper than finding it as a red Frontend Tests job.
+    console.error(
+      `\n${failed.length} locale(s) did not join: ${failed.map(r => r.code).join(', ')}.\n`
+      + 'catalogParity.test.ts requires every locale, so this commit is not shippable yet.',
+    )
+    process.exit(1)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function resolveLocales(argv) {
+  const arg = argv.find(a => a.startsWith('--locales='))
+  if (!arg) return TARGET_LANGUAGES
+  const want = arg.slice('--locales='.length).split(',').map(s => s.trim()).filter(Boolean)
+  const known = new Map(TARGET_LANGUAGES.map(l => [l.code, l]))
+  const unknown = want.filter(c => !known.has(c))
+  if (unknown.length) {
+    console.error(
+      `unknown locale(s): ${unknown.join(', ')}\n`
+      + `shipped targets: ${TARGET_LANGUAGES.map(l => l.code).join(', ')}`,
+    )
+    process.exit(2)
+  }
+  return want.map(c => known.get(c))
+}
+
+function main(argv) {
+  const [cmd, ...rest] = argv
+  const positional = rest.filter(a => !a.startsWith('-'))
+
+  // An unrecognised flag must not fall through to a run that writes files with
+  // default settings — the same footgun `i18n-codemod.mjs` closes.
+  const KNOWN = ['--locales=', '--locale=']
+  const unknown = rest.filter(a => a.startsWith('-') && !KNOWN.some(k => a.startsWith(k)))
+  if (unknown.length) {
+    console.error(`unknown flag(s): ${unknown.join(', ')}\nknown: ${KNOWN.join(' ')}`)
+    process.exit(2)
+  }
+
+  switch (cmd) {
+    case 'plan':
+      return cmdPlan(positional[0])
+    case 'emit':
+      if (!positional[0]) return usage('emit needs a <baseDir>')
+      return cmdEmit(positional[0], resolveLocales(rest))
+    case 'verify': {
+      const localeArg = rest.find(a => a.startsWith('--locale='))
+      const code = localeArg?.slice('--locale='.length)
+      if (!positional[0] || !code) return usage('verify needs a <baseDir> and --locale=<tag>')
+      if (!TARGET_LANGUAGES.some(l => l.code === code)) {
+        console.error(`unknown locale: ${code}\nshipped targets: ${TARGET_LANGUAGES.map(l => l.code).join(', ')}`)
+        process.exit(2)
+      }
+      return cmdVerify(positional[0], code)
+    }
+    case 'merge':
+      if (!positional[0]) return usage('merge needs a <baseDir>')
+      return cmdMerge(positional[0], resolveLocales(rest))
+    case 'join-all':
+      if (!positional[0]) return usage('join-all needs a <baseDir>')
+      return cmdJoinAll(positional[0], resolveLocales(rest))
+    default:
+      return usage(cmd ? `unknown command: ${cmd}` : 'no command given')
+  }
+}
+
+function usage(problem) {
+  console.error(
+    `${problem}\n\n`
+    + 'usage:\n'
+    + '  node scripts/i18n-translate.mjs plan [pathPrefix]\n'
+    + '  node scripts/i18n-translate.mjs emit <baseDir> [--locales=a,b]\n'
+    + '  node scripts/i18n-translate.mjs verify <baseDir> --locale=<tag>\n'
+    + '  node scripts/i18n-translate.mjs merge <baseDir> [--locales=a,b]     # additive, for Phase 1\n'
+    + '  node scripts/i18n-translate.mjs join-all <baseDir> [--locales=a,b]  # whole-catalog rewrite\n',
+  )
+  process.exit(2)
+}
+
+// Only dispatch when run as a script, so the helpers above stay importable by the
+// test suite without executing anything.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  main(process.argv.slice(2))
+}

--- a/website/src/i18n/TRANSLATION-PROMPT.md
+++ b/website/src/i18n/TRANSLATION-PROMPT.md
@@ -1,0 +1,145 @@
+# Translation prompt
+
+The catalogs are AI-translated with contributor edits and no TMS, so **the prompt
+is the pipeline**. An uncommitted prompt makes every run unreproducible: two
+translators get different terminology for the same key and neither result can be
+audited against an intent. This file is that prompt, versioned with the catalogs
+it produces.
+
+`scripts/i18n-translate.mjs emit` renders it once per (locale, shard) with the
+slots below filled in. Do not hand-assemble a prompt — the rendered copy is what
+gets sent, so a change here is the only way to change translator behaviour.
+
+## Slots
+
+| Slot | Filled from |
+|---|---|
+| `{{LOCALE}}` | the BCP-47 tag, e.g. `zh-CN` |
+| `{{LANGUAGE_LABEL}}` | the endonym from `languages.ts`, e.g. `简体中文` |
+| `{{PLURAL_CATEGORIES}}` | `Intl.PluralRules(locale).resolvedOptions().pluralCategories` |
+| `{{STYLE_GUIDE}}` | `src/i18n/style/<locale>.md`, verbatim |
+| `{{DNT_TERMS}}` | the `dnt` array from `src/i18n/glossary.json` |
+| `{{CONTEXT}}` | the matching `shard-NN.context.json`, or an explicit "none" note |
+| `{{SHARD_JSON}}` | the English `shard-NN.json` to translate |
+| `{{EXAMPLES}}` | up to 12 approved key/value pairs already in `<locale>.json` |
+
+---
+
+## PROMPT BEGIN
+
+You are translating the UI catalog of KiroCrew, a developer tool, from English
+into **{{LANGUAGE_LABEL}} (`{{LOCALE}}`)**.
+
+Your output is consumed by a machine and validated by CI. A single deviation from
+the output contract fails the whole shard, so the contract outranks every other
+instruction here.
+
+### Output contract
+
+Return **exactly one JSON object and nothing else** — no prose before or after,
+no markdown fence, no comments.
+
+- The key set of your output must be **identical** to the input's. Do not add,
+  remove, rename, or reorder keys.
+- Every value must be a non-empty string. There is no "leave for later": a
+  missing or empty value makes `i18n-shard.mjs join` refuse to write the catalog.
+- Never return the English string unchanged as a way of skipping a key. If a
+  value is genuinely identical in this language (a proper noun, a symbol), that
+  is fine and expected — but it must be a decision, not a fallthrough.
+
+### Preserve exactly
+
+Copy these byte-for-byte. They are code, not words:
+
+- `{{count}}`, `{{name}}` and every other `{{...}}` interpolation. The **name**
+  inside the braces is an identifier — never translate it. You may move the
+  placeholder to wherever the target grammar needs it.
+- `<0>`, `<1>`, `<link>` and any other tag. Keep them balanced and keep them
+  wrapped around the equivalent words, not the same word positions.
+- `$t(some.key)` nesting references.
+- URLs, file paths, config keys, CLI flags (`--check`), shell commands, and
+  anything inside backticks.
+- Newlines (`\n`). Same count, same positions relative to the text.
+
+### Do not translate
+
+These appear verbatim in every language. Matching is word-boundary, so
+`GitHub` in `GitHub Actions` is protected but a word merely containing those
+letters is not:
+
+{{DNT_TERMS}}
+
+Also keep in English: AWS service names, key legends (`Enter`, `Shift`, `⌘`),
+git refs (`main`, `origin`, `HEAD`), filenames, and `cron` when it names the
+syntax rather than the feature.
+
+### Style guide — {{LOCALE}}
+
+Follow this in full. Where it disagrees with your instinct, it wins.
+
+{{STYLE_GUIDE}}
+
+### Plurals
+
+This locale's CLDR plural categories are: **{{PLURAL_CATEGORIES}}**.
+
+A counted key arrives suffixed (`..._one`, `..._other`). Translate **only the
+suffixes present in the input**, and never invent a suffix this locale does not
+have — a category outside the list above is a form i18next can never select, and
+`catalogParity.test.ts` rejects it. If the input has `_one` and `_other` but this
+locale has only `other`, the shard will contain only the `_other` key; that is
+correct, not an omission.
+
+### Translator context
+
+Short strings are ambiguous by construction: `Run` is a verb on a button but a
+noun in a table, `KB` is kilobytes and not a knowledge base, `K` may be a
+keyboard key. Where a key appears below, its note tells you which sense is meant
+and overrides your reading of the English.
+
+{{CONTEXT}}
+
+### Register
+
+- Translate the **function** of the string, not its words. A button label
+  becomes whatever that language puts on a button, which is often not the
+  same part of speech.
+- Match the terminology already used in this catalog. The examples below are
+  approved output — mirror their word choices for recurring terms.
+- Do not pad. UI strings sit in fixed-width chrome; the shortest accurate
+  wording is the right one.
+- Do not translate a sentence fragment into a fragment that only works in
+  English clause order. If a value is an obvious fragment (`of`, `at`,
+  ` and `), translate it as the standalone phrase it will have to be, and it
+  will be repaired properly when the key is de-fragmented.
+
+### Mechanical rules CI enforces on your output
+
+- Balanced brackets and quotes, **including mixed-width pairs** — `(` must not
+  close with `）`.
+- No full-width Latin letters or digits. Use ASCII for both.
+- No leading or trailing whitespace, and no doubled space.
+- Curly quotes must pair, and must use **this locale's** pair (German opens low).
+
+### Approved examples from this catalog
+
+{{EXAMPLES}}
+
+### Translate this
+
+{{SHARD_JSON}}
+
+## PROMPT END
+
+---
+
+## Reviewing the output
+
+`scripts/i18n-translate.mjs verify <dir> --locale <tag>` checks the contract
+mechanically — key-set identity, placeholder parity, DNT verbatim, plural
+categories, the whitespace and bracket rules, and English passthrough. It runs
+before `join`, so a violation is reported per key instead of arriving as `join`'s
+single fail-closed refusal.
+
+What `verify` cannot check is whether the translation is *good*. That still needs
+a speaker, and the style guides exist so a reviewer has something to point at.

--- a/website/src/i18n/translateDriver.test.ts
+++ b/website/src/i18n/translateDriver.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Guards for the translation driver.
+ *
+ * The driver is the only thing standing between "1767 new English keys" and
+ * "1767 keys x 9 locales landing in one commit", and `catalogParity.test.ts`
+ * gives no partial credit — so the driver's checks have to be right before the
+ * translation run, not after.
+ *
+ * Several rules here are deliberately RELATIVE to the English rather than
+ * absolute, and the comments say which measurement forced that. Run in absolute
+ * form against the already-approved ru/de/zh-CN catalogs, the whitespace, bracket
+ * and plural rules produced 142, 150 and 115 findings respectively — every one
+ * inherited from the English source or from a slug that merely looks plural. A
+ * check that cries wolf on approved work is a check somebody switches off.
+ */
+
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  PHASE1_CATEGORIES,
+  PHASE6_CATEGORIES,
+  parseLanguages,
+  flatten,
+  placeholders,
+  checkValue,
+  passthroughRatio,
+  expectedAbsent,
+  mergeCatalog,
+  sortDeep,
+  renderPrompt,
+  extractPromptBody,
+} from '../../scripts/i18n-translate.mjs'
+import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './languages'
+
+const SRC = path.resolve(__dirname)
+const PROMPT_DOC = fs.readFileSync(path.join(SRC, 'TRANSLATION-PROMPT.md'), 'utf-8')
+const LANGUAGES_SRC = fs.readFileSync(path.join(SRC, 'languages.ts'), 'utf-8')
+
+/** Rule names from a findings array, which is all most assertions care about. */
+const rules = (findings: { rule: string }[]) => findings.map(f => f.rule)
+
+describe('locale list derivation', () => {
+  /**
+   * The driver regex-parses `languages.ts` instead of keeping its own list. That
+   * is the right call — a duplicated list is a second thing to forget when
+   * language #11 ships — but it only stays right while the parse agrees with the
+   * real export. If someone reformats `SUPPORTED_LANGUAGES`, this fails here
+   * rather than by quietly translating eight locales out of nine.
+   */
+  it('parses exactly the shipped, non-devOnly languages', () => {
+    const parsed = parseLanguages(LANGUAGES_SRC)
+    const expected = SUPPORTED_LANGUAGES.filter(l => !('devOnly' in l && l.devOnly))
+    expect(parsed.map((l: { code: string }) => l.code)).toEqual(expected.map(l => l.code))
+    expect(parsed.map((l: { label: string }) => l.label)).toEqual(expected.map(l => l.label))
+  })
+
+  it('excludes the pseudolocale, which is a detector and not a translation target', () => {
+    expect(parseLanguages(LANGUAGES_SRC).map((l: { code: string }) => l.code)).not.toContain('en-XA')
+  })
+
+  it('leaves 9 translation targets once English is removed', () => {
+    const parsed = parseLanguages(LANGUAGES_SRC)
+    expect(parsed.filter((l: { code: string }) => l.code !== DEFAULT_LANGUAGE)).toHaveLength(9)
+  })
+
+  it('throws rather than guessing when the export cannot be found', () => {
+    expect(() => parseLanguages('export const SOMETHING_ELSE = []')).toThrow(/SUPPORTED_LANGUAGES/)
+  })
+})
+
+describe('phase categories', () => {
+  it('partition the classifier buckets with no overlap', () => {
+    expect(PHASE1_CATEGORIES.filter((c: string) => PHASE6_CATEGORIES.includes(c))).toEqual([])
+  })
+
+  /**
+   * Cross-check against the classifier itself, so a new bucket added there cannot
+   * land in neither phase list and quietly vanish from every scope report.
+   *
+   * `check-i18n-strings.mjs` arrives with the Phase 0 gates, so it is legitimately
+   * absent on a tree that predates it — absent-tolerant rather than skipped, so the
+   * assertion becomes mandatory the moment the file exists.
+   */
+  it('cover every bucket check-i18n-strings.mjs can emit', () => {
+    const classifier = path.resolve(SRC, '../../scripts/check-i18n-strings.mjs')
+    if (!fs.existsSync(classifier)) {
+      expect([...PHASE1_CATEGORIES, ...PHASE6_CATEGORIES].length).toBeGreaterThan(0)
+      return
+    }
+    const buckets = [...fs.readFileSync(classifier, 'utf-8').matchAll(/return '([a-z-]+)'/g)].map(m => m[1])
+    expect(buckets.length).toBeGreaterThan(0)
+    for (const b of buckets) {
+      expect([...PHASE1_CATEGORIES, ...PHASE6_CATEGORIES]).toContain(b)
+    }
+  })
+})
+
+describe('placeholders', () => {
+  it('finds interpolation, tags and nesting references', () => {
+    expect(placeholders('{{count}} of <0>{{total}}</0> via $t(a.b)')).toEqual(
+      ['$t(a.b)', '</0>', '<0>', '{{count}}', '{{total}}'].sort(),
+    )
+  })
+
+  it('is order-insensitive so a placeholder may move for target grammar', () => {
+    expect(placeholders('{{a}} then {{b}}')).toEqual(placeholders('{{b}} then {{a}}'))
+  })
+})
+
+describe('checkValue — structural rules', () => {
+  it('accepts a clean translation', () => {
+    expect(checkValue({ key: 'k', en: 'Open {{count}} PR', tr: '打开 {{count}} 个 PR' })).toEqual([])
+  })
+
+  it('rejects an empty or whitespace value', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Save', tr: '   ' }))).toContain('empty')
+  })
+
+  it('rejects a non-string value', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Save', tr: 42 }))).toContain('not-a-string')
+  })
+
+  it('rejects a dropped placeholder', () => {
+    expect(rules(checkValue({ key: 'k', en: '{{count}} items', tr: '若干项目' }))).toContain('placeholder-parity')
+  })
+
+  /**
+   * The real defect this caught in the shipped German catalog: `<path>` became
+   * `<pfad>` and `<your-host>` became `<ihr-host>`. The name inside a placeholder
+   * is an identifier, so translating it silently breaks interpolation at runtime.
+   */
+  it('rejects a TRANSLATED placeholder name', () => {
+    expect(rules(checkValue({ key: 'k', en: 'at <path>', tr: 'bei <pfad>' }))).toContain('placeholder-parity')
+    expect(rules(checkValue({ key: 'k', en: '{{count}} items', tr: '{{数量}} 项' }))).toContain('placeholder-parity')
+  })
+
+  it('accepts a placeholder moved to a different position', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Delete {{name}} now', tr: '现在删除 {{name}}' }))).toEqual([])
+  })
+
+  it('rejects a changed newline count', () => {
+    expect(rules(checkValue({ key: 'k', en: 'a\nb', tr: 'a b' }))).toContain('newline-count')
+  })
+
+  it('does not count brackets inside placeholders or tags', () => {
+    expect(rules(checkValue({ key: 'k', en: 'a <0>b</0> {{c}}', tr: 'a <0>乙</0> {{c}}' }))).toEqual([])
+  })
+})
+
+describe('checkValue — do-not-translate terms', () => {
+  it('rejects a translated do-not-translate term', () => {
+    const f = checkValue({ key: 'k', en: 'Open in GitHub', tr: '在 吉特哈布 中打开', dnt: ['GitHub'] })
+    expect(rules(f)).toContain('dnt-missing')
+  })
+
+  it('does not demand a DNT term the English never used', () => {
+    const f = checkValue({ key: 'k', en: 'Open the file', tr: '打开文件', dnt: ['GitHub'] })
+    expect(rules(f)).not.toContain('dnt-missing')
+  })
+
+  it('matches on word boundaries, not substrings', () => {
+    // `Git` must not count as present just because `Gitea` is.
+    const f = checkValue({ key: 'k', en: 'Use Gitea here', tr: '在 Gitea 中使用', dnt: ['Git'] })
+    expect(rules(f)).not.toContain('dnt-missing')
+  })
+})
+
+describe('checkValue — whitespace, relative to the English', () => {
+  it('rejects whitespace the translation introduces', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Save', tr: ' 保存' }))).toContain('edge-whitespace')
+    expect(rules(checkValue({ key: 'k', en: 'Save now', tr: '立即  保存' }))).toContain('doubled-space')
+  })
+
+  /**
+   * The English catalog itself carries 77 doubled spaces — JSX text extraction kept
+   * the source indentation — and one edge-space value. Billing those to the
+   * translator accounted for 78 of the 142 false findings.
+   */
+  it('does not bill the translation for whitespace the English already has', () => {
+    expect(rules(checkValue({ key: 'k', en: 'namespaces. New  learnings', tr: '命名空间。新  经验' })))
+      .not.toContain('doubled-space')
+    expect(rules(checkValue({ key: 'k', en: ' trailing ', tr: ' 尾随 ' }))).not.toContain('edge-whitespace')
+  })
+})
+
+describe('checkValue — full-width forms', () => {
+  it('rejects full-width Latin letters and digits', () => {
+    expect(rules(checkValue({ key: 'k', en: 'PR 12', tr: 'ＰＲ 12' }))).toContain('fullwidth-latin')
+    expect(rules(checkValue({ key: 'k', en: '12 items', tr: '１２ 项' }))).toContain('fullwidth-latin')
+  })
+
+  it('accepts full-width PUNCTUATION, which is correct CJK typography', () => {
+    // Only letters and digits are banned. A whole-block U+FF01-FF5E check would
+    // flag `，` and `（`, fighting the very style guide it implements.
+    expect(rules(checkValue({ key: 'k', en: 'Save, then close.', tr: '保存，然后关闭。' }))).toEqual([])
+  })
+})
+
+describe('checkValue — brackets, pooled across widths', () => {
+  /**
+   * Two calibrations in one rule. DELTA against the English, because the D1
+   * fragment keys (`'Findings ('` + N + `')'`) are deliberately unbalanced at
+   * source — demanding balance flagged 64 approved values. POOLED across widths,
+   * because zh-CN correctly rewrites `(` as `（`, which its own style guide asks
+   * for — comparing per width flagged 60 more. What is left as a defect is MIXING
+   * both widths in one value, which is the pair `qa.test.ts` rejects.
+   */
+  it('accepts a bracket the English leaves open', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings (', tr: '发现 (' }))).toEqual([])
+    expect(rules(checkValue({ key: 'k', en: 'remaining)', tr: '剩余)' }))).toEqual([])
+  })
+
+  it('accepts a bracket consistently converted to full-width', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings (3)', tr: '发现（3）' }))).toEqual([])
+    expect(rules(checkValue({ key: 'k', en: 'Findings (', tr: '发现（' }))).toEqual([])
+  })
+
+  it('rejects one value using both widths of a pair', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings (3)', tr: '发现 (3）' }))).toContain('mixed-width-bracket')
+  })
+
+  it('rejects a bracket dropped from a balanced English pair', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings (3)', tr: '发现 (3' }))).toContain('unbalanced-bracket')
+  })
+
+  it('rejects a bracket the English never had', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings 3', tr: '发现 (3' }))).toContain('unbalanced-bracket')
+  })
+})
+
+describe('checkValue — plurals, gated on the registry', () => {
+  it('rejects a plural form the locale cannot select', () => {
+    const f = checkValue({
+      key: 'items_one', en: '1 item', tr: '1 项',
+      categories: ['other'], pluralBases: ['items'],
+    })
+    expect(rules(f)).toContain('impossible-plural')
+  })
+
+  it('accepts a plural form the locale does have', () => {
+    const f = checkValue({
+      key: 'items_other', en: '{{count}} items', tr: '{{count}} 项',
+      categories: ['other'], pluralBases: ['items'],
+    })
+    expect(rules(f)).not.toContain('impossible-plural')
+  })
+
+  /**
+   * The slug generator ends a key with the sentence's last word, so `"…to add one"`
+   * becomes `..._add_one`. Judging the suffix alone called three such approved
+   * zh-CN values impossible plurals. Only a key whose BASE is registered in
+   * `pluralKeys.json` is a plural.
+   */
+  it('does not treat a key that merely ends in "one" as a plural form', () => {
+    const f = checkValue({
+      key: 'pages.chatSidebar.add_column_after_this_one',
+      en: 'Add column after this one',
+      tr: '在此列后添加一列',
+      categories: ['other'],
+      pluralBases: ['components.appstore.categoryRail.app'],
+    })
+    expect(rules(f)).not.toContain('impossible-plural')
+  })
+
+  it('stays silent when no registry is supplied rather than guessing', () => {
+    const f = checkValue({ key: 'items_one', en: '1 item', tr: '1 项', categories: ['other'] })
+    expect(rules(f)).not.toContain('impossible-plural')
+  })
+})
+
+describe('expectedAbsent', () => {
+  /**
+   * The carve-out that keeps `verify` in step with `catalogParity.test.ts`. Without
+   * it, zh-CN reported 45 phantom missing keys — every `_one` form of a registered
+   * plural, which Chinese cannot select and therefore must not carry.
+   */
+  it('excuses a plural form the locale has no category for', () => {
+    expect([...expectedAbsent(['items_one', 'items_other'], ['items'], ['other'])]).toEqual(['items_one'])
+  })
+
+  it('demands every form the locale does have a category for', () => {
+    expect([...expectedAbsent(['items_one', 'items_other'], ['items'], ['one', 'other'])]).toEqual([])
+  })
+
+  it('does not excuse a plural-shaped key that is not in the registry', () => {
+    expect([...expectedAbsent(['settings_one'], [], ['other'])]).toEqual([])
+  })
+
+  it('does not excuse a non-plural key that merely ends in a category word', () => {
+    expect([...expectedAbsent(['settings.other'], ['settings'], ['other'])]).toEqual([])
+  })
+})
+
+describe('mergeCatalog', () => {
+  /**
+   * Why `merge` exists at all. `i18n-shard.mjs join` rewrites a catalog from shards
+   * keyed off the ENGLISH corpus, so any form the locale has and English does not is
+   * dropped. Measured on a real round-trip: `ru.json` loses 108 lines and each of
+   * es/fr/pt/it loses 45 keys, all `_few`/`_many` CLDR plural forms. Phase 1 adds
+   * keys, so it must merge, not rewrite.
+   */
+  it('preserves a locale-specific plural form the English corpus cannot carry', () => {
+    const existing = { items_other: 'предметов', items_few: 'предмета', items_one: 'предмет' }
+    const merged = mergeCatalog(existing, { 'newKey': 'новый' })
+    expect(merged.items_few).toBe('предмета')
+    expect(merged.items_one).toBe('предмет')
+    expect(merged.newKey).toBe('новый')
+  })
+
+  it('nests a dotted key into the existing tree', () => {
+    expect(mergeCatalog({ pages: { a: '1' } }, { 'pages.b': '2' })).toEqual({ pages: { a: '1', b: '2' } })
+  })
+
+  it('creates intermediate objects for a wholly new path', () => {
+    expect(mergeCatalog({}, { 'a.b.c': 'x' })).toEqual({ a: { b: { c: 'x' } } })
+  })
+
+  it('overwrites an existing leaf with the new translation', () => {
+    expect(mergeCatalog({ a: 'old' }, { a: 'new' })).toEqual({ a: 'new' })
+  })
+
+  it('does not mutate its input', () => {
+    const before = { a: { b: '1' } }
+    mergeCatalog(before, { 'a.c': '2' })
+    expect(before).toEqual({ a: { b: '1' } })
+  })
+
+  it('refuses a prototype-polluting key segment', () => {
+    expect(() => mergeCatalog({}, { '__proto__.x': 'bad' })).toThrow(/unsafe object-key segment/)
+    expect(() => mergeCatalog({}, { 'a.constructor': 'bad' })).toThrow(/unsafe object-key segment/)
+  })
+
+  it('replaces a leaf that blocks a deeper path rather than throwing', () => {
+    expect(mergeCatalog({ a: 'leaf' }, { 'a.b': 'x' })).toEqual({ a: { b: 'x' } })
+  })
+})
+
+describe('sortDeep', () => {
+  it('sorts keys at every level so a merge produces a stable diff', () => {
+    expect(JSON.stringify(sortDeep({ b: '1', a: { d: '2', c: '3' } })))
+      .toBe(JSON.stringify({ a: { c: '3', d: '2' }, b: '1' }))
+  })
+
+  it('leaves non-objects alone', () => {
+    expect(sortDeep('x')).toBe('x')
+    expect(sortDeep(null)).toBe(null)
+  })
+})
+
+describe('passthroughRatio', () => {
+  it('is 1 when nothing was translated', () => {
+    expect(passthroughRatio({ a: 'Save', b: 'Open' }, { a: 'Save', b: 'Open' })).toBe(1)
+  })
+
+  it('is 0 when everything was', () => {
+    expect(passthroughRatio({ a: 'Save', b: 'Open' }, { a: '保存', b: '打开' })).toBe(0)
+  })
+
+  it('tolerates a proper noun surviving translation', () => {
+    expect(passthroughRatio({ a: 'KiroCrew', b: 'Open' }, { a: 'KiroCrew', b: '打开' })).toBe(0.5)
+  })
+
+  it('is 0 for an empty corpus rather than NaN', () => {
+    expect(passthroughRatio({}, {})).toBe(0)
+  })
+})
+
+describe('flatten', () => {
+  it('produces dotted leaf paths', () => {
+    expect(flatten({ a: { b: 'x' }, c: 'y' })).toEqual({ 'a.b': 'x', c: 'y' })
+  })
+})
+
+describe('the committed prompt', () => {
+  it('has the BEGIN/END markers the driver extracts between', () => {
+    expect(() => extractPromptBody(PROMPT_DOC)).not.toThrow()
+    expect(extractPromptBody(PROMPT_DOC).length).toBeGreaterThan(500)
+  })
+
+  it('throws on a doc missing its markers instead of sending the whole file', () => {
+    expect(() => extractPromptBody('# just prose\n')).toThrow(/PROMPT BEGIN/)
+  })
+
+  /**
+   * `renderPrompt` throws on a leftover slot, so a slot added to the doc and not to
+   * the driver would break a translation run at emit time. Catch it in CI instead.
+   */
+  it('declares only slots the driver supplies', () => {
+    const declared = new Set(
+      [...extractPromptBody(PROMPT_DOC).matchAll(/\{\{([A-Z_]+)\}\}/g)].map(m => m[1]),
+    )
+    const supplied = new Set([
+      'LOCALE', 'LANGUAGE_LABEL', 'PLURAL_CATEGORIES', 'STYLE_GUIDE',
+      'DNT_TERMS', 'CONTEXT', 'SHARD_JSON', 'EXAMPLES',
+    ])
+    expect([...declared].filter(d => !supplied.has(d))).toEqual([])
+  })
+
+  it('documents every slot it declares in the slot table', () => {
+    const declared = [...extractPromptBody(PROMPT_DOC).matchAll(/\{\{([A-Z_]+)\}\}/g)].map(m => m[1])
+    for (const slot of new Set(declared)) {
+      expect(PROMPT_DOC).toContain(`\`{{${slot}}}\``)
+    }
+  })
+
+  it('states the output contract the driver relies on', () => {
+    const body = extractPromptBody(PROMPT_DOC)
+    expect(body).toMatch(/exactly one JSON object/i)
+    expect(body).toMatch(/non-empty string/i)
+  })
+})
+
+describe('renderPrompt', () => {
+  it('substitutes every occurrence of a slot', () => {
+    expect(renderPrompt('{{A}} and {{A}} and {{B}}', { A: 'x', B: 'y' })).toBe('x and x and y')
+  })
+
+  it('throws on an unfilled slot rather than sending a literal {{SLOT}}', () => {
+    expect(() => renderPrompt('{{A}} {{MISSING}}', { A: 'x' })).toThrow(/MISSING/)
+  })
+
+  it('does not treat i18next interpolation in a shard as a prompt slot', () => {
+    // Slots are UPPER_SNAKE; `{{count}}` inside the embedded shard JSON must survive.
+    expect(renderPrompt('{{A}}', { A: 'value is {{count}} items' })).toBe('value is {{count}} items')
+  })
+})


### PR DESCRIPTION
## Problem

Phase 1 of the i18n plan removes visible English by extracting ~1767 hardcoded
strings into catalog keys. `catalogParity.test.ts:131` (`has no key missing
relative to en`) has no allowlist, no TODO escape and no partial-translation
tolerance, so every one of those keys must land in all 9 non-English catalogs in
the **same commit** — roughly 15,900 translated values.

Nothing in the repo produces them reproducibly:

- **No committed prompt.** `website/AGENTS.md:125-130` documents the shard
  mechanics but not what to ask for. The catalogs are AI-translated with
  contributor edits and no TMS, so the prompt *is* the pipeline — and it lived
  only in whatever chat window ran last. Two runs get different terminology for
  the same key and neither can be audited against an intent.
- **No fan-out.** `i18n-shard.mjs join <dir> <tag>` writes one locale per
  invocation, with no loop over `SUPPORTED_LANGUAGES`. Covering 9 locales is 9
  manual invocations — nine chances to skip one and find out as a red
  `Frontend Tests`.
- **No pre-join validation.** `join` is fail-closed but coarse: it refuses the
  whole catalog and names the first few offending keys. A translator gets no
  per-key report and no check at all on placeholder integrity, DNT terms, or
  plural categories.

## Why it matters

Without this, Phase 1 cannot start: the extraction half is mechanical, but the
translation half has no reproducible mechanism, no quality gate, and a
documented workflow that silently deletes data (see the `join` finding below).
Any Phase 1 slice attempted today produces translations that cannot be
regenerated or audited.

## Fix

### `src/i18n/TRANSLATION-PROMPT.md` — the prompt, versioned with the catalogs

A template with 8 slots, rendered per (locale, shard). It encodes the output
contract the driver depends on (exactly one JSON object, identical key set,
no empty values), what must survive byte-for-byte (`{{...}}`, tags, `$t()`,
URLs, newlines), the DNT glossary, the locale's style guide, its CLDR plural
categories, and the translator-context notes for the shard.

### `scripts/i18n-translate.mjs` — plan · emit · verify · merge · join-all

Deliberately does **not** call a model. It renders the prompt and checks the
answer; sending it is the caller's job. That split keeps the pipeline
reproducible and testable with no network, no credentials, and no vendor pinned
into the repo.

Absent-tolerant for the glossary, style guides and context sidecar — the same
contract `i18n-shard.mjs` already uses for the sidecar — so it lands on `main`
today and lights up as those PRs merge, rather than blocking on them.

### Root cause found while calibrating: `join` deletes locale plural forms

`i18n-shard.mjs join` rewrites a catalog from shards keyed off the **English**
corpus, so any form the locale has and English does not is dropped. Measured on
a real round-trip of the shipped catalogs: `ru.json` loses 108 lines and each of
`es`/`fr`/`pt`/`it` loses 45 keys — all `_few`/`_many` CLDR plural forms.
Following the documented workflow on Phase 1 would silently delete them.

`merge` is the additive answer and is what Phase 1 should use; `join-all` is
kept for a genuine full re-translation. This PR does not change
`i18n-shard.mjs` — the finding is documented at the call site and in the header.

## Tests

`src/i18n/translateDriver.test.ts` — 58 tests. The interesting ones pin
calibrations that were **measured against the shipped catalogs**, not guessed.
Run in their obvious absolute form, the rules produced 142 findings on the
approved `ru` catalog, 150 on `de` and 115 on `zh-CN` — every one a false
positive. A check that cries wolf on approved work is a check somebody switches
off, so each is now relative to the English:

| Rule | Absolute form | Why it was wrong | Final form |
|---|---|---|---|
| `doubled-space`, `edge-whitespace` | flag any occurrence | `en.json` itself has 77 doubled spaces (JSX extraction kept source indentation) | fire only if the English lacks it |
| `unbalanced-bracket` | demand balance | the D1 fragment keys (`'Findings ('` + N + `')'`) are unbalanced *by design* — 64 hits | compare the **delta** against English |
| `unbalanced-bracket` | compare per width | zh-CN correctly rewrites `(` as `（`, which its own style guide asks for — 60 hits | pool the widths; flag **mixing** both in one value separately |
| `fullwidth-latin` | `[\uFF01-\uFF5E]` | that block includes full-width *punctuation*, which is correct CJK typography | letters and digits only |
| `impossible-plural` | judge the `_one` suffix | the slug generator ends a key with the sentence's last word, so `"…to add one"` → `..._add_one` — 3 hits | require the base to be in `pluralKeys.json` |
| `missing-key` | demand every English key | zh-CN cannot carry `_one`; 45 phantom misses | carve out plural forms the locale has no category for, mirroring `catalogParity.test.ts` |

After calibration the same run reports **ru 0 findings, de 9, zh-CN 7** — and
those are real. The German ones are worth naming: `<path>` → `<pfad>` and
`<your-host>` → `<ihr-host>`, i.e. the translator translated the placeholder
*name*, which breaks interpolation at runtime. Nothing in CI catches that today.

`mergeCatalog` is separately tested for the plural-preservation property, for
non-mutation, and for prototype-pollution refusal.

## Manual verification

Ran end-to-end against a local integration branch with #898 + #911 + #914 + #921
merged (they merge cleanly, zero conflicts), so glossary, style guides and the
context sidecar were all present:

- `plan pages/settings` → 20 files, 182 Phase 1 sites, 112 deferred to Phase 6,
  x9 locales = 1638 values.
- `i18n-shard.mjs split` → 5 shards, 4048 keys, 85 carrying context.
- `emit` → 45 prompts (9 locales x 5 shards), **zero unfilled slots**, and the
  plural line correctly locale-specific: `zh-CN` → `other`, `ru` → `few, many,
  one, other`, `es` → `many, one, other`, `de`/`hi` → `one, other`.
- `verify` → the calibration numbers above.
- `join-all` / `merge` → per-locale pass/fail table, exit 1 on a partial run.

Also verified on this branch (i.e. with `check-i18n-strings.mjs`, the glossary
and the style guides all **absent**, as on `main`) that the absent-tolerant paths
warn and continue: `tsc -b` 0, `eslint` 0, `vitest run src/i18n/` 213 passed.

Screenshots: N/A — no user-visible UI change. This adds a doc, a CLI script and
its tests; nothing renders.

## Progress map

Remediation plan: `Phase 0 → 0.5 → 1 → 2 → 3 → 4 → 5 → 6 → 7` + Track B + Track C.

- **Phase 0** (gates, glossary, style guides, context sidecar) — in review as
  #898, #911, #914, #921. **Not this PR.**
- **Phase 0.5** (i18next 26) — in review as #915. Not this PR.
- **Phase 1** (remove visible English) — **this PR builds its missing
  prerequisite.** Sub-items:
  1. 887 JSX expression literals — not started
  2. 33 status/notification props — not started
  3. 801 prose nodes + 46 attributes — not started
  4. the `alert()`/`confirm()` concat bypasses — not started
  5. **translate the new keys against the glossary and style guide — the
     mechanism to do so is IN THIS PR** (prompt + driver + validation)
- **Phases 2–7, Track B, Track C** — not started.

Corrects the plan's Phase 1 sizing while it is here: the doc says ~690 sites,
the generated baseline says **1767** (expression 887, prose 801, attribute 46,
status-call 33), with 1120 deferred to Phase 6 (template 804, object-prop 202,
array 114) for a declared total of 2887.
