### PR TITLE
perf(dashboard): stop per-frame store churn on the reasoning stream

### DIFF
--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { SplitGlyph } from './SplitGlyph'
@@ -9,7 +9,7 @@ import ToolCallLine from '../pages/chat/ToolCallLine'
 import type { ChatMessage } from '../types'
 import ChatInput from './ChatInput'
 import PendingQuestionCard from './PendingQuestionCard'
-import QueueStack, { SubagentDeliveryProgress, isSystemDelivery, isNonInteractiveQueued } from './QueueStack'
+import QueueStack, { SubagentDeliveryProgress, splitPaneMessages } from './QueueStack'
 import SubagentProgressBar from '../pages/chat/SubagentProgressBar'
 import AgentDropdownList from './AgentDropdownList'
 import ModelDropdownList from './ModelDropdownList'
@@ -86,10 +86,16 @@ export default function ChatPane({
   // sub-agent deliveries collapse into one progress line, and synthetic
   // turn-recovery injections drain automatically and render as a RecoveryCard.
   // Mirrors ChatPage — split view (⌘D) is a second live QueueStack consumer.
-  const messages = allMessages.filter((m) => m.role !== 'queued')
-  const allQueued = allMessages.filter((m) => m.role === 'queued')
-  const queuedMessages = allQueued.filter((m) => !isNonInteractiveQueued(m))
-  const systemDeliveryCount = allQueued.filter((m) => isSystemDelivery(m)).length
+  //
+  // Memoized on `allMessages`: this pane OWNS the composer `input` state, so it
+  // re-renders on every keystroke. Recomputing these in the render body handed
+  // `messages` a fresh array identity per character, which permanently defeated
+  // the memo() on ChatMessageList and re-ran its O(N) turn grouping while the
+  // user typed.
+  const { messages, queuedMessages, systemDeliveryCount } = useMemo(
+    () => splitPaneMessages(allMessages),
+    [allMessages],
+  )
 
   // Pickers — same hooks/data sources ChatPage uses, but selection targets THIS slot.
   const { agents: installedAgents, defaultAgent } = useAgents(0)

--- a/website/src/components/QueueStack.tsx
+++ b/website/src/components/QueueStack.tsx
@@ -30,6 +30,34 @@ export function isNonInteractiveQueued(m: ChatMessage): boolean {
   return isSystemDelivery(m) || parseRecoveryMessage(m.content || '') !== null
 }
 
+/** Split a slot's message list into the three things a pane surface needs:
+ *  the transcript (everything not queued), the INTERACTIVE queue cards, and a
+ *  count of held sub-agent deliveries for the collapsed progress line.
+ *
+ *  One pass, and one place. Callers own the composer's `input` state, so they
+ *  re-render on every keystroke; deriving these in a render body handed the
+ *  transcript array a fresh identity per character, which defeated the memo()
+ *  on ChatMessageList and re-ran its O(N) turn grouping while the user typed.
+ *  Callers must wrap this in a `useMemo` keyed on the input array. */
+export function splitPaneMessages(allMessages: ChatMessage[]): {
+  messages: ChatMessage[]
+  queuedMessages: ChatMessage[]
+  systemDeliveryCount: number
+} {
+  const messages: ChatMessage[] = []
+  const queuedMessages: ChatMessage[] = []
+  let systemDeliveryCount = 0
+  for (const m of allMessages) {
+    if (m.role !== 'queued') { messages.push(m); continue }
+    // Both queue predicates are independent, not mutually exclusive: a
+    // sub-agent delivery is excluded from the interactive stack AND counted
+    // for the progress line.
+    if (!isNonInteractiveQueued(m)) queuedMessages.push(m)
+    if (isSystemDelivery(m)) systemDeliveryCount++
+  }
+  return { messages, queuedMessages, systemDeliveryCount }
+}
+
 /** One quiet, non-interactive line summarizing held sub-agent deliveries —
  *  "the results are in; they'll be processed when the current turn finishes". */
 export function SubagentDeliveryProgress({ count }: { count: number }) {

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -838,13 +838,25 @@ export function useWebSocket() {
           case 'context_usage':
             dispatch(sseContextUsage(data as { slot: string; pct: number; used_tokens?: number; window_tokens?: number }))
             break
-          case 'chat_thinking':
+          case 'chat_thinking': {
             // kiro-cli/ACP reasoning (agent_thought_chunk) -> collapsible block.
             dispatch(sseThinkingChunk({ slot: data.slot, content: (data as { content?: string }).content || '' }))
-            if (data.slot && store.getState().chat.slotStatusDetail[data.slot]?.kind !== 'streaming') {
+            // Dispatch the status detail only on a genuine kind TRANSITION into
+            // 'thinking'. The old guard tested `!== 'streaming'` and then wrote
+            // 'thinking', which is itself `!== 'streaming'` — so it never
+            // self-limited and re-dispatched on EVERY thought frame with a fresh
+            // `ts`. Because setSlotStatusDetail replaces slotStatusDetail[slot]
+            // wholesale, that bumped the map identity per frame and re-rendered
+            // every whole-map subscriber (ChatSidebar, CommandPalette) for the
+            // duration of the model's reasoning. The sibling chat_chunk guard
+            // above writes 'streaming' and so is naturally idempotent; this is
+            // the same shape, made explicit.
+            const detailKind = data.slot ? store.getState().chat.slotStatusDetail[data.slot]?.kind : undefined
+            if (data.slot && detailKind !== 'streaming' && detailKind !== 'thinking') {
               dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', text: 'Thinking…', ts: Date.now() }))
             }
             break
+          }
           case 'chat_segment':
             flushChunks()
             dispatch(sseChatMessage({ ...data, role: '_segment' }))

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -9,6 +9,7 @@ import { SortableContext, verticalListSortingStrategy, useSortable, sortableKeyb
 import { CSS } from '@dnd-kit/utilities'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { modelListRefetchInterval } from '../providers/modelListHealth'
+import { shallowEqual } from 'react-redux'
 import { useAppDispatch, useAppSelector } from '../store'
 import { useConnected } from '../hooks/useConnected'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubTrigger, DropdownMenuSubContent } from '../components/ui/dropdown-menu'
@@ -707,7 +708,11 @@ function ChatSidebar({
   // has arrived. Used by the auto-drain effect to distinguish "data not yet
   // loaded" from "data loaded and genuinely empty".
   const slotsLoaded = useAppSelector(s => s.dashboard.slotsLoaded)
-  const slotStatusDetail = useAppSelector(s => s.chat.slotStatusDetail)
+  // shallowEqual: this is a whole-map subscription read only for each row's
+  // `.text`, so re-render when some slot's detail object actually changed —
+  // not merely because a reducer produced a new map wrapper. Without it, any
+  // write to one slot's detail re-renders the entire sidebar.
+  const slotStatusDetail = useAppSelector(s => s.chat.slotStatusDetail, shallowEqual)
   // Presence in this map means "this session is in an active goal loop".
   const goalLoops = useAppSelector(s => s.chat.goalLoops)
   // Live subagent activity per slot, for the sidebar row's "N agents running"

--- a/website/src/test/splitPaneMessages.test.ts
+++ b/website/src/test/splitPaneMessages.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `splitPaneMessages` — the one-pass replacement for four render-body filters.
+ *
+ * ChatPane owns the composer `input` state, so it re-renders on every keystroke.
+ * Deriving the transcript with `allMessages.filter(...)` in the render body gave
+ * it a fresh array identity per character, which permanently defeated the memo()
+ * on ChatMessageList and re-ran its O(N) turn grouping while the user typed.
+ *
+ * These tests pin the split's SEMANTICS (the refactor's real risk is a logic
+ * slip, not a perf regression) and the identity contract callers rely on.
+ */
+import { describe, it, expect } from 'vitest'
+import { splitPaneMessages } from '../components/QueueStack'
+import type { ChatMessage } from '../types'
+
+const msg = (role: string, content = ''): ChatMessage =>
+  ({ role, content, cls: '' } as ChatMessage)
+
+const DELIVERY = '[Subagent completion event] agent finished'
+const BATCH_DELIVERY = '[Subagent batch completion event] 3 agents finished'
+
+describe('splitPaneMessages', () => {
+  it('routes non-queued messages to the transcript, preserving order', () => {
+    const all = [msg('user', 'a'), msg('assistant', 'b'), msg('tool', 'c')]
+    const { messages, queuedMessages, systemDeliveryCount } = splitPaneMessages(all)
+    expect(messages.map(m => m.content)).toEqual(['a', 'b', 'c'])
+    expect(queuedMessages).toEqual([])
+    expect(systemDeliveryCount).toBe(0)
+  })
+
+  it('keeps interactive queued entries out of the transcript and in the stack', () => {
+    const all = [msg('user', 'a'), msg('queued', 'please do this next'), msg('assistant', 'b')]
+    const { messages, queuedMessages } = splitPaneMessages(all)
+    expect(messages.map(m => m.content)).toEqual(['a', 'b'])
+    expect(queuedMessages.map(m => m.content)).toEqual(['please do this next'])
+  })
+
+  it('excludes sub-agent deliveries from the interactive stack but counts them', () => {
+    const all = [msg('queued', DELIVERY), msg('queued', 'a real user message')]
+    const { queuedMessages, systemDeliveryCount } = splitPaneMessages(all)
+    // Editing or cancelling a delivery would silently lose a finished agent's
+    // result — it must never render as an interactive card.
+    expect(queuedMessages.map(m => m.content)).toEqual(['a real user message'])
+    expect(systemDeliveryCount).toBe(1)
+  })
+
+  it('counts batch deliveries too', () => {
+    const { queuedMessages, systemDeliveryCount } = splitPaneMessages([
+      msg('queued', DELIVERY),
+      msg('queued', BATCH_DELIVERY),
+    ])
+    expect(queuedMessages).toEqual([])
+    expect(systemDeliveryCount).toBe(2)
+  })
+
+  it('applies the two queue predicates independently, not as else-if', () => {
+    // A delivery satisfies BOTH isNonInteractiveQueued and isSystemDelivery.
+    // Collapsing them into a single if/else would drop the count — the exact
+    // slip this one-pass rewrite could have introduced.
+    const { queuedMessages, systemDeliveryCount } = splitPaneMessages([msg('queued', DELIVERY)])
+    expect(queuedMessages).toEqual([])
+    expect(systemDeliveryCount).toBe(1)
+  })
+
+  it('never counts a non-queued message as a delivery', () => {
+    // Same text, assistant role: the role gate must run first.
+    const { messages, queuedMessages, systemDeliveryCount } = splitPaneMessages([msg('assistant', DELIVERY)])
+    expect(messages).toHaveLength(1)
+    expect(queuedMessages).toEqual([])
+    expect(systemDeliveryCount).toBe(0)
+  })
+
+  it('handles an empty list', () => {
+    const { messages, queuedMessages, systemDeliveryCount } = splitPaneMessages([])
+    expect(messages).toEqual([])
+    expect(queuedMessages).toEqual([])
+    expect(systemDeliveryCount).toBe(0)
+  })
+
+  it('returns the same values a chain of filters would (equivalence oracle)', () => {
+    const all = [
+      msg('user', 'u1'), msg('queued', DELIVERY), msg('assistant', 'a1'),
+      msg('queued', 'q1'), msg('queued', BATCH_DELIVERY), msg('tool', 't1'),
+      msg('queued', 'q2'), msg('permission', 'p1'),
+    ]
+    const got = splitPaneMessages(all)
+
+    // The exact expressions this replaced, kept here as the oracle so a future
+    // edit to the one-pass loop cannot silently drift from the old semantics.
+    const expectedMessages = all.filter(m => m.role !== 'queued')
+    const allQueued = all.filter(m => m.role === 'queued')
+    const expectedQueued = allQueued.filter(m => !(
+      m.content.startsWith('[Subagent completion event]') ||
+      m.content.startsWith('[Subagent batch completion event]')
+    ))
+    const expectedCount = allQueued.filter(m => (
+      m.content.startsWith('[Subagent completion event]') ||
+      m.content.startsWith('[Subagent batch completion event]')
+    )).length
+
+    expect(got.messages).toEqual(expectedMessages)
+    expect(got.queuedMessages).toEqual(expectedQueued)
+    expect(got.systemDeliveryCount).toBe(expectedCount)
+  })
+
+  it('returns fresh arrays per call, so callers MUST memoize', () => {
+    // Documents why ChatPane wraps this in useMemo keyed on allMessages: the
+    // function is pure but not memoizing, so calling it in a render body is
+    // exactly the bug that was fixed.
+    const all = [msg('user', 'a')]
+    expect(splitPaneMessages(all).messages).not.toBe(splitPaneMessages(all).messages)
+  })
+
+  it('does not mutate its input', () => {
+    const all = [msg('user', 'a'), msg('queued', 'q')]
+    const snapshot = [...all]
+    splitPaneMessages(all)
+    expect(all).toEqual(snapshot)
+  })
+})

--- a/website/src/test/useWebSocket.thinkingStatusChurn.test.ts
+++ b/website/src/test/useWebSocket.thinkingStatusChurn.test.ts
@@ -1,0 +1,197 @@
+/**
+ * `chat_thinking` must not re-dispatch its status detail on every thought frame.
+ *
+ * The guard tested `slotStatusDetail[slot]?.kind !== 'streaming'` and then wrote
+ * `kind: 'thinking'` — which is itself `!== 'streaming'`. So it never
+ * self-limited: every reasoning frame dispatched `setSlotStatusDetail` again
+ * with a fresh `ts`. That reducer replaces `slotStatusDetail[slot]` wholesale,
+ * so the map identity changed per frame and every whole-map subscriber
+ * (ChatSidebar, CommandPalette) re-rendered for the entire duration of the
+ * model's reasoning — a ~2,600-line sidebar, per frame, to redraw the same
+ * "Thinking…" string.
+ *
+ * The sibling `chat_chunk` guard writes `kind: 'streaming'` and is therefore
+ * naturally idempotent. These tests pin that same property onto the thinking
+ * path, and pin the transitions that must STILL fire.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { store as globalStore } from '../store'
+import { setActiveSlot, clearSlotState, sseChatMessage } from '../store/chatSlice'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+function storeOnSlot1() {
+  // Deliberately the SINGLETON store, not a fresh createTestStore(). useWebSocket
+  // dispatches through useAppDispatch() (the Provider store) but reads the guard's
+  // current state off the imported singleton (`hooks/useWebSocket.ts:5`). In
+  // production those are the same object; a separate Provider store would make
+  // reads and writes diverge, so the guard would never observe its own write and
+  // these tests would pass against the buggy code too.
+  globalStore.dispatch(clearSlotState())
+  globalStore.dispatch(setActiveSlot('slot-1'))
+  globalStore.dispatch(sseChatMessage({ slot: 'slot-1', role: 'user', content: 'explain this' }))
+  return globalStore
+}
+
+describe('useWebSocket chat_thinking status-detail churn', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalStore.dispatch(clearSlotState())
+    globalStore.dispatch(setActiveSlot(null))
+  })
+
+  function mount(store: ReturnType<typeof storeOnSlot1>) {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return { hook, ws }
+  }
+
+  const thinking = (content: string) => ({
+    type: 'chat_thinking',
+    data: { slot: 'slot-1', content },
+  })
+
+  it('keeps slotStatusDetail[slot] reference-stable across many thought frames', () => {
+    const store = storeOnSlot1()
+    const { ws } = mount(store)
+
+    act(() => { ws.simulateMessage(thinking('Let me ')) })
+    const afterFirst = store.getState().chat.slotStatusDetail['slot-1']
+    expect(afterFirst).toBeDefined()
+    expect(afterFirst.kind).toBe('thinking')
+
+    // 25 more frames, as one reasoning block streams in.
+    act(() => {
+      for (let i = 0; i < 25; i++) ws.simulateMessage(thinking(`token${i} `))
+    })
+
+    // The SAME object — no re-dispatch, so no new map identity, so no
+    // whole-map subscriber re-render. This is the assertion that fails on the
+    // pre-fix code (each frame replaced the detail with a fresh `ts`).
+    expect(store.getState().chat.slotStatusDetail['slot-1']).toBe(afterFirst)
+  })
+
+  it('keeps the slotStatusDetail map itself reference-stable across frames', () => {
+    const store = storeOnSlot1()
+    const { ws } = mount(store)
+
+    act(() => { ws.simulateMessage(thinking('first ')) })
+    const mapAfterFirst = store.getState().chat.slotStatusDetail
+
+    act(() => {
+      for (let i = 0; i < 10; i++) ws.simulateMessage(thinking('more '))
+    })
+
+    expect(store.getState().chat.slotStatusDetail).toBe(mapAfterFirst)
+  })
+
+  it('still accumulates the reasoning text on every frame', () => {
+    const store = storeOnSlot1()
+    const { ws } = mount(store)
+
+    act(() => {
+      ws.simulateMessage(thinking('alpha '))
+      ws.simulateMessage(thinking('beta '))
+      ws.simulateMessage(thinking('gamma'))
+    })
+
+    const think = store.getState().chat.messages.find(m => m.role === 'thinking')
+    expect(think).toBeDefined()
+    // Suppressing the redundant STATUS dispatch must not suppress the content.
+    expect(think!.content).toBe('alpha beta gamma')
+  })
+
+  it('still sets the detail on a genuine transition back into thinking', () => {
+    const store = storeOnSlot1()
+    const { ws } = mount(store)
+
+    act(() => { ws.simulateMessage(thinking('thinking first ')) })
+    expect(store.getState().chat.slotStatusDetail['slot-1'].kind).toBe('thinking')
+
+    // A tool call moves the detail off 'thinking'...
+    act(() => {
+      ws.simulateMessage({
+        type: 'tool_call',
+        data: { slot: 'slot-1', tool: 'fs_read', kind: 'tool', purpose: 'reading a file', input_preview: '' },
+      })
+    })
+    expect(store.getState().chat.slotStatusDetail['slot-1'].kind).toBe('tool')
+    const afterTool = store.getState().chat.slotStatusDetail['slot-1']
+
+    // ...and the next thought frame must restore it. The idempotence fix must
+    // not degrade into "only ever dispatch once".
+    act(() => { ws.simulateMessage(thinking('back to thinking')) })
+    const restored = store.getState().chat.slotStatusDetail['slot-1']
+    expect(restored.kind).toBe('thinking')
+    expect(restored).not.toBe(afterTool)
+  })
+
+  it('does not overwrite a streaming detail with thinking', () => {
+    const store = storeOnSlot1()
+    const { ws } = mount(store)
+
+    act(() => { ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: 'answer', seq: 1 } }) })
+    expect(store.getState().chat.slotStatusDetail['slot-1'].kind).toBe('streaming')
+    const streamingDetail = store.getState().chat.slotStatusDetail['slot-1']
+
+    act(() => { ws.simulateMessage(thinking('late thought')) })
+
+    // Pre-existing behaviour, pinned so the fix cannot regress it: visible
+    // output outranks reasoning in the status line.
+    expect(store.getState().chat.slotStatusDetail['slot-1']).toBe(streamingDetail)
+  })
+})


### PR DESCRIPTION
## Problem

While the model is reasoning, the dashboard re-renders far more than the visible change warrants. Every streamed *thought* frame commits to the Redux store twice — once for the reasoning text, once to re-set a status detail that already says the same thing — and the second commit invalidates a whole-map subscription that the ~2,600-line `ChatSidebar` reads. Separately, typing in a split-view pane re-derives the entire transcript array on every keystroke, so the memoized message list can never short-circuit.

Nothing looks broken; it just does a lot of work to display "Thinking…" and to accept a character of input.

## Why it matters

Both paths scale with things the user does constantly: reasoning frames arrive for the whole duration of a turn, and keystrokes arrive for the whole duration of composing a message. The reasoning path is the worse of the two because the wasted work lands on the sidebar, which is one of the largest components in the app and has nothing to do with the turn in progress. Split view multiplies the typing path across panes.

## Fix (symptom → root cause → change)

**1. `chat_thinking` re-dispatched its status detail on every frame** — `website/src/hooks/useWebSocket.ts`

The guard read `slotStatusDetail[slot]?.kind !== 'streaming'` and then wrote `kind: 'thinking'`. `'thinking' !== 'streaming'` is still true, so the condition never stopped being satisfied: every subsequent thought frame dispatched `setSlotStatusDetail` again with a fresh `ts`. That reducer replaces `state.slotStatusDetail[slot]` wholesale, so the map got a new identity per frame and every whole-map subscriber re-rendered.

The sibling `chat_chunk` guard immediately above writes `kind: 'streaming'` and is therefore naturally idempotent — it fires once per turn. This makes the thinking path match, by testing for a genuine *transition* into `thinking`.

Preserved deliberately: `tool → thinking` still fires (so the status line recovers after a tool call), `'streaming'` still outranks `'thinking'`, and reasoning **text** accumulation is untouched.

**2. `ChatSidebar`'s `slotStatusDetail` subscription is now `shallowEqual`** — `website/src/pages/ChatSidebar.tsx`

It is a whole-map read used only for each row's `.text`, so it should re-render when some slot's detail actually changed, not because a reducer produced a new map wrapper. Composes with fix 1 rather than substituting for it.

**3. `ChatPane` derived its transcript in the render body** — `website/src/components/ChatPane.tsx`, `website/src/components/QueueStack.tsx`

Four `filter()` passes over `allMessages`. The pane owns the composer `input` state, so all four ran on every keystroke and handed `messages` a fresh array identity per character — which permanently defeated the `memo()` on `ChatMessageList` and re-ran its O(N) turn grouping while the user typed.

Extracted to `splitPaneMessages()` in `QueueStack.tsx`, next to the two predicates it uses: one pass, one place, and unit-testable. `ChatPane` memoizes it on `allMessages`.

## Tests

15 new, all frontend.

`website/src/test/useWebSocket.thinkingStatusChurn.test.ts` (5)
- `slotStatusDetail[slot]` stays reference-stable across 26 thought frames
- the `slotStatusDetail` map itself stays reference-stable across frames
- reasoning text still accumulates on every frame (the fix must not suppress content)
- a genuine `tool → thinking` transition still sets the detail (the fix must not degrade into "dispatch once, ever")
- a `streaming` detail is not overwritten by a late thought frame (pre-existing behaviour, pinned)

**These discriminate rather than merely cover.** Reverting the guard to its previous form makes the first two fail and leaves the other three passing — verified locally before committing.

One implementation note worth flagging for reviewers: these tests use the **singleton** Redux store as the Provider store, deliberately. `useWebSocket` dispatches through `useAppDispatch()` (the Provider store) but reads the guard's current state off the imported singleton (`hooks/useWebSocket.ts:5`). In production those are the same object; with a separate test store, reads and writes diverge, the guard never observes its own write, and the tests would pass against the buggy code too. The comment in the test says so.

`website/src/test/splitPaneMessages.test.ts` (10) — role gating, order preservation, sub-agent deliveries excluded from the interactive stack but counted for the progress line, batch deliveries, the two predicates applying **independently** rather than as if/else (the specific slip a one-pass rewrite could introduce), empty input, no input mutation, fresh arrays per call (documenting why callers must memoize), and an **equivalence oracle** that re-implements the exact filter chain this replaced and asserts identical output.

Full suite: **6,462 passed / 534 files**, `tsc -b` clean, eslint 0 errors, `i18n:check` at baseline. No Python changed, so the backend suite is unaffected and was not run.

## Manual verification

N/A — unit coverage is sufficient and better-targeted than clicking would be. The behavioural claims here are all about store-commit *identity* and dispatch *counts* across a frame sequence, which a test asserts precisely and an observer cannot see at all: the correct outcome is that the UI looks and behaves exactly as before. The one thing a human *could* have checked — that the status line still recovers after a tool call and doesn't stick on "Thinking…" — is pinned by two of the five tests.

Verified by reading, not by test: no consumer derives elapsed time, staleness, or a slow-turn warning from `slotStatusDetail[].ts`, so freezing `ts` for the duration of a reasoning block is safe. `sessionStatus` accepts `{ text?: string }` only (`recentsProvider.ts:155-157`); `CommandPalette.tsx:355` folds `.ts` into a cache-busting fingerprint (exactly the churn being removed); `ChatSidebar` reads only `?.text`.

## Screenshots

N/A — no user-visible change. No panel, component, layout, or theme is added or altered; the status line renders the identical string from the identical field. This is a re-render-count change, which a screenshot cannot show.

## Provenance and one open question

The three defects came from a rulebook audit of the frontend, and the specific one fixed first here was found by a **cross-vendor review panel** (OpenAI / DeepSeek / Alibaba / Zhipu) red-teaming that audit — the audit had pointed at the right file and the wrong blast radius. Both local review gates (`gpt-5.6-sol` mirroring `codex-review.yml`, `claude-opus-5` mirroring `claude-review.yml` + AUTOSDE) returned **no findings** on this commit.

**Deliberately not in this PR:** coalescing the `chat_thinking` and `sseSubagentChunk` dispatches into the existing rAF buffer. That is the larger companion fix, and it needs a design decision (shared `chunkBufRef` vs. a parallel buffer, plus the same finalize/segment synchronous-flush handling `chat_chunk` has, or reasoning text can land out of order relative to visible text).

An attempt to measure the real `chat_thinking` frame rate did **not** succeed — the instrumented isolated backend hit an unrelated sandbox permission error. What that attempt did establish by reading the emit path: `EVENT_THINKING_CHUNK → chat_thinking` is 1:1 with **no batching, no time-window coalescing, and no minimum-size gate** (`dashboard/chat_runner.py` ~2058, `acp/_dispatch.py`), so cadence is entirely provider-driven and unbounded from this codebase's side. The only buffer in the path is `StreamRedactor.feed()`, which withholds a possible split-credential tail — a correctness buffer, not a throttle.

So whether real traffic bursts inside a single 16 ms frame is still unmeasured. **That gap does not affect this PR** — a redundant dispatch is wrong at any frame rate — but it should be settled before the rAF change is attempted.
