### PR TITLE
fix(chat): stop streaming-flash for image, table, and diff content

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -269,6 +269,7 @@ function ImgWithFallback({
   ...props
 }: React.ImgHTMLAttributes<HTMLImageElement> & ExtraProps) {
   const [errored, setErrored] = useState(false)
+  const [loaded, setLoaded] = useState(false)
   const basePath = useContext(BasePathCtx)
   if (!src) return null
   const isLocal = src.startsWith('/') || src.startsWith('~') || src.startsWith('.')
@@ -298,6 +299,25 @@ function ImgWithFallback({
   // happen to declare width/height. Give SVGs a definite width basis; the
   // viewBox aspect ratio then derives the height, clamped by max-h.
   const isSvg = /\.svg([?#]|$)/i.test(src)
+  // Reserve vertical layout space BEFORE the bytes decode. A markdown image has
+  // no intrinsic dimensions in the source, so without this it lays out at ~0px
+  // until the network/decode completes, then snaps to its natural height —
+  // shoving every sibling below it (still-streaming text, the next block) down
+  // in one discrete jump. For a user reading a streaming message (or lazily
+  // loading an image below the fold) that reads as a "flash". Holding a
+  // min-height placeholder until `onLoad` reserves the space up front and
+  // bounds the on-load shift; the placeholder is released once loaded so the
+  // final layout is pixel-exact and history/completed images carry no floor.
+  // The floor is a heuristic (markdown gives us no aspect ratio): 120px sits
+  // below the common screenshot/diagram case (which then benefits) but above
+  // small icons/badges — for a sub-120px raster image the on-load change is a
+  // bounded (<=120px) collapse, an accepted residual since such images are
+  // uncommon in markdown. SVGs already get a definite width basis (their viewBox
+  // derives the height), so they need no placeholder. See
+  // MarkdownRenderer.streamingImageShift.test.tsx.
+  const imgStyle: React.CSSProperties | undefined = isSvg
+    ? { width: '760px', height: 'auto' }
+    : (loaded ? undefined : { minHeight: '120px' })
   return (
     <span className="block my-2">
       {/* The <img> is the lightbox trigger; dispatchLightbox needs the image
@@ -309,10 +329,11 @@ function ImgWithFallback({
       <img
         src={url} alt={alt || ''} loading="lazy"
         className="max-w-[min(100%,760px)] max-h-[60vh] object-contain rounded-md border border-border cursor-pointer hover:opacity-90 transition-opacity"
-        style={isSvg ? { width: '760px', height: 'auto' } : undefined}
+        style={imgStyle}
         onClick={(e) => dispatchLightbox(e.currentTarget)}
         data-lightbox-image=""
         title={alt || src}
+        onLoad={() => setLoaded(true)}
         onError={() => setErrored(true)}
         {...props}
       />
@@ -945,11 +966,62 @@ function stripStrayTags(content: string, openMarker: string, stripRe: RegExp): s
 const stripStrayWidgetTags = (content: string) => stripStrayTags(content, '<mcwidget', MCWIDGET_STRIP_RE)
 const stripStrayToolUseTags = (content: string) => stripStrayTags(content, '<tool_use', TOOL_USE_STRIP_RE)
 
+// A GFM table delimiter row, e.g. `| --- | :--: |` or `---|---`. remark-gfm
+// only promotes the preceding header line to a <table> once this row is present.
+const TABLE_DELIM_RE = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/
+
+/**
+ * While STREAMING, withhold an incomplete trailing table so it never paints as
+ * literal pipe text that later reflows into a <table>.
+ *
+ * remark-gfm needs BOTH a header row and a `|---|` delimiter row to recognize a
+ * table. Mid-stream the header arrives first and renders as a <p> containing
+ * literal "| A | B |"; when the delimiter row streams in, that paragraph
+ * RESTRUCTURES into a bordered table — a visible structural snap of
+ * already-shown content (see MarkdownRenderer.streamingTableSnap.test.tsx).
+ * This defers the trailing header run (mirroring how an incomplete fenced code
+ * block is held) until the delimiter arrives, so the transition the user sees
+ * is the standard "content appears", not "paragraph morphs into a table".
+ *
+ * Scoped narrowly to avoid hiding ordinary prose: only a run of trailing
+ * non-blank lines whose FIRST line is a bordered table header (starts with `|`)
+ * is a candidate, and only when that run does NOT yet contain a delimiter row
+ * (a `---` row that actually carries a `|`). A run that already has such a
+ * delimiter is a real (possibly still growing) table and is left to render.
+ *
+ * Scoping choices (both close reviewer-flagged edges):
+ *  - Require the first line to START with `|`. A looser "≥2 pipes" test also
+ *    matched ordinary prose (e.g. a line with an inline `` `cmd | grep | wc` ``)
+ *    and would withhold that whole paragraph for the rest of the stream. Models
+ *    emit bordered tables (`| a | b |`), so start-with-`|` keeps the real case
+ *    while excluding prose; a borderless table simply isn't deferred (it never
+ *    regressed anything — it just renders as before).
+ *  - The delimiter must contain a `|`. A bare `---` is a thematic break / setext
+ *    underline, NOT a GFM table delimiter (which needs matching pipe-separated
+ *    cells), so counting it as "already a table" would wrongly skip deferral and
+ *    let the snap happen.
+ */
+function deferIncompleteStreamingTable(content: string): string {
+  const lines = content.split('\n')
+  let start = lines.length
+  while (start > 0 && lines[start - 1].trim() !== '') start--
+  if (start >= lines.length) return content // trailing blank line / nothing to defer
+  const run = lines.slice(start)
+  if (!/^\s*\|/.test(run[0])) return content // not a bordered table header
+  // A real GFM delimiter row carries at least one pipe; a bare `---` does not.
+  if (run.some((l) => l.includes('|') && TABLE_DELIM_RE.test(l))) return content
+  return lines.slice(0, start).join('\n')
+}
+
 const MarkdownBlock = memo(function MarkdownBlock({ content, sourcePos, startLine, glow, smooth, softBreaks }: { content: string; sourcePos?: boolean; startLine?: number; glow?: boolean; smooth?: boolean; softBreaks?: boolean }) {
   // Strip any <mcwidget> or <tool_use> tags that leak through during
   // streaming transitions or when the agent emits protocol markup as text.
   // Both passes preserve mentions inside inline-code spans.
-  const clean = stripStrayToolUseTags(stripStrayWidgetTags(content))
+  let clean = stripStrayToolUseTags(stripStrayWidgetTags(content))
+  // `glow` marks the live streaming tail block: while streaming, hold back an
+  // incomplete trailing table so it doesn't paint as pipe text then snap into a
+  // <table> when the delimiter row arrives.
+  if (glow) clean = deferIncompleteStreamingTable(clean)
   if (!clean.trim()) return null
   const baseRehype = sourcePos ? REHYPE_PLUGINS_WITH_SOURCEPOS : REHYPE_PLUGINS
   // Streaming tail block only (see MarkdownRenderer's `glow` prop):

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -119,6 +119,20 @@ const SCROLL_SETTLE_MS = 150
 // feedback loop instead of re-rendering every frame.
 const HEIGHT_SYNC_DEBOUNCE_MS = 120
 
+// After the caller stops naming a row via `streamingIndex` (the turn closed —
+// `isStreaming` flipped false), keep that row on the IMMEDIATE height-sync path
+// for this long. A diff/code block wrapped in <SmoothResize> keeps easing its
+// height toward the content height via a `height .32s` CSS transition, and the
+// stream→complete flip is one more height change — all of which fire AFTER the
+// last content byte streamed in. Without this grace those trailing resizes fall
+// back to the debounce and re-create the very spacer lurch `streamingIndex`
+// exists to prevent, at end-of-stream. Sized to comfortably cover SmoothResize's
+// 320ms ease plus the completion snap. It is a FIXED window from the transition
+// (never re-armed per resize), so an oscillating post-stream widget cannot hold
+// the row on the immediate path indefinitely — after this window the row reverts
+// to the debounced path and its render-storm protection is restored.
+const STREAMING_SETTLE_GRACE_MS = 400
+
 // Rows must drift this many items BEYOND the computed window before a
 // SCROLL-path recompute will UNMOUNT them (mounting stays eager — no
 // hysteresis). This deadband breaks a feedback loop seen when a widget sits at
@@ -160,6 +174,48 @@ export function useVirtualChat<T>(
   // force the ResizeObserver to be torn down and reattached.
   const streamingIndexRef = useRef(streamingIndex)
   streamingIndexRef.current = streamingIndex
+
+  // ---- Streaming-settle grace (gap #3) ----
+  // When `streamingIndex` goes undefined (the turn closed — `isStreaming`
+  // flipped false), the row it named often keeps resizing for a short while:
+  // a diff/code <SmoothResize> wrapper eases its height toward the content
+  // height (`height .32s`) and the stream→complete flip is one more change.
+  // Keep that row on the IMMEDIATE-sync path for STREAMING_SETTLE_GRACE_MS so
+  // those trailing resizes don't fall back to the debounce and lurch the
+  // spacer under a scrolled-up user.
+  const graceIndexRef = useRef<number | undefined>(undefined)
+  const graceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const clearStreamingGrace = useCallback(() => {
+    if (graceTimerRef.current) {
+      clearTimeout(graceTimerRef.current)
+      graceTimerRef.current = null
+    }
+    graceIndexRef.current = undefined
+  }, [])
+  const armStreamingGrace = useCallback((idx: number) => {
+    graceIndexRef.current = idx
+    if (graceTimerRef.current) clearTimeout(graceTimerRef.current)
+    graceTimerRef.current = setTimeout(() => {
+      graceTimerRef.current = null
+      graceIndexRef.current = undefined
+    }, STREAMING_SETTLE_GRACE_MS)
+  }, [])
+  // Detect the streaming→idle transition: arm the grace when streaming stops,
+  // and clear it while streaming is active (the streamingIndexRef path covers
+  // that case directly). A LAYOUT effect (not passive) so grace is armed
+  // synchronously at the transition commit — before the ResizeObserver delivers
+  // the completion resize for that same frame, which would otherwise be
+  // debounced (arriving before a passive effect ran) and preserve the lurch.
+  const prevStreamingIndexRef = useRef(streamingIndex)
+  useLayoutEffect(() => {
+    const prev = prevStreamingIndexRef.current
+    prevStreamingIndexRef.current = streamingIndex
+    if (streamingIndex !== undefined) {
+      clearStreamingGrace()
+    } else if (prev !== undefined) {
+      armStreamingGrace(prev)
+    }
+  }, [streamingIndex, armStreamingGrace, clearStreamingGrace])
 
   // ---- DOM refs ----
   const internalScrollerRef = useRef<HTMLDivElement | null>(null)
@@ -811,7 +867,15 @@ export function useVirtualChat<T>(
           // EXCEPT while actively following (see below).
           if (prevH !== undefined) {
             genuineResize = true
-            if (idx === streamingIndexRef.current) streamingRowResized = true
+            // Immediate (non-debounced) sync for the actively-streaming row OR
+            // the row still inside its post-stream settle grace (gap #3). The
+            // grace is a FIXED window from stream completion and is deliberately
+            // NOT re-armed here: re-arming per resize would let an oscillating
+            // auto-height widget in a just-ended message keep the row immediate
+            // forever, defeating the debounce's render-storm protection.
+            if (idx === streamingIndexRef.current || idx === graceIndexRef.current) {
+              streamingRowResized = true
+            }
           } else {
             firstMount = true
           }
@@ -1329,6 +1393,7 @@ export function useVirtualChat<T>(
     return () => {
       detachSmoothAbort()
       if (heightSyncTimerRef.current) clearTimeout(heightSyncTimerRef.current)
+      if (graceTimerRef.current) clearTimeout(graceTimerRef.current)
       cacheRef.current?.flush()
     }
   }, [detachSmoothAbort])

--- a/website/src/test/MarkdownRenderer.streamingImageShift.test.tsx
+++ b/website/src/test/MarkdownRenderer.streamingImageShift.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+/**
+ * REGRESSION GUARD (was a failing repro) — gap #1: IMAGES.
+ *
+ * PR #824 stopped the streaming ROW's height from debouncing into a spacer
+ * "flash" for a scrolled-up user. It did NOT address content that changes
+ * height on a one-shot async event rather than gradual text growth. A markdown
+ * image (`ImgWithFallback` in MarkdownRenderer) renders:
+ *
+ *     <img src=… loading="lazy"
+ *          className="max-w-[min(100%,760px)] max-h-[60vh] object-contain …" />
+ *
+ * with NO reserved intrinsic dimensions (only non-SVG). Before the bytes decode
+ * the element has ~0 layout height; on load it snaps to its natural height. That
+ * snap shifts every sibling below the image inside the same bubble (classic CLS)
+ * — visible as a flash/jump while the message is streaming. Reserving space for
+ * the image (explicit width/height, an aspect-ratio box, or a min-height
+ * placeholder) is what removes the shift; #824's virtualizer spacer smoothing
+ * cannot, because the whole image height arrives in a single RO tick.
+ *
+ * These tests assert the DESIRED post-fix behavior (the image reserves vertical
+ * space before it loads). They are the regression guard for that fix.
+ *
+ * jsdom has no CSS/layout engine, so we assert on the fix's MECHANISM
+ * (dimension attributes / space-reserving inline style) rather than on measured
+ * pixels — the only fix-agnostic signal available pre-load.
+ */
+
+const STREAM = { streaming: true, glow: true, smooth: true } as const
+
+/** True when the <img> (or its wrapper) reserves vertical layout space before
+ *  the bytes load — via width+height attributes, an aspect-ratio, an explicit
+ *  height, or a min-height placeholder. Fix-agnostic across those approaches. */
+function reservesVerticalSpace(img: HTMLImageElement): boolean {
+  const hasWH = img.hasAttribute('width') && img.hasAttribute('height')
+  const spaceStyle = (st: CSSStyleDeclaration | undefined): boolean => {
+    if (!st) return false
+    const ar = st.aspectRatio
+    const mh = st.minHeight
+    const h = st.height
+    return (
+      (!!ar && ar !== 'auto' && ar !== '') ||
+      (!!mh && mh !== '0px' && mh !== '') ||
+      (!!h && h !== 'auto' && h !== '')
+    )
+  }
+  return hasWH || spaceStyle(img.style) || spaceStyle(img.parentElement?.style)
+}
+
+describe('streaming image layout-shift regression (gap #1)', () => {
+  it('PREMISE: a markdown image renders an <img> element', () => {
+    // Survives the fix — a quick check so a rendering regression is distinguishable
+    // from the reserved-space assertion below.
+    const { container } = render(
+      <MarkdownRenderer content={'![diagram](https://example.com/diagram.png)'} {...STREAM} />,
+    )
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('GAP: a raster markdown image reserves vertical space before it loads (no on-load shift)', () => {
+    const { container } = render(
+      <MarkdownRenderer
+        content={'Here is the chart:\n\n![chart](https://example.com/chart.png)\n\nand text below it.'}
+        {...STREAM}
+      />,
+    )
+    const img = container.querySelector('img') as HTMLImageElement | null
+    expect(img).not.toBeNull()
+    // Regression guard: the <img> must reserve vertical space before load
+    // (min-height placeholder here) so on-load it does not pop from 0 to its
+    // natural height and shove the "and text below it." paragraph down.
+    expect(reservesVerticalSpace(img!)).toBe(true)
+  })
+})

--- a/website/src/test/MarkdownRenderer.streamingTableSnap.test.tsx
+++ b/website/src/test/MarkdownRenderer.streamingTableSnap.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+/**
+ * REGRESSION GUARD (was a failing repro) — gap #2: TABLES.
+ *
+ * Tables are NOT a first-class block in `useBlockAssembler` (only code / diff /
+ * mermaid / widget are); they render inline inside the markdown block, so they
+ * get no `SmoothResize` wrapper and no streaming-aware handling. remark-gfm only
+ * recognizes a GFM table once BOTH the header row and the `|---|---|` delimiter
+ * row are present. So mid-stream:
+ *
+ *   1. the header line arrives  → renders as a <p> with literal "| A | B |" text
+ *   2. the delimiter line arrives → the subtree RESTRUCTURES into a bordered
+ *      <table> (padding, borders, overflow-x wrapper, different margins)
+ *
+ * Step 2 is a structural reflow of already-visible content — a snap/flash that
+ * neither the `.ft-word` opacity fix (#661/#697, text-edge only) nor #824
+ * (virtualizer spacer only) addresses. The desired behavior while streaming is
+ * that an incomplete trailing table region is NOT shown as raw pipe-delimited
+ * paragraph text that will later restructure — either withhold it until the
+ * delimiter arrives (mirroring how incomplete fences are held) or render it as a
+ * provisional table. Both fixes share one observable property: the literal
+ * "| Col A | Col B |" pipe row is never painted as visible paragraph text.
+ *
+ * The GAP test asserts that property and FAILS on current `main`. The PREMISE
+ * test documents the current paragraph→table snap and stays true after the fix.
+ */
+
+const STREAM = { streaming: true, glow: true, smooth: true } as const
+
+/** Collapsed visible text of the render (whitespace-normalized). */
+function visibleText(container: HTMLElement): string {
+  return (container.textContent || '').replace(/\s+/g, ' ').trim()
+}
+
+describe('streaming table structural-snap regression (gap #2)', () => {
+  it('PREMISE: without a delimiter row there is no <table> yet (table needs header + |---|)', () => {
+    // Survives the fix — establishes that a lone header line is genuinely
+    // pre-table, so the GAP below is about HOW that pre-table state is shown.
+    const { container } = render(
+      <MarkdownRenderer content={'| Col A | Col B |'} {...STREAM} />,
+    )
+    expect(container.querySelector('table')).toBeNull()
+  })
+
+  it('PREMISE: once the delimiter row arrives the same content becomes a <table>', () => {
+    // Survives the fix — documents that a real structural transition happens
+    // (paragraph text → table), which is exactly the reflow we want to hide.
+    const { container } = render(
+      <MarkdownRenderer content={'| Col A | Col B |\n| --- | --- |\n| 1 | 2 |'} {...STREAM} />,
+    )
+    expect(container.querySelector('table')).not.toBeNull()
+  })
+
+  it('GAP: while streaming, an incomplete table header is not painted as literal pipe text', () => {
+    // The realistic streaming sequence: the header (and maybe a first data line)
+    // has arrived but the delimiter has not yet. Today this renders as a <p>
+    // containing "| Col A | Col B |", which then reflows into a bordered table
+    // the moment the delimiter streams in — the visible snap.
+    const { container } = render(
+      <MarkdownRenderer content={'| Col A | Col B |'} {...STREAM} />,
+    )
+    // Regression guard: while streaming, the incomplete header run is withheld
+    // (deferIncompleteStreamingTable) rather than painted as a <p> of literal
+    // pipes that would later reflow into a bordered table.
+    expect(visibleText(container)).not.toContain('| Col A | Col B |')
+  })
+
+  it('GAP EDGE: a header followed only by a bare `---` (thematic break, not a real delimiter) is still deferred', () => {
+    // `| A | B |` + `---` is NOT a GFM table (a delimiter row needs pipe-separated
+    // cells), so the header would still snap into a table only once a real
+    // `| --- | --- |` arrives. The delimiter check requires a `|`, so the bare
+    // `---` does not count and the run stays deferred.
+    const { container } = render(
+      <MarkdownRenderer content={'| Col A | Col B |\n---'} {...STREAM} />,
+    )
+    expect(visibleText(container)).not.toContain('| Col A | Col B |')
+  })
+
+  it('SCOPING: ordinary streaming prose containing inline pipes is NOT withheld', () => {
+    // Guards against over-broad deferral: a trailing prose line with pipes (e.g.
+    // an inline shell pipeline) must keep rendering — only a line that STARTS
+    // with `|` (a bordered table header) is treated as a deferrable table start.
+    const { container } = render(
+      <MarkdownRenderer content={'Run `cmd | grep x | wc` to count.'} {...STREAM} />,
+    )
+    expect(visibleText(container)).toContain('Run')
+    expect(container.querySelector('table')).toBeNull()
+  })
+})

--- a/website/src/test/useVirtualChat.postStreamLurch.test.tsx
+++ b/website/src/test/useVirtualChat.postStreamLurch.test.tsx
@@ -1,0 +1,185 @@
+// REGRESSION GUARD (was a failing repro) — gap #3: DIFF (and code) blocks.
+//
+// PR #824 added `streamingIndex` so the streaming row's height changes bypass
+// the 120ms HEIGHT_SYNC_DEBOUNCE_MS (see useVirtualChat.scheduleHeightSync).
+// That bypass is scoped to `isStreaming` being true: ChatPage passes
+// `streamingIndex = isStreaming && len>0 ? len-1 : undefined`, so it goes
+// UNDEFINED the instant the turn closes.
+//
+// Diff and code blocks are wrapped in <SmoothResize enabled={!complete}>, which
+// drives the row height toward the content height via a CSS `height .32s`
+// transition. That means the row KEEPS RESIZING for up to ~320ms AFTER the last
+// content byte streamed in — and the completion flip (enabled true→false) is a
+// further one-shot height change. If the turn closes (streamingIndex → undefined)
+// while that height-ease tail / completion snap is still resizing the row, those
+// trailing changes fall back to the DEBOUNCED path — re-creating the exact
+// frozen-then-jump spacer lurch #824 removed, just shifted to the moment a diff
+// finishes at end of stream. For a scrolled-up user that is a visible flash.
+//
+// This test drives the hook's REAL outputs through a controllable fake
+// ResizeObserver under fake timers (same harness as spacerLurch): it streams a
+// row live (tracked), clears streamingIndex (turn closes), then fires the
+// SmoothResize height-ease tail. The GAP test asserts the row that is still
+// visibly resizing as the turn closes keeps tracking live; it passes once the
+// hook keeps the just-ended streaming row on the immediate-sync path for a
+// short settle grace. The CONTROL proves the smooth path (streamingIndex still
+// set) is unaffected.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+import type { UseVirtualChatOptions } from '../hooks/virtualizer/types'
+
+interface Geom { scrollTop: number; scrollHeight: number; clientHeight: number }
+
+function makeScroller(initial: Geom) {
+  const el = document.createElement('div')
+  const state: Geom = { ...initial }
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => state.scrollTop,
+    set: (v: number) => { state.scrollTop = v },
+  })
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => state.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => state.clientHeight })
+  ;(el as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = (o) => { state.scrollTop = o.top }
+  return { el, state }
+}
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+  cb: ResizeObserverCallback
+  observed = new Set<Element>()
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb
+    FakeResizeObserver.instances.push(this)
+  }
+  observe(el: Element) { this.observed.add(el) }
+  unobserve(el: Element) { this.observed.delete(el) }
+  disconnect() { this.observed.clear() }
+  fire(entries: Partial<ResizeObserverEntry>[]) {
+    this.cb(entries as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+}
+
+function mkEntry(target: HTMLElement, height: number): Partial<ResizeObserverEntry> {
+  Object.defineProperty(target, 'offsetHeight', { configurable: true, get: () => height })
+  return { target }
+}
+
+describe('useVirtualChat: SmoothResize tail after stream end (diff/code gap #3)', () => {
+  let origRO: typeof ResizeObserver | undefined
+  let origRaf: typeof requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    FakeResizeObserver.instances = []
+    origRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.ResizeObserver = origRO as typeof ResizeObserver
+    globalThis.requestAnimationFrame = origRaf
+  })
+
+  function mountStreaming(sessionId: string, geom: Geom, items: Item[]) {
+    const { el, state } = makeScroller(geom)
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const lastIdx = items.length - 1
+    const baseProps: UseVirtualChatOptions<Item> = {
+      items, sessionId, getKey, externalScrollerRef: ref, streamingIndex: lastIdx,
+    }
+    const view = renderHook(
+      (props: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(props),
+      { initialProps: baseProps },
+    )
+    const HISTORY_H = 100
+    for (let i = 0; i < lastIdx; i++) {
+      const node = document.createElement('div')
+      Object.defineProperty(node, 'offsetHeight', { configurable: true, get: () => HISTORY_H })
+      act(() => { view.result.current.measureRef(i)(node) })
+    }
+    const streamNode = document.createElement('div')
+    Object.defineProperty(streamNode, 'offsetHeight', { configurable: true, get: () => 40 })
+    act(() => { view.result.current.measureRef(lastIdx)(streamNode) })
+    // Flush the debounced first-mount seed so the baseline is settled.
+    act(() => { vi.advanceTimersByTime(120) })
+    return { el, state, view, streamNode, baseProps, lastIdx }
+  }
+
+  it('GAP: the height-ease tail firing after the turn closes still tracks live (no post-stream lurch)', () => {
+    const { view, streamNode, baseProps } = mountStreaming(
+      'diff-smoothresize-tail',
+      { scrollTop: 500, scrollHeight: 3000, clientHeight: 400 },
+      mkItems(21),
+    )
+    const ro = FakeResizeObserver.instances[FakeResizeObserver.instances.length - 1]
+    const baselineTotal = view.result.current.totalHeight
+
+    // --- Phase 1: diff content streams in. streamingIndex is set, so each RO
+    // tick is synced immediately (the #824 behavior we rely on). ---
+    let h = 40
+    let expected = baselineTotal
+    for (let i = 0; i < 6; i++) {
+      h += 10
+      expected += 10
+      act(() => { ro.fire([mkEntry(streamNode, h)]) })
+      act(() => { vi.advanceTimersByTime(16) })
+      expect(view.result.current.totalHeight).toBe(expected) // tracked live while streaming
+    }
+
+    // --- Phase 2: the turn closes. isStreaming flips false, so ChatPage stops
+    // passing streamingIndex. The row is STILL resizing, though: SmoothResize's
+    // `height .32s` transition is easing the wrapper toward the content height,
+    // and the completion flip is one more height change. ---
+    act(() => { view.rerender({ ...baseProps, streamingIndex: undefined }) })
+
+    // --- Phase 3: the SmoothResize ease tail + completion snap — more genuine
+    // resizes on the SAME row, each within a debounce window (as a 320ms CSS
+    // transition steps frame by frame). ---
+    for (let i = 0; i < 4; i++) {
+      h += 12
+      expected += 12
+      act(() => { ro.fire([mkEntry(streamNode, h)]) })
+      act(() => { vi.advanceTimersByTime(16) }) // << 120ms: still inside the debounce window
+    }
+
+    // Regression guard: because the row is still visibly resizing as the turn
+    // closed, its height is reflected promptly via the post-stream settle grace
+    // (STREAMING_SETTLE_GRACE_MS) — no frozen-then-jump. Before that grace
+    // existed, clearing streamingIndex sent these Phase-3 ticks down the
+    // debounced path, freezing totalHeight at the Phase-1 value (`expected - 48`).
+    expect(view.result.current.totalHeight).toBe(expected)
+  })
+
+  it('CONTROL: the same ease tail is smooth when the turn has NOT yet closed (streamingIndex still set)', () => {
+    // Proves the lurch is caused specifically by streamingIndex clearing at the
+    // stream boundary, not by SmoothResize growth per se. Survives the fix.
+    const { view, streamNode } = mountStreaming(
+      'diff-smoothresize-tail-control',
+      { scrollTop: 500, scrollHeight: 3000, clientHeight: 400 },
+      mkItems(21),
+    )
+    const ro = FakeResizeObserver.instances[FakeResizeObserver.instances.length - 1]
+    let h = 40
+    let expected = view.result.current.totalHeight
+    for (let i = 0; i < 8; i++) {
+      h += 12
+      expected += 12
+      act(() => { ro.fire([mkEntry(streamNode, h)]) })
+      act(() => { vi.advanceTimersByTime(16) })
+      // streamingIndex is still set → immediate sync every tick.
+      expect(view.result.current.totalHeight).toBe(expected)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

PR #824 fixed the "streaming response flashes while scrolled up" report at the
chat‑virtualizer layer (a debounced height→offset sync that lurched the bottom
spacer). But that fix only smooths **gradual, text‑like** growth of the
streaming row. Three kinds of streaming content still flash/jump, for reasons
#824 never touched:

1. **Images** — a markdown `<img>` has no intrinsic dimensions and
   `loading="lazy"`, so it lays out at ~0px until decode, then snaps to its
   natural height, shoving following content down in one jump.
2. **Tables** — a GFM table needs both a header row and a `|---|` delimiter
   row. Mid‑stream the header paints as a `<p>` of literal `| A | B |` text,
   then **structurally reflows** into a bordered `<table>` when the delimiter
   arrives.
3. **Diff / code blocks** — these are wrapped in `<SmoothResize>`, whose
   `height .32s` transition keeps resizing the row for ~320ms *after* the last
   byte streamed in (plus a completion snap). `streamingIndex` (the #824 bypass)
   goes `undefined` the instant the turn closes, so that settle tail falls back
   to the 120ms debounce — re‑creating the exact spacer lurch #824 removed, at
   end‑of‑stream.

## Why it matters

For a user scrolled up reading history while a message streams below the fold,
each of these is a visible flash/jump — the same class of complaint #824
addressed, just from content types its mechanism doesn't cover. Left as‑is, the
"flashing while streaming" report is only partially fixed.

## Fix (symptom → root cause → change)

- **Images** (`website/src/components/MarkdownRenderer.tsx`, `ImgWithFallback`):
  root cause is zero reserved height before decode. Reserve a `min-height`
  placeholder until `onLoad` (new `loaded` state), released on load so
  completed/history images stay pixel‑exact and carry no floor. Markdown gives
  us no aspect ratio, so the floor is a tuned heuristic (**120px**): it sits
  below the common screenshot/diagram case (which benefits) and above small
  icons/badges. Residual: a sub‑120px raster image sees a bounded (≤120px)
  collapse on load — accepted, since such images are uncommon in markdown.
- **Tables** (`MarkdownRenderer.tsx`, new `deferIncompleteStreamingTable` +
  `TABLE_DELIM_RE`, applied in `MarkdownBlock` only when `glow` = the live
  streaming tail): root cause is the header rendering as paragraph text before
  the delimiter exists. Withhold a trailing bordered‑table header run (first
  line starts with `|`) until a real delimiter row (one containing a `|`)
  arrives — mirroring how incomplete fenced code is held. The transition the
  user sees becomes "content appears", not "paragraph morphs into a table". The
  start‑with‑`|` check avoids withholding ordinary prose that contains inline
  pipes; the delimiter‑needs‑`|` check avoids mistaking a bare `---` thematic
  break for a table delimiter.
- **Diff/code** (`website/src/hooks/virtualizer/useVirtualChat.ts`, new
  `STREAMING_SETTLE_GRACE_MS = 400`): root cause is `streamingIndex` clearing
  while the row is still resizing. When it goes `undefined`, keep the
  just‑ended streaming row on the immediate‑sync path for a **fixed** 400ms
  window (armed in a `useLayoutEffect` so it beats the ResizeObserver delivery
  of the completion resize). The window is deliberately **not** re‑armed per
  resize, so an oscillating auto‑height widget in a just‑ended message cannot
  hold the row on the immediate path forever — after the window it reverts to
  the debounce and its render‑storm protection is restored.

## Tests

Three new regression suites (each documents a gap and locks its fix):

- `website/src/test/MarkdownRenderer.streamingImageShift.test.tsx` — a raster
  markdown image reserves vertical space before load.
- `website/src/test/MarkdownRenderer.streamingTableSnap.test.tsx` — a streaming
  incomplete table is not painted as literal pipe text; a bare `---` still
  defers; ordinary prose with inline pipes is not withheld; a completed table
  still renders.
- `website/src/test/useVirtualChat.postStreamLurch.test.tsx` — the post‑stream
  settle tail tracks live (no lurch); a CONTROL proves the smooth path is
  unaffected while `streamingIndex` is still set.

Pre‑existing `useVirtualChat.spacerLurch.test.tsx` and `streamingFlashRepro.test.tsx`
still pass, confirming #824's fix and the `.ft-word` opacity fix are untouched.

## Manual verification

N/A — covered by unit tests. The three behaviors are deterministic at the
component/hook layer (reserved‑space attributes, withheld/rendered text,
immediate vs debounced height sync under a fake ResizeObserver + fake timers), so
unit coverage is decisive; a live scrolled‑up visual pass on a capable host is a
reasonable optional follow‑up (the same note #824 carried).

## Local review

Ran the two‑reviewer local gate before pushing. GPT (`gpt-5.6-sol`, codex‑review
mirror) raised two HIGHs — the `useLayoutEffect` arming and the unbounded grace
re‑arm — both fixed here. Opus (`claude-opus-5`, claude‑review + AUTOSDE mirror)
returned NO BLOCKING FINDINGS; its advisories (table `---` false‑negative, table
over‑broad deferral, image floor tuning) are all folded in.

## Screenshots

N/A — no static UI surface changed at rest; the change is streaming‑time layout
behavior. Full gate: `tsc -b` clean; vitest 527 files / 6386 pass, 3 pre‑existing
skips, 0 failures.
