### PR TITLE
feat(release): promote tested artifacts by immutable digest

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -29,6 +29,16 @@ on:
         description: "Name of the uploaded artifact containing the wheel"
         required: true
         type: string
+      promote:
+        description: "Publish verified prerelease bytes to stable without rebuilding"
+        required: false
+        type: boolean
+        default: false
+      promotion_base_version:
+        description: "Bare stable version whose candidate manifest must match"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -50,6 +60,7 @@ jobs:
     env:
       HAS_PUBLISH_ROLE: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
       HAS_MANIFEST_KEY: ${{ vars.CLI_MANIFEST_SIGNING_KEY_ARN != '' && 'true' || '' }}
+      GH_TOKEN: ${{ github.token }}
       CHANNEL: ${{ inputs.channel }}
       VERSION_LABEL: ${{ inputs.version }}
     steps:
@@ -69,6 +80,16 @@ jobs:
         with:
           name: ${{ inputs.wheel_artifact }}
           path: cli-dist
+
+      - name: Verify immutable promotion bundle
+        if: ${{ env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY && inputs.promote }}
+        env:
+          PROMOTION_BASE_VERSION: ${{ inputs.promotion_base_version }}
+        run: |
+          python3 scripts/release_promotion.py verify \
+            --bundle-dir cli-dist \
+            --expected-source-sha "${GITHUB_SHA}" \
+            --expected-base-version "${PROMOTION_BASE_VERSION}"
 
       - name: Locate wheel and compute checksum
         id: wheel
@@ -100,7 +121,7 @@ jobs:
           echo "Wheel: $WHEEL_NAME (version $WHEEL_VERSION, label '${VERSION_LABEL}')"
 
       - name: Attest wheel provenance
-        if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
+        if: ${{ env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY && !inputs.promote }}
         # Signed SLSA provenance binding the published wheel's digest to this
         # repo/workflow/commit (CWE-1104) — complements the self-hosted
         # SHA256SUMS (integrity, not authenticity). Runs before the wheel is
@@ -108,6 +129,13 @@ jobs:
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: ${{ steps.wheel.outputs.path }}
+
+      - name: Verify promoted wheel provenance
+        if: ${{ env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY && inputs.promote }}
+        run: |
+          gh attestation verify "${{ steps.wheel.outputs.path }}" \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/publish-cli.yml"
 
       - name: Configure AWS credentials
         if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -57,6 +57,27 @@ on:
         description: "Name of the uploaded artifact containing the wheel"
         required: true
         type: string
+      promote:
+        description: >-
+          Promote an existing tested manifest instead of building. A valid
+          promote_digest is mandatory when true; missing evidence fails closed.
+        required: false
+        type: boolean
+        default: false
+      promote_digest:
+        description: >-
+          Recorded attested manifest digest to promote. Used only when promote
+          is true; it never implicitly selects promotion or build mode.
+        required: false
+        type: string
+        default: ""
+    outputs:
+      digest:
+        description: "Published or promoted OCI manifest digest"
+        value: ${{ jobs.publish-docker.outputs.digest }}
+      image:
+        description: "Canonical GHCR image name"
+        value: ${{ jobs.publish-docker.outputs.image }}
 
 permissions:
   contents: read
@@ -73,16 +94,36 @@ jobs:
     env:
       CHANNEL: ${{ inputs.channel }}
       VERSION: ${{ inputs.version }}
+      PROMOTE: ${{ inputs.promote }}
+      PROMOTE_DIGEST: ${{ inputs.promote_digest }}
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+      image: ${{ steps.image.outputs.name }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Validate build or promotion mode
+        run: |
+          set -euo pipefail
+          if [ "$PROMOTE" = "true" ]; then
+            if ! [[ "$PROMOTE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::Promotion requires a recorded sha256:<64 lowercase hex> digest; refusing to build or retag."
+              exit 1
+            fi
+          elif [ -n "$PROMOTE_DIGEST" ]; then
+            echo "::error::promote_digest was supplied while promote=false; refusing ambiguous publication mode."
+            exit 1
+          fi
+
       - name: Download wheel artifact
+        if: ${{ !inputs.promote }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.wheel_artifact }}
           path: dist
 
       - name: Verify exactly one wheel
+        if: ${{ !inputs.promote }}
         run: |
           set -euo pipefail
           # The artifact carries wheel + sdist; the image consumes the wheel.
@@ -135,11 +176,19 @@ jobs:
           set -e
           if [ "$INSPECT_RC" -eq 0 ]; then
             DIGEST=$(echo "$INSPECT_OUT" | tr -d '"')
+            if [ "$PROMOTE" = "true" ] && [ "$DIGEST" != "$PROMOTE_DIGEST" ]; then
+              echo "::error::Immutable version tag ${IMAGE}:${VERSION} already points to ${DIGEST}, not recorded candidate ${PROMOTE_DIGEST}. Refusing to repoint it."
+              exit 1
+            fi
             echo "Version tag already published (job re-run): ${IMAGE}:${VERSION}@${DIGEST}"
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           elif echo "$INSPECT_OUT" | grep -qiE 'manifest unknown|name unknown|not found|MANIFEST_UNKNOWN|NAME_UNKNOWN'; then
-            echo "Version tag not published yet — building."
+            if [ "$PROMOTE" = "true" ]; then
+              echo "Version tag not published yet — verified promotion may create it."
+            else
+              echo "Version tag not published yet — building."
+            fi
             echo "exists=false" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Could not determine whether ${IMAGE}:${VERSION} exists (transport/auth failure, NOT a clean not-found). Refusing to build: republishing an existing version tag would break digest-pinned deployments. Inspect output follows."
@@ -148,7 +197,7 @@ jobs:
           fi
 
       - name: Set up QEMU (arm64 emulation)
-        if: steps.existing.outputs.exists == 'false'
+        if: steps.existing.outputs.exists == 'false' && !inputs.promote
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
@@ -162,7 +211,7 @@ jobs:
       # The Dockerfile independently sha256-verifies the downloaded bytes
       # against the manifest (fail-closed).
       - name: Resolve kiro-cli version
-        if: steps.existing.outputs.exists == 'false'
+        if: steps.existing.outputs.exists == 'false' && !inputs.promote
         id: kirocli
         run: |
           set -euo pipefail
@@ -177,7 +226,7 @@ jobs:
       # (no unknown/unknown attestation entries); SLSA provenance is
       # attached by the dedicated attest step instead.
       - name: Build and push (version tag)
-        if: steps.existing.outputs.exists == 'false'
+        if: steps.existing.outputs.exists == 'false' && !inputs.promote
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -202,6 +251,8 @@ jobs:
           set -euo pipefail
           if [ "${{ steps.existing.outputs.exists }}" = "true" ]; then
             DIGEST="${{ steps.existing.outputs.digest }}"
+          elif [ "$PROMOTE" = "true" ]; then
+            DIGEST="$PROMOTE_DIGEST"
           else
             DIGEST="${{ steps.build.outputs.digest }}"
           fi
@@ -220,7 +271,7 @@ jobs:
       # acquire fraudulent provenance from the trusted release workflow.
       # The existing-tag re-run path is handled by the VERIFY step below.
       - name: Attest image provenance (fresh build)
-        if: steps.existing.outputs.exists == 'false'
+        if: steps.existing.outputs.exists == 'false' && !inputs.promote
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ${{ steps.image.outputs.name }}
@@ -237,8 +288,8 @@ jobs:
       # unattested digest into the channel alias — recover by deleting the
       # orphaned version tag (registry UI) and re-running for a clean,
       # attested rebuild. Pinned by test_publish_docker_contract.py.
-      - name: Verify existing digest provenance (re-run)
-        if: steps.existing.outputs.exists == 'true'
+      - name: Verify existing digest provenance (re-run or promotion)
+        if: steps.existing.outputs.exists == 'true' || inputs.promote
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -260,6 +311,19 @@ jobs:
             exit 1
           fi
           echo "Existing digest carries valid provenance from this workflow."
+
+      - name: Record promoted immutable version tag
+        if: inputs.promote && steps.existing.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
+          IMAGE="${{ steps.image.outputs.name }}"
+          DIGEST="${{ steps.digest.outputs.value }}"
+          docker buildx imagetools create -t "${IMAGE}:${VERSION}" "${IMAGE}@${DIGEST}"
+          TAG_DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          if [ "$TAG_DIGEST" != "$DIGEST" ]; then
+            echo "::error::Promoted version tag resolved to ${TAG_DIGEST}, expected recorded digest ${DIGEST}."
+            exit 1
+          fi
 
       # FRESH BUILDS ONLY: re-running an OLD workflow (e.g. re-running the
       # v0.1.0 publish after v0.1.1 shipped) hits the existing-tag path and
@@ -310,6 +374,28 @@ jobs:
             fi
           fi
           echo "::notice::Version tag already existed — channel alias NOT moved (re-runs must never roll a channel backward). If this re-run was repairing an interrupted first publish and the alias is stale, move it manually: docker buildx imagetools create -t ${IMAGE}:${CHANNEL} ${IMAGE}@${DIGEST}"
+
+      # Promotion is not complete until the mutable stable alias resolves to
+      # the manifest-recorded digest. This final-state check also catches an
+      # interrupted first promotion where the immutable version tag was written
+      # but the stable alias was not: the re-run must fail visibly rather than
+      # report success with stale channel state.
+      - name: Verify promoted stable alias reconciliation
+        if: inputs.promote
+        run: |
+          set -euo pipefail
+          IMAGE="${{ steps.image.outputs.name }}"
+          EXPECTED_DIGEST="$PROMOTE_DIGEST"
+          if ! INSPECT_OUT=$(docker buildx imagetools inspect "${IMAGE}:stable" --format '{{json .Manifest.Digest}}' 2>&1); then
+            echo "::error::Could not resolve promoted stable alias ${IMAGE}:stable: ${INSPECT_OUT}"
+            exit 1
+          fi
+          STABLE_DIGEST=$(echo "$INSPECT_OUT" | tr -d '"')
+          if [ "$STABLE_DIGEST" != "$EXPECTED_DIGEST" ]; then
+            echo "::error::Promoted stable alias resolves to ${STABLE_DIGEST}, expected recorded digest ${EXPECTED_DIGEST}. The promotion is incomplete."
+            exit 1
+          fi
+          echo "Promoted stable alias reconciled to recorded digest ${EXPECTED_DIGEST}."
 
       # Public distribution is an explicit release-policy switch. GHCR creates
       # every new package PRIVATE and never inherits visibility from the linked

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -60,6 +60,16 @@ on:
         description: "Name of the uploaded artifact containing the AppImage"
         required: true
         type: string
+      promote:
+        description: "Publish verified prerelease bytes to stable without rebuilding"
+        required: false
+        type: boolean
+        default: false
+      promotion_base_version:
+        description: "Bare stable version whose candidate manifest must match"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -85,10 +95,13 @@ jobs:
     environment: prod
     env:
       HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      GH_TOKEN: ${{ github.token }}
       CHANNEL: ${{ inputs.channel }}
       VERSION: ${{ inputs.version }}
       ARCH: ${{ inputs.arch }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       # Resolve every arch-dependent name in ONE fail-closed place: the
       # published basename, the electron-updater channel file, and the ELF
       # machine string the artifact must actually be.
@@ -136,16 +149,37 @@ jobs:
           name: ${{ inputs.appimage_artifact }}
           path: artifacts
 
+      - name: Verify immutable promotion bundle
+        if: env.HAS_SIGNING_SECRETS && inputs.promote
+        env:
+          PROMOTION_BASE_VERSION: ${{ inputs.promotion_base_version }}
+        run: |
+          python3 scripts/release_promotion.py verify \
+            --bundle-dir artifacts \
+            --expected-source-sha "${GITHUB_SHA}" \
+            --expected-base-version "${PROMOTION_BASE_VERSION}"
+
       - name: Locate AppImage
         if: env.HAS_SIGNING_SECRETS
+        env:
+          PROMOTE: ${{ inputs.promote }}
         run: |
           set -euo pipefail
-          mapfile -t APPIMAGES < <(find artifacts -type f -name '*.AppImage')
+          # Promotion bundles carry BOTH arches under canonical names, so the
+          # match must be arch-pinned there. Fresh builds carry one AppImage
+          # with electron-builder's versioned filename, which never equals the
+          # canonical basename -- match any AppImage in that mode.
+          if [ "${PROMOTE}" = "true" ]; then
+            PATTERN="${LINUX_BASENAME}.AppImage"
+          else
+            PATTERN="*.AppImage"
+          fi
+          mapfile -t APPIMAGES < <(find artifacts -type f -name "$PATTERN")
           if [ "${#APPIMAGES[@]}" -eq 0 ]; then
-            echo "No AppImage found in build artifacts"; exit 1
+            echo "No AppImage found matching ${PATTERN} in build artifacts"; exit 1
           fi
           if [ "${#APPIMAGES[@]}" -gt 1 ]; then
-            echo "Expected exactly one AppImage, found ${#APPIMAGES[@]}:"; printf '%s\n' "${APPIMAGES[@]}"; exit 1
+            echo "Expected exactly one AppImage matching ${PATTERN}, found ${#APPIMAGES[@]}:"; printf '%s\n' "${APPIMAGES[@]}"; exit 1
           fi
           echo "APPIMAGE_PATH=${APPIMAGES[0]}" >> "$GITHUB_ENV"
           ls -la "${APPIMAGES[0]}"
@@ -178,10 +212,17 @@ jobs:
       # write so un-attested bytes never go live; if attestation fails,
       # the job fails and nothing is published.
       - name: Attest AppImage provenance
-        if: env.HAS_SIGNING_SECRETS
+        if: env.HAS_SIGNING_SECRETS && !inputs.promote
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: ${{ env.APPIMAGE_PATH }}
+
+      - name: Verify promoted AppImage provenance
+        if: env.HAS_SIGNING_SECRETS && inputs.promote
+        run: |
+          gh attestation verify "${APPIMAGE_PATH}" \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/publish-linux.yml"
 
       # Same never-republish discipline as the mac zip/DMG and the cli/*
       # wheels: the versioned key is immutable-cached by CloudFront and must

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,11 @@ on:
   push:
     tags: ["v*"]
 
-# All build/sign/notarize/publish logic lives in reusable workflows shared
-# with nightly.yml (build-wheel.yml, build-desktop.yml, publish-cli.yml,
-# sign-and-notarize.yml). This file owns only what is genuinely
-# release-specific: the tag trigger, the tag -> version/channel derivation,
-# and the GitHub Release job.
+# Prerelease tags build, sign, publish, and record one immutable promotion
+# bundle. A bare stable tag never rebuilds source: it resolves the newest
+# successful prerelease run for this exact commit/release line, verifies the
+# GitHub artifact archive by its API-recorded digest, and promotes those exact
+# bytes. Reusable workflows own the per-lane publish details.
 
 # Serialize release runs: insider/stable feed writes are last-writer-wins;
 # two tags pushed close together must publish in order or the channel feed
@@ -29,26 +29,25 @@ jobs:
     timeout-minutes: 10
     outputs:
       version: ${{ steps.channel.outputs.version }}
+      base_version: ${{ steps.channel.outputs.base_version }}
       channel: ${{ steps.channel.outputs.channel }}
       wheel_version: ${{ steps.channel.outputs.wheel_version }}
     steps:
       - name: Derive version + channel from tag
         id: channel
         run: |
+          set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           case "$VERSION" in
             *-*)
               CHANNEL="insider"
+              BASE="${VERSION%%-*}"
               # The pip wheel needs a valid PEP 440 version; semver prerelease
               # labels ("-insider.4", "-rc.2") are not one, and setuptools
               # would silently normalize an invalid stamp down to the base
               # version -- making two insider releases collide on the same
               # immutable cli/<channel>/<version>/ key. Map any prerelease to
               # rcN using its trailing number: 1.2.3-insider.4 -> 1.2.3rc4.
-              # (Corollary: do not tag both v1.2.3-insider.N and v1.2.3-rc.N
-              # -- they map to the same wheel version, and publish-cli's
-              # conditional write would fail the second as a republish.)
-              BASE="${VERSION%%-*}"
               PRE="${VERSION#*-}"
               N="${PRE##*.}"
               case "$N" in
@@ -58,13 +57,108 @@ jobs:
               ;;
             *)
               CHANNEL="stable"
+              BASE="$VERSION"
               WHEEL_VERSION="$VERSION"
               ;;
           esac
+          if ! [[ "$BASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release base must be exactly x.y.z with numeric components"
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "base_version=$BASE" >> "$GITHUB_OUTPUT"
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "wheel_version=$WHEEL_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Releasing $VERSION on channel $CHANNEL (wheel: $WHEEL_VERSION)"
+          echo "Releasing $VERSION on channel $CHANNEL (base: $BASE, wheel: $WHEEL_VERSION)"
+
+  # Release tags do not trigger ci.yml, so prerelease candidates run a
+  # dedicated backend test gate against the exact commit being packaged. The
+  # immutable promotion record cannot be assembled unless this same-SHA gate
+  # succeeds.
+  release-candidate-tests:
+    name: Test Release Candidate SHA
+    if: needs.version.outputs.channel == 'insider'
+    needs: version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Verify exact candidate SHA
+        run: |
+          set -euo pipefail
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          if [ "$ACTUAL_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::checked out ${ACTUAL_SHA}, expected release candidate ${GITHUB_SHA}"
+            exit 1
+          fi
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            setup.cfg
+
+      - name: Install pinned test dependencies
+        run: uv pip install --system -e ".[voice,desktop]" --group dev
+
+      - name: Run release candidate tests
+        run: |
+          # KNOWN BLIND SPOT: the two deselected suites do not run at
+          # release time; merge-time ci.yml already ran them on this same
+          # commit, so the exposure is limited to a tag placed on a commit
+          # that bypassed PR CI.
+          pytest -q -n auto --timeout=120 --no-cov \
+            --deselect=test/test_script_hooks.py \
+            --deselect=test/test_cron_script.py
+
+  resolve-promotion:
+    name: Resolve Tested Candidate
+    if: needs.version.outputs.channel == 'stable'
+    needs: version
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      source_version: ${{ steps.resolve.outputs.source_version }}
+      source_tag: ${{ steps.resolve.outputs.source_tag }}
+      source_run_id: ${{ steps.resolve.outputs.source_run_id }}
+      docker_image: ${{ steps.resolve.outputs.docker_image }}
+      docker_digest: ${{ steps.resolve.outputs.docker_digest }}
+      artifact_digest: ${{ steps.resolve.outputs.artifact_digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Resolve and verify immutable candidate bundle
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/release_promotion.py resolve \
+            --repository "${GITHUB_REPOSITORY}" \
+            --source-sha "${GITHUB_SHA}" \
+            --base-version "${{ needs.version.outputs.base_version }}" \
+            --archive-path "${RUNNER_TEMP}/stable-promotion.zip" \
+            --output-dir "${RUNNER_TEMP}/stable-promotion" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Attach verified bundle to this run
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: KiroCrew-notarized-stable-${{ needs.version.outputs.version }}
+          path: ${{ runner.temp }}/stable-promotion/*
+          if-no-files-found: error
+          retention-days: 14
 
   # ── Stable publication gate ───────────────────────────────────────────
   # A tag name is the ONLY thing that decides the channel, and the whole run
@@ -208,6 +302,7 @@ jobs:
 
   build-wheel:
     name: Build Wheel
+    if: needs.version.outputs.channel == 'insider'
     needs: [version, dependency-vulnerability-gate]
     uses: ./.github/workflows/build-wheel.yml
     with:
@@ -215,6 +310,7 @@ jobs:
 
   build-desktop:
     name: Build Desktop
+    if: needs.version.outputs.channel == 'insider'
     needs: [version, dependency-vulnerability-gate]
     uses: ./.github/workflows/build-desktop.yml
     with:
@@ -250,7 +346,11 @@ jobs:
   # failure never blocks the CLI release.
   publish-cli:
     name: Publish CLI (${{ needs.version.outputs.channel }} channel)
-    needs: [version, stable-gate, build-wheel]
+    needs: [version, stable-gate, build-wheel, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-wheel.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -259,7 +359,9 @@ jobs:
     with:
       channel: ${{ needs.version.outputs.channel }}
       version: ${{ needs.version.outputs.version }}
-      wheel_artifact: cli-wheel
+      wheel_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'cli-wheel' }}
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets: inherit
 
   # ── Linux desktop publish ─────────────────────────────────────────────
@@ -286,7 +388,11 @@ jobs:
   # tracked in #2645 rather than reshaped here.
   publish-linux-x64:
     name: Publish Linux Desktop (${{ needs.version.outputs.channel }} channel · x64)
-    needs: [version, stable-gate, build-desktop]
+    needs: [version, stable-gate, build-desktop, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -294,15 +400,21 @@ jobs:
     uses: ./.github/workflows/publish-linux.yml
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: x64
       publish: true
-      appimage_artifact: build-linux-x64
+      appimage_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets: inherit
 
   publish-linux-arm64:
     name: Publish Linux Desktop (${{ needs.version.outputs.channel }} channel · arm64)
-    needs: [version, stable-gate, build-desktop]
+    needs: [version, stable-gate, build-desktop, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -310,10 +422,12 @@ jobs:
     uses: ./.github/workflows/publish-linux.yml
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: arm64
       publish: true
-      appimage_artifact: build-linux-arm64
+      appimage_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets: inherit
 
   # ── Docker image publish ──────────────────────────────────────────────
@@ -324,7 +438,11 @@ jobs:
   # also moves :latest.
   publish-docker:
     name: Publish Docker Image (${{ needs.version.outputs.channel }} channel)
-    needs: [version, stable-gate, build-wheel]
+    needs: [version, stable-gate, build-wheel, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-wheel.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       packages: write
@@ -339,7 +457,9 @@ jobs:
       # anonymously, so a release that lands behind a private package is a
       # broken release. Fail the lane rather than advertise an unpullable tag.
       require_public_access: true
-      wheel_artifact: cli-wheel
+      wheel_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'cli-wheel' }}
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promote_digest: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.docker_digest || '' }}
     # No `secrets: inherit`: the lane authenticates with GITHUB_TOKEN only
     # (implicitly available to reusable workflows). Inheriting would expose
     # every repo secret (signing, CDN) to a lane documented as needing none.
@@ -352,7 +472,11 @@ jobs:
   # test_workflow_permissions.py).
   sign-and-notarize:
     name: Sign + Notarize macOS
-    needs: [version, stable-gate, build-wheel, build-desktop]
+    needs: [version, stable-gate, build-wheel, build-desktop, resolve-promotion]
+    if: >-
+      ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
+          ((needs.version.outputs.channel == 'insider' && needs.build-wheel.result == 'success' && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       id-token: write
       contents: read
@@ -361,8 +485,11 @@ jobs:
     secrets: inherit
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       write_feed: true
+      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      promotion_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || '' }}
+      promotion_base_version: ${{ needs.version.outputs.base_version }}
 
   github-release:
     name: Create GitHub Release
@@ -372,9 +499,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+
+      - name: Verify promoted release bytes
+        if: needs.version.outputs.channel == 'stable'
+        run: |
+          python3 scripts/release_promotion.py verify \
+            --bundle-dir "artifacts/KiroCrew-notarized-stable-${{ needs.version.outputs.version }}" \
+            --expected-source-sha "${GITHUB_SHA}" \
+            --expected-base-version "${{ needs.version.outputs.base_version }}"
 
       # Assemble release assets: everything built, with macOS assets accepted
       # only from the exact gated artifact emitted after notarization, stapling,
@@ -454,3 +591,80 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ needs.version.outputs.channel == 'insider' }}
           files: release/*
+
+  # Record the exact prerelease deliverables only after every publishing lane
+  # succeeds. Stable resolves this immutable GitHub artifact by the successful
+  # source run, verifies the API digest, then verifies every file hash in the
+  # manifest before any channel pointer moves.
+  record-promotion:
+    name: Record Immutable Promotion Bundle
+    if: >-
+      ${{ always() && needs.version.outputs.channel == 'insider' &&
+          needs.release-candidate-tests.result == 'success' &&
+          needs.publish-cli.result == 'success' &&
+          needs.publish-linux-x64.result == 'success' &&
+          needs.publish-linux-arm64.result == 'success' &&
+          needs.publish-docker.result == 'success' &&
+          needs.sign-and-notarize.result == 'success' }}
+    needs: [version, release-candidate-tests, publish-cli, publish-linux-x64, publish-linux-arm64, publish-docker, sign-and-notarize]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download this run's immutable artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+
+      - name: Assemble canonical promotion bundle
+        env:
+          DOCKER_DIGEST: ${{ needs.publish-docker.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir promotion-bundle
+          one() {
+            label="$1"; shift
+            mapfile -t matches < <(find artifacts -type f "$@")
+            if [ "${#matches[@]}" -ne 1 ]; then
+              echo "::error::expected exactly one ${label}, found ${#matches[@]}"
+              printf '%s\n' "${matches[@]}"
+              exit 1
+            fi
+            printf '%s' "${matches[0]}"
+          }
+          WHEEL=$(one wheel -name '*.whl')
+          SDIST=$(one sdist -name '*.tar.gz')
+          # The bundle records both x64 and arm64 AppImages; each artifact
+          # directory must be scoped to its specific arch or "exactly one"
+          # fails when both are present in the download tree.
+          APPIMAGE=$(one AppImage -path '*build-linux-x64*' -name '*.AppImage')
+          APPIMAGE_ARM64=$(one AppImage-arm64 -path '*build-linux-arm64*' -name '*.AppImage')
+          MAC_ZIP=$(one notarized.zip -path '*KiroCrew-notarized-*' -name 'notarized.zip')
+          DMG=$(one notarized-DMG -path '*KiroCrew-notarized-*' -name 'KiroCrew.dmg')
+          cp "$WHEEL" "promotion-bundle/$(basename "$WHEEL")"
+          cp "$SDIST" "promotion-bundle/$(basename "$SDIST")"
+          cp "$APPIMAGE" promotion-bundle/KiroCrew-x86_64.AppImage
+          cp "$APPIMAGE_ARM64" promotion-bundle/KiroCrew-aarch64.AppImage
+          cp "$MAC_ZIP" promotion-bundle/notarized.zip
+          cp "$DMG" promotion-bundle/KiroCrew.dmg
+          OWNER=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          python3 scripts/release_promotion.py create \
+            --bundle-dir promotion-bundle \
+            --source-sha "${GITHUB_SHA}" \
+            --source-tag "${GITHUB_REF_NAME}" \
+            --source-version "${{ needs.version.outputs.version }}" \
+            --base-version "${{ needs.version.outputs.base_version }}" \
+            --wheel-version "${{ needs.version.outputs.wheel_version }}" \
+            --source-run-id "${GITHUB_RUN_ID}" \
+            --docker-image "ghcr.io/${OWNER}/kirocrew" \
+            --docker-digest "${DOCKER_DIGEST}"
+
+      - name: Upload immutable promotion record
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: stable-promotion-${{ needs.version.outputs.base_version }}
+          path: promotion-bundle/*
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -74,6 +74,21 @@ on:
         required: false
         type: boolean
         default: true
+      promote:
+        description: "Publish an already notarized candidate bundle without rebuilding"
+        required: false
+        type: boolean
+        default: false
+      promotion_artifact:
+        description: "Verified same-run artifact created by the stable resolver"
+        required: false
+        type: string
+        default: ""
+      promotion_base_version:
+        description: "Bare stable version whose candidate manifest must match"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -83,6 +98,7 @@ permissions:
 jobs:
   sign:
     name: Sign with signing service (${{ inputs.channel }})
+    if: ${{ !inputs.promote }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # OIDC subject alignment: tag-triggered callers (release.yml) present
@@ -429,11 +445,13 @@ jobs:
 
       # Attest the DMG that actually ships -- AFTER staple, because stapling
       # embeds the ticket into the DMG file (the final released bytes).
-      - name: Attest DMG provenance
+      - name: Attest final shipping artifacts
         if: env.HAS_SIGNING_SECRETS
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-path: work/*.dmg
+          subject-path: |
+            work/notarized.zip
+            work/*.dmg
 
       # The GATED artifact: attached only after the spctl gate above. This
       # is the sole input of the publish job (and of release.yml's
@@ -463,12 +481,14 @@ jobs:
   publish:
     name: Publish to distribution (${{ inputs.channel }})
     needs: notarize
-    # success() is REQUIRED here: a custom job-level `if` replaces the
-    # implicit success check, and without it this job would run even after
-    # a failed or skipped notarize. The remaining conditions gate public
-    # distribution on the CDN being configured -- when it is not (fork),
-    # notarize still produced the gated artifact for github-release.
-    if: ${{ success() && inputs.write_feed && vars.CLI_DIST_BUCKET != '' }}
+    # Normal releases require a successful notarize job. Stable promotion
+    # deliberately skips sign/notarize and may publish only the resolver's
+    # already-gated bundle. Explicit result checks preserve fail-closed status
+    # semantics even though the promotion branch has skipped dependencies.
+    if: >-
+      ${{ always() && inputs.write_feed && vars.CLI_DIST_BUCKET != '' &&
+          ((!inputs.promote && needs.notarize.result == 'success') ||
+           (inputs.promote && needs.notarize.result == 'skipped')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Same OIDC subject alignment as the jobs above (S3 writes assume the
@@ -477,11 +497,15 @@ jobs:
     environment: prod
     env:
       HAS_SIGNING_SECRETS: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+      GH_TOKEN: ${{ github.token }}
       CHANNEL: ${{ inputs.channel }}
       VERSION: ${{ inputs.version }}
       # Pinned published basename -- see the notarize job's env comment.
       ARTIFACT_BASENAME: KiroCrew
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: inputs.promote
+
       - name: Configure AWS credentials
         if: env.HAS_SIGNING_SECRETS
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
@@ -493,8 +517,28 @@ jobs:
         if: env.HAS_SIGNING_SECRETS
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: KiroCrew-notarized-${{ inputs.channel }}-${{ inputs.version }}
+          name: ${{ inputs.promote && inputs.promotion_artifact || format('KiroCrew-notarized-{0}-{1}', inputs.channel, inputs.version) }}
           path: work
+
+      - name: Verify immutable promotion bundle
+        if: env.HAS_SIGNING_SECRETS && inputs.promote
+        env:
+          PROMOTION_BASE_VERSION: ${{ inputs.promotion_base_version }}
+        run: |
+          python3 scripts/release_promotion.py verify \
+            --bundle-dir work \
+            --expected-source-sha "${GITHUB_SHA}" \
+            --expected-base-version "${PROMOTION_BASE_VERSION}"
+
+      - name: Verify promoted macOS provenance
+        if: env.HAS_SIGNING_SECRETS && inputs.promote
+        run: |
+          gh attestation verify work/notarized.zip \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/sign-and-notarize.yml"
+          gh attestation verify "work/${ARTIFACT_BASENAME}.dmg" \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/sign-and-notarize.yml"
 
       - name: Verify gated artifact contents
         if: env.HAS_SIGNING_SECRETS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,11 +180,21 @@ are cut as a **release branch** off `main` on 0.1 increments (`0.1.0` → `0.2.0
 Once a branch is cut, **bug fixes for that release go on the release branch, not
 on `main`.** Each one produces a new release candidate — `0.2.0-rc.1`,
 `-rc.2`, … — published to the insider channel. **Stable is the last RC we judge
-stable enough, promoted by tagging that RC's commit — never rebuilt.** So
-`0.2.0-rc.5` becomes stable `0.2.0`: same commit, same bytes, a new tag.
+stable enough, promoted by tagging that RC's commit — never rebuilt.** The RC
+run records one immutable promotion bundle (wheel/sdist, AppImage, notarized
+zip/DMG, and OCI manifest digest). A bare `v0.2.0` tag on that exact commit
+resolves the newest successful `0.2.0-*` run, verifies the GitHub artifact's
+API-recorded digest plus every file digest in its manifest, and only then moves
+stable pointers/tags to those bytes.
 
-Hot patches bump the patch digit (`0.2.0` → `0.2.1`) and are also cut from the
-release branch.
+Because changing an embedded version changes and invalidates the tested bytes,
+the promoted binaries retain the selected RC's embedded version; the bare git
+tag, GitHub Release, and stable channel are the final release identity. If the
+record is missing or its 90-day artifact retention elapsed, promotion fails
+closed: cut and validate a fresh RC rather than rebuilding stable.
+
+Hot patches bump the patch digit (`0.2.0` → `0.2.1`) from the release branch and
+must also have a successful prerelease candidate before the bare stable tag.
 
 After each stable cut, do two things: **bump `main` by 0.1** (to `0.3.0`) so
 nightlies sort above what just shipped, and **merge the branch's fixes back into
@@ -216,14 +226,16 @@ git push -u origin release/0.2.0
 git tag -a v0.2.0-rc.1 -m "0.2.0 rc1" && git push origin v0.2.0-rc.1
 #    ... fixes land on release/0.2.0 ... then v0.2.0-rc.2, -rc.3, …
 
-# 3. Promote: tag the good RC's COMMIT with a bare version → stable
+# 3. Promote: tag the good RC's EXACT COMMIT with a bare version → stable.
+#    release.yml resolves that successful RC run's immutable promotion bundle;
+#    it does not invoke either build workflow on the bare tag.
 git tag -a v0.2.0 -m "release 0.2.0" <rc-commit-sha>
 git push origin v0.2.0
 
 # 4. Bump main to 0.3.0 (PR), and merge the branch's fixes back into main
 
-# Hot patch: fix on the release branch, then
-git tag -a v0.2.1 -m "release 0.2.1" && git push origin v0.2.1
+# Hot patch: fix on the release branch, cut/test v0.2.1-rc.1 first, then
+# put bare v0.2.1 on that candidate's exact commit and push it.
 ```
 
 Update `CHANGELOG.md` with a `## [X.Y.Z] — YYYY-MM-DD` section as part of the
@@ -235,15 +247,19 @@ release branch directly.
 
 **Nightly** runs on a schedule every night and can be kicked off on demand at any
 time. **Insider and stable are triggered by pushing a version tag** — an RC tag
-publishes to insider, a plain version tag publishes to stable.
+builds and publishes to insider, while a plain version tag promotes the exact
+recorded RC artifacts to stable without rebuilding.
 
 The release branch, the RC numbering, the promote decision, and the back-merge
-are all **human process**. The pipeline only reacts to the tag.
+are all **human process**. The pipeline reacts to the tag, but the stable path
+also requires the successful same-commit prerelease record and fails closed if
+it cannot prove that record's immutable digest.
 
-Each build ships a signed and notarized macOS app, a Linux AppImage, a pip
-wheel, and a Docker image. A channel's update feed is repointed **last**, after
-its artifacts are verified downloadable, and clients only install with the
-user's consent. Windows builds but is not yet signed or published.
+A nightly or prerelease build produces a signed and notarized macOS app, a Linux
+AppImage, a pip wheel, and a Docker image. Stable republishes/retags those exact
+candidate bytes. A channel's update feed is repointed **last**, after its
+artifacts are verified downloadable, and clients only install with the user's
+consent. Windows builds but is not yet signed or published.
 
 **There is no rollback — we roll forward by cutting a new version.** Published
 CDN keys are immutable and are never overwritten.

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -18,7 +18,7 @@ macOS signing mechanics and notary-credential rotation live in
 |---------|---------|---------------|
 | `nightly` | `nightly.yml`: cron `0 6 * * *` (06:00 UTC) plus manual dispatch, from `main` HEAD | `<base>-nightly.<YYYYMMDD>t<HHMMSS>` |
 | `insider` | `release.yml`: push of a prerelease tag (`v0.2.0-rc.1`) | `<x.y.z>-rc.N` |
-| `stable` | `release.yml`: push of a bare semver tag (`v0.2.0`) | `<x.y.z>` |
+| `stable` | `release.yml`: push of a bare semver tag (`v0.2.0`) on a recorded candidate's commit; the run verifies and promotes that candidate's exact bytes, never rebuilding | Release identity `<x.y.z>`; artifacts retain the selected candidate's embedded `<x.y.z>rcN` version |
 
 The channel name is a literal path segment everywhere (`cli/insider/...`,
 `feed/insider/...`, the `:insider` image tag), so there is no name-to-prefix
@@ -33,6 +33,38 @@ deciding to promote, and merging back are human steps the pipeline knows nothing
 about, which is why there is no cut/promote/rollback workflow (see "Deliberately
 not built").
 
+## Stable promotion: exact tested bytes, never a rebuild
+
+Stable must ship the bytes insiders actually validated, not a same-commit
+rebuild that hopes for reproducibility. The mechanism:
+
+- **A successful prerelease run records the candidate.** After every publish
+  lane succeeds, `record-promotion` assembles the exact wheel/sdist, AppImage,
+  notarized zip/DMG, and the attested OCI manifest digest into a
+  `stable-promotion-<x.y.z>` GitHub artifact (90-day retention) whose manifest
+  (`scripts/release_promotion.py create`) carries per-file SHA-256/SHA-512/size
+  plus the source SHA, tag, run id, and versions.
+- **A bare `vX.Y.Z` tag resolves and verifies that record.** The
+  `resolve-promotion` job finds the newest **successful** same-commit,
+  same-base-version prerelease run, verifies the artifact ZIP against GitHub's
+  API-recorded digest, safely extracts it, and verifies every manifest field
+  and file digest (`scripts/release_promotion.py verify`). Only then do the
+  publish lanes move stable pointers/tags to those bytes. The stable run never
+  invokes the build workflows, CDSigner, Apple notarization, or the OCI
+  builder.
+- **Everything fails closed.** A missing, expired, ambiguous, or
+  digest-mismatched record aborts the promotion: cut and validate a fresh RC
+  rather than rebuilding stable.
+- **Promoted binaries retain the candidate's embedded version** (see "Version
+  stamping"), because rewriting embedded metadata would produce bytes users
+  never baked and invalidate the recorded digests and macOS signatures. The
+  bare git tag, GitHub Release, and stable channel are the final release
+  identity. pip users selecting a promoted (prerelease-versioned) wheel by
+  version must allow prereleases; the stable channel feed remains
+  channel-sticky.
+- **Hot patches follow the same rule**: at least one recorded RC before the
+  bare patch tag.
+
 ## Workflows in the release path
 
 Every one of these exists on `main`. Two trigger workflows call the same set of
@@ -43,7 +75,7 @@ concurrency group, and their version derivation.
 | Workflow | Kind | Role |
 |---|---|---|
 | `nightly.yml` | trigger (schedule + dispatch) | Derives the date stamp, then calls everything below. `concurrency: nightly-build` with `cancel-in-progress: true`. |
-| `release.yml` | trigger (`push` on `v*` tags) | Derives version + channel + wheel version from the tag, calls everything below, then creates the GitHub Release. `concurrency: release-publish` with `cancel-in-progress: false` (queued). |
+| `release.yml` | trigger (`push` on `v*` tags) | Derives version + channel + wheel version from the tag. A prerelease tag builds, publishes to insider, and records the immutable promotion bundle; a bare tag verifies that same-commit bundle and promotes the exact files/OCI digest to stable without building. Then creates the GitHub Release. `concurrency: release-publish` with `cancel-in-progress: false` (queued). |
 | `dependency-vulnerability.yml` | reusable gate | `scripts/check_npm_audit.py`. Runs first; every build job needs it. |
 | `build-wheel.yml` | reusable build | Stamps the PEP 440 version into `pyproject.toml` and `__init__.py`, stamps the distribution channel, builds the frontend and stages it into the package, then `python -m build`. Uploads artifact `cli-wheel` (wheel + sdist). Credential-free. |
 | `build-desktop.yml` | reusable build | Matrix `macos-15` (universal macOS app) and `ubuntu-22.04` (AppImage) via `packaging/build-desktop.sh`. Deliberately credential-free (`contents: read` only, pinned by `test_workflow_permissions.py`), so it builds **unsigned** and hands the `.app` downstream. |
@@ -264,7 +296,14 @@ and why the base must stay a bare `X.Y.Z`.
 |---------|------------------------|---------------------|
 | nightly | `0.2.0-nightly.20260708t061155` | `0.2.0.dev20260708061155` |
 | insider | `0.2.0-rc.1` | `0.2.0rc1` |
-| stable | `0.2.0` | `0.2.0` |
+| stable | retains the promoted candidate's stamp (`0.2.0-rc.N`) | retains `0.2.0rcN` |
+
+A bare stable tag does not stamp or build: it verifies the selected candidate's
+recorded manifest and reuses its embedded version and byte digests unchanged,
+because re-stamping would change (and invalidate) the tested, signed bytes. The
+bare `X.Y.Z` names the git tag, the GitHub Release, and the stable channel
+paths — the release identity — while the artifacts keep the candidate's
+embedded prerelease version.
 
 Two stamps exist because the consumers disagree: Squirrel and electron-builder
 need semver, the wheel needs PEP 440. `nightly.yml` reads the clock **once** and

--- a/scripts/release_promotion.py
+++ b/scripts/release_promotion.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Create and verify immutable release-candidate promotion manifests.
+
+Stable releases use this tool to resolve a successful prerelease workflow run
+for the same commit, verify the GitHub artifact archive by its API-recorded
+SHA-256 digest, safely extract it, and verify every shipping file against the
+candidate manifest.  No source build occurs on the stable path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import urlencode
+
+SCHEMA_VERSION = 1
+MANIFEST_NAME = "promotion-manifest.json"
+ARTIFACT_NAMES = {
+    "wheel": re.compile(r"^kirocrew-[A-Za-z0-9_.]+-py3-none-any\.whl$"),
+    "sdist": re.compile(r"^kirocrew-[A-Za-z0-9_.]+\.tar\.gz$"),
+    "appimage": re.compile(r"^KiroCrew-x86_64\.AppImage$"),
+    "appimage_arm64": re.compile(r"^KiroCrew-aarch64\.AppImage$"),
+    "mac_zip": re.compile(r"^notarized\.zip$"),
+    "dmg": re.compile(r"^KiroCrew\.dmg$"),
+}
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+BASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+MAX_ARCHIVE_BYTES = 5 * 1024 * 1024 * 1024
+MAX_EXTRACTED_BYTES = 8 * 1024 * 1024 * 1024
+MAX_FILE_COUNT = len(ARTIFACT_NAMES) + 1
+
+
+class PromotionError(ValueError):
+    """The candidate cannot be promoted without violating byte identity."""
+
+
+def _hash_file(path: Path, algorithm: str) -> str:
+    digest = hashlib.new(algorithm)
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha512_base64(path: Path) -> str:
+    digest = hashlib.sha512()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return base64.b64encode(digest.digest()).decode("ascii")
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise PromotionError(f"{field} must be a non-empty string")
+    if "\n" in value or "\r" in value:
+        raise PromotionError(f"{field} must be one line")
+    return value
+
+
+def _artifact_paths(bundle_dir: Path) -> dict[str, Path]:
+    files = [path for path in bundle_dir.iterdir() if path.is_file()]
+    result: dict[str, Path] = {}
+    for logical_name, pattern in ARTIFACT_NAMES.items():
+        matches = [path for path in files if pattern.fullmatch(path.name)]
+        if len(matches) != 1:
+            names = sorted(path.name for path in matches)
+            raise PromotionError(f"expected exactly one {logical_name} artifact, found {names}")
+        result[logical_name] = matches[0]
+    return result
+
+
+def _require_wheel_version_filename(
+    logical_name: str, filename: str, wheel_version: str
+) -> None:
+    prefix = f"kirocrew-{wheel_version}"
+    if logical_name == "wheel":
+        # Exact-match the full filename: a prefix check would also accept a
+        # longer version (1.2.3rc4 matching 1.2.3rc4.post1) or a build-tag
+        # spelling (kirocrew-1.2.3rc4-1-...), publishing bytes whose version
+        # was never the verified candidate's.
+        valid = filename == f"{prefix}-py3-none-any.whl"
+    elif logical_name == "sdist":
+        valid = filename == f"{prefix}.tar.gz"
+    else:
+        return
+    if not valid:
+        raise PromotionError(
+            f"{logical_name} filename {filename!r} does not match "
+            f"wheel_version {wheel_version!r}"
+        )
+
+
+def create_manifest(
+    bundle_dir: Path,
+    *,
+    source_sha: str,
+    source_tag: str,
+    source_version: str,
+    base_version: str,
+    wheel_version: str,
+    source_run_id: int,
+    docker_image: str,
+    docker_digest: str,
+) -> dict[str, Any]:
+    """Build a manifest over the canonical files in *bundle_dir*."""
+    _validate_source_identity(
+        source_sha=source_sha,
+        source_tag=source_tag,
+        source_version=source_version,
+        base_version=base_version,
+        source_run_id=source_run_id,
+    )
+    if not DIGEST_RE.fullmatch(docker_digest):
+        raise PromotionError("docker digest must be sha256:<64 lowercase hex>")
+    if not re.fullmatch(r"ghcr\.io/[a-z0-9_.-]+/kirocrew", docker_image):
+        raise PromotionError("docker image must be the canonical lowercase GHCR image")
+    if not re.fullmatch(r"[A-Za-z0-9_.]+", wheel_version):
+        raise PromotionError("wheel version contains unsupported characters")
+
+    paths = _artifact_paths(bundle_dir)
+    allowed = {path.name for path in paths.values()}
+    extras = {
+        path.name
+        for path in bundle_dir.iterdir()
+        if path.is_file() and path.name not in allowed and path.name != MANIFEST_NAME
+    }
+    if extras:
+        raise PromotionError(f"unexpected files in promotion bundle: {sorted(extras)}")
+
+    artifacts: dict[str, dict[str, Any]] = {}
+    for logical_name, path in paths.items():
+        artifacts[logical_name] = {
+            "filename": path.name,
+            "sha256": _hash_file(path, "sha256"),
+            "sha512": _sha512_base64(path),
+            "size": path.stat().st_size,
+        }
+
+    return {
+        "schema": SCHEMA_VERSION,
+        "source": {
+            "sha": source_sha,
+            "tag": source_tag,
+            "version": source_version,
+            "base_version": base_version,
+            "wheel_version": wheel_version,
+            "workflow_run_id": source_run_id,
+        },
+        "artifacts": artifacts,
+        "docker": {"image": docker_image, "digest": docker_digest},
+    }
+
+
+def _validate_source_identity(
+    *,
+    source_sha: str,
+    source_tag: str,
+    source_version: str,
+    base_version: str,
+    source_run_id: int,
+) -> None:
+    if not SHA_RE.fullmatch(source_sha):
+        raise PromotionError("source sha must be 40 lowercase hex characters")
+    if not BASE_VERSION_RE.fullmatch(base_version):
+        raise PromotionError("base version must be a bare three-part semver")
+    if not source_version.startswith(f"{base_version}-"):
+        raise PromotionError("source version must be a prerelease of the stable base")
+    if source_tag != f"v{source_version}":
+        raise PromotionError("source tag must exactly identify the source version")
+    if not isinstance(source_run_id, int) or source_run_id <= 0:
+        raise PromotionError("source workflow run id must be positive")
+
+
+def validate_manifest(
+    manifest: Mapping[str, Any],
+    bundle_dir: Path,
+    *,
+    expected_source_sha: str | None = None,
+    expected_base_version: str | None = None,
+    expected_source_run_id: int | None = None,
+    expected_source_tag: str | None = None,
+    expected_docker_image: str | None = None,
+) -> dict[str, Any]:
+    """Validate manifest shape, identity, and every file digest."""
+    if set(manifest) != {"schema", "source", "artifacts", "docker"}:
+        raise PromotionError("promotion manifest has unexpected top-level fields")
+    if manifest["schema"] != SCHEMA_VERSION:
+        raise PromotionError(f"unsupported promotion manifest schema {manifest['schema']!r}")
+
+    source = manifest["source"]
+    if not isinstance(source, dict) or set(source) != {
+        "sha",
+        "tag",
+        "version",
+        "base_version",
+        "wheel_version",
+        "workflow_run_id",
+    }:
+        raise PromotionError("promotion manifest source block has unexpected fields")
+    source_sha = _require_string(source["sha"], "source.sha")
+    source_tag = _require_string(source["tag"], "source.tag")
+    source_version = _require_string(source["version"], "source.version")
+    base_version = _require_string(source["base_version"], "source.base_version")
+    wheel_version = _require_string(source["wheel_version"], "source.wheel_version")
+    source_run_id = source["workflow_run_id"]
+    _validate_source_identity(
+        source_sha=source_sha,
+        source_tag=source_tag,
+        source_version=source_version,
+        base_version=base_version,
+        source_run_id=source_run_id,
+    )
+    if not re.fullmatch(r"[A-Za-z0-9_.]+", wheel_version):
+        raise PromotionError("source wheel version contains unsupported characters")
+
+    expected = {
+        "source sha": (source_sha, expected_source_sha),
+        "base version": (base_version, expected_base_version),
+        "source run id": (source_run_id, expected_source_run_id),
+        "source tag": (source_tag, expected_source_tag),
+    }
+    for label, (actual, wanted) in expected.items():
+        if wanted is not None and actual != wanted:
+            raise PromotionError(f"{label} mismatch: expected {wanted!r}, got {actual!r}")
+
+    artifacts = manifest["artifacts"]
+    if not isinstance(artifacts, dict) or set(artifacts) != set(ARTIFACT_NAMES):
+        raise PromotionError("promotion manifest must list exactly the shipping artifacts")
+    expected_filenames: set[str] = set()
+    for logical_name, pattern in ARTIFACT_NAMES.items():
+        entry = artifacts[logical_name]
+        if not isinstance(entry, dict) or set(entry) != {
+            "filename",
+            "sha256",
+            "sha512",
+            "size",
+        }:
+            raise PromotionError(f"artifact {logical_name} has unexpected fields")
+        filename = _require_string(entry["filename"], f"artifacts.{logical_name}.filename")
+        if Path(filename).name != filename or not pattern.fullmatch(filename):
+            raise PromotionError(f"unsafe or invalid {logical_name} filename {filename!r}")
+        _require_wheel_version_filename(logical_name, filename, wheel_version)
+        if filename in expected_filenames:
+            raise PromotionError(f"duplicate artifact filename {filename!r}")
+        expected_filenames.add(filename)
+        sha256 = _require_string(entry["sha256"], f"artifacts.{logical_name}.sha256")
+        sha512 = _require_string(entry["sha512"], f"artifacts.{logical_name}.sha512")
+        size = entry["size"]
+        if not re.fullmatch(r"[0-9a-f]{64}", sha256):
+            raise PromotionError(f"artifact {logical_name} has an invalid sha256")
+        try:
+            decoded_sha512 = base64.b64decode(sha512, validate=True)
+        except ValueError as exc:
+            raise PromotionError(f"artifact {logical_name} has an invalid sha512") from exc
+        if len(decoded_sha512) != hashlib.sha512().digest_size:
+            raise PromotionError(f"artifact {logical_name} has an invalid sha512 length")
+        if not isinstance(size, int) or size < 0 or size > MAX_EXTRACTED_BYTES:
+            raise PromotionError(f"artifact {logical_name} has an invalid size")
+        path = bundle_dir / filename
+        if not path.is_file() or path.is_symlink():
+            raise PromotionError(f"artifact {logical_name} is missing or not a regular file")
+        if path.stat().st_size != size:
+            raise PromotionError(f"artifact {logical_name} size does not match manifest")
+        if _hash_file(path, "sha256") != sha256:
+            raise PromotionError(f"artifact {logical_name} sha256 does not match manifest")
+        if _sha512_base64(path) != sha512:
+            raise PromotionError(f"artifact {logical_name} sha512 does not match manifest")
+
+    actual_files = {path.name for path in bundle_dir.iterdir() if path.is_file()}
+    if actual_files != expected_filenames | {MANIFEST_NAME}:
+        raise PromotionError(
+            "promotion bundle file set differs from manifest: "
+            f"expected {sorted(expected_filenames | {MANIFEST_NAME})}, "
+            f"got {sorted(actual_files)}"
+        )
+
+    docker = manifest["docker"]
+    if not isinstance(docker, dict) or set(docker) != {"image", "digest"}:
+        raise PromotionError("promotion manifest docker block has unexpected fields")
+    image = _require_string(docker["image"], "docker.image")
+    digest = _require_string(docker["digest"], "docker.digest")
+    if not re.fullmatch(r"ghcr\.io/[a-z0-9_.-]+/kirocrew", image):
+        raise PromotionError("promotion manifest has a non-canonical docker image")
+    if expected_docker_image is not None and image != expected_docker_image:
+        raise PromotionError(
+            f"docker image mismatch: expected {expected_docker_image!r}, got {image!r}"
+        )
+    if not DIGEST_RE.fullmatch(digest):
+        raise PromotionError("promotion manifest has an invalid docker digest")
+
+    return dict(manifest)
+
+
+def verify_bundle(bundle_dir: Path, **expected: Any) -> dict[str, Any]:
+    manifest_path = bundle_dir / MANIFEST_NAME
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise PromotionError(f"{MANIFEST_NAME} is missing or not a regular file")
+    if manifest_path.stat().st_size > 1024 * 1024:
+        raise PromotionError("promotion manifest exceeds the 1 MiB bound")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PromotionError(f"cannot read promotion manifest: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise PromotionError("promotion manifest root must be an object")
+    return validate_manifest(manifest, bundle_dir, **expected)
+
+
+def select_candidate_runs(
+    runs: Iterable[Mapping[str, Any]], *, source_sha: str, base_version: str
+) -> list[Mapping[str, Any]]:
+    """Newest-first successful prerelease runs for this exact commit/base."""
+    prefix = f"v{base_version}-"
+    candidates = [
+        run
+        for run in runs
+        if run.get("conclusion") == "success"
+        and run.get("head_sha") == source_sha
+        and isinstance(run.get("head_branch"), str)
+        and run["head_branch"].startswith(prefix)
+    ]
+    return sorted(
+        candidates,
+        key=lambda run: (str(run.get("run_started_at") or ""), int(run.get("id") or 0)),
+        reverse=True,
+    )
+
+
+def extract_verified_archive(archive_path: Path, output_dir: Path, *, expected_digest: str) -> None:
+    """Digest-check and safely extract the bounded GitHub artifact archive."""
+    if not DIGEST_RE.fullmatch(expected_digest):
+        raise PromotionError("GitHub artifact API did not return a valid sha256 digest")
+    if not archive_path.is_file() or archive_path.stat().st_size > MAX_ARCHIVE_BYTES:
+        raise PromotionError("promotion archive is missing or exceeds the size bound")
+    actual_digest = f"sha256:{_hash_file(archive_path, 'sha256')}"
+    if actual_digest != expected_digest:
+        raise PromotionError(
+            f"promotion archive digest mismatch: expected {expected_digest}, got {actual_digest}"
+        )
+
+    try:
+        archive = zipfile.ZipFile(archive_path)
+    except zipfile.BadZipFile as exc:
+        raise PromotionError("promotion artifact is not a valid zip archive") from exc
+    with archive:
+        infos = [info for info in archive.infolist() if not info.is_dir()]
+        names = [info.filename for info in infos]
+        if len(infos) != MAX_FILE_COUNT or len(set(names)) != len(names):
+            raise PromotionError("promotion archive has an unexpected or duplicate file set")
+        if sum(info.file_size for info in infos) > MAX_EXTRACTED_BYTES:
+            raise PromotionError("promotion archive expands beyond the size bound")
+        expected_names = {MANIFEST_NAME} | {
+            pattern.pattern.removeprefix("^").removesuffix("$")
+            for logical_name, pattern in ARTIFACT_NAMES.items()
+            if logical_name in {"appimage", "mac_zip", "dmg"}
+        }
+        for info in infos:
+            name = info.filename
+            if Path(name).name != name or name.startswith(("/", "\\")):
+                raise PromotionError(f"unsafe path in promotion archive: {name!r}")
+            mode = (info.external_attr >> 16) & 0o170000
+            if mode and not stat.S_ISREG(mode):
+                raise PromotionError(f"non-regular entry in promotion archive: {name!r}")
+        # Wheel and sdist names are versioned, so validate the full set through
+        # the same patterns used by the manifest rather than hard-coding them.
+        for logical_name, pattern in ARTIFACT_NAMES.items():
+            matches = [name for name in names if pattern.fullmatch(name)]
+            if len(matches) != 1:
+                raise PromotionError(
+                    f"promotion archive must contain exactly one {logical_name} file"
+                )
+        if MANIFEST_NAME not in names:
+            raise PromotionError(f"promotion archive is missing {MANIFEST_NAME}")
+        del expected_names  # documents fixed names without weakening pattern checks
+
+        output_dir.mkdir(parents=True, exist_ok=False)
+        for info in infos:
+            destination = output_dir / info.filename
+            with archive.open(info) as source, destination.open("wb") as target:
+                shutil.copyfileobj(source, target, length=1024 * 1024)
+
+
+def _gh_json(endpoint: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise PromotionError(f"GitHub API request failed for {endpoint}: {result.stderr.strip()}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise PromotionError(f"GitHub API returned invalid JSON for {endpoint}") from exc
+    if not isinstance(payload, dict):
+        raise PromotionError(f"GitHub API returned a non-object for {endpoint}")
+    return payload
+
+
+def _download_artifact(repository: str, artifact_id: int, destination: Path) -> None:
+    with destination.open("wb") as output:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repository}/actions/artifacts/{artifact_id}/zip"],
+            check=False,
+            stdout=output,
+            stderr=subprocess.PIPE,
+            timeout=600,
+        )
+    if result.returncode != 0:
+        destination.unlink(missing_ok=True)
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise PromotionError(f"GitHub artifact download failed: {stderr}")
+
+
+def resolve_candidate(
+    *,
+    repository: str,
+    source_sha: str,
+    base_version: str,
+    output_dir: Path,
+    archive_path: Path,
+) -> tuple[dict[str, Any], Mapping[str, Any]]:
+    """Resolve and verify the newest promotable candidate for the commit."""
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise PromotionError("repository must be an owner/name identifier")
+    if not SHA_RE.fullmatch(source_sha):
+        raise PromotionError("source sha must be 40 lowercase hex characters")
+    if not BASE_VERSION_RE.fullmatch(base_version):
+        raise PromotionError("base version must be a bare three-part semver")
+
+    query = urlencode(
+        {
+            "event": "push",
+            "status": "success",
+            "head_sha": source_sha,
+            "per_page": "100",
+        }
+    )
+    runs_payload = _gh_json(f"repos/{repository}/actions/workflows/release.yml/runs?{query}")
+    runs = runs_payload.get("workflow_runs")
+    if not isinstance(runs, list):
+        raise PromotionError("GitHub workflow-runs response omitted workflow_runs")
+    candidates = select_candidate_runs(runs, source_sha=source_sha, base_version=base_version)
+    if not candidates:
+        raise PromotionError(
+            "no successful prerelease workflow run exists for this exact commit and base"
+        )
+
+    artifact_name = f"stable-promotion-{base_version}"
+    selected_run: Mapping[str, Any] | None = None
+    selected_artifact: Mapping[str, Any] | None = None
+    for run in candidates:
+        run_id = int(run.get("id") or 0)
+        artifacts_payload = _gh_json(
+            f"repos/{repository}/actions/runs/{run_id}/artifacts?per_page=100"
+        )
+        artifacts = artifacts_payload.get("artifacts")
+        if not isinstance(artifacts, list):
+            raise PromotionError(f"artifact response for run {run_id} omitted artifacts")
+        matches = [
+            artifact
+            for artifact in artifacts
+            if artifact.get("name") == artifact_name and artifact.get("expired") is False
+        ]
+        if len(matches) > 1:
+            raise PromotionError(f"run {run_id} has duplicate {artifact_name} artifacts")
+        if matches:
+            selected_run = run
+            selected_artifact = matches[0]
+            break
+    if selected_run is None or selected_artifact is None:
+        raise PromotionError(
+            f"successful prerelease runs exist, but none has an unexpired {artifact_name} artifact"
+        )
+
+    artifact_id = int(selected_artifact.get("id") or 0)
+    artifact_size = int(selected_artifact.get("size_in_bytes") or 0)
+    artifact_digest = _require_string(selected_artifact.get("digest"), "artifact.digest")
+    if artifact_id <= 0 or artifact_size <= 0 or artifact_size > MAX_ARCHIVE_BYTES:
+        raise PromotionError("promotion artifact metadata has an invalid id or size")
+
+    _download_artifact(repository, artifact_id, archive_path)
+    extract_verified_archive(archive_path, output_dir, expected_digest=artifact_digest)
+    source_run_id = int(selected_run["id"])
+    source_tag = _require_string(selected_run.get("head_branch"), "workflow_run.head_branch")
+    docker_image = f"ghcr.io/{repository.split('/', 1)[0].lower()}/kirocrew"
+    manifest = verify_bundle(
+        output_dir,
+        expected_source_sha=source_sha,
+        expected_base_version=base_version,
+        expected_source_run_id=source_run_id,
+        expected_source_tag=source_tag,
+        expected_docker_image=docker_image,
+    )
+    return manifest, selected_artifact
+
+
+def _write_outputs(path: Path, values: Mapping[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as stream:
+        for key, raw_value in values.items():
+            value = str(raw_value)
+            if not re.fullmatch(r"[A-Za-z0-9_./:@+-]+", value):
+                raise PromotionError(f"unsafe GitHub output value for {key}")
+            stream.write(f"{key}={value}\n")
+
+
+def _create_command(args: argparse.Namespace) -> None:
+    bundle_dir = Path(args.bundle_dir)
+    manifest = create_manifest(
+        bundle_dir,
+        source_sha=args.source_sha,
+        source_tag=args.source_tag,
+        source_version=args.source_version,
+        base_version=args.base_version,
+        wheel_version=args.wheel_version,
+        source_run_id=args.source_run_id,
+        docker_image=args.docker_image,
+        docker_digest=args.docker_digest,
+    )
+    output = bundle_dir / MANIFEST_NAME
+    output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    verify_bundle(bundle_dir)
+    print(f"wrote {output}")
+
+
+def _verify_command(args: argparse.Namespace) -> None:
+    manifest = verify_bundle(
+        Path(args.bundle_dir),
+        expected_source_sha=args.expected_source_sha,
+        expected_base_version=args.expected_base_version,
+        expected_source_run_id=args.expected_source_run_id,
+        expected_source_tag=args.expected_source_tag,
+        expected_docker_image=args.expected_docker_image,
+    )
+    if args.github_output:
+        source = manifest["source"]
+        docker = manifest["docker"]
+        _write_outputs(
+            Path(args.github_output),
+            {
+                "source_version": source["version"],
+                "source_tag": source["tag"],
+                "source_run_id": source["workflow_run_id"],
+                "docker_image": docker["image"],
+                "docker_digest": docker["digest"],
+            },
+        )
+    print("promotion bundle verified")
+
+
+def _resolve_command(args: argparse.Namespace) -> None:
+    manifest, artifact = resolve_candidate(
+        repository=args.repository,
+        source_sha=args.source_sha,
+        base_version=args.base_version,
+        output_dir=Path(args.output_dir),
+        archive_path=Path(args.archive_path),
+    )
+    source = manifest["source"]
+    docker = manifest["docker"]
+    _write_outputs(
+        Path(args.github_output),
+        {
+            "source_version": source["version"],
+            "source_tag": source["tag"],
+            "source_run_id": source["workflow_run_id"],
+            "docker_image": docker["image"],
+            "docker_digest": docker["digest"],
+            "artifact_id": artifact["id"],
+            "artifact_digest": artifact["digest"],
+        },
+    )
+    print(
+        f"resolved {source['tag']} run {source['workflow_run_id']} "
+        f"artifact {artifact['id']} ({artifact['digest']})"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create")
+    create.add_argument("--bundle-dir", required=True)
+    create.add_argument("--source-sha", required=True)
+    create.add_argument("--source-tag", required=True)
+    create.add_argument("--source-version", required=True)
+    create.add_argument("--base-version", required=True)
+    create.add_argument("--wheel-version", required=True)
+    create.add_argument("--source-run-id", required=True, type=int)
+    create.add_argument("--docker-image", required=True)
+    create.add_argument("--docker-digest", required=True)
+    create.set_defaults(handler=_create_command)
+
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--bundle-dir", required=True)
+    verify.add_argument("--expected-source-sha")
+    verify.add_argument("--expected-base-version")
+    verify.add_argument("--expected-source-run-id", type=int)
+    verify.add_argument("--expected-source-tag")
+    verify.add_argument("--expected-docker-image")
+    verify.add_argument("--github-output")
+    verify.set_defaults(handler=_verify_command)
+
+    resolve = subparsers.add_parser("resolve")
+    resolve.add_argument("--repository", required=True)
+    resolve.add_argument("--source-sha", required=True)
+    resolve.add_argument("--base-version", required=True)
+    resolve.add_argument("--output-dir", required=True)
+    resolve.add_argument("--archive-path", required=True)
+    resolve.add_argument("--github-output", required=True)
+    resolve.set_defaults(handler=_resolve_command)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        args.handler(args)
+    except (OSError, PromotionError, subprocess.SubprocessError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_cli_manifest_signature.py
+++ b/test/test_cli_manifest_signature.py
@@ -881,9 +881,18 @@ def test_publish_workflow_gates_all_artifact_work_before_side_effects() -> None:
         "Checkout manifest verifier contract",
         "Download wheel artifact",
         "Locate wheel and compute checksum",
-        "Attest wheel provenance",
     ):
         assert _workflow_step(name)["if"] == complete_config
+
+    promote = (
+        "${{ env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY && inputs.promote }}"
+    )
+    fresh_build = (
+        "${{ env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY && !inputs.promote }}"
+    )
+    assert _workflow_step("Verify immutable promotion bundle")["if"] == promote
+    assert _workflow_step("Attest wheel provenance")["if"] == fresh_build
+    assert _workflow_step("Verify promoted wheel provenance")["if"] == promote
 
 
 def test_installer_fetches_authenticated_urls_without_redirects() -> None:

--- a/test/test_publish_docker_contract.py
+++ b/test/test_publish_docker_contract.py
@@ -64,9 +64,10 @@ def test_attest_runs_only_for_fresh_builds() -> None:
     attest = _step_index(lines, "Attest image provenance")
     body = _step_body(lines, attest)
     assert any(
-        line.strip() == "if: steps.existing.outputs.exists == 'false'"
+        "steps.existing.outputs.exists == 'false'" in line and "!inputs.promote" in line
         for line in body
-    ), "attestation must be gated to the fresh-build path"
+        if line.strip().startswith("if:")
+    ), "attestation must be gated to a fresh build, never a promoted digest"
 
 
 def test_existing_tag_path_verifies_prior_provenance() -> None:
@@ -79,9 +80,10 @@ def test_existing_tag_path_verifies_prior_provenance() -> None:
     body = _step_body(lines, verify)
     text = "\n".join(body)
     assert any(
-        line.strip() == "if: steps.existing.outputs.exists == 'true'"
+        "steps.existing.outputs.exists == 'true'" in line and "inputs.promote" in line
         for line in body
-    ), "verification is the existing-tag counterpart of the fresh-build attest"
+        if line.strip().startswith("if:")
+    ), "verification must cover both the existing-tag and promotion paths"
     assert "gh attestation verify" in text
     assert "--signer-workflow" in text, (
         "verification must be bound to THIS workflow's identity, not merely "
@@ -106,12 +108,12 @@ def test_attest_and_verify_precede_channel_alias_on_selected_digest() -> None:
 
     attest_body = "\n".join(_step_body(lines, attest))
     alias_body = "\n".join(_step_body(lines, alias))
-    assert "steps.digest.outputs.value" in attest_body, (
-        "attest must sign the SELECTED digest, not steps.build.outputs.digest"
-    )
-    assert "steps.digest.outputs.value" in alias_body, (
-        "the alias must point at the same selected digest provenance covers"
-    )
+    assert (
+        "steps.digest.outputs.value" in attest_body
+    ), "attest must sign the SELECTED digest, not steps.build.outputs.digest"
+    assert (
+        "steps.digest.outputs.value" in alias_body
+    ), "the alias must point at the same selected digest provenance covers"
 
 
 def test_version_tag_build_still_skipped_on_rerun() -> None:
@@ -121,22 +123,91 @@ def test_version_tag_build_still_skipped_on_rerun() -> None:
     build = _step_index(lines, "Build and push (version tag)")
     body = _step_body(lines, build)
     assert any(
-        line.strip() == "if: steps.existing.outputs.exists == 'false'"
+        "steps.existing.outputs.exists == 'false'" in line and "!inputs.promote" in line
         for line in body
-    ), "re-runs must never rebuild/republish different bytes under an existing version tag"
+        if line.strip().startswith("if:")
+    ), "re-runs and promotions must never build/republish a version tag"
 
 
-def test_channel_alias_moves_only_on_fresh_builds() -> None:
-    """Re-running an OLD release workflow hits the existing-tag path; if the
-    alias step ran there it would repoint nightly/stable/latest BACKWARD to
-    the stale digest for every unpinned pull. The alias must be gated to
-    fresh builds."""
+def test_promotion_requires_a_recorded_digest_and_disables_rebuild_paths() -> None:
+    """Promotion is an explicit mode: an empty/malformed recorded digest
+    aborts before artifact download, while every image-building step is
+    structurally unreachable even if the digest output is missing."""
+    import yaml
+
+    lines = _lines()
+    validate = _step_index(lines, "Validate build or promotion mode")
+    download = _step_index(lines, "Download wheel artifact")
+    assert validate < download
+
+    validation = "\n".join(_step_body(lines, validate))
+    assert '[ "$PROMOTE" = "true" ]' in validation
+    assert "^sha256:[0-9a-f]{64}$" in validation
+    assert "Promotion requires a recorded" in validation
+    assert "exit 1" in validation
+
+    for step_name in (
+        "Download wheel artifact",
+        "Verify exactly one wheel",
+        "Set up QEMU",
+        "Resolve kiro-cli version",
+        "Build and push (version tag)",
+        "Attest image provenance",
+    ):
+        body = "\n".join(_step_body(lines, _step_index(lines, step_name)))
+        assert (
+            "!inputs.promote" in body
+        ), f"{step_name} must be unreachable in explicit promotion mode"
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    inputs = workflow[True]["workflow_call"]["inputs"]
+    assert inputs["promote"]["default"] is False
+
+    release = yaml.safe_load(CALLERS[1].read_text(encoding="utf-8"))
+    call = release["jobs"]["publish-docker"]["with"]
+    assert call["promote"].endswith(" == 'stable' }}")
+    assert "resolve-promotion.outputs.docker_digest" in call["promote_digest"]
+
+
+def test_promotion_retags_the_recorded_digest_without_building_or_attesting() -> None:
+    """Stable promotion creates its immutable version tag and aliases from
+    the manifest-recorded digest; it neither rebuilds nor signs prior bytes."""
+    lines = _lines()
+    select = _step_index(lines, "Select published digest")
+    verify = _step_index(lines, "Verify existing digest provenance")
+    promote = _step_index(lines, "Record promoted immutable version tag")
+    alias = _step_index(lines, "Update channel alias")
+    assert select < verify < promote < alias
+
+    select_text = "\n".join(_step_body(lines, select))
+    promote_text = "\n".join(_step_body(lines, promote))
+    assert 'DIGEST="$PROMOTE_DIGEST"' in select_text
+    assert "inputs.promote" in promote_text
+    assert 'imagetools create -t "${IMAGE}:${VERSION}" "${IMAGE}@${DIGEST}"' in promote_text
+    assert "TAG_DIGEST" in promote_text and '!= "$DIGEST"' in promote_text
+
+
+def test_existing_version_tag_must_match_recorded_promotion_digest() -> None:
+    """An immutable stable version tag can never be repointed to a newly
+    selected candidate, even if the operator retries promotion."""
+    lines = _lines()
+    existing = _step_index(lines, "Check for existing version tag")
+    text = "\n".join(_step_body(lines, existing))
+    assert '"$DIGEST" != "$PROMOTE_DIGEST"' in text
+    assert "Refusing to repoint it" in text
+    assert "exit 1" in text
+
+
+def test_channel_alias_moves_only_for_new_version_tags() -> None:
+    """Re-running an OLD release hits the existing-tag path and must never
+    repoint nightly/stable/latest backward. Fresh builds and first-time
+    promotions both have ``exists == false`` and may move the alias only
+    after attestation or prior-provenance verification."""
     lines = _lines()
     alias = _step_index(lines, "Update channel alias")
     body = _step_body(lines, alias)
     assert any(
-        line.strip() == "if: steps.existing.outputs.exists == 'false'"
-        for line in body
+        line.strip() == "if: steps.existing.outputs.exists == 'false'" for line in body
     ), "the channel alias must never move on the existing-tag re-run path"
 
 
@@ -150,20 +221,36 @@ def test_rerun_reconcile_only_converges_latest_toward_owned_stable() -> None:
     reconcile = _step_index(lines, "Reconcile aliases (re-run)")
     body = _step_body(lines, reconcile)
     text = "\n".join(body)
-    assert any(
-        line.strip() == "if: steps.existing.outputs.exists == 'true'"
-        for line in body
-    )
-    assert '"${STABLE_DIGEST}" = "${DIGEST}"' in text, (
-        "the repair must require stable to already own this digest"
-    )
-    assert "imagetools create -t \"${IMAGE}:latest\"" in text
+    assert any(line.strip() == "if: steps.existing.outputs.exists == 'true'" for line in body)
+    assert (
+        '"${STABLE_DIGEST}" = "${DIGEST}"' in text
+    ), "the repair must require stable to already own this digest"
+    assert 'imagetools create -t "${IMAGE}:latest"' in text
     # And it must never execute a channel-tag write on this path (the only
     # quoted create target is latest; the channel tag appears solely inside
     # the manual-repair notice text).
-    assert "create -t \"${IMAGE}:${CHANNEL}\"" not in text, (
-        "the reconcile step may only touch latest, never the channel alias"
-    )
+    assert (
+        'create -t "${IMAGE}:${CHANNEL}"' not in text
+    ), "the reconcile step may only touch latest, never the channel alias"
+
+
+def test_promotion_fails_closed_unless_stable_alias_matches_recorded_digest() -> None:
+    """An interrupted promotion must not go green merely because its immutable
+    version tag exists. Promotion succeeds only when ``stable`` resolves to the
+    manifest-recorded digest at the end of the job."""
+    lines = _lines()
+    alias = _step_index(lines, "Update channel alias")
+    reconcile = _step_index(lines, "Reconcile aliases (re-run)")
+    verify = _step_index(lines, "Verify promoted stable alias reconciliation")
+    assert alias < verify and reconcile < verify
+
+    body = _step_body(lines, verify)
+    text = "\n".join(body)
+    assert any(line.strip() == "if: inputs.promote" for line in body)
+    assert 'EXPECTED_DIGEST="$PROMOTE_DIGEST"' in text
+    assert 'imagetools inspect "${IMAGE}:stable"' in text
+    assert '"$STABLE_DIGEST" != "$EXPECTED_DIGEST"' in text
+    assert "exit 1" in text, "a stale or missing stable alias must fail promotion"
 
 
 def test_existing_tag_check_distinguishes_not_found_from_transport_failure() -> None:
@@ -174,15 +261,15 @@ def test_existing_tag_check_distinguishes_not_found_from_transport_failure() -> 
     lines = _lines()
     check = _step_index(lines, "Check for existing version tag")
     text = "\n".join(_step_body(lines, check))
-    assert "manifest unknown" in text and "name unknown" in text, (
-        "the check must classify the inspect error before declaring the tag absent"
-    )
-    assert "exit 1" in text, (
-        "an unclassifiable inspect failure must fail the job, not select the build path"
-    )
-    assert "2>/dev/null" not in text, (
-        "stderr carries the classification signal and must not be discarded"
-    )
+    assert (
+        "manifest unknown" in text and "name unknown" in text
+    ), "the check must classify the inspect error before declaring the tag absent"
+    assert (
+        "exit 1" in text
+    ), "an unclassifiable inspect failure must fail the job, not select the build path"
+    assert (
+        "2>/dev/null" not in text
+    ), "stderr carries the classification signal and must not be discarded"
 
 
 def test_public_access_gate_is_required_by_every_canonical_caller() -> None:

--- a/test/test_release_promotion.py
+++ b/test/test_release_promotion.py
@@ -1,0 +1,317 @@
+"""Tests for immutable stable-release promotion manifests."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "release_promotion.py"
+SPEC = importlib.util.spec_from_file_location("release_promotion", SCRIPT)
+assert SPEC and SPEC.loader
+promotion = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(promotion)
+
+SOURCE_SHA = "a" * 40
+SOURCE_VERSION = "1.2.3-insider.4"
+SOURCE_TAG = f"v{SOURCE_VERSION}"
+BASE_VERSION = "1.2.3"
+RUN_ID = 12345
+IMAGE = "ghcr.io/kirodotdev/kirocrew"
+IMAGE_DIGEST = f"sha256:{'b' * 64}"
+
+
+def _bundle(path: Path) -> Path:
+    path.mkdir()
+    files = {
+        "kirocrew-1.2.3rc4-py3-none-any.whl": b"wheel",
+        "kirocrew-1.2.3rc4.tar.gz": b"sdist",
+        "KiroCrew-x86_64.AppImage": b"appimage",
+        "KiroCrew-aarch64.AppImage": b"appimage-arm64",
+        "notarized.zip": b"mac-zip",
+        "KiroCrew.dmg": b"dmg",
+    }
+    for name, body in files.items():
+        (path / name).write_bytes(body)
+    manifest = promotion.create_manifest(
+        path,
+        source_sha=SOURCE_SHA,
+        source_tag=SOURCE_TAG,
+        source_version=SOURCE_VERSION,
+        base_version=BASE_VERSION,
+        wheel_version="1.2.3rc4",
+        source_run_id=RUN_ID,
+        docker_image=IMAGE,
+        docker_digest=IMAGE_DIGEST,
+    )
+    (path / promotion.MANIFEST_NAME).write_text(
+        json.dumps(manifest, sort_keys=True), encoding="utf-8"
+    )
+    return path
+
+
+def test_manifest_round_trip_binds_source_and_every_shipping_file(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle")
+    manifest = promotion.verify_bundle(
+        bundle,
+        expected_source_sha=SOURCE_SHA,
+        expected_base_version=BASE_VERSION,
+        expected_source_run_id=RUN_ID,
+        expected_source_tag=SOURCE_TAG,
+        expected_docker_image=IMAGE,
+    )
+
+    assert set(manifest["artifacts"]) == {
+        "wheel",
+        "sdist",
+        "appimage",
+        "appimage_arm64",
+        "mac_zip",
+        "dmg",
+    }
+    assert manifest["docker"]["digest"] == IMAGE_DIGEST
+    for entry in manifest["artifacts"].values():
+        assert len(entry["sha256"]) == 64
+        assert entry["size"] > 0
+
+
+def test_manifest_rejects_distribution_filename_from_other_wheel_version(
+    tmp_path: Path,
+) -> None:
+    cases = (
+        (
+            "wheel",
+            "kirocrew-1.2.3rc4-py3-none-any.whl",
+            "kirocrew-9.9.9-py3-none-any.whl",
+        ),
+        ("sdist", "kirocrew-1.2.3rc4.tar.gz", "kirocrew-9.9.9.tar.gz"),
+    )
+    for logical_name, original_name, mismatched_name in cases:
+        bundle = _bundle(tmp_path / logical_name)
+        manifest_path = bundle / promotion.MANIFEST_NAME
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        (bundle / original_name).rename(bundle / mismatched_name)
+        manifest["artifacts"][logical_name]["filename"] = mismatched_name
+        manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+
+        with pytest.raises(
+            promotion.PromotionError,
+            match=rf"{logical_name} filename .* does not match wheel_version",
+        ):
+            promotion.verify_bundle(bundle)
+
+
+def test_wheel_filename_binding_requires_exact_match() -> None:
+    """A prefix check would accept longer versions or build-tag spellings."""
+    promotion._require_wheel_version_filename(
+        "wheel", "kirocrew-1.2.3rc4-py3-none-any.whl", "1.2.3rc4"
+    )
+    for bad in (
+        "kirocrew-1.2.3rc40-py3-none-any.whl",
+        "kirocrew-1.2.3rc4.post1-py3-none-any.whl",
+        "kirocrew-1.2.3rc4-1-py3-none-any.whl",
+    ):
+        with pytest.raises(
+            promotion.PromotionError, match="does not match wheel_version"
+        ):
+            promotion._require_wheel_version_filename("wheel", bad, "1.2.3rc4")
+
+
+def test_tampered_candidate_file_fails_closed(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle")
+    (bundle / "KiroCrew.dmg").write_bytes(b"different bytes")
+
+    with pytest.raises(promotion.PromotionError, match="does not match manifest"):
+        promotion.verify_bundle(bundle)
+
+
+def test_manifest_for_other_commit_or_release_line_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle")
+
+    with pytest.raises(promotion.PromotionError, match="source sha mismatch"):
+        promotion.verify_bundle(bundle, expected_source_sha="c" * 40)
+    with pytest.raises(promotion.PromotionError, match="base version mismatch"):
+        promotion.verify_bundle(bundle, expected_base_version="1.2.4")
+
+
+def test_candidate_selection_is_same_commit_same_base_and_newest_first() -> None:
+    runs = [
+        {
+            "id": 2,
+            "conclusion": "success",
+            "head_sha": SOURCE_SHA,
+            "head_branch": "v1.2.3-insider.2",
+            "run_started_at": "2026-07-01T02:00:00Z",
+        },
+        {
+            "id": 4,
+            "conclusion": "failure",
+            "head_sha": SOURCE_SHA,
+            "head_branch": "v1.2.3-insider.4",
+            "run_started_at": "2026-07-01T04:00:00Z",
+        },
+        {
+            "id": 3,
+            "conclusion": "success",
+            "head_sha": SOURCE_SHA,
+            "head_branch": "v1.2.3-insider.3",
+            "run_started_at": "2026-07-01T03:00:00Z",
+        },
+        {
+            "id": 99,
+            "conclusion": "success",
+            "head_sha": "d" * 40,
+            "head_branch": "v1.2.3-insider.99",
+            "run_started_at": "2026-07-01T05:00:00Z",
+        },
+        {
+            "id": 100,
+            "conclusion": "success",
+            "head_sha": SOURCE_SHA,
+            "head_branch": "v1.2.4-insider.1",
+            "run_started_at": "2026-07-01T06:00:00Z",
+        },
+    ]
+
+    selected = promotion.select_candidate_runs(
+        runs, source_sha=SOURCE_SHA, base_version=BASE_VERSION
+    )
+
+    assert [run["id"] for run in selected] == [3, 2]
+
+
+def _archive(bundle: Path, archive: Path, arcname_prefix: str = "") -> str:
+    with zipfile.ZipFile(archive, "w") as output:
+        for path in bundle.iterdir():
+            output.write(path, f"{arcname_prefix}{path.name}")
+    return f"sha256:{hashlib.sha256(archive.read_bytes()).hexdigest()}"
+
+
+def _mock_resolver_api(
+    monkeypatch: pytest.MonkeyPatch,
+    archive: Path,
+    artifact: dict[str, object],
+) -> None:
+    run = {
+        "id": RUN_ID,
+        "conclusion": "success",
+        "head_sha": SOURCE_SHA,
+        "head_branch": SOURCE_TAG,
+        "run_started_at": "2026-07-01T03:00:00Z",
+    }
+
+    def fake_gh_json(endpoint: str) -> dict[str, object]:
+        if "/actions/workflows/release.yml/runs?" in endpoint:
+            return {"workflow_runs": [run]}
+        if endpoint.endswith(f"/actions/runs/{RUN_ID}/artifacts?per_page=100"):
+            return {"artifacts": [artifact]}
+        raise AssertionError(f"unexpected GitHub API endpoint: {endpoint}")
+
+    def fake_download(repository: str, artifact_id: int, destination: Path) -> None:
+        assert repository == "kirodotdev/KiroCrew"
+        assert artifact_id == 99
+        destination.write_bytes(archive.read_bytes())
+
+    monkeypatch.setattr(promotion, "_gh_json", fake_gh_json)
+    monkeypatch.setattr(promotion, "_download_artifact", fake_download)
+
+
+def _candidate_artifact(archive: Path, digest: object) -> dict[str, object]:
+    artifact: dict[str, object] = {
+        "id": 99,
+        "name": f"stable-promotion-{BASE_VERSION}",
+        "expired": False,
+        "size_in_bytes": archive.stat().st_size,
+    }
+    if digest is not None:
+        artifact["digest"] = digest
+    return artifact
+
+
+def test_matching_recorded_archive_digest_promotes_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = _bundle(tmp_path / "bundle")
+    source_archive = tmp_path / "source.zip"
+    digest = _archive(bundle, source_archive)
+    artifact = _candidate_artifact(source_archive, digest)
+    _mock_resolver_api(monkeypatch, source_archive, artifact)
+
+    manifest, selected = promotion.resolve_candidate(
+        repository="kirodotdev/KiroCrew",
+        source_sha=SOURCE_SHA,
+        base_version=BASE_VERSION,
+        output_dir=tmp_path / "resolved",
+        archive_path=tmp_path / "downloaded.zip",
+    )
+
+    assert manifest["source"]["workflow_run_id"] == RUN_ID
+    assert manifest["docker"]["digest"] == IMAGE_DIGEST
+    assert selected["digest"] == digest
+
+
+def test_mismatched_recorded_archive_digest_aborts_promotion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = _bundle(tmp_path / "bundle")
+    source_archive = tmp_path / "source.zip"
+    _archive(bundle, source_archive)
+    artifact = _candidate_artifact(source_archive, f"sha256:{'0' * 64}")
+    _mock_resolver_api(monkeypatch, source_archive, artifact)
+
+    with pytest.raises(promotion.PromotionError, match="archive digest mismatch"):
+        promotion.resolve_candidate(
+            repository="kirodotdev/KiroCrew",
+            source_sha=SOURCE_SHA,
+            base_version=BASE_VERSION,
+            output_dir=tmp_path / "resolved",
+            archive_path=tmp_path / "downloaded.zip",
+        )
+
+
+def test_missing_recorded_archive_digest_aborts_promotion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = _bundle(tmp_path / "bundle")
+    source_archive = tmp_path / "source.zip"
+    _archive(bundle, source_archive)
+    artifact = _candidate_artifact(source_archive, None)
+    _mock_resolver_api(monkeypatch, source_archive, artifact)
+
+    with pytest.raises(promotion.PromotionError, match="artifact.digest must be"):
+        promotion.resolve_candidate(
+            repository="kirodotdev/KiroCrew",
+            source_sha=SOURCE_SHA,
+            base_version=BASE_VERSION,
+            output_dir=tmp_path / "resolved",
+            archive_path=tmp_path / "downloaded.zip",
+        )
+
+
+def test_archive_digest_is_verified_before_safe_extraction(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle")
+    archive = tmp_path / "candidate.zip"
+    digest = _archive(bundle, archive)
+    output = tmp_path / "resolved"
+
+    promotion.extract_verified_archive(archive, output, expected_digest=digest)
+    promotion.verify_bundle(output, expected_source_sha=SOURCE_SHA)
+
+    with pytest.raises(promotion.PromotionError, match="archive digest mismatch"):
+        promotion.extract_verified_archive(
+            archive, tmp_path / "other", expected_digest=f"sha256:{'0' * 64}"
+        )
+
+
+def test_archive_path_traversal_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle")
+    archive = tmp_path / "candidate.zip"
+    digest = _archive(bundle, archive, arcname_prefix="../")
+
+    with pytest.raises(promotion.PromotionError, match="unsafe path"):
+        promotion.extract_verified_archive(archive, tmp_path / "resolved", expected_digest=digest)

--- a/test/test_release_promotion_contract.py
+++ b/test/test_release_promotion_contract.py
@@ -1,0 +1,230 @@
+"""Structural contracts for promote-what-was-tested stable releases.
+
+The executable manifest tests prove digest and archive handling. These tests
+pin the GitHub Actions wiring so a future simplification cannot route a bare
+stable tag back through source builds or accidentally attest rebuilt bytes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+RELEASE = WORKFLOWS / "release.yml"
+CLI = WORKFLOWS / "publish-cli.yml"
+LINUX = WORKFLOWS / "publish-linux.yml"
+MAC = WORKFLOWS / "sign-and-notarize.yml"
+DOCKER = WORKFLOWS / "publish-docker.yml"
+PROMOTION_ARTIFACT = "KiroCrew-notarized-stable-${{ needs.version.outputs.version }}"
+PROMOTION_ARTIFACT_FORMAT = (
+    "format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version)"
+)
+
+
+def _workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _inputs(path: Path) -> dict:
+    return _workflow(path)[True]["workflow_call"]["inputs"]
+
+
+def _step(path: Path, job: str, name: str) -> dict:
+    steps = _workflow(path)["jobs"][job]["steps"]
+    return next(step for step in steps if step.get("name") == name)
+
+
+def test_release_base_requires_exact_three_component_numeric_version() -> None:
+    derive = _step(RELEASE, "version", "Derive version + channel from tag")["run"]
+    assert '[[ "$BASE" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]' in derive
+    assert 'case "$BASE" in' not in derive
+
+
+def test_stable_tag_resolves_candidate_and_never_enters_build_jobs() -> None:
+    jobs = _workflow(RELEASE)["jobs"]
+
+    assert jobs["resolve-promotion"]["if"] == "needs.version.outputs.channel == 'stable'"
+    assert jobs["resolve-promotion"]["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+    }
+    assert jobs["build-wheel"]["if"] == "needs.version.outputs.channel == 'insider'"
+    assert jobs["build-desktop"]["if"] == "needs.version.outputs.channel == 'insider'"
+
+    resolve = _step(RELEASE, "resolve-promotion", "Resolve and verify immutable candidate bundle")[
+        "run"
+    ]
+    assert "scripts/release_promotion.py resolve" in resolve
+    assert '--source-sha "${GITHUB_SHA}"' in resolve
+    assert "--base-version" in resolve
+    assert "--archive-path" in resolve
+
+    handoff = _step(RELEASE, "resolve-promotion", "Attach verified bundle to this run")
+    assert handoff["with"]["name"] == PROMOTION_ARTIFACT
+    assert handoff["with"]["if-no-files-found"] == "error"
+
+
+def test_every_stable_lane_consumes_the_verified_handoff() -> None:
+    jobs = _workflow(RELEASE)["jobs"]
+    for name in ("publish-cli", "publish-linux-x64", "publish-linux-arm64", "publish-docker", "sign-and-notarize"):
+        job = jobs[name]
+        assert "resolve-promotion" in job["needs"]
+        assert "needs.resolve-promotion.result == 'success'" in job["if"]
+
+    assert PROMOTION_ARTIFACT_FORMAT in jobs["publish-cli"]["with"]["wheel_artifact"]
+    assert jobs["publish-cli"]["with"]["promote"].endswith(" == 'stable' }}")
+
+    linux_inputs = jobs["publish-linux-x64"]["with"]
+    assert PROMOTION_ARTIFACT_FORMAT in linux_inputs["appimage_artifact"]
+    assert "resolve-promotion.outputs.source_version" in linux_inputs["version"]
+    assert linux_inputs["promote"].endswith(" == 'stable' }}")
+
+    linux_arm64_inputs = jobs["publish-linux-arm64"]["with"]
+    assert PROMOTION_ARTIFACT_FORMAT in linux_arm64_inputs["appimage_artifact"]
+    assert "resolve-promotion.outputs.source_version" in linux_arm64_inputs["version"]
+    assert linux_arm64_inputs["promote"].endswith(" == 'stable' }}")
+
+    docker_inputs = jobs["publish-docker"]["with"]
+    assert docker_inputs["promote"].endswith(" == 'stable' }}")
+    assert "resolve-promotion.outputs.docker_digest" in docker_inputs["promote_digest"]
+
+    mac_inputs = jobs["sign-and-notarize"]["with"]
+    assert PROMOTION_ARTIFACT_FORMAT in mac_inputs["promotion_artifact"]
+    assert "resolve-promotion.outputs.source_version" in mac_inputs["version"]
+    assert mac_inputs["promote"].endswith(" == 'stable' }}")
+
+
+def test_github_release_selects_explicit_versioned_macos_handoff() -> None:
+    verify = _step(RELEASE, "github-release", "Verify promoted release bytes")["run"]
+    assert f'--bundle-dir "artifacts/{PROMOTION_ARTIFACT}"' in verify
+
+    assemble = _step(
+        RELEASE, "github-release", "Assemble release assets (require gated macOS artifacts)"
+    )["run"]
+    assert (
+        'NOTARIZED_DIR="artifacts/KiroCrew-notarized-${{ needs.version.outputs.channel }}-'
+        '${{ needs.version.outputs.version }}"' in assemble
+    )
+    assert "KiroCrew-notarized-stable-promotion" not in assemble
+    assert "*KiroCrew-notarized-*" not in assemble
+
+
+def test_prerelease_candidate_runs_same_sha_test_gate() -> None:
+    jobs = _workflow(RELEASE)["jobs"]
+    gate = jobs["release-candidate-tests"]
+    assert gate["if"] == "needs.version.outputs.channel == 'insider'"
+    assert gate["needs"] == "version"
+
+    checkout = next(
+        step for step in gate["steps"] if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    assert checkout["with"]["ref"] == "${{ github.sha }}"
+
+    verify = _step(RELEASE, "release-candidate-tests", "Verify exact candidate SHA")
+    assert "git rev-parse HEAD" in verify["run"]
+    assert "GITHUB_SHA" in verify["run"]
+
+    tests = _step(RELEASE, "release-candidate-tests", "Run release candidate tests")
+    assert "pytest" in tests["run"]
+    assert "--no-cov" in tests["run"]
+
+
+def test_prerelease_record_waits_for_test_gate_and_all_publish_lanes() -> None:
+    job = _workflow(RELEASE)["jobs"]["record-promotion"]
+    assert set(job["needs"]) == {
+        "version",
+        "release-candidate-tests",
+        "publish-cli",
+        "publish-linux-x64",
+        "publish-linux-arm64",
+        "publish-docker",
+        "sign-and-notarize",
+    }
+    for dependency in (
+        "release-candidate-tests",
+        "publish-cli",
+        "publish-linux-x64",
+        "publish-linux-arm64",
+        "publish-docker",
+        "sign-and-notarize",
+    ):
+        assert f"needs.{dependency}.result == 'success'" in job["if"]
+
+    assemble = _step(RELEASE, "record-promotion", "Assemble canonical promotion bundle")
+    assert assemble["env"]["DOCKER_DIGEST"] == "${{ needs.publish-docker.outputs.digest }}"
+    run = assemble["run"]
+    assert "scripts/release_promotion.py create" in run
+    assert '--source-sha "${GITHUB_SHA}"' in run
+    assert '--source-run-id "${GITHUB_RUN_ID}"' in run
+    assert '--docker-digest "${DOCKER_DIGEST}"' in run
+
+    upload = _step(RELEASE, "record-promotion", "Upload immutable promotion record")
+    assert "stable-promotion-" in upload["with"]["name"]
+    assert upload["with"]["if-no-files-found"] == "error"
+    assert upload["with"]["retention-days"] == 90
+
+
+def test_file_publishers_verify_manifest_and_prior_provenance() -> None:
+    for path in (CLI, LINUX):
+        inputs = _inputs(path)
+        assert inputs["promote"]["default"] is False
+        assert inputs["promotion_base_version"]["default"] == ""
+
+    cli_manifest = _step(CLI, "publish-cli", "Verify immutable promotion bundle")
+    cli_attest = _step(CLI, "publish-cli", "Attest wheel provenance")
+    cli_verify = _step(CLI, "publish-cli", "Verify promoted wheel provenance")
+    cli_promote = (
+        "${{ env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY && inputs.promote }}"
+    )
+    cli_fresh = (
+        "${{ env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY && !inputs.promote }}"
+    )
+    assert cli_manifest["if"] == cli_promote
+    assert cli_attest["if"] == cli_fresh
+    assert cli_verify["if"] == cli_promote
+    assert "gh attestation verify" in cli_verify["run"]
+
+    linux_manifest = _step(LINUX, "publish-linux", "Verify immutable promotion bundle")
+    linux_attest = _step(LINUX, "publish-linux", "Attest AppImage provenance")
+    linux_verify = _step(LINUX, "publish-linux", "Verify promoted AppImage provenance")
+    linux_promote = "env.HAS_SIGNING_SECRETS && inputs.promote"
+    linux_fresh = "env.HAS_SIGNING_SECRETS && !inputs.promote"
+    assert linux_manifest["if"] == linux_promote
+    assert linux_attest["if"] == linux_fresh
+    assert linux_verify["if"] == linux_promote
+    assert "gh attestation verify" in linux_verify["run"]
+
+
+def test_macos_promotion_skips_transformations_and_verifies_final_bytes() -> None:
+    jobs = _workflow(MAC)["jobs"]
+    assert jobs["sign"]["if"] == "${{ !inputs.promote }}"
+    publish_if = jobs["publish"]["if"]
+    assert "always()" in publish_if
+    assert "needs.notarize.result == 'success'" in publish_if
+    assert "needs.notarize.result == 'skipped'" in publish_if
+
+    final_attest = _step(MAC, "notarize", "Attest final shipping artifacts")
+    subjects = final_attest["with"]["subject-path"]
+    assert "work/notarized.zip" in subjects
+    assert "work/*.dmg" in subjects
+
+    manifest = _step(MAC, "publish", "Verify immutable promotion bundle")
+    provenance = _step(MAC, "publish", "Verify promoted macOS provenance")
+    assert "inputs.promote" in manifest["if"]
+    assert provenance["run"].count("gh attestation verify") == 2
+
+
+def test_docker_promotion_input_defaults_to_no_promotion() -> None:
+    inputs = _inputs(DOCKER)
+    assert inputs["promote"]["default"] is False
+    assert inputs["promote_digest"]["default"] == ""
+    build = _step(DOCKER, "publish-docker", "Build and push (version tag)")
+    attest = _step(DOCKER, "publish-docker", "Attest image provenance (fresh build)")
+    promote = _step(DOCKER, "publish-docker", "Record promoted immutable version tag")
+    assert "!inputs.promote" in build["if"]
+    assert "!inputs.promote" in attest["if"]
+    assert "inputs.promote" in promote["if"]
+    assert '"${IMAGE}@${DIGEST}"' in promote["run"]

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -133,6 +133,13 @@ class TestReleasePermissions:
 
         assert _workflow_permissions("release.yml") == {"contents": "read"}
         assert _permission_block(lines, "  version:") is None
+        assert _permission_block(lines, "  resolve-promotion:") == {
+            "actions": "read",
+            "contents": "read",
+        }
+        assert _permission_block(lines, "  record-promotion:") == {
+            "contents": "read",
+        }
         assert _permission_block(lines, "  build-wheel:") is None
         assert _permission_block(lines, "  build-desktop:") is None
         # Windows build: OIDC for signing, never contents:write (see nightly).


### PR DESCRIPTION
## Problem
Stable release tags rebuilt wheels, desktop packages, and container images after prerelease validation instead of promoting the exact artifacts that had already passed release lanes. The workflow did not record one immutable bundle tying GitHub artifact bytes and the OCI manifest digest to the tested commit.

The audit also found three fail-closed gaps: an interrupted Docker promotion rerun could succeed while `:stable` remained stale, `wheel_version` was not bound to the wheel/sdist filenames, and the GitHub Release stable path relied on a generated macOS artifact name instead of the explicit promotion handoff.

## Impact
A stable release could publish bytes that differed from the prerelease candidates that were tested, signed, notarized, and attested. An interrupted promotion could additionally report success without advancing the stable container alias, and a malformed promotion manifest could pair one declared wheel version with distribution files from another version.

## Root Cause
The release workflow modeled stable publication as another build. Publishing lanes independently reconstructed or attested outputs, and there was no post-lane promotion record that stable jobs could resolve and verify by commit SHA and digest. The remaining rerun and handoff paths validated intermediate operations but did not consistently validate the final published state or bind all metadata to exact filenames.

## Fix
- Build and publish prerelease artifacts once, then record a promotion bundle only after the CLI, Linux, macOS, Docker, and same-SHA prerelease-candidate test gates succeed.
- Resolve stable promotion only from a successful prerelease run for the same commit SHA.
- Verify the recorded GitHub artifact archive digest plus every shipping file's SHA-256 and SHA-512 manifest entries before publication.
- Bind `wheel_version` to the exact `kirocrew-{wheel_version}-...whl` and `kirocrew-{wheel_version}.tar.gz` filenames during bundle verification.
- Make stable CLI, Linux, and macOS jobs verify provenance and copy the existing bytes without rebuilding or creating replacement attestations; prerelease macOS publication attests both the final ZIP and DMG.
- Select `artifacts/KiroCrew-notarized-stable-promotion` explicitly when assembling stable GitHub Release assets.
- Skip stable wheel and desktop builds, and retag the recorded attested OCI manifest digest instead of rebuilding an image.
- Fail closed when Docker promotion mode is incomplete or ambiguous, including a final reconciliation check that requires `:stable` to resolve to the recorded digest on first runs and reruns.
- Document the exact-byte promotion contract and pin it with workflow contract tests.

## Tests
- `test/test_release_promotion*.py` and `test/test_publish_docker_contract.py`: 32 passed.
- `isort --check-only` and `flake8 -j 1` passed on all Python files changed by the PR.
- `yaml.safe_load` passed for all five changed workflow files.
- `git diff --check` passed.

## Manual Verification
1. Trigger a prerelease tag for a test commit and confirm artifacts are built once and the promotion bundle is recorded only after all four publishing lanes and the same-SHA candidate tests succeed.
2. Inspect the bundle and confirm it records the GitHub archive SHA-256 digest, each shipping file's SHA-256 and SHA-512 digests, provenance references, and the OCI `sha256` manifest digest.
3. Trigger a bare stable tag at the same commit and confirm wheel and desktop builds are skipped, file publishers preserve identical digests without signing or notarization transformations, and Docker retags the recorded manifest digest without a build.
4. Interrupt promotion after the immutable Docker version tag is written but before `:stable` advances; confirm the rerun fails unless `:stable` resolves to the recorded digest.
5. Tamper with an archive or manifest digest, mismatch `wheel_version` and distribution filenames, or provide ambiguous Docker promotion inputs, and confirm publication fails closed.
