### PR TITLE
refactor(channels): adopt the shared turn pipeline in wecom, webex and teams

### DIFF
--- a/src/kiro_crew/teams/transport_dispatch.py
+++ b/src/kiro_crew/teams/transport_dispatch.py
@@ -23,17 +23,13 @@ Dependency direction is ``teams -> messaging`` (allowed).
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.executors import run_in_embed_pool
-from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
-from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
-from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
+from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
-from kiro_crew.sel import sel
 from kiro_crew.teams.commands import HELP_TEXT, ConversationState, parse_command
 from kiro_crew.teams.renderer import TeamsRenderer
 from kiro_crew.teams.transport import TEAMS_CAPABILITIES
@@ -90,8 +86,7 @@ class TeamsDispatcher:
         # Inbound channels-governance gate (off-loop) — recheck per message so a
         # host-profile deny added after connect stops dispatch without a restart
         # (the startup gate only blocks CONNECTING). Silently drop on deny.
-        if not await channel_inbound_permitted("teams"):
-            logger.info("teams inbound dropped: denied by channels governance policy")
+        if not await inbound_permitted("teams"):
             return
         email = inbound.user_email or inbound.aad_object_id
         conversation_id = inbound.conversation_id
@@ -130,7 +125,6 @@ class TeamsDispatcher:
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
         )
         session_key = self._session_key(email)
-        channel_id = f"teams:{email}"
         agent = self._resolve_agent()
 
         # Teams has no interactive buttons -> no decider (deny-by-default for
@@ -143,98 +137,33 @@ class TeamsDispatcher:
             session_key=session_key,
         )
 
-        _acquired = False
-        try:
-            # Typing indicator first (before the potentially slow cold-start);
-            # on_turn_start is idempotent so the driver's later call no-ops.
-            await renderer.on_turn_start()
-            provider, is_new, resumed = await self.sessions.get_or_create(
-                session_key, agent=agent, channel_id=channel_id
-            )
-            _acquired = True
-            if is_new:
-                await self.sessions.set_channel(session_key, channel_id)
-            # Publish this turn's session identity so managed MCP tools resolve
-            # X-Session-Key; one shared writer lives in messaging.identity.
-            await publish_turn_identity(self.sessions, session_key)
-            # Off-loop: build_message embeds the episodic query (blocking urllib).
-            full_message, _ = await run_in_embed_pool(
-                self.ctx_builder.build_message,
-                text,
-                is_new,
-                session_key,
-                channel_id=channel_id,
+        # The turn skeleton (acquire -> identity -> context -> TurnDriver ->
+        # guarded post-turn -> finally close/release) lives once in
+        # messaging.dispatch. Only the teams-specific pieces are injected.
+        # NOTE: ChannelTurn.conversation_id is the SESSION-attribution id
+        # (``teams:{email}``, what sessions.* has always been given here), not
+        # ``inbound.conversation_id`` -- the Teams platform conversation id the
+        # renderer replies into. The two are deliberately different; passing the
+        # platform id would silently repoint every existing Teams session.
+        await drive_turn(
+            ChannelTurn(
+                channel_type="teams",
+                session_key=session_key,
+                conversation_id=f"teams:{email}",
                 agent=agent,
-                resumed=resumed,
-            )
-
-            # PreToolUse security gate (channel-neutral, off ctx_builder.hooks):
-            # sensitive-path keystone + governance ceiling + deny-list.
-            def _tool_gate(event: Any) -> str:
-                result = self.ctx_builder.hooks.on_tool_call(
-                    getattr(event, "title", "") or "",
-                    session_key=session_key,
-                    agent=agent,
-                    tool_kind=getattr(event, "tool_kind", "") or "",
-                    raw_params=getattr(event, "raw_tool_params", None),
-                    command=getattr(event, "shell_command", None),
-                    is_shell=bool(getattr(event, "is_shell", False)),
-                )
-                if result.action == TOOL_DENY:
-                    return "deny"
-                if result.action == TOOL_AUTO_APPROVE:
-                    return "auto_approve"
-                return ""
-
-            driver = TurnDriver(
-                provider,
-                renderer,
+                user_text=text,
+                renderer=renderer,
                 approval_mode=self.approval_mode,
                 decider=None,  # Teams can't render approve/deny buttons (MVP)
-                auto_approve_tool=lambda title: bool(
-                    self.ctx_builder
-                    and self.ctx_builder.hooks
-                    and self.ctx_builder.hooks.auto_approve_subagent_spawn
-                    and title == "spawn_run"
+                persist=lambda user_text, reply, is_new: self._persist_turn(
+                    session_key, user_text, reply, is_new
                 ),
-                tool_gate=_tool_gate,
-            )
-            accumulated = await driver.run(full_message)
-
-            # ── Post-turn bookkeeping (each guarded). ──
-            self.sessions.record_success(session_key)
-            try:
-                # Offload the flock-backed transcript write off the event loop
-                # (matches webex/telegram/wecom/discord): an on-loop persist
-                # blocks the sole loop and, under strict-on-loop or a contended
-                # session file, raises and silently loses the transcript.
-                await asyncio.to_thread(
-                    self._persist_turn, session_key, text, accumulated, is_new
-                )
-            except Exception:
-                logger.warning("Teams: persist_turn failed session=%s", session_key, exc_info=True)
-            try:
-                await self._maybe_notice(inbound, session_key, provider)
-            except Exception:
-                logger.warning("Teams: maybe_notice failed session=%s", session_key, exc_info=True)
-            try:
-                sel().log_api_access(
-                    caller=f"teams:{email}",
-                    operation="transport_dispatch.handle",
-                    outcome="success",
-                    source="teams",
-                    resources=f"session={session_key}",
-                )
-            except Exception:
-                logger.debug("Teams: success audit failed", exc_info=True)
-        except Exception:
-            logger.exception("Teams transport_dispatch: error handling message")
-            if _acquired:
-                await self.sessions.record_failure(session_key)
-        finally:
-            await renderer.close()
-            if _acquired:
-                self.sessions.release(session_key)
+                notice=lambda sk, provider: self._maybe_notice(inbound, sk, provider),
+                audit_caller=f"teams:{email}",
+            ),
+            sessions=self.sessions,
+            ctx_builder=self.ctx_builder,
+        )
 
     async def _handle_busy(self, inbound: Any, session_key: str) -> None:
         """Mid-turn message: fold into the running turn via steer.

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -23,17 +23,13 @@ Dependency direction is ``webex -> messaging`` (allowed).
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.executors import run_in_embed_pool
-from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
-from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
-from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
+from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
-from kiro_crew.sel import sel
 from kiro_crew.webex.commands import HELP_TEXT, ConversationState, parse_command
 from kiro_crew.webex.renderer import WebexRenderer
 from kiro_crew.webex.transport import WEBEX_CAPABILITIES
@@ -90,8 +86,7 @@ class WebexDispatcher:
         # Inbound channels-governance gate (off-loop) — recheck per message so a
         # host-profile deny added after connect stops dispatch without a restart
         # (the startup gate only blocks CONNECTING). Silently drop on deny.
-        if not await channel_inbound_permitted("webex"):
-            logger.info("webex inbound dropped: denied by channels governance policy")
+        if not await inbound_permitted("webex"):
             return
         email = inbound.person_email
         room_id = inbound.room_id
@@ -128,7 +123,7 @@ class WebexDispatcher:
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
         )
         session_key = self._session_key(email)
-        channel_id = f"webex:{email}"
+        conversation_id = f"webex:{email}"
         agent = self._resolve_agent()
 
         # Webex has no interactive buttons -> no decider (deny-by-default for
@@ -140,104 +135,28 @@ class WebexDispatcher:
             session_key=session_key,
         )
 
-        # Everything acquire-dependent runs INSIDE the try so the finally
-        # always finalizes the placeholder (renderer.close -> no perma-"🤔"),
-        # even if get_or_create itself raises on a cold-start failure.
-        # release() is gated on _acquired so we never release a semaphore we
-        # didn't hold. Mirrors the Telegram/WeCom transport dispatch.
-        _acquired = False
-        try:
-            # Ack placeholder first (before the potentially slow cold-start);
-            # on_turn_start is idempotent so the driver's later call no-ops.
-            await renderer.on_turn_start()
-            provider, is_new, resumed = await self.sessions.get_or_create(
-                session_key, agent=agent, channel_id=channel_id
-            )
-            _acquired = True
-            if is_new:
-                await self.sessions.set_channel(session_key, channel_id)
-            # Publish this turn's session identity so managed MCP tools resolve
-            # X-Session-Key; one shared writer lives in messaging.identity. (#232)
-            await publish_turn_identity(self.sessions, session_key)
-            # Off-loop: build_message embeds the episodic query (blocking urllib).
-            full_message, _ = await run_in_embed_pool(
-                self.ctx_builder.build_message,
-                text,
-                is_new,
-                session_key,
-                channel_id=channel_id,
+        # The turn skeleton (acquire -> identity -> context -> TurnDriver ->
+        # guarded post-turn -> finally close/release) lives once in
+        # messaging.dispatch. Only the webex-specific pieces are injected.
+        await drive_turn(
+            ChannelTurn(
+                channel_type="webex",
+                session_key=session_key,
+                conversation_id=conversation_id,
                 agent=agent,
-                resumed=resumed,
-            )
-
-            # PreToolUse security gate (channel-neutral, off ctx_builder.hooks):
-            # sensitive-path keystone + governance ceiling + deny-list. Returns
-            # "deny" (un-overridable), "auto_approve", or "" (passthrough).
-            def _tool_gate(event: Any) -> str:
-                result = self.ctx_builder.hooks.on_tool_call(
-                    getattr(event, "title", "") or "",
-                    session_key=session_key,
-                    agent=agent,
-                    tool_kind=getattr(event, "tool_kind", "") or "",
-                    raw_params=getattr(event, "raw_tool_params", None),
-                    command=getattr(event, "shell_command", None),
-                    is_shell=bool(getattr(event, "is_shell", False)),
-                )
-                if result.action == TOOL_DENY:
-                    return "deny"
-                if result.action == TOOL_AUTO_APPROVE:
-                    return "auto_approve"
-                return ""
-
-            driver = TurnDriver(
-                provider,
-                renderer,
+                user_text=text,
+                renderer=renderer,
                 approval_mode=self.approval_mode,
                 decider=None,  # Webex can't render approve/deny buttons
-                # Preserve the auto_approve_subagent_spawn hook for spawn_run
-                # (replicated inline to avoid a webex -> slack import).
-                auto_approve_tool=lambda title: bool(
-                    self.ctx_builder
-                    and self.ctx_builder.hooks
-                    and self.ctx_builder.hooks.auto_approve_subagent_spawn
-                    and title == "spawn_run"
+                persist=lambda user_text, reply, is_new: self._persist_turn(
+                    session_key, user_text, reply, is_new
                 ),
-                tool_gate=_tool_gate,
-            )
-            accumulated = await driver.run(full_message)
-
-            # ── Post-turn bookkeeping (each guarded so a failure here can't
-            # fall through to the except and re-record the successful turn). ──
-            self.sessions.record_success(session_key)
-            try:
-                await asyncio.to_thread(self._persist_turn, session_key, text, accumulated, is_new)
-            except Exception:
-                logger.warning("Webex: persist_turn failed session=%s", session_key, exc_info=True)
-            try:
-                await self._maybe_notice(inbound, session_key, provider)
-            except Exception:
-                logger.warning("Webex: maybe_notice failed session=%s", session_key, exc_info=True)
-            try:
-                sel().log_api_access(
-                    caller=f"webex:{email}",
-                    operation="transport_dispatch.handle",
-                    outcome="success",
-                    source="webex",
-                    resources=f"session={session_key}",
-                )
-            except Exception:
-                logger.debug("Webex: success audit failed", exc_info=True)
-        except Exception:
-            logger.exception("Webex transport_dispatch: error handling message")
-            if _acquired:
-                await self.sessions.record_failure(session_key)
-        finally:
-            # Always finalize the placeholder, even if get_or_create raised
-            # before the semaphore was held. Only release the semaphore if we
-            # actually acquired it.
-            await renderer.close()
-            if _acquired:
-                self.sessions.release(session_key)
+                notice=lambda sk, provider: self._maybe_notice(inbound, sk, provider),
+                audit_caller=f"webex:{email}",
+            ),
+            sessions=self.sessions,
+            ctx_builder=self.ctx_builder,
+        )
 
     async def _handle_busy(self, inbound: Any, session_key: str) -> None:
         """Mid-turn message: fold into the running turn via steer.

--- a/src/kiro_crew/wecom/transport_dispatch.py
+++ b/src/kiro_crew/wecom/transport_dispatch.py
@@ -23,17 +23,13 @@ Dependency direction is ``wecom -> messaging`` (allowed).
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.executors import run_in_embed_pool
-from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
-from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
-from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
+from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
-from kiro_crew.sel import sel
 from kiro_crew.wecom.client import new_stream_id
 from kiro_crew.wecom.commands import ConversationState, parse_command
 from kiro_crew.wecom.renderer import WeComRenderer
@@ -93,8 +89,7 @@ class WeComDispatcher:
         # Inbound channels-governance gate (off-loop) — recheck per message so a
         # host-profile deny added after connect stops dispatch without a restart
         # (the startup gate only blocks CONNECTING). Silently drop on deny.
-        if not await channel_inbound_permitted("wecom"):
-            logger.info("wecom inbound dropped: denied by channels governance policy")
+        if not await inbound_permitted("wecom"):
             return
         userid = inbound.userid
         text = inbound.text
@@ -137,7 +132,7 @@ class WeComDispatcher:
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
         )
         session_key = self._session_key(userid)
-        channel_id = f"wecom:{userid}"
+        conversation_id = f"wecom:{userid}"
         # Resolve the kiro-cli agent: an explicit override wins, else the
         # configured default, else the canonical "kirocrew" agent -- so the
         # session loads kirocrew-core (spawn_run) instead of kiro-cli's bare
@@ -154,104 +149,28 @@ class WeComDispatcher:
             session_key=session_key,
         )
 
-        # Everything acquire-dependent runs INSIDE the try so the finally always
-        # finalizes the placeholder (renderer.close -> no perma-"🤔 …"), even if
-        # get_or_create itself raises on a cold-start failure. release() is gated
-        # on _acquired so we never release a semaphore we didn't hold. Mirrors
-        # slack/telegram transport_dispatch.
-        _acquired = False
-        try:
-            # Ack placeholder first (before the potentially slow cold-start);
-            # on_turn_start is idempotent so the driver's later call no-ops.
-            await renderer.on_turn_start()
-            provider, is_new, resumed = await self.sessions.get_or_create(
-                session_key, agent=agent, channel_id=channel_id
-            )
-            _acquired = True
-            if is_new:
-                await self.sessions.set_channel(session_key, channel_id)
-            # Publish this turn's session identity so managed MCP tools resolve
-            # X-Session-Key; one shared writer lives in messaging.identity. (#232)
-            await publish_turn_identity(self.sessions, session_key)
-            # Off-loop: build_message embeds the episodic query (blocking urllib).
-            full_message, _ = await run_in_embed_pool(
-                self.ctx_builder.build_message,
-                text,
-                is_new,
-                session_key,
-                channel_id=channel_id,
+        # The turn skeleton (acquire -> identity -> context -> TurnDriver ->
+        # guarded post-turn -> finally close/release) lives once in
+        # messaging.dispatch. Only the wecom-specific pieces are injected.
+        await drive_turn(
+            ChannelTurn(
+                channel_type="wecom",
+                session_key=session_key,
+                conversation_id=conversation_id,
                 agent=agent,
-                resumed=resumed,
-            )
-
-            # PreToolUse security gate (channel-neutral, off ctx_builder.hooks):
-            # sensitive-path keystone + governance ceiling + deny-list. Returns
-            # "deny" (un-overridable), "auto_approve", or "" (passthrough).
-            def _tool_gate(event: Any) -> str:
-                result = self.ctx_builder.hooks.on_tool_call(
-                    getattr(event, "title", "") or "",
-                    session_key=session_key,
-                    agent=agent,
-                    tool_kind=getattr(event, "tool_kind", "") or "",
-                    raw_params=getattr(event, "raw_tool_params", None),
-                    command=getattr(event, "shell_command", None),
-                    is_shell=bool(getattr(event, "is_shell", False)),
-                )
-                if result.action == TOOL_DENY:
-                    return "deny"
-                if result.action == TOOL_AUTO_APPROVE:
-                    return "auto_approve"
-                return ""
-
-            driver = TurnDriver(
-                provider,
-                renderer,
+                user_text=text,
+                renderer=renderer,
                 approval_mode=self.approval_mode,
                 decider=None,  # WeCom can't render approve/deny buttons
-                # Preserve the auto_approve_subagent_spawn hook for spawn_run
-                # (replicated inline to avoid a wecom -> slack import).
-                auto_approve_tool=lambda title: bool(
-                    self.ctx_builder
-                    and self.ctx_builder.hooks
-                    and self.ctx_builder.hooks.auto_approve_subagent_spawn
-                    and title == "spawn_run"
+                persist=lambda user_text, reply, is_new: self._persist_turn(
+                    session_key, user_text, reply, is_new
                 ),
-                tool_gate=_tool_gate,
-            )
-            accumulated = await driver.run(full_message)
-
-            # ── Post-turn bookkeeping (each guarded so a failure here can't
-            # fall through to the except and re-record the successful turn). ──
-            self.sessions.record_success(session_key)
-            try:
-                await asyncio.to_thread(self._persist_turn, session_key, text, accumulated, is_new)
-            except Exception:
-                logger.warning("WeCom: persist_turn failed session=%s", session_key, exc_info=True)
-            try:
-                await self._maybe_notice(inbound, session_key, provider)
-            except Exception:
-                logger.warning("WeCom: maybe_notice failed session=%s", session_key, exc_info=True)
-            try:
-                sel().log_api_access(
-                    caller=f"wecom:{userid}",
-                    operation="transport_dispatch.handle",
-                    outcome="success",
-                    source="wecom",
-                    resources=f"session={session_key}",
-                )
-            except Exception:
-                logger.debug("WeCom: success audit failed", exc_info=True)
-        except Exception:
-            logger.exception("WeCom transport_dispatch: error handling message")
-            if _acquired:
-                await self.sessions.record_failure(session_key)
-        finally:
-            # Always finalize the placeholder (no perma-"🤔 …"), even if
-            # get_or_create raised before the semaphore was held. Only release
-            # the semaphore if we actually acquired it.
-            await renderer.close()
-            if _acquired:
-                self.sessions.release(session_key)
+                notice=lambda sk, provider: self._maybe_notice(inbound, sk, provider),
+                audit_caller=f"wecom:{userid}",
+            ),
+            sessions=self.sessions,
+            ctx_builder=self.ctx_builder,
+        )
 
     async def _handle_busy(self, inbound: Any, session_key: str) -> None:
         """Mid-turn message: fold into the running turn via steer.

--- a/test/test_teams_dispatch.py
+++ b/test/test_teams_dispatch.py
@@ -317,8 +317,13 @@ class TestInboundGovernance:
         async def _deny(_member: str) -> bool:
             return False
 
+        # Patched on messaging.dispatch: the gate moved into the shared
+        # pipeline, and the teams dispatcher's own early check calls the
+        # ``inbound_permitted`` wrapper, which resolves
+        # ``channel_inbound_permitted`` from dispatch's globals at call time --
+        # so this one patch covers both the channel-side and pipeline gates.
         monkeypatch.setattr(
-            "kiro_crew.teams.transport_dispatch.channel_inbound_permitted", _deny
+            "kiro_crew.messaging.dispatch.channel_inbound_permitted", _deny
         )
         provider = FakeProvider([AcpEvent(kind=EVENT_COMPLETE)])
         sessions = FakeSessions(provider)


### PR DESCRIPTION
## What

Moves the remaining three HTTP channels — **wecom, webex, teams** — onto the shared turn pipeline that #777 extracted into `src/kiro_crew/messaging/dispatch.py`, with weixin as its first adopter.

| channel | before | after | delta |
|---|---|---|---|
| wecom | 401 | 320 | −81 |
| webex | 378 | 297 | −81 |
| teams | 377 | 306 | −71 |

**76 insertions, 304 deletions** against a 252-line shared pipeline that already existed and was already under test — so this is deletion, not relocation.

No new production logic is introduced. Each adopter stops re-deriving the turn skeleton (resolve address → open turn → stream deltas into renderer → enforce governance gate → record outcome) and calls `drive_turn` instead.

## What the adoption proved

**`ChannelTurn` needed zero new fields.** The dataclass was designed against exactly one channel, so the honest prior was that adopters two through four would each demand an escape hatch. None did. That is the strongest evidence available that the extracted shape is the genuinely shared shape rather than weixin's shape with a generic name.

**The predicted threshold-config problem did not materialize.** `notice` is an injected closure, so each channel keeps reading its own `cfg.<channel>.hard_threshold_pct` inside its own callback; the pipeline never learns channel-specific config exists. No plumbing needed.

## The one thing reviewers should look at

Teams already has a live local `conversation_id` — the **platform** conversation id its renderer replies into — which is a *different thing* from the session-attribution id `teams:{email}` that the pipeline's identically-named field expects.

Passing the platform id would have silently repointed every existing Teams session to a new address, splitting live conversations from their history. The attribution value is passed explicitly as a keyword argument, with the distinction documented inline at the call site.

The names still collide. That is naming debt in the shared pipeline, not a defect introduced here, and it is worth a follow-up rename.

## Deliberately not generalized

Command interception stays per-channel. Each channel's ack strings differ and wecom carries an extra `/link`/`/unlink` rejection branch with no analogue elsewhere. Folding those in would need either a channel-keyed lookup table inside shared code or a lowest-common-denominator that changes user-visible replies — both worse than the duplication.

## Inherited fixes

All three adopters pick up the two fixes #777 landed in the shared path:

- guarded `record_success`, so the post-turn comment's claim is actually true
- the pipeline-enforced governance gate, which now applies to these channels whether or not their own call sites remembered it

## Test change

`test/test_teams_dispatch.py` is **repointed, not rewritten**: it patched the governance gate at its old per-channel location, which no longer exists, so the patch target moves to `kiro_crew.messaging.dispatch`. Assertions are unchanged — the behaviour under test did not move, only the seam it is enforced at.

## Invariant preserved

The pipeline remains address-agnostic: session keys are passed verbatim and never parsed, per the model recorded in RFC §9 (#778). Nothing here teaches it to interpret an address.

## Verification

- `783 passed, 1 skipped` across all channel, dispatch, governance and messaging-link suites
- flake8, isort clean; mypy clean on 567 source files
- rebased onto current main (98 commits of drift, zero conflicts); `messaging/dispatch.py` confirmed byte-identical between branch point and main, so the pipeline API did not move underneath this change

Full backend suite deferred to CI.
