### PR TITLE
fix(dashboard): stop tool-refusal recovery injections leaking into the composer queue

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4766,7 +4766,11 @@ async def _run_chat(
         ):
             _recovery_body = build_refusal_recovery_prompt(_refusal_reasons)
             if _recovery_body:
-                slot.queue_insert(0, f"{REFUSAL_RECOVERY_PREFIX}\n{_recovery_body}")
+                slot.queue_insert(
+                    0,
+                    f"{REFUSAL_RECOVERY_PREFIX}\n{_recovery_body}",
+                    kind=SYNTHETIC_RECOVERY_KIND,
+                )
 
         # ── Bidirectional sync: mirror response to linked Slack thread ──
         if assistant_text and state.slack_client and _mirror_thread and _mirror_chan:

--- a/test/test_merge_queued_messages.py
+++ b/test/test_merge_queued_messages.py
@@ -71,6 +71,33 @@ class TestDequeueNextMessage:
             # The user message stays queued for its own (user-role) turn.
             assert [i["content"] for i in slot._queue] == ["a genuine user message"]
 
+    def test_refusal_recovery_entry_breaks_merge(self):
+        """A tool-refusal recovery injection (built dynamically, not a constant
+        in _SYNTHETIC_RECOVERY_MSGS) must carry the structural kind tag so it
+        drains ALONE rather than folding into a user-role merged turn — the
+        regression behind the composer leak, where an untagged refusal-recovery
+        entry classified as user speech AND rendered as an editable queue card.
+        Mirrors the chat_runner call site, which now passes
+        kind=SYNTHETIC_RECOVERY_KIND."""
+        from kiro_crew.dashboard.chat_utils import SYNTHETIC_RECOVERY_KIND
+        from kiro_crew.dashboard.state import (
+            REFUSAL_RECOVERY_PREFIX,
+            build_refusal_recovery_prompt,
+        )
+
+        body = build_refusal_recovery_prompt(
+            [("write /tmp/x", "not on read-only allowlist")]
+        )
+        injection = f"{REFUSAL_RECOVERY_PREFIX}\n{body}"
+
+        slot = _ChatSlot("s1")
+        slot.queue_insert(0, "a genuine user message")
+        slot.queue_insert(0, injection, kind=SYNTHETIC_RECOVERY_KIND)
+        next_msg, consumed = _dequeue_next_message(slot, merge_enabled=True)
+        assert next_msg == injection
+        assert [c["content"] for c in consumed] == [injection]
+        assert [i["content"] for i in slot._queue] == ["a genuine user message"]
+
     def test_user_pasted_recovery_text_is_plain_user_content(self):
         """A user PASTING the transcript-visible recovery text verbatim is a
         plain user message: without the structural kind tag it must merge and

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -9,7 +9,7 @@ import ToolCallLine from '../pages/chat/ToolCallLine'
 import type { ChatMessage } from '../types'
 import ChatInput from './ChatInput'
 import PendingQuestionCard from './PendingQuestionCard'
-import QueueStack, { SubagentDeliveryProgress, isSystemDelivery } from './QueueStack'
+import QueueStack, { SubagentDeliveryProgress, isSystemDelivery, isNonInteractiveQueued } from './QueueStack'
 import SubagentProgressBar from '../pages/chat/SubagentProgressBar'
 import AgentDropdownList from './AgentDropdownList'
 import ModelDropdownList from './ModelDropdownList'
@@ -82,12 +82,14 @@ export default function ChatPane({
   const title = paneSlot?.title || slotKey
   const displayMode = approvalMode === 'yolo' ? 'yolo' : paneSlot?.trust ? 'trust' : paneSlot?.trust_reads ? 'trust_reads' : 'normal'
   // Queued messages render in the QueueStack, not inline in the message list.
-  // System sub-agent deliveries collapse into one progress line instead of
-  // interactive (edit/cancel) queue cards.
+  // System injections are excluded from the interactive stack (isNonInteractiveQueued):
+  // sub-agent deliveries collapse into one progress line, and synthetic
+  // turn-recovery injections drain automatically and render as a RecoveryCard.
+  // Mirrors ChatPage — split view (⌘D) is a second live QueueStack consumer.
   const messages = allMessages.filter((m) => m.role !== 'queued')
   const allQueued = allMessages.filter((m) => m.role === 'queued')
-  const queuedMessages = allQueued.filter((m) => !isSystemDelivery(m))
-  const systemDeliveryCount = allQueued.length - queuedMessages.length
+  const queuedMessages = allQueued.filter((m) => !isNonInteractiveQueued(m))
+  const systemDeliveryCount = allQueued.filter((m) => isSystemDelivery(m)).length
 
   // Pickers — same hooks/data sources ChatPage uses, but selection targets THIS slot.
   const { agents: installedAgents, defaultAgent } = useAgents(0)

--- a/website/src/components/QueueStack.tsx
+++ b/website/src/components/QueueStack.tsx
@@ -4,6 +4,7 @@ import { Hourglass, ChevronUp, X, Zap, Pencil, Check, Bot, Loader2 } from 'lucid
 import type { ChatMessage } from '../types'
 
 import { i18nT } from '../i18n/t'
+import { parseRecoveryMessage } from '../pages/chat/RecoveryCard'
 /** System-injected sub-agent completion deliveries waiting for the busy slot.
  *  These are NOT user messages: they must not be editable/cancellable (either
  *  would silently lose a finished agent's result) and rendering each as a
@@ -12,6 +13,21 @@ import { i18nT } from '../i18n/t'
 export function isSystemDelivery(m: ChatMessage): boolean {
   const c = m.content || ''
   return c.startsWith('[Subagent completion event]') || c.startsWith('[Subagent batch completion event]')
+}
+
+/** A queued entry that must NOT render as an interactive (edit/cancel) user
+ *  card. Two families qualify, both machine orchestration rather than user
+ *  speech:
+ *    - sub-agent completion deliveries (isSystemDelivery), and
+ *    - synthetic turn-recovery continuations (tool refusal / stalled turn /
+ *      stalled tool / interrupted / empty response), which the gateway
+ *      re-queues automatically and which surface as a compact RecoveryCard in
+ *      the transcript once dequeued.
+ *  Editing or cancelling either would corrupt an automatic effect, so they are
+ *  filtered out of the QueueStack (sub-agent deliveries are still counted for
+ *  the progress line via isSystemDelivery). */
+export function isNonInteractiveQueued(m: ChatMessage): boolean {
+  return isSystemDelivery(m) || parseRecoveryMessage(m.content || '') !== null
 }
 
 /** One quiet, non-interactive line summarizing held sub-agent deliveries —

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -96,7 +96,7 @@ import SearchHighlightContext, { MessageSearchScope } from '../hooks/SearchHighl
 import SearchBar from '../components/SearchBar'
 import SearchResultsList from '../components/SearchResultsList'
 import { pickSearchScrollBehavior, scrollCurrentMatchIntoView, pollRowSettled, glideOnceStep, attachUserScrollIntent } from '../utils/searchScroll'
-import QueueStack, { SubagentDeliveryProgress, isSystemDelivery } from '../components/QueueStack'
+import QueueStack, { SubagentDeliveryProgress, isSystemDelivery, isNonInteractiveQueued } from '../components/QueueStack'
 import { runBelongsToSlot } from '../apps/workflows/runModel'
 import { TipCard, useTipTrigger } from '../components/TipCard'
 import { useVoiceInput, voiceInputSupported } from '../hooks/useVoiceInput'
@@ -3447,10 +3447,25 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   }, [activeSlot])
 
   const allQueuedMessages = useMemo(() => messages.filter(m => m.role === 'queued'), [messages])
-  // System sub-agent deliveries collapse into one progress line; only
-  // user-typed queued messages get the interactive (edit/cancel) card stack.
-  const queuedMessages = useMemo(() => allQueuedMessages.filter(m => !isSystemDelivery(m)), [allQueuedMessages])
-  const systemDeliveryCount = allQueuedMessages.length - queuedMessages.length
+  // Only user-typed queued messages get the interactive (edit/cancel) card
+  // stack. System injections are excluded (isNonInteractiveQueued): sub-agent
+  // deliveries collapse into one progress line, and synthetic turn-recovery
+  // continuations (tool refusal / stalled turn / stalled tool / interrupted /
+  // empty response) are machine-facing orchestration — they drain
+  // automatically and must never render as an editable/cancellable "user" card
+  // (editing or cancelling one corrupts the recovery). They surface as a
+  // compact RecoveryCard in the transcript once dequeued instead.
+  const queuedMessages = useMemo(
+    () => allQueuedMessages.filter(m => !isNonInteractiveQueued(m)),
+    [allQueuedMessages],
+  )
+  // Count sub-agent deliveries directly (not by subtraction): recovery
+  // injections are also excluded from queuedMessages, but they are NOT
+  // sub-agent results and must not inflate the delivery progress line.
+  const systemDeliveryCount = useMemo(
+    () => allQueuedMessages.filter(m => isSystemDelivery(m)).length,
+    [allQueuedMessages],
+  )
 
   // Mid-turn steer: inject the composer content into the RUNNING turn instead
   // of queueing for the next one. Mirrors send()'s payload prep so pending

--- a/website/src/test/QueueStack.test.tsx
+++ b/website/src/test/QueueStack.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import QueueStack, { SubagentDeliveryProgress, isSystemDelivery } from '../components/QueueStack'
+import QueueStack, { SubagentDeliveryProgress, isSystemDelivery, isNonInteractiveQueued } from '../components/QueueStack'
 import type { ChatMessage } from '../types'
 
 // QueueStack renders framer-motion cards; we only exercise the inline
@@ -86,5 +86,30 @@ describe('system sub-agent delivery handling', () => {
   it('SubagentDeliveryProgress renders nothing at zero', () => {
     render(<SubagentDeliveryProgress count={0} />)
     expect(screen.queryByTestId('subagent-delivery-progress')).toBeNull()
+  })
+})
+
+describe('isNonInteractiveQueued (composer QueueStack exclusion)', () => {
+  it('excludes sub-agent completion deliveries', () => {
+    expect(isNonInteractiveQueued(queued('[Subagent completion event]\nAgent `x` completed', 'q1'))).toBe(true)
+    expect(isNonInteractiveQueued(queued('[Subagent batch completion event]\nWave finished', 'q2'))).toBe(true)
+  })
+
+  it('excludes synthetic turn-recovery injections (the tool-refusal composer leak)', () => {
+    // Regression: a [Tool refusal — automatic recovery] injection was rendering
+    // as an editable/cancellable user card in the composer QueueStack.
+    expect(isNonInteractiveQueued(queued(
+      '[Tool refusal — automatic recovery]\nOne or more tool calls in your previous turn were blocked.', 'q1',
+    ))).toBe(true)
+    expect(isNonInteractiveQueued(queued('[Stalled turn — automatic recovery]\n…', 'q2'))).toBe(true)
+    expect(isNonInteractiveQueued(queued('[Tool stall — automatic recovery]\n…', 'q3'))).toBe(true)
+    expect(isNonInteractiveQueued(queued('[Interrupted turn — automatic recovery]\n…', 'q4'))).toBe(true)
+    expect(isNonInteractiveQueued(queued('[Empty response — automatic recovery]\n…', 'q5'))).toBe(true)
+  })
+
+  it('keeps real user-typed messages interactive', () => {
+    expect(isNonInteractiveQueued(queued('please also check the docs', 'q1'))).toBe(false)
+    // A user quoting the prefix mid-sentence is still a user message.
+    expect(isNonInteractiveQueued(queued('why did I see [Tool refusal — automatic recovery]?', 'q2'))).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem

A `[Tool refusal — automatic recovery]` injection (and its sibling recovery prefixes) renders in the chat **composer's interactive QueueStack** as an editable/cancellable "user" card — see the reporter's screenshot: a yellow hourglass card fused into the input box with edit/interrupt/cancel actions. These are machine-generated orchestration, not user speech.

## Why it matters

- Editing or cancelling one of these cards corrupts an automatic recovery the gateway is mid-flight on.
- On the backend the same entry was misclassified as **user speech**: it could be folded into a `[N queued messages merged]` turn, persisted as user-authored history, and mirrored to linked channels.

## Fix (symptom -> root cause -> change)

Root cause: the refusal-recovery `slot.queue_insert` in `src/kiro_crew/dashboard/chat_runner.py` was queued **without** `kind=SYNTHETIC_RECOVERY_KIND`, unlike its two sibling recovery injections (empty-response and post-transient continue) added by #375, which both pass it. So `is_system_injection_item()` classified it as a user message, and the frontend's `isSystemDelivery` gate (sub-agent prefixes only) never excluded it from the interactive stack.

Changes:
- **Backend** — tag the refusal-recovery `queue_insert` with `kind=SYNTHETIC_RECOVERY_KIND`, matching its siblings. Restores structural classification (breaks user-message merges, drains alone, never consumes the session-reset notice).
- **Frontend** — add an exported, testable predicate `isNonInteractiveQueued` in `QueueStack.tsx` (`isSystemDelivery` OR any of the 5 recovery prefixes via the existing `parseRecoveryMessage`). Both live QueueStack consumers — `ChatPage.tsx` (main) and `ChatPane.tsx` (split view / Cmd-D) — filter the interactive stack with it, and compute `systemDeliveryCount` directly via `isSystemDelivery` so recovery items don't inflate the sub-agent progress line. Recovery injections drain automatically and still render as the compact `RecoveryCard` in the transcript.

## Tests

- `website/src/test/QueueStack.test.tsx` — `isNonInteractiveQueued` excludes all 5 recovery prefixes and both sub-agent completion prefixes, and keeps a user message that merely *quotes* the prefix mid-sentence interactive.
- `test/test_merge_queued_messages.py` — a refusal-recovery entry (built via `build_refusal_recovery_prompt`, carrying the kind tag) drains alone rather than folding into a user-role merged turn.

## Manual verification

Before: reporter's screenshot shows the `[Tool refusal — automatic recovery]` card fused into the composer with edit/interrupt/cancel controls. After: the entry no longer renders as an interactive card in either the main composer or split view; it drains automatically and appears as the transcript `RecoveryCard`. Behavior is locked by the unit tests above. A live "after" capture is not staged because reproducing it requires a tool refused mid-turn while the slot is busy; the change is a filter predicate whose behavior the tests pin.

## Screenshots

N/A — the change *removes* an erroneous card; the observable "after" is its absence, covered by unit tests. The "before" is the reporter's screenshot in the issue thread.

## Notes / out of scope

- Local review flagged that the frontend classifies queued recovery entries by content prefix because the queue payload carries only `{id, content}` (`kind` is dropped at serialization). Impact is Low: it only affects a user message that begins with an exact recovery prefix (an em-dash-bracketed machine string) — the message still sends, only its edit/cancel affordance is hidden while queued — and it matches the existing, intentional content-prefix detection in `RecoveryCard` (documented there as deliberate so history-restored rows render). Threading structural `kind` through the queue serialization/WS/hydration is a reasonable follow-up, tracked separately rather than expanding this fix.
- The `CRON_NOTIFY_PREFIX` composer leak is the same class but untouched here.
