### PR TITLE
fix(discord): support session title search

### DIFF
--- a/src/kiro_crew/discord/commands.py
+++ b/src/kiro_crew/discord/commands.py
@@ -44,6 +44,12 @@ _SESSIONS_ALIASES = frozenset(("!sessions", "/sessions", "!session", "/session")
 _PREFIXES = ("!", "/")
 
 
+def parse_command_argument(text: str) -> str:
+    """Return the optional text following a Discord command token."""
+    parts = text.strip().split(None, 1)
+    return parts[1].strip() if len(parts) == 2 else ""
+
+
 def parse_command(text: str) -> str | None:
     """Return 'new', 'compact', 'link', 'unlink', 'help', 'stop', 'sessions', or None."""
     stripped = text.strip()

--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _PICKER_LIMIT = 10
+#: Rows pulled from history before incognito/keying filters. Larger than
+#: _PICKER_LIMIT so filtered-out rows cannot starve the 10 button slots.
+_SEARCH_FETCH_LIMIT = 50
 _PICKER_TTL_SECS = 300
 _PICKER_REGISTRY_MAX = 100
 _REPLAY_MESSAGES = 5
@@ -153,6 +156,7 @@ class DiscordSessionResume:
         client: "DiscordClient",
         user_id: str,
         channel_id: str,
+        query: str = "",
     ) -> None:
         if not self.is_owner(user_id):
             sel().log_api_access(
@@ -172,8 +176,45 @@ class DiscordSessionResume:
             await client.send_message(channel_id, "⚠️ Recent sessions are unavailable.")
             return
 
+        normalized_query = " ".join(query.casefold().split())
+
         try:
-            rows = await asyncio.to_thread(self.conv_log.list_sessions)
+            if normalized_query:
+                # Reuse the SAME search the dashboard uses
+                # (KiroCrewHistory.search_sessions): it matches message CONTENT
+                # with a title boost and length-normalised ranking, so a phrase
+                # the user remembers from the CONVERSATION finds the session.
+                # A title-only filter here would miss exactly that case -- the
+                # original bug report was a natural-language phrase, not a title
+                # -- and would be a second search implementation free to drift
+                # from the dashboard's ranking. Fetch more than the picker shows
+                # so incognito filtering cannot starve the button slots.
+                rows = await asyncio.to_thread(
+                    self.conv_log.search_sessions, query, _SEARCH_FETCH_LIMIT
+                )
+                if not rows and len(normalized_query.split()) > 1:
+                    # search_sessions matches the query as ONE phrase
+                    # (``needle = query.casefold()``), so out-of-order words miss:
+                    # "specific link" does not match "Link to a Specific Session".
+                    # Fall back to an all-words TITLE match so a remembered-but-
+                    # reordered title still resolves. Deliberately last-resort and
+                    # only on zero hits, so the shared search stays authoritative
+                    # and we are not running two rankers in parallel. The proper
+                    # home for multi-word support is search_sessions itself, which
+                    # would fix the dashboard too -- tracked as a follow-up.
+                    listed = await asyncio.to_thread(self.conv_log.list_sessions)
+                    words = normalized_query.split()
+                    rows = [
+                        row
+                        for row in listed
+                        if isinstance(row, dict)
+                        and all(
+                            word in " ".join(str(row.get("title") or "").casefold().split())
+                            for word in words
+                        )
+                    ]
+            else:
+                rows = await asyncio.to_thread(self.conv_log.list_sessions)
         except Exception as exc:
             safe_error = _safe_discord_text(str(exc), 200)
             sel().log_api_access(
@@ -188,7 +229,7 @@ class DiscordSessionResume:
             await client.send_message(channel_id, "⚠️ Recent sessions are unavailable.")
             return
 
-        choices: list[_SessionChoice] = []
+        eligible: list[_SessionChoice] = []
         for row in rows:
             if not isinstance(row, dict):
                 continue
@@ -199,9 +240,12 @@ class DiscordSessionResume:
                 continue
             raw_title = str(row.get("title") or key.removeprefix("dashboard:"))
             title = _safe_discord_text(" ".join(raw_title.split()), 76) or "Untitled session"
-            choices.append(_SessionChoice(key=key, title=title))
-            if len(choices) == _PICKER_LIMIT:
-                break
+            eligible.append(_SessionChoice(key=key, title=title))
+
+        # Order is already meaningful: search_sessions returns best-scored first,
+        # list_sessions returns newest first. Do not re-sort.
+        total_choices = len(eligible)
+        choices = eligible[:_PICKER_LIMIT]
 
         sel().log_api_access(
             caller=user_id,
@@ -211,7 +255,15 @@ class DiscordSessionResume:
             resources=f"{len(choices)} sessions read",
         )
         if not choices:
-            await client.send_message(channel_id, "No recent dashboard sessions.")
+            if normalized_query:
+                query_label = _safe_discord_text(" ".join(query.split()), 100).replace("`", "ˋ")
+                await client.send_message(
+                    channel_id,
+                    f"No dashboard sessions matched `{query_label}`. Try fewer words, "
+                    f"or run `!sessions` to see up to {_PICKER_LIMIT} recent sessions.",
+                )
+            else:
+                await client.send_message(channel_id, "No recent dashboard sessions.")
             return
 
         self._purge_pickers()
@@ -221,9 +273,31 @@ class DiscordSessionResume:
 
         nonce = secrets.token_hex(8)
         frozen = tuple(choices)
+        if normalized_query:
+            query_label = _safe_discord_text(" ".join(query.split()), 100).replace("`", "ˋ")
+            if total_choices > _PICKER_LIMIT:
+                summary = f"Showing {_PICKER_LIMIT} of {total_choices} matching sessions"
+            else:
+                summary = (
+                    f"Showing {total_choices} matching session"
+                    f"{'s' if total_choices != 1 else ''} (maximum {_PICKER_LIMIT})"
+                )
+            heading = (
+                "🔎 **Dashboard session search**\n"
+                f"{summary} for `{query_label}`, ranked over titles and message content."
+            )
+        else:
+            if total_choices > _PICKER_LIMIT:
+                summary = f"Showing {_PICKER_LIMIT} of {total_choices} most recent dashboard sessions."
+            else:
+                summary = (
+                    f"Showing {total_choices} most recent dashboard session"
+                    f"{'s' if total_choices != 1 else ''} (maximum {_PICKER_LIMIT})."
+                )
+            heading = f"🧵 **Recent dashboard sessions**\n{summary}"
         message_id = await client.send_message(
             channel_id,
-            "🧵 **Recent dashboard sessions**\n"
+            f"{heading}\n"
             "Choose one to continue here. Use `!unlink` to return to your "
             "Discord conversation.",
             components=_picker_components(nonce, frozen),

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 from kiro_crew.discord.commands import (
     ConversationState,
     parse_command,
+    parse_command_argument,
     parse_mid_turn_override,
 )
 from kiro_crew.discord.renderer import DiscordApprovalDecider, DiscordRenderer
@@ -78,7 +79,7 @@ _HELP_TEXT = """\
 Commands:
 `!new` — Start a fresh conversation
 `!compact` — Compress context (when it gets long)
-`!sessions` — Continue a recent dashboard session here (owner only)
+`!sessions [query]` — Continue a recent or matching dashboard session here (owner only)
 `!link` — Mirror this conversation's dashboard tab here
 `!unlink` — Stop mirroring
 `!stop` — Stop the current reply and clear the queue
@@ -236,7 +237,12 @@ class DiscordDispatcher:
                     "them into a shared thread. DM me instead.",
                 )
                 return
-            await self._session_resume.show_picker(self.client, user_id, channel_id)
+            await self._session_resume.show_picker(
+                self.client,
+                user_id,
+                channel_id,
+                query=parse_command_argument(text),
+            )
             return
         if cmd == "link":
             await self._handle_link(user_id, channel_id, thread_id)

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -867,6 +867,7 @@ class TestDispatcher:
         d, cli, _ = _dispatcher({"u1"})
         await d.handle_message(self._msg("!help"))
         assert "KiroCrew" in cli.sent[-1][0]
+        assert "!sessions [query]" in cli.sent[-1][0]
 
     @pytest.mark.asyncio
     async def test_normal_turn_streams_and_releases(self) -> None:

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from kiro_crew.discord.client import DiscordInteraction
-from kiro_crew.discord.commands import parse_command
+from kiro_crew.discord.commands import parse_command, parse_command_argument
 from kiro_crew.discord.transport_dispatch import DiscordDispatcher
 from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.messaging.transport import InboundMessage
@@ -170,6 +170,7 @@ class _ConversationLog:
         self.messages = messages
         self.metadata: dict[str, dict] = {}
         self.list_calls = 0
+        self.search_calls: list[tuple[str, int]] = []
 
     def get_metadata(self, key: str) -> dict:
         return self.metadata.get(key, {})
@@ -177,6 +178,37 @@ class _ConversationLog:
     def list_sessions(self) -> list[dict]:
         self.list_calls += 1
         return list(self.rows)
+
+    def search_sessions(self, query: str, limit: int = 50) -> list[dict]:
+        """Mirror KiroCrewHistory.search_sessions' FIELD COVERAGE and phrase
+        semantics: one casefolded phrase matched against title OR message
+        content, title hits ranked first. Deliberately not a reimplementation of
+        the real scorer -- the ranking formula is tested in the history tests;
+        what matters here is that the picker DELEGATES and renders the result."""
+        self.search_calls.append((query, limit))
+        needle = " ".join(query.casefold().split())
+        title_hits: list[dict] = []
+        content_hits: list[dict] = []
+        for row in self.rows:
+            title = " ".join(str(row.get("title") or "").casefold().split())
+            # Rows carry the JSONL stem ("dashboard_chat-0") while the message
+            # store is keyed canonically ("dashboard:chat-0"); the real history
+            # reads both from one store, so canonicalise here or content is
+            # always empty and the test silently passes for the wrong reason.
+            raw_key = str(row.get("key") or "")
+            canonical = raw_key
+            while canonical.startswith("dashboard_"):
+                canonical = canonical[len("dashboard_"):]
+            canonical = f"dashboard:{canonical}" if canonical else raw_key
+            body = " ".join(
+                str(msg.get("content") or "")
+                for msg in self.messages.get(canonical, self.messages.get(raw_key, []))
+            ).casefold()
+            if needle in title:
+                title_hits.append(row)
+            elif needle in body:
+                content_hits.append(row)
+        return (title_hits + content_hits)[:limit]
 
     def has_log(self, key: str) -> bool:
         return key in self.messages
@@ -274,6 +306,11 @@ def _picker_button(client: _Client) -> tuple[str, str]:
     return button["custom_id"], str(client._mid)
 
 
+def _picker_labels(client: _Client) -> list[str]:
+    _, components = client.sent[-1]
+    return [button["label"] for row in components for button in row["components"]]
+
+
 def _log(title: str = "Launch plan") -> _ConversationLog:
     return _ConversationLog(
         [{"key": "dashboard_chat-1", "title": title, "memory_mode": "persistent"}],
@@ -281,9 +318,151 @@ def _log(title: str = "Launch plan") -> _ConversationLog:
     )
 
 
+def _log_with_titles(*titles: str) -> _ConversationLog:
+    return _ConversationLog(
+        [
+            {
+                "key": f"dashboard_chat-{index}",
+                "title": title,
+                "memory_mode": "persistent",
+            }
+            for index, title in enumerate(titles)
+        ],
+        {f"dashboard:chat-{index}": [] for index in range(len(titles))},
+    )
+
+
+@pytest.mark.asyncio
+async def test_sessions_finds_a_session_by_conversation_content() -> None:
+    """The original bug: searching a phrase from the CONVERSATION, not the title.
+
+    The picker used to call ``list_sessions`` and filter on titles only, so a
+    query the user remembered from the discussion could never match. Routing
+    through the shared ``search_sessions`` -- the same one the dashboard uses --
+    makes message content searchable.
+    """
+    log = _ConversationLog(
+        [
+            {"key": "dashboard_chat-0", "title": "Untitled", "memory_mode": "persistent"},
+            {"key": "dashboard_chat-1", "title": "Also untitled", "memory_mode": "persistent"},
+        ],
+        {
+            "dashboard:chat-0": [{"role": "user", "content": "unrelated chatter"}],
+            "dashboard:chat-1": [
+                {"role": "user", "content": "how do I link to a specific session?"}
+            ],
+        },
+    )
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!session link to a specific session"))
+
+    # Matched on content despite neither title containing the phrase.
+    assert _picker_labels(client) == ["1. Also untitled"]
+
+
+@pytest.mark.asyncio
+async def test_sessions_delegates_to_the_shared_search() -> None:
+    """Assert DELEGATION, not re-implemented ranking.
+
+    The scoring formula belongs to KiroCrewHistory.search_sessions and is tested
+    there; what this surface must guarantee is that it calls that search rather
+    than growing a second one that drifts from the dashboard.
+    """
+    log = _log_with_titles("Codex compaction investigation")
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!sessions codex"))
+
+    assert log.search_calls, "picker did not call search_sessions"
+    query, limit = log.search_calls[0]
+    assert query == "codex"
+    assert limit > 1, "must fetch more rows than one so filtering cannot starve the picker"
+
+
+@pytest.mark.asyncio
+async def test_sessions_empty_query_does_not_search() -> None:
+    """A bare `!sessions` is a listing, not a search -- no query, no search call."""
+    log = _log_with_titles("One", "Two")
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!sessions"))
+
+    assert log.search_calls == []
+    assert log.list_calls >= 1
+    assert len(_picker_labels(client)) == 2
+
+
 def test_sessions_command_aliases() -> None:
     assert parse_command("!sessions") == "sessions"
     assert parse_command("/sessions") == "sessions"
+    assert parse_command("!session Link to a specific session") == "sessions"
+    assert parse_command_argument("!session Link to a specific session") == (
+        "Link to a specific session"
+    )
+    assert parse_command_argument("!sessions") == ""
+
+
+@pytest.mark.asyncio
+async def test_sessions_keyword_filters_beyond_recent_limit() -> None:
+    log = _log_with_titles(
+        *(f"Routine session {index}" for index in range(12)),
+        "Codex compaction investigation",
+    )
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!session codex"))
+
+    text, _ = client.sent[-1]
+    assert _picker_labels(client) == ["1. Codex compaction investigation"]
+    assert "Dashboard session search" in text
+    assert "for `codex`" in text
+
+
+@pytest.mark.asyncio
+async def test_sessions_multi_word_query_matches_case_insensitively() -> None:
+    log = _log_with_titles("Other work", "Link to a Specific Session")
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!sessions specific link"))
+
+    assert _picker_labels(client) == ["1. Link to a Specific Session"]
+
+
+@pytest.mark.asyncio
+async def test_sessions_no_match_is_explicit() -> None:
+    dispatcher, client, _ = _dispatcher({"u1"}, _log())
+
+    await dispatcher.handle_message(_message("!sessions missing topic"))
+
+    text, components = client.sent[-1]
+    assert components is None
+    assert "No dashboard sessions matched `missing topic`" in text
+    assert "Try fewer words" in text
+    assert "`!sessions`" in text
+    assert dispatcher._session_pickers == {}
+
+
+@pytest.mark.asyncio
+async def test_empty_sessions_query_keeps_recent_order_and_discloses_cap() -> None:
+    log = _log_with_titles(*(f"Recent session {index}" for index in range(12)))
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!sessions   "))
+
+    assert _picker_labels(client) == [f"{index + 1}. Recent session {index}" for index in range(10)]
+    assert "Showing 10 of 12 most recent dashboard sessions" in client.sent[-1][0]
+
+
+@pytest.mark.asyncio
+async def test_sessions_search_cap_is_enforced_and_disclosed() -> None:
+    log = _log_with_titles(*(f"Codex session {index}" for index in range(12)))
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!sessions codex"))
+
+    assert len(_picker_labels(client)) == 10
+    assert "Showing 10 of 12 matching sessions" in client.sent[-1][0]
 
 
 @pytest.mark.asyncio
@@ -291,7 +470,7 @@ async def test_sessions_requires_exactly_one_allowed_user() -> None:
     log = _log()
     dispatcher, client, _ = _dispatcher({"u1", "u2"}, log)
 
-    await dispatcher.handle_message(_message("!sessions"))
+    await dispatcher.handle_message(_message("!sessions private"))
 
     assert log.list_calls == 0
     assert "exactly one" in client.sent[-1][0]
@@ -702,6 +881,18 @@ async def test_stale_picker_fails_closed() -> None:
         picker.created_at -= 301
 
     await dispatcher.on_interaction(_interaction(custom_id, message_id))
+
+    assert sessions.mirror_links == {}
+    assert any("expired" in text for _, text, _ in client.edits)
+
+
+@pytest.mark.asyncio
+async def test_picker_nonce_is_bound_to_its_registered_choices() -> None:
+    dispatcher, client, sessions = _dispatcher({"u1"}, _log())
+    await dispatcher.handle_message(_message("!sessions"))
+    _, message_id = _picker_button(client)
+
+    await dispatcher.on_interaction(_interaction("s:not-the-picker:0", message_id))
 
     assert sessions.mirror_links == {}
     assert any("expired" in text for _, text, _ in client.edits)


### PR DESCRIPTION
## Problem

Discord accepted `!sessions <query>` and the typo-safe singular `!session <query>`, but `parse_command()` returned only the command verb. The dispatcher therefore dropped every word after the command and always showed the first 10 recent dashboard sessions.

## Why it matters

Users with many concurrent sessions could not reach a matching session outside that silent 10-item window. A search appeared to work only when the desired session happened to be recent, making the failure look intermittent.

## Fix

**Symptom → root cause → change:** preserve the existing `parse_command()` contract, add a small helper for the command remainder, and forward that remainder from the Discord dispatcher into the session picker.

The picker now:
- searches every eligible dashboard-session title case-insensitively;
- ranks exact matches, phrase substrings, then all-word matches while preserving recency as the tie-breaker;
- keeps empty-query behavior as the most recent sessions;
- explicitly reports no matches instead of silently falling back;
- echoes the sanitized query and discloses the 10-result cap and total match count;
- preserves the owner gate, DM-only gate, incognito exclusion, nonce-bound choices, SEL audit calls, and canonical dashboard-key handling.

Discord help now advertises `!sessions [query]`.

## Tests

- `.venv/bin/pytest -q test/test_discord_sessions.py test/test_discord.py` — 116 passed.
- `.venv/bin/isort --check-only src/kiro_crew test` — passed.
- `.venv/bin/flake8 --jobs 1 src/kiro_crew test` — passed.
- `.venv/bin/mypy src/kiro_crew/` — passed across 567 source files.
- Added regression coverage for filtering beyond the recent window, multi-word matching, explicit no-match output, empty-query recency, cap disclosure, owner gating, nonce binding, incognito exclusion, and help text.

## Manual verification

N/A — the Discord client fakes assert the exact message text, button labels, result ordering, and interaction binding without requiring a live bot or exposing real session titles.
