### PR TITLE
fix(browser): guard the browse-mode writes to kiro's global mcp.json

### DIFF
--- a/src/kiro_crew/browser/cli.py
+++ b/src/kiro_crew/browser/cli.py
@@ -152,14 +152,14 @@ def _cmd_extension(action: str) -> None:
         with os.fdopen(fd, "w") as f:
             f.write(token)
         flag_file.touch()
-        _patch_mcp_config_extension(token)
+        _reregister_proxy()
         print()
         print("Extension mode enabled.")
         print("Restart gateway to apply: kirocrew stop && kirocrew gateway")
     elif action == "off":
         flag_file.unlink(missing_ok=True)
         token_file.unlink(missing_ok=True)
-        _patch_mcp_config_headless()
+        _reregister_proxy()
         print("Extension mode disabled. Using separate headless Chromium.")
         print("Restart gateway to apply: kirocrew stop && kirocrew gateway")
     else:
@@ -167,14 +167,18 @@ def _cmd_extension(action: str) -> None:
         sys.exit(1)
 
 
-def _patch_mcp_config_extension(token: str) -> None:
-    """Update MCP config to use --extension with token env var."""
-    _setup.patch_mcp_extension(token)
+def _reregister_proxy() -> None:
+    """Rewrite the proxy entry for the mode just recorded in the flag file.
 
-
-def _patch_mcp_config_headless() -> None:
-    """Update MCP config to use headless mode with --config."""
-    _setup.patch_mcp_headless()
+    Goes through ``register_playwright_proxy`` rather than the patch primitives so
+    the write takes the shared mcp.json lock, keeps a user-authored non-proxy
+    entry under the canonical key, and creates the config when absent. The mode
+    dispatch is read from the flag file, which the caller has already updated.
+    """
+    _, status = _setup.register_playwright_proxy()
+    if status == "kept-user-entry":
+        print("  Kept your existing playwright-mcp entry in mcp.json (left untouched).")
+        print("  Remove it to let KiroCrew manage the browse server.")
 
 
 def _cmd_auth_health() -> None:

--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -8,6 +8,7 @@ working, but SSO setup is a no-op and reports "not available in OSS".
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -15,6 +16,7 @@ import platform
 import shutil
 import stat
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -326,51 +328,59 @@ def migrate_owned_playwright_registration() -> None:
 
 def _migrate_owned_kiro_registration() -> None:
     """Rewrite KiroCrew's browse entry in kiro's ``mcp.json`` to the canonical key."""
-    mcp_json = Path.home() / ".kiro" / "settings" / "mcp.json"
+    mcp_json = _kiro_mcp_json_path()
+    # Fast-path bail BEFORE taking the lock: this migration never adds Playwright
+    # where none exists, and _kiro_mcp_locked would otherwise create the settings
+    # dir + lock sidecar on an install that has no kiro config at all.
     if not mcp_json.is_file():
         return
-    try:
-        data = json.loads(mcp_json.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return
-    servers = data.get("mcpServers") if isinstance(data, dict) else None
-    if not isinstance(servers, dict):
-        return
-    canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
-    canon_entry = servers.get(canonical)
-    canon_is_proxy = _spec_is_proxy(canon_entry)
-    # There are two KiroCrew-owned things worth migrating to the canonical proxy:
-    #   (a) a superseded PROXY entry (a duplicate proxy under a legacy key), and
-    #   (b) KiroCrew's legacy DIRECT ``npm:@playwright/mcp`` entry — the key
-    #       earlier KiroCrew installs wrote for a direct npm-launched Playwright
-    #       (before the compression proxy existed). Upgrading it to the proxy is
-    #       the ORIGINAL purpose of this boot migration; dropping it would leave
-    #       existing users on the direct server with no compression.
-    # A user-declared *direct* server under the BARE ``@playwright/mcp`` key is
-    # NOT KiroCrew's (authorship is by launch target, not key name) and is left
-    # untouched — only the ``npm:``-prefixed key is a KiroCrew legacy artifact.
-    superseded_proxy_present = any(
-        key != canonical and _spec_is_proxy(servers.get(key)) for key in _SUPERSEDED_PLAYWRIGHT_KEYS
-    )
-    legacy_direct = servers.get(_LEGACY_DIRECT_PLAYWRIGHT_KEY)
-    legacy_direct_present = isinstance(legacy_direct, dict) and not _spec_is_proxy(legacy_direct)
-    # Leave the file untouched unless there is a KiroCrew-owned entry to migrate,
-    # AND the canonical slot is either empty or already our proxy (safe to
-    # (re)write). If the canonical key holds a user-declared *direct* (non-proxy)
-    # server, migrating would call patch_mcp_*, which does servers[canonical] =
-    # proxy_entry and would clobber that user config on every boot — so skip.
-    if not (superseded_proxy_present or legacy_direct_present):
-        return
-    if canon_entry is not None and not canon_is_proxy:
-        return
-    if has_playwright_extension():
-        token = get_extension_token() or ""
-        if token:
-            patch_mcp_extension(token)
-        else:
-            patch_mcp_headless()
-    else:
-        patch_mcp_headless()
+    # The read + decide + write must be ONE critical section: deciding from an
+    # unlocked read and then writing lets a concurrent bridge/dashboard update
+    # land in between, so the write is computed from a stale snapshot and drops
+    # the other writer's entries.
+    with _kiro_mcp_locked():
+        if not mcp_json.is_file():
+            return
+        try:
+            data = json.loads(mcp_json.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return
+        servers = data.get("mcpServers") if isinstance(data, dict) else None
+        if not isinstance(servers, dict):
+            return
+        canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
+        canon_entry = servers.get(canonical)
+        canon_is_proxy = _spec_is_proxy(canon_entry)
+        # There are two KiroCrew-owned things worth migrating to the canonical
+        # proxy:
+        #   (a) a superseded PROXY entry (a duplicate proxy under a legacy key),
+        #       and
+        #   (b) KiroCrew's legacy DIRECT ``npm:@playwright/mcp`` entry — the key
+        #       earlier KiroCrew installs wrote for a direct npm-launched
+        #       Playwright (before the compression proxy existed). Upgrading it to
+        #       the proxy is the ORIGINAL purpose of this boot migration; dropping
+        #       it would leave existing users on the direct server with no
+        #       compression.
+        # A user-declared *direct* server under the BARE ``@playwright/mcp`` key
+        # is NOT KiroCrew's (authorship is by launch target, not key name) and is
+        # left untouched — only the ``npm:``-prefixed key is a KiroCrew legacy
+        # artifact.
+        superseded_proxy_present = any(
+            key != canonical and _spec_is_proxy(servers.get(key))
+            for key in _SUPERSEDED_PLAYWRIGHT_KEYS
+        )
+        legacy_direct = servers.get(_LEGACY_DIRECT_PLAYWRIGHT_KEY)
+        legacy_direct_present = isinstance(legacy_direct, dict) and not _spec_is_proxy(legacy_direct)
+        # Leave the file untouched unless there is a KiroCrew-owned entry to
+        # migrate, AND the canonical slot is either empty or already our proxy
+        # (safe to (re)write). If the canonical key holds a user-declared *direct*
+        # (non-proxy) server, migrating would write servers[canonical] =
+        # proxy_entry and clobber that user config on every boot — so skip.
+        if not (superseded_proxy_present or legacy_direct_present):
+            return
+        if canon_entry is not None and not canon_is_proxy:
+            return
+        _patch_mcp_for_mode_unlocked()
 
 
 def _converge_kirocrew_mcp_json() -> None:
@@ -630,9 +640,43 @@ def _record_owned_mcp_key(key: str) -> None:
         pass
 
 
-def patch_mcp_extension(token: str) -> None:
-    """Update MCP config to use proxy with --extension and token env var."""
-    mcp_json = Path.home() / ".kiro" / "settings" / "mcp.json"
+def _kiro_mcp_json_path() -> Path:
+    """Path to kiro's global MCP config — the file KiroCrew co-manages."""
+    return Path.home() / ".kiro" / "settings" / "mcp.json"
+
+
+@contextlib.contextmanager
+def _kiro_mcp_locked() -> Iterator[None]:
+    """Hold the exclusive advisory lock guarding kiro's global ``mcp.json``.
+
+    Every writer of that file must serialize on the shared ``mcp.lock`` sidecar:
+    the dashboard MCP handler (``handlers/mcp.py`` ``_McpFileLock``) and the app
+    bridges (``apps/bridges.py``) already do. Writers coordinate ONLY if they all
+    take this lock — a lock-free read-modify-write races the others and drops
+    whichever side wrote first, losing that writer's server entries (an app's MCP
+    server silently disappearing, or the browse entry vanishing).
+
+    Blocking: callers on the event loop must dispatch through
+    ``asyncio.to_thread``. Not reentrant — code already inside this block must
+    call the ``_unlocked`` write helpers, never the public ``patch_mcp_*``
+    wrappers (a second exclusive acquire on a fresh fd deadlocks the process
+    against itself).
+    """
+    mcp_json = _kiro_mcp_json_path()
+    mcp_json.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = mcp_json.with_suffix(".lock")
+    lock_path.touch(exist_ok=True)
+    # "r+" (not "r"): Windows msvcrt.locking requires a writable fd, and
+    # platform_compat swallows the EACCES an "r" fd would raise — which would
+    # silently degrade this to a no-op.
+    with open(lock_path, "r+") as lf:
+        with platform_compat.file_lock(lf.fileno(), exclusive=True):
+            yield
+
+
+def _patch_mcp_extension_unlocked(token: str) -> None:
+    """Write the ``--extension`` proxy entry. Caller MUST hold ``_kiro_mcp_locked``."""
+    mcp_json = _kiro_mcp_json_path()
     if not mcp_json.exists():
         return
     try:
@@ -662,15 +706,15 @@ def patch_mcp_extension(token: str) -> None:
         pass
 
 
-def patch_mcp_headless() -> None:
-    """Update MCP config to use proxy with headless mode config."""
-    mcp_json = Path.home() / ".kiro" / "settings" / "mcp.json"
+def _patch_mcp_headless_unlocked() -> None:
+    """Write the headless-config proxy entry. Caller MUST hold ``_kiro_mcp_locked``."""
+    mcp_json = _kiro_mcp_json_path()
     if not mcp_json.exists():
         return
     try:
         data = json.loads(mcp_json.read_text(encoding="utf-8"))
-        # See patch_mcp_extension: guard a non-object mcp.json / non-dict
-        # mcpServers so setdefault/servers[...] can't raise an uncaught
+        # See _patch_mcp_extension_unlocked: guard a non-object mcp.json /
+        # non-dict mcpServers so setdefault/servers[...] can't raise an uncaught
         # AttributeError/TypeError.
         if not isinstance(data, dict):
             data = {}
@@ -689,6 +733,42 @@ def patch_mcp_headless() -> None:
         _record_owned_mcp_key(canonical)
     except (json.JSONDecodeError, OSError):
         pass
+
+
+def _patch_mcp_for_mode_unlocked() -> None:
+    """Write the proxy entry matching the configured browse mode.
+
+    Extension mode needs a token to be usable, so a flagged-but-tokenless install
+    falls back to the headless config rather than writing an entry whose
+    ``PLAYWRIGHT_MCP_EXTENSION_TOKEN`` is empty. Every registration path shares
+    this dispatch so the mode decision cannot drift between them.
+
+    Caller MUST hold ``_kiro_mcp_locked``.
+    """
+    if has_playwright_extension():
+        token = get_extension_token() or ""
+        if token:
+            _patch_mcp_extension_unlocked(token)
+            return
+    _patch_mcp_headless_unlocked()
+
+
+def patch_mcp_extension(token: str) -> None:
+    """Update MCP config to use proxy with --extension and token env var.
+
+    Takes the shared mcp.json lock. Blocking — do not call on the event loop.
+    """
+    with _kiro_mcp_locked():
+        _patch_mcp_extension_unlocked(token)
+
+
+def patch_mcp_headless() -> None:
+    """Update MCP config to use proxy with headless mode config.
+
+    Takes the shared mcp.json lock. Blocking — do not call on the event loop.
+    """
+    with _kiro_mcp_locked():
+        _patch_mcp_headless_unlocked()
 
 
 def check_playwright_launchable() -> tuple[bool, str]:
@@ -724,42 +804,27 @@ def register_playwright_proxy() -> tuple[Path, str]:
     key, so we left it untouched rather than clobber their config — authorship is
     by launch target, not key name, mirroring the boot-time migration guard).
     """
-    mcp_json = Path.home() / ".kiro" / "settings" / "mcp.json"
-    mcp_json.parent.mkdir(parents=True, exist_ok=True)
-    # Serialize with the other writers of this SAME file — the dashboard MCP
-    # handler and the app bridges both take an exclusive flock on the shared
-    # ``mcp.lock`` sidecar (via platform_compat.file_lock) before mutating
-    # mcp.json. Hold that lock across our read + create + patch_mcp_* write so a
-    # concurrent gateway/bridge update can't be clobbered (which would drop the
-    # other writer's server entries).
-    lock_path = mcp_json.with_suffix(".lock")
-    lock_path.touch(exist_ok=True)
+    mcp_json = _kiro_mcp_json_path()
     canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
-    # "r+" (not "r"): Windows msvcrt.locking requires a writable fd.
-    with open(lock_path, "r+") as lf:
-        with platform_compat.file_lock(lf.fileno(), exclusive=True):
-            if mcp_json.exists():
-                try:
-                    existing = json.loads(mcp_json.read_text(encoding="utf-8"))
-                except (json.JSONDecodeError, OSError):
-                    existing = {}
-                servers = existing.get("mcpServers") if isinstance(existing, dict) else None
-                canon = servers.get(canonical) if isinstance(servers, dict) else None
-                # A user may hand-author their OWN direct (non-proxy) server under
-                # the canonical key. patch_mcp_* would overwrite it, silently
-                # losing their config — so leave it untouched and report back.
-                if canon is not None and not _spec_is_proxy(canon):
-                    return mcp_json, "kept-user-entry"
-            else:
-                mcp_json.write_text(json.dumps({"mcpServers": {}}, indent=2), encoding="utf-8")
-            if has_playwright_extension():
-                token = get_extension_token() or ""
-                if token:
-                    patch_mcp_extension(token)
-                else:
-                    patch_mcp_headless()
-            else:
-                patch_mcp_headless()
+    # Serialize with the other writers of this SAME file — see _kiro_mcp_locked.
+    # The lock spans our read + create + write so a concurrent gateway/bridge
+    # update can't be clobbered (which would drop its server entries).
+    with _kiro_mcp_locked():
+        if mcp_json.exists():
+            try:
+                existing = json.loads(mcp_json.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+            servers = existing.get("mcpServers") if isinstance(existing, dict) else None
+            canon = servers.get(canonical) if isinstance(servers, dict) else None
+            # A user may hand-author their OWN direct (non-proxy) server under
+            # the canonical key. The patch helpers would overwrite it, silently
+            # losing their config — so leave it untouched and report back.
+            if canon is not None and not _spec_is_proxy(canon):
+                return mcp_json, "kept-user-entry"
+        else:
+            mcp_json.write_text(json.dumps({"mcpServers": {}}, indent=2), encoding="utf-8")
+        _patch_mcp_for_mode_unlocked()
     return mcp_json, "registered"
 
 

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -19,12 +19,9 @@ from kiro_crew.acp.client import KIRO_CLI_BIN
 from kiro_crew.browser.setup import (
     ensure_playwright_installed,
     generate_playwright_config,
-    get_extension_token,
-    has_playwright_extension,
     is_playwright_installed,
-    patch_mcp_extension,
-    patch_mcp_headless,
     refresh_storage_state,
+    register_playwright_proxy,
 )
 from kiro_crew.cli_chat import _ensure_default_agent_in_config
 from kiro_crew.conductor_skill import generate_conductor_skill
@@ -351,15 +348,14 @@ def _setup(agent_only: bool = False, electron_only: bool = False, clean: bool = 
     try:
         generate_playwright_config()
         refresh_storage_state()
-        if has_playwright_extension():
-            token = get_extension_token()
-            if token:
-                patch_mcp_extension(token)
-            else:
-                patch_mcp_headless()
+        # register_playwright_proxy owns the shared mcp.json lock, the
+        # user-entry guard, and the create-when-absent path — the patch
+        # primitives have none of those.
+        _, status = register_playwright_proxy()
+        if status == "kept-user-entry":
+            print("  Kept your existing playwright-mcp entry in mcp.json (left untouched)")
         else:
-            patch_mcp_headless()
-        print("  Browser proxy registered in mcp.json")
+            print("  Browser proxy registered in mcp.json")
     except Exception:
         pass  # Non-fatal: browser still works without pre-loaded cookies
 

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -19,8 +19,7 @@ from kiro_crew.browser.screencast import BROWSER_FRAME_EVENT, build_frame_payloa
 from kiro_crew.browser.setup import (
     get_extension_token,
     has_playwright_extension,
-    patch_mcp_extension,
-    patch_mcp_headless,
+    register_playwright_proxy,
 )
 from kiro_crew.constants import CHAT_TURN_TIMEOUT
 from kiro_crew.cron import CronStoreBusy
@@ -1763,20 +1762,37 @@ async def api_browser_config_save(request: web.Request) -> web.Response:
             fd = os.open(str(token_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             with os.fdopen(fd, "w") as f:
                 f.write(token)
-            patch_mcp_extension(token)
     else:
         flag_file.unlink(missing_ok=True)
         token_file.unlink(missing_ok=True)
-        patch_mcp_headless()
+
+    # Re-register through register_playwright_proxy rather than the patch
+    # primitives: it holds the shared mcp.json lock (so a concurrent app-bridge or
+    # dashboard MCP write is not clobbered), refuses to overwrite a user-authored
+    # non-proxy entry under the canonical key, and creates the file when a fresh
+    # install has no kiro settings yet. Blocking (file lock + disk I/O), so it
+    # runs off the event loop.
+    #
+    # The mode preference above is already persisted, so an mcp.json-level failure
+    # is reported in the payload rather than raised — a 500 here would tell the
+    # user nothing was saved when the flag/token files were in fact written.
+    try:
+        _, mcp_status = await asyncio.to_thread(register_playwright_proxy)
+    except OSError as exc:
+        logger.warning("browser config: MCP registration failed: %s", exc)
+        mcp_status = "registration-failed"
 
     _sel().log_tool_invocation(
         session_key="dashboard",
         tool_name="browser_config_save",
         outcome="completed",
         downstream_service="browser",
-        resources=f"extension_mode={extension_mode}",
+        resources=f"extension_mode={extension_mode} mcp={mcp_status}",
     )
-    return web.json_response({"ok": True})
+    # ``mcp_status`` is "kept-user-entry" when the caller's own hand-authored
+    # Playwright server was left in place — the mode preference was still saved,
+    # but KiroCrew's proxy was deliberately NOT written over their config.
+    return web.json_response({"ok": True, "mcp_status": mcp_status})
 
 
 # ── Slack configuration API ──

--- a/test/test_browser_mcp_write_guard.py
+++ b/test/test_browser_mcp_write_guard.py
@@ -1,0 +1,363 @@
+"""Guards for the write discipline on kiro's global ``mcp.json``.
+
+Every writer of ``~/.kiro/settings/mcp.json`` must serialize on the shared
+``mcp.lock`` sidecar, refuse to overwrite a user-authored server under the
+canonical Playwright key, and create the file when a fresh install has none.
+The dashboard browser-config endpoint used to call the low-level
+``patch_mcp_*`` primitives directly, which have none of those three properties:
+
+* no lock -> a concurrent app-bridge / dashboard-MCP write is clobbered and
+  that writer's server entries are lost;
+* no guard -> a hand-authored direct ``playwright-mcp`` entry is silently
+  overwritten (data loss, no concurrency required);
+* no create -> a cold install silently no-ops while reporting success.
+
+These tests pin all three, plus a structural tripwire so the primitives cannot
+be called unlocked from a new site again.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+import kiro_crew.browser.setup as setup_mod
+from kiro_crew.dashboard.handlers.messaging import api_browser_config_save
+from kiro_crew.mcp_utils import mcp_server_alias
+
+_CANONICAL = mcp_server_alias("@playwright/mcp")
+_REPO_SRC = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+_PRIMITIVES = {"patch_mcp_extension", "patch_mcp_headless"}
+
+
+def _mcp_json(home: Path) -> Path:
+    return home / ".kiro" / "settings" / "mcp.json"
+
+
+def _write_mcp(home: Path, servers: dict) -> Path:
+    path = _mcp_json(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"mcpServers": servers}, indent=2), encoding="utf-8")
+    return path
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point HOME and the KiroCrew data home at a throwaway tree."""
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    data_home = tmp_path / "data"
+    data_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(setup_mod, "config_dir", lambda: data_home)
+    monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+    return home
+
+
+def _save(body: dict, data_home: Path, monkeypatch: pytest.MonkeyPatch):
+    """Drive the real PUT /api/browser/config handler with ``body``."""
+    import kiro_crew.config.loader as loader_mod
+
+    monkeypatch.setattr(loader_mod, "config_dir", lambda: data_home)
+    req = make_mocked_request("PUT", "/api/browser/config")
+
+    async def _json():
+        return body
+
+    monkeypatch.setattr(req, "json", _json, raising=False)
+    return asyncio.run(api_browser_config_save(req))
+
+
+def _try_lock_noblock(lock_path: Path) -> bool:
+    """True iff an exclusive advisory lock can be taken right now.
+
+    Used to prove a write happened while the caller held the sidecar lock,
+    without any sleep-based timing. POSIX-only: ``fcntl.flock`` is per-fd, so a
+    second fd in this same process is refused while the first fd holds LOCK_EX.
+    """
+    import fcntl
+
+    with open(lock_path, "a+") as probe:
+        try:
+            fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False
+        fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
+        return True
+
+
+needs_posix = pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="fcntl non-blocking probe is POSIX-only"
+)
+
+
+class TestDashboardSaveGuardsUserConfig:
+    def test_keeps_user_authored_direct_entry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A user hand-authored their OWN direct (non-proxy) Playwright server
+        # under the canonical key. Saving browser settings from the dashboard
+        # must not overwrite it — authorship is by launch target, not key name.
+        home = _isolate(tmp_path, monkeypatch)
+        direct = {"command": "npx", "args": ["@playwright/mcp@latest"]}
+        path = _write_mcp(home, {_CANONICAL: dict(direct)})
+        before = path.read_text(encoding="utf-8")
+
+        resp = _save({"extension_mode": False, "token": ""}, tmp_path / "data", monkeypatch)
+
+        assert path.read_text(encoding="utf-8") == before
+        assert json.loads(resp.text)["mcp_status"] == "kept-user-entry"
+
+    def test_refreshes_own_proxy_entry(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # The guard must not freeze KiroCrew's OWN entry — a proxy spec under the
+        # canonical key is ours and is still rewritten.
+        home = _isolate(tmp_path, monkeypatch)
+        stale = {"command": "kirocrew", "args": ["mcp-playwright-proxy", "--config", "/stale"]}
+        path = _write_mcp(home, {_CANONICAL: dict(stale), "other-mcp": {"command": "foo"}})
+
+        resp = _save({"extension_mode": False, "token": ""}, tmp_path / "data", monkeypatch)
+
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        assert servers[_CANONICAL]["args"] != stale["args"]
+        assert servers["other-mcp"] == {"command": "foo"}, "unrelated server must survive"
+        assert json.loads(resp.text)["mcp_status"] == "registered"
+
+
+class TestDashboardSaveColdInstall:
+    def test_creates_mcp_json_when_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # No ~/.kiro/settings/mcp.json yet. The endpoint used to return ok:true
+        # having written nothing, leaving the Browser panel silently unwired.
+        home = _isolate(tmp_path, monkeypatch)
+        path = _mcp_json(home)
+        assert not path.exists()
+
+        resp = _save({"extension_mode": False, "token": ""}, tmp_path / "data", monkeypatch)
+
+        assert path.exists(), "cold install must create the config, not no-op"
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        assert "mcp-playwright-proxy" in servers[_CANONICAL]["args"]
+        assert json.loads(resp.text)["mcp_status"] == "registered"
+
+
+class TestWritesHappenUnderTheLock:
+    @needs_posix
+    def test_dashboard_save_holds_lock_during_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        home = _isolate(tmp_path, monkeypatch)
+        _write_mcp(home, {})
+        lock_path = _mcp_json(home).with_suffix(".lock")
+        observed: list[bool] = []
+        real = setup_mod._patch_mcp_for_mode_unlocked
+
+        def _spy():
+            # Lock must NOT be acquirable here — the caller is holding it.
+            observed.append(_try_lock_noblock(lock_path))
+            real()
+
+        monkeypatch.setattr(setup_mod, "_patch_mcp_for_mode_unlocked", _spy)
+        _save({"extension_mode": False, "token": ""}, tmp_path / "data", monkeypatch)
+
+        assert observed == [False], "write ran without holding the shared mcp.json lock"
+
+    @needs_posix
+    def test_public_primitives_take_the_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Any remaining caller of the public wrappers is correct by construction.
+        home = _isolate(tmp_path, monkeypatch)
+        _write_mcp(home, {})
+        lock_path = _mcp_json(home).with_suffix(".lock")
+        observed: list[bool] = []
+
+        monkeypatch.setattr(
+            setup_mod,
+            "_patch_mcp_headless_unlocked",
+            lambda: observed.append(_try_lock_noblock(lock_path)),
+        )
+        setup_mod.patch_mcp_headless()
+
+        monkeypatch.setattr(
+            setup_mod,
+            "_patch_mcp_extension_unlocked",
+            lambda _t: observed.append(_try_lock_noblock(lock_path)),
+        )
+        setup_mod.patch_mcp_extension("tok-123")
+
+        assert observed == [False, False]
+
+    @needs_posix
+    def test_boot_migration_holds_lock_across_read_and_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The migration decides from a read then writes; both must be one
+        # critical section or the write is computed from a stale snapshot.
+        home = _isolate(tmp_path, monkeypatch)
+        legacy = {"command": "npx", "args": ["@playwright/mcp@latest"]}
+        _write_mcp(home, {"npm:@playwright/mcp": legacy})
+        lock_path = _mcp_json(home).with_suffix(".lock")
+        observed: list[bool] = []
+
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        monkeypatch.setattr(
+            setup_mod,
+            "_patch_mcp_headless_unlocked",
+            lambda: observed.append(_try_lock_noblock(lock_path)),
+        )
+        setup_mod._migrate_owned_kiro_registration()
+
+        assert observed == [False], "boot migration wrote without the shared lock"
+
+    def test_migration_does_not_create_config_on_bare_install(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Taking the lock creates the settings dir + sidecar as a side effect, so
+        # the migration keeps its pre-lock bail: it never adds Playwright (nor
+        # kiro's settings tree) where none exists.
+        home = _isolate(tmp_path, monkeypatch)
+        setup_mod._migrate_owned_kiro_registration()
+        assert not _mcp_json(home).exists()
+        assert not (home / ".kiro" / "settings").exists()
+
+
+class TestDoesNotBlockTheEventLoop:
+    def test_registration_runs_off_the_loop_thread(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The lock acquire is blocking; taking it on the loop thread would stall
+        # every other dashboard request for the duration.
+        home = _isolate(tmp_path, monkeypatch)
+        _write_mcp(home, {})
+        threads: list[int] = []
+        real = setup_mod._patch_mcp_for_mode_unlocked
+
+        def _spy():
+            threads.append(threading.get_ident())
+            real()
+
+        monkeypatch.setattr(setup_mod, "_patch_mcp_for_mode_unlocked", _spy)
+
+        loop_thread: list[int] = []
+
+        async def _drive():
+            loop_thread.append(threading.get_ident())
+            req = make_mocked_request("PUT", "/api/browser/config")
+
+            async def _json():
+                return {"extension_mode": False, "token": ""}
+
+            monkeypatch.setattr(req, "json", _json, raising=False)
+            import kiro_crew.config.loader as loader_mod
+
+            monkeypatch.setattr(loader_mod, "config_dir", lambda: tmp_path / "data")
+            return await api_browser_config_save(req)
+
+        asyncio.run(_drive())
+
+        assert threads and threads[0] != loop_thread[0], "blocking write ran on the event loop"
+
+
+class TestPrimitivesAreNotCalledUnlocked:
+    def test_no_module_outside_browser_setup_calls_the_primitives(self):
+        """Tripwire: the lock-free write path must stay inside browser/setup.py.
+
+        ``patch_mcp_extension`` / ``patch_mcp_headless`` are the only entry points
+        that mutate kiro's global mcp.json without the caller supplying a lock.
+        They are now self-locking wrappers, but a new call site elsewhere is still
+        a smell: it means someone re-derived the extension-vs-headless dispatch
+        instead of calling ``register_playwright_proxy``, and so also skipped the
+        user-entry guard and the create-when-absent path. Fail closed and make the
+        author route through ``register_playwright_proxy`` instead.
+        """
+        offenders: list[str] = []
+        own = (_REPO_SRC / "browser" / "setup.py").resolve()
+        for path in _REPO_SRC.rglob("*.py"):
+            if path.resolve() == own:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError, OSError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                name = (
+                    fn.id
+                    if isinstance(fn, ast.Name)
+                    else fn.attr if isinstance(fn, ast.Attribute) else None
+                )
+                if name in _PRIMITIVES:
+                    rel = path.relative_to(_REPO_SRC)
+                    offenders.append(f"{rel}:{node.lineno} calls {name}()")
+        assert not offenders, (
+            "route these through register_playwright_proxy() (lock + user-entry "
+            "guard + create-when-absent):\n  " + "\n  ".join(offenders)
+        )
+
+    def test_tripwire_detects_a_planted_call(self):
+        # Confirms the AST walk above actually matches both call shapes, so a
+        # green result means "no offenders", not "the matcher is broken".
+        src = "import x\ndef f():\n    patch_mcp_headless()\n    x.patch_mcp_extension('t')\n"
+        tree = ast.parse(src)
+        found = {
+            (
+                n.func.id
+                if isinstance(n.func, ast.Name)
+                else n.func.attr if isinstance(n.func, ast.Attribute) else None
+            )
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+        }
+        assert _PRIMITIVES <= found
+
+
+class TestFailureIsReportedNotRaised:
+    def test_registration_failure_still_saves_the_preference(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The mode flag is persisted before mcp.json is touched, so an
+        # mcp.json-level failure must not 500 — that would tell the user nothing
+        # was saved when the preference in fact was.
+        _isolate(tmp_path, monkeypatch)
+        data_home = tmp_path / "data"
+
+        def _boom():
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.messaging.register_playwright_proxy", _boom
+        )
+        resp = _save({"extension_mode": False, "token": ""}, data_home, monkeypatch)
+
+        body = json.loads(resp.text)
+        assert body["ok"] is True
+        assert body["mcp_status"] == "registration-failed"
+        assert not (data_home / "playwright-extension-mode").exists()
+
+
+def test_lock_probe_is_meaningful(tmp_path: Path):
+    """The probe must report True when nothing holds the lock.
+
+    Without this, every ``observed == [False]`` assertion above could pass for
+    the wrong reason (a probe that always fails).
+    """
+    if sys.platform.startswith("win"):
+        pytest.skip("POSIX-only probe")
+    lock_path = tmp_path / "mcp.lock"
+    lock_path.touch()
+    assert _try_lock_noblock(lock_path) is True
+    with open(lock_path, "r+") as held:
+        import fcntl
+
+        fcntl.flock(held.fileno(), fcntl.LOCK_EX)
+        try:
+            assert _try_lock_noblock(lock_path) is False
+        finally:
+            fcntl.flock(held.fileno(), fcntl.LOCK_UN)


### PR DESCRIPTION
## Problem

Saving browser settings from the dashboard (`PUT /api/browser/config`) wrote KiroCrew's Playwright entry into `~/.kiro/settings/mcp.json` by calling the low-level `patch_mcp_extension` / `patch_mcp_headless` primitives directly. Those do a bare read-modify-write with none of the three properties every other writer of that file has, so three things went wrong:

1. **A user's hand-authored Playwright server was silently overwritten.** `patch_mcp_extension` assigns `servers[canonical] = entry` unconditionally. If you had written your own direct `playwright-mcp` entry, toggling extension mode in the dashboard destroyed it with no warning. No concurrency needed to hit this.
2. **A concurrent write to the same file lost entries.** The dashboard MCP handler (`handlers/mcp.py` `_McpFileLock`) and the app bridges (`apps/bridges.py`) both take an exclusive advisory lock on the shared `mcp.lock` sidecar before mutating `mcp.json`. A lock-free writer races them, and whichever side wrote first is dropped — an app's MCP server silently disappearing, or the browse entry vanishing. Gateway boot is a plausible collision window: `_migrate_owned_kiro_registration` also wrote unlocked, at init, while app bridges start. It additionally *decided* from an unlocked read and then wrote, so the write could be computed from a stale snapshot.
3. **A cold install silently no-opped.** Both primitives `return` early when `mcp.json` does not exist, so on a machine whose kiro settings file had never been created, the endpoint wrote nothing and returned `ok: true`.

## Why it matters

(1) is user data loss in a config file people legitimately hand-edit, and it is silent. (2) can leave `mcp.json` missing a server that the UI believes is installed; a broken or absent entry in this file affects every kiro session, so the blast radius is wider than the browse feature. (3) makes the Browser panel appear enabled while nothing is wired, with a success response and no diagnostic.

## Fix (symptom → root cause → change)

The root cause is the shape rather than any single call site. `register_playwright_proxy` **already** encapsulates exactly the right behaviour — it holds the shared lock across read + create + write, refuses to overwrite a user-authored non-proxy entry (returning `kept-user-entry`), and creates the file when absent. But four of its five sibling call sites hand-rolled the extension-vs-headless dispatch against the raw primitives instead of calling it, and so each independently skipped all three protections.

- Extract the lock as `_kiro_mcp_locked()` and the mode dispatch as `_patch_mcp_for_mode_unlocked()`, so there is one implementation of each instead of five copies.
- Move the raw write bodies to `_patch_mcp_extension_unlocked` / `_patch_mcp_headless_unlocked`, and make the public `patch_mcp_*` names thin self-locking wrappers. Any caller that still uses them is now correct by construction; the lock is not reentrant, so code already inside the critical section calls the `_unlocked` variants.
- Route the dashboard endpoint, the `kirocrew browse extension on|off` CLI toggle, and `kirocrew setup` through `register_playwright_proxy`.
- Put the boot migration's read + decide + write in one critical section, keeping its pre-lock bail so it still never creates kiro's settings tree where none exists.
- The dashboard call goes through `asyncio.to_thread` — the lock acquire is blocking and would otherwise stall every other dashboard request. Its outcome is surfaced as `mcp_status` so `kept-user-entry` is visible rather than silent, and an `OSError` is reported in the payload instead of raised (the mode preference is already persisted at that point, so a 500 would wrongly imply nothing was saved).

Two behaviours are fixed incidentally by sharing one dispatch: extension mode with an **empty token** previously left `mcp.json` untouched, leaving the flag file and the config disagreeing, and now correctly falls back to the headless entry; and `kirocrew setup` no longer prints "Browser proxy registered in mcp.json" when nothing was written.

## Tests

`test/test_browser_mcp_write_guard.py` (12 tests), driving the real handler rather than mocks:

| Test group | Locks in |
|---|---|
| `TestDashboardSaveGuardsUserConfig` | a user-authored direct entry survives byte-identical; KiroCrew's *own* proxy entry is still refreshed, and an unrelated server survives |
| `TestDashboardSaveColdInstall` | absent `mcp.json` is created and wired, not silently skipped |
| `TestWritesHappenUnderTheLock` | the dashboard write, both public primitives, and the boot migration all write while holding the sidecar lock; the migration still does not create kiro's settings tree on a bare install |
| `TestDoesNotBlockTheEventLoop` | the blocking write does not run on the loop thread |
| `TestPrimitivesAreNotCalledUnlocked` | AST tripwire — the primitives are not called from any module outside `browser/setup.py` |
| `TestFailureIsReportedNotRaised` | an `OSError` is reported as `registration-failed`, not a 500 |

Two details worth noting on test quality:

- The lock assertions use a **non-blocking `fcntl` probe** (assert the lock cannot be acquired at write time) rather than sleep-based timing, so they are deterministic. A companion test `test_lock_probe_is_meaningful` proves the probe returns `True` when the lock is free — otherwise every `observed == [False]` assertion could pass for the wrong reason.
- The AST tripwire has its own `test_tripwire_detects_a_planted_call` confirming the walk matches both call shapes. The tripwire is what caught a **fifth** call site I had not found by grepping (`browser/cli.py:172`).

**Revert-verified:** restoring the old dashboard write path fails exactly five tests, one per symptom (user-entry clobber, cold-install no-op, missing lock, loop-blocking write, false success report).

Full backend suite: 22412 passed. Three pre-existing `test_dashboard_origin.py` failures reproduce on clean `main` and are unrelated (URL parsing). `isort` / `flake8` clean; the one `mypy` error (`vector_memory.py`, faiss stubs) also reproduces on clean `main`.

## Manual verification

N/A — the defects are file-state and locking behaviours fully covered by the suite. There is no user-visible UI change: the endpoint response gained an `mcp_status` field that the existing frontend caller (`api.saveBrowserConfig`) ignores.

## Screenshots

N/A — no user-visible UI change.
