### PR TITLE
fix(options): tolerate a stray markdown-link close after [OPTIONS:]

### DIFF
--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -75,13 +75,32 @@ CHAT_TURN_TIMEOUT = 7200.0
 # lines (deleting/splitting a multi-line span the old single-line ``.*`` never
 # matched). Trailing class is ``[ \t]`` (NOT ``\s``, which under MULTILINE would
 # also match ``\n``).
-OPTIONS_RE_LINE = re.compile(r"\[OPTIONS:((?:[^[\n]|\[(?!OPTIONS:))*)\][ \t]*$", re.MULTILINE)
+#
+# OPTIONAL MARKDOWN-LINK CLOSE ``(?:\(...\))?`` after the ``]``: models sometimes
+# append a stray ``(OPTIONS)`` (or any ``(...)``) right after the marker, e.g.
+# ``[OPTIONS: A | B | C](OPTIONS)``. That does TWO bad things at once: the extra
+# text after ``]`` breaks the end anchor so the marker leaks unparsed, AND
+# ``[label](url)`` is valid Markdown so the dashboard renders the whole thing as a
+# clickable link instead of buttons. Absorbing a single tightly-attached ``(...)``
+# here (it stays OUTSIDE the captured label group, so choices are unaffected)
+# makes the parser resilient to that tic. The ``(`` must follow the ``]`` with no
+# gap, so genuine trailing prose (``] and then...``) or a spaced note (``] (note)``)
+# still fails the anchor and is left intact — the deliberate "trailing note on the
+# same line" behaviour is preserved. The inner class is ``[^\s()]`` (NOT ``[^)\n]``)
+# so it shares NO character with the trailing ``[ \t]*`` — that keeps the added group
+# unambiguous and avoids a polynomial-ReDoS (``py/polynomial-redos``) backtracking
+# path over ``[OPTIONS:`` + a long whitespace run. The real tic (``(OPTIONS)``, a
+# bare ``(url)``) contains no whitespace or nested parens, so nothing is lost.
+OPTIONS_RE_LINE = re.compile(r"\[OPTIONS:((?:[^[\n]|\[(?!OPTIONS:))*)\](?:\([^\s()]*\))?[ \t]*$", re.MULTILINE)
 
 # TRAILER (``re.DOTALL``, ``\Z`` anchor) — for the Discord/Telegram/WeCom
 # renderers, which match the marker only at the very END of the message and
 # allow it to span newlines (the body keeps ``[^[]`` because the old ``.*``
-# already spanned newlines under DOTALL). Trailing ``\s*`` before ``\Z``.
-OPTIONS_RE_TRAILER = re.compile(r"\[OPTIONS:((?:[^[]|\[(?!OPTIONS:))*)\]\s*\Z", re.DOTALL)
+# already spanned newlines under DOTALL). Trailing ``\s*`` before ``\Z``. Carries
+# the same optional markdown-link close as LINE (same ``[^\s()]`` inner class, so it
+# shares no character with the trailing ``\s*`` — ReDoS-safe) so the grammar stays
+# identical.
+OPTIONS_RE_TRAILER = re.compile(r"\[OPTIONS:((?:[^[]|\[(?!OPTIONS:))*)\](?:\([^\s()]*\))?\s*\Z", re.DOTALL)
 
 
 # The product wordmark, figlet `small`. ONE definition on purpose: it used to be

--- a/test/test_parse_options.py
+++ b/test/test_parse_options.py
@@ -60,3 +60,16 @@ def test_body_does_not_span_newlines():
     assert _parse_options("Earlier [OPTIONS: draft\nmore prose ]") == []
     # A genuine single-line block after mid-text prose still parses.
     assert _parse_options("Earlier [OPTIONS text.\nNow:\n[OPTIONS: A | B]") == ["A", "B"]
+
+
+def test_trailing_markdown_link_close_tolerated():
+    # Models sometimes append a stray "(OPTIONS)" (or any "(...)") right after the
+    # marker, e.g. "[OPTIONS: A | B](OPTIONS)". That both breaks the end anchor and
+    # forms a valid [label](url) Markdown link, so the marker used to leak as a
+    # clickable link instead of buttons. The optional link-close is now absorbed —
+    # and stays OUTSIDE the label capture, so choices are unaffected.
+    assert _parse_options("Pick one.\n[OPTIONS: A | B | C](OPTIONS)") == ["A", "B", "C"]
+    assert _parse_options("[OPTIONS: Ship it | Park it](https://x)") == ["Ship it", "Park it"]
+    # The "(" must abut the "]" — a spaced "] (note)" is NOT a link close, so the
+    # anchor fails and the marker is left unparsed (deliberate trailing-note case).
+    assert _parse_options("[OPTIONS: A | B] (see note)") == []

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -276,6 +276,27 @@ describe('parseOptions', () => {
     expect(text).toContain('```diff')
   })
 
+  // Regression: the model sometimes appends a stray "(OPTIONS)" (or any "(...)")
+  // immediately after the marker — "[OPTIONS: A | B | C](OPTIONS)". That both broke
+  // the end anchor (marker leaked unparsed) and formed a valid [label](url) Markdown
+  // link, so the whole thing rendered as a purple link instead of buttons. The parser
+  // now absorbs a tightly-attached link-close: options are surfaced and the stray
+  // "(...)" is stripped from the text.
+  it('parses options when a stray markdown-link close follows the marker', () => {
+    const { options, multi, text } = parseOptions('Pick one.\n[OPTIONS: Alpha | Beta | Gamma](OPTIONS)')
+    expect(options).toEqual(['Alpha', 'Beta', 'Gamma'])
+    expect(multi).toBe(true)
+    expect(text).not.toContain('[OPTIONS:')
+    expect(text).not.toContain('(OPTIONS)')
+  })
+
+  // The "(" must abut the "]": a spaced "] (note)" is NOT a link close, so the anchor
+  // fails and the marker is left unparsed — preserving the deliberate trailing-note case.
+  it('does NOT treat a spaced parenthetical after the marker as a link close', () => {
+    const { options } = parseOptions('[OPTIONS: A | B] (see note)')
+    expect(options).toEqual([])
+  })
+
   it('takes the last marker for options and strips ALL markers from text', () => {
     const { options, text } = parseOptions('[OPTION: A | B]\nlater\n[OPTION: Go | Go All | Cancel]')
     expect(options).toEqual(['Go', 'Go All', 'Cancel'])

--- a/website/src/utils/optionsMarker.ts
+++ b/website/src/utils/optionsMarker.ts
@@ -15,6 +15,18 @@
 // question, or diff on later lines is left intact. `i` = case-insensitive OPTION(S);
 // `g` = take the LAST marker / strip all. Group 1 = optional "S"; group 2 = labels.
 //
+// The optional `(?:\([^\s()]*\))?` after the `]` tolerates a stray markdown-link
+// close that models sometimes append, e.g. `[OPTIONS: A | B](OPTIONS)`. Without it
+// that suffix (a) breaks the end anchor so the marker leaks unparsed and (b) forms a
+// valid `[label](url)` link, so the dashboard renders the whole thing as a purple
+// link instead of buttons. The `(` must abut the `]` (no gap), so real trailing
+// prose or a spaced `] (note)` still fails the anchor and is preserved. The group is
+// OUTSIDE the label capture, so choices are unaffected — and because the regex is
+// used with `replace`, the stray `(...)` is stripped from the displayed text too.
+// The inner class is `[^\s()]` (not `[^)\n]`) so it shares no character with the
+// trailing `[ \t]*` — that keeps the group unambiguous and ReDoS-safe (mirrors the
+// backend OPTIONS_RE_LINE). The real tic contains no whitespace, so nothing is lost.
+//
 // Only use with String#matchAll and String#replace (which don't carry the global
 // regex `lastIndex` hazard); do NOT call `.exec`/`.test` on this shared const.
-export const OPTION_MARKER_RE = /\[OPTION(S)?:((?:[^[\n]|\[(?!OPTIONS?:))*)\][ \t]*$/gim
+export const OPTION_MARKER_RE = /\[OPTION(S)?:((?:[^[\n]|\[(?!OPTIONS?:))*)\](?:\([^\s()]*\))?[ \t]*$/gim


### PR DESCRIPTION
## Problem

Assistant turns sometimes append a stray `(OPTIONS)` (or any `(...)`) right after the options marker:

```
[OPTIONS: Repackage and reinstall now | Just restart the dev instance | Repackage and also fix the remaining items first](OPTIONS)
```

This does two bad things at once:
1. **Breaks the parser.** The shared OPTIONS grammar anchors the closing `]` to the end of the line (`\][ \t]*$`). The trailing `(OPTIONS)` is non-whitespace after the `]`, so `parseOptions` never matches and the marker is never turned into buttons.
2. **Renders as a link.** `[label](url)` is valid Markdown, so the dashboard renders the whole thing as a purple underlined link instead of choice buttons.

Confirmed from a real transcript: the leaked marker rendered as a clickable link with no buttons.

## Fix

Widen the single source-of-truth grammar to absorb **one tightly-attached** `(...)` after the `]`:
- `src/kiro_crew/constants.py` — `OPTIONS_RE_LINE` and `OPTIONS_RE_TRAILER` (backend: board pills + Slack/Discord/Telegram/WeCom/Teams/Webex renderers)
- `website/src/utils/optionsMarker.ts` — `OPTION_MARKER_RE` (dashboard chat)

The optional `(?:\(...\))?` group sits **outside** the captured label group, so choices are unaffected, and because the frontend uses `replace`, the stray `(...)` is stripped from the displayed text too. The `(` must **abut** the `]` (no gap), so genuine trailing prose (`] and then...`) or a spaced note (`] (note)`) still fails the anchor and is left intact — the deliberate 'trailing note on the same line' behaviour is preserved.

## Tests
- `test/test_parse_options.py` — new `test_trailing_markdown_link_close_tolerated` (marker+link-close parses; spaced parenthetical does not).
- `website/src/test/AssistantMessage.test.tsx` — two new regression cases (parses + strips the `(...)`; spaced parenthetical is not treated as a link close).

Ran green: backend 322 OPTIONS-related tests across all renderers, frontend AssistantMessage suite 51/51.