### PR TITLE
fix(release): fail closed on missing macOS artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,28 +180,76 @@ jobs:
         with:
           path: artifacts
 
-      # Assemble release assets: everything built, with the macOS zip and DMG
-      # replaced by the notarized ones from the notarize job. The unsigned
-      # electron-builder DMG (built before signing) must never ship; the
-      # shipping DMG is Developer ID signed + notarized + stapled inside
-      # sign-and-notarize.yml (see its header note for the adhoc-DMG
-      # incident that made the signature mandatory).
-      - name: Flatten artifacts (notarized macOS assets win)
+      # Assemble release assets: everything built, with macOS assets accepted
+      # only from the exact gated artifact emitted after notarization, stapling,
+      # and Gatekeeper verification. The unsigned electron-builder zip/DMG are
+      # inter-job inputs only and must never become GitHub Release assets.
+      - name: Assemble release assets (require gated macOS artifacts)
         run: |
+          set -euo pipefail
           mkdir -p release
           find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.AppImage" \) -exec cp {} release/ \;
-          NOTARIZED=$(find artifacts -path "*KiroCrew-notarized-*" -name "notarized.zip" | head -1)
-          if [ -n "$NOTARIZED" ]; then
-            cp "$NOTARIZED" "release/KiroCrew-${{ needs.version.outputs.version }}-universal-mac.zip"
-          else
-            # Unsigned fallback (CDSigner not configured): the electron-builder
-            # mac zip always ends in "-mac.zip" whatever the arch token.
-            find artifacts -type f -name "*-mac.zip" -exec cp {} release/ \;
-          fi
-          NOTARIZED_DMG=$(find artifacts -path "*KiroCrew-notarized-*" -name "*.dmg" | head -1)
-          if [ -n "$NOTARIZED_DMG" ]; then
-            cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.version.outputs.version }}-universal.dmg"
-          fi
+
+          NOTARIZED_DIR="artifacts/KiroCrew-notarized-${{ needs.version.outputs.channel }}-${{ needs.version.outputs.version }}"
+          NOTARIZED_ZIP="${NOTARIZED_DIR}/notarized.zip"
+          NOTARIZED_DMG="${NOTARIZED_DIR}/KiroCrew.dmg"
+          [ -s "$NOTARIZED_ZIP" ] || {
+            echo "::error::Required gated macOS ZIP is missing or empty: ${NOTARIZED_ZIP}"
+            exit 1
+          }
+          [ -s "$NOTARIZED_DMG" ] || {
+            echo "::error::Required gated macOS DMG is missing or empty: ${NOTARIZED_DMG}"
+            exit 1
+          }
+
+          # Fail closed on corrupt or mis-shaped handoff files before granting
+          # the GitHub Release job's contents:write capability to publish them.
+          # Cryptographic Gatekeeper checks happen immediately before the
+          # notarize job uploads this exact, name-bound artifact.
+          python3 - "$NOTARIZED_ZIP" "$NOTARIZED_DMG" <<'PY_VALIDATE'
+          from pathlib import Path, PurePosixPath
+          import sys
+          import zipfile
+
+          zip_path = Path(sys.argv[1])
+          dmg_path = Path(sys.argv[2])
+
+          try:
+              with zipfile.ZipFile(zip_path) as archive:
+                  corrupt_member = archive.testzip()
+                  names = archive.namelist()
+          except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+              raise SystemExit(f"::error::{zip_path} is not a valid ZIP archive: {exc}")
+
+          if corrupt_member is not None:
+              raise SystemExit(
+                  f"::error::{zip_path} failed its CRC check at {corrupt_member}"
+              )
+          app_roots = {
+              parts[0]
+              for name in names
+              if (parts := PurePosixPath(name).parts) and parts[0].endswith(".app")
+          }
+          if len(app_roots) != 1:
+              raise SystemExit(
+                  f"::error::{zip_path} must contain exactly one top-level .app; "
+                  f"found {sorted(app_roots)}"
+              )
+
+          try:
+              if dmg_path.stat().st_size < 512:
+                  raise ValueError("file is smaller than the 512-byte UDIF trailer")
+              with dmg_path.open("rb") as dmg:
+                  dmg.seek(-512, 2)
+                  signature = dmg.read(4)
+              if signature != b"koly":
+                  raise ValueError("UDIF trailer signature is missing")
+          except (OSError, ValueError) as exc:
+              raise SystemExit(f"::error::{dmg_path} is not a valid UDIF DMG: {exc}")
+          PY_VALIDATE
+
+          cp "$NOTARIZED_ZIP" "release/KiroCrew-${{ needs.version.outputs.version }}-universal-mac.zip"
+          cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.version.outputs.version }}-universal.dmg"
           ls -la release/
 
       - name: Create GitHub Release

--- a/test/test_release_macos_fail_closed.py
+++ b/test/test_release_macos_fail_closed.py
@@ -1,0 +1,151 @@
+"""Fail-closed contract tests for macOS assets on GitHub Releases.
+
+The release job has ``contents: write`` and is the final trust-boundary hop
+before files become public.  These tests execute its actual shell step so an
+unsigned fallback, a broad ``find | head`` selector, or a superficial presence
+check cannot silently reappear.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="the GitHub Release assembly step runs under bash on ubuntu-latest",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+STEP_NAME = "Assemble release assets (require gated macOS artifacts)"
+CHANNEL = "stable"
+VERSION = "1.2.3"
+ARTIFACT_NAME = f"KiroCrew-notarized-{CHANNEL}-{VERSION}"
+
+
+def _assembly_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["github-release"]["steps"]
+    step = next((item for item in steps if item.get("name") == STEP_NAME), None)
+    assert step is not None, f"release workflow step {STEP_NAME!r} not found"
+
+    script = step["run"]
+    script = script.replace("${{ needs.version.outputs.channel }}", CHANNEL)
+    script = script.replace("${{ needs.version.outputs.version }}", VERSION)
+    assert "${{" not in script, "test harness left an unresolved GitHub expression"
+    return script
+
+
+def _artifact_dir(root: Path, name: str = ARTIFACT_NAME) -> Path:
+    path = root / "artifacts" / name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_valid_zip(path: Path, app_name: str = "KiroCrew.app") -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(f"{app_name}/Contents/Info.plist", "<plist/>")
+
+
+def _write_valid_dmg(path: Path) -> None:
+    # hdiutil's UDIF output ends in a 512-byte trailer beginning with "koly".
+    path.write_bytes(b"test payload" + b"koly" + bytes(508))
+
+
+def _write_valid_handoff(root: Path, name: str = ARTIFACT_NAME) -> Path:
+    artifact = _artifact_dir(root, name)
+    _write_valid_zip(artifact / "notarized.zip")
+    _write_valid_dmg(artifact / "KiroCrew.dmg")
+    return artifact
+
+
+def _run_assembly(root: Path) -> subprocess.CompletedProcess[str]:
+    (root / "artifacts").mkdir(exist_ok=True)
+    return subprocess.run(
+        ["bash", "-c", _assembly_script()],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_missing_exact_gated_artifact_does_not_fall_back_to_unsigned(tmp_path: Path) -> None:
+    """A valid-looking unsigned build or stale notarized run cannot be selected."""
+    unsigned = _artifact_dir(tmp_path, "unsigned-build-darwin-universal")
+    _write_valid_zip(unsigned / "KiroCrew-universal-mac.zip")
+    _write_valid_dmg(unsigned / "KiroCrew.dmg")
+    _write_valid_handoff(tmp_path, "KiroCrew-notarized-stable-1.2.2")
+
+    result = _run_assembly(tmp_path)
+
+    assert result.returncode != 0
+    assert "Required gated macOS ZIP is missing or empty" in result.stderr + result.stdout
+    assert not list((tmp_path / "release").glob("*mac.zip"))
+    assert not list((tmp_path / "release").glob("*.dmg"))
+
+
+@pytest.mark.parametrize(
+    ("missing_name", "expected_error"),
+    (
+        ("notarized.zip", "Required gated macOS ZIP is missing or empty"),
+        ("KiroCrew.dmg", "Required gated macOS DMG is missing or empty"),
+    ),
+)
+def test_incomplete_gated_handoff_fails(
+    tmp_path: Path, missing_name: str, expected_error: str
+) -> None:
+    artifact = _write_valid_handoff(tmp_path)
+    (artifact / missing_name).unlink()
+
+    result = _run_assembly(tmp_path)
+
+    assert result.returncode != 0
+    assert expected_error in result.stderr + result.stdout
+
+
+def test_corrupt_notarized_zip_fails(tmp_path: Path) -> None:
+    artifact = _artifact_dir(tmp_path)
+    (artifact / "notarized.zip").write_bytes(b"not a zip")
+    _write_valid_dmg(artifact / "KiroCrew.dmg")
+
+    result = _run_assembly(tmp_path)
+
+    assert result.returncode != 0
+    assert "is not a valid ZIP archive" in result.stderr + result.stdout
+
+
+def test_non_udif_dmg_fails(tmp_path: Path) -> None:
+    artifact = _artifact_dir(tmp_path)
+    _write_valid_zip(artifact / "notarized.zip")
+    (artifact / "KiroCrew.dmg").write_bytes(b"not a UDIF image")
+
+    result = _run_assembly(tmp_path)
+
+    assert result.returncode != 0
+    assert "is not a valid UDIF DMG" in result.stderr + result.stdout
+
+
+def test_exact_gated_handoff_is_renamed_for_the_release(tmp_path: Path) -> None:
+    gated = _write_valid_handoff(tmp_path)
+    unsigned = _artifact_dir(tmp_path, "unsigned-build-darwin-universal")
+    (unsigned / "unsigned-mac.zip").write_bytes(b"unsigned zip")
+    (unsigned / "unsigned.dmg").write_bytes(b"unsigned dmg")
+    (tmp_path / "artifacts" / "cli.whl").write_bytes(b"wheel")
+
+    result = _run_assembly(tmp_path)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    release = tmp_path / "release"
+    release_zip = release / f"KiroCrew-{VERSION}-universal-mac.zip"
+    release_dmg = release / f"KiroCrew-{VERSION}-universal.dmg"
+    assert release_zip.read_bytes() == (gated / "notarized.zip").read_bytes()
+    assert release_dmg.read_bytes() == (gated / "KiroCrew.dmg").read_bytes()
+    assert not (release / "unsigned-mac.zip").exists()
+    assert not (release / "unsigned.dmg").exists()


### PR DESCRIPTION
## Problem

The tagged-release workflow fell back to the unsigned electron-builder macOS ZIP when the signed/notarized workflow artifact was absent. A missing notarized DMG was also silently omitted, allowing the GitHub Release job to succeed with an unsafe or incomplete macOS asset set.

## Impact

A release tag could publish macOS bytes that never passed signing, notarization, stapling, and Gatekeeper verification. Users could receive an untrusted or unusable macOS download while the release workflow appeared successful.

## Root Cause and Fix

The GitHub Release assembly step treated the gated macOS artifact as optional and selected it with a broad `find ... | head -1`; otherwise it copied unsigned build output.

The step now requires the exact `KiroCrew-notarized-<channel>-<version>` handoff produced by the notarization job. Both `notarized.zip` and `KiroCrew.dmg` must be present and non-empty. Before publication, the ZIP must pass CRC validation and contain exactly one top-level app bundle, and the DMG must carry a valid UDIF trailer. Any missing, stale, corrupt, or mis-shaped handoff fails the job; unsigned ZIPs and DMGs are never copied into the release directory.

## Tests

- `pytest -q test/test_release_macos_fail_closed.py test/test_publish_feed_contract.py test/test_workflow_permissions.py` with xdist/loadgroup: 36 passed
- `isort --check-only --diff src/kiro_crew test`: passed
- `flake8 --jobs 1 src/kiro_crew test`: passed (`--jobs 1` avoids this sandbox's semaphore restriction)
- `mypy src/kiro_crew/`: passed (563 source files)
- `./scripts/scrub-lint.sh --no-history`: passed
- Repository-wide `isort --check-only --diff .` reports the same seven unrelated, out-of-CI-scope import-order failures on clean `origin/main`; the canonical CI scope above is green.

## Manual Verification

The focused tests execute the workflow's actual assembly shell step. They verify rejection of an unsigned fallback plus stale notarized artifact, either missing gated file, a corrupt ZIP, and a non-UDIF DMG; the valid exact handoff is accepted and renamed while unsigned sibling artifacts remain excluded.

## Operational/External Dependencies

GitHub Releases now intentionally require the existing CDSigner and Apple notarization pipeline to emit the exact gated artifact. If signing credentials, CDSigner, or Apple notarization are unavailable, the macOS GitHub Release fails closed instead of publishing unsigned bytes. No credentials, permissions, or secret-storage behavior changed.