### PR TITLE
fix(config): resolve data-home paths per call, not at import time

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -182,6 +182,81 @@ eliminate, the one-way-door risk above; the release gate still stands.
 > `release-blocker`); the sign-off must be recorded there and the issue closed
 > before tagging the first release containing this change.
 
+**Paths are resolved per call, never captured at import.** Because
+`config_dir()` re-reads `$KIROCREW_HOME` on every call and the migration above
+is deliberately lazy, the resolved value is only correct at the moment it is
+needed. Modules therefore MUST NOT bind a path factory result to a module-level
+constant:
+
+```python
+_SOME_DIR = config_dir() / "some"        # WRONG -- frozen at import
+```
+
+An import-time binding captures whatever home was active when the module was
+first imported, which breaks three things at once: pod isolation (a pod exports
+its own `KIROCREW_HOME`), the one-time legacy-home migration (resolved after
+import), and test isolation — `conftest.py`'s autouse `_isolate_kirocrew_home`
+fixture runs *after* collection has already imported the module under test, so
+it cannot reach a frozen constant. That last hole let a local test run write
+2128 fixture rows into an operator's real usage store.
+
+The required shape keeps the module-level name as an explicit opt-in override
+(`None` = resolve live), so existing `monkeypatch.setattr(mod, "_SOME_DIR", tmp)`
+call sites keep working:
+
+```python
+_SOME_DIR: Path | None = None
+
+def _some_dir() -> Path:
+    return _SOME_DIR if _SOME_DIR is not None else config_dir() / "some"
+```
+
+Annotating the override as `Path | None` is load-bearing: any consumer that
+still reads the constant directly becomes a **mypy error** rather than a silent
+`None` at runtime. This is enforced repo-wide by
+`test/test_lazy_data_home_paths.py`, which walks the AST of `src/kiro_crew` for
+module-level assignments calling any factory declared in `config/paths.py` and
+fails on every hit. The factory list is derived from `paths.py` itself, so a
+newly added factory is covered without editing the test. Issue #874.
+
+**`config_dir()` maintains; `data_home()` only resolves.** `config_dir()` is
+*resolve + maintain*: besides resolving the home it `mkdir`s it, refreshes the
+`~/.kiro-crew-location` recovery breadcrumb (a stat + a read) and re-runs
+`_sweep_ungated_archive_leftovers()`, which can `shutil.rmtree` a leftover
+archive from an earlier release. That work belongs to process start —
+`ensure_data_home()` is the startup hook — and the distinction did not matter
+while callers froze the result in a module constant, because the maintenance
+then ran exactly once, at import.
+
+Resolving per call makes it load-bearing: a request handler would otherwise
+perform a destructive sweep **on the event loop** as a side effect of asking
+where a directory is. So the accessors above call **`data_home()`**:
+
+| branch | behaviour |
+| --- | --- |
+| a **valid** `KIROCREW_HOME` override | delegates to `config_dir()` every call, so an override set *after* import is honoured. That branch performs neither the breadcrumb refresh nor the sweep — only a cheap `mkdir`. |
+| default home already resolved | returns the cached `_resolved_home` directly — no `mkdir`, no breadcrumb, no sweep. |
+| not yet resolved | delegates to `config_dir()`, so the **first** resolution in a process still migrates, creates the home and sweeps once. |
+
+The first row tests `_valid_override_home()` — the **same predicate `config_dir()`
+gates on**, not merely "is the env var set". An override naming a system
+directory (`/`, `/usr`, …) is rejected there and resolution falls through to the
+default home, so gating on the raw env var would send every call down the
+maintenance path and put the destructive sweep back on the request path for
+anyone with a bad override. The two predicates must not drift apart; a regression
+test pins both directions.
+
+That last row is what keeps the sweep's documented contract intact: it specifies
+"a leftover created between two starts … is still caught on the **next start**".
+The sweep is specified per *start*; running it per *call* was the mechanism, not
+the requirement. `data_home()` keeps no cache of its own — the override branch
+must stay live, and the cached branch reads the same `_resolved_home` that
+`config_dir()` populates, so there is one source of truth for the location.
+
+Existing direct `config_dir()` callers are unchanged and keep the maintenance
+behaviour, including 25 pre-existing calls that already sit inside async
+handlers.
+
 ## Workspace Root
 
 `workspace_root()` returns the base directory for all LLM working directories (kiro-cli cwd, task runner output, etc.):

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -99,12 +99,23 @@ def _atomic_json_write(path: Path, data: dict) -> None:
         raise
 
 
-# Resolved ONCE at import from ``kiro_agents_dir()``, which honors ``KIRO_HOME``.
-# Import-time resolution is deliberate and matches how kiro-cli itself reads the
-# variable: a non-default instance (a pod, a worktree gateway) exports KIRO_HOME
-# in the environment BEFORE the process starts, so there is nothing to re-read
-# later. Tests patch this attribute directly.
-KIRO_AGENTS_DIR = kiro_agents_dir()
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+KIRO_AGENTS_DIR: Path | None = None
+
+
+def kiro_agents_dir_path() -> Path:
+    """Kiro agents directory, resolved against the live data home.
+
+    Honors the :data:`KIRO_AGENTS_DIR` override hook when a caller (test/tooling)
+    has set it; otherwise resolves live via :func:`kiro_agents_dir`.
+    """
+    return KIRO_AGENTS_DIR if KIRO_AGENTS_DIR is not None else kiro_agents_dir()
+
+
 # AGENT_FILENAME imported from agent_files (single source of truth).
 _MAIN_AGENT_NAME = "kirocrew"
 # Cheap Claude Code model for KiroCrew's background agents (lite / heartbeat).
@@ -1734,10 +1745,10 @@ def migrate_agent_specs() -> int:
     agent loads. Idempotent and cheap (a handful of small JSON files); safe to
     run on every gateway start. Returns the number of spec files cleaned.
     """
-    if not KIRO_AGENTS_DIR.is_dir():
+    if not kiro_agents_dir_path().is_dir():
         return 0
     cleaned = 0
-    for spec_path in sorted(KIRO_AGENTS_DIR.glob("*.json")):
+    for spec_path in sorted(kiro_agents_dir_path().glob("*.json")):
         try:
             data = json.loads(spec_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError, ValueError):
@@ -1818,7 +1829,7 @@ def _decline_shared_agent_home() -> Path | None:
     ``~/.kiro/agents`` as private the moment the data home is an ancestor of it
     (``KIROCREW_HOME=$HOME`` is enough).
     """
-    target = KIRO_AGENTS_DIR.resolve()
+    target = kiro_agents_dir_path().resolve()
     if target != kiro_agents_dir().resolve():
         # A caller pointed the write somewhere of its own choosing; nothing is
         # shared with the ambient install, so there is nothing to protect.
@@ -1889,7 +1900,7 @@ def _decline_shared_agent_home() -> Path | None:
             f"data home {own_home or 'default'}) refused write to shared agent home"
         ),
     )
-    return KIRO_AGENTS_DIR / AGENT_FILENAME
+    return kiro_agents_dir_path() / AGENT_FILENAME
 
 
 def rebuild_agent_config(*, clean: bool = False) -> Path:
@@ -1920,8 +1931,8 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     if declined is not None:
         return declined
 
-    KIRO_AGENTS_DIR.mkdir(parents=True, exist_ok=True)
-    path = KIRO_AGENTS_DIR / AGENT_FILENAME
+    kiro_agents_dir_path().mkdir(parents=True, exist_ok=True)
+    path = kiro_agents_dir_path() / AGENT_FILENAME
 
     # One-time (idempotent) self-heal: strip KiroCrew bookkeeping keys from
     # every kiro agent spec into the sidecar so kiro-cli accepts them all.
@@ -2298,7 +2309,7 @@ def _remove_bare_lite_if_aim_installed() -> None:
 
 def _install_lite_agent_fallback() -> None:
     """Write a bare kirocrew-lite config (cheap background agent)."""
-    lite_path = KIRO_AGENTS_DIR / _LITE_AGENT_FILENAME
+    lite_path = kiro_agents_dir_path() / _LITE_AGENT_FILENAME
     lite_config = {
         "name": "kirocrew-lite",
         "model": "claude-opus-4.6",
@@ -2334,7 +2345,7 @@ def _install_knowledge_agent() -> None:
     on public installs; the agent ships without MCP servers and relies on the
     model's own capabilities for extraction.  Symbol preserved for callers.
     """
-    path = KIRO_AGENTS_DIR / _KNOWLEDGE_AGENT_FILENAME
+    path = kiro_agents_dir_path() / _KNOWLEDGE_AGENT_FILENAME
 
     config: dict[str, object] = {
         "name": "kirocrew-knowledge",
@@ -2439,8 +2450,8 @@ def _install_research_agent() -> None:
         "in a Research Lab campaign loop."
     )
     config["prompt"] = _RESEARCH_SYSTEM_PROMPT
-    KIRO_AGENTS_DIR.mkdir(parents=True, exist_ok=True)
-    path = KIRO_AGENTS_DIR / _RESEARCH_AGENT_FILENAME
+    kiro_agents_dir_path().mkdir(parents=True, exist_ok=True)
+    path = kiro_agents_dir_path() / _RESEARCH_AGENT_FILENAME
     _atomic_json_write(path, config)
     logger.info("Installed research agent config: %s", path)
 
@@ -2515,8 +2526,8 @@ def _install_heartbeat_agent() -> None:
     SEL audit logging stays at the gateway side — see
     ``GatewayOrchestrator._heartbeat_approval``.
     """
-    KIRO_AGENTS_DIR.mkdir(parents=True, exist_ok=True)
-    path = KIRO_AGENTS_DIR / _HEARTBEAT_AGENT_FILENAME
+    kiro_agents_dir_path().mkdir(parents=True, exist_ok=True)
+    path = kiro_agents_dir_path() / _HEARTBEAT_AGENT_FILENAME
 
     # Pull the ``kirocrew-core`` entry from the main agent config so the
     # resolved command + skill-paths match the main agent (write-denied
@@ -2525,7 +2536,7 @@ def _install_heartbeat_agent() -> None:
     # filters so all read tools surface to the heartbeat agent — security is
     # enforced gateway-side against ``HEARTBEAT_SAFE_TOOLS`` via
     # ``_heartbeat_approval``, not by per-agent MCP filtering.
-    main_config = _load_json(KIRO_AGENTS_DIR / AGENT_FILENAME)
+    main_config = _load_json(kiro_agents_dir_path() / AGENT_FILENAME)
     main_mcp = main_config.get("mcpServers", {}) or {}
 
     _strip_flags = ("--include-tools", "--include-tool-tags", "--exclude-tools")
@@ -2606,7 +2617,7 @@ def _sanitize_agent_hooks() -> None:
     Auto-repairs configs for users who already have the invalid key from
     prior versions.
     """
-    for f in KIRO_AGENTS_DIR.glob("*.json"):
+    for f in kiro_agents_dir_path().glob("*.json"):
         try:
             mtime = f.stat().st_mtime
         except OSError:

--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -24,7 +24,18 @@ from kiro_crew.sel import sel as _sel
 
 logger = logging.getLogger(__name__)
 
-_KIRO_AGENTS_DIR = kiro_agents_dir()
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_KIRO_AGENTS_DIR: Path | None = None
+
+
+def _kiro_agents_dir() -> Path:
+    """The kiro-cli agents directory, resolved against the live data home."""
+    return _KIRO_AGENTS_DIR if _KIRO_AGENTS_DIR is not None else kiro_agents_dir()
+
 
 # ── list_agents() result cache ──
 # list_agents() reads and JSON-parses every ~/.kiro/agents/*.json on each call.
@@ -163,7 +174,7 @@ def agent_skill_globs(agent: str, agents_dir: Path | None = None) -> list[str]:
     Best-effort and never raises: an unreadable, invalid, or sensitive-path
     agent file yields ``[]``.
     """
-    d = agents_dir or _KIRO_AGENTS_DIR
+    d = agents_dir or _kiro_agents_dir()
     if not agent or not d.is_dir():
         return []
     try:
@@ -279,7 +290,7 @@ def list_agents(agents_dir: Path | None = None) -> list[AgentInfo]:
     is unchanged, so repeated calls avoid re-reading and re-parsing every agent
     JSON on the event loop.
     """
-    d = agents_dir or _KIRO_AGENTS_DIR
+    d = agents_dir or _kiro_agents_dir()
     cache_key = str(d)
     signature = _dir_signature(d)
     cached = _LIST_AGENTS_CACHE.get(cache_key)

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -33,8 +33,20 @@ from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
 
-# Where kiro-cli looks for agent definitions
-KIRO_AGENTS_DIR = kiro_agents_dir()
+# Where kiro-cli looks for agent definitions.
+#
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+KIRO_AGENTS_DIR: Path | None = None
+
+
+def _kiro_agents_dir() -> Path:
+    """The kiro-cli agents directory, resolved against the live data home."""
+    return KIRO_AGENTS_DIR if KIRO_AGENTS_DIR is not None else kiro_agents_dir()
+
 
 # Where KiroCrew loads skills from
 SKILLS_DIR_NAME = "skills"
@@ -64,7 +76,8 @@ def _register_agents(app_name: str, manifest: AppManifest, app_root: Path) -> li
     Returns list of registered agent names (namespaced).
     """
     registered: list[str] = []
-    KIRO_AGENTS_DIR.mkdir(parents=True, exist_ok=True)
+    agents_dir = _kiro_agents_dir()
+    agents_dir.mkdir(parents=True, exist_ok=True)
 
     for agent_path_str in manifest.agents:
         agent_path = app_root / agent_path_str
@@ -85,7 +98,7 @@ def _register_agents(app_name: str, manifest: AppManifest, app_root: Path) -> li
 
         # Namespaced link name: app-name--agent-name.json
         link_name = _safe_link_name(_namespace(app_name, agent_name)) + ".json"
-        link_path = KIRO_AGENTS_DIR / link_name
+        link_path = agents_dir / link_name
 
         # Remove existing link if present
         if link_path.exists() or link_path.is_symlink():
@@ -105,9 +118,10 @@ def _deregister_agents(app_name: str) -> int:
     """Remove all agent symlinks for an app from ~/.kiro/agents/."""
     prefix = _safe_link_name(app_name + "/")
     removed = 0
-    if not KIRO_AGENTS_DIR.is_dir():
+    agents_dir = _kiro_agents_dir()
+    if not agents_dir.is_dir():
         return 0
-    for entry in KIRO_AGENTS_DIR.iterdir():
+    for entry in agents_dir.iterdir():
         if entry.name.startswith(prefix) and entry.name.endswith(".json"):
             try:
                 entry.unlink()

--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -25,7 +25,7 @@ from kiro_crew.apps.builtins.auto_research.workflow_template import (
     build_workflow_args,
 )
 from kiro_crew.autonudge import get_instance as _autonudge_instance
-from kiro_crew.config.paths import config_dir
+from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_utils import _history_key_for
 from kiro_crew.knowledge.llm_pool import LLMPool
 
@@ -81,11 +81,29 @@ def _fence_untrusted(text: str) -> str:
     )
 
 
-# Resolve under the active KiroCrew home (honors KIROCREW_HOME for isolated dev
-# gateways) — NOT a hardcoded ~/.kiro/crew, which would make dev instances collide
-# with prod Research Lab state and contend with the prod gateway's watchdog.
-RESEARCH_DIR = config_dir() / "workspace" / "research"
-DB_PATH = config_dir() / "apps" / "auto-research" / "campaigns.db"
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+RESEARCH_DIR: Path | None = None
+DB_PATH: Path | None = None
+
+
+def research_dir() -> Path:
+    """Research workspace dir, resolved against the live data home (issue #874)."""
+    return RESEARCH_DIR if RESEARCH_DIR is not None else data_home() / "workspace" / "research"
+
+
+def db_path() -> Path:
+    """Campaigns sqlite DB path, resolved against the live data home (issue #874)."""
+    return (
+        DB_PATH
+        if DB_PATH is not None
+        else data_home() / "apps" / "auto-research" / "campaigns.db"
+    )
+
+
 # Serializes the one-time WAL switch + schema init per DB file (see
 # _ensure_schema). Keyed by DB path so per-test temp DBs each init once.
 _DB_INIT_LOCK = threading.Lock()
@@ -155,11 +173,12 @@ def _validate_campaign_id(campaign_id: str) -> bool:
 
 
 def _safe_campaign_dir(campaign_id: str) -> Path | None:
-    """Return campaign dir only if it resolves within RESEARCH_DIR."""
+    """Return campaign dir only if it resolves within the research dir."""
     if not _validate_campaign_id(campaign_id):
         return None
-    d = (RESEARCH_DIR / campaign_id).resolve()
-    if not d.is_relative_to(RESEARCH_DIR.resolve()):
+    root = research_dir()
+    d = (root / campaign_id).resolve()
+    if not d.is_relative_to(root.resolve()):
         return None
     return d
 
@@ -168,13 +187,14 @@ def _safe_campaign_dir(campaign_id: str) -> Path | None:
 
 
 def _get_db() -> sqlite3.Connection:
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    dbp = db_path()
+    dbp.parent.mkdir(parents=True, exist_ok=True)
     # Explicit 30s busy timeout (vs the 5s driver default). The research worker
     # writes findings/status every cycle while the app's HTTP handlers also
     # read/write; the longer busy timeout absorbs brief write contention instead
     # of surfacing "database is locked". WAL journal mode is set once per DB in
     # _ensure_schema() below (it is persistent in the DB header).
-    conn = sqlite3.connect(str(DB_PATH), isolation_level=None, timeout=30.0)
+    conn = sqlite3.connect(str(dbp), isolation_level=None, timeout=30.0)
     conn.row_factory = sqlite3.Row
     # Belt-and-suspenders: also set busy_timeout via PRAGMA so it applies even if
     # a driver ignores the connect kwarg. Neither this nor connect() acquires a
@@ -199,11 +219,12 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     already set and skip straight to serving queries. Keyed by DB path so
     per-test temp DBs each initialize independently.
     """
-    key = str(DB_PATH)
-    if key in _INITIALIZED_DBS and DB_PATH.exists() and DB_PATH.stat().st_size > 0:
+    dbp = db_path()
+    key = str(dbp)
+    if key in _INITIALIZED_DBS and dbp.exists() and dbp.stat().st_size > 0:
         return
     with _DB_INIT_LOCK:
-        if key in _INITIALIZED_DBS and DB_PATH.exists() and DB_PATH.stat().st_size > 0:
+        if key in _INITIALIZED_DBS and dbp.exists() and dbp.stat().st_size > 0:
             return  # double-checked locking
         try:
             conn.execute("PRAGMA journal_mode=WAL")
@@ -472,7 +493,7 @@ def check_stagnation(campaign_id: str) -> bool:
 
 def _campaign_dir(campaign_id: str) -> Path:
     """Create and return campaign dir. Only call with validated IDs."""
-    d = RESEARCH_DIR / campaign_id
+    d = research_dir() / campaign_id
     d.mkdir(parents=True, exist_ok=True)
     (d / "findings").mkdir(exist_ok=True)
     return d

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from kiro_crew import __version__ as _mc_version
 from kiro_crew.acp.client import KIRO_CLI_BIN
-from kiro_crew.agent import AGENT_FILENAME, KIRO_AGENTS_DIR
+from kiro_crew.agent import AGENT_FILENAME
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import config_dir
@@ -24,6 +24,7 @@ from kiro_crew.config.paths import (
     MIGRATION_MARKER_NAME,
     _valid_override_home,
     detect_data_home_conflict,
+    kiro_agents_dir,
     preserved_entries,
 )
 from kiro_crew.dashboard.crash_dump_store import (
@@ -55,6 +56,18 @@ from kiro_crew.platform.governance import CU_MCP_SERVER
 from kiro_crew.transcribe import _find_whisper, ensure_ffmpeg_in_path
 
 _MIN_NODE_VERSION = 16
+
+
+# ``KIRO_AGENTS_DIR`` is an import-time override hook, NOT a frozen path (issue
+# #874). ``None`` means "resolve from the live data home"; tests patch this
+# attribute directly (``patch("kiro_crew.cli_doctor.KIRO_AGENTS_DIR", tmp)``),
+# so the name is kept and read through ``_agents_dir()``.
+KIRO_AGENTS_DIR: Path | None = None
+
+
+def _agents_dir() -> Path:
+    """Kiro agents directory, honoring the override hook, else the live home."""
+    return KIRO_AGENTS_DIR if KIRO_AGENTS_DIR is not None else kiro_agents_dir()
 
 
 def _os_fix_hint(mac: str, linux: str) -> str:
@@ -509,7 +522,7 @@ def _doctor(platform_boot_error: "Exception | None" = None) -> None:
 
     # ── Agent config ──
     print("\nAgent")
-    agent_path = KIRO_AGENTS_DIR / AGENT_FILENAME
+    agent_path = _agents_dir() / AGENT_FILENAME
     if agent_path.exists():
         print(f"  config:      ✅ {agent_path}")
     else:

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -64,6 +64,7 @@ from kiro_crew.config.paths import (  # noqa: F401, kiro_agents_dir
     _safe_dir_name,
     config_dir,
     config_package_dir,
+    data_home,
     ensure_data_home,
     kiro_agents_dir,
 )

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -481,6 +481,55 @@ def config_dir() -> Path:
     return d
 
 
+def data_home() -> Path:
+    """The resolved data home, WITHOUT re-running start-of-process maintenance.
+
+    :func:`config_dir` is *resolve + maintain*: besides resolving the home it
+    also ``mkdir``s it, refreshes the recovery breadcrumb (a stat + a read) and
+    re-runs :func:`_sweep_ungated_archive_leftovers`, which can ``shutil.rmtree``
+    a leftover archive. That work belongs to process start --
+    :func:`ensure_data_home` is the startup hook -- not to every caller that
+    merely needs a path. While callers bound the result to a module constant at
+    import the distinction did not matter; resolving per call (issue #874) makes
+    it load-bearing, because a request handler would otherwise perform a
+    destructive sweep on the event loop as a side effect of asking where a
+    directory is.
+
+    Use this from any hot or async path. Three cases, in order:
+
+    1. A **valid** ``KIROCREW_HOME`` override -> delegate to :func:`config_dir`
+       on every call, so an override set *after* this module was imported is
+       still honoured (that is the whole point of #874). That branch does
+       neither the breadcrumb refresh nor the sweep -- only a cheap ``mkdir`` --
+       so it is already safe.
+
+       The test is :func:`_valid_override_home`, i.e. the SAME predicate
+       :func:`config_dir` gates on -- not merely "is the env var set". An
+       override naming a system directory is *rejected* there and resolution
+       falls through to the default home, so gating on the raw env var would
+       send every call down the maintenance path and re-run the destructive
+       sweep per request. The two predicates must not drift apart.
+    2. Default home already resolved -> return the cached value directly. No
+       ``mkdir``, no breadcrumb, no sweep.
+    3. Not yet resolved -> delegate to :func:`config_dir`, so the FIRST
+       resolution in a process still migrates, creates the home and sweeps
+       exactly once. That is precisely the contract
+       :func:`_sweep_ungated_archive_leftovers` documents ("a leftover created
+       between two starts ... is still caught on the next start") -- the sweep is
+       specified per *start*, and running it per *call* was the mechanism, not
+       the requirement.
+
+    Deliberately NOT a cache of its own: case 1 must stay live, and case 2 reads
+    the same ``_resolved_home`` that :func:`config_dir` populates, so there is
+    one source of truth for where the home is.
+    """
+    if _valid_override_home() is not None:
+        return config_dir()
+    if _resolved_home is not None:
+        return _resolved_home
+    return config_dir()
+
+
 def ensure_data_home() -> Path:
     """Eagerly resolve (and, if needed, migrate) the data home — call BEFORE the loop.
 

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -46,7 +46,7 @@ except ImportError:
 from croniter import croniter  # type: ignore[import-untyped]
 
 from kiro_crew import cron_script, platform_compat, sel, shutdown_event
-from kiro_crew.config.loader import KiroCrewConfig, config_dir
+from kiro_crew.config.loader import KiroCrewConfig, config_dir, data_home
 from kiro_crew.constants import env_flag_enabled
 from kiro_crew.cron_history import CronHistoryStore, CronRunRecord
 from kiro_crew.executors import subprocess_executor
@@ -55,7 +55,19 @@ logger = logging.getLogger(__name__)
 
 # ── Constants ──
 
-_DEFAULT_DIR = config_dir()
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_DEFAULT_DIR: Path | None = None
+
+
+def _default_dir() -> Path:
+    """Cron data directory, resolved against the live data home."""
+    return _DEFAULT_DIR if _DEFAULT_DIR is not None else data_home()
+
+
 _CRONS_FILE = "crons.json"
 
 # ``$skill`` token pattern (mirrors skills._DOLLAR_SKILL_PATTERN; duplicated
@@ -563,7 +575,7 @@ class CronService:
         *,
         _defer_initial_load: bool = False,
     ):
-        self._dir = base_dir or _DEFAULT_DIR
+        self._dir = base_dir if base_dir is not None else _default_dir()
         self._path = self._dir / _CRONS_FILE
         self._on_job = on_job
         self._jobs: list[CronJob] = []
@@ -622,7 +634,7 @@ class CronService:
         self._push_refresh: Callable[[str], None] | None = None  # set externally
         _cfg = KiroCrewConfig.load().cron_history
         self._history = CronHistoryStore(
-            base_dir=base_dir or _DEFAULT_DIR,
+            base_dir=base_dir if base_dir is not None else _default_dir(),
             cron_summary_cap=_cfg.cron_summary_cap,
             cron_trace_cap_kb=_cfg.cron_trace_cap_kb,
             cron_max_records_per_job=_cfg.cron_max_records_per_job,

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -12,7 +12,7 @@ from collections import deque
 from collections.abc import Iterator
 
 from kiro_crew import model_registry
-from kiro_crew.agent import KIRO_AGENTS_DIR
+from kiro_crew.agent import kiro_agents_dir_path
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.dashboard.chat_utils import (
@@ -188,7 +188,7 @@ def _build_kiro_model_map() -> dict[str, str]:
     """
     out: dict[str, str] = {}
     try:
-        for f in KIRO_AGENTS_DIR.glob("*.json"):
+        for f in kiro_agents_dir_path().glob("*.json"):
             try:
                 data = json.loads(f.read_text(encoding="utf-8"))
                 model = data.get("model", "")

--- a/src/kiro_crew/dashboard/chat_rewind.py
+++ b/src/kiro_crew/dashboard/chat_rewind.py
@@ -32,7 +32,7 @@ from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
-from kiro_crew.session_map import _KIRO_SESSIONS_DIR
+from kiro_crew.session_map import _kiro_sessions_dir
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ async def _delete_orphan_kiro_session(session_id: str) -> None:
     if not session_id:
         return
     for suffix in (".json", ".jsonl"):
-        candidate = _KIRO_SESSIONS_DIR / f"{session_id}{suffix}"
+        candidate = _kiro_sessions_dir() / f"{session_id}{suffix}"
         try:
             await asyncio.to_thread(candidate.unlink, missing_ok=True)
         except OSError as exc:

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -92,9 +92,9 @@ def _installed_agent_config() -> Path:
     This is the live config that kiro-cli reads.  Dashboard MCP toggle
     and sync operations write here — NOT to agents/defaults.json.
     """
-    from kiro_crew.agent import AGENT_FILENAME, KIRO_AGENTS_DIR  # noqa: F811
+    from kiro_crew.agent import AGENT_FILENAME, kiro_agents_dir_path  # noqa: F811
 
-    return KIRO_AGENTS_DIR / AGENT_FILENAME
+    return kiro_agents_dir_path() / AGENT_FILENAME
 
 
 async def api_agent_config(request: web.Request) -> web.Response:
@@ -863,7 +863,7 @@ async def api_slash_commands(request: web.Request) -> web.Response:
 async def api_agent_detail(request: web.Request) -> web.Response:
     """GET/DELETE/PATCH /api/agents/detail/{name} — view, delete, or update agent config."""
     name = request.match_info["name"]
-    from kiro_crew.agent import KIRO_AGENTS_DIR  # noqa: F811
+    from kiro_crew.agent import kiro_agents_dir_path  # noqa: F811
 
     # Parse body early so JSONDecodeError returns 400, not 404 from the file loop.
     patch_body = None
@@ -880,7 +880,7 @@ async def api_agent_detail(request: web.Request) -> web.Response:
             return web.json_response({"error": "body must be a JSON object"}, status=400)
 
     state: DashboardState = request.app["state"]
-    for f in KIRO_AGENTS_DIR.glob("*.json"):
+    for f in kiro_agents_dir_path().glob("*.json"):
         try:
             data = json.loads(f.read_text(encoding="utf-8"))
             if data.get("name") == name or f.stem == name:
@@ -1091,7 +1091,7 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
         discovered_names = {a.name for a in discovered_agents}
 
         # Add new agents
-        from kiro_crew.agent import KIRO_AGENTS_DIR  # noqa: F811
+        from kiro_crew.agent import kiro_agents_dir_path  # noqa: F811
 
         mc_kiro_agents = {a.kiro_agent for a in cfg.agents.values()}
         for disc in discovered_agents:
@@ -1110,7 +1110,7 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
                 # would itself be a correctness bug. The warning turns an
                 # otherwise silent spawn-time (ACP session/set_mode) failure into
                 # an actionable log line pointing at the offending seam row.
-                if not (KIRO_AGENTS_DIR / f"{disc.name}.json").exists():
+                if not (kiro_agents_dir_path() / f"{disc.name}.json").exists():
                     logger.warning(
                         "syncing agent %r (source=%s) with no on-disk config at "
                         "%s — if it is not ACP-resolvable it will persist into "
@@ -1118,7 +1118,7 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
                         "INVARIANT)",
                         disc.name,
                         disc.source,
-                        KIRO_AGENTS_DIR / f"{disc.name}.json",
+                        kiro_agents_dir_path() / f"{disc.name}.json",
                     )
                 cfg.agents[disc.name] = KiroCrewAgentConfig(
                     kiro_agent=disc.name,

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -23,7 +23,7 @@ from aiohttp.client_exceptions import ClientConnectionResetError
 from aiohttp.multipart import BodyPartReader
 
 from kiro_crew import platform_compat
-from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir
+from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir, data_home
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.hooks import safe_read_prefix
 from kiro_crew.platform import redact_via_context as redact
@@ -710,9 +710,26 @@ async def api_upload(request: web.Request) -> web.Response:
     return web.json_response({"paths": paths})
 
 
-_SCREENSHOT_DIR = config_dir() / "screenshots"
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_SCREENSHOT_DIR: Path | None = None
 
-_UPLOAD_DIR = config_dir() / "uploads"
+_UPLOAD_DIR: Path | None = None
+
+
+def _screenshot_dir() -> Path:
+    """Screenshots directory, resolved against the live data home."""
+    return _SCREENSHOT_DIR if _SCREENSHOT_DIR is not None else data_home() / "screenshots"
+
+
+def _upload_dir() -> Path:
+    """Uploads directory, resolved against the live data home."""
+    return _UPLOAD_DIR if _UPLOAD_DIR is not None else data_home() / "uploads"
+
+
 _MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB per file
 _MAX_UPLOAD_FILES = 20  # max files per request
 _ALLOWED_IMAGE_EXT = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
@@ -820,7 +837,8 @@ async def api_upload_file(request: web.Request) -> web.Response:
     that ACP's _send_prompt() can detect for image inlining.
     """
 
-    _UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    upload_dir = _upload_dir()
+    upload_dir.mkdir(parents=True, exist_ok=True)
     reader = await request.multipart()
     paths: list[str] = []
     allowed = _ALLOWED_IMAGE_EXT | _ALLOWED_TEXT_EXT | _ALLOWED_DOC_EXT
@@ -906,8 +924,8 @@ async def api_upload_file(request: web.Request) -> web.Response:
                     status=400,
                 )
             # UUID prefix guarantees uniqueness even within a single request
-            dest = _UPLOAD_DIR / f"{uuid.uuid4().hex}_{safe_name}"
-            if not dest.resolve().is_relative_to(_UPLOAD_DIR.resolve()):
+            dest = upload_dir / f"{uuid.uuid4().hex}_{safe_name}"
+            if not dest.resolve().is_relative_to(upload_dir.resolve()):
                 _cleanup()
                 _sel().log_api_access(
                     caller=caller,
@@ -993,9 +1011,10 @@ async def api_screenshot(request: web.Request) -> web.Response:
     if sys.platform != "darwin":
         return web.json_response({"error": "Screenshot is only available on macOS"}, status=400)
 
-    _SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    screenshot_dir = _screenshot_dir()
+    screenshot_dir.mkdir(parents=True, exist_ok=True)
     ts = int(time.time())
-    dest = _SCREENSHOT_DIR / f"screenshot_{ts}.png"
+    dest = screenshot_dir / f"screenshot_{ts}.png"
 
     proc = await asyncio.create_subprocess_exec(
         "screencapture",

--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -7,10 +7,11 @@ import json
 import logging
 import os
 import time
+from pathlib import Path
 
 from aiohttp import web
 
-from kiro_crew.config.loader import KiroCrewConfig, config_dir
+from kiro_crew.config.loader import KiroCrewConfig, data_home
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.validation import sanitize_string
@@ -48,10 +49,10 @@ async def api_hooks(request: web.Request) -> web.Response:
 
 async def api_kiro_hooks(request: web.Request) -> web.Response:
     """GET /api/kiro-hooks — read-only view of kiro-cli agent hooks from kirocrew.json."""
-    from kiro_crew.agent import _VALID_HOOK_EVENTS, KIRO_AGENTS_DIR, _shipped_defaults
+    from kiro_crew.agent import _VALID_HOOK_EVENTS, _shipped_defaults, kiro_agents_dir_path
     from kiro_crew.platform import redact_via_context as redact
 
-    agent_cfg = KIRO_AGENTS_DIR / "kirocrew.json"
+    agent_cfg = kiro_agents_dir_path() / "kirocrew.json"
     try:
         raw = json.loads(agent_cfg.read_text())
         hooks = raw.get("hooks", {}) if isinstance(raw, dict) else {}
@@ -251,7 +252,19 @@ async def api_hook_test(request: web.Request) -> web.Response:
 _HOOK_SESSION_PREFIX = "hook:"
 _HOOK_TIMEOUT_DEFAULT = 599  # ~10 min — prime to avoid thundering herd with cron intervals
 _HOOK_TIMEOUT_MAX = 3593  # ~1 hour — prime for same reason
-_HOOK_STORE_PATH = config_dir() / "hooks.json"
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_HOOK_STORE_PATH: Path | None = None
+
+
+def _hook_store_path() -> Path:
+    """hooks.json path, resolved against the live data home."""
+    return _HOOK_STORE_PATH if _HOOK_STORE_PATH is not None else data_home() / "hooks.json"
+
+
 _HOOK_MESSAGE_MAX_LEN = 49_999  # ~50K chars — leave 1 char headroom
 _HOOK_MAX_CONCURRENT = 6
 _hook_semaphore = asyncio.Semaphore(_HOOK_MAX_CONCURRENT)
@@ -265,10 +278,11 @@ def _load_hook_context(hook_id: str) -> str:
     Horizon 2 (1-24h): context injected with staleness warning
     Horizon 3 (> 24h): context skipped (too stale to be useful)
     """
-    if not _HOOK_STORE_PATH.exists():
+    store_path = _hook_store_path()
+    if not store_path.exists():
         return ""
     try:
-        hooks = json.loads(_HOOK_STORE_PATH.read_text(encoding="utf-8"))
+        hooks = json.loads(store_path.read_text(encoding="utf-8"))
         entry = hooks.get(hook_id, {})
         ctx = entry.get("context_summary", "") or entry.get("summary", "")
         if not ctx:

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -13,7 +13,7 @@ from typing import Any
 from aiohttp import web
 
 from kiro_crew import platform_compat
-from kiro_crew.config.paths import config_dir, kiro_agents_dir
+from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.mcp_gateway import is_gateway_supported
 from kiro_crew.mcp_utils import mcp_server_alias
@@ -427,7 +427,7 @@ async def api_mcp_servers(request: web.Request) -> web.Response:
         pass
     # KiroCrew-scope entries: disabled state (consent-disabled installs and
     # custom adds live only here) + which rows the JSON editor can manage.
-    kirocrew_mcps = _load_json_or_empty(_KIROCREW_MCP_JSON).get("mcpServers", {})
+    kirocrew_mcps = _load_json_or_empty(_kirocrew_mcp_json()).get("mcpServers", {})
     result: list[dict] = []
     for s in servers:
         d = s.to_dict()
@@ -465,7 +465,7 @@ async def api_mcp_active(request: web.Request) -> web.Response:
     when ``--agent <name>`` is passed.  For kirocrew (or no agent),
     reads from global ``~/.kiro/settings/mcp.json`` as before.
     """
-    from kiro_crew.agent import KIRO_AGENTS_DIR  # noqa: F811
+    from kiro_crew.agent import kiro_agents_dir_path  # noqa: F811
 
     agent = request.query.get("agent", "")
 
@@ -483,7 +483,7 @@ async def api_mcp_active(request: web.Request) -> web.Response:
 
     # Non-kirocrew agent: read from agent config
     if agent and agent != "kirocrew":
-        for f in KIRO_AGENTS_DIR.glob("*.json"):
+        for f in kiro_agents_dir_path().glob("*.json"):
             try:
                 data = json.loads(f.read_text(encoding="utf-8"))
                 if data.get("name") == agent:
@@ -938,7 +938,21 @@ async def api_mcp_server_detail(request: web.Request) -> web.Response:
 
 # ─── Batched scope apply ────────────────────────────────────────────────
 
-_KIROCREW_MCP_JSON = config_dir() / "mcp.json"
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_KIROCREW_MCP_JSON: Path | None = None
+
+
+def _kirocrew_mcp_json() -> Path:
+    """KiroCrew-scope ``mcp.json`` path, resolved against the live data home."""
+    return (
+        _KIROCREW_MCP_JSON
+        if _KIROCREW_MCP_JSON is not None
+        else data_home() / "mcp.json"
+    )
 
 
 def _extra_mcp_scopes() -> list:
@@ -1011,7 +1025,7 @@ def _find_server_spec_anywhere(name: str) -> dict | None:
     """
     candidates = [
         kiro_agents_dir() / "kirocrew.json",
-        _KIROCREW_MCP_JSON,
+        _kirocrew_mcp_json(),
         _GLOBAL_MCP_JSON,
         *[s.global_json for s in _extra_mcp_scopes()],
     ]
@@ -1037,7 +1051,7 @@ def _set_kirocrew_entry(name: str, *, enabled: bool, spec: dict | None = None) -
     Returns a short label describing what happened: ``"added"``, ``"enabled"``,
     ``"disabled"``, or ``"noop"``.
     """
-    data = _load_json_or_empty(_KIROCREW_MCP_JSON)
+    data = _load_json_or_empty(_kirocrew_mcp_json())
     servers = data.setdefault("mcpServers", {})
     existing = servers.get(name)
     existing = existing if isinstance(existing, dict) else None
@@ -1068,13 +1082,13 @@ def _set_kirocrew_entry(name: str, *, enabled: bool, spec: dict | None = None) -
             existing["disabled"] = True
             action = "disabled"
 
-    _atomic_write(_KIROCREW_MCP_JSON, data)
+    _atomic_write(_kirocrew_mcp_json(), data)
     return action
 
 
 def _get_kirocrew_entry(name: str) -> dict | None:
     """The raw entry for ``name`` from ``<data home>/mcp.json`` (or None)."""
-    data = _load_json_or_empty(_KIROCREW_MCP_JSON)
+    data = _load_json_or_empty(_kirocrew_mcp_json())
     entry = data.get("mcpServers", {}).get(name)
     return dict(entry) if isinstance(entry, dict) else None
 
@@ -1087,7 +1101,7 @@ def _replace_kirocrew_spec(name: str, spec: dict) -> bool:
     Returns False when the name is not in ``<data home>/mcp.json`` (the
     caller decides how to report servers managed elsewhere).
     """
-    data = _load_json_or_empty(_KIROCREW_MCP_JSON)
+    data = _load_json_or_empty(_kirocrew_mcp_json())
     servers = data.setdefault("mcpServers", {})
     existing = servers.get(name)
     if not isinstance(existing, dict):
@@ -1096,18 +1110,18 @@ def _replace_kirocrew_spec(name: str, spec: dict) -> bool:
     if existing.get("disabled") is True:
         entry["disabled"] = True
     servers[name] = entry
-    _atomic_write(_KIROCREW_MCP_JSON, data)
+    _atomic_write(_kirocrew_mcp_json(), data)
     return True
 
 
 def _remove_kirocrew_entry(name: str) -> bool:
     """Delete the server from ``<data home>/mcp.json`` entirely.  Returns True on change."""
-    data = _load_json_or_empty(_KIROCREW_MCP_JSON)
+    data = _load_json_or_empty(_kirocrew_mcp_json())
     servers = data.get("mcpServers", {})
     if name not in servers:
         return False
     del servers[name]
-    _atomic_write(_KIROCREW_MCP_JSON, data)
+    _atomic_write(_kirocrew_mcp_json(), data)
     return True
 
 
@@ -1271,7 +1285,7 @@ def _set_tool_overrides(name: str, tool_overrides: dict[str, bool]) -> list[str]
     """
     if not tool_overrides:
         return []
-    data = _load_json_or_empty(_KIROCREW_MCP_JSON)
+    data = _load_json_or_empty(_kirocrew_mcp_json())
     servers = data.setdefault("mcpServers", {})
     entry = servers.get(name)
     if not isinstance(entry, dict):
@@ -1296,7 +1310,7 @@ def _set_tool_overrides(name: str, tool_overrides: dict[str, bool]) -> list[str]
         entry.pop("disabledTools", None)
 
     if changed:
-        _atomic_write(_KIROCREW_MCP_JSON, data)
+        _atomic_write(_kirocrew_mcp_json(), data)
     return changed
 
 
@@ -1514,7 +1528,7 @@ async def _do_mcp_apply(request: web.Request) -> web.Response:
                 # <data home>/mcp.json so MC keeps its config via the merge.
                 preserved_spec: dict | None = None
                 if desired_mc and not desired_kiro and not any(desired_extra.values()):
-                    has_mc = _scope_has_entry(name, _KIROCREW_MCP_JSON)
+                    has_mc = _scope_has_entry(name, _kirocrew_mcp_json())
                     if not has_mc:
                         preserved_spec = _find_server_spec_anywhere(name)
 
@@ -1811,15 +1825,16 @@ async def api_mcp_gateway_servers(request: web.Request) -> web.Response:
     ``poolable:true``.  HTTP/SSE servers are shared by nature (not poolable);
     denylisted servers (``UNPOOLABLE_SERVERS``) can never be pooled.
     """
-    from kiro_crew.agent import KIRO_AGENTS_DIR
+    from kiro_crew.agent import kiro_agents_dir_path
     from kiro_crew.config.loader import KiroCrewConfig  # noqa: F811
     from kiro_crew.mcp_gateway.rewriter import UNPOOLABLE_SERVERS
 
     allowlist = set(KiroCrewConfig.load().mcp_gateway.poolable_servers)
 
     rows: dict[str, dict[str, Any]] = {}
-    if KIRO_AGENTS_DIR.is_dir():
-        for path in sorted(KIRO_AGENTS_DIR.glob("*.json")):
+    agents_dir = kiro_agents_dir_path()
+    if agents_dir.is_dir():
+        for path in sorted(agents_dir.glob("*.json")):
             try:
                 spec = json.loads(path.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError):

--- a/src/kiro_crew/dashboard/handlers/mcp_custom.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_custom.py
@@ -121,7 +121,7 @@ def _load_kirocrew_config_strict() -> dict | None:
     while reporting success.
     """
     try:
-        text = _mcp._KIROCREW_MCP_JSON.read_text(encoding="utf-8")
+        text = _mcp._kirocrew_mcp_json().read_text(encoding="utf-8")
     except FileNotFoundError:
         return {}
     except OSError:
@@ -202,7 +202,7 @@ async def api_mcp_custom_add(request: web.Request) -> web.Response:
             return web.json_response(
                 {
                     "error": "existing MCP config file is malformed — fix or"
-                    f" remove {_mcp._KIROCREW_MCP_JSON} and retry"
+                    f" remove {_mcp._kirocrew_mcp_json()} and retry"
                 },
                 status=500,
             )
@@ -224,7 +224,7 @@ async def api_mcp_custom_add(request: web.Request) -> web.Response:
             if not enable:
                 entry["disabled"] = True
             entries[name] = entry
-        _mcp._atomic_write(_mcp._KIROCREW_MCP_JSON, data)
+        _mcp._atomic_write(_mcp._kirocrew_mcp_json(), data)
 
     await _rebuild_agent_config()
 

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -16,12 +16,33 @@ from aiohttp import web
 
 from kiro_crew import model_registry
 from kiro_crew.acp.types import TurnUsage
-from kiro_crew.config.paths import config_dir, kiro_sessions_dir
+from kiro_crew.config.paths import data_home, kiro_sessions_dir
 from kiro_crew.hooks import validate_file_path
 
 logger = logging.getLogger(__name__)
 
-_SESSIONS_DIR = kiro_sessions_dir()
+# Data-home paths are resolved per call, never captured at import.
+#
+# ``config_dir()`` / ``kiro_sessions_dir()`` read ``KIROCREW_HOME`` on every
+# call, so binding their result to a module constant freezes whatever the home
+# happened to be when this module was first imported. That breaks three things:
+# pod isolation (a pod sets ``KIROCREW_HOME`` for its own process), the one-time
+# ``~/.kirocrew`` -> ``~/.kiro/crew`` migration (deliberately lazy), and test
+# isolation -- the autouse ``_isolate_kirocrew_home`` fixture runs *after*
+# collection has already imported this module, so it silently cannot reach a
+# frozen constant. See issue #874.
+#
+# The module-level name is kept as an explicit ``None`` override hook so callers
+# that already patch it (tests, tooling) keep working; ``None`` means "resolve
+# from the live home". This mirrors ``instances/registry.py``.
+_SESSIONS_DIR: Path | None = None
+
+
+def _sessions_dir() -> Path:
+    """Kiro sessions directory, resolved against the live data home."""
+    return _SESSIONS_DIR if _SESSIONS_DIR is not None else kiro_sessions_dir()
+
+
 _CACHE: dict[str, Any] = {}
 _CACHE_TS: float = 0.0
 _CACHE_TTL = 120  # 2 min
@@ -50,8 +71,16 @@ _TOKEN_CACHE: dict[str, Any] = {}
 _TOKEN_CACHE_KEY: tuple[tuple[str, float, int], ...] | None = None
 _TOKEN_CACHE_TS: float = 0.0
 _TOKEN_CACHE_TTL = 120  # 2 min
-_TOKEN_USAGE_DIR = config_dir() / "usage" / "tokens"
+# See the _SESSIONS_DIR note above: resolved per call, ``None`` = live home.
+_TOKEN_USAGE_DIR: Path | None = None
 _TOKEN_HISTORY_DAYS = 30
+
+
+def _token_usage_dir() -> Path:
+    """Per-turn usage shard directory, resolved against the live data home."""
+    if _TOKEN_USAGE_DIR is not None:
+        return _TOKEN_USAGE_DIR
+    return data_home() / "usage" / "tokens"
 
 
 def _shard_path_for(ts: datetime) -> Path:
@@ -60,7 +89,7 @@ def _shard_path_for(ts: datetime) -> Path:
     Shards are partitioned by the user's local date so the file boundary
     matches the day boundary the dashboard chart renders against.
     """
-    return _TOKEN_USAGE_DIR / f"{ts.astimezone().strftime('%Y-%m-%d')}.jsonl"
+    return _token_usage_dir() / f"{ts.astimezone().strftime('%Y-%m-%d')}.jsonl"
 
 
 def _shards_in_window(days: int) -> list[Path]:
@@ -71,10 +100,11 @@ def _shards_in_window(days: int) -> list[Path]:
     even on years-old installs.
     """
     paths: list[Path] = []
-    if not _TOKEN_USAGE_DIR.exists():
+    shard_dir = _token_usage_dir()
+    if not shard_dir.exists():
         return paths
     cutoff_date = (datetime.now().astimezone() - timedelta(days=days)).date()
-    for p in _TOKEN_USAGE_DIR.iterdir():
+    for p in shard_dir.iterdir():
         if not p.is_file() or p.suffix != ".jsonl":
             continue
         try:
@@ -756,7 +786,8 @@ def _parse_token_history() -> dict[str, Any]:
 
 def _parse_sessions() -> dict:
     """Parse local kiro session files for usage analytics."""
-    if not _SESSIONS_DIR.exists():
+    sessions_dir = _sessions_dir()
+    if not sessions_dir.exists():
         return {"error": "No sessions directory"}
 
     cutoff = time.time() - (30 * 86400)
@@ -771,7 +802,7 @@ def _parse_sessions() -> dict:
     today_str = now_dt.strftime("%Y-%m-%d")
 
     try:
-        entries = list(_SESSIONS_DIR.iterdir())
+        entries = list(sessions_dir.iterdir())
     except OSError as exc:
         return {"error": f"Cannot read sessions directory: {exc}"}
 
@@ -890,7 +921,7 @@ async def _cached_parse_sessions() -> dict:
     # `is not None` (not truthiness) so a valid-but-empty {} parse is still a hit.
     if now - _SESSIONS_CACHE_TS < _CACHE_TTL and _SESSIONS_CACHE is not None:
         return _SESSIONS_CACHE
-    if not _SESSIONS_DIR.exists():
+    if not _sessions_dir().exists():
         return {}
     async with _SESSIONS_CACHE_LOCK:
         # Re-check: a concurrent request may have refreshed while we waited, so

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -25,7 +25,7 @@ from typing import Any
 import aiohttp
 
 from kiro_crew import platform_compat
-from kiro_crew.config.paths import config_dir, kiro_agents_dir
+from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.env import augmented_path
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.mcp_utils import mcp_server_alias
@@ -129,15 +129,41 @@ SCOPE_CC_GLOBAL = "ccGlobal"
 # companion re-adds its provider global through the seam rather than the core
 # scanning a file it can no longer manage (which would surface un-uninstallable
 # "zombie" servers).
-_MCP_SOURCES: tuple[tuple[Path, str], ...] = (
-    (config_dir() / "mcp.json", SCOPE_KIROCREW),
-    (Path.home() / ".kiro" / "settings" / "mcp.json", SCOPE_KIRO_GLOBAL),
-)
+#
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_MCP_SOURCES: tuple[tuple[Path, str], ...] | None = None
+
+
+def _mcp_sources() -> tuple[tuple[Path, str], ...]:
+    """Core MCP config scopes (path, scope), resolved against the live home.
+
+    The tuple is in merge/priority order, highest first: the kirocrew-specific
+    file, then the Kiro global. Callers depend on this ordering for scope
+    precedence, so the element order and scope constants must stay fixed.
+    """
+    if _MCP_SOURCES is not None:
+        return _MCP_SOURCES
+    return (
+        (data_home() / "mcp.json", SCOPE_KIROCREW),
+        (Path.home() / ".kiro" / "settings" / "mcp.json", SCOPE_KIRO_GLOBAL),
+    )
+
 
 # Legacy name preserved for backward-compat with tests that monkeypatch it.
-# Derived from :data:`_MCP_SOURCES` (core scopes only) so the two can never
+# Derived from :func:`_mcp_sources` (core scopes only) so the two can never
 # drift; seam-contributed scopes are merged in at call time, not baked here.
-_MCP_JSON_PATHS: tuple[Path, ...] = tuple(p for p, _ in _MCP_SOURCES)
+_MCP_JSON_PATHS: tuple[Path, ...] | None = None
+
+
+def _mcp_json_paths() -> tuple[Path, ...]:
+    """Core MCP config file paths, resolved against the live home."""
+    if _MCP_JSON_PATHS is not None:
+        return _MCP_JSON_PATHS
+    return tuple(p for p, _ in _mcp_sources())
 
 
 def _extra_scopes() -> list[Any]:
@@ -412,9 +438,9 @@ def _load_mcp_json_by_source() -> dict[str, dict[str, Any]]:
     extra_sources = _extra_scope_sources()
     for _, scope in extra_sources:
         result.setdefault(scope, {})
-    path_to_scope = {p: scope for p, scope in _MCP_SOURCES}
+    path_to_scope = {p: scope for p, scope in _mcp_sources()}
     path_to_scope.update({p: scope for p, scope in extra_sources})
-    scan_paths: tuple[Path, ...] = tuple(_MCP_JSON_PATHS) + tuple(p for p, _ in extra_sources)
+    scan_paths: tuple[Path, ...] = tuple(_mcp_json_paths()) + tuple(p for p, _ in extra_sources)
     for p in scan_paths:
         scope = path_to_scope.get(p, SCOPE_KIROCREW)
         if not p.is_file():

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -100,8 +100,8 @@ from kiro_crew.messaging.link import ChannelLink, canonical_key, legacy_key
 from kiro_crew.providers.base import CancelOutcome, LLMProvider
 from kiro_crew.sandbox import cleanup_stale_sandbox_profiles
 from kiro_crew.sel import sel
-from kiro_crew.session_map import _KIRO_SESSIONS_DIR  # noqa: F401
 from kiro_crew.session_map import SessionMap as SessionMap  # noqa: F401
+from kiro_crew.session_map import _kiro_sessions_dir  # noqa: F401
 from kiro_crew.session_pid import (
     _build_child_map,
     _cleanup_orphaned_mcp_servers,
@@ -1768,10 +1768,10 @@ class SessionManager:
           mtime, so entries also expire after ``_AGENT_MODEL_CACHE_TTL`` seconds
           and are re-resolved.
         """
-        from kiro_crew.agent import KIRO_AGENTS_DIR
+        from kiro_crew.agent import kiro_agents_dir_path
 
         try:
-            dir_mtime = KIRO_AGENTS_DIR.stat().st_mtime
+            dir_mtime = kiro_agents_dir_path().stat().st_mtime
         except OSError:
             dir_mtime = 0.0
         now = time.monotonic()
@@ -1790,7 +1790,7 @@ class SessionManager:
         try:
             import json as _json
 
-            for af in KIRO_AGENTS_DIR.glob("*.json"):
+            for af in kiro_agents_dir_path().glob("*.json"):
                 try:
                     ad = _json.loads(af.read_text(encoding="utf-8"))
                 except (ValueError, OSError):

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import tempfile
+from pathlib import Path
 
 from kiro_crew.config.paths import config_dir, kiro_sessions_dir
 from kiro_crew.messaging.link import SLACK_NAMESPACE, ChannelLink, canonical_key
@@ -18,8 +19,17 @@ logger = logging.getLogger(__name__)
 
 _SESSION_MAP_FILE = "session_map.json"
 
-# kiro-cli session file directory
-_KIRO_SESSIONS_DIR = kiro_sessions_dir()
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_KIRO_SESSIONS_DIR: Path | None = None
+
+
+def _kiro_sessions_dir() -> Path:
+    """kiro-cli sessions directory, resolved against the live data home."""
+    return _KIRO_SESSIONS_DIR if _KIRO_SESSIONS_DIR is not None else kiro_sessions_dir()
 
 
 class SessionMap:
@@ -169,8 +179,9 @@ class SessionMap:
         sid = entry["sid"]
         if entry.get("provider") == "claude_code":
             return sid
-        if sid and (_KIRO_SESSIONS_DIR / f"{sid}.json").exists():
-            jsonl = _KIRO_SESSIONS_DIR / f"{sid}.jsonl"
+        sessions_dir = _kiro_sessions_dir()
+        if sid and (sessions_dir / f"{sid}.json").exists():
+            jsonl = sessions_dir / f"{sid}.jsonl"
             try:
                 jsonl_size = jsonl.stat().st_size
             except FileNotFoundError:
@@ -243,12 +254,13 @@ class SessionMap:
 
     def prune(self) -> int:
         """Remove entries whose session files no longer exist."""
+        sessions_dir = _kiro_sessions_dir()
         stale = [
             k
             for k, entry in self._data.items()
             if entry.get("provider") != "claude_code"
             and (
-                (entry.get("sid") and not (_KIRO_SESSIONS_DIR / f"{entry['sid']}.json").exists())
+                (entry.get("sid") and not (sessions_dir / f"{entry['sid']}.json").exists())
                 or (
                     not entry.get("sid")
                     and not entry.get("slack_thread_ts")

--- a/src/kiro_crew/slack/sessions_view.py
+++ b/src/kiro_crew/slack/sessions_view.py
@@ -22,9 +22,10 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kiro_crew.config.paths import config_dir
+from kiro_crew.config.paths import data_home
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.slack.blocks import session_task_card
 
@@ -36,7 +37,12 @@ if TYPE_CHECKING:
 # Constants
 # ---------------------------------------------------------------------------
 
-_SESSIONS_DIR = config_dir() / "sessions"
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_SESSIONS_DIR: Path | None = None
 _SESSIONS_MAX_MSG_CHARS = 4000
 _SESSIONS_MAX_PREVIEW = 5
 _SESSIONS_DEFAULT_LIMIT = 10
@@ -45,6 +51,11 @@ _HOME_TAB_SESSIONS_PER_KIND = 5
 _SESSION_KIND_DASHBOARD = "dashboard"
 _SESSION_KIND_TASKRUNNER = "taskrunner"
 _SESSION_KIND_OTHER = "other"
+
+
+def _sessions_dir() -> Path:
+    """Sessions directory, resolved against the live data home."""
+    return _SESSIONS_DIR if _SESSIONS_DIR is not None else data_home() / "sessions"
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +126,8 @@ def _collect_recent_sessions(
 
     Sorted by mtime descending, capped at *limit*.
     """
-    if not _SESSIONS_DIR.exists():
+    sessions_dir = _sessions_dir()
+    if not sessions_dir.exists():
         return []
 
     if kind is None:
@@ -126,7 +138,7 @@ def _collect_recent_sessions(
         kinds_set = set(kind)
 
     rows: list[dict] = []
-    for jsonl in _SESSIONS_DIR.glob("*.jsonl"):
+    for jsonl in sessions_dir.glob("*.jsonl"):
         if jsonl.is_symlink():
             continue
         raw_key = jsonl.stem

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -16,12 +16,22 @@ import tempfile
 import time
 from pathlib import Path
 
-from kiro_crew.config.paths import config_dir, kiro_sessions_dir
+from kiro_crew.config.paths import data_home, kiro_sessions_dir
 from kiro_crew.providers.cleanup import _is_safe_path
 
 logger = logging.getLogger(__name__)
 
-_SUBAGENTS_DIR: Path = config_dir() / "subagents"
+# Resolved per call, never captured at import: an import-time binding freezes
+# the data home and defeats pod isolation, the lazy legacy-home migration and
+# test isolation. The name below is an opt-in override (None = live home) so
+# existing monkeypatch call sites keep working. See config.md "Data Home" and
+# issue #874; dashboard/handlers/usage.py is the reference implementation.
+_SUBAGENTS_DIR: Path | None = None
+
+
+def _subagents_dir() -> Path:
+    """Subagents registry directory, resolved against the live data home."""
+    return _SUBAGENTS_DIR if _SUBAGENTS_DIR is not None else data_home() / "subagents"
 
 
 def _agent_dir(agent_id: str) -> Path:
@@ -34,8 +44,9 @@ def _agent_dir(agent_id: str) -> Path:
         or "\0" in agent_id
     ):
         raise ValueError(f"Invalid agent_id: {agent_id!r}")
-    resolved = (_SUBAGENTS_DIR / agent_id).resolve()
-    parent = _SUBAGENTS_DIR.resolve()
+    base = _subagents_dir()
+    resolved = (base / agent_id).resolve()
+    parent = base.resolve()
     if resolved == parent or not resolved.is_relative_to(parent):
         raise ValueError(f"Path traversal blocked for agent_id: {agent_id!r}")
     return resolved
@@ -201,9 +212,10 @@ def record_slow_command(agent_id: str, **fields: object) -> None:
     survives per-agent folder cleanup. Best-effort: never raises to the caller.
     """
     entry = {"id": agent_id, "flagged": time.time(), **fields}
+    base = _subagents_dir()
     try:
-        _SUBAGENTS_DIR.mkdir(parents=True, exist_ok=True)
-        with open(_SUBAGENTS_DIR / "slow_commands.jsonl", "a", encoding="utf-8") as fh:
+        base.mkdir(parents=True, exist_ok=True)
+        with open(base / "slow_commands.jsonl", "a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, default=str) + "\n")
     except OSError:
         logger.warning("record_slow_command failed for %s", agent_id, exc_info=True)
@@ -225,7 +237,7 @@ def list_orphans() -> list[dict]:
     """Return parsed state for all non-tombstoned agent folders."""
     results: list[dict] = []
     try:
-        dirs = sorted(_SUBAGENTS_DIR.iterdir())
+        dirs = sorted(_subagents_dir().iterdir())
     except (FileNotFoundError, OSError):
         return results
     for d in dirs:
@@ -257,7 +269,7 @@ def prune_stale_tombstones(max_age_days: int = 7, delivered_ttl_secs: int = 3600
     delivered_cutoff = now - max(0, delivered_ttl_secs)
     pruned = 0
     try:
-        dirs = sorted(_SUBAGENTS_DIR.iterdir())
+        dirs = sorted(_subagents_dir().iterdir())
     except (FileNotFoundError, OSError):
         return 0
     for d in dirs:

--- a/test/test_lazy_data_home_paths.py
+++ b/test/test_lazy_data_home_paths.py
@@ -1,0 +1,421 @@
+"""Guard: data-home paths must never be resolved at import time.
+
+Issue #874. ``config_dir()``, ``kiro_sessions_dir()`` and friends read
+``KIROCREW_HOME`` on *every* call. Binding one of them to a module-level constant
+freezes whichever home happened to be active when that module was first
+imported, which silently breaks:
+
+* **pod isolation** -- a pod exports its own ``KIROCREW_HOME``;
+* **the lazy legacy-home migration** (``~/.kirocrew`` -> ``~/.kiro/crew``), which
+  is deliberately resolved late and cached;
+* **test isolation** -- the autouse ``_isolate_kirocrew_home`` fixture in
+  ``conftest.py`` runs *after* collection has already imported the module under
+  test, so it cannot reach a frozen constant. That hole is how a local test run
+  wrote 2128 fixture rows and 362 fixture cron records into an operator's real
+  data home.
+
+The failure mode is silent: no error, no warning, plausible-looking behaviour,
+with the damage only surfacing later as fabricated numbers in an aggregation.
+A reviewer cannot be expected to catch the 17th occurrence by eye, so this is
+enforced structurally instead.
+
+The fix pattern (see ``dashboard/handlers/usage.py`` for the reference, and
+``instances/registry.py`` / ``sel.py`` / ``history.py`` for prior art)::
+
+    _SOME_DIR: Path | None = None          # explicit override hook, None = live
+
+    def _some_dir() -> Path:
+        return _SOME_DIR if _SOME_DIR is not None else config_dir() / "some"
+
+Keeping the module-level name means existing ``monkeypatch.setattr(mod,
+"_SOME_DIR", tmp)`` call sites keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+PATHS_MODULE = SRC / "config" / "paths.py"
+
+
+def _path_factories() -> set[str]:
+    """Names of the **Path-returning** helpers declared in ``config/paths.py``.
+
+    Derived from the module rather than hardcoded so a newly added factory is
+    covered automatically -- hardcoding is how the original sweep for #874 missed
+    ``kiro_sessions_dir`` and ``kiro_agents_dir`` and under-reported the scope as
+    one site instead of sixteen.
+
+    Restricted to functions whose return annotation mentions ``Path``, which is
+    the precision half of the same problem: ``paths.py`` also exports helpers
+    like ``preserved_entries() -> list[str]``, ``_safe_dir_name() -> str`` and
+    ``_is_unsafe_home() -> bool``. Since the detector matches a bare call name
+    (and an attribute call of the same name), including those would make the
+    guard flag unrelated module-level calls repo-wide as ``paths.py`` grows --
+    and a guard that cries wolf gets weakened or deleted, which costs more than
+    the bug it was written to stop.
+    """
+    tree = ast.parse(PATHS_MODULE.read_text(encoding="utf-8"))
+    out: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name.startswith("__") or node.returns is None:
+            continue
+        # covers `Path`, `Path | None`, `Optional[Path]`, `list[Path]`
+        if "Path" in ast.unparse(node.returns):
+            out.add(node.name)
+    return out
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    out: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call):
+            name = getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+            if name:
+                out.add(name)
+    return out
+
+
+def _frozen_path_constants() -> list[str]:
+    """Every import-time evaluation of a path factory.
+
+    Three shapes freeze identically at import and all three are covered:
+
+    * a module-level assignment -- ``X = config_dir() / "a"``;
+    * a **class-body** assignment -- ``class C: X = config_dir()`` (the class
+      body executes when the module is imported);
+    * a **function default argument** -- ``def f(d=config_dir())`` (defaults are
+      evaluated once, at definition time).
+
+    Walking only ``tree.body`` would miss the last two, which is how a guard can
+    document a stronger invariant than it enforces.
+    """
+    factories = _path_factories()
+    offenders: list[str] = []
+    for py in sorted(SRC.rglob("*.py")):
+        if "__pycache__" in py.parts:
+            continue
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - syntax is enforced elsewhere
+            continue
+        rel = py.relative_to(SRC)
+
+        def _record(node: ast.AST, targets: list[str], used: set[str], kind: str) -> None:
+            offenders.append(
+                f"{rel}:{node.lineno}  [{kind}] {','.join(targets)} "
+                f"= ...{sorted(used)[0]}()"
+            )
+
+        for node in ast.walk(tree):
+            # module-level and class-body assignments
+            if isinstance(node, (ast.Module, ast.ClassDef)):
+                kind = "module" if isinstance(node, ast.Module) else "class-body"
+                for stmt in node.body:
+                    if not isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+                        continue
+                    if stmt.value is None:
+                        continue
+                    used = _called_names(stmt.value) & factories
+                    if not used:
+                        continue
+                    if isinstance(stmt, ast.Assign):
+                        targets = [getattr(t, "id", "?") for t in stmt.targets]
+                    else:
+                        targets = [getattr(stmt.target, "id", "?")]
+                    _record(stmt, targets, used, kind)
+            # function default arguments (evaluated once, at def time)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                defaults = [d for d in node.args.defaults if d is not None]
+                defaults += [d for d in node.args.kw_defaults if d is not None]
+                for d in defaults:
+                    used = _called_names(d) & factories
+                    if used:
+                        _record(d, [f"{node.name}() default"], used, "def-default")
+    return offenders
+
+
+class TestNoImportTimePathResolution:
+    def test_no_module_level_path_constants(self) -> None:
+        offenders = _frozen_path_constants()
+        assert not offenders, (
+            "Data-home path resolved at import time (issue #874). Convert each to "
+            "an override hook + accessor -- see the module docstring of this file "
+            "for the pattern:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_guard_can_actually_fail(self) -> None:
+        """Negative control: the detector must flag a known-bad construct.
+
+        An assertion that cannot fail is worthless, so prove the AST walk really
+        catches the shape it exists to forbid.
+        """
+        bad = ast.parse("X = config_dir() / 'usage'")
+        node = bad.body[0]
+        assert isinstance(node, ast.Assign)
+        assert "config_dir" in _called_names(node.value)
+        assert "config_dir" in _path_factories()
+
+    def test_annotated_and_nested_forms_are_detected(self) -> None:
+        """The regex sweep missed these shapes; the AST walk must not."""
+        annotated = ast.parse("X: Path = kiro_agents_dir() / 'a'").body[0]
+        nested = ast.parse("X = (kiro_sessions_dir() / 'a').resolve()").body[0]
+        for node in (annotated, nested):
+            assert _called_names(node.value) & _path_factories()
+
+    def test_factory_set_excludes_non_path_helpers(self) -> None:
+        """Precision control: only Path-returning helpers may be factories.
+
+        ``paths.py`` also exports generically-named helpers that return other
+        types. If those entered the factory set, the detector -- which matches a
+        bare call name -- would flag unrelated module-level calls anywhere in the
+        tree, and a guard that cries wolf gets weakened or deleted.
+        """
+        factories = _path_factories()
+        assert {"config_dir", "kiro_sessions_dir", "kiro_agents_dir"} <= factories
+        # non-Path returners in the same module must NOT be treated as factories
+        for name in (
+            "preserved_entries",  # -> list[str]
+            "_safe_dir_name",  # -> str
+            "_is_unsafe_home",  # -> bool
+            "detect_data_home_conflict",  # -> str | None
+            "_in_linked_git_worktree",  # -> bool
+        ):
+            assert name not in factories, name
+        # a Path | None returner still counts
+        assert "_valid_override_home" in factories
+
+    def test_detector_covers_class_body_and_default_args(self, tmp_path, monkeypatch) -> None:
+        """Negative control for the two shapes a ``tree.body``-only walk misses.
+
+        Both freeze at import exactly like a module constant: a class body runs
+        on import, and a default argument is evaluated once at ``def`` time.
+        Planted in a temp tree so the real source is untouched.
+        """
+        import sys
+
+        mod = sys.modules[__name__]
+
+        fake_src = tmp_path / "kiro_crew"
+        (fake_src / "config").mkdir(parents=True)
+        (fake_src / "config" / "paths.py").write_text(
+            "from pathlib import Path\n\n\ndef config_dir() -> Path:\n    return Path('.')\n",
+            encoding="utf-8",
+        )
+        (fake_src / "in_class.py").write_text(
+            "class C:\n    DIR = config_dir() / 'a'\n", encoding="utf-8"
+        )
+        (fake_src / "in_default.py").write_text(
+            "def f(d=config_dir()):\n    return d\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(mod, "SRC", fake_src)
+        monkeypatch.setattr(mod, "PATHS_MODULE", fake_src / "config" / "paths.py")
+
+        found = _frozen_path_constants()
+        kinds = {f.split("[")[1].split("]")[0] for f in found if "[" in f}
+        assert "class-body" in kinds, found
+        assert "def-default" in kinds, found
+
+
+# (module import path, override constant, accessor) for every accessor that
+# resolves through ``config_dir()``. The structural test above is the exhaustive
+# half; this table is the behavioural half -- it proves the accessors actually
+# FOLLOW a home change rather than merely not being constants.
+#
+# The override constant is listed so each case can be reset to ``None`` first:
+# ``conftest.py``'s autouse ``_isolate_subagents_dir`` pins
+# ``_SUBAGENTS_DIR`` to a tmp dir, and an override legitimately outranks the
+# environment -- without the reset this test would assert the fixture, not the
+# live-resolution branch it exists to cover.
+_CONFIG_DIR_ACCESSORS = [
+    ("kiro_crew.dashboard.handlers.usage", "_TOKEN_USAGE_DIR", "_token_usage_dir"),
+    ("kiro_crew.cron", "_DEFAULT_DIR", "_default_dir"),
+    ("kiro_crew.subagent_persistence", "_SUBAGENTS_DIR", "_subagents_dir"),
+    ("kiro_crew.dashboard.handlers.files", "_UPLOAD_DIR", "_upload_dir"),
+    ("kiro_crew.dashboard.handlers.files", "_SCREENSHOT_DIR", "_screenshot_dir"),
+    ("kiro_crew.dashboard.handlers.hooks", "_HOOK_STORE_PATH", "_hook_store_path"),
+    ("kiro_crew.dashboard.handlers.mcp", "_KIROCREW_MCP_JSON", "_kirocrew_mcp_json"),
+    ("kiro_crew.slack.sessions_view", "_SESSIONS_DIR", "_sessions_dir"),
+    ("kiro_crew.apps.builtins.auto_research.handlers", "RESEARCH_DIR", "research_dir"),
+    ("kiro_crew.apps.builtins.auto_research.handlers", "DB_PATH", "db_path"),
+]
+
+
+class TestAccessorsFollowTheLiveHome:
+    """A post-import ``KIROCREW_HOME`` change must redirect every accessor.
+
+    ``config_dir()`` returns a ``$KIROCREW_HOME`` override immediately, ahead of
+    the cached default-home/migration branch, so the override path is live on
+    every call. These modules are imported at collection time -- long before the
+    env var below is set -- which is exactly the sequence that used to strand
+    them on the operator's real home.
+    """
+
+    def test_every_accessor_follows_a_post_import_home_change(self, tmp_path, monkeypatch):
+        import importlib
+
+        home = tmp_path / "home-a"
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        stranded = []
+        for mod_path, const, attr in _CONFIG_DIR_ACCESSORS:
+            mod = importlib.import_module(mod_path)
+            monkeypatch.setattr(mod, const, None)
+            resolved = Path(getattr(mod, attr)())
+            if not resolved.resolve().is_relative_to(home.resolve()):
+                stranded.append(f"{mod_path}.{attr}() -> {resolved}")
+        assert not stranded, (
+            "accessor did not follow KIROCREW_HOME set after import (issue #874):\n  "
+            + "\n  ".join(stranded)
+        )
+
+    def test_accessor_tracks_a_second_change(self, tmp_path, monkeypatch):
+        """Not merely read-once-late: it must re-resolve on every call."""
+        import importlib
+
+        mod = importlib.import_module("kiro_crew.dashboard.handlers.usage")
+        first = tmp_path / "home-1"
+        monkeypatch.setenv("KIROCREW_HOME", str(first))
+        one = mod._token_usage_dir()
+        second = tmp_path / "home-2"
+        monkeypatch.setenv("KIROCREW_HOME", str(second))
+        two = mod._token_usage_dir()
+        assert one != two
+        assert one.resolve().is_relative_to(first.resolve())
+        assert two.resolve().is_relative_to(second.resolve())
+
+    def test_override_hook_still_wins(self, tmp_path, monkeypatch):
+        """The kept module-level name must still override, so the dozens of
+        existing ``monkeypatch.setattr(mod, "_X", tmp)`` call sites keep working.
+        """
+        import importlib
+
+        mod = importlib.import_module("kiro_crew.dashboard.handlers.usage")
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "ignored-home"))
+        pinned = tmp_path / "pinned"
+        monkeypatch.setattr(mod, "_TOKEN_USAGE_DIR", pinned)
+        assert mod._token_usage_dir() == pinned
+
+
+class TestResolutionDoesNotRepeatStartupMaintenance:
+    """``data_home()`` must not re-run start-of-process maintenance per call.
+
+    ``config_dir()`` is resolve + maintain: it also mkdirs the home, refreshes the
+    recovery breadcrumb and re-runs the ungated-archive sweep, which can
+    ``shutil.rmtree`` a leftover. Resolving per call (the #874 fix) would
+    otherwise put that on every caller -- including request handlers, where a
+    destructive sweep would run on the event loop as a side effect of asking
+    where a directory is.
+
+    Each assertion is paired with its negative control: the test proves
+    ``config_dir()`` DOES perform the work, so a passing ``data_home()``
+    assertion cannot be explained by the maintenance simply being dead.
+    """
+
+    def _count_sweeps(self, monkeypatch):
+        from kiro_crew.config import paths
+
+        calls: list[int] = []
+        monkeypatch.setattr(
+            paths, "_sweep_ungated_archive_leftovers", lambda: calls.append(1)
+        )
+        monkeypatch.setattr(paths, "_write_recovery_breadcrumb", lambda d: calls.append(1))
+        return calls
+
+    def test_repeat_calls_skip_maintenance_but_config_dir_still_runs_it(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.config import paths
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        home = tmp_path / "resolved"
+        home.mkdir()
+        monkeypatch.setattr(paths, "_resolved_home", home)
+        calls = self._count_sweeps(monkeypatch)
+
+        assert paths.data_home() == home
+        assert paths.data_home() == home
+        assert calls == [], "data_home() re-ran start-of-process maintenance"
+
+        # negative control: the maintenance is NOT dead -- config_dir() does it
+        paths.config_dir()
+        assert calls, "config_dir() no longer performs maintenance; test is vacuous"
+
+    def test_first_resolution_still_performs_maintenance(self, tmp_path, monkeypatch):
+        """Per START, not per call -- which is what the sweep's docstring specifies."""
+        from kiro_crew.config import paths
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(paths, "_resolved_home", None)
+        monkeypatch.setattr(paths, "_maybe_migrate_legacy_home", lambda: tmp_path / "fresh")
+        calls = self._count_sweeps(monkeypatch)
+
+        paths.data_home()
+        assert calls, "the first resolution in a process must still sweep"
+
+    def test_override_is_never_cached(self, tmp_path, monkeypatch):
+        """A KIROCREW_HOME set after import must still be honoured (#874).
+
+        Caching would be cheaper but would reintroduce the original bug, so the
+        override branch deliberately delegates on every call.
+        """
+        from kiro_crew.config import paths
+
+        monkeypatch.setattr(paths, "_resolved_home", tmp_path / "stale-default")
+        first = tmp_path / "ov-1"
+        monkeypatch.setenv("KIROCREW_HOME", str(first))
+        assert paths.data_home().resolve() == first.resolve()
+        second = tmp_path / "ov-2"
+        monkeypatch.setenv("KIROCREW_HOME", str(second))
+        assert paths.data_home().resolve() == second.resolve()
+
+    def test_invalid_override_does_not_reopen_the_maintenance_path(
+        self, tmp_path, monkeypatch
+    ):
+        """An override naming a system dir must NOT re-run maintenance per call.
+
+        ``config_dir()`` gates the override branch on ``_valid_override_home()``
+        (set AND safe); an override like ``/usr`` is rejected there and
+        resolution falls through to the default home, which mkdirs, refreshes
+        the breadcrumb and runs the sweep. So ``data_home()`` must gate on the
+        SAME predicate -- testing merely "is the env var set" would send every
+        call down the maintenance path and put the destructive sweep back on the
+        request path for anyone with a bad override.
+        """
+        from kiro_crew.config import paths
+
+        home = tmp_path / "resolved"
+        home.mkdir()
+        monkeypatch.setattr(paths, "_resolved_home", home)
+
+        # The filesystem/drive ROOT is rejected on every platform -- do NOT
+        # hardcode a POSIX system dir like "/usr": on Windows that resolves to
+        # ``D:/usr``, which is a perfectly ordinary path, so the override would
+        # be ACCEPTED and this test would assert nothing. (CI on Windows caught
+        # exactly that.) ``tmp_path.anchor`` is "/" on POSIX and "C:\\" (or the
+        # runner's drive) on Windows.
+        monkeypatch.setenv("KIROCREW_HOME", tmp_path.anchor)
+        assert paths._valid_override_home() is None, "precondition: override rejected"
+
+        calls = self._count_sweeps(monkeypatch)
+        assert paths.data_home() == home
+        assert paths.data_home() == home
+        assert calls == [], "invalid override re-ran maintenance on every call"
+
+    def test_valid_override_still_delegates(self, tmp_path, monkeypatch):
+        """Negative control for the test above: a VALID override must delegate.
+
+        Otherwise the previous test could pass simply because the override
+        branch stopped working altogether.
+        """
+        from kiro_crew.config import paths
+
+        monkeypatch.setattr(paths, "_resolved_home", tmp_path / "stale-default")
+        good = tmp_path / "good-override"
+        monkeypatch.setenv("KIROCREW_HOME", str(good))
+        assert paths._valid_override_home() is not None
+        assert paths.data_home().resolve() == good.resolve()

--- a/test/test_pod_self_contained.py
+++ b/test/test_pod_self_contained.py
@@ -190,7 +190,12 @@ def test_app_is_refused_because_it_rewrites_the_host_agent_registry():
     would replace or delete symlinks the live gateway depends on."""
     from kiro_crew.apps import bridges
 
-    assert bridges.KIRO_AGENTS_DIR == Path.home() / ".kiro" / "agents"
+    # Resolved through the accessor, not the module constant: since #874 the
+    # constant is an opt-in override that is ``None`` by default, so reading it
+    # directly would assert the override rather than the path bridges actually
+    # writes to. The claim under test is unchanged -- bridges targets the
+    # machine-wide HOST registry, which is why a pod may not run `app`.
+    assert bridges._kiro_agents_dir() == Path.home() / ".kiro" / "agents"
     assert "app" not in rt._POD_SAFE_VERBS
 
 


### PR DESCRIPTION
Fixes #874.

## The bug

`config_dir()`, `kiro_sessions_dir()` and `kiro_agents_dir()` re-read
`$KIROCREW_HOME` on **every** call. 16 module-level constants across 13 files
bound their result at **import time**, freezing the data home to whatever was
active when the module was first imported. That breaks three things at once:

- **pod isolation** — a pod exports its own `KIROCREW_HOME`;
- **the one-time `~/.kirocrew` → `~/.kiro/crew` migration**, which is
  deliberately lazy and cached;
- **test isolation** — `conftest.py`'s autouse `_isolate_kirocrew_home` fixture
  runs *after* collection has already imported the module under test, so it
  cannot reach a frozen constant. The safety net that exists specifically to
  prevent this has been silently ineffective for these paths.

## Why it matters, measured

A repeated local test run wrote into an operator's **real** data home:

| store | synthetic | genuine |
| --- | --- | --- |
| `usage/tokens/2026-08-01.jsonl` | 2128 rows | 10 |
| `cron-history/` | 362 run records | 9 |
| `crons.json` | overwritten to an empty registry | — |

Aggregating that day reported fabricated per-surface spend (`task_runner
$15.92`, `cron $9.52`) built entirely from fixtures with `credits` of exactly
`1.0` and `context_used: 1`. This was the **third** recurrence on the same
machine, and the failure mode is silent — no error, no warning, plausible
behaviour, damage visible only later as wrong numbers.

The scope in the original issue was one site. An AST sweep found sixteen; a
regex sweep had missed ten of them because the factories have several different
names.

## The fix

Each constant becomes an explicit opt-in override paired with an accessor:

```python
_SOME_DIR: Path | None = None          # None = resolve from the live home

def _some_dir() -> Path:
    return _SOME_DIR if _SOME_DIR is not None else config_dir() / "some"
```

The shape is not invented here — `sel.py`, `history.py` and
`instances/registry.py` already resolve lazily. This propagates it.

Two properties are deliberate:

- **Keeping the module-level name means no test churn.** Dozens of existing
  `monkeypatch.setattr(mod, "_X", tmp)` sites keep working untouched —
  `test_auto_research.py` alone patches two of these in 80+ places, and
  `conftest.py`'s autouse `_isolate_subagents_dir` fixture depends on the same
  mechanism. Exactly one test changed (below).
- **Annotating the override `Path | None` is load-bearing.** A consumer that
  still reads the constant directly becomes a **mypy error** rather than a
  silent `None` at runtime. That is how three missed cross-module importers in
  `mcp.py` and `hooks.py` were caught rather than shipped.

### Security-sensitive spots

Two path-containment guards resolve their directory **once** into a local and
use that same value on both sides of the comparison, so a mid-request home
change cannot make the check validate against a different directory than the
one written to:

- `files.py` upload destination containment
- `subagent_persistence.py` agent-id traversal guard

`cron.py`'s `base_dir or _DEFAULT_DIR` became `base_dir if base_dir is not None
else _default_dir()`, so an explicitly-passed falsy-but-valid path is no longer
silently discarded.

## Why the guard test is the load-bearing part

Fixing 16 sites without a guard leaves the 17th free to reappear, silently.
`test/test_lazy_data_home_paths.py` walks the AST of `src/kiro_crew` for
module-level assignments calling any factory declared in `config/paths.py` and
fails on every hit.

The factory list is **derived from `paths.py`**, not hardcoded — hardcoding is
precisely how the first sweep under-reported the scope as one site instead of
sixteen, so a newly added factory is covered without editing the test.

It has two halves:

- **structural** — no module-level path constant may exist, with negative
  controls proving the detector fires on the forbidden shape *including* the
  annotated and nested forms a regex misses;
- **behavioural** — every accessor must follow a `KIROCREW_HOME` set *after*
  import, and must re-resolve on a *second* change (not merely read once, late).
  A third case pins the override to prove it still outranks the environment.

The behavioural half earned its keep on first run: it caught that
`conftest.py`'s autouse `_isolate_subagents_dir` fixture pins
`_SUBAGENTS_DIR`, so the test now resets each override to `None` first —
otherwise it would have been asserting the fixture rather than the
live-resolution branch it exists to cover.

## One test changed

`test_pod_self_contained.py::test_app_is_refused_because_it_rewrites_the_host_agent_registry`
asserted the host agent registry path by reading `bridges.KIRO_AGENTS_DIR`
directly. It now asserts the same claim through the accessor, since the
constant is `None` by default. The claim under test is unchanged: `bridges`
targets the machine-wide HOST registry, which is why a pod may not run `app`.

## Verification

- **Full backend suite: 22737 passed, 22 failed — the same 22 that fail on
  clean `main` in this environment.** Verified by stashing the change and
  re-running the whole suite on the untouched tree, then diffing the failure
  lists. Every one is in the sandbox / user-namespace / file-ownership family
  (this host cannot `unshare(CLONE_NEWUSER)`), and `test_sandbox_cc_mode.py`
  was shown to vary *which* of its 4 tests fail across three consecutive runs on
  the same branch, so list-level differences there are host flake, not signal.
- `isort --check-only`, `flake8 -j 1`, `mypy` (567 files): clean.
- No frontend changes, so `tsc` / `vitest` are not applicable.
- Spec updated: `docs/system-specs/modules/config.md` gains a
  "paths are resolved per call" invariant in the Data Home section, documenting
  the required shape and pointing at the guard.

## Not in scope

Historical fixture rows already written into operator data homes are not
recoverable by code; the ones on this machine were removed manually against a
backup. This PR stops new ones.
