### PR TITLE
feat(cli): artifact signature verification

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,8 +124,9 @@ jobs:
 
   # ── CLI channel publish ───────────────────────────────────────────────
   # Publishes the built wheel to the nightly CLI channel (cli/ + latest-cli.json).
-  # Depends only on the wheel (not build-desktop or the signing service), so a macOS signing
-  # failure never blocks the CLI release. See docs/release-automation.md.
+  # Depends only on the wheel and its CLI-specific KMS manifest signer (not
+  # build-desktop, Apple notarization, or CDSigner), so a macOS signing failure
+  # never blocks the CLI release. See docs/release-automation.md.
   publish-cli:
     name: Publish CLI (nightly channel)
     needs: [version, build-wheel]

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -6,8 +6,10 @@ name: Publish CLI (reusable)
 #
 # Key properties:
 #   - CI-direct feed: writes feed/<channel>/latest-cli.json straight from CI.
-#   - Never gated on signing/notarization (Linux has no Gatekeeper), so a macOS
-#     signing failure never blocks a CLI release.
+#   - Independently verifiable manifest: KMS signs every artifact field and the
+#     installer verifies against an offline public key pinned in cli.sh.
+#   - Never gated on macOS signing/notarization (Linux has no Gatekeeper); the
+#     CLI lane uses its own non-exportable asymmetric KMS key.
 #   - Publishes the wheel exactly as built; the manifest version is parsed from
 #     the wheel filename so it always matches what pip will install.
 
@@ -45,11 +47,23 @@ jobs:
     # every job in sign-and-notarize.yml.
     environment: prod
     env:
-      HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      HAS_PUBLISH_ROLE: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      HAS_MANIFEST_KEY: ${{ vars.CLI_MANIFEST_SIGNING_KEY_ARN != '' && 'true' || '' }}
       CHANNEL: ${{ inputs.channel }}
       VERSION_LABEL: ${{ inputs.version }}
     steps:
+      - name: Refuse partial CLI signing configuration
+        if: env.HAS_PUBLISH_ROLE != env.HAS_MANIFEST_KEY
+        run: |
+          echo "::error::CLI publishing requires BOTH AWS_SIGNING_ROLE_ARN and CLI_MANIFEST_SIGNING_KEY_ARN. Refusing to publish an unsigned manifest."
+          exit 1
+
+      - name: Checkout manifest verifier contract
+        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Download wheel artifact
+        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.wheel_artifact }}
@@ -57,19 +71,22 @@ jobs:
 
       - name: Locate wheel and compute checksum
         id: wheel
+        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
         run: |
           set -euo pipefail
-          WHEEL=$(find cli-dist -name '*.whl' | head -1)
-          if [ -z "$WHEEL" ]; then
-            echo "::error::No .whl found in artifact '${{ inputs.wheel_artifact }}'"
+          mapfile -t WHEELS < <(find cli-dist -type f -name '*.whl' -print)
+          if [ "${#WHEELS[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one .whl in artifact '${{ inputs.wheel_artifact }}'; found ${#WHEELS[@]}"
             exit 1
           fi
+          WHEEL="${WHEELS[0]}"
           WHEEL_DIR=$(dirname "$WHEEL")
           WHEEL_NAME=$(basename "$WHEEL")
-          # PEP 427: wheel filename fields are '-'-separated and the distribution
-          # name contains no '-', so the version is always the second field. Using
-          # the wheel's own version keeps the manifest in sync with what pip installs.
-          WHEEL_VERSION=$(echo "$WHEEL_NAME" | awk -F- '{print $2}')
+          if [[ ! "$WHEEL_NAME" =~ ^kirocrew-([A-Za-z0-9][A-Za-z0-9._+]{0,127})-py3-none-any\.whl$ ]]; then
+            echo "::error::Wheel name does not match the canonical KiroCrew pure-Python artifact contract: $WHEEL_NAME"
+            exit 1
+          fi
+          WHEEL_VERSION="${BASH_REMATCH[1]}"
           ( cd "$WHEEL_DIR" && sha256sum "$WHEEL_NAME" > SHA256SUMS )
           SHA256=$(awk '{print $1}' "$WHEEL_DIR/SHA256SUMS")
           {
@@ -82,6 +99,7 @@ jobs:
           echo "Wheel: $WHEEL_NAME (version $WHEEL_VERSION, label '${VERSION_LABEL}')"
 
       - name: Attest wheel provenance
+        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
         # Signed SLSA provenance binding the published wheel's digest to this
         # repo/workflow/commit (CWE-1104) — complements the self-hosted
         # SHA256SUMS (integrity, not authenticity). Runs before the wheel is
@@ -91,14 +109,58 @@ jobs:
           subject-path: ${{ steps.wheel.outputs.path }}
 
       - name: Configure AWS credentials
-        if: env.HAS_SIGNING_SECRETS
+        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Publish wheel and channel manifest
-        if: env.HAS_SIGNING_SECRETS
+      - name: Build and sign CLI artifact manifest
+        id: manifest
+        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
+        env:
+          CDN_BASE: ${{ vars.CLI_CDN_BASE }}
+          KEY_ARN: ${{ vars.CLI_MANIFEST_SIGNING_KEY_ARN }}
+          WHEEL_PATH: ${{ steps.wheel.outputs.path }}
+          WHEEL_NAME: ${{ steps.wheel.outputs.name }}
+          WHEEL_VERSION: ${{ steps.wheel.outputs.version }}
+          SHA256: ${{ steps.wheel.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          case "${CDN_BASE}" in
+            https://*) ;;
+            *) echo "::error::CLI_CDN_BASE must be HTTPS before signing."; exit 1 ;;
+          esac
+          CDN_BASE="${CDN_BASE%/}"
+          PUBLIC_KEY="packaging/signing/cli-manifest-public.pem"
+          PAYLOAD="$RUNNER_TEMP/cli-manifest-payload.json"
+          MANIFEST="$(dirname "$WHEEL_PATH")/cli-manifest.json"
+          PYREQ=$(unzip -p "$WHEEL_PATH" '*.dist-info/METADATA' 2>/dev/null \
+            | awk -F': ' 'tolower($1)=="requires-python"{print $2; exit}' | tr -d '\r')
+          PYREQ="${PYREQ:->=3.10}"
+          # The immutable manifest must be byte-identical when a failed job is
+          # retried. Wall-clock time would change the signed payload and make
+          # put_immutable reject a safe retry, so bind publication time to the
+          # source commit instead.
+          SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")
+          PUB_DATE=$(date -u -d "@${SOURCE_DATE_EPOCH}" +%Y-%m-%dT%H:%M:%SZ)
+          python3 packaging/signing/cli-manifest.py payload \
+            --channel "$CHANNEL" --version "$WHEEL_VERSION" \
+            --wheel-url "${CDN_BASE}/cli/${CHANNEL}/${WHEEL_VERSION}/${WHEEL_NAME}" \
+            --sha256 "$SHA256" --python-requires "$PYREQ" \
+            --pub-date "$PUB_DATE" \
+            --public-key "$PUBLIC_KEY" --output "$PAYLOAD"
+          python3 packaging/signing/cli-manifest.py kms-sign \
+            --payload "$PAYLOAD" --key-arn "$KEY_ARN" \
+            --public-key "$PUBLIC_KEY" --output "$MANIFEST"
+          KEY_ID=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["key_id"])' "$MANIFEST")
+          {
+            echo "path=$MANIFEST"
+            echo "key_id=$KEY_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish wheel and signed channel manifest
+        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
         env:
           BUCKET: ${{ vars.CLI_DIST_BUCKET }}
           CDN_BASE: ${{ vars.CLI_CDN_BASE }}
@@ -107,6 +169,8 @@ jobs:
           SUMS_DIR: ${{ steps.wheel.outputs.sumsdir }}
           WHEEL_VERSION: ${{ steps.wheel.outputs.version }}
           SHA256: ${{ steps.wheel.outputs.sha256 }}
+          MANIFEST_PATH: ${{ steps.manifest.outputs.path }}
+          MANIFEST_KEY_ID: ${{ steps.manifest.outputs.key_id }}
         run: |
           set -euo pipefail
           # The origin bucket is private (OAC), so the raw S3 URL is not publicly
@@ -148,38 +212,27 @@ jobs:
             echo "::error::$key exists with DIFFERENT content -- refusing to republish an immutable versioned key"
             return 1
           }
+          [ -s "$MANIFEST_PATH" ] || { echo "::error::Signed CLI manifest is missing"; exit 1; }
           put_immutable "${PREFIX}/${WHEEL_NAME}" "$WHEEL_PATH"
           put_immutable "${PREFIX}/SHA256SUMS" "${SUMS_DIR}/SHA256SUMS"
+          put_immutable "${PREFIX}/cli-manifest.json" "$MANIFEST_PATH"
 
-          WHEEL_URL="${CDN_BASE}/${PREFIX}/${WHEEL_NAME}"
-
-          # Requires-Python straight from the wheel metadata so the manifest never drifts.
-          PYREQ=$(unzip -p "$WHEEL_PATH" '*.dist-info/METADATA' 2>/dev/null \
-            | awk -F': ' 'tolower($1)=="requires-python"{print $2; exit}' | tr -d '\r')
-          PYREQ="${PYREQ:->=3.10}"
-
-          cat > /tmp/latest-cli.json <<EOF
-          {
-            "channel": "${CHANNEL}",
-            "version": "${WHEEL_VERSION}",
-            "wheel_url": "${WHEEL_URL}",
-            "sha256": "${SHA256}",
-            "python_requires": "${PYREQ}",
-            "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          }
-          EOF
-          aws s3 cp /tmp/latest-cli.json "s3://${BUCKET}/feed/${CHANNEL}/latest-cli.json" \
+          # Signature fields are additive to the legacy channel/version/
+          # wheel_url/sha256 schema, so old clients remain parse-compatible.
+          aws s3 cp "$MANIFEST_PATH" "s3://${BUCKET}/feed/${CHANNEL}/latest-cli.json" \
             --content-type application/json --cache-control no-cache
 
           {
             echo "## CLI Published (${CHANNEL})"
             echo "- Wheel: \`${WHEEL_NAME}\`"
             echo "- Version: \`${WHEEL_VERSION}\`"
+            echo "- Signed manifest: \`${PREFIX}/cli-manifest.json\`"
+            echo "- Key: \`${MANIFEST_KEY_ID}\`"
             echo "- Feed: \`feed/${CHANNEL}/latest-cli.json\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish PEP 503 simple index
-        if: env.HAS_SIGNING_SECRETS
+        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
         env:
           BUCKET: ${{ vars.CLI_DIST_BUCKET }}
           CDN_BASE: ${{ vars.CLI_CDN_BASE }}
@@ -239,7 +292,7 @@ jobs:
           done
           echo "- Simple index: \`${CDN_BASE}/${SIMPLE}/\` ($(wc -l < links.txt) version(s))" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Skipped (no signing secrets)
-        if: ${{ !env.HAS_SIGNING_SECRETS }}
+      - name: Skipped (no publish role or manifest key)
+        if: ${{ !env.HAS_PUBLISH_ROLE && !env.HAS_MANIFEST_KEY }}
         run: |
-          echo "AWS_SIGNING_ROLE_ARN not set - skipping CLI publish (fork / feature-branch run)." >> "$GITHUB_STEP_SUMMARY"
+          echo "CLI publish role and manifest KMS key are not configured - skipping CLI publish (fork / feature-branch run)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-installer.yml
+++ b/.github/workflows/publish-installer.yml
@@ -111,6 +111,85 @@ jobs:
           fi
           test -f cli.sh || { echo "::error::cli.sh is missing from the checkout."; exit 1; }
 
+      # The strict installer ships fail-closed: until KMS provisioning pins a
+      # real key fingerprint, cli.sh carries CLI_MANIFEST_KEY_ID=UNCONFIGURED
+      # and refuses every install before any network I/O. That is correct as a
+      # repository contract, but publishing it would replace the live
+      # `curl … | sh` one-liner with a script that hard-fails on all three
+      # channels. packaging/signing/README.md step 6 orders "publish the strict
+      # cli.sh only after a signed channel feed exists" -- this step is the
+      # mechanical enforcement of that ordering, so a merge alone can never
+      # brick the documented install path.
+      - name: Refuse to publish an unconfigured trust root
+        run: |
+          set -euo pipefail
+          key_id=$(sed -n 's/^CLI_MANIFEST_KEY_ID="\(.*\)"$/\1/p' cli.sh | head -n 1)
+          if [ -z "$key_id" ]; then
+            echo "::error::cli.sh no longer pins CLI_MANIFEST_KEY_ID; refusing to publish an installer without a manifest trust root."
+            exit 1
+          fi
+          if [ "$key_id" = "UNCONFIGURED" ]; then
+            echo "::error::cli.sh pins CLI_MANIFEST_KEY_ID=UNCONFIGURED (fail-closed pre-KMS state). Publishing it would brick 'curl … | sh' for every channel. Complete packaging/signing/README.md steps 1-6 and pin the real key fingerprint first."
+            exit 1
+          fi
+          public_key_b64=$(sed -n 's/^CLI_MANIFEST_PUBLIC_KEY_B64="\(.*\)"$/\1/p' cli.sh | head -n 1)
+          if [ -z "$public_key_b64" ]; then
+            echo "::error::cli.sh no longer pins CLI_MANIFEST_PUBLIC_KEY_B64; refusing to publish an installer without an embedded public key."
+            exit 1
+          fi
+          if ! printf '%s' "$public_key_b64" | base64 -d > /tmp/cli-manifest-public.pem; then
+            echo "::error::cli.sh pins a malformed base64 manifest public key; refusing to publish."
+            exit 1
+          fi
+          if ! openssl pkey -pubin -in /tmp/cli-manifest-public.pem \
+              -outform DER -out /tmp/cli-manifest-public.der; then
+            echo "::error::cli.sh pins an invalid manifest public key; refusing to publish."
+            exit 1
+          fi
+          derived_key_id="sha256:$(sha256sum /tmp/cli-manifest-public.der | awk '{print $1}')"
+          if [ "$key_id" != "$derived_key_id" ]; then
+            echo "::error::CLI_MANIFEST_KEY_ID '${key_id}' does not match the embedded public key fingerprint '${derived_key_id}'; refusing to publish an installer that would reject every signed feed."
+            exit 1
+          fi
+          echo "Manifest trust root pinned and self-consistent: ${key_id}"
+
+      # A pinned key is necessary but NOT sufficient: the strict installer
+      # refuses any feed it cannot verify, so publishing it while a LIVE
+      # channel still serves a legacy (unsigned, or signed-by-another-key)
+      # feed bricks that channel's installs just the same. Prove every live
+      # feed is installable by the strict installer before replacing it.
+      # A channel with NO feed (404) is skipped with a warning: it is not
+      # installable by the CURRENT installer either, so publishing is not a
+      # regression for it. Verification reuses the exact schema/fingerprint/
+      # signature checks cli.sh itself performs (cli-manifest.py verify).
+      - name: Verify every live channel feed against the pinned key
+        run: |
+          set -euo pipefail
+          sed -n 's/^CLI_MANIFEST_PUBLIC_KEY_B64="\(.*\)"$/\1/p' cli.sh | head -n 1 \
+            | base64 -d > /tmp/pinned-public.pem
+          test -s /tmp/pinned-public.pem || { echo "::error::cli.sh pins no manifest public key."; exit 1; }
+          for channel in nightly insider stable; do
+            feed_url="${CDN_BASE}/feed/${channel}/latest-cli.json"
+            status=$(curl -fsS --proto '=https' -o "/tmp/feed-${channel}.json" \
+              -w '%{http_code}' "$feed_url" || true)
+            if [ "$status" = "404" ] || [ "$status" = "403" ]; then
+              echo "::warning::channel '${channel}' serves no feed (${status}); not installable today, so not a publish regression. Skipping."
+              continue
+            fi
+            if [ "$status" != "200" ]; then
+              echo "::error::channel '${channel}' feed fetch failed (${status}); refusing to publish without proving it verifiable."
+              exit 1
+            fi
+            if ! python3 packaging/signing/cli-manifest.py verify \
+                --manifest "/tmp/feed-${channel}.json" \
+                --public-key /tmp/pinned-public.pem \
+                --expected-channel "$channel" \
+                --artifact-base "${CDN_BASE}"; then
+              echo "::error::channel '${channel}' live feed does not verify against the pinned key. Publishing the strict installer would brick '${channel}' installs. Publish signed feeds (packaging/signing/README.md step 6) first."
+              exit 1
+            fi
+          done
+
       # Catches the class of bug that motivated this lane: a syntax error or a
       # channel/prefix mismatch would otherwise reach every new user's shell.
       # The repo's own contract tests (test_publish_feed_contract.py) assert the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,9 @@ jobs:
   # Publishes the release wheel to the insider/stable CLI channel (cli/ +
   # latest-cli.json + PEP 503 index) -- previously release wheels only
   # reached GitHub Releases, so pip/cli.sh users could never track insider
-  # or stable. Depends only on the wheel (not build-desktop or the signing service),
-  # so a macOS signing failure never blocks the CLI release.
+  # or stable. Depends only on the wheel and its CLI-specific KMS manifest signer
+  # (not build-desktop, Apple notarization, or CDSigner), so a macOS signing
+  # failure never blocks the CLI release.
   publish-cli:
     name: Publish CLI (${{ needs.version.outputs.channel }} channel)
     needs: [version, build-wheel]

--- a/cli.sh
+++ b/cli.sh
@@ -6,17 +6,17 @@
 #   curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel nightly
 #
 # Installs the prebuilt `kirocrew` wheel for a release channel. It resolves the
-# channel feed, downloads the wheel over HTTPS from CloudFront, verifies its
-# SHA-256 against the feed manifest, then installs it (pipx if available, else a
-# managed venv). No Brazil workspace, no Node, no build step. Unlike install.sh
-# (which builds from a git clone), this pulls the published wheel.
+# channel feed, verifies its RSA-SHA256 signature against the public key pinned
+# below, downloads the wheel over HTTPS from CloudFront, verifies its SHA-256
+# against the signed digest, then installs it (pipx if available, else a managed
+# venv). No unsigned/checksum-only fallback exists. Unlike install.sh (which
+# builds from a git clone), this pulls the published wheel.
 #
 # Options / env:
 #   --channel <nightly|insider|stable>   (default: stable; env KIROCREW_CHANNEL)
-#   --version <X.Y.Z>                     pin an exact version instead of the
-#                                         channel's latest (verified against the
-#                                         version's published SHA256SUMS)
-#   --cdn <base-url>                      (default CloudFront; env KIROCREW_CDN_BASE)
+#   --version <X.Y.Z>                    pin an exact version, verified against
+#                                        its immutable signed CLI manifest
+#   --cdn <base-url>                     (default CloudFront; env KIROCREW_CDN_BASE)
 # ──────────────────────────────────────────────────────────────────────
 set -eu
 
@@ -36,6 +36,14 @@ ARTIFACT_BASE="${KIROCREW_CDN_BASE:-https://download.crew.kiro.dev}"
 CHANNEL="${KIROCREW_CHANNEL:-stable}"
 PIN_VERSION=""
 
+# Offline trust root for CLI artifact manifests. These two values are replaced
+# together during the operational KMS-key enablement documented in
+# packaging/signing/README.md. They deliberately ship unconfigured in the
+# repository contract: until a non-exportable signing key is provisioned and
+# its public half is pinned here, the installer refuses before any network I/O.
+CLI_MANIFEST_KEY_ID="UNCONFIGURED"
+CLI_MANIFEST_PUBLIC_KEY_B64="UNCONFIGURED"
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --channel) CHANNEL="${2:?--channel needs a value}"; shift 2 ;;
@@ -52,15 +60,16 @@ KiroCrew CLI installer (channel / wheel based).
   curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel nightly
 
 Installs the prebuilt `kirocrew` wheel for a release channel: resolves the
-channel feed, downloads the wheel over HTTPS, verifies its SHA-256 against
-the published manifest, then installs it (pipx if available, else a managed
-venv BESIDE the data home — "$KIROCREW_HOME"-venv or ~/.kiro/crew-venv, never
-inside the data home itself). Records the channel in the data home.
+channel feed, verifies its signature against the installer-pinned public key,
+downloads the wheel over HTTPS, verifies its SHA-256 against the signed digest,
+then installs it (pipx if available, else a managed venv BESIDE the data home —
+"$KIROCREW_HOME"-venv or ~/.kiro/crew-venv, never inside the data home itself).
+Records the channel in the data home. There is no unsigned fallback.
 
 Options / env:
   --channel <nightly|insider|stable>   (default: stable; env KIROCREW_CHANNEL)
   --version <X.Y.Z>                    pin an exact version, verified against
-                                       that version's published SHA256SUMS
+                                       its immutable signed CLI manifest
   --cdn <base-url>                     (default CloudFront; env KIROCREW_CDN_BASE)
   KIROCREW_VENV                        override the managed venv location
 EOF
@@ -105,7 +114,12 @@ _is_within() {
   [ "$_within_rest" != "$1" ]
 }
 
+[ "$CLI_MANIFEST_KEY_ID" != "UNCONFIGURED" ] \
+  && [ "$CLI_MANIFEST_PUBLIC_KEY_B64" != "UNCONFIGURED" ] \
+  || err "manifest signing trust root is not configured; refusing unsigned installation"
+
 command -v curl    >/dev/null 2>&1 || err "curl is required"
+command -v openssl >/dev/null 2>&1 || err "openssl is required to verify the signed manifest"
 # KiroCrew needs Python >=3.10 at runtime (contextlib.aclosing, etc.) even
 # though older published wheels' METADATA claimed >=3.9 -- pip would install
 # fine on 3.9 and then crash on first run. Pick the best interpreter, newest
@@ -135,35 +149,159 @@ else err "need sha256sum or shasum to verify the download"; fi
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT INT TERM
 
-if [ -n "$PIN_VERSION" ]; then
-  # Pinned install: skip the feed; fetch the exact version's wheel and verify
-  # against the SHA256SUMS published beside it at release time.
-  VER="$PIN_VERSION"
-  WHEEL_NAME="kirocrew-${VER}-py3-none-any.whl"
-  WHEEL_URL="$ARTIFACT_BASE/cli/$CHANNEL_PATH/$VER/$WHEEL_NAME"
-  echo "Resolving KiroCrew $VER ($CHANNEL channel, pinned) ..."
-  curl -fsSL "$ARTIFACT_BASE/cli/$CHANNEL_PATH/$VER/SHA256SUMS" -o "$TMP/SHA256SUMS" \
-    || err "version '$VER' not found on the $CHANNEL channel (no $ARTIFACT_BASE/cli/$CHANNEL_PATH/$VER/SHA256SUMS)"
-  SHA="$(awk -v w="$WHEEL_NAME" '$2==w{print $1}' "$TMP/SHA256SUMS")"
-  [ -n "$SHA" ] || err "SHA256SUMS for $VER does not list $WHEEL_NAME"
-else
-  FEED="$FEED_BASE/feed/$CHANNEL_PATH/latest-cli.json"
-  echo "Resolving KiroCrew ($CHANNEL channel) ..."
-  curl -fsSL "$FEED" -o "$TMP/feed.json" \
-    || err "channel '$CHANNEL' has no feed at $FEED (try: --channel nightly)"
+# Materialize and self-check the embedded trust root. The key id is the SHA-256
+# fingerprint of SubjectPublicKeyInfo DER, so an accidental edit to either
+# pinned value fails before the network is consulted.
+if ! printf '%s' "$CLI_MANIFEST_PUBLIC_KEY_B64" \
+    | "$PY" -c 'import base64,sys; open(sys.argv[1], "xb").write(base64.b64decode(sys.stdin.buffer.read(), validate=True))' \
+        "$TMP/cli-manifest-public.pem" 2>/dev/null; then
+  err "embedded CLI manifest public key is malformed"
+fi
+if ! openssl pkey -pubin -in "$TMP/cli-manifest-public.pem" \
+    -outform DER -out "$TMP/cli-manifest-public.der" 2>/dev/null; then
+  err "embedded CLI manifest public key is invalid"
+fi
+PINNED_KEY_SHA="$($SHA_CMD "$TMP/cli-manifest-public.der" | awk '{print $1}')"
+[ "$CLI_MANIFEST_KEY_ID" = "sha256:$PINNED_KEY_SHA" ] \
+  || err "embedded CLI manifest public key fingerprint mismatch"
 
-  # Parse the manifest with python3 (portable; no jq dependency). Read the path
-  # from argv so no shell value is interpolated into the program text.
-  read_field() { "$PY" -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$TMP/feed.json" "$1"; }
-  WHEEL_URL="$(read_field wheel_url)"
-  SHA="$(read_field sha256)"
-  VER="$(read_field version)"
-  [ -n "$WHEEL_URL" ] && [ -n "$SHA" ] || err "malformed feed manifest"
+if [ -n "$PIN_VERSION" ]; then
+  case "$PIN_VERSION" in
+    *[!A-Za-z0-9._+]*) err "invalid pinned version '$PIN_VERSION'" ;;
+  esac
+  MANIFEST_URL="$ARTIFACT_BASE/cli/$CHANNEL_PATH/$PIN_VERSION/cli-manifest.json"
+  echo "Resolving KiroCrew $PIN_VERSION ($CHANNEL channel, pinned) ..."
+else
+  MANIFEST_URL="$FEED_BASE/feed/$CHANNEL_PATH/latest-cli.json"
+  echo "Resolving KiroCrew ($CHANNEL channel) ..."
+fi
+# Bound unauthenticated metadata before it reaches disk. curl 7.58+ enforces
+# --max-filesize against received bytes even without a Content-Length header.
+curl -fsS --proto '=https' --max-filesize 65536 "$MANIFEST_URL" \
+  -o "$TMP/cli-manifest.json" \
+  || err "signed CLI manifest not found at $MANIFEST_URL"
+
+# The signature covers canonical JSON containing every field except the
+# signature itself. Reject duplicate/extra/missing keys, decode into bounded
+# files, and only parse artifact metadata AFTER OpenSSL authenticates those
+# canonical bytes against the offline key above.
+if ! "$PY" - "$TMP/cli-manifest.json" "$TMP/signed-payload.json" \
+    "$TMP/manifest-signature.bin" "$CLI_MANIFEST_KEY_ID" <<'PY'
+import base64
+import json
+import sys
+
+manifest_path, payload_path, signature_path, pinned_key_id = sys.argv[1:]
+expected = {
+    "algorithm", "channel", "key_id", "pub_date", "python_requires",
+    "schema", "sha256", "signature", "version", "wheel_url",
+}
+
+def no_duplicates(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate key")
+        value[key] = item
+    return value
+
+try:
+    raw = open(manifest_path, "rb").read(65537)
+    if len(raw) > 65536:
+        raise ValueError("oversized manifest")
+    manifest = json.loads(raw.decode("utf-8"), object_pairs_hook=no_duplicates)
+    if not isinstance(manifest, dict) or set(manifest) != expected:
+        raise ValueError("unexpected fields")
+    if not all(isinstance(value, str) and value for value in manifest.values()):
+        raise ValueError("invalid field type")
+    if manifest["schema"] != "kirocrew-cli-artifact-manifest-v1":
+        raise ValueError("unsupported schema")
+    if manifest["algorithm"] != "RSASSA_PKCS1_V1_5_SHA_256":
+        raise ValueError("unsupported algorithm")
+    if manifest["key_id"] != pinned_key_id:
+        raise ValueError("untrusted key id")
+    signature = base64.b64decode(manifest.pop("signature"), validate=True)
+    if not signature or len(signature) > 1024:
+        raise ValueError("invalid signature size")
+    canonical = (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+    if len(canonical) > 16384:
+        raise ValueError("oversized payload")
+    open(payload_path, "xb").write(canonical)
+    open(signature_path, "xb").write(signature)
+except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+    raise SystemExit(1)
+PY
+then
+  err "malformed signed manifest — refusing to install"
 fi
 
-WHL="$TMP/$(basename "$WHEEL_URL")"
+if ! openssl dgst -sha256 -verify "$TMP/cli-manifest-public.pem" \
+    -signature "$TMP/manifest-signature.bin" "$TMP/signed-payload.json" \
+    >/dev/null 2>&1; then
+  err "manifest signature verification failed — refusing to install"
+fi
+echo "Verified signed manifest."
+
+# Validate the authenticated fields against the request. In particular, the
+# wheel URL must be the one canonical URL implied by the selected byte host,
+# channel, and signed version; a valid signer cannot redirect this installer to
+# an unrelated origin by accident.
+if ! "$PY" - "$TMP/signed-payload.json" "$CHANNEL" "$PIN_VERSION" \
+    "$ARTIFACT_BASE" <<'PY'
+import json
+import re
+import sys
+
+path, expected_channel, pinned_version, artifact_base = sys.argv[1:]
+payload = json.load(open(path, encoding="ascii"))
+expected_fields = {
+    "algorithm", "channel", "key_id", "pub_date", "python_requires",
+    "schema", "sha256", "version", "wheel_url",
+}
+try:
+    if set(payload) != expected_fields:
+        raise ValueError
+    if payload["channel"] != expected_channel:
+        raise ValueError
+    version = payload["version"]
+    if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+]{0,127}", version) is None:
+        raise ValueError
+    if pinned_version and version != pinned_version:
+        raise ValueError
+    if re.fullmatch(r"[0-9a-f]{64}", payload["sha256"]) is None:
+        raise ValueError
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", payload["pub_date"]) is None:
+        raise ValueError
+    if len(payload["python_requires"]) > 128 or any(
+        ord(char) < 0x20 or ord(char) > 0x7E for char in payload["python_requires"]
+    ):
+        raise ValueError
+    wheel_name = f"kirocrew-{version}-py3-none-any.whl"
+    expected_url = f"{artifact_base}/cli/{expected_channel}/{version}/{wheel_name}"
+    if payload["wheel_url"] != expected_url:
+        raise ValueError
+except (KeyError, TypeError, ValueError):
+    raise SystemExit(1)
+PY
+then
+  err "signed manifest does not match the requested channel/version/artifact host"
+fi
+
+read_field() {
+  "$PY" -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' \
+    "$TMP/signed-payload.json" "$1"
+}
+WHEEL_URL="$(read_field wheel_url)"
+SHA="$(read_field sha256)"
+VER="$(read_field version)"
+WHEEL_NAME="kirocrew-${VER}-py3-none-any.whl"
+WHL="$TMP/$WHEEL_NAME"
+
 echo "Downloading kirocrew $VER ..."
-curl -fsSL "$WHEEL_URL" -o "$WHL" || err "failed to download wheel from $WHEEL_URL"
+curl -fsS --proto '=https' "$WHEEL_URL" -o "$WHL" || err "failed to download wheel from $WHEEL_URL"
 
 GOT="$($SHA_CMD "$WHL" | awk '{print $1}')"
 [ "$GOT" = "$SHA" ] || err "SHA-256 mismatch (expected $SHA, got $GOT) — refusing to install"

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -8,7 +8,7 @@ human process (release branches, RC numbering, promotion, back-merge);
 **docs/release-process-design.md** records the design rationale and the
 platform-lane contract. This file documents what the pipeline does.
 
-## As built (authoritative, 2026-07-30)
+## As built (authoritative, 2026-08-01)
 
 This section is the contract. An earlier revision of this file carried a
 ~440-line original design below it — a release-branch automation model
@@ -143,14 +143,17 @@ older run finishing last from rolling a channel feed backward. There is no
 `blocked-versions.json` and no rollback workflow: the recovery path is to
 **roll forward** — cut a new version and let the feed advance to it.
 
-**CLI channel (as built):** `publish-cli.yml` publishes the wheel +
-SHA256SUMS + PEP 503 index to `cli/{channel}/`, called by `nightly.yml`
-(`channel: nightly`) and by `release.yml` (`channel: insider | stable`,
-derived from the tag) — so all three channels are wired, and wheels also
-ship as GitHub Release assets. It depends only on the wheel build, never on
-CDSigner, so a macOS signing failure cannot block a CLI release. The
-signing trust domain for the wheel (minisign/cosign detached signatures)
-remains an open item.
+**CLI channel (repository implementation; external enablement pending):**
+`publish-cli.yml` is wired to publish the wheel +
+backward-compatible signed JSON manifest + SHA256SUMS + PEP 503 index to
+`cli/{channel}/`, then copies the same signed manifest to
+`feed/{channel}/latest-cli.json`. It is called by `nightly.yml` (`channel:
+nightly`) and by `release.yml` (`channel: insider | stable`, derived from the
+tag), so all three channels are wired, and wheels also ship as GitHub Release
+assets. The manifest is signed by a non-exportable RSA KMS key after its public
+half is byte-compared with the repository/installer pin. It depends only on the
+wheel build and this CLI-specific key, never on Apple/CDSigner, so a macOS
+signing failure cannot block a CLI release.
 
 **Docker channel (as built):** `publish-docker.yml` publishes the same wheel
 inside a multi-arch image to `ghcr.io/kirodotdev/kirocrew`, with immutable
@@ -173,8 +176,18 @@ no beta→insider name mapping.
 
 ### How it differs from the desktop path
 
-- **No notarization, but a signature is required.** Linux has no Gatekeeper, so the CLI never touches CDSigner or Apple. A `SHA256SUMS` beside the wheel is only a corruption check — whoever can overwrite the wheel in S3/CloudFront (or via compromised CI) can rewrite `SHA256SUMS` and the feed's `sha256` in the same breath. So the installer verifies a required signature over the manifest — Sigstore cosign (keyless, identity-pinned) or minisign with a public key pinned in the installer/repo — against a trust root that is not stored beside the artifact. That pinned-key signature, not the checksum, is the authenticity anchor.
-- **CI-direct feed, independent of signing.** The wheel has no `signed/` stage at all, so `publish-cli.yml` writes `latest-cli.json` straight from CI (as every lane now does — see "Feed (as built)" above). It depends only on the built wheel, so a macOS signing failure never blocks a CLI release.
+- **No notarization; a signature is mandatory.** Linux has no Gatekeeper, so
+  the CLI never touches CDSigner or Apple. `SHA256SUMS` remains beside the wheel
+  for legacy tooling, but it is only a corruption check. The publisher signs
+  the complete artifact metadata with a non-exportable RSA KMS key; `cli.sh`
+  reconstructs canonical JSON and verifies that signature against an offline
+  public key pinned in the installer/repository before it reads `wheel_url` or
+  `sha256`. It then validates the authenticated URL/channel/version and checks
+  the downloaded wheel against the signed digest. Missing key, missing
+  signature, malformed/duplicate fields, wrong key id, bad signature, redirect
+  metadata, and digest mismatch all refuse installation with no unsigned
+  fallback.
+- **CI-direct feed, independent of desktop signing.** The wheel has no desktop `signed/` stage. `publish-cli.yml` signs the artifact manifest with the CLI-specific KMS key and writes `latest-cli.json` straight from CI (as every lane now does — see "Feed (as built)" above). It depends only on the built wheel and that manifest key, so an Apple/CDSigner failure never blocks a CLI release.
 - **Build once per tag.** `nightly.yml` publishes the nightly wheel;
   `release.yml` publishes the tagged wheel to insider (RC tag) or stable
   (bare tag). Promotion is a human step — tagging the good RC's commit — so
@@ -234,21 +247,27 @@ flowchart TB
 ```
 cli/{channel}/{version}/
   ├── kirocrew-{version}-py3-none-any.whl
-  └── SHA256SUMS
-feed/{channel}/latest-cli.json
+  ├── SHA256SUMS                         # legacy integrity metadata
+  └── cli-manifest.json                  # immutable signed manifest
+feed/{channel}/latest-cli.json            # same signed JSON, mutable pointer
 ```
 
-`feed/{channel}/latest-cli.json`:
+The manifest keeps the six legacy fields and adds four signature fields, so
+older channel installers remain parse-compatible while strict installers can
+authenticate the same object:
 
 ```json
 {
+  "algorithm": "RSASSA_PKCS1_V1_5_SHA_256",
   "channel": "insider",
-  "version": "0.2.0",
-  "wheel_url": "https://download.crew.kiro.dev/cli/insider/0.2.0/kirocrew-0.2.0-py3-none-any.whl",
-  "sha256": "…",
-  "sig_url": "https://download.crew.kiro.dev/cli/insider/0.2.0/kirocrew-0.2.0-py3-none-any.whl.sig",
+  "key_id": "sha256:<SubjectPublicKeyInfo digest>",
+  "pub_date": "2026-07-18T06:15:00Z",
   "python_requires": ">=3.10",
-  "pub_date": "2026-07-18T06:15:00Z"
+  "schema": "kirocrew-cli-artifact-manifest-v1",
+  "sha256": "<wheel digest>",
+  "signature": "<base64 RSA signature over canonical JSON without this field>",
+  "version": "0.2.0",
+  "wheel_url": "https://download.crew.kiro.dev/cli/insider/0.2.0/kirocrew-0.2.0-py3-none-any.whl"
 }
 ```
 
@@ -267,7 +286,8 @@ The wheel version is read from `pyproject.toml` `[project].version`, so the nigh
 ```bash
 # install, or switch channels
 curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel {nightly|insider|stable}
-#   reads feed/{channel}/latest-cli.json -> downloads wheel -> verifies SHA256
+#   reads the signed feed -> verifies RSA signature with the offline pin
+#   -> validates artifact metadata -> downloads wheel -> verifies signed SHA256
 #   installs isolated via pipx (or uv tool) -> records channel in ~/.kiro/crew/channel
 
 # self-update, staying on the recorded channel
@@ -278,11 +298,18 @@ This is a new download path, separate from the source-build `install.sh` (git cl
 
 ### CI and infrastructure delta
 
-Remaining open item: a detached signature (cosign/minisign) over the manifest,
-verified against a trust root not stored beside the artifact. `SHA256SUMS`
-alone is a corruption check, not an authenticity anchor — see "How it differs
-from the desktop path" above. The `cli/*` + `feed/*` PutObject grants and
-`cli.sh` serving are deployed.
+The repository contract is implemented, but signing remains intentionally
+fail-closed until operators provision the non-exportable KMS key and pin its
+public half. The protected `prod` environment must set
+`CLI_MANIFEST_SIGNING_KEY_ARN`, and the publication role needs only
+`kms:GetPublicKey` + `kms:Sign` on that key in addition to its existing publish
+permissions. A role/key mismatch or an `UNCONFIGURED` public key aborts before
+artifact upload; a fork with neither setting skips publication. Follow
+`packaging/signing/README.md` for the key-pinning and signed-feed-first rollout
+sequence. The `cli/*` + `feed/*` PutObject grants and `cli.sh` serving
+pre-date this change; this change does not claim that KMS/IAM provisioning,
+signed-feed publication, CDN propagation, or the final strict-installer rollout
+has been performed or externally validated.
 
 ## Superseded design
 

--- a/docs/release-process-design.md
+++ b/docs/release-process-design.md
@@ -210,7 +210,7 @@ Every public URL is one of exactly two classes:
 | Human download permalink | `/desktop/{channel}/latest/KiroCrew.dmg` | Pointer (max-age=300) |
 | Versioned desktop artifacts | `/desktop/{channel}/{version}/…` (zip + DMG) | Immutable |
 | Desktop update feed | `/feed/{channel}/latest-mac.yml`, `/feed/{channel}/latest-linux.yml` | Pointer (uncached) |
-| CLI update feed | `/feed/{channel}/latest-cli.json` (version + sha256) | Pointer (uncached) |
+| CLI update feed | `/feed/{channel}/latest-cli.json` (signed manifest: version + URL + sha256 + key id) | Pointer (uncached) |
 | pip index (PEP 503) | `/feed/{channel}/simple/` | Pointer |
 | GitHub Releases | `github.com/kirodotdev/KiroCrew/releases/tag/v…` | Immutable |
 
@@ -229,8 +229,13 @@ Rules that make the scheme work:
    `files[].url` + base64 `sha512`, `path`, `sha512`, and `releaseDate`.
    The client fetches the static file and compares versions client-side;
    the yml sits on the pointer host while `files[].url` points
-   absolutely at the byte host. CLI feed carries the wheel version and
-   sha256 so the installer verifies fail-closed before installing.
+   absolutely at the byte host. The CLI feed is a backward-compatible
+   RSA-signed artifact manifest. Its canonical payload authenticates the
+   channel, wheel version and URL, sha256, Python requirement, publication
+   date, schema, algorithm, and key id. The installer verifies that signature
+   against its offline pin before consuming artifact metadata, then verifies
+   the downloaded wheel against the authenticated digest. Both checks fail
+   closed.
 5. pip installs use `--extra-index-url` against the channel's simple
    index, keeping PyPI available for dependency resolution.
 

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -1,14 +1,52 @@
 # CLI Module
 
-Last Updated: 2026-07-27 (the Kiro CLI is now always launched IN PLACE — the
-resolve-to-exec integrity snapshot is REMOVED; it broke Kiro CLI 2.15+, a
-multi-call binary that exec's a sibling `kiro-cli-chat` resolved relative to its
-own path. Prior: trust simplified to "runs + valid login" — install
-source/owner/path do not gate setup or ACP launch)
+Last Updated: 2026-08-01 (standalone wheel installation now requires a
+pinned-key RSA-signed artifact manifest and a matching signed SHA-256 digest;
+the repository deliberately fails closed until its operational KMS public key
+is pinned. The Kiro CLI remains always launched IN PLACE — the resolve-to-exec
+integrity snapshot is REMOVED; it broke Kiro CLI 2.15+, a multi-call binary that
+exec's a sibling `kiro-cli-chat` resolved relative to its own path. Prior: trust
+simplified to "runs + valid login" — install source/owner/path do not gate setup
+or ACP launch)
 
 ## Overview
 
 The CLI module (`kiro_crew/cli.py`) provides the `kirocrew` command using stdlib `argparse`.
+
+## Standalone Wheel Installer Trust Contract
+
+`cli.sh` installs channel or pinned-version wheels only from an authenticated
+manifest. This distribution trust boundary is independent of the runtime CLI
+and of macOS signing/notarization.
+
+- Schema: `kirocrew-cli-artifact-manifest-v1`.
+- Algorithm: `RSASSA_PKCS1_V1_5_SHA_256`.
+- Key identity: `sha256:` plus the lowercase SHA-256 digest of the public
+  SubjectPublicKeyInfo DER bytes.
+- Signed fields: `algorithm`, `channel`, `key_id`, `pub_date`,
+  `python_requires`, `schema`, `sha256`, `version`, and `wheel_url`.
+- Signature field: base64 RSA signature over sorted, compact UTF-8 JSON of all
+  signed fields; `signature` itself is excluded.
+- Channel source: `feed/<channel>/latest-cli.json`. Pinned-version source:
+  `cli/<channel>/<version>/cli-manifest.json`; pinned installs do not resolve
+  through the mutable channel feed.
+
+The installer embeds the public key and expected key id. Before any network
+request, it requires OpenSSL, rejects an unconfigured pin, materializes the key,
+and verifies its DER fingerprint. It then applies bounded input/object sizes,
+duplicate-key and exact-field-set rejection, printable-ASCII/string checks,
+canonical URL and digest validation, requested channel/version matching, and
+pinned-key signature verification. Artifact fields are not consumed and wheel
+bytes are not fetched until the signature succeeds. The downloaded wheel must
+then match the authenticated SHA-256 digest before `pipx install` runs.
+
+Any unavailable trust root, malformed or unsigned legacy feed, unknown field,
+wrong schema/algorithm/key id, signature failure, metadata mismatch, network
+failure, or wheel digest mismatch terminates installation. There is no unsigned,
+`SHA256SUMS`, or trust-on-first-use fallback. Until the operational public key is
+pinned, the repository's explicit `UNCONFIGURED` state therefore makes stock
+`cli.sh` non-installing by design. Provisioning and rollout are specified in
+`packaging/signing/README.md`.
 
 ## Project Directory Detection
 

--- a/packaging/signing/README.md
+++ b/packaging/signing/README.md
@@ -28,3 +28,73 @@ trigger macOS Gatekeeper warnings).
 
 Access to the signing service must be onboarded (a security review plus
 sign-off). See `docs/release-automation.md` for the full onboarding runbook.
+
+## CLI artifact manifests (separate trust domain)
+
+The wheel installer does **not** reuse Apple/CDSigner. `publish-cli.yml` signs a
+canonical JSON artifact manifest with an asymmetric AWS KMS key and publishes the
+same signed JSON at both:
+
+- `cli/<channel>/<version>/cli-manifest.json` (immutable, used by `--version`)
+- `feed/<channel>/latest-cli.json` (mutable channel pointer)
+
+The legacy `channel`, `version`, `wheel_url`, `sha256`, `python_requires`, and
+`pub_date` fields remain top-level for older installers. Schema v1 adds
+`schema`, `algorithm`, `key_id`, and `signature`. The signature is RSA
+PKCS#1 v1.5 with SHA-256 over canonical JSON containing every field except
+`signature`. `cli.sh` reconstructs those exact bytes, verifies them with the
+offline public key embedded in the installer, validates the authenticated URL,
+channel, version, and digest, and only then downloads the wheel. The SHA-256
+check remains a second fail-closed check over the downloaded bytes. There is no
+`SHA256SUMS` or unsigned-feed fallback in the strict installer.
+
+Threat model: this protects against unauthorized mutation of distribution
+objects or channel feeds while the installer trust root and signing-enabled
+publisher role remain trusted. The publisher role holds `kms:Sign`, so its
+compromise can produce a valid manifest and is explicitly out of scope; the
+signature does not create a separate trust boundary from that role.
+
+### Repository bootstrap state
+
+The repository intentionally carries `UNCONFIGURED` in both
+`cli-manifest-public.pem` and the two `CLI_MANIFEST_*` constants in `cli.sh`.
+This is fail-closed: the installer exits before network I/O, and a trusted
+publisher configuration with only one of the role/key settings fails before any
+upload. Forks with neither setting still skip publication.
+
+No private key should be generated, exported, committed, pasted into CI, or
+handled by an agent. Operational enablement is a human/infrastructure step:
+
+1. Create a non-exportable asymmetric KMS key in `us-west-2` with key usage
+   `SIGN_VERIFY` and key spec `RSA_3072` or `RSA_4096`.
+2. Grant the existing CLI publication role only `kms:GetPublicKey` and
+   `kms:Sign` on that one key. Keep the existing OIDC subject/environment
+   restriction; do not grant decrypt or broad `kms:*` access.
+3. Retrieve the **public** key with `kms:GetPublicKey`, convert its
+   SubjectPublicKeyInfo DER bytes to PEM, and replace
+   `packaging/signing/cli-manifest-public.pem`.
+4. Run
+   `python3 packaging/signing/cli-manifest.py key-info --public-key packaging/signing/cli-manifest-public.pem`.
+   Copy the returned public `key_id` and `public_key_pem_base64` values into the
+   matching constants in `cli.sh`. Commit the public-key pin normally.
+5. Set the protected `prod` environment variable
+   `CLI_MANIFEST_SIGNING_KEY_ARN` to the key ARN. The workflow compares KMS
+   `GetPublicKey` output byte-for-byte with the committed key before every sign,
+   and verifies the returned signature locally before publishing.
+6. Run `test/test_cli_manifest_signature.py`, then dispatch a publish and verify
+   the immutable manifest is present. Publish the strict `cli.sh` only after a
+   signed channel feed exists. Because the added fields are backward-compatible,
+   the signed feed may safely go live before the strict installer. This ordering
+   is enforced mechanically: `publish-installer.yml` refuses to publish while
+   `cli.sh` still pins `CLI_MANIFEST_KEY_ID="UNCONFIGURED"`, and — once a key
+   is pinned — refuses unless every LIVE channel feed verifies against that
+   key (`cli-manifest.py verify`, the same checks the installer runs), so
+   neither the pin commit nor any later merge can replace the live installer
+   with one that refuses the feeds it is pointed at.
+
+Pinned versions released before enablement have no immutable signed manifest and
+therefore fail closed under the new installer unless an authorized backfill signs
+the already-published digest. Do not replace the KMS key in place: schema v1 pins
+one key. For rotation, first ship an installer revision that trusts both old and
+new public keys, then switch the publisher, and retire the old key only after the
+overlap window.

--- a/packaging/signing/cli-manifest-public.pem
+++ b/packaging/signing/cli-manifest-public.pem
@@ -1,0 +1,2 @@
+# UNCONFIGURED: replace with a PEM-encoded RSA public key (3072 bits or stronger).
+# The corresponding private key must remain non-exportable in AWS KMS.

--- a/packaging/signing/cli-manifest.py
+++ b/packaging/signing/cli-manifest.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Build and verify the signed CLI artifact-manifest envelope.
+
+The production workflow signs the canonical payload with an asymmetric AWS KMS
+key.  This helper never accepts or reads a private key: it prepares the digest
+input, derives the committed public-key identity, and refuses to assemble an
+envelope unless OpenSSL verifies the returned signature.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+SCHEMA = "kirocrew-cli-artifact-manifest-v1"
+ALGORITHM = "RSASSA_PKCS1_V1_5_SHA_256"
+CHANNELS = ("nightly", "insider", "stable")
+SIGNED_FIELDS = {
+    "algorithm",
+    "channel",
+    "key_id",
+    "pub_date",
+    "python_requires",
+    "schema",
+    "sha256",
+    "version",
+    "wheel_url",
+}
+_VERSION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+]{0,127}\Z")
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+_PUB_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z")
+_KEY_BITS_RE = re.compile(r"Public-Key:\s*\((\d+)\s+bit\)")
+_MAX_PAYLOAD_BYTES = 16 * 1024
+_MAX_SIGNATURE_BYTES = 1024
+
+
+class ManifestError(ValueError):
+    """A manifest or trust-root contract violation."""
+
+
+def _run_openssl(args: list[str]) -> bytes:
+    try:
+        proc = subprocess.run(
+            ["openssl", *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise ManifestError("openssl is required") from exc
+    if proc.returncode != 0:
+        raise ManifestError("openssl rejected the CLI manifest public key or signature")
+    return proc.stdout
+
+
+def _run_aws_json(args: list[str]) -> dict[str, Any]:
+    try:
+        proc = subprocess.run(
+            ["aws", *args, "--output", "json", "--no-cli-pager"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError as exc:
+        raise ManifestError("AWS CLI is required for KMS signing") from exc
+    if proc.returncode != 0 or len(proc.stdout) > 64 * 1024:
+        raise ManifestError("AWS KMS rejected the CLI manifest signing request")
+    try:
+        value = json.loads(proc.stdout)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManifestError("AWS KMS returned a malformed response") from exc
+    if not isinstance(value, dict):
+        raise ManifestError("AWS KMS returned a malformed response")
+    return value
+
+
+def _public_key_der(public_key: Path) -> bytes:
+    if not public_key.is_file():
+        raise ManifestError("CLI manifest public key is missing")
+    raw = public_key.read_bytes()
+    if b"UNCONFIGURED" in raw:
+        raise ManifestError("CLI manifest public key is not configured")
+
+    details = _run_openssl(["pkey", "-pubin", "-in", str(public_key), "-text", "-noout"])
+    decoded = details.decode("utf-8", errors="replace")
+    match = _KEY_BITS_RE.search(decoded)
+    if match is None or "Modulus:" not in decoded:
+        raise ManifestError("CLI manifest public key must be RSA")
+    if int(match.group(1)) < 3072:
+        raise ManifestError("CLI manifest RSA public key must be at least 3072 bits")
+    return _run_openssl(["pkey", "-pubin", "-in", str(public_key), "-outform", "DER"])
+
+
+def public_key_id(public_key: Path) -> str:
+    return f"sha256:{hashlib.sha256(_public_key_der(public_key)).hexdigest()}"
+
+
+def _canonical_json(value: dict[str, str]) -> bytes:
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
+    ).encode("ascii")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ManifestError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    raw = path.read_bytes()
+    if len(raw) > _MAX_PAYLOAD_BYTES:
+        raise ManifestError("CLI manifest payload is too large")
+    try:
+        value = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManifestError("CLI manifest payload is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise ManifestError("CLI manifest payload must be a JSON object")
+    return value
+
+
+def _require_text(payload: dict[str, Any], key: str, *, max_len: int = 2048) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value or len(value) > max_len:
+        raise ManifestError(f"CLI manifest field {key!r} must be non-empty text")
+    if any(ord(char) < 0x20 or ord(char) > 0x7E for char in value):
+        raise ManifestError(f"CLI manifest field {key!r} must contain printable ASCII only")
+    return value
+
+
+def _validate_signed_payload(payload: dict[str, Any]) -> dict[str, str]:
+    if set(payload) != SIGNED_FIELDS:
+        raise ManifestError("CLI manifest signed field set does not match schema v1")
+
+    normalized = {key: _require_text(payload, key) for key in SIGNED_FIELDS}
+    if normalized["schema"] != SCHEMA:
+        raise ManifestError("unsupported CLI manifest schema")
+    if normalized["algorithm"] != ALGORITHM:
+        raise ManifestError("unsupported CLI manifest signature algorithm")
+    if normalized["channel"] not in CHANNELS:
+        raise ManifestError("unsupported CLI manifest channel")
+    if _VERSION_RE.fullmatch(normalized["version"]) is None:
+        raise ManifestError("invalid CLI manifest version")
+    if _SHA256_RE.fullmatch(normalized["sha256"]) is None:
+        raise ManifestError("invalid CLI manifest SHA-256")
+    if _PUB_DATE_RE.fullmatch(normalized["pub_date"]) is None:
+        raise ManifestError("invalid CLI manifest publication date")
+    if not normalized["key_id"].startswith("sha256:") or not _SHA256_RE.fullmatch(
+        normalized["key_id"][len("sha256:") :]
+    ):
+        raise ManifestError("invalid CLI manifest key id")
+    _require_text(payload, "python_requires", max_len=128)
+
+    wheel_name = f"kirocrew-{normalized['version']}-py3-none-any.whl"
+    parsed = urlsplit(normalized["wheel_url"])
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or not parsed.path.endswith(
+            f"/cli/{normalized['channel']}/{normalized['version']}/{wheel_name}"
+        )
+    ):
+        raise ManifestError("CLI manifest wheel URL is not a canonical HTTPS artifact URL")
+    return normalized
+
+
+def _validate_target_binding(
+    payload: dict[str, str], *, expected_channel: str, artifact_base: str
+) -> None:
+    if payload["channel"] != expected_channel:
+        raise ManifestError("CLI manifest channel does not match the expected channel")
+
+    normalized_base = artifact_base.rstrip("/")
+    parsed_base = urlsplit(normalized_base)
+    if (
+        parsed_base.scheme != "https"
+        or not parsed_base.hostname
+        or parsed_base.username is not None
+        or parsed_base.password is not None
+        or parsed_base.query
+        or parsed_base.fragment
+    ):
+        raise ManifestError("artifact base must be a canonical HTTPS URL")
+
+    version = payload["version"]
+    wheel_name = f"kirocrew-{version}-py3-none-any.whl"
+    expected_url = (
+        f"{normalized_base}/cli/{expected_channel}/{version}/{wheel_name}"
+    )
+    if payload["wheel_url"] != expected_url:
+        raise ManifestError("CLI manifest wheel URL does not match the artifact base")
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_bytes(content)
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _payload_command(args: argparse.Namespace) -> None:
+    key_id = public_key_id(args.public_key)
+    payload = {
+        "algorithm": ALGORITHM,
+        "channel": args.channel,
+        "key_id": key_id,
+        "pub_date": args.pub_date,
+        "python_requires": args.python_requires,
+        "schema": SCHEMA,
+        "sha256": args.sha256,
+        "version": args.version,
+        "wheel_url": args.wheel_url,
+    }
+    normalized = _validate_signed_payload(payload)
+    _atomic_write(args.output, _canonical_json(normalized))
+
+
+def _assemble_command(args: argparse.Namespace) -> None:
+    payload_any = _load_json(args.payload)
+    payload = _validate_signed_payload(payload_any)
+    canonical = _canonical_json(payload)
+    if args.payload.read_bytes() != canonical:
+        raise ManifestError("CLI manifest payload is not canonical JSON")
+    expected_key_id = public_key_id(args.public_key)
+    if payload["key_id"] != expected_key_id:
+        raise ManifestError("CLI manifest payload does not name the committed public key")
+
+    signature = args.signature.read_bytes()
+    if not signature or len(signature) > _MAX_SIGNATURE_BYTES:
+        raise ManifestError("CLI manifest signature has an invalid size")
+    _run_openssl(
+        [
+            "dgst",
+            "-sha256",
+            "-verify",
+            str(args.public_key),
+            "-signature",
+            str(args.signature),
+            str(args.payload),
+        ]
+    )
+
+    manifest = dict(payload)
+    manifest["signature"] = base64.b64encode(signature).decode("ascii")
+    rendered = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("ascii")
+    _atomic_write(args.output, rendered)
+
+
+def _verify_command(args: argparse.Namespace) -> None:
+    """Verify a SIGNED manifest (e.g. a live channel feed) end to end.
+
+    Mirrors what cli.sh enforces at install time: schema validation, the
+    pinned-key fingerprint, the embedded signature over the canonical payload,
+    and binding to the requested channel and artifact base. Used by
+    publish-installer.yml to prove every live feed is installable by the strict
+    installer BEFORE it replaces the live cli.sh.
+    """
+    manifest_any = _load_json(args.manifest)
+    if not isinstance(manifest_any, dict):
+        raise ManifestError("CLI manifest must be a JSON object")
+    manifest = dict(manifest_any)
+    signature_b64 = manifest.pop("signature", None)
+    if not isinstance(signature_b64, str) or not signature_b64:
+        raise ManifestError("CLI manifest is missing its signature")
+    try:
+        signature = base64.b64decode(signature_b64, validate=True)
+    except ValueError as exc:
+        raise ManifestError("CLI manifest signature is not valid base64") from exc
+    if not signature or len(signature) > _MAX_SIGNATURE_BYTES:
+        raise ManifestError("CLI manifest signature has an invalid size")
+
+    payload = _validate_signed_payload(manifest)
+    expected_key_id = public_key_id(args.public_key)
+    if payload["key_id"] != expected_key_id:
+        raise ManifestError("CLI manifest does not name the pinned public key")
+
+    with tempfile.TemporaryDirectory() as scratch:
+        payload_path = Path(scratch) / "payload.json"
+        signature_path = Path(scratch) / "signature.bin"
+        payload_path.write_bytes(_canonical_json(payload))
+        signature_path.write_bytes(signature)
+        _run_openssl(
+            [
+                "dgst",
+                "-sha256",
+                "-verify",
+                str(args.public_key),
+                "-signature",
+                str(signature_path),
+                str(payload_path),
+            ]
+        )
+    _validate_target_binding(
+        payload,
+        expected_channel=args.expected_channel,
+        artifact_base=args.artifact_base,
+    )
+    print(f"verified: {args.manifest} signed by {expected_key_id}")
+
+
+def _kms_sign_command(args: argparse.Namespace) -> None:
+    payload_any = _load_json(args.payload)
+    payload = _validate_signed_payload(payload_any)
+    canonical = _canonical_json(payload)
+    if args.payload.read_bytes() != canonical:
+        raise ManifestError("CLI manifest payload is not canonical JSON")
+
+    pinned_der = _public_key_der(args.public_key)
+    expected_key_id = f"sha256:{hashlib.sha256(pinned_der).hexdigest()}"
+    if payload["key_id"] != expected_key_id:
+        raise ManifestError("CLI manifest payload does not name the committed public key")
+
+    public_response = _run_aws_json(["kms", "get-public-key", "--key-id", args.key_arn])
+    if public_response.get("KeyUsage") != "SIGN_VERIFY":
+        raise ManifestError("CLI manifest KMS key must have SIGN_VERIFY usage")
+    if public_response.get("KeySpec") not in {"RSA_3072", "RSA_4096"}:
+        raise ManifestError("CLI manifest KMS key must be RSA_3072 or RSA_4096")
+    algorithms = public_response.get("SigningAlgorithms")
+    if not isinstance(algorithms, list) or ALGORITHM not in algorithms:
+        raise ManifestError("CLI manifest KMS key does not allow the required algorithm")
+    encoded_public = public_response.get("PublicKey")
+    if not isinstance(encoded_public, str):
+        raise ManifestError("AWS KMS did not return a public key")
+    try:
+        kms_der = base64.b64decode(encoded_public, validate=True)
+    except ValueError as exc:
+        raise ManifestError("AWS KMS returned an invalid public key") from exc
+    if not hmac.compare_digest(kms_der, pinned_der):
+        raise ManifestError("configured KMS key does not match the committed public key")
+
+    digest = hashlib.sha256(canonical).digest()
+    sign_response = _run_aws_json(
+        [
+            "kms",
+            "sign",
+            "--key-id",
+            args.key_arn,
+            "--message",
+            base64.b64encode(digest).decode("ascii"),
+            "--message-type",
+            "DIGEST",
+            "--signing-algorithm",
+            ALGORITHM,
+            "--cli-binary-format",
+            "base64",
+        ]
+    )
+    encoded_signature = sign_response.get("Signature")
+    if not isinstance(encoded_signature, str):
+        raise ManifestError("AWS KMS did not return a signature")
+    try:
+        signature = base64.b64decode(encoded_signature, validate=True)
+    except ValueError as exc:
+        raise ManifestError("AWS KMS returned an invalid signature") from exc
+
+    with tempfile.TemporaryDirectory(prefix="kirocrew-cli-manifest-") as temporary:
+        signature_path = Path(temporary) / "signature.bin"
+        signature_path.write_bytes(signature)
+        _assemble_command(
+            argparse.Namespace(
+                payload=args.payload,
+                signature=signature_path,
+                public_key=args.public_key,
+                output=args.output,
+            )
+        )
+
+
+def _key_info_command(args: argparse.Namespace) -> None:
+    raw = args.public_key.read_bytes()
+    info = {
+        "key_id": public_key_id(args.public_key),
+        "public_key_pem_base64": base64.b64encode(raw).decode("ascii"),
+    }
+    print(json.dumps(info, indent=2, sort_keys=True))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    payload = subparsers.add_parser("payload", help="write the canonical payload to sign")
+    payload.add_argument("--channel", choices=CHANNELS, required=True)
+    payload.add_argument("--version", required=True)
+    payload.add_argument("--wheel-url", required=True)
+    payload.add_argument("--sha256", required=True)
+    payload.add_argument("--python-requires", required=True)
+    payload.add_argument("--pub-date", required=True)
+    payload.add_argument("--public-key", type=Path, required=True)
+    payload.add_argument("--output", type=Path, required=True)
+    payload.set_defaults(handler=_payload_command)
+
+    assemble = subparsers.add_parser(
+        "assemble", help="verify a detached signature and write the signed manifest"
+    )
+    assemble.add_argument("--payload", type=Path, required=True)
+    assemble.add_argument("--signature", type=Path, required=True)
+    assemble.add_argument("--public-key", type=Path, required=True)
+    assemble.add_argument("--output", type=Path, required=True)
+    assemble.set_defaults(handler=_assemble_command)
+
+    kms_sign = subparsers.add_parser(
+        "kms-sign", help="sign the canonical payload with a non-exportable AWS KMS key"
+    )
+    kms_sign.add_argument("--payload", type=Path, required=True)
+    kms_sign.add_argument("--key-arn", required=True)
+    kms_sign.add_argument("--public-key", type=Path, required=True)
+    kms_sign.add_argument("--output", type=Path, required=True)
+    kms_sign.set_defaults(handler=_kms_sign_command)
+
+    verify = subparsers.add_parser(
+        "verify", help="verify a signed manifest against the pinned public key"
+    )
+    verify.add_argument("--manifest", type=Path, required=True)
+    verify.add_argument("--public-key", type=Path, required=True)
+    verify.add_argument("--expected-channel", choices=CHANNELS, required=True)
+    verify.add_argument("--artifact-base", required=True)
+    verify.set_defaults(handler=_verify_command)
+
+    key_info = subparsers.add_parser(
+        "key-info", help="print the public values that must be pinned in cli.sh"
+    )
+    key_info.add_argument("--public-key", type=Path, required=True)
+    key_info.set_defaults(handler=_key_info_command)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        args.handler(args)
+    except (ManifestError, OSError) as exc:
+        print(f"cli-manifest: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_cli_manifest_signature.py
+++ b/test/test_cli_manifest_signature.py
@@ -1,0 +1,831 @@
+"""Signed CLI artifact-manifest and installer verification tests."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "packaging" / "signing" / "cli-manifest.py"
+INSTALLER = ROOT / "cli.sh"
+CLI_WORKFLOW = ROOT / ".github" / "workflows" / "publish-cli.yml"
+PINNED_PUBLIC_KEY = ROOT / "packaging" / "signing" / "cli-manifest-public.pem"
+VERSION = "1.2.3"
+CHANNEL = "stable"
+WHEEL_NAME = f"kirocrew-{VERSION}-py3-none-any.whl"
+CDN_BASE = "https://fixtures.invalid"
+
+
+@dataclass(frozen=True)
+class SigningKey:
+    private: Path
+    public: Path
+    key_id: str
+    public_b64: str
+
+
+@pytest.fixture(scope="module")
+def test_key(tmp_path_factory: pytest.TempPathFactory) -> SigningKey:
+    root = tmp_path_factory.mktemp("cli-manifest-key")
+    private = root / "private.pem"
+    public = root / "public.pem"
+    subprocess.run(
+        [
+            "openssl",
+            "genpkey",
+            "-algorithm",
+            "RSA",
+            "-pkeyopt",
+            "rsa_keygen_bits:3072",
+            "-out",
+            str(private),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ["openssl", "pkey", "-in", str(private), "-pubout", "-out", str(public)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    der = subprocess.run(
+        ["openssl", "pkey", "-pubin", "-in", str(public), "-outform", "DER"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    ).stdout
+    return SigningKey(
+        private=private,
+        public=public,
+        key_id=f"sha256:{hashlib.sha256(der).hexdigest()}",
+        public_b64=base64.b64encode(public.read_bytes()).decode("ascii"),
+    )
+
+
+def _run_helper(
+    *args: str,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HELPER), *args],
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+
+def _write_canonical_json(path: Path, value: dict[str, object]) -> None:
+    path.write_bytes(
+        (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode(
+            "ascii"
+        )
+    )
+
+
+def _build_manifest(
+    root: Path,
+    key: SigningKey,
+    wheel: Path,
+    *,
+    channel: str = CHANNEL,
+    artifact_base: str = CDN_BASE,
+) -> Path:
+    payload = root / "payload.json"
+    signature = root / "signature.bin"
+    manifest = root / "cli-manifest.json"
+    digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+    wheel_url = f"{artifact_base.rstrip('/')}/cli/{channel}/{VERSION}/{WHEEL_NAME}"
+    _run_helper(
+        "payload",
+        "--channel",
+        channel,
+        "--version",
+        VERSION,
+        "--wheel-url",
+        wheel_url,
+        "--sha256",
+        digest,
+        "--python-requires",
+        ">=3.10",
+        "--pub-date",
+        "2026-08-01T00:00:00Z",
+        "--public-key",
+        str(key.public),
+        "--output",
+        str(payload),
+    )
+    subprocess.run(
+        [
+            "openssl",
+            "dgst",
+            "-sha256",
+            "-sign",
+            str(key.private),
+            "-out",
+            str(signature),
+            str(payload),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    _run_helper(
+        "assemble",
+        "--payload",
+        str(payload),
+        "--signature",
+        str(signature),
+        "--public-key",
+        str(key.public),
+        "--output",
+        str(manifest),
+    )
+    return manifest
+
+
+def test_helper_builds_a_canonical_independently_verifiable_manifest(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"signed wheel bytes")
+    manifest_path = _build_manifest(tmp_path, test_key, wheel)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["schema"] == "kirocrew-cli-artifact-manifest-v1"
+    assert manifest["algorithm"] == "RSASSA_PKCS1_V1_5_SHA_256"
+    assert manifest["key_id"] == test_key.key_id
+    assert manifest["sha256"] == hashlib.sha256(wheel.read_bytes()).hexdigest()
+
+    signature = tmp_path / "decoded-signature.bin"
+    signature.write_bytes(base64.b64decode(manifest.pop("signature"), validate=True))
+    payload = tmp_path / "reconstructed-payload.json"
+    _write_canonical_json(payload, manifest)
+    verified = subprocess.run(
+        [
+            "openssl",
+            "dgst",
+            "-sha256",
+            "-verify",
+            str(test_key.public),
+            "-signature",
+            str(signature),
+            str(payload),
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert verified.returncode == 0, verified.stderr
+
+
+def test_helper_refuses_to_assemble_a_tampered_payload(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"original")
+    manifest = _build_manifest(tmp_path, test_key, wheel)
+    assert manifest.exists()
+
+    payload = tmp_path / "payload.json"
+    signature = tmp_path / "signature.bin"
+    data = json.loads(payload.read_text(encoding="utf-8"))
+    data["sha256"] = "0" * 64
+    _write_canonical_json(payload, data)
+    refused = _run_helper(
+        "assemble",
+        "--payload",
+        str(payload),
+        "--signature",
+        str(signature),
+        "--public-key",
+        str(test_key.public),
+        "--output",
+        str(tmp_path / "refused.json"),
+        check=False,
+    )
+    assert refused.returncode == 1
+    assert "rejected" in refused.stderr
+    assert not (tmp_path / "refused.json").exists()
+
+
+def test_repository_public_key_is_explicitly_unconfigured_or_valid() -> None:
+    result = _run_helper(
+        "key-info",
+        "--public-key",
+        str(PINNED_PUBLIC_KEY),
+        check=False,
+    )
+    if b"UNCONFIGURED" in PINNED_PUBLIC_KEY.read_bytes():
+        assert result.returncode == 1
+        assert "not configured" in result.stderr
+    else:
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)["key_id"].startswith("sha256:")
+
+
+def _installer_with_trust_root(tmp_path: Path, *, key_id: str, public_b64: str) -> Path:
+    source = INSTALLER.read_text(encoding="utf-8")
+    source, key_id_changes = re.subn(
+        r'^CLI_MANIFEST_KEY_ID="[^"]*"$',
+        f'CLI_MANIFEST_KEY_ID="{key_id}"',
+        source,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    source, public_key_changes = re.subn(
+        r'^CLI_MANIFEST_PUBLIC_KEY_B64="[^"]*"$',
+        f'CLI_MANIFEST_PUBLIC_KEY_B64="{public_b64}"',
+        source,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    assert key_id_changes == public_key_changes == 1
+    script = tmp_path / "cli.sh"
+    script.write_text(source, encoding="utf-8")
+    script.chmod(0o755)
+    return script
+
+
+def _patched_installer(
+    tmp_path: Path,
+    key: SigningKey,
+    *,
+    key_id: str | None = None,
+    public_b64: str | None = None,
+) -> Path:
+    return _installer_with_trust_root(
+        tmp_path,
+        key_id=key.key_id if key_id is None else key_id,
+        public_b64=key.public_b64 if public_b64 is None else public_b64,
+    )
+
+
+def _write_fake_tools(root: Path) -> tuple[Path, Path, Path]:
+    root.mkdir(parents=True, exist_ok=True)
+    tools = root / "tools"
+    tools.mkdir()
+    curl_marker = root / "curl-called"
+    install_marker = root / "pipx-installed"
+    curl = tools / "curl"
+    curl.write_text(
+        """#!/bin/sh
+set -eu
+touch "$FAKE_CURL_MARKER"
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+case "$url" in
+  https://fixtures.invalid/*) rel=${url#https://fixtures.invalid/} ;;
+  *) echo "unexpected URL: $url" >&2; exit 9 ;;
+esac
+[ -n "$out" ] || exit 10
+cp "$FAKE_CDN_ROOT/$rel" "$out"
+""",
+        encoding="utf-8",
+    )
+    pipx = tools / "pipx"
+    pipx.write_text(
+        """#!/bin/sh
+set -eu
+case "$1" in
+  install) touch "$FAKE_INSTALL_MARKER" ;;
+  environment) printf '%s\\n' "$HOME/.local/bin" ;;
+  *) exit 11 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    curl.chmod(0o755)
+    pipx.chmod(0o755)
+    return tools, curl_marker, install_marker
+
+
+def _stage_cdn(root: Path, manifest: Path, wheel: Path, *, include_feed: bool = True) -> Path:
+    cdn = root / "cdn"
+    version_dir = cdn / "cli" / CHANNEL / VERSION
+    version_dir.mkdir(parents=True)
+    shutil.copy2(wheel, version_dir / WHEEL_NAME)
+    shutil.copy2(manifest, version_dir / "cli-manifest.json")
+    if include_feed:
+        feed_dir = cdn / "feed" / CHANNEL
+        feed_dir.mkdir(parents=True)
+        shutil.copy2(manifest, feed_dir / "latest-cli.json")
+    return cdn
+
+
+def _run_installer(
+    script: Path,
+    root: Path,
+    cdn: Path,
+    *args: str,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    if os.name == "nt":
+        pytest.skip("cli.sh is supported on macOS and Linux only")
+    tools, curl_marker, install_marker = _write_fake_tools(root)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tools}{os.pathsep}{env['PATH']}",
+            "HOME": str(root / "home"),
+            "KIROCREW_HOME": str(root / "data-home"),
+            "FAKE_CDN_ROOT": str(cdn),
+            "FAKE_CURL_MARKER": str(curl_marker),
+            "FAKE_INSTALL_MARKER": str(install_marker),
+        }
+    )
+    result = subprocess.run(
+        ["sh", str(script), "--cdn", CDN_BASE, *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    return result, curl_marker, install_marker
+
+
+@pytest.mark.parametrize("pinned", [False, True])
+def test_installer_verifies_signature_and_digest_before_installing(
+    tmp_path: Path, test_key: SigningKey, pinned: bool
+) -> None:
+    case = tmp_path / ("pinned" if pinned else "channel")
+    case.mkdir()
+    wheel = case / WHEEL_NAME
+    wheel.write_bytes(b"verified wheel")
+    manifest = _build_manifest(case, test_key, wheel)
+    cdn = _stage_cdn(case, manifest, wheel, include_feed=not pinned)
+    script = _patched_installer(case, test_key)
+
+    extra = ("--version", VERSION) if pinned else ()
+    result, curl_marker, install_marker = _run_installer(script, case / "run", cdn, *extra)
+
+    assert result.returncode == 0, result.stderr
+    assert curl_marker.exists()
+    assert install_marker.exists()
+    assert "Verified signed manifest." in result.stdout
+    assert "Verified SHA-256." in result.stdout
+
+
+@pytest.mark.parametrize("pinned", [False, True])
+def test_installer_refuses_when_signed_manifest_is_missing(
+    tmp_path: Path, test_key: SigningKey, pinned: bool
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"wheel")
+    manifest = _build_manifest(tmp_path, test_key, wheel)
+    cdn = _stage_cdn(tmp_path, manifest, wheel, include_feed=False)
+    if pinned:
+        (cdn / "cli" / CHANNEL / VERSION / "cli-manifest.json").unlink()
+    script = _patched_installer(tmp_path, test_key)
+
+    extra = ("--version", VERSION) if pinned else ()
+    result, _, install_marker = _run_installer(script, tmp_path / "run", cdn, *extra)
+
+    assert result.returncode == 1
+    assert "signed CLI manifest not found" in result.stderr
+    assert not install_marker.exists()
+
+
+def test_installer_refuses_corrupted_embedded_public_key_before_network(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    corrupted = base64.b64encode(b"not an RSA public key").decode("ascii")
+    script = _patched_installer(tmp_path, test_key, public_b64=corrupted)
+
+    result, curl_marker, install_marker = _run_installer(
+        script, tmp_path / "run", tmp_path / "unused-cdn"
+    )
+
+    assert result.returncode == 1
+    assert "embedded CLI manifest public key is invalid" in result.stderr
+    assert not curl_marker.exists(), "a corrupted trust root must fail before network I/O"
+    assert not install_marker.exists()
+
+
+def test_installer_refuses_a_manifest_changed_after_signing(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"verified wheel")
+    manifest_path = _build_manifest(tmp_path, test_key, wheel)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    cdn = _stage_cdn(tmp_path, manifest_path, wheel)
+    script = _patched_installer(tmp_path, test_key)
+
+    result, _, install_marker = _run_installer(script, tmp_path / "run", cdn)
+
+    assert result.returncode == 1
+    assert "manifest signature verification failed" in result.stderr
+    assert not install_marker.exists()
+
+
+def test_installer_refuses_wheel_bytes_that_do_not_match_signed_digest(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"signed wheel")
+    manifest = _build_manifest(tmp_path, test_key, wheel)
+    wheel.write_bytes(b"tampered wheel")
+    cdn = _stage_cdn(tmp_path, manifest, wheel)
+    script = _patched_installer(tmp_path, test_key)
+
+    result, _, install_marker = _run_installer(script, tmp_path / "run", cdn)
+
+    assert result.returncode == 1
+    assert "SHA-256 mismatch" in result.stderr
+    assert not install_marker.exists()
+
+
+def test_installer_refuses_unsigned_legacy_feed_without_fallback(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"wheel")
+    legacy = {
+        "channel": CHANNEL,
+        "version": VERSION,
+        "wheel_url": f"{CDN_BASE}/cli/{CHANNEL}/{VERSION}/{WHEEL_NAME}",
+        "sha256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        "python_requires": ">=3.10",
+        "pub_date": "2026-08-01T00:00:00Z",
+    }
+    manifest = tmp_path / "legacy.json"
+    manifest.write_text(json.dumps(legacy), encoding="utf-8")
+    cdn = _stage_cdn(tmp_path, manifest, wheel)
+    script = _patched_installer(tmp_path, test_key)
+
+    result, _, install_marker = _run_installer(script, tmp_path / "run", cdn)
+
+    assert result.returncode == 1
+    assert "malformed signed manifest" in result.stderr
+    assert not install_marker.exists()
+
+
+def test_installer_fails_before_network_when_trust_root_is_unconfigured(
+    tmp_path: Path,
+) -> None:
+    script = _installer_with_trust_root(
+        tmp_path,
+        key_id="UNCONFIGURED",
+        public_b64="UNCONFIGURED",
+    )
+    result, curl_marker, install_marker = _run_installer(
+        script, tmp_path / "run", tmp_path / "unused-cdn"
+    )
+
+    assert result.returncode == 1
+    assert "manifest signing trust root is not configured" in result.stderr
+    assert not curl_marker.exists(), "unconfigured trust must fail before any network request"
+    assert not install_marker.exists()
+
+
+def test_installer_and_repository_public_key_are_one_fail_closed_contract() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+    key_id = re.search(r'^CLI_MANIFEST_KEY_ID="([^"]+)"$', source, re.M)
+    key_b64 = re.search(r'^CLI_MANIFEST_PUBLIC_KEY_B64="([^"]+)"$', source, re.M)
+    assert key_id and key_b64
+
+    public_bytes = PINNED_PUBLIC_KEY.read_bytes()
+    if key_id.group(1) == "UNCONFIGURED":
+        assert key_b64.group(1) == "UNCONFIGURED"
+        assert b"UNCONFIGURED" in public_bytes
+    else:
+        assert key_id.group(1).startswith("sha256:")
+        assert base64.b64decode(key_b64.group(1), validate=True) == public_bytes
+        assert b"UNCONFIGURED" not in public_bytes
+
+
+def test_kms_signer_requires_matching_non_exportable_key_and_verifies_output(
+    tmp_path: Path, test_key: SigningKey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"kms-signed wheel")
+    payload = tmp_path / "payload.json"
+    signature = tmp_path / "signature.bin"
+    manifest = tmp_path / "manifest.json"
+    _run_helper(
+        "payload",
+        "--channel",
+        CHANNEL,
+        "--version",
+        VERSION,
+        "--wheel-url",
+        f"{CDN_BASE}/cli/{CHANNEL}/{VERSION}/{WHEEL_NAME}",
+        "--sha256",
+        hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        "--python-requires",
+        ">=3.10",
+        "--pub-date",
+        "2026-08-01T00:00:00Z",
+        "--public-key",
+        str(test_key.public),
+        "--output",
+        str(payload),
+    )
+    subprocess.run(
+        [
+            "openssl",
+            "dgst",
+            "-sha256",
+            "-sign",
+            str(test_key.private),
+            "-out",
+            str(signature),
+            str(payload),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    public_der = subprocess.run(
+        ["openssl", "pkey", "-pubin", "-in", str(test_key.public), "-outform", "DER"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    ).stdout
+
+    spec = importlib.util.spec_from_file_location("cli_manifest_test_helper", HELPER)
+    assert spec is not None and spec.loader is not None
+    helper = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(helper)
+
+    key_arn = "arn:aws:kms:us-west-2:000000000000:key/test"
+    aws_calls: list[list[str]] = []
+
+    def fake_aws_json(args: list[str]) -> dict[str, object]:
+        aws_calls.append(args)
+        if args[:2] == ["kms", "get-public-key"]:
+            return {
+                "KeyUsage": "SIGN_VERIFY",
+                "KeySpec": "RSA_3072",
+                "SigningAlgorithms": ["RSASSA_PKCS1_V1_5_SHA_256"],
+                "PublicKey": base64.b64encode(public_der).decode("ascii"),
+            }
+        if args[:2] == ["kms", "sign"]:
+            return {
+                "Signature": base64.b64encode(signature.read_bytes()).decode("ascii")
+            }
+        raise AssertionError(f"unexpected AWS CLI arguments: {args}")
+
+    monkeypatch.setattr(helper, "_run_aws_json", fake_aws_json)
+    helper._kms_sign_command(
+        argparse.Namespace(
+            payload=payload,
+            key_arn=key_arn,
+            public_key=test_key.public,
+            output=manifest,
+        )
+    )
+
+    assert [call[:2] for call in aws_calls] == [
+        ["kms", "get-public-key"],
+        ["kms", "sign"],
+    ]
+    assert json.loads(manifest.read_text(encoding="utf-8"))["key_id"] == test_key.key_id
+
+
+def _workflow_steps() -> list[dict]:
+    workflow = yaml.safe_load(CLI_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["publish-cli"]["steps"]
+
+
+def _workflow_step(name: str) -> dict:
+    return next(step for step in _workflow_steps() if step.get("name") == name)
+
+
+def test_publish_workflow_fails_closed_and_uses_non_exportable_kms_signing() -> None:
+    steps = _workflow_steps()
+    names = [step.get("name") for step in steps]
+    guard = _workflow_step("Refuse partial CLI signing configuration")
+    signer = _workflow_step("Build and sign CLI artifact manifest")
+    publisher = _workflow_step("Publish wheel and signed channel manifest")
+
+    assert names.index("Configure AWS credentials") < names.index(signer["name"])
+    assert names.index(signer["name"]) < names.index(publisher["name"])
+    assert guard["if"] == "env.HAS_PUBLISH_ROLE != env.HAS_MANIFEST_KEY"
+    assert "kms-sign" in signer["run"]
+    assert "CLI_MANIFEST_SIGNING_KEY_ARN" in CLI_WORKFLOW.read_text(encoding="utf-8")
+    assert "PRIVATE_KEY" not in signer["run"]
+    assert "AWS_SECRET_ACCESS_KEY" not in signer["run"]
+
+
+def test_publish_workflow_uses_a_deterministic_manifest_publication_date() -> None:
+    run = _workflow_step("Build and sign CLI artifact manifest")["run"]
+
+    assert 'git show -s --format=%ct "$GITHUB_SHA"' in run
+    assert 'date -u -d "@${SOURCE_DATE_EPOCH}"' in run
+    assert '--pub-date "$PUB_DATE"' in run
+    assert '--pub-date "$(date -u' not in run
+
+
+def _verify_manifest(
+    manifest: Path,
+    key: SigningKey,
+    *,
+    expected_channel: str = CHANNEL,
+    artifact_base: str = CDN_BASE,
+) -> subprocess.CompletedProcess[str]:
+    return _run_helper(
+        "verify",
+        "--manifest",
+        str(manifest),
+        "--public-key",
+        str(key.public),
+        "--expected-channel",
+        expected_channel,
+        "--artifact-base",
+        artifact_base,
+        check=False,
+    )
+
+
+def test_verify_accepts_a_signed_manifest_and_rejects_tampering(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"wheel-bytes")
+    manifest = _build_manifest(tmp_path, test_key, wheel)
+
+    verified = _verify_manifest(manifest, test_key)
+    assert verified.returncode == 0, verified.stderr
+
+    # Tampered field: signature no longer covers the payload.
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    data["version"] = "9.9.9"
+    tampered = tmp_path / "tampered.json"
+    tampered.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+    refused = _verify_manifest(tampered, test_key)
+    assert refused.returncode == 1
+
+    # Missing signature: fail closed before any crypto.
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    del data["signature"]
+    unsigned = tmp_path / "unsigned.json"
+    unsigned.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+    refused = _verify_manifest(unsigned, test_key)
+    assert refused.returncode == 1
+    assert "signature" in refused.stderr
+
+
+def test_verify_refuses_a_valid_manifest_for_another_channel(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"wrong-channel-wheel")
+    manifest = _build_manifest(tmp_path, test_key, wheel, channel="nightly")
+
+    refused = _verify_manifest(manifest, test_key, expected_channel=CHANNEL)
+
+    assert refused.returncode == 1
+    assert "channel does not match" in refused.stderr
+
+
+def test_verify_refuses_a_valid_manifest_from_another_artifact_host(
+    tmp_path: Path, test_key: SigningKey
+) -> None:
+    wheel = tmp_path / WHEEL_NAME
+    wheel.write_bytes(b"wrong-host-wheel")
+    manifest = _build_manifest(
+        tmp_path, test_key, wheel, artifact_base="https://attacker.invalid"
+    )
+
+    refused = _verify_manifest(manifest, test_key)
+
+    assert refused.returncode == 1
+    assert "wheel URL does not match" in refused.stderr
+
+
+def test_installer_publish_refuses_an_unconfigured_trust_root() -> None:
+    """Merging the strict cli.sh must not brick the live curl one-liner.
+
+    publish-installer.yml path-triggers on cli.sh pushes to main. Until KMS
+    provisioning pins a real fingerprint, cli.sh is deliberately fail-closed
+    (CLI_MANIFEST_KEY_ID=UNCONFIGURED refuses every install), so the publish
+    lane must refuse to replace the live installer with it. This pins the
+    guard's presence, its refusal semantics, and its position before any
+    credentialed/upload step.
+    """
+    installer_workflow = ROOT / ".github" / "workflows" / "publish-installer.yml"
+    workflow = yaml.safe_load(installer_workflow.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["publish-installer"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    guard = next(
+        step
+        for step in steps
+        if step.get("name") == "Refuse to publish an unconfigured trust root"
+    )
+    assert "CLI_MANIFEST_KEY_ID" in guard["run"]
+    assert "UNCONFIGURED" in guard["run"]
+    assert "exit 1" in guard["run"]
+    # A non-placeholder key id is not enough: it must be the SPKI-DER SHA-256
+    # fingerprint of the exact public key embedded in cli.sh, or the published
+    # installer rejects every feed before installation.
+    assert "CLI_MANIFEST_PUBLIC_KEY_B64" in guard["run"]
+    assert "base64 -d" in guard["run"]
+    assert "openssl pkey -pubin" in guard["run"]
+    assert "-outform DER" in guard["run"]
+    assert "sha256sum" in guard["run"]
+    assert 'if [ "$key_id" != "$derived_key_id" ]' in guard["run"]
+    feed_gate = next(
+        step
+        for step in steps
+        if step.get("name") == "Verify every live channel feed against the pinned key"
+    )
+    # A pinned key alone is not sufficient: every LIVE feed must verify with
+    # the exact checks cli.sh performs, or publishing the strict installer
+    # bricks that channel. Absent feeds (404) are skip-with-warning: they are
+    # not installable by the current installer either.
+    assert "cli-manifest.py verify" in feed_gate["run"]
+    assert '--expected-channel "$channel"' in feed_gate["run"]
+    assert '--artifact-base "${CDN_BASE}"' in feed_gate["run"]
+    for channel in ("nightly", "insider", "stable"):
+        assert channel in feed_gate["run"]
+    assert "exit 1" in feed_gate["run"]
+    upload_indexes = [
+        index
+        for index, step in enumerate(steps)
+        if "aws" in str(step.get("run", "")) or "credentials" in str(step.get("uses", ""))
+    ]
+    assert upload_indexes, "publish lane must still publish"
+    assert names.index(guard["name"]) < names.index(feed_gate["name"]) < min(upload_indexes)
+
+
+def test_publish_workflow_writes_immutable_manifest_before_signed_feed() -> None:
+    run = _workflow_step("Publish wheel and signed channel manifest")["run"]
+    immutable = 'put_immutable "${PREFIX}/cli-manifest.json" "$MANIFEST_PATH"'
+    feed = 'aws s3 cp "$MANIFEST_PATH" "s3://${BUCKET}/feed/${CHANNEL}/latest-cli.json"'
+
+    assert immutable in run
+    assert feed in run
+    assert run.index(immutable) < run.index(feed)
+    assert "cat > /tmp/latest-cli.json" not in run
+    assert "--cache-control no-cache" in run
+
+
+def test_installer_authenticates_before_reading_or_downloading_artifact() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+    executable = "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+
+    verify = executable.index("openssl dgst -sha256 -verify")
+    parse_fields = executable.index("read_field()")
+    wheel_download = executable.index("curl -fsS --proto '=https' \"$WHEEL_URL\"")
+    assert verify < parse_fields < wheel_download
+    assert "SHA256SUMS" not in executable, "strict installer must have no unsigned fallback"
+
+
+def test_publish_workflow_gates_all_artifact_work_before_side_effects() -> None:
+    steps = _workflow_steps()
+    assert steps[0]["name"] == "Refuse partial CLI signing configuration"
+    complete_config = "env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY"
+    for name in (
+        "Checkout manifest verifier contract",
+        "Download wheel artifact",
+        "Locate wheel and compute checksum",
+        "Attest wheel provenance",
+    ):
+        assert _workflow_step(name)["if"] == complete_config
+
+
+def test_installer_fetches_authenticated_urls_without_redirects() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+    fetches = [
+        line.strip()
+        for line in source.splitlines()
+        if line.strip().startswith("curl ") and '"$' in line
+    ]
+
+    assert len(fetches) == 2
+    assert all("--proto '=https'" in line for line in fetches)
+    assert all(re.search(r"(?:^|\s)-[^\s]*L", line) is None for line in fetches)
+    manifest_fetch = next(line for line in fetches if '"$MANIFEST_URL"' in line)
+    assert "--max-filesize 65536" in manifest_fetch


### PR DESCRIPTION
## Problem

The CLI installer authenticated wheel bytes against SHA-256 metadata fetched from the same unsigned distribution channel. An unauthorized mutation of a distribution object or channel feed could therefore replace both the artifact and its digest without possessing an independent signing capability.

## Why it matters

`cli.sh` installs code that users execute locally. Forged release metadata could turn distribution-path write access into arbitrary code execution on developer and fleet hosts. The channel must fail closed unless metadata is authenticated by the installer’s pinned public key.

## Fix (symptom → root cause → change)

- **Symptom:** the installer could not distinguish reviewed release metadata from metadata modified in the object/feed delivery path.
- **Root cause:** manifests carried integrity hashes but no asymmetric signature rooted in the installer.
- **Change:** publish a canonical JSON manifest whose in-band `signature` field is produced by a non-exportable AWS KMS key; pin the public key in the repository and installer; authenticate the manifest before consuming its metadata; bind live-feed verification to the expected channel and configured artifact base; then verify the downloaded wheel digest. Missing, malformed, duplicate-field, wrong-key, invalid-signature, wrong-channel, wrong-host, metadata-mismatch, and digest-mismatch inputs fail closed with no unsigned fallback.
- `packaging/signing/cli-manifest.py` constructs canonical manifests, checks the KMS public key, verifies the embedded signature locally, and emits the signed envelope.
- Release workflows publish immutable versioned manifests before moving mutable channel feeds and require both the publication role and signing-key configuration.
- The committed trust root intentionally remains `UNCONFIGURED`; the stock installer refuses network access until operational enablement is complete.

### Trust boundary

This protects against unauthorized object/feed mutation while the installer trust root and signing-enabled publisher role remain trusted. The publisher role has `kms:Sign`, so compromise of that role can create valid manifests and is out of scope; this design does not claim protection from publisher compromise. Signed-manifest replay is also not an anti-rollback mechanism.

## Tests

- `/workplace/txd/KiroCrew/KiroCrew/.venv/bin/python -m pytest test/test_cli_manifest_signature.py -q` — **24 passed in 4.70s**.
- `isort --check-only packaging/signing/cli-manifest.py test/test_cli_manifest_signature.py` — passed.
- `flake8 -j 1 packaging/signing/cli-manifest.py test/test_cli_manifest_signature.py` — passed.
- PyYAML parsing of `.github/workflows/publish-installer.yml` — passed.
- `bash -n cli.sh` — passed.
- `git diff --check` — passed.
- The pre-audit revision completed **42/42 GitHub checks** successfully; this audit revision adds targeted wrong-channel and wrong-host coverage.

## Manual verification

The repository-side fail-closed bootstrap state was verified: with the trust root still `UNCONFIGURED`, the installer refuses to fetch or install network content. End-to-end KMS signing and CDN installation cannot be exercised until the operational dependencies below exist; this PR does not claim that external validation.

## Operational dependencies

Before enabling signed CLI delivery in production:

1. Provision the asymmetric AWS KMS signing key.
2. Grant the release role least-privilege `kms:GetPublicKey` and `kms:Sign` access.
3. Replace the `UNCONFIGURED` pin with the reviewed public key and configure `CLI_MANIFEST_SIGNING_KEY_ARN`.
4. Publish signed manifests/feeds and verify them through the public CDN.
5. Only then roll out the strict installer.

The implementation deliberately remains unavailable rather than accepting unsigned artifacts while these dependencies are unmet.
