### PR TITLE
test(e2e): widen the window the pulsing spec asserts on

### DIFF
--- a/src/kiro_crew/testing/fake_acp_backend.py
+++ b/src/kiro_crew/testing/fake_acp_backend.py
@@ -34,6 +34,11 @@ Prompt-driven behaviour on ``session/prompt`` (the reply is always sent last):
 * ``[[SLOW_NOACK]]`` -> the same slow stream but deliberately DEAF to cancel,
   so the host's ``soft_stop_budget_secs`` expires. Models an agent wedged in a
   long tool call, which is the "Stop Failed, Session Reset" path.
+* ``[[SLOW_LATEACK]]`` -> honours the cancel like ``[[SLOW]]`` but winds down
+  over ``SLOW_LATEACK_CHUNKS`` more chunks first. ``[[SLOW]]`` acks within one
+  chunk, so the host's ``soft_pending`` state lasts ~250ms on average and a
+  loaded browser can miss it entirely; the wind-down makes that state
+  observable while still acking well inside the budget.
 * ``[[ERROR]]`` -> reply with a JSON-RPC error instead of a result.
 * ``[[MAXTOKENS]]`` / ``[[REFUSAL]]`` -> alternate terminal ``stopReason``.
 
@@ -79,9 +84,12 @@ PERMISSION_TRIGGER = "[[PERMISSION]]"
 GATED_PERMISSION_TRIGGER = "[[GATED]]"
 # A turn long enough for a host to press Stop mid-flight. SLOW honours
 # session/cancel; SLOW_NOACK deliberately ignores it so the host's soft-stop
-# budget expires (the "Stop Failed, Session Reset" path).
+# budget expires (the "Stop Failed, Session Reset" path). SLOW_LATEACK honours
+# it but winds down over a few chunks first, so the host's `soft_pending` state
+# is observable for a bounded interval instead of a race.
 SLOW_TRIGGER = "[[SLOW]]"
 SLOW_NOACK_TRIGGER = "[[SLOW_NOACK]]"
+SLOW_LATEACK_TRIGGER = "[[SLOW_LATEACK]]"
 # Terminal outcomes other than end_turn.
 ERROR_TRIGGER = "[[ERROR]]"
 MAX_TOKENS_TRIGGER = "[[MAXTOKENS]]"
@@ -93,6 +101,14 @@ REFUSAL_TRIGGER = "[[REFUSAL]]"
 SLOW_CHUNKS = 30
 SLOW_CHUNK_DELAY_SECS = 0.5
 SLOW_CHUNK_TEXT = "fake slow chunk "
+# How many MORE chunks a SLOW_LATEACK turn emits after it notices the cancel,
+# before acking. Counted in chunks rather than seconds so the unit test is
+# deterministic and does not depend on wall clock. At the default
+# SLOW_CHUNK_DELAY_SECS that is ~3s, which is well inside the 0.5s-60s
+# soft_stop_budget_secs range (so the ack always beats the budget and the turn
+# ends cooperatively) and roughly 12x the ~250ms window a plain SLOW cancel
+# leaves, which is too short for a loaded browser to paint.
+SLOW_LATEACK_CHUNKS = 6
 # How long a gated permission waits for the host's answer before giving up.
 # Bounded on purpose: the headless backend suite has nothing to resolve a modal,
 # and a hang there would stall the whole turn.
@@ -302,15 +318,34 @@ def _emit_tool_call(
     )
 
 
-def _stream_slowly(session_id: str, *, cancel_aware: bool) -> bool:
+def _stream_slowly(
+    session_id: str, *, cancel_aware: bool, ack_after_chunks: int = 0
+) -> bool:
     """Stream SLOW_CHUNKS chunks with a delay. True if cancelled mid-stream.
 
     cancel_aware=False models an agent stuck in a long tool call that cannot
     acknowledge a stop, so the host's soft-stop budget expires.
+
+    ack_after_chunks>0 models an agent that notices the cancel but takes a
+    bounded moment to wind down: it emits that many more chunks, then acks. The
+    host stays in `soft_pending` for the whole wind-down, which is what makes
+    that state observable to a UI assertion instead of a ~250ms race, while
+    still ending the turn cooperatively so nothing leaks into the next turn.
+
+    The cancel observation is LATCHED because `_cancel_requested` consumes the
+    message from the inbox: a second call after the wind-down starts would
+    return False and the ack would never fire.
     """
+    cancelled = False
+    winding_down = 0
     for i in range(SLOW_CHUNKS):
-        if cancel_aware and _cancel_requested(session_id):
-            return True
+        if cancel_aware and not cancelled and _cancel_requested(session_id):
+            cancelled = True
+            winding_down = ack_after_chunks
+        if cancelled:
+            if winding_down <= 0:
+                return True
+            winding_down -= 1
         _update(
             session_id,
             {
@@ -320,7 +355,7 @@ def _stream_slowly(session_id: str, *, cancel_aware: bool) -> bool:
         )
         time.sleep(SLOW_CHUNK_DELAY_SECS)
     # A cancel arriving during the final sleep still counts.
-    return bool(cancel_aware and _cancel_requested(session_id))
+    return bool(cancelled or (cancel_aware and _cancel_requested(session_id)))
 
 
 def _handle(msg: dict[str, Any]) -> None:
@@ -362,6 +397,11 @@ def _handle(msg: dict[str, Any]) -> None:
         if SLOW_NOACK_TRIGGER in text:
             _stream_slowly(session_id, cancel_aware=False)
             stop_reason = "end_turn"
+        elif SLOW_LATEACK_TRIGGER in text:
+            cancelled = _stream_slowly(
+                session_id, cancel_aware=True, ack_after_chunks=SLOW_LATEACK_CHUNKS
+            )
+            stop_reason = "cancelled" if cancelled else "end_turn"
         elif SLOW_TRIGGER in text:
             cancelled = _stream_slowly(session_id, cancel_aware=True)
             stop_reason = "cancelled" if cancelled else "end_turn"

--- a/test/test_fake_acp_backend.py
+++ b/test/test_fake_acp_backend.py
@@ -287,6 +287,81 @@ def test_slow_noack_ignores_cancel(monkeypatch, fast_slow_stream):
     assert _messages(buf)[-1]["result"]["stopReason"] == "end_turn"
 
 
+def test_slow_lateack_winds_down_then_acks(monkeypatch):
+    """LATEACK keeps streaming for SLOW_LATEACK_CHUNKS, then acks.
+
+    Asserted in CHUNKS, not seconds: the point of the wind-down is that the
+    host's `soft_pending` state lasts long enough to be observed, and chunk
+    count is the deterministic proxy for that duration. Contrast the SLOW case
+    below, which emits nothing before acking.
+    """
+    monkeypatch.setattr(fake, "SLOW_CHUNKS", 10)
+    monkeypatch.setattr(fake, "SLOW_CHUNK_DELAY_SECS", 0)
+    monkeypatch.setattr(fake, "SLOW_LATEACK_CHUNKS", 4)
+    buf = _capture(monkeypatch)
+    fake._INBOX.put(
+        {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "s1"}}
+    )
+    fake._handle(_prompt(fake.SLOW_LATEACK_TRIGGER))
+    msgs = _messages(buf)
+    chunks = [m for m in msgs if m.get("method") == "session/update"]
+    # Four wind-down chunks, then the cooperative ack -- NOT the full 10.
+    assert len(chunks) == 4
+    assert msgs[-1]["result"]["stopReason"] == "cancelled"
+
+
+def test_slow_acks_immediately_unlike_lateack(monkeypatch):
+    """Pins the contrast: plain SLOW emits zero chunks before acking.
+
+    This is the ~250ms window that made chat.spec.ts's pulsing assertion flaky
+    on a loaded runner. If this ever starts emitting chunks, SLOW has acquired
+    a wind-down of its own and LATEACK is redundant.
+    """
+    monkeypatch.setattr(fake, "SLOW_CHUNKS", 10)
+    monkeypatch.setattr(fake, "SLOW_CHUNK_DELAY_SECS", 0)
+    buf = _capture(monkeypatch)
+    fake._INBOX.put(
+        {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "s1"}}
+    )
+    fake._handle(_prompt(fake.SLOW_TRIGGER))
+    msgs = _messages(buf)
+    assert [m for m in msgs if m.get("method") == "session/update"] == []
+    assert msgs[-1]["result"]["stopReason"] == "cancelled"
+
+
+def test_slow_lateack_without_a_cancel_ends_the_turn_normally(
+    monkeypatch, fast_slow_stream
+):
+    """No cancel means no wind-down: the stream runs to completion."""
+    buf = _capture(monkeypatch)
+    fake._handle(_prompt(fake.SLOW_LATEACK_TRIGGER))
+    msgs = _messages(buf)
+    assert len([m for m in msgs if m.get("method") == "session/update"]) == 3
+    assert msgs[-1]["result"]["stopReason"] == "end_turn"
+
+
+def test_slow_lateack_acks_even_if_the_stream_ends_first(monkeypatch):
+    """The ack must survive the wind-down outliving the stream.
+
+    `_cancel_requested` CONSUMES the message from `_INBOX`, so the observation
+    has to be latched. If the wind-down runs past the last chunk and the final
+    return re-polls instead of reading the latch, the poll comes back False and
+    the turn reports `end_turn` -- the host then waits out the whole soft-stop
+    budget and hard-kills a session the agent actually cancelled.
+    """
+    monkeypatch.setattr(fake, "SLOW_CHUNKS", 3)
+    monkeypatch.setattr(fake, "SLOW_CHUNK_DELAY_SECS", 0)
+    monkeypatch.setattr(fake, "SLOW_LATEACK_CHUNKS", 5)
+    buf = _capture(monkeypatch)
+    fake._INBOX.put(
+        {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "s1"}}
+    )
+    fake._handle(_prompt(fake.SLOW_LATEACK_TRIGGER))
+    # Inbox drained by the single consuming poll, yet the ack still lands.
+    assert fake._INBOX.empty()
+    assert _messages(buf)[-1]["result"]["stopReason"] == "cancelled"
+
+
 def _permission_answer(option_id: str) -> dict[str, Any]:
     return {
         "jsonrpc": "2.0",

--- a/website/playwright/chat.spec.ts
+++ b/website/playwright/chat.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test'
 
 // Prompt sentinels understood by the stub ACP backend. Keep in sync with
-// SLOW_TRIGGER / SLOW_NOACK_TRIGGER in src/kiro_crew/testing/fake_acp_backend.py.
+// SLOW_TRIGGER / SLOW_NOACK_TRIGGER / SLOW_LATEACK_TRIGGER in
+// src/kiro_crew/testing/fake_acp_backend.py.
 const SLOW = '[[SLOW]]'
 const SLOW_NOACK = '[[SLOW_NOACK]]'
+const SLOW_LATEACK = '[[SLOW_LATEACK]]'
 
 // @needs-agent: these specs drive a live agent turn (send/stream/soft-stop),
 // so they require model/agent credentials the credential-less CI gateway
@@ -153,10 +155,33 @@ test.describe('Soft-Stop E2E Tests', { tag: '@needs-agent' }, () => {
     await expect(page.getByPlaceholder(/message/i)).toBeVisible({ timeout: 10000 })
   })
 
+  /**
+   * Uses [[SLOW_LATEACK]] rather than [[SLOW]] because this is the only spec
+   * here that asserts an INTERMEDIATE state, and [[SLOW]] destroys that state
+   * before a loaded browser can paint it.
+   *
+   * `stop-button-pulsing` renders only while `stop_state === 'soft_pending'`
+   * (ChatInput.tsx). The client keeps no optimistic copy: ChatPage passes
+   * `currentSlot?.stop_state` straight through. So the element exists for
+   * exactly as long as the host waits for the cancel ack. Under [[SLOW]] the
+   * stub checks for the cancel once per chunk and acks on the first check, so
+   * that is under 500ms, averaging ~250ms. Two WebSocket pushes bracket it and
+   * the first push's render can consume the whole window.
+   *
+   * [[SLOW_LATEACK]] acks after SLOW_LATEACK_CHUNKS more chunks (~3s at the
+   * default chunk delay), so the state is observable with real margin. It still
+   * acks well inside `agent.soft_stop_budget_secs`, so the turn ends
+   * cooperatively and nothing leaks into the spec that follows.
+   *
+   * [[SLOW_NOACK]] would also widen the window, but it leaves the slot mid-budget
+   * with a hard kill pending, which makes the sibling spec below fail. Measured:
+   * with NOACK here, `stop resolves to Stopped on soft ack` failed 4 of 4 runs.
+   */
   test('stop mid-tool-call triggers pulsing', async ({ page }) => {
-    // A cancel-aware slow turn, so the Stop button stays live long enough to click.
+    // A cancel-aware slow turn that winds down before acking, so the
+    // soft_pending state is observable rather than a ~250ms race.
     const messageInput = page.getByPlaceholder(/message/i)
-    await messageInput.fill(`Run a long command: sleep 30 ${SLOW}`)
+    await messageInput.fill(`Run a long command: sleep 30 ${SLOW_LATEACK}`)
     await page.keyboard.press('Enter')
 
     // Wait for the stop button to appear (agent is running)


### PR DESCRIPTION
## Description

`chat.spec.ts` "stop mid-tool-call triggers pulsing" fails intermittently on
loaded CI runners. The assertion is sound; the window it targets is too narrow.

`stop-button-pulsing` renders only while `stop_state === 'soft_pending'`
(`ChatInput.tsx`). There is no optimistic client copy: `ChatPage` passes
`currentSlot?.stop_state` straight through, so the element exists for exactly as
long as the host waits for the cancel ack. `_stream_slowly` checks for the
cancel at the top of each chunk and returns on the first check, so `[[SLOW]]`
acks in under 500ms, averaging ~250ms. Two WebSocket pushes bracket that window
and the first push's render can consume all of it.

This adds `[[SLOW_LATEACK]]` to the stub ACP backend. It honours the cancel like
`[[SLOW]]`, but emits `SLOW_LATEACK_CHUNKS` more chunks first (~3s at the
default chunk delay) before acking, then still returns
`stopReason: "cancelled"`. The pulsing spec points at the new marker. No spec is
added or removed, so the `MIN_EXECUTED_SPECS` floor is unchanged.

Two design notes:

- The wind-down is counted in **chunks, not seconds**, so the unit test is
  deterministic and does not read the wall clock.
- The cancel observation is **latched**. `_cancel_requested` calls
  `_poll_inbox`, which consumes the matching message, so a wind-down that
  re-polled each iteration would see `False` on the second pass and never ack.
  There is a regression test for exactly that.

`[[SLOW_NOACK]]` was the smaller change and it does widen the window
(6 pass / 0 fail on the pulsing spec under load). It cannot ship: it leaves the
slot mid-budget with a hard kill pending, and the sibling
`stop resolves to Stopped on soft ack` then failed **4 of 4** full-describe
runs. The wind-down acks well inside `agent.soft_stop_budget_secs`
(default 10.0s), so the turn settles cooperatively and nothing leaks into the
next spec.

## Related Issues

Relates to #934, which lists `chat.spec.ts:156` alongside an embed spec and
attributes both to the i18n Phase 0 wave. That diagnosis does not hold for the
pulsing half: the spec selects by `data-testid`, not by copy, and CI passed a
re-run of the identical commit. The cause is the ack-window race above.

## Testing

- [x] Existing tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

All measurements use one fresh gateway per run with the stub backend asserted to
be serving (a run that cannot prove the stub was wired is discarded, not
counted). Load was reproduced with `nproc` busy loops.

Interleaved A/B on the pulsing spec, 6 pairs, loadavg 25-39:

| Arm | Result |
|---|---|
| `[[SLOW]]` (before) | 2 pass / 4 fail |
| `[[SLOW_LATEACK]]` (after) | 6 pass / 0 fail |

Full `Soft-Stop E2E Tests` describe, 4 runs under load: 4/4 clean, 3 passed each
run. This is the check that rejected `[[SLOW_NOACK]]`, which produced
1 failed / 2 passed on every iteration. Re-verified after rebasing onto current
`main` with a rebuilt frontend bundle: 3/3 clean.

New unit tests, both confirmed non-vacuous by mutating the source:

- `test_slow_lateack_winds_down_then_acks` -- forcing the wind-down count to 0
  gives `assert 0 == 4`.
- `test_slow_lateack_acks_even_if_the_stream_ends_first` -- dropping the latch
  from the final return gives `assert 'end_turn' == 'cancelled'`.

Gates: `test/test_fake_acp_backend.py`, `test/test_e2e_smoke.py` and
`test/test_kiro_prerequisite.py` (selected by grepping the changed symbols
across the test tree) give 158 passed / 12 skipped. `isort`, `flake8 -j 1` and
`mypy` clean. `npx tsc -b` exits 0 and `npx jscpd .` finds 0 clones.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
