### PR TITLE
fix: end assistant text with a trailing space before tool calls

### DIFF
--- a/src/kiro_crew/config/prompt-orchestrator.md
+++ b/src/kiro_crew/config/prompt-orchestrator.md
@@ -215,6 +215,7 @@ Summary: Found 2 security issues in auth.py...
 
 - Be concise. No filler, no preamble.
 - Execute tasks — don't just describe how.
+- End your text with a trailing space before you invoke a tool.
 - When asked about personal preferences, past conversations, or anything the user previously told you, ALWAYS search your memory context and lessons FIRST before answering. Never say "I don't have that information" without checking.
 - When corrected, ALWAYS save the lesson using the `learn_add` MCP tool immediately. Include what to do and what not to do.
 - For hard or long-running work, or to keep bulk data out of your context, use `spawn_run` — but not for simple steps (a couple of reads, a grep, a bit of research you can hold in context), which are faster done directly in the parent. When you do spawn, `spawn_run` is the only mechanism — do NOT use any built-in subagent or parallel execution mechanism.

--- a/src/kiro_crew/config/prompt.md
+++ b/src/kiro_crew/config/prompt.md
@@ -67,6 +67,7 @@ Skills loaded into your context describe exact syntax. Read them before using a 
 
 - Be concise. No filler, no preamble.
 - Execute tasks — don't just describe how.
+- End your text with a trailing space before you invoke a tool.
 - When asked about personal preferences, past conversations, or anything the user previously told you, ALWAYS search your memory context and lessons FIRST before answering. Never say "I don't have that information" without checking.
 - When corrected, ALWAYS save the lesson using the `learn_add` MCP tool immediately. Include what to do and what not to do.
 - Delegate to KiroCrew's `spawn_run` MCP tool for **genuinely hard or large problems** worth splitting into parallel pieces, or to keep **bulk research/output out of your own context** (large files, log dumps, wide searches) — a sub-agent absorbs the volume and returns a distilled result. Taking several steps or doing a bit of research does not by itself warrant delegation: simple work stays in the parent, even when multi-step. When you do spawn, `spawn_run` is the ONLY mechanism — do NOT use any other built-in subagent or parallel execution mechanism.

--- a/test/test_prompt_trailing_space_rule.py
+++ b/test/test_prompt_trailing_space_rule.py
@@ -1,0 +1,29 @@
+"""The shipped system prompts must keep the trailing-space-before-tool rule.
+
+``StreamRedactor`` withholds the maximal trailing run of ``_CRED_CLASS``
+characters until a terminator arrives, so assistant text ending flush on ``.``
+or ``:`` is not delivered to the client until the next chunk. When the next
+event is a tool call, that wait is the tool-argument composition time --
+measured at 36.7 s for a tool with a large argument payload, during which the
+user sees a sentence one word short and no tool pill.
+
+Whitespace is not in ``_CRED_CLASS``, so a model-emitted trailing space
+terminates the run scan and the text commits immediately. The rule reads as
+stray whitespace guidance and is exactly the kind of line a prompt rewrite
+drops, which silently reintroduces the stall -- so it is pinned by a test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "config"
+PROMPTS = ("prompt.md", "prompt-orchestrator.md")
+
+
+@pytest.mark.parametrize("name", PROMPTS)
+def test_prompt_requires_trailing_space_before_tool_calls(name: str) -> None:
+    text = (CONFIG_DIR / name).read_text(encoding="utf-8")
+    assert "trailing space before you invoke a tool" in text


### PR DESCRIPTION
## Problem

An assistant sentence stops one word short and stays that way, with a blinking
caret and no tool pill, for as long as the model takes to compose the arguments
of its next tool call. Measured over ACP with a timestamped client:

| tool call | last text chunk → `tool_call` | events in between |
|---|---|---|
| `ls /tmp` | 301 ms | zero |
| `fs_write`, ~1,000 words | **36,676 ms** | zero |

At 301 ms this is imperceptible. At 36.7 s the user is looking at a truncated
sentence and no indication that anything is happening.

## Why it matters

It fires on **every** turn that talks before calling a tool, not occasionally.
Measured across 4 samples of a text-then-tool turn, the model ended its text
flush on `.` in 4/4 cases, so the withhold engages every time — only the
visible duration varies, in proportion to tool-argument size. Big file writes
are common, so the worst case is common too.

The truncation is also indistinguishable from the agent having stalled or
crashed, which is the expensive part: it invites the user to interrupt a turn
that is working correctly.

## Fix (symptoms → root cause → change)

**Symptom.** Text ends mid-sentence and resumes only when the tool pill appears.

**Root cause.** `StreamRedactor.feed` withholds the maximal trailing run of
`_CRED_CLASS` characters, because that run could be the leading half of a
credential whose remainder arrives in the next chunk. `.` `:` and `?` are all in
`_CRED_CLASS`, so an ordinary sentence has its final word *and* terminator
withheld. Nothing releases the run until the next chunk arrives — and when the
next event is a tool call, "the next chunk" is on the far side of argument
composition. The pill cannot cover for it either: `chat_runner`'s
`EVENT_TOOL_CALL` branch drives both the text flush and the `slot.append("tool", …)`
that renders the pill, so both are gated on the same delayed event.

**Change.** One line in each shipped system prompt template instructing the model
to end its text with a trailing space before invoking a tool.

Whitespace is not in `_CRED_CLASS`, so a trailing space terminates the run scan
and the text commits immediately. This is a documented property of the holdback,
not a bypass — the design comment above `_CRED_CLASS` states the run is held
"until a terminator arrives or the stream ends", and whitespace is precisely such
a terminator.

The distinction that makes this safe: the space is **emitted by the model**, so it
is evidence that the preceding token is complete. A space *synthesised by the
gateway* would be an unconditional flush wearing a disguise, and would put partial
secrets on the wire — verified directly against the redactor, where feeding
`"key is AKIAIOSFODNN7EXAMPL" + "\n"` commits the partial key raw, while the
unmodified holdback correctly withholds it. No security code is touched here.

Why a space and not a newline, measured with the instruction delivered as a
steering resource and a canary token confirming delivery:

| arm | canary delivered | text withheld |
|---|---|---|
| control (no instruction) | 0/4 | 4/4 |
| **trailing space** | 4/4 | **0/4** |
| trailing newline | 4/4 | 4/4 |

The model ignores a trailing newline even when the instruction demonstrably
reaches it. A space also renders as nothing, so no visible break appears before
the tool pill.

**This is a mitigation, not a fix.** It depends on model compliance and will
regress silently if a future model stops emitting the space. The durable fix is a
text-part boundary signal in ACP, so the client learns the text part ended without
waiting for tool arguments to finish composing. ACP has no such signal today: its
update vocabulary has no per-block terminator, `stopReason` is turn-level only, and
the first `tool_call` already carries the complete payload (14,140 B, `status`
absent) with `status: completed` following just 6 ms later — so there is no early
pending stub to hook.

## Tests

`test/test_prompt_trailing_space_rule.py` — pins the rule in both templates,
parametrized over `prompt.md` and `prompt-orchestrator.md`.

It mirrors the existing `test_prompt_pr_link_rule.py`, which exists for exactly
this reason: a prompt rewrite once silently dropped a rule and removed a dashboard
feature. This rule reads as stray whitespace guidance, so it invites precisely that
deletion. The test pins the rule's *presence*; it cannot pin the model's compliance.

Verified RED-first — removing the line from both templates fails 2/2; restoring it
passes 4/4 alongside the existing PR-link test.

## Manual verification

Applied the same one-line rule to the running gateway's live prompt template and
confirmed the agent config resolves `prompt` to a `file://` URI pointing at it, so
the edit takes effect without re-running `setup --agent-only`.

The A/B above is the load-bearing evidence rather than my own observation: having
discussed this rule at length in-session, I am a contaminated instrument — I would
emit the space whether or not the rule were live, so my own behaviour proves
nothing. The steering-resource arms with a canary are what separate delivery from
compliance.

Not verified: that compliance measured through a steering resource transfers
identically to the `prompt.md` channel. The system prompt should be an equal or
stronger channel, but that is an inference, not a measurement.

## Notes for the reviewer

The one flagged `diff_signals.py` signal is `config/infra file changed` — the two
config files *are* the change; they are the shipped system prompt templates.

No UI code is touched, so the Screenshots section is omitted. The observable effect
is a timing property of streamed text that a still frame cannot demonstrate; the
ACP measurements above stand in its place.

An earlier attempt at this fixed the same defect inside `StreamRedactor` by
releasing sentence-terminated runs. It was **abandoned as unsound** — `SG.`,
`postgres:`, `mysql:`, `mongodb:`, and digit-free base64url JWT headers such as
`eyJxIjoiUEgifQ.` all read as ordinary prose while being genuine credential
prefixes, and the same redactor feeds Slack's `append_stream`, so a leak would
leave the machine. That work is not part of this PR.
