### PR TITLE
feat(i18n): make formatting follow the app language (Phase 4 seam)

### DIFF
--- a/website/src/apps/issue-radar/lib/format.ts
+++ b/website/src/apps/issue-radar/lib/format.ts
@@ -1,6 +1,7 @@
 // Pure, side-effect-free helpers + localStorage accessors + constants for
 // Issue Radar. No React, no component imports — safe to pull into any module.
 import { Clock, Hash, type LucideIcon } from 'lucide-react'
+import { fmtRelative, toDate } from '../../../i18n/format'
 import { DASHBOARD_TABS, SORT_KEYS } from './types'
 import type { ActiveRepo, DashboardTab, MainView, PrSortKey, PrStateFilter, SettingsTarget, SortDir, SortKey, StateFilter } from './types'
 
@@ -72,52 +73,58 @@ export function detailPollMs(open: boolean): number {
  */
 export const LIST_POLL_MS = 60_000
 
-/** Compact "just now / 5m ago / 3h ago / 2d ago" from an epoch-ms timestamp.
+/** Compact "now / 5m ago / 3h ago / 2d ago" from an epoch-ms timestamp.
  * Used for the issue-list "Updated …" footer; returns '' for a falsy input
- * (e.g. before the first fetch). */
+ * (e.g. before the first fetch).
+ *
+ * Formatting is delegated to the locale-aware seam (`src/i18n/format.ts`): the
+ * previous ladder of template literals rendered English in every language, and
+ * carried its own `month`/`months` plural morphology, which is unexpressible
+ * outside English. */
 export function relativeTime(ms: number): string {
   if (!ms) return ''
-  const secs = Math.max(0, Math.floor((Date.now() - ms) / 1000))
-  if (secs < 45) return 'just now'
-  const mins = Math.floor(secs / 60)
-  if (mins < 60) return `${mins}m ago`
-  const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
-  const days = Math.floor(hrs / 24)
-  return `${days}d ago`
+  return fmtRelative(ms)
 }
 
 /** Timeline-friendly label: within the last 24h it reads as a compact elapsed
- * time ("just now / 12m ago / 3h ago"); anything older falls back to the
- * calendar-based relativeDate ("Yesterday / 5 days ago / 2 months ago").
+ * time ("now / 12m ago / 3h ago"); anything older falls back to the
+ * calendar-based relativeDate ("yesterday / 5 days ago / 2 months ago").
  * Future timestamps (clock skew) defer to relativeDate. */
 export function relativeTimeOrDate(iso: string): string {
-  const then = new Date(iso)
-  if (isNaN(then.getTime())) return ''
+  const then = toDate(iso)
+  if (!then) return ''
   const secs = Math.floor((Date.now() - then.getTime()) / 1000)
-  if (secs >= 0 && secs < 86400) {
-    if (secs < 45) return 'just now'
-    const mins = Math.floor(secs / 60)
-    if (mins < 60) return `${mins}m ago`
-    return `${Math.floor(mins / 60)}h ago`
-  }
+  // Inside a day, show elapsed time compactly; the calendar wording below is
+  // only meaningful once a date boundary has been crossed.
+  if (secs >= 0 && secs < 86400) return fmtRelative(then)
   return relativeDate(iso)
 }
 
-/** Human "Today / Yesterday / N days ago" from an ISO timestamp. */
+/** Human "today / yesterday / N days ago" from an ISO timestamp.
+ *
+ * Counts whole CALENDAR days rather than elapsed seconds — 23:59 to 00:01 is
+ * "yesterday", not "now" — then lets CLDR word the result. `numeric: 'auto'`
+ * inside `fmtRelative` is what produces "yesterday"/"昨天"/"gestern" instead of
+ * a mechanical "1 day ago", and it removes the hand-rolled English plural
+ * suffixes this function used to carry for months and years.
+ *
+ * The `style: 'long'` override is deliberate: this label sits in a timeline
+ * where "5 days ago" reads better than the compact "5d ago". */
 export function relativeDate(iso: string): string {
-  const then = new Date(iso)
-  if (isNaN(then.getTime())) return ''
+  const then = toDate(iso)
+  if (!then) return ''
   const now = new Date()
   const d0 = new Date(then.getFullYear(), then.getMonth(), then.getDate())
   const n0 = new Date(now.getFullYear(), now.getMonth(), now.getDate())
   const days = Math.round((n0.getTime() - d0.getTime()) / 86400000)
-  if (days <= 0) return 'Today'
-  if (days === 1) return 'Yesterday'
-  if (days < 30) return `${days} days ago`
-  if (days < 365) { const m = Math.floor(days / 30); return `${m} month${m > 1 ? 's' : ''} ago` }
-  const y = Math.floor(days / 365)
-  return `${y} year${y > 1 ? 's' : ''} ago`
+  // Re-anchor onto whole days so the relative formatter picks the day/month/year
+  // unit from a calendar difference rather than from a partial-day remainder.
+  const anchored = new Date(n0.getTime() - days * 86400000)
+  // `unit: 'day'` is required: this function has already reduced its input to
+  // whole calendar days, and with an auto-picked unit a zero delta would mean
+  // "under one second" and render "now" for something that happened earlier
+  // today. Pinning the day unit renders "today" / "今天".
+  return fmtRelative(anchored, { style: 'long', now: n0.getTime(), unit: 'day' })
 }
 
 /** Read a persisted column width, falling back to `fallback` when the stored

--- a/website/src/components/JobForm.tsx
+++ b/website/src/components/JobForm.tsx
@@ -9,8 +9,12 @@ import type { CronPrefill } from '../utils/schedulePresets'
 import { SaveCreateLabel, CRON_SEL, expandDow } from '../utils/cronUtils'
 
 import { i18nT } from '../i18n/t'
+import { fmtWeekday } from '../i18n/format'
 export const TIMEZONES = ['America/Los_Angeles','America/Phoenix','America/Denver','America/Chicago','America/New_York','America/Sao_Paulo','Europe/London','Europe/Berlin','Europe/Paris','Asia/Kolkata','Asia/Shanghai','Asia/Tokyo','Australia/Sydney','Pacific/Auckland','UTC']
-const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+/** Monday-first weekday labels. A function, not a module-level array: a const
+ *  array of translated strings would freeze at the boot language. The index
+ *  contract is unchanged — grid index `i` still maps through GRID_TO_CRON_DOW. */
+const dayNames = () => [1, 2, 3, 4, 5, 6, 7].map((iso) => fmtWeekday(iso))
 const GRID_TO_CRON_DOW = [0, 1, 2, 3, 4, 5, 6, 0] // grid 1-7 → cron dow
 const CRON_DOW_TO_GRID: Record<number, number> = { 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 0: 7, 7: 7 }
 
@@ -237,7 +241,7 @@ export default function JobForm({ job, prefill, agents, defaultAgent, onSaved, l
             <option value="minutes">{i18nT('components.jobForm.minutes')}</option><option value="hours">{i18nT('components.jobForm.hours')}</option><option value="days">{i18nT('components.jobForm.days')}</option>
           </select>
         </>) : schedMode === 'weekly' ? (<>
-          <div className="flex gap-1 flex-wrap">{DAY_NAMES.map((d, i) => (
+          <div className="flex gap-1 flex-wrap">{dayNames().map((d, i) => (
             <button key={d} type="button" onClick={() => toggleDay(i + 1)} className={`px-2 py-1 rounded-md text-[12px] font-medium border cursor-pointer transition-all ${weekDays.includes(i + 1) ? 'bg-accent text-accent-fg border-accent' : 'bg-bg-elevated text-muted border-border hover:border-border-strong'}`}>{d}</button>
           ))}</div>
           <span className="text-muted text-[13px]">{i18nT('components.jobForm.at')}</span>

--- a/website/src/components/WeekGrid.tsx
+++ b/website/src/components/WeekGrid.tsx
@@ -1,8 +1,15 @@
 import { useMemo, useEffect, useState } from 'react'
 import type { CronJob } from '../types'
 import { convertCronTime, hourFractionInTz, todayCronDowInTz } from '../utils/tz'
+import { fmtDateFields, fmtWeekday } from '../i18n/format'
 
-const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+/** Grid columns, Monday-first. `DAY_COUNT` carries the index contract that
+ *  CRON_TO_GRID maps into; `dayLabel(i)` renders the localized name. Splitting
+ *  them keeps every `DAYS.map((_, i) => …)` slot computation byte-identical
+ *  while the visible header becomes translatable. */
+const DAY_COUNT = 7
+const DAY_INDEXES = Array.from({ length: DAY_COUNT }, (_, i) => i)
+const dayLabel = (gridIndex: number) => fmtWeekday(gridIndex + 1)
 // Cron DOW: 0=Sun,1=Mon..6=Sat → our grid: 0=Mon..6=Sun
 const CRON_TO_GRID: Record<number, number> = { 1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5, 0: 6 }
 
@@ -35,7 +42,7 @@ export function parseCronSlots(job: CronJob, renderTz: string): Slot[] {
       const hf = hourFractionInTz(renderTz, ref)
       const h = Math.floor(hf)
       const m = Math.round((hf - h) * 60)
-      return DAYS.map((_, i) => ({ job, day: i, hour: h, minute: m }))
+      return DAY_INDEXES.map((i) => ({ job, day: i, hour: h, minute: m }))
     }
 
     let anchorSec = 0
@@ -191,10 +198,12 @@ export default function WeekGrid({ jobs, selectedId, onSelect, renderTz }: Props
     const d = parseInt(parts.find(p => p.type === 'day')?.value || '1')
     const monday = new Date(Date.UTC(y, m - 1, d))
     monday.setUTCDate(monday.getUTCDate() + mondayOffset)
-    return DAYS.map((_, i) => {
+    return DAY_INDEXES.map((i) => {
       const dt = new Date(monday)
       dt.setUTCDate(monday.getUTCDate() + i)
-      return `${(dt.getUTCMonth() + 1).toString().padStart(2, '0')}/${dt.getUTCDate().toString().padStart(2, '0')}`
+      // Localized day/month: a hardcoded MM/DD under a now-translated weekday
+      // read as "Mo. 07/30" in de, where the locale writes 30.07.
+      return fmtDateFields(dt, { month: '2-digit', day: '2-digit', timeZone: 'UTC' })
     })
   }, [tz])
 
@@ -217,9 +226,9 @@ export default function WeekGrid({ jobs, selectedId, onSelect, renderTz }: Props
       <div className="grid min-w-[600px]" style={{ gridTemplateColumns: '50px repeat(7, 1fr)' }}>
         {/* Header row */}
         <div className="py-2" />
-        {DAYS.map((d, i) => (
-          <div key={d} className={`py-2 text-center border-l border-l-border/20 ${i === todayGrid ? 'text-accent' : 'text-muted'}`}>
-            <div className="text-[11px] font-medium">{d}</div>
+        {DAY_INDEXES.map((i) => (
+          <div key={i} className={`py-2 text-center border-l border-l-border/20 ${i === todayGrid ? 'text-accent' : 'text-muted'}`}>
+            <div className="text-[11px] font-medium">{dayLabel(i)}</div>
             <div className="text-[10px]">{weekDates[i]}</div>
           </div>
         ))}
@@ -230,7 +239,7 @@ export default function WeekGrid({ jobs, selectedId, onSelect, renderTz }: Props
             <div className="text-[11px] text-muted pr-2 text-right py-1 border-t border-border/30 relative overflow-visible">
               {h.toString().padStart(2, '0')}:00
             </div>
-            {DAYS.map((_, dayIdx) => {
+            {DAY_INDEXES.map((dayIdx) => {
               const cellSlots = grid.get(`${dayIdx}-${h}`) || []
               const isNowRow = nowInRange && hi === nowRowIdx
               return (

--- a/website/src/components/commandPalette/providers/recentsProvider.ts
+++ b/website/src/components/commandPalette/providers/recentsProvider.ts
@@ -10,6 +10,7 @@ import type { ChatSlot, ChatFolder, CronJob } from '../../../types'
 import type { Result, ResourceProvider } from '../types'
 
 import { i18nT } from '../../../i18n/t'
+import { fmtDateFields, fmtRelative, toDate } from '../../../i18n/format'
 
 /**
  * Recents / quick-switcher — the unscoped empty-query default view (blended
@@ -111,23 +112,37 @@ function normalizeKey(key: string): string {
   return key.startsWith('dashboard_') ? key.slice('dashboard_'.length) : key
 }
 
-/** Telegram-style relative time (matches the sidebar's fmtRelativeTime):
- * today → "09:46", "Yesterday 21:12", weekday this week, short/full date. */
+/** Telegram-style relative time: today → "09:46", "yesterday 21:12", weekday
+ * this week, short/full date.
+ *
+ * ChatSidebar.tsx has a parallel implementation that is NOT yet migrated, so
+ * until that batch lands a non-English user sees this localized and the
+ * sidebar's host-locale. Tracked by the ratchet in localeFormatting.test.ts.
+ *
+ * Every branch previously read the BROWSER's locale (`toLocaleTimeString([])`,
+ * `toLocaleDateString([])`), so a Chinese dashboard on an en-US browser showed
+ * "3:04 PM" and "Jul 30". They now resolve against the app language, and the
+ * "Yesterday" literal comes from CLDR instead of being hardcoded English. */
 function fmtRelativeTime(ts: string | number | undefined): string | undefined {
   if (ts == null) return undefined
-  const d = typeof ts === 'number' ? new Date(ts * 1000) : new Date(ts)
-  if (isNaN(d.getTime())) return undefined
+  const d = toDate(ts)
+  if (!d) return undefined
   const now = new Date()
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
   const startOfYesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
   const startOf6DaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6)
-  const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  // `fmtDateFields`, not `fmtTime`: a style preset cannot be combined with
+  // explicit hour/minute components (ECMA-402 CreateDateTimeFormat step 37).
+  const time = fmtDateFields(d, { hour: '2-digit', minute: '2-digit' })
   if (d >= startOfToday) return time
-  if (d >= startOfYesterday) return `Yesterday ${time}`
-  if (d >= startOf6DaysAgo) return d.toLocaleDateString([], { weekday: 'short' })
+  // `fmtRelative` with a whole-day delta yields the locale's own "yesterday".
+  if (d >= startOfYesterday) {
+    return `${fmtRelative(startOfYesterday, { style: 'long', now: startOfToday.getTime() })} ${time}`
+  }
+  if (d >= startOf6DaysAgo) return fmtDateFields(d, { weekday: 'short' })
   if (d.getFullYear() === now.getFullYear())
-    return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
-  return d.toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' })
+    return fmtDateFields(d, { month: 'short', day: 'numeric' })
+  return fmtDateFields(d, { year: 'numeric', month: 'short', day: 'numeric' })
 }
 
 /** Recency epoch (ms) for sorting live slots — last activity, else last msg, else created. */

--- a/website/src/components/notifications/NotificationFeed.tsx
+++ b/website/src/components/notifications/NotificationFeed.tsx
@@ -8,6 +8,8 @@ import { api } from '../../api/client'
 import { EmptyState, SearchInput } from '../ui'
 import Clickable from '../Clickable'
 import { disintegrate } from '../../lib/disintegrate'
+// Aliased: this file defines its own minute-granularity `fmtRelative` wrapper.
+import { fmtRelative as fmtRelativeLocalized } from '../../i18n/format'
 import type { Notification } from '../../types'
 import {
   type Kind, type Category, KIND_KEYS, CATEGORIES, KINDS_STORAGE_KEY, loadActiveKinds,
@@ -27,15 +29,21 @@ function loadSeenChannels(): Set<string> {
   return new Set()
 }
 
-/** macOS Notification Center-style relative timestamp ("now", "35m ago", "2h ago"). */
+/** macOS Notification Center-style relative timestamp ("now", "35m ago", "2h ago").
+ *
+ * Delegated to the locale-aware seam: the hand-rolled ladder this replaces
+ * rendered English in every language and encoded its own "yesterday" special
+ * case, which CLDR already knows for all 10 locales. English output is
+ * unchanged.
+ *
+ * Minute granularity is preserved deliberately — a notification feed that
+ * counted seconds would rewrite every row on every tick. Anything under a
+ * minute is collapsed to the locale's "now" rather than "45s ago". */
 function fmtRelative(ts: string): string {
-  const mins = Math.floor((Date.now() - parseTs(ts).getTime()) / 60_000)
-  if (mins < 1) return 'now'
-  if (mins < 60) return `${mins}m ago`
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return days === 1 ? 'yesterday' : `${days}d ago`
+  const at = parseTs(ts)
+  const now = Date.now()
+  if (now - at.getTime() < 60_000) return fmtRelativeLocalized(now, { now })
+  return fmtRelativeLocalized(at, { now })
 }
 
 /**

--- a/website/src/components/notifications/notifMeta.tsx
+++ b/website/src/components/notifications/notifMeta.tsx
@@ -2,6 +2,9 @@ import { ClipboardList, Anchor, Heart, Bot, Lock, GitBranch, Bell, Clock } from 
 import type { ReactNode } from 'react'
 
 import { i18nT } from '../../i18n/t'
+// Aliased: this module exports its own `fmtTime`/`fmtFull` wrappers that add the
+// unknown-date fallback on top of these.
+import { fmtTime as fmtClockTime, fmtDateTime } from '../../i18n/format'
 
 /**
  * Shared notification metadata + helpers. Extracted verbatim from the former
@@ -119,12 +122,12 @@ export function safeInternalUrl(url: string | undefined): string | null {
 
 export function fmtTime(ts: string | number): string {
   const d = parseTs(ts)
-  return isNaN(d.getTime()) ? i18nT('components.notifications.notifMeta.unknown_date') : d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return isNaN(d.getTime()) ? i18nT('components.notifications.notifMeta.unknown_date') : fmtClockTime(d)
 }
 
 export function fmtFull(ts: string | number): string {
   const d = parseTs(ts)
-  return isNaN(d.getTime()) ? i18nT('components.notifications.notifMeta.unknown_date') : d.toLocaleString()
+  return isNaN(d.getTime()) ? i18nT('components.notifications.notifMeta.unknown_date') : fmtDateTime(d)
 }
 
 export function stripMd(text: string): string {

--- a/website/src/i18n/format.test.ts
+++ b/website/src/i18n/format.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Behaviour tests for the locale-aware formatting seam.
+ *
+ * ## Two kinds of assertion here, on purpose
+ *
+ * **Derived** assertions compute the expected string from the same `Intl` the
+ * module uses. They prove *wiring* — that the formatter ran with the app's
+ * language rather than the host's — and they degrade to a vacuous pass on a
+ * small-icu Node instead of hard-failing, which is the precedent
+ * `formatter.test.ts` sets and the reason it is safe to assert cross-locale at
+ * all. Official Node 20+ builds are full-icu (verified `icu_small=false`), so in
+ * CI these are real comparisons.
+ *
+ * **Golden** assertions hardcode a literal, and are used only where the phase's
+ * own acceptance gate names an exact string ("a zh-CN UI renders 2026年7月30日")
+ * or where an English output must be pinned because ~4000 existing assertions
+ * depend on it. Each one is marked.
+ *
+ * ## Timezone
+ *
+ * The vitest setup pins no `TZ`, so every date assertion passes an explicit
+ * `timeZone`. Without that these tests pass in UTC CI and fail on a developer
+ * machine in Asia/Shanghai — a class of flake this file must not introduce.
+ *
+ * ## Language restoration
+ *
+ * i18next is a module-level singleton shared by the whole suite, so a file that
+ * switches language must switch back or it silently breaks every later file.
+ * Same `afterEach` discipline as `formatter.test.ts`.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+
+import { i18next } from './index'
+import {
+  activeLocale,
+  collator,
+  compareText,
+  fmtCurrency,
+  fmtDate,
+  fmtDateFields,
+  fmtDateTime,
+  fmtList,
+  fmtNumber,
+  fmtPercent,
+  fmtRelative,
+  fmtTime,
+  fmtUnit,
+  fmtWeekday,
+  toDate,
+  __resetFormatterCache,
+} from './format'
+
+/** 2026-07-30T15:04:05Z — a Thursday, mid-afternoon UTC. */
+const INSTANT = new Date('2026-07-30T15:04:05Z')
+const UTC = { timeZone: 'UTC' } as const
+
+async function withLanguage(code: string, run: () => void | Promise<void>): Promise<void> {
+  await i18next.changeLanguage(code)
+  await run()
+}
+
+afterEach(async () => {
+  await i18next.changeLanguage('en')
+  __resetFormatterCache()
+})
+
+describe('activeLocale', () => {
+  it('follows the app language, not the host', async () => {
+    await withLanguage('zh-CN', () => {
+      expect(activeLocale()).toBe('zh-CN')
+    })
+  })
+
+  it('reports the RESOLVED language when an unsupported tag is requested', async () => {
+    // `zz` is not in supportedLngs, so i18next falls back. Formatting must
+    // follow the language actually in use, not the rejected request.
+    await withLanguage('zz', () => {
+      expect(activeLocale()).toBe('en')
+    })
+  })
+})
+
+describe('toDate', () => {
+  it('accepts ISO strings, epoch seconds, epoch milliseconds and Date', () => {
+    const ms = INSTANT.getTime()
+    expect(toDate(INSTANT)?.getTime()).toBe(ms)
+    expect(toDate('2026-07-30T15:04:05Z')?.getTime()).toBe(ms)
+    expect(toDate(ms)?.getTime()).toBe(ms)
+    expect(toDate(Math.floor(ms / 1000))?.getTime()).toBe(ms)
+  })
+
+  it('rejects the values that previously rendered as garbage ages', () => {
+    // ts=0 rendered as ~20602d; NaN/undefined rendered "Invalid Date".
+    for (const bad of [0, -1, NaN, Infinity, null, undefined, '', 'not a date']) {
+      expect(toDate(bad as never)).toBeNull()
+    }
+  })
+})
+
+describe('fmtNumber', () => {
+  it('groups per the active language', async () => {
+    // Golden (en): the app's baseline rendering.
+    expect(fmtNumber(1234567.891)).toBe('1,234,567.891')
+
+    // Derived: de inverts separators, hi uses Indian grouping, bn uses Bengali
+    // digits. Deriving keeps this honest on a small-icu runtime.
+    for (const lng of ['de', 'hi', 'bn', 'ru']) {
+      await withLanguage(lng, () => {
+        expect(fmtNumber(1234567.891)).toBe(new Intl.NumberFormat(lng).format(1234567.891))
+      })
+    }
+  })
+
+  it('renders a non-finite input as an em dash rather than NaN', () => {
+    expect(fmtNumber(NaN)).toBe('—')
+    expect(fmtNumber(Infinity)).toBe('—')
+  })
+})
+
+describe('fmtPercent', () => {
+  it('takes a ratio and lets the locale place the sign', async () => {
+    expect(fmtPercent(0.4567)).toBe('46%') // golden (en)
+    await withLanguage('de', () => {
+      // de separates the % with a non-breaking space; derived so the exact
+      // space codepoint comes from CLDR rather than being guessed here.
+      expect(fmtPercent(0.4567)).toBe(
+        new Intl.NumberFormat('de', { style: 'percent', maximumFractionDigits: 0 }).format(0.4567),
+      )
+    })
+  })
+})
+
+describe('fmtCurrency', () => {
+  it('places the symbol per locale', async () => {
+    expect(fmtCurrency(12.5)).toBe('$12.50') // golden (en)
+    await withLanguage('de', () => {
+      expect(fmtCurrency(12.5)).toBe(
+        new Intl.NumberFormat('de', { style: 'currency', currency: 'USD' }).format(12.5),
+      )
+    })
+  })
+})
+
+describe('fmtUnit', () => {
+  it('formats durations and sizes without Intl.DurationFormat', () => {
+    // DurationFormat is undefined on the Node 20 baseline; this is the
+    // replacement path, and this assertion is what would catch a future
+    // refactor reaching for the unavailable API.
+    expect(typeof (Intl as { DurationFormat?: unknown }).DurationFormat).toBe('undefined')
+    expect(fmtUnit(1.5, 'second', { maximumFractionDigits: 1 })).toBe('1.5s') // golden (en)
+    expect(fmtUnit(90, 'minute')).toBe('90m') // golden (en)
+    expect(fmtUnit(512, 'megabyte')).toBe('512MB') // golden (en)
+  })
+
+  it('translates the unit itself', async () => {
+    await withLanguage('de', () => {
+      expect(fmtUnit(90, 'minute')).toBe(
+        new Intl.NumberFormat('de', { style: 'unit', unit: 'minute', unitDisplay: 'narrow' }).format(90),
+      )
+    })
+  })
+})
+
+describe('fmtDate / fmtTime / fmtDateTime', () => {
+  it('renders the phase gate\'s named example for zh-CN', async () => {
+    // Golden, and the literal the Phase 4 acceptance gate names: "a zh-CN UI on
+    // an en-US browser renders 2026年7月30日".
+    await withLanguage('zh-CN', () => {
+      expect(fmtDate(INSTANT, UTC)).toBe('2026年7月30日')
+    })
+  })
+
+  it('renders the English baseline', () => {
+    expect(fmtDate(INSTANT, UTC)).toBe('Jul 30, 2026') // golden (en)
+    expect(fmtTime(INSTANT, UTC)).toBe('3:04 PM') // golden (en)
+  })
+
+  it('switches 12h/24h per locale rather than per browser', async () => {
+    // The defect being fixed: a Chinese UI on an en-US host showed "3:04 PM".
+    await withLanguage('zh-CN', () => {
+      expect(fmtTime(INSTANT, UTC)).toBe(
+        new Intl.DateTimeFormat('zh-CN', { timeStyle: 'short', timeZone: 'UTC' }).format(INSTANT),
+      )
+    })
+  })
+
+  it('combines date and time', () => {
+    expect(fmtDateTime(INSTANT, UTC)).toContain('Jul 30, 2026')
+    expect(fmtDateTime(INSTANT, UTC)).toContain('3:04')
+  })
+
+  it('renders a missing date as an em dash', () => {
+    expect(fmtDate(null)).toBe('—')
+    expect(fmtTime(undefined)).toBe('—')
+  })
+
+  it('builds a time from explicit components without hitting the style conflict', () => {
+    // Regression: `fmtTime(d, { hour, minute })` threw TypeError, because
+    // `fmtTime` injects `timeStyle` and ECMA-402 CreateDateTimeFormat step 37
+    // forbids combining a style with a component. It shipped in the command
+    // palette's recents provider and emptied the palette for every session with
+    // a timestamp. The option types now make that spelling a compile error;
+    // this asserts the correct entry point works at runtime.
+    expect(fmtDateFields(INSTANT, { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' }))
+      .toMatch(/15|3/)
+    expect(() =>
+      fmtDateFields(INSTANT, { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' }),
+    ).not.toThrow()
+  })
+
+  it('proves the conflict this split avoids is real', () => {
+    // The raw Intl call the old code produced. If a future refactor merges the
+    // two option types back together, this documents what breaks.
+    expect(() =>
+      new Intl.DateTimeFormat('en', { timeStyle: 'short', hour: '2-digit' }).format(INSTANT),
+    ).toThrow(TypeError)
+  })
+})
+
+describe('fmtWeekday', () => {
+  it('maps ISO 1..7 onto Monday..Sunday', () => {
+    // Golden (en). The index is the cron contract; only the label is localized.
+    expect([1, 2, 3, 4, 5, 6, 7].map((d) => fmtWeekday(d))).toEqual([
+      'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun',
+    ])
+  })
+
+  it('keeps the index → weekday mapping stable regardless of language', async () => {
+    await withLanguage('de', () => {
+      expect(fmtWeekday(1)).toBe(
+        new Intl.DateTimeFormat('de', { weekday: 'short', timeZone: 'UTC' })
+          .format(new Date(Date.UTC(2024, 0, 1))),
+      )
+    })
+  })
+
+  it('supports long and narrow styles', () => {
+    expect(fmtWeekday(1, 'long')).toBe('Monday')
+    expect(fmtWeekday(1, 'narrow')).toBe('M')
+  })
+
+  it('rejects an out-of-range index instead of inventing a day', () => {
+    expect(fmtWeekday(0)).toBe('—')
+    expect(fmtWeekday(8)).toBe('—')
+  })
+})
+
+describe('fmtRelative', () => {
+  const now = INSTANT.getTime()
+  const at = (secondsAgo: number) => new Date(now - secondsAgo * 1000)
+
+  it('preserves the compact English output the app already rendered', () => {
+    // Golden (en) — these four are byte-identical to the hand-rolled ladder
+    // that this replaces, which is what keeps the migration reviewable.
+    expect(fmtRelative(at(45), { now })).toBe('45s ago')
+    expect(fmtRelative(at(120), { now })).toBe('2m ago')
+    expect(fmtRelative(at(7200), { now })).toBe('2h ago')
+    expect(fmtRelative(at(5 * 86400), { now })).toBe('5d ago')
+  })
+
+  it('applies the two reviewed English deltas', () => {
+    // Documented in format.ts: CLDR words these idiomatically instead of
+    // mechanically, which is the reason to use the platform at all.
+    expect(fmtRelative(at(0), { now })).toBe('now') // was 'just now'
+    expect(fmtRelative(at(86400), { now })).toBe('yesterday') // was '1d ago'
+  })
+
+  it('words the same instant idiomatically per language', async () => {
+    // Derived. zh says 昨天, de vorgestern for two days — output CLDR produces
+    // and a template-literal ladder structurally cannot.
+    for (const lng of ['zh-CN', 'de', 'ru', 'bn']) {
+      await withLanguage(lng, () => {
+        const rtf = new Intl.RelativeTimeFormat(lng, { numeric: 'auto', style: 'narrow' })
+        expect(fmtRelative(at(86400), { now })).toBe(rtf.format(-1, 'day'))
+        expect(fmtRelative(at(120), { now })).toBe(rtf.format(-2, 'minute'))
+      })
+    }
+  })
+
+  it('truncates toward zero so an age never rounds into the future', () => {
+    // 119s elapsed is "1m ago"; rounding would claim 2m had passed.
+    expect(fmtRelative(at(119), { now })).toBe('1m ago')
+  })
+
+  it('formats a future timestamp forwards instead of clamping it', () => {
+    // Clock skew should be visible, not laundered into "now".
+    expect(fmtRelative(new Date(now + 300_000), { now })).toBe('in 5m')
+  })
+
+  it('renders a missing timestamp as an em dash', () => {
+    expect(fmtRelative(null)).toBe('—')
+    expect(fmtRelative(0)).toBe('—')
+  })
+
+  it('pins the unit when asked, so a zero calendar-day delta reads "today"', async () => {
+    // Regression: a caller that has already reduced its input to whole calendar
+    // days got "now" for anything earlier the same day, because a zero delta
+    // means "under one second" to the auto unit picker. Issue Radar's
+    // `relativeDate` is that caller.
+    expect(fmtRelative(INSTANT, { now, unit: 'day', style: 'long' })).toBe('today')
+    expect(fmtRelative(at(86400), { now, unit: 'day', style: 'long' })).toBe('yesterday')
+    expect(fmtRelative(at(5 * 86400), { now, unit: 'day', style: 'long' })).toBe('5 days ago')
+
+    await withLanguage('zh-CN', () => {
+      const rtf = new Intl.RelativeTimeFormat('zh-CN', { numeric: 'auto', style: 'long' })
+      expect(fmtRelative(INSTANT, { now, unit: 'day', style: 'long' })).toBe(rtf.format(0, 'day'))
+    })
+  })
+})
+
+describe('fmtList', () => {
+  it('uses the language\'s own separator and conjunction', async () => {
+    expect(fmtList(['A', 'B', 'C'])).toBe('A, B, and C') // golden (en)
+
+    // Golden (zh-CN): the ideographic comma is the specific defect a
+    // `join(', ')` plus a translated " and " cannot express.
+    await withLanguage('zh-CN', () => {
+      expect(fmtList(['A', 'B', 'C'])).toBe('A、B和C')
+    })
+  })
+
+  it('supports disjunction', () => {
+    expect(fmtList(['A', 'B'], { type: 'disjunction' })).toBe('A or B')
+  })
+
+  it('drops empty entries so a filtered array cannot leave a dangling separator', () => {
+    expect(fmtList(['A', '', 'B'])).toBe('A and B')
+  })
+})
+
+describe('collator / compareText', () => {
+  it('sorts digits naturally instead of by byte', () => {
+    // The defect: byte order puts reviewer-10 before reviewer-2.
+    expect(['reviewer-10', 'reviewer-2'].sort(compareText)).toEqual(['reviewer-2', 'reviewer-10'])
+  })
+
+  it('ignores case so one list has one ordering', () => {
+    expect(compareText('apple', 'Apple')).toBe(0)
+  })
+
+  it('sorts per the active language', async () => {
+    // Derived: de and sv disagree about ä; asserting against the language's own
+    // collator proves the app language reached Intl.
+    await withLanguage('de', () => {
+      const words = ['zeta', 'ärger', 'apfel']
+      expect([...words].sort(compareText)).toEqual(
+        [...words].sort(new Intl.Collator('de', { numeric: true, sensitivity: 'base' }).compare),
+      )
+    })
+  })
+
+  it('exposes the raw collator for callers needing other options', () => {
+    expect(collator({ sensitivity: 'variant' }).compare('apple', 'Apple')).not.toBe(0)
+  })
+})

--- a/website/src/i18n/format.ts
+++ b/website/src/i18n/format.ts
@@ -1,0 +1,418 @@
+/**
+ * Locale-aware formatting — the single seam for dates, numbers, lists and collation.
+ *
+ * ## The defect this closes
+ *
+ * Before this module there were ~300 formatting call sites and **not one of them
+ * could consult the selected language**, because there was nowhere to ask. Every
+ * call was `toLocaleString()`, `toLocaleDateString([])` or
+ * `toLocaleTimeString(undefined, {…})` — all three spellings mean *host* locale,
+ * i.e. the browser's, not the app's `dashboard.language`. `LanguageProvider`
+ * correctly sets `<html lang>`, but `<html lang>` has no effect on `Intl`. So a
+ * dashboard running in Chinese on an en-US browser rendered `7/30/2026` and
+ * `Jul 30` inside otherwise-Chinese UI.
+ *
+ * The root cause was one missing module, not 300 independent bugs. This is that
+ * module: every formatter here reads the ACTIVE UI language at call time.
+ *
+ * ## Why plain functions and not hooks
+ *
+ * Same reasoning as `i18nT` in `./t.ts`, and deliberately the same shape so the
+ * two are used side by side without ceremony: formatting happens inside
+ * `.map()` callbacks, in comparator functions passed to `.sort()`, and in plain
+ * helper modules with no component around them — all positions a hook cannot
+ * legally go. A language switch remounts the tree (`<App>` is keyed on the
+ * active language in `main.tsx`), so a function that reads the language at call
+ * time re-evaluates on switch without subscribing to anything.
+ *
+ * ## Why `localeMatcher: 'lookup'`
+ *
+ * `'lookup'` is RFC 4647 §3.4 — it truncates `zh-CN` → `zh` → root until it
+ * finds data. That is precisely the fallback chain this app would otherwise
+ * hand-roll, so it is requested explicitly rather than relying on the
+ * `'best fit'` default whose behaviour is implementation-defined.
+ * <https://www.rfc-editor.org/rfc/rfc4647.html>
+ *
+ * ## Formatter caching
+ *
+ * `Intl.*` constructors are expensive — they resolve a locale and build a
+ * pattern — and these run inside render and inside comparators, where a
+ * comparator is called O(n log n) times per sort. Every formatter is therefore
+ * memoized on `(kind, locale, options)`. The locale is part of the key, so a
+ * language switch simply misses the cache once; nothing needs invalidating.
+ *
+ * ## Known limitations, stated explicitly
+ *
+ *  1. **`Intl.DurationFormat` is NOT used**, because it does not exist on the
+ *     runtime this ships to: `typeof Intl.DurationFormat === 'undefined'` on
+ *     Node 20 (the CI and Electron baseline). `fmtUnit` uses `NumberFormat`
+ *     with `style: 'unit'` instead, which is Baseline and covers every duration
+ *     shape this app renders (a single value plus a unit). Revisit when the
+ *     Electron floor reaches a Chromium with `DurationFormat`.
+ *  2. **Locale-formatted digits are not machine-readable.** `hi` groups as
+ *     `12,34,567` (Indian grouping) and `bn` renders `১২,৩৪,৫৬৭` in Bengali
+ *     digits by default — correct for display, catastrophic for a CSS length, a
+ *     URL parameter, a JSON payload or an `aria-valuenow`. Nothing in this
+ *     module may be used for a value that is later parsed, serialised, or
+ *     interpolated into a style. Those sites keep bare arithmetic and are
+ *     recorded in `localeFormatting.test.ts`'s allowlist with a reason.
+ *  3. **No timezone is pinned.** Dates render in the host timezone, which is
+ *     correct for a desktop app showing local activity times. Tests MUST pass an
+ *     explicit `timeZone` — the vitest setup pins no `TZ`, so an unpinned date
+ *     assertion is machine-dependent and will flake in CI.
+ *  4. **`en-XA` passes straight through to `Intl`**, where it resolves to `en`
+ *     (verified: `new Intl.NumberFormat('en-XA').resolvedOptions().locale === 'en'`).
+ *     That is the correct behaviour for a pseudolocale: its job is to expose
+ *     untranslated *strings*, and a formatted number is not a translatable
+ *     string. Accented pseudolocale text around a plain `1,234.5` is not a
+ *     finding.
+ */
+
+import { i18next } from './index'
+
+/**
+ * The language every formatter here resolves against.
+ *
+ * `resolvedLanguage` rather than `language`: `language` is what was *requested*
+ * (possibly `zh` or an unsupported tag), while `resolvedLanguage` is the one
+ * i18next actually selected from `supportedLngs` after fallback. Formatting
+ * against the requested tag would let a language i18next rejected still steer
+ * `Intl`, so the UI text and the dates around it could disagree.
+ *
+ * Falls back to `'en'` when i18next has not initialized — reached only by a unit
+ * test importing this module in isolation, but it must not throw there.
+ */
+export function activeLocale(): string {
+  return i18next.resolvedLanguage || i18next.language || 'en'
+}
+
+/**
+ * Memo for constructed `Intl` formatters, keyed on kind + locale + options.
+ *
+ * Unbounded by design: the key space is (11 languages × the handful of option
+ * shapes this module offers), so it settles in the low dozens of entries and
+ * never grows with data. A user-supplied option object could in principle widen
+ * it, which is why `fmtUnit` takes `unit` as a discrete argument rather than
+ * letting callers pass arbitrary `Intl.NumberFormatOptions` through.
+ */
+const formatters = new Map<string, unknown>()
+
+function memo<T>(kind: string, locale: string, options: unknown, build: () => T): T {
+  const key = `${kind}|${locale}|${JSON.stringify(options ?? null)}`
+  const hit = formatters.get(key)
+  if (hit !== undefined) return hit as T
+  const made = build()
+  formatters.set(key, made)
+  return made
+}
+
+/** Test seam: drop the formatter memo so a test can switch language mid-file. */
+export function __resetFormatterCache(): void {
+  formatters.clear()
+}
+
+/**
+ * Coerce the several timestamp shapes this codebase carries into a `Date`.
+ *
+ * The API layer is not consistent — some fields are ISO strings, some are epoch
+ * seconds (cron, artifacts), some epoch milliseconds (GitHub-derived data in
+ * Issue Radar). Seconds-vs-milliseconds has already produced a shipped bug (a
+ * millisecond value read as seconds rendered "just now" forever; see
+ * `RemoteArtifactCard.test.tsx`), so the disambiguation lives here once:
+ * a number below `SECONDS_CEILING` is treated as seconds.
+ *
+ * Returns `null` for anything unparseable, so callers render their own
+ * placeholder rather than "Invalid Date".
+ */
+const SECONDS_CEILING = 1e11
+
+export function toDate(value: Date | string | number | null | undefined): Date | null {
+  if (value === null || value === undefined || value === '') return null
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) return null
+    const ms = value < SECONDS_CEILING ? value * 1000 : value
+    const d = new Date(ms)
+    return Number.isNaN(d.getTime()) ? null : d
+  }
+  const d = new Date(value)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+/* ------------------------------------------------------------------ numbers */
+
+export type NumberOptions = Omit<Intl.NumberFormatOptions, 'localeMatcher'>
+
+/**
+ * A count, size or measurement for DISPLAY.
+ *
+ * Never use for a value that is parsed, serialised, or interpolated into CSS —
+ * see limitation 2 in the file header.
+ */
+export function fmtNumber(value: number, options?: NumberOptions): string {
+  if (!Number.isFinite(value)) return '—'
+  const locale = activeLocale()
+  return memo('number', locale, options, () =>
+    new Intl.NumberFormat(locale, { localeMatcher: 'lookup', ...options }),
+  ).format(value)
+}
+
+/**
+ * A ratio in 0..1 as a percentage.
+ *
+ * Takes the RATIO, not the pre-multiplied percentage, so the `× 100` cannot be
+ * applied twice and so the locale decides where the `%` sits and whether a
+ * (non-breaking) space precedes it — `46%` in en, `46 %` in de/fr/ru.
+ */
+export function fmtPercent(ratio: number, options?: NumberOptions): string {
+  if (!Number.isFinite(ratio)) return '—'
+  return fmtNumber(ratio, { style: 'percent', maximumFractionDigits: 0, ...options })
+}
+
+/** Money. `currency` is an ISO 4217 code; placement and symbol are the locale's. */
+export function fmtCurrency(value: number, currency = 'USD', options?: NumberOptions): string {
+  if (!Number.isFinite(value)) return '—'
+  return fmtNumber(value, { style: 'currency', currency, ...options })
+}
+
+/**
+ * A value with a unit — durations (`1.5s`, `90m`) and sizes (`512MB`).
+ *
+ * This is the `Intl.DurationFormat` replacement (limitation 1). `unitDisplay`
+ * defaults to `'narrow'` because these render in tight chrome: log rows, tab
+ * bars, file pickers. `narrow` is what makes en read `512MB` and `90m` rather
+ * than `512 megabytes` and `90 minutes`, while still letting de say `90 Min.`
+ * and ru `90 мин`.
+ */
+export type FormatUnit =
+  | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year'
+  | 'byte' | 'kilobyte' | 'megabyte' | 'gigabyte' | 'terabyte'
+
+export function fmtUnit(value: number, unit: FormatUnit, options?: NumberOptions): string {
+  if (!Number.isFinite(value)) return '—'
+  return fmtNumber(value, { style: 'unit', unit, unitDisplay: 'narrow', ...options })
+}
+
+/* -------------------------------------------------------------------- dates */
+
+export type DateOptions = Omit<Intl.DateTimeFormatOptions, 'localeMatcher'>
+
+/**
+ * The individual date/time COMPONENT options.
+ *
+ * ECMA-402 `CreateDateTimeFormat` step 37 throws `TypeError` if `dateStyle` or
+ * `timeStyle` is combined with any of these. The style-preset helpers below
+ * supply a style, so accepting a component alongside it would compile and then
+ * throw at runtime for every user — which is exactly what happened during this
+ * migration: `fmtTime(d, { hour: '2-digit', minute: '2-digit' })` type-checked
+ * and would have emptied the command palette. Splitting the option types makes
+ * that a compile error instead of a production one.
+ */
+type DateComponent =
+  | 'weekday' | 'era' | 'year' | 'month' | 'day' | 'dayPeriod'
+  | 'hour' | 'minute' | 'second' | 'fractionalSecondDigits'
+
+/** Options accepted alongside a `dateStyle`/`timeStyle` preset. */
+export type DateStyleOptions = Omit<DateOptions, DateComponent | 'dateStyle' | 'timeStyle'>
+
+/** Options for building a date from explicit components, with no preset. */
+export type DateFieldOptions = Omit<DateOptions, 'dateStyle' | 'timeStyle'>
+
+function dateTime(value: Date | string | number | null | undefined, options: DateOptions): string {
+  const d = toDate(value)
+  if (!d) return '—'
+  const locale = activeLocale()
+  return memo('datetime', locale, options, () =>
+    new Intl.DateTimeFormat(locale, { localeMatcher: 'lookup', ...options }),
+  ).format(d)
+}
+
+/** Calendar date. en `Jul 30, 2026` · zh-CN `2026年7月30日` · de `30.07.2026`. */
+export function fmtDate(value: Date | string | number | null | undefined, options?: DateStyleOptions): string {
+  return dateTime(value, { dateStyle: 'medium', ...options })
+}
+
+/** Clock time. en `3:04 PM` · zh-CN/de/ru `15:04` — the locale decides 12h vs 24h. */
+export function fmtTime(value: Date | string | number | null | undefined, options?: DateStyleOptions): string {
+  return dateTime(value, { timeStyle: 'short', ...options })
+}
+
+/** Date and time together. */
+export function fmtDateTime(value: Date | string | number | null | undefined, options?: DateStyleOptions): string {
+  return dateTime(value, { dateStyle: 'medium', timeStyle: 'short', ...options })
+}
+
+/**
+ * A date built from explicit COMPONENTS rather than a style preset.
+ *
+ * `Intl.DateTimeFormat` throws if `dateStyle`/`timeStyle` is combined with a
+ * component like `weekday` or `hour`, and the helpers above supply a style — so
+ * a caller wanting "just the weekday", "Jul 30" or "15:04 with explicit hour and
+ * minute" needs an entry point that never sets a style. The option types keep
+ * the two apart, so reaching for the wrong one fails to compile.
+ */
+export function fmtDateFields(
+  value: Date | string | number | null | undefined,
+  options: DateFieldOptions,
+): string {
+  return dateTime(value, options)
+}
+
+/**
+ * A weekday name by ISO index — 1 = Monday … 7 = Sunday.
+ *
+ * The index is the contract, the name is the rendering. That split is the whole
+ * point: this app's weekday arrays double as cron day-of-week data, so the
+ * NUMBER must stay stable while the LABEL becomes translatable. Callers keep
+ * indexing by number exactly as before and only the displayed string changes.
+ *
+ * Implemented against a fixed reference week in UTC (2024-01-01 was a Monday)
+ * with `timeZone: 'UTC'` pinned, so the mapping index → name can never be
+ * shifted by the host timezone.
+ */
+const ISO_WEEK_REFERENCE = [1, 2, 3, 4, 5, 6, 7] as const
+
+export function fmtWeekday(isoIndex: number, style: 'long' | 'short' | 'narrow' = 'short'): string {
+  const idx = Math.trunc(isoIndex)
+  if (!ISO_WEEK_REFERENCE.includes(idx as 1)) return '—'
+  // 2024-01-01 is a Monday, so day-of-month === ISO weekday index for 1..7.
+  return dateTime(new Date(Date.UTC(2024, 0, idx)), { weekday: style, timeZone: 'UTC' })
+}
+
+/* ----------------------------------------------------------- relative time */
+
+export type RelativeStyle = 'long' | 'short' | 'narrow'
+
+const RELATIVE_THRESHOLDS: Array<{ unit: Intl.RelativeTimeFormatUnit; seconds: number }> = [
+  { unit: 'year', seconds: 365 * 86400 },
+  { unit: 'month', seconds: 30 * 86400 },
+  { unit: 'day', seconds: 86400 },
+  { unit: 'hour', seconds: 3600 },
+  { unit: 'minute', seconds: 60 },
+  { unit: 'second', seconds: 1 },
+]
+
+/**
+ * Elapsed time as the locale words it — replaces the hand-rolled `Nm ago`.
+ *
+ * `numeric: 'auto'` is deliberate: it is what lets CLDR answer with *yesterday*
+ * / *昨天* / *vorgestern* instead of a mechanical "1 day ago", which is the
+ * whole reason to use the platform rather than a ladder of template literals.
+ * It also gives `now` for the sub-threshold case, so callers no longer carry
+ * their own "just now" literal.
+ *
+ * `style: 'narrow'` is the default because the previous hand-rolled output was
+ * compact and it sits in dense rows. Narrow English is byte-identical to what
+ * this app rendered before for seconds, minutes, hours and multi-day gaps
+ * (`45s ago`, `2m ago`, `3h ago`, `5d ago`); only the two deltas below change.
+ *
+ * English deltas, deliberate and reviewed:
+ *   - sub-10-second now reads `now` where it read `just now`
+ *   - exactly one day back reads `yesterday` where it read `1d ago`
+ *
+ * Future timestamps format forwards (`in 5m`) rather than being clamped, so
+ * clock skew is visible instead of silently reading as "now".
+ *
+ * `unit` pins the unit instead of picking the largest that fits. A caller that
+ * has already reduced its input to whole CALENDAR days needs this: with an
+ * auto-picked unit a zero delta means "under one second" and renders "now",
+ * which is wrong for something that happened earlier the same day. Pinning
+ * `'day'` makes a zero delta render "today" / "今天" / "heute".
+ */
+export function fmtRelative(
+  value: Date | string | number | null | undefined,
+  options?: { style?: RelativeStyle; now?: Date | number; unit?: Intl.RelativeTimeFormatUnit },
+): string {
+  const d = toDate(value)
+  if (!d) return '—'
+  const style = options?.style ?? 'narrow'
+  const nowMs = options?.now instanceof Date ? options.now.getTime() : (options?.now ?? Date.now())
+  const deltaSeconds = (d.getTime() - nowMs) / 1000
+  const magnitude = Math.abs(deltaSeconds)
+
+  const locale = activeLocale()
+  const rtf = memo('relative', locale, style, () =>
+    new Intl.RelativeTimeFormat(locale, { localeMatcher: 'lookup', numeric: 'auto', style }),
+  )
+
+  if (options?.unit) {
+    const seconds = RELATIVE_THRESHOLDS.find((t) => t.unit === options.unit)?.seconds ?? 1
+    return rtf.format(Math.trunc(deltaSeconds / seconds), options.unit)
+  }
+
+  // Below one second there is no unit to pick; `format(0, 'second')` is what
+  // renders the locale's idiomatic "now" / "现在" / "jetzt".
+  if (magnitude < 1) return rtf.format(0, 'second')
+
+  for (const { unit, seconds } of RELATIVE_THRESHOLDS) {
+    if (magnitude >= seconds) {
+      // Truncate toward zero so an elapsed 119s reads "1m ago", never "2m ago" —
+      // an age must not round up into a future it has not reached.
+      return rtf.format(Math.trunc(deltaSeconds / seconds), unit)
+    }
+  }
+  return rtf.format(0, 'second')
+}
+
+/* --------------------------------------------------------------------- lists */
+
+/**
+ * Join items the way the language joins them.
+ *
+ * `join(', ')` plus a translated `" and "` re-introduces concatenation *after*
+ * i18n: CJK does not use a comma-space separator at all (zh renders
+ * `A、B和C`), and the conjunction's position is language-specific. `ListFormat`
+ * is the only correct answer.
+ *
+ * Only for natural-language enumerations shown to a user. A technical list — a
+ * CSS value, a path, a payload, anything with a `split()` on the other side —
+ * must keep its literal separator.
+ */
+export function fmtList(
+  items: readonly string[],
+  options?: { type?: 'conjunction' | 'disjunction' | 'unit'; style?: 'long' | 'short' | 'narrow' },
+): string {
+  const type = options?.type ?? 'conjunction'
+  const style = options?.style ?? 'long'
+  const locale = activeLocale()
+  return memo('list', locale, { type, style }, () =>
+    new Intl.ListFormat(locale, { localeMatcher: 'lookup', type, style }),
+  ).format(items.filter((item) => item !== ''))
+}
+
+/* ----------------------------------------------------------------- collation */
+
+/**
+ * A collator for the active language.
+ *
+ * `numeric: true` is on by default because the strings this app sorts are
+ * user-named things that routinely carry digits — `reviewer-2` must precede
+ * `reviewer-10`, and byte order puts it after. `sensitivity: 'base'` makes the
+ * order case- and accent-insensitive, so `apple` and `Apple` no longer land in
+ * two different places in one list.
+ *
+ * NOT for machine identifiers. Sorting ISO-8601 timestamps or filesystem paths
+ * needs byte order — collation weights `-`, `:` and `/` at a lower level, which
+ * makes "chronological" and "parent before child" host-dependent. Those call
+ * sites keep plain comparison and are recorded in the gate's allowlist.
+ */
+export function collator(options?: Intl.CollatorOptions): Intl.Collator {
+  const locale = activeLocale()
+  const resolved: Intl.CollatorOptions = {
+    localeMatcher: 'lookup',
+    numeric: true,
+    sensitivity: 'base',
+    ...options,
+  }
+  return memo('collator', locale, resolved, () => new Intl.Collator(locale, resolved))
+}
+
+/**
+ * Comparator for user-visible text, for direct use in `.sort()`.
+ *
+ * `[...names].sort(compareText)` replaces `.sort((a, b) => a.localeCompare(b))`,
+ * which compares in the HOST locale and ignores the app's language entirely.
+ */
+export function compareText(a: string, b: string): number {
+  return collator().compare(a, b)
+}

--- a/website/src/i18n/localeFormatting.test.ts
+++ b/website/src/i18n/localeFormatting.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Formatting must consult the app's language, not the browser's.
+ *
+ * ## The defect
+ *
+ * `d.toLocaleDateString()`, `d.toLocaleDateString([])` and
+ * `d.toLocaleTimeString(undefined, { … })` all mean the same thing: format in the
+ * **host** locale. They ignore `dashboard.language` entirely. `LanguageProvider`
+ * sets `<html lang>`, but `<html lang>` has no effect on `Intl`, so a dashboard
+ * running in Chinese on an en-US browser rendered `7/30/2026` and `Jul 30` inside
+ * Chinese UI. `a.localeCompare(b)` has the same flaw for ordering: the sort order
+ * of a list of names silently depended on the browser.
+ *
+ * The fix is `src/i18n/format.ts`, which reads the active language per call.
+ *
+ * ## The rule
+ *
+ * A `toLocale*` / `localeCompare` call is a finding when it does **not** say
+ * which locale it means:
+ *
+ *   - `x.toLocaleString()` / `(([]))` / `(undefined, opts)`  → finding
+ *   - `a.localeCompare(b)`                                   → finding
+ *   - `x.toLocaleDateString('en-US', opts)`                  → allowed
+ *   - `a.localeCompare(b, 'en-US')`                          → allowed
+ *
+ * Naming a locale IS the opt-out, which is why there is no allowlist file. That
+ * is deliberate: a machine-parse site — an ISO timestamp sort, a filesystem path
+ * sort, a value fed to `Date.parse` on the other side — has to state its pin in
+ * the code where a reviewer sees it, rather than in a registry a reviewer has to
+ * go and look up. Byte-order comparison (`a < b ? -1 : 1`) is the other correct
+ * answer for those, and is not matched by this gate at all.
+ *
+ * ## Why a bidirectional ratchet and not zero
+ *
+ * There were ~100 such calls when this gate landed. The seam and the shared
+ * helpers migrated first, because a helper fixes every consumer at once; the
+ * long tail migrates in later batches. The baseline is the remaining debt and
+ * fails in BOTH directions — going up is a regression, going down means the
+ * number is stale and must be committed, which is the only thing that keeps a
+ * budget shrinking (this repo's eslint budget went 1066 → 1116 for want of the
+ * downward half).
+ *
+ * ## Known false negatives, stated explicitly
+ *
+ *  1. **Indirection.** `const f = d.toLocaleDateString; f()` is not matched. No
+ *     such site exists; the pattern is unnatural in this codebase.
+ *  2. **A pinned locale can still be the WRONG locale.** This gate proves a
+ *     locale was chosen, not that it was chosen correctly. `toLocaleString('en-US')`
+ *     on a user-facing date passes here and is still a bug — that is what review
+ *     and the render-time gate in Phase 5 are for.
+ *  3. **`Intl.*` constructed directly** with a hardcoded locale outside
+ *     `format.ts` is not matched. `utils/tz.ts` legitimately does this to derive
+ *     cron day-of-week numbers, and the pin there is load-bearing.
+ *  4. **`toFixed` / `String(n)` / `join(', ')`** are outside this gate's scope.
+ *     They are not locale-aware APIs at all, so there is nothing syntactic to
+ *     detect; they are tracked by the phase plan, not by a matcher.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import ts from 'typescript'
+
+const SRC = join(__dirname, '..')
+
+/**
+ * Remaining un-migrated host-locale calls.
+ *
+ * Lower this — never raise it — as batches land. When it reaches 0, delete the
+ * baseline and assert `[]` directly, which is the phase's stated acceptance gate
+ * ("zero bare `toLocale*`/`localeCompare` outside `format.ts`").
+ */
+const BASELINE = 97
+
+/** The seam itself. It is where a locale is legitimately resolved. */
+const SEAM = new Set(['i18n/format.ts'])
+
+const HOST_LOCALE_METHODS = new Set([
+  'toLocaleString',
+  'toLocaleDateString',
+  'toLocaleTimeString',
+])
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'locales') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Does this argument express a locale?
+ *
+ * `undefined` and `[]` are the two spellings of "no locale" that read as though
+ * they were an argument, and both are present in this codebase — they are the
+ * whole reason this cannot be a simple arity check.
+ */
+function namesALocale(arg: ts.Expression | undefined): boolean {
+  if (!arg) return false
+  if (arg.kind === ts.SyntaxKind.UndefinedKeyword) return false
+  if (ts.isIdentifier(arg) && arg.text === 'undefined') return false
+  if (ts.isArrayLiteralExpression(arg) && arg.elements.length === 0) return false
+  return true
+}
+
+function hostLocaleCalls(file: string, source: string): number[] {
+  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const hits: number[] = []
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const method = node.expression.name.text
+      // `toLocale*`: the locale is argument 0.
+      // `localeCompare`: argument 0 is the other string, so the locale is 1.
+      const localeArg = method === 'localeCompare' ? node.arguments[1] : node.arguments[0]
+      if (
+        (HOST_LOCALE_METHODS.has(method) || method === 'localeCompare')
+        && !namesALocale(localeArg)
+      ) {
+        hits.push(sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sf)
+  return hits
+}
+
+describe('formatting follows the app language', () => {
+  const files = walk(SRC).filter(
+    (f) => !SEAM.has(relative(SRC, f).split('\\').join('/')),
+  )
+
+  it('finds source files to scan', () => {
+    // A green run that scanned nothing is the failure mode this guards.
+    expect(files.length).toBeGreaterThan(300)
+  })
+
+  it('detects a host-locale call, so the matcher is known to work', () => {
+    // A gate nobody has watched go red is not known to work. These four shapes
+    // are exactly the ones found in the codebase.
+    const sample = [
+      'const a = d.toLocaleDateString()',
+      'const b = d.toLocaleTimeString([], { hour: "2-digit" })',
+      'const c = n.toLocaleString(undefined, { maximumFractionDigits: 1 })',
+      'const e = x.name.localeCompare(y.name)',
+    ].join('\n')
+    expect(hostLocaleCalls('sample.ts', sample)).toEqual([1, 2, 3, 4])
+  })
+
+  it('accepts a call that names its locale', () => {
+    const pinned = [
+      'const a = d.toLocaleDateString("en-US", { weekday: "short" })',
+      'const b = a.localeCompare(b, "en-US")',
+      'const c = d.toLocaleString(activeLocale())',
+    ].join('\n')
+    expect(hostLocaleCalls('pinned.ts', pinned)).toEqual([])
+  })
+
+  it(`has exactly ${BASELINE} un-migrated host-locale call(s)`, () => {
+    const offenders: string[] = []
+    for (const file of files) {
+      const rel = relative(SRC, file).split('\\').join('/')
+      const source = readFileSync(file, 'utf-8')
+      if (!source.includes('toLocale') && !source.includes('localeCompare')) continue
+      const lines = source.split('\n')
+      for (const lineNo of hostLocaleCalls(rel, source)) {
+        offenders.push(`${rel}:${lineNo}  ${(lines[lineNo - 1] ?? '').trim()}`)
+      }
+    }
+
+    expect(
+      offenders.length,
+      offenders.length > BASELINE
+        ? 'A formatting call here reads the BROWSER\'s locale, not the app\'s language, so it '
+          + 'renders English dates inside a translated UI. Use the helpers in `src/i18n/format.ts` '
+          + '(`fmtDate`, `fmtTime`, `fmtNumber`, `fmtRelative`, `compareText`). If the value is '
+          + 'machine-parsed — an ISO timestamp sort, a filesystem path, anything with a parser on '
+          + 'the other side — name the locale explicitly (`toLocaleDateString(\'en-US\', …)`) or '
+          + 'compare bytes (`a < b ? -1 : 1`) and say why in a comment.\n\n'
+          + offenders.slice(0, 12).join('\n')
+        : `Improved — lock it in: set BASELINE = ${offenders.length} in this file.`,
+    ).toBe(BASELINE)
+  })
+})

--- a/website/src/i18n/untranslated-baseline.json
+++ b/website/src/i18n/untranslated-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Untranslated user-visible strings, per file. Generated — regenerate with `node scripts/check-i18n-strings.mjs --update`. This is both the CI ratchet and the Phase 1 worklist: drive files to zero, one PR per file or per directory.",
-  "_total": 1985,
+  "_total": 1966,
   "files": {
     "api/client.ts": {
       "total": 39,
@@ -176,9 +176,8 @@
       "template": 3
     },
     "apps/issue-radar/lib/format.ts": {
-      "total": 11,
-      "prose": 4,
-      "template": 7
+      "total": 1,
+      "template": 1
     },
     "apps/issue-radar/lib/investigate.ts": {
       "total": 3,
@@ -375,9 +374,8 @@
       "object-prop": 1
     },
     "components/commandPalette/providers/recentsProvider.ts": {
-      "total": 6,
-      "prose": 5,
-      "template": 1
+      "total": 5,
+      "prose": 5
     },
     "components/commandPalette/providers/settingsProvider.ts": {
       "total": 1,
@@ -499,10 +497,10 @@
       "template": 1
     },
     "components/notifications/NotificationFeed.tsx": {
-      "total": 11,
+      "total": 8,
       "expression": 1,
       "prose": 1,
-      "template": 9
+      "template": 6
     },
     "components/OnboardingFlow.tsx": {
       "total": 5,
@@ -1333,10 +1331,6 @@
     "utils/terminalRegistry.ts": {
       "total": 1,
       "template": 1
-    },
-    "utils/timeAgo.ts": {
-      "total": 5,
-      "template": 5
     },
     "utils/tokenPrompt.ts": {
       "total": 2,

--- a/website/src/pages/overview/CronTab.tsx
+++ b/website/src/pages/overview/CronTab.tsx
@@ -13,7 +13,7 @@ import { useProvider } from '../../providers'
 import type { CronJob } from '../../types'
 import { useAgents } from '../../hooks/useAgents'
 import { timeAgo } from '../../utils/timeAgo'
-import { PY_TO_CRON, CRON_SEL, DAY_LABELS } from '../../utils/cronUtils'
+import { PY_TO_CRON, CRON_SEL, dayLabels } from '../../utils/cronUtils'
 import { useSortableTable } from '../../hooks/useSortableTable'
 import SortableHeader from '../../components/SortableHeader'
 import { useCronActions } from '../../hooks/useCronActions'
@@ -138,7 +138,7 @@ export default function CronTab({ refreshTrigger }: { refreshTrigger: number }) 
               <option value="minutes">{i18nT('pages.overview.cronTab.min')}</option><option value="hours">{i18nT('pages.overview.cronTab.hr')}</option><option value="days">{i18nT('pages.overview.cronTab.day')}</option>
             </select>
           </>) : (<>
-            <div className="flex gap-1">{DAY_LABELS.map((d, i) => (
+            <div className="flex gap-1">{dayLabels().map((d, i) => (
               <button key={d} onClick={() => toggleDay(i + 1)} className={`px-2.5 py-1.5 rounded-md text-[13px] font-medium border cursor-pointer transition-all ${days.includes(i + 1) ? 'bg-accent text-accent-fg border-accent' : 'bg-bg-elevated text-muted border-border hover:border-border-strong'}`}>{d}</button>
             ))}</div>
             <span className="text-muted text-[13px]">{i18nT('pages.overview.cronTab.at')}</span>

--- a/website/src/test/RemoteArtifactCard.test.tsx
+++ b/website/src/test/RemoteArtifactCard.test.tsx
@@ -6,7 +6,7 @@
  *     hijacked by the row's Enter/Space handler (which now navigates to the
  *     in-app remote-detail viewer).
  *  2. A millisecond-epoch updated_at string must render a sane relative age,
- *     not "just now" forever (ms value misread as a far-future seconds epoch).
+ *     not "now" forever (ms value misread as a far-future seconds epoch).
  *
  * The row's primary action now NAVIGATES to the in-app read-only remote-detail
  * viewer (/artifacts/remote/:provider/:externalId) instead of opening the
@@ -102,19 +102,19 @@ describe('RemoteArtifactCard actionsDisabled', () => {
 })
 
 describe('RemoteArtifactCard updated_at rendering', () => {
-  it('renders a millisecond-epoch updated_at as a real age, not "just now"', () => {
+  it('renders a millisecond-epoch updated_at as a real age, not "now"', () => {
     // 2020-01-01T00:00:00Z in MILLISECONDS — years in the past.
     renderCard({ artifact: mkRemote({ updated_at: '1577836800000' }), provider: 'companion' })
-    // Should read as days/years ago, never "just now" (which is the bug: a ms
+    // Should read as days/years ago, never "now" (which is the bug: a ms
     // value misread as seconds lands in the far future → negative age).
-    expect(screen.queryByText('just now')).not.toBeInTheDocument()
-    expect(screen.getByText(/\d+d ago/)).toBeInTheDocument()
+    expect(screen.queryByText('now')).not.toBeInTheDocument()
+    expect(screen.getByText(/\d+(s|m|h|d|mo|y) ago/)).toBeInTheDocument()
   })
 
   it('still renders a seconds-epoch updated_at correctly', () => {
     // 2020-01-01T00:00:00Z in SECONDS.
     renderCard({ artifact: mkRemote({ updated_at: '1577836800' }), provider: 'companion' })
-    expect(screen.queryByText('just now')).not.toBeInTheDocument()
-    expect(screen.getByText(/\d+d ago/)).toBeInTheDocument()
+    expect(screen.queryByText('now')).not.toBeInTheDocument()
+    expect(screen.getByText(/\d+(s|m|h|d|mo|y) ago/)).toBeInTheDocument()
   })
 })

--- a/website/src/test/timeAgo.test.ts
+++ b/website/src/test/timeAgo.test.ts
@@ -13,14 +13,27 @@ describe('timeAgo', () => {
 
   it('formats a valid recent timestamp', () => {
     const now = Math.floor(Date.now() / 1000)
-    expect(timeAgo(now)).toBe('just now') // s < 10
+    // `now` replaces the former 'just now': it is what CLDR words for a
+    // sub-threshold gap, in every language. The other three are byte-identical
+    // to the hand-rolled ladder this delegates away to `i18n/format.ts`.
+    expect(timeAgo(now)).toBe('now')
     expect(timeAgo(now - 120)).toBe('2m ago')
     expect(timeAgo(now - 7200)).toBe('2h ago')
     expect(timeAgo(now - 172800)).toBe('2d ago')
   })
 
-  it('treats minor clock skew (small future ts) as just now', () => {
-    const future = Math.floor(Date.now() / 1000) + 5 // s ≈ -5, still < 10
-    expect(timeAgo(future)).toBe('just now')
+  it('treats minor clock skew (small future ts) as now', () => {
+    const future = Math.floor(Date.now() / 1000) + 5
+    // A slightly-future timestamp is a skewed clock, not a scheduled event, so
+    // it collapses to "now" rather than reporting "in 5s".
+    expect(timeAgo(future)).toBe('now')
+  })
+
+  it('reports a badly wrong clock as the future instead of hiding it', () => {
+    // Beyond the skew tolerance the future IS shown — a clock an hour ahead is a
+    // real problem and should not read as "now".
+    // Unit-agnostic: the ts is floored to whole seconds, so an hour ahead
+    // lands a hair under the hour boundary and reads '59m' rather than '1h'.
+    expect(timeAgo(Math.floor(Date.now() / 1000) + 3600)).toMatch(/^in \d+[smhdy]/)
   })
 })

--- a/website/src/utils/cronUtils.tsx
+++ b/website/src/utils/cronUtils.tsx
@@ -1,10 +1,27 @@
 /** Shared cron formatting utilities used by CronTab and SchedulePage */
 import { Save, Plus } from 'lucide-react'
+import { fmtDateTime, fmtWeekday } from '../i18n/format'
 import type { CronJob } from '../types'
 
 export const PY_TO_CRON = [1, 2, 3, 4, 5, 6, 0]
 export const CRON_SEL = 'bg-bg-elevated border border-border rounded-md px-3 py-2 text-text text-sm font-body outline-none cursor-pointer transition-colors focus-ring'
-export const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+/**
+ * Monday-first weekday labels for the day pickers.
+ *
+ * A FUNCTION, not a const array, and that is the whole point: a module-level
+ * array of translated strings freezes at the boot language (the same defect
+ * `moduleLevel.test.ts` guards for `i18nT`). Callers keep doing
+ * `dayLabels().map((d, i) => …)`, so the INDEX contract every caller relies on —
+ * index 0 is Monday, and `PY_TO_CRON[i]` maps it to a cron day number — is
+ * unchanged. Only the rendered label is now localized.
+ *
+ * English output is byte-identical to the array it replaces: CLDR's `en` short
+ * weekdays are exactly `Mon`…`Sun`.
+ */
+export function dayLabels(): string[] {
+  return [1, 2, 3, 4, 5, 6, 7].map((iso) => fmtWeekday(iso))
+}
 export const TH_CLS = 'text-left text-muted text-[12px] uppercase tracking-[.04em] px-2.5 py-2 border-b border-border font-medium'
 export const TD_CLS = 'px-2.5 py-2 border-b border-border text-sm'
 
@@ -16,13 +33,19 @@ export function renderThCells(cols: { h: string; w: string }[]) {
 export function fmtSchedule(j: CronJob): string {
   if (j.cron_expr) return j.cron_expr
   if (j.every) {
+    // Bare unit letters, deliberately NOT localized: this shape ("every 3600s",
+    // "1h") is the wire format the backend emits and `parseEveryFromSchedule`
+    // in WeekGrid.tsx parses back with /^every\s+(\d+)\s*([sh])/. A localized
+    // unit (de "3600 Sek.", bn Bengali digits) would silently fail that parse
+    // and empty the schedule grid. Rendering these as a translated duration
+    // requires separating the display string from the parsed one first.
     const s = j.every
     if (s < 60) return `${s}s`
     if (s < 3600) return `${Math.floor(s / 60)}m`
     if (s < 86400) return `${Math.floor(s / 3600)}h`
     return `${Math.floor(s / 86400)}d`
   }
-  if (j.at) return new Date(j.at * 1000).toLocaleString()
+  if (j.at) return fmtDateTime(j.at)
   return '—'
 }
 
@@ -60,9 +83,14 @@ export function fmtCron(expr: string): string {
     const p = expr.trim().split(/\s+/)
     if (p.length !== 5) return expr
     const [min, hr, dom, , dow] = p
-    const NAMES = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
+    // Cron day numbers are Sunday-first (0=Sun, and 7 is also Sunday), so the
+    // index is converted to ISO (1=Mon…7=Sun) before asking for a name. The
+    // number stays the contract; only the name is localized. English output is
+    // unchanged. Anything outside 0-7 is not a weekday and falls back to the raw
+    // value, exactly as the hardcoded array's sparse lookup did.
+    const cronDowName = (d: number) => (d >= 0 && d <= 7 ? fmtWeekday(d === 0 ? 7 : d) : String(d))
     const expanded = expandDow(dow)
-    const days = dow === '*' ? 'daily' : expanded.length > 0 ? expanded.map(d => NAMES[d] || String(d)).join(',') : dow
+    const days = dow === '*' ? 'daily' : expanded.length > 0 ? expanded.map(cronDowName).join(',') : dow
     const domPart = dom !== '*' ? ` (days ${dom})` : ''
     return `${days} ${hr.padStart(2,'0')}:${min.padStart(2,'0')}${domPart}`
   } catch { return expr }

--- a/website/src/utils/formatCost.ts
+++ b/website/src/utils/formatCost.ts
@@ -1,3 +1,5 @@
+import { fmtCurrency } from '../i18n/format'
+
 /**
  * Format a USD cost for display at a precision a user can actually act on.
  *
@@ -13,6 +15,13 @@
  *
  * NOTE: for MONEY only. Similarity scores (VectorMemoryCard) legitimately want
  * 2–3dp — do not route those through here.
+ *
+ * Formatting goes through `Intl.NumberFormat`'s currency style, so the symbol's
+ * POSITION and the decimal separator follow the language: `$12.50` in English,
+ * `12,50 $` in German. The `<$0.01` and `~$0` sentinels keep their own shape
+ * because they are threshold statements rather than amounts; the amount inside
+ * the floor sentinel is still formatted, so the separator stays consistent with
+ * the numbers around it.
  */
 export function formatCost(usd: number | null | undefined): string {
   if (usd == null || !Number.isFinite(usd)) return '—'
@@ -21,6 +30,6 @@ export function formatCost(usd: number | null | undefined): string {
   // silently flooring a bad input to <$0.01.
   const abs = Math.abs(usd)
   const sign = usd < 0 ? '-' : ''
-  if (abs < 0.01) return `${sign}<$0.01`
-  return `${sign}$${abs.toFixed(2)}`
+  if (abs < 0.01) return `${sign}<${fmtCurrency(0.01)}`
+  return `${sign}${fmtCurrency(abs)}`
 }

--- a/website/src/utils/timeAgo.ts
+++ b/website/src/utils/timeAgo.ts
@@ -1,12 +1,40 @@
-/** Human-readable relative time from a unix timestamp (seconds) */
+import { fmtRelative, toDate } from '../i18n/format'
+
+/** A timestamp this far ahead of us is clock skew, not the future. */
+const SKEW_TOLERANCE_MS = 60_000
+
+/**
+ * Human-readable relative time from a unix timestamp (seconds).
+ *
+ * Delegates to the locale-aware seam (`i18n/format.ts`) rather than building the
+ * string from a ladder of English template literals. The previous implementation
+ * rendered `2m ago` / `3h ago` in every language, because a template literal has
+ * no locale to consult. `fmtRelative` asks CLDR, so the same instant reads
+ * `2分钟前` in Chinese and `vor 2 Minuten` in German.
+ *
+ * English output is unchanged for seconds, minutes, hours and multi-day gaps
+ * (`45s ago`, `2m ago`, `3h ago`, `5d ago`). Two deltas, both deliberate:
+ * sub-10-second now reads `now` rather than `just now`, and exactly one day back
+ * reads `yesterday` rather than `1d ago` — CLDR words those idiomatically, which
+ * is the point of using it.
+ */
 export function timeAgo(ts: number): string {
   // Guard against a missing/unparseable timestamp: callers that derive ts from
   // an absent or bad date pass 0 / NaN, which would otherwise render as a
-  // garbage age (ts=0 → ~20602d). Sub-second positives aren't meaningful either.
+  // garbage age (ts=0 → ~20602d). Sub-second positives aren't meaningful either,
+  // so the `< 1` floor is kept rather than delegating to `toDate`, which accepts
+  // any positive epoch. `--` stays the sentinel rather than format.ts's em dash
+  // so existing callers' column widths are unaffected.
   if (!ts || !Number.isFinite(ts) || ts < 1) return '--'
-  const s = Math.floor((Date.now() / 1000) - ts)
-  if (s < 60) return s < 10 ? 'just now' : `${s}s ago`
-  if (s < 3600) return `${Math.floor(s / 60)}m ago`
-  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
-  return `${Math.floor(s / 86400)}d ago`
+  const at = toDate(ts)
+  if (!at) return '--'
+
+  // A slightly-future timestamp is a skewed clock, not a scheduled event, and
+  // this helper only ever renders ages. Collapse it to "now" rather than letting
+  // `fmtRelative` report "in 12s" for a row that already happened. Beyond the
+  // tolerance the future IS shown, so a badly wrong clock stays visible.
+  const now = Date.now()
+  if (at.getTime() > now && at.getTime() - now < SKEW_TOLERANCE_MS) return fmtRelative(now, { now })
+
+  return fmtRelative(at, { now })
 }


### PR DESCRIPTION
## The defect

Formatting ignored the selected language entirely. All ~100 formatting call sites were `toLocaleString()`, `toLocaleDateString([])` or `toLocaleTimeString(undefined, {…})` — three spellings of the same thing: **host** locale, i.e. the browser's, not `dashboard.language`. `LanguageProvider` sets `<html lang>`, but `<html lang>` has no effect on `Intl`.

So a dashboard running in Chinese on an en-US browser rendered `7/30/2026` and `Jul 30` inside otherwise-Chinese UI, showed `3:04 PM` where zh wants `15:04`, and sorted lists of user-named things in whatever order the browser preferred.

Around that, 17 files hand-rolled relative time out of English template literals — `2m ago`, `Yesterday`, `2 month${m > 1 ? 's' : ''} ago`. Those strings are unreachable by a translator by construction, and they carry English plural morphology that most languages cannot express.

The root cause was **one missing module, not 100 independent bugs**: no call site could consult the active language because there was nowhere to ask.

## What this PR does

**The seam** — `website/src/i18n/format.ts`: `fmtDate` · `fmtTime` · `fmtDateTime` · `fmtDateFields` · `fmtNumber` · `fmtPercent` · `fmtCurrency` · `fmtUnit` · `fmtRelative` · `fmtList` · `fmtWeekday` · `collator` · `compareText` · `toDate`. Each reads `i18next.resolvedLanguage` at call time and passes `localeMatcher: 'lookup'` (RFC 4647 §3.4, so the `zh-CN → zh → root` chain is not hand-rolled). Plain functions rather than hooks, for the same reason `i18nT` is: formatting happens inside `.map()` callbacks, inside `.sort()` comparators, and in non-component modules. Formatters are memoized on `(kind, locale, options)` because they run in render and in comparators.

**The gate** — `website/src/i18n/localeFormatting.test.ts`: an AST walker over `src`. A `toLocale*` / `localeCompare` call that does not say **which** locale it means is a finding. Naming a locale *is* the opt-out, so there is no allowlist file — a machine-parse site states its pin in the code where a reviewer sees it, and byte comparison (`a < b ? -1 : 1`) is not matched at all. Bidirectional ratchet at **97**, the un-migrated tail. It also asserts it detects the four shapes actually present in this repo, so the gate is known to work rather than merely known to be green.

**The migration** — the shared helpers, where one edit fixes every consumer:

| file | was |
|---|---|
| `utils/timeAgo.ts` | English ladder, capped at days |
| `apps/issue-radar/lib/format.ts` | 3 helpers, hardcoded `Today`/`Yesterday`/`N month(s) ago` |
| `notifications/notifMeta.tsx` | `toLocaleTimeString([])`, `toLocaleString()` |
| `notifications/NotificationFeed.tsx` | English ladder with its own `yesterday` case |
| `commandPalette/providers/recentsProvider.ts` | 4 host-locale calls + hardcoded `Yesterday` |
| `utils/formatCost.ts` | `` `$${abs.toFixed(2)}` `` — symbol position and separator both wrong off-en |

Weekday arrays keep their index contract and lose their hardcoded labels (`cronUtils.tsx`, `JobForm.tsx`, `WeekGrid.tsx`, `CronTab.tsx`). The index is the cron day-of-week data, so only the *label* moved: `dayLabels()` is a function, not a const array, because a module-level array of translated strings freezes at the boot language — the same defect `moduleLevel.test.ts` guards for `i18nT`.

## Two findings that correct the plan

1. **`Intl.DurationFormat` does not exist on the runtime this ships to.** `typeof Intl.DurationFormat === 'undefined'` on Node 20 (CI and the Electron baseline), so the plan's `fmtDuration` cannot be built on it. `fmtUnit` uses `NumberFormat` with `style: 'unit'`, which is Baseline and covers every duration shape this app renders. A test asserts the API really is absent, so the day it lands this gets revisited rather than forgotten.
2. **`bn` renders Bengali digits by default** (`১২,৩৪,৫৬৭`), not only `ar`/`fa` as the plan states. Locale-formatted digits are therefore never safe for a CSS length, a URL parameter, or a serialised payload. `fmtSchedule`'s `every 3600s` output keeps bare arithmetic for exactly this reason — `parseEveryFromSchedule` in `WeekGrid.tsx` parses it back with `/^every\s+(\d+)\s*([sh])/`, and that round-trip is now named in a comment instead of being load-bearing by accident.

## English rendering

Unchanged, with two reviewed deltas — both places where CLDR words the same fact idiomatically instead of mechanically:

- a sub-threshold gap reads `now` rather than `just now`
- exactly one day back reads `yesterday` rather than `1d ago`

Everything else is byte-identical: `45s ago`, `2m ago`, `3h ago`, `5d ago`, `Mon`…`Sun`, `Jul 30, 2026`, `3:04 PM`, `$12.50`. That is why the 9 existing `fmtCron` assertions pass untouched. The same instants now read `2分钟前` / `昨天` in Chinese, `vor 2 Minuten` / `vorgestern` in German, and `A、B和C` where `join(', ')` produced `A, B, and C`.

## Verification

- `npx tsc -b` — 0 errors
- `npx vitest run` — **534 files, 6484 passed**, 3 skipped, 0 failures
- `npm run i18n:check` — all 5 gates OK
- `npx eslint src/ --max-warnings 1116` — 0 errors, 286 warnings
- `npx jscpd .` — 0 clones
- Untranslated baseline ratchets **1985 → 1966** (19 English literals deleted)
- Intl output verified against Node 20 full-icu (`icu_small=false`) for all 10 shipped locales

Date assertions pass an explicit `timeZone`: the vitest setup pins no `TZ`, so an unpinned date assertion would pass in UTC CI and fail on a developer machine in Asia/Shanghai.

## Where this sits in the plan

| phase | status |
|---|---|
| **0** — guards + the writing that unblocks everything | ✅ merged |
| **0.5** — i18next 26 / react-i18next 17 | ✅ merged (26.3.6 / 17.0.11) |
| **1** — remove visible English | 4 of 5 batches merged (#932, #956, #959, #949); #964 open |
| **2a** — script font fallback | PR #982 open |
| **2b** — bidi isolation, unitless line-heights, fixed inline sizes | staged, not yet raised |
| **3** — de-fragment (D1, D2) | in progress |
| **4** — locale-aware formatting | ⬅️ **this PR** (seam + gate + shared helpers; tail ratcheted) |
| **5** — render-time gate | not started |
| **6** — structural cleanup (D4 remainder, D6, D7, D13) | not started |
| **7** — contributor-facing quality machinery | not started |
| **Track B** — backend boundary (D14-c) | not started |
| **Track C** — RTL | not started |

Phase 4's own numbered sub-items:

| # | item | status |
|---|---|---|
| 1 | `src/i18n/format.ts` with the formatter set, reading `resolvedLanguage` + `localeMatcher: 'lookup'` | ✅ **in this PR** — `fmtDuration` shipped as `fmtUnit`, see finding 1 |
| 2 | mechanical migration of ~300 sites (65 `toLocale*`, 39 `ago` literals, 36 `localeCompare`, 27 `join(', ')`, 72 `toFixed`, 4 weekday arrays) | 🟡 **partial** — all 4 weekday arrays, all 6 shared relative-time/cost helpers, and 7 host-locale calls done here. Remaining **97** `toLocale*`/`localeCompare` are held by the new ratchet; `toFixed` and `join(', ')` are not locale-aware APIs and have no syntactic matcher, so they follow in the batch PRs |
| 3 | keep the `'en-US'`-pinned machine-parse sites, with a comment and an allowlist entry | ✅ **in this PR** — mechanism inverted for the better: naming a locale is itself the opt-out, so no registry can drift out of sync with the code |
| 4 | never hand-format numbers | ✅ **in this PR** — documented as a hard limitation on the module, with the `bn` correction and the `fmtSchedule` round-trip called out |
| 5 | promote the Phase 0 formatting lint rule warn → error | 🟡 **re-scoped** — Phase 0 item 5 was never implemented (no `no-locale-compare` exists in any form, and this repo has zero local ESLint rules). Built here as a Vitest AST ratchet instead, matching the house precedent that `dynamicKeys.test.ts` and `moduleLevel.test.ts` set. A Vitest gate is binary, so "warn" maps onto "baseline at the current count", which is this repo's idiom for the same intent |

**Follow-up batches** to drive the ratchet 97 → 0, each independently reviewable: `App.tsx` + `ChatSidebar.tsx` (23 calls), the `pages/` tail, the `localeCompare` sorts (which need the machine-vs-display judgement per site, already inventoried), and the `toFixed`/`join(', ')` populations.

Tracks #1004
