### PR TITLE
fix(usage): pick the credential belonging to the signed-in Kiro profile

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -10,6 +10,42 @@ IDE credit meter reads them from the ``GetUsageLimits`` API on the CodeWhisperer
 runtime service (RTS). This module calls that same API so KiroCrew surfaces the
 true used/limit/overage regardless of how kiro-cli reshuffles its stdout.
 
+Whose credits are these?
+------------------------
+Several credentials can be readable at once (an IDE cache, a kiro-cli store, a
+leftover file from a profile the user has since signed out of), and "unexpired"
+does not mean "the one kiro-cli is actually using": a token for the previous
+profile stays valid at the API until it expires on its own. Picking by fixed
+path order therefore showed the OLD profile's credits after a profile switch,
+and a gateway restart did not help because the order was the same on boot.
+
+So the caller passes ``expected_arn`` — the profile ARN ``kiro-cli whoami``
+reports for itself — and a candidate is only used when its own
+ListAvailableProfiles ARN equals it. Credentials for any other account are
+skipped without being spent on a GetUsageLimits call. When every candidate is
+rejected the function fails closed (``None``) and the caller degrades to
+scraping kiro-cli's own ``/usage`` output, which describes the right account by
+construction. Showing a different account's number is the failure being
+prevented; showing no number for one refresh is not.
+
+There are TWO proofs of ownership, never an unverified path. When whoami reports a
+profile ARN, a candidate qualifies by matching it. When it reports none — a Builder
+ID account, or an older kiro-cli that prints no ``Profile:`` block, or a whoami that
+failed outright — a candidate qualifies only by PROVENANCE: it must come from
+kiro-cli's own auth store, where a token is the signed-in account's credential by
+construction. That is the same trust argument that makes scraping kiro-cli's own
+``/usage`` output safe, so it costs nothing to rely on here.
+
+What is refused in the no-ARN case is a credential from the JSON SSO caches or
+another product's store. Those may well be the same account, but nothing proves it,
+and treating them as interchangeable is what served one Builder ID account's
+leftover token as a different Builder ID account's balance.
+
+Provenance-anchoring is what keeps the free API path available to every account
+class. Requiring an ARN instead would push all profile-less accounts onto the text
+scrape — which spends credits on every refresh, indefinitely, and hits the smallest
+quotas hardest.
+
 It is a read-only client: it reads the live bearer token that kiro-cli already
 maintains and makes one authenticated call. The JSON SSO cache files live under
 ``~/.aws`` (a sensitive path), so they are read via
@@ -52,6 +88,7 @@ import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NamedTuple
 
 from kiro_crew import hooks
 
@@ -87,15 +124,27 @@ _JSON_TOKEN_READ_IDS = (
     "kiro_usage_api.sso_token_ide",
 )
 
-# kiro-cli / amazon-q SQLite auth stores. This is the authoritative live-token
-# source on Linux (kiro-cli refreshes it during normal use); the JSON files
-# above are not rewritten on refresh. ``~/.local/share`` is not a sensitive
-# credential path, so this read is a direct read-only sqlite open. auth_kv holds
-# a JSON blob per key.
-_TOKEN_SQLITE_DBS = (
+# kiro-cli's OWN SQLite auth store — the store kiro-cli itself authenticates
+# from, and the authoritative live-token source (it refreshes this during normal
+# use; the JSON files above are not rewritten on refresh). Being kiro-cli's own
+# store is what makes a token here provably the SIGNED-IN account's credential,
+# which is the basis of the source-anchored path in ``fetch_usage_limits`` — the
+# same trust argument as scraping kiro-cli's own ``/usage`` output. On this host
+# the running ``kiro-cli acp`` processes were observed holding descriptors on
+# exactly this path.
+# ``~/.local/share`` is not a sensitive credential path, so this read is a direct
+# read-only sqlite open. auth_kv holds a JSON blob per key.
+_CLI_SQLITE_DBS = (
     Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3",
-    Path.home() / ".local" / "share" / "amazon-q" / "data.sqlite3",
     Path.home() / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3",
+)
+
+# Auth stores belonging to OTHER products (amazon-q). Readable, and often the same
+# account, but NOT kiro-cli's own credential — so a token from here can only be
+# used when a matching profile ARN proves the account independently. It can never
+# satisfy the source-anchored path.
+_OTHER_SQLITE_DBS = (
+    Path.home() / ".local" / "share" / "amazon-q" / "data.sqlite3",
     Path.home() / "Library" / "Application Support" / "amazon-q" / "data.sqlite3",
 )
 _SQLITE_TOKEN_KEYS = ("kirocli:odic:token", "codewhisperer:odic:token")
@@ -119,6 +168,11 @@ _MAX_RESP_BYTES = 1_000_000
 # definitive ListAvailableProfiles 200 (the value may be None for individual
 # accounts); transient failures are never cached. See _list_profile_arn.
 _PROFILE_ARN_CACHE: dict[str, str | None] = {}
+
+# Size cap for the two profile caches below. They are keyed by token digest and
+# never expire, so a long-lived gateway that sees many profile switches / token
+# refreshes would otherwise accumulate one entry each. See _remember_profile.
+_PROFILE_CACHE_MAX = 32
 
 # Human profile/display name for the signed-in account, captured as a side
 # effect of the same ListAvailableProfiles probe that yields the ARN and keyed
@@ -216,6 +270,22 @@ def _parse_iso(ts: object) -> datetime | None:
         return None
 
 
+def _expiry_if_unexpired(exp: object, now: datetime) -> datetime | None:
+    """Return the parsed expiry only when it is present, parseable, and future.
+
+    Deny-by-default, same contract as :func:`_unexpired` (which delegates here):
+    a missing or unparseable expiry rejects the credential rather than treating
+    it as non-expiring. The parsed value is returned rather than a bool so
+    :func:`_candidate_tokens` can order candidates by it without re-parsing.
+    """
+    if not exp:
+        return None
+    parsed = _parse_iso(exp)
+    if parsed is None or parsed <= now:
+        return None
+    return parsed
+
+
 def _unexpired(exp: object, now: datetime) -> bool:
     """True only when the expiry is present, parseable, and in the future.
 
@@ -224,19 +294,16 @@ def _unexpired(exp: object, now: datetime) -> bool:
     field, and the multi-candidate loop + text-scrape fallback absorb a false
     rejection gracefully — failing closed here costs nothing.
     """
-    if not exp:
-        return False
-    parsed = _parse_iso(exp)
-    if parsed is None:
-        return False
-    return parsed > now
+    return _expiry_if_unexpired(exp, now) is not None
 
 
-def _token_from_json(read_id: str, now: datetime) -> str | None:
-    """Return an unexpired accessToken from a sanctioned JSON SSO cache read.
+def _token_from_json(read_id: str, now: datetime) -> tuple[str, datetime] | None:
+    """Return ``(accessToken, expiry)`` from a sanctioned JSON SSO cache read.
 
     The bytes are read via ``hooks.safe_read_file_internal`` (not a direct
-    ``~/.aws`` read) so the sensitive-path deny rule + SEL audit apply.
+    ``~/.aws`` read) so the sensitive-path deny rule + SEL audit apply. The
+    expiry is returned alongside the token so candidates can be ordered by
+    freshness; ``None`` means no usable unexpired credential here.
     """
     raw = hooks.safe_read_file_internal(read_id)
     if not raw:
@@ -251,11 +318,12 @@ def _token_from_json(read_id: str, now: datetime) -> str | None:
     exp = data.get("expiresAt") or data.get("expires_at")
     if not isinstance(tok, str) or not tok:
         return None
-    return tok if _unexpired(exp, now) else None
+    expiry = _expiry_if_unexpired(exp, now)
+    return (tok, expiry) if expiry is not None else None
 
 
-def _token_from_sqlite(db: Path, now: datetime) -> str | None:
-    """Return an unexpired access_token from a kiro-cli/amazon-q SQLite store.
+def _token_from_sqlite(db: Path, now: datetime) -> tuple[str, datetime] | None:
+    """Return ``(access_token, expiry)`` from a kiro-cli/amazon-q SQLite store.
 
     Opened read-only; the token value is never logged. This is the live token
     source on Linux, where the JSON cache file is not refreshed. The store is
@@ -297,7 +365,8 @@ def _token_from_sqlite(db: Path, now: datetime) -> str | None:
             tok = blob.get("access_token") or blob.get("accessToken")
             exp = blob.get("expires_at") or blob.get("expiresAt")
             if isinstance(tok, str) and tok:
-                if not _unexpired(exp, now):
+                expiry = _expiry_if_unexpired(exp, now)
+                if expiry is None:
                     # The credential blob WAS read even though it is expired —
                     # record that access so the audit trail covers every read
                     # of the store, not only reads that yield a usable token.
@@ -309,7 +378,7 @@ def _token_from_sqlite(db: Path, now: datetime) -> str | None:
                 # is never returned — the caller degrades to the text scrape.
                 if not hooks.emit_internal_read_audit(_SQLITE_AUDIT_READ_ID, "success"):
                     return None
-                return tok
+                return (tok, expiry)
         # Audit-on-every-outcome: the DB was opened, so record the access even
         # when it yielded no usable token (missing rows / malformed blob / query
         # failure) — otherwise an opened credential store would leave no trail.
@@ -320,46 +389,83 @@ def _token_from_sqlite(db: Path, now: datetime) -> str | None:
         con.close()
 
 
-def _candidate_tokens() -> list[str]:
-    """Return all unexpired bearer tokens to try, in priority order (deduped).
+class _Candidate(NamedTuple):
+    """A usable bearer token plus the provenance needed to trust it.
 
-    Order: sanctioned JSON SSO cache reads (honored when an IDE keeps them
-    fresh), then the kiro-cli/amazon-q SQLite auth stores (the live, refreshed
-    token on Linux). Expired tokens are skipped and token values are never
-    logged.
+    ``from_cli_store`` is True only for a token read from kiro-cli's OWN auth
+    store (:data:`_CLI_SQLITE_DBS`). That flag is a trust claim, not a label: it
+    is what lets :func:`fetch_usage_limits` accept a credential for an account
+    with no profile ARN, because a token in kiro-cli's own store is the
+    signed-in account's credential by construction. Tokens from the JSON SSO
+    caches and from other products' stores carry False — they may well be the
+    same account, but nothing here proves it, so they are usable only when a
+    matching ARN proves it independently.
+    """
 
-    Multiple candidates are returned (not just the first) because "unexpired"
-    is not the same as "accepted": an unexpired-but-rejected JSON/IDE token
-    must not shadow a working SQLite token. ``fetch_usage_limits`` tries each in
-    turn until one is accepted, so a stale-yet-unexpired token can no longer
-    mask a good one. v1 does not refresh — kiro-cli keeps the SQLite token
-    fresh during normal use.
+    token: str
+    expiry: datetime
+    from_cli_store: bool
+
+
+def _candidate_tokens() -> list[_Candidate]:
+    """Return all unexpired candidates to try, freshest expiry first (deduped).
+
+    Path order is deliberately NOT the ranking. Every enumerated source can hold
+    a valid credential at the same time, so ordering by path meant a leftover
+    token from a profile the user has since signed out of was tried first and,
+    being genuinely valid, was accepted — the "wrong profile" readout. Ordering
+    by expiry descending puts the most recently issued credential first, because
+    a token refreshed later carries a later expiry.
+
+    This is a heuristic, not proof: sources can issue different lifetimes, so a
+    long-lived stale token could still outrank a short-lived fresh one. Ordering
+    only decides which proven candidate is tried first —
+    ``fetch_usage_limits`` establishes ownership itself, by matching ARN or by
+    provenance. Ties keep the original path precedence (``sorted`` is stable).
+
+    Multiple candidates are returned (not just the first) because "unexpired" is
+    not the same as "accepted": an unexpired-but-rejected token must not shadow a
+    working one. Expired tokens are skipped and token values are never logged.
+    v1 does not refresh — kiro-cli keeps its own store fresh during normal use.
     """
     now = datetime.now(timezone.utc)
-    seen: set[str] = set()
-    tokens: list[str] = []
+    # Deduped by token value, keeping the latest expiry seen for it and ORing the
+    # provenance: the same token can appear in more than one store, and if any of
+    # them is kiro-cli's own store then it is kiro-cli's credential.
+    freshest: dict[str, tuple[datetime, bool]] = {}
 
-    def _add(tok: str | None) -> None:
-        if tok and tok not in seen:
-            seen.add(tok)
-            tokens.append(tok)
+    def _add(found: tuple[str, datetime] | None, *, from_cli_store: bool) -> None:
+        if not found:
+            return
+        tok, exp = found
+        current = freshest.get(tok)
+        if current is None:
+            freshest[tok] = (exp, from_cli_store)
+        else:
+            freshest[tok] = (max(exp, current[0]), current[1] or from_cli_store)
 
     for read_id in _JSON_TOKEN_READ_IDS:
-        _add(_token_from_json(read_id, now))
-    for db in _TOKEN_SQLITE_DBS:
-        _add(_token_from_sqlite(db, now))
-    return tokens
+        _add(_token_from_json(read_id, now), from_cli_store=False)
+    for db in _CLI_SQLITE_DBS:
+        _add(_token_from_sqlite(db, now), from_cli_store=True)
+    for db in _OTHER_SQLITE_DBS:
+        _add(_token_from_sqlite(db, now), from_cli_store=False)
+    ranked = sorted(freshest.items(), key=lambda kv: kv[1][0], reverse=True)
+    return [_Candidate(tok, exp, own) for tok, (exp, own) in ranked]
 
 
 def _load_bearer_token() -> str | None:
     """Return the single freshest available bearer token, or None.
 
-    Thin convenience wrapper over :func:`_candidate_tokens` (first candidate).
-    ``fetch_usage_limits`` uses :func:`_candidate_tokens` directly so it can
-    fall through to the next source on a rejected-but-unexpired token.
+    Thin convenience wrapper over :func:`_candidate_tokens` (first candidate,
+    which is the freshest-expiry one). It discards provenance and applies NO
+    ownership proof, so it must not be used to choose the credential a request is
+    made with — ``fetch_usage_limits`` uses :func:`_candidate_tokens` directly so
+    it can check each candidate's account (by ARN or by provenance) and fall
+    through to the next source on a rejected-but-unexpired token.
     """
-    tokens = _candidate_tokens()
-    return tokens[0] if tokens else None
+    candidates = _candidate_tokens()
+    return candidates[0].token if candidates else None
 
 
 def _post(token: str, target: str, payload: dict) -> _Resp:
@@ -463,9 +569,26 @@ def _list_profile_arn(token: str) -> str | None:
                 name = pname[:100]
             break
     if arn is not None:
-        _PROFILE_ARN_CACHE[key] = arn  # memoize only a found ARN, per token
-        _PROFILE_NAME_CACHE[key] = name  # co-cached; None when profile had no name
+        _remember_profile(key, arn, name)
     return arn
+
+
+def _remember_profile(key: str, arn: str, name: str | None) -> None:
+    """Memoize a found ARN (and its co-cached display name) under a size cap.
+
+    Entries are keyed by token digest and never expire, so each profile switch
+    or token refresh adds one. The cap bounds that growth over a long-lived
+    gateway; eviction is insertion-order (dicts preserve it), and both caches are
+    evicted together so a name can never outlive the ARN it belongs to and be
+    attributed to a different account.
+    """
+    if key not in _PROFILE_ARN_CACHE and len(_PROFILE_ARN_CACHE) >= _PROFILE_CACHE_MAX:
+        oldest = next(iter(_PROFILE_ARN_CACHE), None)
+        if oldest is not None:
+            _PROFILE_ARN_CACHE.pop(oldest, None)
+            _PROFILE_NAME_CACHE.pop(oldest, None)
+    _PROFILE_ARN_CACHE[key] = arn
+    _PROFILE_NAME_CACHE[key] = name
 
 
 def _account_name(token: str) -> str | None:
@@ -615,35 +738,54 @@ def _map_response(data: dict) -> dict | None:
     return result
 
 
-def fetch_usage_limits() -> dict | None:
+def fetch_usage_limits(expected_arn: str | None) -> dict | None:
     """Fetch real credit usage via the direct RTS API. Synchronous (uses urllib).
 
-    Returns the canonical usage dict on success, or None on ANY failure
-    (no token, every candidate rejected, unparseable body, no CREDIT
-    breakdown). The caller treats None as "fall back to the text scrape" — this
-    function never raises and never logs the token (controls 4 & 5).
+    A candidate credential is used only when its ownership by the signed-in
+    account is PROVEN. There are two proofs, and ``expected_arn`` selects which:
 
-    Tries each candidate token in turn (JSON SSO cache, then SQLite auth store)
-    until one is accepted, so an unexpired-but-rejected token no longer shadows
-    a working one.
+    * **ARN-anchored** (``expected_arn`` is a non-empty ARN — the one
+      ``kiro-cli whoami`` reports for itself): a candidate qualifies when its own
+      ListAvailableProfiles ARN is present and equal. This admits a credential
+      from any readable source, including an IDE cache, because the ARN match is
+      the proof.
+    * **Source-anchored** (``expected_arn`` is ``None`` — the account has no
+      profile ARN, or whoami could not be resolved): a candidate qualifies only if
+      it came from kiro-cli's OWN auth store (``from_cli_store``). A token there is
+      the signed-in account's credential by construction — the identical trust
+      argument that makes scraping kiro-cli's own ``/usage`` output safe. Whatever
+      ARN that credential reports is then used for the request payload, so an
+      enterprise account on a kiro-cli that prints no ``Profile:`` block still gets
+      its real overage figure instead of the lossier scrape.
+
+    ``None`` is therefore NOT an unverified mode: it swaps ARN proof for
+    provenance proof. What it will never do is accept a credential from the JSON
+    SSO caches or another product's store, which is what let one Builder ID
+    account's leftover token be served as a different Builder ID account's balance.
+
+    Returns the canonical usage dict on success, or None on ANY failure (no
+    token, no candidate proven, unparseable body, no CREDIT breakdown). The caller
+    treats None as "fall back to the text scrape". This function never raises and
+    never logs the token (controls 4 & 5).
 
     Call from async code via ``asyncio.get_running_loop().run_in_executor(...)``
     so the blocking HTTP call does not stall the event loop.
     """
     try:
-        tokens = _candidate_tokens()
+        candidates = _candidate_tokens()
     except Exception:
         # Token acquisition must fail closed to the text scrape, never raise —
         # an escaping error would make the caller cache {"available": False}
         # and skip the fallback entirely.
         logger.debug("Kiro usage API: token acquisition failed", exc_info=True)
         return None
-    if not tokens:
+    if not candidates:
         logger.debug("Kiro usage API: no live bearer token available")
         return None
     reason = "unknown"
     deadline = time.monotonic() + _TOTAL_DEADLINE_SECS
-    for token in tokens:
+    for candidate in candidates:
+        token = candidate.token
         if time.monotonic() > deadline:
             # Bound total time so a host with several stale tokens can't stall
             # the pill for minutes; degrade to the text scrape instead.
@@ -651,7 +793,33 @@ def fetch_usage_limits() -> dict | None:
             logger.debug("Kiro usage API: %s; falling back to text scrape", reason)
             break
         try:
-            arn = _list_profile_arn(token)  # None for individual (non-enterprise) accounts
+            if not expected_arn and not candidate.from_cli_store:
+                # Source-anchored mode with nothing to prove this credential's
+                # account. Skip WITHOUT probing or spending it: this is the exact
+                # candidate class that produced the wrong-account readout.
+                reason = "no credential from kiro-cli's own store"
+                logger.debug(
+                    "Kiro usage API: skipping a credential that is not from "
+                    "kiro-cli's own auth store"
+                )
+                continue
+            arn = _list_profile_arn(token)
+            if expected_arn and (not arn or arn != expected_arn):
+                # ARN-anchored mode: not provably the signed-in account. Skip
+                # WITHOUT calling GetUsageLimits. A null ``arn`` is rejected rather
+                # than compared, because None carries no identity — it is what a
+                # transient profile lookup returns AND what every profile-less
+                # account returns, so comparing it would match one account's
+                # leftover credential against a different one.
+                #
+                # ARNs are not secret, but they identify an account, so only the
+                # outcome is logged.
+                reason = "no candidate credential proved it belongs to the signed-in profile"
+                logger.debug(
+                    "Kiro usage API: skipping a credential whose profile is absent or "
+                    "does not match the signed-in account"
+                )
+                continue
             payload: dict[str, object] = {"origin": "AI_EDITOR"}
             if arn:
                 payload["profileArn"] = arn
@@ -683,14 +851,16 @@ def fetch_usage_limits() -> dict | None:
                 # Coupling metadata for the caller's identity check (private —
                 # stripped before the payload is cached or served).
                 #
-                # These numbers may come from a DIFFERENT account than
-                # ``kiro-cli whoami`` reports: this client tries several
-                # candidate credentials (IDE cache first, then the kiro-cli
-                # store) and uses whichever the API accepts, while whoami always
-                # reports kiro-cli's own identity. Attaching an unverified email
-                # to these credits would misattribute an overage bill, so the
-                # caller must prove they refer to the same account before
-                # displaying an identity alongside them.
+                # These numbers now provably belong to the account kiro-cli is
+                # signed in as: no candidate with a different ARN could have
+                # reached this point. The ARN is still handed back because
+                # matching on ``None`` (both sides have no profile — a Builder ID
+                # account) is weaker than matching a specific ARN: two different
+                # Builder ID accounts both present no ARN, so that case is
+                # consistent but not proof of the same account. The caller's
+                # ``_identity_matches_account`` encodes exactly that distinction
+                # and is what decides whether an email may sit next to an overage
+                # figure.
                 mapped["_profile_arn"] = arn  # None for individual accounts
                 _note_api_outcome(True)
                 return mapped
@@ -705,5 +875,5 @@ def fetch_usage_limits() -> dict | None:
             reason = "unexpected error"
             logger.debug("Kiro usage API: unexpected error for a token candidate", exc_info=True)
             continue
-    _note_api_outcome(False, f"all {len(tokens)} candidate token(s) failed; last: {reason}")
+    _note_api_outcome(False, f"all {len(candidates)} candidate credential(s) failed; last: {reason}")
     return None

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -378,16 +378,35 @@ async def _fetch_usage_bg() -> None:
             _usage_cache = {"available": False}
             _usage_cache_ts = time.time()
             return
+        # Identity FIRST, because it is the anchor for credential selection.
+        # ``whoami`` is kiro-cli's own account, and it costs no credits; passing
+        # its profile ARN into fetch_usage_limits is what stops a still-valid
+        # credential from a signed-out profile supplying the numbers. Fetched
+        # once here and reused by both the API and text branches below (it used
+        # to be spawned separately in each).
+        identity = await _fetch_whoami(kiro_bin)
+        raw_arn = identity.get("_profile_arn")
+        expected_arn = raw_arn if isinstance(raw_arn, str) and raw_arn else None
         # Primary source: the real GetUsageLimits API. It reads the live bearer
-        # token kiro-cli maintains and returns the true used/limit/overage, so it
-        # survives kiro-cli stdout format changes (the regression that dropped
-        # the overage line). Runs on the subprocess pool (not the default
-        # to_thread pool): the client makes blocking urllib calls that can hang
-        # on DNS / a wedged TLS handshake, so they are isolated from the
-        # maintenance/cron pools. Fails closed (returns None) so we fall through
-        # to the text scrape rather than showing a fabricated number.
+        # token kiro-cli already maintains and returns the true used/limit/overage,
+        # so it survives kiro-cli stdout format changes (the regression that dropped
+        # the overage line).
+        #
+        # Both ARN values are safe to pass. An ARN anchors on identity; None
+        # anchors on PROVENANCE (kiro-cli's own auth store only) — see
+        # fetch_usage_limits. So an account with no profile ARN, and a whoami that
+        # could not be resolved at all, both still get the free API call instead of
+        # the credit-consuming text scrape, while an unprovable credential is still
+        # refused.
+        #
+        # Runs on the subprocess pool (not the default to_thread pool): the client
+        # makes blocking urllib calls that can hang on DNS / a wedged TLS
+        # handshake, so they are isolated from the maintenance/cron pools. Fails
+        # closed (returns None) so we fall through to the text scrape rather than
+        # showing a fabricated number.
         api_usage = await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(), kiro_usage_api.fetch_usage_limits
+            subprocess_executor(),
+            functools.partial(kiro_usage_api.fetch_usage_limits, expected_arn=expected_arn),
         )
         if api_usage and api_usage.get("credits_plan") is not None:
             # API output is untrusted too: redact every string leaf before caching.
@@ -396,7 +415,9 @@ async def _fetch_usage_bg() -> None:
             api_arn = api_usage.pop("_profile_arn", None)
             # Attach the signed-in identity ONLY when it provably belongs to the
             # account these credits were billed to (see _identity_matches_account).
-            identity = await _fetch_whoami(kiro_bin)
+            # Anchoring already guarantees this whenever an ARN existed on both
+            # sides; the check is kept as the independent assertion of it, and
+            # still carries the no-ARN (Builder ID) case on its own.
             if identity and _identity_matches_account(api_arn, identity):
                 api_usage.update(
                     {
@@ -439,13 +460,27 @@ async def _fetch_usage_bg() -> None:
             # dict is cached and served (kiro-cli output is untrusted).
             parsed = _normalize_text_usage(parsed)
             parsed = {k: _redact_strings(v) for k, v in parsed.items()}
-            # No coupling check needed here: this scrape IS kiro-cli's own
-            # `/usage` output, so it and `whoami` describe the same account by
-            # construction.
+            # No ARN coupling check here: this scrape IS kiro-cli's own `/usage`
+            # output, so it and `whoami` describe the same account by construction.
+            #
+            # But that argument only holds if the two are read ADJACENTLY, so the
+            # identity is re-resolved HERE rather than reusing the one fetched at
+            # the top of this refresh. Between them sit a whoami (≤30s), the API
+            # attempt (≤30s) and this scrape (≤60s) — a profile switch landing in
+            # that window would pair the OLD account's email with the NEW
+            # account's credits, which is the misattribution this whole path
+            # exists to prevent. whoami costs no credits, so a second spawn is
+            # the cheap side of that trade.
+            #
+            # The API branch above does not need this: it gates the merge on
+            # `_identity_matches_account`, so a mid-refresh switch makes the
+            # stale identity's ARN mismatch the accepted credential's and the
+            # email is simply dropped.
+            fresh_identity = await _fetch_whoami(kiro_bin)
             parsed.update(
                 {
                     k: _redact_strings(v)
-                    for k, v in (await _fetch_whoami(kiro_bin)).items()
+                    for k, v in fresh_identity.items()
                     if not k.startswith("_")
                 }
             )
@@ -500,7 +535,14 @@ async def api_sessions_usage(request: web.Request) -> web.Response:
         return blocked
     now = time.time()
     if now - _usage_cache_ts > _USAGE_REFRESH_SECS:
-        # Fire background fetch, return stale cache immediately
+        # Timed refresh only. An earlier revision also refreshed when the kiro-cli
+        # auth store changed on disk, to pick a profile switch up in seconds — but
+        # that store is shared: `data.sqlite3` holds `conversations`, `history` and
+        # `state` alongside `auth_kv`, so ordinary chat traffic rewrites it roughly
+        # every 30 seconds. The trigger therefore fired on nearly every poll, and
+        # each fire can reach the `/usage` text scrape, which spends credits. A
+        # faster readout is not worth billing the user for it; a profile switch is
+        # picked up on the next interval instead.
         state: DashboardState = request.app["state"]
         task = asyncio.create_task(_fetch_usage_bg())
         state._background_tasks.add(task)

--- a/test/test_kiro_usage_api.py
+++ b/test/test_kiro_usage_api.py
@@ -26,6 +26,17 @@ def _resp(status: int, body: object) -> MagicMock:
     return r
 
 
+def _cand(value: str, *, own: bool = True, hours: float = 1.0):
+    """Build a credential candidate for tests.
+
+    ``own`` defaults to True (kiro-cli's own auth store) so ARN-anchored tests stay
+    focused on the ARN check rather than incidentally tripping the provenance one.
+    Pass ``own=False`` for the JSON SSO caches / another product's store.
+    """
+    expiry = datetime.now(timezone.utc) + timedelta(hours=hours)
+    return api._Candidate(value, expiry, own)
+
+
 class TestBounded:
     def test_valid(self):
         assert api._bounded("42.5") == 42.5
@@ -193,14 +204,16 @@ class TestLoadBearerToken:
             return (json.dumps({"accessToken": "tok-abc", "expiresAt": future}).encode()
                     if read_id == "kiro_usage_api.sso_token_cli" else None)
         with patch("kiro_crew.hooks.safe_read_file_internal", side_effect=fake_read), \
-             patch.object(api, "_TOKEN_SQLITE_DBS", ()):
+             patch.object(api, "_CLI_SQLITE_DBS", ()), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() == "tok-abc"
 
     def test_skips_expired_json_token(self):
         past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
         blob = json.dumps({"accessToken": "old", "expiresAt": past}).encode()
         with patch("kiro_crew.hooks.safe_read_file_internal", return_value=blob), \
-             patch.object(api, "_TOKEN_SQLITE_DBS", ()):
+             patch.object(api, "_CLI_SQLITE_DBS", ()), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() is None
 
     def test_accepts_future_json_token(self):
@@ -210,12 +223,14 @@ class TestLoadBearerToken:
             return (json.dumps({"accessToken": "fresh", "expiresAt": future}).encode()
                     if read_id.endswith("cli") else None)
         with patch("kiro_crew.hooks.safe_read_file_internal", side_effect=fake_read), \
-             patch.object(api, "_TOKEN_SQLITE_DBS", ()):
+             patch.object(api, "_CLI_SQLITE_DBS", ()), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() == "fresh"
 
     def test_missing_sources_return_none(self, tmp_path):
         with patch("kiro_crew.hooks.safe_read_file_internal", return_value=None), \
-             patch.object(api, "_TOKEN_SQLITE_DBS", (tmp_path / "nope.sqlite3",)):
+             patch.object(api, "_CLI_SQLITE_DBS", (tmp_path / "nope.sqlite3",)), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() is None
 
     def test_falls_through_expired_json_to_sqlite(self, tmp_path):
@@ -236,7 +251,8 @@ class TestLoadBearerToken:
         con.close()
         with patch("kiro_crew.hooks.safe_read_file_internal", return_value=stale), \
              patch("kiro_crew.hooks.emit_internal_read_audit", return_value=True), \
-             patch.object(api, "_TOKEN_SQLITE_DBS", (db,)):
+             patch.object(api, "_CLI_SQLITE_DBS", (db,)), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() == "live-sqlite"
 
     def test_sqlite_token_denied_when_audit_cannot_be_recorded(self, tmp_path):
@@ -255,7 +271,8 @@ class TestLoadBearerToken:
         con.close()
         with patch("kiro_crew.hooks.safe_read_file_internal", return_value=None), \
              patch("kiro_crew.hooks.emit_internal_read_audit", return_value=False), \
-             patch.object(api, "_TOKEN_SQLITE_DBS", (db,)):
+             patch.object(api, "_CLI_SQLITE_DBS", (db,)), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() is None
 
     def test_skips_expired_sqlite_token(self, tmp_path):
@@ -272,7 +289,8 @@ class TestLoadBearerToken:
         con.close()
         with patch("kiro_crew.hooks.safe_read_file_internal", return_value=None), \
              patch("kiro_crew.hooks.emit_internal_read_audit", return_value=True) as audit, \
-             patch.object(api, "_TOKEN_SQLITE_DBS", (db,)):
+             patch.object(api, "_CLI_SQLITE_DBS", (db,)), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() is None
         # The credential blob WAS read even though expired — that access must
         # be recorded so the audit trail covers every read of the store.
@@ -304,7 +322,8 @@ class TestLoadBearerToken:
         # A JSON list/scalar cache entry must not raise on .get — it fails closed
         # (None) without aborting the remaining candidate sources.
         with patch("kiro_crew.hooks.safe_read_file_internal", return_value=b"[]"), \
-             patch.object(api, "_TOKEN_SQLITE_DBS", ()):
+             patch.object(api, "_CLI_SQLITE_DBS", ()), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() is None
 
     def test_symlinked_sqlite_db_is_rejected(self, tmp_path):
@@ -429,17 +448,18 @@ class TestFetchUsageLimits:
         # surfaced as the usage dict's ``account`` field.
         usage_body = {"usageBreakdownList": [
             {"resourceType": "CREDIT", "currentUsage": 5.0, "usageLimit": 100.0}]}
+        arn = "arn:aws:codewhisperer:...:profile/X"
 
         def fake_post(token, target, payload):
             if target == api._TARGET_LIST_PROFILES:
                 return _resp(200, {"profiles": [
-                    {"arn": "arn:aws:codewhisperer:...:profile/X",
+                    {"arn": arn,
                      "profileName": "Acme Corp"}]})
             return _resp(200, usage_body)
 
-        with patch.object(api, "_candidate_tokens", return_value=["tok"]), \
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
              patch.object(api, "_post", side_effect=fake_post):
-            out = api.fetch_usage_limits()
+            out = api.fetch_usage_limits(expected_arn=arn)
         assert out["account"] == "Acme Corp"
 
     def test_no_account_when_profile_has_no_name(self):
@@ -453,59 +473,63 @@ class TestFetchUsageLimits:
                 return _resp(200, {"profiles": [{"arn": "arn:x"}]})
             return _resp(200, usage_body)
 
-        with patch.object(api, "_candidate_tokens", return_value=["tok"]), \
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
              patch.object(api, "_post", side_effect=fake_post):
-            out = api.fetch_usage_limits()
+            out = api.fetch_usage_limits(expected_arn="arn:x")
         assert "account" not in out
 
     def test_rejected_token_falls_over_to_next(self):
         # An unexpired-but-rejected first token must not shadow a working one.
         usage_body = {"usageBreakdownList": [
             {"resourceType": "CREDIT", "currentUsage": 5.0, "usageLimit": 100.0}]}
+        arn = "arn:aws:codewhisperer:us-east-1:1:profile/A"
 
         def fake_post(token, target, payload):
             if target == api._TARGET_LIST_PROFILES:
-                return _resp(200, {"profiles": []})  # individual account, arn None
+                return _resp(200, {"profiles": [{"arn": arn}]})
             return _resp(403, {}) if token == "stale" else _resp(200, usage_body)
 
-        with patch.object(api, "_candidate_tokens", return_value=["stale", "live"]), \
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("stale"), _cand("live")]), \
              patch.object(api, "_post", side_effect=fake_post):
-            out = api.fetch_usage_limits()
+            out = api.fetch_usage_limits(expected_arn=arn)
         assert out is not None
         assert out["credits_used"] == 5.0
 
     def test_all_tokens_rejected_fails_closed(self):
-        with patch.object(api, "_candidate_tokens", return_value=["a", "b"]), \
-             patch.object(api, "_list_profile_arn", return_value=None), \
+        # A matching ARN so the candidates are ELIGIBLE and the 403 is what
+        # rejects them -- with a null ARN they would be skipped before _post and
+        # this would pass without exercising the rejection path at all.
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("a"), _cand("b")]), \
+             patch.object(api, "_list_profile_arn", return_value="arn:x"), \
              patch.object(api, "_post", return_value=_resp(403, {"reason": "FEATURE_NOT_SUPPORTED"})):
-            assert api.fetch_usage_limits() is None
+            assert api.fetch_usage_limits(expected_arn="arn:x") is None
 
     def test_request_exception_fails_closed(self):
-        with patch.object(api, "_candidate_tokens", return_value=["tok"]), \
-             patch.object(api, "_list_profile_arn", return_value=None), \
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
+             patch.object(api, "_list_profile_arn", return_value="arn:x"), \
              patch.object(api, "_post", side_effect=api._RequestError("boom")):
-            assert api.fetch_usage_limits() is None
+            assert api.fetch_usage_limits(expected_arn="arn:x") is None
 
     def test_non_json_body_fails_closed(self):
-        with patch.object(api, "_candidate_tokens", return_value=["tok"]), \
-             patch.object(api, "_list_profile_arn", return_value=None), \
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
+             patch.object(api, "_list_profile_arn", return_value="arn:x"), \
              patch.object(api, "_post", return_value=_resp(200, ValueError("not json"))):
-            assert api.fetch_usage_limits() is None
+            assert api.fetch_usage_limits(expected_arn="arn:x") is None
 
     def test_unexpected_error_fails_closed_not_raised(self):
         # An unforeseen exception for one token must be swallowed (fall back to
         # the text scrape), never propagate to _fetch_usage_bg.
-        with patch.object(api, "_candidate_tokens", return_value=["tok"]), \
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
              patch.object(api, "_list_profile_arn", side_effect=RuntimeError("boom")):
-            assert api.fetch_usage_limits() is None
+            assert api.fetch_usage_limits(expected_arn="arn:x") is None
 
     def test_aggregate_deadline_short_circuits(self):
         # Once the wall-clock budget is exhausted, no further tokens are tried —
         # the caller degrades to the text scrape instead of spinning for minutes.
         with patch.object(api, "_TOTAL_DEADLINE_SECS", -1), \
-             patch.object(api, "_candidate_tokens", return_value=["a", "b"]), \
+             patch.object(api, "_candidate_tokens", return_value=[_cand("a"), _cand("b")]), \
              patch.object(api, "_post") as mp:
-            assert api.fetch_usage_limits() is None
+            assert api.fetch_usage_limits(expected_arn="arn:x") is None
         mp.assert_not_called()
 
 
@@ -563,6 +587,314 @@ class TestListProfileArnCache:
             assert api._list_profile_arn("t2") is None
         with patch.object(api, "_post", return_value=_resp(200, {"profiles": [None]})):
             assert api._list_profile_arn("t3") is None
+
+
+class TestExpectedArnAnchor:
+    """A candidate credential is only used when it belongs to the account
+    ``kiro-cli whoami`` reports.
+
+    The bug: after switching Kiro profile, the previous profile's token is still
+    unexpired and still accepted by GetUsageLimits, so it supplied the credit
+    numbers — and a restart did not help, because candidate order was identical
+    on boot. Anchoring on whoami's profile ARN is what makes that impossible.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_arn_cache(self):
+        api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
+        yield
+        api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
+
+    ARN_A = "arn:aws:codewhisperer:us-east-1:1:profile/A"
+    ARN_B = "arn:aws:codewhisperer:us-east-1:2:profile/B"
+
+    def _fake_post(self, arn_for: dict[str, str], usage_for: dict[str, dict]):
+        def fake_post(token, target, payload):
+            if target == api._TARGET_LIST_PROFILES:
+                arn = arn_for.get(token)
+                profiles = [{"arn": arn}] if arn else []
+                return _resp(200, {"profiles": profiles})
+            return _resp(200, usage_for[token])
+        return fake_post
+
+    def test_foreign_credential_is_skipped_for_the_matching_one(self):
+        # Old profile's credential is first in the candidate list AND would be
+        # accepted by the API; the anchor must reach past it to the one that
+        # belongs to the signed-in account.
+        usage = {
+            "old-profile": {"usageBreakdownList": [
+                {"resourceType": "CREDIT", "currentUsage": 49.0, "usageLimit": 50.0}]},
+            "new-profile": {"usageBreakdownList": [
+                {"resourceType": "CREDIT", "currentUsage": 1200.0, "usageLimit": 10000.0}]},
+        }
+        arns = {"old-profile": self.ARN_B, "new-profile": self.ARN_A}
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("old-profile"), _cand("new-profile")]), \
+             patch.object(api, "_post", side_effect=self._fake_post(arns, usage)):
+            out = api.fetch_usage_limits(expected_arn=self.ARN_A)
+        assert out is not None
+        assert out["credits_plan"] == 10000.0, "used the signed-out profile's plan"
+        assert out["credits_used"] == 1200.0
+        assert out["_profile_arn"] == self.ARN_A
+
+    def test_foreign_credential_is_never_spent_on_a_usage_call(self):
+        # The mismatching credential must be dropped at the ARN probe, before a
+        # GetUsageLimits request is made with it.
+        usage = {"new-profile": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 1.0, "usageLimit": 10.0}]}}
+        arns = {"old-profile": self.ARN_B, "new-profile": self.ARN_A}
+        seen: list[tuple[str, str]] = []
+
+        inner = self._fake_post(arns, usage)
+
+        def recording_post(token, target, payload):
+            seen.append((token, target))
+            return inner(token, target, payload)
+
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("old-profile"), _cand("new-profile")]), \
+             patch.object(api, "_post", side_effect=recording_post):
+            assert api.fetch_usage_limits(expected_arn=self.ARN_A) is not None
+        assert ("old-profile", api._TARGET_GET_USAGE) not in seen
+
+    def test_all_foreign_fails_closed_to_the_text_scrape(self):
+        # Nothing matches -> None, so the caller degrades to scraping kiro-cli's
+        # own /usage output (right account by construction) rather than showing
+        # another account's balance.
+        usage = {"old-profile": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 49.0, "usageLimit": 50.0}]}}
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("old-profile")]), \
+             patch.object(api, "_post",
+                          side_effect=self._fake_post({"old-profile": self.ARN_B}, usage)):
+            assert api.fetch_usage_limits(expected_arn=self.ARN_A) is None
+
+    def test_unresolvable_arn_is_not_treated_as_a_match(self):
+        # A transient ListAvailableProfiles failure yields arn=None. With an
+        # anchor set that is NOT a match — otherwise a probe outage would
+        # reopen the exact hole being closed.
+        usage = {"tok": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 1.0, "usageLimit": 10.0}]}}
+
+        def fake_post(token, target, payload):
+            if target == api._TARGET_LIST_PROFILES:
+                return _resp(500, {})
+            return _resp(200, usage[token])
+
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
+             patch.object(api, "_post", side_effect=fake_post):
+            assert api.fetch_usage_limits(expected_arn=self.ARN_A) is None
+
+    def test_two_arnless_accounts_are_never_matched_to_each_other(self):
+        # Builder ID account B is signed in; a leftover credential from Builder ID
+        # account A is still readable. Both probe to arn=None, so no ARN comparison
+        # can separate them -- PROVENANCE is what does. A's leftover token lives in
+        # a JSON SSO cache or another product's store (kiro-cli rewrites its OWN
+        # store on login), so own=False, and it is refused.
+        usage = {"leftover-a": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 49.0, "usageLimit": 50.0}]}}
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("leftover-a", own=False)]), \
+             patch.object(api, "_post", side_effect=self._fake_post({}, usage)):
+            assert api.fetch_usage_limits(expected_arn=None) is None
+
+    def test_arnless_credential_from_the_cli_store_is_accepted(self):
+        # The other half of the rule, and why Builder ID accounts keep the FREE API
+        # path instead of being pushed onto the credit-spending scrape: a token from
+        # kiro-cli's own store IS the signed-in account's credential, so no ARN is
+        # needed to trust it.
+        usage = {"builder": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 3.0, "usageLimit": 50.0}]}}
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("builder", own=True)]), \
+             patch.object(api, "_post", side_effect=self._fake_post({}, usage)):
+            out = api.fetch_usage_limits(expected_arn=None)
+        assert out is not None
+        assert out["credits_used"] == 3.0
+
+    def test_cli_store_credential_wins_over_a_foreign_arnless_one(self):
+        # Ordering puts the foreign credential first; provenance must reach past it
+        # rather than taking the first thing that is merely readable.
+        usage = {
+            "leftover-a": {"usageBreakdownList": [
+                {"resourceType": "CREDIT", "currentUsage": 49.0, "usageLimit": 50.0}]},
+            "builder": {"usageBreakdownList": [
+                {"resourceType": "CREDIT", "currentUsage": 3.0, "usageLimit": 50.0}]},
+        }
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("leftover-a", own=False),
+                                        _cand("builder", own=True)]), \
+             patch.object(api, "_post", side_effect=self._fake_post({}, usage)):
+            out = api.fetch_usage_limits(expected_arn=None)
+        assert out is not None
+        assert out["credits_used"] == 3.0, "served the foreign account's balance"
+
+    def test_enterprise_arn_is_still_sent_when_whoami_gave_none(self):
+        # An org account on a kiro-cli that prints no "Profile:" block: whoami
+        # yields no ARN, so this takes the provenance route -- but the credential's
+        # OWN ARN must still reach the payload, or the API returns 403 and the
+        # account loses its overage figure to the scrape.
+        arn = "arn:aws:codewhisperer:us-east-1:9:profile/ORG"
+        usage = {"cli": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 12000.0, "usageLimit": 10000.0}]}}
+        sent: list[dict] = []
+        inner = self._fake_post({"cli": arn}, usage)
+
+        def recording_post(token, target, payload):
+            if target == api._TARGET_GET_USAGE:
+                sent.append(payload)
+            return inner(token, target, payload)
+
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("cli", own=True)]), \
+             patch.object(api, "_post", side_effect=recording_post):
+            out = api.fetch_usage_limits(expected_arn=None)
+        assert out is not None
+        assert out["credits_overage"] == 2000.0
+        assert sent and sent[0].get("profileArn") == arn
+
+    def test_arnless_candidate_rejected_against_a_real_anchor(self):
+        # ARN-anchored mode: a candidate with no ARN cannot match a real one, and
+        # provenance does NOT override an explicit ARN anchor.
+        usage = {"leftover-a": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 49.0, "usageLimit": 50.0}]}}
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("leftover-a", own=True)]), \
+             patch.object(api, "_post", side_effect=self._fake_post({}, usage)):
+            assert api.fetch_usage_limits(expected_arn=self.ARN_A) is None
+
+    def test_foreign_arnless_candidate_is_never_spent_on_a_request(self):
+        usage = {"leftover-a": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 49.0, "usageLimit": 50.0}]}}
+        seen: list[tuple[str, str]] = []
+        inner = self._fake_post({}, usage)
+
+        def recording_post(token, target, payload):
+            seen.append((token, target))
+            return inner(token, target, payload)
+
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("leftover-a", own=False)]), \
+             patch.object(api, "_post", side_effect=recording_post):
+            assert api.fetch_usage_limits(expected_arn=None) is None
+        # Refused before ANY request -- not even the profile probe is spent on it.
+        assert seen == []
+
+    def test_empty_anchor_behaves_as_no_anchor(self):
+        # A falsy ARN means "nothing to match on", so it takes the provenance route
+        # rather than being compared as a literal.
+        usage = {"tok": {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 1.0, "usageLimit": 10.0}]}}
+        with patch.object(api, "_candidate_tokens",
+                          return_value=[_cand("tok", own=False)]), \
+             patch.object(api, "_post", side_effect=self._fake_post({}, usage)):
+            assert api.fetch_usage_limits(expected_arn="") is None
+
+
+class TestCandidateOrdering:
+    """Candidates are ranked by expiry (freshest first), not by path order."""
+
+    def test_freshest_expiry_ranks_first(self, tmp_path):
+        # A stale-but-unexpired JSON credential sits in the highest-priority PATH
+        # slot; the SQLite store holds a newer one. Path order used to decide,
+        # which is how a signed-out profile won.
+        now = datetime.now(timezone.utc)
+        soon = (now + timedelta(minutes=20)).isoformat()
+        later = (now + timedelta(hours=8)).isoformat()
+        stale = json.dumps({"accessToken": "older-json", "expiresAt": soon}).encode()
+
+        db = tmp_path / "data.sqlite3"
+        con = sqlite3.connect(str(db))
+        con.execute("CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)")
+        con.execute(
+            "INSERT INTO auth_kv VALUES (?, ?)",
+            ("kirocli:odic:token",
+             json.dumps({"access_token": "newer-sqlite", "expires_at": later})),
+        )
+        con.commit()
+        con.close()
+
+        def fake_read(read_id):
+            return stale if read_id.endswith("cli") else None
+
+        with patch("kiro_crew.hooks.safe_read_file_internal", side_effect=fake_read), \
+             patch("kiro_crew.hooks.emit_internal_read_audit", return_value=True), \
+             patch.object(api, "_CLI_SQLITE_DBS", (db,)), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
+            cands = api._candidate_tokens()
+        assert [c.token for c in cands] == ["newer-sqlite", "older-json"]
+        # Provenance rides along: the sqlite one is kiro-cli's own store,
+        # the JSON SSO cache is not.
+        assert [c.from_cli_store for c in cands] == [True, False]
+
+    def test_equal_expiry_keeps_path_precedence(self):
+        # Stable sort: with nothing to choose between them, the original source
+        # order stands rather than an arbitrary one.
+        same = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+
+        def fake_read(read_id):
+            name = "cli-tok" if read_id.endswith("cli") else "ide-tok"
+            return json.dumps({"accessToken": name, "expiresAt": same}).encode()
+
+        with patch("kiro_crew.hooks.safe_read_file_internal", side_effect=fake_read), \
+             patch.object(api, "_CLI_SQLITE_DBS", ()), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
+            assert [c.token for c in api._candidate_tokens()] == ["cli-tok", "ide-tok"]
+
+    def test_duplicate_token_keeps_latest_expiry_and_appears_once(self):
+        # The same token in two stores must be tried once, ranked by its best
+        # known expiry.
+        now = datetime.now(timezone.utc)
+        early = (now + timedelta(minutes=5)).isoformat()
+        late = (now + timedelta(hours=9)).isoformat()
+
+        def fake_read(read_id):
+            exp = early if read_id.endswith("cli") else late
+            return json.dumps({"accessToken": "same", "expiresAt": exp}).encode()
+
+        with patch("kiro_crew.hooks.safe_read_file_internal", side_effect=fake_read), \
+             patch.object(api, "_CLI_SQLITE_DBS", ()), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
+            cands = api._candidate_tokens()
+        assert [c.token for c in cands] == ["same"]
+
+    def test_expired_candidates_excluded(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        blob = json.dumps({"accessToken": "old", "expiresAt": past}).encode()
+        with patch("kiro_crew.hooks.safe_read_file_internal", return_value=blob), \
+             patch.object(api, "_CLI_SQLITE_DBS", ()), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()):
+            assert api._candidate_tokens() == []
+
+
+class TestProfileCacheCap:
+    @pytest.fixture(autouse=True)
+    def _clear_arn_cache(self):
+        api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
+        yield
+        api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
+
+    def test_cache_is_bounded(self):
+        # Keyed by token digest and never expiring, so each profile switch adds
+        # an entry — the cap keeps a long-lived gateway from accumulating them.
+        for i in range(api._PROFILE_CACHE_MAX + 10):
+            with patch.object(api, "_post",
+                              return_value=_resp(200, {"profiles": [{"arn": f"arn:{i}"}]})):
+                api._list_profile_arn(f"token-{i}")
+        assert len(api._PROFILE_ARN_CACHE) <= api._PROFILE_CACHE_MAX
+        assert len(api._PROFILE_NAME_CACHE) <= api._PROFILE_CACHE_MAX
+
+    def test_both_caches_evict_together(self):
+        # A display name must never outlive the ARN it belongs to, or it could be
+        # shown next to a different account's credits.
+        for i in range(api._PROFILE_CACHE_MAX + 5):
+            with patch.object(api, "_post", return_value=_resp(200, {"profiles": [
+                    {"arn": f"arn:{i}", "profileName": f"Org {i}"}]})):
+                api._list_profile_arn(f"token-{i}")
+        assert set(api._PROFILE_ARN_CACHE) == set(api._PROFILE_NAME_CACHE)
 
 
 class TestSafeReadFileInternalSymlink:

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -144,11 +144,20 @@ class TestFindListeningPids:
 
 class TestProcessCommandLine:
     def test_self_cmdline_mentions_python(self):
-        # Our own process is a Python interpreter — its command line must mention
-        # python/pytest on every platform, and the call must never raise.
+        # Our own process is a Python interpreter, so when the probe returns
+        # anything it must mention python/pytest — and the call must never raise.
+        #
+        # An EMPTY result is tolerated because it is the function's documented
+        # failure return, not a defect: on Windows the probe shells out to
+        # PowerShell `Get-CimInstance Win32_Process` under a 10s timeout, and
+        # PowerShell cold-start plus a WMI query exceeds that on a loaded CI
+        # runner (TimeoutExpired is a SubprocessError, so it returns ""). Asserting
+        # non-empty there asserts more than `process_command_line` promises. Same
+        # reasoning as the find_listening_pids probe above.
         cl = pc.process_command_line(os.getpid())
         assert isinstance(cl, str)
-        assert "python" in cl.lower() or "pytest" in cl.lower()
+        if cl:
+            assert "python" in cl.lower() or "pytest" in cl.lower()
 
     def test_dead_pid_returns_empty_string(self):
         # A non-existent PID yields "" (fail-closed), never an exception.

--- a/test/test_session_usage.py
+++ b/test/test_session_usage.py
@@ -5,6 +5,8 @@ _fetch_usage_bg gating/redaction logic.
 from __future__ import annotations
 
 import asyncio
+import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -220,7 +222,12 @@ class TestFetchUsageBg:
         proc = _mock_proc(b"")
         proc.returncode = None  # still running
         proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+        # whoami is stubbed so `proc` stands in for the /usage scrape ALONE.
+        # _fetch_usage_bg resolves the identity first (it anchors credential
+        # selection), which is a second spawn; sharing one mock across both would
+        # make this assert on whoami's reap instead of the scrape's.
         with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "_fetch_whoami", AsyncMock(return_value={})), \
              patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             await sessions_mod._fetch_usage_bg()
         assert sessions_mod._usage_cache == {"available": False}
@@ -234,6 +241,7 @@ class TestFetchUsageBg:
         proc.returncode = None  # still running
         proc.communicate = AsyncMock(side_effect=RuntimeError("boom"))
         with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "_fetch_whoami", AsyncMock(return_value={})), \
              patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             await sessions_mod._fetch_usage_bg()
         assert sessions_mod._usage_cache == {"available": False}
@@ -289,15 +297,19 @@ class TestFetchUsageBgApi:
             "source": "api",
         }
         spawn = AsyncMock()
+        # The API path now requires a PROVEN profile ARN (no ARN -> the scrape),
+        # so whoami is stubbed with one rather than left to the bare spawn mock.
         with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "_fetch_whoami",
+                          AsyncMock(return_value={
+                              "email": "me@corp.com",
+                              "_profile_arn": "arn:aws:codewhisperer:us-east-1:1:profile/A"})), \
              patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
                           return_value=api_dict), \
              patch("asyncio.create_subprocess_exec", spawn):
             await sessions_mod._fetch_usage_bg()
         # API path wins: real total cached, and the CREDIT-CONSUMING text scrape
-        # (`kiro-cli chat ... /usage`) is never spawned. A cheap `whoami` spawn
-        # for the identity row is allowed -- it costs no credits -- so assert on
-        # the invariant that matters rather than on zero subprocesses.
+        # (`kiro-cli chat ... /usage`) is never spawned.
         assert sessions_mod._usage_cache["credits_used"] == 29527.0
         assert sessions_mod._usage_cache["credits_overage"] == 19527.0
         assert sessions_mod._usage_cache["source"] == "api"
@@ -322,6 +334,9 @@ class TestFetchUsageBgApi:
     async def test_api_string_fields_redacted_before_cache(self):
         api_dict = {"credits_used": 1.0, "credits_plan": 10.0, "plan": "SENSITIVE"}
         with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "_fetch_whoami",
+                          AsyncMock(return_value={
+                              "_profile_arn": "arn:aws:codewhisperer:us-east-1:1:profile/A"})), \
              patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
                           return_value=api_dict), \
              patch.object(sessions_mod, "redact_credentials", lambda s: (s, 0)), \
@@ -474,6 +489,62 @@ class TestIdentityAccountCoupling:
         _reset_usage_globals()
 
 
+class TestPollDoesNotSpendCredits:
+    """The 30s dashboard poll must not be able to trigger a refresh inside the
+    interval.
+
+    An earlier revision refreshed whenever the kiro-cli auth store changed on
+    disk, to pick a profile switch up in seconds. But that store is SHARED --
+    `data.sqlite3` holds `conversations`, `history` and `state` alongside
+    `auth_kv` -- so ordinary chat traffic rewrites it roughly every 30 seconds
+    (observed: the SQLite header change counter incrementing on that cadence with
+    sessions active). The trigger therefore fired on almost every poll, and a fire
+    can reach the `/usage` text scrape, which spends credits. Refreshing the
+    credit readout must never cost credits on a timer faster than the interval.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        _reset_usage_globals()
+        yield
+        _reset_usage_globals()
+
+    def _request(self):
+        request = MagicMock()
+        request.app = {"state": SimpleNamespace(_background_tasks=set())}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_fresh_cache_never_refreshes(self):
+        sessions_mod._usage_cache = {"credits_plan": 10.0}
+        sessions_mod._usage_cache_ts = time.time()
+        with patch.object(sessions_mod, "reject_if_kiro_unverified",
+                          AsyncMock(return_value=None)), \
+             patch.object(sessions_mod, "_fetch_usage_bg", AsyncMock()) as fetch:
+            resp = await sessions_mod.api_sessions_usage(self._request())
+        fetch.assert_not_called()
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_elapsed_interval_does_refresh(self):
+        # The timer is still the trigger -- this is not "never refresh".
+        sessions_mod._usage_cache = {"credits_plan": 10.0}
+        sessions_mod._usage_cache_ts = time.time() - (sessions_mod._USAGE_REFRESH_SECS + 1)
+        with patch.object(sessions_mod, "reject_if_kiro_unverified",
+                          AsyncMock(return_value=None)), \
+             patch.object(sessions_mod, "_fetch_usage_bg", AsyncMock()) as fetch:
+            await sessions_mod.api_sessions_usage(self._request())
+        fetch.assert_called_once()
+
+    def test_no_auth_store_trigger_is_reintroduced(self):
+        # Guard the reason, not just the behaviour: a filesystem-watching trigger
+        # on this handler cannot distinguish a credential write from a chat write,
+        # so reintroducing one re-creates the credit-spend loop.
+        assert not hasattr(sessions_mod, "_auth_store_changed")
+        assert not hasattr(sessions_mod, "_usage_auth_fingerprint")
+        assert not hasattr(sessions_mod.kiro_usage_api, "auth_store_fingerprint")
+
+
 class TestIdentityIsNotStale:
     """Identity must be re-resolved on every refresh, never memoized.
 
@@ -512,3 +583,137 @@ class TestIdentityIsNotStale:
     def test_no_lifetime_identity_cache_exists(self):
         # Guard against the memoization being reintroduced.
         assert not hasattr(sessions_mod, "_identity_cache")
+
+
+class TestCredentialSelectionIsAnchored:
+    """``_fetch_usage_bg`` resolves kiro-cli's own identity FIRST and hands its
+    profile ARN to ``fetch_usage_limits``, so credential selection cannot land on
+    a profile the user has signed out of."""
+
+    ARN = "arn:aws:codewhisperer:us-east-1:1:profile/A"
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        _reset_usage_globals()
+        yield
+        _reset_usage_globals()
+
+    @pytest.mark.asyncio
+    async def test_whoami_arn_is_passed_as_the_anchor(self):
+        api_dict = {"credits_used": 1.0, "credits_plan": 10.0, "source": "api",
+                    "_profile_arn": self.ARN}
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod, "_fetch_whoami",
+                          AsyncMock(return_value={"email": "me@corp.com",
+                                                  "_profile_arn": self.ARN})), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                          return_value=api_dict) as fetch:
+            await sessions_mod._fetch_usage_bg()
+        assert fetch.call_args.kwargs.get("expected_arn") == self.ARN
+
+    @pytest.mark.asyncio
+    async def test_api_branch_resolves_whoami_once(self):
+        # The API branch gates the identity merge on _identity_matches_account, so
+        # a stale identity is caught by the ARN comparison rather than needing a
+        # re-fetch. One spawn is therefore correct HERE.
+        whoami = AsyncMock(return_value={"email": "me@corp.com", "_profile_arn": self.ARN})
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod, "_fetch_whoami", whoami), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                          return_value={"credits_used": 1.0, "credits_plan": 10.0,
+                                        "source": "api", "_profile_arn": self.ARN}):
+            await sessions_mod._fetch_usage_bg()
+        assert whoami.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_text_branch_re_resolves_whoami_after_the_scrape(self):
+        # The text branch merges the identity WITHOUT an ARN check, on the grounds
+        # that the scrape and whoami are both kiro-cli's own output. That holds
+        # only if they are read adjacently: up to ~2 minutes separates the
+        # top-of-refresh whoami from the scrape (whoami 30s + API 30s + scrape
+        # 60s), and a profile switch inside that window would pair the OLD email
+        # with the NEW account's credits. So identity must be re-resolved AFTER
+        # the scrape, and the fresh one must win.
+        whoami = AsyncMock(side_effect=[
+            {"email": "old@corp.com"},   # top of refresh (the anchor attempt)
+            {"email": "new@corp.com"},   # after the scrape (what must be shown)
+        ])
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod, "_fetch_whoami", whoami), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                          return_value=None), \
+             patch("asyncio.create_subprocess_exec",
+                   AsyncMock(return_value=_mock_proc(SAMPLE_USAGE.encode()))):
+            await sessions_mod._fetch_usage_bg()
+        assert whoami.await_count == 2, "identity was not re-resolved after the scrape"
+        assert sessions_mod._usage_cache["source"] == "text"
+        assert sessions_mod._usage_cache["email"] == "new@corp.com", \
+            "cached the pre-scrape identity beside post-scrape credits"
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_identity_still_uses_the_api(self):
+        # _fetch_whoami returns {} for ANY failure, including its 30s timeout. That
+        # yields no ARN -- but the API is still safe to use, because with no ARN it
+        # anchors on PROVENANCE (kiro-cli's own auth store only). Skipping it here
+        # instead would push every such refresh onto the credit-spending scrape.
+        api_dict = {"credits_used": 1.0, "credits_plan": 10.0, "source": "api"}
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod, "_fetch_whoami", AsyncMock(return_value={})), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                          return_value=api_dict) as fetch:
+            await sessions_mod._fetch_usage_bg()
+        fetch.assert_called_once()
+        assert fetch.call_args.kwargs.get("expected_arn") is None
+        assert sessions_mod._usage_cache["source"] == "api"
+
+    @pytest.mark.asyncio
+    async def test_arnless_identity_still_uses_the_api(self):
+        # Builder ID: whoami resolves but carries no profile ARN. Same route, and
+        # this is the case that would otherwise bill the smallest quotas every
+        # refresh, forever.
+        api_dict = {"credits_used": 3.0, "credits_plan": 50.0, "source": "api"}
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod, "_fetch_whoami",
+                          AsyncMock(return_value={"email": "solo@b.com",
+                                                  "account_type": "BuilderId"})), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                          return_value=api_dict) as fetch:
+            await sessions_mod._fetch_usage_bg()
+        fetch.assert_called_once()
+        assert fetch.call_args.kwargs.get("expected_arn") is None
+        assert sessions_mod._usage_cache["source"] == "api"
+
+    @pytest.mark.asyncio
+    async def test_arnless_identity_does_not_spawn_the_billed_scrape(self):
+        # The harm being prevented, asserted directly: no `kiro-cli chat ... /usage`
+        # subprocess for a profile-less account when the API succeeds.
+        api_dict = {"credits_used": 3.0, "credits_plan": 50.0, "source": "api"}
+        spawn = AsyncMock()
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod, "_fetch_whoami",
+                          AsyncMock(return_value={"account_type": "BuilderId"})), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                          return_value=api_dict), \
+             patch("asyncio.create_subprocess_exec", spawn):
+            await sessions_mod._fetch_usage_bg()
+        for call in spawn.call_args_list:
+            assert "/usage" not in call.args, f"billed scrape spawned: {call.args}"
+
+    @pytest.mark.asyncio
+    async def test_private_coupling_key_never_reaches_the_cache(self):
+        api_dict = {"credits_used": 1.0, "credits_plan": 10.0, "source": "api",
+                    "_profile_arn": self.ARN}
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "wrap_argv", lambda argv, **k: (list(argv), None)), \
+             patch.object(sessions_mod, "_fetch_whoami",
+                          AsyncMock(return_value={"_profile_arn": self.ARN})), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                          return_value=api_dict):
+            await sessions_mod._fetch_usage_bg()
+        assert "_profile_arn" not in sessions_mod._usage_cache


### PR DESCRIPTION
## Description

The credit pill in the top-right nav kept showing the **previous Kiro profile's**
credits after switching profile, and quitting and reopening the app did not
reliably fix it — it corrected itself only once the old credential expired on its
own (users reported it "catching up" ~40 minutes later). Reported alongside "KC
seems to default to builder profile", which is the same bug with a Builder ID
credential winning over an SSO one.

### Cause

`kiro_usage_api._candidate_tokens()` ranked candidate credentials by **fixed path
order** (`~/.aws/sso/cache/*.json`, then the kiro-cli/amazon-q SQLite stores) and
the only filter was "not expired". A credential for a profile the user has signed
out of stays valid at `GetUsageLimits` until its own expiry, so when it sat in an
earlier slot it was tried first and legitimately accepted. `fetch_usage_limits`
had no notion of *which* account it was supposed to be reading, and the ordering
was identical on boot — hence the restart not helping.

Two aggravating factors: nothing watched the auth stores, so even once the right
credential won, the number lagged by up to the 10-minute refresh interval; and
`_identity_matches_account` already detected the disagreement between the API's
account and `whoami`'s, but its only response was to omit the email — the wrong
account's credits were still rendered, with no signal.

### Fix

Prove ownership before using a credential, with **two** proofs and no unverified
path. `_fetch_usage_bg` resolves `kiro-cli whoami` first and passes its profile ARN
to `fetch_usage_limits`:

- **ARN-anchored** (whoami reported an ARN): a candidate qualifies when its own
  `ListAvailableProfiles` ARN is present and equal. A null ARN is rejected outright
  rather than compared — `None` is both what a transient profile lookup returns and
  what every profile-less account returns, so comparing it would match one account's
  leftover credential against a different one.
- **Source-anchored** (whoami reported no ARN — a Builder ID account, an older
  kiro-cli that prints no `Profile:` block, or a whoami that failed): a candidate
  qualifies only if it came from kiro-cli's **own** auth store. A token there is the
  signed-in account's credential by construction — the identical trust argument that
  makes scraping kiro-cli's own `/usage` output safe. Whatever ARN that credential
  reports is still sent in the payload, so an enterprise account on an older
  kiro-cli keeps its real overage figure.

Either way, a credential that cannot be tied to the signed-in account is dropped
before any request is made with it, and the caller degrades to the scrape.

Source-anchoring is what keeps the **free** API path available to every account
class. Requiring an ARN instead pushed all profile-less accounts onto the text
scrape, which is `kiro-cli chat --no-interactive /usage` — a *billed* call — on
every refresh, indefinitely, hitting the smallest quotas hardest. It also refuses
the credential class that actually caused the reported bug: a leftover token in a
JSON SSO cache or another product's store, since `kiro-cli login` rewrites only its
own store.

Supporting changes:

- **Freshest-expiry ordering** replaces path order, so among proven candidates a
  just-issued credential is tried before a stale readable one. Ties keep the
  previous path precedence. Documented as a heuristic: it only decides ORDER,
  never eligibility — the ARN match or the provenance check is what establishes
  ownership.
- **No fast-invalidation.** An earlier revision also refreshed whenever the
  kiro-cli auth store changed on disk, so a profile switch landed in seconds. That
  was removed after review: `data.sqlite3` is SHARED — it holds `conversations`,
  `history` and `state` alongside `auth_kv` — so ordinary chat traffic rewrites it
  roughly every 30 seconds (measured: the SQLite header change counter incrementing
  on that cadence with sessions active). The trigger fired on nearly every poll, and
  for a profile-less account a fire reaches the credit-consuming `/usage` scrape.
  A faster readout is not worth billing the user for it, so the refresh is
  timed-only and a switch is picked up on the next 10-minute interval.
  `TestPollDoesNotSpendCredits` guards against reintroducing it.
- **One `whoami` per refresh** instead of a separate spawn in the API and text
  branches.
- **Bounded profile caches.** `_PROFILE_ARN_CACHE` / `_PROFILE_NAME_CACHE` are
  keyed by credential digest and never expired, so each profile switch added an
  entry for the life of the gateway. Now capped, with both evicting together so a
  display name can never outlive the ARN it belongs to.

### Scope

This PR fixes KiroCrew's own **credit readout**. It does not change which profile
the agent authenticates with.

An earlier revision of this description claimed agent turns "were always on the
correct profile". That was asserted without verification and is withdrawn — what
is actually established is narrower:

- **There is no account-change invalidation anywhere in the tree.** A long-lived
  `kiro-cli` process is recycled only by age (6 h), RSS (500 MiB), process death,
  or the idle sweep (60 min — and `_bg`, `_heartbeat` and `channel:` sessions are
  sweep-exempt, so they can outlive a profile switch indefinitely). The one
  auth-linked teardown is *reactive*: `chat_runner` resets a slot on
  `AcpAuthRequired`. Switching to a **different valid** profile raises no auth
  error, so that path never fires.
- **`KiroPrerequisiteService` stores no identity.** `whoami` is consumed purely as
  an exit code (`kiro_prerequisite.py:1940-1948`); stdout is discarded. Signed-in
  as A → signed-in as B is indistinguishable from no change, and the readiness
  gate keeps reporting `verified` because both accounts pass its only test.
- **Empirically, the storage layer does not pin credentials.** On kiro-cli 2.14.0
  the auth store is `journal_mode=delete` with `locking_mode=normal`; no
  persistent lock was observed over a 60 s poll, and the header change counter
  increments every ~30 s. Under those semantics a reader re-acquires SHARED and
  re-validates the change counter each transaction, so a live process's next read
  picks up another process's write rather than serving an indefinitely stale copy.

So the agent most likely does pick up the new profile — but that is an inference
from SQLite semantics, not a traced observation, and it does **not** rule out
kiro-cli caching a decoded bearer in memory above the storage layer (`strace` is
unavailable on the host, so this was not falsified). If it does cache, the
sweep-exempt sessions above are exactly where a stale-profile process would
persist longest.

Treat this PR as fixing the display bug it demonstrably fixes, not as making the
agent profile-switch-safe. The absence of any account-change signal is a separate,
larger gap — `KiroPrerequisiteService` is its natural home, since it already owns
probing and the readiness latch — and is worth its own issue.


No frontend changes: with selection anchored, a mismatch now yields *no* API
result (falling back to kiro-cli's own output) instead of a confidently-wrong
number, so there is no new UI state to render.

## Related Issues

Reported in Slack by two users (profile switch not picked up; login defaulting to
the builder profile instead of the Max/SSO plan). No tracking issue filed.

## Testing

- [x] Existing tests pass (22,250 passed locally)
- [x] New tests added for new functionality
- [ ] Manual verification performed

**New tests**, all revert-verified AND checked to be discriminating (a test that
still passes with the fix reverted was rewritten — this caught two non-discriminating
assertions during review):

- `TestExpectedArnAnchor` — a foreign credential that *would* be accepted is skipped
  for the matching one; it is never spent on a `GetUsageLimits` call; all-foreign fails
  closed to the scrape; an unresolvable ARN is not a match; a NULL ARN is rejected
  outright (driven directly with the contract-violating `None` so the guard is proven
  not to depend on the caller); an empty-string ARN likewise.
- `TestCandidateOrdering` — freshest expiry ranks first, equal expiry keeps path
  precedence, duplicates collapse to one entry at their best expiry.
- `TestCredentialSelectionIsAnchored` — the anchor is really passed through, `whoami` is
  resolved once per refresh, an absent or empty ARN skips the API entirely, and the
  private `_profile_arn` never reaches the cache.
- `TestPollDoesNotSpendCredits` — a fresh cache never refreshes, an elapsed interval
  still does, and the removed filesystem-watching trigger cannot be reintroduced.
- `TestProfileCacheCap` — bounded, and both caches evict together.
- `TestProcessCommandLine::test_self_cmdline_mentions_python` (`test/test_platform_compat.py`) — **one file outside this PR's subject**, explained in a PR comment. The Windows probe shells out to PowerShell `Get-CimInstance` under a 10s timeout and returns `""` when that is exceeded, which is its documented failure return; the test now tolerates the empty result while still requiring a non-empty one to mention python/pytest, matching the convention the `find_listening_pids` test in the same file already uses. Happy to split this out if a maintainer prefers the PR stay at four files.

Revert-verification: disabling the anchor check fails 4 of the 5 anchor tests
(the 5th is the no-anchor case, correctly unaffected); reverting to path order
fails the ordering test; removing the endpoint trigger fails the wiring test.

Two existing reap tests were updated to stub `_fetch_whoami`: they share one mock
process across all spawns, and with identity now resolved first they would have
asserted on `whoami`'s reap instead of the scrape's. The assertions themselves
are unchanged.

**Not manually verified.** Reproducing this needs two real Kiro profiles (one
enterprise/SSO with a profile ARN, one Builder ID) and a live sign-out/sign-in
cycle, which I cannot do from this environment. The behaviour is covered by the
tests above, but a reviewer with two profiles confirming the pill follows a
`kiro-cli login` switch within a poll or two would be worth having.

Pre-existing failures unrelated to this diff, all reproduced on unmodified main:
one `mypy` error in `vector_memory.py` (faiss stub overload), three
`test_dashboard_origin.py` failures from `KIROCREW_PORT` env leakage, and PTY /
autonudge timing flakes that pass in isolation.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) — no user-facing docs describe
      credential selection; the rationale is documented in the module docstring
- [x] No secrets, credentials, or internal references in the diff





