### PR TITLE
feat(release): add fail-closed emergency controls

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,13 +14,18 @@ on:
 permissions:
   contents: read
 
-# Single-flight nightly runs. cancel-in-progress also protects the channel
-# feeds (feed/nightly/latest-mac.yml + latest-linux.yml, last-writer-wins):
-# an overlapping older run is cancelled rather than finishing last and
-# rolling a feed back to an older build for every client.
+# Single-flight nightly runs, serialized by queueing. The group is shared
+# with release-emergency-controls.yml (nightly channel), so this workflow
+# must never cancel-in-progress: an emergency freeze/withdraw run in this
+# group has to finish even if the nightly schedule fires mid-run. Queueing
+# still protects the channel feeds (feed/nightly/latest-mac.yml +
+# latest-linux.yml, last-writer-wins): overlapping runs execute in order
+# instead of an older run finishing last and rolling a feed back to an
+# older build for every client. Emergency runs hold cancel-in-progress:
+# true on their side, so they preempt a nightly rather than queue behind it.
 concurrency:
   group: nightly-build
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   version:

--- a/.github/workflows/release-emergency-controls.yml
+++ b/.github/workflows/release-emergency-controls.yml
@@ -1,0 +1,326 @@
+# Break-glass operator workflow for the per-channel release control
+# document at feed/{channel}/release-control.json (the fail-closed
+# contract in scripts/release_feed_control.py and
+# docs/release-automation.md "Emergency release controls").
+#
+# Scope: this workflow manages the control DOCUMENT lifecycle only --
+# bootstrap a channel, freeze/unfreeze, withdraw a version, set/clear the
+# minimum supported version, or mark a restore generation. It does NOT
+# rewind feeds to recovery snapshots and the publishers do not yet call
+# `guard`; that wiring ships separately (see the runbook's operational
+# dependency list) because enabling the guard before every channel is
+# bootstrapped and unfrozen would fail-close all publishing.
+#
+# Controls, per the documented contract:
+#   - main-only: the validate job hard-fails on any other ref, and the
+#     execute job (which holds the prod environment + OIDC role) is
+#     additionally gated on refs/heads/main.
+#   - typed confirmation: the `confirm` input must be exactly
+#     "<channel>:<operation>".
+#   - prod environment: same required-reviewer approval gate and
+#     write-only OIDC publishing role as the release publishers. The role
+#     needs only s3:PutObject on feed/*; every read/verification goes
+#     through the public CDN (the read plane).
+#   - two-scope concurrency: all emergency runs serialize in one queued
+#     workflow-level group (a dispatch cancels nothing at queue time),
+#     and only the validated, approved `execute` job enters the
+#     publishers' groups -- `nightly-build` for nightly, `release-publish`
+#     shared by insider AND stable -- with cancel-in-progress: true to
+#     preempt an in-flight publish. The publishers queue rather than
+#     cancel in those groups, so they can never cancel emergency work.
+#
+# Every run ends by re-reading the document through the public CDN and
+# byte-comparing it to what was written, so success means the emergency
+# state is actually being served (CloudFront max-age=300 bounds the wait).
+
+name: Release Emergency Controls
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release channel"
+        required: true
+        type: choice
+        options: [nightly, insider, stable]
+      operation:
+        description: "Control-document operation"
+        required: true
+        type: choice
+        options:
+          - bootstrap
+          - freeze
+          - unfreeze
+          - withdraw
+          - set-minimum
+          - clear-minimum
+          - restore
+      version:
+        description: "SemVer (required for withdraw / set-minimum; must be empty otherwise)"
+        required: false
+        type: string
+        default: ""
+      reason:
+        description: "Incident reference and operator rationale (recorded in the document)"
+        required: true
+        type: string
+      confirm:
+        description: "Type '<channel>:<operation>' to confirm (e.g. stable:freeze)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# Concurrency is split across two scopes so that nothing is ever cancelled
+# by an unvalidated or unapproved dispatch:
+#
+#   - Workflow level (here): ALL emergency runs serialize in one queued
+#     group. `queue: max` keeps every pending dispatch (FIFO, up to 100)
+#     instead of GitHub's default single-slot queue, where a newer
+#     dispatch -- even one that would fail validation -- silently replaces
+#     a pending freeze/withdraw. A second dispatch waits; it can never
+#     cancel a control mutation mid-flight, and entering this group
+#     cancels nothing. Known property, shared with the publishers (which
+#     hold their groups while awaiting the same prod approval): a
+#     dispatch left unapproved holds this queue until it is approved,
+#     rejected, or cancelled from the Actions tab -- cancel stale
+#     dispatches rather than stacking new ones.
+#   - Job level (on `execute`): only the execute job -- which runs strictly
+#     after input/ref validation has passed and the `prod` environment
+#     approval has been granted -- enters the publishers' group
+#     (`nightly-build` for the nightly channel; `release-publish`, which
+#     insider and stable releases share) with cancel-in-progress: true,
+#     preempting an in-flight publish. The publishers queue rather than
+#     cancel in those groups, so they can never cancel emergency work.
+#
+# A dispatch from a non-main ref, with a failed typed confirmation, or
+# left unapproved therefore skips the execute job entirely and never
+# touches the publisher groups.
+concurrency:
+  group: release-emergency-controls
+  queue: max
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      CHANNEL: ${{ inputs.channel }}
+      OPERATION: ${{ inputs.operation }}
+      VERSION: ${{ inputs.version }}
+      REASON: ${{ inputs.reason }}
+      CONFIRM: ${{ inputs.confirm }}
+    steps:
+      - name: Enforce main-only dispatch
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Emergency controls must be dispatched from main (got ${GITHUB_REF})."
+          exit 1
+
+      - name: Validate typed confirmation and inputs
+        run: |
+          set -euo pipefail
+          EXPECTED="${CHANNEL}:${OPERATION}"
+          if [ "${CONFIRM}" != "${EXPECTED}" ]; then
+            echo "::error::Confirmation mismatch: expected '${EXPECTED}'."
+            exit 1
+          fi
+          if [ -z "${REASON// /}" ]; then
+            echo "::error::A non-empty reason is required."
+            exit 1
+          fi
+          case "${OPERATION}" in
+            withdraw|set-minimum)
+              if [ -z "${VERSION}" ]; then
+                echo "::error::Operation '${OPERATION}' requires the version input."
+                exit 1
+              fi
+              ;;
+            *)
+              if [ -n "${VERSION}" ]; then
+                echo "::error::Operation '${OPERATION}' does not take a version; leave it empty."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "Validated: ${EXPECTED}"
+
+      - name: Require distribution configuration
+        env:
+          DIST_BUCKET: ${{ vars.CLI_DIST_BUCKET }}
+          CDN_BASE: ${{ vars.CLI_CDN_BASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DIST_BUCKET}" ] || [ -z "${CDN_BASE}" ]; then
+            echo "::error::CLI_DIST_BUCKET / CLI_CDN_BASE repository variables are not configured."
+            exit 1
+          fi
+
+  execute:
+    name: Apply ${{ inputs.operation }} to ${{ inputs.channel }}
+    needs: validate
+    # Redundant with the validate gate by design: this job holds the prod
+    # environment and the OIDC subject, so it must independently refuse
+    # any ref that is not main.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: prod
+    # Publisher preemption lives HERE, not at the workflow level: this job
+    # is reached only after validate has passed and the prod approval has
+    # been granted, so only a validated, approved emergency operation can
+    # cancel an in-flight publish. Insider and stable share the
+    # release-publish group (mirroring release.yml, which serializes both
+    # channels), so an approved emergency run on either of those channels
+    # preempts an in-flight release publish of either.
+    concurrency:
+      group: ${{ inputs.channel == 'nightly' && 'nightly-build' || 'release-publish' }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CHANNEL: ${{ inputs.channel }}
+      OPERATION: ${{ inputs.operation }}
+      VERSION: ${{ inputs.version }}
+      REASON: ${{ inputs.reason }}
+      CDN_BASE: ${{ vars.CLI_CDN_BASE }}
+      DIST_BUCKET: ${{ vars.CLI_DIST_BUCKET }}
+      CONTROL_KEY: feed/${{ inputs.channel }}/release-control.json
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: scripts/release_feed_control.py
+          sparse-checkout-cone-mode: false
+
+      - name: Require publishing role
+        env:
+          HAS_ROLE: ${{ secrets.AWS_SIGNING_ROLE_ARN != '' && 'true' || '' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HAS_ROLE}" ]; then
+            echo "::error::AWS_SIGNING_ROLE_ARN is not configured for the prod environment."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Produce control document (bootstrap)
+        if: inputs.operation == 'bootstrap'
+        run: |
+          set -euo pipefail
+          # Existence is NOT probed through the CDN here: a 403 cannot
+          # distinguish "absent" from "present but unreadable", and
+          # guessing wrong would overwrite live control state. The upload
+          # step below enforces create-only at the origin instead.
+          python3 scripts/release_feed_control.py bootstrap \
+            --channel "${CHANNEL}" \
+            --reason "${REASON}" \
+            --output /tmp/control.json
+
+      - name: Produce control document (mutate)
+        if: inputs.operation != 'bootstrap'
+        run: |
+          set -euo pipefail
+          # fetch applies the full fail-closed validation (size cap,
+          # schema, channel match, HTTPS origin) before any mutation. A
+          # missing or malformed document therefore stops here: bootstrap
+          # handles the missing case, and a corrupted document is an
+          # operator-recovery scenario this workflow refuses to paper over.
+          python3 scripts/release_feed_control.py fetch \
+            --url "${CDN_BASE}/${CONTROL_KEY}" \
+            --channel "${CHANNEL}" \
+            --output /tmp/current.json
+          python3 scripts/release_feed_control.py mutate \
+            --input /tmp/current.json \
+            --channel "${CHANNEL}" \
+            --operation "${OPERATION}" \
+            --version "${VERSION}" \
+            --reason "${REASON}" \
+            --output /tmp/control.json
+
+      - name: Upload control document (create-only bootstrap)
+        if: inputs.operation == 'bootstrap'
+        run: |
+          set -euo pipefail
+          # S3 conditional write: If-None-Match: * makes the origin itself
+          # refuse the PUT when any object already exists at the key
+          # (412 PreconditionFailed), atomically -- no read access or CDN
+          # inference needed, so bootstrap can never reset an active
+          # freeze, withdrawal list, or generation history. Requires
+          # s3api put-object; the high-level `aws s3 cp` has no
+          # conditional-write support.
+          if ! ERR=$(aws s3api put-object \
+              --bucket "${DIST_BUCKET}" \
+              --key "${CONTROL_KEY}" \
+              --body /tmp/control.json \
+              --content-type application/json \
+              --cache-control "public, max-age=300" \
+              --if-none-match '*' 2>&1); then
+            if printf '%s' "${ERR}" | grep -q 'PreconditionFailed'; then
+              echo "::error::A control document already exists for ${CHANNEL}; use a mutate operation."
+            else
+              echo "::error::Bootstrap upload failed: ${ERR}"
+            fi
+            exit 1
+          fi
+          echo "Created s3://${DIST_BUCKET}/${CONTROL_KEY}"
+
+      - name: Upload control document (mutate)
+        if: inputs.operation != 'bootstrap'
+        run: |
+          set -euo pipefail
+          aws s3 cp /tmp/control.json "s3://${DIST_BUCKET}/${CONTROL_KEY}" \
+            --content-type application/json \
+            --cache-control "public, max-age=300"
+          echo "Wrote s3://${DIST_BUCKET}/${CONTROL_KEY}"
+
+      - name: Verify served control state
+        run: |
+          set -euo pipefail
+          # The CDN is the read plane guard() consumes, so success is
+          # defined as the CDN serving exactly what was written. Overwrites
+          # propagate within the feed norm max-age=300; poll past one full
+          # TTL before failing.
+          CONTROL_URL="${CDN_BASE}/${CONTROL_KEY}"
+          for attempt in $(seq 1 16); do
+            if python3 scripts/release_feed_control.py fetch \
+                 --url "${CONTROL_URL}" \
+                 --channel "${CHANNEL}" \
+                 --output /tmp/served.json \
+               && cmp -s /tmp/control.json /tmp/served.json; then
+              echo "CDN serves the new control document (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/16: CDN not yet serving the new document; retrying in 30s."
+            sleep 30
+          done
+          echo "::error::CDN never served the written control document within the polling window."
+          exit 1
+
+      - name: Record audit summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## Emergency control: ${OPERATION} on ${CHANNEL}"
+            echo ""
+            echo "- Reason: ${REASON}"
+            echo "- Object: \`s3://${DIST_BUCKET}/${CONTROL_KEY}\`"
+            echo "- Read plane: ${CDN_BASE}/${CONTROL_KEY}"
+            echo ""
+            if [ -f /tmp/control.json ]; then
+              echo '```json'
+              cat /tmp/control.json
+              echo '```'
+            else
+              echo "_No control document was produced (validation or fetch failed)._"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -43,8 +43,14 @@ this — it only reacts to a pushed tag, which is why there is no
 `beta-cut.yml`, `beta-hotfix.yml`, or `promote-stable.yml`. See
 CONTRIBUTING.md → "Releasing New Versions" for the process itself.
 
-There is no `rollback.yml` and no rollback mechanism: **we roll forward by
-cutting a new version.**
+There is no production `rollback.yml` yet. Normal incident recovery remains a
+roll-forward release. The launch-readiness emergency-control contract is now
+implemented and tested in `scripts/release_feed_control.py`. Desktop clients that
+contain this implementation honor its `minimumSupportedVersion` /
+`withdrawnVersions` feed metadata; already-deployed older clients do not enforce
+those fields and cannot be retrofitted by changing a feed. The contract is **not
+an operational control until the CDN publisher integration listed under
+"Emergency release controls" below is deployed and bootstrapped**.
 
 **Buckets (as built) — two, not one:**
 
@@ -138,10 +144,103 @@ other escape.
    electron-builder DMG)
 
 **Feed-ordering protection (as built):** workflow-level `concurrency`
-groups (nightly: `cancel-in-progress: true`; release: queued) prevent an
-older run finishing last from rolling a channel feed backward. There is no
-`blocked-versions.json` and no rollback workflow: the recovery path is to
-**roll forward** — cut a new version and let the feed advance to it.
+groups (nightly and release: both queued/serialized) prevent an older run
+finishing last from rolling a channel feed backward; only emergency-control
+runs carry cancellation rights in those groups. Production still has no
+deployed guard on the publishers; the contract and dependency are below.
+
+### Emergency release controls (fail-closed contract; deployment dependency)
+
+`scripts/release_feed_control.py` is the stdlib-only contract shared by normal
+publishers and the break-glass workflow
+(`.github/workflows/release-emergency-controls.yml`). Per channel it validates this
+bounded public document at `feed/{channel}/release-control.json`:
+
+```json
+{
+  "schema_version": 1,
+  "channel": "stable",
+  "frozen": true,
+  "minimum_supported_version": "1.2.3",
+  "withdrawn_versions": ["1.2.2"],
+  "generation": 4,
+  "updated_at": "2026-08-01T00:00:00Z",
+  "reason": "incident reference and operator rationale"
+}
+```
+
+The contract is fail-closed in both directions:
+
+- `guard` refuses a pointer write when the document is missing, unreachable,
+  oversized, malformed, channel-mismatched, frozen, or when the candidate is
+  withdrawn/below the floor. It exports only newline-free validated values.
+- `snapshot` validates the currently served feed before it can become
+  `feed/{channel}/recovery/latest-*`; a same-version retry never rotates away
+  the prior last-known-good snapshot.
+- `rewrite` preserves artifact URLs and digests while applying the floor and
+  withdrawal list. It refuses a recovery target that is withdrawn, below the
+  floor, malformed, or outside the configured HTTPS byte host.
+- `bootstrap` starts **frozen**. Restore/withdraw operations also stay frozen;
+  returning to service is a separate reviewed `unfreeze` generation.
+- Immutable versioned artifacts are never deleted. Withdrawal rewinds mutable
+  feeds and human-download aliases to validated recovery metadata; normal
+  recovery remains roll-forward when that is faster/safer.
+
+Desktop clients containing this implementation consume the two extra
+electron-updater metadata fields. A build below `minimumSupportedVersion` or
+named in `withdrawnVersions` starts the sha512-verified download without ordinary
+download consent; this active floor/withdrawal policy is the explicit emergency
+exception to the normal consent-first flow. Once staged, its modal has no Later,
+close, Escape, or backdrop dismissal. Malformed policy, a withdrawn target, or a
+target below the floor is rejected before download. Older deployed clients lack
+this enforcement and cannot be made mandatory retroactively through feed data.
+
+This feed-served floor is deliberately distinct from the enterprise-governance
+`updates.min_version` in `security_policy.json`
+(`src/kiro_crew/platform/update_governance.py`): that value is an
+administrator's policy for gateway installs they already manage and reaches
+only machines carrying that local file, while `minimum_supported_version` is a
+release-operator action on the public CDN that reaches every desktop install.
+They intentionally share no source, plumbing, or precedence; an install
+subject to both simply satisfies each independently.
+
+**Exact operational dependency (item 1 ships in this repository; items 2–5
+remain outstanding):**
+
+1. **Implemented in this change:**
+   `.github/workflows/release-emergency-controls.yml` is the protected,
+   `main`-only `workflow_dispatch` using the `prod` environment and a typed
+   confirmation (`<channel>:<operation>`). Emergency runs serialize in their
+   own queued group; only the validated, approved execute job enters the
+   publishers' groups (`nightly-build` for nightly; `release-publish`, which
+   insider and stable share, so an emergency run on either preempts an
+   in-flight release publish of either) with
+   emergency runs allowed to cancel a publisher and publishers forbidden from
+   cancelling emergency work.
+2. Wire **every** mutable writer in `sign-and-notarize.yml`,
+   `publish-linux.yml`, and `publish-cli.yml` to call `guard` immediately before
+   its first feed/index/alias write, snapshot the previous valid live pointer,
+   and inject both control fields. A failed guard must stop the pointer chain.
+   For CLI publishing, `guard --candidate-version` must receive the release's
+   human-readable canonical SemVer label, not the PEP 440 wheel version stored in
+   `latest-cli.json`; the latter remains the installer-facing package version.
+3. Bootstrap `nightly`, `insider`, and `stable` before enabling that guard:
+   create generation 1 with `frozen=true`, seed all current feeds as recovery,
+   verify bytes through the public CDN, then separately unfreeze. Otherwise the
+   deliberately missing-control failure will stop the next release.
+4. The external KiroCrewPublishCDK OIDC role must continue to grant only
+   `s3:PutObject` on the distribution bucket's `feed/*` and mutable
+   `desktop/*/latest/*` keys. No `s3:GetObject`, object deletion, CloudFront
+   invalidation, signing-bucket access, or secret reads are needed: bounded
+   reads and verification use the public HTTPS CDN. Protect the `prod`
+   environment with required reviewers because its OIDC subject can publish.
+5. Run one non-production bucket/CDN rehearsal covering bootstrap → unfreeze →
+   publish → freeze → withdraw/restore → unfreeze, then record the production
+   object/version evidence. This repository has no production CDN/signing
+   credentials, so that deployment/rehearsal cannot be truthfully claimed here.
+
+Until all five items are complete, operators must treat the helper as a tested
+contract, **not** as evidence that production feeds are frozen or recoverable.
 
 **CLI channel (repository implementation; external enablement pending):**
 `publish-cli.yml` is wired to publish the wheel +

--- a/docs/release-process-design.md
+++ b/docs/release-process-design.md
@@ -46,9 +46,9 @@ the strongest quotes are cited so the provenance is checkable.
 |---|---|---|---|
 | P1 | The user gets an easy-to-install, packaged, signed and notarized native application, for macOS and Linux and in the future Windows, without needing a terminal or a Python setup | macOS: done, all Macs (Developer-ID-signed universal DMG, "ready for distribution" per `syspolicy_check`). Linux: packaged (AppImage) with signed SLSA provenance; not code-signed by design, since Linux has no Gatekeeper equivalent. Windows: source install only | #108 ("DMG for the first install, zip feed for every update after"), #137/#139/#144 (the DMG must survive Gatekeeper on a real user machine), #152 ("Every Intel-Mac user is locked out", which led to the universal app), #162 ("a link a human can click or paste into docs"), #63 (install must fail closed or auto-provision, never produce a broken install) |
 | P2 | Multiple release channels, so contributors get the latest build while normal users get a stable, tested build | Done: nightly, insider, and stable all live (insider 2026-07-22 18:47 UTC, stable v0.1.0 2026-07-22 19:36 UTC, each with 7 verified public surfaces). Nightly ships as a separate side-by-side app; insider/stable are two update lanes of one app | #132 ("pip/cli.sh users could never track insider or stable"), #176 (tag releases must be able to publish), #193 ("a nightly and the production app can be installed together"), #224 (in-place channel opt-in, "the Slack-beta model") |
-| P3 | Users self-update directly from the app, without ever touching the CLI or terminal, and nothing downloads or installs without explicit consent | macOS: done, macOS Software Update semantics (a check only discovers; update card with explicit Download & Install; nudge is inform-only). Linux: done — the desktop AppImage self-updates through the electron-updater feed (`latest-linux.yml`), and the CLI lane self-updates (channel-sticky, sha256-verified via `latest-cli.json`) | #98 (close the gaps so auto-update "actually delivers bytes publicly"), #125 ("explicit user consent… Nothing downloads automatically"), #241 ("inform only — download and install stay in Settings > About"), #224 ("Switching never downloads or installs by itself") |
-| P4 | A bad release can be pulled back quickly, so users are not stranded on a broken build | Partial: pullback exercised once for real (#137 withdrew the Gatekeeper-broken DMG from every public surface); the pointer mechanics exist (mutable latest aliases + immutable versioned keys), but rollback automation and force-update (`blocked-versions`) remain unbuilt | #137 (the one live pullback event), #162/#132/#133 (mutable-pointer + never-republish discipline a rollback would flip) |
-| P5 | Users behind a minimum required version can be forced to update: a critical security patch must have a guaranteed propagation path | Designed, not built: pairs with P4's rollback design (the feed serves a minimum-version floor; clients below it force-trigger the update flow) | Design articulated alongside rollback and the update nudge; no dedicated PR yet |
+| P3 | Users self-update directly from the app without touching the CLI or terminal. Ordinary updates require explicit download/install consent; a valid active minimum-version floor or withdrawal is the explicit emergency exception | macOS: done for the ordinary consent flow (a check only discovers; update card with explicit Download & Install; nudge is inform-only). Linux: done — the desktop AppImage self-updates through the electron-updater feed (`latest-linux.yml`), and the CLI lane self-updates (channel-sticky, sha256-verified via `latest-cli.json`). Clients containing the emergency implementation automatically download a compliant verified desktop target and remove staged-update dismissal while the emergency policy applies | #98 (close the gaps so auto-update "actually delivers bytes publicly"), #125 ("explicit user consent… Nothing downloads automatically"), #241 ("inform only — download and install stay in Settings > About"), #224 ("Switching never downloads or installs by itself"); emergency exception: Electron updater tests |
+| P4 | A bad release can be pulled back quickly, so users are not stranded on a broken build | Contract + upgraded-client behavior built, production wiring pending: fail-closed freeze/withdraw/last-known-good helpers and tests exist, but the protected CDN writer and per-channel bootstrap are the exact remaining operational dependency. Older deployed clients cannot gain this behavior from feed changes alone | `scripts/release_feed_control.py`, `test/test_release_feed_control.py`, and the dependency checklist in `release-automation.md` |
+| P5 | Users behind a minimum required version can be forced to update: a critical security patch must have a guaranteed propagation path | Upgraded-client + feed contract built, production wiring pending: `minimumSupportedVersion` is validated fail-closed and forces the verified download/non-dismissible staged flow only in clients containing this implementation; publishers must still be wired and bootstrapped before operators can set the floor | Electron updater tests + `test/test_release_feed_control.py`; operational dependency in `release-automation.md` |
 
 ### Engineering requirements
 
@@ -106,8 +106,9 @@ separate installable app (KiroCrew Nightly.app, its own icon, shared
 bundle id) so a nightly and the production app can be installed side by
 side; insider and stable are two update lanes of one production app, with
 an in-place Stable/Insider switcher in Settings, the Slack-beta model.
-Switching channels never downloads or installs by itself; the consent
-flow (section 6) is unchanged.
+Switching channels never downloads or installs by itself; the ordinary consent
+flow (section 6) is unchanged unless a valid active floor/withdrawal policy makes
+the emergency exception apply.
 
 ## 3. Versioning
 
@@ -235,7 +236,9 @@ Rules that make the scheme work:
    date, schema, algorithm, and key id. The installer verifies that signature
    against its offline pin before consuming artifact metadata, then verifies
    the downloaded wheel against the authenticated digest. Both checks fail
-   closed.
+   closed. Future CLI publisher guard calls must separately pass the
+   human-readable canonical SemVer release label; the PEP 440 wheel version
+   is not the control-policy key.
 5. pip installs use `--extra-index-url` against the channel's simple
    index, keeping PyPI available for dependency resolution.
 
@@ -465,9 +468,11 @@ hold. These are the invariants; the per-OS mechanics are free.
    working publish lane (`SUPPORTED_PLATFORMS` in `auto-update.js`);
    adding the lane means adding the platform there.
 9. Roll-forward: a new version published to the lane MUST reach clients
-   through the same feed + updater path, since **rolling forward is the only
-   recovery mechanism** — there is no rollback. A lane whose updater cannot
-   pick up a newer version has no recovery story and is not supported.
+   through the same feed + updater path; this remains the normal recovery path.
+   Emergency pointer restore is a break-glass exception and is not operational
+   until the protected CDN wiring in `release-automation.md` is deployed. A lane
+   whose updater cannot pick up the roll-forward or a restored pointer has no
+   recovery story and is not supported.
 10. Retention: the lane's artifacts follow the channel lifecycle (nightly
     expiring, stable pinned), so no lane accumulates unbounded nightly
     artifacts.
@@ -478,8 +483,8 @@ Open as of 2026-07-28:
 
 | Item | Type | Notes |
 |---|---|---|
-| Rollback automation (P4) | **dropped** | Superseded by process decision: **there is no rollback — we roll forward by cutting a new version.** The `rollback.yml` + `blocked-versions` design described in P4/P5 above is not being built. The client-side capability remains (`allowDowngrade=true`, so a repointed feed *would* be offered), but the operational answer to a bad release is a new version cut from the release branch, not a feed rewind |
-| Forced minimum version (P5) | roadmap | Unbuilt and independent of rollback: a feed-served minimum-version floor that force-triggers the update flow for a critical security patch |
+| Emergency restore (P4) | integration pending | The fail-closed freeze/withdraw/recovery contract and tests are built. Production still needs the protected per-channel writer lock, publisher guard/snapshot wiring, and bootstrap rehearsal listed in `release-automation.md`; until then roll-forward remains the only operational recovery |
+| Forced minimum version (P5) | integration pending | Desktop enforcement and strict feed metadata validation are built. The floor cannot be operated until every publisher preserves it and the production control object is bootstrapped |
 | S3 lifecycle rules | roadmap | Designed (intermediates 7d, nightly 30d, insider 180d, stable forever); unmanaged growth is ~1 TB/year |
 | Windows lane | roadmap | CI builds a Squirrel.Windows `Setup.exe` (installer-only, unpublished); win32 auto-update stays disabled in the client until the NSIS migration (#598); the supported install path is still source |
 | Update-consent nudge polish, custom icon setting | roadmap | Nudge dots shipped; Settings card for custom icons deliberately deferred |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -49,8 +49,14 @@ human process; the pipeline only reacts to the tag.
 
 Each build ships a signed and notarized macOS app, a Linux AppImage, a CLI
 installer, a pip wheel, and a Docker image. The update feed for a channel is
-repointed last, after the artifacts are verified downloadable, and clients only
-install with the user's consent. Windows builds but is not yet signed or
-published.
+repointed last, after the artifacts are verified downloadable. Ordinary updates
+install only with the user's consent; a valid active minimum-version floor or
+withdrawal is the explicit emergency exception for clients containing that
+implementation. Windows builds but is not yet signed or published.
 
-There is no rollback: we roll forward by cutting a new version.
+Normal recovery is roll-forward: cut a new version. A tested emergency-feed
+contract now defines freeze, withdrawal, last-known-good restore, and a
+minimum-supported-version floor, but it is not operational until the protected
+publisher/CDN wiring and per-channel bootstrap in `release-automation.md` are
+completed. Already-deployed older clients do not enforce this metadata and cannot
+be retrofitted through a feed change.

--- a/scripts/release_feed_control.py
+++ b/scripts/release_feed_control.py
@@ -1,0 +1,949 @@
+#!/usr/bin/env python3
+"""Fail-closed helpers for release-feed emergency controls.
+
+The public CDN is the read plane because the production publisher role is
+intentionally write-only for ``feed/*``.  Every mutable pointer writer calls
+``guard`` immediately before changing a feed.  Missing, oversized, malformed,
+or frozen control state therefore blocks the pointer mutation while leaving
+immutable release artifacts untouched.
+
+This file is stdlib-only so GitHub-hosted runners can use it without installing
+packages after assuming the production publishing role.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import ipaddress
+import json
+import re
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Sequence
+
+CONTROL_SCHEMA_VERSION = 1
+ALLOWED_CHANNELS = frozenset({"nightly", "insider", "stable"})
+CONTROL_KEYS = frozenset(
+    {
+        "schema_version",
+        "channel",
+        "frozen",
+        "minimum_supported_version",
+        "withdrawn_versions",
+        "generation",
+        "updated_at",
+        "reason",
+    }
+)
+FEED_NAMES = frozenset(
+    {"latest-mac.yml", "latest-linux.yml", "latest-mac.json", "latest-cli.json"}
+)
+MAX_CONTROL_BYTES = 32 * 1024
+MAX_FEED_BYTES = 128 * 1024
+MAX_REASON_CHARS = 500
+MAX_WITHDRAWN_VERSIONS = 100
+MAX_FEED_FILES = 10
+MAX_VERSION_CHARS = 128
+_HTTP_TIMEOUT_SECS = 15
+
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_BASE64_SHA512_RE = re.compile(r"^[A-Za-z0-9+/]{86}==$")
+_OPAQUE_VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.!+_-]*$")
+
+
+class ReleaseControlError(ValueError):
+    """A release-control or feed contract violation."""
+
+
+def _require_channel(channel: Any) -> str:
+    if not isinstance(channel, str) or channel not in ALLOWED_CHANNELS:
+        raise ReleaseControlError(
+            f"channel must be one of {sorted(ALLOWED_CHANNELS)}, got {channel!r}"
+        )
+    return channel
+
+
+def _parse_semver(value: Any, *, field: str, allow_empty: bool = False) -> tuple:
+    if allow_empty and value == "":
+        return ()
+    if not isinstance(value, str):
+        raise ReleaseControlError(f"{field} must be a string")
+    if len(value) > MAX_VERSION_CHARS:
+        # Also bounds every numeric component BEFORE int(): Python 3.12 raises
+        # a plain ValueError for >4300-digit conversions, which would escape
+        # the fail-closed ReleaseControlError contract as a raw traceback.
+        raise ReleaseControlError(
+            f"{field} must contain at most {MAX_VERSION_CHARS} characters"
+        )
+    match = _SEMVER_RE.fullmatch(value)
+    if not match:
+        raise ReleaseControlError(f"{field} must be a canonical SemVer value, got {value!r}")
+    prerelease = match.group(4)
+    identifiers: tuple[tuple[int, Any], ...] = ()
+    if prerelease is not None:
+        parsed: list[tuple[int, Any]] = []
+        for identifier in prerelease.split("."):
+            if identifier.isdigit():
+                if len(identifier) > 1 and identifier.startswith("0"):
+                    raise ReleaseControlError(
+                        f"{field} has a numeric prerelease identifier with a leading zero"
+                    )
+                parsed.append((0, int(identifier)))
+            else:
+                parsed.append((1, identifier))
+        identifiers = tuple(parsed)
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)), identifiers)
+
+
+def _semver_lt(left: str, right: str) -> bool:
+    l_major, l_minor, l_patch, l_pre = _parse_semver(left, field="version")
+    r_major, r_minor, r_patch, r_pre = _parse_semver(right, field="version")
+    core_left = (l_major, l_minor, l_patch)
+    core_right = (r_major, r_minor, r_patch)
+    if core_left != core_right:
+        return core_left < core_right
+    if not l_pre:
+        return False  # a release is newer than any prerelease of the same core
+    if not r_pre:
+        return True
+    for left_id, right_id in zip(l_pre, r_pre):
+        if left_id == right_id:
+            continue
+        # Numeric identifiers have lower precedence than non-numeric ones.
+        if left_id[0] != right_id[0]:
+            return left_id[0] < right_id[0]
+        return left_id[1] < right_id[1]
+    return len(l_pre) < len(r_pre)
+
+
+def _timestamp(value: Any, *, field: str = "updated_at") -> str:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise ReleaseControlError(
+            f"{field} must be an RFC 3339 UTC timestamp ending in Z"
+        )
+    try:
+        dt.datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise ReleaseControlError(f"{field} must be a valid RFC 3339 timestamp") from exc
+    return value
+
+
+def _now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _reason(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ReleaseControlError("reason must be a string")
+    value = value.strip()
+    if (
+        not value
+        or len(value) > MAX_REASON_CHARS
+        or any(ord(character) < 0x20 for character in value)
+    ):
+        raise ReleaseControlError(
+            f"reason must contain 1-{MAX_REASON_CHARS} characters without controls"
+        )
+    return value
+
+
+def _opaque_version(value: Any, *, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > MAX_VERSION_CHARS
+        or not _OPAQUE_VERSION_RE.fullmatch(value)
+    ):
+        raise ReleaseControlError(
+            f"{field} must be a non-empty, bounded release version"
+        )
+    return value
+
+
+def _feed_version(value: Any, feed_name: str, *, field: str) -> str:
+    if feed_name == "latest-cli.json":
+        return _opaque_version(value, field=field)
+    _parse_semver(value, field=field)
+    return value
+
+
+def validate_control(raw: Any, *, expected_channel: str | None = None) -> dict[str, Any]:
+    """Validate and normalize one release-control document."""
+    if not isinstance(raw, dict):
+        raise ReleaseControlError("release control must be a JSON object")
+    keys = frozenset(raw)
+    if keys != CONTROL_KEYS:
+        missing = sorted(CONTROL_KEYS - keys)
+        unknown = sorted(keys - CONTROL_KEYS)
+        raise ReleaseControlError(
+            f"release control keys do not match schema (missing={missing}, unknown={unknown})"
+        )
+    if raw["schema_version"] != CONTROL_SCHEMA_VERSION:
+        raise ReleaseControlError(
+            f"unsupported release-control schema_version {raw['schema_version']!r}"
+        )
+    channel = _require_channel(raw["channel"])
+    if expected_channel is not None and channel != _require_channel(expected_channel):
+        raise ReleaseControlError(
+            f"control channel {channel!r} does not match requested channel {expected_channel!r}"
+        )
+    if type(raw["frozen"]) is not bool:  # bool only; integers are not accepted
+        raise ReleaseControlError("frozen must be a JSON boolean")
+    minimum = raw["minimum_supported_version"]
+    _parse_semver(minimum, field="minimum_supported_version", allow_empty=True)
+    withdrawn = raw["withdrawn_versions"]
+    if not isinstance(withdrawn, list) or len(withdrawn) > MAX_WITHDRAWN_VERSIONS:
+        raise ReleaseControlError(
+            f"withdrawn_versions must be a JSON array with at most {MAX_WITHDRAWN_VERSIONS} entries"
+        )
+    normalized_withdrawn: list[str] = []
+    for index, version in enumerate(withdrawn):
+        _parse_semver(version, field=f"withdrawn_versions[{index}]")
+        if version in normalized_withdrawn:
+            raise ReleaseControlError(f"withdrawn_versions contains duplicate {version!r}")
+        normalized_withdrawn.append(version)
+    generation = raw["generation"]
+    if type(generation) is not int or generation < 1:
+        raise ReleaseControlError("generation must be an integer >= 1")
+    return {
+        "schema_version": CONTROL_SCHEMA_VERSION,
+        "channel": channel,
+        "frozen": raw["frozen"],
+        "minimum_supported_version": minimum,
+        "withdrawn_versions": normalized_withdrawn,
+        "generation": generation,
+        "updated_at": _timestamp(raw["updated_at"]),
+        "reason": _reason(raw["reason"]),
+    }
+
+
+def bootstrap_control(channel: str, reason: str, *, now: str | None = None) -> dict[str, Any]:
+    """Create the first control document, frozen by default."""
+    return validate_control(
+        {
+            "schema_version": CONTROL_SCHEMA_VERSION,
+            "channel": _require_channel(channel),
+            "frozen": True,
+            "minimum_supported_version": "",
+            "withdrawn_versions": [],
+            "generation": 1,
+            "updated_at": now or _now(),
+            "reason": _reason(reason),
+        }
+    )
+
+
+def mutate_control(
+    control: dict[str, Any],
+    operation: str,
+    *,
+    reason: str,
+    version: str = "",
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Apply one audited emergency operation to a valid control document."""
+    updated = validate_control(control)
+    updated["generation"] += 1
+    updated["updated_at"] = now or _now()
+    updated["reason"] = _reason(reason)
+
+    if operation == "freeze":
+        updated["frozen"] = True
+    elif operation == "unfreeze":
+        updated["frozen"] = False
+    elif operation == "restore":
+        # A restore is deliberately sticky: a normal publisher cannot race the
+        # recovered pointers until an operator separately unfreezes the channel.
+        updated["frozen"] = True
+    elif operation == "withdraw":
+        _parse_semver(version, field="withdraw version")
+        updated["frozen"] = True
+        if version not in updated["withdrawn_versions"]:
+            updated["withdrawn_versions"].append(version)
+    elif operation == "set-minimum":
+        _parse_semver(version, field="minimum supported version")
+        updated["minimum_supported_version"] = version
+    elif operation == "clear-minimum":
+        updated["minimum_supported_version"] = ""
+    else:
+        raise ReleaseControlError(f"unsupported operation {operation!r}")
+    return validate_control(updated)
+
+
+def _decode_json(data: bytes, *, source: str) -> Any:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        parsed: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in parsed:
+                raise ReleaseControlError(
+                    f"{source} repeats JSON object key {key!r}"
+                )
+            parsed[key] = value
+        return parsed
+
+    try:
+        return json.loads(data.decode("utf-8"), object_pairs_hook=reject_duplicates)
+    except ReleaseControlError:
+        raise
+    except (UnicodeDecodeError, ValueError) as exc:
+        # ValueError (not just JSONDecodeError): a >4300-digit number inside
+        # otherwise-bounded JSON raises Python's int-conversion limit as a
+        # plain ValueError, which must fail closed, not traceback.
+        raise ReleaseControlError(f"{source} is not valid UTF-8 JSON") from exc
+
+
+def _load_json(path: Path, *, limit: int) -> Any:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise ReleaseControlError(f"cannot read {path}: {exc}") from exc
+    if len(data) > limit:
+        raise ReleaseControlError(f"{path} exceeds the {limit}-byte limit")
+    return _decode_json(data, source=str(path))
+
+
+def _safe_url(url: str) -> str:
+    try:
+        parsed = urllib.parse.urlsplit(url)
+    except ValueError as exc:
+        raise ReleaseControlError("control URL is invalid") from exc
+    if parsed.username is not None or parsed.password is not None:
+        raise ReleaseControlError("URLs containing credentials are not permitted")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ReleaseControlError("URL port is invalid") from exc
+    if parsed.fragment or not parsed.hostname:
+        raise ReleaseControlError("URL must have a host and no fragment")
+    if parsed.scheme == "https":
+        return url
+    if parsed.scheme != "http":
+        raise ReleaseControlError("URL must use HTTPS (HTTP is test-only on loopback)")
+    host = parsed.hostname
+    try:
+        loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        loopback = host == "localhost"
+    if not loopback:
+        raise ReleaseControlError("plain HTTP is permitted only for loopback tests")
+    return url
+
+
+def _url_origin(url: str) -> tuple[str, str, int]:
+    parsed = urllib.parse.urlsplit(_safe_url(url))
+    default_port = 443 if parsed.scheme == "https" else 80
+    return parsed.scheme, parsed.hostname.lower(), parsed.port or default_port
+
+
+class _SameOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Allow redirects only within the original public origin."""
+
+    def __init__(self, origin: tuple[str, str, int]) -> None:
+        super().__init__()
+        self._origin = origin
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        if _url_origin(newurl) != self._origin:
+            raise ReleaseControlError("cross-origin release-feed redirect refused")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def fetch_bytes(url: str, *, limit: int) -> bytes:
+    """Fetch a bounded public document, rejecting unsafe redirects and failures."""
+    safe_url = _safe_url(url)
+    origin = _url_origin(safe_url)
+    request = urllib.request.Request(
+        safe_url,
+        headers={"Accept": "application/json, text/yaml", "Cache-Control": "no-cache"},
+    )
+    opener = urllib.request.build_opener(_SameOriginRedirectHandler(origin))
+    try:
+        with opener.open(request, timeout=_HTTP_TIMEOUT_SECS) as response:
+            if _url_origin(response.geturl()) != origin:
+                raise ReleaseControlError("cross-origin release-feed response refused")
+            length = response.headers.get("Content-Length")
+            if length is not None:
+                try:
+                    if int(length) > limit:
+                        raise ReleaseControlError(
+                            f"response exceeds the {limit}-byte limit"
+                        )
+                except ValueError as exc:
+                    raise ReleaseControlError("response Content-Length is invalid") from exc
+            data = response.read(limit + 1)
+    except ReleaseControlError:
+        raise
+    except (OSError, urllib.error.URLError) as exc:
+        raise ReleaseControlError(f"cannot fetch release control/feed: {exc}") from exc
+    if len(data) > limit:
+        raise ReleaseControlError(f"response exceeds the {limit}-byte limit")
+    return data
+
+
+def load_control_url(url: str, *, expected_channel: str) -> dict[str, Any]:
+    raw = _decode_json(
+        fetch_bytes(url, limit=MAX_CONTROL_BYTES),
+        source="release-control response",
+    )
+    return validate_control(raw, expected_channel=expected_channel)
+
+
+def _validate_artifact_url(url: Any, artifact_base: str) -> str:
+    if not isinstance(url, str):
+        raise ReleaseControlError("feed artifact URL must be a string")
+    safe_url = _safe_url(url)
+    base = _safe_url(artifact_base.rstrip("/")) if artifact_base else ""
+    if not base:
+        raise ReleaseControlError("artifact_base must name the public byte host")
+    base_parts = urllib.parse.urlsplit(base)
+    url_parts = urllib.parse.urlsplit(safe_url)
+    if base_parts.query or url_parts.query:
+        raise ReleaseControlError("artifact URLs must not contain a query string")
+    base_path = base_parts.path.rstrip("/")
+    if (
+        _url_origin(safe_url) != _url_origin(base)
+        or not url_parts.path.startswith(base_path + "/")
+    ):
+        raise ReleaseControlError(
+            f"feed artifact URL {url!r} is outside the configured byte host"
+        )
+    return url
+
+
+def _validate_channel_urls(
+    urls: list[str],
+    *,
+    feed_name: str,
+    expected_channel: str,
+    artifact_base: str,
+    feed_version: str,
+) -> None:
+    channel = _require_channel(expected_channel)
+    version = _feed_version(feed_version, feed_name, field="feed version")
+    base_path = urllib.parse.urlsplit(
+        _safe_url(artifact_base.rstrip("/"))
+    ).path.rstrip("/")
+    lane = "cli" if feed_name == "latest-cli.json" else "desktop"
+    expected_prefix = f"{base_path}/{lane}/{channel}/{version}/"
+    for url in urls:
+        path = urllib.parse.urlsplit(url).path
+        decoded = urllib.parse.unquote(path)
+        # Electron and CDNs normalize dot-segments and (on Windows)
+        # backslashes AFTER this validation, so a raw prefix match is not
+        # enough: a URL like .../<version>/../<other>/x.dmg passes
+        # startswith() yet downloads outside the declared channel/version.
+        # Reject the traversal artifacts before trusting the prefix.
+        if "\\" in decoded or any(
+            segment in (".", "..") for segment in decoded.split("/")
+        ):
+            raise ReleaseControlError(
+                f"{feed_name} artifact URL contains a path traversal artifact"
+            )
+        if not path.startswith(expected_prefix):
+            raise ReleaseControlError(
+                f"{feed_name} artifact URL does not belong to version "
+                f"{version!r} in channel {channel!r}"
+            )
+
+
+def _metadata_fields(raw: Any) -> tuple[str, list[str]]:
+    minimum = ""
+    withdrawn: list[str] = []
+    if isinstance(raw, dict):
+        minimum = raw.get("minimumSupportedVersion", "")
+        withdrawn_raw = raw.get("withdrawnVersions", [])
+        if (
+            not isinstance(withdrawn_raw, list)
+            or len(withdrawn_raw) > MAX_WITHDRAWN_VERSIONS
+        ):
+            raise ReleaseControlError(
+                f"withdrawnVersions must be an array with at most "
+                f"{MAX_WITHDRAWN_VERSIONS} entries"
+            )
+        withdrawn = withdrawn_raw
+    _parse_semver(minimum, field="minimumSupportedVersion", allow_empty=True)
+    for index, version in enumerate(withdrawn):
+        _parse_semver(version, field=f"withdrawnVersions[{index}]")
+    if len(withdrawn) != len(set(withdrawn)):
+        raise ReleaseControlError("withdrawnVersions contains duplicates")
+    return minimum, withdrawn
+
+
+def _yaml_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _parse_yaml_feed(text: str, *, artifact_base: str) -> dict[str, Any]:
+    if "\t" in text:
+        raise ReleaseControlError("feed YAML must not contain tabs")
+    top: dict[str, str] = {}
+    files: list[dict[str, Any]] = []
+    in_files = False
+    for line in text.splitlines():
+        if line and not line.startswith(" "):
+            match = re.fullmatch(r"([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?", line)
+            if match:
+                key = match.group(1)
+                if key in top:
+                    raise ReleaseControlError(f"feed YAML repeats top-level key {key!r}")
+                top[key] = match.group(2) or ""
+                in_files = key == "files"
+                continue
+        if not in_files or not line:
+            continue
+        url_match = re.fullmatch(r"  - url:\s*(.+)", line)
+        if url_match:
+            if len(files) >= MAX_FEED_FILES:
+                raise ReleaseControlError(
+                    f"desktop feed files must have at most {MAX_FEED_FILES} entries"
+                )
+            files.append(
+                {
+                    "url": _validate_artifact_url(
+                        _yaml_scalar(url_match.group(1)), artifact_base
+                    )
+                }
+            )
+            continue
+        sha_match = re.fullmatch(r"    sha512:\s*(.+)", line)
+        if sha_match and files:
+            if "sha512" in files[-1]:
+                raise ReleaseControlError("desktop feed file repeats sha512")
+            files[-1]["sha512"] = _yaml_scalar(sha_match.group(1))
+            continue
+        size_match = re.fullmatch(r"    size:\s*([0-9]+)", line)
+        if size_match and files:
+            if "size" in files[-1]:
+                raise ReleaseControlError("desktop feed file repeats size")
+            size_text = size_match.group(1)
+            if len(size_text) > 20:  # bounds int() below any uint64 (and the
+                # 4300-digit ValueError limit), keeping parsing fail-closed
+                raise ReleaseControlError("desktop feed file size is too large")
+            files[-1]["size"] = int(size_text)
+            continue
+        raise ReleaseControlError(f"desktop feed has malformed files entry {line!r}")
+    required = {"version", "files", "path", "sha512", "releaseDate"}
+    if not required.issubset(top):
+        raise ReleaseControlError(
+            f"desktop feed lacks required top-level keys {sorted(required - set(top))}"
+        )
+    version = _yaml_scalar(top["version"])
+    _parse_semver(version, field="feed version")
+    if top["files"]:
+        raise ReleaseControlError("desktop feed files must be a block sequence")
+    if not files:
+        raise ReleaseControlError("desktop feed files must not be empty")
+    urls: list[str] = []
+    digest_by_url: dict[str, str] = {}
+    for entry in files:
+        if set(entry) != {"url", "sha512", "size"}:
+            raise ReleaseControlError("each desktop feed file needs url, sha512, and size")
+        if not _BASE64_SHA512_RE.fullmatch(entry["sha512"]):
+            raise ReleaseControlError(
+                "desktop feed sha512 values must be base64 raw digests"
+            )
+        if entry["size"] < 1:
+            raise ReleaseControlError("desktop feed file sizes must be positive")
+        if entry["url"] in digest_by_url:
+            raise ReleaseControlError("desktop feed files contain duplicate URLs")
+        urls.append(entry["url"])
+        digest_by_url[entry["url"]] = entry["sha512"]
+    path_url = _validate_artifact_url(_yaml_scalar(top["path"]), artifact_base)
+    if path_url not in urls:
+        raise ReleaseControlError("desktop feed path must name one of files[].url")
+    top_digest = _yaml_scalar(top["sha512"])
+    if not _BASE64_SHA512_RE.fullmatch(top_digest):
+        raise ReleaseControlError(
+            "desktop feed top-level sha512 must be a base64 raw digest"
+        )
+    if digest_by_url[path_url] != top_digest:
+        raise ReleaseControlError(
+            "desktop feed path digest does not match files[].sha512"
+        )
+    _timestamp(_yaml_scalar(top["releaseDate"]), field="releaseDate")
+    minimum = _yaml_scalar(top.get("minimumSupportedVersion", ""))
+    withdrawn_text = top.get("withdrawnVersions", "[]")
+    try:
+        withdrawn = json.loads(withdrawn_text)
+    except ValueError as exc:
+        # Includes JSONDecodeError and the >4300-digit int-conversion limit.
+        raise ReleaseControlError(
+            "withdrawnVersions must use a JSON-compatible flow array"
+        ) from exc
+    _metadata_fields(
+        {"minimumSupportedVersion": minimum, "withdrawnVersions": withdrawn}
+    )
+    return {
+        "version": version,
+        "urls": urls,
+        "minimumSupportedVersion": minimum,
+        "withdrawnVersions": withdrawn,
+    }
+
+
+def feed_info(
+    path: Path,
+    feed_name: str,
+    *,
+    artifact_base: str,
+    expected_channel: str,
+) -> dict[str, Any]:
+    """Validate a known feed and return its version, URLs, and controls."""
+    if feed_name not in FEED_NAMES:
+        raise ReleaseControlError(f"unknown feed name {feed_name!r}")
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise ReleaseControlError(f"cannot read {path}: {exc}") from exc
+    if len(data) > MAX_FEED_BYTES:
+        raise ReleaseControlError(f"feed exceeds the {MAX_FEED_BYTES}-byte limit")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ReleaseControlError("feed is not UTF-8") from exc
+    if feed_name.endswith(".yml"):
+        info = _parse_yaml_feed(text, artifact_base=artifact_base)
+        _validate_channel_urls(
+            info["urls"],
+            feed_name=feed_name,
+            expected_channel=expected_channel,
+            artifact_base=artifact_base,
+            feed_version=info["version"],
+        )
+        return info
+    raw = _decode_json(data, source="feed")
+    if not isinstance(raw, dict):
+        raise ReleaseControlError("feed JSON must be an object")
+    minimum, withdrawn = _metadata_fields(raw)
+    version = raw.get("version")
+    if feed_name == "latest-mac.json":
+        _parse_semver(version, field="feed version")
+        required = {"version", "url", "dmg", "name", "pub_date"}
+        if not required.issubset(raw):
+            raise ReleaseControlError(
+                f"legacy mac feed lacks keys {sorted(required - set(raw))}"
+            )
+        urls = [
+            _validate_artifact_url(raw["url"], artifact_base),
+            _validate_artifact_url(raw["dmg"], artifact_base),
+        ]
+    else:
+        _feed_version(version, feed_name, field="CLI feed version")
+        required = {
+            "channel",
+            "version",
+            "wheel_url",
+            "sha256",
+            "python_requires",
+            "pub_date",
+        }
+        if not required.issubset(raw):
+            raise ReleaseControlError(
+                f"CLI feed lacks keys {sorted(required - set(raw))}"
+            )
+        channel = _require_channel(raw["channel"])
+        if channel != _require_channel(expected_channel):
+            raise ReleaseControlError(
+                f"CLI feed channel {channel!r} does not match {expected_channel!r}"
+            )
+        if not isinstance(raw["sha256"], str) or not _SHA256_RE.fullmatch(raw["sha256"]):
+            raise ReleaseControlError(
+                "CLI feed sha256 must be 64 lowercase hex characters"
+            )
+        urls = [_validate_artifact_url(raw["wheel_url"], artifact_base)]
+    _validate_channel_urls(
+        urls,
+        feed_name=feed_name,
+        expected_channel=expected_channel,
+        artifact_base=artifact_base,
+        feed_version=version,
+    )
+    return {
+        "version": version,
+        "urls": urls,
+        "minimumSupportedVersion": minimum,
+        "withdrawnVersions": withdrawn,
+    }
+
+
+def rewrite_feed(
+    source: Path,
+    destination: Path,
+    feed_name: str,
+    control: dict[str, Any],
+    *,
+    artifact_base: str = "",
+) -> dict[str, Any]:
+    """Apply current control metadata to an existing valid feed."""
+    normalized = validate_control(control)
+    info = feed_info(
+        source,
+        feed_name,
+        artifact_base=artifact_base,
+        expected_channel=normalized["channel"],
+    )
+    if info["version"] in normalized["withdrawn_versions"]:
+        raise ReleaseControlError(
+            f"refusing to publish withdrawn version {info['version']!r} as a live feed"
+        )
+    minimum = normalized["minimum_supported_version"]
+    if minimum:
+        try:
+            below_floor = _semver_lt(info["version"], minimum)
+        except ReleaseControlError as exc:
+            # A version that cannot be compared to the floor (e.g. a PEP 440
+            # CLI dev stamp like 1.1.0.dev1) must FAIL CLOSED: treating it as
+            # above-floor would let `rewrite` republish exactly the build an
+            # emergency floor was set to retire. The operator can clear the
+            # floor or publish a SemVer-comparable version instead.
+            raise ReleaseControlError(
+                f"cannot compare {info['version']!r} to minimum {minimum!r}; "
+                "refusing to publish a version the floor cannot vet"
+            ) from exc
+        if below_floor:
+            raise ReleaseControlError(
+                f"refusing to publish {info['version']!r} below minimum {minimum!r}"
+            )
+
+    if feed_name.endswith(".json"):
+        raw = _load_json(source, limit=MAX_FEED_BYTES)
+        raw["minimumSupportedVersion"] = minimum
+        raw["withdrawnVersions"] = normalized["withdrawn_versions"]
+        body = json.dumps(raw, indent=2, sort_keys=False) + "\n"
+    else:
+        text = source.read_text(encoding="utf-8")
+        lines = [
+            line
+            for line in text.splitlines()
+            if not line.startswith("minimumSupportedVersion:")
+            and not line.startswith("withdrawnVersions:")
+        ]
+        lines.extend(
+            [
+                f"minimumSupportedVersion: {json.dumps(minimum)}",
+                "withdrawnVersions: "
+                + json.dumps(normalized["withdrawn_versions"], separators=(",", ":")),
+            ]
+        )
+        body = "\n".join(lines) + "\n"
+    destination.write_text(body, encoding="utf-8", newline="\n")
+    return feed_info(
+        destination,
+        feed_name,
+        artifact_base=artifact_base,
+        expected_channel=normalized["channel"],
+    )
+
+
+def snapshot_feed(
+    url: str,
+    destination: Path,
+    feed_name: str,
+    new_version: str,
+    *,
+    artifact_base: str,
+    expected_channel: str,
+) -> bool:
+    """Capture a valid live feed unless this is an idempotent same-version retry."""
+    _feed_version(new_version, feed_name, field="new version")
+    data = fetch_bytes(url, limit=MAX_FEED_BYTES)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    candidate: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            delete=False,
+        ) as handle:
+            handle.write(data)
+            candidate = Path(handle.name)
+        info = feed_info(
+            candidate,
+            feed_name,
+            artifact_base=artifact_base,
+            expected_channel=expected_channel,
+        )
+        if info["version"] == new_version:
+            return False
+        candidate.replace(destination)
+        candidate = None
+        return True
+    finally:
+        if candidate is not None:
+            candidate.unlink(missing_ok=True)
+
+
+def _dump_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def _append_env(path: Path, control: dict[str, Any]) -> None:
+    normalized = validate_control(control)
+    values = {
+        "MINIMUM_SUPPORTED_VERSION": normalized["minimum_supported_version"],
+        "WITHDRAWN_VERSIONS": json.dumps(
+            normalized["withdrawn_versions"], separators=(",", ":")
+        ),
+        "RELEASE_CONTROL_GENERATION": str(normalized["generation"]),
+    }
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        for key, value in values.items():
+            if "\n" in value or "\r" in value:
+                raise ReleaseControlError(f"unsafe newline in {key}")
+            handle.write(f"{key}={value}\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    bootstrap = sub.add_parser("bootstrap")
+    bootstrap.add_argument("--channel", required=True)
+    bootstrap.add_argument("--reason", required=True)
+    bootstrap.add_argument("--output", type=Path, required=True)
+
+    mutate = sub.add_parser("mutate")
+    mutate.add_argument("--input", type=Path, required=True)
+    mutate.add_argument("--channel", required=True)
+    mutate.add_argument(
+        "--operation",
+        choices=("freeze", "unfreeze", "restore", "withdraw", "set-minimum", "clear-minimum"),
+        required=True,
+    )
+    mutate.add_argument("--version", default="")
+    mutate.add_argument("--reason", required=True)
+    mutate.add_argument("--output", type=Path, required=True)
+
+    fetch = sub.add_parser("fetch")
+    fetch.add_argument("--url", required=True)
+    fetch.add_argument("--channel", required=True)
+    fetch.add_argument("--output", type=Path, required=True)
+
+    guard = sub.add_parser("guard")
+    guard.add_argument("--url", required=True)
+    guard.add_argument("--channel", required=True)
+    guard.add_argument("--candidate-version", required=True)
+    guard.add_argument("--save", type=Path, required=True)
+    guard.add_argument("--github-env", type=Path, required=True)
+
+    snapshot = sub.add_parser("snapshot")
+    snapshot.add_argument("--url", required=True)
+    snapshot.add_argument("--channel", required=True)
+    snapshot.add_argument("--feed-name", choices=sorted(FEED_NAMES), required=True)
+    snapshot.add_argument("--new-version", required=True)
+    snapshot.add_argument("--artifact-base", required=True)
+    snapshot.add_argument("--output", type=Path, required=True)
+
+    rewrite = sub.add_parser("rewrite")
+    rewrite.add_argument("--input", type=Path, required=True)
+    rewrite.add_argument("--output", type=Path, required=True)
+    rewrite.add_argument("--feed-name", choices=sorted(FEED_NAMES), required=True)
+    rewrite.add_argument("--control", type=Path, required=True)
+    rewrite.add_argument("--artifact-base", required=True)
+
+    info = sub.add_parser("feed-info")
+    info.add_argument("--input", type=Path, required=True)
+    info.add_argument("--channel", required=True)
+    info.add_argument("--feed-name", choices=sorted(FEED_NAMES), required=True)
+    info.add_argument("--artifact-base", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "bootstrap":
+            _dump_json(args.output, bootstrap_control(args.channel, args.reason))
+        elif args.command == "mutate":
+            control = validate_control(
+                _load_json(args.input, limit=MAX_CONTROL_BYTES),
+                expected_channel=args.channel,
+            )
+            _dump_json(
+                args.output,
+                mutate_control(
+                    control,
+                    args.operation,
+                    reason=args.reason,
+                    version=args.version,
+                ),
+            )
+        elif args.command == "fetch":
+            control = load_control_url(args.url, expected_channel=args.channel)
+            _dump_json(args.output, control)
+        elif args.command == "guard":
+            control = load_control_url(args.url, expected_channel=args.channel)
+            _dump_json(args.save, control)
+            if control["frozen"]:
+                raise ReleaseControlError(
+                    f"release feed for {args.channel} is frozen at generation "
+                    f"{control['generation']}: {control['reason']}"
+                )
+            candidate = args.candidate_version
+            _parse_semver(candidate, field="candidate version")
+            if candidate in control["withdrawn_versions"]:
+                raise ReleaseControlError(
+                    f"candidate version {candidate!r} has been withdrawn"
+                )
+            minimum = control["minimum_supported_version"]
+            if minimum and _semver_lt(candidate, minimum):
+                raise ReleaseControlError(
+                    f"candidate version {candidate!r} is below minimum {minimum!r}"
+                )
+            _append_env(args.github_env, control)
+        elif args.command == "snapshot":
+            snapshot_feed(
+                args.url,
+                args.output,
+                args.feed_name,
+                args.new_version,
+                artifact_base=args.artifact_base,
+                expected_channel=args.channel,
+            )
+        elif args.command == "rewrite":
+            control = validate_control(_load_json(args.control, limit=MAX_CONTROL_BYTES))
+            info = rewrite_feed(
+                args.input,
+                args.output,
+                args.feed_name,
+                control,
+                artifact_base=args.artifact_base,
+            )
+            print(json.dumps(info, separators=(",", ":")))
+        elif args.command == "feed-info":
+            print(
+                json.dumps(
+                    feed_info(
+                        args.input,
+                        args.feed_name,
+                        artifact_base=args.artifact_base,
+                        expected_channel=args.channel,
+                    ),
+                    separators=(",", ":"),
+                )
+            )
+        return 0
+    except ReleaseControlError as exc:
+        print(f"release-feed-control: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_release_feed_control.py
+++ b/test/test_release_feed_control.py
@@ -1,0 +1,737 @@
+"""Emergency release-control state and feed rewrite contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "release_feed_control.py"
+SPEC = importlib.util.spec_from_file_location("release_feed_control", SCRIPT)
+assert SPEC and SPEC.loader
+release_control = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_control)
+
+BYTE_BASE = "https://download.crew.kiro.dev"
+_SHA512 = "A" * 86 + "=="
+
+
+def _control(**updates):
+    body = release_control.bootstrap_control(
+        "stable", "initialize emergency controls", now="2026-08-01T00:00:00Z"
+    )
+    body.update(updates)
+    return release_control.validate_control(body)
+
+
+def _mac_yaml(version: str = "1.2.3") -> str:
+    return f"""version: {version}
+files:
+  - url: {BYTE_BASE}/desktop/stable/{version}/KiroCrew.zip
+    sha512: '{_SHA512}'
+    size: 123
+  - url: {BYTE_BASE}/desktop/stable/{version}/KiroCrew.dmg
+    sha512: '{_SHA512}'
+    size: 456
+path: {BYTE_BASE}/desktop/stable/{version}/KiroCrew.zip
+sha512: '{_SHA512}'
+releaseDate: '2026-08-01T00:00:00Z'
+"""
+
+
+def _legacy_mac(version: str = "1.2.3") -> dict:
+    return {
+        "version": version,
+        "url": f"{BYTE_BASE}/desktop/stable/{version}/KiroCrew.zip",
+        "dmg": f"{BYTE_BASE}/desktop/stable/{version}/KiroCrew.dmg",
+        "name": version,
+        "pub_date": "2026-08-01T00:00:00Z",
+    }
+
+
+def _cli_feed(version: str = "1.2.3") -> dict:
+    return {
+        "channel": "stable",
+        "version": version,
+        "wheel_url": f"{BYTE_BASE}/cli/stable/{version}/kirocrew-{version}-py3-none-any.whl",
+        "sha256": "a" * 64,
+        "python_requires": ">=3.10",
+        "pub_date": "2026-08-01T00:00:00Z",
+    }
+
+
+class TestControlSchema:
+    def test_bootstrap_is_frozen_and_generation_one(self):
+        control = _control()
+        assert control["frozen"] is True
+        assert control["generation"] == 1
+        assert control["minimum_supported_version"] == ""
+        assert control["withdrawn_versions"] == []
+
+    @pytest.mark.parametrize(
+        "mutation",
+        [
+            {"schema_version": 2},
+            {"channel": "production"},
+            {"frozen": 1},
+            {"minimum_supported_version": "latest"},
+            {"generation": 0},
+            {"withdrawn_versions": ["1.2.3", "1.2.3"]},
+        ],
+    )
+    def test_invalid_control_fails_closed(self, mutation):
+        body = _control()
+        body.update(mutation)
+        with pytest.raises(release_control.ReleaseControlError):
+            release_control.validate_control(body, expected_channel="stable")
+
+    def test_unknown_key_fails_closed(self):
+        body = _control()
+        body["freezed"] = True
+        with pytest.raises(release_control.ReleaseControlError, match="unknown"):
+            release_control.validate_control(body)
+
+    def test_duplicate_json_keys_fail_closed(self):
+        with pytest.raises(release_control.ReleaseControlError, match="repeats"):
+            release_control._decode_json(
+                b'{"channel":"stable","channel":"nightly"}',
+                source="control",
+            )
+
+    def test_reason_rejects_log_control_characters(self):
+        body = _control()
+        body["reason"] = "incident\n::warning::forged"
+        with pytest.raises(release_control.ReleaseControlError, match="controls"):
+            release_control.validate_control(body)
+
+    def test_channel_mismatch_fails_closed(self):
+        with pytest.raises(release_control.ReleaseControlError, match="does not match"):
+            release_control.validate_control(_control(), expected_channel="insider")
+
+    def test_semver_prerelease_order_matches_release_rules(self):
+        assert release_control._semver_lt("1.2.3-insider.2", "1.2.3")
+        assert release_control._semver_lt("1.2.3-insider.2", "1.2.3-insider.10")
+        assert not release_control._semver_lt("1.2.4-nightly.20260801t000000", "1.2.3")
+
+
+class TestMutations:
+    def test_freeze_and_unfreeze_are_separate_audited_generations(self):
+        unfrozen = release_control.mutate_control(
+            _control(),
+            "unfreeze",
+            reason="release window opened",
+            now="2026-08-01T00:01:00Z",
+        )
+        frozen = release_control.mutate_control(
+            unfrozen,
+            "freeze",
+            reason="incident response",
+            now="2026-08-01T00:02:00Z",
+        )
+        assert unfrozen["frozen"] is False
+        assert frozen["frozen"] is True
+        assert frozen["generation"] == 3
+        assert frozen["reason"] == "incident response"
+
+    def test_withdraw_is_idempotent_and_always_freezes(self):
+        first = release_control.mutate_control(
+            _control(frozen=False),
+            "withdraw",
+            version="1.2.3",
+            reason="known-bad updater",
+            now="2026-08-01T00:02:00Z",
+        )
+        second = release_control.mutate_control(
+            first,
+            "withdraw",
+            version="1.2.3",
+            reason="retry same incident",
+            now="2026-08-01T00:03:00Z",
+        )
+        assert first["frozen"] is True
+        assert second["withdrawn_versions"] == ["1.2.3"]
+        assert second["generation"] == first["generation"] + 1
+
+    def test_restore_stays_frozen_until_explicit_unfreeze(self):
+        restored = release_control.mutate_control(
+            _control(frozen=False),
+            "restore",
+            reason="restore previous pointers",
+            now="2026-08-01T00:02:00Z",
+        )
+        assert restored["frozen"] is True
+
+    def test_minimum_version_can_be_set_and_cleared(self):
+        pinned = release_control.mutate_control(
+            _control(),
+            "set-minimum",
+            version="1.2.3",
+            reason="critical security floor",
+            now="2026-08-01T00:02:00Z",
+        )
+        cleared = release_control.mutate_control(
+            pinned,
+            "clear-minimum",
+            reason="floor no longer required",
+            now="2026-08-01T00:03:00Z",
+        )
+        assert pinned["minimum_supported_version"] == "1.2.3"
+        assert cleared["minimum_supported_version"] == ""
+
+
+class TestFeedRewrites:
+    def test_desktop_yaml_gets_control_metadata_without_changing_artifacts(self, tmp_path):
+        source = tmp_path / "in.yml"
+        output = tmp_path / "out.yml"
+        source.write_text(_mac_yaml(), encoding="utf-8")
+        control = _control(
+            minimum_supported_version="1.2.0",
+            withdrawn_versions=["1.1.9"],
+        )
+
+        info = release_control.rewrite_feed(
+            source,
+            output,
+            "latest-mac.yml",
+            control,
+            artifact_base=BYTE_BASE,
+        )
+
+        text = output.read_text(encoding="utf-8")
+        assert 'minimumSupportedVersion: "1.2.0"' in text
+        assert 'withdrawnVersions: ["1.1.9"]' in text
+        assert f"{BYTE_BASE}/desktop/stable/1.2.3/KiroCrew.zip" in text
+        assert info["version"] == "1.2.3"
+        assert len(info["urls"]) == 2
+
+    @pytest.mark.parametrize(
+        "feed_name,body",
+        [
+            ("latest-mac.json", _legacy_mac()),
+            ("latest-cli.json", _cli_feed()),
+        ],
+    )
+    def test_json_feeds_get_the_same_control_metadata(self, tmp_path, feed_name, body):
+        source = tmp_path / "in.json"
+        output = tmp_path / "out.json"
+        source.write_text(json.dumps(body), encoding="utf-8")
+        release_control.rewrite_feed(
+            source,
+            output,
+            feed_name,
+            _control(
+                minimum_supported_version="1.2.0",
+                withdrawn_versions=["1.1.9"],
+            ),
+            artifact_base=BYTE_BASE,
+        )
+        rewritten = json.loads(output.read_text(encoding="utf-8"))
+        assert rewritten["minimumSupportedVersion"] == "1.2.0"
+        assert rewritten["withdrawnVersions"] == ["1.1.9"]
+        assert rewritten["version"] == body["version"]
+
+    def test_withdrawn_target_is_never_restored_live(self, tmp_path):
+        source = tmp_path / "in.yml"
+        source.write_text(_mac_yaml("1.2.3"), encoding="utf-8")
+        with pytest.raises(release_control.ReleaseControlError, match="withdrawn"):
+            release_control.rewrite_feed(
+                source,
+                tmp_path / "out.yml",
+                "latest-mac.yml",
+                _control(withdrawn_versions=["1.2.3"]),
+                artifact_base=BYTE_BASE,
+            )
+
+    def test_target_below_minimum_is_never_restored_live(self, tmp_path):
+        source = tmp_path / "in.yml"
+        source.write_text(_mac_yaml("1.2.2"), encoding="utf-8")
+        with pytest.raises(release_control.ReleaseControlError, match="below minimum"):
+            release_control.rewrite_feed(
+                source,
+                tmp_path / "out.yml",
+                "latest-mac.yml",
+                _control(minimum_supported_version="1.2.3"),
+                artifact_base=BYTE_BASE,
+            )
+
+    def test_uncomparable_cli_version_fails_closed_against_the_floor(self, tmp_path):
+        # A PEP 440 dev stamp cannot be SemVer-compared to the floor. Failing
+        # OPEN here would let `rewrite` republish exactly the build the
+        # emergency floor was set to retire (1.1.0.dev1 dodging a 1.2.0
+        # floor that plain 1.1.0 would trip).
+        source = tmp_path / "latest-cli.json"
+        source.write_text(json.dumps(_cli_feed("1.1.0.dev1")), encoding="utf-8")
+        with pytest.raises(
+            release_control.ReleaseControlError, match="cannot compare"
+        ):
+            release_control.rewrite_feed(
+                source,
+                tmp_path / "out.json",
+                "latest-cli.json",
+                _control(minimum_supported_version="1.2.0"),
+                artifact_base=BYTE_BASE,
+            )
+
+    def test_comparable_cli_version_above_the_floor_still_publishes(self, tmp_path):
+        source = tmp_path / "latest-cli.json"
+        source.write_text(json.dumps(_cli_feed("1.2.3")), encoding="utf-8")
+        info = release_control.rewrite_feed(
+            source,
+            tmp_path / "out.json",
+            "latest-cli.json",
+            _control(minimum_supported_version="1.2.0"),
+            artifact_base=BYTE_BASE,
+        )
+        assert info["version"] == "1.2.3"
+
+    def test_artifact_host_escape_is_rejected(self, tmp_path):
+        source = tmp_path / "in.yml"
+        source.write_text(
+            _mac_yaml().replace(BYTE_BASE, "https://attacker.invalid"),
+            encoding="utf-8",
+        )
+        with pytest.raises(release_control.ReleaseControlError, match="outside"):
+            release_control.feed_info(
+                source,
+                "latest-mac.yml",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+    def test_malformed_digest_is_rejected_before_recovery_capture(self, tmp_path):
+        source = tmp_path / "bad.yml"
+        source.write_text(_mac_yaml().replace(_SHA512, "hex-not-base64"), encoding="utf-8")
+        with pytest.raises(release_control.ReleaseControlError, match="base64"):
+            release_control.feed_info(
+                source,
+                "latest-mac.yml",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+    def test_channel_escape_is_rejected(self, tmp_path):
+        source = tmp_path / "wrong-channel.yml"
+        source.write_text(
+            _mac_yaml().replace("/desktop/stable/", "/desktop/insider/"),
+            encoding="utf-8",
+        )
+        with pytest.raises(release_control.ReleaseControlError, match="channel"):
+            release_control.feed_info(
+                source,
+                "latest-mac.yml",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+    @pytest.mark.parametrize(
+        "feed_name,body",
+        [
+            ("latest-mac.yml", _mac_yaml("2.0.0")),
+            ("latest-linux.yml", _mac_yaml("2.0.0")),
+            ("latest-mac.json", json.dumps(_legacy_mac("2.0.0"))),
+            ("latest-cli.json", json.dumps(_cli_feed("2.0.0"))),
+        ],
+    )
+    def test_artifact_version_must_match_feed_version(
+        self, tmp_path, feed_name, body
+    ):
+        source = tmp_path / feed_name
+        source.write_text(
+            body.replace("/2.0.0/", "/1.0.0/"),
+            encoding="utf-8",
+        )
+        with pytest.raises(release_control.ReleaseControlError, match="version"):
+            release_control.feed_info(
+                source,
+                feed_name,
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+    @pytest.mark.parametrize(
+        "traversal",
+        [
+            "/2.0.0/../2.0.0/",
+            "/2.0.0/%2E%2E/2.0.0/",
+            "/2.0.0/x%5C../",
+        ],
+        ids=["dot-dot", "encoded-dot-dot", "encoded-backslash"],
+    )
+    def test_artifact_url_traversal_is_rejected(self, tmp_path, traversal):
+        # The raw path still starts with the expected /desktop/stable/2.0.0/
+        # prefix, so only the traversal guard can catch these: consumers
+        # normalize dot-segments and backslashes AFTER this validation.
+        source = tmp_path / "latest-mac.yml"
+        source.write_text(
+            _mac_yaml("2.0.0").replace("/2.0.0/", traversal),
+            encoding="utf-8",
+        )
+        with pytest.raises(
+            release_control.ReleaseControlError, match="traversal"
+        ):
+            release_control.feed_info(
+                source,
+                "latest-mac.yml",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+    def test_oversized_numerics_fail_closed_not_traceback(self, tmp_path):
+        # Python 3.12 raises a plain ValueError for int() conversions past
+        # 4,300 digits. A bounded (<=128 KiB) document can carry a 5,000-digit
+        # number, so every numeric parse must surface ReleaseControlError,
+        # never an uncaught conversion traceback.
+        huge = "1" * 5000
+
+        # yml files[].size
+        source = tmp_path / "latest-mac.yml"
+        source.write_text(
+            _mac_yaml("2.0.0").replace("size: 123", f"size: {huge}"),
+            encoding="utf-8",
+        )
+        with pytest.raises(release_control.ReleaseControlError, match="size"):
+            release_control.feed_info(
+                source,
+                "latest-mac.yml",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+        # yml withdrawnVersions flow array (json.loads int conversion)
+        source = tmp_path / "withdrawn.yml"
+        source.write_text(
+            _mac_yaml("2.0.0") + f"withdrawnVersions: [{huge}]\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(
+            release_control.ReleaseControlError, match="withdrawnVersions"
+        ):
+            release_control.feed_info(
+                source,
+                "latest-mac.yml",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+        # JSON feed body (shared _decode_json path)
+        source = tmp_path / "latest-cli.json"
+        body = json.dumps(_cli_feed("2.0.0"))[:-1] + f', "x": {huge}}}'
+        source.write_text(body, encoding="utf-8")
+        with pytest.raises(release_control.ReleaseControlError):
+            release_control.feed_info(
+                source,
+                "latest-cli.json",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+    def test_overlong_version_string_fails_closed(self):
+        with pytest.raises(release_control.ReleaseControlError, match="128"):
+            release_control._parse_semver(
+                "1.0.0-" + "9" * 5000, field="version"
+            )
+
+    def test_path_digest_must_match_its_file_entry(self, tmp_path):
+        source = tmp_path / "mismatched-digest.yml"
+        replacement = "B" * 86 + "=="
+        text = _mac_yaml().rsplit(f"sha512: '{_SHA512}'", 1)[0]
+        text += f"sha512: '{replacement}'\nreleaseDate: '2026-08-01T00:00:00Z'\n"
+        source.write_text(text, encoding="utf-8")
+        with pytest.raises(release_control.ReleaseControlError, match="does not match"):
+            release_control.feed_info(
+                source,
+                "latest-mac.yml",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+
+    def test_cli_feed_channel_must_match_control_channel(self, tmp_path):
+        source = tmp_path / "cli.json"
+        source.write_text(json.dumps(_cli_feed()), encoding="utf-8")
+        with pytest.raises(release_control.ReleaseControlError, match="does not match"):
+            release_control.feed_info(
+                source,
+                "latest-cli.json",
+                artifact_base=BYTE_BASE,
+                expected_channel="insider",
+            )
+
+    def test_rewrite_replaces_old_metadata_instead_of_duplicating_it(self, tmp_path):
+        source = tmp_path / "in.yml"
+        output = tmp_path / "out.yml"
+        source.write_text(
+            _mac_yaml()
+            + 'minimumSupportedVersion: "1.0.0"\n'
+            + 'withdrawnVersions: ["1.0.1"]\n',
+            encoding="utf-8",
+        )
+        release_control.rewrite_feed(
+            source,
+            output,
+            "latest-mac.yml",
+            _control(minimum_supported_version="1.2.0"),
+            artifact_base=BYTE_BASE,
+        )
+        text = output.read_text(encoding="utf-8")
+        assert text.count("minimumSupportedVersion:") == 1
+        assert text.count("withdrawnVersions:") == 1
+        assert "1.0.1" not in text
+
+
+class TestRecoverySnapshots:
+    def test_valid_feed_is_promoted_atomically(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        live_feed = _mac_yaml("2.1.0").encode()
+        monkeypatch.setattr(
+            release_control,
+            "fetch_bytes",
+            lambda _url, *, limit: live_feed,
+        )
+        destination = tmp_path / "recovery" / "latest-mac.yml"
+
+        assert release_control.snapshot_feed(
+            "https://updates.example.invalid/latest-mac.yml",
+            destination,
+            "latest-mac.yml",
+            "2.2.0",
+            artifact_base=BYTE_BASE,
+            expected_channel="stable",
+        )
+        assert destination.read_bytes() == live_feed
+        assert not list(destination.parent.glob(f".{destination.name}.*"))
+
+    def test_same_version_keeps_existing_candidate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        live_feed = _mac_yaml("2.2.0").encode()
+        monkeypatch.setattr(
+            release_control,
+            "fetch_bytes",
+            lambda _url, *, limit: live_feed,
+        )
+        destination = tmp_path / "latest-mac.yml"
+        destination.write_bytes(b"existing recovery candidate")
+
+        assert not release_control.snapshot_feed(
+            "https://updates.example.invalid/latest-mac.yml",
+            destination,
+            "latest-mac.yml",
+            "2.2.0",
+            artifact_base=BYTE_BASE,
+            expected_channel="stable",
+        )
+        assert destination.read_bytes() == b"existing recovery candidate"
+        assert not list(tmp_path.glob(f".{destination.name}.*"))
+
+    def test_invalid_feed_never_replaces_existing_candidate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            release_control,
+            "fetch_bytes",
+            lambda _url, *, limit: b"not: a desktop release feed\n",
+        )
+        destination = tmp_path / "latest-mac.yml"
+        destination.write_bytes(b"existing recovery candidate")
+
+        with pytest.raises(release_control.ReleaseControlError):
+            release_control.snapshot_feed(
+                "https://updates.example.invalid/latest-mac.yml",
+                destination,
+                "latest-mac.yml",
+                "2.2.0",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+        assert destination.read_bytes() == b"existing recovery candidate"
+        assert not list(tmp_path.glob(f".{destination.name}.*"))
+
+    def test_invalid_new_version_fails_before_fetch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fetched = False
+
+        def fetch(_url, *, limit):
+            nonlocal fetched
+            fetched = True
+            return b""
+
+        monkeypatch.setattr(release_control, "fetch_bytes", fetch)
+        with pytest.raises(release_control.ReleaseControlError, match="SemVer"):
+            release_control.snapshot_feed(
+                "https://updates.example.invalid/latest-mac.yml",
+                tmp_path / "latest-mac.yml",
+                "latest-mac.yml",
+                "",
+                artifact_base=BYTE_BASE,
+                expected_channel="stable",
+            )
+        assert fetched is False
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            [
+                "guard",
+                "--url",
+                "https://updates.example.invalid/control.json",
+                "--channel",
+                "stable",
+                "--save",
+                "control.json",
+                "--github-env",
+                "github.env",
+            ],
+            [
+                "snapshot",
+                "--url",
+                "https://updates.example.invalid/latest-mac.yml",
+                "--feed-name",
+                "latest-mac.yml",
+                "--new-version",
+                "2.2.0",
+                "--output",
+                "recovery.yml",
+            ],
+        ],
+    )
+    def test_operational_inputs_are_required(self, argv: list[str]) -> None:
+        with pytest.raises(SystemExit):
+            release_control._parser().parse_args(argv)
+
+
+class TestPublisherGuard:
+    def test_cross_origin_redirect_is_rejected_before_following(self):
+        handler = release_control._SameOriginRedirectHandler(
+            ("https", "updates.example", 443)
+        )
+        request = release_control.urllib.request.Request(
+            "https://updates.example/control.json"
+        )
+        with pytest.raises(release_control.ReleaseControlError, match="cross-origin"):
+            handler.redirect_request(
+                request,
+                None,
+                302,
+                "Found",
+                {},
+                "https://attacker.invalid/control.json",
+            )
+
+    def test_frozen_guard_fails_before_writing_environment(self, tmp_path, monkeypatch):
+        control = _control(frozen=True)
+        monkeypatch.setattr(
+            release_control,
+            "load_control_url",
+            lambda url, expected_channel: control,
+        )
+        env = tmp_path / "env"
+        rc = release_control.main(
+            [
+                "guard",
+                "--url",
+                "https://updates.example/feed/stable/release-control.json",
+                "--channel",
+                "stable",
+                "--candidate-version",
+                "1.2.3",
+                "--save",
+                str(tmp_path / "saved.json"),
+                "--github-env",
+                str(env),
+            ]
+        )
+        assert rc == 2
+        assert not env.exists()
+
+    def test_unfrozen_guard_exports_bounded_values(self, tmp_path, monkeypatch):
+        control = _control(
+            frozen=False,
+            minimum_supported_version="1.2.0",
+            withdrawn_versions=["1.1.9"],
+        )
+        monkeypatch.setattr(
+            release_control,
+            "load_control_url",
+            lambda url, expected_channel: control,
+        )
+        env = tmp_path / "env"
+        rc = release_control.main(
+            [
+                "guard",
+                "--url",
+                "https://updates.example/feed/stable/release-control.json",
+                "--channel",
+                "stable",
+                "--candidate-version",
+                "1.2.3",
+                "--save",
+                str(tmp_path / "saved.json"),
+                "--github-env",
+                str(env),
+            ]
+        )
+        assert rc == 0
+        assert env.read_text(encoding="utf-8").splitlines() == [
+            "MINIMUM_SUPPORTED_VERSION=1.2.0",
+            'WITHDRAWN_VERSIONS=["1.1.9"]',
+            "RELEASE_CONTROL_GENERATION=1",
+        ]
+
+    def test_guard_rejects_empty_candidate_version(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            release_control,
+            "load_control_url",
+            lambda url, expected_channel: _control(frozen=False),
+        )
+        env = tmp_path / "empty.env"
+        rc = release_control.main(
+            [
+                "guard",
+                "--url",
+                "https://updates.example/feed/stable/release-control.json",
+                "--channel",
+                "stable",
+                "--candidate-version",
+                "",
+                "--save",
+                str(tmp_path / "saved.json"),
+                "--github-env",
+                str(env),
+            ]
+        )
+        assert rc == 2
+        assert not env.exists()
+
+    def test_guard_rejects_withdrawn_or_below_floor_candidate(self, tmp_path, monkeypatch):
+        control = _control(
+            frozen=False,
+            minimum_supported_version="1.2.3",
+            withdrawn_versions=["1.2.4"],
+        )
+        monkeypatch.setattr(
+            release_control,
+            "load_control_url",
+            lambda url, expected_channel: control,
+        )
+        for candidate in ("1.2.2", "1.2.4"):
+            rc = release_control.main(
+                [
+                    "guard",
+                    "--url",
+                    "https://updates.example/feed/stable/release-control.json",
+                    "--channel",
+                    "stable",
+                    "--candidate-version",
+                    candidate,
+                    "--save",
+                    str(tmp_path / f"{candidate}.json"),
+                    "--github-env",
+                    str(tmp_path / f"{candidate}.env"),
+                ]
+            )
+            assert rc == 2

--- a/website/capture/update-card.tsx
+++ b/website/capture/update-card.tsx
@@ -26,6 +26,7 @@ import { Provider } from 'react-redux'
 import { initI18n } from '../src/i18n'
 import { store } from '../src/store'
 import { AboutPanel } from '../src/pages/settings/AboutPanel'
+import UpdateModal from '../src/components/UpdateModal'
 import '../src/index.css'
 
 const VERSION = '0.1.3-nightly.20260730t061200'
@@ -65,6 +66,15 @@ const SCENES: Record<string, Record<string, unknown>> = {
     channel: 'nightly',
     pubDate: '2026-07-30T06:12:00Z',
     notes: NOTES,
+  },
+  'mandatory-downloaded': {
+    state: 'downloaded',
+    version: VERSION,
+    channel: 'nightly',
+    pubDate: '2026-07-30T06:12:00Z',
+    notes: NOTES,
+    mandatory: true,
+    minimumSupportedVersion: VERSION,
   },
   'download-failed': {
     state: 'error',
@@ -128,9 +138,13 @@ createRoot(document.getElementById('root')!).render(
         style={{ background: 'var(--bg)', color: 'var(--text)', padding: 24, minHeight: '100vh' }}
         data-capture-root
       >
-        <div style={{ maxWidth: 720 }}>
-          <AboutPanel />
-        </div>
+        {scene === 'mandatory-downloaded' ? (
+          <UpdateModal />
+        ) : (
+          <div style={{ maxWidth: 720 }}>
+            <AboutPanel />
+          </div>
+        )}
       </div>
     </QueryClientProvider>
   </Provider>,

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -33,6 +33,7 @@
 // fileUrl is absolute. That behaviour is structural but undocumented, so
 // test/auto-update.test.js pins it against the real installed library — a
 // version bump that changes it must fail CI, not strand installs in the field.
+const semver = require("semver");
 const {
   classifyBundleLocation,
   containingDirForBundle,
@@ -66,6 +67,7 @@ const DEFAULT_FEED_BASE = "https://updates.crew.kiro.dev/feed";
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // every 4h while running
 const LAUNCH_CHECK_DELAY_MS = 30 * 1000; // let startup settle first
 const FORCE_EXIT_AFTER_MS = 5 * 1000; // failsafe: guarantee exit after quitAndInstall
+const MAX_WITHDRAWN_VERSIONS = 100;
 
 /** Platforms with a working publish lane + updater. win32 lands with NSIS (#598). */
 const SUPPORTED_PLATFORMS = new Set(["darwin", "linux"]);
@@ -160,6 +162,72 @@ function buildFeedBase({ base, channel }) {
     throw new Error(`feed base must be https (or http on loopback): ${parsed.protocol}//${parsed.hostname}`);
   }
   return url;
+}
+
+/**
+ * Evaluate emergency policy carried in the signed update-feed metadata.
+ *
+ * A malformed floor/list or a feed whose advertised target is itself
+ * withdrawn/below the floor is rejected rather than downloaded. A running
+ * build below the floor (or explicitly withdrawn) is mandatory: discovery
+ * starts the verified download immediately and the renderer removes every
+ * dismissal path once it is staged.
+ *
+ * @param {object|null|undefined} info electron-updater UpdateInfo
+ * @param {string} currentVersion app.getVersion()
+ * @returns {{mandatory:boolean, minimumSupportedVersion:string, withdrawnVersions:string[]}}
+ */
+function evaluateReleasePolicy(info, currentVersion) {
+  const metadata = info && typeof info === "object" ? info : {};
+  const hasMinimum = Object.prototype.hasOwnProperty.call(
+    metadata,
+    "minimumSupportedVersion",
+  );
+  const hasWithdrawn = Object.prototype.hasOwnProperty.call(
+    metadata,
+    "withdrawnVersions",
+  );
+  // Pre-control feeds carry neither field. Once a publisher opts in it must
+  // carry BOTH: accepting a partial document would let one broken writer strip
+  // the floor or withdrawal list while still looking policy-aware.
+  if (hasMinimum !== hasWithdrawn) {
+    throw new Error("release feed has incomplete emergency policy metadata");
+  }
+  const minimum = hasMinimum ? metadata.minimumSupportedVersion : "";
+  const withdrawn = hasWithdrawn ? metadata.withdrawnVersions : [];
+
+  const canonicalSemver = (value) => (
+    typeof value === "string"
+    && /^[0-9]/.test(value)
+    && semver.valid(value) !== null
+  );
+  if (typeof minimum !== "string" || (minimum && !canonicalSemver(minimum))) {
+    throw new Error("release feed has an invalid minimumSupportedVersion");
+  }
+  if (!Array.isArray(withdrawn)
+      || withdrawn.length > MAX_WITHDRAWN_VERSIONS
+      || withdrawn.some((version) => !canonicalSemver(version))
+      || new Set(withdrawn).size !== withdrawn.length) {
+    throw new Error("release feed has an invalid withdrawnVersions list");
+  }
+
+  const targetVersion = metadata.version;
+  if (!canonicalSemver(targetVersion) || !canonicalSemver(currentVersion)) {
+    throw new Error("release feed or running build has an invalid version");
+  }
+  if (withdrawn.includes(targetVersion)) {
+    throw new Error(`release feed advertises withdrawn target ${targetVersion}`);
+  }
+  if (minimum && semver.lt(targetVersion, minimum)) {
+    throw new Error(`release feed target does not satisfy minimum ${minimum}`);
+  }
+
+  const currentIsBelowMinimum = !!minimum && semver.lt(currentVersion, minimum);
+  return {
+    mandatory: currentIsBelowMinimum || withdrawn.includes(currentVersion),
+    minimumSupportedVersion: minimum,
+    withdrawnVersions: [...withdrawn],
+  };
 }
 
 /**
@@ -471,9 +539,13 @@ function initAutoUpdate(deps) {
   let stagedVersion = null; // version electron-updater has downloaded + staged
   let stagedNotes = "";
   let foundVersion = null; // last version surfaced to the user, awaiting consent
+  let mandatoryUpdate = false; // current build is withdrawn or below the feed floor
+  let minimumSupportedVersion = "";
   let installing = false;
   let quitHandled = false;
   let checking = false;
+  let checkFailed = false;
+  let validatedCheckGeneration = 0;
 
   /**
    * Version of the update currently being fetched/held -- NOT the running
@@ -497,6 +569,13 @@ function initAutoUpdate(deps) {
    * @param {"check"|"download"|"install"} phase
    * @param {unknown} err
    */
+  function policyFields() {
+    return {
+      mandatory: mandatoryUpdate,
+      minimumSupportedVersion,
+    };
+  }
+
   function emitError(phase, err) {
     const { code, detail, httpStatus } = classifyError(err);
     log.error(`[update] ${phase} failed (${code})`, err);
@@ -504,6 +583,7 @@ function initAutoUpdate(deps) {
       phase,
       code,
       message: detail,
+      ...policyFields(),
       ...(httpStatus === undefined ? {} : { httpStatus }),
       ...(phase === "download" ? { version: pendingVersion() } : {}),
     });
@@ -528,14 +608,14 @@ function initAutoUpdate(deps) {
    * download requires the explicit download() consent call below.
    */
   async function safeCheck() {
-    if (checking) return;
+    if (checking) return false;
     if (downloading) {
       // A download is in flight. Re-entering the check would restart the
       // updater's flow underneath the running download; report progress
       // instead. update-downloaded/error clears the flag.
       log.info("[update] check requested while download in flight — reporting progress");
-      emit("downloading", { version: pendingVersion() });
-      return;
+      emit("downloading", { version: pendingVersion(), ...policyFields() });
+      return false;
     }
     if (updateReady && stagedVersion) {
       // NOTE: deliberately NOT a short-circuit. A check must ALWAYS consult
@@ -547,25 +627,33 @@ function initAutoUpdate(deps) {
       log.info(`[update] ${stagedVersion} staged — checking whether it is still latest`);
     }
     checking = true;
+    checkFailed = false;
+    const validationBefore = validatedCheckGeneration;
     try {
       configureFeed(); // re-read flavor/channel each check
       emit("checking");
       await autoUpdater.checkForUpdates();
+      // A resolved promise alone is not evidence: installation needs a valid
+      // update-available/not-available event from THIS check. A buggy provider
+      // that resolves silently must therefore block the staged install.
+      return !checkFailed && validatedCheckGeneration > validationBefore;
     } catch (err) {
+      checkFailed = true;
       emitError("check", err);
+      return false;
     } finally {
       checking = false;
     }
   }
 
   /**
-   * Explicit user consent: download the version last surfaced by safeCheck.
-   * Never called automatically — this is the whole point of autoDownload=false.
+   * Download the version last surfaced by safeCheck. Ordinary updates require
+   * explicit user consent; unsupported running builds enter the mandatory path.
    */
   async function startDownload() {
-    if (downloading) { emit("downloading", { version: pendingVersion() }); return; }
+    if (downloading) { emit("downloading", { version: pendingVersion(), ...policyFields() }); return; }
     if (updateReady && stagedVersion) {
-      emit("downloaded", { version: stagedVersion, notes: stagedNotes });
+      emit("downloaded", { version: stagedVersion, notes: stagedNotes, ...policyFields() });
       return;
     }
     if (!foundVersion) {
@@ -577,7 +665,7 @@ function initAutoUpdate(deps) {
     }
     log.info(`[update] user consented — downloading ${foundVersion}`);
     downloading = true;
-    emit("downloading", { version: pendingVersion() });
+    emit("downloading", { version: pendingVersion(), ...policyFields() });
     try {
       await autoUpdater.downloadUpdate();
     } catch (err) {
@@ -644,6 +732,30 @@ function initAutoUpdate(deps) {
     autoUpdater.quitAndInstall(false, true);
   }
 
+  async function revalidateStagedUpdate(reason) {
+    const expectedVersion = stagedVersion;
+    if (!updateReady || !expectedVersion) return false;
+    log.info(`[update] revalidating staged ${expectedVersion} before ${reason}`);
+    const checked = await safeCheck();
+    if (!checked) {
+      log.warn(`[update] refusing ${reason}: release feed could not be revalidated`);
+      // A feed outage says nothing about the already-staged bytes. safeCheck
+      // emitted checking/error states that replaced the downloaded card, so
+      // without this re-emit a MANDATORY modal silently disappears (and, with
+      // polling stopped while staged, never comes back). Restore the staged
+      // state so the modal survives the failed revalidation.
+      if (updateReady && stagedVersion === expectedVersion) {
+        emit("downloaded", { version: stagedVersion, notes: stagedNotes, ...policyFields() });
+      }
+      return false;
+    }
+    if (!updateReady || stagedVersion !== expectedVersion) {
+      log.warn(`[update] refusing ${reason}: staged ${expectedVersion} is no longer current`);
+      return false;
+    }
+    return true;
+  }
+
   async function applyUpdateAndRestart() {
     if (installing) return;
     // REQUIRE a staged update. Without this guard an install() dispatched
@@ -659,6 +771,7 @@ function initAutoUpdate(deps) {
       emit(foundVersion ? "found" : "not-available", foundVersion ? { version: foundVersion } : {});
       return;
     }
+    if (!(await revalidateStagedUpdate("install"))) return;
     installing = true;
     // BEFORE stopGateway, or the watchdog can win the race and respawn the
     // gateway into the middle of the bundle swap.
@@ -689,25 +802,41 @@ function initAutoUpdate(deps) {
       // No onInstallDispatched here: this handler only runs from before-quit,
       // where main.js has already set isQuitting -- the watchdog is covered.
       log.info("[update] deferred install on quit");
+      if (!(await revalidateStagedUpdate("deferred install"))) {
+        // before-quit was already prevented. Resume the user's requested quit
+        // without installing bytes whose current feed policy is unknown/stale.
+        log.warn("[update] deferred install blocked — quitting without the staged update");
+        app.removeListener("before-quit", deferredInstallOnQuit);
+        try {
+          if (typeof app.quit === "function") app.quit();
+          else app.exit(0);
+        } catch (err) {
+          log.error("[update] clean quit after blocked deferred install failed", err);
+          try { app.exit(0); } catch { /* last-resort shutdown */ }
+        }
+        return;
+      }
       try { await stopGateway(); } catch (err) { log.error("[update] stop on quit errored", err); }
       quitAndInstall();
       forceExitFailsafe("deferred install on quit");
     })();
   }
 
-  async function promptInstall(versionName, notes) {
+  async function promptInstall(versionName, notes, mandatory = false) {
+    const buttons = mandatory ? ["Restart & Update"] : ["Restart & Update", "Later"];
     const { response } = await dialog.showMessageBox({
       type: "info",
-      buttons: ["Restart & Update", "Later"],
+      buttons,
       defaultId: 0,
-      cancelId: 1,
+      cancelId: mandatory ? 0 : 1,
+      noLink: true,
       title: "Kiro Crew update ready",
       message: `Kiro Crew ${versionName || ""} is ready to install.`.trim(),
       detail:
         (notes || "").slice(0, 500) +
         "\n\nKiro Crew will stop the local gateway, install the update, and relaunch.",
     });
-    if (response === 0) {
+    if (mandatory || response === 0) {
       await applyUpdateAndRestart();
     } else {
       app.once("before-quit", deferredInstallOnQuit);
@@ -733,6 +862,7 @@ function initAutoUpdate(deps) {
     // from what we were doing. Read the flags BEFORE clearing `downloading`, or
     // a mid-download failure would be reported as a check failure.
     const phase = downloading ? "download" : installing ? "install" : "check";
+    if (phase === "check") checkFailed = true;
     downloading = false;
     if (phase === "install") {
       // The dispatch is over: allow a retry (updateReady is still true -- the
@@ -745,7 +875,16 @@ function initAutoUpdate(deps) {
     emitError(phase, err);
   });
   autoUpdater.on("checking-for-update", () => { log.info("[update] checking…"); emit("checking"); });
-  autoUpdater.on("update-not-available", () => {
+  autoUpdater.on("update-not-available", (info) => {
+    let policyFailure = null;
+    try {
+      const policy = evaluateReleasePolicy(info, app.getVersion());
+      if (policy.mandatory) {
+        policyFailure = new Error("running version is unsupported but the feed has no compliant target");
+      }
+    } catch (err) {
+      policyFailure = err;
+    }
     downloading = false;
     foundVersion = null;
     // Clear the STAGED state too, not just the found state. The feed reporting
@@ -763,12 +902,40 @@ function initAutoUpdate(deps) {
     stagedNotes = "";
     quitHandled = false;
     app.removeListener("before-quit", deferredInstallOnQuit);
+    if (policyFailure) {
+      checkFailed = true;
+      mandatoryUpdate = true;
+      minimumSupportedVersion = (info && info.minimumSupportedVersion) || "";
+      emitError("check", policyFailure);
+      return;
+    }
+    validatedCheckGeneration += 1;
+    mandatoryUpdate = false;
+    minimumSupportedVersion = "";
     log.info("[update] up to date");
     emit("not-available");
   });
   // CONSENT GATE: with autoDownload=false this fires on DISCOVERY, before any
   // bytes move. Surface what was found and wait for an explicit download().
   autoUpdater.on("update-available", (info) => {
+    let policy;
+    try {
+      policy = evaluateReleasePolicy(info, app.getVersion());
+    } catch (err) {
+      checkFailed = true;
+      mandatoryUpdate = false;
+      minimumSupportedVersion = "";
+      foundVersion = null;
+      updateReady = false;
+      stagedVersion = null;
+      stagedNotes = "";
+      app.removeListener("before-quit", deferredInstallOnQuit);
+      emitError("check", err);
+      return;
+    }
+    validatedCheckGeneration += 1;
+    mandatoryUpdate = policy.mandatory;
+    minimumSupportedVersion = policy.minimumSupportedVersion;
     foundVersion = (info && info.version) || null;
     // A stage is only useful if it is still the latest thing on the feed.
     // Because the RUNNING version never changes mid-session, the updater
@@ -777,7 +944,7 @@ function initAutoUpdate(deps) {
     if (updateReady && stagedVersion) {
       if (foundVersion === stagedVersion) {
         log.info(`[update] ${stagedVersion} already downloaded — awaiting install`);
-        emit("downloaded", { version: stagedVersion, notes: stagedNotes });
+        emit("downloaded", { version: stagedVersion, notes: stagedNotes, ...policyFields() });
         return;
       }
       // Superseded: drop the stale stage so consent re-downloads the NEWEST
@@ -799,7 +966,12 @@ function initAutoUpdate(deps) {
       version: foundVersion,
       notes: notesFrom(info),
       pubDate: (info && info.releaseDate) || "",
+      ...policyFields(),
     });
+    if (mandatoryUpdate) {
+      log.warn(`[update] ${app.getVersion()} is below the supported floor or withdrawn — starting mandatory download`);
+      setImmediate(() => { void startDownload(); });
+    }
   });
   autoUpdater.on("download-progress", (p) => {
     // New capability vs. the hand-rolled updater: real progress, so the card
@@ -808,6 +980,7 @@ function initAutoUpdate(deps) {
       version: pendingVersion(),
       percent: p && typeof p.percent === "number" ? p.percent : undefined,
       bytesPerSecond: p && p.bytesPerSecond,
+      ...policyFields(),
     });
   });
   autoUpdater.on("update-downloaded", (info) => {
@@ -816,30 +989,53 @@ function initAutoUpdate(deps) {
     stagedVersion = (info && info.version) || null;
     stagedNotes = notesFrom(info);
     log.info(`[update] downloaded ${stagedVersion} — ${uiDriven ? "notifying UI" : "prompting"}`);
-    emit("downloaded", { version: stagedVersion || app.getVersion(), notes: stagedNotes });
+    emit("downloaded", {
+      version: stagedVersion || app.getVersion(),
+      notes: stagedNotes,
+      ...policyFields(),
+    });
     if (uiDriven) {
       // In-app UI owns the prompt. Still install on a natural quit if the user
       // dismisses the modal with "Later" (mirrors the native dialog's deferral).
       app.once("before-quit", deferredInstallOnQuit);
     } else {
-      promptInstall(stagedVersion, stagedNotes);
+      promptInstall(stagedVersion, stagedNotes, mandatoryUpdate);
     }
   });
 
   configureFeed();
   const launchTimer = setTimeout(safeCheck, LAUNCH_CHECK_DELAY_MS);
-  const pollTimer = setInterval(() => { if (!updateReady) safeCheck(); }, CHECK_INTERVAL_MS);
+  const pollTimer = setInterval(() => {
+    // A staged update owns the install prompt until install or an explicit
+    // check revalidates it; a background poll must never replace that state.
+    if (!updateReady) void safeCheck();
+  }, CHECK_INTERVAL_MS);
   // Timers must never hold the process open (Electron quit, tests).
   if (typeof launchTimer.unref === "function") launchTimer.unref();
   if (typeof pollTimer.unref === "function") pollTimer.unref();
 
   // Renderer-callable triggers (wired to ipcMain in main.js). Background
-  // timers only ever DISCOVER (safeCheck emits "found") — downloading
-  // requires the explicit download() consent call.
+  // timers refresh feed policy and discover updates. Ordinary downloading
+  // requires consent; only minimum-version/withdrawal policy may force it.
+  // A renderer reload loses its in-memory React Query cache while the main
+  // process keeps the staged bytes. Replay that authoritative staged state on
+  // subscription without consulting the feed: background/reconnect activity
+  // must not replace a staged mandatory update or re-enter electron-updater.
+  function replayState() {
+    if (!updateReady || !stagedVersion) return false;
+    emit("downloaded", {
+      version: stagedVersion,
+      notes: stagedNotes,
+      ...policyFields(),
+    });
+    return true;
+  }
+
   return {
     check: () => safeCheck(),
     download: () => startDownload(),
     install: () => applyUpdateAndRestart(),
+    replayState,
     getInfo,
     isReady: () => updateReady,
   };
@@ -851,6 +1047,7 @@ module.exports = {
   channelForVersion,
   resolveChannel,
   buildFeedBase,
+  evaluateReleasePolicy,
   configureUpdater,
   classifyError,
   manualDownloadUrl,

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -2093,6 +2093,10 @@ app.whenReady().then(async () => {
   // silently does nothing. undefined on the armed path, which reads as falsy.
   const updaterInfo = () => ({ ...updater.getInfo(), disabled: updater.disabled });
   ipcMain.handle("update:get-info", () => updaterInfo());
+  ipcMain.handle("update:replay-state", () => {
+    updater.replayState?.();
+    return { ok: true };
+  });
   ipcMain.handle("update:check", () => { updater.check(); return { ok: true }; });
   ipcMain.handle("update:download", () => { updater.download(); return { ok: true }; });
   ipcMain.handle("update:install", async () => { await updater.install(); return { ok: true }; });

--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.2",
       "dependencies": {
         "electron-store": "^8.2.0",
-        "electron-updater": "^6.8.9"
+        "electron-updater": "^6.8.9",
+        "semver": "7.7.3"
       },
       "devDependencies": {
         "@electron/notarize": "^2.5.0",
@@ -104,6 +105,16 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@electron/notarize": {
@@ -4897,13 +4908,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "electron-store": "^8.2.0",
-    "electron-updater": "^6.8.9"
+    "electron-updater": "^6.8.9",
+    "semver": "7.7.3"
   },
   "devDependencies": {
     "@electron/notarize": "^2.5.0",

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -63,6 +63,9 @@ contextBridge.exposeInMainWorld("updateAPI", {
   onState: (cb) => {
     const handler = (_e, payload) => cb(payload);
     ipcRenderer.on("update-state", handler);
+    // Main survives Cmd/Ctrl+R while the renderer's state cache does not.
+    // Attach first, then ask main to replay any staged update into this listener.
+    ipcRenderer.invoke("update:replay-state").catch(() => {});
     return () => ipcRenderer.removeListener("update-state", handler);
   },
   check: () => ipcRenderer.invoke("update:check"),

--- a/website/electron/test/auto-update-install-timing.test.js
+++ b/website/electron/test/auto-update-install-timing.test.js
@@ -25,9 +25,12 @@ function makeDeps({ appVersion = "1.0.0", withNative = true } = {}) {
   const calls = { quitAndInstall: [], exit: 0 };
   const handlers = {};
   const nativeHandlers = {};
+  let stagedVersion = null;
   const autoUpdater = {
     setFeedURL: () => {},
-    checkForUpdates: async () => {},
+    checkForUpdates: async () => {
+      if (stagedVersion) handlers["update-available"]?.({ version: stagedVersion });
+    },
     downloadUpdate: async () => {},
     quitAndInstall: (...a) => calls.quitAndInstall.push(a),
     on: (ev, fn) => { handlers[ev] = fn; },
@@ -60,7 +63,10 @@ function makeDeps({ appVersion = "1.0.0", withNative = true } = {}) {
   return {
     deps,
     calls,
-    emit: (ev, p) => handlers[ev] && handlers[ev](p),
+    emit: (ev, p) => {
+      if (ev === "update-downloaded") stagedVersion = p.version;
+      return handlers[ev] && handlers[ev](p);
+    },
     fireNative: (ev) => nativeHandlers[ev] && nativeHandlers[ev](),
     hasNativeListener: (ev) => typeof nativeHandlers[ev] === "function",
   };

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -6,6 +6,7 @@ const {
   channelForVersion,
   resolveChannel,
   buildFeedBase,
+  evaluateReleasePolicy,
   configureUpdater,
   DEFAULT_FEED_BASE,
   SUPPORTED_PLATFORMS,
@@ -124,6 +125,87 @@ test("buildFeedBase ALLOWS plain http on loopback (local update harness)", () =>
 });
 
 // ---------------------------------------------------------------------------
+// Emergency feed policy: malformed/withdrawn targets fail closed; a running
+// build below the floor or explicitly withdrawn is mandatory.
+// ---------------------------------------------------------------------------
+
+test("evaluateReleasePolicy marks a build below minimumSupportedVersion mandatory", () => {
+  const policy = evaluateReleasePolicy(
+    { version: "1.2.3", minimumSupportedVersion: "1.2.0", withdrawnVersions: [] },
+    "1.1.9",
+  );
+  assert.strictEqual(policy.mandatory, true);
+  assert.strictEqual(policy.minimumSupportedVersion, "1.2.0");
+});
+
+test("evaluateReleasePolicy marks the running withdrawn version mandatory", () => {
+  const policy = evaluateReleasePolicy(
+    { version: "1.2.2", minimumSupportedVersion: "", withdrawnVersions: ["1.2.1"] },
+    "1.2.1",
+  );
+  assert.strictEqual(policy.mandatory, true);
+});
+
+test("evaluateReleasePolicy rejects a withdrawn or below-floor target", () => {
+  assert.throws(
+    () => evaluateReleasePolicy(
+      { version: "1.2.3", minimumSupportedVersion: "", withdrawnVersions: ["1.2.3"] },
+      "1.2.2",
+    ),
+    /withdrawn target/,
+  );
+  assert.throws(
+    () => evaluateReleasePolicy(
+      { version: "1.2.2", minimumSupportedVersion: "1.2.3", withdrawnVersions: [] },
+      "1.2.1",
+    ),
+    /does not satisfy minimum/,
+  );
+});
+
+test("evaluateReleasePolicy rejects malformed control metadata", () => {
+  assert.throws(
+    () => evaluateReleasePolicy(
+      { version: "1.2.3", minimumSupportedVersion: "latest", withdrawnVersions: [] },
+      "1.2.2",
+    ),
+    /invalid minimum/,
+  );
+  assert.throws(
+    () => evaluateReleasePolicy(
+      { version: "1.2.3", minimumSupportedVersion: "", withdrawnVersions: ["1.2.2", "1.2.2"] },
+      "1.2.1",
+    ),
+    /invalid withdrawnVersions/,
+  );
+  assert.throws(
+    () => evaluateReleasePolicy(
+      { version: "1.2.3", minimumSupportedVersion: "1.2.0" },
+      "1.2.1",
+    ),
+    /incomplete emergency policy/,
+  );
+  assert.throws(
+    () => evaluateReleasePolicy(
+      {
+        version: "1.2.3",
+        minimumSupportedVersion: "",
+        withdrawnVersions: Array.from({ length: 101 }, (_, i) => `1.0.${i}`),
+      },
+      "1.2.1",
+    ),
+    /invalid withdrawnVersions/,
+  );
+  assert.throws(
+    () => evaluateReleasePolicy(
+      { version: "v1.2.3", minimumSupportedVersion: "", withdrawnVersions: [] },
+      "1.2.1",
+    ),
+    /invalid version/,
+  );
+});
+
+// ---------------------------------------------------------------------------
 // configureUpdater: the four policy flags this app depends on. EVERY one
 // differs from the electron-updater default; a regression on any of them
 // re-introduces a bug class we already fixed.
@@ -198,6 +280,22 @@ test("CONTRACT: relative channel-file names resolve under the feed base director
   );
 });
 
+test("CONTRACT: electron-updater preserves emergency metadata from channel YAML", () => {
+  const { parseUpdateInfo } = require("electron-updater/out/providers/Provider");
+  const parsed = parseUpdateInfo(
+    [
+      "version: 1.2.3",
+      "minimumSupportedVersion: 1.2.0",
+      "withdrawnVersions: [1.1.9]",
+      "files: []",
+    ].join("\n"),
+    "latest-mac.yml",
+    new URL("https://updates.crew.kiro.dev/feed/stable/latest-mac.yml"),
+  );
+  assert.strictEqual(parsed.minimumSupportedVersion, "1.2.0");
+  assert.deepStrictEqual(parsed.withdrawnVersions, ["1.1.9"]);
+});
+
 // ---------------------------------------------------------------------------
 // initAutoUpdate fixture: fake electron-updater AppUpdater (EventEmitter-like,
 // recording setFeedURL / checkForUpdates / downloadUpdate / quitAndInstall)
@@ -255,7 +353,23 @@ function makeDeps(opts = {}) {
   };
   const emit = (ev, payload) => handlers[ev] && handlers[ev](payload);
   const stateNames = () => states.map((s) => s.state);
-  return { deps, calls, handlers, emit, states, stateNames, appOnce, appRemoved };
+  const revalidateAs = (version, extra = {}) => {
+    deps.autoUpdater.checkForUpdates = async () => {
+      calls.checkForUpdates += 1;
+      emit("update-available", { version, ...extra });
+    };
+  };
+  return {
+    deps,
+    calls,
+    handlers,
+    emit,
+    states,
+    stateNames,
+    appOnce,
+    appRemoved,
+    revalidateAs,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -502,7 +616,112 @@ test("'update-available' surfaces 'found' and does NOT call downloadUpdate (disc
   assert.strictEqual(found.pubDate, "2026-07-28T00:00:00Z");
 });
 
-test("download() is the consent gate: it alone calls downloadUpdate", async () => {
+test("minimum-supported build auto-starts the verified download and marks every state mandatory", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "1.1.9" });
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", {
+    version: "1.2.3",
+    minimumSupportedVersion: "1.2.0",
+    withdrawnVersions: [],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.strictEqual(calls.downloadUpdate, 1, "the floor overrides ordinary download consent");
+  const found = states.find((state) => state.state === "found");
+  const downloading = states.find((state) => state.state === "downloading");
+  assert.strictEqual(found.mandatory, true);
+  assert.strictEqual(found.minimumSupportedVersion, "1.2.0");
+  assert.strictEqual(downloading.mandatory, true);
+});
+
+test("periodic checks cannot replace a staged mandatory update", async () => {
+  const realSetInterval = global.setInterval;
+  let periodicCheck = null;
+  global.setInterval = (fn, ms, ...args) => {
+    if (ms === 4 * 60 * 60 * 1000) {
+      periodicCheck = fn;
+      return { unref: () => {} };
+    }
+    return realSetInterval(fn, ms, ...args);
+  };
+
+  try {
+    const { deps, calls, emit, states } = makeDeps({ appVersion: "1.1.9" });
+    const updater = initAutoUpdate(deps);
+    emit("update-available", {
+      version: "1.2.3",
+      minimumSupportedVersion: "1.2.0",
+      withdrawnVersions: [],
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    emit("update-downloaded", { version: "1.2.3" });
+
+    assert.ok(periodicCheck, "periodic update callback must be registered");
+    assert.strictEqual(updater.isReady(), true);
+    assert.strictEqual(states.at(-1).state, "downloaded");
+    assert.strictEqual(states.at(-1).mandatory, true);
+    const checksBeforePoll = calls.checkForUpdates;
+
+    periodicCheck();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(
+      calls.checkForUpdates,
+      checksBeforePoll,
+      "a background poll must not re-enter the updater while mandatory bytes are staged",
+    );
+    assert.strictEqual(states.at(-1).state, "downloaded");
+    assert.strictEqual(states.at(-1).mandatory, true);
+  } finally {
+    global.setInterval = realSetInterval;
+  }
+});
+
+test("renderer re-subscribe replays a staged mandatory update without re-entering the updater", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "1.1.9" });
+  const updater = initAutoUpdate(deps);
+  emit("update-available", {
+    version: "1.2.3",
+    minimumSupportedVersion: "1.2.0",
+    withdrawnVersions: [],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  emit("update-downloaded", { version: "1.2.3", releaseNotes: "Required fixes" });
+
+  const checksBeforeSubscribe = calls.checkForUpdates;
+  states.length = 0; // Cmd/Ctrl+R discarded the renderer's prior cache.
+  assert.strictEqual(updater.replayState(), true);
+
+  assert.strictEqual(
+    calls.checkForUpdates,
+    checksBeforeSubscribe,
+    "renderer attachment must not re-enter electron-updater while mandatory bytes are staged",
+  );
+  assert.deepStrictEqual(states.at(-1), {
+    state: "downloaded",
+    channel: "stable",
+    version: "1.2.3",
+    notes: "Required fixes",
+    mandatory: true,
+    minimumSupportedVersion: "1.2.0",
+  });
+});
+
+test("malformed emergency metadata fails closed without downloading", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "1.1.9" });
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", {
+    version: "1.2.3",
+    minimumSupportedVersion: "latest",
+    withdrawnVersions: [],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.strictEqual(calls.downloadUpdate, 0);
+  assert.ok(states.some((state) => state.state === "error" && state.phase === "check"));
+});
+
+test("download() is the ordinary consent gate: it alone calls downloadUpdate", async () => {
   const { deps, calls, emit, stateNames } = makeDeps({ appVersion: "1.0.0" });
   const u = initAutoUpdate(deps);
   await u.check();
@@ -566,8 +785,21 @@ test("'update-not-available' surfaces 'not-available'", async () => {
   const { deps, emit, stateNames } = makeDeps();
   const u = initAutoUpdate(deps);
   await u.check();
-  emit("update-not-available");
+  emit("update-not-available", { version: "1.0.0" });
   assert.ok(stateNames().includes("not-available"));
+});
+
+test("an unsupported running build is never reported up to date without a compliant target", async () => {
+  const { deps, emit, states } = makeDeps({ appVersion: "1.1.9" });
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-not-available", {
+    version: "1.1.9",
+    minimumSupportedVersion: "1.2.0",
+    withdrawnVersions: [],
+  });
+  assert.ok(states.some((state) => state.state === "error" && state.mandatory === true));
+  assert.ok(!states.some((state) => state.state === "not-available"));
 });
 
 // ---------------------------------------------------------------------------
@@ -667,13 +899,138 @@ test("updater 'error' clears the in-flight download so consent can retry", async
   await Promise.all([dl1, dl2]);
 });
 
+test("install revalidates the staged version and refuses a newly withdrawn target", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "1.0.0" });
+  let gatewayStops = 0;
+  deps.stopGateway = async () => { gatewayStops += 1; };
+  deps.autoUpdater.checkForUpdates = async () => {
+    calls.checkForUpdates += 1;
+    emit("update-available", {
+      version: "1.1.0",
+      minimumSupportedVersion: "",
+      withdrawnVersions: ["1.1.0"],
+    });
+  };
+  const u = initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0" });
+
+  await u.install();
+
+  assert.strictEqual(calls.checkForUpdates, 1, "install must consult the live feed");
+  assert.strictEqual(u.isReady(), false, "the withdrawn stage must be disarmed");
+  assert.strictEqual(gatewayStops, 0, "revalidation happens before gateway shutdown");
+  assert.strictEqual(calls.quitAndInstall.length, 0);
+  assert.ok(states.some((state) => state.state === "error" && state.phase === "check"));
+});
+
+test("install fails closed when the staged version cannot be revalidated", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "1.0.0" });
+  let gatewayStops = 0;
+  deps.stopGateway = async () => { gatewayStops += 1; };
+  deps.autoUpdater.checkForUpdates = async () => {
+    calls.checkForUpdates += 1;
+    throw new Error("release feed unavailable");
+  };
+  const u = initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0" });
+
+  await u.install();
+
+  assert.strictEqual(calls.checkForUpdates, 1);
+  assert.strictEqual(u.isReady(), true, "a network failure must not corrupt the local stage");
+  assert.strictEqual(gatewayStops, 0);
+  assert.strictEqual(calls.quitAndInstall.length, 0);
+  assert.ok(states.some((state) => state.state === "error" && state.phase === "check"));
+});
+
+test("failed revalidation restores the staged mandatory modal instead of dismissing it", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "1.1.9" });
+  const u = initAutoUpdate(deps);
+  // Stage a MANDATORY update (running build is below the feed floor).
+  emit("update-available", {
+    version: "1.2.3",
+    minimumSupportedVersion: "1.2.0",
+    withdrawnVersions: [],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  emit("update-downloaded", { version: "1.2.3" });
+  assert.strictEqual(states.at(-1).state, "downloaded");
+  assert.strictEqual(states.at(-1).mandatory, true);
+
+  // Install revalidation hits a feed outage: checking/error states replace
+  // the downloaded card mid-flight.
+  deps.autoUpdater.checkForUpdates = async () => {
+    calls.checkForUpdates += 1;
+    throw new Error("release feed unavailable");
+  };
+
+  await u.install();
+
+  assert.strictEqual(calls.quitAndInstall.length, 0, "outage must refuse the install");
+  assert.strictEqual(u.isReady(), true, "the local stage must survive the outage");
+  assert.ok(
+    states.some((state) => state.state === "error" && state.phase === "check"),
+    "the outage itself is still surfaced",
+  );
+  assert.strictEqual(
+    states.at(-1).state,
+    "downloaded",
+    "the staged state must be re-emitted so the modal is not dismissed",
+  );
+  assert.strictEqual(states.at(-1).mandatory, true);
+  assert.strictEqual(states.at(-1).version, "1.2.3");
+});
+
+test("install fails closed when a provider resolves without a validated feed event", async () => {
+  const { deps, calls, emit } = makeDeps({ appVersion: "1.0.0" });
+  let gatewayStops = 0;
+  deps.stopGateway = async () => { gatewayStops += 1; };
+  const u = initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0" });
+
+  await u.install();
+
+  assert.strictEqual(calls.checkForUpdates, 1);
+  assert.strictEqual(gatewayStops, 0);
+  assert.strictEqual(calls.quitAndInstall.length, 0);
+  assert.strictEqual(u.isReady(), true, "silent checks must not corrupt the local stage");
+});
+
+test("deferred install quits without applying a stage withdrawn before natural quit", async () => {
+  const { deps, calls, emit, appOnce } = makeDeps({ appVersion: "1.0.0" });
+  let cleanQuits = 0;
+  let prevented = false;
+  deps.app.quit = () => { cleanQuits += 1; };
+  deps.autoUpdater.checkForUpdates = async () => {
+    calls.checkForUpdates += 1;
+    emit("update-available", {
+      version: "1.1.0",
+      minimumSupportedVersion: "",
+      withdrawnVersions: ["1.1.0"],
+    });
+  };
+  initAutoUpdate(deps);
+  emit("update-downloaded", { version: "1.1.0" });
+  const quitHook = appOnce.find((entry) => entry.ev === "before-quit");
+  assert.ok(quitHook, "staging must arm deferred installation");
+
+  quitHook.fn({ preventDefault: () => { prevented = true; } });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.strictEqual(prevented, true);
+  assert.strictEqual(calls.checkForUpdates, 1);
+  assert.strictEqual(calls.quitAndInstall.length, 0);
+  assert.strictEqual(cleanQuits, 1, "the original quit request must still complete");
+});
+
 // ---------------------------------------------------------------------------
 // install(): STRICT ORDER -- stopGateway must complete BEFORE quitAndInstall.
 // A live gateway child during the bundle swap can leave a half-replaced app.
 // ---------------------------------------------------------------------------
 
 test("install() awaits stopGateway BEFORE quitAndInstall (strict order)", async () => {
-  const { deps, emit } = makeDeps();
+  const { deps, emit, revalidateAs } = makeDeps();
+  revalidateAs("1.1.0");
   const events = [];
   deps.stopGateway = async () => {
     events.push("stopGateway:begin");
@@ -698,7 +1055,8 @@ test("install() awaits stopGateway BEFORE quitAndInstall (strict order)", async 
 });
 
 test("install() proceeds to quitAndInstall even when stopGateway errors (still in order)", async () => {
-  const { deps, emit } = makeDeps();
+  const { deps, emit, revalidateAs } = makeDeps();
+  revalidateAs("1.1.0");
   const events = [];
   deps.stopGateway = async () => {
     events.push("stopGateway:threw");
@@ -715,7 +1073,8 @@ test("install() proceeds to quitAndInstall even when stopGateway errors (still i
 });
 
 test("install path arms a force-exit failsafe after quitAndInstall (app-still-running guard)", async () => {
-  const { deps, emit } = makeDeps();
+  const { deps, emit, revalidateAs } = makeDeps();
+  revalidateAs("1.1.0");
   const events = [];
   deps.app.exit = (code) => events.push(`exit:${code}`);
   deps.autoUpdater.quitAndInstall = () => events.push("quitAndInstall");
@@ -873,7 +1232,8 @@ test("install() with nothing staged is refused, so the force-exit failsafe is ne
 });
 
 test("install() proceeds once an update IS staged", async () => {
-  const { deps, calls, emit } = makeDeps({ appVersion: "1.0.0" });
+  const { deps, calls, emit, revalidateAs } = makeDeps({ appVersion: "1.0.0" });
+  revalidateAs("1.1.0");
   const u = initAutoUpdate(deps);
   emit("update-downloaded", { version: "1.1.0" });
   await u.install();

--- a/website/electron/test/update-ipc-registration.test.js
+++ b/website/electron/test/update-ipc-registration.test.js
@@ -29,6 +29,7 @@ const SRC = readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
 const BOOT_AWAITS = ["await startGateway();", "await showLoadingThenConnect(win);"];
 const UPDATE_HANDLERS = [
   'ipcMain.handle("update:get-info"',
+  'ipcMain.handle("update:replay-state"',
   'ipcMain.handle("update:check"',
   'ipcMain.handle("update:download"',
   'ipcMain.handle("update:install"',

--- a/website/scripts/capture-update-card.mjs
+++ b/website/scripts/capture-update-card.mjs
@@ -46,6 +46,12 @@ const SCENES = [
     note: 'staged + manual reinstall escape hatch',
   },
   {
+    scene: 'mandatory-downloaded',
+    marker: '[role="dialog"]',
+    forbiddenButtonNames: ['later', 'dismiss'],
+    note: 'mandatory stage has no Later or close/dismiss control',
+  },
+  {
     scene: 'download-failed',
     marker: '[data-testid="update-download-error"]',
     note: 'card SURVIVES with a retry (#735/#736)',
@@ -66,7 +72,7 @@ const run = async () => {
   const browser = await chromium.launch()
   let failed = 0
   for (const theme of ['dark', 'light']) {
-    for (const { scene, marker, note } of SCENES) {
+    for (const { scene, marker, forbiddenButtonNames = [], note } of SCENES) {
       const ctx = await browser.newContext({
         viewport: { width: 820, height: 620 },
         deviceScaleFactor: 2,
@@ -89,10 +95,25 @@ const run = async () => {
         await ctx.close()
         continue
       }
-      // Prefer the card itself; the check-failure scene has no card, so fall
-      // back to the padded root so the status line is still framed.
+      let forbiddenRendered = false
+      for (const name of forbiddenButtonNames) {
+        const count = await page.getByRole('button', { name: new RegExp(name, 'i') }).count()
+        if (count > 0) {
+          console.error(`  FAIL ${theme}/${scene}: forbidden ${name} button rendered`)
+          failed += 1
+          forbiddenRendered = true
+        }
+      }
+      if (forbiddenRendered) {
+        await ctx.close()
+        continue
+      }
+      // Prefer the card, then a modal dialog. The check-failure scene has
+      // neither, so fall back to the padded root to frame its status line.
       const target =
-        (await page.$('[data-testid="update-card"]')) || (await page.$('[data-capture-root]'))
+        (await page.$('[data-testid="update-card"]')) ||
+        (await page.$('[role="dialog"]')) ||
+        (await page.$('[data-capture-root]'))
       await target.screenshot({ path: `${OUT}/${theme}-${scene}.png` })
       console.log(`  ${theme}/${scene} -> ${note}`)
       await ctx.close()

--- a/website/src/components/UpdateModal.tsx
+++ b/website/src/components/UpdateModal.tsx
@@ -23,6 +23,8 @@ type UpdateState = {
   notes?: string
   channel?: string
   message?: string
+  mandatory?: boolean
+  minimumSupportedVersion?: string
 }
 
 type UpdateAPI = {
@@ -51,37 +53,46 @@ export default function UpdateModal() {
 
   const installMutation = useMutation({ mutationFn: () => getUpdateApi()!.install() })
   const installing = installMutation.isPending
+  const mandatory = update?.mandatory === true
 
-  const open = !!update && update.state === 'downloaded' && !dismissed
+  const open = !!update && update.state === 'downloaded' && (mandatory || !dismissed)
 
   // Escape dismisses the modal (unless an install is in flight), matching the
   // backdrop-click affordance and keeping the overlay keyboard-accessible.
   useEffect(() => {
     if (!open) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !installing) setDismissed(true)
+      if (e.key === 'Escape' && !installing && !mandatory) setDismissed(true)
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [open, installing])
+  }, [open, installing, mandatory])
 
   if (!open) return null
 
   const version = update!.version || ''
   const notes = (update!.notes || '').trim()
-  const dismiss = () => { if (!installing) setDismissed(true) }
+  const dismiss = () => { if (!installing && !mandatory) setDismissed(true) }
 
   return (
     <div
       className="fixed inset-0 z-50 bg-bg/80 backdrop-blur-sm flex items-center justify-center animate-rise"
-      role="button"
-      tabIndex={-1}
-      aria-label={i18nT('components.updateModal.dismiss_update_dialog')}
-      // Only dismiss when the click lands on the backdrop itself, not when it
-      // bubbles up from the dialog — avoids needing a stopPropagation handler
-      // (and its a11y warning) on the non-interactive dialog element.
-      onClick={e => { if (e.target === e.currentTarget) dismiss() }}
-      onKeyDown={e => { if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); dismiss() } }}
+      {...(mandatory ? {} : {
+        role: 'button',
+        tabIndex: -1,
+        'aria-label': i18nT('components.updateModal.dismiss_update_dialog'),
+        // Only dismiss when the click lands on the backdrop itself, not when it
+        // bubbles up from the dialog.
+        onClick: (e: React.MouseEvent<HTMLDivElement>) => {
+          if (e.target === e.currentTarget) dismiss()
+        },
+        onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
+          if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault()
+            dismiss()
+          }
+        },
+      })}
     >
       <div
         className="bg-card border border-border rounded-xl shadow-xl w-[460px] max-w-[90vw] flex flex-col overflow-hidden"
@@ -94,15 +105,17 @@ export default function UpdateModal() {
             <Download className="lucide-inline text-accent" size={16} />
             <span className="text-sm font-semibold text-text">{i18nT('components.updateModal.update_ready')}</span>
           </div>
-          <button
-            type="button"
-            className="text-muted hover:text-text cursor-pointer bg-transparent border-none disabled:opacity-50"
-            onClick={dismiss}
-            disabled={installing}
-            aria-label={i18nT('components.updateModal.dismiss')}
-          >
-            <X size={16} />
-          </button>
+          {!mandatory && (
+            <button
+              type="button"
+              className="text-muted hover:text-text cursor-pointer bg-transparent border-none disabled:opacity-50"
+              onClick={dismiss}
+              disabled={installing}
+              aria-label={i18nT('components.updateModal.dismiss')}
+            >
+              <X size={16} />
+            </button>
+          )}
         </div>
 
         <div className="px-4 py-3 text-sm text-text">
@@ -116,14 +129,16 @@ export default function UpdateModal() {
         </div>
 
         <div className="flex items-center justify-end gap-2 px-4 py-2.5 border-t border-border bg-bg-elevated">
-          <button
-            type="button"
-            className="px-3 py-1.5 text-sm text-muted hover:text-text bg-transparent border-none cursor-pointer disabled:opacity-50"
-            onClick={dismiss}
-            disabled={installing}
-          >
-            {i18nT('components.updateModal.later')}
-          </button>
+          {!mandatory && (
+            <button
+              type="button"
+              className="px-3 py-1.5 text-sm text-muted hover:text-text bg-transparent border-none cursor-pointer disabled:opacity-50"
+              onClick={dismiss}
+              disabled={installing}
+            >
+              {i18nT('components.updateModal.later')}
+            </button>
+          )}
           <button
             type="button"
             className="px-3 py-1.5 text-sm rounded-md bg-accent text-accent-fg hover:opacity-90 cursor-pointer disabled:opacity-50"

--- a/website/src/hooks/useUpdateSubscription.ts
+++ b/website/src/hooks/useUpdateSubscription.ts
@@ -9,6 +9,8 @@ export type UpdateState = {
   notes?: string
   channel?: string
   message?: string
+  mandatory?: boolean
+  minimumSupportedVersion?: string
 }
 
 type UpdateAPI = {

--- a/website/src/pages/settings/AboutPanel.tsx
+++ b/website/src/pages/settings/AboutPanel.tsx
@@ -27,6 +27,9 @@ type UpdateState = {
   /** Download progress, 0-100. Absent until the first progress event arrives. */
   percent?: number
   bytesPerSecond?: number
+  /** True when the running build is withdrawn or below the feed floor. */
+  mandatory?: boolean
+  minimumSupportedVersion?: string
 }
 
 /** Human-readable transfer rate for the progress label. */

--- a/website/src/test/UpdateModal.minimumVersion.test.tsx
+++ b/website/src/test/UpdateModal.minimumVersion.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import UpdateModal from '../components/UpdateModal'
+
+function renderModal(mandatory: boolean) {
+  const install = vi.fn().mockResolvedValue({ ok: true })
+  ;(window as unknown as { updateAPI?: unknown }).updateAPI = { install }
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client.setQueryData(['update-state'], {
+    state: 'downloaded',
+    version: '1.2.3',
+    mandatory,
+    minimumSupportedVersion: mandatory ? '1.2.0' : '',
+  })
+  const result = render(
+    <QueryClientProvider client={client}>
+      <UpdateModal />
+    </QueryClientProvider>,
+  )
+  return { ...result, install }
+}
+
+describe('UpdateModal minimum-supported-version enforcement', () => {
+  afterEach(() => {
+    cleanup()
+    delete (window as unknown as { updateAPI?: unknown }).updateAPI
+  })
+
+  it('removes every dismissal path for a mandatory staged update', async () => {
+    const { container } = renderModal(true)
+    expect(await screen.findByRole('dialog')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /later/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /dismiss/i })).toBeNull()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.getByRole('dialog')).toBeTruthy()
+
+    const backdrop = container.firstElementChild as HTMLElement
+    fireEvent.click(backdrop)
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /restart & update/i })).toBeTruthy()
+  })
+
+  it('keeps the ordinary update dismissible', async () => {
+    renderModal(false)
+    expect(await screen.findByRole('dialog')).toBeTruthy()
+    const later = screen.getByRole('button', { name: /later/i })
+    fireEvent.click(later)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

KiroCrew's mutable desktop release feeds had no shared, auditable emergency-control contract. Operators could not reliably freeze pointer writes, withdraw a bad version, restore a validated last-known-good feed, or require unsupported clients to update without risking partial or permissive behavior — and there was no defined way to *operate* such controls in an incident.

## Why it matters

A broken or security-sensitive release needs a bounded break-glass path. Without fail-closed controls, a malformed or unavailable policy could allow unsafe pointer mutation, a withdrawal could rotate away recovery state, and affected desktop clients could continue running or defer the required update.

## Fix

- Add a stdlib-only `scripts/release_feed_control.py` contract for `nightly`, `insider`, and `stable` channels.
  - validates bounded, versioned control documents and monotonic generations
  - supports bootstrap, freeze, unfreeze, withdraw, restore, minimum-version, guard, snapshot, and feed-rewrite operations
  - blocks writes on missing, unreachable, oversized, malformed, mismatched, or frozen state
  - preserves immutable artifacts and validates recovery URLs, hashes, versions, and allowed HTTPS byte hosts
- **Add the break-glass operator workflow** `.github/workflows/release-emergency-controls.yml` (`workflow_dispatch`): the "how do you actually run it" answer.
  - `main`-only, `prod` environment (same required-reviewer approval gate and write-only OIDC publishing role as the release publishers), typed confirmation `<channel>:<operation>`
  - manages the control **document** lifecycle only — bootstrap / freeze / unfreeze / withdraw / set-minimum / clear-minimum / restore — then verifies through the public CDN that the exact written bytes are being served
  - bootstrap is create-only, enforced at the origin with an S3 conditional write (`If-None-Match: *`), so it can never reset an active freeze, withdrawal list, or generation history — no CDN-absence inference
  - two-scope concurrency: all emergency runs serialize in one queued FIFO group (`queue: max` — a new dispatch can never cancel or displace pending emergency work), and only the validated, **approved** execute job enters the publishers' groups (`nightly-build`; `release-publish`, which insider and stable share) with cancellation rights, so an unvalidated or unapproved dispatch can never preempt an in-flight publish
  - `nightly.yml` accordingly flips `cancel-in-progress` to `false` (queued): publishers can never cancel emergency work; ordering protection is preserved by serialization
- Extend Electron update-feed handling with `minimumSupportedVersion` and `withdrawnVersions` policy.
  - rejects malformed policy and unsafe or withdrawn targets before download
  - keeps ordinary updates consent-first
  - automatically starts the existing verified download only when the running build is below the floor or explicitly withdrawn
  - makes a staged mandatory update non-dismissible (no Later, close, Escape, or backdrop dismissal)
  - revalidates staged feed policy immediately before install and fails closed when current policy cannot authorize the staged artifact
- Surface mandatory state through update subscriptions, the update modal, About settings, and capture tooling.
- Document the remaining production wiring, bootstrap, OIDC permission, and rehearsal dependencies. This PR deliberately does **not** claim that production feeds are already protected.

## Relationship to governance's `updates.min_version` (intentionally separate)

KiroCrew now carries two version floors, and they are deliberately independent:

- `updates.min_version` in `security_policy.json` (enterprise governance, `src/kiro_crew/platform/update_governance.py`) is an **administrator's** policy for gateway installs they already manage. It reaches only machines carrying that local policy file.
- `minimum_supported_version` in this PR's per-channel release-control document is a **release operator's** action, projected into the CDN update feeds, and reaches **every** desktop install — including machines nobody administers.

They share a concept name but not an audience, a distribution channel, or a failure domain, so they intentionally share no source, plumbing, or precedence: an install subject to both simply satisfies each independently. Documented in `docs/release-automation.md`.

## Tests

Focused coverage on the current head:
- 49 Python emergency-control cases passed
- 423 Electron tests passed
- 2 React minimum-version and modal tests passed (plus the full vitest suite)
- isort / flake8 passed; workflow YAML validated (structure + concurrency semantics cross-checked against GitHub's concurrency documentation, including `queue: max` FIFO behavior)

A prior revision of this branch passed 42/42 GitHub checks; CI is re-running after the rebase onto current `main` and the operator-workflow addition.

## Manual verification

The operator workflow cannot be truthfully exercised from this repository (no production CDN/signing credentials; `workflow_dispatch` requires the file on a live ref). Its fail-closed input validation, conditional-create upload, and CDN verification are enforced by construction and were reviewed against the `release_feed_control.py` contract; the non-production rehearsal remains an explicit operational dependency below.

## Operational dependencies

Item 1 of the previously documented dependency list — the protected `main`-only emergency `workflow_dispatch` — **ships in this PR**. Before production use, a follow-up must still:
1. wire `guard` + `snapshot` into every mutable macOS, Linux, and CLI publisher (a failed guard must stop the pointer chain);
2. bootstrap frozen control state and validated recovery feeds for all channels **before** enabling that guard, then separately unfreeze — otherwise the deliberately missing-control failure stops the next release;
3. retain the write-only, least-privilege external publishing role (bootstrap's conditional create needs only `s3:PutObject`) and protect the `prod` environment with required reviewers; and
4. complete a non-production CDN rehearsal (bootstrap → unfreeze → publish → freeze → withdraw/restore → unfreeze) before production bootstrap.

No production credentials were read or used for this source-only change.
