### PR TITLE
feat(i18n): commit the translation prompt and a 9-locale translation driver

### DIFF
--- a/website/scripts/i18n-translate.mjs
+++ b/website/scripts/i18n-translate.mjs
@@ -1,0 +1,701 @@
+#!/usr/bin/env node
+/**
+ * Translation driver: renders the committed prompt per (locale, shard), validates
+ * filled shards, and drives `i18n-shard.mjs join` across every shipped locale.
+ *
+ * `i18n-shard.mjs` is deliberately single-locale — `join <dir> <tag>` writes one
+ * catalog per invocation. That is the right shape for the primitive and the wrong
+ * shape for the job: Phase 1 adds ~1767 keys, and `catalogParity.test.ts` demands
+ * every one of them in all 9 non-English catalogs in the SAME commit, so a
+ * translation run is inherently a 9-way fan-out. Doing that by hand is nine
+ * chances to skip a locale and discover it as a red `Frontend Tests`.
+ *
+ * This script does NOT call a model. It renders the prompt and checks the answer;
+ * sending it is the caller's job (an agent, a contributor, whatever). That split is
+ * deliberate — it keeps the pipeline reproducible and testable with no network, no
+ * credentials, and no vendor pinned into the repo.
+ *
+ * Usage:
+ *   node scripts/i18n-translate.mjs plan [pathPrefix]        # what needs translating
+ *   node scripts/i18n-translate.mjs emit <baseDir> [--locales a,b]
+ *   node scripts/i18n-translate.mjs verify <baseDir> --locale <tag>
+ *   node scripts/i18n-translate.mjs merge <baseDir> [--overwrite]
+ *
+ * `merge`, never `i18n-shard.mjs join`, for a translation produced here. `join`
+ * rewrites the catalog from shards keyed off the ENGLISH corpus, so any form the
+ * locale has and English does not is silently dropped — a measured round-trip
+ * removes 108 lines from `ru.json` and 45 keys from each of es/fr/pt/it, all
+ * `_few`/`_many` CLDR plural forms. It also cannot accept the locale-specific
+ * plural keys `emit` now asks for, since it validates against the English key set.
+ * `merge` is insert-only by default and preserves both.
+ *
+ * Layout under <baseDir> (keep it OUTSIDE the worktree — a dirty tree blocks
+ * worktree pruning, see website/AGENTS.md Rule 9):
+ *   en/       shard-NN.json + shard-NN.context.json   <- `i18n-shard.mjs split` output
+ *   prompts/  <locale>/shard-NN.prompt.md             <- `emit` writes these
+ *   <locale>/ shard-NN.json                           <- filled translations
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+const SRC = path.join(ROOT, 'src/i18n')
+
+const PROMPT_FILE = path.join(SRC, 'TRANSLATION-PROMPT.md')
+const GLOSSARY_FILE = path.join(SRC, 'glossary.json')
+const CONTEXT_FILE = path.join(SRC, 'en.context.json')
+const STYLE_DIR = path.join(SRC, 'style')
+const LANGUAGES_FILE = path.join(SRC, 'languages.ts')
+const BASELINE_FILE = path.join(SRC, 'untranslated-baseline.json')
+const PLURAL_KEYS_FILE = path.join(SRC, 'pluralKeys.json')
+const LOCALES_DIR = path.join(SRC, 'locales')
+
+/**
+ * Categories `check-i18n-strings.mjs` assigns that Phase 1 owns. The other three
+ * — `template`, `object-prop`, `array` — need a change of shape rather than a
+ * local edit, so they belong to Phase 6 and must not inflate a Phase 1 estimate.
+ */
+export const PHASE1_CATEGORIES = ['expression', 'prose', 'attribute', 'status-call']
+export const PHASE6_CATEGORIES = ['template', 'object-prop', 'array']
+
+/**
+ * Parse the shipped locales out of `languages.ts` rather than duplicating them.
+ * A second hardcoded list is a second thing to forget when language #11 ships;
+ * `translateDriver.test.ts` asserts this parse against the real
+ * `SUPPORTED_LANGUAGES` so a format change here fails loudly instead of silently
+ * translating eight languages out of nine.
+ */
+export function parseLanguages(source) {
+  const block = source.match(/SUPPORTED_LANGUAGES[^=]*=\s*\[([\s\S]*?)\n\]/)
+  if (!block) throw new Error('could not locate SUPPORTED_LANGUAGES in languages.ts')
+  const out = []
+  for (const m of block[1].matchAll(/\{\s*code:\s*'([^']+)'\s*,\s*label:\s*'([^']+)'([^}]*)\}/g)) {
+    if (/devOnly:\s*true/.test(m[3])) continue
+    out.push({ code: m[1], label: m[2] })
+  }
+  if (out.length === 0) throw new Error('parsed zero languages from languages.ts')
+  return out
+}
+
+const ALL_LANGUAGES = parseLanguages(fs.readFileSync(LANGUAGES_FILE, 'utf-8'))
+const DEFAULT_LANGUAGE = 'en'
+const TARGET_LANGUAGES = ALL_LANGUAGES.filter(l => l.code !== DEFAULT_LANGUAGE)
+
+// ---------------------------------------------------------------------------
+// pure helpers (exported for the test suite)
+// ---------------------------------------------------------------------------
+
+export function flatten(obj, prefix = '') {
+  const out = {}
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k
+    if (v && typeof v === 'object' && !Array.isArray(v)) Object.assign(out, flatten(v, key))
+    else out[key] = v
+  }
+  return out
+}
+
+/** i18next interpolation, tags, and `$t()` nesting — the things that are code. */
+export function placeholders(value) {
+  return [
+    ...String(value).matchAll(/\{\{[^}]*\}\}/g),
+    ...String(value).matchAll(/<\/?[^>]+>/g),
+    ...String(value).matchAll(/\$t\([^)]*\)/g),
+  ].map(m => m[0]).sort()
+}
+
+/**
+ * Every rule `verify` can decide mechanically. Ordered so the cheapest and most
+ * certain failures report first.
+ *
+ * `dnt` is word-boundary, matching `glossary.test.ts` — a substring check would
+ * flag any word that merely contains `Git`, and a term absent from the English
+ * is not required to appear in the translation.
+ */
+export function checkValue({ key, en, tr, dnt = [], categories = null, pluralBases = null }) {
+  const findings = []
+  const push = (rule, detail) => findings.push({ key, rule, detail })
+
+  if (typeof tr !== 'string') return [{ key, rule: 'not-a-string', detail: typeof tr }]
+  if (tr.trim() === '') return [{ key, rule: 'empty', detail: 'value is empty or whitespace' }]
+
+  const ph = { en: placeholders(en), tr: placeholders(tr) }
+  if (ph.en.join('|') !== ph.tr.join('|')) {
+    push('placeholder-parity', `en=[${ph.en.join(' ')}] tr=[${ph.tr.join(' ')}]`)
+  }
+
+  const nl = s => (String(s).match(/\n/g) ?? []).length
+  if (nl(en) !== nl(tr)) push('newline-count', `en=${nl(en)} tr=${nl(tr)}`)
+
+  for (const term of dnt) {
+    const re = new RegExp(`(?<![\\p{L}\\p{N}])${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\p{L}\\p{N}])`, 'u')
+    if (re.test(en) && !re.test(tr)) push('dnt-missing', `"${term}" is in the English but not the translation`)
+  }
+
+  // The next three rules are RELATIVE to the English, not absolute. Measured
+  // against the shipped catalogs, absolute forms produced 142 findings on
+  // already-approved translations — and every one was inherited: the English
+  // itself carries 77 doubled spaces (JSX text extraction kept the source
+  // indentation) and 64 unbalanced brackets (the D1 fragment keys, `'Findings ('`
+  // + N + `')'`). Those are SOURCE defects that Phase 3 repairs by de-fragmenting
+  // the key; reporting them against the translator is noise that would get this
+  // whole check switched off. Fire only on a defect the translation introduces.
+  if (tr !== tr.trim() && en === String(en).trim()) {
+    push('edge-whitespace', 'leading or trailing whitespace the English does not have')
+  }
+  if (/ {2}/.test(tr) && !/ {2}/.test(String(en))) {
+    push('doubled-space', 'two consecutive spaces the English does not have')
+  }
+
+  // Full-width LETTERS and DIGITS only. The whole U+FF01-FF5E block would also
+  // catch full-width punctuation, which is correct CJK typography and is what the
+  // style guides ask for — flagging `（` here would fight the rule it implements.
+  // Absolute rather than relative: English never contains these.
+  if (/[\uFF10-\uFF19\uFF21-\uFF3A\uFF41-\uFF5A]/.test(tr)) {
+    push('fullwidth-latin', 'full-width Latin letter or digit')
+  }
+
+  // Bracket balance, pooled across widths, as a DELTA against the English. Two
+  // calibrations are baked in, both measured against the shipped catalogs:
+  //
+  //  - DELTA, not balance: the D1 fragment keys (`'Findings ('` + N + `')'`) are
+  //    deliberately unbalanced at source, so demanding balance reported 64
+  //    findings against already-approved translations.
+  //  - POOLED across widths: zh-CN correctly rewrites `(` as `（`, which its own
+  //    style guide asks for. Comparing per width called all 60 of those a defect.
+  //
+  // What remains a defect is MIXING the widths inside one value — `发现 (3）`, the
+  // failure `qa.test.ts` exists for — which pooling would hide, so it is checked
+  // separately below.
+  const FAMILIES = [
+    { name: 'round', opens: '(（', closes: ')）' },
+    { name: 'square', opens: '[【', closes: ']】' },
+    { name: 'curly', opens: '{', closes: '}' },
+  ]
+  for (const { name, opens, closes } of FAMILIES) {
+    const bal = s => countOutside(s, c => opens.includes(c)) - countOutside(s, c => closes.includes(c))
+    const dEn = bal(en)
+    const dTr = bal(tr)
+    if (dEn !== dTr) {
+      push('unbalanced-bracket', `${name} bracket balance ${dTr >= 0 ? '+' : ''}${dTr}, English is ${dEn >= 0 ? '+' : ''}${dEn}`)
+    }
+    // Consistent conversion is fine; using both widths of one family in a single
+    // value is the mixed-width pair the QA suite rejects.
+    const ascii = countOutside(tr, c => c === opens[0] || c === closes[0]) > 0
+    const wide = opens.length > 1 && countOutside(tr, c => c === opens[1] || c === closes[1]) > 0
+    if (ascii && wide) push('mixed-width-bracket', `${name} brackets use both ASCII and full-width forms`)
+  }
+
+  // A key is a plural form only if its BASE is in `pluralKeys.json`. Shape alone is
+  // not enough: the slug generator ends a key with the sentence's last word, so
+  // `"…to add one"` becomes `..._add_one` and looked like an impossible `_one` form
+  // in three approved zh-CN values. With no registry supplied, stay silent rather
+  // than guess — a false blocker here costs more than a missed one.
+  if (categories && pluralBases) {
+    const m = key.match(/^(.*)_(zero|one|two|few|many|other)$/)
+    if (m && pluralBases.includes(m[1]) && !categories.includes(m[2])) {
+      push('impossible-plural', `_${m[2]} is not a CLDR category for this locale (${categories.join(', ')})`)
+    }
+  }
+
+  return findings
+}
+
+/**
+ * English passthrough is reported separately from `checkValue`'s findings because
+ * it is not always wrong — a proper noun or a symbol legitimately survives
+ * translation — but a shard where most values match English is a shard nobody
+ * translated, and that is worth a hard failure.
+ */
+export function passthroughRatio(en, tr) {
+  const keys = Object.keys(en)
+  if (keys.length === 0) return 0
+  return keys.filter(k => tr[k] === en[k]).length / keys.length
+}
+
+export function renderPrompt(template, slots) {
+  let out = template
+  for (const [name, value] of Object.entries(slots)) {
+    out = out.split(`{{${name}}}`).join(value)
+  }
+  const leftover = out.match(/\{\{[A-Z_]+\}\}/g)
+  if (leftover) throw new Error(`unfilled prompt slot(s): ${[...new Set(leftover)].join(', ')}`)
+  return out
+}
+
+/** The prompt body between the two markers — the doc's prose is not part of it. */
+export function extractPromptBody(doc) {
+  const m = doc.match(/^## PROMPT BEGIN\s*$([\s\S]*?)^## PROMPT END\s*$/m)
+  if (!m) throw new Error('TRANSLATION-PROMPT.md is missing its "## PROMPT BEGIN" / "## PROMPT END" markers')
+  return m[1].trim()
+}
+
+// ---------------------------------------------------------------------------
+// absent-tolerant inputs
+// ---------------------------------------------------------------------------
+
+/**
+ * The glossary, style guides and context sidecar each land in their own PR, so a
+ * translation run must not hard-fail because one has not merged yet. Same
+ * contract `i18n-shard.mjs` uses for the sidecar: degrade, but say so loudly —
+ * silently producing context-free, glossary-free output is the exact failure
+ * these files exist to prevent.
+ */
+function readOptional(file, what) {
+  if (fs.existsSync(file)) return fs.readFileSync(file, 'utf-8')
+  console.warn(`warning: ${path.relative(ROOT, file)} is missing, so ${what}`)
+  return null
+}
+
+function dntTerms() {
+  const raw = readOptional(GLOSSARY_FILE, 'do-not-translate terms cannot be enforced')
+  return raw ? (JSON.parse(raw).dnt ?? []) : []
+}
+
+function pluralRegistry() {
+  return fs.existsSync(PLURAL_KEYS_FILE)
+    ? JSON.parse(fs.readFileSync(PLURAL_KEYS_FILE, 'utf-8'))
+    : []
+}
+
+function pluralCategories(code) {
+  try {
+    return new Intl.PluralRules(code).resolvedOptions().pluralCategories
+  } catch {
+    return ['other']
+  }
+}
+
+// ---------------------------------------------------------------------------
+// subcommands
+// ---------------------------------------------------------------------------
+
+function cmdPlan(prefix) {
+  if (!fs.existsSync(BASELINE_FILE)) {
+    console.error(
+      `${path.relative(ROOT, BASELINE_FILE)} does not exist.\n`
+      + 'It is generated by `node scripts/check-i18n-strings.mjs --update` and is the\n'
+      + 'Phase 1 worklist. Without it there is nothing to plan against.',
+    )
+    process.exit(2)
+  }
+  const { files } = JSON.parse(fs.readFileSync(BASELINE_FILE, 'utf-8'))
+  const rows = Object.entries(files)
+    .filter(([f]) => !prefix || f.startsWith(prefix))
+    .map(([f, cats]) => ({
+      file: f,
+      phase1: PHASE1_CATEGORIES.reduce((n, c) => n + (cats[c] ?? 0), 0),
+      phase6: PHASE6_CATEGORIES.reduce((n, c) => n + (cats[c] ?? 0), 0),
+      cats,
+    }))
+    .filter(r => r.phase1 > 0)
+    .sort((a, b) => b.phase1 - a.phase1)
+
+  const p1 = rows.reduce((n, r) => n + r.phase1, 0)
+  const p6 = rows.reduce((n, r) => n + r.phase6, 0)
+  console.log(`${rows.length} file(s)${prefix ? ` under ${prefix}` : ''} with Phase 1 work`)
+  console.log(`  Phase 1 (this phase):    ${p1}`)
+  console.log(`  Phase 6 (deferred):      ${p6}`)
+  console.log(`  x ${TARGET_LANGUAGES.length} locales:          ${p1 * TARGET_LANGUAGES.length} translated values\n`)
+  for (const r of rows.slice(0, 40)) {
+    const detail = Object.entries(r.cats)
+      .filter(([c]) => c !== 'total')
+      .map(([c, n]) => `${c}:${n}`)
+      .join(' ')
+    console.log(`  ${String(r.phase1).padStart(4)} p1  ${String(r.phase6).padStart(4)} p6  ${r.file}`)
+    console.log(`             ${detail}`)
+  }
+  if (rows.length > 40) console.log(`  … and ${rows.length - 40} more`)
+}
+
+function cmdEmit(baseDir, locales) {
+  const enDir = path.join(baseDir, 'en')
+  if (!fs.existsSync(enDir)) {
+    console.error(
+      `${enDir} does not exist.\n`
+      + `Run \`node scripts/i18n-shard.mjs split ${enDir}\` first — that is what produces\n`
+      + 'the English shards and their translator-context sidecars.',
+    )
+    process.exit(2)
+  }
+  const template = extractPromptBody(fs.readFileSync(PROMPT_FILE, 'utf-8'))
+  const dnt = dntTerms()
+  const pluralBases = pluralRegistry()
+  const shards = fs.readdirSync(enDir)
+    .filter(f => /^shard-\d+\.json$/.test(f))
+    .sort()
+  if (shards.length === 0) {
+    console.error(`no shard-NN.json found in ${enDir}`)
+    process.exit(2)
+  }
+
+  let written = 0
+  for (const { code, label } of locales) {
+    const categories = pluralCategories(code)
+    const style = readOptional(path.join(STYLE_DIR, `${code}.md`), `${code} has no style guide to follow`)
+    const existing = fs.existsSync(path.join(LOCALES_DIR, `${code}.json`))
+      ? flatten(JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, `${code}.json`), 'utf-8')))
+      : {}
+    const examples = Object.entries(existing)
+      .filter(([, v]) => typeof v === 'string' && v.length > 2 && v.length < 60)
+      .slice(0, 12)
+    const outDir = path.join(baseDir, 'prompts', code)
+    fs.mkdirSync(outDir, { recursive: true })
+
+    for (const shard of shards) {
+      const stem = shard.replace(/\.json$/, '')
+      const ctxFile = path.join(enDir, `${stem}.context.json`)
+      const ctx = fs.existsSync(ctxFile) ? fs.readFileSync(ctxFile, 'utf-8') : null
+      // Re-key for THIS locale's plural categories, so the prompt asks for the
+      // forms it can select and none it cannot. See `localiseShard`.
+      const source = localiseShard(
+        JSON.parse(fs.readFileSync(path.join(enDir, shard), 'utf-8')),
+        pluralBases,
+        categories,
+      )
+      const body = renderPrompt(template, {
+        LOCALE: code,
+        LANGUAGE_LABEL: label,
+        PLURAL_CATEGORIES: categories.join(', '),
+        STYLE_GUIDE: style ?? '_(no style guide has landed for this locale yet — apply the general rules above.)_',
+        DNT_TERMS: dnt.length
+          ? dnt.map(t => `- \`${t}\``).join('\n')
+          : '_(no glossary has landed yet — keep product names and proper nouns in Latin script.)_',
+        CONTEXT: ctx
+          ? `\`\`\`json\n${ctx.trim()}\n\`\`\``
+          : '_(no context entries apply to this shard.)_',
+        SHARD_JSON: `\`\`\`json\n${JSON.stringify(source, null, 2)}\n\`\`\``,
+        EXAMPLES: examples.length
+          ? `\`\`\`json\n${JSON.stringify(Object.fromEntries(examples), null, 2)}\n\`\`\``
+          : '_(this locale has no catalog yet — you are establishing the terminology.)_',
+      })
+      fs.writeFileSync(path.join(outDir, `${stem}.prompt.md`), `${body}\n`)
+      written += 1
+    }
+    console.log(`${code}: ${shards.length} prompt(s), plurals [${categories.join(' ')}] -> ${path.relative(process.cwd(), outDir)}`)
+  }
+  console.log(`\n${written} prompt(s) for ${locales.length} locale(s). Answers go in <baseDir>/<locale>/shard-NN.json.`)
+}
+
+/**
+ * Character ranges covered by a placeholder, tag or nesting reference.
+ *
+ * Deliberately NOT implemented as `replace(/<[^>]+>/g, '')`. That shape is a
+ * multi-character sanitizer — CodeQL flags it high severity, and correctly in
+ * general, because removing `<…>` once can splice a new `<script` out of
+ * `<scr<x>ipt`. Nothing here is sanitising untrusted markup for rendering; the
+ * only question is which offsets to ignore while counting brackets, and offsets
+ * answer it without rewriting the string at all.
+ */
+export function maskedRanges(value) {
+  const ranges = []
+  for (const re of [/\{\{[^}]*\}\}/g, /<\/?[^>]+>/g, /\$t\([^)]*\)/g]) {
+    for (const m of String(value).matchAll(re)) ranges.push([m.index, m.index + m[0].length])
+  }
+  return ranges
+}
+
+/** Count characters satisfying `pred` that lie OUTSIDE any masked range. */
+export function countOutside(value, pred) {
+  const s = String(value)
+  const ranges = maskedRanges(s)
+  let n = 0
+  for (let i = 0; i < s.length; i += 1) {
+    if (ranges.some(([a, b]) => i >= a && i < b)) continue
+    if (pred(s[i])) n += 1
+  }
+  return n
+}
+
+/**
+ * Re-key an English shard for one locale's CLDR plural categories.
+ *
+ * English carries `x_one` + `x_other`. Sending that verbatim asks for exactly the
+ * wrong set: zh-CN (categories: `other`) is asked for an `_one` form it can never
+ * select — and `verify` then rejects the compliant answer — while ru
+ * (`one/few/many/other`) is never asked for `_few`/`_many` at all, so the
+ * documented pipeline cannot produce a correct Russian plural.
+ *
+ * `other` seeds any form the English does not carry: it is the one category every
+ * locale has, so it is always present to translate from.
+ */
+export function localiseShard(shard, pluralBases, categories) {
+  const bases = new Set(pluralBases)
+  const out = {}
+  const grouped = new Map()
+  for (const [k, v] of Object.entries(shard)) {
+    const m = k.match(/^(.*)_(zero|one|two|few|many|other)$/)
+    if (m && bases.has(m[1])) {
+      if (!grouped.has(m[1])) grouped.set(m[1], {})
+      grouped.get(m[1])[m[2]] = v
+    } else {
+      out[k] = v
+    }
+  }
+  for (const [base, forms] of grouped) {
+    const seed = forms.other ?? Object.values(forms)[0]
+    for (const cat of categories) out[`${base}_${cat}`] = forms[cat] ?? seed
+  }
+  return Object.fromEntries(Object.keys(out).sort().map(k => [k, out[k]]))
+}
+
+function cmdVerify(baseDir, code) {
+  const enDir = path.join(baseDir, 'en')
+  const trDir = path.join(baseDir, code)
+  for (const [dir, hint] of [[enDir, 'run `i18n-shard.mjs split` first'], [trDir, 'no filled shards for this locale']]) {
+    if (!fs.existsSync(dir)) {
+      console.error(`${dir} does not exist — ${hint}.`)
+      process.exit(2)
+    }
+  }
+  const dnt = dntTerms()
+  const categories = pluralCategories(code)
+  const pluralBases = pluralRegistry()
+  const read = f => JSON.parse(fs.readFileSync(f, 'utf-8'))
+  const shards = fs.readdirSync(enDir).filter(f => /^shard-\d+\.json$/.test(f)).sort()
+
+  const PASSTHROUGH_LIMIT = 0.5
+  const findings = []
+  const overRatio = []
+  let keyCount = 0
+  let identical = 0
+
+  // PER SHARD, not aggregated. One untranslated shard sitting among translated
+  // ones stays under an aggregate 50% and would pass, after which `merge` writes
+  // English into the catalog — which is exactly the state this gate exists to
+  // stop. A shard is the unit a translator fills, so it is the unit to judge.
+  for (const shard of shards) {
+    const expected = localiseShard(read(path.join(enDir, shard)), pluralBases, categories)
+    const trFile = path.join(trDir, shard)
+    if (!fs.existsSync(trFile)) {
+      findings.push({ key: shard, rule: 'missing-shard', detail: 'no translation for this shard' })
+      continue
+    }
+    const tr = read(trFile)
+    keyCount += Object.keys(expected).length
+    for (const k of Object.keys(expected)) {
+      if (!(k in tr)) findings.push({ key: k, rule: 'missing-key', detail: `absent from ${shard}` })
+    }
+    for (const k of Object.keys(tr)) {
+      if (!(k in expected)) findings.push({ key: k, rule: 'unknown-key', detail: `not expected for ${code} in ${shard}` })
+    }
+    for (const k of Object.keys(expected)) {
+      if (k in tr) findings.push(...checkValue({ key: k, en: expected[k], tr: tr[k], dnt, categories, pluralBases }))
+    }
+    const ratio = passthroughRatio(
+      Object.fromEntries(Object.entries(expected).filter(([k]) => k in tr)),
+      tr,
+    )
+    identical += Object.keys(expected).filter(k => tr[k] === expected[k]).length
+    if (ratio > PASSTHROUGH_LIMIT) overRatio.push({ shard, ratio })
+  }
+
+  const overall = keyCount ? identical / keyCount : 0
+  console.log(
+    `[${code}] ${shards.length} shard(s), ${keyCount} key(s), plurals [${categories.join(' ')}], `
+    + `${findings.length} finding(s), ${(overall * 100).toFixed(1)}% identical to English`,
+  )
+  if (findings.length) {
+    const byRule = {}
+    for (const f of findings) (byRule[f.rule] ??= []).push(f)
+    for (const [rule, items] of Object.entries(byRule).sort((a, b) => b[1].length - a[1].length)) {
+      console.error(`\n  ${rule} (${items.length})`)
+      for (const it of items.slice(0, 8)) console.error(`    ${it.key}: ${it.detail}`)
+      if (items.length > 8) console.error(`    … and ${items.length - 8} more`)
+    }
+  }
+  for (const { shard, ratio } of overRatio) {
+    console.error(
+      `\n  passthrough: ${shard} is ${(ratio * 100).toFixed(1)}% byte-identical to English, above the `
+      + `${PASSTHROUGH_LIMIT * 100}% limit.\n  That is the shape of a shard nobody translated.`,
+    )
+  }
+  if (findings.length || overRatio.length) process.exit(1)
+  console.log(`OK: ${code} is ready to merge.`)
+}
+
+/**
+ * Merge translated keys into an existing catalog.
+ *
+ * INSERT-ONLY by default. A translation run is normally adding keys, and every
+ * value already in the catalog may carry a contributor edit — the catalogs are
+ * AI-generated *plus* human correction, so silently replacing 4000 existing
+ * values because someone sharded the full corpus instead of the new keys would
+ * discard exactly the work that is hardest to reproduce. Overwriting is a
+ * deliberate act (`--overwrite`), not a default.
+ *
+ * Returns `{ merged, skipped }` so the caller can report what it declined to
+ * touch rather than leaving it invisible.
+ */
+export function mergeCatalog(existing, additions, { overwrite = false } = {}) {
+  const out = structuredClone(existing)
+  const skipped = []
+  let merged = 0
+  for (const [key, value] of Object.entries(additions)) {
+    const parts = key.split('.')
+    const leaf = parts.pop()
+    for (const seg of [...parts, leaf]) {
+      if (seg === '__proto__' || seg === 'constructor' || seg === 'prototype') {
+        throw new Error(`Refusing to nest key '${key}': unsafe object-key segment.`)
+      }
+    }
+    let node = out
+    for (const p of parts) {
+      if (typeof node[p] !== 'object' || node[p] === null || Array.isArray(node[p])) node[p] = {}
+      node = node[p]
+    }
+    if (!overwrite && Object.prototype.hasOwnProperty.call(node, leaf)) {
+      skipped.push(key)
+      continue
+    }
+    node[leaf] = value
+    merged += 1
+  }
+  return { catalog: out, merged, skipped }
+}
+
+export function sortDeep(obj) {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) return obj
+  return Object.fromEntries(Object.keys(obj).sort().map(k => [k, sortDeep(obj[k])]))
+}
+
+function cmdMerge(baseDir, locales, { overwrite }) {
+  const results = []
+  for (const { code } of locales) {
+    const dir = path.join(baseDir, code)
+    const target = path.join(LOCALES_DIR, `${code}.json`)
+    if (!fs.existsSync(dir)) {
+      results.push({ code, ok: false, why: 'no shard directory' })
+      continue
+    }
+    if (!fs.existsSync(target)) {
+      results.push({ code, ok: false, why: `${path.relative(ROOT, target)} does not exist` })
+      continue
+    }
+    const additions = Object.assign(
+      {},
+      ...fs.readdirSync(dir)
+        .filter(f => f.endsWith('.json') && !f.endsWith('.context.json'))
+        .sort()
+        .map(f => flatten(JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')))),
+    )
+    const empty = Object.entries(additions).filter(([, v]) => typeof v !== 'string' || !v.trim())
+    if (empty.length) {
+      // Fail closed. A blank value merged into a catalog renders as nothing at
+      // all — worse than the English fallback it replaces — and
+      // `returnEmptyString: false` makes it invisible in review.
+      results.push({ code, ok: false, why: `${empty.length} empty value(s), e.g. ${empty[0][0]}` })
+      continue
+    }
+    const before = JSON.parse(fs.readFileSync(target, 'utf-8'))
+    const beforeCount = Object.keys(flatten(before)).length
+    const { catalog, merged, skipped } = mergeCatalog(before, additions, { overwrite })
+    const afterCount = Object.keys(flatten(catalog)).length
+    fs.writeFileSync(target, `${JSON.stringify(sortDeep(catalog), null, 2)}\n`)
+    results.push({
+      code,
+      ok: true,
+      why: `${merged} key(s) merged, ${beforeCount} -> ${afterCount}`
+        + (skipped.length ? `, ${skipped.length} left alone (already translated)` : ''),
+      skipped,
+    })
+  }
+
+  for (const r of results) console.log(`${r.ok ? 'ok  ' : 'FAIL'} ${r.code.padEnd(6)} ${r.why}`)
+  const withSkips = results.filter(r => r.ok && r.skipped?.length)
+  if (withSkips.length && !overwrite) {
+    const sample = withSkips[0].skipped.slice(0, 5)
+    console.log(
+      `\nKeys already present were left as they are — a catalog value may carry a\n`
+      + `contributor edit, and replacing it is a deliberate act. Pass --overwrite to\n`
+      + `replace them. Example: ${sample.join(', ')}`,
+    )
+  }
+  const failed = results.filter(r => !r.ok)
+  console.log(`\n${results.length - failed.length}/${results.length} locale(s) merged.`)
+  if (failed.length) {
+    console.error(
+      `\n${failed.length} locale(s) did not merge: ${failed.map(r => r.code).join(', ')}.\n`
+      + 'catalogParity.test.ts requires every locale, so this commit is not shippable yet.',
+    )
+    process.exit(1)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function resolveLocales(argv) {
+  const arg = argv.find(a => a.startsWith('--locales='))
+  if (!arg) return TARGET_LANGUAGES
+  const want = arg.slice('--locales='.length).split(',').map(s => s.trim()).filter(Boolean)
+  const known = new Map(TARGET_LANGUAGES.map(l => [l.code, l]))
+  const unknown = want.filter(c => !known.has(c))
+  if (unknown.length) {
+    console.error(
+      `unknown locale(s): ${unknown.join(', ')}\n`
+      + `shipped targets: ${TARGET_LANGUAGES.map(l => l.code).join(', ')}`,
+    )
+    process.exit(2)
+  }
+  return want.map(c => known.get(c))
+}
+
+function main(argv) {
+  const [cmd, ...rest] = argv
+  const positional = rest.filter(a => !a.startsWith('-'))
+
+  // An unrecognised flag must not fall through to a run that writes files with
+  // default settings — the same footgun `i18n-codemod.mjs` closes.
+  const KNOWN = ['--locales=', '--locale=', '--overwrite']
+  const unknown = rest.filter(a => a.startsWith('-') && !KNOWN.some(k => a.startsWith(k)))
+  if (unknown.length) {
+    console.error(`unknown flag(s): ${unknown.join(', ')}\nknown: ${KNOWN.join(' ')}`)
+    process.exit(2)
+  }
+
+  switch (cmd) {
+    case 'plan':
+      return cmdPlan(positional[0])
+    case 'emit':
+      if (!positional[0]) return usage('emit needs a <baseDir>')
+      return cmdEmit(positional[0], resolveLocales(rest))
+    case 'verify': {
+      const localeArg = rest.find(a => a.startsWith('--locale='))
+      const code = localeArg?.slice('--locale='.length)
+      if (!positional[0] || !code) return usage('verify needs a <baseDir> and --locale=<tag>')
+      if (!TARGET_LANGUAGES.some(l => l.code === code)) {
+        console.error(`unknown locale: ${code}\nshipped targets: ${TARGET_LANGUAGES.map(l => l.code).join(', ')}`)
+        process.exit(2)
+      }
+      return cmdVerify(positional[0], code)
+    }
+    case 'merge':
+      if (!positional[0]) return usage('merge needs a <baseDir>')
+      return cmdMerge(positional[0], resolveLocales(rest), { overwrite: rest.includes('--overwrite') })
+    default:
+      return usage(cmd ? `unknown command: ${cmd}` : 'no command given')
+  }
+}
+
+function usage(problem) {
+  console.error(
+    `${problem}\n\n`
+    + 'usage:\n'
+    + '  node scripts/i18n-translate.mjs plan [pathPrefix]\n'
+    + '  node scripts/i18n-translate.mjs emit <baseDir> [--locales=a,b]\n'
+    + '  node scripts/i18n-translate.mjs verify <baseDir> --locale=<tag>\n'
+    + '  node scripts/i18n-translate.mjs merge <baseDir> [--locales=a,b] [--overwrite]\n',
+  )
+  process.exit(2)
+}
+
+// Only dispatch when run as a script, so the helpers above stay importable by the
+// test suite without executing anything.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  main(process.argv.slice(2))
+}

--- a/website/src/i18n/TRANSLATION-PROMPT.md
+++ b/website/src/i18n/TRANSLATION-PROMPT.md
@@ -1,0 +1,145 @@
+# Translation prompt
+
+The catalogs are AI-translated with contributor edits and no TMS, so **the prompt
+is the pipeline**. An uncommitted prompt makes every run unreproducible: two
+translators get different terminology for the same key and neither result can be
+audited against an intent. This file is that prompt, versioned with the catalogs
+it produces.
+
+`scripts/i18n-translate.mjs emit` renders it once per (locale, shard) with the
+slots below filled in. Do not hand-assemble a prompt — the rendered copy is what
+gets sent, so a change here is the only way to change translator behaviour.
+
+## Slots
+
+| Slot | Filled from |
+|---|---|
+| `{{LOCALE}}` | the BCP-47 tag, e.g. `zh-CN` |
+| `{{LANGUAGE_LABEL}}` | the endonym from `languages.ts`, e.g. `简体中文` |
+| `{{PLURAL_CATEGORIES}}` | `Intl.PluralRules(locale).resolvedOptions().pluralCategories` |
+| `{{STYLE_GUIDE}}` | `src/i18n/style/<locale>.md`, verbatim |
+| `{{DNT_TERMS}}` | the `dnt` array from `src/i18n/glossary.json` |
+| `{{CONTEXT}}` | the matching `shard-NN.context.json`, or an explicit "none" note |
+| `{{SHARD_JSON}}` | the English `shard-NN.json` to translate |
+| `{{EXAMPLES}}` | up to 12 approved key/value pairs already in `<locale>.json` |
+
+---
+
+## PROMPT BEGIN
+
+You are translating the UI catalog of KiroCrew, a developer tool, from English
+into **{{LANGUAGE_LABEL}} (`{{LOCALE}}`)**.
+
+Your output is consumed by a machine and validated by CI. A single deviation from
+the output contract fails the whole shard, so the contract outranks every other
+instruction here.
+
+### Output contract
+
+Return **exactly one JSON object and nothing else** — no prose before or after,
+no markdown fence, no comments.
+
+- The key set of your output must be **identical** to the input's. Do not add,
+  remove, rename, or reorder keys.
+- Every value must be a non-empty string. There is no "leave for later": a
+  missing or empty value makes `i18n-shard.mjs join` refuse to write the catalog.
+- Never return the English string unchanged as a way of skipping a key. If a
+  value is genuinely identical in this language (a proper noun, a symbol), that
+  is fine and expected — but it must be a decision, not a fallthrough.
+
+### Preserve exactly
+
+Copy these byte-for-byte. They are code, not words:
+
+- `{{count}}`, `{{name}}` and every other `{{...}}` interpolation. The **name**
+  inside the braces is an identifier — never translate it. You may move the
+  placeholder to wherever the target grammar needs it.
+- `<0>`, `<1>`, `<link>` and any other tag. Keep them balanced and keep them
+  wrapped around the equivalent words, not the same word positions.
+- `$t(some.key)` nesting references.
+- URLs, file paths, config keys, CLI flags (`--check`), shell commands, and
+  anything inside backticks.
+- Newlines (`\n`). Same count, same positions relative to the text.
+
+### Do not translate
+
+These appear verbatim in every language. Matching is word-boundary, so
+`GitHub` in `GitHub Actions` is protected but a word merely containing those
+letters is not:
+
+{{DNT_TERMS}}
+
+Also keep in English: AWS service names, key legends (`Enter`, `Shift`, `⌘`),
+git refs (`main`, `origin`, `HEAD`), filenames, and `cron` when it names the
+syntax rather than the feature.
+
+### Style guide — {{LOCALE}}
+
+Follow this in full. Where it disagrees with your instinct, it wins.
+
+{{STYLE_GUIDE}}
+
+### Plurals
+
+This locale's CLDR plural categories are: **{{PLURAL_CATEGORIES}}**.
+
+A counted key arrives suffixed (`..._one`, `..._other`). Translate **only the
+suffixes present in the input**, and never invent a suffix this locale does not
+have — a category outside the list above is a form i18next can never select, and
+`catalogParity.test.ts` rejects it. If the input has `_one` and `_other` but this
+locale has only `other`, the shard will contain only the `_other` key; that is
+correct, not an omission.
+
+### Translator context
+
+Short strings are ambiguous by construction: `Run` is a verb on a button but a
+noun in a table, `KB` is kilobytes and not a knowledge base, `K` may be a
+keyboard key. Where a key appears below, its note tells you which sense is meant
+and overrides your reading of the English.
+
+{{CONTEXT}}
+
+### Register
+
+- Translate the **function** of the string, not its words. A button label
+  becomes whatever that language puts on a button, which is often not the
+  same part of speech.
+- Match the terminology already used in this catalog. The examples below are
+  approved output — mirror their word choices for recurring terms.
+- Do not pad. UI strings sit in fixed-width chrome; the shortest accurate
+  wording is the right one.
+- Do not translate a sentence fragment into a fragment that only works in
+  English clause order. If a value is an obvious fragment (`of`, `at`,
+  ` and `), translate it as the standalone phrase it will have to be, and it
+  will be repaired properly when the key is de-fragmented.
+
+### Mechanical rules CI enforces on your output
+
+- Balanced brackets and quotes, **including mixed-width pairs** — `(` must not
+  close with `）`.
+- No full-width Latin letters or digits. Use ASCII for both.
+- No leading or trailing whitespace, and no doubled space.
+- Curly quotes must pair, and must use **this locale's** pair (German opens low).
+
+### Approved examples from this catalog
+
+{{EXAMPLES}}
+
+### Translate this
+
+{{SHARD_JSON}}
+
+## PROMPT END
+
+---
+
+## Reviewing the output
+
+`scripts/i18n-translate.mjs verify <dir> --locale <tag>` checks the contract
+mechanically — key-set identity, placeholder parity, DNT verbatim, plural
+categories, the whitespace and bracket rules, and English passthrough. It runs
+before `join`, so a violation is reported per key instead of arriving as `join`'s
+single fail-closed refusal.
+
+What `verify` cannot check is whether the translation is *good*. That still needs
+a speaker, and the style guides exist so a reviewer has something to point at.

--- a/website/src/i18n/translateDriver.test.ts
+++ b/website/src/i18n/translateDriver.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Guards for the translation driver.
+ *
+ * The driver is the only thing standing between "1767 new English keys" and
+ * "1767 keys x 9 locales landing in one commit", and `catalogParity.test.ts`
+ * gives no partial credit — so the driver's checks have to be right before the
+ * translation run, not after.
+ *
+ * Several rules here are deliberately RELATIVE to the English rather than
+ * absolute, and the comments say which measurement forced that. Run in absolute
+ * form against the already-approved ru/de/zh-CN catalogs, the whitespace, bracket
+ * and plural rules produced 142, 150 and 115 findings respectively — every one
+ * inherited from the English source or from a slug that merely looks plural. A
+ * check that cries wolf on approved work is a check somebody switches off.
+ */
+
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  PHASE1_CATEGORIES,
+  PHASE6_CATEGORIES,
+  parseLanguages,
+  flatten,
+  placeholders,
+  checkValue,
+  passthroughRatio,
+  localiseShard,
+  maskedRanges,
+  countOutside,
+  mergeCatalog,
+  sortDeep,
+  renderPrompt,
+  extractPromptBody,
+} from '../../scripts/i18n-translate.mjs'
+import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './languages'
+
+const SRC = path.resolve(__dirname)
+const PROMPT_DOC = fs.readFileSync(path.join(SRC, 'TRANSLATION-PROMPT.md'), 'utf-8')
+const LANGUAGES_SRC = fs.readFileSync(path.join(SRC, 'languages.ts'), 'utf-8')
+
+/** Rule names from a findings array, which is all most assertions care about. */
+const rules = (findings: { rule: string }[]) => findings.map(f => f.rule)
+
+describe('locale list derivation', () => {
+  /**
+   * The driver regex-parses `languages.ts` instead of keeping its own list. That
+   * is the right call — a duplicated list is a second thing to forget when
+   * language #11 ships — but it only stays right while the parse agrees with the
+   * real export. If someone reformats `SUPPORTED_LANGUAGES`, this fails here
+   * rather than by quietly translating eight locales out of nine.
+   */
+  it('parses exactly the shipped, non-devOnly languages', () => {
+    const parsed = parseLanguages(LANGUAGES_SRC)
+    const expected = SUPPORTED_LANGUAGES.filter(l => !('devOnly' in l && l.devOnly))
+    expect(parsed.map((l: { code: string }) => l.code)).toEqual(expected.map(l => l.code))
+    expect(parsed.map((l: { label: string }) => l.label)).toEqual(expected.map(l => l.label))
+  })
+
+  it('excludes the pseudolocale, which is a detector and not a translation target', () => {
+    expect(parseLanguages(LANGUAGES_SRC).map((l: { code: string }) => l.code)).not.toContain('en-XA')
+  })
+
+  it('leaves 9 translation targets once English is removed', () => {
+    const parsed = parseLanguages(LANGUAGES_SRC)
+    expect(parsed.filter((l: { code: string }) => l.code !== DEFAULT_LANGUAGE)).toHaveLength(9)
+  })
+
+  it('throws rather than guessing when the export cannot be found', () => {
+    expect(() => parseLanguages('export const SOMETHING_ELSE = []')).toThrow(/SUPPORTED_LANGUAGES/)
+  })
+})
+
+describe('phase categories', () => {
+  it('partition the classifier buckets with no overlap', () => {
+    expect(PHASE1_CATEGORIES.filter((c: string) => PHASE6_CATEGORIES.includes(c))).toEqual([])
+  })
+
+  /**
+   * Cross-check against the classifier itself, so a new bucket added there cannot
+   * land in neither phase list and quietly vanish from every scope report.
+   *
+   * `check-i18n-strings.mjs` arrives with the Phase 0 gates, so it is legitimately
+   * absent on a tree that predates it — absent-tolerant rather than skipped, so the
+   * assertion becomes mandatory the moment the file exists.
+   */
+  it('cover every bucket check-i18n-strings.mjs can emit', () => {
+    const classifier = path.resolve(SRC, '../../scripts/check-i18n-strings.mjs')
+    if (!fs.existsSync(classifier)) {
+      expect([...PHASE1_CATEGORIES, ...PHASE6_CATEGORIES].length).toBeGreaterThan(0)
+      return
+    }
+    const buckets = [...fs.readFileSync(classifier, 'utf-8').matchAll(/return '([a-z-]+)'/g)].map(m => m[1])
+    expect(buckets.length).toBeGreaterThan(0)
+    for (const b of buckets) {
+      expect([...PHASE1_CATEGORIES, ...PHASE6_CATEGORIES]).toContain(b)
+    }
+  })
+})
+
+describe('placeholders', () => {
+  it('finds interpolation, tags and nesting references', () => {
+    expect(placeholders('{{count}} of <0>{{total}}</0> via $t(a.b)')).toEqual(
+      ['$t(a.b)', '</0>', '<0>', '{{count}}', '{{total}}'].sort(),
+    )
+  })
+
+  it('is order-insensitive so a placeholder may move for target grammar', () => {
+    expect(placeholders('{{a}} then {{b}}')).toEqual(placeholders('{{b}} then {{a}}'))
+  })
+})
+
+describe('checkValue — structural rules', () => {
+  it('accepts a clean translation', () => {
+    expect(checkValue({ key: 'k', en: 'Open {{count}} PR', tr: '打开 {{count}} 个 PR' })).toEqual([])
+  })
+
+  it('rejects an empty or whitespace value', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Save', tr: '   ' }))).toContain('empty')
+  })
+
+  it('rejects a non-string value', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Save', tr: 42 }))).toContain('not-a-string')
+  })
+
+  it('rejects a dropped placeholder', () => {
+    expect(rules(checkValue({ key: 'k', en: '{{count}} items', tr: '若干项目' }))).toContain('placeholder-parity')
+  })
+
+  /**
+   * The real defect this caught in the shipped German catalog: `<path>` became
+   * `<pfad>` and `<your-host>` became `<ihr-host>`. The name inside a placeholder
+   * is an identifier, so translating it silently breaks interpolation at runtime.
+   */
+  it('rejects a TRANSLATED placeholder name', () => {
+    expect(rules(checkValue({ key: 'k', en: 'at <path>', tr: 'bei <pfad>' }))).toContain('placeholder-parity')
+    expect(rules(checkValue({ key: 'k', en: '{{count}} items', tr: '{{数量}} 项' }))).toContain('placeholder-parity')
+  })
+
+  it('accepts a placeholder moved to a different position', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Delete {{name}} now', tr: '现在删除 {{name}}' }))).toEqual([])
+  })
+
+  it('rejects a changed newline count', () => {
+    expect(rules(checkValue({ key: 'k', en: 'a\nb', tr: 'a b' }))).toContain('newline-count')
+  })
+
+  it('does not count brackets inside placeholders or tags', () => {
+    expect(rules(checkValue({ key: 'k', en: 'a <0>b</0> {{c}}', tr: 'a <0>乙</0> {{c}}' }))).toEqual([])
+  })
+})
+
+describe('checkValue — do-not-translate terms', () => {
+  it('rejects a translated do-not-translate term', () => {
+    const f = checkValue({ key: 'k', en: 'Open in GitHub', tr: '在 吉特哈布 中打开', dnt: ['GitHub'] })
+    expect(rules(f)).toContain('dnt-missing')
+  })
+
+  it('does not demand a DNT term the English never used', () => {
+    const f = checkValue({ key: 'k', en: 'Open the file', tr: '打开文件', dnt: ['GitHub'] })
+    expect(rules(f)).not.toContain('dnt-missing')
+  })
+
+  it('matches on word boundaries, not substrings', () => {
+    // `Git` must not count as present just because `Gitea` is.
+    const f = checkValue({ key: 'k', en: 'Use Gitea here', tr: '在 Gitea 中使用', dnt: ['Git'] })
+    expect(rules(f)).not.toContain('dnt-missing')
+  })
+})
+
+describe('checkValue — whitespace, relative to the English', () => {
+  it('rejects whitespace the translation introduces', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Save', tr: ' 保存' }))).toContain('edge-whitespace')
+    expect(rules(checkValue({ key: 'k', en: 'Save now', tr: '立即  保存' }))).toContain('doubled-space')
+  })
+
+  /**
+   * The English catalog itself carries 77 doubled spaces — JSX text extraction kept
+   * the source indentation — and one edge-space value. Billing those to the
+   * translator accounted for 78 of the 142 false findings.
+   */
+  it('does not bill the translation for whitespace the English already has', () => {
+    expect(rules(checkValue({ key: 'k', en: 'namespaces. New  learnings', tr: '命名空间。新  经验' })))
+      .not.toContain('doubled-space')
+    expect(rules(checkValue({ key: 'k', en: ' trailing ', tr: ' 尾随 ' }))).not.toContain('edge-whitespace')
+  })
+})
+
+describe('checkValue — full-width forms', () => {
+  it('rejects full-width Latin letters and digits', () => {
+    expect(rules(checkValue({ key: 'k', en: 'PR 12', tr: 'ＰＲ 12' }))).toContain('fullwidth-latin')
+    expect(rules(checkValue({ key: 'k', en: '12 items', tr: '１２ 项' }))).toContain('fullwidth-latin')
+  })
+
+  it('accepts full-width PUNCTUATION, which is correct CJK typography', () => {
+    // Only letters and digits are banned. A whole-block U+FF01-FF5E check would
+    // flag `，` and `（`, fighting the very style guide it implements.
+    expect(rules(checkValue({ key: 'k', en: 'Save, then close.', tr: '保存，然后关闭。' }))).toEqual([])
+  })
+})
+
+describe('checkValue — brackets, pooled across widths', () => {
+  /**
+   * Two calibrations in one rule. DELTA against the English, because the D1
+   * fragment keys (`'Findings ('` + N + `')'`) are deliberately unbalanced at
+   * source — demanding balance flagged 64 approved values. POOLED across widths,
+   * because zh-CN correctly rewrites `(` as `（`, which its own style guide asks
+   * for — comparing per width flagged 60 more. What is left as a defect is MIXING
+   * both widths in one value, which is the pair `qa.test.ts` rejects.
+   */
+  it('accepts a bracket the English leaves open', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings (', tr: '发现 (' }))).toEqual([])
+    expect(rules(checkValue({ key: 'k', en: 'remaining)', tr: '剩余)' }))).toEqual([])
+  })
+
+  it('accepts a bracket consistently converted to full-width', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings (3)', tr: '发现（3）' }))).toEqual([])
+    expect(rules(checkValue({ key: 'k', en: 'Findings (', tr: '发现（' }))).toEqual([])
+  })
+
+  it('rejects one value using both widths of a pair', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings (3)', tr: '发现 (3）' }))).toContain('mixed-width-bracket')
+  })
+
+  it('rejects a bracket dropped from a balanced English pair', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings (3)', tr: '发现 (3' }))).toContain('unbalanced-bracket')
+  })
+
+  it('rejects a bracket the English never had', () => {
+    expect(rules(checkValue({ key: 'k', en: 'Findings 3', tr: '发现 (3' }))).toContain('unbalanced-bracket')
+  })
+})
+
+describe('checkValue — plurals, gated on the registry', () => {
+  it('rejects a plural form the locale cannot select', () => {
+    const f = checkValue({
+      key: 'items_one', en: '1 item', tr: '1 项',
+      categories: ['other'], pluralBases: ['items'],
+    })
+    expect(rules(f)).toContain('impossible-plural')
+  })
+
+  it('accepts a plural form the locale does have', () => {
+    const f = checkValue({
+      key: 'items_other', en: '{{count}} items', tr: '{{count}} 项',
+      categories: ['other'], pluralBases: ['items'],
+    })
+    expect(rules(f)).not.toContain('impossible-plural')
+  })
+
+  /**
+   * The slug generator ends a key with the sentence's last word, so `"…to add one"`
+   * becomes `..._add_one`. Judging the suffix alone called three such approved
+   * zh-CN values impossible plurals. Only a key whose BASE is registered in
+   * `pluralKeys.json` is a plural.
+   */
+  it('does not treat a key that merely ends in "one" as a plural form', () => {
+    const f = checkValue({
+      key: 'pages.chatSidebar.add_column_after_this_one',
+      en: 'Add column after this one',
+      tr: '在此列后添加一列',
+      categories: ['other'],
+      pluralBases: ['components.appstore.categoryRail.app'],
+    })
+    expect(rules(f)).not.toContain('impossible-plural')
+  })
+
+  it('stays silent when no registry is supplied rather than guessing', () => {
+    const f = checkValue({ key: 'items_one', en: '1 item', tr: '1 项', categories: ['other'] })
+    expect(rules(f)).not.toContain('impossible-plural')
+  })
+})
+
+describe('localiseShard', () => {
+  /**
+   * The prompt must ask each locale for the plural forms it can actually select.
+   * Sending the English shard verbatim asks for exactly the wrong set: zh-CN gets
+   * an `_one` it can never select — and `checkValue` then rejects the compliant
+   * answer — while ru is never asked for `_few`/`_many` at all, so the pipeline
+   * cannot produce a correct Russian plural.
+   */
+  it('drops a plural form the locale cannot select', () => {
+    const out = localiseShard({ items_one: '1 item', items_other: '{{count}} items' }, ['items'], ['other'])
+    expect(Object.keys(out)).toEqual(['items_other'])
+  })
+
+  it('ADDS the forms the locale needs but English does not carry', () => {
+    const out = localiseShard(
+      { items_one: '1 item', items_other: '{{count}} items' },
+      ['items'],
+      ['one', 'few', 'many', 'other'],
+    )
+    expect(Object.keys(out).sort()).toEqual(['items_few', 'items_many', 'items_one', 'items_other'])
+    // `other` seeds a form English lacks: it is the one category every locale has.
+    expect(out.items_few).toBe('{{count}} items')
+    expect(out.items_many).toBe('{{count}} items')
+    // An existing form is preserved rather than overwritten by the seed.
+    expect(out.items_one).toBe('1 item')
+  })
+
+  it('leaves non-plural keys untouched', () => {
+    const out = localiseShard({ save: 'Save', 'a.b': 'X' }, ['items'], ['other'])
+    expect(out).toEqual({ 'a.b': 'X', save: 'Save' })
+  })
+
+  it('does not treat an unregistered plural-shaped key as a plural', () => {
+    // `"…to add one"` slugs to `..._add_one`, which is a real key, not a form.
+    const out = localiseShard({ add_one: 'Add one' }, [], ['other'])
+    expect(out).toEqual({ add_one: 'Add one' })
+  })
+
+  it('is deterministic in key order so a rendered prompt is reproducible', () => {
+    const a = localiseShard({ b: '2', a: '1' }, [], ['other'])
+    const b = localiseShard({ a: '1', b: '2' }, [], ['other'])
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+  })
+})
+
+describe('maskedRanges / countOutside', () => {
+  /**
+   * These exist instead of `replace(/<[^>]+>/g, '')`. That shape is a
+   * multi-character sanitizer — CodeQL flags it high severity, correctly in
+   * general, since removing `<…>` once can splice a new `<script` out of
+   * `<scr<x>ipt`. Counting by offset never rewrites the string, so the dangerous
+   * shape does not exist to get wrong.
+   */
+  it('covers interpolation, tags and nesting references', () => {
+    expect(maskedRanges('a {{b}} c').length).toBe(1)
+    expect(maskedRanges('<0>x</0>').length).toBe(2)
+    expect(maskedRanges('$t(a.b)').length).toBe(1)
+  })
+
+  it('ignores characters inside a masked range', () => {
+    expect(countOutside('({{a(b}})', c => c === '(')).toBe(1)
+    expect(countOutside('<a(b>', c => c === '(')).toBe(0)
+  })
+
+  it('counts characters outside every masked range', () => {
+    expect(countOutside('(a) {{b}} (c)', c => c === '(')).toBe(2)
+  })
+
+  it('does not rewrite the input', () => {
+    const s = '<scr<x>ipt>alert(1)</script>'
+    expect(countOutside(s, c => c === '(')).toBeGreaterThanOrEqual(0)
+    expect(s).toBe('<scr<x>ipt>alert(1)</script>')
+  })
+})
+
+describe('mergeCatalog', () => {
+  /**
+   * Why `merge` exists instead of `i18n-shard.mjs join`. `join` rewrites a catalog
+   * from shards keyed off the ENGLISH corpus, so any form the locale has and
+   * English does not is dropped. Measured on a real round-trip: `ru.json` loses 108
+   * lines and each of es/fr/pt/it loses 45 keys, all `_few`/`_many` CLDR plural
+   * forms.
+   */
+  it('preserves a locale-specific plural form the English corpus cannot carry', () => {
+    const existing = { items_other: 'предметов', items_few: 'предмета', items_one: 'предмет' }
+    const { catalog } = mergeCatalog(existing, { newKey: 'новый' })
+    expect(catalog.items_few).toBe('предмета')
+    expect(catalog.items_one).toBe('предмет')
+    expect(catalog.newKey).toBe('новый')
+  })
+
+  /**
+   * INSERT-ONLY by default. The catalogs are AI-generated plus human correction, so
+   * an existing value may carry a contributor edit. Sharding the full corpus by
+   * mistake and then merging would otherwise replace every one of ~4000 values —
+   * discarding exactly the work that is hardest to reproduce.
+   */
+  it('leaves an existing translation alone and reports it as skipped', () => {
+    const { catalog, merged, skipped } = mergeCatalog({ a: '译文' }, { a: 'new', b: '新' })
+    expect(catalog.a).toBe('译文')
+    expect(catalog.b).toBe('新')
+    expect(merged).toBe(1)
+    expect(skipped).toEqual(['a'])
+  })
+
+  it('replaces an existing translation only when overwrite is asked for', () => {
+    const { catalog, merged, skipped } = mergeCatalog({ a: '译文' }, { a: 'new' }, { overwrite: true })
+    expect(catalog.a).toBe('new')
+    expect(merged).toBe(1)
+    expect(skipped).toEqual([])
+  })
+
+  it('treats a nested existing key as present, not just a top-level one', () => {
+    const { catalog, skipped } = mergeCatalog({ pages: { a: '旧' } }, { 'pages.a': 'new' })
+    expect(catalog.pages.a).toBe('旧')
+    expect(skipped).toEqual(['pages.a'])
+  })
+
+  it('nests a dotted key into the existing tree', () => {
+    const { catalog } = mergeCatalog({ pages: { a: '1' } }, { 'pages.b': '2' })
+    expect(catalog).toEqual({ pages: { a: '1', b: '2' } })
+  })
+
+  it('creates intermediate objects for a wholly new path', () => {
+    expect(mergeCatalog({}, { 'a.b.c': 'x' }).catalog).toEqual({ a: { b: { c: 'x' } } })
+  })
+
+  it('does not mutate its input', () => {
+    const before = { a: { b: '1' } }
+    mergeCatalog(before, { 'a.c': '2' })
+    expect(before).toEqual({ a: { b: '1' } })
+  })
+
+  it('refuses a prototype-polluting key segment, in any position', () => {
+    expect(() => mergeCatalog({}, { '__proto__.x': 'bad' })).toThrow(/unsafe object-key segment/)
+    expect(() => mergeCatalog({}, { 'a.constructor': 'bad' })).toThrow(/unsafe object-key segment/)
+    expect(() => mergeCatalog({}, { prototype: 'bad' })).toThrow(/unsafe object-key segment/)
+  })
+
+  it('replaces a leaf that blocks a deeper path rather than throwing', () => {
+    expect(mergeCatalog({ a: 'leaf' }, { 'a.b': 'x' }).catalog).toEqual({ a: { b: 'x' } })
+  })
+})
+
+describe('sortDeep', () => {
+  it('sorts keys at every level so a merge produces a stable diff', () => {
+    expect(JSON.stringify(sortDeep({ b: '1', a: { d: '2', c: '3' } })))
+      .toBe(JSON.stringify({ a: { c: '3', d: '2' }, b: '1' }))
+  })
+
+  it('leaves non-objects alone', () => {
+    expect(sortDeep('x')).toBe('x')
+    expect(sortDeep(null)).toBe(null)
+  })
+})
+
+describe('passthroughRatio', () => {
+  it('is 1 when nothing was translated', () => {
+    expect(passthroughRatio({ a: 'Save', b: 'Open' }, { a: 'Save', b: 'Open' })).toBe(1)
+  })
+
+  it('is 0 when everything was', () => {
+    expect(passthroughRatio({ a: 'Save', b: 'Open' }, { a: '保存', b: '打开' })).toBe(0)
+  })
+
+  it('tolerates a proper noun surviving translation', () => {
+    expect(passthroughRatio({ a: 'KiroCrew', b: 'Open' }, { a: 'KiroCrew', b: '打开' })).toBe(0.5)
+  })
+
+  it('is 0 for an empty corpus rather than NaN', () => {
+    expect(passthroughRatio({}, {})).toBe(0)
+  })
+})
+
+describe('flatten', () => {
+  it('produces dotted leaf paths', () => {
+    expect(flatten({ a: { b: 'x' }, c: 'y' })).toEqual({ 'a.b': 'x', c: 'y' })
+  })
+})
+
+describe('the committed prompt', () => {
+  it('has the BEGIN/END markers the driver extracts between', () => {
+    expect(() => extractPromptBody(PROMPT_DOC)).not.toThrow()
+    expect(extractPromptBody(PROMPT_DOC).length).toBeGreaterThan(500)
+  })
+
+  it('throws on a doc missing its markers instead of sending the whole file', () => {
+    expect(() => extractPromptBody('# just prose\n')).toThrow(/PROMPT BEGIN/)
+  })
+
+  /**
+   * `renderPrompt` throws on a leftover slot, so a slot added to the doc and not to
+   * the driver would break a translation run at emit time. Catch it in CI instead.
+   */
+  it('declares only slots the driver supplies', () => {
+    const declared = new Set(
+      [...extractPromptBody(PROMPT_DOC).matchAll(/\{\{([A-Z_]+)\}\}/g)].map(m => m[1]),
+    )
+    const supplied = new Set([
+      'LOCALE', 'LANGUAGE_LABEL', 'PLURAL_CATEGORIES', 'STYLE_GUIDE',
+      'DNT_TERMS', 'CONTEXT', 'SHARD_JSON', 'EXAMPLES',
+    ])
+    expect([...declared].filter(d => !supplied.has(d))).toEqual([])
+  })
+
+  it('documents every slot it declares in the slot table', () => {
+    const declared = [...extractPromptBody(PROMPT_DOC).matchAll(/\{\{([A-Z_]+)\}\}/g)].map(m => m[1])
+    for (const slot of new Set(declared)) {
+      expect(PROMPT_DOC).toContain(`\`{{${slot}}}\``)
+    }
+  })
+
+  it('states the output contract the driver relies on', () => {
+    const body = extractPromptBody(PROMPT_DOC)
+    expect(body).toMatch(/exactly one JSON object/i)
+    expect(body).toMatch(/non-empty string/i)
+  })
+})
+
+describe('renderPrompt', () => {
+  it('substitutes every occurrence of a slot', () => {
+    expect(renderPrompt('{{A}} and {{A}} and {{B}}', { A: 'x', B: 'y' })).toBe('x and x and y')
+  })
+
+  it('throws on an unfilled slot rather than sending a literal {{SLOT}}', () => {
+    expect(() => renderPrompt('{{A}} {{MISSING}}', { A: 'x' })).toThrow(/MISSING/)
+  })
+
+  it('does not treat i18next interpolation in a shard as a prompt slot', () => {
+    // Slots are UPPER_SNAKE; `{{count}}` inside the embedded shard JSON must survive.
+    expect(renderPrompt('{{A}}', { A: 'value is {{count}} items' })).toBe('value is {{count}} items')
+  })
+})


### PR DESCRIPTION
## Problem

Phase 1 of the i18n plan removes visible English by extracting ~1767 hardcoded
strings into catalog keys. `catalogParity.test.ts:131` (`has no key missing
relative to en`) has no allowlist, no TODO escape and no partial-translation
tolerance, so every one of those keys must land in all 9 non-English catalogs in
the **same commit** — roughly 15,900 translated values.

Nothing in the repo produces them reproducibly:

- **No committed prompt.** `website/AGENTS.md:125-130` documents the shard
  mechanics but not what to ask for. The catalogs are AI-translated with
  contributor edits and no TMS, so the prompt *is* the pipeline — and it lived
  only in whatever chat window ran last. Two runs get different terminology for
  the same key and neither can be audited against an intent.
- **No fan-out.** `i18n-shard.mjs join <dir> <tag>` writes one locale per
  invocation, with no loop over `SUPPORTED_LANGUAGES`. Covering 9 locales is 9
  manual invocations — nine chances to skip one and find out as a red
  `Frontend Tests`.
- **No pre-join validation.** `join` is fail-closed but coarse: it refuses the
  whole catalog and names the first few offending keys. A translator gets no
  per-key report and no check at all on placeholder integrity, DNT terms, or
  plural categories.

## Why it matters

Without this, Phase 1 cannot start: the extraction half is mechanical, but the
translation half has no reproducible mechanism, no quality gate, and a
documented workflow that silently deletes data (see the `join` finding below).
Any Phase 1 slice attempted today produces translations that cannot be
regenerated or audited.

## Fix

### `src/i18n/TRANSLATION-PROMPT.md` — the prompt, versioned with the catalogs

A template with 8 slots, rendered per (locale, shard). It encodes the output
contract the driver depends on (exactly one JSON object, identical key set,
no empty values), what must survive byte-for-byte (`{{...}}`, tags, `$t()`,
URLs, newlines), the DNT glossary, the locale's style guide, its CLDR plural
categories, and the translator-context notes for the shard.

### `scripts/i18n-translate.mjs` — plan · emit · verify · merge · join-all

Deliberately does **not** call a model. It renders the prompt and checks the
answer; sending it is the caller's job. That split keeps the pipeline
reproducible and testable with no network, no credentials, and no vendor pinned
into the repo.

Absent-tolerant for the glossary, style guides and context sidecar — the same
contract `i18n-shard.mjs` already uses for the sidecar — so it lands on `main`
today and lights up as those PRs merge, rather than blocking on them.

### Root cause found while calibrating: `join` deletes locale plural forms

`i18n-shard.mjs join` rewrites a catalog from shards keyed off the **English**
corpus, so any form the locale has and English does not is dropped. Measured on
a real round-trip of the shipped catalogs: `ru.json` loses 108 lines and each of
`es`/`fr`/`pt`/`it` loses 45 keys — all `_few`/`_many` CLDR plural forms.
Following the documented workflow on Phase 1 would silently delete them.

`merge` is the additive answer and is what Phase 1 should use; `join-all` is
kept for a genuine full re-translation. This PR does not change
`i18n-shard.mjs` — the finding is documented at the call site and in the header.

## Tests

`src/i18n/translateDriver.test.ts` — 58 tests. The interesting ones pin
calibrations that were **measured against the shipped catalogs**, not guessed.
Run in their obvious absolute form, the rules produced 142 findings on the
approved `ru` catalog, 150 on `de` and 115 on `zh-CN` — every one a false
positive. A check that cries wolf on approved work is a check somebody switches
off, so each is now relative to the English:

| Rule | Absolute form | Why it was wrong | Final form |
|---|---|---|---|
| `doubled-space`, `edge-whitespace` | flag any occurrence | `en.json` itself has 77 doubled spaces (JSX extraction kept source indentation) | fire only if the English lacks it |
| `unbalanced-bracket` | demand balance | the D1 fragment keys (`'Findings ('` + N + `')'`) are unbalanced *by design* — 64 hits | compare the **delta** against English |
| `unbalanced-bracket` | compare per width | zh-CN correctly rewrites `(` as `（`, which its own style guide asks for — 60 hits | pool the widths; flag **mixing** both in one value separately |
| `fullwidth-latin` | `[\uFF01-\uFF5E]` | that block includes full-width *punctuation*, which is correct CJK typography | letters and digits only |
| `impossible-plural` | judge the `_one` suffix | the slug generator ends a key with the sentence's last word, so `"…to add one"` → `..._add_one` — 3 hits | require the base to be in `pluralKeys.json` |
| `missing-key` | demand every English key | zh-CN cannot carry `_one`; 45 phantom misses | carve out plural forms the locale has no category for, mirroring `catalogParity.test.ts` |

After calibration the same run reports **ru 0 findings, de 9, zh-CN 7** — and
those are real. The German ones are worth naming: `<path>` → `<pfad>` and
`<your-host>` → `<ihr-host>`, i.e. the translator translated the placeholder
*name*, which breaks interpolation at runtime. Nothing in CI catches that today.

`mergeCatalog` is separately tested for the plural-preservation property, for
non-mutation, and for prototype-pollution refusal.

## Manual verification

Ran end-to-end against a local integration branch with #898 + #911 + #914 + #921
merged (they merge cleanly, zero conflicts), so glossary, style guides and the
context sidecar were all present:

- `plan pages/settings` → 20 files, 182 Phase 1 sites, 112 deferred to Phase 6,
  x9 locales = 1638 values.
- `i18n-shard.mjs split` → 5 shards, 4048 keys, 85 carrying context.
- `emit` → 45 prompts (9 locales x 5 shards), **zero unfilled slots**, and the
  plural line correctly locale-specific: `zh-CN` → `other`, `ru` → `few, many,
  one, other`, `es` → `many, one, other`, `de`/`hi` → `one, other`.
- `verify` → the calibration numbers above.
- `join-all` / `merge` → per-locale pass/fail table, exit 1 on a partial run.

Also verified on this branch (i.e. with `check-i18n-strings.mjs`, the glossary
and the style guides all **absent**, as on `main`) that the absent-tolerant paths
warn and continue: `tsc -b` 0, `eslint` 0, `vitest run src/i18n/` 213 passed.

Screenshots: N/A — no user-visible UI change. This adds a doc, a CLI script and
its tests; nothing renders.

## Progress map

Remediation plan: `Phase 0 → 0.5 → 1 → 2 → 3 → 4 → 5 → 6 → 7` + Track B + Track C.

- **Phase 0** (gates, glossary, style guides, context sidecar) — in review as
  #898, #911, #914, #921. **Not this PR.**
- **Phase 0.5** (i18next 26) — in review as #915. Not this PR.
- **Phase 1** (remove visible English) — **this PR builds its missing
  prerequisite.** Sub-items:
  1. 887 JSX expression literals — not started
  2. 33 status/notification props — not started
  3. 801 prose nodes + 46 attributes — not started
  4. the `alert()`/`confirm()` concat bypasses — not started
  5. **translate the new keys against the glossary and style guide — the
     mechanism to do so is IN THIS PR** (prompt + driver + validation)
- **Phases 2–7, Track B, Track C** — not started.

Corrects the plan's Phase 1 sizing while it is here: the doc says ~690 sites,
the generated baseline says **1767** (expression 887, prose 801, attribute 46,
status-call 33), with 1120 deferred to Phase 6 (template 804, object-prop 202,
array 114) for a declared total of 2887.


---

## Round 2 — GPT 5.6 blocking findings and a CodeQL high, all fixed

This branch supersedes #924 (same change plus the round-2 fixes). Force-push is
blocked by policy in my environment and the repo takes one commit per PR, so the
corrected commit landed on a fresh branch rather than as a second commit there.

**1. Prompts contained plural forms invalid for the target locale — FIXED.**
The most substantive finding: it made the pipeline unable to produce a correct
Russian plural at all. `emit` sent the English shard verbatim, so zh-CN
(categories: `other`) was asked for an `_one` form it can never select — which
`verify` then rejected as `impossible-plural` — while ru (`one/few/many/other`)
was never asked for `_few`/`_many`. `emit` now re-keys each shard through
`localiseShard()` first: forms the locale cannot select are dropped, forms
English does not carry are added, seeded from `_other` (the one category every
locale has). `verify` compares against the same localised expectation.

Verified — the emitted prompt for `components.appstore.categoryRail.app` now
requests `other` for zh-CN, `few many one other` for ru, `one other` for de. As a
side effect, zh-CN's 3 `impossible-plural` findings and 45 phantom missing keys
against the approved catalog are gone: the expectation is now locale-correct
rather than carved out after the fact, so `expectedAbsent()` was deleted.

**2. Passthrough validation aggregated all shards — FIXED.**
`verify` now walks shard by shard and enforces the 50% limit per shard. Proof:
replacing one of ru's five shards with raw English is caught —
`passthrough: shard-03.json is 100.0% byte-identical to English, above the 50%
limit`. Under the aggregate it measured ~20%, passed silently, and `merge` would
have written English into the catalog.

**3. CodeQL high, `js/incomplete-multi-character-sanitization` — FIXED.**
The bracket check used `replace(/<\/?[^>]+>/g, '')` to skip placeholders before
counting. Removing `<…>` once can splice a new `<script` out of `<scr<x>ipt`, so
the alert is right about the shape even though nothing here sanitises markup for
rendering — and a tag-stripping regex was the wrong tool anyway. Replaced with
`maskedRanges()` / `countOutside()`, which count by character offset and never
rewrite the string, so the shape does not exist to get wrong. Covered by 4 new
tests including an explicit non-mutation assertion on `<scr<x>ipt>`.

Tests: **63 passing** (was 58). `tsc -b` 0, `eslint` 0. Re-calibrated against the
shipped catalogs: **ru 0 findings, de 9, zh-CN 7** — all genuine.

The one failing check on #924 not addressed here is `E2E (stub ACP backend,
offline)`, specifically `chat Soft Stop E2E > stop mid tool call triggers
pulsing`. This PR adds a markdown doc, a CLI script and a test file — nothing
reachable from the chat UI — and that suite passes on #911, #916, #918 and #921.
Treating it as unrelated; if it reproduces on this SHA I will dig in rather than
re-run it.


---

## Round 3 — two more GPT blocking findings, both fixed; rebased onto post-Phase-0 `main`

Supersedes #930. Rebased onto `a03e914`, so the Phase 0 files this script reads —
`glossary.json`, `style/*.md`, `en.context.json`, `pluralKeys.json` — now exist,
and the classifier cross-check test that was absent-tolerant is a **live
assertion** against the real `check-i18n-strings.mjs`.

**1. `merge` overwrote existing translations — FIXED, and it was the right call.**
`mergeCatalog` assigned unconditionally. The intent was "additive at the tree
level" — preserve keys the shard does not mention — but the failure mode GPT
describes is real and bad: nothing stopped someone sharding the *full* corpus
instead of the new keys and silently replacing all ~4000 values. These catalogs
are AI-generated **plus human correction**, so those are the values hardest to
reproduce.

`merge` is now **insert-only by default**. It reports what it declined to touch
and names `--overwrite` for a deliberate re-translation. Verified by running it
three times against the same shards: run 1 inserts 17 keys per locale, run 2
reports `0 key(s) merged … 17 left alone (already translated)`, run 3 with
`--overwrite` replaces them.

**2. `join-all` partially rewrote catalogs before failing — FIXED by deleting it.**
GPT's recommended fix was to remove it, and that is right — my own round-2 change
had already made it dead on arrival. Now that `emit` asks each locale for its own
CLDR categories, a filled shard legitimately contains `_few`/`_many` keys that
`i18n-shard.mjs join` rejects, because `join` validates against the English key
set. So `join-all` could only ever fail, and it failed *after* writing some
catalogs. Both problems disappear with the subcommand; `merge` is the supported
path and the `execFileSync` import went with it.

`join`'s data-loss behaviour is still documented at the top of the script — it is
the reason `merge` exists, and someone will otherwise reach for the workflow
`website/AGENTS.md` describes.

Tests: **66** (was 63); whole i18n suite **301 passing across 26 files**.
`tsc -b` 0, `eslint` 0.

**Depends on #931** for a green `Frontend Lint & Type Check` — `en-XA.json` is
stale on `main` itself (#909 changed `artifacts_library` without regenerating it,
since #898 added the drift gate afterwards). This PR touches no catalog, so it
cannot fix or affect that; #931 is the one-line standalone fix.
