### PR TITLE
fix(dashboard): clear SelectionToolbar's deferred checks on unmount

### DIFF
--- a/website/src/components/SelectionToolbar.tsx
+++ b/website/src/components/SelectionToolbar.tsx
@@ -356,12 +356,28 @@ export default function SelectionToolbar({ containerRef, actions, externalSelect
   }, [externalSelection])
 
   useEffect(() => {
+    // Every deferred selection check has to be cancellable. These fire 0-50ms
+    // after a pointer/key event, so an unmount inside that window leaves a
+    // check running for a component that is gone. In a browser that is benign
+    // but wrong — `setVisible` on an unmounted component is a no-op and the
+    // stale `checkSelection` just reads the live selection for nothing. Where
+    // it actually breaks is host teardown: with the document/window already
+    // gone (jsdom between tests), the same late callback throws an uncaught
+    // `ReferenceError: window is not defined` from `window.getSelection()`.
+    // That is the identical failure mode `copyTimerRef` above already guards;
+    // only the touch-path `selectionChangeTimer` below was ever cleared here.
+    const pending = new Set<ReturnType<typeof setTimeout>>()
+    const defer = (fn: () => void, ms: number) => {
+      const id = setTimeout(() => { pending.delete(id); fn() }, ms)
+      pending.add(id)
+    }
+
     const onMouseUp = (e: MouseEvent) => {
       if (toolbarRef.current && toolbarRef.current.contains(e.target as Node)) return
       triggeredByMouseRef.current = true
       lastMouseRef.current = { x: e.clientX, y: e.clientY }
       // Small delay to let selection finalize
-      setTimeout(checkSelection, 50)
+      defer(checkSelection, 50)
     }
 
     const onKeyUp = (e: KeyboardEvent) => {
@@ -369,7 +385,7 @@ export default function SelectionToolbar({ containerRef, actions, externalSelect
       // Check selection on Shift+Arrow keys (keyboard selection)
       if (e.shiftKey) {
         triggeredByMouseRef.current = false
-        setTimeout(checkSelection, 50)
+        defer(checkSelection, 50)
       }
     }
 
@@ -379,7 +395,7 @@ export default function SelectionToolbar({ containerRef, actions, externalSelect
       // Clicking inside the container clears the selection (cursor reposition) —
       // dismiss after a tick so the new (empty) selection state is readable.
       if (containerRef.current && containerRef.current.contains(e.target as Node)) {
-        setTimeout(() => { if (!window.getSelection()?.toString().trim()) setVisible(false) }, 0)
+        defer(() => { if (!window.getSelection()?.toString().trim()) setVisible(false) }, 0)
         return
       }
       setVisible(false)
@@ -413,6 +429,11 @@ export default function SelectionToolbar({ containerRef, actions, externalSelect
       document.removeEventListener('mousedown', onMouseDown)
       document.removeEventListener('selectionchange', onSelectionChange)
       if (selectionChangeTimer) clearTimeout(selectionChangeTimer)
+      // Cancel every deferred check still in flight. `checkSelection` depends
+      // only on the stable `containerRef`, so this effect does not re-run after
+      // mount and this cleanup is effectively unmount-only.
+      for (const id of pending) clearTimeout(id)
+      pending.clear()
     }
     // `containerRef` is a stable RefObject (its identity never changes across
     // renders), so listing it does not re-run the effect; it satisfies the

--- a/website/src/test/SelectionToolbar.timerCleanup.test.tsx
+++ b/website/src/test/SelectionToolbar.timerCleanup.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * SelectionToolbar must not leave timers running after unmount.
+ *
+ * Three deferred selection checks fire 0-50ms after a pointer/key event:
+ * `mouseup` and Shift+`keyup` schedule `checkSelection` at 50ms, and a
+ * `mousedown` inside the container schedules a dismiss check at 0ms. None of
+ * them were cancelled on unmount — only the touch-path `selectionchange`
+ * debounce was. Unmounting inside that window (a panel closing right after a
+ * click, or a test tearing down) left a timer that ran against a torn-down
+ * document and surfaced as an uncaught `ReferenceError: window is not defined`.
+ *
+ * The component already documents this exact failure mode for its "copied!"
+ * reset timer, which IS cleared on unmount. These tests extend the same
+ * guarantee to the listener effect's timers.
+ *
+ * Asserting on the pending fake-timer count rather than on a thrown error is
+ * deliberate: the throw only happens once the host is gone, which a normal test
+ * never reproduces. The timer count tests the mechanism, and fails against the
+ * pre-fix code.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { createElement, createRef } from 'react'
+import SelectionToolbar, { type SelectionAction } from '../components/SelectionToolbar'
+
+// Typed explicitly: tsconfig.app.json excludes `src/test`, so `tsc -b` never
+// checks this file. Annotating the fixture is what makes a wrong shape a
+// compile error under `tsc --noEmit` on the test project instead of a silent
+// pass that only holds because these assertions never invoke the action.
+const ACTIONS: SelectionAction[] = [
+  { id: 'quote', label: 'Quote', icon: null, onClick: () => {} },
+]
+
+function mount() {
+  const containerRef = createRef<HTMLDivElement>()
+  const view = render(
+    createElement('div', { ref: containerRef },
+      createElement(SelectionToolbar, {
+        containerRef: containerRef as React.RefObject<HTMLElement>,
+        actions: ACTIONS,
+      }),
+    ),
+  )
+  return { view, containerRef }
+}
+
+describe('SelectionToolbar timer cleanup', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('cancels the deferred check scheduled by mouseup', () => {
+    const { view } = mount()
+    act(() => { document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })) })
+    // The 50ms "let the selection finalize" timer is now armed.
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    view.unmount()
+    // Pre-fix this stayed > 0: the timer outlived the component and would fire
+    // against a torn-down document.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels the deferred check scheduled by a Shift keyup', () => {
+    const { view } = mount()
+    act(() => { document.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', shiftKey: true, bubbles: true })) })
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    view.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels the 0ms dismiss check scheduled by mousedown inside the container', () => {
+    const { view, containerRef } = mount()
+    act(() => {
+      containerRef.current!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    })
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    view.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels MULTIPLE deferred checks queued by rapid events', () => {
+    // Each event arms its own timer — they are not coalesced — so cleanup has to
+    // clear all of them, not just the most recent.
+    const { view } = mount()
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+      document.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft', shiftKey: true, bubbles: true }))
+    })
+    expect(vi.getTimerCount()).toBeGreaterThanOrEqual(3)
+
+    view.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('still runs the deferred check when the component stays mounted', () => {
+    // The fix must cancel on unmount WITHOUT breaking the normal path: a mouseup
+    // on a live component still has to reach checkSelection.
+    const getSelection = vi.spyOn(window, 'getSelection')
+    mount()
+    getSelection.mockClear()
+
+    act(() => { document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })) })
+    expect(getSelection).not.toHaveBeenCalled()   // still deferred
+
+    act(() => { vi.advanceTimersByTime(50) })
+    expect(getSelection).toHaveBeenCalled()       // fired, as before
+
+    getSelection.mockRestore()
+  })
+
+  it('drains its own timer bookkeeping as timers fire', () => {
+    // The tracking Set must not grow unbounded: a fired timer removes itself, so
+    // a long-lived toolbar does not accumulate dead ids.
+    const { view } = mount()
+    act(() => { document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })) })
+    act(() => { vi.advanceTimersByTime(50) })
+    expect(vi.getTimerCount()).toBe(0)
+    // And unmount after everything already drained is still clean.
+    view.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})


### PR DESCRIPTION
Found while investigating an intermittent CI failure on an unrelated perf PR. Pre-existing defect, not a regression.

## Problem

`SelectionToolbar` schedules three deferred selection checks and cancels none of them:

| trigger | delay | what it schedules |
|---|---|---|
| `mouseup` | 50ms | `checkSelection` |
| Shift + `keyup` | 50ms | `checkSelection` |
| `mousedown` inside the container | 0ms | a dismiss check |

Only the touch-path `selectionchange` debounce was ever cleared. Unmounting inside that 0-50ms window leaves a check running for a component that no longer exists.

## Why it matters — scoped honestly

**In a browser this is benign but wrong.** `setVisible` on an unmounted component is a React no-op, and the stale `checkSelection` just reads the live selection for nothing. No user-visible symptom.

**Where it actually breaks is host teardown.** With the document/window already gone — jsdom between tests — the same late callback throws an uncaught `ReferenceError: window is not defined` from `window.getSelection()`. That surfaces as intermittent red in the frontend suite: it appeared in 2 of 4 full-suite runs while I was working on an unrelated PR, originating in `integration/MarkdownPanelComment.integration.test.tsx` (which renders `MarkdownPanel` → `SelectionToolbar`).

So: a cleanup-correctness and test-hygiene fix, **not** a user-facing crash. Calling it the latter would overstate it.

This is also the *same* failure mode the component already documents for its "copied!" reset timer, which **is** correctly cleared on unmount — see the comment above `copyTimerRef`. Whoever wrote that knew the class existed; the listener effect's three timers were simply missed.

## Fix (symptom → root cause → change)

Symptom: an uncaught post-teardown `ReferenceError` from a timer callback. Root cause: three `setTimeout` ids created inside the listener effect were never retained, so its cleanup — which already removes four `document` listeners and the touch debounce — had nothing to cancel them with.

Change: a `Set` local to the effect holds the pending ids, a small `defer(fn, ms)` helper registers each one, and the existing cleanup clears them all. Each timer deletes its own id when it fires, so the Set does not accumulate over a long-lived toolbar.

Two properties worth checking as a reviewer, both verified:

- **The cleanup is effectively unmount-only.** The listener effect's deps are `[checkSelection, containerRef]`, and `checkSelection`'s deps are `[containerRef]`. All five call sites (`MarkdownPanel.tsx:738,742`, `ArtifactPanel.tsx:106,108`, `AssistantMessage.tsx:143`) pass a `useRef`-created object, so both deps are identity-stable and the effect cannot re-run while mounted. This matters: if it *could* re-run, this change would cancel a check a live user is waiting on and the toolbar would stop appearing after a selection.
- **The touch path is untouched.** `onSelectionChange` keeps its own `selectionChangeTimer`, its 350ms debounce, and its `isTouchDevice()` gate; it is not routed through `defer`. Semantics are byte-identical.

## Tests

6 new in `website/src/test/SelectionToolbar.timerCleanup.test.tsx`.

Four assert the pending fake-timer count drops to 0 on unmount — one per scheduling path, plus a rapid-events case proving *all* pending timers are cleared rather than only the most recent. **These fail against the pre-fix component** (verified by checking out the base version of the file with `git show`, not by stashing — see below) and pass after.

Two pin behaviour that must not change: a `mouseup` on a live component still reaches `checkSelection` after 50ms, and a fired timer drains its own bookkeeping.

Asserting on the timer count rather than on a thrown error is deliberate. The throw only happens once the host is gone, which an ordinary test never reproduces — so the count is what actually tests the mechanism, and `toBe(0)` is strict enough that a leaked timer cannot slip through.

**A gate gap worth knowing about:** `website/tsconfig.app.json` sets `exclude: ["src/test", ...]`, so **`tsc -b` does not typecheck test files.** The first version of this test's action fixture did not satisfy `SelectionAction` (used `onSelect`, omitted `icon`) and the gate could not see it — the tests passed only because they never invoke the action. The fixture is now explicitly annotated `SelectionAction[]` so a wrong shape is a compile error rather than a silent pass.

## Manual verification

N/A — unit coverage is sufficient and strictly sharper than clicking. The defect is invisible in a browser by construction (see scope above), so there is nothing for a human to observe; the failure only manifests under host teardown, which is exactly what the tests simulate.

## Screenshots

N/A — no user-visible change. No panel, component, layout, or theme is altered; this changes only whether a timer is cancelled on unmount.

## Honest caveats

- **This does not make the frontend suite flake-free.** It removes one documented source of cross-test pollution. While verifying, a *different* intermittent failure appeared once — `AgentImportFlow > shows only detected supported sources` — which passes 14/14 in isolation and did not recur on a clean full-suite re-run. Unrelated to this diff; noted so the next person chasing suite flakiness knows it exists.
- Local review: `gpt-5.6-sol` (mirroring `codex-review.yml`) and `claude-opus-5` (mirroring `claude-review.yml` + both `AUTOSDE.yaml` files) both returned no blocking findings. Opus contributed the scope correction above — my original comment claimed a browser-side `ReferenceError`, which is wrong — and caught the untyped test fixture. The GPT marker names the pre-amend SHA; the amend changed only that comment and the fixture, and gates were re-run afterwards.
