### PR TITLE
ci: publish cli.sh from CI instead of by hand

### DIFF
--- a/.github/workflows/publish-installer.yml
+++ b/.github/workflows/publish-installer.yml
@@ -1,0 +1,186 @@
+name: Publish Installer
+
+# Publishes cli.sh -- the bootstrap installer behind the documented one-liner
+#
+#   curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel X
+#
+# to the ROOT of the public distribution bucket. It is the only root object.
+#
+# Why this is its own workflow rather than a step in publish-cli.yml:
+# publish-cli.yml is workflow_call'd by BOTH nightly.yml (schedule, checks out
+# main) and release.yml (tag push, checks out the tag), once per channel. The
+# installer is channel-agnostic -- ONE live copy serves nightly, insider and
+# stable, because the script's only job is to resolve whichever channel feed it
+# is asked for. Publishing it from there would upload it once per channel from
+# whichever ref that lane happened to check out, so the live bytes would depend
+# on whether a nightly or a release ran most recently. Nondeterministic, and
+# silent when wrong.
+#
+# Ref policy: main, path-filtered. The installer's contract (resolve the feed,
+# verify sha256, install) is channel-independent, so a stable user running an
+# installer built from main is fine -- whereas a STALE installer is not. That
+# is not hypothetical: with no publish lane at all, cli.sh drifted 11 days and
+# 5 commits behind main and shipped a `beta` channel prefix nothing had ever
+# published, so `--channel insider` died on an opaque CDN 403 (#978). The
+# obligation this creates is real and belongs in review: the installer must
+# stay backward-compatible with every live channel.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cli.sh'
+      - '.github/workflows/publish-installer.yml'
+  # Manual re-publish. Restricted to main by the ref guard in the first step:
+  # the Actions UI lets a maintainer pick any ref, and `environment: prod` does
+  # not constrain that, so the guard is what keeps this main-only. Needed
+  # because the path filter above only fires when cli.sh itself changes -- a
+  # republish after an infrastructure fix (e.g. the bucket grant landing) would
+  # otherwise require a no-op commit to the installer.
+  workflow_dispatch: {}
+
+# Never let two publishes race the same key. cancel-in-progress stays FALSE:
+# cancelling mid-publish could leave the object uploaded but unverified.
+concurrency:
+  group: publish-installer
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish-installer:
+    name: Publish cli.sh
+    runs-on: ubuntu-latest
+    # Upstream only. Forks pushing to their own main have no publish role and
+    # nothing to publish to; skipping at the JOB level (rather than gating each
+    # step on a secret) is what keeps the fail-closed behaviour below honest.
+    if: github.repository == 'kirodotdev/KiroCrew'
+    # REQUIRED: the publish role's OIDC trust accepts exactly two subjects --
+    # ref:refs/heads/main and environment:prod. See publish-cli.yml.
+    environment: prod
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      BUCKET: ${{ vars.CLI_DIST_BUCKET }}
+      CDN_BASE: ${{ vars.CLI_CDN_BASE }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Publish the CURRENT tip of main, never the triggering event's SHA.
+          # cli.sh is a mutable pointer artifact -- unlike cli/<version>/ wheels,
+          # there is one live copy and the only correct content is "latest
+          # reviewed main". Checking out github.sha (the default) means a
+          # re-run of an older run, or a queued run executing after a newer one,
+          # would overwrite newer bytes with older ones and silently roll the
+          # installer back for every new user. The ref guard below still
+          # restricts WHICH refs may trigger a publish; this decides WHAT gets
+          # published.
+          ref: main
+
+      # Fail-closed, deliberately NOT the `if: env.HAS_SIGNING_SECRETS` skip
+      # pattern the other publish lanes use. Those turn a missing secret into a
+      # GREEN run that published nothing -- the exact shape of failure that let
+      # this file rot unnoticed for 11 days. On upstream main these are always
+      # present, so absence is a misconfiguration and must be loud.
+      - name: Verify publish configuration
+        env:
+          ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+          # main-only, enforced here rather than trusted from the trigger.
+          # `push` is already filtered to main, but workflow_dispatch lets a
+          # maintainer pick ANY ref in the Actions UI -- and `environment: prod`
+          # does not save us, because the environment switches any caller's OIDC
+          # subject to environment:prod (see publish-cli.yml). Without this
+          # check, dispatching from a feature branch would check that ref out
+          # and publish its cli.sh, making unreviewed shell publicly executable
+          # by every new user. Fails loudly rather than skipping, so a mistaken
+          # dispatch leaves a clear reason in the run log.
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::Refusing to publish from '${GITHUB_REF}'. cli.sh is published from main only -- it is publicly executable, so it must be reviewed and merged first."
+            exit 1
+          fi
+          missing=""
+          [ -n "$ROLE_ARN" ] || missing="${missing} AWS_SIGNING_ROLE_ARN"
+          [ -n "${BUCKET}" ] || missing="${missing} vars.CLI_DIST_BUCKET"
+          [ -n "${CDN_BASE}" ] || missing="${missing} vars.CLI_CDN_BASE"
+          if [ -n "$missing" ]; then
+            echo "::error::Installer publish is misconfigured (missing:${missing}). Refusing to report success without publishing."
+            exit 1
+          fi
+          test -f cli.sh || { echo "::error::cli.sh is missing from the checkout."; exit 1; }
+
+      # Catches the class of bug that motivated this lane: a syntax error or a
+      # channel/prefix mismatch would otherwise reach every new user's shell.
+      # The repo's own contract tests (test_publish_feed_contract.py) assert the
+      # channel names match publish-cli.yml; this is the cheap shell-level gate.
+      - name: Check the installer parses and rejects a bad channel
+        run: |
+          set -euo pipefail
+          sh -n cli.sh
+          if sh cli.sh --channel definitely-not-a-channel 2>/dev/null; then
+            echo "::error::cli.sh accepted an unknown channel; it must fail before reaching the CDN."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+          aws-region: us-west-2
+
+      # `--cache-control no-cache` is load-bearing, not cosmetic. The bucket
+      # root falls under the distribution's DEFAULT behaviour (CACHING_OPTIMIZED,
+      # 24h default TTL); feed/* is the only prefix with CACHING_DISABLED. Drop
+      # this header and CloudFront pins a stale installer at the edges for a day
+      # with no invalidation issued. With it, edges revalidate and the publish
+      # is live immediately.
+      - name: Publish cli.sh
+        run: |
+          set -euo pipefail
+          aws s3api put-object \
+            --bucket "${BUCKET}" \
+            --key cli.sh \
+            --body cli.sh \
+            --content-type 'text/x-shellscript' \
+            --cache-control 'no-cache' > /dev/null
+          echo "Uploaded s3://${BUCKET}/cli.sh"
+
+      # "Uploaded" is not "live and correct". Read the object back over the
+      # PUBLIC CloudFront URL (not S3) and compare sha256 against the file we
+      # just published, so the check exercises what a user's curl actually
+      # receives -- including the CDN path and the cache headers above. Retries
+      # cover edge revalidation, then fail closed.
+      - name: Verify the published installer is live
+        run: |
+          set -euo pipefail
+          EXPECTED=$(sha256sum cli.sh | awk '{print $1}')
+          # The checkout above pins main's tip, which is NOT necessarily the
+          # event SHA, so report what was actually published rather than
+          # ${GITHUB_SHA} -- otherwise the summary names a commit whose cli.sh
+          # may differ from the bytes now live.
+          PUBLISHED_SHA=$(git rev-parse HEAD)
+          URL="${CDN_BASE%/}/cli.sh"
+          for attempt in 1 2 3 4 5; do
+            ACTUAL=$(curl -fsSL "$URL" | sha256sum | awk '{print $1}') || ACTUAL=""
+            if [ "$ACTUAL" = "$EXPECTED" ]; then
+              echo "Verified ${URL} == cli.sh@${PUBLISHED_SHA} (sha256 ${EXPECTED})"
+              CACHE=$(curl -fsSI "$URL" | tr -d '\r' | awk -F': ' 'tolower($1)=="cache-control"{print $2}')
+              [ "$CACHE" = "no-cache" ] || {
+                echo "::error::Published installer is served with cache-control='${CACHE}', expected 'no-cache'."
+                exit 1
+              }
+              {
+                echo "### Installer published"
+                echo "- URL: \`${URL}\`"
+                echo "- sha256: \`${EXPECTED}\`"
+                echo "- source: \`cli.sh\` @ \`${PUBLISHED_SHA}\` (tip of main)"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "Attempt ${attempt}: live sha256 '${ACTUAL:-<fetch failed>}' != '${EXPECTED}'; retrying..."
+            sleep 10
+          done
+          echo "::error::${URL} did not converge on the published bytes. The upload may have landed without going live -- check the CloudFront behaviour for the bucket root."
+          exit 1


### PR DESCRIPTION
## Problem

`cli.sh` — the bootstrap installer behind the one-liner published in the README and `docs/getting-started.md` — has **no publish lane**. Every update was a hand upload to S3, and that eventually stopped happening.

The result, observed in the field today:

```
$ curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel insider
Resolving KiroCrew (insider channel) ...
curl: (56) The requested URL returned error: 403
kirocrew-install: channel 'insider' has no feed at .../feed/beta/latest-cli.json
```

The served script was dated **20 Jul** and had missed five commits: #396 (crew.kiro.dev hostname cutover), #459, #564, #595, and #978. It still defaulted to the retired `d28nxu9if70cmc.cloudfront.net` host and still remapped `insider` onto a `beta` path prefix nothing has ever published.

## Why it matters

This is the documented install path for every Linux/EC2 user, and it was broken for 11 days with **no signal anywhere**: the repo file was correct, CI was green, the docs were correct, and the tests added in #978 pass. Nothing in this repository can catch it, because the artifact under test isn't in the repo's control surface. A manual step with no monitoring sat in the release critical path.

Fixing the script (#978, merged) doesn't fix this — I had to republish the object by hand again today. Without a lane, the next `cli.sh` change drifts exactly the same way.

## Fix (symptom → root cause → change)

**Symptom:** users get an installer that doesn't match the repo.
**Root cause:** no automated publish, because the publish role has no S3 grant on the bucket root — so CI *could not* write the key even if a step existed. Hand uploads were the only mechanism, and they are unmonitored by construction.
**Change:** a dedicated `publish-installer.yml` that uploads `cli.sh` on every push to `main` that touches it, then verifies the object is live.

Three design decisions worth reviewing:

**Its own workflow, not a step in `publish-cli.yml`.** That workflow is `workflow_call`'d by both `nightly.yml` (schedule, checks out `main`) and `release.yml` (tag push, checks out the *tag*), once per channel. The installer is channel-agnostic — one live copy serves nightly, insider and stable, because its only job is to resolve whichever feed it's asked for. Publishing from there would upload it once per channel from whichever ref that lane happened to check out, making the live bytes depend on whether a nightly or a release ran most recently. Nondeterministic and silent.

**Ref policy: `main`, path-filtered** (same shape `pages.yml` uses for `site/**`). Since the installer's contract is channel-independent, a stable user running an installer built from `main` is fine — whereas a *stale* installer is not, as this bug demonstrates. Publishing from the stable tag instead would have made #978 wait for the next stable promotion. The obligation this creates is stated in the workflow header and belongs in review: **the installer must stay backward-compatible with every live channel.**

**Fails closed instead of skipping.** The other publish lanes gate each step on `if: env.HAS_SIGNING_SECRETS`, which turns a missing secret into a **green run that published nothing** — the exact shape of failure that let this rot unnoticed. This job excludes forks at the job level and then *errors* on missing configuration.

Two details a human upload kept getting wrong, now encoded:

- **`--cache-control no-cache`.** The bucket root falls under the distribution's default behaviour (`CACHING_OPTIMIZED`, 24h); only `feed/*` is `CACHING_DISABLED`. Without the header CloudFront pins a stale installer at the edges for a day. The current object only revalidates because a human set it by hand in July.
- **Read-back verification.** After upload it fetches the object over the **public CloudFront URL** (not S3) and compares sha256 against the file it just published, asserting the cache header too. "Uploaded" is not "live and correct" — the distinction this entire bug lived inside.

## Blocked on a matching CDK change

**This workflow is inert until the bucket-policy grant is deployed** — the publish role's grants are `cli/*`, `feed/*`, `desktop/*` only, so the upload step fails `AccessDenied` on the root key today. The grant is in review as **CR-293648104** on `KiroCrewPublishCDK`. Order matters: that deploys first, or the first run of this workflow fails.

That CR also carries a related finding worth knowing about here: the existing `distBucket.grantPut(...)` calls render *nothing* against a `mutable: false` imported role, so the live grants were all added out of band by hand.

## Tests

`test/test_github_workflow_security.py` and `test/test_publish_feed_contract.py` — **22 passed**, covering this new workflow's action pinning and permissions.

No new tests added here. The contract this workflow depends on (installer channel names matching what `publish-cli.yml` publishes) is already locked by the three guards added in #978 to `test_publish_feed_contract.py`, which read the valid channel set out of `publish-cli.yml`'s own input description rather than duplicating it.

## Manual verification

Partial, and the gap is structural — a workflow cannot be executed before it is merged.

Verified locally, against byte-identical content:

- `sh -n cli.sh` clean; `sh cli.sh --channel <invalid>` exits 1 with the valid channel list (the "reject a bad channel" gate).
- The `cache-control` header parse in the verify step returns exactly `no-cache` against the live object.
- The sha256 comparison the verify step performs: repo `cli.sh` at `7c41b042` matches the currently-served object (`5e27f2fb…`), i.e. the assertion would pass.
- YAML parses; `actions/checkout` and `configure-aws-credentials` pins match the rest of the repo.

**Not verified:** the upload-and-verify path has never run. Its first real execution is its first test, and it cannot succeed until CR-293648104 deploys.

## Screenshots

N/A — CI-only change, no user-visible UI.
