### PR TITLE
fix: gate provider hrefs through safeHttpUrl + deny deploy tamper of audit log bucket

### DIFF
--- a/src/kiro_crew/deploy/iam.py
+++ b/src/kiro_crew/deploy/iam.py
@@ -229,6 +229,26 @@ def policy_document(*, include_custom_domain: bool = False, tier: str = "static"
             "Resource": [f"arn:aws:s3:::{S3_PREFIX}/*", f"{S3_PREFIX_WEB}/*"],
         },
         {
+            # CWE-732: the S3BucketLevel/S3ObjectLevel grants above use the
+            # kirocrew-deploy-* wildcard, which also matches the append-only
+            # audit bucket kirocrew-deploy-logs-* (CloudTrail data events + S3
+            # server access logs, base-stack.yaml). Deny overrides Allow, so
+            # this blocks the deploy principal from DIRECT object write/delete
+            # and bucket deletion on that bucket. It does NOT cover bucket-config
+            # tamper (PutLifecycleConfiguration / Put|DeleteBucketPolicy) — base-
+            # stack CFN legitimately calls those on the log bucket at create time,
+            # so safely denying them needs an aws:CalledVia=cloudformation
+            # condition, tracked as a follow-up. Legitimate deploys never write
+            # objects to the -logs- bucket, so this Deny has no functional cost.
+            "Sid": "S3DenyAuditLogTamper",
+            "Effect": "Deny",
+            "Action": ["s3:PutObject", "s3:DeleteObject", "s3:DeleteBucket"],
+            "Resource": [
+                "arn:aws:s3:::kirocrew-deploy-logs-*",
+                "arn:aws:s3:::kirocrew-deploy-logs-*/*",
+            ],
+        },
+        {
             "Sid": "CloudFrontCreateList",
             "Effect": "Allow",
             "Action": [

--- a/test/test_deploy_log_bucket_deny.py
+++ b/test/test_deploy_log_bucket_deny.py
@@ -1,0 +1,34 @@
+"""Regression: deploy IAM must Deny tampering the append-only audit LogBucket.
+
+CWE-732: the S3BucketLevel/S3ObjectLevel Allow grants use the kirocrew-deploy-*
+wildcard, which also matches the audit bucket kirocrew-deploy-logs-* (CloudTrail
+data events + S3 access logs). An explicit Deny (Deny overrides Allow) fences the
+deploy principal out of Put/Delete on that bucket without affecting real deploys.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.deploy.iam import policy_document
+
+
+def _by_sid(doc: dict, sid: str) -> dict | None:
+    for st in doc["Statement"]:
+        if st.get("Sid") == sid:
+            return st
+    return None
+
+
+def test_policy_denies_audit_log_bucket_tamper():
+    # Present in every tier (it lives in the base statements list).
+    for tier in ("static", "fullstack"):
+        doc = policy_document(tier=tier)
+        deny = _by_sid(doc, "S3DenyAuditLogTamper")
+        assert deny is not None, f"{tier}: S3DenyAuditLogTamper missing"
+        assert deny["Effect"] == "Deny"
+        acts = deny["Action"] if isinstance(deny["Action"], list) else [deny["Action"]]
+        for need in ("s3:PutObject", "s3:DeleteObject", "s3:DeleteBucket"):
+            assert need in acts, f"{tier}: Deny missing {need}"
+        res = deny["Resource"] if isinstance(deny["Resource"], list) else [deny["Resource"]]
+        assert res and all("kirocrew-deploy-logs-" in r for r in res), res
+        # The legitimate object-level Allow is still present (real deploys work).
+        assert _by_sid(doc, "S3ObjectLevel") is not None, f"{tier}: S3ObjectLevel missing"

--- a/website/src/apps/issue-radar/components/PrDetail.tsx
+++ b/website/src/apps/issue-radar/components/PrDetail.tsx
@@ -326,7 +326,7 @@ function eventVisual(
         body: (
           <>
             {who} {i18nT('apps.issueRadar.components.prDetail.referenced_this_in')}{' '}
-            <a href={ev.source?.url} target="_blank" rel="noreferrer" className="text-accent hover:underline">
+            <a href={safeHttpUrl(ev.source?.url ?? '') ?? undefined} target="_blank" rel="noreferrer" className="text-accent hover:underline">
               {ev.source?.is_pr ? providerTerms(repoRef).changeRequestShort : 'issue'}
               {providerTerms(repoRef).sigil}{ev.source?.number}
             </a>
@@ -680,7 +680,7 @@ export default function PrDetail({ pull }: { pull: PullRequest }) {
                 >
                   {copied ? <Check size={13} className="text-ok" /> : <Copy size={13} />}
                 </button>
-                <a href={detail?.url ?? pull.url} target="_blank" rel="noreferrer" title={`Open on ${terms.providerName}`} className="font-mono text-muted hover:text-accent hover:underline">
+                <a href={safeHttpUrl(detail?.url ?? pull.url ?? '') ?? undefined} target="_blank" rel="noreferrer" title={`Open on ${terms.providerName}`} className="font-mono text-muted hover:text-accent hover:underline">
                   #{pull.number}
                 </a>
               </span>

--- a/website/src/components/SkillBrowserModal.tsx
+++ b/website/src/components/SkillBrowserModal.tsx
@@ -13,6 +13,7 @@ import { api, ApiError } from '../api/client'
 import Modal from './Modal'
 import { Btn } from './ui'
 import MarkdownRenderer from './MarkdownRenderer'
+import { safeHttpUrl } from '../lib/safeUrl'
 import { DiscoverySearchBar, DiscoveryStates } from './DiscoverySearchBar'
 import { SkillMetaStrip } from './SkillDirectoryBrowser'
 import { parseFrontmatter } from './SkillForm'
@@ -417,9 +418,9 @@ function SkillDetailPanel({
             <FileText size={11} aria-hidden="true" /> {i18nT('components.skillBrowserModal.file', { count: preview!.file_count })}
           </span>
         )}
-        {skill.repo_url && (
+        {safeHttpUrl(skill.repo_url ?? '') && (
           <a
-            href={skill.repo_url}
+            href={safeHttpUrl(skill.repo_url ?? '')!}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 text-accent hover:underline"

--- a/website/src/components/notifications/NotificationDetailPanel.tsx
+++ b/website/src/components/notifications/NotificationDetailPanel.tsx
@@ -10,6 +10,7 @@ import { CronAckBar } from '../../pages/chat'
 import { api } from '../../api/client'
 import type { Notification } from '../../types'
 import { KIND_META, DEFAULT_META, fmtFull, safeInternalUrl } from './notifMeta'
+import { safeHttpUrl } from '../../lib/safeUrl'
 
 import { i18nT } from '../../i18n/t'
 /** Intentional failure diagnostic for the navigation/approval actions below. */
@@ -95,8 +96,8 @@ export default function NotificationDetailPanel({ n, onClose }: { n: Notificatio
         {!directSlot && !n.slot && relatedSlot && (
           <button className="px-3 py-1.5 rounded-md bg-accent text-accent-fg text-[13px] font-medium cursor-pointer border-none hover:brightness-110 transition-all" onClick={() => { dispatch(switchSlot(relatedSlot.key)); navigate('/chat') }}><MessageSquare className="lucide-inline" /> {i18nT('components.notifications.notificationDetailPanel.go_to_chat')}</button>
         )}
-        {n.slack_link && (
-          <a href={n.slack_link} target="_blank" rel="noopener noreferrer" className="px-3 py-1.5 rounded-md border border-border text-[13px] font-medium cursor-pointer bg-transparent text-muted hover:text-text hover:border-border-strong transition-all font-body no-underline inline-flex items-center gap-1"><MessageSquare className="lucide-inline" /> {i18nT('components.notifications.notificationDetailPanel.open_in_slack')}</a>
+        {safeHttpUrl(n.slack_link ?? '') && (
+          <a href={safeHttpUrl(n.slack_link ?? '')!} target="_blank" rel="noopener noreferrer" className="px-3 py-1.5 rounded-md border border-border text-[13px] font-medium cursor-pointer bg-transparent text-muted hover:text-text hover:border-border-strong transition-all font-body no-underline inline-flex items-center gap-1"><MessageSquare className="lucide-inline" /> {i18nT('components.notifications.notificationDetailPanel.open_in_slack')}</a>
         )}
         {/* RFC Phase 4: dashboard-internal deep link (validated path-only). */}
         {safeInternalUrl(n.url) && (


### PR DESCRIPTION
## Problem
Two open CSE findings on `main`:
- **CWE-79 (DOM-XSS):** three dashboard components render provider/registry-supplied URLs into `<a href>` with no scheme allowlist — `skill.repo_url` (SkillBrowserModal), PrDetail cross-referenced-event + header `#`-link, and `NotificationDetailPanel` `slack_link`. A `javascript:`/`data:` URL from a skill-registry entry, GitHub/GitLab API payload, or notification payload executes on click in the dashboard's own origin.
- **CWE-732 (audit-log tamper):** the deploy-web IAM policy's `S3ObjectLevel`/`S3BucketLevel` Allow grants use the `kirocrew-deploy-*` wildcard, which also matches the append-only audit `LogBucket` (`kirocrew-deploy-logs-*`: CloudTrail data events + S3 server access logs). The deploy principal — an LLM-triggerable skill sandbox — can overwrite/delete audit-log objects.

## Why it matters
Both are reachable local-user harm on a personal tool: script execution in the dashboard origin, and an integrity gap letting a prompt-injected deploy session rewrite its own audit trail.

## Fix (symptom → root cause → change)
- **hrefs:** the fix is the codebase's own inconsistency — `safeHttpUrl()` exists and is applied to sibling sinks in the same files but was skipped at these four. Route each through `safeHttpUrl()` and render nothing when it returns null (matches the file precedent, and the already-merged IssueDetail fix in #890).
- **IAM:** add an explicit `Deny` (`S3DenyAuditLogTamper`) on `s3:PutObject`/`DeleteObject`/`DeleteBucket` for `arn:aws:s3:::kirocrew-deploy-logs-*` (+ `/*`). Deny overrides Allow; legitimate deploys never write objects to the `-logs-` bucket, so zero functional cost. **Residual (tracked follow-up, deliberately not fixed here):** bucket-config tamper (`PutLifecycleConfiguration`, `Put`/`DeleteBucketPolicy`) is NOT covered — base-stack CloudFormation legitimately calls those on the log bucket at create time, so denying them unconditionally would break base-stack creation. The safe closure is a second `Deny` conditioned on `aws:CalledVia != cloudformation.amazonaws.com`, which needs its own change + a live CFN create/update/delete validation.

## Tests
- `test/test_deploy_log_bucket_deny.py` — asserts the `S3DenyAuditLogTamper` Deny is present and scoped to the `kirocrew-deploy-logs-*` prefix in every tier, and that the legitimate `S3ObjectLevel` Allow still exists (real deploys unaffected).
- Frontend: covered by `tsc -b` (all four edits typecheck) + the existing `src/lib/safeUrl.test.ts`.

## Manual verification
N/A — unit + local gates (isort, flake8, mypy, `tsc -b`) are sufficient. Full `vitest` was not run locally (this host's Node 16 lacks `BroadcastChannel`, which `msw` needs); CI runs it.

## Screenshots
N/A — no new UI surface. The href edits only gate an existing link's scheme: valid `https` links render unchanged; a non-`http(s)` URL now drops the link instead of rendering a live `javascript:` sink.
