### PR TITLE
fix(install): stop cli.sh requesting the unpublished `beta` channel prefix

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -71,16 +71,19 @@ done
 FEED_BASE="${FEED_BASE%/}"
 ARTIFACT_BASE="${ARTIFACT_BASE%/}"
 
-# Users say "insider"; the release pipeline publishes that channel under the
-# `beta` prefix (see docs/release-automation.md channel naming). Map the
-# user-facing name to the storage prefix; keep the user-facing name for the
-# recorded channel file.
-case "$CHANNEL" in
-  insider) CHANNEL_PATH="beta" ;;
-  *) CHANNEL_PATH="$CHANNEL" ;;
-esac
-
 err() { echo "kirocrew-install: $*" >&2; exit 1; }
+
+# The channel name IS the storage path segment: publish-cli.yml writes
+# feed/<channel>/latest-cli.json and cli/<channel>/<version>/ using the literal
+# channel, and "beta" was renamed to "insider" everywhere including the path
+# segment (docs/release-automation.md -> "Deliberately not built"). So there is
+# no name-to-prefix mapping. Reject anything outside the known set here: a
+# typo'd channel otherwise reaches the CDN and surfaces as an opaque 403.
+case "$CHANNEL" in
+  nightly|insider|stable) ;;
+  *) err "unknown channel '$CHANNEL' (expected one of: nightly, insider, stable)" ;;
+esac
+CHANNEL_PATH="$CHANNEL"
 
 # Canonical physical path of an EXISTING directory (symlinks and `..` resolved),
 # or empty output when it cannot be resolved. Used to compare two directory

--- a/test/test_publish_feed_contract.py
+++ b/test/test_publish_feed_contract.py
@@ -480,3 +480,74 @@ def test_mac_notarize_attaches_gated_artifact_fail_closed() -> None:
     assert step["with"]["if-no-files-found"] == "error", (
         "the gated artifact upload must error when empty -- it is the publish job's sole input"
     )
+
+
+# ---------------------------------------------------------------------------
+# Installer <-> publisher channel-name agreement
+# ---------------------------------------------------------------------------
+
+CLI_INSTALLER = ROOT / "cli.sh"
+CLI_WORKFLOW = WORKFLOWS / "publish-cli.yml"
+
+# The channels the publisher accepts, as documented on its workflow_call input.
+# Kept as the single source both assertions read, so a channel added to the
+# pipeline without teaching the installer about it fails here.
+_PUBLISHED_CHANNELS = ("nightly", "insider", "stable")
+
+
+def _installer_source() -> str:
+    return CLI_INSTALLER.read_text(encoding="utf-8")
+
+
+def _installer_code() -> str:
+    """Installer source with comment lines stripped, for code-only assertions."""
+    lines = _installer_source().splitlines()
+    return "\n".join(ln for ln in lines if not ln.lstrip().startswith("#"))
+
+
+def test_publisher_documents_the_expected_channel_set() -> None:
+    """Anchor _PUBLISHED_CHANNELS to the workflow instead of duplicating it."""
+    doc = yaml.safe_load(CLI_WORKFLOW.read_text(encoding="utf-8"))
+    # PyYAML resolves the bare `on:` key to the boolean True (YAML 1.1).
+    described = doc[True]["workflow_call"]["inputs"]["channel"]["description"]
+    declared = tuple(part.strip() for part in described.split(":", 1)[1].split("|"))
+    assert declared == _PUBLISHED_CHANNELS, (
+        "publish-cli.yml's channel set changed; cli.sh's accepted channels and "
+        f"_PUBLISHED_CHANNELS must move with it (workflow says {declared})"
+    )
+
+
+def test_installer_channel_name_is_the_literal_path_segment() -> None:
+    """The installer must not remap a channel name to a different prefix.
+
+    ``publish-cli.yml`` writes ``feed/${CHANNEL}/latest-cli.json`` and
+    ``cli/${CHANNEL}/${VERSION}/`` using the literal channel, and "beta" was
+    renamed to "insider" everywhere *including* the path segment. A remap here
+    (``insider`` -> ``beta``) makes the installer request a prefix that was
+    never published: the CDN answers 403 and the user sees "channel has no
+    feed", with no hint that the channel itself is fine.
+    """
+    code = _installer_code()
+    assert re.search(r'^CHANNEL_PATH="\$CHANNEL"$', code, re.M), (
+        "cli.sh must use the channel verbatim as the storage prefix"
+    )
+    assert "beta" not in code, (
+        "cli.sh has executable code referencing a `beta` prefix; the published "
+        "path segment is `insider` (docs/release-automation.md)"
+    )
+
+
+def test_installer_rejects_an_unknown_channel_before_hitting_the_cdn() -> None:
+    """A typo'd channel must fail with the valid set, not an opaque CDN 403."""
+    src = _installer_source()
+    guard = re.search(r"^case \"\$CHANNEL\" in\n\s*([a-z|]+)\) ;;", src, re.M)
+    assert guard, "cli.sh must validate --channel against a known set"
+    assert tuple(guard.group(1).split("|")) == _PUBLISHED_CHANNELS, (
+        "cli.sh's accepted channels must match what publish-cli.yml publishes"
+    )
+    # The rejection has to name the alternatives; that message is the whole
+    # point of validating locally instead of letting the fetch 403.
+    for channel in _PUBLISHED_CHANNELS:
+        assert channel in src.split("unknown channel", 1)[1][:200], (
+            f"the unknown-channel error must list '{channel}'"
+        )


### PR DESCRIPTION
## Problem

`--channel insider` has never worked. Reported from the field:

```
$ curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel insiders
Resolving KiroCrew (insiders channel) ...
curl: (56) The requested URL returned error: 403
kirocrew-install: channel 'insiders' has no feed at .../feed/insiders/latest-cli.json (try: --channel nightly)
```

The reported invocation has a typo (`insiders`), but correcting it to `insider` fails identically — because `cli.sh` remapped the channel name onto a storage prefix that nothing publishes:

```sh
case "$CHANNEL" in
  insider) CHANNEL_PATH="beta" ;;
```

`publish-cli.yml` writes `feed/${CHANNEL}/latest-cli.json` and `cli/${CHANNEL}/${VERSION}/` using the **literal** channel name. `docs/release-automation.md` says so explicitly:

> The channel is a literal path segment (`cli/insider/…`), so there is no beta→insider name mapping. (L171-172)

> "Beta" as a channel name — **Renamed** to `insider` everywhere, including the feed path segment. (L300)

The installer's own comment cited those docs as justification for the mapping they rule out.

Live probes confirm the prefix was never published:

| path | `updates.crew.kiro.dev` | `download.crew.kiro.dev` |
|---|---|---|
| `feed/insider/latest-cli.json` | 200 (`0.1.1rc1`) | 200 |
| `feed/beta/latest-cli.json` | **403** | **403** |
| `cli/insider/0.1.1rc1/SHA256SUMS` | — | 200 |
| `cli/beta/0.1.1rc1/SHA256SUMS` | — | **403** |

The 403 surfaced as `channel 'insider' has no feed`, blaming a channel the user had spelled correctly.

## Change

1. Use the channel verbatim as the storage prefix — delete the remap.
2. Validate `--channel` against the published set before any fetch. A typo previously travelled to the CDN and came back as the same misleading "no feed" line; it now fails locally naming the three valid channels.

## Tests

Three guards appended to the existing `test_publish_feed_contract.py`:

- `test_publisher_documents_the_expected_channel_set` reads the valid set out of `publish-cli.yml`'s own `workflow_call` input description instead of duplicating it, so adding a pipeline channel without teaching the installer fails at PR time.
- `test_installer_channel_name_is_the_literal_path_segment` pins `CHANNEL_PATH="$CHANNEL"` and rejects a `beta` prefix in executable code.
- `test_installer_rejects_an_unknown_channel_before_hitting_the_cdn` asserts the guard's accepted set matches the publisher's and that the error names the alternatives.

Verified locally: 21/21 in that suite, `sh -n cli.sh` clean, flake8 + isort clean. Mutation-checked — re-introducing the `insider) CHANNEL_PATH="beta"` case fails `test_installer_channel_name_is_the_literal_path_segment`.

## Not fixed here (separate issue)

The `/cli.sh` served from the CDN is a **stale manual upload**, so this fix does not reach users until it is republished. The live copy still defaults both feed and artifact bases to the retired `d28nxu9if70cmc.cloudfront.net` — which is why that hostname appears in the report above — whereas `main` already split `FEED_BASE=updates.crew.kiro.dev` / `ARTIFACT_BASE=download.crew.kiro.dev` (#396). No workflow publishes `cli.sh` at all; `git log` on the file stops at #595. The installer will keep drifting from source until it gets a publish lane.
