### PR TITLE
fix(channels): preserve options trailers across chunking

### DIFF
--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -84,6 +84,30 @@ OPTIONS_RE_LINE = re.compile(r"\[OPTIONS:((?:[^[\n]|\[(?!OPTIONS:))*)\][ \t]*$",
 OPTIONS_RE_TRAILER = re.compile(r"\[OPTIONS:((?:[^[]|\[(?!OPTIONS:))*)\]\s*\Z", re.DOTALL)
 
 
+def split_trailing_protocol_suffix(text: str) -> tuple[str, str]:
+    """Detach protocol trailers before a renderer length-splits ``text``.
+
+    A still-streaming ``[STEERING`` or ``[OPTIONS`` fragment normally breaks
+    :data:`OPTIONS_RE_TRAILER`'s end-of-buffer anchor. If a complete OPTIONS
+    block immediately precedes that fragment, detaching only the unfinished
+    marker leaves the complete block eligible for a mid-token chunk split.
+    Return the visible prefix plus the entire protocol suffix so renderers can
+    keep both markers together on the surviving tail.
+    """
+    suffix_start = len(text)
+    idx = max(text.rfind("[STEERING"), text.rfind("[OPTIONS"))
+    if idx != -1 and "]" not in text[idx:]:
+        suffix_start = idx
+
+    options = OPTIONS_RE_TRAILER.search(text[:suffix_start])
+    if options:
+        suffix_start = options.start()
+
+    if suffix_start == len(text):
+        return text, ""
+    return text[:suffix_start], text[suffix_start:]
+
+
 # The product wordmark, figlet `small`. ONE definition on purpose: it used to be
 # copy-pasted into cli.py and cli_chat.py, and a rename left both spelling a
 # stale product name in the two most-seen surfaces (bare `kirocrew`, the chat

--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -35,7 +35,7 @@ import secrets
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
+from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
 from kiro_crew.messaging.renderer import Renderer
 from kiro_crew.messaging.transport import TransportCapabilities
 
@@ -333,8 +333,16 @@ class DiscordRenderer(Renderer):
         """Seal the pre-steer segment at the driver's structured boundary."""
         self._materialize_chip()
         await self._rotate_on_length()
-        sealed = bool(self._segment_text().strip())
-        await self._seal_current()
+        # A trailing [OPTIONS:] block belongs to the visible PRE-STEER answer,
+        # but the steering marker sits after it in the raw buffer, so the
+        # end-of-buffer anchor no longer sees it. Extract it here -- BEFORE the
+        # seal -- so the choices ship as buttons on the sealed message instead of
+        # being frozen as literal protocol text the user cannot act on.
+        body_raw, opts = _extract_options("".join(self._buf))
+        self._buf = [body_raw]
+        components = build_option_components(opts) if opts else None
+        sealed = bool(self._segment_text().strip()) or components is not None
+        await self._seal_current(components=components)
         clean_summary = _neutralize_md(summary)
         if clean_summary:
             chip: str | None = "> ↪️ " + clean_summary
@@ -369,20 +377,13 @@ class DiscordRenderer(Renderer):
         raw = "".join(self._buf)
         if len(raw) <= limit:
             return
-        partial = ""
-        cm = _OPTIONS_RE.search(raw)
-        if cm:
-            raw, partial = raw[: cm.start()], raw[cm.start() :]
-        else:
-            idx = max(raw.rfind("[STEERING"), raw.rfind("[OPTIONS"))
-            if idx != -1 and "]" not in raw[idx:]:
-                raw, partial = raw[:idx], raw[idx:]
+        raw, protocol_suffix = split_trailing_protocol_suffix(raw)
         chunks = _split_markdown(raw, limit)
         for ch in chunks[:-1]:
             self._buf = [ch]
             await self._seal_current()
             self._open_new_message()
-        self._buf = [(chunks[-1] if chunks else "") + partial]
+        self._buf = [(chunks[-1] if chunks else "") + protocol_suffix]
 
     def _open_new_message(self) -> None:
         """Next render creates a fresh message instead of editing the old one."""
@@ -429,7 +430,9 @@ class DiscordRenderer(Renderer):
         are skipped so a bare steer doesn't post a blank bubble."""
         text = self._segment_text().strip()
         if not text:
-            return
+            if components is None:
+                return
+            text = "…"
         if self._stream_mid is not None:
             ok = await self._client.edit_message(
                 self._channel_id, self._stream_mid, text, components=components

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -30,7 +30,7 @@ import re
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
+from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
 from kiro_crew.messaging.renderer import Renderer
 from kiro_crew.messaging.transport import TransportCapabilities
 
@@ -424,8 +424,16 @@ class TelegramRenderer(Renderer):
         """Seal the pre-steer segment at the driver's structured boundary."""
         self._materialize_chip()
         await self._rotate_on_length()
-        sealed = bool(self._segment_text().strip())
-        await self._seal_current()
+        # A trailing [OPTIONS:] block belongs to the visible PRE-STEER answer,
+        # but the steering marker sits after it in the raw buffer, so the
+        # end-of-buffer anchor no longer sees it. Extract it here -- BEFORE the
+        # seal -- so the choices ship as a keyboard on the sealed message instead of
+        # being frozen as literal protocol text the user cannot act on.
+        body_raw, opts = _extract_options("".join(self._buf))
+        self._buf = [body_raw]
+        keyboard = build_inline_keyboard(opts) if opts else None
+        sealed = bool(self._segment_text().strip()) or keyboard is not None
+        await self._seal_current(keyboard=keyboard)
         clean_summary = _neutralize_md(summary)
         if clean_summary:
             chip: str | None = f"> ↪️ {clean_summary}"
@@ -465,23 +473,13 @@ class TelegramRenderer(Renderer):
         raw = "".join(self._buf)
         if len(raw) <= limit:
             return
-        partial = ""
-        cm = _OPTIONS_RE.search(raw)
-        if cm:
-            # Complete trailing [OPTIONS: …] — keep it intact on the tail so
-            # finalization can extract the inline keyboard (a bare split would
-            # leak "NS: A | B]" as raw text and lose the keyboard).
-            raw, partial = raw[: cm.start()], raw[cm.start():]
-        else:
-            idx = max(raw.rfind("[STEERING"), raw.rfind("[OPTIONS"))
-            if idx != -1 and "]" not in raw[idx:]:
-                raw, partial = raw[:idx], raw[idx:]
+        raw, protocol_suffix = split_trailing_protocol_suffix(raw)
         chunks = _split_markdown(raw, limit)
         for ch in chunks[:-1]:
             self._buf = [ch]
             await self._seal_current()
             self._open_new_message()
-        self._buf = [(chunks[-1] if chunks else "") + partial]
+        self._buf = [(chunks[-1] if chunks else "") + protocol_suffix]
 
     def _open_new_message(self) -> None:
         """Next render creates a fresh message instead of editing the old one."""
@@ -534,7 +532,9 @@ class TelegramRenderer(Renderer):
         Empty segments are skipped so a bare steer doesn't post a blank bubble."""
         text = self._segment_text().strip()
         if not text:
-            return
+            if keyboard is None:
+                return
+            text = "…"
         html_text = _md_to_telegram_html(text)
         if self._stream_mid is not None:
             ok = await self._client.edit_message(

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -732,6 +732,30 @@ class TestRenderer:
         assert "[OPTIONS" not in cli.final_text()
 
     @pytest.mark.asyncio
+    async def test_long_options_before_streamed_steer_ack_become_buttons(self) -> None:
+        r, cli = self._renderer()
+        await r.on_turn_start()
+        # The assistant's final line is a valid OPTIONS trailer. The provider's
+        # internal steer acknowledgment follows it and arrives across chunks,
+        # with the combined buffer well past Discord's message cap.
+        await r.on_text_chunk(
+            ("x" * 3800)
+            + "\n\n[OPTIONS: Alpha | Bravo | Charlie]"
+            + "\n\n[STEERING steer-7e6a4a0d"
+        )
+        await r.on_text_chunk("94314d2db: acknowledged]")
+        await r.on_done()
+
+        components = [c for _, c in cli.sent if c] + [c for _, _, c in cli.edits if c]
+        labels = [b["label"] for row in components[0] for b in row["components"]]
+        assert labels == ["Alpha", "Bravo", "Charlie"]
+        visible = "\n".join([t for t, _ in cli.sent] + [t for _, t, _ in cli.edits])
+        assert "[OPTIONS" not in visible
+        assert "[STEERING" not in visible
+        assert "steer-7e6a4a0d" not in visible
+        assert "94314d2db" not in visible
+
+    @pytest.mark.asyncio
     async def test_long_output_rotates_messages(self) -> None:
         r, cli = self._renderer()
         await r.on_turn_start()

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -759,6 +759,29 @@ class TestRenderer:
         all_text = " ".join(t for t, _ in cli.sent) + " ".join(t for _, t, _ in cli.edits)
         assert "[OPTIONS" not in all_text
 
+    def test_long_options_before_streamed_steer_ack_become_keyboard(self) -> None:
+        cli = self._drive(
+            [
+                OutputEvent(
+                    kind=TEXT_CHUNK,
+                    text=("x" * 7680)
+                    + "\n\n[OPTIONS: Alpha | Bravo | Charlie]"
+                    + "\n\n[STEERING steer-7e6a4a0d",
+                ),
+                OutputEvent(kind=TEXT_CHUNK, text="94314d2db: acknowledged]"),
+                OutputEvent(kind=DONE, stop_reason=""),
+            ]
+        )
+
+        markups = [m for _, m in cli.sent if m] + [m for _, _, m in cli.edits if m]
+        labels = [b["text"] for row in markups[0]["inline_keyboard"] for b in row]
+        assert labels == ["Alpha", "Bravo", "Charlie"]
+        visible = "\n".join([t for t, _ in cli.sent] + [t for _, t, _ in cli.edits])
+        assert "[OPTIONS" not in visible
+        assert "[STEERING" not in visible
+        assert "steer-7e6a4a0d" not in visible
+        assert "94314d2db" not in visible
+
     def test_tool_only_message_not_orphaned_at_steer_boundary(self) -> None:
         # Codex finding: a tool call BEFORE any assistant text creates a live
         # "🔧 tool…" message. If a steer marker then arrives with no pre-marker


### PR DESCRIPTION
## Problem

A long assistant response could end with a valid `[OPTIONS: ...]` trailer but deliver it as plain text when a streamed internal `[STEERING ...]` acknowledgment followed it near a channel chunk boundary.

## Why it matters

Discord and Telegram users lost the native choice buttons/keyboards and saw internal protocol text. A marker could also be split across platform messages, exposing fragments of a steering UUID.

## Fix

- **Symptom:** a complete OPTIONS trailer was chunked or sealed as visible text when a following partial steering marker displaced it from the end of the raw buffer.
- **Root cause:** `OPTIONS_RE_TRAILER` correctly requires end-of-buffer, but length rotation checked it before detaching the following unfinished protocol marker. The OPTIONS block therefore entered `_split_markdown`; when the steering marker completed, the pre-steer seal did not extract controls.
- **Change:** add a canonical suffix splitter that keeps a complete OPTIONS trailer together with any following unfinished protocol marker, then have Discord and Telegram extract native controls before sealing a pre-steer segment. Options-only segments retain their controls on a placeholder.

The LINE and TRAILER regex variants remain separate. Slack/dashboard intentionally match one line under `MULTILINE`, while channel renderers require an end-of-buffer trailer that may span lines; unifying those semantics would reintroduce cross-line false matches.

## Tests

- Added failing-before-fix reproductions for Discord (>3,800 characters) and Telegram (>7,680 characters), with the steering UUID split across provider chunks.
- Verified buttons/keyboards are produced and neither OPTIONS nor steering fragments reach visible messages.
- `450 passed`: all channel renderer suites plus option/parser/preview format tests.
- `.venv/bin/isort --check-only src/kiro_crew test`
- `.venv/bin/flake8 --jobs 1 src/kiro_crew test`
- `.venv/bin/mypy src/kiro_crew/`

## Manual verification

Drove both renderers with their fake clients using over-cap responses whose final assistant line was `[OPTIONS: Alpha | Bravo | Charlie]`, followed by an internal steering acknowledgment split mid-UUID. Discord emitted three button components and Telegram emitted a three-choice inline keyboard; no raw protocol token or UUID fragment appeared in sends or edits.
