### PR TITLE
fix(metrics): give each duration histogram its own bucket boundaries

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -20,7 +20,7 @@ Source: `src/kiro_crew/metrics/` — `schema.py`, `recorder.py`, `provider.py`,
 |------|---------|
 | `schema.py` | Namespace constants (`NS_CORE = "kirocrew."`, `NS_GENAI = "gen_ai."`, `NS_APP_PREFIX = "app."`) + `validate_name` / `validate_attrs` / `redact` guardrails. Documents the low-cardinality contract. |
 | `recorder.py` | `MetricsRecorder` — facade over the OTEL `Meter`. Every metric passes namespace + privacy guardrails BEFORE reaching an instrument. Instrument-cache creation is lock-guarded (atomic check-then-create). Best-effort: a telemetry failure never propagates to the caller. `meter=None` = no-op recorder. |
-| `provider.py` | Consent gate + process-global recorder (`get_recorder()`) + graceful `shutdown()` / `reset_for_testing()`. When enabled, wires a `PeriodicExportingMetricReader` to the local JSONL exporter. Installs a `View` applying `ExplicitBucketHistogramAggregation(_LATENCY_BUCKETS_MS)` (1ms–60s boundaries) to EVERY histogram so bucket-derived p50/p90 stay meaningful across the full startup / acquire / lazy-load range (OTEL's default buckets top out at 10s). |
+| `provider.py` | Consent gate + process-global recorder (`get_recorder()`) + graceful `shutdown()` / `reset_for_testing()`. When enabled, wires a `PeriodicExportingMetricReader` to the local JSONL exporter. Installs **one `View` per instrument** from `_HISTOGRAM_BUCKETS_MS`, each with its own `ExplicitBucketHistogramAggregation` boundaries (see below) — deliberately NOT a catch-all `instrument_type=Histogram` View. |
 | `local_exporter.py` | `JsonlMetricExporter` — appends one JSON line per export cycle to `<dir>/metrics-YYYY-MM-DD-<pid>.jsonl` (default dir `~/.kiro/crew/metrics`). Per-PID single-writer shards keep append + rotation lock-free, so concurrent exporters do not lose DELTA cycles. A private `.metrics.lock` serializes only retention sweeps; pruning skips canonical shards owned by live PIDs or modified within the safety window. **Bounded retention (rec #14):** shards rotate before an append exceeds `max_total_mb`; closed/expired shards are pruned directly by age and oldest-first size. Pruning is throttled to at most once per 300s and fully best-effort. Dir mode is 0o700, file mode 0o600, and nothing egresses the host. Declares DELTA `preferred_temporality` for Counter/UpDownCounter/Histogram so daily aggregation is an element-wise sum across cycles/PIDs. |
 | `http_metrics.py` | Gateway HTTP observability (rec #1): `record_boot_to_ready()` (boot-to-ready histogram) + `make_route_latency_middleware()` (per-route latency, wired as the outermost middleware on both `start_dashboard`/`start_api_server`). Bounds `route_template` cardinality via `collect_route_templates()` (build-time snapshot) + `route_template()` (`__unknown__` fallback); clamps `method` to a fixed allowlist and `status_class` to `1xx`..`5xx`/`other`. Upgraded WebSocket connections and `text/event-stream` SSE responses are excluded because their handler elapsed time is connection/turn lifetime, not HTTP request latency. Best-effort — a telemetry failure never alters a response. |
 
@@ -148,6 +148,75 @@ when extra missing), `test/metrics/test_schema.py` (redaction / namespace).
 | `kirocrew.skill.lazy_load.count` / `.duration` | counter + histogram (ms) | `hit` (bool) | `skills.py::SkillsLoader.load_skill` via `_emit_lazy_load_metric` (best-effort; never breaks skill loading). |
 | `kirocrew.gateway.boot.duration` | histogram (ms) | `server` (`dashboard` / `api`), `outcome` (`ready`) | `dashboard/server.py::start_dashboard` / `start_api_server` — boot-to-ready: wall-clock from the server's `start_time` until full init completes and it is about to accept traffic. Emitted via `metrics/http_metrics.py::record_boot_to_ready`. Best-effort; never blocks startup. |
 | `kirocrew.gateway.request.duration` | histogram (ms) | `method` (fixed HTTP-verb allowlist, else `OTHER`), `route_template` (matched aiohttp canonical TEMPLATE, e.g. `/api/artifacts/{slug}`, else `__unknown__`), `status_class` (`1xx`..`5xx` / `other`) | `metrics/http_metrics.py::make_route_latency_middleware` — outermost gateway middleware on BOTH `start_dashboard` and `start_api_server`. Times full in-gateway HTTP handling; upgraded WebSocket connections and `text/event-stream` SSE responses are excluded so connection/turn lifetime cannot pollute request latency. **Bounded cardinality** (see below). |
+
+### Histogram bucket boundaries: per instrument, not shared
+
+Boundaries live in `metrics/provider.py::_HISTOGRAM_BUCKETS_MS`, a metric-name →
+boundaries map from which one `View(instrument_name=…)` is built per instrument.
+Three families, each sized to its instrument's measured range:
+
+| Family | Range | Instruments |
+|---|---|---|
+| `_FAST_BUCKETS_MS` | 0.5ms – 60s | `gateway.request`, `mcp.backend.acquire`, `skill.lazy_load` |
+| `_STARTUP_BUCKETS_MS` | 1ms – 60s | `session.startup`, `mcp.lazy_load`, `gateway.boot` |
+| `_TURN_BUCKETS_MS` | 1s – 1h | `turn.duration` |
+
+**Why not one shared array.** A single 1ms–60s array previously served every
+histogram through a catch-all `View(instrument_type=Histogram)`. Its ceiling was
+sized for session startup, so the first `kirocrew.turn.duration` sample ever
+recorded (227589ms — an agent turn is a whole agent loop including tool
+round-trips and any wait on an interactive approval) landed in the `+Inf`
+overflow bucket. Since `_pct_from_buckets` can only report an overflow bucket's
+LOWER bound, the aggregator returned `p50 == p90 == 60000` — a ceiling artifact
+presented as a real latency, while `mean`/`max` (exact, from `sum`/`max`) stayed
+correct beside it. `p50 == p90` is the signature of this failure. Instruments in
+this system span six orders of magnitude (sub-ms pooled acquires to multi-minute
+agent turns), so one array must sacrifice either fast-end resolution or slow-end
+truth.
+
+**Why there is no catch-all fallback.** The OTEL SDK applies EVERY matching
+View, not the first. A per-instrument View plus a catch-all therefore publishes
+the same metric name twice with different bounds. The SDK offers no negation in
+View matching, so the catch-all had to be removed rather than narrowed.
+
+**Boundary generations never merge.** Bounds are baked into each data point at
+record time, so any boundary change makes the 14-day scan window straddle two
+incompatible generations of one metric. `handlers/telemetry.py::_Hist` therefore
+groups data points by their EXACT `explicit_bounds` and reports statistics from a
+single group — **the one holding the newest data point**. Selection is by recency,
+not volume: majority selection would let a stale generation keep winning while it
+out-counted the new one, so right after a boundary change the old bounds would be
+reported for up to the whole 14-day window — for `turn.duration` that means
+continuing to serve the ceiling-pinned percentiles this grouping exists to remove,
+while omitting the new samples. Recency makes the change take effect on the first
+post-change sample; the reported population is then small but truthful, and
+`count` says so. (`count` remains a tie-break for data points carrying no
+`time_unix_nano`.) **Outcome tallies
+are grouped too** — accumulated inside `_Hist` rather than alongside it, because
+scoping only the buckets and count would leave the outcome breakdown summing
+across generations: the page would show N turns beside an outcome bar totalling
+more than N, and a `fault_rate` computed over a different population than the
+latency next to it. Both the `startup` and `turn` blocks expose
+`other_generations` (0 = a clean window; >0 = the window straddles a boundary
+change and only the dominant generation is reported).
+
+This is load-bearing, not defensive: the historical shared array and
+`_TURN_BUCKETS_MS` have the SAME bucket-count length, so a length-only check
+would have merged them positionally — adding a pre-change sample from the old
+`+Inf` bucket into the new `+Inf` bucket and reporting **p90 = 3,600,000ms (one
+hour)**, while a 5s sample landed in a 5-minute bucket. Grouping also keeps
+`count`/`sum`/`min`/`max` consistent with the percentiles; accumulating those
+across generations while only one generation's buckets survived would describe a
+mean over one population and percentiles over another.
+
+**Completeness is therefore load-bearing.** With no catch-all, a histogram
+missing from the map silently falls back to OTEL's default 10s-ceiling
+boundaries — reintroducing the same class of bug. `test/metrics/
+test_provider_bucket_views.py` scans the source for `kirocrew.*.duration` metric
+names and fails when one has no map entry (and when a map entry has no emitting
+call site). It also pins the no-duplicate-streams property and asserts the
+227589ms regression sample no longer overflows. **When adding a duration
+histogram, add it to `_HISTOGRAM_BUCKETS_MS`.**
 
 ### Bounded cardinality of `kirocrew.gateway.request.duration` (rec #1)
 

--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -133,44 +133,155 @@ def _pct_from_buckets(
 
 
 class _Hist:
-    """Accumulator merging histogram data points that share a dimension key."""
+    """Accumulator merging histogram data points that share a dimension key.
 
-    __slots__ = ("count", "sum", "min", "max", "buckets", "bounds")
+    Data points are grouped by their EXACT ``explicit_bounds``, and every
+    reported statistic comes from a single group. This matters whenever bucket
+    boundaries change: a data point's bounds are baked in at record time, so a
+    14-day scan window straddling a boundary change holds two incompatible
+    generations of the same metric.
+
+    Merging them positionally fabricates values. Two generations with the same
+    bucket-count length would pass a naive length check while meaning entirely
+    different things — a pre-change sample sitting in the old ``+Inf`` bucket
+    would be added to the new ``+Inf`` bucket, and a 5s sample could be counted
+    into a 5-minute bucket, letting ``_pct_from_buckets`` report a p90 that no
+    turn ever took. Grouping also keeps ``count``/``sum``/``min``/``max``
+    consistent with the percentiles: accumulating those across generations while
+    only one generation's buckets survive would describe a mean over one
+    population and percentiles over another.
+
+    The reported group is the one holding the **newest** data point, not the
+    largest. Majority selection would let a stale generation keep winning for as
+    long as it out-counted the new one: right after a boundary change the window
+    still holds up to ``_WINDOW_DAYS`` of old samples against a handful of new
+    ones, so the OLD bounds would be reported — for the turn metric that means
+    continuing to serve the very ceiling-pinned percentiles this grouping exists
+    to eliminate, while omitting the new samples entirely. Recency makes the
+    change take effect on the first post-change sample. The reported population
+    is then small but truthful, and ``count`` says so; fuller-but-wrong is the
+    failure mode being fixed.
+
+    ``other_generations`` exposes how many groups were seen beyond the reported
+    one so a caller can surface a mixed window rather than silently trusting a
+    subset.
+    """
+
+    __slots__ = ("_groups",)
 
     def __init__(self) -> None:
-        self.count = 0
-        self.sum = 0.0
-        self.min: float | None = None
-        self.max: float | None = None
-        self.buckets: list[int] = []
-        self.bounds: list[float] = []
+        # bounds signature -> accumulated stats for that boundary generation
+        self._groups: dict[tuple[float, ...], dict[str, Any]] = {}
 
-    def add(self, dp: dict[str, Any]) -> None:
+    def add(self, dp: dict[str, Any], outcome: str = "") -> None:
         bc = dp.get("bucket_counts") or []
-        eb = dp.get("explicit_bounds") or []
-        self.count += int(dp.get("count", 0) or 0)
-        self.sum += float(dp.get("sum", 0.0) or 0.0)
+        try:
+            key = tuple(float(b) for b in (dp.get("explicit_bounds") or []))
+        except (TypeError, ValueError):
+            return
+        g = self._groups.get(key)
+        if g is None:
+            g = {
+                "count": 0,
+                "sum": 0.0,
+                "min": None,
+                "max": None,
+                "buckets": [0] * len(bc) if bc else [],
+                "bounds": list(key),
+                "outcomes": {},
+                "newest_ns": 0,
+            }
+            self._groups[key] = g
+        try:
+            ns = int(dp.get("time_unix_nano") or 0)
+        except (TypeError, ValueError):
+            ns = 0
+        if ns > int(g["newest_ns"]):
+            g["newest_ns"] = ns
+        n = int(dp.get("count", 0) or 0)
+        g["count"] += n
+        g["sum"] += float(dp.get("sum", 0.0) or 0.0)
+        if outcome:
+            # Outcome tallies MUST be grouped too. Scoping only the buckets and
+            # count would leave the outcome breakdown summing across generations
+            # while count reported one — the dashboard would show N turns beside
+            # an outcome bar totalling more than N, and a fault rate computed
+            # over a different population than the latency next to it.
+            g["outcomes"][outcome] = g["outcomes"].get(outcome, 0) + n
         mn, mx = dp.get("min"), dp.get("max")
         if mn is not None:
-            self.min = mn if self.min is None else min(self.min, mn)
+            g["min"] = mn if g["min"] is None else min(g["min"], mn)
         if mx is not None:
-            self.max = mx if self.max is None else max(self.max, mx)
+            g["max"] = mx if g["max"] is None else max(g["max"], mx)
         if bc:
-            if not self.buckets:
-                self.buckets = [0] * len(bc)
-                self.bounds = list(eb)
-            if len(bc) == len(self.buckets):
+            if not g["buckets"]:
+                g["buckets"] = [0] * len(bc)
+            # Same bounds signature implies same bucket length; the guard only
+            # defends against a malformed shard mixing lengths under one bounds
+            # list, which would otherwise raise IndexError.
+            if len(bc) == len(g["buckets"]):
                 for j, v in enumerate(bc):
-                    self.buckets[j] += int(v or 0)
+                    g["buckets"][j] += int(v or 0)
+
+    def _dominant(self) -> dict[str, Any] | None:
+        """The generation holding the newest sample.
+
+        ``count`` is only a tie-break, reached when data points carry no
+        ``time_unix_nano`` (synthetic or older shards) so every group ties at 0.
+        """
+        if not self._groups:
+            return None
+        return max(
+            self._groups.values(),
+            key=lambda g: (int(g["newest_ns"]), int(g["count"])),
+        )
+
+    @property
+    def count(self) -> int:
+        g = self._dominant()
+        return int(g["count"]) if g else 0
+
+    @property
+    def buckets(self) -> list[int]:
+        g = self._dominant()
+        return list(g["buckets"]) if g else []
+
+    @property
+    def bounds(self) -> list[float]:
+        g = self._dominant()
+        return list(g["bounds"]) if g else []
+
+    @property
+    def other_generations(self) -> int:
+        """Boundary generations present beyond the reported one (0 = clean)."""
+        return max(0, len(self._groups) - 1)
+
+    @property
+    def outcomes(self) -> dict[str, int]:
+        """Outcome tallies for the reported generation only.
+
+        Consistent by construction with ``count`` and the percentiles, so a
+        fault rate derived from this describes the same population as the
+        latency shown beside it.
+        """
+        g = self._dominant()
+        return dict(g["outcomes"]) if g else {}
 
     def stats(self) -> dict[str, Any]:
+        g = self._dominant()
+        if g is None:
+            return {
+                "count": 0, "mean_ms": 0.0, "p50_ms": 0.0,
+                "p90_ms": 0.0, "min_ms": 0.0, "max_ms": 0.0,
+            }
+        cnt = int(g["count"])
         return {
-            "count": self.count,
-            "mean_ms": round(self.sum / self.count, 1) if self.count else 0.0,
-            "p50_ms": round(_pct_from_buckets(self.buckets, self.bounds, 0.50), 1),
-            "p90_ms": round(_pct_from_buckets(self.buckets, self.bounds, 0.90), 1),
-            "min_ms": round(self.min, 1) if self.min is not None else 0.0,
-            "max_ms": round(self.max, 1) if self.max is not None else 0.0,
+            "count": cnt,
+            "mean_ms": round(float(g["sum"]) / cnt, 1) if cnt else 0.0,
+            "p50_ms": round(_pct_from_buckets(g["buckets"], g["bounds"], 0.50), 1),
+            "p90_ms": round(_pct_from_buckets(g["buckets"], g["bounds"], 0.90), 1),
+            "min_ms": round(g["min"], 1) if g["min"] is not None else 0.0,
+            "max_ms": round(g["max"], 1) if g["max"] is not None else 0.0,
         }
 
 
@@ -192,14 +303,12 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
     overall = _Hist()
     cold = _Hist()  # spawned == True
     warm = _Hist()  # spawned == False
-    outcome: dict[str, int] = {}
     daily: dict[str, dict[str, _Hist]] = {}  # day -> {"cold"|"warm": _Hist}
     phases: dict[str, _Hist] = {}  # startup internal phase -> _Hist
     # generic surface for every other kirocrew.* metric
     other_hist: dict[str, _Hist] = {}
     other_ctr: dict[str, dict[str, Any]] = {}  # name -> {total, by_attr}
     turn = _Hist()
-    turn_outcome: dict[str, int] = {}  # kirocrew.turn.duration count by outcome
 
     for p in shard_paths:
         shard_day = "-".join(p.stem.split("-")[1:4])
@@ -236,23 +345,24 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
                                         if phase != _PHASE_TOTAL:
                                             phases.setdefault(phase, _Hist()).add(dp)
                                             continue
-                                        overall.add(dp)
                                         spawned = bool(attrs.get("spawned"))
-                                        (cold if spawned else warm).add(dp)
                                         oc = str(attrs.get("outcome", "unknown"))
-                                        outcome[oc] = outcome.get(oc, 0) + int(
-                                            dp.get("count", 0) or 0
-                                        )
+                                        (cold if spawned else warm).add(dp)
+                                        # Outcomes go through _Hist so they are
+                                        # scoped to the same bounds generation as
+                                        # the count and percentiles reported.
+                                        overall.add(dp, outcome=oc)
                                         day = _day_of(dp, shard_day)
                                         db = daily.setdefault(
                                             day, {"cold": _Hist(), "warm": _Hist()}
                                         )
                                         db["cold" if spawned else "warm"].add(dp)
                                     elif name == _TURN_METRIC and is_hist:
-                                        turn.add(dp)
-                                        oc = str(attrs.get("outcome", "unknown"))
-                                        turn_outcome[oc] = turn_outcome.get(oc, 0) + int(
-                                            dp.get("count", 0) or 0
+                                        turn.add(
+                                            dp,
+                                            outcome=str(
+                                                attrs.get("outcome", "unknown")
+                                            ),
                                         )
                                     elif is_hist:
                                         other_hist.setdefault(name, _Hist()).add(dp)
@@ -302,12 +412,16 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
             }
         )
 
+    turn_outcome = turn.outcomes
     turn_total = sum(turn_outcome.values())
     turn_faults = sum(v for k, v in turn_outcome.items() if k != "ok")
     turn_block = {
         **turn.stats(),
         "outcome": turn_outcome,
         "fault_rate": round(turn_faults / turn_total, 4) if turn_total else 0.0,
+        # >0 means the window straddles a bucket-boundary change and only the
+        # dominant generation is reported (see _Hist).
+        "other_generations": turn.other_generations,
     }
 
     return {
@@ -315,7 +429,8 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
             "overall": overall.stats(),
             "cold": cold.stats(),
             "warm": warm.stats(),
-            "outcome": outcome,
+            "outcome": overall.outcomes,
+            "other_generations": overall.other_generations,
             "daily": daily_out,
             "distribution": {"buckets": overall.buckets, "bounds": overall.bounds},
             # Internal phase split (kiro backend): spawn_init, session_new,

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -51,7 +51,7 @@ from kiro_crew.metrics.recorder import MetricsRecorder
 # import preserves the degrade contract. recorder.py is annotation-only on
 # OTel symbols (TYPE_CHECKING import) and stays loadable either way.
 try:
-    from opentelemetry.sdk.metrics import Histogram, MeterProvider
+    from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
     from opentelemetry.sdk.metrics.view import (
         ExplicitBucketHistogramAggregation,
@@ -63,7 +63,7 @@ try:
 
     _OTEL_AVAILABLE = True
 except ImportError:
-    Histogram = MeterProvider = PeriodicExportingMetricReader = None  # type: ignore[assignment,misc]
+    MeterProvider = PeriodicExportingMetricReader = None  # type: ignore[assignment,misc]
     ExplicitBucketHistogramAggregation = View = Resource = None  # type: ignore[assignment,misc]
     JsonlMetricExporter = None  # type: ignore[assignment,misc]
     _OTEL_AVAILABLE = False
@@ -73,17 +73,68 @@ logger = logging.getLogger(__name__)
 _SERVICE_NAME = "kirocrew"
 _SCOPE = "kiro_crew"
 
-# Explicit histogram bucket boundaries (milliseconds), applied to EVERY kirocrew
-# duration histogram via a MeterProvider View. OTEL's default boundaries top out
-# at 10s, so a cold session startup (15-25s) or a cold MCP lazy-load would fall
-# entirely into the +Inf overflow bucket and make bucket-derived p50/p90
-# meaningless. These boundaries span sub-ms acquire latencies through ~60s cold
-# starts so startup / backend.acquire / mcp.lazy_load / skill.lazy_load all get
-# usable percentiles from the exported bucket counts.
-_LATENCY_BUCKETS_MS = [
+# Explicit histogram bucket boundaries (milliseconds), applied PER INSTRUMENT via
+# MeterProvider Views. OTEL's default boundaries top out at 10s, so anything
+# slower lands entirely in the +Inf overflow bucket — and because
+# `_pct_from_buckets` can only report an overflow bucket's LOWER bound, the
+# derived p50/p90 then silently pin to the top boundary instead of reporting the
+# real value. A single shared array cannot serve every instrument: sub-ms MCP
+# acquires and multi-minute agent turns differ by six orders of magnitude, and
+# sizing one array for both costs either resolution at the fast end or truth at
+# the slow end.
+#
+# Three families, each sized to its instrument's MEASURED range:
+
+# Sub-ms through a minute — pooled acquires, skill loads, HTTP requests.
+# These are dominated by ~1ms values, so the fine end matters. The 60s ceiling
+# is retained from the historical shared array rather than tightened: request
+# duration excludes WebSocket upgrades and SSE streams, but ordinary slow
+# endpoints (installers, long provisioning calls) do run past 30s, and any
+# sample above the top bound has its percentile floored at that bound — the
+# exact artifact this change exists to remove.
+_FAST_BUCKETS_MS: list[float] = [
+    0.5, 1, 2, 5, 10, 25, 50, 100, 250, 500,
+    1000, 2500, 5000, 10000, 30000, 60000,
+]
+
+# Milliseconds through ~1 minute — session startup and other cold-start work.
+# Unchanged from the historical shared array: startup spans a 0.5ms set_model
+# phase through 15-25s cold spawns, and this is the range it was sized for.
+_STARTUP_BUCKETS_MS: list[float] = [
     1, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 3000,
     5000, 7500, 10000, 15000, 20000, 30000, 45000, 60000,
 ]
+
+# One second through one hour — agent turns. A turn is an entire agent loop
+# (model calls plus every tool round-trip, and any wait on an interactive
+# approval prompt), so minutes are ordinary and the old 60s ceiling overflowed
+# on the very first sample ever recorded (227589ms). Resolution is deliberately
+# densest between 1 and 10 minutes, where turns actually land.
+_TURN_BUCKETS_MS: list[float] = [
+    1000, 2500, 5000, 10000, 20000, 30000, 45000, 60000, 90000,
+    120000, 180000, 300000, 450000, 600000, 900000, 1200000,
+    1800000, 2700000, 3600000,
+]
+
+# Instrument name -> boundaries. This map is the COMPLETE set of kirocrew
+# duration histograms: the Views below are built from it and there is no
+# catch-all, because the OTEL SDK applies EVERY matching View rather than the
+# first, so a per-instrument View plus a catch-all would emit two conflicting
+# streams under one metric name.
+#
+# Consequence: a new histogram missing from this map falls back to OTEL's
+# default 10s-ceiling boundaries. `test/metrics/test_provider_bucket_views.py`
+# fails when a histogram metric name in the source has no entry here — add the
+# instrument to this map when you add the metric.
+_HISTOGRAM_BUCKETS_MS: dict[str, list[float]] = {
+    "kirocrew.gateway.request.duration": _FAST_BUCKETS_MS,
+    "kirocrew.mcp.backend.acquire.duration": _FAST_BUCKETS_MS,
+    "kirocrew.skill.lazy_load.duration": _FAST_BUCKETS_MS,
+    "kirocrew.session.startup.duration": _STARTUP_BUCKETS_MS,
+    "kirocrew.mcp.lazy_load.duration": _STARTUP_BUCKETS_MS,
+    "kirocrew.gateway.boot.duration": _STARTUP_BUCKETS_MS,
+    "kirocrew.turn.duration": _TURN_BUCKETS_MS,
+}
 
 _lock = threading.Lock()
 _recorder: Optional[MetricsRecorder] = None
@@ -163,16 +214,19 @@ def _build_recorder() -> MetricsRecorder:
         _provider = MeterProvider(
             metric_readers=readers,
             resource=Resource.create({"service.name": _SERVICE_NAME}),
-            # Apply the latency bucket set to every histogram so bucket-derived
-            # p50/p90 stay meaningful across the full startup / acquire /
-            # lazy-load range (OTEL's default histogram tops out at 10s).
+            # One View per instrument, from _HISTOGRAM_BUCKETS_MS. Deliberately
+            # NOT a catch-all `instrument_type=Histogram` View: the OTEL SDK
+            # applies every matching View, so a catch-all alongside these would
+            # publish each named instrument twice under one metric name with
+            # different bounds, and the telemetry aggregator merges same-length
+            # bucket arrays without comparing bounds — it would silently double
+            # the counts. See the completeness guard test.
             views=[
                 View(
-                    instrument_type=Histogram,
-                    aggregation=ExplicitBucketHistogramAggregation(
-                        _LATENCY_BUCKETS_MS
-                    ),
-                ),
+                    instrument_name=name,
+                    aggregation=ExplicitBucketHistogramAggregation(bounds),
+                )
+                for name, bounds in _HISTOGRAM_BUCKETS_MS.items()
             ],
         )
         logger.info(

--- a/test/metrics/test_provider_bucket_views.py
+++ b/test/metrics/test_provider_bucket_views.py
@@ -1,0 +1,349 @@
+"""Guards for the per-instrument histogram bucket Views.
+
+Context: bucket boundaries used to be ONE shared array applied through a single
+catch-all ``View(instrument_type=Histogram)``. Its top bound was 60s, sized for
+session startup, so the first ``kirocrew.turn.duration`` sample ever recorded
+(227589ms) fell into the +Inf overflow bucket and the aggregator reported
+``p50 == p90 == 60000`` — a ceiling artifact rendered as a real latency.
+
+The fix replaces the catch-all with one View per instrument. That makes two
+properties load-bearing, and both are asserted here:
+
+1. **Completeness.** With no catch-all, an instrument missing from
+   ``_HISTOGRAM_BUCKETS_MS`` silently falls back to OTEL's default 10s-ceiling
+   boundaries. ``test_every_source_histogram_has_bounds`` fails when a histogram
+   metric name appears in the source with no map entry.
+2. **No duplicate streams.** The OTEL SDK applies EVERY matching View, not the
+   first, so re-introducing a catch-all would publish each named instrument
+   twice under one metric name. ``test_no_duplicate_streams_per_instrument``
+   pins that.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.dashboard.handlers.telemetry import _Hist
+from kiro_crew.metrics import provider as provider_mod
+from kiro_crew.metrics.provider import (
+    _FAST_BUCKETS_MS,
+    _HISTOGRAM_BUCKETS_MS,
+    _STARTUP_BUCKETS_MS,
+    _TURN_BUCKETS_MS,
+)
+
+_SRC = Path(provider_mod.__file__).resolve().parent.parent
+# Histogram instrument names are the `.duration` metrics; counters end in
+# `.count` / `.acquire` and carry no bounds.
+_NAME_RE = re.compile(r'"(kirocrew\.[a-z0-9_.]*\.duration)"')
+
+
+def _source_histogram_names() -> set[str]:
+    found: set[str] = set()
+    for path in _SRC.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        found.update(_NAME_RE.findall(text))
+    return found
+
+
+class TestCompleteness:
+    def test_source_scan_finds_the_known_instruments(self):
+        """Guard the guard: a scan that matches nothing would pass vacuously."""
+        names = _source_histogram_names()
+        assert "kirocrew.turn.duration" in names
+        assert "kirocrew.session.startup.duration" in names
+        assert len(names) >= 7
+
+    def test_every_source_histogram_has_bounds(self):
+        missing = sorted(_source_histogram_names() - set(_HISTOGRAM_BUCKETS_MS))
+        assert not missing, (
+            "These duration histograms have no entry in "
+            "provider._HISTOGRAM_BUCKETS_MS, so they would silently fall back to "
+            f"OTEL's default 10s-ceiling buckets: {missing}. Add each one to the "
+            "map with boundaries covering its real range."
+        )
+
+    def test_no_stale_map_entries(self):
+        """A name dropped from the source should not linger in the map."""
+        stale = sorted(set(_HISTOGRAM_BUCKETS_MS) - _source_histogram_names())
+        assert not stale, f"map entries with no emitting call site: {stale}"
+
+
+class TestBoundaryShape:
+    @pytest.mark.parametrize("name,bounds", sorted(_HISTOGRAM_BUCKETS_MS.items()))
+    def test_bounds_are_sorted_positive_and_unique(self, name, bounds):
+        assert bounds, name
+        assert all(b > 0 for b in bounds), name
+        assert list(bounds) == sorted(bounds), name
+        assert len(set(bounds)) == len(bounds), name
+
+    def test_turn_ceiling_covers_a_realistic_agent_turn(self):
+        """227589ms is the real first sample that exposed the overflow bug."""
+        assert _TURN_BUCKETS_MS[-1] >= 227589 * 2
+        assert _TURN_BUCKETS_MS[-1] == 3_600_000
+
+    def test_fast_family_keeps_sub_millisecond_resolution(self):
+        # backend.acquire and skill.lazy_load sit at ~1ms; without a sub-ms
+        # bound their p50 collapses onto the first boundary.
+        assert _FAST_BUCKETS_MS[0] < 1
+
+    def test_fast_family_ceiling_is_not_lowered_from_the_historical_array(self):
+        """Slow-but-ordinary endpoints (installers, provisioning) exceed 30s.
+
+        Tightening this ceiling to 30s would floor their percentile at 30000ms
+        — the same overflow artifact this change exists to remove, relocated to
+        a different threshold.
+        """
+        assert _FAST_BUCKETS_MS[-1] == 60_000
+
+    def test_startup_family_unchanged_range(self):
+        assert _STARTUP_BUCKETS_MS[-1] == 60_000
+
+
+class TestMixedBoundaryGenerations:
+    """A boundary change makes the 14-day window straddle two generations.
+
+    Bounds are baked into each data point at record time, so after this change
+    lands the reader sees pre-change and post-change shards for the same metric.
+    Merging them positionally fabricates percentiles: the OLD shared array and
+    ``_TURN_BUCKETS_MS`` have the SAME bucket-count length, so a naive
+    length-only check would add a pre-change sample sitting in the old ``+Inf``
+    bucket into the new ``+Inf`` bucket (reporting p90 = 1 hour) and drop a 5s
+    sample into a 5-minute bucket.
+    """
+
+    OLD_SHARED_BOUNDS = [
+        1, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 3000,
+        5000, 7500, 10000, 15000, 20000, 30000, 45000, 60000,
+    ]
+
+    def _dp(self, bounds, landed_index, count=1, total=None, ns=None):
+        counts = [0] * (len(bounds) + 1)
+        counts[landed_index] = count
+        val = total if total is not None else count * 1000.0
+        dp = {
+            "attributes": {},
+            "count": count,
+            "sum": float(val),
+            "min": 1.0,
+            "max": float(val),
+            "bucket_counts": counts,
+            "explicit_bounds": list(bounds),
+        }
+        if ns is not None:
+            dp["time_unix_nano"] = ns
+        return dp
+
+    def test_old_and_new_turn_bounds_have_the_same_length(self):
+        """Pins the precondition — without it the bug needs no guard."""
+        assert len(self.OLD_SHARED_BOUNDS) == len(_TURN_BUCKETS_MS)
+
+    def test_legacy_overflow_point_cannot_fabricate_a_one_hour_p90(self):
+        h = _Hist()
+        # Pre-change: a 227589ms turn, recorded as old-bounds +Inf overflow.
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, len(self.OLD_SHARED_BOUNDS),
+                       count=1, total=227589))
+        # Post-change: three ordinary ~30s turns under the new bounds.
+        for _ in range(3):
+            h.add(self._dp(_TURN_BUCKETS_MS, 5, count=1, total=30000))
+
+        s = h.stats()
+        assert s["p90_ms"] != 3_600_000.0, "legacy overflow leaked into new bounds"
+        assert s["p90_ms"] <= _TURN_BUCKETS_MS[5]
+        # Dominant generation is the new one (3 samples vs 1), and count is
+        # consistent with the percentiles rather than summing both populations.
+        assert s["count"] == 3
+        assert h.other_generations == 1
+
+    def test_generations_do_not_cross_contaminate_buckets(self):
+        h = _Hist()
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=5))   # 5 old samples
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=9))           # 9 new samples
+        assert h.bounds == list(_TURN_BUCKETS_MS)
+        assert sum(h.buckets) == 9, "old-generation counts bled into new buckets"
+
+    def test_outnumbered_new_generation_still_wins_on_recency(self):
+        """The reported scenario: 5 legacy turns vs 1 new turn.
+
+        Majority selection would keep the legacy bounds — so the page would
+        still serve the ceiling-pinned 60000ms percentiles and omit the new
+        sample — for as long as the old generation out-counted the new one,
+        which right after an upgrade is up to the whole 14-day window.
+        """
+        h = _Hist()
+        for _ in range(5):
+            h.add(self._dp(self.OLD_SHARED_BOUNDS, len(self.OLD_SHARED_BOUNDS),
+                           count=1, total=227589, ns=1_000))
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=1, total=5000, ns=2_000))
+
+        assert h.bounds == list(_TURN_BUCKETS_MS), "stale generation kept winning"
+        assert h.stats()["count"] == 1
+        assert h.stats()["p90_ms"] != 60000.0
+        assert h.other_generations == 1
+
+    def test_selection_prefers_recency_over_volume_either_direction(self):
+        """A revert must also take effect immediately, not after out-counting."""
+        h = _Hist()
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=50, ns=1_000))
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=1, ns=9_999))
+        assert h.bounds == list(self.OLD_SHARED_BOUNDS)
+
+    def test_count_is_the_tiebreak_when_no_timestamps_exist(self):
+        """Synthetic/older shards carry no time_unix_nano; all groups tie at 0."""
+        h = _Hist()
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=10))
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=11))
+        assert h.bounds == list(_TURN_BUCKETS_MS)
+
+    def test_single_generation_is_unaffected(self):
+        """The startup family did not change bounds, so it must behave as before."""
+        h = _Hist()
+        h.add(self._dp(_STARTUP_BUCKETS_MS, 3, count=2, total=8000))
+        h.add(self._dp(_STARTUP_BUCKETS_MS, 3, count=2, total=8000))
+        s = h.stats()
+        assert s["count"] == 4
+        assert h.other_generations == 0
+        assert s["mean_ms"] == 4000.0
+
+    def test_outcomes_are_scoped_to_the_reported_generation(self):
+        """Otherwise the outcome bar totals more than `count`.
+
+        Scoping buckets and count but not outcomes would show N turns beside an
+        outcome breakdown summing to more than N, with a fault rate computed
+        over a different population than the latency next to it.
+        """
+        h = _Hist()
+        # Pre-change generation: one error turn.
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=1), outcome="error")
+        # Post-change generation: three successful turns.
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=3), outcome="ok")
+
+        assert h.outcomes == {"ok": 3}, "legacy outcome leaked into the new generation"
+        assert sum(h.outcomes.values()) == h.stats()["count"]
+
+    def test_fault_rate_matches_the_reported_population(self):
+        h = _Hist()
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=9), outcome="error")
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=3), outcome="ok")
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=1), outcome="error")
+        oc = h.outcomes
+        total = sum(oc.values())
+        faults = sum(v for k, v in oc.items() if k != "ok")
+        # New generation dominates (4 vs 9? no — 4 < 9), so old wins here and
+        # the point stands either way: totals must agree with count.
+        assert total == h.stats()["count"]
+        assert 0.0 <= faults / total <= 1.0
+
+    def test_outcomes_accumulate_within_one_generation(self):
+        h = _Hist()
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=3), outcome="ok")
+        h.add(self._dp(_TURN_BUCKETS_MS, 4, count=2), outcome="ok")
+        h.add(self._dp(_TURN_BUCKETS_MS, 6, count=1), outcome="timeout")
+        assert h.outcomes == {"ok": 5, "timeout": 1}
+        assert sum(h.outcomes.values()) == h.stats()["count"] == 6
+
+
+class TestViewWiring:
+    """Drive the real SDK to prove the Views behave as intended."""
+
+    def _provider(self):
+        pytest.importorskip("opentelemetry.sdk.metrics")
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from opentelemetry.sdk.metrics.view import (
+            ExplicitBucketHistogramAggregation,
+            View,
+        )
+
+        reader = InMemoryMetricReader()
+        mp = MeterProvider(
+            metric_readers=[reader],
+            views=[
+                View(
+                    instrument_name=name,
+                    aggregation=ExplicitBucketHistogramAggregation(bounds),
+                )
+                for name, bounds in _HISTOGRAM_BUCKETS_MS.items()
+            ],
+        )
+        return mp, reader
+
+    def _points(self, reader, name):
+        data = reader.get_metrics_data()
+        out = []
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    if m.name == name:
+                        out.extend(m.data.data_points)
+        return out
+
+    def test_long_turn_does_not_land_in_the_overflow_bucket(self):
+        """The regression: 227589ms must fall inside an explicit bucket."""
+        mp, reader = self._provider()
+        mp.get_meter("t").create_histogram(
+            "kirocrew.turn.duration", unit="ms"
+        ).record(227589)
+
+        (dp,) = self._points(reader, "kirocrew.turn.duration")
+        counts = list(dp.bucket_counts)
+        overflow_index = len(dp.explicit_bounds)
+        assert counts[overflow_index] == 0, "sample fell into the +Inf bucket"
+        assert sum(counts) == 1
+        # ...and the bucket it landed in is bounded above, so an interpolated
+        # percentile can report a real value rather than a floor.
+        landed = next(i for i, c in enumerate(counts) if c)
+        assert landed < overflow_index
+
+    def test_no_duplicate_streams_per_instrument(self):
+        mp, reader = self._provider()
+        meter = mp.get_meter("t")
+        meter.create_histogram("kirocrew.turn.duration", unit="ms").record(5000)
+        meter.create_histogram(
+            "kirocrew.session.startup.duration", unit="ms"
+        ).record(4400)
+
+        assert len(self._points(reader, "kirocrew.turn.duration")) == 1
+        assert len(self._points(reader, "kirocrew.session.startup.duration")) == 1
+
+    def test_each_instrument_gets_its_own_family(self):
+        mp, reader = self._provider()
+        meter = mp.get_meter("t")
+        meter.create_histogram("kirocrew.turn.duration", unit="ms").record(60000)
+        meter.create_histogram(
+            "kirocrew.mcp.backend.acquire.duration", unit="ms"
+        ).record(1)
+
+        (turn,) = self._points(reader, "kirocrew.turn.duration")
+        (fast,) = self._points(reader, "kirocrew.mcp.backend.acquire.duration")
+        assert list(turn.explicit_bounds) == list(_TURN_BUCKETS_MS)
+        assert list(fast.explicit_bounds) == list(_FAST_BUCKETS_MS)
+
+
+class TestAggregatorReadsRealPercentiles:
+    """End-to-end: the fix must change what the Telemetry page reports."""
+
+    def test_turn_percentiles_are_no_longer_pinned_to_the_ceiling(self):
+        from kiro_crew.dashboard.handlers.telemetry import _pct_from_buckets
+
+        # Same sample, old vs new boundaries.
+        old_bounds = _STARTUP_BUCKETS_MS  # what every histogram used to get
+        old_counts = [0] * len(old_bounds) + [1]  # 227589ms -> overflow
+        assert _pct_from_buckets(old_counts, old_bounds, 0.50) == 60000.0
+        assert _pct_from_buckets(old_counts, old_bounds, 0.90) == 60000.0
+
+        new_bounds = _TURN_BUCKETS_MS
+        landed = next(
+            i for i, b in enumerate(new_bounds) if b >= 227589
+        )
+        new_counts = [0] * (len(new_bounds) + 1)
+        new_counts[landed] = 1
+        p50 = _pct_from_buckets(new_counts, new_bounds, 0.50)
+        p90 = _pct_from_buckets(new_counts, new_bounds, 0.90)
+        # Reported inside the bucket that actually contains the sample.
+        assert new_bounds[landed - 1] <= p50 <= new_bounds[landed]
+        assert p50 != 60000.0
+        assert p90 != 60000.0


### PR DESCRIPTION
Fixes #967.

## Problem

The Telemetry page's **Turn latency** card reports `p50 = p90 = 60000ms` no matter what the real turn durations are. `p50 == p90` is the signature — real data essentially never produces identical percentiles.

## Why it matters

Turn latency and fault rate are the two headline health numbers on that page, and one of them is a constant dressed up as a measurement. A user reading "p50 60.0s" concludes turns take a minute; the actual first sample was 3m48s. This is the same class of defect as #869 (which this repo just fixed in #875): render a plausible number that is really an artifact. Worse, `mean` and `max` sit in the same block and *are* correct, so the card is internally inconsistent without saying so.

## Fix: symptom → root cause → change

**Symptom.** First `kirocrew.turn.duration` sample ever recorded on the live gateway, read straight from the shard:

```
value sum: 227589   count: 1
explicit_bounds: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 3000,
                  5000, 7500, 10000, 15000, 20000, 30000, 45000, 60000]
bucket_counts:   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
                                                                          ^ +Inf
aggregator: p50=60000.0  p90=60000.0  mean=227589.0  max=227589
```

**Root cause.** The sample is in the `+Inf` overflow bucket, and `_pct_from_buckets` can only report an overflow bucket's *lower* bound — so any bucket-derived percentile pins to the top boundary. That boundary was 60s because ONE array served every histogram through a single catch-all `View(instrument_type=Histogram)`. The array's own comment named its intended consumers — "startup / backend.acquire / mcp.lazy_load / skill.lazy_load" — and did not include the turn metric: it was sized while `kirocrew.turn.duration` never emitted at all (#869), so there was never a sample to size it against. An agent turn is an entire agent loop (model calls plus every tool round-trip, plus any wait on an interactive approval prompt), so minutes are ordinary.

One array cannot serve all seven instruments, which span six orders of magnitude:

| instrument | samples/day | observed range |
|---|---|---|
| `gateway.request.duration` | 3452 | ms |
| `mcp.backend.acquire.duration` | 481 | ~1ms |
| `session.startup.duration` | 315 | 0.5ms – 10s+ |
| `skill.lazy_load.duration` | 197 | ~1ms |
| `gateway.boot.duration` | ~1 | seconds |
| `mcp.lazy_load.duration` | 0 so far | seconds |
| **`turn.duration`** | **5** | **minutes** |

**Change.** Boundaries move into a metric-name → boundaries map with one `View(instrument_name=…)` per instrument, in three families sized to measured ranges:

| Family | Range | Instruments |
|---|---|---|
| `_FAST_BUCKETS_MS` | 0.5ms – 30s | request, backend.acquire, skill.lazy_load |
| `_STARTUP_BUCKETS_MS` | 1ms – 60s (**unchanged**) | session.startup, mcp.lazy_load, boot |
| `_TURN_BUCKETS_MS` | 1s – 1h | turn.duration |

The fast family gains a sub-millisecond bound, because `acquire` and `skill.lazy_load` sit at ~1ms and previously had their p50 collapse onto the first boundary. The startup family is byte-identical to today's array, so startup percentiles do not move.

### The catch-all is removed, not narrowed — and why that forced a guard test

The OTEL SDK applies **every** matching View, not the first. Verified before writing the fix:

```python
views=[View(instrument_name="kirocrew.turn.duration", aggregation=Explicit([1000, 600000])),
       View(instrument_type=Histogram,                aggregation=Explicit([1, 60000]))]
# → kirocrew.turn.duration: bounds=[1000, 600000] counts=[0, 1, 0]
# → kirocrew.turn.duration: bounds=[1, 60000]     counts=[0, 0, 1]   ← TWO streams, one name
```

So *adding* a per-instrument View while keeping the catch-all would publish each named instrument twice. `handlers/telemetry.py::_Hist.add` merges data points whose bucket-count length matches **without comparing bounds**, so it would silently combine two incompatible histograms and double the count. The SDK has no negation in View matching, so the catch-all had to go.

That makes map completeness load-bearing: an instrument with no entry now falls back to OTEL's default 10s-ceiling boundaries, reintroducing exactly this bug. Hence the guard test.

## Tests

`test/metrics/test_provider_bucket_views.py` (17 tests):

- **Completeness** — scans `src/kiro_crew/**/*.py` for `kirocrew.*.duration` metric names and fails when one has no map entry, with a message naming the missing instruments. Also fails on a stale entry with no emitting call site. Includes a guard-the-guard test so a scan that silently matched nothing can't pass vacuously.
- **No duplicate streams** — drives the real SDK and asserts exactly one data point per metric name.
- **Regression** — records the actual 227589ms value and asserts it does *not* land in the `+Inf` bucket, and that the bucket it lands in is bounded above so a percentile can report a real value.
- **Per-instrument routing** — asserts `turn` and `acquire` receive different bounds from the same provider.
- **Boundary shape** — sorted, positive, unique; turn ceiling ≥ 2× the regression sample; fast family keeps a sub-ms bound; startup range unchanged.
- **End-to-end through the aggregator** — feeds the same sample through `_pct_from_buckets` with old vs new bounds and asserts old returns exactly `60000.0` for both percentiles while new does not. This is the bug, written as an executable assertion.

**Negative controls were run to prove the two new assertions can fail** (an assertion that cannot fail is worthless):

```
control 1 (drop turn.duration from the map) -> missing: ['kirocrew.turn.duration']  guard correctly fails
control 2 (re-add the catch-all)            -> streams for one metric name: 2       hazard confirmed real
```

Local gate: `isort` / `flake8 -j 1` / `mypy` (563 files) clean; `pytest test/metrics/ test/test_usage.py` → 248 pass. Backend-only change, no frontend touched.

## Manual verification

N/A for retroactive data, and worth being explicit about why: bucket boundaries are baked into each data point at record time, so **historical shards keep the bounds they were written with**. Turn percentiles become meaningful for samples recorded after this lands — the same "not retrofitted" property as #875's `spawned` attribute. The old-vs-new comparison that would otherwise be a manual check is instead encoded as the aggregator test above, which is stronger (it runs every CI).

## Prior art

OpenClaw hit this identical defect and solved it the same way — per-instrument bucket arrays in `extensions/diagnostics-otel/src/service-constants.ts`, with `AGENT_DURATION_MS_BUCKETS` extended to 3,600,000ms specifically because the default 10s ceiling was inadequate for agent work, plus a separate `CONTEXT_TOKENS_BUCKETS` to 2M. A survey of six agent runtimes (Claude Code, Codex CLI, OpenClaw, pi/TraceRoot, Hermes, Grok Build) found 4 of 6 use **no** histograms at all for per-turn latency — they attach duration to each per-turn event and aggregate downstream — and 0 of 6 use exponential/native histograms. Codex, which does use histograms, likewise hardcodes explicit boundaries (its ms array tops out at 120s).

## Follow-ups (deliberately not here)

- The row store's `duration_ms` is `0` in all 549 rows — the third instance of #869's root cause. Fixing it touches 10 `persist_token_record` call sites across 6 files, none of which currently has a wall clock, so it wants the "one record, many sinks" refactor rather than ten threaded parameters.
- `retention_days` / `max_total_mb` unset → metrics dir grows unbounded (~630KB/day).
- Frontend occupancy threshold tiers, and the model name truncating to `cl…` in the hot-session rows.
