### PR TITLE
fix: preserve user data on uninstall

### DIFF
--- a/docs/app-classification-redesign.md
+++ b/docs/app-classification-redesign.md
@@ -518,12 +518,13 @@ Returns an impact analysis classifying each dependency:
 
 ```jsonc
 {
-  "keep_data": false,
+  "purge_data": true,
   "keep_dependencies": false,
   "keep_specific": ["aws-documentation-mcp-server"]
 }
 ```
 
+- `purge_data: true` → explicitly delete the app's `data/` subtree; omission preserves it
 - `keep_dependencies: true` → skip all dependency cleanup
 - `keep_dependencies: false` → remove `removable` deps not in `keep_specific`
 - `shared` and `userInstalled` are never removed regardless of flags
@@ -713,10 +714,12 @@ register_app(app_name)
 ### 9.1 Uninstall API
 
 The uninstall endpoint (`POST /api/apps/{name}/uninstall`) remains
-backward-compatible. Existing clients that send `{ "keep_data": true }`
-continue to work — the new `keep_dependencies` and `keep_specific`
-fields default to `false` and `[]` respectively, which means "clean up
-removable dependencies" (the safe default).
+backward-compatible for non-destructive requests. Existing clients that send
+`{ "keep_data": true }` continue to preserve data. Legacy `keep_data: false`
+is intentionally ignored because deletion now requires the dedicated literal
+`{ "purge_data": true }` action. The new `keep_dependencies` and
+`keep_specific` fields default to `false` and `[]` respectively, which means
+"clean up removable dependencies" (the safe default).
 
 The new preview endpoint (`GET /api/apps/{name}/uninstall/preview`) is
 additive — existing clients that don't call it simply skip the preview

--- a/docs/install.md
+++ b/docs/install.md
@@ -182,6 +182,35 @@ of `kirocrew`.
 > also pass `--port` on the CLI to override it. The `dashboard.url` config key is
 > only for advertising a remote URL.
 
+## Uninstall and data retention
+
+Uninstalling KiroCrew preserves `$KIROCREW_HOME` (`~/.kiro/crew` by default).
+That directory contains configuration, credentials, memory, sessions, apps, and
+the audit chain; none of the repository-controlled uninstall paths remove it:
+
+- `kirocrew service uninstall` removes only the systemd unit or launchd plist.
+- Python/npm package removal has no `preuninstall` or `postuninstall` cleanup hook.
+- The macOS DMG/zip and Linux AppImage have no repository cleanup hook. Removing
+  the application bundle/image therefore leaves the data home intact.
+- App Kit uninstall preserves `apps/<name>/data/` by default. Deleting that app
+  data is a separate, explicit action: `kirocrew app uninstall NAME --purge-data`
+  or uncheck **Keep app data** in the confirmation dialog.
+
+There is intentionally no implicit whole-home purge. Back up with `kirocrew
+snapshot` before manually removing a data home you no longer need.
+
+**External certification dependency.** Windows desktop releases use
+Squirrel.Windows, whose generated uninstaller is external to this repository.
+The repository's `--squirrel-uninstall` handler removes only the application
+shortcut and exits; it never resolves or removes the KiroCrew home, which is
+outside Squirrel's application install directory. Each signed Windows installer
+must nevertheless pass an install → create sentinel under
+`~/.kiro/crew` → uninstall → verify sentinel smoke test before release. A
+separate Kiro-family uninstaller could remove the parent `~/.kiro/` directory;
+it must exclude `~/.kiro/crew` or prompt explicitly. That release-blocking
+cross-product sign-off is tracked in
+[issue #355](https://github.com/kirodotdev/KiroCrew/issues/355).
+
 ## Troubleshooting
 
 For runtime issues (ACP handshake timeouts, embedding/memory search, Slack,

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -35,7 +35,8 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 | `kirocrew doctor` | Verify kiro-cli is installed and config is valid |
 | `kirocrew cron add/list/remove` | Manage cron jobs |
 | `kirocrew spawn run/list` | Manage background subagents |
-| `kirocrew app install/list/enable/disable/uninstall` | Manage App Kit apps |
+| `kirocrew app install/list/enable/disable/uninstall` | Manage App Kit apps. Uninstall preserves `apps/<name>/data/` by default. |
+| `kirocrew app uninstall NAME --purge-data` | Explicitly uninstall an app and permanently delete its app data. |
 | `kirocrew app dev <name> [--off]` | Toggle an installed app into/out of dev mode (no-store UI serving + live reload on file change). See [App Dev Mode](#app-dev-mode). |
 | `kirocrew learn add/list/remove` | Manage learned corrections |
 | `kirocrew run TASK.md` | Run an autonomous task from a spec file |

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -134,7 +134,18 @@ leaves) on every default-path resolution. It never follows a symlink at either
 root, is best-effort (a removal failure is logged and retried on the next
 start, never blocks startup), and is a quiet no-op once both are gone.
 
-**Uninstaller consideration (Zezhen's open question).** Because the data home now
+**Repository-controlled uninstall contract.** Every uninstall path owned by this
+repository preserves the KiroCrew data home by default. `kirocrew service
+uninstall` removes only its service definition; the Python/npm packages define
+no uninstall lifecycle hook; and the desktop shell's
+`--squirrel-uninstall` handler removes only its application shortcut, without
+resolving or removing the KiroCrew home. App Kit uninstall also preserves the
+app's `data/` subtree unless the dedicated `purge_data=true` API action (CLI
+`--purge-data`, or an explicit dashboard choice) is supplied. The API checks
+for the literal boolean `true`; absent, legacy, or malformed values fail closed
+to preservation. A whole-home purge is never coupled to uninstall.
+
+**Uninstaller consideration (external dependency).** Because the data home now
 lives under `~/.kiro/`, a hypothetical Kiro-family uninstaller that removes
 `~/.kiro/` would also remove `~/.kiro/crew` and take KiroCrew's data — config,
 credentials, memory DB, session history, and the SEL audit chain — with it. This

--- a/skills/kirocrew-commands/SKILL.md
+++ b/skills/kirocrew-commands/SKILL.md
@@ -238,8 +238,8 @@ keystone paths are still refused). The CLI is the stricter of the two.
 | `kirocrew app install /path/to/app-dir` | Install app from local directory (needs app.json) |
 | `kirocrew app enable NAME` | Enable an installed app |
 | `kirocrew app disable NAME` | Disable an installed app |
-| `kirocrew app uninstall NAME` | Uninstall an app |
-| `kirocrew app uninstall NAME --keep-data` | Uninstall but preserve data directory |
+| `kirocrew app uninstall NAME` | Uninstall an app and preserve its data directory |
+| `kirocrew app uninstall NAME --purge-data` | Uninstall and explicitly delete the app data directory |
 | `kirocrew app info NAME` | Show app details |
 | `kirocrew app init NAME` | Scaffold a new app (kebab-case name) |
 | `kirocrew app init NAME --backend --ui --cron` | Scaffold with backend, UI, and sample cron |

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -458,7 +458,7 @@ def install_app(source: str | Path) -> AppResult:
         )
 
     # Copy app files to install directory
-    # Preserve existing data/ directory (left behind by prior uninstall --keep-data)
+    # Preserve existing data/ directory (left behind by a prior default uninstall)
     existing_data = dest / "data" if dest.exists() else None
     # Use same temp name as uninstall_app/update_app so data stranded by a
     # crashed sibling operation is reclaimable by whichever lifecycle runs next.
@@ -712,11 +712,11 @@ def update_app(source: str | Path, *, expected_name: str | None = None) -> AppRe
 # ---------------------------------------------------------------------------
 
 
-def uninstall_app(name: str, *, keep_data: bool = False) -> AppResult:
-    """Uninstall an app by removing its directory.
+def uninstall_app(name: str, *, keep_data: bool = True) -> AppResult:
+    """Uninstall an app while preserving its ``data/`` directory by default.
 
-    If *keep_data* is True, the ``data/`` subdirectory is preserved.
-    Resource deregistration should be done before calling this.
+    Passing ``keep_data=False`` is the explicit purge action. Resource
+    deregistration should be done before calling this.
     Built-in apps cannot be uninstalled — only disabled.
     """
     if not _check_path_safety(name):

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -692,7 +692,7 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
     3. Run onUninstall script (if declared)
     4. Stop backend + deregister resources (gateway-managed only)
     5. Clean removable dependencies (unless keep_dependencies=true)
-    6. Remove app files (preserve data/ if keep_data=true)
+    6. Remove app files (preserve data/ unless purge_data=true)
 
     Steps 2–6 run inside the per-app lifecycle lock so the whole teardown is
     atomic and the cron precondition can abort before any irreversible action.
@@ -714,12 +714,15 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
     uninstall_log: list[str] = []
 
     # Parse body
-    keep_data = False
+    # Preserve app data unless the caller supplies the dedicated destructive
+    # action. Legacy ``keep_data: false`` payloads are intentionally ignored:
+    # absence or malformed values must never become an implicit purge.
+    keep_data = True
     keep_dependencies = False
     keep_specific: list[str] = []
     try:
         body = await request.json()
-        keep_data = body.get("keep_data", False)
+        keep_data = body.get("purge_data") is not True
         keep_dependencies = body.get("keep_dependencies", False)
         # Sanitize here, at the parse boundary: this is unvalidated client JSON,
         # and the dependency step that consumes it runs AFTER the onUninstall
@@ -826,7 +829,10 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
         if on_uninstall:
             script_output = await _run_lifecycle_script(
                 name, on_uninstall, timeout=120,
-                extra_env={"KEEP_DATA": "1" if keep_data else "0"},
+                extra_env={
+                    "KEEP_DATA": "1" if keep_data else "0",
+                    "PURGE_DATA": "0" if keep_data else "1",
+                },
             )
             if script_output.get("output"):
                 from kiro_crew.security import redact_credentials, redact_exfiltration_urls

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1691,10 +1691,14 @@ Examples:
     app_enable.add_argument("name", help="App name to enable")
     app_disable = app_sub.add_parser("disable", help="Disable an installed app")
     app_disable.add_argument("name", help="App name to disable")
-    app_uninstall = app_sub.add_parser("uninstall", help="Uninstall an app")
+    app_uninstall = app_sub.add_parser(
+        "uninstall", help="Uninstall an app (preserves app data by default)"
+    )
     app_uninstall.add_argument("name", help="App name to uninstall")
     app_uninstall.add_argument(
-        "--keep-data", action="store_true", help="Preserve app data directory"
+        "--purge-data",
+        action="store_true",
+        help="Permanently delete the app data directory",
     )
     app_info = app_sub.add_parser("info", help="Show app details")
     app_info.add_argument("name", help="App name")

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -580,7 +580,7 @@ def _handle_app(args: argparse.Namespace) -> None:
     elif action == "uninstall":
         _cleanup_app_crons_from_scheduler(args.name)
         deregister_app(args.name)
-        keep_data = getattr(args, "keep_data", False)
+        keep_data = not getattr(args, "purge_data", False)
         result = uninstall_app(args.name, keep_data=keep_data)
         if result.ok:
             print(f"✅ {result.message}")

--- a/test/test_app_cli.py
+++ b/test/test_app_cli.py
@@ -106,18 +106,42 @@ class TestHandleApp:
         assert data["name"] == "cli-test-app"
         assert "manifest" in data
 
-    def test_uninstall(self, tmp_path, app_env):
+    def test_uninstall_preserves_data_by_default(self, tmp_path, app_env):
         import argparse
 
         from kiro_crew.cli import _handle_app
 
         src = _make_app_source(tmp_path)
         install_app(src)
+        data_file = app_env["home"] / "apps" / "cli-test-app" / "data" / "state.json"
+        data_file.write_text('{"saved": true}')
 
-        ns = argparse.Namespace(app_action="uninstall", name="cli-test-app", keep_data=False)
+        ns = argparse.Namespace(
+            app_action="uninstall", name="cli-test-app", purge_data=False
+        )
         _handle_app(ns)
+
         from kiro_crew.apps.manager import get_app
+
         assert get_app("cli-test-app") is None
+        assert data_file.read_text() == '{"saved": true}'
+
+    def test_uninstall_purge_data_requires_explicit_flag(self, tmp_path, app_env):
+        import argparse
+
+        from kiro_crew.cli import _handle_app
+
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        app_dir = app_env["home"] / "apps" / "cli-test-app"
+        (app_dir / "data" / "state.json").write_text('{"saved": true}')
+
+        ns = argparse.Namespace(
+            app_action="uninstall", name="cli-test-app", purge_data=True
+        )
+        _handle_app(ns)
+
+        assert not app_dir.exists()
 
     def test_install_invalid_source(self, app_env):
         import argparse

--- a/test/test_app_manager.py
+++ b/test/test_app_manager.py
@@ -156,10 +156,26 @@ class TestInstall:
 # ---------------------------------------------------------------------------
 
 class TestUninstall:
-    def test_uninstall(self, tmp_path, app_home):
+    def test_uninstall_preserves_data_by_default(self, tmp_path, app_home):
         src = _make_app_source(tmp_path)
         install_app(src)
+        data_file = app_home / "apps" / "test-app" / "data" / "state.json"
+        data_file.write_text('{"saved": true}')
+
         result = uninstall_app("test-app")
+
+        assert result.ok
+        assert data_file.read_text() == '{"saved": true}'
+        assert not (app_home / "apps" / "test-app" / APP_MANIFEST_FILENAME).exists()
+
+    def test_uninstall_purges_data_only_when_explicit(self, tmp_path, app_home):
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        data_file = app_home / "apps" / "test-app" / "data" / "state.json"
+        data_file.write_text('{"saved": true}')
+
+        result = uninstall_app("test-app", keep_data=False)
+
         assert result.ok
         assert not (app_home / "apps" / "test-app").exists()
 
@@ -183,7 +199,7 @@ class TestUninstall:
         assert not (app_home / "apps" / "test-app" / APP_MANIFEST_FILENAME).exists()
 
     def test_install_preserves_existing_data(self, tmp_path, app_home):
-        """Reinstall after uninstall --keep-data must preserve user data."""
+        """Reinstall after default uninstall must preserve user data."""
         src = _make_app_source(tmp_path)
         install_app(src)
         # Write user data

--- a/test/test_app_routes.py
+++ b/test/test_app_routes.py
@@ -139,16 +139,58 @@ async def test_enable_disable(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_uninstall(tmp_path, monkeypatch):
-    _setup_env(tmp_path, monkeypatch)
+async def test_uninstall_preserves_data_by_default(tmp_path, monkeypatch):
+    home = _setup_env(tmp_path, monkeypatch)
     src = _make_app_source(tmp_path)
     install_app(src)
+    data_file = home / "apps" / "api-test-app" / "data" / "state.json"
+    data_file.write_text('{"saved": true}')
+
     async with TestClient(TestServer(_make_app())) as client:
         resp = await client.post("/api/apps/api-test-app/uninstall")
         assert resp.status == 200
 
         resp = await client.get("/api/apps/api-test-app")
         assert resp.status == 404
+
+    assert data_file.read_text() == '{"saved": true}'
+
+
+@pytest.mark.asyncio
+async def test_uninstall_purges_data_only_with_explicit_action(tmp_path, monkeypatch):
+    home = _setup_env(tmp_path, monkeypatch)
+    src = _make_app_source(tmp_path)
+    install_app(src)
+    app_dir = home / "apps" / "api-test-app"
+    (app_dir / "data" / "state.json").write_text('{"saved": true}')
+
+    async with TestClient(TestServer(_make_app())) as client:
+        # The legacy destructive field is ignored and fails closed.
+        resp = await client.post(
+            "/api/apps/api-test-app/uninstall", json={"keep_data": False}
+        )
+        assert resp.status == 200
+    assert (app_dir / "data" / "state.json").is_file()
+
+    # Reinstall over the preserved data, then prove malformed purge intent also
+    # fails closed.
+    install_app(src)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(
+            "/api/apps/api-test-app/uninstall", json={"purge_data": "true"}
+        )
+        assert resp.status == 200
+    assert (app_dir / "data" / "state.json").is_file()
+
+    # Reinstall again, then invoke the dedicated literal-boolean purge action.
+    install_app(src)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(
+            "/api/apps/api-test-app/uninstall", json={"purge_data": True}
+        )
+        assert resp.status == 200
+
+    assert not app_dir.exists()
 
 
 @pytest.mark.asyncio

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -689,6 +689,11 @@ class TestLinuxControlPaths:
         # would also affect pytest/fixture machinery).
         unit_path = tmp_path / "kirocrew.service"
         unit_path.write_text("")
+        data_home = tmp_path / "crew-home"
+        data_home.mkdir()
+        sentinel = data_home / "memory.db"
+        sentinel.write_text("user data")
+        monkeypatch.setenv("KIROCREW_HOME", str(data_home))
         monkeypatch.setattr(svc_linux, "UNIT_PATH", unit_path)
         ok = MagicMock(returncode=0, stdout="", stderr="")
         with patch(
@@ -703,6 +708,7 @@ class TestLinuxControlPaths:
             c[:3] == ["sudo", "rm", "-f"] for c in called
         ), f"expected sudo rm of unit file; got {called}"
         assert ["sudo", "systemctl", "daemon-reload"] in called
+        assert sentinel.read_text() == "user data"
 
     def test_is_active_returns_true_when_systemctl_says_active(self):
         from kiro_crew.service import linux as svc_linux
@@ -953,6 +959,11 @@ class TestMacOSControlPaths:
         plist_path = plist_dir / f"{LAUNCHD_LABEL}.plist"
         plist_dir.mkdir(parents=True)
         plist_path.write_text("<plist/>")
+        data_home = tmp_path / "crew-home"
+        data_home.mkdir()
+        sentinel = data_home / "memory.db"
+        sentinel.write_text("user data")
+        monkeypatch.setenv("KIROCREW_HOME", str(data_home))
         monkeypatch.setattr(svc_macos, "PLIST_PATH", plist_path)
 
         ok = MagicMock(returncode=0, stdout="", stderr="")
@@ -963,6 +974,7 @@ class TestMacOSControlPaths:
         assert not plist_path.exists()
         called = [c.args[0] for c in run.call_args_list]
         assert ["launchctl", "unload", "-w", str(plist_path)] in called
+        assert sentinel.read_text() == "user data"
 
     def test_uninstall_idempotent_when_plist_missing(self, tmp_path, monkeypatch):
         from kiro_crew.service import macos as svc_macos

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -50,3 +50,39 @@ describe("macOS bundle naming", () => {
     assert.doesNotMatch(buildScript, /-c\.mac\.extendInfo\.CFBundleName=/);
   });
 });
+
+
+describe("uninstall data preservation contract", () => {
+  const electronPkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  const websitePkg = JSON.parse(
+    fs.readFileSync(path.resolve(ROOT, "..", "package.json"), "utf8")
+  );
+  const main = fs.readFileSync(path.join(ROOT, "main.js"), "utf8");
+
+  it("defines no package-manager uninstall hooks", () => {
+    for (const [name, scripts] of [
+      ["electron", electronPkg.scripts || {}],
+      ["website", websitePkg.scripts || {}],
+    ]) {
+      assert.equal(Object.hasOwn(scripts, "preuninstall"), false, `${name} preuninstall`);
+      assert.equal(Object.hasOwn(scripts, "postuninstall"), false, `${name} postuninstall`);
+    }
+  });
+
+  it("keeps the Squirrel uninstall handler shortcut-only", () => {
+    const match = main.match(
+      /else if \(cmd === "--squirrel-uninstall"\) \{([\s\S]*?)\n  \} else if/
+    );
+    assert.ok(match, "expected an explicit Squirrel uninstall branch");
+    assert.equal(
+      match[1].trim(),
+      'run(["--removeShortcut=" + target]);',
+      "Squirrel uninstall must remain shortcut-only and never touch the data home"
+    );
+    assert.notEqual(
+      electronPkg.build.nsis?.deleteAppDataOnUninstall,
+      true,
+      "desktop uninstall must not opt into deleting app data"
+    );
+  });
+});

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1396,9 +1396,9 @@ export const api = {
   enableApp: (name: string) => post('/api/apps/' + encodeURIComponent(name) + '/enable').then(j),
   disableApp: (name: string) => post('/api/apps/' + encodeURIComponent(name) + '/disable').then(j),
   openApp: (name: string) => post('/api/apps/' + encodeURIComponent(name) + '/open').then(j),
-  uninstallApp: (name: string, keepData?: boolean, keepDependencies?: boolean, keepSpecific?: string[]) =>
+  uninstallApp: (name: string, keepData = true, keepDependencies?: boolean, keepSpecific?: string[]) =>
     post('/api/apps/' + encodeURIComponent(name) + '/uninstall', {
-      ...(keepData ? { keep_data: true } : {}),
+      ...(keepData === false ? { purge_data: true } : {}),
       ...(keepDependencies ? { keep_dependencies: true } : {}),
       ...(keepSpecific?.length ? { keep_specific: keepSpecific } : {}),
     }).then(j),

--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -194,7 +194,7 @@ export default function AppDetailPage() {
   const [copied, setCopied] = useState(false)
   const [serverHostname, setServerHostname] = useState('')
   const [showUninstallConfirm, setShowUninstallConfirm] = useState(false)
-  const [keepData, setKeepData] = useState(false)
+  const [keepData, setKeepData] = useState(true)
 
   // Helper: open chat with a pre-filled message (same mechanism as useChatLauncher from app-sdk)
   const openChatWithMessage = useCallback((message: string) => {
@@ -362,7 +362,7 @@ export default function AppDetailPage() {
     // Intercept uninstall to show confirmation modal
     if (action === 'uninstall') {
       setShowUninstallConfirm(true)
-      setKeepData(false)
+      setKeepData(true)
       return
     }
     setActionLoading(action)

--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -93,7 +93,7 @@ export default function AppsPage() {
 
   // Uninstall confirmation state (Library)
   const [uninstallTarget, setUninstallTarget] = useState<InstalledApp | null>(null)
-  const [keepData, setKeepData] = useState(false)
+  const [keepData, setKeepData] = useState(true)
   const [uninstallPreview, setUninstallPreview] = useState<UninstallPreview | null>(null)
   const [keepSpecific, setKeepSpecific] = useState<Set<string>>(new Set())
 
@@ -271,7 +271,7 @@ export default function AppsPage() {
       const app = apps.find(a => a.name === name)
       if (app) {
         setUninstallTarget(app)
-        setKeepData(false)
+        setKeepData(true)
         setKeepSpecific(new Set())
         // Fetch uninstall preview (best-effort — dialog works without it)
         try {


### PR DESCRIPTION
## Problem
Repository-controlled App Kit uninstall paths deleted app user data unless callers opted in to preservation. Missing or malformed API intent could therefore become destructive.

## Why it matters
Uninstall must not destroy KiroCrew or app state by default. Destructive cleanup needs explicit, auditable user intent across manager, API, CLI, dashboard, service, and desktop packaging paths.

## Fix
- Preserve `apps/<name>/data/` by default in the manager, API, CLI, and both dashboard dialogs.
- Require CLI `--purge-data` or literal API `{"purge_data": true}` for app-data deletion.
- Treat omitted, legacy `keep_data:false`, malformed, and string purge values as preservation requests.
- Pass `KEEP_DATA` and `PURGE_DATA` to app lifecycle scripts.
- Lock service/package/desktop paths against whole-home deletion, including an exact shortcut-only Squirrel uninstall-handler contract.
- Document the repository contract and external installer certification requirements.

## Tests
- `195 passed`: affected app manager, CLI, route, and Linux/macOS service suites.
- `408 passed`: full Electron suite.
- Python `isort`, `flake8`, and `mypy` passed across `src/kiro_crew` and `test`.
- Frontend `npx tsc -b`, ESLint (286 existing warnings within 1116 budget), and production Vite build passed.
- Python wheel build passed (`kirocrew-0.1.2-py3-none-any.whl`).
- `scripts/scrub-lint.sh --no-history` passed.

## Manual verification
- Real CLI help exposes `--purge-data` and states permanent deletion.
- API tests verify omission and legacy/malformed values preserve data; only literal boolean `true` purges.

## Screenshots
Not captured: the UI reuses the existing uninstall dialog and checkbox; the only visible change is that **Keep app data** opens checked by default, with no layout or copy change.

## External dependencies
- Certify each signed Windows installer with install → create `~/.kiro/crew` sentinel → uninstall → verify sentinel.
- The separate Kiro-family uninstaller must exclude `~/.kiro/crew` from parent `~/.kiro/` deletion or prompt explicitly (release-blocking #355).
- macOS bundle deletion and Linux AppImage deletion remain OS/user actions; repository cleanup hooks are absent.
