### PR TITLE
fix: no-op the child watcher install on Python 3.14

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -363,6 +363,33 @@ CLI compaction is blocking (single-user, acceptable).
 
 `console_scripts` in `setup.cfg` maps `kirocrew` → `kiro_crew.cli:main`.
 
+### Gateway asyncio child watcher
+
+`_install_child_watcher()` runs once on the **`gateway` command path only** (not
+`chat`, `doctor`, or any other subcommand) and must be called before
+`asyncio.run`, on the main thread. It replaces CPython's default
+thread-per-child `ThreadedChildWatcher` — whose `os.waitpid` reaper threads can
+starve the event loop when many `kiro-cli`/MCP children die at once — with a
+single-descriptor alternative:
+
+| Runtime | Installed watcher |
+|---------|-------------------|
+| Linux, `os.pidfd_open` probe succeeds (kernel ≥ 5.3) | `PidfdChildWatcher` |
+| Linux, probe raises `OSError`/`AttributeError` | `SafeChildWatcher` (SIGCHLD) |
+| macOS / other non-Linux Unix | `SafeChildWatcher` (SIGCHLD) |
+| **Python ≥ 3.14** (child-watcher API removed) | **none — no-op** |
+| `SafeChildWatcher` unavailable (e.g. Windows) | none — default retained |
+
+**Python 3.14+ is a deliberate no-op.** CPython 3.14 removed
+`set_child_watcher`, `PidfdChildWatcher`, `SafeChildWatcher`, and
+`ThreadedChildWatcher`; the Unix event loop reaps children itself with a single
+non-thread reaper, so the loop-starvation wedge this installer exists to prevent
+cannot occur. The function short-circuits on `hasattr(asyncio,
+"set_child_watcher")` — probed by capability, not `sys.version_info`, so a
+runtime that still ships the API keeps the mitigation. Without that guard the
+Linux pidfd branch raised `AttributeError` and `kirocrew gateway` died before
+binding its port, while every other subcommand kept working.
+
 ## Environment Variables
 
 | Variable | Purpose |

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -338,10 +338,16 @@ def _install_child_watcher() -> None:
     shrank the surface; the reaper storm itself remained on the default
     watcher).
 
-    Forward-compat note: ``set_child_watcher`` / ``PidfdChildWatcher`` /
-    ``SafeChildWatcher`` are deprecated in CPython 3.12 and removed in 3.14 (the
-    event loop reaps children directly).  This whole function should become a
-    no-op / be deleted when KiroCrew moves off 3.10; guard or drop it then.
+    Python 3.14: ``set_child_watcher`` / ``PidfdChildWatcher`` /
+    ``SafeChildWatcher`` are deprecated in CPython 3.12 and REMOVED in 3.14 --
+    the event loop reaps children directly.  The whole function is therefore a
+    no-op there, short-circuited by the ``hasattr`` guard below; without it the
+    unguarded Linux pidfd branch raised ``AttributeError: module 'asyncio' has
+    no attribute 'set_child_watcher'`` and killed ``kirocrew gateway`` on
+    startup, before the port was ever bound.  The mitigation is not lost: 3.14
+    reaps with a single non-thread reaper, so the thread-per-child storm this
+    function exists to prevent cannot occur (verified on 3.14.6 -- 24
+    concurrent children, ``threading.active_count()`` never left 1).
     ``set_child_watcher`` on a pre-run policy is attached to the loop by
     ``asyncio.run`` -> ``set_event_loop`` (main thread), so installing before
     ``asyncio.run`` here is correct on 3.10 for both watchers.
@@ -379,6 +385,17 @@ def _install_child_watcher() -> None:
     fall through to the SIGCHLD-based SafeChildWatcher, the same watcher the
     macOS path uses.
     """
+    # CPython 3.14 removed the child-watcher API (set_child_watcher,
+    # PidfdChildWatcher, SafeChildWatcher, and the ThreadedChildWatcher default);
+    # the Unix event loop reaps children itself. Bail out BEFORE the Linux pidfd
+    # branch below, which references the removed names unconditionally and would
+    # raise AttributeError during `kirocrew gateway` startup. This is a true
+    # no-op and not a lost mitigation: 3.14's reaper spawns no thread per child,
+    # so the loop-starvation wedge cannot recur. Probed via hasattr rather than
+    # sys.version_info so a backport/vendored runtime that still ships the API
+    # keeps the mitigation.
+    if not hasattr(asyncio, "set_child_watcher"):
+        return
     if sys.platform == "linux":
         try:
             # Probe real kernel support (pidfd_open: Linux 5.3+) BEFORE installing,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4196,6 +4196,10 @@ class TestPrintTokenUrl:
         assert "kirocrew token" in out
 
 
+@pytest.mark.skipif(
+    not hasattr(__import__("asyncio"), "set_child_watcher"),
+    reason="asserts the 3.10-3.13 child-watcher semantics; the API was removed in 3.14",
+)
 class TestInstallPidfdChildWatcher:
     """Verify _install_child_watcher's platform behavior."""
 
@@ -4389,8 +4393,22 @@ class TestInstallPidfdChildWatcher:
         Runs in a clean child process (its own main thread) so it is immune to
         pytest-xdist executing this test body on a non-main worker thread, where
         set_event_loop's main-thread-guarded attach_loop would be skipped.
+
+        The expected watcher is derived from the SAME probe the installer uses
+        rather than hard-coded: a Python build that omits the ``os.pidfd_open``
+        wrapper (observed on uv-managed CPython) correctly installs
+        SafeChildWatcher instead — the documented fallback. Asserting
+        PidfdChildWatcher unconditionally made this test fail on such an
+        interpreter even though the product behaved exactly as designed.
         """
-        self._install_then_spawn_in_child(expected_watcher="PidfdChildWatcher")
+        try:
+            fd = os.pidfd_open(os.getpid())
+            os.close(fd)
+        except (OSError, AttributeError):
+            expected = "SafeChildWatcher"
+        else:
+            expected = "PidfdChildWatcher"
+        self._install_then_spawn_in_child(expected_watcher=expected)
 
     @pytest.mark.skipif(
         sys.platform == "linux" or not hasattr(__import__("asyncio"), "SafeChildWatcher"),
@@ -4413,6 +4431,91 @@ class TestInstallPidfdChildWatcher:
         pytest-xdist worker thread would fail spuriously.
         """
         self._install_then_spawn_in_child(expected_watcher="SafeChildWatcher")
+
+
+class TestChildWatcherApiRemoved:
+    """``_install_child_watcher()`` must no-op when the child-watcher API is gone.
+
+    CPython 3.14 removed ``set_child_watcher`` / ``PidfdChildWatcher`` /
+    ``SafeChildWatcher`` (the event loop reaps children directly). The Linux
+    pidfd branch referenced those names unconditionally, so on 3.14 the FIRST
+    thing ``kirocrew gateway`` did was raise ``AttributeError: module 'asyncio'
+    has no attribute 'set_child_watcher'`` -- the gateway died before binding
+    its port, while every other subcommand (``chat``, ``doctor``) kept working
+    because this installer is only called on the gateway path.
+    """
+
+    @staticmethod
+    def _remove_child_watcher_api(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Make asyncio look like 3.14: no child-watcher API at all."""
+        import asyncio
+
+        for name in (
+            "set_child_watcher",
+            "get_child_watcher",
+            "PidfdChildWatcher",
+            "SafeChildWatcher",
+            "ThreadedChildWatcher",
+            "AbstractChildWatcher",
+        ):
+            monkeypatch.delattr(asyncio, name, raising=False)
+
+    @pytest.mark.parametrize("platform", ["linux", "darwin"])
+    def test_noop_when_child_watcher_api_removed(self, monkeypatch, platform) -> None:
+        """Simulated removal, so 3.10-3.13 CI also protects the 3.14 code path."""
+        import asyncio
+
+        from kiro_crew.cli import _install_child_watcher
+
+        monkeypatch.setattr("kiro_crew.cli.sys.platform", platform)
+        # A pidfd-capable kernel is the WORST case: without the guard the Linux
+        # branch reaches `asyncio.set_child_watcher(asyncio.PidfdChildWatcher())`
+        # and raises. Keep the probe succeeding so the regression is real.
+        # Hand back a REAL fd (the real os.close then reclaims it) rather than
+        # stubbing os.close: `kiro_crew.cli.os` IS the shared os module, so a
+        # stub there would also be seen by asyncio's own internals.
+        monkeypatch.setattr(
+            "kiro_crew.cli.os.pidfd_open",
+            lambda pid: os.open(os.devnull, os.O_RDONLY),
+            raising=False,
+        )
+        self._remove_child_watcher_api(monkeypatch)
+
+        _install_child_watcher()  # must not raise
+
+        assert not hasattr(
+            asyncio, "set_child_watcher"
+        ), "the guard must not resurrect the removed API"
+
+    @pytest.mark.skipif(
+        hasattr(__import__("asyncio"), "set_child_watcher"),
+        reason="only meaningful on a runtime that really removed the API (3.14+)",
+    )
+    def test_real_subprocess_works_after_noop_install(self) -> None:
+        """On a real 3.14+ runtime, the gateway's install-before-run call must be
+        survivable AND leave subprocess support working.
+
+        No monkeypatching: the API is genuinely absent here, so this asserts the
+        property that actually matters (spawning still works after the no-op)
+        rather than the mechanism. 3.14 reaps children in the event loop with a
+        single non-thread reaper, so nothing is lost by not installing a watcher.
+        """
+        import asyncio
+
+        from kiro_crew.cli import _install_child_watcher
+
+        _install_child_watcher()  # mirror the gateway: install BEFORE run
+
+        async def _spawn_true() -> int:
+            proc = await asyncio.create_subprocess_exec(
+                "true",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+            return proc.returncode
+
+        assert asyncio.run(_spawn_true()) == 0
 
 
 class TestTokenCommand:


### PR DESCRIPTION
Fixes #992. Supersedes #993 (same change, reopened from an in-repo branch — a fork head cannot reach `readiness: passed`, see the note at the bottom).

## Problem

`kirocrew gateway` cannot start on **Python 3.14**:

```
File ".../kiro_crew/cli.py", line 405, in _install_child_watcher
  asyncio.set_child_watcher(asyncio.PidfdChildWatcher())
AttributeError: module 'asyncio' has no attribute 'set_child_watcher'
```

CPython 3.14 removed the child-watcher API; the event loop reaps children
directly. `_install_child_watcher()`'s Linux pidfd branch referenced those names
unconditionally, so the gateway died **before binding its port** and crash-looped
under systemd. `kirocrew chat` and every other subcommand kept working — the
installer is only called on the `gateway` path (`cli.py:1936`, inside
`elif args.command == "gateway":`).

Only **Linux with a working `os.pidfd_open`** ever reached the crashing line. The
macOS / no-pidfd tail already `getattr`-guarded `SafeChildWatcher` and returned
harmlessly. So this is "modern kernel + 3.14", i.e. rolling-release distros —
and Arch ships 3.14.6 as the system `python3` today. Reported from a headless
Arch box.

## The code predicted this

`cli.py`'s own docstring, before this change:

> `set_child_watcher` / `PidfdChildWatcher` / `SafeChildWatcher` are deprecated
> in CPython 3.12 and removed in 3.14 … **This whole function should become a
> no-op / be deleted when KiroCrew moves off 3.10; guard or drop it then.**

The guard never landed. This adds it.

## Fix

```python
if not hasattr(asyncio, "set_child_watcher"):
    return
```

Probed by **capability** rather than `sys.version_info`, so a backported or
vendored runtime that still ships the API keeps the mitigation.

### No mitigation is lost

This installer exists to avoid `ThreadedChildWatcher`'s thread-per-child
`os.waitpid` reaper storm — the 2026-07-10 loop-stall wedge cited in its
comments. Measured on 3.14.6 with 24 concurrent children:

```
threads: baseline=1 peak_with_24_children=1 after=1
verdict: NO thread-per-child (single reaper)
```

3.14 reaps in the loop with no thread per child, and `create_subprocess_exec`
works with no watcher installed, so the wedge cannot recur.

## Second, adjacent change

`test_real_subprocess_works_after_install_on_linux` hard-coded
`expected_watcher="PidfdChildWatcher"`. A Python build that omits the
`os.pidfd_open` wrapper — observed on a uv-managed CPython 3.13.11 — correctly
installs `SafeChildWatcher`, the fallback the function's own docstring documents.
The test therefore failed on such an interpreter while the product behaved
exactly as designed. It now derives the expectation from the same pidfd probe the
installer uses.

Included here rather than split out because it is the same test class exercising
the same function, and without it a reviewer running the suite locally on a
uv-managed interpreter sees a failure in the very class this PR touches.

## Testing

New `TestChildWatcherApiRemoved`:

- `test_noop_when_child_watcher_api_removed[linux|darwin]` — simulates the
  removal via `monkeypatch.delattr` with the pidfd probe **succeeding** (the
  worst case, which reaches the crashing line). Runs on every version, so
  3.10/3.12 CI protects the 3.14 path too.
- `test_real_subprocess_works_after_noop_install` — on a runtime that really
  removed the API, asserts spawning still works after the no-op.

`TestInstallPidfdChildWatcher` gets a class-level skip when the API is absent:
its six tests `monkeypatch.setattr(asyncio, "set_child_watcher", …)`, which
raises `AttributeError` on 3.14. They assert 3.10–3.13 semantics that no longer
exist. `test/windows-expected-failures.txt` needs no update — `set_child_watcher`
is defined unconditionally in `asyncio.events`, so the skip does not fire on
Windows (confirmed by the Windows matrix passing on #993).

One deliberate choice: the new spawn test does **not** stub `os`. Patching
`kiro_crew.cli.os.close` mutates the shared `os` module and asyncio's own
subprocess internals then call the stub — it surfaced as
`TypeError: <lambda>() takes 1 positional argument but 2 were given` from
`unix_events.py`. The simulated test hands back a real fd instead.

### Results — full suite incl. `KIROCREW_E2E=1`, Linux x86_64

| | 3.13.11 | 3.14.6 |
|---|---|---|
| Passed | 22793 | 22789 |
| Failed | 3 | **2** |

The failure profile is now **identical across both interpreters** — nothing
3.14-specific remains:

- `test_app_backend.py::…::test_survival_check_exits_early_for_a_healthy_child` —
  timing assertion, fails by ~1 ms (`1.6011 < 1.6`)
- `test_module_loader.py::TestModuleUnload::test_reload_after_unload_gets_fresh_code` —
  module reload caching
- (3.13 only) `test_apps_registry.py::test_list_registry_reaps_detect_probe_tree_on_timeout` —
  xdist-only flake

All reproduce on `main` without this change.

Watcher tests specifically: 3.14 went **6 failed → 3 passed, 7 skipped**; 3.13
went **1 failed → 8 passed, 2 skipped** (the second change).

### Real gateway, real ACP child

`test_e2e_smoke.py` with `KIROCREW_E2E=1` on 3.14.6 — 12/12, including
`test_chat_send_receives_reply` (real gateway subprocess, real spawned ACP child,
initialize/session-new handshake, prompt, streamed reply) and
`test_chat_tool_call_renders`. This matters because the unit suite mocks
`kiro-cli`, so it never exercises real child-process spawn/reap — precisely what
3.14 changed.

End to end, the gateway now serves on 3.14.6:

```
KIROCREW_READY:{"port": 37805, "token": "...", "pid": 26660, "home": "/tmp/..."}
```

`uv pip install -e ".[dev]"` also resolves the full dependency set on 3.14, so
3.14 is a viable target rather than something to block.

`flake8`, `mypy`, `isort` clean. `black` not run over the files — `main` is not
black-clean and `black --check` is disabled in CI pending a bulk pass, so the
added lines were hand-formatted to satisfy it without touching adjacent code.

## Spec

`docs/system-specs/modules/cli.md` gains a "Gateway asyncio child watcher"
subsection: the per-runtime watcher table including the 3.14 no-op, that the
installer is gateway-only, and why capability-probing is used.

## Not in this PR

1. Adding 3.13/3.14 to the `ci.yml` matrix (currently `["3.10", "3.12"]`, so this
   class of break cannot be caught). Now well-supported by the results above, but
   it is a CI-cost decision and `ci.yml` has steps keyed on
   `matrix.python-version == '3.12'` (coverage upload) that need care.
2. #86's interpreter-discovery ordering — `cli.sh:114` has a version floor but no
   ceiling, which is *why* installs land on 3.14. Left alone deliberately: with
   this fix 3.14 works, so ordering is a separate packaging decision. Commented
   on #86 with details, including that its numpy rationale is now stale
   (`setup.cfg:22` allows numpy 2.x).

## Note on #993

#993 was opened from a fork before I had write access. `pr-readiness.yml`
deliberately refuses to let a fork head reach `passed` — the AI reviews cannot
run without OIDC, and passing public CI is explicitly "NOT full validation". Its
32 substantive checks were green, but readiness sat pending on the 4 skipped
reviews. Reopened here from an in-repo branch so the full gate can run.

Separately, that fork path is *supposed* to emit a red "readiness: maintainer
review" verdict, but ours stayed yellow at "4 readiness check(s) still pending"
indefinitely. Since no fork PR appears to have been merged in the last 100, that
path may simply never have been exercised. Filing separately if useful.
