### PR TITLE
feat(i18n): give zh-CN, hi and bn a script font fallback (Phase 2a)

### DIFF
--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -201,13 +201,13 @@ function injectCustomThemeCSS(theme: CustomThemeData) {
 
   // Static defaults (not user-controlled)
   const darkDefaults =
-    '--font-body:\'Space Grotesk\',-apple-system,BlinkMacSystemFont,sans-serif;' +
-    '--mono:\'JetBrains Mono\',ui-monospace,SFMono-Regular,monospace;' +
+    '--font-body:var(--script-fallbacks),\'Space Grotesk\',-apple-system,BlinkMacSystemFont,sans-serif;' +
+    '--mono:var(--script-fallbacks-mono),\'JetBrains Mono\',ui-monospace,SFMono-Regular,monospace;' +
     '--radius-sm:6px;--radius-md:8px;--radius-lg:12px;--radius-xl:16px;' +
     'color-scheme:dark;'
   const lightDefaults =
-    '--font-body:\'Space Grotesk\',-apple-system,BlinkMacSystemFont,sans-serif;' +
-    '--mono:\'JetBrains Mono\',ui-monospace,SFMono-Regular,monospace;' +
+    '--font-body:var(--script-fallbacks),\'Space Grotesk\',-apple-system,BlinkMacSystemFont,sans-serif;' +
+    '--mono:var(--script-fallbacks-mono),\'JetBrains Mono\',ui-monospace,SFMono-Regular,monospace;' +
     '--radius-sm:6px;--radius-md:8px;--radius-lg:12px;--radius-xl:16px;' +
     'color-scheme:light;'
 
@@ -286,7 +286,7 @@ function injectThemeFonts(theme: CustomThemeData) {
   style.textContent =
     faces.join('\n') +
     `\n[data-theme="custom-${slug}-dark"],[data-theme="custom-${slug}-light"]{` +
-    `--font-body:'${primary}','Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;}`
+    `--font-body:'${primary}',var(--script-fallbacks),'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;}`
   document.head.appendChild(style)
 }
 

--- a/website/src/hooks/useZoom.ts
+++ b/website/src/hooks/useZoom.ts
@@ -5,9 +5,9 @@ export type FontFamily = 'sans' | 'mono' | 'system'
 
 const FAMILIES: FontFamily[] = ['sans', 'mono', 'system']
 const FAMILY_MAP: Record<FontFamily, string> = {
-  sans: "'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif",
-  mono: "'JetBrains Mono',ui-monospace,SFMono-Regular,monospace",
-  system: "-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
+  sans: "var(--script-fallbacks),'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif",
+  mono: "var(--script-fallbacks-mono),'JetBrains Mono',ui-monospace,SFMono-Regular,monospace",
+  system: "var(--script-fallbacks),-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
 }
 
 // Native zoom bridge exposed by electron/preload.js. Chromium's per-origin

--- a/website/src/i18n/scriptFonts.test.ts
+++ b/website/src/i18n/scriptFonts.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Script fallback faces must lead every font stack, and must never claim Latin.
+ *
+ * zh-CN, hi and bn have no font coverage otherwise: every family in `--font-body`
+ * and `--mono` covers Latin only, so those scripts fall through to the browser's
+ * per-script fallback, which picks a face per character and silently mismatches.
+ * CJK punctuation is the visible symptom — Unicode uses one code point for the
+ * Chinese and Japanese comma and full stop, so only the font decides where in the
+ * em box the glyph sits.
+ *
+ * The mechanism is four `unicode-range`-restricted `@font-face` aliases over
+ * locally installed faces, placed at the FRONT of each stack. Two properties make
+ * that correct, and both are asserted here because neither is visible from reading
+ * a family list:
+ *
+ *  1. **No alias range may include Latin.** `unicode-range` is what makes a leading
+ *     position safe: a face whose range excludes Latin is never consulted for
+ *     Latin, so leading cannot change how Latin renders. If someone widens a range
+ *     to cover Latin, every stack in the app silently switches its Latin face.
+ *     This is the assertion that matters most.
+ *  2. **Every declaration site must reference the alias token.** The stacks are
+ *     declared in TWELVE places across three files — nine `--font-body`/`--mono`
+ *     declarations (`index.css` 4, `hooks/useTheme.tsx` 5) plus the three
+ *     `FAMILY_MAP` entries in `hooks/useZoom.ts` that are written into `--font-body`
+ *     at runtime. A thirteenth added later without the aliases would silently lose
+ *     script coverage on whichever path it feeds, so the check globs the tree rather
+ *     than naming files.
+ *  3. **Each alias needs a REAL bold face.** Weight matching happens *within* the
+ *     selected family, so an alias backed by one Regular face makes every
+ *     `font-semibold` in these scripts render as Chromium's synthetic bold — worse
+ *     than today, where browser fallback reaches the platform's real Semibold. Two
+ *     faces per alias (400 and 700) is what keeps the real face, and dropping the
+ *     700 later would silently reintroduce faux-bold.
+ *
+ * Why not simply append the script families to the end of each stack: every stack
+ * already terminates in a generic (`sans-serif` / `monospace`), and on macOS
+ * `-apple-system` resolves Han from the OS cascade before any appended family is
+ * reached — so an appended tail is platform-dependent, and possibly a no-op. A
+ * leading unicode-ranged alias is deterministic regardless of what follows it.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+const SRC = join(__dirname, '..')
+const INDEX_CSS = readFileSync(join(SRC, 'index.css'), 'utf8')
+
+/** The alias faces, and the script each one covers. */
+const ALIASES = [
+  'KC Han Fallback',
+  'KC Han Mono Fallback',
+  'KC Devanagari Fallback',
+  'KC Bengali Fallback',
+] as const
+
+/**
+ * Ranges that must stay OUT of every alias. Latin proper plus general punctuation:
+ * an alias claiming U+2000-206F would take over quotes, dashes and ellipses in
+ * Latin text, which is the same class of silent regression as claiming Latin.
+ */
+const FORBIDDEN = [
+  { name: 'Latin (Basic through Extended-B)', lo: 0x0000, hi: 0x024f },
+  { name: 'General Punctuation', lo: 0x2000, hi: 0x206f },
+]
+
+/**
+ * The Latin base families. Aliases must precede all of them in every stack.
+ *
+ * Known limit, stated so this gate is not read as complete coverage: the check is
+ * LINE-scoped, so a stack wrapped across lines by a formatter, or a family name not
+ * listed here, would pass. It catches the realistic regression — someone appending
+ * the token instead of leading with it — not every possible ordering mistake.
+ */
+const BASE_FAMILIES = [
+  "'Space Grotesk'",
+  '-apple-system',
+  'BlinkMacSystemFont',
+  "'JetBrains Mono'",
+  'ui-monospace',
+  'SFMono-Regular',
+  "'Segoe UI'",
+  'Menlo',
+  'sans-serif',
+  'monospace',
+]
+
+/** Every @font-face block declaring `family`, one per weight. */
+function faceBlocks(family: string): string[] {
+  // @font-face blocks here contain no nested braces, so a non-greedy match to the
+  // first `}` is sufficient. Asserted non-empty by the first test.
+  const re = new RegExp(`@font-face\\s*\\{([^}]*?font-family:\\s*'${family}'[^}]*?)\\}`, 'g')
+  return [...INDEX_CSS.matchAll(re)].map((m) => m[1])
+}
+
+function faceBlock(family: string): string {
+  return faceBlocks(family).join('\n')
+}
+
+function parseUnicodeRange(block: string): Array<{ lo: number; hi: number }> {
+  const decl = block.match(/unicode-range:\s*([^;}]+)/)
+  if (!decl) return []
+  return decl[1]
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((token) => {
+      const m = token.match(/^U\+([0-9A-Fa-f]+)(?:-([0-9A-Fa-f]+))?$/)
+      if (!m) throw new Error(`unparseable unicode-range token: "${token}"`)
+      const lo = parseInt(m[1], 16)
+      return { lo, hi: m[2] ? parseInt(m[2], 16) : lo }
+    })
+}
+
+/** Every file that DECLARES --font-body or --mono, found by walking the tree. */
+function declarationSites(): Array<{ file: string; line: number; text: string }> {
+  const out: Array<{ file: string; line: number; text: string }> = []
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        walk(full)
+        continue
+      }
+      if (!/\.(css|ts|tsx)$/.test(entry)) continue
+      // Tests never declare a font stack, and this file necessarily contains the
+      // detection pattern as a literal — without the exclusion it matches itself.
+      // The only false-negative this creates is a stack declared inside a test,
+      // which would not reach the app.
+      if (/\.test\.(ts|tsx)$/.test(entry)) continue
+      readFileSync(full, 'utf8')
+        .split('\n')
+        .forEach((text, i) => {
+          // A declaration, not a read: `--font-body:` / `--mono:` with a value, and
+          // the FAMILY_MAP entries that are written into --font-body at runtime.
+          const declares = /--(?:font-body|mono)\s*:/.test(text)
+          const familyMap = /^\s*(?:sans|mono|system):\s*"/.test(text)
+          if (declares || familyMap) out.push({ file: relative(SRC, full), line: i + 1, text })
+        })
+    }
+  }
+  walk(SRC)
+  return out
+}
+
+describe('script fallback faces', () => {
+  it.each(ALIASES)('defines %s with a unicode-range and local()-only sources', (family) => {
+    const block = faceBlock(family)
+    expect(block, `no @font-face for '${family}' in index.css`).not.toBe('')
+    expect(block).toMatch(/unicode-range:/)
+    expect(block).toMatch(/src:[^;]*local\(/)
+    // local() only: a url() here would make the dashboard fetch a font at runtime.
+    expect(block, `'${family}' must not fetch a remote font`).not.toMatch(/url\(/)
+  })
+
+  it.each(ALIASES)('keeps %s out of Latin and general punctuation', (family) => {
+    const ranges = parseUnicodeRange(faceBlock(family))
+    expect(ranges.length, `'${family}' declares no parseable unicode-range`).toBeGreaterThan(0)
+    for (const r of ranges) {
+      for (const bad of FORBIDDEN) {
+        const overlaps = r.lo <= bad.hi && r.hi >= bad.lo
+        expect(
+          overlaps,
+          `'${family}' range U+${r.lo.toString(16).toUpperCase()}-${r.hi
+            .toString(16)
+            .toUpperCase()} overlaps ${bad.name}; a leading alias must never claim it`,
+        ).toBe(false)
+      }
+    }
+  })
+
+  it.each(ALIASES)('backs %s with a real 400 and 700 face, not one 100-900 face', (family) => {
+    const blocks = faceBlocks(family)
+    const weights = blocks
+      .map((b) => b.match(/font-weight:\s*([^;]+);/)?.[1].trim())
+      .filter(Boolean)
+      .sort()
+    expect(weights, `'${family}' must declare exactly two weights`).toEqual(['400', '700'])
+    // A range like `100 900` on a single Regular face is the faux-bold trap.
+    for (const w of weights) expect(w).not.toMatch(/\s/)
+    // Both weights must cover the same code points, or bold text falls out of the alias.
+    const [a, b] = blocks.map((blk) => blk.match(/unicode-range:\s*([^;}]+)/)?.[1].replace(/\s+/g, ' '))
+    expect(a, `'${family}' weights disagree on unicode-range`).toBe(b)
+  })
+
+  it('declares both tokens in :root so every consumer inherits them', () => {
+    // If either moved into a [data-theme=…] block or was renamed, every --font-body
+    // would become guaranteed-invalid at computed-value time and `font-family:
+    // var(--mono)` consumers would drop to their initial value — app-wide font loss,
+    // which every other assertion here would still pass through.
+    const root = INDEX_CSS.match(/:root\s*\{([^}]*)\}/)?.[1] ?? ''
+    expect(root, 'no :root block found in index.css').not.toBe('')
+    expect(root).toMatch(/--script-fallbacks:/)
+    expect(root).toMatch(/--script-fallbacks-mono:/)
+  })
+
+  it('lists every alias in the shared tokens', () => {
+    const root = INDEX_CSS.match(/--script-fallbacks:\s*([^;]+);/)?.[1] ?? ''
+    const rootMono = INDEX_CSS.match(/--script-fallbacks-mono:\s*([^;]+);/)?.[1] ?? ''
+    expect(root, 'no --script-fallbacks token').not.toBe('')
+    expect(rootMono, 'no --script-fallbacks-mono token').not.toBe('')
+    for (const family of ALIASES) {
+      if (family === 'KC Han Mono Fallback') {
+        // Mono-only: a proportional stack must not lead with a monospace face.
+        expect(rootMono).toContain(family)
+        expect(root).not.toContain(family)
+      } else {
+        expect(root, `${family} missing from --script-fallbacks`).toContain(family)
+        expect(rootMono, `${family} missing from --script-fallbacks-mono`).toContain(family)
+      }
+    }
+  })
+})
+
+describe('font stack declarations', () => {
+  it('finds every declaration site the tree actually contains', () => {
+    // Guards the walker itself: if this drops to a handful, the glob broke and the
+    // next assertion would pass vacuously.
+    expect(declarationSites().length).toBeGreaterThanOrEqual(12)
+  })
+
+  it('references the alias token at every declaration site', () => {
+    const offenders = declarationSites()
+      .filter((s) => !/var\(--script-fallbacks(-mono)?\)/.test(s.text))
+      .map((s) => `${s.file}:${s.line}: ${s.text.trim().slice(0, 96)}`)
+    expect(
+      offenders,
+      `these declare a font stack without the script fallbacks:\n${offenders.join('\n')}`,
+    ).toEqual([])
+  })
+
+  it('puts the aliases ahead of every Latin base family', () => {
+    const offenders: string[] = []
+    for (const site of declarationSites()) {
+      const aliasAt = site.text.search(/var\(--script-fallbacks(-mono)?\)/)
+      if (aliasAt < 0) continue
+      for (const base of BASE_FAMILIES) {
+        const baseAt = site.text.indexOf(base)
+        if (baseAt >= 0 && baseAt < aliasAt) {
+          offenders.push(`${site.file}:${site.line}: ${base} precedes the aliases`)
+        }
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+})

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -2,11 +2,123 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Script fallback faces ──
+   zh-CN, hi and bn have no font coverage otherwise: every family in --font-body
+   and --mono below covers Latin only, so those scripts fall through to the
+   browser's per-script fallback, which picks a face per character and silently
+   mismatches. CJK punctuation makes it visible — Unicode uses one code point for
+   the Chinese and Japanese comma and full stop, so only the FONT decides where in
+   the em box the glyph sits.
+
+   Each alias below is a `unicode-range`-restricted @font-face over locally
+   installed faces. That restriction is the whole point: a face whose range
+   excludes Latin is never consulted for Latin, so the alias can sit FIRST in a
+   family list without changing how Latin renders. Ordering therefore stops
+   mattering — this works regardless of what follows, including the terminal
+   `sans-serif`/`monospace` generic, which is what a plain appended tail could not
+   guarantee (on macOS `-apple-system` resolves Han from the OS cascade before any
+   appended family is reached).
+
+   Each alias declares a REAL 400 and 700 face rather than one face spanning
+   100-900. Weight matching happens *within* the selected family, so a single
+   Regular face would make every `font-semibold` in these scripts render as
+   Chromium's SYNTHETIC bold — worse than today, where browser fallback reaches the
+   platform's real Semibold/Bold. Declaring the bold locals keeps the real face.
+
+   Not claimed on purpose: CJK quotes, dashes and ellipsis (U+2018/2019/201C/201D/
+   2014/2026) live in General Punctuation, which the aliases must exclude or they
+   would take over Latin punctuation too. Those glyphs keep coming from the Latin
+   face, exactly as today.
+
+   `src` is local()-only, so nothing is ever downloaded. Several candidates per
+   face, by family and PostScript name, because local() matching differs by
+   platform. If none is installed the face has no usable source and matching falls
+   through to the next family — i.e. exactly today's behaviour, never worse. */
+@font-face {
+  font-family: 'KC Han Fallback';
+  font-style: normal; font-weight: 400;
+  src: local('PingFang SC'), local('PingFangSC-Regular'), local('Hiragino Sans GB'),
+       local('Microsoft YaHei'), local('MicrosoftYaHei'), local('Noto Sans CJK SC'),
+       local('NotoSansCJKsc-Regular'), local('Source Han Sans SC'),
+       local('WenQuanYi Micro Hei');
+  unicode-range: U+2E80-2EFF, U+2F00-2FDF, U+3000-303F, U+3100-312F, U+31C0-31EF,
+                 U+3200-32FF, U+3300-33FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF,
+                 U+FE30-FE4F, U+FF00-FFEF;
+}
+@font-face {
+  font-family: 'KC Han Fallback';
+  font-style: normal; font-weight: 700;
+  src: local('PingFang SC Semibold'), local('PingFangSC-Semibold'),
+       local('Hiragino Sans GB W6'), local('Microsoft YaHei Bold'),
+       local('MicrosoftYaHei-Bold'), local('Noto Sans CJK SC Bold'),
+       local('NotoSansCJKsc-Bold'), local('Source Han Sans SC Bold');
+  unicode-range: U+2E80-2EFF, U+2F00-2FDF, U+3000-303F, U+3100-312F, U+31C0-31EF,
+                 U+3200-32FF, U+3300-33FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF,
+                 U+FE30-FE4F, U+FF00-FFEF;
+}
+/* Monospace Han, for code and CLI surfaces. Rarely installed on a stock machine;
+   when absent 'KC Han Fallback' follows it in --script-fallbacks-mono, so Han in a
+   code block draws from a proportional face — the same pairing the browser's own
+   fallback produces today, and better than a missing glyph. */
+@font-face {
+  font-family: 'KC Han Mono Fallback';
+  font-style: normal; font-weight: 400;
+  src: local('Sarasa Mono SC'), local('SarasaMonoSC-Regular'), local('Noto Sans Mono CJK SC'),
+       local('NotoSansMonoCJKsc-Regular');
+  unicode-range: U+2E80-2EFF, U+2F00-2FDF, U+3000-303F, U+3100-312F, U+31C0-31EF,
+                 U+3200-32FF, U+3300-33FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF,
+                 U+FE30-FE4F, U+FF00-FFEF;
+}
+@font-face {
+  font-family: 'KC Han Mono Fallback';
+  font-style: normal; font-weight: 700;
+  src: local('Sarasa Mono SC Bold'), local('SarasaMonoSC-Bold'),
+       local('Noto Sans Mono CJK SC Bold'), local('NotoSansMonoCJKsc-Bold');
+  unicode-range: U+2E80-2EFF, U+2F00-2FDF, U+3000-303F, U+3100-312F, U+31C0-31EF,
+                 U+3200-32FF, U+3300-33FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF,
+                 U+FE30-FE4F, U+FF00-FFEF;
+}
+@font-face {
+  font-family: 'KC Devanagari Fallback';
+  font-style: normal; font-weight: 400;
+  src: local('Noto Sans Devanagari'), local('NotoSansDevanagari-Regular'), local('Nirmala UI'),
+       local('NirmalaUI'), local('Kohinoor Devanagari'), local('Devanagari Sangam MN');
+  unicode-range: U+0900-097F, U+1CD0-1CFF, U+A8E0-A8FF;
+}
+@font-face {
+  font-family: 'KC Devanagari Fallback';
+  font-style: normal; font-weight: 700;
+  src: local('Noto Sans Devanagari Bold'), local('NotoSansDevanagari-Bold'),
+       local('Nirmala UI Bold'), local('NirmalaUI-Bold'), local('Kohinoor Devanagari Semibold');
+  unicode-range: U+0900-097F, U+1CD0-1CFF, U+A8E0-A8FF;
+}
+@font-face {
+  font-family: 'KC Bengali Fallback';
+  font-style: normal; font-weight: 400;
+  src: local('Noto Sans Bengali'), local('NotoSansBengali-Regular'), local('Nirmala UI'),
+       local('NirmalaUI'), local('Vrinda'), local('Bangla Sangam MN');
+  unicode-range: U+0980-09FF;
+}
+@font-face {
+  font-family: 'KC Bengali Fallback';
+  font-style: normal; font-weight: 700;
+  src: local('Noto Sans Bengali Bold'), local('NotoSansBengali-Bold'), local('Nirmala UI Bold'),
+       local('NirmalaUI-Bold'), local('Vrinda Bold');
+  unicode-range: U+0980-09FF;
+}
+
 /* ── Design tokens ── */
 /* Shared across all themes */
 :root {
-  --font-body:'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;
-  --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,monospace;
+  /* Single source of truth for the script fallbacks. Every declaration of
+     --font-body / --mono — here, in the theme blocks below, and the ones built in
+     hooks/useTheme.tsx and hooks/useZoom.ts — references these by name instead of
+     repeating the list, so adding a script is one edit. They lead each stack;
+     unicode-range is what makes leading safe. */
+  --script-fallbacks:'KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
+  --script-fallbacks-mono:'KC Han Mono Fallback','KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
+  --font-body:var(--script-fallbacks),'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;
+  --mono:var(--script-fallbacks-mono),'JetBrains Mono',ui-monospace,SFMono-Regular,monospace;
   --radius-sm:6px;--radius-md:8px;--radius-lg:12px;--radius-xl:16px;
 }
 /* Dark theme shadows */
@@ -597,8 +709,8 @@
   --diff-hunk:rgba(10,132,255,.15);--diff-hunk-text:#64d2ff;
   --diff-meta-text:#e4e4e7;
   --json-key:#64d2ff;--json-str:#30d158;--json-num:#bf5af2;--json-bool:#0a84ff;
-  --font-body:'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;
-  --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,monospace;
+  --font-body:var(--script-fallbacks),'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;
+  --mono:var(--script-fallbacks-mono),'JetBrains Mono',ui-monospace,SFMono-Regular,monospace;
   --shadow-sm:none;
   --shadow-md:0 0 0 1px rgba(255,255,255,.06);
   --shadow-lg:0 0 0 1px rgba(255,255,255,.08);


### PR DESCRIPTION
Tracks #1004

## Problem

zh-CN, hi and bn have **no font coverage today**. The dashboard has exactly two font custom properties, and neither contains a family covering Han, Devanagari or Bengali:

```css
--font-body:'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;
--mono:'JetBrains Mono',ui-monospace,SFMono-Regular,monospace;
```

Those three shipped locales therefore render through the browser's per-script fallback, which picks a face *per character* and silently mismatches rather than failing loudly with tofu. `--mono` is worse off: not one family in it is CJK-capable — only the generic `monospace` keyword. `website/src/i18n/style/hi.md:41` asks for `Noto Sans Devanagari`, which `main` does not provide.

`:lang()` selectors on `main` before this change: **zero**.

## Why it matters

CJKV punctuation makes the mismatch visible rather than merely imperfect: Unicode does not distinguish the per-language comma and full-stop glyphs, so the same code point must be *rendered* by a locale-appropriate face to sit in the correct corner of the em box. Without it, Simplified Chinese gets whatever face the fallback chain reaches first, with punctuation positioned for another language. Devanagari and Bengali fare worse — mixed-script runs can shift face mid-word.

## Fix

**Symptom** → Chinese, Hindi and Bengali text renders with mismatched faces and misplaced punctuation.
**Root cause** → the only two font stacks in the app are Latin-only, and nothing varies them by script.
**Change** → four `unicode-range`-restricted `@font-face` aliases over locally installed faces, placed at the **front** of every stack via two shared tokens.

### Why leading aliases, and not the obvious appended tail

This PR originally appended the script families to the *end* of each stack. That was wrong, and the reason is worth recording:

- Every stack **already terminates in a generic** (`sans-serif` / `monospace`), which would sit ahead of anything appended.
- On macOS, `-apple-system` precedes the generic and **already resolves Han from the CoreText cascade**, so an appended family is never reached at all.

An appended tail is therefore platform-dependent and plausibly a no-op on macOS. A leading `unicode-range` alias is deterministic everywhere, because **`unicode-range` is what makes leading safe**: a face whose range excludes Latin is never consulted for Latin, so a first-position alias cannot change how Latin renders. Ordering stops mattering entirely.

Three consequences of putting the aliases inside the tokens rather than appending at each consumer:

- **No consumer is edited.** All 21 `var(--font-body)` / `var(--mono)` references across 12 files pick them up unchanged — including Tailwind's `font-body`/`font-mono` utilities and the four inline `fontFamily: 'var(--font-body, inherit)'` sites in the Worlds surfaces, which sit in files an in-flight Phase 1 PR also touches and so could not be edited here without a conflict.
- **The user's Font Family preference and installed theme packs keep working**, because the paths that rebuild the stack (`hooks/useZoom.ts` FAMILY_MAP, `hooks/useTheme.tsx` defaults and the installed-pack rule) all reference the shared tokens instead of dropping them.
- **One source of truth** for the family list, referenced from all 12 declaration sites.

### Real bold faces, not one 100–900 face

Each alias declares a **real 400 and a real 700** face. Weight matching happens *within* the selected family, so an alias backed by a single Regular face would make every `font-semibold` in these scripts render as Chromium's **synthetic** bold — actively worse than today, where browser fallback reaches the platform's real Semibold. `font-semibold` is pervasive in this dashboard, so this is the difference between an improvement and a regression. Caught by local review, not by me.

`src` is `local()`-only, so **nothing is ever downloaded**. Several candidates per face, by both family and PostScript name, because `local()` matching differs by platform. If none is installed, the face has no usable source and matching falls through to the next family — exactly today's behaviour, never worse.

## Limits, stated rather than left to be discovered

- **Monospace Han is best-effort.** `KC Han Mono Fallback` lists only Sarasa Mono SC and Noto Sans Mono CJK SC, neither of which ships by default on macOS, Windows or mainstream Linux. On a stock machine, Han in a code block draws from the proportional alias that follows it — the same pairing the browser produces today.
- **The terminal grid gains nothing.** `components/CliPanel.tsx:80` hardcodes xterm's own `fontFamily`, bypassing the tokens. That is correct — xterm needs a fixed advance width — but it means CLI *output* is uncovered while CLI *chrome* is.
- **CJK quotes, dashes and ellipsis are deliberately not claimed.** They live in General Punctuation, which the aliases must exclude or they would take over Latin punctuation too. Those glyphs keep coming from the Latin face, as today.
- **Widget iframes are uncovered.** `WidgetFrame.tsx` forwards only `THEME_VAR_NAMES` and no font variables, and `@font-face` is document-scoped, so widget content is unchanged. Pre-existing, not a regression.

## Tests

`website/src/i18n/scriptFonts.test.ts` (new) gates the properties that are invisible in a family list:

- **no alias range overlaps Latin (U+0000–024F) or General Punctuation (U+2000–206F)** — the property that makes a leading position safe; widening a range would silently switch the Latin face app-wide;
- each alias keeps a real 400 and 700 face over one shared `unicode-range`, so dropping the bold cannot silently reintroduce faux-bold;
- both tokens stay declared in `:root`, where every consumer inherits them — if either moved into a `[data-theme=…]` block, every `--font-body` would become guaranteed-invalid at computed-value time and `font-family: var(--mono)` consumers would drop to their initial value, i.e. app-wide font loss that every other assertion would pass through;
- all 12 declaration sites reference the tokens, ahead of the Latin families. The check **walks the tree** rather than naming files, so a thirteenth declaration cannot silently lose coverage.

Stated limit: the ordering check is line-scoped, so a formatter-wrapped multi-line stack would pass it. It catches the realistic regression — appending the token instead of leading with it — not every possible ordering mistake.

## Manual verification

- `tsc -b` clean.
- Tailwind + postcss compile clean; all 8 `@font-face` blocks and both tokens confirmed present in the compiled output.
- `check-source-strings`: 0 new keys, 0 findings. `gen-pseudolocale`: no drift (`en-XA.json` unchanged).
- **No ratchet regeneration needed** — CSS plus two hooks; `eslint.i18n.config.js:38` ignores `*.test.*`, and `untranslated-baseline.json` has no CSS or test entries.

Two gaps stated plainly rather than papered over:

- ⚠️ **vitest did not run locally.** The dev host is Node 16.20.2 and the suite needs Node 18+ (`BroadcastChannel is not defined`; a pre-existing i18n test fails identically). All 41 assertions were replicated as a standalone Node 16 script and pass, but **CI is the first real run of the vitest suite**.
- ⚠️ **No glyph screenshots.** This host has 13 fonts installed and **zero** CJK or Devanagari coverage (`fc-match sans-serif:lang=zh` returns DejaVu Sans), so a screenshot would document this machine's fallback rather than the fix. Attaching one would be misleading evidence.

## Where this sits in the remediation plan

**Phase 0** — merged (#898, #911, #914, #921, #922, #933, #937, #946)
**Phase 0.5** — merged (#915: i18next 26 + react-i18next 17)
**Phase 1** — 5 PRs open, all CI-green, all awaiting rebase: #932, #949, #956, #959, #964
**Phase 2** — split into 2a / 2b after a full audit; **this PR is 2a.1**

| item | status |
|---|---|
| 2a.1 per-locale script font coverage | **in this PR** |
| 2a.2 global `overflow-wrap: anywhere` | **removed from this PR** — inherited, and it drops min-content intrinsic size app-wide; 89 `white-space:pre-wrap` sites would break paths, SHAs and URLs mid-token. Needs its own PR with before/after evidence |
| 2a.2 `<html lang>` dynamic | already true on `main` |
| 2b.3 `<bdi>` on untrusted strings — ~152 sites, ~37 high-risk, 60+ files | not started; needs its own batch plan, blocked on Phase 1 by file overlap |
| 2b.4 unitless `line-height` — 16 sites / 10 files | not started; 5 of 10 files collide with Phase 1 |
| 2b.4 fixed heights — 82 text-bearing sites / 31 files | not started; only ~30 leaf controls are safely mechanical |
| 2b.4 codemod out `w-[Npx]` — 420 sites | **blocked**: contradicts `website/AUTOSDE.yaml:39-46`, which prescribes arbitrary values. Needs an agreed rule first |
| 2b.5 flex `min-width:auto` truncate trap | not started; size unmeasured — 432 `truncate` / 301 `min-w-0`, and grep cannot see ancestor chains, so it needs an AST pass |
| ~~2.3 strip spaces around DNT terms~~ | **withdrawn**: premise inverted. `style/zh-CN.md:47-50` *requires* the CJK↔Latin space; executing it would introduce ~697 style violations across zh-CN/hi/bn/ru |

**Phases 3–7, Track B (backend boundary), Track C (RTL)** — not started.

Phase 2a was separated because it is the only part of Phase 2 with **zero file overlap** with the five in-flight Phase 1 PRs (verified against their 204-file union), so it can land in parallel with their rebases instead of queueing behind them.

