### PR TITLE
fix(channels): drive /compact through the prompt transport in Discord, Slack, Telegram

### DIFF
--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -28,7 +28,6 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.acp.types import EVENT_COMPACTION_STATUS, EVENT_COMPLETE
 from kiro_crew.discord.commands import (
     ConversationState,
     parse_command,
@@ -979,40 +978,29 @@ class DiscordDispatcher:
 
             try:
 
-                async def _run() -> None:
-                    nonlocal result_text
-                    async for ev in provider.stream_command("/compact"):
-                        if ev.kind == EVENT_COMPACTION_STATUS:
-                            if ev.text == "completed":
-                                summary = _safe(ev.title or "")
-                                result_text = (
-                                    f"✅ Compacted: {summary}"
-                                    if summary
-                                    else "✅ Context compacted."
-                                )
-                            elif ev.text == "failed":
-                                result_text = (
-                                    f"❌ Compaction failed: "
-                                    f"{_safe(ev.title or '') or 'unknown error'}"
-                                )
-                        elif ev.kind == EVENT_COMPLETE:
-                            break
-
-                await asyncio.wait_for(_run(), timeout=120)
-                if not result_text:
-                    cr = await provider.wait_for_compaction(timeout=120.0)
-                    if cr["type"] == "completed":
-                        summary = _safe(cr.get("summary", ""))
-                        result_text = (
-                            f"✅ Compacted: {summary}" if summary else "✅ Context compacted."
-                        )
-                    elif cr["type"] == "failed":
-                        err = _safe(cr.get("summary", ""))
-                        result_text = (
-                            f"❌ Compaction failed: {err}" if err else "❌ Compaction failed."
-                        )
-                    else:
-                        result_text = "⚠️ Compaction timed out."
+                # Compaction runs over the prompt transport (#276):
+                # provider.compact() drives /compact via session/prompt (the
+                # commands/execute path does NOT run compaction — it returns
+                # with no status, the pre-#276 bug). Bound compact()'s prompt
+                # turn here, then let wait_for_compaction() own its OWN deadline
+                # for a status emitted async after end_turn — it must NOT be
+                # nested inside another timeout, or the graceful "timed out"
+                # branch is unreachable and a slow-but-healthy session gets
+                # destroyed by the outer TimeoutError.
+                await asyncio.wait_for(provider.compact(), timeout=120)
+                cr = await provider.wait_for_compaction(timeout=120.0)
+                if cr["type"] == "completed":
+                    summary = _safe(cr.get("summary", ""))
+                    result_text = (
+                        f"✅ Compacted: {summary}" if summary else "✅ Context compacted."
+                    )
+                elif cr["type"] == "failed":
+                    err = _safe(cr.get("summary", ""))
+                    result_text = (
+                        f"❌ Compaction failed: {err}" if err else "❌ Compaction failed."
+                    )
+                else:
+                    result_text = "⚠️ Compaction timed out."
             except Exception:
                 logger.warning("Discord !compact failed for %s", session_key, exc_info=True)
                 result_text = "❌ Compaction failed unexpectedly."

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -66,7 +66,6 @@ from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn
 from kiro_crew.messaging.link import canonical_key
 from kiro_crew.platform import current_context
 from kiro_crew.providers.base import (
-    EVENT_COMPACTION_STATUS,
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
     EVENT_TEXT_CHUNK,
@@ -2110,54 +2109,67 @@ async def _handle_compact_command(
     session_key: str,
 ) -> None:
     """Trigger in-place ACP ``/compact`` on the current thread's session."""
-    provider = sessions.get_provider(session_key)
-    if not provider:
-        await slack.post_message(channel, "No active session to compact.", reply_ts)
-        sel().log_tool_invocation(
-            session_key=session_key,
-            source="slack",
-            tool_name="compact",
-            tool_kind="command",
-            outcome="no_session",
-        )
+    # Atomically take the turn semaphore for the WHOLE compaction, or refuse.
+    # Slack dispatches each message as its own task (asyncio.create_task), so a
+    # bare get_provider() + compact() would race a normal turn that holds the
+    # session and interleave two prompts on one stdio channel — corrupting
+    # session state (the reason Discord/Telegram guard the same way). Since
+    # #276 routes /compact through session/prompt, that collision now surfaces
+    # as "turn already active" and the except path would destroy a healthy
+    # session; try_acquire() serializes against the in-flight turn and the
+    # finally always releases.
+    if not await sessions.try_acquire(session_key):
+        if sessions.has_session(session_key):
+            await slack.post_message(
+                channel,
+                "⏳ Still working on your last message — try `!compact` once it finishes.",
+                reply_ts,
+            )
+        else:
+            await slack.post_message(channel, "No active session to compact.", reply_ts)
+            sel().log_tool_invocation(
+                session_key=session_key,
+                source="slack",
+                tool_name="compact",
+                tool_kind="command",
+                outcome="no_session",
+            )
         return
-
-    _t0 = time.monotonic()
-
-    # --- Phase 1: Pre-compaction UI (cosmetic — log failures, don't abort) ---
     try:
-        await slack.add_reaction(channel, msg_ts, "recycle")
-        await slack.post_message(channel, "🔄 Compacting context…", reply_ts)
-    except Exception:
-        logger.debug("Pre-compact UI failed for %s", session_key, exc_info=True)
+        provider = sessions.get_provider(session_key)
+        if not provider:
+            await slack.post_message(channel, "No active session to compact.", reply_ts)
+            sel().log_tool_invocation(
+                session_key=session_key,
+                source="slack",
+                tool_name="compact",
+                tool_kind="command",
+                outcome="no_session",
+            )
+            return
 
-    # --- Phase 2: Actual compaction (failures warrant error + session teardown) ---
-    result_text: str | None = None
-    outcome = "unknown"
-    try:
+        _t0 = time.monotonic()
 
-        async def _run_compact_stream() -> None:
-            nonlocal result_text, outcome
-            async for event in provider.stream_command("/compact"):
-                if event.kind == EVENT_COMPACTION_STATUS:
-                    if event.text == "completed":
-                        summary = event.title or ""
-                        result_text = (
-                            f"✅ Compacted: {summary}" if summary else "✅ Context compacted."
-                        )
-                        outcome = "completed"
-                    elif event.text == "failed":
-                        error = event.title or "unknown error"
-                        result_text = f"❌ Compaction failed: {error}"
-                        outcome = "failed"
-                elif event.kind == EVENT_COMPLETE:
-                    break
+        # --- Phase 1: Pre-compaction UI (cosmetic — log failures, don't abort) ---
+        try:
+            await slack.add_reaction(channel, msg_ts, "recycle")
+            await slack.post_message(channel, "🔄 Compacting context…", reply_ts)
+        except Exception:
+            logger.debug("Pre-compact UI failed for %s", session_key, exc_info=True)
 
-        await asyncio.wait_for(_run_compact_stream(), timeout=120)
-
-        # kiro-cli fires compaction asynchronously after EVENT_COMPLETE —
-        # wait for the real result, mirroring the dashboard's deferred path.
-        if not result_text:
+        # --- Phase 2: Actual compaction (failures warrant error + session teardown) ---
+        result_text: str | None = None
+        outcome = "unknown"
+        try:
+            # Compaction runs over the prompt transport (#276):
+            # provider.compact() drives /compact via session/prompt (the
+            # commands/execute path does NOT run compaction — it returns with
+            # no status, the pre-#276 bug). Bound compact()'s prompt turn here,
+            # then let wait_for_compaction() own its OWN deadline for a status
+            # emitted async after end_turn — it must NOT be nested inside
+            # another timeout, or the graceful "timed out" branch is
+            # unreachable and a slow-but-healthy session gets destroyed.
+            await asyncio.wait_for(provider.compact(), timeout=120)
             cr = await provider.wait_for_compaction(timeout=120.0)
             if cr["type"] == "completed":
                 summary = cr.get("summary", "")
@@ -2165,65 +2177,71 @@ async def _handle_compact_command(
                 outcome = "completed"
             elif cr["type"] == "failed":
                 error = cr.get("summary", "")
-                result_text = f"❌ Compaction failed: {error}" if error else "❌ Compaction failed."
+                result_text = (
+                    f"❌ Compaction failed: {error}" if error else "❌ Compaction failed."
+                )
                 outcome = "failed"
             else:
                 result_text = "⚠️ Compaction timed out."
                 outcome = "timeout"
-    except Exception:
-        logger.warning("Compact command failed for %s", session_key, exc_info=True)
-        try:
-            await slack.post_message(channel, "❌ Compaction failed unexpectedly.", reply_ts)
         except Exception:
-            logger.debug("Failed to post compact error for %s", session_key, exc_info=True)
-        try:
-            await sessions.destroy(session_key)
-        except Exception:
-            logger.warning(
-                "Failed to destroy session %s after compact failure", session_key, exc_info=True
+            logger.warning("Compact command failed for %s", session_key, exc_info=True)
+            try:
+                await slack.post_message(channel, "❌ Compaction failed unexpectedly.", reply_ts)
+            except Exception:
+                logger.debug("Failed to post compact error for %s", session_key, exc_info=True)
+            try:
+                await sessions.destroy(session_key)
+            except Exception:
+                logger.warning(
+                    "Failed to destroy session %s after compact failure",
+                    session_key,
+                    exc_info=True,
+                )
+            sel().log_tool_invocation(
+                session_key=session_key,
+                source="slack",
+                tool_name="compact",
+                tool_kind="command",
+                outcome="failed",
+                error="exception",
             )
-        sel().log_tool_invocation(
-            session_key=session_key,
-            source="slack",
-            tool_name="compact",
-            tool_kind="command",
-            outcome="failed",
-            error="exception",
-        )
+            try:
+                await slack.remove_reaction(channel, msg_ts, "recycle")
+                await _add_phase_reaction(slack, channel, msg_ts, "done")
+            except Exception:
+                pass
+            return
+
+        # --- Phase 3: Post-compaction reporting (log failures, don't mislead) ---
+        try:
+            result_text, _ = redact_exfiltration_urls(result_text)
+            result_text, _ = redact_credentials(result_text)
+            await slack.post_message(channel, result_text, reply_ts)
+
+            elapsed = time.monotonic() - _t0
+            footer_blocks, footer_text = build_timing_footer(elapsed)
+            await slack.post_blocks(channel, footer_blocks, footer_text, reply_ts)
+        except Exception:
+            logger.debug("Post-compact reporting failed for %s", session_key, exc_info=True)
+
+        try:
+            sel().log_tool_invocation(
+                session_key=session_key,
+                source="slack",
+                tool_name="compact",
+                tool_kind="command",
+                outcome=outcome,
+            )
+        except Exception:
+            logger.debug("Failed to log compact outcome for %s", session_key, exc_info=True)
         try:
             await slack.remove_reaction(channel, msg_ts, "recycle")
             await _add_phase_reaction(slack, channel, msg_ts, "done")
         except Exception:
             pass
-        return
-
-    # --- Phase 3: Post-compaction reporting (log failures, don't mislead) ---
-    try:
-        result_text, _ = redact_exfiltration_urls(result_text)
-        result_text, _ = redact_credentials(result_text)
-        await slack.post_message(channel, result_text, reply_ts)
-
-        elapsed = time.monotonic() - _t0
-        footer_blocks, footer_text = build_timing_footer(elapsed)
-        await slack.post_blocks(channel, footer_blocks, footer_text, reply_ts)
-    except Exception:
-        logger.debug("Post-compact reporting failed for %s", session_key, exc_info=True)
-
-    try:
-        sel().log_tool_invocation(
-            session_key=session_key,
-            source="slack",
-            tool_name="compact",
-            tool_kind="command",
-            outcome=outcome,
-        )
-    except Exception:
-        logger.debug("Failed to log compact outcome for %s", session_key, exc_info=True)
-    try:
-        await slack.remove_reaction(channel, msg_ts, "recycle")
-        await _add_phase_reaction(slack, channel, msg_ts, "done")
-    except Exception:
-        pass
+    finally:
+        sessions.release(session_key)
 
 
 async def maybe_handle_keyword_command(

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -29,7 +29,6 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.acp.types import EVENT_COMPACTION_STATUS, EVENT_COMPLETE
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
@@ -995,37 +994,29 @@ class TelegramDispatcher:
             result_text: str | None = None
             try:
 
-                async def _run() -> None:
-                    nonlocal result_text
-                    async for ev in provider.stream_command("/compact"):
-                        if ev.kind == EVENT_COMPACTION_STATUS:
-                            if ev.text == "completed":
-                                summary = ev.title or ""
-                                result_text = (
-                                    f"✅ Compacted: {summary}"
-                                    if summary
-                                    else "✅ Context compacted."
-                                )
-                            elif ev.text == "failed":
-                                result_text = f"❌ Compaction failed: {ev.title or 'unknown error'}"
-                        elif ev.kind == EVENT_COMPLETE:
-                            break
-
-                await asyncio.wait_for(_run(), timeout=120)
-                if not result_text:
-                    cr = await provider.wait_for_compaction(timeout=120.0)
-                    if cr["type"] == "completed":
-                        summary = cr.get("summary", "")
-                        result_text = (
-                            f"✅ Compacted: {summary}" if summary else "✅ Context compacted."
-                        )
-                    elif cr["type"] == "failed":
-                        err = cr.get("summary", "")
-                        result_text = (
-                            f"❌ Compaction failed: {err}" if err else "❌ Compaction failed."
-                        )
-                    else:
-                        result_text = "⚠️ Compaction timed out."
+                # Compaction runs over the prompt transport (#276):
+                # provider.compact() drives /compact via session/prompt (the
+                # commands/execute path does NOT run compaction — it returns
+                # with no status, the pre-#276 bug). Bound compact()'s prompt
+                # turn here, then let wait_for_compaction() own its OWN deadline
+                # for a status emitted async after end_turn — it must NOT be
+                # nested inside another timeout, or the graceful "timed out"
+                # branch is unreachable and a slow-but-healthy session gets
+                # destroyed by the outer TimeoutError.
+                await asyncio.wait_for(provider.compact(), timeout=120)
+                cr = await provider.wait_for_compaction(timeout=120.0)
+                if cr["type"] == "completed":
+                    summary = cr.get("summary", "")
+                    result_text = (
+                        f"✅ Compacted: {summary}" if summary else "✅ Context compacted."
+                    )
+                elif cr["type"] == "failed":
+                    err = cr.get("summary", "")
+                    result_text = (
+                        f"❌ Compaction failed: {err}" if err else "❌ Compaction failed."
+                    )
+                else:
+                    result_text = "⚠️ Compaction timed out."
             except Exception:
                 logger.warning("Telegram /compact failed for %s", session_key, exc_info=True)
                 result_text = "❌ Compaction failed unexpectedly."

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -167,6 +167,9 @@ class FakeProvider:
         yield _Ev(EVENT_COMPACTION_STATUS, text="completed", title="ok")
         yield _Ev(EVENT_COMPLETE, stop_reason="end_turn")
 
+    async def compact(self, context: str = "") -> None:
+        return None
+
     async def wait_for_compaction(self, timeout: float = 0.0) -> dict:
         return {"type": "completed", "summary": "ok"}
 
@@ -938,6 +941,23 @@ class TestDispatcher:
         assert any("Compacted" in t for _, t, _ in cli.edits) or any(
             "Compacted" in t for t, _ in cli.sent
         )
+
+    @pytest.mark.asyncio
+    async def test_compact_timeout_reports_gracefully(self) -> None:
+        # Regression: nested 120s timeouts made the graceful-timeout branch
+        # unreachable and destroyed a healthy session. A compaction that yields
+        # no terminal status must report a timeout and KEEP the session.
+        d, cli, sess = _dispatcher({"u1"})
+
+        async def _timeout(timeout: float = 0.0) -> dict:
+            return {"type": "timeout"}
+
+        sess._gp.wait_for_compaction = _timeout
+        await d.handle_message(self._msg("!compact"))
+        assert any("timed out" in t for _, t, _ in cli.edits) or any(
+            "timed out" in t for t, _ in cli.sent
+        )
+        assert sess.destroyed == []  # healthy session preserved
 
     @pytest.mark.asyncio
     async def test_link_and_unlink(self) -> None:

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -98,6 +98,11 @@ class FakeSessionManager:
     async def record_failure(self, key):
         return False
 
+    async def try_acquire(self, key):
+        # Mirror the real SessionManager: succeed only when a session exists
+        # (an idle one to compact); the tests never simulate a busy turn.
+        return self.has_session(key)
+
     def release(self, key):
         pass
 
@@ -2519,22 +2524,29 @@ class TestCompactCommand:
         set_allowed_users({"U_OWNER"})
 
     def _make_provider_with_compact(self, events=None):
-        """Create a FakeProvider that supports stream_command for /compact."""
+        """Create a FakeProvider whose /compact runs via the prompt transport
+        (provider.compact() + wait_for_compaction()), the path #276 fixed.
+
+        The optional ``events`` list (compaction_status LLMEvents) is
+        translated into the terminal result wait_for_compaction() returns, so
+        existing call sites keep expressing the outcome the same way.
+        """
         provider = FakeProvider(events)
-        compact_events = (
-            events
-            if events is not None
-            else [
-                LLMEvent(kind="compaction_status", text="completed", title="Summary preserved"),
-            ]
-        )
+        result = {"type": "completed", "summary": "Summary preserved"}
+        if events is not None:
+            result = {"type": "timeout", "summary": ""}
+            for e in events:
+                if e.kind == "compaction_status" and e.text in ("completed", "failed"):
+                    result = {"type": e.text, "summary": e.title or ""}
 
-        async def stream_command(command):
-            for e in compact_events:
-                yield e
-            yield LLMEvent(kind="complete")
+        async def compact(context=""):
+            return None
 
-        provider.stream_command = stream_command
+        async def wait_for_compaction(timeout=120.0):
+            return result
+
+        provider.compact = compact
+        provider.wait_for_compaction = wait_for_compaction
         return provider
 
     def _make_sessions_with_active(self, provider):
@@ -2659,8 +2671,8 @@ class TestCompactCommand:
 
     @pytest.mark.asyncio
     async def test_compact_deferred_via_wait_for_compaction(self):
-        """When stream_command yields no compaction_status, handler falls back to wait_for_compaction."""
-        provider = self._make_provider_with_compact(events=[])  # no compaction_status events
+        """The terminal status arrives via wait_for_compaction (async after end_turn)."""
+        provider = self._make_provider_with_compact(events=[])  # no mid-turn status
 
         async def wait_for_compaction(timeout=120.0):
             return {"type": "completed", "summary": "Deferred summary"}
@@ -2676,14 +2688,13 @@ class TestCompactCommand:
 
     @pytest.mark.asyncio
     async def test_compact_exception_cleans_up(self):
-        """When stream_command raises, handler posts error and removes session."""
+        """When compact() raises, handler posts error and removes session."""
         provider = FakeProvider()
 
-        async def stream_command(command):
+        async def compact(context=""):
             raise RuntimeError("process died")
-            yield  # noqa: unreachable — makes this an async generator
 
-        provider.stream_command = stream_command
+        provider.compact = compact
         sessions = self._make_sessions_with_active(provider)
         slack = MockSlackClient()
 
@@ -2710,6 +2721,46 @@ class TestCompactCommand:
         assert footer["blocks"][0]["type"] == "context"
         assert "Finished in" in footer["text"]
         assert "ctx" not in footer["text"], "Footer must NOT include stale ctx% after compact"
+
+    @pytest.mark.asyncio
+    async def test_compact_timeout_reports_gracefully(self):
+        """A compaction that yields no terminal status reports a graceful
+        timeout and keeps the session (regression: nested 120s timeouts made
+        this branch dead code and destroyed a healthy session)."""
+        provider = self._make_provider_with_compact()
+
+        async def wait_for_compaction(timeout=120.0):
+            return {"type": "timeout"}
+
+        provider.wait_for_compaction = wait_for_compaction
+        sessions = self._make_sessions_with_active(provider)
+        slack = MockSlackClient()
+
+        await handle_message(slack, sessions, "C1", "!compact", "thread1", "msg1", "U_OWNER")
+
+        texts = self._posted_texts(slack)
+        assert any("timed out" in t for t in texts)
+        assert "destroy:thread1" not in sessions.removed
+
+    @pytest.mark.asyncio
+    async def test_compact_busy_refuses_without_starting(self):
+        """While a turn holds the session semaphore, /compact refuses politely
+        and never starts a second prompt or tears the session down."""
+        provider = self._make_provider_with_compact()
+        sessions = self._make_sessions_with_active(provider)
+
+        async def try_acquire(key):
+            return False  # a turn is already in flight
+
+        sessions.try_acquire = try_acquire
+        slack = MockSlackClient()
+
+        await handle_message(slack, sessions, "C1", "!compact", "thread1", "msg1", "U_OWNER")
+
+        texts = self._posted_texts(slack)
+        assert any("Still working" in t for t in texts)
+        assert not any("Compacting context" in t for t in texts)  # never started
+        assert "destroy:thread1" not in sessions.removed
 
 
 class TestBuildTimingFooter:

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -177,6 +177,9 @@ class FakeProvider:
         yield _Ev(EVENT_COMPACTION_STATUS, text="completed", title="ok")
         yield _Ev(EVENT_COMPLETE, stop_reason="end_turn")
 
+    async def compact(self, context: str = "") -> None:
+        return None
+
     async def wait_for_compaction(self, timeout: float = 0.0) -> dict:
         return {"type": "completed", "summary": "ok"}
 
@@ -1248,6 +1251,30 @@ class TestDispatcher:
         assert sess.acquired == ["telegram:kirocrew:direct:7"]  # acquired the turn semaphore
         assert sess.released == ["telegram:kirocrew:direct:7"]  # and released it in finally
         assert any("Compact" in s[0] for s in cli.sent) or any("Compact" in e[1] for e in cli.edits)
+
+    def test_compact_timeout_reports_gracefully(self) -> None:
+        # Regression: nested 120s timeouts made the graceful-timeout branch
+        # unreachable and destroyed a healthy session. A compaction that yields
+        # no terminal status must report a timeout and KEEP the session.
+        d, cli, sess = _dispatcher({7})
+
+        async def _timeout(timeout: float = 0.0) -> dict:
+            return {"type": "timeout"}
+
+        sess._gp.wait_for_compaction = _timeout
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(
+                    channel_type="telegram", user_id="7", conversation_id="7", text="/compact"
+                )
+            )
+
+        asyncio.run(_go())
+        assert any("timed out" in s[0] for s in cli.sent) or any(
+            "timed out" in e[1] for e in cli.edits
+        )
+        assert sess.destroyed == []  # healthy session preserved
 
     def test_callback_option_echoes_choice_and_redispatches(self) -> None:
         d, cli, sess = _dispatcher({7})


### PR DESCRIPTION
## Problem

Running `/compact` from a messaging channel fails. On Discord the user sees `❌ Compaction failed.` and `⚠️ Compaction timed out.` — both returning in ~0.0s — and the context is never compacted. Slack and Telegram share the same defect.

## Why it matters

`/compact` is the only in-channel way to recover a session whose context window is filling up. When it silently no-ops, the conversation eventually overflows and the user has to start over — losing their working context on the exact channels where that hurts most.

## Fix (symptom → root cause → change)

- **Symptom:** instant `Compaction failed` / `Compaction timed out` with no compaction.
- **Root cause:** the Discord/Slack/Telegram `/compact` handlers called `provider.stream_command("/compact")`, which on the kiro backend routes through `_kiro.dev/commands/execute`. PR #276 established that `/compact` only runs over `session/prompt` (it's the path that actually drives compaction and emits `_kiro.dev/compaction/status`), and migrated the `compact()` method — but these three channel command handlers were left on the old transport. `commands/execute` returns no compaction status, so the stream loop fell straight through to a fast failed/timeout result.
- **Change:** route all three through `provider.compact()` + `provider.wait_for_compaction()`, exactly matching the already-correct Teams/Webex/WeCom/WeChat handlers.

Two follow-on defects surfaced in local review were fixed in the same change:

- **Nested-timeout regression (all three channels):** wrapping both `compact()` and `wait_for_compaction()` under one `asyncio.wait_for(..., 120)` made the graceful `⚠️ Compaction timed out.` branch unreachable — the outer timeout always fired first and a slow-but-healthy session was destroyed via the except path. Now only `compact()` is bounded; `wait_for_compaction(timeout=120.0)` owns its own deadline, so the timeout branch is reachable and the session survives.
- **Slack turn-semaphore guard:** Slack dispatches each message via `asyncio.create_task`, so a `!compact` racing a live turn could interleave two prompts on one stdio channel; with the new `session/prompt` transport that collision surfaces as "turn already active" and the except path would tear down a healthy session. `_handle_compact_command` now `try_acquire()`s the turn semaphore up front (busy → "Still working…"; no session → "No active session"), wraps the body in `try/finally`, and releases in `finally` — matching Discord/Telegram.

## Tests

- `test_discord.py::test_compact_timeout_reports_gracefully`, `test_slack_handler.py::test_compact_timeout_reports_gracefully`, `test_telegram.py::test_compact_timeout_reports_gracefully` — lock in that a no-terminal-status compaction reports a graceful timeout and does NOT destroy the session (regression guard for the nested-timeout bug).
- `test_slack_handler.py::test_compact_busy_refuses_without_starting` — a `!compact` while a turn holds the semaphore refuses politely, never starts a second prompt, and doesn't tear the session down.
- Existing per-channel compact tests updated to model the prompt transport (`compact()` + `wait_for_compaction()`).
- Full backend gate green locally: isort, flake8, mypy (562 files), and the touched channel test files (397 passing).

## Manual verification

N/A — unit coverage sufficient. The kiro-cli behavior that `commands/execute` does not drive `/compact` is established by PR #276's live-probe notes (this PR aligns the three stragglers to the transport that fix already validated).

## Screenshots

N/A — no user-visible UI change (channel message text only).
