### PR TITLE
perf(memory): batch episodic fetch, debounce access touch, bound transcript reads

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1639,9 +1639,12 @@ class ContextBuilder:
         # (skipped for temporary sessions)
         lessons_ctx = ""
         if not blocks_reads:
-            if memory.vector_store and memory.vector_store.get_lessons():
-                lessons_ctx = memory.vector_store.get_lessons_context()
-            else:
+            # One query, not two: get_lessons_context() already returns "" when the
+            # store holds no lessons, so the former get_lessons() existence probe
+            # was a duplicate SELECT * over the same rows (embedding blobs included)
+            # whose only use was an emptiness check.
+            lessons_ctx = memory.vector_store.get_lessons_context() if memory.vector_store else ""
+            if not lessons_ctx:
                 lessons_ctx = self.lessons.get_context()
             # Merge workspace-scoped lessons if workspace differs from default
             if workspace and workspace != "default":

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -1614,9 +1614,11 @@ class ConversationLog:
     ) -> list[dict]:
         """Return recent messages from sessions matching *source_prefix*.
 
-        Optimized: only scans the 5 most recently modified files and reads
-        only the last 50 lines from each, avoiding full-file I/O on large
-        session histories.
+        Considers at most 50 matching files (newest mtime first) and stops after
+        5 have contributed messages. Each contributing file costs a 5-line head
+        read (to detect incognito/temporary sessions, which are skipped) plus a
+        bounded tail read via :meth:`_read_tail_messages` — never a full-file
+        read, which on large transcripts dominated the call.
         """
         if not self._dir.exists():
             return []
@@ -1635,41 +1637,28 @@ class ConversationLog:
         for path in paths[:_max_scan]:
             if included >= 5:
                 break
-            # Single-pass read: check metadata head, then read remainder via same handle
+            # The memory_mode marker lives in the metadata line at the head of the
+            # file, so only the head is read here; the messages come from the tail.
             is_restricted = False
             try:
                 with open(path, encoding="utf-8") as f:
-                    head_lines = []
                     for _, line in zip(range(5), f):
-                        head_lines.append(line)
                         try:
                             d = json.loads(line.strip())
-                            if d.get("_type") == "metadata" and d.get("memory_mode") in (
-                                "incognito",
-                                "temporary",
-                            ):
-                                is_restricted = True
-                                break
                         except (json.JSONDecodeError, ValueError):
-                            pass
-                    if is_restricted:
-                        continue
-                    raw = "".join(head_lines) + f.read()
+                            continue
+                        if d.get("_type") == "metadata" and d.get("memory_mode") in (
+                            "incognito",
+                            "temporary",
+                        ):
+                            is_restricted = True
+                            break
             except OSError:
                 continue
+            if is_restricted:
+                continue
             included += 1
-            lines = raw.splitlines()
-            for line in lines[-50:]:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    data = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if data.get("_type") == "metadata":
-                    continue
-                candidates.append(data)
+            candidates.extend(self._read_tail_messages(path, 50, None))
         # Sort by timestamp and return most recent
         candidates.sort(key=lambda m: m.get("ts", ""))
         return [{"role": m["role"], "content": m["content"]} for m in candidates[-max_messages:]]

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -369,6 +369,10 @@ class VectorMemoryStore:
         # write load. Without it, two writers can both observe embed_fn is None and
         # cooldown elapsed at the same instant, then both call the factory + probe.
         self._embed_fn_rebind_lock = threading.Lock()
+        # id -> time.monotonic() of the last last_accessed_at write for that
+        # episodic row. Backs the debounce in _touch_last_accessed; swept when it
+        # grows past _LAST_ACCESSED_CACHE_MAX.
+        self._last_accessed_touch: dict[str, float] = {}
 
     def init(self) -> None:
         """Create DB, apply migrations, set permissions."""
@@ -378,6 +382,13 @@ class VectorMemoryStore:
         )
         self._db.row_factory = sqlite3.Row
         self._db.execute("PRAGMA journal_mode=WAL")
+        # synchronous stays at the sqlite default (FULL). NORMAL would drop the
+        # per-commit fsync, but under WAL that only survives a process crash --
+        # an OS crash or power loss can still lose the unsynced WAL tail, and
+        # here that tail is acknowledged semantic memories, lessons and episodic
+        # rows. The write-volume problem it was meant to address is handled by
+        # debouncing the last_accessed_at touch instead, which removes the
+        # commits rather than weakening the ones that remain.
         self._db.execute("PRAGMA busy_timeout=5000")
         self._db.isolation_level = ""  # Restore implicit transaction handling
 
@@ -1305,16 +1316,25 @@ class VectorMemoryStore:
             with self._db_lock:
                 k = min(limit * 2, self._faiss_index.ntotal)  # type: ignore[attr-defined]
                 distances, indices = self._faiss_index.search(vec.reshape(1, -1), k)  # type: ignore[attr-defined]
+                # FAISS returns ids and distances only. The row bodies used to be
+                # fetched one "SELECT *" per hit — an N+1 that also dragged each
+                # row's embedding BLOB back out of the store even though the
+                # vectors are already resident in the index. Resolve every hit in
+                # a single IN (...) query over an explicit column list instead.
+                hits: list[tuple[str, float]] = []
                 for dist, idx in zip(distances[0], indices[0]):
                     if idx == -1:
                         break
-                    mem_id = self._faiss_id_map[int(idx)]
-                    mem = self._get_episodic(mem_id)
-                    if not mem or mem["is_deleted"]:
+                    hits.append((self._faiss_id_map[int(idx)], float(dist)))
+                rows_by_id = self._get_episodic_batch([mem_id for mem_id, _ in hits])
+                for mem_id, cosine_sim in hits:
+                    # Absent from the mapping == row missing or tombstoned; the
+                    # per-hit lookup treated both the same way.
+                    mem = rows_by_id.get(mem_id)
+                    if mem is None:
                         continue
                     if tag_filter and not self._matches_tags(mem, tag_filter):
                         continue
-                    cosine_sim = float(dist)
                     created = datetime.fromisoformat(mem["created_at"])
                     days_old = max(0, (now - created).days)
                     score = (
@@ -1334,14 +1354,8 @@ class VectorMemoryStore:
             # busy_timeout (set at connection init) waits out contention while the
             # lock keeps this metadata write consistent with the FAISS index. RLock
             # is reentrant, so re-acquiring here is safe regardless of caller.
-            if result:
-                with self._db_lock:
-                    for c in result:
-                        self.db.execute(
-                            "UPDATE episodic_memories SET last_accessed_at = ? WHERE id = ?",
-                            (_now_iso(), c["id"]),
-                        )
-                    self.db.commit()
+            # _touch_last_accessed does the locking and debouncing.
+            self._touch_last_accessed([c["id"] for c in result])
             return result
 
         # Fallback 1: stdlib cosine search over SQLite embeddings (no FAISS/numpy needed)
@@ -1431,15 +1445,8 @@ class VectorMemoryStore:
         # connection: two unsynchronized writers can both observe autocommit=1
         # and both issue BEGIN, and the loser raises "cannot start a transaction
         # within a transaction". RLock is reentrant, so re-acquiring here is safe
-        # regardless of caller.
-        if result:
-            with self._db_lock:
-                for c in result:
-                    self.db.execute(
-                        "UPDATE episodic_memories SET last_accessed_at = ? WHERE id = ?",
-                        (_now_iso(), c["id"]),
-                    )
-                self.db.commit()
+        # regardless of caller. _touch_last_accessed does the locking and debouncing.
+        self._touch_last_accessed([c["id"] for c in result])
         return result
 
     def get_episodic_list(
@@ -1556,6 +1563,72 @@ class VectorMemoryStore:
             "SELECT * FROM episodic_memories WHERE id = ? AND is_deleted = 0", (mem_id,)
         ).fetchone()
         return dict(row) if row else None
+
+    #: Columns returned for episodic search hits. Deliberately omits the
+    #: ``embedding`` BLOB — search results never read it (FAISS already holds the
+    #: vectors) and it is by far the widest column in the row. Matches the column
+    #: set the stdlib fallback (_sqlite_vector_search) puts in its candidates.
+    _EPISODIC_SEARCH_COLUMNS = (
+        "id, conversation_id, text, tags, importance, created_at, last_accessed_at"
+    )
+
+    def _get_episodic_batch(self, mem_ids: list[str]) -> dict[str, dict]:
+        """Fetch several active episodic rows in one query, keyed by id.
+
+        Replaces a per-hit ``SELECT *`` on the FAISS search path. Missing or
+        tombstoned ids are simply absent from the returned mapping. The id list
+        is bounded by the FAISS ``k`` (2x the search limit), so it stays well
+        under sqlite's bound-parameter ceiling.
+        """
+        if not mem_ids:
+            return {}
+        placeholders = ",".join("?" * len(mem_ids))
+        rows = self.db.execute(
+            f"SELECT {self._EPISODIC_SEARCH_COLUMNS} FROM episodic_memories "
+            f"WHERE id IN ({placeholders}) AND is_deleted = 0",
+            tuple(mem_ids),
+        ).fetchall()
+        return {row["id"]: dict(row) for row in rows}
+
+    #: Minimum interval between last_accessed_at writes for the same episodic row.
+    _LAST_ACCESSED_DEBOUNCE_SECS = 60.0
+    #: Cap on the in-process debounce map before expired entries are swept.
+    _LAST_ACCESSED_CACHE_MAX = 4096
+
+    def _touch_last_accessed(self, mem_ids: list[str]) -> None:
+        """Record an access timestamp for episodic rows, debounced per row.
+
+        Every context assembly searches episodic memory, so an unconditional
+        UPDATE per hit turns each read into a write transaction (fsync included).
+        last_accessed_at only feeds recency reporting, so a row written within
+        ``_LAST_ACCESSED_DEBOUNCE_SECS`` is skipped and the rest go out in one
+        ``executemany``. Holds ``_db_lock`` for the whole body so the debounce
+        bookkeeping cannot interleave with a concurrent searcher's.
+        """
+        if not mem_ids:
+            return
+        with self._db_lock:
+            now = time.monotonic()
+            cutoff = now - self._LAST_ACCESSED_DEBOUNCE_SECS
+            due = [
+                m
+                for m in dict.fromkeys(mem_ids)
+                if self._last_accessed_touch.get(m, -1e18) < cutoff
+            ]
+            if not due:
+                return
+            stamp = _now_iso()
+            self.db.executemany(
+                "UPDATE episodic_memories SET last_accessed_at = ? WHERE id = ?",
+                [(stamp, m) for m in due],
+            )
+            self.db.commit()
+            for m in due:
+                self._last_accessed_touch[m] = now
+            if len(self._last_accessed_touch) > self._LAST_ACCESSED_CACHE_MAX:
+                self._last_accessed_touch = {
+                    k: v for k, v in self._last_accessed_touch.items() if v >= cutoff
+                }
 
     def _delete_episodic_row(self, mem_id: str) -> None:
         with self._db_lock:

--- a/test/test_perf_memory_quickwins.py
+++ b/test/test_perf_memory_quickwins.py
@@ -1,0 +1,394 @@
+"""Regression tests for the memory-store performance quick wins (batch 6).
+
+Each test is written to FAIL if its corresponding fix is reverted:
+
+- ``TestEpisodicBatchFetch`` — the FAISS search path resolves all hits in one
+  ``IN (...)`` query that excludes the embedding BLOB (was one ``SELECT *``
+  per hit).
+- ``TestStorePragmas`` — ``memory.db`` runs WAL and keeps ``synchronous=FULL``
+  (a durability guard against relaxing it to ``NORMAL``).
+- ``TestLastAccessedDebounce`` — repeated searches within the debounce window
+  issue no further ``last_accessed_at`` writes.
+- ``TestLessonsSingleQuery`` — context assembly calls ``get_lessons_context()``
+  once instead of probing with ``get_lessons()`` first.
+- ``TestRecentFromSourceTailRead`` — ``recent_from_source`` reads a bounded
+  tail rather than the whole transcript.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.history import ConversationLog
+from kiro_crew.vector_memory import _HAS_FAISS, _HAS_NUMPY, VectorMemoryStore
+
+
+def _fake_embed(dim: int):
+    """Deterministic pseudo-embedding so FAISS has real vectors, no network."""
+
+    def _embed(text: str) -> list[float]:
+        seed = sum(ord(c) for c in text)
+        return [float((seed + i) % 7) + 0.1 for i in range(dim)]
+
+    return _embed
+
+
+class _SqlRecorder:
+    """Collects every statement sqlite executes on a connection."""
+
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    def __call__(self, sql: str) -> None:
+        self.statements.append(" ".join(sql.split()))
+
+    def matching(self, *needles: str) -> list[str]:
+        return [s for s in self.statements if all(n in s for n in needles)]
+
+
+def _faiss_store(tmp_path: Path, n_entries: int = 12, dim: int = 16) -> VectorMemoryStore:
+    store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=dim)
+    store.init()
+    store.embed_fn = _fake_embed(dim)
+    store.build_faiss_index()
+    for i in range(n_entries):
+        store.write_episodic(f"episodic memory number {i} about topic alpha beta")
+    return store
+
+
+class TestEpisodicBatchFetch:
+    def test_faiss_hits_resolved_in_one_query(self, tmp_path: Path) -> None:
+        """N hits cost ONE SELECT, not one per hit."""
+        if not (_HAS_FAISS and _HAS_NUMPY):
+            pytest.skip("FAISS/numpy not available on this platform")
+        store = _faiss_store(tmp_path)
+        recorder = _SqlRecorder()
+        store.db.set_trace_callback(recorder)
+        try:
+            results = store.search_episodic(
+                query_embedding=_fake_embed(16)("topic alpha"),
+                query_text="topic alpha",
+                limit=5,
+            )
+        finally:
+            store.db.set_trace_callback(None)
+
+        assert results, "expected episodic hits"
+        selects = recorder.matching("SELECT", "FROM episodic_memories")
+        # Pre-fix this was `limit * 2` separate `SELECT * ... WHERE id = ?`
+        # statements (10 for limit=5 with 12 rows indexed).
+        assert len(selects) == 1, f"expected a single batched SELECT, got {selects}"
+        assert " IN (" in selects[0]
+
+    def test_batched_select_excludes_embedding_blob(self, tmp_path: Path) -> None:
+        """Search results never carry the embedding column."""
+        if not (_HAS_FAISS and _HAS_NUMPY):
+            pytest.skip("FAISS/numpy not available on this platform")
+        store = _faiss_store(tmp_path)
+        results = store.search_episodic(
+            query_embedding=_fake_embed(16)("topic alpha"),
+            query_text="topic alpha",
+            limit=5,
+        )
+        assert results
+        for r in results:
+            assert "embedding" not in r, "embedding BLOB leaked into a search result"
+        # The useful fields are all still present.
+        assert {"id", "text", "importance", "created_at", "score", "cosine_sim"} <= set(results[0])
+
+    def test_tombstoned_rows_are_excluded(self, tmp_path: Path) -> None:
+        """A tombstoned row indexed in FAISS is dropped by the batch fetch."""
+        if not (_HAS_FAISS and _HAS_NUMPY):
+            pytest.skip("FAISS/numpy not available on this platform")
+        store = _faiss_store(tmp_path)
+        victim = store.db.execute(
+            "SELECT id FROM episodic_memories WHERE is_deleted = 0 LIMIT 1"
+        ).fetchone()["id"]
+        store._delete_episodic_row(victim)
+        results = store.search_episodic(
+            query_embedding=_fake_embed(16)("topic alpha"),
+            query_text="topic alpha",
+            limit=10,
+        )
+        assert victim not in {r["id"] for r in results}
+
+    def test_get_episodic_batch_empty_input(self, tmp_path: Path) -> None:
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        assert store._get_episodic_batch([]) == {}
+
+
+class TestStorePragmas:
+    def test_wal_with_full_synchronous(self, tmp_path: Path) -> None:
+        """memory.db runs WAL but keeps the default FULL synchronous setting.
+
+        This is a durability guard, not a perf assertion. Relaxing to NORMAL (1)
+        drops the per-commit fsync, and under WAL that is only crash-safe across
+        a process crash -- an OS crash or power loss can lose the unsynced WAL
+        tail, which here means acknowledged memories and lessons. Write volume
+        is reduced by debouncing the last_accessed_at touch instead.
+        """
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        journal = store.db.execute("PRAGMA journal_mode").fetchone()[0]
+        assert str(journal).lower() == "wal"
+        # 2 == FULL, the sqlite default. Must not be relaxed to 1 (NORMAL).
+        assert store.db.execute("PRAGMA synchronous").fetchone()[0] == 2
+
+
+class TestLastAccessedDebounce:
+    def test_repeat_search_skips_last_accessed_write(self, tmp_path: Path) -> None:
+        """A second search inside the debounce window issues no UPDATE."""
+        if not (_HAS_FAISS and _HAS_NUMPY):
+            pytest.skip("FAISS/numpy not available on this platform")
+        store = _faiss_store(tmp_path)
+        embed = _fake_embed(16)
+
+        first = store.search_episodic(
+            query_embedding=embed("topic alpha"), query_text="topic alpha", limit=5
+        )
+        assert first
+        # First search persisted the timestamp.
+        row = store.db.execute(
+            "SELECT last_accessed_at FROM episodic_memories WHERE id = ?", (first[0]["id"],)
+        ).fetchone()
+        assert row["last_accessed_at"] is not None
+
+        recorder = _SqlRecorder()
+        store.db.set_trace_callback(recorder)
+        try:
+            for _ in range(3):
+                store.search_episodic(
+                    query_embedding=embed("topic alpha"), query_text="topic alpha", limit=5
+                )
+        finally:
+            store.db.set_trace_callback(None)
+
+        updates = recorder.matching("UPDATE episodic_memories SET last_accessed_at")
+        assert updates == [], f"expected debounced touches, got {len(updates)} UPDATEs"
+
+    def test_touch_resumes_after_debounce_window(self, tmp_path: Path) -> None:
+        """Debouncing is time-bounded, not a permanent suppression."""
+        if not (_HAS_FAISS and _HAS_NUMPY):
+            pytest.skip("FAISS/numpy not available on this platform")
+        store = _faiss_store(tmp_path)
+        embed = _fake_embed(16)
+        store.search_episodic(
+            query_embedding=embed("topic alpha"), query_text="topic alpha", limit=5
+        )
+        # Age every recorded touch past the window.
+        store._last_accessed_touch = {
+            k: v - (store._LAST_ACCESSED_DEBOUNCE_SECS + 1)
+            for k, v in store._last_accessed_touch.items()
+        }
+        recorder = _SqlRecorder()
+        store.db.set_trace_callback(recorder)
+        try:
+            store.search_episodic(
+                query_embedding=embed("topic alpha"), query_text="topic alpha", limit=5
+            )
+        finally:
+            store.db.set_trace_callback(None)
+        assert recorder.matching("UPDATE episodic_memories SET last_accessed_at")
+
+    def test_sqlite_fallback_path_also_debounces(self, tmp_path: Path) -> None:
+        """The no-FAISS cosine fallback shares the debounced touch helper."""
+        dim = 16
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=dim)
+        store.init()
+        store.embed_fn = _fake_embed(dim)
+        for i in range(5):
+            store.write_episodic(f"episodic memory number {i} about topic alpha beta")
+        q = _fake_embed(dim)("topic alpha")
+        # Force the stdlib fallback regardless of whether FAISS is installed.
+        store._faiss_index = None
+        assert store._sqlite_vector_search(q, "topic alpha", 5)
+
+        recorder = _SqlRecorder()
+        store.db.set_trace_callback(recorder)
+        try:
+            store._sqlite_vector_search(q, "topic alpha", 5)
+        finally:
+            store.db.set_trace_callback(None)
+        assert recorder.matching("UPDATE episodic_memories SET last_accessed_at") == []
+
+
+class TestLessonsSingleQuery:
+    def _builder(self, tmp_path: Path):
+        from kiro_crew.context import ContextBuilder, LessonStore, MemoryStore, SkillsLoader
+
+        return ContextBuilder(
+            memory=MemoryStore(workspace=tmp_path / "ws"),
+            skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
+            lessons=LessonStore(base_dir=tmp_path),
+        )
+
+    def test_lessons_probe_query_is_gone(self, tmp_path: Path) -> None:
+        """get_lessons() is no longer used as an emptiness probe."""
+        from kiro_crew.context import ContextBuilder
+
+        vector_store = MagicMock()
+        vector_store.get_lessons_context.return_value = (
+            "[Learned corrections]\n- always run the formatter\n[End of learned corrections]\n"
+        )
+        vector_store.get_semantic_context.return_value = ""
+        vector_store.get_episodic_context.return_value = ""
+        fake_memory = MagicMock()
+        fake_memory.vector_store = vector_store
+        fake_memory.get_context.return_value = ""
+
+        builder = self._builder(tmp_path)
+        with patch.object(ContextBuilder, "get_memory_for", return_value=fake_memory):
+            ctx = builder.build_session_context(session_key="sess-lessons")
+
+        assert "always run the formatter" in ctx
+        vector_store.get_lessons.assert_not_called()
+        assert vector_store.get_lessons_context.call_count == 1
+
+    def test_empty_store_falls_back_to_file_lessons(self, tmp_path: Path) -> None:
+        """An empty vector store still yields the file-backed lessons."""
+        from kiro_crew.context import ContextBuilder
+        from kiro_crew.learn import Lesson, LessonStore
+
+        lessons = LessonStore(base_dir=tmp_path)
+        lessons.save(Lesson(ts="1", rule="never force push to mainline", category="knowledge"))
+
+        vector_store = MagicMock()
+        vector_store.get_lessons_context.return_value = ""
+        vector_store.get_semantic_context.return_value = ""
+        vector_store.get_episodic_context.return_value = ""
+        fake_memory = MagicMock()
+        fake_memory.vector_store = vector_store
+        fake_memory.get_context.return_value = ""
+
+        builder = self._builder(tmp_path)
+        builder.lessons = lessons
+        with patch.object(ContextBuilder, "get_memory_for", return_value=fake_memory):
+            ctx = builder.build_session_context(session_key="sess-lessons-empty")
+
+        assert "never force push to mainline" in ctx
+
+
+class _ByteCountingOpen:
+    """builtins.open wrapper that tallies bytes read from watched paths."""
+
+    def __init__(self, watched: Path) -> None:
+        self._real = builtins.open
+        self._watched = str(watched)
+        self.bytes_read = 0
+
+    def __call__(self, file, *args, **kwargs):  # type: ignore[no-untyped-def]
+        handle = self._real(file, *args, **kwargs)
+        if str(file) != self._watched:
+            return handle
+        outer = self
+
+        class _Counting:
+            def __init__(self, inner) -> None:  # type: ignore[no-untyped-def]
+                self._inner = inner
+
+            def read(self, *a, **k):  # type: ignore[no-untyped-def]
+                data = self._inner.read(*a, **k)
+                outer.bytes_read += len(data)
+                return data
+
+            def readline(self, *a, **k):  # type: ignore[no-untyped-def]
+                data = self._inner.readline(*a, **k)
+                outer.bytes_read += len(data)
+                return data
+
+            def __iter__(self):  # type: ignore[no-untyped-def]
+                for line in self._inner:
+                    outer.bytes_read += len(line)
+                    yield line
+
+            def __enter__(self):  # type: ignore[no-untyped-def]
+                self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc):  # type: ignore[no-untyped-def]
+                return self._inner.__exit__(*exc)
+
+            def __getattr__(self, name):  # type: ignore[no-untyped-def]
+                return getattr(self._inner, name)
+
+        return _Counting(handle)
+
+
+class TestRecentFromSourceTailRead:
+    #: Messages written to the fixture transcript. Large enough that a
+    #: whole-file read is unmistakably distinguishable from a tail read.
+    _N_MESSAGES = 3000
+
+    def _write_transcript(self, log: ConversationLog, key: str) -> Path:
+        path = log._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        filler = "x" * 400
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(json.dumps({"_type": "metadata", "tab_id": "t1"}) + "\n")
+            for i in range(self._N_MESSAGES):
+                f.write(
+                    json.dumps(
+                        {
+                            "role": "user" if i % 2 == 0 else "assistant",
+                            "content": f"msg-{i} {filler}",
+                            "ts": f"2026-01-01T00:00:{i:04d}",
+                        }
+                    )
+                    + "\n"
+                )
+        return path
+
+    def test_reads_bounded_tail_not_whole_file(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        path = self._write_transcript(log, "slack-C1-alpha")
+        total = path.stat().st_size
+        assert total > 1_000_000, "fixture must be large enough to show the difference"
+
+        counter = _ByteCountingOpen(path)
+        with patch.object(builtins, "open", counter):
+            msgs = log.recent_from_source("slack-C1", max_messages=20)
+
+        assert len(msgs) == 20
+        assert msgs[-1]["content"].startswith(f"msg-{self._N_MESSAGES - 1} ")
+        # Bounded tail window (~51 KB) plus a 5-line head probe. The pre-fix
+        # implementation read the entire file.
+        assert counter.bytes_read < 200_000, (
+            f"read {counter.bytes_read} of {total} bytes — expected a bounded tail read"
+        )
+
+    def test_restricted_sessions_still_skipped(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        path = log._path("slack-C2-secret")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(json.dumps({"_type": "metadata", "memory_mode": "incognito"}) + "\n")
+            f.write(
+                json.dumps({"role": "user", "content": "secret", "ts": "2026-01-01T00:00:00"})
+                + "\n"
+            )
+        assert log.recent_from_source("slack-C2", max_messages=20) == []
+
+    def test_excludes_named_key_and_orders_by_timestamp(self, tmp_path: Path) -> None:
+        log = ConversationLog(base_dir=tmp_path)
+        for name, stamp in (("slack-C3-a", "01"), ("slack-C3-b", "02")):
+            path = log._path(name)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "role": "user",
+                            "content": f"from-{name}",
+                            "ts": f"2026-01-{stamp}T00:00:00",
+                        }
+                    )
+                    + "\n"
+                )
+        msgs = log.recent_from_source("slack-C3", exclude_key="slack-C3-a", max_messages=20)
+        assert [m["content"] for m in msgs] == ["from-slack-C3-b"]


### PR DESCRIPTION
Batch 6 of the wf_000019 performance-audit remediation: the memory-store S-effort
findings. Four self-contained fixes, each with a revert-verified regression test in
`test/test_perf_memory_quickwins.py` (13 tests, all new).

## Fixes

### 1. FAISS episodic search: N+1 collapsed into one `IN (...)` query

`search_episodic` resolved every FAISS hit with its own `SELECT * FROM
episodic_memories WHERE id = ?` (`_get_episodic`), so a `limit=5` search issued 10
round trips, and `SELECT *` dragged each row's `embedding` BLOB back out of the
store even though the vectors are already resident in the index. New
`_get_episodic_batch` resolves all hits in one `IN (...)` query over the same
explicit column list the stdlib fallback (`_sqlite_vector_search`) already used, so
the two search paths now return the same result shape.

Basis: audit finding `vector_memory.py:1312`. The id list is bounded by the FAISS
`k` (`2 * limit`), well under sqlite's bound-parameter ceiling. The
`is_deleted` check moves into the WHERE clause; absent-from-mapping now covers both
"row gone" and "row tombstoned", which the per-hit lookup treated identically.

Revert-verification: `TestEpisodicBatchFetch::test_faiss_hits_resolved_in_one_query`
and `::test_batched_select_excludes_embedding_blob` both FAIL with the fix reverted
(10 SELECTs instead of 1; `embedding` present in every result dict) and PASS with it
applied. `::test_tombstoned_rows_are_excluded` and `::test_get_episodic_batch_empty_input`
are correctness guards on the new code path and pass either way by design.

### 2. Debounced `last_accessed_at` touch

`memory.db` already ran `journal_mode=WAL` on `main`, so that half of the audit
finding was already satisfied. This PR initially also relaxed `synchronous` to
`NORMAL` to drop the per-commit fsync; that has been removed after review. Under
WAL, `NORMAL` survives a process crash but an OS crash or power loss can still
lose the unsynced WAL tail — acknowledged memories and lessons. The debounce
below removes the frequent commits outright, which is the right fix for write
volume; weakening the durability of the commits that remain is not. `synchronous`
therefore stays at sqlite's default FULL, unchanged from `main`.

The real cost was that both search paths issued one unconditional `UPDATE ... SET
last_accessed_at` per result on every search, turning each read into a write
transaction. `_touch_last_accessed` now skips rows written within 60 s and sends the
remainder in one `executemany`. `last_accessed_at` only feeds recency reporting, so
60 s of staleness is not observable in any consumer. The in-process debounce map is
swept past 4096 entries, and the helper holds `_db_lock` for its whole body so the
bookkeeping cannot interleave with a concurrent searcher's — the pre-existing lock
discipline on this write is preserved.

Basis: audit finding "memory.db has no WAL … and debounce the `last_accessed_at` touch". The WAL half was already on `main`; the `synchronous` half was rejected on durability grounds during review.

Revert-verification: `TestStorePragmas::test_wal_with_full_synchronous` is a
durability guard — it FAILS (`assert 1 == 2`) if `synchronous` is relaxed to
`NORMAL` and PASSES at the default FULL.
`TestLastAccessedDebounce::test_repeat_search_skips_last_accessed_write` and
`::test_sqlite_fallback_path_also_debounces` both FAIL with the debounce reverted
(UPDATEs on every repeat search) and PASS with it applied.
`::test_touch_resumes_after_debounce_window` guards that suppression is
time-bounded rather than permanent.

### 3. Context assembly: one lessons query instead of two

`build_session_context` called `vector_store.get_lessons()` purely as an emptiness
probe and then `get_lessons_context()`, which re-queried the same rows. The probe
was an unbounded `SELECT *` over `semantic_memory` (embedding blobs included) whose
only use was `if …:`. `get_lessons_context()` already returns `""` for an empty
store, so branching on the returned string is exactly equivalent — a non-empty
lesson set cannot produce an empty `LIMIT 50` slice.

Basis: audit finding `context.py:1642-1644`.

Revert-verification: `TestLessonsSingleQuery::test_lessons_probe_query_is_gone`
FAILS with the fix reverted (`get_lessons` is called) and PASSES with it applied.
`::test_empty_store_falls_back_to_file_lessons` covers the fallback branch.

### 4. `recent_from_source`: bounded tail read instead of a whole-file read

`recent_from_source` read the head of each transcript for the `memory_mode` marker
and then `f.read()` the entire remainder, only to keep `lines[-50:]`. On large
transcripts that is up to tens of MB of reads discarded immediately.
`_read_tail_messages` — which already exists on the same class and seeks to the file
tail with geometric window growth — now supplies the messages, while the 5-line head
probe for incognito/temporary sessions is unchanged. Output is byte-identical: the
newest messages always sit at EOF, so the tail window is always the true
most-recent slice. The docstring claimed behaviour the function did not have
("reads only the last 50 lines from each") and now describes what it does.

Basis: audit finding `history.py:1657`.

Revert-verification:
`TestRecentFromSourceTailRead::test_reads_bounded_tail_not_whole_file` instruments
`open` to tally bytes read from a 1.5 MB fixture transcript. It FAILS with the fix
reverted (whole file read) and PASSES with it applied (~51 KB tail window plus the
head probe, asserted under 200 KB), with the returned messages asserted identical
either way. `::test_restricted_sessions_still_skipped` and
`::test_excludes_named_key_and_orders_by_timestamp` guard the surrounding behaviour.

## Gates

Run from the worktree root at CI's exact scope:

| Gate | Result |
| --- | --- |
| `isort --check-only src/kiro_crew test` | pass |
| `flake8 src/kiro_crew test` | pass |
| `mypy src/kiro_crew/` | pass for this change — 1 pre-existing error |
| `pytest` (full suite) | 22449 passed, 68 skipped, 5 xfailed; 3 pre-existing failures |

The single mypy error (`vector_memory.py` `faiss.write_index` overload, in
`build_faiss_index`) reproduces unchanged on pristine `origin/main`; this branch
only shifts its line number.

The 3 pytest failures are all `test/test_dashboard_origin.py::TestParseDashboardUrlMalformed`
and reproduce on pristine `origin/main` in this environment (an ambient dashboard
URL on port 6776 leaks into the parse assertions). `dashboard/origin.py` is Batch
3's file, not touched here.

## Scope

Files touched: `src/kiro_crew/vector_memory.py`, `src/kiro_crew/context.py`,
`src/kiro_crew/history.py` (only `recent_from_source`), plus the new
`test/test_perf_memory_quickwins.py`. Nothing deferred.

Cross-batch note: the excluded single-owner refactors #2 (history.py transcript
I/O) and #3 (vector_memory.py embedding persistence) both target these files and
should run after this lands. #3 in particular will want the embedding column back
in the search path, so it should build on `_get_episodic_batch` /
`_EPISODIC_SEARCH_COLUMNS` rather than reinstate the per-hit `SELECT *`.

