### PR TITLE
fix(test): budget xdist workers across concurrent pytest runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,20 +216,25 @@ npm run test     # vitest unit/integration tests
 For faster iteration during development, use `pytest-testmon` to run only tests affected by changed files instead of the full suite. This uses dependency tracking to skip unaffected tests.
 
 ```bash
-# Fast iteration — only tests affected by your changes (no coverage overhead).
-# Multi-test runs MUST keep the xdist flags (-n auto --dist loadgroup):
-# loadgroup keeps @pytest.mark.xdist_group-serialized tests on one worker, and
-# a bare addopts override silently drops it, producing flaky races.
-python -m pytest --testmon --override-ini="addopts=-v --ignore=build/private -n auto --dist loadgroup --durations=5 --color=yes" -q 2>&1 | tail -25
+# Fast iteration — only tests affected by your changes.
+# Coverage is NOT in addopts, so you no longer need an override to avoid it;
+# override only when you actually want to change the xdist flags.
+# Multi-test runs MUST keep the xdist flags (-n auto --dist loadgroup) and the
+# restart cap: loadgroup keeps @pytest.mark.xdist_group-serialized tests on one
+# worker, a bare addopts override silently drops it (producing flaky races), and
+# --max-worker-restart=2 turns worker loss into a fast loud failure instead of a
+# long silent thrash.
+python -m pytest --testmon --override-ini="addopts=-v --ignore=build/private -n auto --dist loadgroup --max-worker-restart=2 --durations=5 --color=yes" -q 2>&1 | tail -25
 
 # Only previously failed tests:
-python -m pytest --lf --override-ini="addopts=-v --ignore=build/private -n auto --dist loadgroup --durations=5 --color=yes" -q
+python -m pytest --lf --override-ini="addopts=-v --ignore=build/private -n auto --dist loadgroup --max-worker-restart=2 --durations=5 --color=yes" -q
 
-# Specific test file only (serial — xdist not needed for one file):
-python -m pytest test/test_dashboard_chat.py --override-ini="addopts=-v --ignore=build/private --durations=5 --color=yes" -q
+# Specific test file only — use -n0; per-worker startup dominates a small
+# selection (one test measured 36.9s under -n 2 vs ~1.4s under -n0):
+python -m pytest test/test_dashboard_chat.py -n0 -q
 
 # Specific test by keyword:
-python -m pytest -k "flush_segment" --override-ini="addopts=-v --ignore=build/private --durations=5 --color=yes" -q
+python -m pytest -k "flush_segment" -n0 -q
 ```
 
 **When to use which:**

--- a/setup.cfg
+++ b/setup.cfg
@@ -170,12 +170,21 @@ addopts =
     # concurrency-sensitive tests marked xdist_group(name="serial") (transcribe,
     # dashboard approval) run on one worker instead of racing under -n auto.
     --dist loadgroup
+    # Fail fast instead of thrashing. When workers die from memory pressure
+    # xdist silently clones replacements, up to numprocesses*4 of them -- a
+    # 10-worker run will quietly restart 40 times, which on a host that has
+    # started swapping means ~20 minutes of zero progress and an empty log.
+    # Two replacements is enough to absorb a genuine one-off crash; past that
+    # the run is not going to finish, so surface it loudly and immediately.
+    --max-worker-restart=2
     --timeout=120
-    --cov kiro_crew
-    --cov-config setup.cfg
-    --cov-report term-missing
-    --cov-report html:build/coverage
-    --cov-report xml:build/coverage/coverage.xml
+    # Coverage is NOT enabled by default: measured on a 1,231-test subset it
+    # costs +21% wall time (52.5s -> 63.4s) and +36% peak worker RSS (387MB ->
+    # 527MB) on every local and agent run, while CI asks for it explicitly
+    # (ci.yml passes --cov=kiro_crew on the 3.12 shards and --no-cov on 3.10,
+    # and the coverage-combine job builds coverage.xml from the shard data
+    # files). `pytest --cov=kiro_crew` still gives a term-missing report via
+    # [coverage:report] below; add --cov-report for the html/xml artifacts.
     # show the slowest 5 tests at the end
     --durations=5
     # Default to colorful output
@@ -196,6 +205,12 @@ parallel = true
 source =
     src/
     build/lib/*/site-packages/
+
+# Kept here rather than as an addopts --cov-report so that an explicit
+# `pytest --cov=kiro_crew` still shows uncovered lines now that coverage is
+# opt-in.
+[coverage:report]
+show_missing = true
 
 [coverage:html]
 directory = build/coverage

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import pathlib
 import shutil
+import socket
 import sys
 
 import pytest
@@ -176,32 +177,201 @@ def pytest_configure(config: pytest.Config) -> None:
         pass  # Probe failure must not break unrelated tests.
 
 
-def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
-    """Cap the worker count used by ``-n auto`` (and ``-n logical``).
+_MAX_WORKERS_ENV = "KIROCREW_MAX_TEST_WORKERS"
+_SLOT_DIR_ENV = "KIROCREW_TEST_SLOT_DIR"
+_DEFAULT_WORKER_CAP = 32
+_GIB = 1024**3
+# Headroom to reserve per worker. Measured peak RSS for a worker on a heavy
+# 1,231-test subset is ~0.37 GiB (~0.50 GiB under --cov), so 2 GiB reserves
+# roughly 4x typical and keeps the term from binding on ordinary hosts while
+# still refusing to spawn, say, 32 workers on an 8 GiB machine. Note this sizes
+# for EXPECTED footprint: it cannot save a host from a genuinely leaking worker
+# (one orphaned run was observed at 4.3 GiB RSS), which is a separate bug.
+_GIB_PER_WORKER = 2
 
-    The optimal worker count for this suite plateaus around 24-32 and then
-    *regresses*: every extra xdist worker pays a fixed cost -- it re-imports the
-    full app (aiohttp/boto3/numpy/pdfplumber/transcribe) and writes its own
-    ``.coverage.*`` data file that must be combined at the end. Past ~32 that
-    fixed cost outweighs the added parallelism. Measured on a 64-core host:
+# Lock files this process holds for its whole lifetime -- the fds MUST stay open,
+# because the lock lives exactly as long as the fd does.
+_held_slots: list[int] = []
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ[name])
+    except (KeyError, ValueError):
+        return default
+
+
+def _slot_root() -> pathlib.Path:
+    override = os.environ.get(_SLOT_DIR_ENV)
+    if override:
+        return pathlib.Path(override)
+    return pathlib.Path.home() / ".cache" / "kirocrew" / "test-slots"
+
+
+def _host_key() -> str:
+    """Filesystem-safe identity for this machine, as a single path segment."""
+    raw = socket.gethostname() or ""
+    safe = "".join(ch if (ch.isalnum() or ch in "-._") else "_" for ch in raw)[:64]
+    return safe.strip(".") or "unknown-host"
+
+
+def _slot_dir() -> pathlib.Path:
+    """Where concurrent pytest runs ON THIS HOST contend for worker capacity.
+
+    Deliberately host-global and *not* derived from ``KIROCREW_HOME``: the point
+    is that two worktrees -- which have different homes and know nothing about
+    each other -- still coordinate over the one thing they truly share, the
+    machine's cores and RAM.
+
+    Scoped by hostname because ``~/.cache`` is frequently a network home shared
+    by many machines, whose contention is not ours.
+    """
+    return _slot_root() / _host_key()
+
+
+def _slot_path(slot_dir: pathlib.Path, index: int) -> pathlib.Path:
+    return slot_dir / f"worker-{index:03d}.lock"
+
+
+def _host_total_gib() -> int:
+    """Total physical RAM in GiB, or 0 when it cannot be determined."""
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except (AttributeError, OSError, ValueError):
+        return 0
+    if pages <= 0 or page_size <= 0:
+        return 0
+    return int(pages * page_size // _GIB)
+
+
+def _claim_worker_slots(capacity: int, cap: int) -> int:
+    """Take up to ``cap`` of the host's ``capacity`` worker slots and HOLD them.
+
+    ``capacity`` is how many slots the HOST has (cores, bounded by RAM) and is
+    the range probed; ``cap`` is the most any single run may take. Keeping these
+    separate matters on a large host: with 64 cores and a cap of 32, a first run
+    takes slots 0-31 and a second still finds 32-63 free and gets its full 32.
+    Probing only ``cap`` slots would have collapsed that second run to one
+    worker while half the machine sat idle.
+
+    Each slot is an advisory lock on its own file, acquired non-blocking and
+    never released until the process exits. That is the whole design: the kernel
+    owns the lease, so capacity returns automatically when a run ends --
+    including a run that is orphaned or terminated outright, which is exactly
+    the state that caused the incident this budget exists to prevent.
+
+    This deliberately replaces an earlier design where runs wrote reservation
+    FILES describing themselves. Files outlive their owners, so that version
+    needed PID-liveness probing, a staleness backstop, ownership proof against
+    look-alike files, and boot/suspend forensics to decide when a reservation
+    was defunct -- and every one of those cleanup paths produced a real bug. A
+    held lock needs none of it.
+
+    Returns the number of slots taken, at least 1: a run arriving at a genuinely
+    full host proceeds single-worker rather than stalling.
+    """
+    if _held_slots:
+        # Already claimed in this process. Re-locking would fail: flock treats
+        # two fds on one file as independent even within the same process, so a
+        # second pass would take nothing and collapse the run to one worker.
+        return len(_held_slots)
+    try:
+        # Resolution itself must be inside the guard: Path.home() raises
+        # RuntimeError when the home directory cannot be determined, and
+        # gethostname() can raise OSError. Neither may break pytest startup.
+        root = _slot_root()
+        slot_dir = _slot_dir()
+        # Refuse a symlink at either level: the root is caller-supplied via
+        # KIROCREW_TEST_SLOT_DIR and could redirect our writes.
+        if root.exists() and root.is_symlink():
+            return min(capacity, cap)
+        slot_dir.mkdir(parents=True, exist_ok=True)
+        if slot_dir.is_symlink() or not slot_dir.is_dir():
+            return min(capacity, cap)
+    except (OSError, RuntimeError, ValueError):
+        return min(capacity, cap)  # fail open to the unbudgeted ceiling
+
+    taken = 0
+    for index in range(capacity):
+        if taken >= cap:
+            break
+        try:
+            fd = os.open(str(_slot_path(slot_dir, index)), os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError:
+            break
+        if platform_compat.try_acquire_lock(fd, exclusive=True):
+            _held_slots.append(fd)  # keep the fd -- closing it drops the lock
+            taken += 1
+        else:
+            os.close(fd)
+    return max(1, taken)
+
+
+def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
+    """Budget the worker count for ``-n auto`` (and ``-n logical``).
+
+    Two separate quantities.
+
+    **Host capacity** -- how many slots exist to compete for:
+
+    1. **Cores.** ``os.cpu_count()``.
+    2. **RAM.** ~2 GiB per worker. Cores alone are the wrong unit: a 10-core /
+       32 GiB laptop cannot back 32 multi-GiB workers, and once it starts
+       swapping the run stops making progress altogether.
+
+    **Per-run cap** (``KIROCREW_MAX_TEST_WORKERS``, default 32) -- the most any
+    single run may take. The optimal worker count for this suite plateaus around
+    24-32 and then *regresses*: every extra worker re-imports the full app
+    (aiohttp/boto3/numpy/pdfplumber/transcribe) and writes its own
+    ``.coverage.*`` file to combine at the end. Measured on a 64-core host:
     156s @ 64 workers vs 92s @ 32 workers (-41%).
 
-    ``min(cpu, CAP)`` stays optimal on every machine and is architecture-
-    agnostic -- the cap addresses fixed per-worker serialization cost, not
-    per-core speed, so it holds across Intel / ARM / Apple silicon. An 8-core
-    laptop gets 8 workers (the cap never binds, so no oversubscription), a
-    16-core build host gets 16 (unchanged from today), while 64/128-core
-    desktops are held at 32 instead of stampeding. Override the ceiling with
-    ``KIROCREW_MAX_TEST_WORKERS`` for a host that profiles differently. An
-    explicit ``-n <N>`` on the command line always wins; this hook only fires
+    Keeping them separate is what makes a big host behave: with 64 cores and a
+    cap of 32, two runs get 32 workers each rather than the second collapsing
+    while half the machine idles.
+
+    Sharing is what stops the failure this hook was extended for. Two worktrees
+    each running ``-n auto`` on a 10-core box previously took 10 workers *each*,
+    and the resulting swap thrash produced a load average of ~590 with zero
+    tests completing in 21 minutes. Now each run holds a lock per worker it
+    intends to spawn (under ``~/.cache/kirocrew/test-slots/<hostname>``, root
+    overridable with ``KIROCREW_TEST_SLOT_DIR``): a run alone takes the whole
+    machine, and a later run takes only what is unlocked. The locks are held for
+    the process's lifetime and released by the kernel when it exits, so an
+    orphaned or terminated run frees its share with no cleanup logic at all.
+
+    The cost is fairness, not safety, and only when the host is GENUINELY full:
+    a late run arriving at a fully-locked machine drops to its floor of one
+    worker -- slow, but never stalled, and never oversubscribing the host the
+    way the incident did. While free capacity remains, a later run gets its full
+    share.
+
+    An explicit ``-n <N>`` on the command line always wins; this hook only fires
     for ``auto`` / ``logical``.
     """
-    cpu = os.cpu_count() or 1
-    try:
-        cap = int(os.environ.get("KIROCREW_MAX_TEST_WORKERS", "32"))
-    except ValueError:
-        cap = 32
-    return min(cpu, max(1, cap))
+    capacity = os.cpu_count() or 1
+    total_gib = _host_total_gib()
+    if total_gib:
+        capacity = min(capacity, max(1, total_gib // _GIB_PER_WORKER))
+    cap = max(1, _int_env(_MAX_WORKERS_ENV, _DEFAULT_WORKER_CAP))
+    return _claim_worker_slots(capacity, cap)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Drop this run's worker slots promptly.
+
+    Not strictly required -- the kernel releases every lock when the process
+    exits -- but it returns capacity at the end of the run rather than at
+    interpreter teardown, and is a no-op in xdist workers, which hold no slots.
+    """
+    while _held_slots:
+        fd = _held_slots.pop()
+        platform_compat.release_lock(fd)
+        try:
+            os.close(fd)
+        except OSError:
+            pass
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_xdist_host_budget.py
+++ b/test/test_xdist_host_budget.py
@@ -1,0 +1,439 @@
+"""Tests for the xdist host worker budget in ``test/conftest.py``.
+
+The budget exists because two worktrees each running ``pytest -n auto`` on the
+same 10-core host took 10 workers *each*, swapped the machine to a load average
+of ~590, and completed zero tests in 21 minutes while xdist silently cloned
+replacement workers.
+
+Capacity is a set of advisory locks held for the run's lifetime, so the property
+these tests care most about is that a dead holder's share comes back with no
+cleanup logic -- the orphaned-run case that caused the incident.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import textwrap
+
+import conftest as ct
+import pytest
+
+needs_symlinks = pytest.mark.skipif(
+    os.name != "posix", reason="symlink creation needs privileges on Windows"
+)
+
+
+@pytest.fixture
+def slot_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """Point the budget at a throwaway slot dir and isolate held locks.
+
+    Returns the HOST-SCOPED leaf, which is what the budget actually uses; the
+    env var names the root above it. Any fds a test acquires are closed on
+    teardown, so a test can never hold real capacity for the rest of the run.
+    """
+    root = tmp_path / "slots"
+    monkeypatch.setenv(ct._SLOT_DIR_ENV, str(root))
+    held: list[int] = []
+    monkeypatch.setattr(ct, "_held_slots", held)
+    yield root / ct._host_key()
+    for fd in held:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def budget_host(slot_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """A deterministic 10-core / 32 GiB host, so only contention varies."""
+    monkeypatch.setattr(os, "cpu_count", lambda: 10)
+    monkeypatch.setattr(ct, "_host_total_gib", lambda: 32)
+    monkeypatch.delenv(ct._MAX_WORKERS_ENV, raising=False)
+    return slot_dir
+
+
+def _hold_slots_in_subprocess(slot_dir: pathlib.Path, count: int) -> subprocess.Popen[str]:
+    """Start a child holding ``count`` slot locks; it exits when stdin closes."""
+    code = textwrap.dedent(
+        f"""
+        import os, sys
+        sys.path.insert(0, {str(pathlib.Path(ct.__file__).parent)!r})
+        sys.path.insert(0, {str(pathlib.Path(ct.__file__).parent.parent / "src")!r})
+        from kiro_crew import platform_compat
+        held = []
+        for i in range({count}):
+            fd = os.open(os.path.join({str(slot_dir)!r}, "worker-%03d.lock" % i),
+                         os.O_CREAT | os.O_RDWR, 0o600)
+            assert platform_compat.try_acquire_lock(fd, exclusive=True), i
+            held.append(fd)
+        print("ready", flush=True)
+        sys.stdin.read()
+        """
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None
+    assert proc.stdout.readline().strip() == "ready"
+    return proc
+
+
+# ── slot directory resolution ──────────────────────────────────────────
+
+
+def test_slot_dir_is_scoped_by_host(slot_dir: pathlib.Path) -> None:
+    assert ct._slot_dir() == slot_dir
+    assert slot_dir.name == ct._host_key()
+
+
+def test_slot_root_defaults_under_cache_not_kirocrew_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Must be host-global: two worktrees with different homes still coordinate."""
+    monkeypatch.delenv(ct._SLOT_DIR_ENV, raising=False)
+    monkeypatch.setenv("KIROCREW_HOME", "/tmp/some-unrelated-home")
+    resolved = ct._slot_root()
+    assert resolved == pathlib.Path.home() / ".cache" / "kirocrew" / "test-slots"
+    assert "some-unrelated-home" not in str(resolved)
+
+
+def test_slot_dir_separates_hosts_sharing_a_network_home(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A shared ~/.cache must not mix contention across machines."""
+    root = tmp_path / "shared-home"
+    monkeypatch.setenv(ct._SLOT_DIR_ENV, str(root))
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "build-host-a")
+    dir_a = ct._slot_dir()
+    monkeypatch.setattr(socket, "gethostname", lambda: "build-host-b")
+    dir_b = ct._slot_dir()
+
+    assert dir_a != dir_b
+    assert dir_a.parent == dir_b.parent == root
+
+
+@pytest.mark.parametrize("raw", ["host-1.example.com", "", "../../etc", "a/b", "  ", "."])
+def test_host_key_is_a_safe_single_path_segment(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setattr(socket, "gethostname", lambda: raw)
+    key = ct._host_key()
+
+    assert key, "must never be empty -- that would collapse to the root dir"
+    assert "/" not in key and os.sep not in key
+    assert key not in (".", "..")
+    base = pathlib.Path(os.sep) / "tmp" / "base"
+    assert str((base / key).resolve()).startswith(str(base.resolve()))
+
+
+def test_slot_path_is_zero_padded(tmp_path: pathlib.Path) -> None:
+    assert ct._slot_path(tmp_path, 7).name == "worker-007.lock"
+    assert ct._slot_path(tmp_path, 31).name == "worker-031.lock"
+
+
+# ── memory term ────────────────────────────────────────────────────────
+
+
+def test_host_total_gib_converts_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        os,
+        "sysconf",
+        lambda name: {"SC_PHYS_PAGES": 2097152, "SC_PAGE_SIZE": 16384}[name],
+        raising=False,
+    )
+    assert ct._host_total_gib() == 32
+
+
+@pytest.mark.parametrize("pages,size", [(0, 4096), (100, 0), (-1, 4096)])
+def test_host_total_gib_rejects_nonsense(
+    monkeypatch: pytest.MonkeyPatch, pages: int, size: int
+) -> None:
+    monkeypatch.setattr(
+        os,
+        "sysconf",
+        lambda name: {"SC_PHYS_PAGES": pages, "SC_PAGE_SIZE": size}[name],
+        raising=False,
+    )
+    assert ct._host_total_gib() == 0
+
+
+def test_host_total_gib_survives_unsupported_sysconf(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(name: str) -> int:
+        raise ValueError(name)
+
+    monkeypatch.setattr(os, "sysconf", _boom, raising=False)
+    assert ct._host_total_gib() == 0
+
+
+# ── claiming ───────────────────────────────────────────────────────────
+
+
+def test_claim_alone_takes_the_ceiling(slot_dir: pathlib.Path) -> None:
+    assert ct._claim_worker_slots(6, 64) == 6
+    assert len(ct._held_slots) == 6
+    assert sorted(p.name for p in slot_dir.iterdir()) == [
+        f"worker-{i:03d}.lock" for i in range(6)
+    ]
+
+
+def test_claim_respects_the_per_run_cap(slot_dir: pathlib.Path) -> None:
+    """Capacity is what exists; cap is what one run may take."""
+    assert ct._claim_worker_slots(64, 32) == 32
+    assert len(ct._held_slots) == 32
+
+
+def test_big_host_lets_a_second_run_use_the_free_half(slot_dir: pathlib.Path) -> None:
+    """Regression: probing only `cap` slots starved a second run on a big host.
+
+    With 64 cores and a cap of 32, run A takes slots 0-31. Probing only 32 slots
+    made run B find them all locked and collapse to one worker while half the
+    machine sat idle -- worse than the pre-budget behaviour, where both runs got
+    32 and coexisted.
+    """
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    holder = _hold_slots_in_subprocess(slot_dir, 32)
+    try:
+        assert ct._claim_worker_slots(64, 32) == 32
+    finally:
+        holder.communicate()
+
+
+def test_floor_applies_only_when_the_host_is_really_full(slot_dir: pathlib.Path) -> None:
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    holder = _hold_slots_in_subprocess(slot_dir, 10)
+    try:
+        assert ct._claim_worker_slots(10, 32) == 1
+    finally:
+        holder.communicate()
+
+
+def test_claim_takes_only_unlocked_capacity(slot_dir: pathlib.Path) -> None:
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    holder = _hold_slots_in_subprocess(slot_dir, 4)
+    try:
+        assert ct._claim_worker_slots(10, 64) == 6
+    finally:
+        holder.communicate()
+
+
+def test_claim_never_returns_zero_when_host_is_full(slot_dir: pathlib.Path) -> None:
+    """Floor of 1 -- a late run is slow, never stalled."""
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    holder = _hold_slots_in_subprocess(slot_dir, 4)
+    try:
+        assert ct._claim_worker_slots(4, 64) == 1
+        assert ct._held_slots == []  # took nothing, but still runs
+    finally:
+        holder.communicate()
+
+
+def test_dead_holder_releases_its_share_with_no_cleanup(slot_dir: pathlib.Path) -> None:
+    """THE property: an orphaned or terminated run frees capacity by dying.
+
+    This is the incident case -- both wedged runs were reparented to init with
+    nobody reading their results. The kernel drops their locks; no pruning, no
+    PID probing, no staleness heuristics.
+    """
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    holder = _hold_slots_in_subprocess(slot_dir, 10)
+    assert ct._claim_worker_slots(10, 64) == 1  # fully contended while it lives
+
+    for fd in ct._held_slots:
+        os.close(fd)
+    ct._held_slots.clear()
+    holder.communicate()  # closing stdin ends the child
+    assert holder.wait() == 0
+
+    assert ct._claim_worker_slots(10, 64) == 10  # capacity is back
+
+
+def test_claim_is_idempotent_within_a_process(slot_dir: pathlib.Path) -> None:
+    """A second call returns the same share instead of collapsing to one worker.
+
+    flock treats two fds on one file as independent even in the same process, so
+    a naive re-claim would take nothing.
+    """
+    assert ct._claim_worker_slots(3, 64) == 3
+    assert ct._claim_worker_slots(3, 64) == 3
+    assert len(ct._held_slots) == 3
+
+
+@needs_symlinks
+def test_claim_refuses_symlinked_slot_root(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A symlink at either level could redirect our writes."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+    monkeypatch.setenv(ct._SLOT_DIR_ENV, str(link))
+    monkeypatch.setattr(ct, "_held_slots", [])
+
+    assert ct._claim_worker_slots(10, 64) == 10  # fails open to unbudgeted
+    assert list(real.iterdir()) == []
+    assert ct._held_slots == []
+
+
+@needs_symlinks
+def test_claim_refuses_symlinked_host_leaf(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (root / ct._host_key()).symlink_to(elsewhere, target_is_directory=True)
+    monkeypatch.setenv(ct._SLOT_DIR_ENV, str(root))
+    monkeypatch.setattr(ct, "_held_slots", [])
+
+    assert ct._claim_worker_slots(10, 64) == 10
+    assert list(elsewhere.iterdir()) == []
+    assert ct._held_slots == []
+
+
+@pytest.mark.parametrize("boom", [RuntimeError, OSError, ValueError])
+def test_claim_fails_open_when_path_resolution_raises(
+    monkeypatch: pytest.MonkeyPatch, boom: type[Exception]
+) -> None:
+    """Resolution must not break pytest startup.
+
+    Regression: the slot path was resolved OUTSIDE the guard, so an
+    unresolvable home (``Path.home()`` -> RuntimeError) or a failing
+    ``gethostname()`` propagated out of the hook instead of failing open.
+    """
+    monkeypatch.delenv(ct._SLOT_DIR_ENV, raising=False)
+    monkeypatch.setattr(ct, "_held_slots", [])
+
+    def _raise() -> pathlib.Path:
+        raise boom("nope")
+
+    monkeypatch.setattr(pathlib.Path, "home", staticmethod(_raise))
+
+    assert ct._claim_worker_slots(10, 4) == 4  # min(capacity, cap)
+    assert ct._held_slots == []
+
+
+def test_claim_fails_open_when_hostname_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ct, "_held_slots", [])
+
+    def _raise() -> str:
+        raise OSError("no hostname")
+
+    monkeypatch.setattr(socket, "gethostname", _raise)
+
+    assert ct._claim_worker_slots(10, 6) == 6
+    assert ct._held_slots == []
+
+
+def test_claim_fails_open_when_the_dir_cannot_be_made(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bookkeeping trouble must never block a test run."""
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("", encoding="utf-8")
+    monkeypatch.setenv(ct._SLOT_DIR_ENV, str(blocker))
+    monkeypatch.setattr(ct, "_held_slots", [])
+
+    assert ct._claim_worker_slots(8, 64) == 8
+    assert ct._held_slots == []
+
+
+# ── the hook ───────────────────────────────────────────────────────────
+
+
+def test_alone_gets_the_whole_machine(budget_host: pathlib.Path) -> None:
+    """The speed guarantee: testing alone is unchanged by this budget."""
+    assert ct.pytest_xdist_auto_num_workers(None) == 10
+
+
+def test_second_run_takes_what_is_left(budget_host: pathlib.Path) -> None:
+    budget_host.mkdir(parents=True, exist_ok=True)
+    holder = _hold_slots_in_subprocess(budget_host, 7)
+    try:
+        assert ct.pytest_xdist_auto_num_workers(None) == 3
+    finally:
+        holder.communicate()
+
+
+def test_memory_binds_before_cores(budget_host: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """8 GiB cannot back 10 workers, whatever the core count says."""
+    monkeypatch.setattr(ct, "_host_total_gib", lambda: 8)
+    assert ct.pytest_xdist_auto_num_workers(None) == 8 // ct._GIB_PER_WORKER
+
+
+def test_unknown_memory_falls_back_to_cores(
+    budget_host: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(ct, "_host_total_gib", lambda: 0)
+    assert ct.pytest_xdist_auto_num_workers(None) == 10
+
+
+def test_env_cap_lowers_the_ceiling(budget_host: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ct._MAX_WORKERS_ENV, "3")
+    assert ct.pytest_xdist_auto_num_workers(None) == 3
+
+
+def test_garbage_env_cap_falls_back_to_default(
+    budget_host: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ct._MAX_WORKERS_ENV, "not-a-number")
+    assert ct.pytest_xdist_auto_num_workers(None) == 10
+
+
+def test_big_host_still_capped_at_default(
+    slot_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The original 64-core regression finding stays enforced."""
+    monkeypatch.setattr(os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(ct, "_host_total_gib", lambda: 512)
+    monkeypatch.delenv(ct._MAX_WORKERS_ENV, raising=False)
+    assert ct.pytest_xdist_auto_num_workers(None) == ct._DEFAULT_WORKER_CAP
+
+
+def test_two_runs_on_a_big_host_both_get_the_cap(
+    slot_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End of the same regression, seen through the hook."""
+    monkeypatch.setattr(os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(ct, "_host_total_gib", lambda: 512)
+    monkeypatch.delenv(ct._MAX_WORKERS_ENV, raising=False)
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    holder = _hold_slots_in_subprocess(slot_dir, ct._DEFAULT_WORKER_CAP)
+    try:
+        assert ct.pytest_xdist_auto_num_workers(None) == ct._DEFAULT_WORKER_CAP
+    finally:
+        holder.communicate()
+
+
+# ── release ────────────────────────────────────────────────────────────
+
+
+def test_sessionfinish_releases_every_slot(slot_dir: pathlib.Path) -> None:
+    ct._claim_worker_slots(5, 64)
+    assert len(ct._held_slots) == 5
+
+    ct.pytest_sessionfinish(None, 0)
+
+    assert ct._held_slots == []
+
+
+def test_sessionfinish_is_a_noop_without_slots(slot_dir: pathlib.Path) -> None:
+    """xdist workers also run this hook and hold nothing."""
+    assert ct._held_slots == []
+    ct.pytest_sessionfinish(None, 0)
+    assert ct._held_slots == []
+
+
+def test_released_capacity_is_reusable(slot_dir: pathlib.Path) -> None:
+    assert ct._claim_worker_slots(4, 64) == 4
+    ct.pytest_sessionfinish(None, 0)
+    assert ct._claim_worker_slots(4, 64) == 4


### PR DESCRIPTION
## Problem

Two worktrees each ran `pytest -n auto` on the same 10-core host. Each took 10 workers, so the box was 2x oversubscribed. It swapped 23.0 GB of a 23.5 GB pool, load average reached ~590, and **zero tests completed in 21 minutes** — `/tmp/gate-pytest.log` was still 0 bytes when the runs were terminated.

The thing that looked like a fork bomb was not one: process count held steady at ~740. xdist was **replacing** workers lost to memory pressure, up to `numprocesses * 4` of them, so each spawn matched a death. Worker PIDs turned over completely between two snapshots two minutes apart, and 67 zombie children sat under the two controllers, which were too starved to reap them.

Both runs were orphaned (`PPID 1`), so nothing was ever going to clean up after them — and nobody was reading their results either.

## Why it happened

`-n auto` in shared `addopts` means every invocation in this repo silently claims all cores. `pytest_xdist_auto_num_workers` in `test/conftest.py` already existed, but only as a **ceiling for large hosts** (`min(cpu, 32)`, from a 64-core measurement). On a 10-core box it returns 10 and has no notion of another run already using the machine.

## Change

A ceiling from three terms, then reduced to whatever share of the host is actually free:

| Ceiling term | Value |
|---|---|
| Cores | `os.cpu_count()` |
| Fixed ceiling | `KIROCREW_MAX_TEST_WORKERS`, default 32 (unchanged; preserves the 64-core finding) |
| RAM | ~2 GiB per worker, via `os.sysconf` — no new dependency |

The run then claims **one advisory lock per worker it intends to spawn** and holds them for its whole lifetime. A run alone takes its full share (speed unchanged); a later run takes whatever is still unlocked, dropping to a floor of one worker only when the host is genuinely full.

Host capacity and the per-run cap are deliberately **separate**: capacity (cores, bounded by RAM) is the range of slots probed, while the cap is the most one run may take. The ceiling table above splits accordingly — cores and RAM set capacity, `KIROCREW_MAX_TEST_WORKERS` sets the cap.

Locks live under `<root>/<hostname>/` — hostname-scoped because `~/.cache` is often a network home shared by many machines — with the root overridable via `KIROCREW_TEST_SLOT_DIR`, symlinks refused at both levels, and every failure path returning the unbudgeted ceiling so bookkeeping trouble can never block a test run. Locking goes through `platform_compat.try_acquire_lock` / `release_lock`, so this works on Windows too.

**The kernel owns the lease.** That is the whole point: capacity is released when the process exits, including a run that is orphaned or terminated outright — exactly the state both wedged runs were in.

Also in this PR:

- **`--max-worker-restart=2`.** Zero speed cost. Turns 40 silent replacements over 21 minutes into one loud failure in about a minute, which an agent can actually report.
- **Coverage is no longer forced by `addopts`.** Measured on a 1,231-test subset: **+21% wall time** (52.5s → 63.4s) and **+36% peak worker RSS** (387 MB → 527 MB), paid by every local and agent run. CI never relied on the default — `ci.yml` passes `--cov=kiro_crew` on the 3.12 shards and `--no-cov` on 3.10, and `coverage-combine` builds `coverage.xml` from the shard `.coverage.<group>` data files, not from `addopts` reports. `[coverage:report] show_missing` keeps `pytest --cov=kiro_crew` useful locally.
- **`AGENTS.md`** testmon recipes updated: they no longer justify `--override-ini` by "`setup.cfg` hardcodes `--cov`", they carry the restart cap, and single-file selections use `-n0`.

## Review history — and the redesign it produced

Eight rounds. Every round found something real, and **seven of the eight blocking findings landed in one place**: the code that decided when a *reservation file* was defunct.

| Round | Blocking finding |
|---|---|
| 1 | Test called `_process_alive(os.getpid())` unguarded — `os.kill(pid, 0)` is `TerminateProcess` on Windows, so it would terminate its own test worker |
| 2 | Pruning `unlink`ed any non-numeric filename — an override dir holding other files lost them |
| 3 | Staleness check ran independently of liveness, so a run outliving the 6h backstop lost its reservation while alive |
| 4 | Ownership decided by filename, so a foreign `<pid>.slot` was still deletable |
| 5 | A shared network `~/.cache` mixed reservations across hosts |
| 6 | Boot estimate from `time.monotonic()` — which stops during suspend — erased a live reservation after resume |
| 7 | A recycled controller PID adopted a stale oversized reservation, bypassing the ceiling |
| 8 | Boot estimate from `time.time()` — an NTP correction erased a live reservation |

Design Review named the root cause rather than the instance: *every* one of those defenses existed only because reservations were files that outlive their owners. A **held lock** is kernel-tied to process lifetime and needs none of it.

So this revision deletes the reservation-file machinery entirely — PID-liveness taxonomy, staleness backstop, magic-header ownership proof, boot/suspend forensics, PID-recycling clamp — and replaces it with held locks. `test/conftest.py` went from **+380 to +195 lines**, and the fix for round 8 is that the code containing it no longer exists. Rounds 5's host scoping and the symlink refusal are kept, because those were about *where* we write, not about deciding when a file is dead.

### Round 9 — first clean GPT round, and two more real findings

GPT 5.6 and Arbiter both came back with **no blocking findings** on the redesign — the first clean GPT round in nine. Two things still needed fixing:

- **Windows shard 4 (5 failures), mine.** The new revision enables the budget on Windows, so the test module now runs there — and `monkeypatch.setattr(os, "sysconf", ...)` raises, because that attribute does not exist on Windows. Production code was already correct (`_host_total_gib` catches `AttributeError` and returns 0); the tests needed `raising=False`.
- **Design Review (CONCERNS) — a regression I introduced.** `_claim_worker_slots` probed only `range(ceiling)` where `ceiling` already included the per-run cap of 32. On a 64-core host, run A locks slots 0–31 and run B probes the same 32, finds them all locked, and collapses to one worker while 32 cores idle — worse than pre-PR, where both runs got 32 and coexisted. Fixed by decoupling capacity from cap, with regression tests at both the claim and hook levels (`test_big_host_lets_a_second_run_use_the_free_half`, `test_two_runs_on_a_big_host_both_get_the_cap`).

### Round 10 — Design Review PASS, one fail-open gap

Design Review flipped to **PASS**. GPT found one more real thing: `slot_dir = _slot_dir()` sat *outside* the guard, so `Path.home()` raising `RuntimeError` (unresolvable home) or `gethostname()` raising `OSError` would propagate out of the hook and break pytest startup rather than falling open to the unbudgeted ceiling. Resolution is now inside the guard, which also catches `RuntimeError`/`ValueError`. Covered by a parametrised fail-open test plus a hostname-failure test.

Two of Design Review's three points are also applied: `platform_compat` locking instead of raw `fcntl` (which the repo's shim table forbids, and which gains Windows support), and the stale `AGENTS.md` note.

## Correcting one number

An earlier draft of the memory constant cited "multiple GiB" per worker, generalising from the 4.3 GiB orphan. Measured peak is **~0.37 GiB** (~0.50 GiB under `--cov`). The 4.3 GiB case was pathological — a leak under sustained thrash — so `_GIB_PER_WORKER = 2` is ~4x typical headroom, and the comment says so. The budget sizes for *expected* footprint and **cannot** save a host from a real leak; that deserves its own issue.

## Verification

- **41 tests** in `test/test_xdist_host_budget.py` (down from 75 — two-thirds of the old tests existed to cover cleanup logic that is now gone). Covers the ceiling terms, taking only unlocked capacity, the floor of one, idempotent re-entry, cross-host separation, symlink refusal at both levels, failing open when the directory cannot be made, and release on session finish. The load-bearing one is `test_dead_holder_releases_its_share_with_no_cleanup`: a real subprocess takes all 10 slots, the budget correctly gets 1 while it lives, and after the child exits the budget gets 10 again.
- **End-to-end** with `KIROCREW_MAX_TEST_WORKERS=2`: `created: 2/2 workers`; a second run after the first exited also gets `2/2`, proving capacity returns with no cleanup step; a pre-existing `notes.txt` in the slot dir survives byte-identical.
- `isort` and `flake8` clean. Earlier CI rounds passed `Backend Lint & Type Check` on 3.10 and 3.12 and all backend shards including Windows, which also retired the local-only `mypy` error I saw (`asyncio.set_child_watcher`, removed in my local Python 3.14 venv; the diff touches no `src/` file and mypy only checks `src/kiro_crew/`).

**Gap, stated plainly:** I did not run the full backend suite locally. The host was still recovering from the incident above, and `ps`/`top` became unavailable partway through the session so I could not confirm what was loading it. The CI shards are the suite gate for this PR.

## CI impact

None expected. A GitHub runner is 4 cores / 16 GB, so cores bind first (`min(4, 32, 8) = 4`), each shard is a separate job on its own runner with no shared lock directory, and a shard that somehow found the directory contended would still get its floor of one worker rather than failing.
