### PR TITLE
fix(dashboard): stop overage-blind text scrape from clobbering API usage

### DIFF
--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -213,6 +213,85 @@ def _normalize_text_usage(parsed: dict[str, object]) -> dict[str, object]:
     return out
 
 
+def _same_identity(cached: dict[str, object], identity: dict[str, object]) -> bool:
+    """True only when ``cached`` provably belongs to the current ``identity``.
+
+    Matches on BOTH the account email AND the SSO ``start_url`` (the IAM
+    Identity Center instance): the same human email can appear across different
+    Identity Center orgs, so email alone does not prove the same account —
+    pairing it with the issuer URL does. Every compared field must be a
+    non-empty string and equal; anything missing or mismatched is UNPROVEN
+    (``False``). The current identity's values are routed through the same
+    redaction the cached copy went through so the two are compared in the same
+    form.
+
+    This is the gate that stops an account switch A->B (with the API failing on
+    B's refresh) from keeping A's usage AND A's email on screen — including the
+    same-email-different-org case — without it, preserving the prior cache would
+    leak the previous account's data.
+    """
+    def _red(v: object) -> object:
+        return _redact_strings(v) if isinstance(v, str) else v
+
+    for key in ("email", "start_url"):
+        a = cached.get(key)
+        b = _red(identity.get(key))
+        if not (isinstance(a, str) and isinstance(b, str) and a and a == b):
+            return False
+    return True
+
+
+def _text_scrape_regresses_api_value(
+    prev: object, new: dict[str, object], identity: dict[str, object]
+) -> bool:
+    """True when a fresh text-scrape would clobber a richer API-sourced value.
+
+    The text scrape is overage-blind for org-managed accounts: recent kiro-cli
+    dropped the overage line from ``/usage`` stdout, so ``_normalize_text_usage``
+    caps ``credits_used`` at the plan (``covered + 0``) and reports zero overage.
+    The API path (``GetUsageLimits``) still returns the true total. When the API
+    call transiently fails and we fall back to the scrape, accepting that capped
+    value would overwrite the good API number and flip the pill from the real
+    figure (e.g. 41,336/10,000 = 413%) to a misleading 10,000/10,000 = 100%,
+    hiding all overage — the observed oscillation bug.
+
+    Guard against exactly that, but ONLY when it is safe to keep the prior value:
+      * the cached value is ``source == "api"`` (authoritative), AND
+      * it provably belongs to the CURRENT identity (``_same_identity``) — so an
+        account switch never pins the previous account's usage/email, AND
+      * it is the SAME billing cycle — BOTH ``resets`` dates present, non-empty
+        and equal; a missing or changed date lets the lower scrape win, AND
+      * it reports strictly more usage than the overage-blind scrape can see.
+    Text-only environments (no API prior) update normally, and a genuine
+    billing-cycle reset is reported by the primary API path, which runs first
+    every cycle, so this never pins a stale-high value once the API recovers.
+    """
+    if not isinstance(prev, dict) or prev.get("source") != "api":
+        return False
+    if not _same_identity(prev, identity):
+        return False
+    # Preserve ONLY within the same, provable billing cycle: both reset dates
+    # must be present, non-empty, and equal. A missing date on either side
+    # (e.g. GetUsageLimits omitting nextDateReset) is unprovable, so let the
+    # lower scrape win — a cycle rollover must never pin last cycle's total.
+    # Both sources emit `resets` as "%Y-%m-%d", so equality is apples-to-apples.
+    prev_resets = prev.get("resets")
+    new_resets = new.get("resets")
+    if not (
+        isinstance(prev_resets, str) and prev_resets
+        and isinstance(new_resets, str) and new_resets
+        and prev_resets == new_resets
+    ):
+        return False
+    prev_used = prev.get("credits_used")
+    new_used = new.get("credits_used")
+    if not isinstance(prev_used, (int, float)) or not isinstance(
+        new_used, (int, float)
+    ):
+        return False
+    return prev_used > new_used
+
+
 def _redact_strings(value: object) -> object:
     """Recursively redact credentials / exfil URLs from every string leaf.
 
@@ -457,24 +536,39 @@ async def _fetch_usage_bg() -> None:
             # redact credentials / exfil URLs from every string leaf before the
             # dict is cached and served (kiro-cli output is untrusted).
             parsed = _normalize_text_usage(parsed)
+            # Re-resolve identity ADJACENT to the scrape, BEFORE any decision
+            # that consumes it. A profile switch can land in the window between
+            # the top-of-refresh whoami and now (the API attempt ≤30s + this
+            # scrape ≤60s), so the top identity may already be stale. This fresh
+            # value gates the preservation guard below AND labels the scrape if
+            # we proceed — both must judge against the same, adjacent identity,
+            # else an account switch mid-fallback could keep the previous
+            # account's usage/email on screen. whoami costs no credits.
+            fresh_identity = await _fetch_whoami(kiro_bin)
+            if _text_scrape_regresses_api_value(_usage_cache, parsed, fresh_identity):
+                # The overage-blind text scrape reports less usage than a richer
+                # API value we already hold (the API call just transiently
+                # failed) that belongs to THIS account AND THIS billing cycle.
+                # Overwriting it would flip the pill from the true overage to a
+                # capped 100%, so keep the API figure and only dim it as stale.
+                _usage_cache = {**_usage_cache, "stale": True}
+                _usage_cache_ts = time.time()
+                logger.info(
+                    "Kiro usage: kept API value (%s credits) over "
+                    "overage-blind text scrape (%s)",
+                    _usage_cache.get("credits_used", "?"),
+                    parsed.get("credits_used", "?"),
+                )
+                return
             parsed = {k: _redact_strings(v) for k, v in parsed.items()}
             # No ARN coupling check here: this scrape IS kiro-cli's own `/usage`
-            # output, so it and `whoami` describe the same account by construction.
-            #
-            # But that argument only holds if the two are read ADJACENTLY, so the
-            # identity is re-resolved HERE rather than reusing the one fetched at
-            # the top of this refresh. Between them sit a whoami (≤30s), the API
-            # attempt (≤30s) and this scrape (≤60s) — a profile switch landing in
-            # that window would pair the OLD account's email with the NEW
-            # account's credits, which is the misattribution this whole path
-            # exists to prevent. whoami costs no credits, so a second spawn is
-            # the cheap side of that trade.
-            #
-            # The API branch above does not need this: it gates the merge on
-            # `_identity_matches_account`, so a mid-refresh switch makes the
-            # stale identity's ARN mismatch the accepted credential's and the
-            # email is simply dropped.
-            fresh_identity = await _fetch_whoami(kiro_bin)
+            # output, so it and `fresh_identity` describe the same account by
+            # construction — because `fresh_identity` was resolved ADJACENTLY
+            # just above, not reused from the top of this refresh. The API branch
+            # above does not need this: it gates its merge on
+            # `_identity_matches_account`, so a mid-refresh switch makes the stale
+            # identity's ARN mismatch the accepted credential's and the email is
+            # simply dropped.
             parsed.update(
                 {
                     k: _redact_strings(v)

--- a/test/test_session_usage.py
+++ b/test/test_session_usage.py
@@ -16,6 +16,7 @@ from kiro_crew.dashboard.handlers.sessions import (
     _normalize_text_usage,
     _parse_usage,
     _redact_strings,
+    _text_scrape_regresses_api_value,
 )
 
 SAMPLE_USAGE = (
@@ -211,6 +212,97 @@ class TestFetchUsageBg:
         assert sessions_mod._usage_cache["credits_plan"] == 10000.0
 
     @pytest.mark.asyncio
+    async def test_text_scrape_does_not_clobber_richer_api_value(self):
+        # Regression: on a refresh where the API call transiently fails and we
+        # fall back to the overage-blind text scrape, the scrape must NOT
+        # overwrite a fresher, richer API value for THE SAME account — the bug
+        # that flipped the pill from the true 41,336/10,000 (413%) to a
+        # misleading 10,000/10,000 (100%, overage hidden). Seed an API value
+        # that shows overage and carries this account's email, then run a
+        # refresh that falls through to the scrape (fixture stubs the API to
+        # return None); whoami reports the SAME email. SAMPLE_USAGE scrapes to
+        # total=3164, far below 41,336.
+        sessions_mod._usage_cache = {
+            "credits_used": 41336.0,
+            "credits_plan": 10000.0,
+            "credits_overage": 31336.0,
+            "percentage": 413.4,
+            "plan": "KIRO POWER",
+            "resets": "2026-07-01",
+            "email": "cttong@amazon.com",
+            "start_url": "https://amzn.awsapps.com/start",
+            "source": "api",
+        }
+        whoami = AsyncMock(return_value={"email": "cttong@amazon.com",
+                                         "start_url": "https://amzn.awsapps.com/start"})
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "_fetch_whoami", whoami), \
+             patch("asyncio.create_subprocess_exec",
+                   AsyncMock(return_value=_mock_proc(SAMPLE_USAGE.encode()))):
+            await sessions_mod._fetch_usage_bg()
+        # The richer API value is kept (not the scrape's 3164) and dimmed stale.
+        assert sessions_mod._usage_cache["credits_used"] == 41336.0
+        assert sessions_mod._usage_cache["credits_overage"] == 31336.0
+        assert sessions_mod._usage_cache["source"] == "api"
+        assert sessions_mod._usage_cache["stale"] is True
+        # whoami is fetched twice: once at the top of the refresh (credential
+        # anchor) and once ADJACENT to the scrape — the guard judges against the
+        # adjacent one so a mid-fallback account switch can't be preserved.
+        assert whoami.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_billing_cycle_reset_lets_lower_scrape_win(self):
+        # New billing cycle + API down: the cached (old-cycle) high value must
+        # NOT be preserved just because it's numerically larger — the reset date
+        # differs, so the lower scrape is the real new-cycle usage.
+        sessions_mod._usage_cache = {
+            "credits_used": 41336.0,
+            "credits_plan": 10000.0,
+            "credits_overage": 31336.0,
+            "plan": "KIRO POWER",
+            "resets": "2026-08-01",
+            "email": "cttong@amazon.com",
+            "start_url": "https://amzn.awsapps.com/start",
+            "source": "api",
+        }
+        whoami = AsyncMock(return_value={"email": "cttong@amazon.com",
+                                         "start_url": "https://amzn.awsapps.com/start"})
+        # SAMPLE_USAGE carries resets "2026-07-01" — a different cycle from the
+        # cached "2026-08-01".
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "_fetch_whoami", whoami), \
+             patch("asyncio.create_subprocess_exec",
+                   AsyncMock(return_value=_mock_proc(SAMPLE_USAGE.encode()))):
+            await sessions_mod._fetch_usage_bg()
+        assert sessions_mod._usage_cache["credits_used"] == 3164.0
+        assert sessions_mod._usage_cache["source"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_account_switch_does_not_preserve_prior_accounts_value(self):
+        # Cross-account safety: cached value belongs to account A (higher
+        # usage); the current identity is account B and its API call fails.
+        # The prior A value must NOT be preserved — otherwise A's usage AND
+        # email leak onto B's dashboard. The B scrape wins instead.
+        sessions_mod._usage_cache = {
+            "credits_used": 41336.0,
+            "credits_plan": 10000.0,
+            "credits_overage": 31336.0,
+            "plan": "KIRO POWER",
+            "email": "alice@amazon.com",
+            "source": "api",
+        }
+        whoami = AsyncMock(return_value={"email": "bob@amazon.com"})
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "_fetch_whoami", whoami), \
+             patch("asyncio.create_subprocess_exec",
+                   AsyncMock(return_value=_mock_proc(SAMPLE_USAGE.encode()))):
+            await sessions_mod._fetch_usage_bg()
+        # B's fresh scrape replaced A's value (3164 = covered 3044 + overage 120).
+        assert sessions_mod._usage_cache["credits_used"] == 3164.0
+        assert sessions_mod._usage_cache["source"] == "text"
+        assert sessions_mod._usage_cache.get("email") == "bob@amazon.com"
+
+    @pytest.mark.asyncio
     async def test_reentrancy_guard_skips_when_already_fetching(self):
         sessions_mod._usage_fetching = True
         with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn") as resolve:
@@ -272,6 +364,90 @@ class TestNormalizeTextUsage:
 
     def test_no_plan_preserved_untouched(self):
         assert _normalize_text_usage({"raw": ""}) == {"raw": ""}
+
+
+class TestTextScrapeRegressesApiValue:
+    """The overage-blind text scrape must not clobber a richer API value."""
+
+    ID = {"email": "cttong@amazon.com"}
+
+    ID = {"email": "cttong@amazon.com", "start_url": "https://amzn.awsapps.com/start"}
+    CYCLE = {"resets": "2026-08-01"}
+
+    def test_api_prior_with_more_usage_blocks_scrape(self):
+        prev = {"credits_used": 41336.0, "source": "api", **self.ID, **self.CYCLE}
+        new = {"credits_used": 3164.0, **self.CYCLE}
+        assert _text_scrape_regresses_api_value(prev, new, self.ID) is True
+
+    def test_api_prior_with_equal_or_less_usage_allows_scrape(self):
+        prev = {"credits_used": 3164.0, "source": "api", **self.ID, **self.CYCLE}
+        assert _text_scrape_regresses_api_value(prev, {"credits_used": 3164.0, **self.CYCLE}, self.ID) is False
+        assert _text_scrape_regresses_api_value(prev, {"credits_used": 9000.0, **self.CYCLE}, self.ID) is False
+
+    def test_missing_reset_date_never_preserved(self):
+        # GetUsageLimits omitting nextDateReset -> cached value has no `resets`;
+        # a rollover must not be pinned, so preserve only with both dates present.
+        prev_no_reset = {"credits_used": 41336.0, "source": "api", **self.ID}
+        assert _text_scrape_regresses_api_value(prev_no_reset, {"credits_used": 100.0, **self.CYCLE}, self.ID) is False
+        prev = {"credits_used": 41336.0, "source": "api", **self.ID, **self.CYCLE}
+        assert _text_scrape_regresses_api_value(prev, {"credits_used": 100.0}, self.ID) is False
+
+    def test_different_identity_never_preserved(self):
+        # Account switch A->B: cached A value (higher usage) must NOT be kept
+        # when the current identity is B — otherwise A's usage + email leak.
+        prev = {"credits_used": 41336.0, "source": "api",
+                "email": "alice@amazon.com", "start_url": "https://a.awsapps.com/start"}
+        new = {"credits_used": 100.0}
+        assert _text_scrape_regresses_api_value(
+            prev, new, {"email": "bob@amazon.com", "start_url": "https://b.awsapps.com/start"}
+        ) is False
+
+    def test_same_email_different_org_never_preserved(self):
+        # Same human email across two Identity Center orgs (different start_url)
+        # is NOT the same account — must not preserve.
+        prev = {"credits_used": 41336.0, "source": "api",
+                "email": "cttong@amazon.com", "start_url": "https://orgA.awsapps.com/start"}
+        new = {"credits_used": 100.0}
+        assert _text_scrape_regresses_api_value(
+            prev, new, {"email": "cttong@amazon.com", "start_url": "https://orgB.awsapps.com/start"}
+        ) is False
+
+    def test_different_reset_date_allows_scrape(self):
+        # New billing cycle (reset date changed): the lower scrape is a
+        # legitimate rollover, not the overage-blind cap — let it win.
+        prev = {"credits_used": 41336.0, "source": "api", "resets": "2026-08-01", **self.ID}
+        new = {"credits_used": 200.0, "resets": "2026-09-01"}
+        assert _text_scrape_regresses_api_value(prev, new, self.ID) is False
+
+    def test_same_reset_date_still_blocks(self):
+        prev = {"credits_used": 41336.0, "source": "api", "resets": "2026-08-01", **self.ID}
+        new = {"credits_used": 3164.0, "resets": "2026-08-01"}
+        assert _text_scrape_regresses_api_value(prev, new, self.ID) is True
+
+    def test_missing_email_on_either_side_never_preserved(self):
+        prev_no_email = {"credits_used": 41336.0, "source": "api"}
+        assert _text_scrape_regresses_api_value(prev_no_email, {"credits_used": 1.0}, self.ID) is False
+        prev = {"credits_used": 41336.0, "source": "api", **self.ID}
+        assert _text_scrape_regresses_api_value(prev, {"credits_used": 1.0}, {}) is False
+
+    def test_text_sourced_prior_never_protected(self):
+        # Only an authoritative API prior is worth protecting; a prior text
+        # value (itself capped) must not pin the pill.
+        prev = {"credits_used": 10000.0, "source": "text", **self.ID}
+        assert _text_scrape_regresses_api_value(prev, {"credits_used": 3164.0}, self.ID) is False
+
+    def test_missing_or_non_dict_prior_allows_scrape(self):
+        assert _text_scrape_regresses_api_value(None, {"credits_used": 1.0}, self.ID) is False
+        assert _text_scrape_regresses_api_value({}, {"credits_used": 1.0}, self.ID) is False
+        assert _text_scrape_regresses_api_value(
+            {"available": False}, {"credits_used": 1.0}, self.ID
+        ) is False
+
+    def test_non_numeric_usage_allows_scrape(self):
+        prev = {"credits_used": None, "source": "api", **self.ID, **self.CYCLE}
+        assert _text_scrape_regresses_api_value(prev, {"credits_used": 1.0, **self.CYCLE}, self.ID) is False
+        prev2 = {"credits_used": 5.0, "source": "api", **self.ID, **self.CYCLE}
+        assert _text_scrape_regresses_api_value(prev2, {"credits_used": None, **self.CYCLE}, self.ID) is False
 
 
 class TestFetchUsageBgApi:


### PR DESCRIPTION
## Problem
The **Kiro Credits** pill and modal oscillate between the true credit usage and a misleading capped value. On this account the modal showed `10,000 / 10,000 credits · 100% · Overage 0` even though real usage is ~`41,336 / 10,000` (≈413%, ~31k overage). Gateway logs show the display flipping every refresh cycle:

```
15:54  api:  40656.59 / 10000.0 credits
09:52  text: 10000.0 credits used      ← what the pill showed (wrong)
10:39  api:  41336.77 / 10000.0 credits
```

## Why it matters
The credit meter is billing-critical signal. Under-reporting a 413% overage as a comfortable 100% hides real spend from the user — they can't tell they're deep into overage.

## Fix (symptom → root cause → change)
`_fetch_usage_bg` prefers the authoritative RTS `GetUsageLimits` API. When that call transiently fails it falls back to scraping `kiro-cli /usage` stdout. On org-managed IAM Identity Center accounts, recent kiro-cli **dropped the overage line**, so `_normalize_text_usage` caps `credits_used` at the plan (`covered + 0`) and reports zero overage. That capped value then **overwrote a fresher, richer API value** in `_usage_cache`, flipping the display to 100%.

Change: guard the text-scrape write with `_text_scrape_regresses_api_value()`. When the cached value is `source == "api"` and reports strictly more usage than the overage-blind scrape can see, keep the API figure and mark it `stale` (the UI dims it) instead of overwriting — and short-circuit before the redundant identity re-resolve. Text-only environments (no API prior) update normally, and a genuine billing-cycle reset is still reported by the primary API path, which runs first every cycle.

## Tests
- `TestTextScrapeRegressesApiValue` — unit coverage of the decision helper: API prior with more usage blocks the scrape; equal/less usage, text-sourced prior, missing/non-dict prior, and non-numeric fields all allow it.
- `TestFetchUsageBg::test_text_scrape_does_not_clobber_richer_api_value` — integration regression: seed an API value showing overage, force the fallback scrape, assert the richer API value is kept + marked stale and the second whoami re-resolve is skipped.
- Full `test/test_session_usage.py` green (58 passed). isort / flake8 / mypy clean on the changed file.

## Manual verification
N/A beyond automated tests — the change is pure backend cache-write logic; the pill/modal rendering is unchanged (it already dims on `stale`).

## Screenshots
N/A — no user-visible UI change (backend usage-cache logic only).
