### PR TITLE
fix(acp): forward diff fields through AcpProvider._to_llm_event

### DIFF
--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -954,6 +954,8 @@ class AcpProvider(LLMProvider):
             # effect (the gate sees an empty server name and never records).
             tool_name=e.tool_name,
             mcp_server_name=e.mcp_server_name,
+            diff_old_text=e.diff_old_text,
+            diff_path=e.diff_path,
         )
 
     async def stream(self, message: str) -> AsyncIterator[LLMEvent]:

--- a/test/test_acp_provider.py
+++ b/test/test_acp_provider.py
@@ -122,6 +122,24 @@ class TestToLlmEventFieldPropagation:
         assert ev.usage.cache_creation_tokens == 33
         assert ev.usage.cache_read_tokens == 44
 
+    @pytest.mark.asyncio
+    async def test_stream_propagates_diff_fields(self):
+        provider = _build_provider(backend=ACP_BACKEND_CLAUDE)
+        src = AcpEvent(
+            kind="tool_result",
+            tool_call_id="tc-diff",
+            diff_old_text="old content",
+            diff_path="src/example.py",
+        )
+        provider._client.stream_events = MagicMock(return_value=_async_iter([src]))
+
+        events = await _drain(provider.stream("hi"))
+
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.diff_old_text == "old content"
+        assert ev.diff_path == "src/example.py"
+
 
 class TestCompactRouting:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The merged PR #920 race fix derives file-change "before" snapshots from `diff_old_text`/`diff_path` content blocks emitted by kiro-cli. However, `AcpProvider._to_llm_event` was not forwarding those fields from the raw `AcpEvent` to the `LLMEvent` yielded to `chat_runner`.

## Why it matters

Without this forwarding, the race fix is inert on the production path — `chat_runner` never sees the authoritative before-text and falls back to the racy disk read that #920 was designed to eliminate.

## Fix

Add the two missing kwargs (`diff_old_text=e.diff_old_text`, `diff_path=e.diff_path`) to the `_to_llm_event` static method.

## Tests

- Added `test_stream_propagates_diff_fields` to `TestToLlmEventFieldPropagation` — confirms the fields survive the provider mapping.
- Existing `test_file_change_snapshots.py` suite (39 tests) continues to pass, covering the downstream consumer path.

Completes merged #920 whose fix is inert without this change.