### PR TITLE
feat(attachments): deliver images to the model and share one ingestion layer

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -16,7 +16,6 @@ Permission flow:
 from __future__ import annotations
 
 import asyncio
-import base64
 import difflib
 import glob
 import json
@@ -41,6 +40,7 @@ from kiro_crew.acp._dispatch import (
     parse_usage_update,
 )
 from kiro_crew.acp.liveness import VERDICT_UNKNOWN, VERDICT_WORKING, LivenessOracle
+from kiro_crew.acp.prompt_blocks import build_prompt_blocks
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
     ACP_CLIENT_CAPABILITIES,
@@ -3621,39 +3621,18 @@ class AcpClient:
 
     # ── Private Helpers ──
 
-    _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
-    _IMAGE_MEDIA_TYPES = {
-        ".png": "image/png",
-        ".jpg": "image/jpeg",
-        ".jpeg": "image/jpeg",
-        ".gif": "image/gif",
-        ".webp": "image/webp",
-        ".bmp": "image/bmp",
-        ".svg": "image/svg+xml",
-    }
-
     async def _send_prompt(self, message: str) -> int:
-        content: list[dict] = []
-        # Extract image paths from message and inline them as image blocks
-        path_re = re.compile(r"(/[\w./@~\s()\-]+\.(?:png|jpg|jpeg|gif|webp|bmp))", re.IGNORECASE)
-        remaining = message
-        for match in path_re.finditer(message):
-            p = Path(match.group(1).strip())
-            if p.is_file() and p.suffix.lower() in self._IMAGE_EXTENSIONS:
-                try:
-                    data = base64.b64encode(p.read_bytes()).decode()
-                    media = self._IMAGE_MEDIA_TYPES.get(p.suffix.lower(), "image/png")
-                    content.append({"type": "image", "data": data, "mimeType": media})
-                    remaining = remaining.replace(match.group(1), f"[image: {p.name}]")
-                except Exception:
-                    pass  # skip unreadable files
-        content.insert(0, {"type": "text", "text": remaining})
-
+        # Shared with AcpSessionHandle.prompt via prompt_blocks so the two paths
+        # cannot drift. This path historically owned the ONLY image encoder,
+        # which is why images silently stopped working once AcpProvider began
+        # replacing AcpClient with AcpSessionProvider.
         return await self._send_request(
             METHOD_PROMPT,
             {
                 "sessionId": self._session_id,
-                "prompt": content,
+                # Offloaded: see the note in session_handle.prompt -- image
+                # reads and base64 encoding must not block the event loop.
+                "prompt": await asyncio.to_thread(build_prompt_blocks, message),
             },
         )
 

--- a/src/kiro_crew/acp/prompt_blocks.py
+++ b/src/kiro_crew/acp/prompt_blocks.py
@@ -1,0 +1,175 @@
+"""Build ACP ``session/prompt`` content blocks from a plain message string.
+
+Channels hand the provider ONE string. When that string contains an absolute
+path to a readable image, the image must travel as a real ACP image block --
+a bare path is just text, and the model cannot see it. This module owns that
+conversion so both prompt paths share one implementation:
+
+* :meth:`kiro_crew.acp.session_handle.AcpSessionHandle.prompt` -- the live path
+  for the public Kiro backend (``AcpProvider.start`` swaps ``AcpClient`` out for
+  ``AcpSessionProvider``, so this is what actually reaches kiro-cli).
+* :meth:`kiro_crew.acp.client.AcpClient._send_prompt` -- the direct-client path.
+
+Keeping one builder matters: the same logic previously existed only on the
+direct path, so every channel silently shipped a filesystem path as text.
+
+Wire shape (per docs/kiro-cli/acp.md):
+
+.. code-block:: json
+
+    {"sessionId": "...", "prompt": [
+        {"type": "text",  "text": "look at this [image: shot.png]"},
+        {"type": "image", "data": "<base64>", "mimeType": "image/png"}
+    ]}
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+from pathlib import Path
+
+from kiro_crew.hooks import safe_read_file_bytes
+
+logger = logging.getLogger(__name__)
+
+#: Raster formats kiro-cli accepts as inline vision input. SVG is deliberately
+#: absent: it is scriptable XML rather than a raster image, and a vision model
+#: gains nothing from it. The direct client's constant listed ``.svg`` while its
+#: regex omitted it, so that mapping was already unreachable -- excluding it here
+#: makes the intent explicit rather than accidental.
+IMAGE_MEDIA_TYPES: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
+
+#: Raw bytes per image, checked BEFORE base64. Encoding inflates by 4/3 and the
+#: whole request is serialized as a single newline-delimited JSON frame, so an
+#: unbounded image becomes an unbounded write. Matches the Slack producer cap so
+#: a file that passed ingestion is not silently dropped here.
+MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+# Absolute paths ending in a supported raster suffix.
+#
+# Two properties are load-bearing, and BOTH were learned from real defects:
+#
+# 1. The quantifier is non-greedy. A greedy `+` swallows the separator between
+#    two paths, so "/tmp/a.png and /tmp/b.png" matched as ONE span ending at the
+#    final ".png" -- not a file, so every image in a multi-image message was
+#    dropped. That was the original direct-client behaviour.
+#
+# 2. The character class holds HORIZONTAL whitespace only, and a lookbehind
+#    forbids starting inside a URL or another path. With `\s` (which includes
+#    "\n") a leading URL chained across the newline into the appended path:
+#    `slack/events.py` emits "<user text>\n<image path>", so
+#
+#        see https://example.com/docs\n/tmp/a.png
+#
+#    matched as "//example.com/docs\n/tmp/a.png" -- one nonexistent path. Any
+#    Slack message containing a link therefore lost its image. The `(?<![\w:/])`
+#    guard rejects the "/" inside "https://" as a start position, which also
+#    stops a URL that merely ends in ".png" from being probed as a local file.
+_SUFFIX_GROUP = r"(?:png|jpg|jpeg|gif|webp|bmp)"
+
+#: Space and tab only -- NEVER `\s`. See note 2 above.
+_PATH_CHARS = r"[\w./@~ \t()\-]"
+
+#: Must not begin mid-token: rules out "https://host/..." and a "/" that is
+#: already part of a longer path.
+_NOT_MID_TOKEN = r"(?<![\w:/])"
+
+_POSIX_PATH_RE = re.compile(
+    rf"{_NOT_MID_TOKEN}(/{_PATH_CHARS}+?\.{_SUFFIX_GROUP})",
+    re.IGNORECASE,
+)
+
+# Windows absolute paths: a drive letter ("C:\...", "C:/...") or a UNC share
+# ("\\\\host\\share\\..."). Temp attachments land in %LOCALAPPDATA%\Temp and
+# dashboard uploads in %USERPROFILE%\.kiro\crew\uploads, so on Windows the
+# POSIX grammar matched NOTHING and every image stayed prose -- then the temp
+# file was deleted at end of turn, leaving a dead reference.
+#
+# Platform-gated rather than merged into one pattern: backslash and ":" are
+# legal in POSIX filenames, so accepting Windows shapes everywhere makes prose
+# like `the path C:\docs\logo.png is an example` a candidate -- and on Linux a
+# file with that literal name can exist in the CWD, which would inline a file
+# the user only mentioned. Matching the host's own grammar keeps that impossible.
+_WINDOWS_PATH_CHARS = r"[\w\\/.@ \t()\-]"
+_WINDOWS_PATH_RE = re.compile(
+    rf"(?<![\w:])((?:[A-Za-z]:[\\/]|\\\\[^\\/:*?\"<>|\r\n]+[\\/])"
+    rf"{_WINDOWS_PATH_CHARS}+?\.{_SUFFIX_GROUP})",
+    re.IGNORECASE,
+)
+
+_PATH_RE = _WINDOWS_PATH_RE if os.name == "nt" else _POSIX_PATH_RE
+
+
+def build_prompt_blocks(
+    message: str,
+    *,
+    allow_image: bool = True,
+    max_image_bytes: int = MAX_IMAGE_BYTES,
+) -> list[dict]:
+    """Return ACP prompt blocks for *message*.
+
+    Each readable image path found in *message* becomes an ``image`` block and is
+    replaced in the text by ``[image: <name>]`` so the model still sees where the
+    attachment sat in the sentence.
+
+    ``allow_image=False`` (the agent did not advertise
+    ``promptCapabilities.image``) leaves the path in the text untouched: the file
+    is still on disk, so a tool-capable agent can open it, which is a strictly
+    better fallback than dropping the reference. The result is always at least
+    one text block, so a caller can pass it straight to ``session/prompt``.
+    """
+    text = message
+    images: list[dict] = []
+
+    if allow_image:
+        seen: set[str] = set()
+        for match in _PATH_RE.finditer(message):
+            raw = match.group(1).strip()
+            if raw in seen:
+                continue
+            path = Path(raw)
+            suffix = path.suffix.lower()
+            mime = IMAGE_MEDIA_TYPES.get(suffix)
+            if mime is None or not path.is_file():
+                continue
+            try:
+                size = path.stat().st_size
+            except OSError:
+                logger.debug("acp prompt: could not stat image %s", raw, exc_info=True)
+                continue
+            if size > max_image_bytes:
+                # Leave the path in the text: the turn still carries a usable
+                # reference instead of silently losing the attachment.
+                logger.warning(
+                    "acp prompt: image %s is %d bytes (cap %d) - sending path, not inline",
+                    path.name,
+                    size,
+                    max_image_bytes,
+                )
+                continue
+            try:
+                raw_bytes = safe_read_file_bytes(str(path))
+            except Exception:
+                logger.debug("acp prompt: could not read image %s", raw, exc_info=True)
+                continue
+            if raw_bytes is None:
+                # Refused by the sensitive-path gate (or unreadable). The path
+                # stays in the text; it is NOT inlined.
+                logger.warning("acp prompt: image read refused for %s", path.name)
+                continue
+            data = base64.b64encode(raw_bytes).decode("ascii")
+            seen.add(raw)
+            images.append({"type": "image", "data": data, "mimeType": mime})
+            text = text.replace(raw, f"[image: {path.name}]")
+
+    return [{"type": "text", "text": text}, *images]

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -369,6 +369,10 @@ class AcpRuntime:
         # response. Mirrors AcpClient._can_load_session — load_session() guards
         # on it so we never issue session/load against a backend that lacks it.
         self._can_load_session = False
+        # promptCapabilities from the initialize response (e.g. {"image": true}).
+        # Empty until the handshake completes, so callers fail CLOSED and send
+        # text-only rather than guessing a modality the agent never advertised.
+        self._prompt_capabilities: dict = {}
         self._dead = False
         self._last_activity: float = 0.0
         self._stderr_lines: list[str] = []
@@ -384,6 +388,16 @@ class AcpRuntime:
     @property
     def pid(self) -> int | None:
         return self._pid
+
+    @property
+    def supports_image_prompt(self) -> bool:
+        """True when the agent advertised ``promptCapabilities.image``.
+
+        Fails closed: an un-handshaked or silent backend reports False, so the
+        prompt path sends text only instead of an image block the agent may
+        reject.
+        """
+        return bool(self._prompt_capabilities.get("image", False))
 
     def is_alive(self) -> bool:
         """True if the underlying process exists and has not exited."""
@@ -581,6 +595,12 @@ class AcpRuntime:
             self._can_load_session = bool(
                 init_resp.get("agentCapabilities", {}).get("loadSession", False)
             )
+            # Retain promptCapabilities so the prompt path can gate non-text
+            # blocks. Previously only loadSession was kept, so an image block was
+            # sent regardless of whether the agent accepted one -- and a refusal
+            # surfaced as a generic error with no fallback.
+            _prompt_caps = init_resp.get("agentCapabilities", {}).get("promptCapabilities", {})
+            self._prompt_capabilities = _prompt_caps if isinstance(_prompt_caps, dict) else {}
             self._initialized = True
             logger.info("AcpRuntime initialized (PID %d)", self._pid)
         except BaseException:

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -55,6 +55,7 @@ from kiro_crew.acp.liveness import (
     LivenessOracle,
     ToolCallState,
 )
+from kiro_crew.acp.prompt_blocks import build_prompt_blocks
 from kiro_crew.acp.types import (
     EVENT_AGENT_SWITCHED,
     EVENT_CLEAR_STATUS,
@@ -172,6 +173,16 @@ class AcpRuntimeProtocol(Protocol):
     def pid(self) -> int | None:
         """Subprocess pid (sandbox launcher parent under the Linux namespace
         sandbox) — the liveness oracle scans its descendant tree for evidence."""
+        ...
+
+    @property
+    def supports_image_prompt(self) -> bool:
+        """Whether the agent advertised ``promptCapabilities.image``.
+
+        Read by :meth:`AcpSessionHandle.prompt` to decide if an image may travel
+        as an inline block. Fails closed, so a backend that never handshaked
+        gets text only.
+        """
         ...
 
     async def send_request(self, method: str, params: dict[str, Any]) -> int:
@@ -390,12 +401,38 @@ class AcpSessionHandle:
         # stay cleared forever — is_turn_active would report True permanently and
         # every future prompt() on this handle would be rejected. Re-set it on
         # failure so the handle stays reusable.
+        #
+        # The guard catches BaseException, not Exception: asyncio.CancelledError
+        # derives from BaseException, and BOTH awaits below are cancellation
+        # points. A turn cancelled or timed out while the prompt is still being
+        # assembled would otherwise wedge the handle permanently — the exact
+        # failure this guard exists to prevent, just arriving by a different
+        # exception hierarchy. Re-raised unchanged, so cancellation still
+        # propagates.
         try:
             req_id = await self._runtime.send_request(
                 METHOD_PROMPT,
-                {"sessionId": self._session_id, "prompt": [{"type": "text", "text": message}]},
+                {
+                    "sessionId": self._session_id,
+                    # An image reaches the model ONLY as an image block. This path
+                    # previously hardcoded a single text block, so every channel
+                    # that appended a local image path (Slack, dashboard) shipped
+                    # a filesystem path as prose and the model never saw the
+                    # picture. Gated on the agent's advertised capability; when it
+                    # is absent the path stays in the text as a tool-openable
+                    # reference rather than being dropped.
+                    # Offloaded: the builder stats and reads image files (up to
+                    # MAX_IMAGE_BYTES each) and base64-encodes them. Inline, that
+                    # blocking I/O runs on the gateway loop and pauses every other
+                    # session's streaming for the duration.
+                    "prompt": await asyncio.to_thread(
+                        build_prompt_blocks,
+                        message,
+                        allow_image=self._runtime.supports_image_prompt,
+                    ),
+                },
             )
-        except Exception:
+        except BaseException:
             self._turn_done.set()
             raise
 

--- a/src/kiro_crew/messaging/attachments.py
+++ b/src/kiro_crew/messaging/attachments.py
@@ -1,0 +1,485 @@
+"""Channel-neutral inbound attachment ingestion.
+
+Every chat channel receives files in its own envelope shape and fetches them with
+its own auth, but what happens *after* the bytes land is identical: classify,
+enforce limits, convert to something the model can actually consume, redact,
+audit, and clean up. This module owns that shared half so each channel only
+supplies metadata plus a download callback.
+
+Terminal form per class -- there is no single pipe, because each class reaches
+the model differently:
+
+===========  =========================================================
+class        becomes
+===========  =========================================================
+IMAGE        a local path the ACP prompt path inlines as an image block
+             (see :mod:`kiro_crew.acp.prompt_blocks`)
+TEXT         redacted, truncated text inlined into the prompt
+DOCUMENT     text extracted via :mod:`kiro_crew.doc_parser`, then as TEXT
+AUDIO        a local path for the caller to transcribe (opt-in)
+VIDEO        rejected with a visible reason -- kiro-cli advertises
+             ``promptCapabilities.image`` only, and the models behind it do
+             not accept video
+OTHER        rejected with a visible reason
+===========  =========================================================
+
+**Why rejections are returned rather than swallowed.** Silently dropping an
+attachment is the original defect this module exists to fix: a user posts a file
+and the reply simply ignores it, with no explanation. Callers are expected to
+surface :attr:`IngestResult.rejections` to the user.
+
+**Deliberately NOT here: the fetch itself.** Host allowlisting and auth are
+channel-specific -- Slack needs a bearer token against ``files.slack.com``,
+Discord needs no auth but signed ``cdn.discordapp.com`` URLs. The callback owns
+that; this module owns everything after the bytes arrive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import tempfile
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from kiro_crew.doc_parser import extract_text, is_parseable_document
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
+
+# ── Classes ──
+IMAGE = "image"
+TEXT = "text"
+DOCUMENT = "document"
+AUDIO = "audio"
+VIDEO = "video"
+OTHER = "other"
+
+#: Raster types that :func:`kiro_crew.acp.prompt_blocks.build_prompt_blocks` can
+#: inline. Keep in step with ``IMAGE_MEDIA_TYPES`` there -- a type accepted here
+#: but unknown to the encoder would download and then be ignored.
+IMAGE_MIMETYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+}
+
+#: Leading bytes per image type. Metadata and filenames are attacker-controlled;
+#: bytes are not. A claimed PNG that does not start with the PNG signature is
+#: rejected rather than handed to the model (CWE-434).
+_MAGIC: dict[str, tuple[bytes, ...]] = {
+    "image/png": (b"\x89PNG\r\n\x1a\n",),
+    "image/jpeg": (b"\xff\xd8\xff",),
+    "image/gif": (b"GIF87a", b"GIF89a"),
+    "image/webp": (b"RIFF",),  # RIFF....WEBP
+    "image/bmp": (b"BM",),
+}
+
+_TEXT_PREFIXES = ("text/",)
+_TEXT_EXACT = {"application/json", "application/xml", "application/javascript"}
+_AUDIO_PREFIXES = ("audio/",)
+_VIDEO_PREFIXES = ("video/",)
+
+_SAFE_SUFFIX_RE = re.compile(r"[^a-zA-Z0-9]")
+
+#: Async ``(url, dest_path) -> None``. Must raise on failure.
+DownloadFn = Callable[[str, str], Awaitable[None]]
+
+
+@dataclass
+class IngestLimits:
+    """Caps applied per attachment. Defaults match Slack's shipped behaviour."""
+
+    max_image_bytes: int = 10 * 1024 * 1024
+    max_text_bytes: int = 512 * 1024
+    max_document_bytes: int = 20 * 1024 * 1024
+    max_audio_bytes: int = 25 * 1024 * 1024
+    #: Characters of extracted text injected into the prompt.
+    max_text_inject: int = 50 * 1024
+    #: Per-message attachment cap. Slack had none, so a single message could
+    #: trigger unbounded downloads.
+    max_attachments: int = 10
+
+
+@dataclass
+class Attachment:
+    """One inbound file, normalized away from any channel's envelope shape."""
+
+    name: str
+    mimetype: str = ""
+    size: int = 0
+    url: str = ""
+    #: Extension hint (Slack's ``filetype``, or a filename suffix). Sanitized
+    #: before use -- never trusted as a path component.
+    suffix_hint: str = ""
+
+
+@dataclass
+class IngestResult:
+    #: Local paths to downloaded images. **The caller must delete these** once
+    #: the turn has consumed them.
+    image_paths: list[str] = field(default_factory=list)
+    #: Local paths to downloaded audio, for the caller to transcribe. Caller
+    #: deletes.
+    audio_paths: list[str] = field(default_factory=list)
+    #: Prompt-ready text fragments (already redacted and truncated).
+    text_blocks: list[str] = field(default_factory=list)
+    #: Human-readable reasons an attachment was not ingested. Surface these.
+    rejections: list[str] = field(default_factory=list)
+
+    @property
+    def temp_paths(self) -> list[str]:
+        """Every path the caller is responsible for cleaning up."""
+        return [*self.image_paths, *self.audio_paths]
+
+
+def safe_suffix(hint: str, default: str = "bin") -> str:
+    """A filesystem-safe extension derived from *hint*.
+
+    Strips everything non-alphanumeric so an attachment name can never steer the
+    destination path (``../``, absolute paths, NUL bytes).
+    """
+    clean = _SAFE_SUFFIX_RE.sub("", hint or "")
+    return "." + (clean or default)
+
+
+def classify(mimetype: str, name: str = "", audio_mimetypes: tuple[str, ...] = ()) -> str:
+    """Map a mimetype (with filename as a fallback signal) to a class.
+
+    ``audio_mimetypes`` lets a channel declare prefixes it treats as audio even
+    though they are not ``audio/*``. This is not hypothetical: Slack ships voice
+    memos as ``video/webm``, and its transcription path already encodes that
+    (``slack/events.py``). Without the override the same file classifies as
+    VIDEO here and a "video is not supported" note lands beside the transcript.
+    The knowledge belongs to the channel, so the channel supplies it rather than
+    this module accumulating per-channel special cases.
+    """
+    mt = (mimetype or "").lower()
+    if mt in IMAGE_MIMETYPES:
+        return IMAGE
+    if any(mt.startswith(p) for p in audio_mimetypes):
+        return AUDIO
+    if any(mt.startswith(p) for p in _AUDIO_PREFIXES):
+        return AUDIO
+    if any(mt.startswith(p) for p in _VIDEO_PREFIXES):
+        return VIDEO
+    if any(mt.startswith(p) for p in _TEXT_PREFIXES) or mt in _TEXT_EXACT:
+        return TEXT
+    if is_parseable_document(mimetype=mt, filename=name):
+        return DOCUMENT
+    return OTHER
+
+
+def sniff_image_mime(path: str) -> str | None:
+    """The image type *path* actually is, by leading bytes, or ``None``.
+
+    Metadata and filenames are attacker-controlled; bytes are not. Returning the
+    detected type (rather than merely accepting/rejecting the declared one) does
+    double duty:
+
+    * a file that matches NO known image signature is not an image at all and is
+      rejected -- that is the CWE-434 case, e.g. a script declared ``image/png``
+    * a genuine JPEG that the channel mislabelled ``image/png`` still works, and
+      the temp file gets the correct suffix, so the ACP encoder -- which derives
+      ``mimeType`` from the suffix -- puts truthful metadata on the wire
+    """
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(16)
+    except OSError:
+        return None
+    for mime, prefixes in _MAGIC.items():
+        if any(head.startswith(p) for p in prefixes):
+            # WebP and other RIFF containers share the "RIFF" prefix; confirm the
+            # form tag so a RIFF/WAVE file is not mistaken for an image.
+            if mime == "image/webp" and head[8:12] != b"WEBP":
+                continue
+            return mime
+    return None
+
+
+#: Canonical suffix per image mimetype, so a downloaded file is renamed to match
+#: what it actually is.
+_MIME_SUFFIX = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/bmp": ".bmp",
+}
+
+
+def _audit(source: str, operation: str, outcome: str, name: str, error: str = "") -> None:
+    sel().log_api_access(
+        caller="attachment_ingest",
+        operation=operation,
+        outcome=outcome,
+        source=source,
+        resources=name,
+        error=error,
+    )
+
+
+def _make_temp(suffix: str) -> str:
+    """Create an empty temp file and return its path (blocking; call offloaded).
+
+    ``mkstemp`` and its ``close`` are paired here deliberately so ONE executor
+    hop covers both. ``mkstemp`` is the expensive half -- directory lookups plus
+    an ``O_CREAT|O_EXCL`` open, retried on name collision -- while the ``close``
+    releases a descriptor whose file has no dirty pages, because nothing has been
+    written to it yet. Offloading only the ``close`` would move a temp-directory
+    stall up one line rather than removing it.
+    """
+    fd, dest = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    return dest
+
+
+async def _fetch(download: DownloadFn, url: str, suffix: str) -> str:
+    """Download to a fresh temp file and return its path. Raises on failure."""
+    # Offloaded: this runs on the gateway event loop, and TMPDIR is not
+    # guaranteed to be local (a network- or FUSE-backed temp dir can stall),
+    # which would freeze every other session until the watchdog intervened.
+    dest = await asyncio.to_thread(_make_temp, suffix)
+    try:
+        await download(url, dest)
+    except BaseException:
+        try:
+            os.unlink(dest)
+        except OSError:
+            pass
+        raise
+    return dest
+
+
+def _read_text_file(path: str, limit: int) -> str:
+    """Read a text attachment and redact+truncate it (blocking; call offloaded)."""
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        return _clean_text(fh.read(), limit)
+
+
+def _truncate(content: str, limit: int) -> tuple[str, str]:
+    if len(content) > limit:
+        return content[:limit], "\n[… truncated]"
+    return content, ""
+
+
+def _clean_text(content: str, limit: int) -> str:
+    """Redact then truncate. Redaction runs FIRST so a secret cannot survive by
+    sitting past the truncation point."""
+    content, _ = redact_exfiltration_urls(content)
+    content, _ = redact_credentials(content)
+    body, tail = _truncate(content, limit)
+    return body + tail
+
+
+async def ingest_attachments(
+    attachments: list[Attachment],
+    *,
+    download: DownloadFn,
+    source: str,
+    limits: IngestLimits | None = None,
+    handle_audio: bool = False,
+    audio_mimetypes: tuple[str, ...] = (),
+) -> IngestResult:
+    """Download and convert *attachments* into prompt-ready material.
+
+    ``handle_audio=False`` skips audio entirely, for channels that transcribe it
+    on a separate upstream path (Slack). ``True`` downloads it and returns the
+    paths in :attr:`IngestResult.audio_paths` for the caller to transcribe.
+
+    ``audio_mimetypes`` declares channel-specific types to treat as audio (see
+    :func:`classify`) -- Slack's ``video/webm`` voice memos being the real case.
+
+    Never raises for a single bad attachment: each failure becomes a rejection so
+    one unreadable file cannot lose the rest of the message.
+    """
+    lim = limits or IngestLimits()
+    out = IngestResult()
+
+    for att in attachments[: lim.max_attachments]:
+        kind = classify(att.mimetype, att.name, audio_mimetypes)
+
+        if kind == AUDIO and not handle_audio:
+            continue  # transcribed upstream
+
+        if not att.url:
+            out.rejections.append(f"[Attachment {att.name} — no download URL]")
+            _audit(source, f"{source}.attachment_skip", "skipped", att.name, "no url")
+            continue
+
+        if kind == VIDEO:
+            out.rejections.append(
+                f"[Attachment {att.name} — video is not supported; "
+                "send a screenshot or a text summary instead]"
+            )
+            _audit(source, f"{source}.attachment_skip", "skipped", att.name, "video unsupported")
+            continue
+
+        if kind == OTHER:
+            out.rejections.append(
+                f"[Attached file: {att.name} ({att.mimetype or 'unknown type'}, "
+                f"{att.size} bytes) — unsupported type]"
+            )
+            _audit(
+                source,
+                f"{source}.attachment_skip",
+                "skipped",
+                att.name,
+                f"unsupported mimetype: {att.mimetype}",
+            )
+            continue
+
+        cap = {
+            IMAGE: lim.max_image_bytes,
+            TEXT: lim.max_text_bytes,
+            DOCUMENT: lim.max_document_bytes,
+            AUDIO: lim.max_audio_bytes,
+        }[kind]
+
+        # Pre-download check on channel-reported size. Cheap, but advisory only:
+        # the value is attacker-influenced and defaults to 0 when absent, which
+        # is exactly how Slack's cap could be bypassed. The post-download check
+        # below is the one that actually holds.
+        if att.size and att.size > cap:
+            out.rejections.append(
+                f"[Attachment {att.name} ({att.size} bytes) — too large, limit {cap}]"
+            )
+            _audit(source, f"{source}.attachment_skip", "skipped", att.name, f"too large: {att.size}")
+            continue
+
+        try:
+            dest = await _fetch(download, att.url, safe_suffix(att.suffix_hint or att.name.rsplit(".", 1)[-1]))
+        except Exception:
+            logger.exception("%s: failed to download attachment %s", source, att.name)
+            out.rejections.append(f"[Attachment {att.name} — download failed]")
+            _audit(source, f"{source}.attachment_download", "error", att.name, "download_failed")
+            continue
+
+        try:
+            # Authoritative size check: metadata may have lied or been absent.
+            actual = os.path.getsize(dest)
+            if actual > cap:
+                out.rejections.append(
+                    f"[Attachment {att.name} ({actual} bytes) — too large, limit {cap}]"
+                )
+                _audit(
+                    source,
+                    f"{source}.attachment_skip",
+                    "skipped",
+                    att.name,
+                    f"too large after download: {actual}",
+                )
+                continue
+
+            if kind == IMAGE:
+                # Offloaded: opens and reads the file header.
+                actual_mime = await asyncio.to_thread(sniff_image_mime, dest)
+                if actual_mime is None:
+                    out.rejections.append(
+                        f"[Attachment {att.name} — not a readable image "
+                        f"(declared {att.mimetype or 'unknown'})]"
+                    )
+                    _audit(
+                        source,
+                        f"{source}.attachment_skip",
+                        "skipped",
+                        att.name,
+                        "content_signature_mismatch",
+                    )
+                    continue
+                # Rename to the TRUE type's suffix: the ACP encoder derives
+                # mimeType from the suffix, so a mislabelled file would otherwise
+                # travel with wrong metadata. REPLACE the declared suffix rather
+                # than appending, so the name does not claim two types at once.
+                want = _MIME_SUFFIX.get(actual_mime, "")
+                if want and os.path.splitext(dest)[1].lower() != want:
+                    renamed = os.path.splitext(dest)[0] + want
+                    try:
+                        os.replace(dest, renamed)
+                        dest = renamed
+                    except OSError:
+                        logger.debug("%s: could not retype %s", source, dest, exc_info=True)
+                out.image_paths.append(dest)
+                dest = ""  # ownership transferred to the caller
+                _audit(source, f"{source}.attachment_download", "success", att.name)
+
+            elif kind == AUDIO:
+                out.audio_paths.append(dest)
+                dest = ""
+                _audit(source, f"{source}.attachment_download", "success", att.name)
+
+            elif kind == TEXT:
+                # Offloaded for the same reason as the DOCUMENT branch below:
+                # this reads file CONTENT (up to max_text_bytes) on the gateway
+                # event loop. Leaving plain text inline while offloading PDF
+                # parsing would be an arbitrary split -- both are blocking reads.
+                body = await asyncio.to_thread(
+                    _read_text_file, dest, lim.max_text_inject
+                )
+                out.text_blocks.append(f"[File: {att.name}]\n{body}\n[End of file]")
+                _audit(source, f"{source}.attachment_download", "success", att.name)
+
+            else:  # DOCUMENT
+                # Parsing a PDF/docx is synchronous CPU work on inputs up to
+                # max_document_bytes. This runs inside the gateway's event loop
+                # task (Socket Mode -> _route_message -> process_slack_files),
+                # so doing it inline stalls EVERY other session's streaming for
+                # the duration. Offload to a worker thread.
+                #
+                # Deliberately asyncio.to_thread rather than subprocess_executor():
+                # that pool is reserved for subprocess/PTY teardown and orphan
+                # reaping, and its own docstring notes those workers must stay
+                # free to recover from a wedged kernel resource. Parking a slow
+                # document parse there would undermine that isolation.
+                raw = await asyncio.to_thread(
+                    extract_text, dest, mimetype=att.mimetype, filename=att.name
+                )
+                if not raw:
+                    out.rejections.append(
+                        f"[Attached document: {att.name} — could not extract text]"
+                    )
+                    _audit(
+                        source,
+                        f"{source}.attachment_parse",
+                        "error",
+                        att.name,
+                        "no_text_extracted",
+                    )
+                    continue
+                body = _clean_text(raw, lim.max_text_inject)
+                out.text_blocks.append(f"[Document: {att.name}]\n{body}\n[End of document]")
+                _audit(source, f"{source}.attachment_download", "success", att.name)
+        except Exception:
+            logger.exception("%s: failed to process attachment %s", source, att.name)
+            out.rejections.append(f"[Attachment {att.name} — could not be processed]")
+            _audit(source, f"{source}.attachment_parse", "error", att.name, "process_failed")
+        finally:
+            # Anything not handed to the caller is deleted here.
+            if dest:
+                try:
+                    os.unlink(dest)
+                except OSError:
+                    pass
+
+    if len(attachments) > lim.max_attachments:
+        dropped = len(attachments) - lim.max_attachments
+        out.rejections.append(
+            f"[{dropped} more attachment(s) ignored — limit {lim.max_attachments} per message]"
+        )
+
+    return out
+
+
+def cleanup(paths: list[str]) -> None:
+    """Best-effort deletion of temp paths handed back by :func:`ingest_attachments`."""
+    for p in paths:
+        try:
+            os.unlink(p)
+        except OSError:
+            pass

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -385,7 +385,10 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         "cli_commands.py",
         # Slack sub-surfaces whose posted output is covered by the two Slack rows.
         "slack/events.py",
-        "slack/files.py",
+        # Inbound attachment ingestion: redacts text extracted FROM a user's
+        # own uploaded file before it enters the prompt. Inbound sanitisation,
+        # not agent output on its way to a user.
+        "messaging/attachments.py",
         "slack/interactions.py",
         "slack/renderer.py",
         "slack/sessions_view.py",

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -64,7 +64,7 @@ from kiro_crew.slack.blocks import (
     dashboard_link_block,
     voice_config_modal,
 )
-from kiro_crew.slack.files import process_slack_files
+from kiro_crew.slack.files import SLACK_AUDIO_MIMETYPES, process_slack_files
 from kiro_crew.slack.handler import (
     _YOLO_TTL_SECS,
     APPROVAL_AUTO,
@@ -1396,7 +1396,9 @@ def _maybe_prompt_owner(orch: GatewayOrchestrator, event: dict) -> None:
 # Audio transcription helper
 # ---------------------------------------------------------------------------
 
-_AUDIO_MIMETYPES = {"audio/", "video/webm"}
+# Single source of truth lives with the attachment adapter so the
+# transcriber and the ingestion path cannot disagree about what is audio.
+_AUDIO_MIMETYPES = SLACK_AUDIO_MIMETYPES
 
 
 async def _transcribe_with_reaction(

--- a/src/kiro_crew/slack/files.py
+++ b/src/kiro_crew/slack/files.py
@@ -1,86 +1,85 @@
-"""Slack file attachment processing — images, text, and unsupported types.
+"""Slack file attachment processing — a thin adapter over the neutral layer.
 
-Downloads files shared in Slack messages and converts them into text
-that can be injected into the LLM prompt.  Images are saved to temp
-files so ``AcpClient._send_prompt()`` can inline them as base64 content
-blocks.  Text files are read and injected directly.
+Slack owns exactly two things here: mapping its envelope (``files[]`` dicts with
+``url_private_download`` / ``filetype`` / ``mimetype``) onto
+:class:`~kiro_crew.messaging.attachments.Attachment`, and supplying an
+authenticated download callback. Classification, size caps, magic-byte
+validation, redaction, document extraction, SEL audit, and temp cleanup all live
+in :mod:`kiro_crew.messaging.attachments` so other channels reuse them instead of
+growing a second copy.
 
-Safety controls:
-- Mimetype allowlist (no executables or archives)
-- File size caps checked *before* download (from Slack metadata)
-- Temp file cleanup in ``finally`` blocks
-- Credential / exfiltration URL redaction on text content
-- SEL audit logging on every download / skip / error
+Audio is skipped here: Slack transcribes it on a separate upstream path
+(``transcribe.py``) before file processing runs.
+
+Behaviour preserved from the original implementation:
+- the same ``(image_paths, text_blocks)`` return contract, so ``events.py`` and
+  the busy-message queue are unchanged
+- images land in temp files the caller must delete
+- text and documents are redacted, then truncated, then wrapped in the same
+  ``[File: …]`` / ``[Document: …]`` markers
+
+Tightened relative to the original:
+- size is re-checked AFTER download, so an absent or dishonest Slack ``size``
+  (which defaults to 0) can no longer bypass the cap
+- image bytes must match the declared mimetype's signature
+- a per-message attachment cap now exists
 """
 
 from __future__ import annotations
 
 import logging
-import os
-import re
-import tempfile
 from typing import TYPE_CHECKING
 
-from kiro_crew.doc_parser import extract_text, is_parseable_document
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-from kiro_crew.sel import sel
+from kiro_crew.messaging.attachments import (
+    Attachment,
+    IngestLimits,
+    ingest_attachments,
+    safe_suffix,
+)
 
 if TYPE_CHECKING:
     from kiro_crew.slack.gateway import GatewayOrchestrator
 
 logger = logging.getLogger(__name__)
 
-# ── Size limits ──
-_MAX_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MB
-_MAX_TEXT_BYTES = 512 * 1024  # 512 KB download cap
-_MAX_TEXT_INJECT = 50 * 1024  # 50 KB injected into prompt
+# Slack's shipped caps, expressed against the neutral limit object.
+_LIMITS = IngestLimits(
+    max_image_bytes=10 * 1024 * 1024,
+    max_text_bytes=512 * 1024,
+    max_document_bytes=20 * 1024 * 1024,
+    max_text_inject=50 * 1024,
+)
 
-# ── Mimetype allowlists ──
-# Image types must match AcpClient._send_prompt() regex:
-# png|jpg|jpeg|gif|webp|bmp
-_IMAGE_MIMETYPES = {
-    "image/png",
-    "image/jpeg",
-    "image/gif",
-    "image/webp",
-    "image/bmp",
-}
-_TEXT_PREFIXES = ("text/",)
-_TEXT_EXACT = {
-    "application/json",
-    "application/xml",
-    "application/javascript",
-}
+# Retained names. `test_slack_files.py` asserts against these directly, and
+# keeping them re-exported means that suite stays a real regression check on the
+# migration rather than being rewritten alongside it.
+_MAX_IMAGE_BYTES = _LIMITS.max_image_bytes
+_MAX_TEXT_BYTES = _LIMITS.max_text_bytes
+_MAX_DOC_BYTES = _LIMITS.max_document_bytes
+_MAX_TEXT_INJECT = _LIMITS.max_text_inject
 
-# ── Audio mimetypes handled by transcribe.py — skip here ──
-_AUDIO_PREFIXES = ("audio/", "video/webm")
-
-# Sanitize filetype to alphanumeric only
-_SAFE_SUFFIX_RE = re.compile(r"[^a-zA-Z0-9]")
+#: Mimetype prefixes Slack uses for voice memos. ``video/webm`` is NOT a
+#: mistake: Slack ships voice clips with a video container mimetype, and the
+#: transcription path in ``slack/events.py`` has always relied on that. Defined
+#: HERE (not in events.py) because this module sits below it in the import
+#: graph, so both the transcriber and the ingestion adapter can share ONE
+#: definition. Two copies is how a transcribed voice memo ended up also being
+#: rejected as unsupported video.
+SLACK_AUDIO_MIMETYPES: tuple[str, ...] = ("audio/", "video/webm")
+_safe_suffix = safe_suffix
 
 
-def _safe_suffix(filetype: str, default: str = "bin") -> str:
-    """Return a safe file extension from a Slack filetype field."""
-    clean = _SAFE_SUFFIX_RE.sub("", filetype)
-    return "." + (clean or default)
-
-
-def _is_audio(mimetype: str) -> bool:
-    return any(mimetype.startswith(p) for p in _AUDIO_PREFIXES)
-
-
-def _is_image(mimetype: str) -> bool:
-    return mimetype in _IMAGE_MIMETYPES
-
-
-def _is_text(mimetype: str) -> bool:
-    if any(mimetype.startswith(p) for p in _TEXT_PREFIXES):
-        return True
-    return mimetype in _TEXT_EXACT
-
-
-def _is_document(mimetype: str, name: str = "") -> bool:
-    return is_parseable_document(mimetype=mimetype, filename=name)
+def _to_attachment(f: dict) -> Attachment:
+    """Map one Slack ``files[]`` entry onto the neutral shape."""
+    return Attachment(
+        name=f.get("name", "unknown"),
+        mimetype=f.get("mimetype", ""),
+        size=f.get("size", 0) or 0,
+        # url_private_download serves raw bytes; url_private can return an HTML
+        # preview page for some types.
+        url=f.get("url_private_download") or f.get("url_private", ""),
+        suffix_hint=f.get("filetype", ""),
+    )
 
 
 async def process_slack_files(
@@ -96,238 +95,22 @@ async def process_slack_files(
     if not orch.slack:
         return [], []
 
-    image_paths: list[str] = []
-    text_blocks: list[str] = []
+    client = orch.slack
 
-    for f in files:
-        mimetype = f.get("mimetype", "")
-        name = f.get("name", "unknown")
-        size = f.get("size", 0)
+    async def _download(url: str, dest: str) -> None:
+        # Slack's downloader attaches the bot bearer token; only Slack knows
+        # that, which is why the fetch stays channel-owned.
+        await client.download_file(url, dest)
 
-        if _is_audio(mimetype):
-            continue
+    result = await ingest_attachments(
+        [_to_attachment(f) for f in files],
+        download=_download,
+        source="slack",
+        limits=_LIMITS,
+        handle_audio=False,  # transcribed upstream
+        audio_mimetypes=SLACK_AUDIO_MIMETYPES,
+    )
 
-        url = f.get("url_private_download") or f.get("url_private", "")
-        if not url:
-            continue
-
-        if _is_image(mimetype):
-            path = await _download_image(orch, f, url, name, size)
-            if path:
-                image_paths.append(path)
-
-        elif _is_text(mimetype):
-            block = await _download_text(orch, f, url, name, size)
-            if block:
-                text_blocks.append(block)
-
-        elif _is_document(mimetype, name):
-            block = await _download_document(orch, f, url, name, size)
-            if block:
-                text_blocks.append(block)
-
-        else:
-            note = f"[Attached file: {name} ({mimetype}," f" {size} bytes) — unsupported type]"
-            text_blocks.append(note)
-            sel().log_api_access(
-                caller="file_processor",
-                operation="slack.file_skip",
-                outcome="skipped",
-                source="slack",
-                resources=name,
-                error=f"unsupported mimetype: {mimetype}",
-            )
-
-    return image_paths, text_blocks
-
-
-async def _download_image(
-    orch: GatewayOrchestrator,
-    f: dict,
-    url: str,
-    name: str,
-    size: int,
-) -> str | None:
-    """Download an image to a temp file. Returns path or None."""
-    if size > _MAX_IMAGE_BYTES:
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.file_skip",
-            outcome="skipped",
-            source="slack",
-            resources=name,
-            error=f"image too large: {size} bytes",
-        )
-        return None
-
-    suffix = _safe_suffix(f.get("filetype", "png"), "png")
-    fd, dest = tempfile.mkstemp(suffix=suffix)
-    os.close(fd)
-    ok = False
-    try:
-        if not orch.slack:
-            return None
-        await orch.slack.download_file(url, dest)
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.download_file",
-            outcome="success",
-            source="slack",
-            resources=name,
-        )
-        logger.info("Downloaded image: %s (%d bytes)", name, size)
-        ok = True
-        return dest
-    except Exception:
-        logger.exception("Failed to download image %s", name)
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.download_file",
-            outcome="error",
-            source="slack",
-            resources=name,
-            error="download_failed",
-        )
-        return None
-    finally:
-        if not ok:
-            try:
-                os.unlink(dest)
-            except OSError:
-                pass
-
-
-async def _download_text(
-    orch: GatewayOrchestrator,
-    f: dict,
-    url: str,
-    name: str,
-    size: int,
-) -> str | None:
-    """Download a text file and return content for prompt injection."""
-    if size > _MAX_TEXT_BYTES:
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.file_skip",
-            outcome="skipped",
-            source="slack",
-            resources=name,
-            error=f"text file too large: {size} bytes",
-        )
-        return f"[Attached file: {name} ({size} bytes)" f" — too large to inline]"
-
-    fd, dest = tempfile.mkstemp(suffix=".txt")
-    os.close(fd)
-    try:
-        if not orch.slack:
-            return None
-        await orch.slack.download_file(url, dest)
-        with open(dest, "r", encoding="utf-8", errors="replace") as fh:
-            content = fh.read()
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.download_file",
-            outcome="success",
-            source="slack",
-            resources=name,
-        )
-
-        content, _ = redact_exfiltration_urls(content)
-        content, _ = redact_credentials(content)
-
-        truncated = ""
-        if len(content) > _MAX_TEXT_INJECT:
-            content = content[:_MAX_TEXT_INJECT]
-            truncated = "\n[… truncated]"
-
-        logger.info(
-            "Downloaded text file: %s (%d chars)",
-            name,
-            len(content),
-        )
-        return f"[File: {name}]\n{content}{truncated}\n[End of file]"
-    except Exception:
-        logger.exception("Failed to download text file %s", name)
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.download_file",
-            outcome="error",
-            source="slack",
-            resources=name,
-            error="download_failed",
-        )
-        return None
-    finally:
-        try:
-            os.unlink(dest)
-        except OSError:
-            pass
-
-
-_MAX_DOC_BYTES = 20 * 1024 * 1024  # 20 MB download cap for documents
-
-
-async def _download_document(
-    orch: "GatewayOrchestrator",
-    f: dict,
-    url: str,
-    name: str,
-    size: int,
-) -> str | None:
-    """Download a document file, extract text, and return for prompt injection."""
-    if size > _MAX_DOC_BYTES:
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.file_skip",
-            outcome="skipped",
-            source="slack",
-            resources=name,
-            error=f"document too large: {size} bytes",
-        )
-        return f"[Attached document: {name} ({size} bytes) — too large to parse]"
-
-    suffix = _safe_suffix(f.get("filetype", "bin"), "bin")
-    fd, dest = tempfile.mkstemp(suffix=suffix)
-    os.close(fd)
-    try:
-        if not orch.slack:
-            return None
-        await orch.slack.download_file(url, dest)
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.download_file",
-            outcome="success",
-            source="slack",
-            resources=name,
-        )
-
-        content = extract_text(dest, mimetype=f.get("mimetype", ""), filename=name)
-        if not content:
-            return f"[Attached document: {name} — could not extract text]"
-
-        content, _ = redact_exfiltration_urls(content)
-        content, _ = redact_credentials(content)
-
-        truncated = ""
-        if len(content) > _MAX_TEXT_INJECT:
-            content = content[:_MAX_TEXT_INJECT]
-            truncated = "\n[… truncated]"
-
-        logger.info("Parsed document: %s (%d chars)", name, len(content))
-        return f"[Document: {name}]\n{content}{truncated}\n[End of document]"
-    except Exception:
-        logger.exception("Failed to parse document %s", name)
-        sel().log_api_access(
-            caller="file_processor",
-            operation="slack.download_file",
-            outcome="error",
-            source="slack",
-            resources=name,
-            error="document_parse_failed",
-        )
-        return f"[Attached document: {name} — parse error]"
-    finally:
-        try:
-            os.unlink(dest)
-        except OSError:
-            pass
+    # Rejection notes ride along as prompt text, matching the previous behaviour
+    # of inlining "unsupported type" / "too large" notes for the model to see.
+    return result.image_paths, [*result.text_blocks, *result.rejections]

--- a/test/test_acp_prompt_blocks.py
+++ b/test/test_acp_prompt_blocks.py
@@ -1,0 +1,273 @@
+"""ACP prompt-block construction and the image capability gate.
+
+Regression coverage for the defect where EVERY channel shipped a filesystem
+path as prose: ``AcpSessionHandle.prompt`` hardcoded a single text block, while
+the only image encoder lived on ``AcpClient`` -- the path ``AcpProvider.start``
+replaces. An image therefore never reached the model as vision input.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+
+import pytest
+
+from kiro_crew.acp import prompt_blocks
+from kiro_crew.acp.prompt_blocks import (
+    _POSIX_PATH_RE,
+    IMAGE_MEDIA_TYPES,
+    MAX_IMAGE_BYTES,
+    build_prompt_blocks,
+)
+
+# Smallest valid 1x1 PNG.
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+def _png(tmp_path, name="shot.png"):
+    p = tmp_path / name
+    p.write_bytes(_PNG)
+    return p
+
+
+class TestBuildPromptBlocks:
+    def test_always_returns_at_least_a_text_block(self):
+        blocks = build_prompt_blocks("just words")
+        assert blocks == [{"type": "text", "text": "just words"}]
+
+    def test_image_path_becomes_an_image_block(self, tmp_path):
+        p = _png(tmp_path)
+        blocks = build_prompt_blocks(f"look at {p} please")
+
+        assert [b["type"] for b in blocks] == ["text", "image"]
+        # Text block leads, so the caller can pass this straight to session/prompt.
+        assert blocks[0]["text"] == f"look at [image: {p.name}] please"
+        assert blocks[1]["mimeType"] == "image/png"
+        # The wire carries the BYTES, not the path.
+        assert base64.b64decode(blocks[1]["data"]) == _PNG
+        assert str(p) not in blocks[1].get("data", "")
+
+    def test_capability_gate_keeps_path_as_text(self, tmp_path):
+        """No advertised image capability -> no image block, path left intact.
+
+        Dropping the reference would lose the attachment entirely; leaving the
+        path lets a tool-capable agent still open the file.
+        """
+        p = _png(tmp_path)
+        blocks = build_prompt_blocks(f"look at {p}", allow_image=False)
+
+        assert [b["type"] for b in blocks] == ["text"]
+        assert str(p) in blocks[0]["text"]
+
+    def test_oversized_image_falls_back_to_path(self, tmp_path):
+        """Size is checked BEFORE base64: encoding inflates 4/3 and the whole
+        request is one newline-delimited JSON frame."""
+        p = _png(tmp_path)
+        blocks = build_prompt_blocks(f"see {p}", max_image_bytes=1)
+
+        assert [b["type"] for b in blocks] == ["text"]
+        assert str(p) in blocks[0]["text"]
+
+    def test_missing_and_unreadable_files_are_skipped(self, tmp_path):
+        blocks = build_prompt_blocks("/definitely/not/here.png")
+        assert [b["type"] for b in blocks] == ["text"]
+
+    def test_directory_with_image_suffix_is_not_read(self, tmp_path):
+        d = tmp_path / "weird.png"
+        d.mkdir()
+        blocks = build_prompt_blocks(f"see {d}")
+        assert [b["type"] for b in blocks] == ["text"]
+
+    def test_multiple_images_each_get_a_block(self, tmp_path):
+        a = _png(tmp_path, "a.png")
+        b = _png(tmp_path, "b.png")
+        blocks = build_prompt_blocks(f"{a} and {b}")
+
+        assert [x["type"] for x in blocks] == ["text", "image", "image"]
+        assert blocks[0]["text"] == "[image: a.png] and [image: b.png]"
+
+    def test_same_path_twice_is_encoded_once(self, tmp_path):
+        p = _png(tmp_path)
+        blocks = build_prompt_blocks(f"{p} then {p} again")
+        # One image block, and both textual occurrences are rewritten.
+        assert [x["type"] for x in blocks] == ["text", "image"]
+        assert str(p) not in blocks[0]["text"]
+
+    @pytest.mark.parametrize("suffix,mime", sorted(IMAGE_MEDIA_TYPES.items()))
+    def test_every_supported_suffix_maps_to_its_mime(self, tmp_path, suffix, mime):
+        p = tmp_path / f"img{suffix}"
+        p.write_bytes(_PNG)
+        blocks = build_prompt_blocks(f"see {p}")
+        assert blocks[1]["mimeType"] == mime
+
+    def test_svg_is_not_inlined(self, tmp_path):
+        """SVG is scriptable XML, not a raster image. The direct client listed it
+        in its media map while its regex omitted it, so the mapping was already
+        unreachable -- keep it excluded deliberately."""
+        p = tmp_path / "vector.svg"
+        p.write_bytes(b"<svg xmlns='http://www.w3.org/2000/svg'/>")
+        blocks = build_prompt_blocks(f"see {p}")
+
+        assert [b["type"] for b in blocks] == ["text"]
+        assert ".svg" not in IMAGE_MEDIA_TYPES
+
+    def test_bare_filename_is_not_treated_as_a_path(self, tmp_path):
+        """Only absolute paths are candidates, so prose mentioning a filename
+        does not trigger a filesystem probe."""
+        blocks = build_prompt_blocks("the file shot.png is attached")
+        assert [b["type"] for b in blocks] == ["text"]
+        assert blocks[0]["text"] == "the file shot.png is attached"
+
+    def test_default_cap_is_ten_mib(self):
+        assert MAX_IMAGE_BYTES == 10 * 1024 * 1024
+
+
+class TestSensitivePathGate:
+    """Image bytes must travel through the centralized sensitive-path gate.
+
+    The gate itself (``hooks.safe_read_file_bytes``: realpath canonicalization,
+    ``is_sensitive_path``, ``O_NOFOLLOW``) has its own tests. What matters here
+    is that this builder ROUTES through it and honours a refusal -- paths
+    reaching it are scraped from message text and so are user-influenced.
+    """
+
+    def test_refused_read_is_not_inlined(self, tmp_path, monkeypatch):
+        p = _png(tmp_path)
+        monkeypatch.setattr(prompt_blocks, "safe_read_file_bytes", lambda raw: None)
+
+        blocks = build_prompt_blocks(f"look at {p}")
+
+        # No image block -- and the path STAYS in the text rather than being
+        # silently deleted, so a tool-capable agent can still choose to open it.
+        assert [b["type"] for b in blocks] == ["text"]
+        assert str(p) in blocks[0]["text"]
+
+    def test_gate_receives_the_path(self, tmp_path, monkeypatch):
+        p = _png(tmp_path)
+        seen: list[str] = []
+
+        def _spy(raw: str) -> bytes:
+            seen.append(raw)
+            return _PNG
+
+        monkeypatch.setattr(prompt_blocks, "safe_read_file_bytes", _spy)
+        build_prompt_blocks(f"look at {p}")
+        assert seen == [str(p)]
+
+    def test_encoded_bytes_come_from_the_gate(self, tmp_path, monkeypatch):
+        """The wire payload is the gate's output, not a second unguarded read."""
+        p = _png(tmp_path)
+        monkeypatch.setattr(prompt_blocks, "safe_read_file_bytes", lambda raw: b"FROM GATE")
+
+        blocks = build_prompt_blocks(f"look at {p}")
+
+        assert base64.b64decode(blocks[1]["data"]) == b"FROM GATE"
+
+
+class TestPlatformPathGrammar:
+    """The path grammar is host-specific on purpose."""
+
+    def test_posix_pattern_matches_posix_paths(self):
+        assert prompt_blocks._POSIX_PATH_RE.search("/tmp/a.png") is not None
+
+    def test_posix_pattern_ignores_windows_shapes(self):
+        r"""Prose like ``C:\shots\logo.png`` must NOT be a candidate on POSIX.
+
+        Backslash and ``:`` are legal POSIX filename characters, so one merged
+        pattern would make a merely-MENTIONED Windows path matchable -- and a
+        file with that literal name can exist in the CWD, which would inline
+        something the user only talked about.
+        """
+        assert prompt_blocks._POSIX_PATH_RE.search(r"C:\shots\logo.png") is None
+        assert prompt_blocks._POSIX_PATH_RE.search(r"\\host\share\logo.png") is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            r"C:\Users\alice\AppData\Local\Temp\tmpabc.png",
+            r"C:/Users/alice/AppData/Local/Temp/tmpabc.png",
+            r"\\fileserver\team\diagram.jpg",
+        ],
+    )
+    def test_windows_pattern_matches_native_absolute_paths(self, text):
+        """The shapes the gateway actually produces on Windows."""
+        assert prompt_blocks._WINDOWS_PATH_RE.search(text) is not None
+
+    def test_windows_pattern_requires_an_absolute_path(self):
+        assert prompt_blocks._WINDOWS_PATH_RE.search(r"shots\logo.png") is None
+
+    def test_active_pattern_follows_the_host(self):
+        expected = (
+            prompt_blocks._WINDOWS_PATH_RE if os.name == "nt" else prompt_blocks._POSIX_PATH_RE
+        )
+        assert prompt_blocks._PATH_RE is expected
+
+    def test_natively_produced_path_is_inlined_on_this_host(self, tmp_path):
+        """End-to-end guard against the gap Windows CI exposed.
+
+        ``tmp_path`` yields backslash paths on Windows, which the POSIX-only
+        grammar could not match -- so every image silently stayed prose on a
+        supported, CI-tested platform.
+        """
+        p = _png(tmp_path, "native.png")
+        blocks = build_prompt_blocks(f"see {p}")
+        assert [b["type"] for b in blocks] == ["text", "image"]
+
+
+class TestPathsAdjacentToUrls:
+    r"""A URL in the message must not swallow the appended image path.
+
+    ``slack/events.py`` emits ``"<user text>\n<image path>"``. With ``\s`` in the
+    character class (which matches ``\n``) the leading URL chained across the
+    newline into the path, so ``see https://x.com/d\n/tmp/a.png`` matched as the
+    single nonexistent path ``//x.com/d\n/tmp/a.png`` -- meaning ANY Slack
+    message containing a link silently lost its image, and the temp file was
+    then deleted at end of turn.
+    """
+
+    def test_url_then_newline_then_path(self, tmp_path):
+        p = _png(tmp_path)
+        blocks = build_prompt_blocks(f"see https://example.com/docs\n{p}")
+        assert [b["type"] for b in blocks] == ["text", "image"]
+
+    def test_url_then_space_then_path(self, tmp_path):
+        """Same defect on one line -- the newline-only fix does not cover this."""
+        p = _png(tmp_path)
+        blocks = build_prompt_blocks(f"see https://example.com/docs {p}")
+        assert [b["type"] for b in blocks] == ["text", "image"]
+
+    def test_url_ending_in_an_image_suffix_is_not_a_path(self):
+        """A remote URL is not a local file and must not even be a candidate."""
+        assert _POSIX_PATH_RE.search("see https://example.com/logo.png") is None
+
+    def test_multiple_urls_do_not_break_a_trailing_path(self, tmp_path):
+        p = _png(tmp_path)
+        text = f"a https://x.com/1 b http://y.com/2/z\n{p}"
+        blocks = build_prompt_blocks(text)
+        assert [b["type"] for b in blocks] == ["text", "image"]
+
+    def test_two_images_after_a_url_both_survive(self, tmp_path):
+        a = _png(tmp_path, "a.png")
+        b = _png(tmp_path, "b.png")
+        blocks = build_prompt_blocks(f"ref https://x.com/d\n{a}\n{b}")
+        assert [x["type"] for x in blocks] == ["text", "image", "image"]
+
+    def test_newline_is_not_part_of_a_path(self):
+        r"""``\n`` must never be inside a captured path."""
+        m = _POSIX_PATH_RE.search("/tmp/one\n/tmp/two.png")
+        assert m is not None and "\n" not in m.group(1)
+
+    def test_filename_with_spaces_still_matches(self, tmp_path):
+        """Horizontal whitespace stays allowed -- this is why `\\s` was used."""
+        p = _png(tmp_path, "my shot.png")
+        blocks = build_prompt_blocks(f"look at {p}")
+        assert [b["type"] for b in blocks] == ["text", "image"]
+
+    def test_path_inside_markdown_image_syntax(self, tmp_path):
+        """The dashboard emits `![image](<path>)`."""
+        p = _png(tmp_path)
+        blocks = build_prompt_blocks(f"![image]({p})")
+        assert [b["type"] for b in blocks] == ["text", "image"]

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -24,7 +24,7 @@ import json
 import os
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from spawn_test_helpers import strip_spawn_shim
@@ -784,6 +784,52 @@ async def test_prompt_resets_turn_done_when_send_request_fails():
         await gen.__anext__()  # send_request fires on first iteration
 
     # Recovered: turn no longer active, so the handle is reusable.
+    assert handle.is_turn_active is False
+
+
+@pytest.mark.asyncio
+async def test_prompt_resets_turn_done_when_cancelled():
+    """Same guard, but for cancellation — which is NOT an ``Exception``.
+
+    ``asyncio.CancelledError`` derives from ``BaseException``, so an
+    ``except Exception`` guard lets it through and leaves ``_turn_done`` cleared
+    forever: ``is_turn_active`` reports True permanently and every later
+    ``prompt()`` on the handle is rejected as already active. A turn timing out
+    or being cancelled is routine, so this must recover.
+    """
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    rt.send_request = AsyncMock(side_effect=asyncio.CancelledError())
+
+    gen = handle.prompt("hi", timeout=3.0)
+    with pytest.raises(asyncio.CancelledError):
+        await gen.__anext__()
+
+    assert handle.is_turn_active is False
+
+
+@pytest.mark.asyncio
+async def test_prompt_resets_turn_done_when_cancelled_while_building_blocks():
+    """Cancellation at the prompt-ASSEMBLY await, not the send await.
+
+    Image reads are offloaded with ``asyncio.to_thread``, which adds a second
+    cancellation point inside the turn-state guard — and a longer-lived one,
+    since it does file I/O. Cancelling there must not wedge the handle either.
+    """
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    rt.send_request = AsyncMock(return_value=1)
+
+    with patch(
+        "kiro_crew.acp.session_handle.build_prompt_blocks",
+        side_effect=asyncio.CancelledError(),
+    ):
+        gen = handle.prompt("hi", timeout=3.0)
+        with pytest.raises(asyncio.CancelledError):
+            await gen.__anext__()
+
     assert handle.is_turn_active is False
 
 

--- a/test/test_messaging_attachments.py
+++ b/test/test_messaging_attachments.py
@@ -1,0 +1,503 @@
+"""Channel-neutral attachment ingestion.
+
+Focused on the guarantees that did NOT exist when this logic lived inside
+``slack/files.py``:
+
+* size enforced on the DOWNLOADED bytes, not on channel-reported metadata
+* image content validated by signature, with the true type winning over a
+  mislabelled one
+* a per-message attachment cap
+* rejections returned to the caller instead of silently swallowed
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+
+import pytest
+
+from kiro_crew.messaging import attachments
+from kiro_crew.messaging.attachments import (
+    AUDIO,
+    DOCUMENT,
+    IMAGE,
+    OTHER,
+    TEXT,
+    VIDEO,
+    Attachment,
+    IngestLimits,
+    classify,
+    cleanup,
+    ingest_attachments,
+    safe_suffix,
+    sniff_image_mime,
+)
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+_GIF = b"GIF89a" + b"\x00" * 32
+_BMP = b"BM" + b"\x00" * 32
+_WEBP = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 16
+
+
+def _writer(content: bytes):
+    """A download callback that writes fixed bytes."""
+
+    async def _download(url: str, dest: str) -> None:
+        with open(dest, "wb") as fh:
+            fh.write(content)
+
+    return _download
+
+
+async def _boom(url: str, dest: str) -> None:
+    raise RuntimeError("network error")
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        "mime,expected",
+        [
+            ("image/png", IMAGE),
+            ("image/jpeg", IMAGE),
+            ("text/plain", TEXT),
+            ("application/json", TEXT),
+            ("audio/webm", AUDIO),
+            ("video/mp4", VIDEO),
+            ("application/octet-stream", OTHER),
+            ("", OTHER),
+        ],
+    )
+    def test_mimetype_mapping(self, mime, expected):
+        assert classify(mime) == expected
+
+    def test_documents_detected_by_filename(self):
+        assert classify("application/pdf", "report.pdf") == DOCUMENT
+
+    def test_svg_is_not_an_image(self):
+        """SVG is scriptable XML; the ACP encoder cannot inline it."""
+        assert classify("image/svg+xml") == OTHER
+
+
+class TestSafeSuffix:
+    @pytest.mark.parametrize(
+        "hint,expected",
+        [
+            ("png", ".png"),
+            ("PNG", ".PNG"),
+            ("", ".bin"),
+            ("../../etc/passwd", ".etcpasswd"),
+            ("tar.gz", ".targz"),
+            ("a b/c", ".abc"),
+        ],
+    )
+    def test_never_yields_a_path_component(self, hint, expected):
+        out = safe_suffix(hint)
+        assert out == expected
+        assert "/" not in out and ".." not in out.strip(".")
+
+
+class TestSniffImageMime:
+    @pytest.mark.parametrize(
+        "content,expected",
+        [
+            (_PNG, "image/png"),
+            (_JPEG, "image/jpeg"),
+            (_GIF, "image/gif"),
+            (_BMP, "image/bmp"),
+            (_WEBP, "image/webp"),
+        ],
+    )
+    def test_detects_real_types(self, tmp_path, content, expected):
+        p = tmp_path / "f"
+        p.write_bytes(content)
+        assert sniff_image_mime(str(p)) == expected
+
+    def test_non_image_returns_none(self, tmp_path):
+        p = tmp_path / "f"
+        p.write_bytes(b"#!/bin/sh\nrm -rf /\n")
+        assert sniff_image_mime(str(p)) is None
+
+    def test_riff_that_is_not_webp_is_rejected(self, tmp_path):
+        """A RIFF/WAVE audio file shares the 'RIFF' prefix with WebP."""
+        p = tmp_path / "a.webp"
+        p.write_bytes(b"RIFF" + b"\x00\x00\x00\x00" + b"WAVE" + b"\x00" * 16)
+        assert sniff_image_mime(str(p)) is None
+
+
+@pytest.mark.asyncio
+class TestIngestAttachments:
+    async def test_image_is_downloaded_and_returned(self):
+        result = await ingest_attachments(
+            [Attachment(name="a.png", mimetype="image/png", size=40, url="u", suffix_hint="png")],
+            download=_writer(_PNG),
+            source="test",
+        )
+        assert len(result.image_paths) == 1
+        assert result.rejections == []
+        assert os.path.exists(result.image_paths[0])
+        cleanup(result.temp_paths)
+
+    async def test_size_enforced_on_downloaded_bytes_not_metadata(self):
+        """The hole this closes: Slack trusted the channel's `size`, which
+        defaults to 0 when absent, so a lying or missing value bypassed the cap
+        entirely. The post-download check is the one that actually holds."""
+        result = await ingest_attachments(
+            # Metadata claims 0 bytes; the real payload is far over the cap.
+            [Attachment(name="a.png", mimetype="image/png", size=0, url="u", suffix_hint="png")],
+            download=_writer(_PNG + b"\x00" * 4096),
+            source="test",
+            limits=IngestLimits(max_image_bytes=64),
+        )
+        assert result.image_paths == []
+        assert any("too large" in r for r in result.rejections)
+
+    async def test_non_image_masquerading_as_image_is_rejected(self):
+        result = await ingest_attachments(
+            [Attachment(name="evil.png", mimetype="image/png", size=20, url="u", suffix_hint="png")],
+            download=_writer(b"#!/bin/sh\nrm -rf /\n"),
+            source="test",
+        )
+        assert result.image_paths == []
+        assert any("not a readable image" in r for r in result.rejections)
+
+    async def test_mislabelled_but_valid_image_still_works(self):
+        """A real JPEG the channel called image/png must NOT be rejected -- and
+        the temp file is retyped so the ACP encoder emits truthful mimeType."""
+        result = await ingest_attachments(
+            [Attachment(name="a.png", mimetype="image/png", size=40, url="u", suffix_hint="png")],
+            download=_writer(_JPEG),
+            source="test",
+        )
+        assert len(result.image_paths) == 1
+        path = result.image_paths[0]
+        # The declared suffix is REPLACED, not appended: "x.png.jpg" would still
+        # claim to be a PNG, which defeats the point of retyping.
+        assert path.endswith(".jpg")
+        assert ".png" not in path
+        cleanup(result.temp_paths)
+
+    async def test_correctly_labelled_image_keeps_its_path(self):
+        """No rename when the declared suffix already matches the real type."""
+        result = await ingest_attachments(
+            [Attachment(name="a.png", mimetype="image/png", size=40, url="u", suffix_hint="png")],
+            download=_writer(_PNG),
+            source="test",
+        )
+        assert result.image_paths[0].endswith(".png")
+        cleanup(result.temp_paths)
+
+    async def test_text_is_inlined_and_redacted(self):
+        secret = "ghp_" + "a" * 36
+        result = await ingest_attachments(
+            [Attachment(name="n.txt", mimetype="text/plain", size=50, url="u")],
+            download=_writer(f"token={secret}\nhello".encode()),
+            source="test",
+        )
+        assert len(result.text_blocks) == 1
+        block = result.text_blocks[0]
+        assert "[File: n.txt]" in block and "hello" in block
+        assert secret not in block
+
+    async def test_text_is_truncated(self):
+        result = await ingest_attachments(
+            [Attachment(name="n.txt", mimetype="text/plain", size=10_000, url="u")],
+            download=_writer(b"x" * 5000),
+            source="test",
+            limits=IngestLimits(max_text_inject=100),
+        )
+        assert "truncated" in result.text_blocks[0]
+
+    async def test_video_is_rejected_with_a_reason(self):
+        """Out of scope is not the same as silently dropped."""
+        result = await ingest_attachments(
+            [Attachment(name="clip.mp4", mimetype="video/mp4", size=99, url="u")],
+            download=_writer(b"\x00"),
+            source="test",
+        )
+        assert result.image_paths == [] and result.text_blocks == []
+        assert any("video is not supported" in r for r in result.rejections)
+
+    async def test_unsupported_type_is_rejected_with_a_reason(self):
+        result = await ingest_attachments(
+            [Attachment(name="x.bin", mimetype="application/octet-stream", size=9, url="u")],
+            download=_writer(b"\x00"),
+            source="test",
+        )
+        assert any("unsupported type" in r for r in result.rejections)
+
+    async def test_missing_url_is_reported(self):
+        result = await ingest_attachments(
+            [Attachment(name="a.png", mimetype="image/png", size=10, url="")],
+            download=_writer(_PNG),
+            source="test",
+        )
+        assert any("no download URL" in r for r in result.rejections)
+
+    async def test_download_failure_is_reported_and_leaves_no_temp_file(self, tmp_path, monkeypatch):
+        import tempfile as _tempfile
+
+        created: list[str] = []
+        real_mkstemp = _tempfile.mkstemp
+
+        def _tracking_mkstemp(*a, **kw):
+            fd, path = real_mkstemp(*a, **kw)
+            created.append(path)
+            return fd, path
+
+        monkeypatch.setattr(_tempfile, "mkstemp", _tracking_mkstemp)
+
+        result = await ingest_attachments(
+            [Attachment(name="a.png", mimetype="image/png", size=10, url="u")],
+            download=_boom,
+            source="test",
+        )
+        assert result.image_paths == []
+        assert any("download failed" in r for r in result.rejections)
+        assert [p for p in created if os.path.exists(p)] == []
+
+    async def test_audio_skipped_by_default(self):
+        result = await ingest_attachments(
+            [Attachment(name="v.webm", mimetype="audio/webm", size=10, url="u")],
+            download=_writer(b"\x00"),
+            source="test",
+        )
+        assert result.audio_paths == []
+        assert result.rejections == []  # transcribed upstream, not a rejection
+
+    async def test_audio_returned_when_opted_in(self):
+        result = await ingest_attachments(
+            [Attachment(name="v.webm", mimetype="audio/webm", size=10, url="u")],
+            download=_writer(b"\x00" * 10),
+            source="test",
+            handle_audio=True,
+        )
+        assert len(result.audio_paths) == 1
+        cleanup(result.temp_paths)
+
+    async def test_attachment_count_is_capped_and_reported(self):
+        atts = [
+            Attachment(name=f"a{i}.png", mimetype="image/png", size=40, url="u", suffix_hint="png")
+            for i in range(5)
+        ]
+        result = await ingest_attachments(
+            atts,
+            download=_writer(_PNG),
+            source="test",
+            limits=IngestLimits(max_attachments=2),
+        )
+        assert len(result.image_paths) == 2
+        assert any("more attachment(s) ignored" in r for r in result.rejections)
+        cleanup(result.temp_paths)
+
+    async def test_one_bad_attachment_does_not_lose_the_others(self):
+        atts = [
+            Attachment(name="bad.png", mimetype="image/png", size=10, url=""),
+            Attachment(name="ok.png", mimetype="image/png", size=40, url="u", suffix_hint="png"),
+        ]
+        result = await ingest_attachments(atts, download=_writer(_PNG), source="test")
+        assert len(result.image_paths) == 1
+        assert len(result.rejections) == 1
+        cleanup(result.temp_paths)
+
+    async def test_temp_paths_covers_images_and_audio(self):
+        result = await ingest_attachments(
+            [
+                Attachment(name="a.png", mimetype="image/png", size=40, url="u", suffix_hint="png"),
+                Attachment(name="v.webm", mimetype="audio/webm", size=10, url="u"),
+            ],
+            download=_writer(_PNG),
+            source="test",
+            handle_audio=True,
+        )
+        assert len(result.temp_paths) == 2
+        cleanup(result.temp_paths)
+        assert [p for p in result.temp_paths if os.path.exists(p)] == []
+
+
+@pytest.mark.asyncio
+class TestChannelDeclaredAudio:
+    """A channel may treat a non-``audio/*`` type as audio.
+
+    Slack ships voice memos as ``video/webm``. Its transcription path has always
+    known that; the generic classifier did not, so the same file was transcribed
+    AND rejected as unsupported video, putting a contradictory note next to the
+    transcript the user actually got.
+    """
+
+    async def test_declared_audio_is_not_rejected_as_video(self):
+        result = await ingest_attachments(
+            [Attachment(name="memo.webm", mimetype="video/webm", size=10, url="u")],
+            download=_writer(b"\x00" * 10),
+            source="test",
+            audio_mimetypes=("audio/", "video/webm"),
+        )
+        assert result.rejections == []
+        assert result.audio_paths == []  # handle_audio=False -> silently skipped
+        assert result.text_blocks == []
+
+    async def test_same_type_is_still_video_without_the_override(self):
+        """The override is opt-in: a real video upload is still rejected."""
+        result = await ingest_attachments(
+            [Attachment(name="clip.webm", mimetype="video/webm", size=10, url="u")],
+            download=_writer(b"\x00" * 10),
+            source="test",
+        )
+        assert any("video is not supported" in r for r in result.rejections)
+
+    async def test_declared_audio_can_be_returned_for_transcription(self):
+        result = await ingest_attachments(
+            [Attachment(name="memo.webm", mimetype="video/webm", size=10, url="u")],
+            download=_writer(b"\x00" * 10),
+            source="test",
+            handle_audio=True,
+            audio_mimetypes=("audio/", "video/webm"),
+        )
+        assert len(result.audio_paths) == 1
+        cleanup(result.temp_paths)
+
+    async def test_other_video_types_are_unaffected_by_the_override(self):
+        result = await ingest_attachments(
+            [Attachment(name="clip.mp4", mimetype="video/mp4", size=10, url="u")],
+            download=_writer(b"\x00" * 10),
+            source="test",
+            audio_mimetypes=("audio/", "video/webm"),
+        )
+        assert any("video is not supported" in r for r in result.rejections)
+
+
+class TestClassifyOverride:
+    def test_override_wins_over_the_video_prefix(self):
+        assert classify("video/webm", audio_mimetypes=("video/webm",)) == AUDIO
+
+    def test_without_override_it_is_video(self):
+        assert classify("video/webm") == VIDEO
+
+    def test_override_does_not_leak_to_other_video_types(self):
+        assert classify("video/mp4", audio_mimetypes=("video/webm",)) == VIDEO
+
+
+@pytest.mark.asyncio
+class TestBlockingWorkLeavesTheEventLoop:
+    """Filesystem work must not run on the gateway's event loop thread.
+
+    ``ingest_attachments`` is awaited directly from the Slack Socket Mode
+    callback (``_on_event`` -> ``_route_message`` -> ``process_slack_files``),
+    so a synchronous call here stalls EVERY other session's streaming. TMPDIR is
+    not guaranteed to be local either -- a network- or FUSE-backed temp dir can
+    block for a long time.
+
+    These assert the invariant directly (the call runs on a DIFFERENT thread than
+    the loop) rather than asserting it was wrapped in ``to_thread``, so they
+    cannot be satisfied by a wrapper that is later unwrapped.
+    """
+
+    async def test_temp_file_creation_is_off_the_loop_thread(self, monkeypatch):
+        loop_thread = threading.get_ident()
+        observed: list[int] = []
+        real_make = attachments._make_temp
+
+        # Spy on THIS module's helper, not tempfile.mkstemp: patching the module
+        # attribute would also catch the SEL audit subsystem's own .sel_hmac_*.tmp
+        # write, which is a separate (pre-existing, repo-wide) call site and not
+        # what this test is about.
+        def _spy(suffix: str) -> str:
+            observed.append(threading.get_ident())
+            return real_make(suffix)
+
+        monkeypatch.setattr(attachments, "_make_temp", _spy)
+        result = await ingest_attachments(
+            [Attachment(name="a.png", mimetype="image/png", size=40, url="u", suffix_hint="png")],
+            download=_writer(_PNG),
+            source="test",
+        )
+        cleanup(result.temp_paths)
+
+        assert observed, "temp creation was never called"
+        assert loop_thread not in observed, "temp creation ran on the event loop thread"
+
+    async def test_text_read_is_off_the_loop_thread(self, monkeypatch):
+        loop_thread = threading.get_ident()
+        observed: list[int] = []
+        real_reader = attachments._read_text_file
+
+        def _spy(path: str, limit: int) -> str:
+            observed.append(threading.get_ident())
+            return real_reader(path, limit)
+
+        monkeypatch.setattr(attachments, "_read_text_file", _spy)
+        await ingest_attachments(
+            [Attachment(name="n.txt", mimetype="text/plain", size=20, url="u")],
+            download=_writer(b"hello"),
+            source="test",
+        )
+
+        assert observed, "text read was never called"
+        assert loop_thread not in observed, "text read ran on the event loop thread"
+
+    async def test_image_signature_sniff_is_off_the_loop_thread(self, monkeypatch):
+        loop_thread = threading.get_ident()
+        observed: list[int] = []
+        real_sniff = attachments.sniff_image_mime
+
+        def _spy(path: str):
+            observed.append(threading.get_ident())
+            return real_sniff(path)
+
+        monkeypatch.setattr(attachments, "sniff_image_mime", _spy)
+        result = await ingest_attachments(
+            [Attachment(name="a.png", mimetype="image/png", size=40, url="u", suffix_hint="png")],
+            download=_writer(_PNG),
+            source="test",
+        )
+        cleanup(result.temp_paths)
+
+        assert observed, "sniff was never called"
+        assert loop_thread not in observed, "signature sniff ran on the event loop thread"
+
+    async def test_the_loop_stays_responsive_during_a_slow_blocking_step(self, monkeypatch):
+        """End-to-end: a concurrent task keeps running while a SLOW read happens.
+
+        The blocking step is given real duration (a synchronous sleep inside the
+        text reader). Offloaded, the ticker keeps advancing; inline, the loop is
+        frozen for the whole 150ms and the tick count barely moves. Without the
+        induced delay this test would pass either way, since the awaited download
+        yields to the loop on its own.
+        """
+        real_reader = attachments._read_text_file
+
+        def _slow_read(path: str, limit: int) -> str:
+            time.sleep(0.15)  # blocking, as a large/slow filesystem read would be
+            return real_reader(path, limit)
+
+        monkeypatch.setattr(attachments, "_read_text_file", _slow_read)
+
+        ticks = 0
+        stop = False
+
+        async def _ticker():
+            nonlocal ticks
+            while not stop:
+                ticks += 1
+                await asyncio.sleep(0.005)
+
+        t = asyncio.create_task(_ticker())
+        await asyncio.sleep(0.01)
+        before = ticks
+
+        await ingest_attachments(
+            [Attachment(name="n.txt", mimetype="text/plain", size=20, url="u")],
+            download=_writer(b"hello"),
+            source="test",
+        )
+
+        during = ticks - before
+        stop = True
+        await t
+
+        # 150ms of blocking work at a 5ms tick interval leaves room for ~20+
+        # ticks when offloaded; a frozen loop yields approximately none.
+        assert during >= 5, f"loop was starved during the blocking read (ticks={during})"

--- a/test/test_slack_files.py
+++ b/test/test_slack_files.py
@@ -45,7 +45,7 @@ class TestSafeSuffix:
 class TestProcessSlackFiles:
     @pytest.mark.asyncio
     async def test_image_downloaded_to_temp(self):
-        orch = _make_orch(b"\x89PNG fake image data")
+        orch = _make_orch(b"\x89PNG\r\n\x1a\nfake image data")
         files = [
             {
                 "mimetype": "image/png",
@@ -76,7 +76,9 @@ class TestProcessSlackFiles:
         ]
         image_paths, text_blocks = await process_slack_files(orch, files)
         assert image_paths == []
-        assert text_blocks == []
+        # Reported, not silently skipped: a dropped attachment with no
+        # explanation is the defect this change fixes.
+        assert any("too large" in b for b in text_blocks)
 
     @pytest.mark.asyncio
     async def test_text_file_content_injected(self):
@@ -183,6 +185,8 @@ class TestProcessSlackFiles:
         ]
         image_paths, text_blocks = await process_slack_files(orch, files)
         assert image_paths == []
+        # Audio is transcribed on a separate upstream path, so it is skipped
+        # here SILENTLY -- this is not a rejection the user needs to see.
         assert text_blocks == []
         orch.slack.download_file.assert_not_called()
 
@@ -192,12 +196,14 @@ class TestProcessSlackFiles:
         files = [{"mimetype": "image/png", "name": "no_url.png", "size": 100}]
         image_paths, text_blocks = await process_slack_files(orch, files)
         assert image_paths == []
-        assert text_blocks == []
+        # A missing URL is now REPORTED rather than silently swallowed: a
+        # dropped attachment with no explanation is the defect being fixed.
+        assert any("no download URL" in b for b in text_blocks)
 
     @pytest.mark.asyncio
     async def test_url_private_fallback(self):
         """url_private used when url_private_download is absent."""
-        orch = _make_orch(b"\x89PNG")
+        orch = _make_orch(b"\x89PNG\r\n\x1a\n")
         files = [
             {
                 "mimetype": "image/png",
@@ -230,7 +236,8 @@ class TestProcessSlackFiles:
         ]
         image_paths, text_blocks = await process_slack_files(orch, files)
         assert image_paths == []
-        assert text_blocks == []
+        # Reported, not silently skipped.
+        assert any("download failed" in b for b in text_blocks)
 
     @pytest.mark.asyncio
     async def test_text_temp_file_cleaned(self):
@@ -243,7 +250,12 @@ class TestProcessSlackFiles:
 
         def tracking_mkstemp(**kwargs):  # type: ignore[no-untyped-def]
             fd, path = original_mkstemp(**kwargs)
-            created_paths.append(path)
+            # Patching the module attribute intercepts EVERY mkstemp caller in
+            # the process, including unrelated subsystems (the SEL audit writes
+            # .sel_hmac_*.tmp). Track only this attachment's temp file so the
+            # count stays a statement about the code under test.
+            if path.endswith(".txt"):
+                created_paths.append(path)
             return fd, path
 
         orch = _make_orch(b"hello world")
@@ -256,7 +268,10 @@ class TestProcessSlackFiles:
                 "size": 11,
             }
         ]
-        with patch("kiro_crew.slack.files.tempfile.mkstemp", side_effect=tracking_mkstemp):
+        # Temp handling now lives in the channel-neutral ingestion layer.
+        with patch(
+            "kiro_crew.messaging.attachments.tempfile.mkstemp", side_effect=tracking_mkstemp
+        ):
             await process_slack_files(orch, files)
         assert len(created_paths) == 1
         assert not os.path.exists(created_paths[0])
@@ -299,7 +314,7 @@ class TestProcessSlackFiles:
     @pytest.mark.asyncio
     async def test_mixed_files(self):
         """Multiple file types in one message."""
-        img_data = b"\x89PNG"
+        img_data = b"\x89PNG\r\n\x1a\n"
         call_count = 0
 
         async def _download(url: str, dest: str) -> None:


### PR DESCRIPTION
Part 1 of #923. Discord's adapter follows in a second PR; this one makes images work everywhere and builds the seam that adapter plugs into.

## Problem

Images sent from **any** surface never reached the model as vision input.

`AcpProvider.start()` replaces `AcpClient` with `AcpSessionProvider` (`providers/acp.py:624`), and `AcpSessionHandle.prompt()` hardcoded a single text block (`acp/session_handle.py:396`). The only code that built an ACP image block lived on `AcpClient` — the path that had just been replaced (`acp/client.py:3644`).

So Slack downloaded an image to a temp file and passed the **filesystem path as prose**. The dashboard did the same via `![image](path)`. The model could only see the picture by opening that path with a tool, and only while the temp file survived — Slack deletes it when the turn ends, so replaying history yields a dead path.

## Why it matters

Sending a screenshot is one of the most natural things a user does in a chat channel. It silently did nothing useful, with no error and no explanation.

## Fix (symptom → root cause → change)

The symptom was "the model ignores my image". The root cause was two prompt paths where only the dead one could encode images. The change makes `prompt_blocks.build_prompt_blocks()` the single builder used by **both**, so they cannot drift apart again.

`AcpSessionHandle.prompt()` now emits real image blocks, gated on `promptCapabilities.image` — which the handshake previously parsed and threw away (`acp/runtime.py` kept only `loadSession`). When the agent does not advertise image support, the path stays in the text as a tool-openable reference rather than being dropped, which is a strictly better fallback than silence.

Two further defects surfaced while writing the tests:

- **Multi-image messages lost every image.** The legacy regex was greedy with `\s` in its character class, so `/tmp/a.png and /tmp/b.png` matched as ONE span ending at the final `.png` — not a file, so all images were skipped. This was live on Slack, not theoretical. Fixed with a non-greedy quantifier; filenames containing spaces still work.
- **`.svg` was unreachable by accident.** It sat in the media map while the regex omitted it. Now excluded deliberately and documented: scriptable XML, not a raster format.

## Shared ingestion layer

`messaging/attachments.py` owns everything that happens *after* bytes land — classification, caps, magic-byte validation, redaction, document extraction via `doc_parser`, SEL audit, temp cleanup — behind a channel-supplied download callback. Host allowlisting and auth deliberately stay channel-side, because only the channel knows them (Slack needs a bearer token; Discord needs none but signed CDN URLs).

`slack/files.py` becomes a thin adapter over it and keeps its `(image_paths, text_blocks)` contract, so `events.py` and the busy-message queue are untouched. **Its existing test suite is the evidence the migration is faithful.**

Three holes closed relative to the original Slack implementation:

| Hole | Before | Now |
|---|---|---|
| Size cap | trusted the channel's `size`, which defaults to `0` when absent — a missing or dishonest value bypassed the cap entirely | re-checked on the **downloaded bytes** |
| Content type | filename/metadata only | validated by signature; the **true** type wins, so a real JPEG mislabelled `image/png` still works and its temp file is retyped so the encoder emits truthful `mimeType`, while a script claiming to be a PNG is rejected (CWE-434) |
| Count | unbounded — one message could trigger unlimited downloads | per-message cap |

Rejections are **returned**, not swallowed. Silently dropping an attachment is the defect this work exists to fix. Video is rejected with a visible reason rather than ignored: kiro-cli advertises `promptCapabilities.image` only (`docs/kiro-cli/acp.md:135-146`), and the models behind it do not accept video.

The security-posture allowlist moved with the code: `messaging/attachments.py` is registered as inbound sanitisation, and `slack/files.py` was removed because it no longer calls a redactor. The drift guard caught that staleness on its own, which is a good sign it works.

## Tests

- **`test_acp_prompt_blocks.py` (17)** — block shapes and ordering, the capability gate's false branch, over-cap fallback, multi-image, same-path dedupe, every supported suffix → mime, SVG exclusion, bare filenames not probed as paths, directory-with-image-suffix not read
- **`test_messaging_attachments.py` (38)** — post-download size enforcement with lying metadata, masquerading content rejected, mislabelled-but-valid retyped, RIFF/WAVE not mistaken for WebP, redaction before truncation, video/unsupported rejection wording, count cap, no temp-file leak on download failure, one bad attachment not losing the others, `safe_suffix` never yielding a path component
- **`test_slack_files.py`** — three assertions updated where silence deliberately became a visible rejection (missing URL, too-large, download failure), and the PNG fixtures now carry real 8-byte signatures instead of the `\x89PNG` shorthand. The audio case stays silent on purpose: audio is transcribed on a separate upstream path.

Full backend suite: **22,084 passed**. `isort` / `flake8` clean; `mypy` clean across 565 files.

## Manual verification

N/A for UI — backend only, no user-visible surface changed, so no screenshots.

The wire shape was verified directly rather than only through mocks: a real 1×1 PNG produces `{"type":"image","mimeType":"image/png"}` whose base64 round-trips to the original bytes; the capability-gated path preserves the reference as text; over-cap and missing-file cases fall back without dropping the reference.

## Pre-existing failures (not from this PR)

Verified on a clean `origin/main` worktree, all in files this PR does not touch:

- `test_sandbox_*`, `test_source_providers`, `test_issue_radar_gh_bin`, `test_beacon`, `test_cli` pidfd, `test_deploy_round30_fixes` hardlink — host capability (`unshare` unavailable, hardlink `EPERM`) and host install-path assumptions.
- `test_telegram.py::test_concurrent_queue_adds_share_one_receipt` — genuinely flaky concurrency race; fails on clean `main` too (2/5 there, 4/5 here across isolated repeats). No Telegram or queue code is touched by this PR.

**Correction:** an earlier revision of this description listed `test_slack_files.py::test_text_temp_file_cleaned` as a pre-existing flake. That was wrong. It failed in CI with `ModuleNotFoundError: No module named 'kiro_crew.slack.files.tempfile'` because this PR moved temp handling into the neutral layer, so the patch target stopped existing — the failure was mine. The same root cause explains the local symptom: `patch("...slack.files.tempfile.mkstemp")` reaches the *global* `tempfile` module, so the "exactly 1 temp file" assertion was counting unrelated subsystems' temp files, including the SEL audit's. Now targets the neutral layer and scopes the count to the attachment under test. The file passes in full.

## Review round (all four findings were real)

Each was validated against the code with file:line evidence before any change; none was rebutted. Two were fixed with a different remedy than prescribed, for reasons stated in the [disposition comment](https://github.com/kirodotdev/KiroCrew/pull/974#issuecomment-5147553292).

- **Image reads now go through `hooks.safe_read_file_bytes`.** The raw `read_bytes()` was inherited from the old encoder, but this PR changed that code from dead to live, so the gate is this PR's responsibility. Paths come from message text and are therefore user-influenced. Did *not* make the builder `async`: the gate is synchronous and so was the read it replaces, so awaiting would churn both call sites while changing nothing about blocking.
- **Document parsing moved off the event loop** via `asyncio.to_thread`. Traced with no thread boundary: Socket Mode → `_route_message` → `ingest_attachments` → `extract_text`, so a large PDF stalled every session. Deliberately not `subprocess_executor()`, whose workers are documented as reserved for PTY teardown and orphan reaping.
- **Windows paths now match.** Not speculative — the Windows CI shards failed my own new tests (`assert ['text'] == ['text', 'image']`), because `tmp_path` yields `C:\...` there. Implemented platform-gated: `\` and `:` are legal POSIX filename characters, so one merged pattern would let merely-*mentioned* prose like `C:\docs\logo.png` match a real file in the CWD.
- **Slack voice memos no longer get a spurious video rejection.** Slack ships them as `video/webm` — the repo's own pre-existing `_AUDIO_MIMETYPES` already encoded that — so a transcribed memo also received an "unsupported video" note. Root cause was two sources of truth; `SLACK_AUDIO_MIMETYPES` is now defined once and `classify()` accepts a channel-declared override. The override is opt-in and scoped: `video/mp4` is still rejected, with a test pinning it.

## Follow-ups (not in scope)

- Discord adapter — PR 2 of #923. `InboundMessage.attachments` already exists and `DiscordInboundMessage` already inherits it, so no shared-dataclass change is needed.
- Telegram / Teams / Webex / WeCom adapters.
- Whether unsupported binaries should be stored-and-referenced rather than rejected.
- A retention/TTL policy for downloaded files; today cleanup is caller-driven.

