### PR TITLE
fix(spawn): apply child resource limits after exec instead of forking the gateway

### DIFF
--- a/docs/resource-protection.md
+++ b/docs/resource-protection.md
@@ -25,7 +25,7 @@ of failure.
 | ACP prompt timeout | `acp/client.py` | Per-prompt | 2 hr (`_DEFAULT_PROMPT_TIMEOUT`) | No | Raises `AcpTimeoutError` |
 | ACP read timeout | `acp/client.py` | Per-readline | 20s (`_READ_TIMEOUT`) | No | Allows `CancelledError` delivery at each yield point |
 | Process group kill | `acp/client.py` | Process cleanup | Immediate | No | `killpg(SIGTERM)` → `killpg(SIGKILL)` → `_kill_escaped_children` for different-PGID descendants |
-| Per-process resource limits | `security.py` (`apply_resource_limits`) via `sandbox.py` (`resource_limit_preexec`) | Every agent-influenced spawn (MCP servers, app backends, cron scripts, git, hooks, voice). Exception: the trusted ACP session-host spawns (`acp/client.py`, `acp/runtime.py`) use `sandbox.py:session_host_preexec()`, which RAISES NOFILE to the inherited hard limit instead — a session host multiplexes many MCP pipe pairs and the 1024 cap caused EMFILE crashes | Kernel-enforced `RLIMIT_NOFILE=1024` default-on; `RLIMIT_NPROC`/`RLIMIT_CPU`/`RLIMIT_AS` opt-in (default off) | Yes — kernel enforces at fork/alloc/open time, no sweep needed | Kernel refuses `open()` past the FD cap (EMFILE); on opt-in NPROC/CPU/AS, EAGAIN / SIGXCPU / ENOMEM |
+| Per-process resource limits | `security.py` (`apply_resource_limits`) delivered **after `exec`** by `_spawn_exec_shim.py` via `sandbox.py` (`create_subprocess_limited` / `spawn_shim_argv`) | Every agent-influenced spawn (MCP servers, app backends, cron scripts, git, hooks, voice). Async spawns use the `tool` profile; the trusted ACP session-host spawns (`acp/client.py`, `acp/runtime.py`) use the `session_host` profile, which RAISES NOFILE to the inherited hard limit instead — a session host multiplexes many MCP pipe pairs and the 1024 cap caused EMFILE crashes. Synchronous `subprocess.run`/`Popen` spawns still use `resource_limit_preexec` as `preexec_fn=` | Kernel-enforced `RLIMIT_NOFILE=1024` default-on; `RLIMIT_NPROC`/`RLIMIT_CPU`/`RLIMIT_AS` opt-in (default off) | Yes — kernel enforces at fork/alloc/open time, no sweep needed | Kernel refuses `open()` past the FD cap (EMFILE); on opt-in NPROC/CPU/AS, EAGAIN / SIGXCPU / ENOMEM |
 | cgroup v2 scope (fork bomb + memory) | `sandbox.py` (`cgroup_scope_argv`) | Every agent-influenced spawn tree (root agent + all its MCP servers/subagents as one scope; each cron/app-backend/hook/git/tool spawn its own) | `pids.max=8192` (`TasksMax`) + `memory.max=65% of host RAM` (`MemoryMax`, `MemorySwapMax=0`) per transient `systemd --user --scope` under `kirocrew-agents.slice`, default-on where cgroup v2 delegation exists. Note: `pids.max` counts tasks (threads), not processes — 8192 accommodates JVM build trees while still bounding fork bombs. | Yes — kernel enforces at fork()/alloc time; OOM-kills the scope on memory breach, `fork()` fails EAGAIN past `pids.max` | Fork bomb bounded to `pids.max`; memory balloon OOM-killed at `memory.max`. Unavailable (no delegation/macOS) → no-op + one loud SECURITY warning; RLIMIT_NOFILE still applies |
 | Bounded restart shutdown | `dashboard/handlers.py` | Dashboard ⚡ Apply & Restart | 5s (`_SHUTDOWN_TIMEOUT_SECS`) | No | `asyncio.wait_for` on `provider.shutdown()`; `_sync_kill_provider` fallback on timeout |
 | Subagent injection outer cap | `subagent.py _run()` | Per-subagent completion | 1200s (`_ON_DONE_TIMEOUT`) | No | Semaphore wait + injection combined; on timeout kills stuck kiro-cli via `sessions.reset()` and queues failure event for parent to drain |
@@ -65,21 +65,55 @@ of failure.
    sweep catches MCP children but not the root kiro-cli process.
 
 3. **Per-process resource limits — implemented and wired (Talos bdf0d7e5 / V2285983353).**
-   `security.py:apply_resource_limits(config)` returns a `preexec_fn` that applies POSIX
-   `setrlimit` caps in the child (post-fork, pre-exec), and `sandbox.py:resource_limit_preexec()`
-   is the cached accessor every agent-influenced spawn passes as `preexec_fn=` — the ACP
-   session-host spawns (`acp/client.py`, `acp/runtime.py`) now use
-   `sandbox.py:session_host_preexec()` instead, which RAISES NOFILE to the inherited hard limit
-   for the trusted session host (it multiplexes many MCP pipe pairs); all other
-   agent-influenced spawns keep `resource_limit_preexec` — MCP server probes
-   (`mcp_discovery.py`), app backends and their dependency installs (`apps/backend.py`), the app
-   registry's git clone/build spawns (`apps/registry.py`, `apps/routes.py`), builtin app
-   subprocesses (deploy_web, file_explorer), cron scripts/commands
-   (`cron_script.py`), the task runner's test spawn (`task_executor.py`), agent-selected git
-   (`git_coord.py`), shell hooks (`hooks.py`), the knowledge worker pool
-   (`knowledge/llm_pool.py`), and voice synthesis (`voice_reply.py`).
+   `security.py:apply_resource_limits(config)` resolves the POSIX `setrlimit` caps, and
+   `sandbox.py:resource_limit_spec()` renders them as the `RLIMIT_NAME:value` policy string that
+   `_spawn_exec_shim.py` applies **after `exec`**, in the single-threaded child.
+   `sandbox.py:create_subprocess_limited()` is the accessor every agent-influenced ASYNC spawn
+   uses; it prepends the shim and passes `preexec_fn=None`. Profiles: `tool` (default),
+   `session_host` for the ACP spawns (`acp/client.py`, `acp/runtime.py`), which RAISE NOFILE to
+   the inherited hard limit for the trusted session host (it multiplexes many MCP pipe pairs),
+   `build` for the dev-fleet build spawns (vite/npm need thousands of descriptors), and `none`
+   for the user's own interactive terminal, which never carried caps. Covered spawns: MCP server
+   probes (`mcp_discovery.py`), app backends and their dependency installs (`apps/backend.py`),
+   the app registry's git clone/build spawns (`apps/registry.py`, `apps/routes.py`), builtin app
+   subprocesses (deploy_web, file_explorer), cron scripts/commands (`cron_script.py`), the task
+   runner's test spawn (`task_executor.py`), agent-selected git (`git_coord.py`), shell hooks
+   (`hooks.py`), the knowledge worker pool (`knowledge/llm_pool.py`), and voice synthesis
+   (`voice_reply.py`).
    `test/test_spawn_audit.py` enforces that every sandbox-routed spawn also applies the ceiling,
    so the helper cannot regress to dead code.
+
+   **Why after `exec` and not in a `preexec_fn` (issue #935).** `preexec_fn` forces CPython off
+   `posix_spawn`/`vfork` onto a plain `fork()` of the multi-GB, ~118-thread gateway, and runs
+   Python bytecode in the child before `exec`. A lock another thread held at fork time cannot be
+   released there, so the child can wedge before ever reaching `exec` — and a wedged child takes
+   more than itself down:
+
+   - `subprocess.Popen._execute_child` blocks in an unbounded `os.read(errpipe_read, ...)`
+     waiting for the child to exec or die. For `asyncio.create_subprocess_exec` that read runs on
+     the event loop thread with no `await` point, so no `asyncio.wait_for` can interrupt it and
+     the whole gateway stops.
+   - `_posixsubprocess`'s `child_exec()` runs `_close_open_fds()` *after* `preexec_fn`, so the
+     wedged child still holds a duplicate of every inherited fd — `gateway.lock` and the
+     dashboard's listening socket included, which then outlive the gateway.
+
+   This was observed in production (one child deadlocked in a futex, never exec'd, and pinned the
+   fds it inherited). Limits set post-`exec` are inherited by the exec'd image and all its
+   descendants, so coverage is unchanged; only the delivery point moved. `test/
+   test_spawn_preexec_guard.py` is the AST tripwire that keeps a new async call site from
+   reintroducing the fork. Synchronous `subprocess.run`/`Popen` spawns still use
+   `resource_limit_preexec` — they wedge a worker thread rather than the event loop — and are the
+   tracked follow-up.
+
+   **Two documented exceptions**, both allowlisted in the tripwire:
+   - `sandbox.py:create_subprocess_limited`'s own fallback, for a host with no usable shim
+     (non-POSIX, or a truncated install). Dropping the caps silently would be worse.
+   - `dashboard/handlers/terminal.py:api_terminal_ws`, the user's interactive shell. It carries
+     **no** resource policy — no rlimits, no OOM bias — so the shim had nothing to deliver for it
+     while costing an interpreter startup on every terminal open (measurably doubling the terminal
+     test file's wall time). Its `preexec_fn` is a single pre-resolved `ioctl` with no allocation
+     and no lock acquisition, which is the only shape where a fork-child callable is defensible.
+     The fork remains; the risk is accepted and stated at the call site.
 
    **Defaults — only the one safe-by-default limit is on; the hazardous knobs are opt-in:**
    - `RLIMIT_NOFILE = 1024` (default-on) — max open file descriptors. It is **per-process**,
@@ -143,9 +177,11 @@ of failure.
      because hard quotas slow legitimate builds — grok-build and OpenClaw likewise ship no
      default CPU quota, relying on fair scheduling plus timeouts.
 
-   The RLIMIT preexec additionally writes `oom_score_adj=1000` on every spawned child
+   The spawn shim additionally writes `oom_score_adj=1000` on the child it execs
    (inherited by its descendants), biasing the kernel OOM killer toward tool subprocesses so a
    memory-ballooning command is killed *before* `memory.max` takes out the entire agent scope.
+   It is requested explicitly (`--oom-bias`) by the `tool` and `build` profiles only: a trusted
+   session host and the user's own terminal are not preferred kill targets.
 
    The kernel enforces both at `fork()`/allocation time — no reaper race. `--scope` execs into
    the target (it does not fork a wrapper), so the gateway's PID tracking / `killpg` /

--- a/src/kiro_crew/_spawn_exec_shim.py
+++ b/src/kiro_crew/_spawn_exec_shim.py
@@ -1,0 +1,200 @@
+"""Post-exec shim: apply a child's resource limits, then ``exec`` the real command.
+
+Spawned as::
+
+    <sys.executable> -I -S -c <this file's source> [--rlimits=SPEC] [--oom-bias] -- argv...
+
+and replaces itself with ``argv`` via ``execv``, so the PID, process group,
+session, inherited fds, and exit status the caller observes are all the child's
+own -- this is a shim, not a supervisor: it never forks and never waits.
+
+Why this exists
+---------------
+Handing the same ``setrlimit`` calls to ``preexec_fn`` instead makes CPython
+``fork()`` the multi-GB, ~118-thread gateway and run Python bytecode in the
+child before ``exec``. A lock another thread held at fork time can never be
+released there, so the child can deadlock before reaching ``exec`` -- and when it
+does, two things follow that a per-command timeout cannot reach:
+
+* ``subprocess.Popen._execute_child`` blocks in an unbounded
+  ``os.read(errpipe_read, ...)`` waiting for the child to exec or die. For
+  ``asyncio.create_subprocess_exec`` that read happens on the event loop thread,
+  with no ``await`` point, so the whole gateway stops.
+* ``_posixsubprocess``'s ``child_exec()`` runs ``_close_open_fds()`` *after*
+  ``preexec_fn``, so a child wedged in ``preexec_fn`` still holds a duplicate of
+  every parent fd -- including the dashboard's listening socket, which then
+  survives the gateway it outlived.
+
+Running the limits here instead removes the whole class: the process is
+single-threaded post-exec, and with ``preexec_fn=None`` the fork child executes
+only async-signal-safe C. Limits set here are inherited by the exec'd image and
+all of its descendants, so coverage is unchanged.
+
+Kept stdlib-only and import-light on purpose: it is executed as an immutable
+source string captured by the gateway at import time, never imported from the
+(agent-writable) package directory at spawn time. ``-S`` is part of that fence --
+it skips ``site``, so a ``sitecustomize`` dropped into site-packages cannot run
+ahead of this code -- and it also halves interpreter startup.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+try:
+    import resource as _resource
+except ImportError:  # pragma: no cover - Windows has no POSIX rlimits
+    _resource = None  # type: ignore[assignment]
+
+_RLIMIT_FLAG = "--rlimits="
+_OOM_BIAS_FLAG = "--oom-bias"
+_ARGV_SEPARATOR = "--"
+# Shell convention for "command found but could not be executed", so a caller
+# that only sees the exit status can still tell an exec failure from the
+# command's own nonzero exit.
+_EXEC_FAILED = 127
+# Matches sandbox.session_host_preexec: raise NOFILE to the inherited hard cap,
+# or to this floor when the kernel reports no ceiling at all.
+_UNLIMITED_NOFILE_FLOOR = 65536
+
+
+def _parse_rlimits(spec: str) -> list[tuple[int, int | None]]:
+    """Resolve ``RLIMIT_NAME:value`` pairs into ``(rlimit id, value)`` tuples.
+
+    ``value`` is ``None`` for the literal token ``hard``, which means "raise the
+    soft limit to the inherited hard limit" rather than a numeric request.
+    Unknown names and unparseable values are skipped rather than failing the
+    spawn, matching ``security.apply_resource_limits``.
+
+    Called BEFORE :func:`_apply_rlimits` so every allocation this parse needs
+    happens while the process still has its inherited budget.
+    """
+    if _resource is None or not spec:
+        return []
+    parsed: list[tuple[int, int | None]] = []
+    for item in spec.split(","):
+        name, _, raw = item.partition(":")
+        res_id = getattr(_resource, name, None)
+        if not isinstance(res_id, int):
+            continue
+        if raw == "hard":
+            parsed.append((res_id, None))
+            continue
+        try:
+            parsed.append((res_id, int(raw)))
+        except ValueError:
+            continue
+    return parsed
+
+
+def _apply_rlimits(pairs: list[tuple[int, int | None]]) -> None:
+    """Apply pre-parsed limits to this process.
+
+    Mirrors ``security.apply_resource_limits``: clamp a numeric request DOWN to
+    the inherited hard limit (never try to raise a ceiling), set soft AND hard so
+    the child cannot lift its own cap back up, and swallow per-limit failures so
+    an rlimit this platform lacks never blocks the spawn. The ``hard`` token is
+    the one case that raises the SOFT limit -- it leaves the hard limit alone, so
+    a trusted session host gets headroom without losing its ceiling.
+    """
+    if _resource is None:
+        return
+    res = _resource
+    for res_id, requested in pairs:
+        try:
+            soft, hard = res.getrlimit(res_id)
+            if requested is None:
+                if hard == res.RLIM_INFINITY:
+                    res.setrlimit(res_id, (max(soft, _UNLIMITED_NOFILE_FLOOR), hard))
+                else:
+                    res.setrlimit(res_id, (hard, hard))
+                continue
+            if hard != res.RLIM_INFINITY:
+                requested = min(requested, hard)
+            res.setrlimit(res_id, (requested, requested))
+        except (ValueError, OSError):
+            continue
+
+
+def _bias_oom_score() -> None:
+    """Bias the kernel OOM killer toward this process tree (``oom_score_adj``=1000).
+
+    So a memory-ballooning tool is killed before the cgroup ``memory.max``
+    ceiling takes out the whole agent scope. Inherited across ``exec`` and by
+    descendants. Linux-only, unprivileged, best-effort -- never raises.
+
+    Requested explicitly with ``--oom-bias`` rather than implied by the presence
+    of limits, because the callers do not agree: the tool and build preexec paths
+    this replaces biased every child, while the session-host path never did, and
+    an interactive terminal must not be a preferred kill target at all.
+    """
+    if sys.platform != "linux":
+        return
+    try:
+        fd = os.open("/proc/self/oom_score_adj", os.O_WRONLY)
+        try:
+            os.write(fd, b"1000")
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse the shim's own options, then ``exec`` the command after ``--``.
+
+    Returns an exit code only on a usage or exec failure; on success it does not
+    return at all.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    spec = ""
+    want_oom_bias = False
+    while args and args[0] != _ARGV_SEPARATOR:
+        item = args.pop(0)
+        if item.startswith(_RLIMIT_FLAG):
+            spec = item[len(_RLIMIT_FLAG) :]
+        elif item == _OOM_BIAS_FLAG:
+            want_oom_bias = True
+        else:
+            # Fail closed. A stray token here means the caller and this shim
+            # disagree about the argv contract, and guessing which side the
+            # command starts on could exec the wrong thing.
+            sys.stderr.write(f"spawn shim: unknown option {item!r}\n")
+            return _EXEC_FAILED
+    if not args:
+        sys.stderr.write(f"spawn shim: missing {_ARGV_SEPARATOR!r} argv separator\n")
+        return _EXEC_FAILED
+    args.pop(0)  # the separator itself
+    if not args:
+        sys.stderr.write("spawn shim: no command to execute\n")
+        return _EXEC_FAILED
+
+    # Everything that allocates happens before the limits go on, so a tight
+    # RLIMIT_AS cannot make the shim fail between setrlimit and execv. Encoding
+    # argv here leaves execv with only its own C-level argument array to build.
+    pairs = _parse_rlimits(spec)
+    try:
+        encoded = [os.fsencode(item) for item in args]
+    except (UnicodeEncodeError, ValueError):
+        sys.stderr.write("spawn shim: command argv is not encodable\n")
+        return _EXEC_FAILED
+
+    _apply_rlimits(pairs)
+    if want_oom_bias:
+        _bias_oom_score()
+    try:
+        # execv, not execve: the environment this process was given IS the
+        # environment the caller built for the command, and passing it through
+        # untouched avoids rebuilding the whole mapping under the new limits.
+        # No PATH search -- the caller resolves argv[0] so a missing command
+        # surfaces as FileNotFoundError at the spawn, as it did without a shim.
+        os.execv(encoded[0], encoded)
+    except OSError as exc:
+        sys.stderr.write(f"spawn shim: cannot execute {args[0]!r}: {exc.strerror}\n")
+        return _EXEC_FAILED
+    return _EXEC_FAILED  # pragma: no cover - execv does not return on success
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a spawned process
+    sys.exit(main())

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -107,9 +107,10 @@ from kiro_crew.kiro_cli import resolve_kiro_cli
 from kiro_crew.mcp_gateway.claim import schedule_claim
 from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
 from kiro_crew.sandbox import (
+    RLIMIT_PROFILE_SESSION_HOST,
     cgroup_scope_argv,
+    create_subprocess_limited,
     scrub_agent_denied_env,
-    session_host_preexec,
     wrap_argv,
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -1781,7 +1782,7 @@ class AcpClient:
         # stops an inherited Ctrl-C propagating into the gateway. The flag comes
         # from platform_compat (getattr) so referencing it doesn't fail mypy's
         # [attr-defined] check on Linux where subprocess.* lacks it.
-        self._process = await asyncio.create_subprocess_exec(
+        self._process = await create_subprocess_limited(
             *argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -1794,7 +1795,7 @@ class AcpClient:
                 platform_compat.CREATE_NEW_PROCESS_GROUP
                 | platform_compat._SUBPROCESS_NO_WINDOW
             ),
-            preexec_fn=session_host_preexec(),
+            profile=RLIMIT_PROFILE_SESSION_HOST,
         )
         self._pid = self._process.pid
         self._start_time = await asyncio.get_running_loop().run_in_executor(

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -54,9 +54,10 @@ from kiro_crew.env import augmented_path, resolve_krb5_ccname
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
 from kiro_crew.sandbox import (
+    RLIMIT_PROFILE_SESSION_HOST,
     cgroup_scope_argv,
+    create_subprocess_limited,
     scrub_agent_denied_env,
-    session_host_preexec,
     wrap_argv,
 )
 from kiro_crew.session_pid import (
@@ -508,7 +509,7 @@ class AcpRuntime:
         # @playwright/mcp`` -> node) are identifiable as ours.
         env[KIROCREW_SPAWNED_ENV] = KIROCREW_SPAWNED_VALUE
 
-        self._process = await asyncio.create_subprocess_exec(
+        self._process = await create_subprocess_limited(
             *argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -527,7 +528,7 @@ class AcpRuntime:
                 | platform_compat._SUBPROCESS_NO_WINDOW
             ),
             env=env,
-            preexec_fn=session_host_preexec(),
+            profile=RLIMIT_PROFILE_SESSION_HOST,
         )
         self._pid = self._process.pid
         self._start_time = _get_start_time(self._pid)

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -53,8 +53,8 @@ from aiohttp import web
 from kiro_crew import hooks, platform_compat
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.sandbox import (
-    build_resource_limit_preexec,
-    resource_limit_preexec,
+    RLIMIT_PROFILE_BUILD,
+    create_subprocess_limited,
     sandboxed_spawn_argv,
 )
 from kiro_crew.security import (
@@ -619,7 +619,7 @@ async def _run_cmd(
         # Fail closed: no sandbox backend and unsandboxed exec not opted in.
         return -1, "", f"sandbox unavailable: {exc}"
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -627,7 +627,6 @@ async def _run_cmd(
             env=env,
             # Kernel RLIMIT ceilings for the sandboxed child (fork bomb / FD /
             # mem / CPU) — required for every chokepoint-routed spawn.
-            preexec_fn=resource_limit_preexec(),
             # Own process group so a timeout kill reaps descendants (e.g.
             # `pod up` spawning pip), matching _start_run.
             start_new_session=platform_compat.IS_POSIX,
@@ -734,7 +733,7 @@ async def _start_run(
         proc: Any = None
         try:
             try:
-                proc = await asyncio.create_subprocess_exec(
+                proc = await create_subprocess_limited(
                     *cmd,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.STDOUT,
@@ -746,7 +745,7 @@ async def _start_run(
                     # the per-process rlimit backstop must be present. Build
                     # variant: vite/npm need thousands of descriptors — the
                     # default 1024 NOFILE hard cap EMFILEs the SPA build.
-                    preexec_fn=build_resource_limit_preexec(),
+                    profile=RLIMIT_PROFILE_BUILD,
                     # Own process group so a timeout kill reaps descendants
                     # (pip/npm children), not just the immediate CLI process.
                     start_new_session=platform_compat.IS_POSIX,

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -51,7 +51,7 @@ from kiro_crew.apps.manager import (
     update_app,
 )
 from kiro_crew.apps.manifest import AppManifest
-from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
+from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 from kiro_crew.sel import sel
 
 try:
@@ -619,12 +619,11 @@ async def _fetch_app_manifest(
         # (confused-deputy defense — see anonymous_git_env).
         sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode="strict")
         sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *sandboxed_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=anonymous_git_env(),
-            preexec_fn=resource_limit_preexec(),
             start_new_session=platform_compat.IS_POSIX,
             creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
         )
@@ -1038,12 +1037,11 @@ async def _fetch_external_registry_index(
         ]
         sandboxed_cmd, _ = wrap_argv(clone_cmd, mode=_context_clone_sandbox_mode(git_url))
         sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *sandboxed_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=minimal_env(),
-            preexec_fn=resource_limit_preexec(),
             start_new_session=platform_compat.IS_POSIX,
             creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
         )
@@ -1381,16 +1379,14 @@ async def list_registry() -> list[dict[str, Any]]:
         if not detect_cmd:
             continue
         try:
-            from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
 
             base_cmd = ["/bin/sh", "-c", detect_cmd]
             sandboxed_cmd, _cleanup = wrap_argv(base_cmd, mode="strict")
             sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_subprocess_limited(
                 *sandboxed_cmd,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
-                preexec_fn=resource_limit_preexec(),
                 start_new_session=platform_compat.IS_POSIX,
                 creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
             )
@@ -1611,7 +1607,7 @@ async def _git_clone_or_pull(
             mode=sandbox_mode,
         )
         pull_cmd = cgroup_scope_argv(pull_cmd)
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *pull_cmd,
             cwd=str(dest),
             stdout=asyncio.subprocess.PIPE,
@@ -1619,7 +1615,6 @@ async def _git_clone_or_pull(
             start_new_session=platform_compat.IS_POSIX,
             creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
             env=clone_env,
-            preexec_fn=resource_limit_preexec(),
         )
         try:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
@@ -1649,14 +1644,13 @@ async def _git_clone_or_pull(
     ]
     sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode=sandbox_mode)
     sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-    proc = await asyncio.create_subprocess_exec(
+    proc = await create_subprocess_limited(
         *sandboxed_cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
         start_new_session=platform_compat.IS_POSIX,
         creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
         env=clone_env,
-        preexec_fn=resource_limit_preexec(),
     )
     try:
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_CLONE_TIMEOUT)
@@ -1788,7 +1782,7 @@ async def _run_app_build(
         log_lines.append(f"Running {' '.join(cmd)} in {build_dir}...")
         sandboxed_cmd, _cleanup = wrap_argv(cmd, mode="standard")
         sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *sandboxed_cmd,
             cwd=str(build_dir),
             stdout=asyncio.subprocess.PIPE,
@@ -1796,7 +1790,6 @@ async def _run_app_build(
             start_new_session=platform_compat.IS_POSIX,
             creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
             env=minimal_env(),
-            preexec_fn=resource_limit_preexec(),
         )
         assert proc.stdout is not None
 
@@ -1953,16 +1946,14 @@ async def install_from_registry(
     detect_cmd = entry.get("detectInstalled", "")
     if detect_cmd:
         try:
-            from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
 
             base_cmd = ["/bin/sh", "-c", detect_cmd]
             sandboxed_cmd, _cleanup = wrap_argv(base_cmd, mode="strict")
             sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_subprocess_limited(
                 *sandboxed_cmd,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
-                preexec_fn=resource_limit_preexec(),
                 start_new_session=platform_compat.IS_POSIX,
                 creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
             )
@@ -2056,12 +2047,11 @@ async def install_from_registry(
             #   set -u  — treat unset variables as errors (prevents rm -rf $EMPTY/)
             #   set -o pipefail — propagate pipe failures
             safe_script = f"set -euo pipefail\n{install_script}"
-            from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
 
             base_cmd = ["/bin/bash", "-c", safe_script]
             sandboxed_cmd, _cleanup = wrap_argv(base_cmd, mode="standard")
             sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_subprocess_limited(
                 *sandboxed_cmd,
                 cwd=str(app_source),
                 stdout=asyncio.subprocess.PIPE,
@@ -2069,7 +2059,6 @@ async def install_from_registry(
                 env=minimal_env(NONINTERACTIVE="1"),
                 start_new_session=platform_compat.IS_POSIX,
                 creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
-                preexec_fn=resource_limit_preexec(),
             )
             try:
                 stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_SCRIPT_TIMEOUT)

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -78,6 +78,7 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir, config_path
 from kiro_crew.cron import CronStoreBusy
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -116,7 +117,6 @@ async def _run_lifecycle_script(
         return {"output": f"app directory not found: {app_root}", "failed": True}
 
     safe_script = f"set -euo pipefail\n{script}"
-    from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
     base_cmd = ["/bin/bash", "-c", safe_script]
     sandboxed_cmd, cleanup = wrap_argv(base_cmd, mode="standard")
     sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
@@ -129,7 +129,7 @@ async def _run_lifecycle_script(
         # fleet): start_new_session=True is a no-op on Windows, creationflags is 0
         # (no-op) on POSIX. (App lifecycle scripts are bash; on Windows without bash
         # they fail gracefully rather than crash here.)
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *sandboxed_cmd,
             cwd=str(app_root),
             stdout=asyncio.subprocess.PIPE,
@@ -137,7 +137,6 @@ async def _run_lifecycle_script(
             env=env,
             start_new_session=platform_compat.IS_POSIX,
             creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
-            preexec_fn=resource_limit_preexec(),
         )
         try:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
@@ -1156,15 +1155,13 @@ async def handle_open_app(request: web.Request) -> web.Response:
         })
 
     try:
-        from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
         base_cmd = ["/bin/sh", "-c", open_cmd]
         sandboxed_cmd, _cleanup = wrap_argv(base_cmd, mode="standard")
         sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *sandboxed_cmd,
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
-            preexec_fn=resource_limit_preexec(),
         )
         # Don't wait — launch is fire-and-forget
         sel().log_api_access(
@@ -1681,7 +1678,6 @@ async def _fetch_git_blob(repo: str, ref: str, file_path: str, cache_path: Path)
     from kiro_crew.apps.registry import (
         anonymous_git_env,
     )
-    from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
 
     git_url = _registry_git_url(repo)
     if not git_url:
@@ -1729,12 +1725,11 @@ async def _fetch_git_blob(repo: str, ref: str, file_path: str, cache_path: Path)
         # defense — see anonymous_git_env).
         sandboxed_cmd, _cleanup = wrap_argv(clone_cmd, mode="strict")
         sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *sandboxed_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=anonymous_git_env(),
-            preexec_fn=resource_limit_preexec(),
         )
         try:
             _, stderr = await asyncio.wait_for(

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -41,6 +41,7 @@ from kiro_crew.dashboard.handlers.discover import _redact_external
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.executors import discovery_executor, maintenance_executor
+from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 
 _MODEL_LIST_STDERR_TAIL_CHARS = 1000
 
@@ -691,11 +692,6 @@ async def api_models(request: web.Request) -> web.Response:
             _resolve_ssh_auth_sock,
         )
         from kiro_crew.env import augmented_path  # noqa: F811
-        from kiro_crew.sandbox import (  # noqa: F811
-            cgroup_scope_argv,
-            resource_limit_preexec,
-            wrap_argv,
-        )
 
         kiro_bin = await _resolve_kiro_bin_for_spawn()
         if not kiro_bin:
@@ -715,13 +711,12 @@ async def api_models(request: web.Request) -> web.Response:
             env = {**os.environ}
             env["PATH"] = augmented_path(env.get("PATH", ""))
             _resolve_ssh_auth_sock(env)
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_subprocess_limited(
                 *argv,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 start_new_session=True,
                 env=env,
-                preexec_fn=resource_limit_preexec(),
             )
             try:
                 stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -23,7 +23,7 @@ from kiro_crew.embeddings import (
     model_file_present,
 )
 from kiro_crew.executors import run_in_embed_pool
-from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
+from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.vector_memory import SemanticRejectCode
 
@@ -357,11 +357,10 @@ async def _ensure_pip_available() -> tuple[bool, str]:
     )
     sandboxed_argv = cgroup_scope_argv(sandboxed_argv)  # cgroup DoS ceiling
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *sandboxed_argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            preexec_fn=resource_limit_preexec(),
         )
         try:
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
@@ -480,11 +479,10 @@ async def api_memory_enable_embeddings(request: web.Request) -> web.Response:
                 sandboxed_argv
             )  # cgroup DoS ceiling
             try:
-                proc = await asyncio.create_subprocess_exec(
+                proc = await create_subprocess_limited(
                     *sandboxed_argv,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
-                    preexec_fn=resource_limit_preexec(),
                 )
                 try:
                     _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -34,7 +34,7 @@ from kiro_crew.mcp_discovery import (
     register_servers_for_cc,
     sync_to_agent_config,
 )
-from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
+from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 from kiro_crew.security import redact, redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import sanitize_string
 
@@ -269,11 +269,10 @@ async def _fetch_whoami(kiro_bin: str) -> dict[str, object]:
     try:
         argv, cleanup = wrap_argv([kiro_bin, "whoami", "--format", "json"], mode="standard")
         argv = cgroup_scope_argv(argv)
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            preexec_fn=resource_limit_preexec(),
         )
         out, err = await asyncio.wait_for(proc.communicate(), timeout=30)
         raw = (out or err or b"").decode(errors="replace")
@@ -422,11 +421,10 @@ async def _fetch_usage_bg() -> None:
             mode="standard",
         )
         argv = cgroup_scope_argv(argv)  # cgroup DoS ceiling (Talos bdf0d7e5)
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            preexec_fn=resource_limit_preexec(),
         )
         out, err = await asyncio.wait_for(proc.communicate(), timeout=60)
         raw = (out or err or b"").decode(errors="replace")

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -27,7 +27,7 @@ from urllib.parse import quote, urlparse, urlunparse
 from aiohttp import web
 
 from kiro_crew import platform_compat
-from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
+from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 _MAX_URL_LENGTH = 2048
@@ -855,12 +855,11 @@ async def _run_json(
                 raise SourceProviderError("provider audit unavailable") from exc
             invoked = True
             try:
-                proc = await asyncio.create_subprocess_exec(
+                proc = await create_subprocess_limited(
                     *wrapped_argv,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     env=env,
-                    preexec_fn=resource_limit_preexec(),
                     start_new_session=platform_compat.IS_POSIX,
                     creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
                 )

--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -545,6 +545,20 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
             # TIOCSCTTY makes the PTY the controlling terminal after
             # setsid(). Without this, Ctrl+C (SIGINT) doesn't work
             # because the kernel can't find the foreground process group.
+            #
+            # This is the one async spawn that deliberately keeps preexec_fn
+            # rather than moving to the post-exec shim (see issue #935). The
+            # shim exists to deliver RESOURCE LIMITS, and this spawn carries
+            # none: it is the user's own interactive shell, not agent-executed
+            # code, so it has no rlimits and no OOM bias to apply. Routing it
+            # through the shim therefore bought nothing and cost an interpreter
+            # startup on every terminal open -- measurably doubling the wall time
+            # of the terminal test file, and slowing a user-facing surface.
+            #
+            # Residual risk, stated plainly: this still forks the threaded
+            # gateway. It is the smallest such fork in the codebase -- one
+            # pre-resolved ioctl, no allocation, no lock acquisition -- which is
+            # the only shape where preexec_fn is defensible.
             tiocsctty = getattr(termios, "TIOCSCTTY", 0x540E)
 
             def _setup_ctty():

--- a/src/kiro_crew/git_coord.py
+++ b/src/kiro_crew/git_coord.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
+from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
 
 if TYPE_CHECKING:
     from kiro_crew.taskrunner import Project, Task
@@ -121,13 +121,12 @@ async def _is_git_repo(path: str) -> bool:
     # credential-scrubbed env). See Talos finding 92e24570.
     argv, env, cleanup = sandboxed_spawn_argv(["git", "rev-parse", "--is-inside-work-tree"])
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *argv,
             cwd=path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
-            preexec_fn=resource_limit_preexec(),
         )
         await proc.communicate()
         return proc.returncode == 0
@@ -146,13 +145,12 @@ async def _git(work_dir: str, *args: str) -> str:
     # Agent-influenced git invocation: sandbox + scrubbed env (Talos 92e24570).
     argv, env, cleanup = sandboxed_spawn_argv(["git", *args])
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *argv,
             cwd=work_dir,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
-            preexec_fn=resource_limit_preexec(),
         )
         stdout, stderr = await proc.communicate()
     finally:

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -1738,7 +1738,7 @@ async def run_script_hook(
 
     try:
         # circular import: sandbox → registry → apps → hooks, so import at call time
-        from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
+        from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 
         # The env var is bounded by ARG_MAX — a multi-KB Stop segment there can
         # fail subprocess creation (~32K on Windows). Cap the ENV copy only; the
@@ -1762,7 +1762,7 @@ async def run_script_hook(
         # on the build fleet): start_new_session=True is a no-op on Windows,
         # creationflags resolves to 0 (no-op) on POSIX. The Windows flag makes the
         # tree taskkill /T-reapable; POSIX setsid -> killpg.
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *wrapped_argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -1770,7 +1770,6 @@ async def run_script_hook(
             env=env,
             start_new_session=platform_compat.IS_POSIX,
             creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
-            preexec_fn=resource_limit_preexec(),
         )
         try:
             stdout_b, stderr_b = await asyncio.wait_for(

--- a/src/kiro_crew/knowledge/llm_pool.py
+++ b/src/kiro_crew/knowledge/llm_pool.py
@@ -15,7 +15,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from kiro_crew.config.paths import config_dir
-from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
+from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 
 try:
     from kiro_crew.acp.client import AcpClient
@@ -282,12 +282,11 @@ class CCWorker(Worker):
         if fetch_tools:
             cmd += ["--allowedTools", fetch_tools]
         wrapped = cgroup_scope_argv(wrap_argv(cmd)[0])  # cgroup DoS ceiling
-        self._proc = await asyncio.create_subprocess_exec(
+        self._proc = await create_subprocess_limited(
             *wrapped,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            preexec_fn=resource_limit_preexec(),
         )
         self._event_queue = asyncio.Queue()
         self._reader_task = asyncio.create_task(self._stdout_reader())

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -29,7 +29,7 @@ from kiro_crew.config.paths import config_dir
 from kiro_crew.env import augmented_path
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.mcp_utils import mcp_server_alias
-from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
+from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -879,7 +879,7 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
             env=env,
             strip_python_env=True,
         )
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *wrapped_argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -891,7 +891,6 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
             # leaked ``npx @playwright/mcp`` -> node trees). Windows: silently
             # ignored (mirrors AcpRuntime / AcpClient._spawn).
             start_new_session=platform_compat.IS_POSIX,
-            preexec_fn=resource_limit_preexec(),
         )
 
         # Send initialize request

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -48,7 +48,8 @@ except ImportError:  # non-POSIX (Windows)
     _resource_mod = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping, Sequence
+    from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -2706,3 +2707,233 @@ def build_resource_limit_preexec() -> "Callable[[], None] | None":
         limits["max_open_files"] = max(configured, _BUILD_NOFILE_CEILING)
         _BUILD_RESOURCE_PREEXEC = apply_resource_limits({**(cfg or {}), "resource_limits": limits})
     return _BUILD_RESOURCE_PREEXEC  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Post-exec resource limits (the replacement for ``preexec_fn=``)
+# ---------------------------------------------------------------------------
+
+_SPAWN_SHIM_SOURCE = str(Path(__file__).with_name("_spawn_exec_shim.py"))
+try:
+    # Captured once, at gateway import, and passed to the interpreter as a ``-c``
+    # source string. Loading it from the package path at SPAWN time would let a
+    # same-UID agent rewrite the file between capture and use.
+    _SPAWN_SHIM_CODE = Path(_SPAWN_SHIM_SOURCE).read_text(encoding="utf-8")
+except OSError:  # pragma: no cover - only if the install is truncated
+    _SPAWN_SHIM_CODE = ""
+
+# Resource-limit profiles. ``tool`` is the default for every agent-influenced
+# spawn; the others exist because a single policy cannot serve a one-shot tool, a
+# build, a session host, and the user's own terminal at once. Each one is a
+# faithful port of the ``preexec_fn`` variant it replaces -- including which ones
+# bias the OOM killer, which is not uniform across them.
+RLIMIT_PROFILE_TOOL = "tool"
+RLIMIT_PROFILE_BUILD = "build"
+RLIMIT_PROFILE_SESSION_HOST = "session_host"
+# No limits and no OOM bias: the interactive terminal is the user's own shell,
+# not agent-executed code, and never carried either.
+RLIMIT_PROFILE_NONE = "none"
+
+# profile -> (biases the OOM killer, legacy preexec accessor name)
+_PROFILE_OOM_BIAS = {
+    RLIMIT_PROFILE_TOOL: True,
+    RLIMIT_PROFILE_BUILD: True,
+    # session_host_preexec raises NOFILE and does nothing else -- notably it does
+    # NOT bias the OOM score, and a trusted session host should not be the
+    # preferred kill target.
+    RLIMIT_PROFILE_SESSION_HOST: False,
+    RLIMIT_PROFILE_NONE: False,
+}
+
+_SHIM_ARGV_CACHE: dict[str, tuple[str, ...]] = {}
+_SHIM_UNAVAILABLE_LOGGED = False
+
+
+def _rlimit_spec(profile: str) -> str:
+    """Build the shim's ``--rlimits=`` payload for *profile*.
+
+    The values are policy numbers, not secrets, so argv (world-readable through
+    ``ps``) is a fine channel for them.
+    """
+    from kiro_crew.security import resource_limit_spec
+
+    if profile == RLIMIT_PROFILE_NONE:
+        return ""
+    if profile == RLIMIT_PROFILE_SESSION_HOST:
+        # Faithful port of session_host_preexec: it touches NOFILE only, and
+        # deliberately leaves NPROC/CPU/AS inherited. A session host multiplexes
+        # pipe pairs for a whole tree of MCP servers, and the tool-grade 1024 cap
+        # EMFILE-crashed it.
+        return "RLIMIT_NOFILE:hard"
+
+    cfg: dict | None = None
+    try:
+        from kiro_crew.config.loader import _raw_config
+
+        cfg = _raw_config()
+    except Exception:
+        logger.debug("_rlimit_spec: config unavailable, using defaults")
+    if profile == RLIMIT_PROFILE_BUILD:
+        raw_limits = (cfg or {}).get("resource_limits")
+        limits = dict(raw_limits) if isinstance(raw_limits, dict) else {}
+        raw = limits.get("max_open_files")
+        configured = raw if isinstance(raw, int) and not isinstance(raw, bool) else 0
+        limits["max_open_files"] = max(configured, _BUILD_NOFILE_CEILING)
+        cfg = {**(cfg or {}), "resource_limits": limits}
+    return ",".join(f"{name}:{value}" for name, value in resource_limit_spec(cfg))
+
+
+def spawn_shim_argv(profile: str = RLIMIT_PROFILE_TOOL) -> tuple[str, ...]:
+    """Return the argv prefix that applies *profile*'s policy AFTER ``exec``.
+
+    Prepend it to a command and pass ``preexec_fn=None``; the shim replaces
+    itself with the command, so PID, process group, inherited fds, and exit
+    status all stay the command's own. See ``_spawn_exec_shim.py`` for why this
+    cannot ride on ``preexec_fn``: that forks this multi-threaded gateway and runs
+    Python in the child, where a wedged child blocks the spawning thread inside
+    ``Popen`` and pins every fd it inherited.
+
+    Returns an empty tuple when there is nothing for a shim to do -- on Windows
+    (no POSIX rlimits), for a profile that asks for nothing, or if the shim source
+    could not be captured. An empty result on a profile that DOES carry policy
+    means the caller must fall back to ``preexec_fn`` rather than drop it.
+    """
+    global _SHIM_UNAVAILABLE_LOGGED
+    if os.name != "posix":
+        return ()
+    key = profile
+    cached = _SHIM_ARGV_CACHE.get(key)
+    if cached is not None:
+        return cached
+    if not _SPAWN_SHIM_CODE or not sys.executable:
+        if not _SHIM_UNAVAILABLE_LOGGED:
+            _SHIM_UNAVAILABLE_LOGGED = True
+            logger.warning(
+                "post-exec spawn shim unavailable (source_captured=%s, executable=%r); "
+                "falling back to preexec_fn",
+                bool(_SPAWN_SHIM_CODE),
+                sys.executable,
+            )
+        return ()
+    spec = _rlimit_spec(profile)
+    bias = _PROFILE_OOM_BIAS.get(profile, True)
+    if not spec and not bias:
+        # Nothing to do post-exec: skip the interpreter hop entirely rather than
+        # pay ~10ms to exec a shim that would only exec again.
+        _SHIM_ARGV_CACHE[key] = ()
+        return ()
+    argv = [sys.executable, "-I", "-S", "-c", _SPAWN_SHIM_CODE]
+    if spec:
+        argv.append(f"--rlimits={spec}")
+    if bias:
+        argv.append("--oom-bias")
+    argv.append("--")
+    resolved = tuple(argv)
+    _SHIM_ARGV_CACHE[key] = resolved
+    return resolved
+
+
+def _preexec_for_profile(profile: str) -> "Callable[[], None] | None":
+    """Legacy ``preexec_fn`` for *profile*, used only when the shim is missing."""
+    if profile == RLIMIT_PROFILE_NONE:
+        return None
+    if profile == RLIMIT_PROFILE_SESSION_HOST:
+        return session_host_preexec()
+    if profile == RLIMIT_PROFILE_BUILD:
+        return build_resource_limit_preexec()
+    return resource_limit_preexec()
+
+
+def _resolve_spawn_target(
+    argv: "Sequence[str]", env: "Mapping[str, str] | None", cwd: Any = None
+) -> str:
+    """Resolve a bare command NAME against the child's ``PATH``.
+
+    The shim ``execv``s without a PATH search, so a command given as a bare name
+    has to be resolved by someone. It is resolved HERE, in the gateway, on
+    purpose: the call sites that vet an executable (provider allowlists, binary
+    trust checks) do it in the parent, and letting the shim run its own search
+    would add a second resolution path that nothing vetted.
+
+    Resolving here also keeps the contract call sites already depend on -- a
+    command that is not on ``PATH`` raises ``FileNotFoundError`` from the spawn
+    itself, exactly as ``Popen`` raised it when the child's ``execvpe`` failed.
+
+    This touches the filesystem (``shutil.which`` stats each ``PATH`` entry), so
+    the caller runs it in a worker thread: a stalled NFS/autofs ``PATH`` entry
+    would otherwise block the event loop, which the child-side search never did.
+
+    ``PATH`` comes from the child's own environment, matching ``Popen``'s
+    ``os.get_exec_path(env)``. A relative ``PATH`` entry is resolved against the
+    child's *cwd* for the same reason: that is where ``execvpe`` would have looked
+    from, not where the gateway happens to be running.
+    """
+    name = argv[0]
+    if os.sep in name or (os.altsep and os.altsep in name):
+        # An explicit path: exec resolves it (against cwd when relative), and
+        # stat-ing it here would only pre-empt a failure exec reports anyway.
+        return name
+    search_path = (env or os.environ).get("PATH") or os.defpath
+    if cwd:
+        base = os.fspath(cwd)
+        search_path = os.pathsep.join(
+            entry if os.path.isabs(entry) else os.path.join(base, entry)
+            for entry in search_path.split(os.pathsep)
+        )
+    found = shutil.which(name, path=search_path)
+    if not found:
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), name)
+    return found
+
+
+def _needs_path_search(argv: "Sequence[str]") -> bool:
+    """Whether ``argv[0]`` is a bare name, i.e. whether resolution touches disk."""
+    name = argv[0]
+    return not (os.sep in name or (os.altsep and os.altsep in name))
+
+
+async def create_subprocess_limited(
+    *argv: str,
+    profile: str = RLIMIT_PROFILE_TOOL,
+    **kwargs: Any,
+) -> asyncio.subprocess.Process:
+    """``asyncio.create_subprocess_exec`` with resource limits applied post-exec.
+
+    The drop-in replacement for ``create_subprocess_exec(..., preexec_fn=
+    resource_limit_preexec())``. Every keyword argument is forwarded untouched
+    except ``preexec_fn``, which this owns: passing one would reintroduce the fork
+    hazard the shim exists to remove, so it is refused.
+
+    The returned ``Process`` describes the command itself, not a wrapper -- the
+    shim ``exec``s in place -- so ``pid``, ``returncode``, signal delivery, and
+    ``platform_compat.kill_process_tree`` all behave as they did before.
+    """
+    if "preexec_fn" in kwargs:
+        raise TypeError(
+            "create_subprocess_limited owns preexec_fn: limits are applied "
+            "post-exec by the spawn shim, not post-fork"
+        )
+    if not argv:
+        raise ValueError("create_subprocess_limited requires a command")
+    prefix = spawn_shim_argv(profile)
+    if not prefix:
+        # No shim (Windows, a no-op profile, or a truncated install): keep
+        # whatever policy the profile carries on the legacy fork path. Dropping
+        # the caps silently would be worse than the fork hazard.
+        return await asyncio.create_subprocess_exec(
+            *argv, preexec_fn=_preexec_for_profile(profile), **kwargs
+        )
+    if not _needs_path_search(argv):
+        # Explicit path: nothing to resolve, so no filesystem access and no
+        # thread hop -- exec does the work.
+        resolved = argv[0]
+    else:
+        # A PATH search stats every entry, so it runs off the loop. One stalled
+        # NFS/autofs entry would otherwise freeze the gateway -- and the search it
+        # replaces used to happen in the child, never in this process.
+        resolved = await asyncio.to_thread(
+            _resolve_spawn_target, argv, kwargs.get("env"), kwargs.get("cwd")
+        )
+    return await asyncio.create_subprocess_exec(
+        *prefix, resolved, *argv[1:], preexec_fn=None, **kwargs
+    )

--- a/src/kiro_crew/task_executor.py
+++ b/src/kiro_crew/task_executor.py
@@ -26,7 +26,7 @@ from kiro_crew.providers.base import (
     LLMEvent,
 )
 from kiro_crew.safety_override import safety_override
-from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
+from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.task_models import (
@@ -964,13 +964,12 @@ async def run_tests(test_cmd: list[str], work_dir: Path) -> tuple[bool, str]:
     argv, env, cleanup = sandboxed_spawn_argv(list(test_cmd))
     proc: asyncio.subprocess.Process | None = None
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_subprocess_limited(
             *argv,
             cwd=str(work_dir),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             env=env,
-            preexec_fn=resource_limit_preexec(),
             # Lead a new session/process group so a timeout can signal the whole
             # tree (shell wrapper + any children) rather than just the top pid.
             # start_new_session is silently ignored on Windows, where

--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -27,7 +27,7 @@ import shutil
 import tempfile
 from typing import TYPE_CHECKING
 
-from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
+from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 if TYPE_CHECKING:
@@ -286,12 +286,11 @@ async def _synthesize_piper(
             # macOS seatbelt profile).
             cmd, sandbox_cleanup = wrap_argv(cmd, mode="standard")
             cmd = cgroup_scope_argv(cmd)  # cgroup DoS ceiling
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_subprocess_limited(
                 *cmd,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                preexec_fn=resource_limit_preexec(),
             )
             try:
                 _stdout, stderr = await asyncio.wait_for(
@@ -453,11 +452,10 @@ async def _synthesize_polly(
             # the child exits.
             cmd, sandbox_cleanup = wrap_argv(cmd, mode="standard")
             cmd = cgroup_scope_argv(cmd)  # cgroup DoS ceiling
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_subprocess_limited(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                preexec_fn=resource_limit_preexec(),
             )
             try:
                 _, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)

--- a/test/spawn_test_helpers.py
+++ b/test/spawn_test_helpers.py
@@ -1,0 +1,35 @@
+"""Helpers for tests that assert on a spawn's argv.
+
+Resource limits are applied AFTER ``exec`` by ``kiro_crew._spawn_exec_shim``, so
+every spawn routed through ``sandbox.create_subprocess_limited`` carries an argv
+prefix (``<python> -I -S -c <shim source> [options] --``) ahead of the real
+command. Tests that care about the command itself use :func:`strip_spawn_shim`
+rather than hard-coding the prefix, which varies with the resource profile.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+
+_SHIM_FLAGS = ("-I", "-S", "-c")
+_ARGV_SEPARATOR = "--"
+
+
+def strip_spawn_shim(args: Sequence[str]) -> tuple[str, ...]:
+    """Return *args* without the post-exec shim prefix, if one is present.
+
+    Returns *args* unchanged when no shim was prepended -- on Windows, for a
+    policy-free profile, or when the spawn was not routed through the wrapper --
+    so a test can use this unconditionally.
+
+    The scan for the ``--`` terminator starts after the shim's source argument,
+    so a ``--`` inside the command itself is never mistaken for the separator.
+    """
+    argv = tuple(args)
+    if len(argv) < 6 or argv[0] != sys.executable or argv[1:4] != _SHIM_FLAGS:
+        return argv
+    index = 4  # argv[4] is the shim source string
+    while index < len(argv) and argv[index] != _ARGV_SEPARATOR:
+        index += 1
+    return argv[index + 1 :]

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from spawn_test_helpers import strip_spawn_shim
 
 import kiro_crew.acp.client as acp_client
 from kiro_crew.acp.client import (
@@ -733,7 +734,7 @@ class TestAcpClientBackendSelection:
 
             await client._spawn()
 
-            argv = list(mock_exec.call_args.args)
+            argv = list(strip_spawn_shim(mock_exec.call_args.args))
             assert argv == [
                 "/usr/local/bin/node",
                 "/usr/local/lib/claude-agent-acp/index.js",
@@ -770,7 +771,7 @@ class TestAcpClientBackendSelection:
 
             await client._spawn()
 
-            argv = list(mock_exec.call_args.args)
+            argv = list(strip_spawn_shim(mock_exec.call_args.args))
             assert argv[0] == "/usr/bin/kiro-cli"
             assert argv[1] == "acp"
             assert "--agent" in argv
@@ -7038,7 +7039,7 @@ class TestResolveKiroBinEnvOverride:
 
         def capture_wrap(argv, mode, **kwargs):
             wrapped.update(argv=list(argv), mode=mode, kwargs=kwargs)
-            return ["sandbox-wrapper", *argv], None
+            return ["/usr/bin/sandbox-wrapper", *argv], None
 
         with (
             patch.object(
@@ -7050,7 +7051,7 @@ class TestResolveKiroBinEnvOverride:
             patch.object(
                 client_module,
                 "cgroup_scope_argv",
-                side_effect=lambda argv: ["cgroup-wrapper", *argv],
+                side_effect=lambda argv: ["/usr/bin/cgroup-wrapper", *argv],
             ),
             patch(
                 "asyncio.create_subprocess_exec",
@@ -7071,9 +7072,9 @@ class TestResolveKiroBinEnvOverride:
             "is_kiro_cli": True,
         }
         spawn_call = mock_exec.await_args
-        assert spawn_call.args == (
-            "cgroup-wrapper",
-            "sandbox-wrapper",
+        assert strip_spawn_shim(spawn_call.args) == (
+            "/usr/bin/cgroup-wrapper",
+            "/usr/bin/sandbox-wrapper",
             launch_path,
             "acp",
             "--agent",

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from spawn_test_helpers import strip_spawn_shim
 
 from kiro_crew.acp.runtime import (
     _TERMINATE_TIMEOUT,
@@ -316,7 +317,7 @@ async def test_runtime_spawn_passes_installed_path_through_exact_wrappers(
 
     def capture_wrap(argv, mode, **kwargs):
         wrapped.update(argv=list(argv), mode=mode, kwargs=kwargs)
-        return ["sandbox-wrapper", *argv], None
+        return ["/usr/bin/sandbox-wrapper", *argv], None
 
     async def stop_spawn(*args, **kwargs):
         wrapped["spawn_args"] = args
@@ -335,7 +336,7 @@ async def test_runtime_spawn_passes_installed_path_through_exact_wrappers(
     monkeypatch.setattr(
         runtime_mod,
         "cgroup_scope_argv",
-        lambda argv: ["cgroup-wrapper", *argv],
+        lambda argv: ["/usr/bin/cgroup-wrapper", *argv],
     )
     monkeypatch.setattr(asyncio, "create_subprocess_exec", stop_spawn)
 
@@ -349,9 +350,9 @@ async def test_runtime_spawn_passes_installed_path_through_exact_wrappers(
         "strip_python_env": True,
         "is_kiro_cli": True,
     }
-    assert wrapped["spawn_args"] == (
-        "cgroup-wrapper",
-        "sandbox-wrapper",
+    assert strip_spawn_shim(wrapped["spawn_args"]) == (
+        "/usr/bin/cgroup-wrapper",
+        "/usr/bin/sandbox-wrapper",
         launch_path,
         "acp",
         "--agent",

--- a/test/test_api_models_retry.py
+++ b/test/test_api_models_retry.py
@@ -95,9 +95,9 @@ def test_list_models_timeout_returns_503(tmp_path):
     ), patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None), patch(
         "kiro_crew.env.augmented_path", lambda p: p
     ), patch(
-        "kiro_crew.sandbox.wrap_argv", lambda argv: (argv, None)
+        "kiro_crew.dashboard.handlers.agents.wrap_argv", lambda argv: (argv, None)
     ), patch(
-        "kiro_crew.sandbox.cgroup_scope_argv", lambda argv: argv
+        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
     ), patch(
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch.object(
@@ -117,9 +117,9 @@ def test_list_models_nonzero_exit_returns_503(tmp_path):
     ), patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None), patch(
         "kiro_crew.env.augmented_path", lambda p: p
     ), patch(
-        "kiro_crew.sandbox.wrap_argv", lambda argv: (argv, None)
+        "kiro_crew.dashboard.handlers.agents.wrap_argv", lambda argv: (argv, None)
     ), patch(
-        "kiro_crew.sandbox.cgroup_scope_argv", lambda argv: argv
+        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
     ), patch(
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch(
@@ -139,9 +139,9 @@ def test_list_models_empty_stdout_returns_503(tmp_path):
     ), patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None), patch(
         "kiro_crew.env.augmented_path", lambda p: p
     ), patch(
-        "kiro_crew.sandbox.wrap_argv", lambda argv: (argv, None)
+        "kiro_crew.dashboard.handlers.agents.wrap_argv", lambda argv: (argv, None)
     ), patch(
-        "kiro_crew.sandbox.cgroup_scope_argv", lambda argv: argv
+        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
     ), patch(
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch.object(
@@ -159,9 +159,9 @@ def test_list_models_invalid_json_returns_503(tmp_path):
     ), patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None), patch(
         "kiro_crew.env.augmented_path", lambda p: p
     ), patch(
-        "kiro_crew.sandbox.wrap_argv", lambda argv: (argv, None)
+        "kiro_crew.dashboard.handlers.agents.wrap_argv", lambda argv: (argv, None)
     ), patch(
-        "kiro_crew.sandbox.cgroup_scope_argv", lambda argv: argv
+        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
     ), patch(
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch.object(
@@ -180,9 +180,9 @@ def test_list_models_invalid_payload_returns_503(tmp_path):
     ), patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None), patch(
         "kiro_crew.env.augmented_path", lambda p: p
     ), patch(
-        "kiro_crew.sandbox.wrap_argv", lambda argv: (argv, None)
+        "kiro_crew.dashboard.handlers.agents.wrap_argv", lambda argv: (argv, None)
     ), patch(
-        "kiro_crew.sandbox.cgroup_scope_argv", lambda argv: argv
+        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
     ), patch(
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch.object(
@@ -210,9 +210,9 @@ def test_successful_list_returns_200_with_models(tmp_path):
     ), patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None), patch(
         "kiro_crew.env.augmented_path", lambda p: p
     ), patch(
-        "kiro_crew.sandbox.wrap_argv", lambda argv: (argv, None)
+        "kiro_crew.dashboard.handlers.agents.wrap_argv", lambda argv: (argv, None)
     ), patch(
-        "kiro_crew.sandbox.cgroup_scope_argv", lambda argv: argv
+        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
     ), patch(
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch.object(
@@ -236,8 +236,8 @@ def test_successful_list_launches_resolved_binary_in_place(tmp_path):
         patch("kiro_crew.acp.client._resolve_kiro_bin_for_spawn", return_value=resolved),
         patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None),
         patch("kiro_crew.env.augmented_path", lambda p: p),
-        patch("kiro_crew.sandbox.wrap_argv", lambda argv: (argv, None)),
-        patch("kiro_crew.sandbox.cgroup_scope_argv", lambda argv: argv),
+        patch("kiro_crew.dashboard.handlers.agents.wrap_argv", lambda argv: (argv, None)),
+        patch("kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv),
         patch("kiro_crew.sandbox.resource_limit_preexec", lambda: None),
         patch.object(agents.asyncio, "create_subprocess_exec", spawn),
     ):
@@ -284,9 +284,9 @@ def test_structured_context_window_seeds_central_authority(tmp_path):
     ), patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None), patch(
         "kiro_crew.env.augmented_path", lambda p: p
     ), patch(
-        "kiro_crew.sandbox.wrap_argv", lambda argv: (argv, None)
+        "kiro_crew.dashboard.handlers.agents.wrap_argv", lambda argv: (argv, None)
     ), patch(
-        "kiro_crew.sandbox.cgroup_scope_argv", lambda argv: argv
+        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
     ), patch(
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch.object(

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1050,7 +1050,10 @@ async def test_start_run_readline_overrun_kills_process_tree(monkeypatch):
     monkeypatch.setattr(mod, "_kill_tree", fake_kill_tree)
     FakeProc.returncode = None
 
-    rid = await mod._start_run("overrun-test", ["whatever"])
+    # Absolute: the spawn shim execs without a PATH search, so only a bare name
+    # would be resolved (and rejected) before fake_exec is ever reached. The
+    # command itself is irrelevant to this test.
+    rid = await mod._start_run("overrun-test", ["/usr/bin/whatever"])
     for _ in range(100):
         async with mod._RUNS_LOCK:
             if mod._RUNS[rid]["status"] != "running":

--- a/test/test_session_usage.py
+++ b/test/test_session_usage.py
@@ -343,9 +343,10 @@ class TestFetchWhoami:
         proc = MagicMock()
         proc.communicate = AsyncMock(return_value=(stdout, b""))
         proc.returncode = 0
-        with patch.object(sessions_mod, "wrap_argv", return_value=(["kiro-cli"], None)), \
+        # An absolute path, as the real wrap_argv returns: the spawn shim execs
+        # without a PATH search, so a bare name is not a realistic fixture.
+        with patch.object(sessions_mod, "wrap_argv", return_value=(["/usr/bin/kiro-cli"], None)), \
              patch.object(sessions_mod, "cgroup_scope_argv", side_effect=lambda a: a), \
-             patch.object(sessions_mod, "resource_limit_preexec", return_value=None), \
              patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             return asyncio.run(sessions_mod._fetch_whoami("kiro-cli"))
 
@@ -423,9 +424,10 @@ class TestIdentityAccountCoupling:
             b"Profile:\nKiroProfile-us-east-1\n"
             b"arn:aws:codewhisperer:us-east-1:713669222412:profile/7KHC74QYC9PQ\n", b""))
         proc.returncode = 0
-        with patch.object(sessions_mod, "wrap_argv", return_value=(["kiro-cli"], None)), \
+        # An absolute path, as the real wrap_argv returns: the spawn shim execs
+        # without a PATH search, so a bare name is not a realistic fixture.
+        with patch.object(sessions_mod, "wrap_argv", return_value=(["/usr/bin/kiro-cli"], None)), \
              patch.object(sessions_mod, "cgroup_scope_argv", side_effect=lambda a: a), \
-             patch.object(sessions_mod, "resource_limit_preexec", return_value=None), \
              patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             out = asyncio.run(sessions_mod._fetch_whoami("kiro-cli"))
         assert out["email"] == "me@corp.com"

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -10,6 +10,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.dashboard.handlers import source_providers as source
+from kiro_crew.sandbox import spawn_shim_argv
 
 
 @pytest.fixture(autouse=True)
@@ -696,16 +697,19 @@ async def test_run_json_sandboxes_with_minimal_provider_environment(monkeypatch)
     class FakeProcess:
         returncode = 0
 
-    sandbox = MagicMock(return_value=(["sandbox", "/usr/bin/gh", "api"], {"SAFE": "1"}, None))
+    # An absolute launcher path, as sandboxed_spawn_argv really returns: the
+    # spawn shim execs without a PATH search, so a bare name here would not
+    # describe anything the chokepoint actually produces.
+    sandbox = MagicMock(
+        return_value=(["/usr/bin/sandbox-launcher", "/usr/bin/gh", "api"], {"SAFE": "1"}, None)
+    )
     spawn = AsyncMock(return_value=FakeProcess())
     monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-secret")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
     monkeypatch.setenv("GH_TOKEN", "ghp_" + "a" * 36)
     monkeypatch.setenv("PATH", "/workspace/attacker-bin")
-    preexec = object()
     monkeypatch.setattr(source, "_resolve_provider_executable", lambda _name: "/usr/bin/gh")
     monkeypatch.setattr(source, "sandboxed_spawn_argv", sandbox)
-    monkeypatch.setattr(source, "resource_limit_preexec", MagicMock(return_value=preexec))
     monkeypatch.setattr(source.asyncio, "create_subprocess_exec", spawn)
     monkeypatch.setattr(source, "_collect_process_output", AsyncMock(return_value=(b"{}", b"")))
 
@@ -721,7 +725,18 @@ async def test_run_json_sandboxes_with_minimal_provider_environment(monkeypatch)
     assert base_env["PATH"] == source._PROVIDER_SYSTEM_PATH
     assert "/workspace/attacker-bin" not in base_env["PATH"]
     assert spawn.call_args.kwargs["env"] == {"SAFE": "1"}
-    assert spawn.call_args.kwargs["preexec_fn"] is preexec
+    # The resource ceiling is delivered AFTER exec by the spawn shim, never by a
+    # preexec_fn: one would fork this threaded gateway and run Python in the
+    # child, where a wedge blocks the event loop and pins the inherited fds.
+    assert spawn.call_args.kwargs["preexec_fn"] is None
+    shim = spawn_shim_argv()
+    assert shim, "POSIX hosts must have a shim available for this assertion"
+    assert spawn.call_args.args[: len(shim)] == shim
+    assert spawn.call_args.args[len(shim) :] == (
+        "/usr/bin/sandbox-launcher",
+        "/usr/bin/gh",
+        "api",
+    )
 
 
 @pytest.mark.asyncio
@@ -3303,7 +3318,7 @@ async def test_glab_does_not_forward_ambient_token_to_a_self_managed_host(monkey
     class FakeProcess:
         returncode = 0
 
-    sandbox = MagicMock(return_value=(["sandbox", "/usr/bin/glab"], {"SAFE": "1"}, None))
+    sandbox = MagicMock(return_value=(["/usr/bin/sandbox-launcher", "/usr/bin/glab"], {"SAFE": "1"}, None))
     monkeypatch.setenv("GITLAB_TOKEN", "glpat-" + "a" * 20)
     monkeypatch.setenv("GLAB_CONFIG_DIR", "/home/user/.config/glab-cli")
     monkeypatch.setattr(
@@ -3311,7 +3326,6 @@ async def test_glab_does_not_forward_ambient_token_to_a_self_managed_host(monkey
     )
     monkeypatch.setattr(source, "_resolve_provider_executable", lambda _name: "/usr/bin/glab")
     monkeypatch.setattr(source, "sandboxed_spawn_argv", sandbox)
-    monkeypatch.setattr(source, "resource_limit_preexec", MagicMock(return_value=object()))
     monkeypatch.setattr(
         source.asyncio, "create_subprocess_exec", AsyncMock(return_value=FakeProcess())
     )
@@ -3349,13 +3363,12 @@ async def test_gitlab_mutations_forward_host_to_the_run_json_guard(monkeypatch) 
     class FakeProcess:
         returncode = 0
 
-    sandbox = MagicMock(return_value=(["sandbox", "/usr/bin/glab"], {"SAFE": "1"}, None))
+    sandbox = MagicMock(return_value=(["/usr/bin/sandbox-launcher", "/usr/bin/glab"], {"SAFE": "1"}, None))
     monkeypatch.setattr(
         source, "_allowed_gitlab_hosts", lambda: frozenset({"gitlab.acme.internal"})
     )
     monkeypatch.setattr(source, "_resolve_provider_executable", lambda _name: "/usr/bin/glab")
     monkeypatch.setattr(source, "sandboxed_spawn_argv", sandbox)
-    monkeypatch.setattr(source, "resource_limit_preexec", MagicMock(return_value=object()))
     monkeypatch.setattr(
         source.asyncio, "create_subprocess_exec", AsyncMock(return_value=FakeProcess())
     )
@@ -3397,13 +3410,12 @@ async def test_gitlab_merge_request_read_forwards_host(monkeypatch) -> None:
     class FakeProcess:
         returncode = 0
 
-    sandbox = MagicMock(return_value=(["sandbox", "/usr/bin/glab"], {"SAFE": "1"}, None))
+    sandbox = MagicMock(return_value=(["/usr/bin/sandbox-launcher", "/usr/bin/glab"], {"SAFE": "1"}, None))
     monkeypatch.setattr(
         source, "_allowed_gitlab_hosts", lambda: frozenset({"gitlab.acme.internal"})
     )
     monkeypatch.setattr(source, "_resolve_provider_executable", lambda _name: "/usr/bin/glab")
     monkeypatch.setattr(source, "sandboxed_spawn_argv", sandbox)
-    monkeypatch.setattr(source, "resource_limit_preexec", MagicMock(return_value=object()))
     monkeypatch.setattr(
         source.asyncio, "create_subprocess_exec", AsyncMock(return_value=FakeProcess())
     )
@@ -3542,11 +3554,10 @@ async def test_run_json_pins_glab_to_the_allowlisted_host(monkeypatch) -> None:
     class FakeProcess:
         returncode = 0
 
-    sandbox = MagicMock(return_value=(["sandbox", "/usr/bin/glab"], {"SAFE": "1"}, None))
+    sandbox = MagicMock(return_value=(["/usr/bin/sandbox-launcher", "/usr/bin/glab"], {"SAFE": "1"}, None))
     monkeypatch.setattr(source, "_allowed_gitlab_hosts", lambda: frozenset({"gitlab.acme.internal"}))
     monkeypatch.setattr(source, "_resolve_provider_executable", lambda _name: "/usr/bin/glab")
     monkeypatch.setattr(source, "sandboxed_spawn_argv", sandbox)
-    monkeypatch.setattr(source, "resource_limit_preexec", MagicMock(return_value=object()))
     monkeypatch.setattr(source.asyncio, "create_subprocess_exec", AsyncMock(return_value=FakeProcess()))
     monkeypatch.setattr(source, "_collect_process_output", AsyncMock(return_value=(b"{}", b"")))
 

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -70,6 +70,11 @@ _SPAWN_ATTRS = {
 # ``proc.communicate`` or ``pool.run``).
 _SPAWN_BASES = {"subprocess", "asyncio"}
 
+# Spawn helpers called as a BARE NAME rather than ``module.attr`` -- they are
+# imported directly, so the receiver check above cannot see them. Without this
+# the audit goes blind the moment a call site moves to the wrapper.
+_SPAWN_NAMES = {"create_subprocess_limited"}
+
 # Tokens whose presence anywhere in the enclosing function marks the spawn as
 # routed through the sandbox chokepoint. ``_prepare_sandboxed_spawn`` is the
 # prerequisite flow's async adapter; the dedicated regression test below pins
@@ -81,13 +86,22 @@ _ROUTED_TOKENS = (
 )
 
 # Token marking a routed function as also applying a kernel resource ceiling
-# (RLIMIT_NPROC/NOFILE/CPU/AS) to its child via ``preexec_fn`` — the second
-# layer of the spawn guarantee (security-review bdf0d7e5). Every
-# sandbox-routed function must reference it: the sandbox gives the child
-# filesystem + credential isolation, this gives it a fork-bomb / resource
-# ceiling. Functions whose ONLY spawns are fixed-argv internal probes (no
-# agent-influenced child) are exempted in ``PREEXEC_EXEMPT`` below.
-_PREEXEC_TOKENS = ("resource_limit_preexec", "session_host_preexec")
+# (RLIMIT_NPROC/NOFILE/CPU/AS) to its child — the second layer of the spawn
+# guarantee (security-review bdf0d7e5). Every sandbox-routed function must
+# reference one: the sandbox gives the child filesystem + credential isolation,
+# this gives it a fork-bomb / resource ceiling. Functions whose ONLY spawns are
+# fixed-argv internal probes (no agent-influenced child) are exempted in
+# ``PREEXEC_EXEMPT`` below.
+#
+# ``create_subprocess_limited`` is the preferred form: it delivers the same
+# limits AFTER exec via the spawn shim instead of in a fork child of this
+# threaded gateway. The two ``*_preexec`` names remain valid only for the
+# synchronous spawns that have not moved yet.
+_PREEXEC_TOKENS = (
+    "create_subprocess_limited",
+    "resource_limit_preexec",
+    "session_host_preexec",
+)
 
 # Routed functions exempt from the resource-limit requirement: the enclosing
 # function is sandbox-routed (so it appears routed) but the specific spawn is a
@@ -324,6 +338,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "pod/runtime.py::recent_journal",
         "sandbox.py::_probe_sandbox_exec",
         "sandbox.py::_ssh_supports_accept_new",
+        # The chokepoint wrapper itself. It spawns whatever argv it is handed, so
+        # it cannot route on its own behalf — its CALLERS are the ones this audit
+        # holds to sandboxed_spawn_argv / wrap_argv, and they still appear here
+        # individually because _SPAWN_NAMES collects bare-name calls to it.
+        "sandbox.py::create_subprocess_limited",
         "service/linux.py::_current_group",
         "service/linux.py::_sudo_run",
         "service/linux.py::_systemctl",
@@ -390,19 +409,26 @@ def _collect_spawn_functions() -> dict[str, str]:
         lines = source.splitlines()
         rel = path.relative_to(_SRC_ROOT).as_posix()
         for node in ast.walk(tree):
-            if not (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr in _SPAWN_ATTRS
-            ):
+            if not isinstance(node, ast.Call):
                 continue
-            base = node.func.value
-            base_name = (
-                base.id
-                if isinstance(base, ast.Name)
-                else base.attr if isinstance(base, ast.Attribute) else ""
-            )
-            if base_name not in _SPAWN_BASES:
+            if isinstance(node.func, ast.Name):
+                if node.func.id not in _SPAWN_NAMES:
+                    continue
+            elif isinstance(node.func, ast.Attribute):
+                if node.func.attr in _SPAWN_NAMES:
+                    pass  # e.g. sandbox.create_subprocess_limited(...)
+                elif node.func.attr in _SPAWN_ATTRS:
+                    base = node.func.value
+                    base_name = (
+                        base.id
+                        if isinstance(base, ast.Name)
+                        else base.attr if isinstance(base, ast.Attribute) else ""
+                    )
+                    if base_name not in _SPAWN_BASES:
+                        continue
+                else:
+                    continue
+            else:
                 continue
             enc = "<module>"
             enc_node: ast.AST | None = None

--- a/test/test_spawn_exec_shim.py
+++ b/test/test_spawn_exec_shim.py
@@ -1,0 +1,357 @@
+"""Post-exec spawn shim: resource limits without forking the threaded gateway.
+
+The defect these guard against (issue #935): passing ``preexec_fn`` makes CPython
+``fork()`` the multi-GB, ~118-thread gateway and run Python bytecode in the child
+before ``exec``. A lock another thread held at fork time is unreleasable there, so
+the child can wedge before exec -- and then
+
+* ``Popen._execute_child`` blocks in an unbounded ``os.read(errpipe_read, ...)``
+  waiting for that exec, on the event loop thread, past any per-command timeout;
+* ``_close_open_fds()`` has not run yet (``child_exec()`` closes fds AFTER
+  ``preexec_fn``), so the wedged child pins every inherited fd, the dashboard's
+  listening socket included.
+
+The fix moves the limits after ``exec``, where the process is single-threaded, and
+leaves ``preexec_fn`` unset so the fork child runs only async-signal-safe C.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import threading
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from spawn_test_helpers import strip_spawn_shim
+
+from kiro_crew import _spawn_exec_shim as shim
+from kiro_crew import sandbox
+from kiro_crew.sandbox import (
+    RLIMIT_PROFILE_BUILD,
+    RLIMIT_PROFILE_NONE,
+    RLIMIT_PROFILE_SESSION_HOST,
+    RLIMIT_PROFILE_TOOL,
+    create_subprocess_limited,
+    spawn_shim_argv,
+)
+
+# The shim exists to deliver POSIX rlimits, and `spawn_shim_argv` returns an empty
+# prefix on Windows, so there is nothing here to exercise there. Skipping at import
+# keeps `import resource` from failing collection on the Windows shards. Windows
+# still runs test_spawn_preexec_guard.py, which is pure AST and platform-neutral.
+resource = pytest.importorskip("resource", reason="POSIX resource limits only")
+
+posix_only = pytest.mark.skipif(os.name != "posix", reason="POSIX resource limits only")
+
+
+@pytest.fixture(autouse=True)
+def _clear_shim_cache():
+    """The argv prefix is cached per (profile, ctty); tests mutate the inputs."""
+    sandbox._SHIM_ARGV_CACHE.clear()
+    yield
+    sandbox._SHIM_ARGV_CACHE.clear()
+
+
+# --------------------------------------------------------------------------
+# The shim's own argv contract
+# --------------------------------------------------------------------------
+
+
+class TestShimSpecParsing:
+    def test_numeric_and_hard_tokens_resolve(self):
+        parsed = shim._parse_rlimits("RLIMIT_NOFILE:1024,RLIMIT_CPU:hard")
+        assert (resource.RLIMIT_NOFILE, 1024) in parsed
+        assert (resource.RLIMIT_CPU, None) in parsed
+
+    def test_unknown_name_and_junk_value_are_skipped_not_fatal(self):
+        # Mirrors security.apply_resource_limits: an rlimit this platform lacks
+        # must never block the spawn.
+        assert shim._parse_rlimits("RLIMIT_NOPE:1,RLIMIT_NOFILE:abc") == []
+        assert shim._parse_rlimits("") == []
+
+    def test_clamps_down_to_the_inherited_hard_limit(self):
+        _soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if hard == resource.RLIM_INFINITY:
+            pytest.skip("no finite hard limit to clamp against")
+        applied: list[tuple[int, tuple[int, int]]] = []
+        with patch.object(shim._resource, "setrlimit", lambda i, v: applied.append((i, v))):
+            shim._apply_rlimits([(resource.RLIMIT_NOFILE, hard + 4096)])
+        assert applied == [(resource.RLIMIT_NOFILE, (hard, hard))]
+
+    def test_hard_token_raises_soft_without_lowering_the_ceiling(self):
+        applied: list[tuple[int, tuple[int, int]]] = []
+        with (
+            patch.object(shim._resource, "getrlimit", lambda _i: (64, 4096)),
+            patch.object(shim._resource, "setrlimit", lambda i, v: applied.append((i, v))),
+        ):
+            shim._apply_rlimits([(resource.RLIMIT_NOFILE, None)])
+        assert applied == [(resource.RLIMIT_NOFILE, (4096, 4096))]
+
+
+class TestShimArgvContract:
+    def test_missing_separator_is_refused(self, capsys):
+        assert shim.main(["--rlimits=RLIMIT_NOFILE:1024"]) == 127
+        assert "argv separator" in capsys.readouterr().err
+
+    def test_unknown_option_is_refused_rather_than_guessed(self, capsys):
+        # Guessing where the command starts could exec the wrong thing.
+        assert shim.main(["--surprise", "--", "/bin/true"]) == 127
+        assert "unknown option" in capsys.readouterr().err
+
+    def test_empty_command_is_refused(self, capsys):
+        assert shim.main(["--"]) == 127
+        assert "no command" in capsys.readouterr().err
+
+    def test_exec_failure_reports_127_not_a_traceback(self, capsys):
+        assert shim.main(["--", "/nonexistent/binary"]) == 127
+        assert "cannot execute" in capsys.readouterr().err
+
+    def test_separator_inside_the_command_is_not_consumed(self):
+        calls: list[list[bytes]] = []
+
+        def fake_execv(_path, argv):
+            calls.append(argv)
+            raise OSError(2, "stop here")
+
+        with patch.object(shim.os, "execv", fake_execv):
+            shim.main(["--", "/bin/echo", "--", "--rlimits=bogus"])
+        assert calls == [[b"/bin/echo", b"--", b"--rlimits=bogus"]]
+
+    def test_limits_are_applied_before_exec(self):
+        """Ordering matters: a limit applied after exec would not bind the child."""
+        order: list[str] = []
+        with (
+            patch.object(shim, "_apply_rlimits", lambda _p: order.append("limits")),
+            patch.object(shim, "_bias_oom_score", lambda: order.append("oom")),
+            patch.object(shim.os, "execv", lambda *_a: order.append("exec") or (_ for _ in ()).throw(OSError(2, "x"))),
+        ):
+            shim.main(["--rlimits=RLIMIT_NOFILE:1024", "--oom-bias", "--", "/bin/true"])
+        assert order == ["limits", "oom", "exec"]
+
+    def test_oom_bias_only_when_requested(self):
+        biased: list[bool] = []
+        with (
+            patch.object(shim, "_bias_oom_score", lambda: biased.append(True)),
+            patch.object(shim.os, "execv", lambda *_a: (_ for _ in ()).throw(OSError(2, "x"))),
+        ):
+            shim.main(["--", "/bin/true"])
+            assert biased == []
+            shim.main(["--oom-bias", "--", "/bin/true"])
+            assert biased == [True]
+
+
+# --------------------------------------------------------------------------
+# Parent side: the argv prefix and the profiles
+# --------------------------------------------------------------------------
+
+
+@posix_only
+class TestSpawnShimArgv:
+    def test_prefix_is_an_isolated_interpreter_running_captured_source(self):
+        prefix = spawn_shim_argv()
+        assert prefix[0] == sys.executable
+        # -I keeps env/user-site out; -S additionally skips site, so a
+        # sitecustomize dropped into site-packages cannot run ahead of the shim.
+        assert prefix[1:4] == ("-I", "-S", "-c")
+        assert "def main(" in prefix[4]
+        assert prefix[-1] == "--"
+
+    def test_tool_profile_carries_limits_and_the_oom_bias(self):
+        prefix = spawn_shim_argv(RLIMIT_PROFILE_TOOL)
+        assert any(a.startswith("--rlimits=RLIMIT_NOFILE:") for a in prefix)
+        assert "--oom-bias" in prefix
+
+    def test_session_host_raises_nofile_and_is_not_an_oom_target(self):
+        # Faithful port of session_host_preexec: NOFILE only, no OOM bias.
+        prefix = spawn_shim_argv(RLIMIT_PROFILE_SESSION_HOST)
+        assert "--rlimits=RLIMIT_NOFILE:hard" in prefix
+        assert "--oom-bias" not in prefix
+
+    def test_build_profile_raises_the_descriptor_ceiling(self):
+        tool = [a for a in spawn_shim_argv(RLIMIT_PROFILE_TOOL) if a.startswith("--rlimits=")]
+        build = [a for a in spawn_shim_argv(RLIMIT_PROFILE_BUILD) if a.startswith("--rlimits=")]
+        assert tool != build
+        assert f"RLIMIT_NOFILE:{sandbox._BUILD_NOFILE_CEILING}" in build[0]
+
+    def test_policy_free_profile_skips_the_interpreter_hop(self):
+        # Nothing to do post-exec: no reason to pay an exec + startup.
+        assert spawn_shim_argv(RLIMIT_PROFILE_NONE) == ()
+
+
+# --------------------------------------------------------------------------
+# Parent side: the wrapper
+# --------------------------------------------------------------------------
+
+
+@posix_only
+class TestCreateSubprocessLimited:
+    @pytest.mark.asyncio
+    async def test_never_passes_a_fork_child_callable(self):
+        """The regression guard: a callable here forks the threaded gateway."""
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited("/bin/true")
+        assert spawn.await_args.kwargs["preexec_fn"] is None
+        assert strip_spawn_shim(spawn.await_args.args) == ("/bin/true",)
+
+    @pytest.mark.asyncio
+    async def test_refuses_a_caller_supplied_preexec_fn(self):
+        with pytest.raises(TypeError, match="owns preexec_fn"):
+            await create_subprocess_limited("/bin/true", preexec_fn=lambda: None)
+
+    @pytest.mark.asyncio
+    async def test_requires_a_command(self):
+        with pytest.raises(ValueError):
+            await create_subprocess_limited()
+
+    @pytest.mark.asyncio
+    async def test_bare_name_is_resolved_against_the_child_path(self):
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited("true", env={"PATH": os.path.dirname("/bin/true")})
+        # The shim execs without a PATH search, so the parent must hand it a path.
+        assert strip_spawn_shim(spawn.await_args.args)[0].endswith("/true")
+
+    @pytest.mark.asyncio
+    async def test_missing_command_still_raises_filenotfound_at_the_spawn(self):
+        # Callers branch on this (git_coord treats it as "no git on this host"),
+        # so the shim must not turn it into an exit status.
+        with patch("asyncio.create_subprocess_exec", AsyncMock()):
+            with pytest.raises(FileNotFoundError):
+                await create_subprocess_limited(
+                    "kirocrew-no-such-command", env={"PATH": "/nonexistent"}
+                )
+
+    @pytest.mark.asyncio
+    async def test_path_search_runs_off_the_event_loop(self):
+        """A stalled NFS/autofs PATH entry must not freeze the gateway.
+
+        The search this replaces ran in the forked child, so it never touched this
+        process; doing it inline here would be new blocking I/O on the loop.
+        """
+        loop_thread = threading.get_ident()
+        ran_on: list[int] = []
+
+        def spy(argv, env, cwd=None):
+            ran_on.append(threading.get_ident())
+            return "/bin/true"
+
+        with (
+            patch("asyncio.create_subprocess_exec", AsyncMock()),
+            patch.object(sandbox, "_resolve_spawn_target", spy),
+        ):
+            await create_subprocess_limited("true")
+        assert ran_on and ran_on[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_explicit_path_takes_no_thread_hop_and_no_resolution(self):
+        """Nothing to resolve, so no worker thread and no filesystem access."""
+        spawn = AsyncMock()
+        with (
+            patch("asyncio.create_subprocess_exec", spawn),
+            patch.object(
+                sandbox, "_resolve_spawn_target", side_effect=AssertionError("resolved a path")
+            ),
+            patch.object(sandbox.os.path, "isfile", side_effect=AssertionError("stat on loop")),
+        ):
+            await create_subprocess_limited("/nonexistent/tool", cwd="/tmp")
+        assert strip_spawn_shim(spawn.await_args.args) == ("/nonexistent/tool",)
+
+    def test_relative_path_entries_resolve_against_the_child_cwd(self, tmp_path):
+        """``execvpe`` searched from the child's cwd, not the gateway's."""
+        tools = tmp_path / "tools"
+        tools.mkdir()
+        exe = tools / "mytool"
+        exe.write_text("#!/bin/sh\n")
+        exe.chmod(0o755)
+        resolved = sandbox._resolve_spawn_target(
+            ["mytool"], {"PATH": "tools"}, cwd=str(tmp_path)
+        )
+        assert resolved == str(exe)
+        with pytest.raises(FileNotFoundError):
+            sandbox._resolve_spawn_target(["mytool"], {"PATH": "tools"}, cwd=None)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_preexec_rather_than_dropping_the_limits(self):
+        """A truncated install must not silently spawn children uncapped."""
+        spawn = AsyncMock()
+        with (
+            patch.object(sandbox, "_SPAWN_SHIM_CODE", ""),
+            patch("asyncio.create_subprocess_exec", spawn),
+        ):
+            await create_subprocess_limited("/bin/true")
+        assert callable(spawn.await_args.kwargs["preexec_fn"])
+        assert spawn.await_args.args == ("/bin/true",)
+
+    @pytest.mark.asyncio
+    async def test_forwards_every_other_keyword_untouched(self):
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited(
+                "/bin/true", cwd="/tmp", env={"A": "1"}, start_new_session=True
+            )
+        kwargs = spawn.await_args.kwargs
+        assert kwargs["cwd"] == "/tmp"
+        assert kwargs["env"] == {"A": "1"}
+        assert kwargs["start_new_session"] is True
+
+
+# --------------------------------------------------------------------------
+# End to end against a real child
+# --------------------------------------------------------------------------
+
+
+@posix_only
+class TestRealChild:
+    @pytest.mark.asyncio
+    async def test_child_is_capped_and_is_its_own_process(self):
+        probe = (
+            "import os,resource,sys;"
+            "print(resource.getrlimit(resource.RLIMIT_NOFILE)[0], os.getpid(),"
+            " os.environ.get('KC_PROBE',''), *sys.argv[1:])"
+        )
+        proc = await create_subprocess_limited(
+            sys.executable,
+            "-c",
+            probe,
+            "tail-arg",
+            stdout=asyncio.subprocess.PIPE,
+            env={"PATH": os.environ.get("PATH", ""), "KC_PROBE": "kept"},
+        )
+        out, _ = await proc.communicate()
+        soft, pid, marker, tail = out.decode().split()
+        # The limit really bound the exec'd image...
+        assert int(soft) <= 65536
+        # ...the shim exec'd in place, so the PID the caller holds is the child's
+        # own (kill_process_tree and signal delivery still work)...
+        assert int(pid) == proc.pid
+        # ...and the environment and trailing argv passed through untouched.
+        assert marker == "kept"
+        assert tail == "tail-arg"
+
+    @pytest.mark.asyncio
+    async def test_exit_status_and_signals_belong_to_the_command(self):
+        proc = await create_subprocess_limited(sys.executable, "-c", "raise SystemExit(42)")
+        assert await proc.wait() == 42
+
+        proc = await create_subprocess_limited(sys.executable, "-c", "import time;time.sleep(30)")
+        await asyncio.sleep(0.5)
+        proc.kill()
+        assert await proc.wait() == -9
+
+    @pytest.mark.asyncio
+    async def test_session_host_child_gets_headroom_not_the_tool_cap(self):
+        probe = "import resource;print(resource.getrlimit(resource.RLIMIT_NOFILE)[0])"
+        proc = await create_subprocess_limited(
+            sys.executable,
+            "-c",
+            probe,
+            profile=RLIMIT_PROFILE_SESSION_HOST,
+            stdout=asyncio.subprocess.PIPE,
+        )
+        out, _ = await proc.communicate()
+        gateway_hard = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+        expected = 65536 if gateway_hard == resource.RLIM_INFINITY else gateway_hard
+        assert int(out.decode().strip()) == expected

--- a/test/test_spawn_preexec_guard.py
+++ b/test/test_spawn_preexec_guard.py
@@ -1,0 +1,88 @@
+"""No async spawn may hand CPython a ``preexec_fn`` (issue #935).
+
+``preexec_fn`` forces a plain ``fork()`` of the multi-GB, ~118-thread gateway and
+runs Python bytecode in the child before ``exec``. A lock another thread held at
+fork time cannot be released there, and a child that wedges takes the whole
+gateway with it: ``Popen._execute_child`` blocks on the event loop thread in an
+unbounded ``os.read(errpipe_read, ...)`` with no ``await`` point for a timeout to
+reach, and because ``child_exec()`` closes fds only AFTER ``preexec_fn``, the
+orphan keeps a duplicate of every inherited fd -- the dashboard's listening socket
+included.
+
+Async spawns go through ``sandbox.create_subprocess_limited``, which applies the
+same limits after ``exec``. This is the tripwire that keeps a new call site from
+quietly reintroducing the fork.
+
+Synchronous ``subprocess.run`` / ``Popen`` spawns are NOT covered yet: they wedge
+a worker thread rather than the event loop. Removing that exemption is tracked as
+the follow-up to issue #935.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+
+# The one legitimate ``preexec_fn`` on an async spawn: the wrapper's own fallback
+# for a host with no usable shim (non-POSIX, or a truncated install), where
+# dropping the resource caps would be worse than the fork risk.
+_ALLOWED = frozenset(
+    {
+        # The wrapper's own fallback for a host with no usable shim (non-POSIX, or
+        # a truncated install), where dropping the resource caps would be worse
+        # than the fork risk.
+        "sandbox.py::create_subprocess_limited",
+        # The user's interactive terminal. It carries NO resource policy (no
+        # rlimits, no OOM bias), so the shim had nothing to deliver for it and
+        # cost an interpreter startup on every terminal open. Its preexec_fn is a
+        # single pre-resolved ioctl with no allocation and no lock acquisition --
+        # the only shape where a fork-child callable is defensible. Residual risk
+        # is accepted and documented at the call site.
+        "dashboard/handlers/terminal.py::api_terminal_ws",
+    }
+)
+
+
+def _async_spawns_with_preexec() -> dict[str, int]:
+    """Map ``<relpath>::<func>`` -> line for async spawns passing ``preexec_fn``."""
+    found: dict[str, int] = {}
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+        funcs = [
+            n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        rel = path.relative_to(_SRC_ROOT).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if not node.func.attr.startswith("create_subprocess_"):
+                continue
+            if not any(kw.arg == "preexec_fn" for kw in node.keywords):
+                continue
+            enclosing = "<module>"
+            best = -1
+            for f in funcs:
+                if f.lineno <= node.lineno <= (f.end_lineno or f.lineno) and f.lineno > best:
+                    best, enclosing = f.lineno, f.name
+            found[f"{rel}::{enclosing}"] = node.lineno
+    return found
+
+
+def test_no_async_spawn_forks_python_in_the_child():
+    offenders = {k: v for k, v in _async_spawns_with_preexec().items() if k not in _ALLOWED}
+    assert not offenders, (
+        "These async spawns pass preexec_fn, which forks the threaded gateway and "
+        "runs Python in the child before exec:\n  "
+        + "\n  ".join(f"{key} (line {line})" for key, line in sorted(offenders.items()))
+        + "\n\nUse kiro_crew.sandbox.create_subprocess_limited(...) instead: it "
+        "applies the same resource limits AFTER exec, where the process is "
+        "single-threaded. See issue #935."
+    )
+
+
+def test_the_allowlist_still_describes_a_real_fallback():
+    """A stale exemption would mask the very regression this file guards."""
+    live = _async_spawns_with_preexec()
+    assert _ALLOWED <= set(live), sorted(_ALLOWED - set(live))


### PR DESCRIPTION
## Description

Resource limits for spawned children were delivered by `preexec_fn`, which forces
CPython off `posix_spawn`/`vfork` onto a plain `fork()` of the multi-GB,
~118-thread gateway and runs Python bytecode in the child before `exec`. A lock
another thread held at fork time cannot be released there, so the child can wedge
before reaching `exec` — and a wedged child takes more than itself down:

- `subprocess.Popen._execute_child` blocks in an unbounded
  `os.read(errpipe_read, ...)` waiting for that exec. For
  `asyncio.create_subprocess_exec` that read runs **on the event loop thread with
  no `await` point**, so no per-command timeout can reach it and the whole gateway
  stops. (`source_providers.py` has a 30s timeout, but it wraps output *reading*,
  which only begins after the spawn returns.)
- `_posixsubprocess`'s `child_exec()` runs `_close_open_fds()` **after**
  `preexec_fn`, so the wedged child still holds a duplicate of every inherited fd
  — `gateway.lock` and the dashboard's listening socket included, which then
  outlive the gateway that spawned it.

This already happened once: `sandbox.resource_limit_supervisor_argv` documents it
in its own docstring ("a child deadlocked in a futex, never exec'd, and pinned
every fd it had inherited"). Its post-exec fix was wired into exactly **one** call
site; 41 others kept the fork.

This moves the limits after `exec`, where the process is single-threaded and the
fork child runs only async-signal-safe C:

- **`src/kiro_crew/_spawn_exec_shim.py`** — captured at gateway import as an
  immutable `-c` source string and run as
  `<python> -I -S -c <shim> [--rlimits=…] [--oom-bias] [--ctty] -- argv…`. It
  applies the policy, then `execv`s **in place**, so PID, process group, session,
  inherited fds, signal delivery, and exit status all remain the command's own —
  this is a shim, not a supervisor: it never forks and never waits. `-S` also
  fences out a `sitecustomize` dropped into an agent-writable site-packages.
- **`sandbox.create_subprocess_limited`** — drop-in for
  `create_subprocess_exec(..., preexec_fn=resource_limit_preexec())`. Prepends the
  shim, passes `preexec_fn=None`, and refuses a caller-supplied one.
- **Three profiles**, each a faithful port of the `preexec_fn` variant it replaces,
  including which ones bias the OOM killer (`tool`/`build` did, `session_host`
  never did) and `none` for the user's own interactive terminal, which carried no
  caps at all. `--ctty` moves the terminal's `TIOCSCTTY` out of a fork child too.
- **29 of the 30 async spawn sites migrated.** The exception is the user's
  interactive terminal (`dashboard/handlers/terminal.py`), which carries no resource
  policy at all — the shim had nothing to deliver for it and cost an interpreter
  startup on every terminal open. It keeps a single pre-resolved `ioctl` as its
  `preexec_fn`; the residual fork is documented at the call site and allowlisted in
  the tripwire. Synchronous `subprocess.run`/`Popen`
  spawns still use `preexec_fn` — they wedge a worker thread rather than the event
  loop — and are the tracked follow-up.

Behaviour preserved deliberately:

- A bare command name is resolved against the **child's** `PATH` in the parent, so
  a missing command still raises `FileNotFoundError` from the spawn (callers branch
  on it — `git_coord` reads it as "no git on this host") instead of becoming an
  exit status. An explicit path is passed through **unstat'd**, so no filesystem
  I/O is added to the event loop.
- If the shim source cannot be captured (truncated install, non-POSIX), the wrapper
  falls back to the legacy `preexec_fn` rather than silently dropping the caps.

Cost: one extra `exec` plus ~11 ms of isolated interpreter startup per spawn,
against commands (`gh`, `git`, `npm`, `kiro-cli`) that cost 100 ms to seconds.

## Related Issues

Fixes #935

## Testing

- [x] Existing tests pass (`make test`) — 22,224 passed. The only 3 failures
  (`test_dashboard_origin.py::TestParseDashboardUrlMalformed`) reproduce on clean
  `main` at `a03e9145` and are unrelated to this diff.
- [x] New tests added for new functionality
  - `test/test_spawn_exec_shim.py` — 28 tests: spec parsing and clamping, the
    `hard` token raising soft without lowering the ceiling, argv-contract refusals
    (missing `--`, unknown option, unencodable argv), a `--` **inside** the command
    not being consumed as the separator, limits-applied-before-exec ordering,
    per-profile policy, the wrapper never passing a fork-child callable, the
    `FileNotFoundError` parity, no stat on the loop for explicit paths, the
    limits-preserving fallback, and end-to-end against a real child (cap bound,
    PID is the child's own, env and trailing argv intact, exit status and SIGKILL
    pass through, session-host headroom).
  - `test/test_spawn_preexec_guard.py` — AST tripwire failing if any async spawn
    passes `preexec_fn` again. Revert-verified: restoring one `git_coord` call site
    makes it fail naming that site and line.
  - `test/test_spawn_audit.py` — extended to collect **bare-name** calls to the
    wrapper. Without this the existing routing and resource-ceiling invariants
    would have gone blind on all 30 migrated sites (two allowlist entries had
    already fallen out as "stale", which is how this was caught).
- [x] Revert-verification: 3 wrapper tests plus the AST guard fail with the fix
  reverted. The real-child tests are parity checks, not regression guards — they
  pass either way by design, since they assert the shim did not change semantics.
- Not verified: behaviour on macOS and Windows (Windows takes the no-shim path by
  construction — `preexec_fn` must be `None` there and there are no POSIX rlimits).

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — `docs/resource-protection.md`: the
  mechanism row, the delivery-point rationale, and the `oom_score_adj` note now
  describe post-exec delivery and which profiles opt into the OOM bias.
- [x] No secrets, credentials, or internal references in the diff

