### PR TITLE
perf(dashboard): defer meta redaction to display time, keep content at load

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -31,8 +31,6 @@ from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_orchestrator import _stage_loop
 from kiro_crew.dashboard.chat_persistence import (
     _attach_variants,
-    _redact_meta,
-    _redact_meta_for_role,
     get_reasoning_effort_values,
     save_slot_off_loop,
 )
@@ -46,6 +44,8 @@ from kiro_crew.dashboard.chat_utils import (
     _normalize_model,
     _prepare_messages,
     _redact_for_display,
+    _redact_meta,
+    _redact_meta_for_role,
     _remove_queued_by_id,
     _sync_dashboard_slots,
 )
@@ -661,7 +661,10 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     return web.json_response(
         {
             "key": slot.key,
-            "title": slot.display_title,
+            # Redacted at emit like every sibling path (_ChatSlot.to_dict does the
+            # same for the sidebar payload). Titles can be LLM-generated or set by
+            # a rename, so they are content, not configuration.
+            "title": _redact_for_display(slot.display_title),
             "running": slot.running,
             "stopping": slot._stopping,
             "messages": prepared,

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -118,7 +118,15 @@ def _capture_stage_result(
         if isinstance(cls, str) and "stage-sep" in cls:
             break  # hit the separator for this stage
         if role == "assistant":
-            result_parts.append(m.get("content", ""))
+            # Defence in depth before this reaches disk. Both upstream sources are
+            # already clean — live turns via chat_runner._flush_segment, restored
+            # turns via the load-time content pass — but this writes a NEW file
+            # outside the history log's own redaction, so it does not depend on
+            # that. Redaction is idempotent, so the common case is a no-op.
+            text = m.get("content", "")
+            text, _ = redact_exfiltration_urls(text)
+            text, _ = redact_credentials(text)
+            result_parts.append(text)
     result_parts.reverse()
     result_text = "\n\n".join(result_parts)
 

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -18,6 +18,7 @@ from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.dashboard.chat_utils import (
     _history_key_for,
     _normalize_model,
+    _redact_meta_for_role,
     _sync_dashboard_slots,
 )
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _normalize_slot_key
@@ -27,47 +28,6 @@ from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import ARTIFACT_SLUG_RE
 
 logger = logging.getLogger(__name__)
-
-
-def _redact_value(v):  # type: ignore[no-untyped-def]
-    """Recursively redact any value (str, dict, list, or passthrough)."""
-    if isinstance(v, str):
-        v, _ = redact_exfiltration_urls(v)
-        v, _ = redact_credentials(v)
-        return v
-    if isinstance(v, dict):
-        return _redact_meta(v)
-    if isinstance(v, list):
-        return [_redact_value(i) for i in v]
-    return v
-
-
-def _redact_meta(meta: dict) -> dict:
-    """Recursively redact string values in meta dict."""
-    return {k: _redact_value(v) for k, v in meta.items()}
-
-
-def _redact_meta_for_role(role: str, meta: dict) -> dict:
-    """Redact meta, but preserve role-specific user-actionable external URLs (e.g. mcp_oauth)."""
-    if role == "mcp_oauth":
-        out: dict = {}
-        for k, v in meta.items():
-            if k == "oauth_url" and isinstance(v, str):
-                # Two gates on rehydrate:
-                #   1. http(s)-only — a tampered history line can't smuggle a
-                #      javascript:/data: URL into <a href>.
-                #   2. URL must not embed a credential or exfil-eligible host —
-                #      a legit OAuth consent URL never carries credential
-                #      patterns; presence of one means it's tampered/bogus.
-                lower = v.lower()
-                safe_scheme = lower.startswith("https://") or lower.startswith("http://")
-                _, hit_cred = redact_credentials(v)
-                _, hit_exfil = redact_exfiltration_urls(v)
-                out[k] = v if (safe_scheme and not hit_cred and not hit_exfil) else ""
-            else:
-                out[k] = _redact_value(v)
-        return out
-    return _redact_meta(meta)
 
 
 _MAX_HISTORY_CHARS = 8000
@@ -513,6 +473,38 @@ def _rehydrate_slot_from_history(
         role = m.get("role", "assistant")
         cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
         content = m.get("content", "")
+        # Neither content nor meta is redacted here. Redaction happens where the
+        # data is EMITTED (chat_utils._prepare_messages for the slot detail
+        # endpoint, _ChatSlot.to_dict for the sidebar payload,
+        # _build_history_prefix for the ACP prompt) — every path a client or model
+        # can observe.
+        #
+        # CONTENT, however, is redacted right here, on load. That split is
+        # deliberate and measured, and it is the crux of this change:
+        #
+        #   field    | read sites | share of the ~7s load cost
+        #   ---------|------------|---------------------------
+        #   content  |    ~204    | ~0.4s  (6%)
+        #   meta     |     31     | ~5.5s  (79%)
+        #
+        # `meta.tool_input` carries the large tool payloads, so meta is where the
+        # boot cost actually lives — and its 31 readers are tractable: outside the
+        # emit sites (which redact and are covered by
+        # test_display_time_redaction.py) every one reads only CONTROL fields
+        # (`done`, `tool_call_id`), never payload text. Deferring meta to display
+        # time is therefore both where the win is and safely enumerable.
+        #
+        # `content` is the opposite on both axes: it is cheap (0.4s) and it has
+        # ~204 readers across the dashboard, so "every reader must remember to
+        # redact" is not an invariant anyone can hold. Three separate egress paths
+        # (the side-chat prompt, the orchestrator stage-result file, and the
+        # title-model prompt) were each found leaking restored content one review
+        # round at a time. Paying 0.4s here restores the single chokepoint — any
+        # present or FUTURE reader of `m["content"]` gets clean bytes — instead of
+        # relying on an enumeration that already failed three times.
+        # `role != "user"`, never `not in ("user", "system")`: user-authored text
+        # stays raw because its author is its only reader, but `system` MUST be
+        # redacted — the write path excludes it, so system bytes reach disk raw.
         if role != "user":
             content, _ = redact_exfiltration_urls(content)
             content, _ = redact_credentials(content)
@@ -521,9 +513,20 @@ def _rehydrate_slot_from_history(
             content,
             cls,
             ts=m.get("ts", ""),
-            meta=(
-                _redact_meta_for_role(role, m["meta"]) if isinstance(m.get("meta"), dict) else None
-            ),
+            # broadcast=False: replaying history must not emit N `chat_message`
+            # events. _broadcast_chat_message ships content verbatim, and this
+            # helper also runs for on-demand cold-slot rehydrates while clients
+            # ARE connected, so broadcasting here would push unredacted history
+            # straight to them. Clients get the transcript from the slot detail
+            # endpoint (redacted) and the sidebar from the coalesced slots push.
+            broadcast=False,
+            # meta is NOT redacted here — same reasoning as content, and
+            # it is where the cost actually was: tool `meta.tool_input` carries
+            # the large payloads, so meta redaction was ~5.5s of a ~7s restore
+            # while content redaction was only ~0.4s. Redacted at emit instead
+            # (chat_utils._prepare_messages), which is the only path that returns
+            # meta to a client.
+            meta=(m["meta"] if isinstance(m.get("meta"), dict) else None),
         )
         _attach_variants(slot, m)
     slot.drain()
@@ -656,6 +659,10 @@ def _restore_recent_sessions_steps(
             role = m.get("role", "assistant")
             cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
             content = m.get("content", "")
+            # CONTENT is redacted on load; META is deferred to the emit sites.
+            # See the equivalent loop in _rehydrate_slot_from_history for the
+            # measured rationale (content ~0.4s / ~204 readers, meta ~5.5s /
+            # 31 readers that touch only control fields outside the emit sites).
             if role != "user":
                 content, _ = redact_exfiltration_urls(content)
                 content, _ = redact_credentials(content)
@@ -664,11 +671,8 @@ def _restore_recent_sessions_steps(
                 content,
                 cls,
                 ts=m.get("ts", ""),
-                meta=(
-                    _redact_meta_for_role(role, m["meta"])
-                    if isinstance(m.get("meta"), dict)
-                    else None
-                ),
+                broadcast=False,
+                meta=(m["meta"] if isinstance(m.get("meta"), dict) else None),
             )
             _attach_variants(slot, m)
         slot.drain()
@@ -783,7 +787,14 @@ def _build_message_entry(m: dict) -> dict | None:
     if role in ("chunk", "done", "streaming", "queued", "permission"):
         return None
     content = m.get("content", "")
-    if role not in ("user", "system"):
+    # Gate is `!= "user"`, NOT `not in ("user", "system")`. _save_slot_to_history
+    # re-serializes the WHOLE in-memory window on every flush, so this is the
+    # write-back boundary. It used to exclude `system`, which was survivable only
+    # because the load path redacted `system` on the way in and this rewrite then
+    # laundered the file. With load-time redaction removed, excluding `system`
+    # here would let unredacted bytes from a legacy or foreign writer survive the
+    # rewrite indefinitely.
+    if role != "user":
         content, _ = redact_exfiltration_urls(content)
         content, _ = redact_credentials(content)
     entry: dict = {
@@ -1405,7 +1416,14 @@ async def save_slot_off_loop(
 
 
 def _build_history_prefix(slot: _ChatSlot) -> str:
-    """Build a condensed history prefix from slot messages for session re-injection."""
+    """Build a condensed history prefix from slot messages for session re-injection.
+
+    Redacts here as defence in depth. The returned prefix is prepended to the ACP
+    prompt, so it leaves the dashboard's own storage and is persisted by kiro-cli
+    into its session file — an egress path, not an internal read, so it does not
+    rely solely on the load-time content pass upstream. Redaction is idempotent,
+    so the common case is a no-op.
+    """
     lines: list[str] = []
     total = 0
     for m in slot.messages:
@@ -1414,6 +1432,9 @@ def _build_history_prefix(slot: _ChatSlot) -> str:
             continue
         label = "User" if role == "user" else "Assistant"
         text = m.get("content", "")[:500]
+        if role != "user":
+            text, _ = redact_exfiltration_urls(text)
+            text, _ = redact_credentials(text)
         line = f"{label}: {text}"
         if total + len(line) > _MAX_HISTORY_CHARS:
             break

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -64,6 +64,7 @@ from kiro_crew.dashboard.chat_utils import (
     _maybe_inject_persona,
     _normalize_model,
     _redact_for_display,
+    _redact_meta_for_role,
     _redact_tool_field,
     _remove_queued_by_id,
     _validate_tool_name,
@@ -767,7 +768,39 @@ def _mark_mcp_oauth_completed(
         break
     if target is None:
         return
-    new_meta = dict(target.get("meta") or {})
+    # Redact the RESTORED payload before it is re-emitted. This function copies the
+    # whole stored dict into both slot.messages and the `chat_message_update`
+    # broadcast below, and that broadcast bypasses _prepare_messages — a genuine
+    # egress point.
+    #
+    # Scope of the exposure, stated precisely: the SAVE path already redacts meta
+    # (`_build_message_entry`), and `ConversationLog.append` has no `meta` parameter
+    # at all, so meta this version wrote to disk comes back already clean. What this
+    # guards is history lines this version did not write — legacy lines, a tampered
+    # session file, or the verbatim-preserved foreign byte ranges. That is the same
+    # threat model the sibling gates are written against, so it is defence in depth
+    # rather than a live hole.
+    #
+    # The matching loop above reads only control fields (`server_name`,
+    # `completed`, `failed`), which is why this reader looked safe on a first pass.
+    # What decides safety is not which fields a reader INSPECTS but whether it
+    # re-emits the dict. This one does.
+    #
+    # CAREFUL — `_redact_meta_for_role` is STRICTER than the emit-path gate and does
+    # NOT preserve realistic `oauth_url`s: it calls `redact_exfiltration_urls`,
+    # whose query-length (>=200) and base64-blob heuristics blank a real Google OIDC
+    # or GitHub PKCE consent URL. (Measured: those two are blanked; only a short URL
+    # survives.) The emit-path gate `_oauth_url_contains_credential` deliberately
+    # exempts OAuth params from exactly those heuristics — its docstring notes they
+    # "would reject every real OAuth URL".
+    #
+    # That is harmless HERE only because `oauth_url` is dead data by this point:
+    # every path through this function sets `completed` or `failed`, and
+    # McpOAuthBanner.tsx returns on the `failed` (line 50) and `completed` (line 61)
+    # branches BEFORE the link-rendering branch (line 73). Do NOT reuse this gate on
+    # a path where the authorize link is still rendered — there it would break the
+    # user's ability to authorize an MCP server.
+    new_meta = _redact_meta_for_role("mcp_oauth", dict(target.get("meta") or {}))
     if success:
         new_meta["completed"] = True
         new_meta.pop("failed", None)

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -487,6 +487,69 @@ def _sync_dashboard_slots(state: "DashboardState") -> None:
     )
 
 
+def _redact_value(v):  # type: ignore[no-untyped-def]
+    """Recursively redact any value (str, dict, list, or passthrough)."""
+    if isinstance(v, str):
+        v, _ = redact_exfiltration_urls(v)
+        v, _ = redact_credentials(v)
+        return v
+    if isinstance(v, dict):
+        return _redact_meta(v)
+    if isinstance(v, list):
+        return [_redact_value(i) for i in v]
+    return v
+
+
+def _redact_meta(meta: dict) -> dict:
+    """Recursively redact string values in meta dict."""
+    return {k: _redact_value(v) for k, v in meta.items()}
+
+
+def _redact_meta_for_role(role: str, meta: dict) -> dict:
+    """Redact meta, but preserve role-specific user-actionable external URLs (e.g. mcp_oauth).
+
+    Lives here (the display-redaction module) rather than in chat_persistence
+    because it is now called on the EMIT path — see _prepare_messages. The
+    dependency runs chat_persistence -> chat_utils, so keeping it here lets both
+    the save path and the emit path share one implementation without a cycle.
+    """
+    if role == "mcp_oauth":
+        out: dict = {}
+        for k, v in meta.items():
+            if k == "oauth_url" and isinstance(v, str):
+                # Two gates, and deliberately NOT a third:
+                #   1. http(s)-only — a tampered history line can't smuggle a
+                #      javascript:/data: URL into <a href>.
+                #   2. URL must not embed an actual credential — a legit OAuth
+                #      consent URL never carries credential patterns; presence of
+                #      one means it's tampered/bogus.
+                #
+                # The generic EXFIL heuristic is deliberately NOT applied, matching
+                # `_oauth_url_contains_credential` (chat_runner.py), whose docstring
+                # says it omits the long-query heuristic because that heuristic
+                # "would reject every real OAuth URL". test/oauth_url_corpus.py is
+                # the contract: real provider URLs routinely exceed 200 query chars
+                # and carry a 43-char base64url `code_challenge`, so the exfil
+                # heuristic fires on all of them.
+                #
+                # This function runs on the EMIT path (_prepare_messages), which
+                # serves the slot-detail endpoint that the frontend refetches on
+                # `chat_done`, on WS reconnect, and on switchSlot. Blanking the URL
+                # here therefore hits a PRE-TERMINAL banner: renderMcpOAuthMessage
+                # returns null when `oauth_url` is empty and neither completed nor
+                # failed is set, so the Authorize banner would silently vanish and
+                # the user could never authorize the server. Keeping the two gates
+                # aligned is what prevents that.
+                lower = v.lower()
+                safe_scheme = lower.startswith("https://") or lower.startswith("http://")
+                _, hit_cred = redact_credentials(v)
+                out[k] = v if (safe_scheme and not hit_cred) else ""
+            else:
+                out[k] = _redact_value(v)
+        return out
+    return _redact_meta(meta)
+
+
 def _redact_for_display(text: str) -> str:
     """Apply all redaction passes for dashboard/WS display."""
     text, _ = redact_exfiltration_urls(text)
@@ -647,7 +710,16 @@ def _prepare_messages(messages: list[dict], running: bool) -> list[dict]:
                 out.append({"role": "streaming", "content": redacted_chunk, "cls": "msg msg-a"})
                 chunk_text = ""
             text = m.get("content", "")
-            if role not in ("user", "system") and text:
+            # Gate is `!= "user"`, NOT `not in ("user", "system")`. This is the
+            # display-time redaction boundary for everything the slot detail
+            # endpoint returns — including the frozen-prefix lines read straight
+            # off disk — so it must cover every role the LOAD path used to clean.
+            # `system` content is written to disk unredacted (see
+            # _build_message_entry's historical gate), so excluding it here would
+            # emit raw stored bytes now that the load path no longer launders them.
+            # User-authored content stays raw: the user typed it and is the only
+            # one who sees it back.
+            if role != "user" and text:
                 text, _ = redact_exfiltration_urls(text)
                 text, _ = redact_credentials(text)
                 m = {**m, "content": text}
@@ -659,7 +731,14 @@ def _prepare_messages(messages: list[dict], running: bool) -> list[dict]:
                 ]
             meta = parse_cls_meta(m.get("cls", ""))
             if meta is not None:
-                msg_out["meta"] = meta
+                msg_out["meta"] = _redact_meta_for_role(role, meta)
+            elif isinstance(msg_out.get("meta"), dict):
+                # Redact the STORED meta too. Without this branch the stored dict
+                # passes through by reference (dict(m) is shallow), so it would
+                # reach the client exactly as loaded. The load path used to redact
+                # meta on the way in; that moved here, so this is now the only
+                # guard on meta for the slot-detail response.
+                msg_out["meta"] = _redact_meta_for_role(role, msg_out["meta"])
             out.append(msg_out)
     if chunk_text:
         redacted_chunk, _ = redact_exfiltration_urls(chunk_text)

--- a/src/kiro_crew/dashboard/side_context.py
+++ b/src/kiro_crew/dashboard/side_context.py
@@ -12,6 +12,7 @@ from kiro_crew.dashboard.side_prompts import (
     SIDE_BOUNDARY_PROMPT,
     build_side_system_prompt,
 )
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 if TYPE_CHECKING:
     from kiro_crew.dashboard.state import _ChatSlot
@@ -45,6 +46,16 @@ def _format_parent_snapshot(slot: _ChatSlot) -> str:
         label = "User" if role == "user" else "Assistant"
         text = entry.get("content", "") or ""
         text = text[:_PARENT_LINE_TRUNCATE]
+        if role != "user":
+            # Defence in depth. The restore path now redacts `content` on load, so
+            # slot.messages should already be clean here — but this block goes into
+            # the side-chat PROMPT, which leaves the dashboard's own storage and is
+            # persisted by kiro-cli into its session file. That is an egress path,
+            # not an internal read, so it does not rely solely on an upstream
+            # guarantee. Redaction is idempotent and this text is truncated to
+            # _PARENT_LINE_TRUNCATE, so the cost is bounded.
+            text, _ = redact_exfiltration_urls(text)
+            text, _ = redact_credentials(text)
         line = f"{label}: {text}"
         if total + len(line) > _MAX_PARENT_SNAPSHOT_CHARS:
             break

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2793,7 +2793,27 @@ class DashboardState:
             meta = parse_cls_meta(cls_val)
             if meta is not None:
                 payload["meta"] = meta
-        # Also include direct meta (e.g. tool_call_id on tool messages)
+        # Also include direct meta (e.g. tool_call_id on tool messages).
+        #
+        # Deliberately NOT redacted here, unlike the `cls` branch above (which is
+        # sanitised by parse_cls_meta). Two reasons, both load-bearing:
+        #
+        # 1. This is the LIVE oauth banner's egress path. _emit_mcp_oauth_request
+        #    appends the banner with a real `oauth_url`, already gated by
+        #    _oauth_url_contains_credential — a gate that deliberately exempts OAuth
+        #    params from the query-length / base64 heuristics because those
+        #    "would reject every real OAuth URL". Running _redact_meta_for_role here
+        #    would blank a genuine Google/GitHub consent URL and break the user's
+        #    ability to authorize an MCP server.
+        # 2. chat_utils imports from this module, so importing the redactors the
+        #    other way would be a cycle.
+        #
+        # What makes that safe: live tool meta is redacted at source (_tool_meta),
+        # and no DISK-LOADED message is ever appended with broadcast=True — both
+        # restore loops pass broadcast=False. That invariant is what lets the load
+        # path skip meta redaction, and it is pinned by
+        # test_rehydrate_does_not_broadcast_replayed_messages and
+        # test_restore_recent_sessions_does_not_broadcast_either. Do not relax it.
         direct_meta = msg.get("meta")
         if direct_meta and isinstance(direct_meta, dict):
             payload["meta"] = {**(payload.get("meta") or {}), **direct_meta}

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -107,6 +107,13 @@ class PostureControl:
 # Where a sink runs only ONE of the two scanners, its detail text says so.
 _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
     (
+        "Side-chat parent snapshot",
+        "dashboard/side_context.py",
+        "Parent user/assistant turns embedded in the side-chat prompt. The prompt "
+        "leaves the dashboard's own storage and is persisted by kiro-cli into its "
+        "session file, so this is an egress boundary rather than an internal read.",
+    ),
+    (
         "Dashboard live stream",
         "dashboard/chat_runner.py",
         "Per-chunk StreamRedactor on the chat_chunk WebSocket stream — withholds a "

--- a/test/test_display_time_redaction.py
+++ b/test/test_display_time_redaction.py
@@ -1,0 +1,517 @@
+"""Regression tests for splitting redaction between load time and display time.
+
+The startup restore used to redact BOTH `content` and `meta` on every message it
+loaded, and that pass was silently covering for four emit sites that did not
+redact. Removing it wholesale then leaked stored content through three further
+paths that build model prompts (side-chat, orchestrator stage file, title model).
+
+So the split is asymmetric, and measured:
+
+  content -> still redacted ON LOAD. Only ~0.4s of the ~7s, but ~204 read sites,
+             so a single chokepoint is the only holdable invariant.
+  meta    -> redacted AT THE EMIT SITES. ~5.5s of the ~7s (tool_input payloads)
+             is the real boot cost, and its 31 readers are tractable: outside the
+             emit sites every one reads control fields only.
+
+Each emit-site test here fails against the pre-change code for a DIFFERENT site,
+so they cannot all be satisfied by re-adding a blanket load-time pass.
+
+The `system` role is the crux of the emit-site half: the write path never redacted
+it, the old load path did, and the emit paths did not — so `system` content
+reached disk raw and was cleaned only in memory.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard.chat_persistence import (
+    _build_history_prefix,
+    _build_message_entry,
+    _rehydrate_slot_from_history,
+)
+from kiro_crew.dashboard.chat_utils import _history_key_for, _prepare_messages
+
+# A credential shape `redact_credentials` catches, kept in one place so a change
+# to the detector surfaces as one failure rather than six.
+SECRET = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _seed(state, slot_key: str, role: str, content: str) -> None:
+    log = state.conversation_log
+    assert log is not None
+    log.append(_history_key_for(slot_key), role, content)
+
+
+def _rewrite_last_meta(log, key: str, meta: dict) -> None:
+    """Attach `meta` to the last stored record by editing the JSONL directly.
+
+    ``ConversationLog.append()`` takes no ``meta=`` kwarg, and going through the
+    normal write path would redact the payload before it landed — which is
+    exactly what these tests need to NOT happen. Writing the file directly is the
+    only way to stage bytes that a legacy or foreign writer could have left.
+    """
+    path = pathlib.Path(log._path(key))
+    lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+    assert lines, "precondition: something was written"
+    rec = json.loads(lines[-1])
+    rec["meta"] = meta
+    lines[-1] = json.dumps(rec)
+    path.write_text("\n".join(lines) + "\n")
+
+
+# ── 1. emit path: _prepare_messages must cover `system` ──────────────────────
+
+
+@pytest.mark.parametrize("role", ["assistant", "system", "tool"])
+def test_prepare_messages_redacts_every_non_user_role(role: str) -> None:
+    """`system` was excluded by the old gate, so stored secrets were emitted raw."""
+    out = _prepare_messages([{"role": role, "content": f"key {SECRET}", "cls": "msg"}], False)
+    assert SECRET not in json.dumps(out), f"{role} content emitted unredacted"
+
+
+def test_prepare_messages_leaves_user_content_alone() -> None:
+    """User content is deliberately NOT redacted — the author is the only reader."""
+    out = _prepare_messages(
+        [{"role": "user", "content": f"key {SECRET}", "cls": "msg msg-u"}], False
+    )
+    assert SECRET in out[0]["content"]
+
+
+def test_prepare_messages_redacts_stored_meta_not_just_cls_meta() -> None:
+    """`dict(m)` is shallow, so stored meta reached the client by reference.
+
+    The old code only overwrote `meta` when `parse_cls_meta(cls)` returned
+    something; otherwise the loaded dict passed straight through. Load-time
+    redaction was the only guard.
+    """
+    out = _prepare_messages(
+        [{"role": "tool", "content": "ok", "cls": "msg", "meta": {"tool_input": SECRET}}], False
+    )
+    assert SECRET not in json.dumps(out), "stored meta emitted unredacted"
+
+
+# ── 2. save path: _build_message_entry must cover `system` ───────────────────
+
+
+@pytest.mark.parametrize("role", ["assistant", "system"])
+def test_build_message_entry_redacts_every_non_user_role(role: str) -> None:
+    """_save_slot_to_history rewrites the whole window, so this is a write-back gate.
+
+    With load-time redaction gone, an unredacted `system` line from a legacy or
+    foreign writer would otherwise survive every future rewrite.
+    """
+    entry = _build_message_entry({"role": role, "content": f"key {SECRET}", "cls": "msg"})
+    assert entry is not None
+    assert SECRET not in json.dumps(entry), f"{role} persisted unredacted"
+
+
+# ── 3. ACP prompt path: _build_history_prefix must redact ───────────────────
+
+
+def test_history_prefix_redacts_assistant_content(tmp_path, monkeypatch) -> None:
+    """Its output is prepended to the ACP prompt, so kiro-cli persists it."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    slot = state.get_or_create_slot("chat-1-prefix")
+    slot.append("assistant", f"here is {SECRET}", "msg msg-a", broadcast=False)
+
+    assert SECRET not in _build_history_prefix(slot)
+
+
+def test_history_prefix_keeps_user_text() -> None:
+    """User turns are the prompt's own history; redacting them would corrupt it."""
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    slot = _ChatSlot("chat-1-u")
+    slot.append("user", "my own note", "msg msg-u", broadcast=False)
+    assert "my own note" in _build_history_prefix(slot)
+
+
+# ── 3b. the OTHER prompt paths, found by the CI GPT lane ─────────────────────
+#
+# My own egress audit covered client-facing routes thoroughly and under-covered
+# prompt builders. The GPT review lane caught `side_context`; auditing that class
+# properly then turned up `chat_orchestrator` as the same defect writing to disk.
+# Both are pinned here so the class stays closed.
+
+
+def test_side_chat_parent_snapshot_redacts_assistant_content() -> None:
+    """The side-chat prompt embeds parent turns, so it is an egress path."""
+    from kiro_crew.dashboard.side_context import _format_parent_snapshot
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    slot = _ChatSlot("chat-1-side")
+    slot.append("assistant", f"here is {SECRET}", "msg msg-a", broadcast=False)
+
+    snapshot = _format_parent_snapshot(slot)
+    assert snapshot, "precondition: a snapshot was produced"
+    assert SECRET not in snapshot
+
+
+def test_side_chat_parent_snapshot_keeps_user_text() -> None:
+    """Same carve-out as the history prefix: the user's own words must survive."""
+    from kiro_crew.dashboard.side_context import _format_parent_snapshot
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    slot = _ChatSlot("chat-1-sideu")
+    slot.append("user", "my own question", "msg msg-u", broadcast=False)
+    assert "my own question" in _format_parent_snapshot(slot)
+
+
+def test_stage_result_capture_redacts_before_writing_to_disk(tmp_path, monkeypatch) -> None:
+    """_capture_stage_result writes assistant text to a NEW file on disk.
+
+    A gateway restart mid-orchestration leaves restored (now unredacted) turns in
+    the window, so without redaction here those bytes would be written out.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    from kiro_crew.dashboard.chat_orchestrator import _capture_stage_result
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    slot = _ChatSlot("chat-1-stage")
+    slot.append("assistant", f"result with {SECRET}", "msg msg-a", broadcast=False)
+
+    path = _capture_stage_result(slot, 1)
+    written = pathlib.Path(path).read_text()
+    assert SECRET not in written, "stage result persisted an unredacted credential"
+
+
+# ── 4. restore must not broadcast replayed history ───────────────────────────
+
+
+def test_restore_recent_sessions_does_not_broadcast_either(tmp_path, monkeypatch) -> None:
+    """The SECOND restore loop must hold the same invariant as the first.
+
+    This invariant is load-bearing for the meta deferral, not just a nicety.
+    `_broadcast_chat_message` merges a message's whole `meta` into its websocket
+    payload and applies NO redaction to it (only the `cls`-derived branch is
+    sanitised, via `parse_cls_meta`). Deferring meta redaction is therefore safe
+    only because no disk-loaded message is ever appended with `broadcast=True`.
+    Both restore loops must be pinned or the guarantee has a hole nobody notices.
+
+    Deliberately NOT fixed by redacting inside `_broadcast_chat_message`: the LIVE
+    oauth banner is appended there with a real `oauth_url`
+    (`_emit_mcp_oauth_request`), and `_redact_meta_for_role` would blank a genuine
+    Google/GitHub consent URL and break the user's ability to authorize. Also
+    `chat_utils` imports from `state`, so that direction would be an import cycle.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-1-nb2", "assistant", f"key {SECRET}")
+
+    state2 = _make_state(tmp_path / "sessions")
+    seen: list[tuple[str, dict]] = []
+    # Install the observer the way get_or_create_slot does, before the restore runs.
+    # (Hooking state._on_message instead does NOT observe anything — an earlier
+    # revision of this test did that and passed even with broadcast=True.)
+    orig = state2.get_or_create_slot
+
+    def _spy(*a, **kw):
+        slot = orig(*a, **kw)
+        slot._on_message = lambda key, msg: seen.append((key, msg))
+        return slot
+
+    monkeypatch.setattr(state2, "get_or_create_slot", _spy)
+
+    from kiro_crew.dashboard.chat_persistence import restore_recent_sessions
+
+    restored = restore_recent_sessions(state2, window_minutes=0)
+    assert restored == 1, "precondition: the session was restored"
+    slot = state2._slots.get("chat-1-nb2")
+    assert slot is not None and slot.messages, "precondition: messages were replayed"
+    assert seen == [], f"restore_recent_sessions broadcast {len(seen)} message(s)"
+
+
+def test_rehydrate_does_not_broadcast_replayed_messages(tmp_path, monkeypatch) -> None:
+    """_broadcast_chat_message ships content verbatim.
+
+    This helper also runs for on-demand cold-slot rehydrates, i.e. while clients
+    are connected — so replaying history through it would push unredacted content
+    straight to them.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed(state, "chat-1-bcast", "assistant", "hello from history")
+
+    state2 = _make_state(tmp_path / "sessions")
+    seen: list[tuple[str, dict]] = []
+    # Install the observer the way get_or_create_slot does, before rehydrate runs.
+    orig = state2.get_or_create_slot
+
+    def _spy(*a, **kw):
+        slot = orig(*a, **kw)
+        slot._on_message = lambda key, msg: seen.append((key, msg))
+        return slot
+
+    monkeypatch.setattr(state2, "get_or_create_slot", _spy)
+
+    slot = _rehydrate_slot_from_history(state2, "chat-1-bcast")
+    assert slot is not None and slot.messages, "precondition: history was restored"
+    assert seen == [], f"restore broadcast {len(seen)} message(s) it should not have"
+
+
+# ── 5. the content/meta split, pinned on BOTH axes ───────────────────────────
+#
+# This is the crux of the change and it is deliberately asymmetric:
+#
+#   content -> redacted ON LOAD.  ~0.4s, but ~204 read sites, so "every reader
+#              remembers to redact" is not holdable. Three egress paths (side-chat
+#              prompt, orchestrator stage file, title-model prompt) each leaked
+#              restored content before this. One chokepoint instead.
+#   meta    -> redacted AT EMIT.  ~5.5s of the ~7s load (tool_input payloads) —
+#              the actual boot cost — and only 31 readers, all of which read
+#              control fields (`done`, `tool_call_id`) outside the emit sites.
+#
+# Both directions are pinned: flipping either one silently regresses something.
+
+
+def test_load_redacts_content_restoring_the_chokepoint(tmp_path, monkeypatch) -> None:
+    """Content is clean in memory, so all ~204 readers are safe by construction.
+
+    A security assertion. The emit-site redaction remains as defence in depth,
+    but this is what makes a NEW reader of `m["content"]` safe without having to
+    know it must redact.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    log = state.conversation_log
+    assert log is not None
+    # Write through the log directly so the STORED bytes keep the secret —
+    # simulating a legacy/foreign writer whose bytes predate the write-path pass.
+    log.append(_history_key_for("chat-1-raw"), "assistant", f"key {SECRET}")
+
+    state2 = _make_state(tmp_path / "sessions")
+    slot = _rehydrate_slot_from_history(state2, "chat-1-raw")
+    assert slot is not None and slot.messages, "precondition: history was restored"
+    loaded = " ".join(m.get("content", "") for m in slot.messages)
+    assert SECRET not in loaded, "content must be clean in memory (the chokepoint)"
+    # …and still clean on the way out.
+    assert SECRET not in json.dumps(_prepare_messages(slot.messages, False))
+
+
+def test_load_leaves_user_content_raw(tmp_path, monkeypatch) -> None:
+    """The load-time pass is gated `role != "user"`, not `not in ("user","system")`.
+
+    Regression test for a real slip: the content pass was first written
+    unconditionally, which silently redacted the user's OWN words on restore. The
+    author is the only reader of their own text, so mangling it is a correctness
+    bug — and no existing test caught it, because none restored a user message
+    containing a credential shape.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    log = state.conversation_log
+    assert log is not None
+    key = _history_key_for("chat-1-userraw")
+    log.append(key, "user", f"my key is {SECRET}")
+    log.append(key, "assistant", f"noted {SECRET}")
+
+    state2 = _make_state(tmp_path / "sessions")
+    slot = _rehydrate_slot_from_history(state2, "chat-1-userraw")
+    assert slot is not None and len(slot.messages) >= 2
+    by_role = {m.get("role"): m.get("content", "") for m in slot.messages}
+    assert SECRET in by_role["user"], "user's own text was redacted on load"
+    assert SECRET not in by_role["assistant"], "assistant text was not redacted"
+
+
+def test_load_redacts_system_role(tmp_path, monkeypatch) -> None:
+    """`system` is on the redacted side of the gate, and must stay there.
+
+    The write path excludes `system`, so system content reaches disk raw. A gate
+    of `not in ("user", "system")` would therefore leave it raw in memory too.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    log = state.conversation_log
+    assert log is not None
+    log.append(_history_key_for("chat-1-sysload"), "system", f"key {SECRET}")
+
+    state2 = _make_state(tmp_path / "sessions")
+    slot = _rehydrate_slot_from_history(state2, "chat-1-sysload")
+    assert slot is not None and slot.messages
+    loaded = " ".join(m.get("content", "") for m in slot.messages)
+    assert SECRET not in loaded, "system content left raw in memory"
+
+
+def test_load_does_not_redact_meta_keeping_boot_fast(tmp_path, monkeypatch) -> None:
+    """Meta is NOT scanned on load — that deferral IS the performance win.
+
+    Not a security hole: meta payload egress is confined to the emit sites (see
+    the meta tests above), and every other reader touches only control fields.
+    This exists so re-adding the meta pass fails loudly instead of quietly
+    handing back the ~5.5s of boot time this change removed.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    log = state.conversation_log
+    assert log is not None
+    key = _history_key_for("chat-1-rawmeta")
+    log.append(key, "tool", "ran a tool")
+    # Put the secret in the stored meta payload, where the real cost lives.
+    _rewrite_last_meta(log, key, {"tool_input": {"cmd": f"aws --key {SECRET}"}})
+
+    state2 = _make_state(tmp_path / "sessions")
+    slot = _rehydrate_slot_from_history(state2, "chat-1-rawmeta")
+    assert slot is not None and slot.messages, "precondition: history was restored"
+    loaded_meta = json.dumps([m.get("meta") for m in slot.messages])
+    assert SECRET in loaded_meta, "meta was scanned on load — the ~5.5s cost is back"
+    # …and the emit path still cleans it on the way out.
+    assert SECRET not in json.dumps(_prepare_messages(slot.messages, False))
+
+
+# ── 6. the META side: a non-emit reader that RE-EMITS the dict ────────────────
+#
+# The meta deferral rests on the claim that outside the emit sites, meta readers
+# are harmless. The first pass at verifying that checked which FIELDS each reader
+# inspects, saw only control fields (`done`, `tool_call_id`, `server_name`), and
+# concluded they were safe. That was the wrong question.
+# `_mark_mcp_oauth_completed` inspects only control fields for its matching logic
+# — and then copies the whole stored dict into a `chat_message_update` broadcast
+# that bypasses _prepare_messages. What matters is not which fields a reader
+# INSPECTS but whether it RE-EMITS what it read.
+
+
+def test_oauth_completion_redacts_restored_meta_before_broadcast() -> None:
+    """A legacy or tampered oauth banner's meta must not reach the dashboard raw.
+
+    Scope, stated honestly: the SAVE path already redacts meta
+    (`_build_message_entry`) and `ConversationLog.append` takes no `meta`, so meta
+    THIS version wrote to disk comes back clean. The reachable payload is a line
+    this version did not write — a legacy line, a tampered session file, or a
+    verbatim-preserved foreign byte range. This test stages that by appending the
+    banner directly rather than round-tripping through disk, because a real save
+    would have redacted it; the point is the re-emit, not the disk state.
+    """
+    from kiro_crew.dashboard.chat_runner import _mark_mcp_oauth_completed
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    slot = _ChatSlot("chat-1-oauth")
+    slot.append(
+        "mcp_oauth",
+        "authorize please",
+        "msg",
+        broadcast=False,
+        meta={"server_name": "acme", "oauth_url": f"https://ex.com/cb?tok={SECRET}"},
+    )
+
+    sent: list[dict] = []
+
+    class _FakeState:
+        def broadcast_ws(self, kind, payload):  # noqa: ANN001, ANN202
+            sent.append({"kind": kind, "payload": payload})
+
+    _mark_mcp_oauth_completed(_FakeState(), slot, "acme", success=True)
+
+    assert sent, "precondition: a completion update was broadcast"
+    assert SECRET not in json.dumps(sent), "restored oauth meta broadcast unredacted"
+    # Redaction must not break the flow: the banner still reaches a terminal state.
+    assert sent[0]["payload"]["meta"].get("completed") is True
+
+
+def test_oauth_url_corpus_survives_the_emit_path(monkeypatch) -> None:
+    """Every real provider's consent URL must survive `_prepare_messages`.
+
+    This is the test whose absence let a real regression through. The repo already
+    had `test/oauth_url_corpus.py` pinning that `_oauth_url_contains_credential`
+    never rejects a real provider URL — but nothing routed that corpus through the
+    DISPLAY gate, and this PR newly called `_redact_meta_for_role` from
+    `_prepare_messages`.
+
+    The consequence was not cosmetic. `_prepare_messages` serves the slot-detail
+    endpoint, which the frontend refetches on `chat_done`, on WS reconnect, and on
+    switchSlot. With the exfil heuristic still in the gate, 8 of the 9 corpus
+    providers (GitHub, Google, Microsoft, Slack, …) had `oauth_url` blanked, and
+    `renderMcpOAuthMessage` returns null when the URL is empty and the banner is
+    neither completed nor failed — so the Authorize banner silently disappeared and
+    the MCP server could never be authorized.
+    """
+    from oauth_url_corpus import LEGIT_OAUTH_URLS
+
+    assert LEGIT_OAUTH_URLS, "precondition: the corpus is non-empty"
+    blanked = []
+    for provider, url in LEGIT_OAUTH_URLS:
+        out = _prepare_messages(
+            [
+                {
+                    "role": "mcp_oauth",
+                    "content": "authorize",
+                    "cls": "msg msg-info",
+                    "meta": {"server_name": "acme", "oauth_url": url},
+                }
+            ],
+            False,
+        )
+        if out[0]["meta"].get("oauth_url") != url:
+            blanked.append(provider)
+    assert not blanked, (
+        "the emit path blanked a legitimate consent URL — the Authorize banner "
+        f"would silently vanish for: {blanked}"
+    )
+
+
+def test_oauth_url_gate_still_blocks_a_tampered_url() -> None:
+    """Dropping the exfil heuristic must not open the two gates that matter."""
+    from kiro_crew.dashboard.chat_utils import _redact_meta_for_role
+
+    # 1. Non-http(s) scheme: must never reach an <a href>.
+    out = _redact_meta_for_role(
+        "mcp_oauth", {"oauth_url": "javascript:alert(document.cookie)"}
+    )
+    assert out["oauth_url"] == "", "javascript: URL survived the scheme gate"
+
+    # 2. An embedded real credential still blanks it.
+    out = _redact_meta_for_role(
+        "mcp_oauth", {"oauth_url": f"https://ex.com/cb?tok={SECRET}"}
+    )
+    assert out["oauth_url"] == "", "credential-bearing URL survived the cred gate"
+
+
+def test_oauth_completion_preserves_a_legitimate_url() -> None:
+    """A real consent URL must survive the completion path too — one gate everywhere.
+
+    An earlier revision of this test asserted the OPPOSITE: that blanking a real URL
+    here was acceptable "because oauth_url is dead data once the banner is terminal".
+    The premise was true for THIS call site and the conclusion was still wrong,
+    because `_redact_meta_for_role` has another caller — `_prepare_messages` — where
+    the banner is PRE-TERMINAL and the URL is rendered. Pinning the blanking as
+    acceptable had frozen the exact behaviour that silently deleted the Authorize
+    banner for 8 of the 9 providers in test/oauth_url_corpus.py.
+
+    The lesson worth keeping: a shared helper cannot be judged safe from one call
+    site. The gate now matches `_oauth_url_contains_credential` for every caller.
+    """
+    from kiro_crew.dashboard.chat_runner import _mark_mcp_oauth_completed
+    from kiro_crew.dashboard.state import _ChatSlot
+
+    legit = (
+        "https://accounts.google.com/o/oauth2/v2/auth?"
+        "client_id=1234567890-abcdefghijklmnopqrstuvwxyz012345.apps.googleusercontent.com"
+        "&redirect_uri=http%3A%2F%2Flocalhost%3A5476%2Fcallback&response_type=code"
+        "&scope=openid%20email%20profile&state=Ab3dEf6hIj9lMn2pQr5tUv8xYz1cD4fG"
+    )
+    slot = _ChatSlot("chat-1-oauthlegit")
+    slot.append(
+        "mcp_oauth",
+        "authorize please",
+        "msg",
+        broadcast=False,
+        meta={"server_name": "acme", "oauth_url": legit},
+    )
+
+    sent: list[dict] = []
+
+    class _FakeState:
+        def broadcast_ws(self, kind, payload):  # noqa: ANN001, ANN202
+            sent.append({"kind": kind, "payload": payload})
+
+    _mark_mcp_oauth_completed(_FakeState(), slot, "acme", success=True)
+
+    assert sent, "precondition: a completion update was broadcast"
+    meta = sent[0]["payload"]["meta"]
+    assert meta.get("oauth_url") == legit, "a legitimate consent URL was blanked"
+    assert meta.get("completed") is True

--- a/test/test_knowledge_search_upgrade.py
+++ b/test/test_knowledge_search_upgrade.py
@@ -293,7 +293,7 @@ class TestRedactMeta:
 
     def test_redacts_strings(self):
         try:
-            from kiro_crew.dashboard.chat_persistence import _redact_meta
+            from kiro_crew.dashboard.chat_utils import _redact_meta
         except TypeError:
             pytest.skip("requires Python 3.10+")
         meta = {"title": "safe text", "content": "key is AKIAIOSFODNN7EXAMPLE here"}
@@ -303,7 +303,7 @@ class TestRedactMeta:
 
     def test_redacts_nested_dicts(self):
         try:
-            from kiro_crew.dashboard.chat_persistence import _redact_meta
+            from kiro_crew.dashboard.chat_utils import _redact_meta
         except TypeError:
             pytest.skip("requires Python 3.10+")
         meta = {"knowledge": {"content": [{"title": "ok", "text": "AKIAIOSFODNN7EXAMPLE"}]}}
@@ -312,7 +312,7 @@ class TestRedactMeta:
 
     def test_preserves_non_strings(self):
         try:
-            from kiro_crew.dashboard.chat_persistence import _redact_meta
+            from kiro_crew.dashboard.chat_utils import _redact_meta
         except TypeError:
             pytest.skip("requires Python 3.10+")
         meta = {"items": 3, "tokens": 1054, "titles": ["safe"]}

--- a/test/test_mcp_oauth_banner.py
+++ b/test/test_mcp_oauth_banner.py
@@ -18,13 +18,13 @@ from unittest.mock import MagicMock
 import pytest
 from oauth_url_corpus import LEGIT_OAUTH_URLS
 
-from kiro_crew.dashboard.chat_persistence import _redact_meta_for_role
 from kiro_crew.dashboard.chat_runner import (
     _emit_mcp_oauth_request,
     _is_safe_oauth_url,
     _mark_mcp_oauth_completed,
     _oauth_url_contains_credential,
 )
+from kiro_crew.dashboard.chat_utils import _redact_meta_for_role
 from kiro_crew.dashboard.state import _ChatSlot
 
 # ── _is_safe_oauth_url ──

--- a/test/test_session_restore.py
+++ b/test/test_session_restore.py
@@ -273,7 +273,14 @@ class TestRestoreRecentSessions:
         assert state._slots["mychat"].messages[0]["content"] == "colon test"
 
     def test_redacts_credentials_in_restored_messages(self, tmp_path, monkeypatch):
-        """LLM-sourced content is redacted before being added to dashboard slots."""
+        """LLM-sourced content is redacted before it can reach a client.
+
+        Redaction moved from load time to display time: the restore now loads
+        stored bytes as-is and every EMIT site cleans them. The security property
+        is unchanged (a credential must never reach a client) but the enforcement
+        point moved, so this asserts the emit path rather than the slot contents.
+        See test_display_time_redaction.py for the per-site coverage.
+        """
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         _write_session(
             tmp_path,
@@ -293,11 +300,22 @@ class TestRestoreRecentSessions:
         restored = restore_recent_sessions(state, window_minutes=60)
         assert restored == 1
         slot = state._slots["redact"]
-        # User content should be preserved as-is
+        # User content is preserved as-is, on load and on emit.
         assert slot.messages[0]["content"] == "show me the key"
-        # Assistant content should have the AWS key redacted
-        assert "AKIAIOSFODNN7EXAMPLE" not in slot.messages[1]["content"]
-        assert "[REDACTED" in slot.messages[1]["content"]
+
+        # The credential is gone from what the slot-detail endpoint returns...
+        from kiro_crew.dashboard.chat_utils import _prepare_messages
+
+        emitted = _prepare_messages(slot.messages, False)
+        rendered = " ".join(m.get("content", "") for m in emitted)
+        assert "AKIAIOSFODNN7EXAMPLE" not in rendered
+        assert "[REDACTED" in rendered
+        # ...and from the prompt-building paths that leave the process.
+        from kiro_crew.dashboard.chat_persistence import _build_history_prefix
+        from kiro_crew.dashboard.side_context import _format_parent_snapshot
+
+        assert "AKIAIOSFODNN7EXAMPLE" not in _build_history_prefix(slot)
+        assert "AKIAIOSFODNN7EXAMPLE" not in _format_parent_snapshot(slot)
 
     def test_zero_window_restores_all_sessions(self, tmp_path, monkeypatch):
         """window_minutes=0 means infinite — restores sessions regardless of age."""


### PR DESCRIPTION
## Problem

Opening the dashboard with a normal number of tabs is slow, and on #833 it
crash-looped the gateway. The startup restore re-redacted every message it loaded:
on a real 35-tab home (62 MB of transcripts) that is **~7s** of CPU-bound work on
the event loop, in blocks up to **1.4s** — long enough to starve the heartbeat.

#885 fixed the crash by yielding between tabs. That made the symptom survivable
without making boot any faster, which is the objection this PR answers.

The work was also redundant: the write path already redacts, so on a real
472-session home the load pass changed **0 of 24,432** messages. It was
re-scanning bytes that were already clean.

## Why it matters

Boot latency is the first thing a user experiences, and it scales with how much
they have used the product — the more history, the slower the start. At the tail
it stops being slow and becomes a crash loop.

## Fix (symptom → root cause → change)

Profiling the ~7s split it unevenly, and that split shapes the whole fix:

| field | read sites | share of load cost |
|---|---|---|
| `content` | ~204 | ~0.4s (6%) |
| `meta` | 31 | **~5.5s (79%)** |

The cost is **`meta`, not content** — tool `meta.tool_input` carries the large
payloads while `content` is mostly prose. (My first attribution here was wrong: I
assumed content dominated. It does not.) So the two fields get opposite treatment:

- **`meta` → redacted at the emit sites.** That is where the 5.5s is. On-disk meta
  is **already clean by construction**: `_build_message_entry` redacts meta on
  write (pre-existing, and the sole window serialiser), and `ConversationLog.append`
  has **no `meta` parameter**, so cross-process writers cannot write meta at all. So
  the load path was doing a *second* pass over clean bytes. Residual exposure is
  narrow and specific — legacy lines, a tampered session file, or the
  verbatim-preserved foreign byte ranges.
- **`content` → still redacted on load.** Only 0.4s, but ~204 read sites — "every
  reader remembers to redact" is not an invariant anyone can hold. One chokepoint
  means any present *or future* reader of `m["content"]` is safe by construction.

That second half was learned the hard way, in the open, on this PR. An earlier
revision removed the content pass too, and three separate egress paths were each
caught leaking restored content, one review round at a time:

1. the side-chat prompt (`side_context._format_parent_snapshot`),
2. the orchestrator stage-result file (`chat_orchestrator._capture_stage_result`),
3. the title-model prompt (`chat_title._generate_title_via_kiro`).

The GPT lane found #1 and #3; the design lane named the structural reason
("the invariant moves from one chokepoint to an unenforced enumeration of emit
sites"). Both were right, and keeping the cheap chokepoint is the correct
resolution rather than patching a fourth site.

Deferring `meta` still required fixing the emit sites the load pass had been
silently covering for:

- **`chat_utils._prepare_messages`** gated on `role not in ("user", "system")`.
  `system` content is written to disk raw (the write path excludes it) and was
  excluded at emit too — so removing the load pass would have leaked it via
  `GET /api/chat/slots/{slot}`, resume, and forks. Widened to `role != "user"`.
- **`_build_message_entry`** (save path) had the same narrow gate. Because
  `_save_slot_to_history` rewrites the whole window on every flush, unredacted
  `system` bytes were being *laundered clean* on each save; without this they would
  persist instead.
- **`_build_history_prefix`** fed the ACP prompt from raw `slot.messages`.
- **`api_chat_slot_detail`** emitted `slot.display_title` unredacted.
- Both restore loops now pass **`broadcast=False`** — `_broadcast_chat_message`
  ships content verbatim, and `_rehydrate_slot_from_history` also runs for
  cold-slot rehydrates *while clients are connected*.

### A user-visible regression this PR introduced, and its fix

Caught by the Opus lane, and self-inflicted in an instructive way: the previous
revision added a warning at `_mark_mcp_oauth_completed` saying this gate must not be
reused where the authorize link is still rendered — and the same revision reused it
on exactly such a path.

`_redact_meta_for_role`'s `mcp_oauth` branch blanked `oauth_url` whenever the generic
exfil heuristic fired. That condition is **pre-existing**, but on the parent commit
the function ran only at load and save time. Calling it from `_prepare_messages` —
new here — put it on the **slot-detail response**, which the frontend refetches on
`chat_done`, on websocket reconnect, and on `switchSlot`. For an **open**
(pre-terminal) banner that is fatal: `renderMcpOAuthMessage` returns `null` when
`oauth_url` is empty and neither `completed` nor `failed` is set, so the **Authorize
banner silently disappears and the MCP server can never be authorized**.

Measured against the repo's own `test/oauth_url_corpus.py`:

| | providers with `oauth_url` blanked |
|---|---|
| before fix | **8 of 9** — GitHub, Google, Microsoft, Slack, Atlassian, … |
| after fix | **0** |

Real consent URLs routinely exceed 200 query chars and carry a 43-char base64url
`code_challenge`, so the heuristic fires on nearly all of them. That corpus's own
docstring states the contract: *"the generic data-exfiltration heuristic must not
fire on them. A regression here silently breaks sign-in."*

**Fix:** drop the exfil term, keep the http(s)-scheme check and the credential check
— aligning with `_oauth_url_contains_credential`, whose docstring already explains it
omits the long-query heuristic because it "would reject every real OAuth URL". One
gate, same rule, every caller.

The corpus already pinned the **emit** gate; nothing routed it through the **display**
gate. `test_oauth_url_corpus_survives_the_emit_path` now does (verified to fail and
name the providers when the term is restored), and
`test_oauth_url_gate_still_blocks_a_tampered_url` keeps the two real gates honest.

A test of mine had pinned the **wrong** behaviour and is replaced: it asserted that
blanking a real URL was fine "because the URL is dead data once the banner is
terminal". True for that call site, wrong as a conclusion — the helper has another
caller where the banner is pre-terminal, so the assertion had frozen the very bug.

**Lesson, recorded because it cost four review rounds:** a shared helper cannot be
judged safe from one call site. Enumerate its callers.

### Corrections this PR earned in review

Three claims in earlier revisions of this description were wrong. They are listed
because the reasoning, not just the code, is what a reviewer has to trust.

**1. The content chokepoint is SIX population paths, not two.** `slot.messages` is
filled by `_rehydrate_slot_from_history`, `_restore_recent_sessions_steps`,
`api_chat_resume`, `surface_channel_session`, `chat_fork`, and
`hydrate_slot_from_history` (cron_inject). All six **do** redact on entry (four
already did before this change), so there is no hole — but "two loops" was the
sentence a reviewer would have trusted. The guarantee also covers only
**slot-sourced** bytes: anything reading a transcript straight from
`ConversationLog` bypasses it and must redact at its own egress.

**2. The `oauth_url` preservation claim was false — measured, not argued.** An
earlier comment said `_redact_meta_for_role` "keeps the user-actionable oauth_url so
the authorize link still works". It does not: it blanks a realistic Google OIDC and
GitHub PKCE consent URL, because it calls `redact_exfiltration_urls` whose
query-length (≥200) and base64-blob heuristics fire — while the emit-path gate
`_oauth_url_contains_credential` deliberately **exempts** OAuth params from exactly
those, its docstring noting they "would reject every real OAuth URL". The two gates
disagree.

It is harmless *at this call site* only because `oauth_url` is dead data once the
banner is terminal: `McpOAuthBanner.tsx` returns on the `failed` (line 50) and
`completed` (line 61) branches **before** the link render (line 73). The comment now
says that, and warns against reusing this gate anywhere the link is still rendered.

This is also why a reviewer suggestion to redact `direct_meta` inside
`_broadcast_chat_message` was **not** applied: that is the **live** banner's egress
path (`_emit_mcp_oauth_request` appends the real URL through it), so redacting there
would blank a genuine consent URL and break authorization — a regression worse than
the leak. (`chat_utils` also imports from `state`, so that direction is an import
cycle.)

**3. The `broadcast=False` invariant is now pinned on both restore loops.**
`_broadcast_chat_message` merges a message's whole meta into its websocket payload
with no redaction (only the `cls`-derived branch is sanitised, via
`parse_cls_meta`). The meta deferral is safe *only* because no disk-loaded message
is ever appended with `broadcast=True` — load-bearing, and previously asserted for
one loop only. The new test was verified to fail when the flag is flipped; its own
first revision hooked the wrong observer and passed even with `broadcast=True`,
which is why it now asserts the restore precondition too.

### The meta egress point, and a correction

`chat_runner._mark_mcp_oauth_completed` patches an open `mcp_oauth` banner to a
terminal state. It copies the banner's stored meta into both `slot.messages` and a
`chat_message_update` **websocket broadcast** — and that broadcast bypasses
`_prepare_messages`. So a banner restored from disk with credential-bearing meta
reached the dashboard raw once OAuth completed. Now redacted with
`_redact_meta_for_role("mcp_oauth", ...)`, which preserves the user-actionable
`oauth_url` so the authorize link still works; the freshly computed
`completed`/`failed` flags are applied *after* redaction so trusted local values
are never scrubbed.

An earlier revision of this description claimed the non-emit meta readers "touch
only control fields, never payload text". **That was wrong**, and wrong in an
instructive way: it was established by checking which fields each reader
*inspects*. This one inspects only `server_name`/`completed`/`failed` for its
matching logic — and then re-emits the whole dict. The question that decides
safety is not which fields a reader inspects but whether it **re-emits what it
read**. Re-audited on that basis:

| reader | why it is safe |
|---|---|
| `_broadcast_chat_message` + its WS relay | merges whole meta into the payload, but restored messages are appended `broadcast=False` (this PR, test-pinned), and live tool meta is redacted at source by `_tool_meta` |
| `_ChatSlot.update_message` | mutates only, never broadcasts — precisely why the oauth path leaked, since it broadcast separately |
| `_ChatSlot.to_dict` | reads meta only for the compaction flag; emits a redacted title, no per-message meta |
| `chat_fork` | copies meta with `broadcast=False`, and redacts content itself under the same `role != "user"` gate |
| streaming `tool_call_id`/`done` lookups | local control flow |
| `handlers/prompts.py` | reads a skill-candidate `meta`, not message meta |

Two low-risk paths noted and deliberately **not** changed, to avoid widening
scope: `chat_title._message_attachment_paths` puts `meta["files"]` paths
(length- and count-capped, user-supplied) into the title prompt, and
`handlers/artifacts.py` reads messages straight off disk to scan
`file_changes[].path` — the latter is the same family as the pre-existing
disk-reading endpoints listed at the bottom of this description.

Every gate is `role != "user"`, never `not in ("user", "system")`: user-authored
text stays raw because its author is its only reader, but `system` must be
redacted. `_redact_value` / `_redact_meta` / `_redact_meta_for_role` moved
`chat_persistence` → `chat_utils` (the dependency already ran that way; avoids a
cycle).

### Security-posture inventory

`test_security_posture.py` enforces that every module calling a redactor is
**either** a declared `redaction_paths` sink (so the security panel counts it)
**or** allowlisted as non-egress with a reason — an omission-detection test, built
precisely so a new output path cannot be added without being counted. Adding
redaction to `side_context.py` tripped it, correctly: the side-chat prompt *is* an
egress boundary, so it is now declared in `_REDACTION_SINKS` rather than
allowlisted.

That failure also exposed a gap in how this change was being verified — the local
gate was run against a hand-picked list of "affected suites" that omitted the
cross-cutting governance tests. The **full** backend suite now passes (22,683
tests); the only failures are pre-existing local-environment ones (macOS
`PermissionError` in `test_api_server`, Linux-namespace assertions in
`test_sandbox_argv`, a missing optional `qrcode` dep), each reproduced on the
parent commit.

## Measurement

Frozen copy of the 35-tab / 62 MB home, arms **interleaved in one quiet window**
so machine load cannot favour either. (Freezing matters: the live home is written
continuously by the running gateway *including the measuring session*, which
inflated an early run to 19.8s vs 12.8s for the same arm.)

| | baseline | this change |
|---|---|---|
| total restore | 7.46s / 7.02s | **1.19s / 1.07s** |
| worst on-loop block | 1.44s / 1.37s | **0.19s / 0.18s** |

**~6.5x faster boot, ~7.5x shorter worst block.** Keeping the content pass costs
~0.45s of that (0.66s without it) — deliberately paid for the chokepoint.

Note on an earlier plan: issue #895's Stage 1 proposed offloading this with
`asyncio.to_thread`. That would not have worked — file I/O is only ~3% (0.33s);
the `re` matching and the pure-Python classifier hold the GIL. Corrected on #895.

## Tests

`test/test_display_time_redaction.py`, 17 tests. **8 fail against the parent
commit** — one per fixed emit site, plus a pin that the `meta` deferral is not
quietly undone:

| test | site it pins |
|---|---|
| `test_prepare_messages_redacts_every_non_user_role[system]` | slot-detail emit |
| `test_prepare_messages_redacts_stored_meta_not_just_cls_meta` | shallow-`dict(m)` meta passthrough |
| `test_build_message_entry_redacts_every_non_user_role[system]` | save path |
| `test_history_prefix_redacts_assistant_content` | ACP prompt |
| `test_side_chat_parent_snapshot_redacts_assistant_content` | side-chat prompt |
| `test_stage_result_capture_redacts_before_writing_to_disk` | orchestrator stage file |
| `test_rehydrate_does_not_broadcast_replayed_messages` | restore broadcast |
| `test_load_does_not_redact_meta_keeping_boot_fast` | the perf claim itself |

The other 9 pass on both on purpose — they are over-correction guards that
user-authored content stays raw, at load and at emit. One of them,
`test_load_leaves_user_content_raw`, exists because the content pass was first
written **without** the `role != "user"` gate and silently redacted the user's own
words; it fails if that gate is removed again.

`test_session_restore.py::test_redacts_credentials_in_restored_messages` was
**converted, not deleted**: it asserted the old enforcement point, so it now
asserts the same property (a credential must never reach a client) at the emit
path, the history prefix, and the side-chat snapshot.

Gates: 736 passed across the affected suites, mypy clean (567 files), isort and
flake8 clean.

## Manual verification

N/A — unit coverage is the stronger evidence here. The behaviour is byte-level
redaction at specific call sites, which the per-site tests assert directly; the
perf claim is covered by the interleaved benchmark above rather than by
eyeballing a boot.

## Not fixed here (pre-existing, filed separately)

Four prompt builders in `context.py` read transcripts straight off disk and reach
an **LLM prompt** without redacting: `build_cancelled_turn_preamble`,
`compress_thread_history`, the fallback branch of `build_session_context`, and
`recent_with_provenance` → `context.py:1688`. `build_session_replay` in the same
file **does** redact, so the asymmetry reads as oversight. All four are unchanged by
this PR and confirmed present on the parent commit.


Several endpoints read from disk directly and never touch a slot, so this PR does
not change them — but they return unredacted stored bytes today. Worst is
`GET /api/sessions/{key}`, which returns `read_messages` bare. Also
`api_sessions` (title), `api_memory_history`, `api_memory_context_preview`,
`api_hook_test`, `api_taskrunner` to-chat/plan-context, `api_portability_export`.
Out of scope here; being filed as its own issue.

## Screenshots

N/A — no user-visible UI change. Redaction output format is unchanged; only where
in the pipeline it runs.
