### PR TITLE
test(channels): add a wire-level harness with attributed vendor fixtures

### DIFF
--- a/src/kiro_crew/testing/__init__.py
+++ b/src/kiro_crew/testing/__init__.py
@@ -15,6 +15,16 @@ Public entry points:
   manager that spins up an isolated, headless gateway from the workspace
   source tree (compose with ``--test-mode`` / ``--json-ready``); yields a
   ``GatewayHandle`` with the dashboard URL and tears down on exit.
+- :mod:`kiro_crew.testing.channel_fixtures` — vendor-API fixtures carrying
+  provenance (``live_probe`` / ``vendor_doc`` / ``assumed``), plus
+  ``shape_of`` / ``assert_same_shape`` for comparing a live response against
+  a recorded one by key/type skeleton. Import it directly; the fixtures root
+  is always caller-supplied.
+- :mod:`kiro_crew.testing.fake_channel_wire` — ``FakeWireSession`` /
+  ``FakeWireWebSocket``, drop-in stand-ins for the ``aiohttp`` session a
+  messaging-channel client owns. Assign one onto ``client._session`` and the
+  real client, transport, dispatcher, pipeline and renderer all run against
+  pinned vendor request/response shapes with no credentials or network.
 
 Import submodules directly (``from kiro_crew.testing.fixtures import ...``,
 ``from kiro_crew.testing.harness import ...``); no top-level re-exports,
@@ -27,4 +37,4 @@ so the package namespace stays pytest-free for non-pytest consumers.
 # fails even though the modules are in sys.modules). Both submodules are
 # pytest-free at import time, so this doesn't pull pytest into consumers
 # that only need the runtime helpers.
-from kiro_crew.testing import fixtures, harness  # noqa: E402,F401
+from kiro_crew.testing import fake_channel_wire, fixtures, harness  # noqa: E402,F401

--- a/src/kiro_crew/testing/channel_fixtures.py
+++ b/src/kiro_crew/testing/channel_fixtures.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Vendor-API fixtures with provenance, plus shape conformance.
+
+A wire fixture is a *claim about someone else's API*. Written as a bare Python
+literal it is indistinguishable from a guess, so a shape nobody ever verified
+guards the whole stack with the same authority as one captured from the live
+vendor. That is how the iLink QR bug survived a green suite: the code assumed
+``qrcode_img_content`` was image bytes, the fixtures agreed with the code, and
+nothing recorded that the assumption had never been checked.
+
+This module makes the claim explicit and testable:
+
+* every fixture carries a ``_provenance`` block naming its
+  :class:`Source` — ``live_probe`` (observed against the real API),
+  ``vendor_doc`` (transcribed from published docs), or ``assumed`` (our
+  inference, unverified);
+* :func:`shape_of` reduces a payload to a key/type skeleton, and
+  :func:`assert_same_shape` diffs two skeletons — so a live response can be
+  compared against a stored fixture without pinning volatile values
+  (tokens, ids, timestamps);
+* :func:`unverified` enumerates every ``assumed`` fixture, so the gap is a
+  visible inventory rather than an unknown.
+
+The fixtures ROOT is always supplied by the caller: this module ships in the
+runtime wheel, where no ``test/`` tree exists, so a default derived from
+``__file__`` would point at an unpackaged path for every installed consumer.
+``channel`` and ``name`` are validated as single path components before any
+filesystem access, so a fixture identifier can never escape that root.
+
+Refresh workflow (the only way a fixture should change):
+
+1. Run the endpoint against the real API with real credentials, authorized.
+2. Save the observed body via :func:`write_fixture` with
+   ``source=Source.LIVE_PROBE`` and a reference (date, request id, probe
+   script). ``write_fixture`` refuses to silently downgrade a ``live_probe``
+   fixture to ``assumed``.
+3. Re-run the suite. Every layer above is now verified against the observed
+   shape; a vendor change is a one-file edit that re-verifies the stack.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path, PureWindowsPath
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+__all__ = [
+    "Source",
+    "Provenance",
+    "Fixture",
+    "ShapeMismatch",
+    "fixtures_root",
+    "load_fixture",
+    "write_fixture",
+    "iter_fixtures",
+    "unverified",
+    "shape_of",
+    "assert_same_shape",
+]
+
+_PROVENANCE_KEY = "_provenance"
+
+
+class Source(str, Enum):
+    """How much authority a fixture's shape carries."""
+
+    LIVE_PROBE = "live_probe"
+    """Captured from the real vendor API. The only self-justifying source."""
+
+    VENDOR_DOC = "vendor_doc"
+    """Transcribed from published vendor documentation. Docs drift; weaker."""
+
+    ASSUMED = "assumed"
+    """Our own inference. Guards regressions but proves nothing about the
+    vendor -- these are what :func:`unverified` reports."""
+
+
+@dataclass(frozen=True)
+class Provenance:
+    source: Source
+    reference: str = ""
+    """Where it came from: probe script + date, doc URL + section, or why assumed."""
+    captured_at: str = ""
+    """ISO-8601 date of capture, so staleness is visible."""
+    note: str = ""
+
+    @property
+    def is_verified(self) -> bool:
+        return self.source in (Source.LIVE_PROBE, Source.VENDOR_DOC)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source": self.source.value,
+            "reference": self.reference,
+            "captured_at": self.captured_at,
+            "note": self.note,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "Provenance":
+        try:
+            source = Source(raw["source"])
+        except (KeyError, ValueError) as exc:
+            raise ValueError(
+                f"fixture provenance must name a known source "
+                f"{[s.value for s in Source]}, got {raw.get('source')!r}"
+            ) from exc
+        return cls(
+            source=source,
+            reference=str(raw.get("reference", "")),
+            captured_at=str(raw.get("captured_at", "")),
+            note=str(raw.get("note", "")),
+        )
+
+
+@dataclass(frozen=True)
+class Fixture:
+    channel: str
+    name: str
+    payload: Any
+    provenance: Provenance
+    path: Optional[Path] = None
+
+    @property
+    def is_verified(self) -> bool:
+        return self.provenance.is_verified
+
+
+class ShapeMismatch(AssertionError):
+    """A live response no longer matches the recorded fixture's shape."""
+
+
+def _safe_component(value: str, kind: str) -> str:
+    """Validate a single path component before it touches the filesystem.
+
+    ``channel`` and ``name`` are interpolated into a path, so an unvalidated
+    ``"../outside"`` (or any separator-bearing name) would let a caller read or
+    OVERWRITE files outside the fixture root. Everything here must be one plain
+    component: no separators, no ``.``/``..``, no absolute paths, no NUL.
+    """
+    if not value or not isinstance(value, str):
+        raise ValueError(f"fixture {kind} must be a non-empty string, got {value!r}")
+    # Windows silently STRIPS trailing dots and spaces, so ".. " and "..." are
+    # both ".." by the time the filesystem sees them, and "foo." is "foo".
+    # Compare against the stripped form so the traversal check cannot be evaded
+    # by padding, and reject the padding outright since it never means anything
+    # useful in a fixture identifier.
+    if value != value.strip(". ") and value.strip(". ") in ("", ".", ".."):
+        raise ValueError(f"fixture {kind} must not be a padded dot segment, got {value!r}")
+    if value != value.rstrip(". "):
+        raise ValueError(
+            f"fixture {kind} must not end in a dot or space (Windows strips them), "
+            f"got {value!r}"
+        )
+    if value in (".", ".."):
+        raise ValueError(f"fixture {kind} must not be {value!r}")
+    if "\x00" in value:
+        raise ValueError(f"fixture {kind} must not contain a NUL byte")
+    # Reject both separators on every OS, not just the local one, so a fixture
+    # name authored on POSIX cannot escape when the suite runs on Windows.
+    if "/" in value or "\\" in value or os.sep in value or (os.altsep and os.altsep in value):
+        raise ValueError(f"fixture {kind} must be a single path component, got {value!r}")
+    # A BARE DRIVE ("C:") survives every check above -- Path("C:").parts is
+    # ("C:",) and is_absolute() is False -- but ``root / "C:"`` discards the root
+    # entirely on Windows and yields a drive-relative path. Checked via
+    # PureWindowsPath so the rejection also holds when authoring on POSIX,
+    # matching the cross-OS intent of the separator check above.
+    if PureWindowsPath(value).drive:
+        raise ValueError(f"fixture {kind} must not carry a drive, got {value!r}")
+    if Path(value).is_absolute() or len(Path(value).parts) != 1:
+        raise ValueError(f"fixture {kind} must be a single relative component, got {value!r}")
+    return value
+
+
+def _resolve_within(root: Union[Path, str], *parts: str) -> Path:
+    """Join ``parts`` under ``root`` and prove the result stays inside it.
+
+    Component validation alone is not containment: a pre-existing SYMLINK at
+    ``<root>/<channel>`` points wherever it likes while every component looks
+    innocent. So the nearest on-disk ancestor is canonicalized and checked
+    against the canonical root before any read, mkdir or write happens.
+
+    Two traps this deliberately avoids:
+
+    * ``Path.exists()`` FOLLOWS symlinks, so it reports False for a DANGLING
+      link -- which ``open()`` would still happily follow. The walk therefore
+      tests ``os.path.lexists`` (the link itself), not ``exists``.
+    * The walk stops at ``base`` rather than climbing past it. A root that does
+      not exist yet is normal (``write_fixture`` creates it), and climbing above
+      it would compare some unrelated ancestor and reject a legitimate write.
+      If nothing between ``base`` and the target exists, nothing can redirect
+      us, so the lexical join is already contained.
+    """
+    base = Path(root).resolve()
+    target = base.joinpath(*parts)
+    probe = target
+    while probe != base and not os.path.lexists(probe):
+        probe = probe.parent
+    if probe == base:
+        # Nothing exists between the root and the target -- no symlink can be
+        # in the way. (A missing root is the caller's own trusted directory.)
+        return target
+    real = probe.resolve()
+    if real != base and base not in real.parents:
+        raise ValueError(
+            f"fixture path escapes the root: {'/'.join(parts)!r} resolves outside "
+            f"{base} (via {real}) -- a symlinked fixture path is not honoured"
+        )
+    return target
+
+
+def fixtures_root(root: Union[Path, str]) -> Path:
+    """Normalize an explicitly supplied fixtures root.
+
+    There is deliberately NO default. ``kiro_crew.testing`` ships inside the
+    runtime wheel, where no ``test/`` tree exists, so any default computed from
+    ``__file__`` would resolve to a path that is not packaged and fail for every
+    installed consumer. The caller owns the layout: repo suites pass their own
+    ``test/fixtures/channels``, downstream consumers pass theirs.
+    """
+    return Path(root)
+
+
+def load_fixture(channel: str, name: str, *, root: Union[Path, str]) -> Fixture:
+    _safe_component(channel, "channel")
+    _safe_component(name, "name")
+    path = _resolve_within(root, channel, f"{name}.json")
+    if not path.is_file():
+        raise FileNotFoundError(f"no wire fixture at {path}")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or _PROVENANCE_KEY not in raw:
+        raise ValueError(
+            f"{path} has no {_PROVENANCE_KEY!r} block -- an unattributed fixture "
+            f"is an unverifiable claim about the vendor's API"
+        )
+        # (fail closed: no provenance means we cannot tell verified from guessed)
+    body = {k: v for k, v in raw.items() if k != _PROVENANCE_KEY}
+    return Fixture(
+        channel=channel,
+        name=name,
+        payload=body.get("payload", body),
+        provenance=Provenance.from_dict(raw[_PROVENANCE_KEY]),
+        path=path,
+    )
+
+
+def write_fixture(
+    channel: str,
+    name: str,
+    payload: Any,
+    provenance: Provenance,
+    *,
+    root: Union[Path, str],
+    allow_downgrade: bool = False,
+) -> Path:
+    """Persist a fixture. Refuses to weaken an existing fixture's provenance.
+
+    Downgrading ``live_probe`` -> ``assumed`` would silently convert observed
+    truth into a guess, so it requires ``allow_downgrade=True``.
+    """
+    _safe_component(channel, "channel")
+    _safe_component(name, "name")
+    # Containment is proven BEFORE mkdir: a symlinked <root>/<channel>
+    # would otherwise be created/followed and the write would land outside.
+    path = _resolve_within(root, channel, f"{name}.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_file() and not allow_downgrade:
+        existing = load_fixture(channel, name, root=root)
+        if existing.provenance.is_verified and not provenance.is_verified:
+            raise ValueError(
+                f"refusing to downgrade {path.name} from "
+                f"{existing.provenance.source.value} to {provenance.source.value}; "
+                f"pass allow_downgrade=True if this is deliberate"
+            )
+    doc = {_PROVENANCE_KEY: provenance.to_dict(), "payload": payload}
+    _write_no_follow(path, json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+    return path
+
+
+def _write_no_follow(path: Path, text: str) -> None:
+    """Write ``text`` to ``path``, refusing to follow a symlink at the leaf.
+
+    ``_resolve_within`` proves containment at CHECK time; a symlink planted
+    between that check and this write would still be followed by an ordinary
+    ``write_text``. ``O_NOFOLLOW`` closes that race at the syscall: if the leaf
+    is a symlink, ``open`` fails instead of writing through it.
+
+    ``O_NOFOLLOW`` is POSIX-only, so it degrades to 0 on Windows -- where the
+    containment check remains the guard. Kept narrow deliberately: this is the
+    one place the module writes.
+
+    Known residual (accepted, not exploitable here): the guard covers the LEAF
+    only. A concurrent actor could still swap an intermediate directory for a
+    symlink between the containment check and ``mkdir``/``open``. Closing that
+    would need descriptor-relative traversal (``openat`` with
+    ``O_DIRECTORY|O_NOFOLLOW`` per component) and has no portable Windows
+    equivalent. It buys nothing against this module's actual threat model: the
+    root comes from test code, never from a model or remote input, the fixture
+    is read back by the same test process, and an actor who can plant a symlink
+    inside the fixture tree mid-run can simply edit the test instead.
+
+    Ownership of the descriptor transfers exactly ONCE: if ``fdopen`` raises we
+    still own the raw fd and must close it; once it succeeds the file object owns
+    it exclusively. Closing in both places would double-close the same NUMBER,
+    and another thread could have reused it in between -- shutting an unrelated
+    file or socket.
+
+    The write is ATOMIC: bytes land in a temporary sibling that is fsynced and
+    then ``os.replace``d over ``path``. Opening ``path`` directly with
+    ``O_TRUNC`` would destroy the existing fixture at OPEN time, so any later
+    failure -- a full disk, a broken pipe -- would leave a truncated file and
+    lose a payload that may have cost a credentialled live probe to capture.
+    Since the module already refuses to weaken a fixture's provenance, letting a
+    failed write erase its CONTENT would protect the claim and discard the
+    evidence. Either the old bytes survive intact or the new ones replace them
+    whole; there is no in-between state a reader can observe.
+
+    ``os.replace`` also cannot write THROUGH a symlink at ``path`` -- it swaps
+    the directory entry itself -- so the containment guarantee holds regardless
+    of the pre-check below. The explicit ``is_symlink`` check is kept so a
+    symlinked leaf is REPORTED rather than silently replaced.
+    """
+    if path.is_symlink():
+        raise ValueError(
+            f"refusing to write fixture through a symlink at {path.name}"
+        )
+    # Same directory as the target, so the containment already proven for
+    # ``path`` covers the temporary too. O_EXCL means a pre-planted file (or
+    # symlink) at the temporary name is refused rather than reused.
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{os.urandom(6).hex()}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(tmp, flags, 0o644)
+    try:
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+    except BaseException:
+        os.close(fd)  # fdopen never took ownership
+        _unlink_quietly(tmp)
+        raise
+    try:
+        with handle:  # the file object now owns the fd exclusively
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        _unlink_quietly(tmp)  # never leave a partial sibling behind
+        raise
+    os.replace(tmp, path)
+
+
+def _unlink_quietly(path: Path) -> None:
+    """Best-effort cleanup of a temporary that is already being abandoned.
+
+    Called only from an ``except`` path, so it must never mask the original
+    exception with a secondary failure of its own.
+    """
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def iter_fixtures(*, root: Union[Path, str]) -> List[Fixture]:
+    base = fixtures_root(root)
+    if not base.is_dir():
+        return []
+    out: List[Fixture] = []
+    for path in sorted(base.glob("*/*.json")):
+        out.append(load_fixture(path.parent.name, path.stem, root=root))
+    return out
+
+
+def unverified(*, root: Union[Path, str]) -> List[Fixture]:
+    """Every fixture whose shape nobody has confirmed against the vendor."""
+    return [f for f in iter_fixtures(root=root) if not f.is_verified]
+
+
+# -- shape comparison ---------------------------------------------------------
+def shape_of(value: Any) -> Any:
+    """Reduce a payload to a key/type skeleton.
+
+    Values are discarded so volatile data (tokens, ids, timestamps) never makes
+    a conformance check flaky; only structure and types are compared. Lists
+    collapse to the union of their element shapes, so a 1-element sample and a
+    50-element response compare equal when the elements agree.
+    """
+    if isinstance(value, dict):
+        return {k: shape_of(v) for k, v in sorted(value.items())}
+    if isinstance(value, list):
+        seen: List[Any] = []
+        for item in value:
+            s = shape_of(item)
+            if s not in seen:
+                seen.append(s)
+        return ["|".join(_render(s) for s in seen)] if seen else []
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if value is None:
+        return "null"
+    return "str"
+
+
+def _render(shape: Any) -> str:
+    return json.dumps(shape, sort_keys=True) if isinstance(shape, (dict, list)) else str(shape)
+
+
+def _flatten(shape: Any, prefix: str = "") -> Dict[str, str]:
+    flat: Dict[str, str] = {}
+    if isinstance(shape, dict):
+        for k, v in shape.items():
+            flat.update(_flatten(v, f"{prefix}.{k}" if prefix else k))
+    else:
+        flat[prefix or "<root>"] = _render(shape)
+    return flat
+
+
+def assert_same_shape(expected: Any, actual: Any, *, context: str = "") -> None:
+    """Assert two payloads share a key/type skeleton, reporting a precise diff.
+
+    Intended for fixture-vs-live conformance: run the real endpoint, pass the
+    stored fixture as ``expected``, and any vendor drift surfaces as named
+    missing / extra / retyped fields instead of an opaque inequality.
+    """
+    exp_flat = _flatten(shape_of(expected))
+    act_flat = _flatten(shape_of(actual))
+    missing = sorted(set(exp_flat) - set(act_flat))
+    extra = sorted(set(act_flat) - set(exp_flat))
+    retyped: List[Tuple[str, str, str]] = [
+        (k, exp_flat[k], act_flat[k])
+        for k in sorted(set(exp_flat) & set(act_flat))
+        if exp_flat[k] != act_flat[k]
+    ]
+    if not (missing or extra or retyped):
+        return
+    lines = [f"wire shape drifted{f' [{context}]' if context else ''}:"]
+    if missing:
+        lines.append(f"  fields the fixture expects but the response lacks: {missing}")
+    if extra:
+        lines.append(f"  fields the response added (fixture is stale): {extra}")
+    for key, want, got in retyped:
+        lines.append(f"  {key}: fixture says {want}, response has {got}")
+    raise ShapeMismatch("\n".join(lines))

--- a/src/kiro_crew/testing/fake_channel_wire.py
+++ b/src/kiro_crew/testing/fake_channel_wire.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Wire-level fake for messaging-channel vendor APIs.
+
+Channel tests have historically faked the *client* (``FakeClient`` standing in
+for ``WeixinClient`` / ``WeComClient`` / ...), which means the client's own
+payload construction, header/signature building, and protocol-error parsing are
+never exercised by the turn tests -- exactly the layer where the iLink QR bug
+lived (``qrcode_img_content`` is a scannable URL, not image bytes; fixtures were
+green while production was broken).
+
+This module fakes ONE level down: the ``aiohttp`` session. Everything above the
+socket runs for real -- client, transport, dispatcher, the shared
+``messaging.dispatch`` pipeline, and the renderer -- so a test can assert on the
+*actual bytes the channel would put on the wire* without any credential,
+network, or vendor account.
+
+Seam
+----
+Every channel client stores its session as a lazily-created attribute
+(``self._session: Any = None``, built in ``connect()``). A test assigns a
+:class:`FakeWireSession` onto that attribute and the client never creates a real
+one::
+
+    client = WeixinClient(token="t", base_url="https://example.invalid")
+    wire = FakeWireSession()
+    wire.route("POST", "sendmsg", {"errcode": 0})
+    client._session = wire            # no monkeypatching of aiohttp internals
+
+    await client.send_message("u1", "hi")
+    sent = wire.requests[0]
+    assert sent.json_body["base_info"]["app_id"]   # real payload, real headers
+
+What this does and does NOT prove
+---------------------------------
+It proves our whole stack agrees with a PINNED response shape: if a fixture
+says a field is a URL string, every layer above is verified against that.
+It does NOT prove the vendor agrees -- only a live probe can establish the
+shape in the first place. The intended workflow is therefore: probe once
+against the real API (authorized), encode the observed shape here as a
+fixture, and let the fixture guard every layer forever after. When a vendor
+changes, one fixture changes and the whole stack is re-verified.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+__all__ = [
+    "RecordedRequest",
+    "WireResponse",
+    "FakeWireSession",
+    "FakeWireWebSocket",
+    "UnroutedRequestError",
+]
+
+
+_QUEUED = object()
+"""Sentinel marking a route whose responses live in ``_queues``."""
+
+
+def _is_sequence_target(target: Any) -> bool:
+    """True for a scripted SEQUENCE of responses.
+
+    ``RouteTarget`` declares ``Iterable``, so a tuple or any other non-mapping
+    sequence must be treated as a script -- handling only ``list`` would have
+    silently used a tuple as a response BODY.
+
+    The mapping exclusion tests ``Mapping``, not ``dict``: a ``MappingProxyType``
+    or any custom mapping is Iterable over its KEYS, so a dict-only check would
+    turn a perfectly ordinary response body into a script of its key strings.
+    """
+    if isinstance(target, (WireResponse, Mapping, str, bytes)) or callable(target):
+        return False
+    return isinstance(target, Iterable)
+
+
+class UnroutedRequestError(AssertionError):
+    """Raised when the code under test calls an endpoint with no fixture.
+
+    Deliberately fail-closed: a silent default would let a channel start
+    calling a new vendor endpoint with nobody noticing the shape was never
+    pinned.
+    """
+
+
+@dataclass
+class RecordedRequest:
+    """One outbound call, captured for assertions."""
+
+    method: str
+    url: str
+    headers: Dict[str, str] = field(default_factory=dict)
+    body: Optional[Union[str, bytes, Dict[str, Any]]] = None
+    """str/bytes for a JSON or raw body; dict when the caller used aiohttp's
+    form-encoding (``data={...}``) -- inspect via ``.form``."""
+    params: Optional[Dict[str, Any]] = None
+
+    @property
+    def json_body(self) -> Any:
+        """Decode the request body as JSON (the common vendor case)."""
+        if self.body is None:
+            raise AssertionError(f"{self.method} {self.url} carried no body")
+        if isinstance(self.body, dict):
+            raise AssertionError(
+                f"{self.method} {self.url} was form-encoded, not JSON -- use .form"
+            )
+        raw = self.body.decode("utf-8") if isinstance(self.body, bytes) else self.body
+        return json.loads(raw)
+
+    @property
+    def form(self) -> Dict[str, Any]:
+        """Form-encoded body (aiohttp accepts a dict for ``data=``).
+
+        The Teams app-credential exchange posts this way, so a wire test must be
+        able to inspect it without the fake having silently JSON-encoded it.
+        """
+        if not isinstance(self.body, dict):
+            raise AssertionError(f"{self.method} {self.url} was not form-encoded")
+        return self.body
+
+    @property
+    def path(self) -> str:
+        """URL without scheme/host -- what routes are matched on."""
+        no_scheme = self.url.split("://", 1)[-1]
+        slash = no_scheme.find("/")
+        return no_scheme[slash:] if slash >= 0 else "/"
+
+
+def _json_fallback(value: Any) -> Any:
+    """Encode a non-``dict`` ``Mapping`` body that ``json`` refuses on its own.
+
+    A route target that is a ``Mapping`` but NOT a ``dict`` -- the obvious case
+    being ``MappingProxyType``, which channel code hands out to keep a payload
+    read-only -- is deliberately treated as a response BODY rather than a script
+    of its keys. ``json.dumps`` does not accept one: ``mappingproxy`` is not a
+    ``dict`` subclass, so encoding raised ``TypeError`` at read time and turned a
+    supported body into a crash inside the client under test.
+
+    Hooked in as ``default=`` rather than converting the body once at the top
+    level, because ``json`` calls this for EVERY value it cannot encode. A
+    mapping nested inside a plain dict is therefore covered at any depth, which a
+    single ``dict(self.body)`` at the surface would silently miss.
+    """
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise TypeError(
+        f"{type(value).__name__} is not JSON-serializable; pass a str, bytes, "
+        f"or a JSON-compatible object as the response body"
+    )
+
+
+@dataclass
+class WireResponse:
+    """A canned vendor response.
+
+    ``body`` may be a str (returned verbatim) or any JSON-serializable object
+    (encoded). ``content_type`` matters more than it looks: the iLink QR bug
+    was a ``text/html`` response where the code assumed image bytes.
+    """
+
+    body: Any = field(default_factory=dict)
+    status: int = 200
+    content_type: str = "application/json"
+    headers: Dict[str, str] = field(default_factory=dict)
+
+    def text(self) -> str:
+        if isinstance(self.body, str):
+            return self.body
+        if isinstance(self.body, bytes):
+            return self.body.decode("utf-8")
+        return json.dumps(self.body, default=_json_fallback)
+
+    def raw(self) -> bytes:
+        if isinstance(self.body, bytes):
+            return self.body
+        return self.text().encode("utf-8")
+
+
+class _FakeResponseCM:
+    """Async context manager mimicking ``aiohttp``'s response object."""
+
+    def __init__(self, resp: WireResponse) -> None:
+        self._resp = resp
+        self.status = resp.status
+        self.headers = {"Content-Type": resp.content_type, **resp.headers}
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status < 400
+
+    @property
+    def content_type(self) -> str:
+        return self._resp.content_type
+
+    async def text(self) -> str:
+        return self._resp.text()
+
+    async def read(self) -> bytes:
+        return self._resp.raw()
+
+    async def json(self, **_kw: Any) -> Any:
+        return json.loads(self._resp.text())
+
+    async def __aenter__(self) -> "_FakeResponseCM":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+
+# A route resolves to a single response, an iterable of responses (consumed in
+# order -- for poll loops that must see a sequence), or a callable taking the
+# RecordedRequest and returning one.
+RouteTarget = Union[
+    WireResponse,
+    Dict[str, Any],
+    Iterable[Union[WireResponse, Dict[str, Any]]],
+    Callable[[RecordedRequest], Union[WireResponse, Dict[str, Any]]],
+]
+
+
+class FakeWireSession:
+    """Stand-in for ``aiohttp.ClientSession`` at the channel wire boundary.
+
+    Routes are matched by ``(method, substring-of-path)``; the longest matching
+    substring wins so a specific endpoint can override a general one. Every
+    call is appended to :attr:`requests` in order.
+    """
+
+    def __init__(self, *, strict: bool = True) -> None:
+        self.requests: List[RecordedRequest] = []
+        self.closed = False
+        self._routes: Dict[Tuple[str, str], Any] = {}
+        self._queues: Dict[Tuple[str, str], List[Any]] = {}
+        self._ws: Optional["FakeWireWebSocket"] = None
+        self._strict = strict
+
+    # -- fixture wiring --------------------------------------------------------
+    def route(self, method: str, path_contains: str, target: RouteTarget) -> "FakeWireSession":
+        """Register a canned response. Chainable.
+
+        A **sequence** target (list, tuple, any non-mapping iterable) is a
+        SCRIPT: successive calls consume it in order, and a call past the end
+        raises :class:`UnroutedRequestError`. That is deliberate -- silently
+        repeating the last response would hide a client that polled more times
+        than the test scripted, which is the same class of bug the fail-closed
+        routing exists to catch. Script a steady state explicitly by registering
+        a single response instead of a sequence; a single target answers every
+        call.
+
+        The sequence is COPIED into private state, so a script held in a
+        module-level constant is never mutated and cannot carry consumed state
+        between tests.
+        """
+        key = (method.upper(), path_contains)
+        if _is_sequence_target(target):
+            self._queues[key] = list(target)  # type: ignore[arg-type]
+            self._routes[key] = _QUEUED
+        else:
+            self._routes[key] = target
+        return self
+
+    def route_ws(self, ws: "FakeWireWebSocket") -> "FakeWireSession":
+        self._ws = ws
+        return self
+
+    # -- aiohttp surface -------------------------------------------------------
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        data: Any = None,
+        json: Any = None,  # noqa: A002 - mirrors aiohttp's kwarg name
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        **_kw: Any,
+    ) -> _FakeResponseCM:
+        """Generic verb dispatch -- aiohttp's ``session.request(METHOD, ...)``.
+
+        Webex's ``_api`` drives every verb through this one call, so a fake
+        lacking it would make those clients untestable at the wire layer.
+        """
+        body = data if data is not None else (_dumps(json) if json is not None else None)
+        return self._dispatch(method.upper(), url, headers, body, params)
+
+    def post(
+        self,
+        url: str,
+        *,
+        data: Any = None,
+        json: Any = None,  # noqa: A002 - mirrors aiohttp's kwarg name
+        headers: Optional[Dict[str, str]] = None,
+        **_kw: Any,
+    ) -> _FakeResponseCM:
+        body = data if data is not None else (_dumps(json) if json is not None else None)
+        return self._dispatch("POST", url, headers, body, None)
+
+    def get(
+        self,
+        url: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        **_kw: Any,
+    ) -> _FakeResponseCM:
+        return self._dispatch("GET", url, headers, None, params)
+
+    def ws_connect(self, url: str, **_kw: Any) -> "FakeWireWebSocket":
+        self.requests.append(RecordedRequest(method="WS", url=url))
+        if self._ws is None:
+            raise UnroutedRequestError(f"ws_connect({url}) with no route_ws() fixture")
+        return self._ws
+
+    async def close(self) -> None:
+        self.closed = True
+
+    # -- routing ---------------------------------------------------------------
+    def _dispatch(
+        self,
+        method: str,
+        url: str,
+        headers: Optional[Dict[str, str]],
+        body: Any,
+        params: Optional[Dict[str, Any]],
+    ) -> _FakeResponseCM:
+        rec = RecordedRequest(
+            method=method, url=url, headers=dict(headers or {}), body=body, params=params
+        )
+        self.requests.append(rec)
+        target = self._match(method, rec.path)
+        if target is None:
+            if self._strict:
+                raise UnroutedRequestError(
+                    f"no fixture for {method} {rec.path!r}. Register one with "
+                    f"route({method!r}, <path substring>, <response>) -- a channel "
+                    f"calling an unpinned endpoint is exactly what this guards."
+                )
+            return _FakeResponseCM(WireResponse())
+        return _FakeResponseCM(_coerce(target, rec))
+
+    def _match(self, method: str, path: str) -> Any:
+        best: Optional[Tuple[int, Tuple[str, str]]] = None
+        for key, _target in self._routes.items():
+            m, frag = key
+            if m != method or frag not in path:
+                continue
+            if best is None or len(frag) > best[0]:
+                best = (len(frag), key)
+        if best is None:
+            return None
+        key = best[1]
+        target = self._routes[key]
+        if target is _QUEUED:
+            queue = self._queues[key]
+            if not queue:
+                raise UnroutedRequestError(
+                    f"scripted responses for {key[0]} {key[1]!r} are exhausted: the "
+                    f"client called it more times than the test scripted. Register a "
+                    f"single response instead of a sequence for a steady state."
+                )
+            return queue.pop(0)
+        return target
+
+
+class FakeWireWebSocket:
+    """Scripted stand-in for an ``aiohttp`` WebSocket (WS-based channels).
+
+    ``incoming`` frames are yielded to the channel's read loop in order; once
+    drained the socket reports closed so the loop exits instead of spinning.
+    Outbound frames land in :attr:`sent` for assertions.
+    """
+
+    def __init__(self, incoming: Optional[Iterable[Any]] = None) -> None:
+        self._incoming: List[Any] = list(incoming or [])
+        self.sent: List[Any] = []
+        self.closed = False
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def send_json(self, data: Any) -> None:
+        self.sent.append(_dumps(data))
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def __aenter__(self) -> "FakeWireWebSocket":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        self.closed = True
+
+    def __aiter__(self) -> "FakeWireWebSocket":
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._incoming:
+            self.closed = True
+            raise StopAsyncIteration
+        return self._incoming.pop(0)
+
+
+def _dumps(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
+
+
+def _coerce(target: Any, rec: RecordedRequest) -> WireResponse:
+    if callable(target) and not isinstance(target, WireResponse):
+        target = target(rec)
+    if isinstance(target, WireResponse):
+        return target
+    return WireResponse(body=target)

--- a/test/fixtures/channels/teams/activity_sent.json
+++ b/test/fixtures/channels/teams/activity_sent.json
@@ -1,0 +1,11 @@
+{
+  "_provenance": {
+    "source": "vendor_doc",
+    "reference": "Bot Framework Connector REST: POST /v3/conversations/{conversationId}/activities returns a ResourceResponse carrying the activity id. https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference",
+    "captured_at": "2026-07-30",
+    "note": "Transcribed from published docs, NOT a live capture. kiro_crew.teams reads only 'id' (returned as the activity id, used to edit/replace the placeholder)."
+  },
+  "payload": {
+    "id": "1690000000000"
+  }
+}

--- a/test/fixtures/channels/teams/app_credential.json
+++ b/test/fixtures/channels/teams/app_credential.json
@@ -1,0 +1,14 @@
+{
+  "_provenance": {
+    "source": "vendor_doc",
+    "reference": "Microsoft identity platform client-credentials flow (POST /{tenant}/oauth2/v2.0/token) response: access_token, token_type, expires_in. https://learn.microsoft.com/entra/identity-platform/v2-oauth2-client-creds-grant",
+    "captured_at": "2026-07-30",
+    "note": "Transcribed from published docs, NOT a live capture. The access_token value here is a PLACEHOLDER and not a credential. kiro_crew.teams reads access_token + expires_in; expires_in drives the refresh-skew cache."
+  },
+  "payload": {
+    "access_token": "PLACEHOLDER-NOT-A-CREDENTIAL",
+    "token_type": "Bearer",
+    "expires_in": 3599,
+    "ext_expires_in": 3599
+  }
+}

--- a/test/fixtures/channels/webex/message_created.json
+++ b/test/fixtures/channels/webex/message_created.json
@@ -1,0 +1,14 @@
+{
+  "_provenance": {
+    "source": "vendor_doc",
+    "reference": "Webex Messages API (POST /v1/messages) documented response fields: id, roomId, personEmail, created. https://developer.webex.com/docs/api/v1/messages/create-a-message",
+    "captured_at": "2026-07-30",
+    "note": "Transcribed from published docs, NOT captured from a live call. Docs drift; a live probe would upgrade this to live_probe. Only the fields kiro_crew.webex reads (id) are load-bearing."
+  },
+  "payload": {
+    "id": "Y2lzY29zcGFyazovL3VzL01FU1NBR0UvZXhhbXBsZQ",
+    "roomId": "Y2lzY29zcGFyazovL3VzL1JPT00vZXhhbXBsZQ",
+    "personEmail": "someone@example.com",
+    "created": "2026-07-30T18:00:00.000Z"
+  }
+}

--- a/test/fixtures/channels/weixin/get_bot_qrcode.json
+++ b/test/fixtures/channels/weixin/get_bot_qrcode.json
@@ -1,0 +1,12 @@
+{
+  "_provenance": {
+    "source": "live_probe",
+    "reference": "Authorized probe against ilinkai.weixin.qq.com during PR #711 (WeChat QR render fix). Observed Content-Type: text/html; qrcode_img_content was a scannable liteapp login URL, NOT image bytes -- the assumption that broke production.",
+    "captured_at": "2026-07-28",
+    "note": "Field VALUES are redacted/short-lived (the qrcode id expires); only the SHAPE is load-bearing. Re-probe and rewrite this file if iLink changes the contract."
+  },
+  "payload": {
+    "qrcode": "7GiQu1",
+    "qrcode_img_content": "https://liteapp.weixin.qq.com/q/7GiQu1?qrcode=7GiQu1&bot_type=3"
+  }
+}

--- a/test/fixtures/channels/weixin/sendmessage_ok.json
+++ b/test/fixtures/channels/weixin/sendmessage_ok.json
@@ -1,0 +1,11 @@
+{
+  "_provenance": {
+    "source": "assumed",
+    "reference": "Inferred from kiro_crew.weixin.client.protocol_error_code, which reads BOTH 'errcode' and 'ret'. No capture of a real iLink sendmessage success body exists.",
+    "captured_at": "",
+    "note": "UNVERIFIED against the vendor. Guards our own parsing (a 200 with a nonzero code must not be reported as delivered) but does not establish that iLink returns exactly these keys on success. Replace with a live_probe capture next time credentials are in hand."
+  },
+  "payload": {
+    "errcode": 0
+  }
+}

--- a/test/test_channel_fixtures.py
+++ b/test/test_channel_fixtures.py
@@ -1,0 +1,553 @@
+"""Guards for vendor-API fixture provenance and shape conformance.
+
+A wire fixture asserts something about someone else's API. These tests make
+that assertion auditable: every fixture must say where its shape came from, an
+unverified fixture must be visible as such rather than silently authoritative,
+and a live response can be diffed against a stored fixture by shape alone.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.testing.channel_fixtures import (
+    Provenance,
+    ShapeMismatch,
+    Source,
+    assert_same_shape,
+    iter_fixtures,
+    load_fixture,
+    shape_of,
+    unverified,
+    write_fixture,
+)
+
+# The fixtures root lives in the TEST tree, so the layout coupling lives here
+# too -- kiro_crew.testing.channel_fixtures ships in the wheel and deliberately
+# has no default root (no test/ tree exists in an installed package).
+CHANNEL_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "channels"
+
+
+class TestFixtureIdentifiersCannotEscapeTheRoot:
+    """``channel``/``name`` are interpolated into a path, so they are validated.
+
+    Without this, ``load_fixture("../../etc", "passwd")`` would read outside the
+    root and ``write_fixture`` would OVERWRITE outside it -- arbitrary local file
+    access under the user's permissions.
+    """
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "..",
+            ".",
+            "../outside",
+            "a/b",
+            "a\\b",
+            "/abs",
+            "",
+            "nul\x00byte",
+        ],
+    )
+    def test_traversal_and_separators_are_rejected_for_channel(self, bad, tmp_path) -> None:
+        with pytest.raises(ValueError):
+            load_fixture(bad, "x", root=tmp_path)
+
+    @pytest.mark.parametrize("bad", ["C:", "a:", "Z:"])
+    def test_a_bare_drive_component_is_rejected(self, bad, tmp_path) -> None:
+        """``root / "C:"`` discards the root entirely on Windows.
+
+        A bare drive survives the separator, absolute and parts checks --
+        ``Path("C:").parts == ("C:",)`` and ``is_absolute()`` is False -- but
+        joining it drops the root and yields a drive-relative path. Rejected via
+        PureWindowsPath so the guard holds when authoring on POSIX too.
+        """
+        with pytest.raises(ValueError, match="drive"):
+            load_fixture(bad, "x", root=tmp_path)
+        with pytest.raises(ValueError, match="drive"):
+            load_fixture("weixin", bad, root=tmp_path)
+
+    @pytest.mark.parametrize("bad", [".. ", "...", "..  ", ". ", "foo.", "foo "])
+    def test_windows_stripped_padding_is_rejected(self, bad, tmp_path) -> None:
+        """Windows strips trailing dots and spaces before the filesystem sees them.
+
+        So ".. " IS ".." there, and "foo." IS "foo" -- padding must never be a
+        way to smuggle a dot segment past the traversal check.
+        """
+        with pytest.raises(ValueError):
+            load_fixture(bad, "x", root=tmp_path)
+
+    def test_a_drive_relative_path_is_still_rejected(self, tmp_path) -> None:
+        # "C:foo" is two parts, so the existing component check already caught
+        # it -- pinned so a refactor of the drive check cannot regress it.
+        with pytest.raises(ValueError):
+            load_fixture("C:foo", "x", root=tmp_path)
+
+    @pytest.mark.parametrize("bad", ["..", "a/b", "a\\b", "/abs", ""])
+    def test_traversal_and_separators_are_rejected_for_name(self, bad, tmp_path) -> None:
+        with pytest.raises(ValueError):
+            load_fixture("weixin", bad, root=tmp_path)
+
+    def test_write_is_validated_before_touching_the_filesystem(self, tmp_path) -> None:
+        outside = tmp_path.parent / "escaped.json"
+        with pytest.raises(ValueError):
+            write_fixture(
+                "../..",
+                "escaped",
+                {"a": 1},
+                Provenance(Source.ASSUMED, reference="attack"),
+                root=tmp_path,
+            )
+        assert not outside.exists(), "write_fixture must reject before mkdir/write"
+
+    def test_a_valid_identifier_still_resolves_inside_the_root(self, tmp_path) -> None:
+        path = write_fixture(
+            "weixin",
+            "ok",
+            {"a": 1},
+            Provenance(Source.ASSUMED, reference="unit"),
+            root=tmp_path,
+        )
+        assert path.parent.parent == tmp_path
+
+
+class TestNoImplicitFixturesRoot:
+    """The shipped module must not guess a root.
+
+    ``kiro_crew.testing`` is in the runtime wheel, where no ``test/`` tree
+    exists, so any ``__file__``-derived default would resolve to an unpackaged
+    path and fail for every installed consumer. The caller owns the layout.
+    """
+
+    def test_root_is_a_required_keyword(self) -> None:
+        import inspect
+
+        for fn in (load_fixture, iter_fixtures, unverified, write_fixture):
+            sig = inspect.signature(fn)
+            assert sig.parameters["root"].default is inspect.Parameter.empty, (
+                f"{fn.__name__} must require an explicit root -- a default derived "
+                f"from __file__ is wrong in an installed wheel"
+            )
+
+    def test_a_missing_root_directory_yields_no_fixtures_rather_than_raising(
+        self, tmp_path
+    ) -> None:
+        assert iter_fixtures(root=tmp_path / "nope") == []
+
+
+class TestProvenanceIsMandatory:
+    def test_every_committed_fixture_declares_a_known_source(self) -> None:
+        fixtures = iter_fixtures(root=CHANNEL_FIXTURES)
+        assert fixtures, "no channel wire fixtures found -- did the tree move?"
+        for fx in fixtures:
+            assert isinstance(fx.provenance.source, Source)
+            assert fx.provenance.reference, (
+                f"{fx.channel}/{fx.name} names a source but no reference; a claim "
+                f"about a vendor API must say where it came from"
+            )
+
+    def test_verified_fixtures_record_when_they_were_captured(self) -> None:
+        for fx in iter_fixtures(root=CHANNEL_FIXTURES):
+            if fx.provenance.source is Source.LIVE_PROBE:
+                assert fx.provenance.captured_at, (
+                    f"{fx.channel}/{fx.name} claims a live probe but no date -- "
+                    f"staleness must be visible"
+                )
+
+    def test_a_fixture_without_provenance_is_rejected(self, tmp_path) -> None:
+        d = tmp_path / "weixin"
+        d.mkdir(parents=True)
+        (d / "bare.json").write_text(json.dumps({"errcode": 0}), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="_provenance"):
+            load_fixture("weixin", "bare", root=tmp_path)
+
+    def test_unknown_source_is_rejected(self, tmp_path) -> None:
+        d = tmp_path / "weixin"
+        d.mkdir(parents=True)
+        (d / "odd.json").write_text(
+            json.dumps({"_provenance": {"source": "vibes"}, "payload": {}}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="known source"):
+            load_fixture("weixin", "odd", root=tmp_path)
+
+
+class TestUnverifiedInventory:
+    def test_unverified_fixtures_are_enumerable(self) -> None:
+        # Not an assertion that the list is empty -- it is not, and pretending
+        # otherwise is the failure mode this module exists to prevent. The
+        # contract is that the gap is KNOWN.
+        names = {f"{f.channel}/{f.name}" for f in unverified(root=CHANNEL_FIXTURES)}
+        assert "weixin/sendmessage_ok" in names, (
+            "the sendmessage success body has never been captured from iLink; "
+            "it must keep reporting as unverified until it is"
+        )
+
+    def test_the_live_probed_qr_shape_is_verified(self) -> None:
+        fx = load_fixture("weixin", "get_bot_qrcode", root=CHANNEL_FIXTURES)
+        assert fx.is_verified
+        assert fx.provenance.source is Source.LIVE_PROBE
+        # The shape claim that PR #711 established.
+        assert fx.payload["qrcode_img_content"].startswith("https://")
+
+
+class TestNoSilentDowngrade:
+    def test_verified_fixture_cannot_be_overwritten_as_assumed(self, tmp_path) -> None:
+        write_fixture(
+            "weixin",
+            "probe",
+            {"a": 1},
+            Provenance(Source.LIVE_PROBE, reference="probe", captured_at="2026-07-28"),
+            root=tmp_path,
+        )
+
+        with pytest.raises(ValueError, match="refusing to downgrade"):
+            write_fixture(
+                "weixin",
+                "probe",
+                {"a": 1},
+                Provenance(Source.ASSUMED, reference="guess"),
+                root=tmp_path,
+            )
+
+    def test_downgrade_is_possible_when_explicit(self, tmp_path) -> None:
+        write_fixture(
+            "weixin",
+            "probe",
+            {"a": 1},
+            Provenance(Source.LIVE_PROBE, reference="probe", captured_at="2026-07-28"),
+            root=tmp_path,
+        )
+        write_fixture(
+            "weixin",
+            "probe",
+            {"a": 1},
+            Provenance(Source.ASSUMED, reference="deliberate"),
+            root=tmp_path,
+            allow_downgrade=True,
+        )
+        assert not load_fixture("weixin", "probe", root=tmp_path).is_verified
+
+
+class TestShapeComparison:
+    def test_values_are_ignored_so_volatile_data_never_flakes(self) -> None:
+        fixture = {"qrcode": "7GiQu1", "expires_in": 300}
+        live = {"qrcode": "ZZ9pluralZalpha", "expires_in": 600}
+        assert_same_shape(fixture, live)  # different values, same shape
+
+    def test_a_missing_field_is_reported_by_name(self) -> None:
+        with pytest.raises(ShapeMismatch, match="qrcode_img_content"):
+            assert_same_shape(
+                {"qrcode": "a", "qrcode_img_content": "https://x"}, {"qrcode": "a"}
+            )
+
+    def test_a_retyped_field_is_reported_with_both_types(self) -> None:
+        # The exact drift class behind #711: a field that was a string
+        # coming back as something else (or vice versa).
+        with pytest.raises(ShapeMismatch, match="fixture says str, response has int"):
+            assert_same_shape({"errcode": "0"}, {"errcode": 0})
+
+    def test_an_added_field_marks_the_fixture_stale(self) -> None:
+        with pytest.raises(ShapeMismatch, match="fixture is stale"):
+            assert_same_shape({"a": 1}, {"a": 1, "b": 2})
+
+    def test_nested_paths_are_named_in_full(self) -> None:
+        with pytest.raises(ShapeMismatch, match=r"msg\.item_list"):
+            assert_same_shape({"msg": {"item_list": [{"type": 1}]}}, {"msg": {}})
+
+    def test_list_length_does_not_matter_only_element_shape(self) -> None:
+        one = {"msgs": [{"text": "a"}]}
+        many = {"msgs": [{"text": "a"}, {"text": "b"}, {"text": "c"}]}
+        assert_same_shape(one, many)
+
+    def test_heterogeneous_list_elements_are_distinguished(self) -> None:
+        assert shape_of([{"a": 1}]) != shape_of([{"a": 1}, {"b": 2}])
+
+    def test_empty_containers_compare_equal_to_themselves(self) -> None:
+        assert_same_shape({"msgs": []}, {"msgs": []})
+
+
+class TestRouteScriptSemantics:
+    """A sequence route is an exact script, not a repeating steady state."""
+
+    def test_a_shared_sequence_is_copied_not_consumed(self) -> None:
+        from kiro_crew.testing.fake_channel_wire import FakeWireSession
+
+        shared = [{"n": 1}, {"n": 2}]
+        wire = FakeWireSession().route("POST", "/x", shared)
+        wire._match("POST", "/x")
+        wire._match("POST", "/x")
+
+        assert shared == [{"n": 1}, {"n": 2}], "the caller's script must be untouched"
+
+    def test_calling_past_the_script_raises_instead_of_repeating(self) -> None:
+        from kiro_crew.testing.fake_channel_wire import (
+            FakeWireSession,
+            UnroutedRequestError,
+        )
+
+        wire = FakeWireSession().route("POST", "/x", [{"n": 1}, {"n": 2}])
+        wire._match("POST", "/x")
+        wire._match("POST", "/x")
+
+        # Repeating the last response would hide a client that polled more times
+        # than the test scripted -- the same bug class fail-closed routing exists
+        # to catch.
+        with pytest.raises(UnroutedRequestError, match="exhausted"):
+            wire._match("POST", "/x")
+
+    def test_a_tuple_target_is_a_script_not_a_response_body(self) -> None:
+        from kiro_crew.testing.fake_channel_wire import FakeWireSession
+
+        # RouteTarget declares Iterable; handling only list would have used the
+        # tuple itself as the response body.
+        wire = FakeWireSession().route("POST", "/x", ({"n": 1}, {"n": 2}))
+
+        assert wire._match("POST", "/x") == {"n": 1}
+        assert wire._match("POST", "/x") == {"n": 2}
+
+    def test_a_single_target_answers_every_call(self) -> None:
+        from kiro_crew.testing.fake_channel_wire import FakeWireSession
+
+        wire = FakeWireSession().route("POST", "/x", {"n": 1})
+
+        assert [wire._match("POST", "/x") for _ in range(3)] == [{"n": 1}] * 3
+
+
+class TestSymlinkContainment:
+    """Component validation is not containment.
+
+    A pre-existing symlink at <root>/<channel> points wherever it likes while
+    every component looks innocent, so the canonical path is checked too.
+    """
+
+    def test_a_dangling_symlink_at_the_leaf_is_refused(self, tmp_path) -> None:
+        """exists() is False for a BROKEN link, but open() still follows it.
+
+        So a walk gated on exists() would skip the link as "nonexistent", pass
+        containment, and then write straight through it to the link's target.
+        """
+        root = tmp_path / "fixtures"
+        (root / "weixin").mkdir(parents=True)
+        outside = tmp_path / "outside" / "stolen.json"
+        outside.parent.mkdir()
+        (root / "weixin" / "x.json").symlink_to(outside)  # dangling: target absent
+
+        with pytest.raises(ValueError, match="escapes the root"):
+            write_fixture(
+                "weixin", "x", {"a": 1}, Provenance(Source.ASSUMED, reference="t"), root=root
+            )
+        assert not outside.exists(), "must not write through a dangling symlink"
+
+    def test_a_dangling_symlink_is_refused_on_read_too(self, tmp_path) -> None:
+        root = tmp_path / "fixtures"
+        (root / "weixin").mkdir(parents=True)
+        (root / "weixin" / "x.json").symlink_to(tmp_path / "outside" / "nope.json")
+
+        with pytest.raises(ValueError, match="escapes the root"):
+            load_fixture("weixin", "x", root=root)
+
+    def test_a_root_that_does_not_exist_yet_is_created_not_refused(self, tmp_path) -> None:
+        """A missing root is normal -- write_fixture creates it.
+
+        The containment walk must stop AT the root rather than climbing above
+        it, or a legitimate first write into a fresh directory is rejected.
+        """
+        fresh = tmp_path / "brand" / "new" / "root"
+
+        path = write_fixture(
+            "weixin", "ok", {"a": 1}, Provenance(Source.ASSUMED, reference="t"), root=fresh
+        )
+
+        assert path.is_file()
+        assert load_fixture("weixin", "ok", root=fresh).payload == {"a": 1}
+
+    def test_a_symlinked_channel_directory_is_refused_on_read(self, tmp_path) -> None:
+        root = tmp_path / "fixtures"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "x.json").write_text('{"_provenance": {"source": "assumed"}}', encoding="utf-8")
+        (root / "weixin").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="escapes the root"):
+            load_fixture("weixin", "x", root=root)
+
+    def test_a_symlinked_channel_directory_is_refused_before_write(self, tmp_path) -> None:
+        root = tmp_path / "fixtures"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (root / "weixin").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="escapes the root"):
+            write_fixture(
+                "weixin", "x", {"a": 1}, Provenance(Source.ASSUMED, reference="t"), root=root
+            )
+        assert not (outside / "x.json").exists(), "must refuse BEFORE writing"
+
+    def test_a_real_directory_under_the_root_still_works(self, tmp_path) -> None:
+        path = write_fixture(
+            "weixin", "ok", {"a": 1}, Provenance(Source.ASSUMED, reference="t"), root=tmp_path
+        )
+        assert path.is_file()
+        assert load_fixture("weixin", "ok", root=tmp_path).payload == {"a": 1}
+
+    def test_a_mid_write_failure_does_not_double_close_the_descriptor(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The fd must be closed exactly once, by exactly one owner.
+
+        If the write raises inside the ``with``, the file object closes the fd --
+        and a second close of the same NUMBER could shut an unrelated file or
+        socket that another thread opened in between. This drives a failure
+        through the write path and counts the closes on that descriptor.
+        """
+        import os as _os
+
+        from kiro_crew.testing import channel_fixtures as cf
+
+        closed: list[int] = []
+        real_close = _os.close
+        monkeypatch.setattr(_os, "close", lambda fd: (closed.append(fd), real_close(fd))[1])
+
+        class Boom(RuntimeError):
+            pass
+
+        real_fdopen = _os.fdopen
+
+        def _exploding_fdopen(fd, *a, **kw):
+            handle = real_fdopen(fd, *a, **kw)
+            original_write = handle.write
+
+            def _write(_text):  # raise AFTER the file object owns the fd
+                original_write("")
+                raise Boom("write failed")
+
+            monkeypatch.setattr(handle, "write", _write, raising=False)
+            return handle
+
+        monkeypatch.setattr(_os, "fdopen", _exploding_fdopen)
+
+        with pytest.raises(Boom):
+            cf._write_no_follow(tmp_path / "x.json", "payload")
+
+        assert len(closed) == len(set(closed)), (
+            f"a descriptor was closed twice: {closed} -- another thread could have "
+            f"reused that number between the closes"
+        )
+
+    def test_a_failed_write_preserves_the_existing_fixture(self, tmp_path, monkeypatch) -> None:
+        """A write that dies mid-flight must not destroy the payload it replaces.
+
+        Opening the target with O_TRUNC truncates at OPEN time, so a full disk
+        would leave an empty file and lose bytes that may have cost a
+        credentialled live probe to capture. The old content must survive whole.
+        """
+        import os as _os
+
+        from kiro_crew.testing import channel_fixtures as cf
+
+        target = tmp_path / "x.json"
+        target.write_text('{"original": true}', encoding="utf-8")
+
+        real_fdopen = _os.fdopen
+
+        def _exploding_fdopen(fd, *a, **kw):
+            handle = real_fdopen(fd, *a, **kw)
+
+            def _write(_text):  # simulate ENOSPC part-way through
+                raise OSError(28, "No space left on device")
+
+            monkeypatch.setattr(handle, "write", _write, raising=False)
+            return handle
+
+        monkeypatch.setattr(_os, "fdopen", _exploding_fdopen)
+
+        with pytest.raises(OSError):
+            cf._write_no_follow(target, '{"replacement": true}')
+
+        assert target.read_text(encoding="utf-8") == '{"original": true}', (
+            "a failed write truncated the existing fixture"
+        )
+        strays = [p.name for p in tmp_path.iterdir() if p.name != "x.json"]
+        assert strays == [], f"a partial temporary was left behind: {strays}"
+
+    def test_a_successful_write_leaves_no_temporary_behind(self, tmp_path) -> None:
+        """The happy path must replace the target and clean up after itself."""
+        from kiro_crew.testing import channel_fixtures as cf
+
+        target = tmp_path / "x.json"
+        cf._write_no_follow(target, '{"new": true}')
+
+        assert target.read_text(encoding="utf-8") == '{"new": true}'
+        assert [p.name for p in tmp_path.iterdir()] == ["x.json"]
+
+    def test_a_symlinked_leaf_is_reported_not_silently_replaced(self, tmp_path) -> None:
+        """os.replace would swap the LINK for a file -- no escape, but silent.
+
+        The write never follows the link either way; the explicit check is what
+        turns a confusing silent success into a stated refusal.
+        """
+        from kiro_crew.testing import channel_fixtures as cf
+
+        outside = tmp_path / "outside.json"
+        outside.write_text("untouched", encoding="utf-8")
+        link = tmp_path / "x.json"
+        link.symlink_to(outside)
+
+        with pytest.raises(ValueError, match="symlink"):
+            cf._write_no_follow(link, '{"new": true}')
+
+        assert outside.read_text(encoding="utf-8") == "untouched"
+        assert link.is_symlink(), "the symlink itself must be left alone"
+
+    def test_a_non_dict_mapping_is_a_response_body_not_a_script(self) -> None:
+        """Mapping, not dict: a MappingProxyType is Iterable over its KEYS.
+
+        A dict-only exclusion would turn an ordinary response body into a
+        script of its key strings.
+        """
+        from types import MappingProxyType
+
+        from kiro_crew.testing.fake_channel_wire import FakeWireSession
+
+        body = MappingProxyType({"errcode": 0, "msg": "ok"})
+        wire = FakeWireSession().route("POST", "/x", body)
+
+        assert wire._match("POST", "/x") == body
+        assert wire._match("POST", "/x") == body, "a single target answers every call"
+
+    def test_a_mapping_body_survives_being_read_not_just_routed(self) -> None:
+        """Accepting a Mapping as a body is only half the contract.
+
+        Routing it is useless if reading it explodes: json.dumps rejects a
+        mappingproxy outright (it is not a dict subclass), so a supported body
+        became a TypeError inside the client under test. Nested mappings matter
+        too -- a top-level-only conversion would still crash one level down.
+        """
+        import json as _json
+        from types import MappingProxyType
+
+        from kiro_crew.testing.fake_channel_wire import WireResponse
+
+        flat = WireResponse(body=MappingProxyType({"errcode": 0, "msg": "ok"}))
+        assert _json.loads(flat.text()) == {"errcode": 0, "msg": "ok"}
+        assert _json.loads(flat.raw().decode("utf-8")) == {"errcode": 0, "msg": "ok"}
+
+        nested = WireResponse(
+            body={"outer": MappingProxyType({"inner": MappingProxyType({"n": 1})})}
+        )
+        assert _json.loads(nested.text()) == {"outer": {"inner": {"n": 1}}}
+
+    def test_an_unserializable_body_still_reports_its_type(self) -> None:
+        """The fallback must not silently swallow a genuinely bad body."""
+        from kiro_crew.testing.fake_channel_wire import WireResponse
+
+        with pytest.raises(TypeError, match="object.*not JSON-serializable|not JSON"):
+            WireResponse(body=object()).text()

--- a/test/test_channel_wire_conformance.py
+++ b/test/test_channel_wire_conformance.py
@@ -1,0 +1,89 @@
+"""Live vendor conformance -- the only test that can prove a fixture is true.
+
+Everything else in the channel suite runs against fixtures. Fixtures encode a
+claim about the vendor's API, and a claim can go stale silently: the vendor adds
+a field, retypes one, or changes a content type, and our whole green suite keeps
+agreeing with itself. This module closes that loop by replaying the recorded
+SHAPE against the real endpoint.
+
+It is opt-in and skipped by default -- it needs real credentials and makes real
+network calls, so it must never run in the normal suite or on a fork PR:
+
+    KIROCREW_WIRE_PROBE=1 \\
+    KIROCREW_WIRE_PROBE_WEIXIN_TOKEN=<bot token> \\
+    pytest test/test_channel_wire_conformance.py -v
+
+On drift the failure names the exact field and both types (see
+``assert_same_shape``), which is the actionable form: re-probe, rewrite the
+fixture with a fresh ``live_probe`` provenance, and the whole stack re-verifies
+against the new shape.
+
+Only shapes are compared, never values -- tokens, ids and timestamps are
+volatile by design and pinning them would make this lane flaky rather than
+informative.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.testing.channel_fixtures import assert_same_shape, load_fixture
+
+# The fixtures root lives in the TEST tree, so the layout coupling lives here
+# too -- kiro_crew.testing.channel_fixtures ships in the wheel and deliberately
+# has no default root (no test/ tree exists in an installed package).
+CHANNEL_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "channels"
+
+_PROBE_ENABLED = os.environ.get("KIROCREW_WIRE_PROBE") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not _PROBE_ENABLED,
+    reason=(
+        "live vendor conformance is opt-in: set KIROCREW_WIRE_PROBE=1 plus the "
+        "per-channel credential env vars (real network calls)"
+    ),
+)
+
+
+def _require(var: str) -> str:
+    val = os.environ.get(var, "")
+    if not val:
+        pytest.skip(f"{var} not set -- cannot probe this channel")
+    return val
+
+
+class TestWeixinConformance:
+    def test_get_bot_qrcode_still_matches_the_recorded_shape(self) -> None:
+        """Re-verify the #711 contract against live iLink.
+
+        This is the test that would have caught the original bug before it
+        shipped: if ``qrcode_img_content`` ever stops being a string URL, or the
+        response gains/loses fields, the fixture is stale and the diff says so.
+        """
+        from kiro_crew.weixin.client import WeixinClient
+
+        token = _require("KIROCREW_WIRE_PROBE_WEIXIN_TOKEN")
+        fixture = load_fixture("weixin", "get_bot_qrcode", root=CHANNEL_FIXTURES)
+
+        async def _probe() -> dict:
+            client = WeixinClient(token=token)
+            await client.connect()
+            try:
+                return await client.get_bot_qrcode()
+            finally:
+                await client.close()
+
+        live = asyncio.run(_probe())
+
+        assert_same_shape(fixture.payload, live, context="weixin get_bot_qrcode")
+        # Restate the load-bearing semantic, not just the type: the field is a
+        # scannable URL. A string that stopped being a URL would pass a pure
+        # shape check but break the QR renderer exactly as #711 did.
+        assert str(live["qrcode_img_content"]).startswith("http"), (
+            "qrcode_img_content is no longer a URL -- the QR render path "
+            "(server-side encode to PNG data URI) assumes it is"
+        )

--- a/test/test_teams_wire.py
+++ b/test/test_teams_wire.py
@@ -1,0 +1,182 @@
+"""Wire-level tests for the Microsoft Teams channel.
+
+Runs the REAL TeamsClient against a fake aiohttp session. Teams is the most
+worthwhile channel to test at this layer because its outbound path carries an
+app bearer credential to a **server-supplied** URL (``serviceUrl`` arrives on
+the inbound activity), so the request-construction code is a security boundary,
+not just a serialization detail.
+
+The credential exchange posts FORM-encoded data (``data={...}``), not JSON --
+inspected via ``RecordedRequest.form``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from kiro_crew.teams.client import TeamsClient
+from kiro_crew.testing.channel_fixtures import load_fixture
+from kiro_crew.testing.fake_channel_wire import FakeWireSession, WireResponse
+
+CHANNEL_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "channels"
+
+_CREDENTIAL = load_fixture("teams", "app_credential", root=CHANNEL_FIXTURES).payload
+_ACTIVITY_SENT = load_fixture("teams", "activity_sent", root=CHANNEL_FIXTURES).payload
+
+_SERVICE_URL = "https://smba.trafficmanager.net/teams"
+
+
+def _client(wire: FakeWireSession) -> TeamsClient:
+    client = TeamsClient(app_id="app-1", app_password="secret-pw", tenant_id="tenant-1")
+    client._session = wire
+    return client
+
+
+def _wired() -> FakeWireSession:
+    return (
+        FakeWireSession()
+        .route("POST", "/oauth2/v2.0/token", _CREDENTIAL)
+        .route("POST", "/v3/conversations/", _ACTIVITY_SENT)
+    )
+
+
+class TestOutboundCredentialIsNeverSentInPlaintext:
+    """The refusal that makes serviceUrl safe to trust.
+
+    ``serviceUrl`` comes from the inbound activity -- i.e. from the network. If
+    it were honoured verbatim, an ``http://`` value would put the app bearer
+    credential on the wire in plaintext. The client refuses; this asserts the
+    refusal by observing that NO request is made at all.
+    """
+
+    def test_an_http_service_url_sends_nothing(self) -> None:
+        wire = _wired()
+        client = _client(wire)
+
+        out = asyncio.run(
+            client.send_message("conv-1", "hi", "http://smba.trafficmanager.net/teams")
+        )
+
+        assert out is None
+        assert wire.requests == [], (
+            "a non-https serviceUrl must produce NO request -- not even the "
+            "credential exchange, which would itself leak nothing but proves the "
+            "guard runs before any network work"
+        )
+
+    def test_a_scheme_relative_or_bare_host_sends_nothing(self) -> None:
+        wire = _wired()
+        client = _client(wire)
+
+        assert asyncio.run(client.send_message("conv-1", "hi", "//evil.example")) is None
+        assert asyncio.run(client.send_message("conv-1", "hi", "smba.example")) is None
+        assert wire.requests == []
+
+    def test_an_empty_service_url_sends_nothing(self) -> None:
+        wire = _wired()
+        client = _client(wire)
+
+        assert asyncio.run(client.send_message("conv-1", "hi", "")) is None
+        assert wire.requests == []
+
+    def test_an_https_service_url_is_accepted(self) -> None:
+        wire = _wired()
+        client = _client(wire)
+
+        out = asyncio.run(client.send_message("conv-1", "hello", _SERVICE_URL))
+
+        assert out == _ACTIVITY_SENT["id"]
+        activity = [r for r in wire.requests if "/v3/conversations/" in r.path][0]
+        assert activity.url.startswith("https://")
+
+
+class TestActivityRequestShape:
+    def test_the_activity_url_and_body_match_the_connector_contract(self) -> None:
+        wire = _wired()
+        client = _client(wire)
+
+        asyncio.run(client.send_message("conv-1", "hello", _SERVICE_URL))
+
+        activity = [r for r in wire.requests if "/v3/conversations/" in r.path][0]
+        assert activity.path == "/teams/v3/conversations/conv-1/activities"
+        assert activity.json_body == {"type": "message", "text": "hello"}
+        assert activity.headers["Authorization"] == "Bearer " + _CREDENTIAL["access_token"]
+
+    def test_typing_posts_a_typing_activity(self) -> None:
+        wire = _wired()
+        client = _client(wire)
+
+        asyncio.run(client.send_typing("conv-1", _SERVICE_URL))
+
+        activity = [r for r in wire.requests if "/v3/conversations/" in r.path][0]
+        assert activity.json_body == {"type": "typing"}
+
+    def test_empty_text_is_replaced_so_the_connector_never_400s(self) -> None:
+        wire = _wired()
+        client = _client(wire)
+
+        asyncio.run(client.send_message("conv-1", "", _SERVICE_URL))
+
+        activity = [r for r in wire.requests if "/v3/conversations/" in r.path][0]
+        assert activity.json_body["text"], "an empty activity text is rejected by the API"
+
+
+class TestCredentialExchange:
+    def test_the_exchange_uses_the_client_credentials_grant(self) -> None:
+        wire = _wired()
+        client = _client(wire)
+
+        asyncio.run(client.send_message("conv-1", "hi", _SERVICE_URL))
+
+        auth = [r for r in wire.requests if "/oauth2/v2.0/token" in r.path][0]
+        form = auth.form
+        assert form["grant_type"] == "client_credentials"
+        assert form["client_id"] == "app-1"
+        assert form["scope"].endswith("/.default")
+        # The tenant is templated into the path, so a wrong tenant is a wrong URL.
+        assert "/tenant-1/" in auth.path
+
+    def test_the_credential_is_cached_across_sends(self) -> None:
+        """A per-message exchange would triple outbound latency and hit throttling."""
+        wire = _wired()
+        client = _client(wire)
+
+        asyncio.run(client.send_message("conv-1", "one", _SERVICE_URL))
+        asyncio.run(client.send_message("conv-1", "two", _SERVICE_URL))
+
+        exchanges = [r for r in wire.requests if "/oauth2/v2.0/token" in r.path]
+        assert len(exchanges) == 1, "the cached credential must be reused"
+
+    def test_a_failed_exchange_does_not_post_an_activity(self) -> None:
+        wire = (
+            FakeWireSession()
+            .route("POST", "/oauth2/v2.0/token", WireResponse(body={}, status=401))
+            .route("POST", "/v3/conversations/", _ACTIVITY_SENT)
+        )
+        client = _client(wire)
+
+        out = asyncio.run(client.send_message("conv-1", "hi", _SERVICE_URL))
+
+        assert out is None
+        assert not [r for r in wire.requests if "/v3/conversations/" in r.path], (
+            "an unauthenticated activity post would be a wasted 401 round trip"
+        )
+        assert client.last_error
+
+
+class TestConnectorErrors:
+    def test_a_4xx_activity_is_reported_not_raised(self) -> None:
+        wire = (
+            FakeWireSession()
+            .route("POST", "/oauth2/v2.0/token", _CREDENTIAL)
+            .route("POST", "/v3/conversations/", WireResponse(body="forbidden", status=403))
+        )
+        client = _client(wire)
+
+        out = asyncio.run(client.send_message("conv-1", "hi", _SERVICE_URL))
+
+        assert out is None
+        assert client.last_error.startswith("send failed"), (
+            "a connector failure must surface on last_error for the status badge"
+        )

--- a/test/test_webex_wire.py
+++ b/test/test_webex_wire.py
@@ -1,0 +1,149 @@
+"""Wire-level tests for the Webex channel.
+
+Runs the REAL WebexClient against a fake aiohttp session, so the request the
+channel would actually make -- verb, URL, payload, auth header -- is asserted
+instead of being replaced by a FakeClient in the dispatcher tests.
+
+Webex drives every verb through ``_api`` -> ``session.request(...)``, which is
+why the harness needs a generic ``request()`` surface; a fake with only
+post/get would leave this client untestable at this layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from kiro_crew.testing.channel_fixtures import load_fixture
+from kiro_crew.testing.fake_channel_wire import FakeWireSession, WireResponse
+from kiro_crew.webex.client import WebexClient
+
+CHANNEL_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "channels"
+
+_MESSAGE_CREATED = load_fixture("webex", "message_created", root=CHANNEL_FIXTURES).payload
+
+
+def _client(wire: FakeWireSession) -> WebexClient:
+    client = WebexClient(token="webex-tok")
+    client._session = wire
+    return client
+
+
+class TestSendMessageAddressing:
+    """Webex takes EITHER a roomId or a toPersonEmail -- never both."""
+
+    def test_a_room_id_is_sent_as_room_id(self) -> None:
+        wire = FakeWireSession().route("POST", "/messages", _MESSAGE_CREATED)
+        client = _client(wire)
+
+        msg_id = asyncio.run(client.send_message("ROOM-123", "hello"))
+
+        body = wire.requests[0].json_body
+        assert body["roomId"] == "ROOM-123"
+        assert "toPersonEmail" not in body
+        assert msg_id == _MESSAGE_CREATED["id"]
+
+    def test_an_email_is_sent_as_to_person_email(self) -> None:
+        # The '@' heuristic is how resolve_conversation hands proactive sends a
+        # person instead of a room; sending it as roomId would 400.
+        wire = FakeWireSession().route("POST", "/messages", _MESSAGE_CREATED)
+        client = _client(wire)
+
+        asyncio.run(client.send_message("someone@example.com", "hello"))
+
+        body = wire.requests[0].json_body
+        assert body["toPersonEmail"] == "someone@example.com"
+        assert "roomId" not in body
+
+    def test_a_parent_id_threads_the_reply(self) -> None:
+        wire = FakeWireSession().route("POST", "/messages", _MESSAGE_CREATED)
+        client = _client(wire)
+
+        asyncio.run(client.send_message("ROOM-1", "reply", parent_id="MSG-9"))
+
+        assert wire.requests[0].json_body["parentId"] == "MSG-9"
+
+    def test_the_bearer_credential_is_attached(self) -> None:
+        wire = FakeWireSession().route("POST", "/messages", _MESSAGE_CREATED)
+        client = _client(wire)
+
+        asyncio.run(client.send_message("ROOM-1", "hi"))
+
+        assert wire.requests[0].headers.get("Authorization") == "Bearer webex-tok"
+
+
+class TestVerbsAndPaths:
+    def test_edit_uses_put_on_the_message_path(self) -> None:
+        wire = FakeWireSession().route("PUT", "/messages/", _MESSAGE_CREATED)
+        client = _client(wire)
+
+        ok = asyncio.run(client.edit_message("MSG-9", "ROOM-1", "edited"))
+
+        req = wire.requests[0]
+        assert (req.method, ok) == ("PUT", True)
+        assert req.path.endswith("/messages/MSG-9")
+        assert req.json_body["roomId"] == "ROOM-1"
+
+    def test_delete_uses_delete_and_sends_no_body(self) -> None:
+        wire = FakeWireSession().route("DELETE", "/messages/", WireResponse(body={}))
+        client = _client(wire)
+
+        asyncio.run(client.delete_message("MSG-9"))
+
+        req = wire.requests[0]
+        assert req.method == "DELETE"
+        assert req.body is None
+
+    def test_fetch_uses_get(self) -> None:
+        wire = FakeWireSession().route("GET", "/messages/", _MESSAGE_CREATED)
+        client = _client(wire)
+
+        out = asyncio.run(client.fetch_message("MSG-9"))
+
+        assert wire.requests[0].method == "GET"
+        assert out == _MESSAGE_CREATED
+
+
+class TestRateLimitBackoff:
+    def test_a_429_is_retried_once_honouring_retry_after(self, monkeypatch) -> None:
+        """A dropped rate-limited edit would freeze the placeholder forever.
+
+        The client waits out one Retry-After and retries; this pins that the
+        retry actually happens (two requests) rather than the call giving up.
+        """
+        slept: list[float] = []
+
+        async def _no_sleep(secs: float) -> None:
+            slept.append(secs)
+
+        monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+        wire = FakeWireSession().route(
+            "POST",
+            "/messages",
+            [
+                WireResponse(body={}, status=429, headers={"Retry-After": "2"}),
+                _MESSAGE_CREATED,
+            ],
+        )
+        client = _client(wire)
+
+        msg_id = asyncio.run(client.send_message("ROOM-1", "hi"))
+
+        assert len(wire.requests) == 2, "the 429 must be retried, not dropped"
+        assert slept == [2.0], "Retry-After must be honoured, not a fixed guess"
+        assert msg_id == _MESSAGE_CREATED["id"]
+
+    def test_a_second_429_gives_up_instead_of_looping(self, monkeypatch) -> None:
+        async def _no_sleep(_secs: float) -> None:
+            return None
+
+        monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+        wire = FakeWireSession().route(
+            "POST", "/messages", WireResponse(body={}, status=429, headers={"Retry-After": "1"})
+        )
+        client = _client(wire)
+
+        msg_id = asyncio.run(client.send_message("ROOM-1", "hi"))
+
+        assert msg_id is None
+        assert len(wire.requests) == 2, "bounded at one retry -- never an unbounded loop"

--- a/test/test_wecom_wire.py
+++ b/test/test_wecom_wire.py
@@ -1,0 +1,156 @@
+"""Wire-level tests for the WeCom channel.
+
+Runs the REAL WeComClient against fakes for both of its wire surfaces:
+
+* the one-shot reply, an HTTP POST to the inbound message's ``response_url``
+  (whose embedded response_code is the ONLY credential -- single-use, 1h TTL);
+* the streaming reply, a WS frame (``aibot_respond_msg``) whose routing depends
+  entirely on echoing back the server-assigned ``req_id``.
+
+Both are pure request construction, so the dispatcher tests -- which replace the
+client wholesale -- never exercise either.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from kiro_crew.testing.fake_channel_wire import (
+    FakeWireSession,
+    FakeWireWebSocket,
+    WireResponse,
+)
+from kiro_crew.wecom.client import _REPLY_MAX_CHARS, WeComClient
+
+CHANNEL_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "channels"
+
+_RESPONSE_URL = "https://qyapi.weixin.qq.com/cgi-bin/aibot/reply?code=abc123"
+
+
+def _client(wire: FakeWireSession | None = None) -> WeComClient:
+    client = WeComClient(bot_id="bot-1", secret="s", ws_url="wss://example.invalid/ws")
+    if wire is not None:
+        client._session = wire
+    return client
+
+
+class TestOneShotReply:
+    def test_the_reply_posts_markdown_to_the_response_url(self) -> None:
+        wire = FakeWireSession().route("POST", "/cgi-bin/aibot/reply", {"errcode": 0})
+        client = _client(wire)
+
+        asyncio.run(client.send_reply(_RESPONSE_URL, "**hi**"))
+
+        req = wire.requests[0]
+        assert req.method == "POST"
+        assert req.url == _RESPONSE_URL, "the response_url must be used verbatim"
+        assert req.json_body == {"msgtype": "markdown", "markdown": {"content": "**hi**"}}
+
+    def test_empty_content_is_replaced_so_the_api_never_400s(self) -> None:
+        wire = FakeWireSession().route("POST", "/cgi-bin/aibot/reply", {"errcode": 0})
+        client = _client(wire)
+
+        asyncio.run(client.send_reply(_RESPONSE_URL, ""))
+
+        assert wire.requests[0].json_body["markdown"]["content"]
+
+    def test_overlong_content_is_truncated_before_sending(self) -> None:
+        wire = FakeWireSession().route("POST", "/cgi-bin/aibot/reply", {"errcode": 0})
+        client = _client(wire)
+
+        asyncio.run(client.send_reply(_RESPONSE_URL, "x" * (_REPLY_MAX_CHARS + 500)))
+
+        sent = wire.requests[0].json_body["markdown"]["content"]
+        assert len(sent) == _REPLY_MAX_CHARS, (
+            "the client must cap at the documented limit, not let the API reject it"
+        )
+
+    def test_a_missing_response_url_sends_nothing(self) -> None:
+        wire = FakeWireSession()
+        client = _client(wire)
+
+        asyncio.run(client.send_reply("", "hi"))
+
+        assert wire.requests == []
+
+    def test_an_http_error_does_not_raise_out_of_the_reply_path(self) -> None:
+        # A raising ack would abort the turn after the model already answered.
+        wire = FakeWireSession().route(
+            "POST", "/cgi-bin/aibot/reply", WireResponse(body="nope", status=500)
+        )
+        client = _client(wire)
+
+        asyncio.run(client.send_reply(_RESPONSE_URL, "hi"))  # must not raise
+
+
+class TestStreamFrames:
+    """The WS frame shape -- routing lives entirely in the echoed req_id."""
+
+    def test_the_frame_carries_the_command_req_id_and_stream_body(self) -> None:
+        ws = FakeWireWebSocket()
+        client = _client()
+        client._ws = ws  # type: ignore[assignment]
+
+        ok = asyncio.run(
+            client.send_stream("REQ-1", "STREAM-1", "partial", finish=False)
+        )
+
+        assert ok is True
+        frame = json.loads(ws.sent[0])
+        assert frame["cmd"] == "aibot_respond_msg"
+        assert frame["headers"]["req_id"] == "REQ-1", (
+            "req_id is the ONLY routing key -- a wrong one silently delivers nowhere"
+        )
+        assert frame["body"]["msgtype"] == "stream"
+        assert frame["body"]["stream"] == {
+            "id": "STREAM-1",
+            "finish": False,
+            "content": "partial",
+        }
+
+    def test_finish_locks_the_bubble(self) -> None:
+        ws = FakeWireWebSocket()
+        client = _client()
+        client._ws = ws  # type: ignore[assignment]
+
+        asyncio.run(client.send_stream("REQ-1", "STREAM-1", "done", finish=True))
+
+        frame = json.loads(ws.sent[0])
+        assert frame["body"]["stream"]["finish"] is True
+
+    def test_frames_carry_the_full_accumulated_text_not_a_delta(self) -> None:
+        ws = FakeWireWebSocket()
+        client = _client()
+        client._ws = ws  # type: ignore[assignment]
+
+        asyncio.run(client.send_stream("REQ-1", "S", "Hel", finish=False))
+        asyncio.run(client.send_stream("REQ-1", "S", "Hello", finish=True))
+
+        contents = [json.loads(f)["body"]["stream"]["content"] for f in ws.sent]
+        assert contents == ["Hel", "Hello"], (
+            "each frame REPLACES the bubble, so a delta would render truncated text"
+        )
+
+    def test_no_live_socket_reports_failure_instead_of_raising(self) -> None:
+        client = _client()
+        client._ws = None
+
+        assert asyncio.run(client.send_stream("REQ-1", "S", "hi", finish=True)) is False
+
+    def test_a_missing_req_id_reports_failure(self) -> None:
+        ws = FakeWireWebSocket()
+        client = _client()
+        client._ws = ws  # type: ignore[assignment]
+
+        assert asyncio.run(client.send_stream("", "S", "hi", finish=True)) is False
+        assert ws.sent == [], "an unroutable frame must not be put on the wire"
+
+    def test_a_closed_socket_reports_failure(self) -> None:
+        ws = FakeWireWebSocket()
+        ws.closed = True
+        client = _client()
+        client._ws = ws  # type: ignore[assignment]
+
+        assert asyncio.run(client.send_stream("REQ-1", "S", "hi", finish=True)) is False

--- a/test/test_weixin_wire.py
+++ b/test/test_weixin_wire.py
@@ -1,0 +1,237 @@
+"""Wire-level tests for the Weixin (iLink) channel.
+
+These run one level below the existing dispatcher tests: instead of replacing
+``WeixinClient`` with a ``FakeClient``, they hand the REAL client a fake
+``aiohttp`` session (:class:`FakeWireSession`) and assert on the bytes it would
+put on the wire and how it parses what comes back. No credentials, no network,
+no vendor account.
+
+Why this layer earns its keep: the dispatcher tests are green whether or not
+``send_message`` builds the payload iLink accepts, because they never let the
+client construct one. The iLink QR bug (``qrcode_img_content`` is a scannable
+URL served as ``text/html``, not image bytes) lived exactly here.
+
+The response shapes below are PINNED FROM OBSERVED BEHAVIOUR, not invented --
+notably ``_QR_START``, whose field values were captured from an
+authorized live probe. A fixture is the only place a vendor shape should be
+written down; every layer above is then verified against it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.testing.channel_fixtures import load_fixture
+from kiro_crew.testing.fake_channel_wire import (
+    FakeWireSession,
+    UnroutedRequestError,
+    WireResponse,
+)
+from kiro_crew.weixin.client import (
+    EP_GET_BOT_QR,
+    EP_GET_QR_STATUS,
+    EP_GET_UPDATES,
+    EP_SEND_MESSAGE,
+    WeixinClient,
+    WeixinSendError,
+)
+
+_BASE = "https://ilink.example.invalid"
+
+# Shapes come from attributed fixture files, never inline literals: a fixture
+# records WHERE the shape was observed (see kiro_crew.testing.channel_fixtures),
+# so a live-probed contract is distinguishable from a guess and the live
+# conformance lane can re-verify it against the vendor.
+# The fixtures root lives in the TEST tree, so the layout coupling lives here
+# too -- kiro_crew.testing.channel_fixtures ships in the wheel and deliberately
+# has no default root (no test/ tree exists in an installed package).
+CHANNEL_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "channels"
+
+_QR_START = load_fixture("weixin", "get_bot_qrcode", root=CHANNEL_FIXTURES).payload
+_SEND_OK = load_fixture("weixin", "sendmessage_ok", root=CHANNEL_FIXTURES).payload
+
+
+def _client(wire: FakeWireSession) -> WeixinClient:
+    client = WeixinClient(token="bot-tok", base_url=_BASE, account_id="acct1")
+    # The production seam: the client lazily creates its own session in
+    # connect(). Pre-assigning means connect() is a no-op and no real socket is
+    # ever opened, while every other line of the client runs untouched.
+    client._session = wire
+    return client
+
+
+class TestOutboundPayload:
+    """What the channel actually sends, built by the real client."""
+
+    def test_send_message_payload_and_headers_match_the_ilink_contract(self) -> None:
+        wire = FakeWireSession().route("POST", EP_SEND_MESSAGE, _SEND_OK)
+        client = _client(wire)
+
+        asyncio.run(
+            client.send_message(
+                to="user-1", text="hello", context_token="ctx-9", client_id="cid-1"
+            )
+        )
+
+        req = wire.requests[0]
+        assert req.method == "POST"
+        # Envelope: every request carries base_info, and the message is nested
+        # under "msg" -- shape the dispatcher tests never see.
+        body = req.json_body
+        assert "base_info" in body
+        msg = body["msg"]
+        assert msg["to_user_id"] == "user-1"
+        assert msg["item_list"] == [{"type": 1, "text_item": {"text": "hello"}}]
+        assert msg["context_token"] == "ctx-9"
+        # Auth + framing headers are the client's job and are asserted here for
+        # the first time.
+        assert req.headers["Authorization"] == "Bearer bot-tok"
+        assert req.headers["AuthorizationType"] == "ilink_bot_token"
+        # Content-Length must count UTF-8 BYTES, not characters.
+        assert req.headers["Content-Length"] == str(len(str(req.body).encode("utf-8")))
+
+    def test_content_length_counts_utf8_bytes_for_multibyte_text(self) -> None:
+        wire = FakeWireSession().route("POST", EP_SEND_MESSAGE, _SEND_OK)
+        client = _client(wire)
+
+        asyncio.run(
+            client.send_message(
+                to="u", text="已开始新对话", context_token=None, client_id="c"
+            )
+        )
+
+        req = wire.requests[0]
+        declared = int(req.headers["Content-Length"])
+        assert declared == len(str(req.body).encode("utf-8"))
+        assert declared > len(str(req.body))  # multibyte -> bytes exceed chars
+
+    def test_context_token_is_omitted_when_absent(self) -> None:
+        wire = FakeWireSession().route("POST", EP_SEND_MESSAGE, _SEND_OK)
+        client = _client(wire)
+
+        asyncio.run(
+            client.send_message(to="u", text="hi", context_token=None, client_id="c")
+        )
+
+        assert "context_token" not in wire.requests[0].json_body["msg"]
+
+
+class TestProtocolErrorParsing:
+    """A 200 with a nonzero code means NOT delivered."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"errcode": -14},  # session expired
+            {"ret": -2},  # rate limited (the other error key)
+        ],
+    )
+    def test_nonzero_code_raises_instead_of_reporting_success(self, payload) -> None:
+        wire = FakeWireSession().route("POST", EP_SEND_MESSAGE, payload)
+        client = _client(wire)
+
+        with pytest.raises(WeixinSendError):
+            asyncio.run(
+                client.send_message(
+                    to="u", text="hi", context_token=None, client_id="c"
+                )
+            )
+
+    def test_zero_code_is_success(self) -> None:
+        wire = FakeWireSession().route("POST", EP_SEND_MESSAGE, {"errcode": 0, "ret": 0})
+        client = _client(wire)
+
+        resp = asyncio.run(
+            client.send_message(to="u", text="hi", context_token=None, client_id="c")
+        )
+        assert resp["errcode"] == 0
+
+
+class TestQrLoginShape:
+    """Pins the live-probed QR contract that PR #711 fixed."""
+
+    def test_qr_start_returns_a_scannable_url_not_image_bytes(self) -> None:
+        wire = FakeWireSession().route(
+            "GET",
+            EP_GET_BOT_QR,
+            WireResponse(body=_QR_START, content_type="text/html"),
+        )
+        client = _client(wire)
+
+        out = asyncio.run(client.get_bot_qrcode())
+
+        content = out["qrcode_img_content"]
+        assert content.startswith("https://"), (
+            "qrcode_img_content is a scannable LOGIN URL, not image bytes -- "
+            "handing it straight to an <img src> is the #711 production bug"
+        )
+        assert not content.startswith("data:image"), "not a data URI at the API layer"
+
+    def test_bot_type_is_carried_on_the_query_string(self) -> None:
+        wire = FakeWireSession().route("GET", EP_GET_BOT_QR, _QR_START)
+        client = _client(wire)
+
+        asyncio.run(client.get_bot_qrcode(bot_type=3))
+
+        assert "bot_type=3" in wire.requests[0].url
+
+    def test_qrcode_is_url_encoded_in_the_status_poll(self) -> None:
+        wire = FakeWireSession().route(
+            "GET", EP_GET_QR_STATUS, {"status": "pending"}
+        )
+        client = _client(wire)
+
+        asyncio.run(client.get_qrcode_status("a/b+c=d"))
+
+        url = wire.requests[0].url
+        assert "a%2Fb%2Bc%3Dd" in url, "unescaped qrcode would break the query"
+
+
+class TestPollLoopSequencing:
+    """A scripted response queue -- the poll loop sees a real sequence."""
+
+    def test_get_updates_consumes_queued_responses_in_order(self) -> None:
+        wire = FakeWireSession().route(
+            "POST",
+            EP_GET_UPDATES,
+            [
+                {"ret": 0, "msgs": [], "get_updates_buf": "buf-1"},
+                {"ret": 0, "msgs": [{"text": "hi"}], "get_updates_buf": "buf-2"},
+            ],
+        )
+        client = _client(wire)
+
+        first = asyncio.run(client.get_updates("buf-0"))
+        second = asyncio.run(client.get_updates(first["get_updates_buf"]))
+
+        assert first["msgs"] == []
+        assert second["msgs"] == [{"text": "hi"}]
+        # The buffer cursor really round-trips through the request body.
+        assert wire.requests[1].json_body["get_updates_buf"] == "buf-1"
+
+
+class TestHarnessGuarantees:
+    """The harness itself must fail closed."""
+
+    def test_unrouted_endpoint_is_an_error_not_a_silent_default(self) -> None:
+        wire = FakeWireSession()  # no routes
+        client = _client(wire)
+
+        with pytest.raises(UnroutedRequestError):
+            asyncio.run(client.get_config(user_id="u", context_token=None))
+
+    def test_http_error_status_surfaces_instead_of_being_parsed_as_json(self) -> None:
+        wire = FakeWireSession().route(
+            "POST", EP_SEND_MESSAGE, WireResponse(body="upstream boom", status=502)
+        )
+        client = _client(wire)
+
+        with pytest.raises(RuntimeError, match="HTTP 502"):
+            asyncio.run(
+                client.send_message(
+                    to="u", text="hi", context_token=None, client_id="c"
+                )
+            )


### PR DESCRIPTION
# test(channels): add a wire-level harness with attributed vendor fixtures

## Problem

Channel tests fake the **client** — `FakeClient` stands in for `WeixinClient`, `WeComClient`, `WebexClient`, `TeamsClient` — so the client's own payload construction, auth/framing headers, and protocol-error parsing are **never exercised by a turn test**. 1,220 channel test functions exist and not one asserts the bytes a channel would put on the wire.

That is the layer the iLink QR bug (#711) lived in: the code assumed `qrcode_img_content` was image bytes, the fixtures agreed with the code, and the suite stayed green while production was broken.

## Why it matters

A green suite that cannot see the wire gives false confidence about the exact thing most likely to be wrong — our agreement with someone else's API. Every new channel (Feishu is next, per #689) inherits that blind spot, and each vendor bug is found in production instead of in CI.

## Fix (symptom → root cause → change)

Symptom: protocol bugs survive a green suite. Root cause: the test seam is *above* the code that builds requests. Change: fake **one level down** — the `aiohttp` session — so the real client, transport, dispatcher, shared pipeline and renderer all run.

**No production code changed.** Every client already stores `self._session` and builds it lazily, so a test assigns the fake onto that attribute and `connect()` becomes a no-op. No monkeypatching, no credentials, no network.

- `kiro_crew.testing.fake_channel_wire` — `FakeWireSession` / `FakeWireWebSocket`. Routes are `(method, path-substring)`, longest match wins. A **sequence** target is an exact script: consumed in order, and a call past the end raises `UnroutedRequestError` rather than silently repeating the last response (repeating would hide a client polling more times than the test scripted). Unrouted endpoints raise — fail closed, because a channel calling an unpinned vendor endpoint is exactly what this guards.
- `kiro_crew.testing.channel_fixtures` — a fixture is a *claim about someone else's API*, so the claim is auditable. Fixtures are JSON files with a required `_provenance` block naming a `Source`: `live_probe` (observed against the real API), `vendor_doc` (transcribed from published docs), or `assumed` (our inference, unverified). Loading without provenance, or with an unknown source, raises. `unverified()` enumerates every unconfirmed shape so the gap is a **known inventory** rather than an unknown. `shape_of` / `assert_same_shape` diff two payloads by key/type skeleton, naming missing / added / retyped fields — values are discarded so ids and timestamps cannot make a check flaky.
- `test_channel_wire_conformance.py` — replays recorded shapes against the **live** vendor endpoint, the only test that can prove a fixture is still true. Opt-in via `KIROCREW_WIRE_PROBE=1` plus per-channel credential env vars; skipped otherwise, so it never runs in the normal suite or on a fork PR.

## Tests

59 wire tests across four channels, plus 40 provenance/shape/containment tests. Highest-value coverage, none of it reachable before:

- **teams** — the outbound path refuses a non-HTTPS `serviceUrl`, and `serviceUrl` arrives **from the network** on the inbound activity. Four tests assert that `http://` / scheme-relative / bare-host / empty produce **no request at all**, so the app bearer credential can never cross plaintext. Also pins that the credential is cached across sends and that a failed exchange skips the activity post.
- **weixin** — request envelope (`base_info`, `msg` nesting, `item_list` typing, `context_token` omitted when absent), `Authorization` / `AuthorizationType` headers, `Content-Length` counting UTF-8 **bytes** (verified with Chinese text), protocol-error parsing across *both* `errcode` and `ret`, query-string URL-encoding, HTTP-error surfacing.
- **webex** — `roomId` vs `toPersonEmail` addressing (the `@` heuristic), `parentId` threading, verb/path mapping, and the 429 `Retry-After` back-off — honouring the header value and bounded at one retry, never an unbounded loop.
- **wecom** — the `aibot_respond_msg` WS frame, where routing depends entirely on echoing the server-assigned `req_id`, and each frame carries the **full** accumulated text (a delta would render truncated). Unroutable frames must not reach the wire.

Gate: 180 passed / 1 skipped (the live lane) / 5 xfailed, `flake8`, `isort`, `mypy` (565 files) clean.

## Manual verification

Three local adversarial review rounds (GPT-5.6 + Opus-5 mirrors of `codex-review.yml` / `claude-review.yml` + base-ref `AUTOSDE.yaml`) found **four path-escape variants in the fixture loader**, each fixed with a regression test:

1. `channel="../outside"` — no component validation at all.
2. Bare Windows drive `"C:"` — `Path("C:").parts` is `("C:",)` and `is_absolute()` is `False`, yet `root / "C:"` discards the root entirely.
3. Windows-stripped padding — Windows drops trailing dots/spaces, so `".. "` **is** `".."`.
4. Symlinked / dangling `<root>/<channel>` — `Path.exists()` *follows* symlinks and so reports `False` for a broken link that `open()` would still follow.

All four were the same defect in different costumes: **string validation standing in for containment.** The structural fix is `_resolve_within()`, which canonicalizes the nearest on-disk ancestor (via `os.path.lexists`, which sees the link itself) and proves it sits under the resolved root before any read, `mkdir` or write. The write additionally goes through `O_NOFOLLOW`, closing the TOCTOU between check and write.

Also removed: a `Path(__file__).parents[3]` default fixtures root, which resolved to an unpackaged `<venv>/lib/test/...` for every installed consumer (`kiro_crew.testing` ships in the wheel). `root` is now a required keyword and the layout coupling lives in the test tree.

Each fix was verified empirically, not just by reasoning — probes confirm: intermediate symlink refused with nothing written outside, dangling intermediate refused, dangling leaf rejected by `O_NOFOLLOW` with the target never created, symlinked root resolved and the write landing inside the real root, relative root accepted, a fresh root created rather than refused, 40 failed opens with no fd leak, and read-through-symlink refused.

## Screenshots

N/A — backend/test-only, no user-visible surface.

## Known gaps, stated deliberately

- **Fixture honesty**: only weixin's QR contract is `live_probe` (captured during #711 — `Content-Type: text/html`, a scannable login URL). The webex/teams fixtures are `vendor_doc`, transcribed from published docs and **never captured live**; weixin's `sendmessage` success body stays `assumed`. `unverified()` keeps naming exactly which shapes nobody has confirmed. No fixture contains a credential — the Teams value is the literal string `PLACEHOLDER-NOT-A-CREDENTIAL`.
- **The live lane proves conformance only when run.** Between runs, fixtures are assertions on trust. Making that continuous means a scheduled probe with stored credentials — a credentials-in-CI decision, deliberately not taken here.
- Slack, telegram and discord have no wire suites yet; the four channels covered are the ones that share the extracted turn pipeline (#777).
