### PR TITLE
feat(discord): ingest inbound attachments

### DIFF
--- a/src/kiro_crew/discord/attachments.py
+++ b/src/kiro_crew/discord/attachments.py
@@ -1,0 +1,121 @@
+"""Discord-specific adapter over channel-neutral attachment ingestion.
+
+Discord owns the envelope mapping, CDN download callback, and voice-message
+transcription. Classification, limits, signature validation, extraction,
+redaction, rejection text, and temp-file ownership stay in
+``kiro_crew.messaging.attachments``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from kiro_crew.messaging.attachments import (
+    Attachment,
+    IngestResult,
+    ingest_attachments,
+)
+from kiro_crew.transcribe import is_available as stt_available
+from kiro_crew.transcribe import transcribe_audio
+
+if TYPE_CHECKING:
+    from kiro_crew.discord.client import DiscordClient
+
+logger = logging.getLogger(__name__)
+
+
+def _to_attachment(raw: Any) -> Attachment:
+    """Map one Discord attachment object onto the shared neutral shape."""
+    if not isinstance(raw, dict):
+        return Attachment(name="unknown")
+
+    filename = raw.get("filename")
+    name = filename if isinstance(filename, str) and filename else "unknown"
+    content_type = raw.get("content_type")
+    mimetype = content_type if isinstance(content_type, str) else ""
+    url_value = raw.get("url")
+    url = url_value if isinstance(url_value, str) else ""
+    size_value = raw.get("size")
+    size = (
+        size_value
+        if isinstance(size_value, int)
+        and not isinstance(size_value, bool)
+        and size_value >= 0
+        else 0
+    )
+    suffix = name.rsplit(".", 1)[-1] if "." in name else ""
+    return Attachment(
+        name=name,
+        mimetype=mimetype,
+        size=size,
+        url=url,
+        suffix_hint=suffix,
+    )
+
+
+async def process_discord_attachments(
+    client: DiscordClient,
+    raw_attachments: list[Any],
+) -> IngestResult:
+    """Ingest Discord files and transcribe any ``audio/*`` attachments.
+
+    Discord voice messages are audio attachments (currently Opus in OGG), so
+    the shared classifier's normal ``audio/`` rule is sufficient: no
+    channel-specific mimetype override is needed. The returned temp paths stay
+    caller-owned and must live until the consuming turn finishes.
+    """
+
+    result = await ingest_attachments(
+        [_to_attachment(raw) for raw in raw_attachments],
+        download=client.download_attachment,
+        source="discord",
+        handle_audio=True,
+    )
+
+    if not result.audio_paths:
+        return result
+
+    try:
+        available = await asyncio.to_thread(stt_available)
+    except Exception:
+        logger.exception("Discord: failed to check speech-to-text availability")
+        available = False
+
+    if not available:
+        result.rejections.extend(
+            "[Audio attachment — transcription is unavailable]"
+            for _ in result.audio_paths
+        )
+        return result
+
+    for path in result.audio_paths:
+        try:
+            transcript = await transcribe_audio(path)
+        except Exception:
+            logger.exception("Discord: audio transcription raised")
+            transcript = None
+        if transcript:
+            result.text_blocks.append(
+                "[Voice memo transcription]\n"
+                f"{transcript}\n"
+                "[End of transcription]"
+            )
+        else:
+            result.rejections.append("[Audio attachment — transcription failed]")
+
+    return result
+
+
+def append_attachment_context(text: str, result: IngestResult) -> str:
+    """Append prompt-ready attachment material using Slack's proven layout."""
+    if result.image_paths:
+        paths_text = "\n".join(result.image_paths)
+        text = f"{text}\n{paths_text}" if text else paths_text
+
+    blocks = [*result.text_blocks, *result.rejections]
+    if blocks:
+        blocks_text = "\n\n".join(blocks)
+        text = f"{text}\n\n{blocks_text}" if text else blocks_text
+    return text

--- a/src/kiro_crew/discord/client.py
+++ b/src/kiro_crew/discord/client.py
@@ -25,7 +25,7 @@ import logging
 import os
 import random
 import urllib.parse
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
 import aiohttp
@@ -39,6 +39,11 @@ DISCORD_CHUNK_LIMIT = 1900
 
 _API_BASE = "https://discord.com/api/v10"
 _GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
+
+# Attachment URLs are signed but unauthenticated. Keep the exact CDN host
+# allow-list here at the channel boundary; redirects are disabled during fetch
+# so an allowed URL cannot bounce the downloader to an arbitrary host.
+_ATTACHMENT_HOSTS = frozenset({"cdn.discordapp.com", "media.discordapp.net"})
 
 # Gateway intents. DM-only installations request DIRECT_MESSAGES alone. When
 # an explicit server-thread allow-list is configured, GUILD_MESSAGES delivers
@@ -77,6 +82,7 @@ class DiscordInbound:
     message_id: str = ""
     guild_id: str = ""  # empty string == DM channel
     is_bot: bool = False
+    attachments: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -265,6 +271,42 @@ class DiscordClient:
             f"/interactions/{interaction_id}/{interaction_token}/callback",
             {"type": _CALLBACK_DEFERRED_UPDATE_MESSAGE},
         )
+
+    async def download_attachment(self, url: str, dest: str) -> None:
+        """Download a signed Discord CDN attachment without bot credentials.
+
+        Only Discord's two documented delivery hosts are accepted. Redirects
+        are deliberately refused so host validation remains true for the bytes
+        ultimately written to ``dest``.
+        """
+        try:
+            parsed = urllib.parse.urlsplit(url)
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError("invalid Discord attachment URL") from exc
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname not in _ATTACHMENT_HOSTS
+            or port not in (None, 443)
+        ):
+            raise ValueError("refusing non-Discord attachment URL")
+
+        session = await self._ensure_session()
+        async with session.get(
+            url,
+            proxy=self._proxy,
+            timeout=aiohttp.ClientTimeout(total=30),
+            allow_redirects=False,
+        ) as resp:
+            if 300 <= resp.status < 400:
+                raise ValueError("refusing redirected Discord attachment URL")
+            resp.raise_for_status()
+            fh = await asyncio.to_thread(open, dest, "wb")
+            try:
+                async for chunk in resp.content.iter_chunked(8192):
+                    await asyncio.to_thread(fh.write, chunk)
+            finally:
+                await asyncio.to_thread(fh.close)
 
     async def create_dm_channel(self, user_id: str) -> str:
         """Create (or fetch) the DM channel for a user id. Returns the channel
@@ -482,6 +524,11 @@ class DiscordClient:
                 message_id=str(d.get("id", "")),
                 guild_id=str(d.get("guild_id", "") or ""),
                 is_bot=bool(author.get("bot", False)),
+                attachments=[
+                    attachment
+                    for attachment in (d.get("attachments") or [])
+                    if isinstance(attachment, dict)
+                ],
             )
             if inbound.is_bot or inbound.user_id == self.bot_user_id:
                 return  # never respond to bots (incl. ourselves) — loop guard

--- a/src/kiro_crew/discord/transport.py
+++ b/src/kiro_crew/discord/transport.py
@@ -59,7 +59,7 @@ DISCORD_CAPABILITIES = TransportCapabilities(
     streaming=True,
     edit=True,
     reactions=True,  # add_reaction — used for the steer-ack receipt
-    files=False,
+    files=True,
     rich_blocks=False,
     threads=True,
     max_message_chars=DISCORD_CHUNK_LIMIT,
@@ -157,13 +157,13 @@ class DiscordTransport(MessagingTransport):
         The low-level client's Gateway loop normalizes MESSAGE_CREATE into
         ``DiscordInbound``; this adapter maps that onto the neutral
         ``InboundMessage``, enforces deny-by-default auth, and hands an
-        authorized message to the turn dispatcher. Non-text messages
-        (attachments/stickers only) are dropped.
+        authorized message to the turn dispatcher. Attachment-only messages
+        continue through the same authorized path; sticker-only messages do not.
         """
         if not isinstance(raw_envelope, DiscordInbound):
             return
         inbound = raw_envelope
-        if not inbound.text:
+        if not inbound.text and not inbound.attachments:
             return
         thread_id: str | None = None
         if inbound.guild_id:
@@ -189,6 +189,7 @@ class DiscordTransport(MessagingTransport):
             text=inbound.text,
             thread_id=thread_id,
             message_id=inbound.message_id,
+            attachments=list(inbound.attachments),
         )
         if not self.authorize(msg):
             return

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -28,6 +28,10 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.discord.attachments import (
+    append_attachment_context,
+    process_discord_attachments,
+)
 from kiro_crew.discord.commands import (
     ConversationState,
     parse_command,
@@ -38,6 +42,8 @@ from kiro_crew.discord.session_resume import DiscordSessionResume
 from kiro_crew.discord.transport import DISCORD_CAPABILITIES
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
+from kiro_crew.messaging.attachments import IngestLimits
+from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import (
@@ -71,6 +77,8 @@ _AGENT_SENTINELS = frozenset({"default", "auto"})
 
 # Upper bound on how many queued messages collapse into a single combined turn.
 _MAX_COLLAPSE = 50
+# Keep queue collapse within the shared ingestion layer's per-turn file cap.
+_MAX_COLLAPSED_ATTACHMENTS = IngestLimits().max_attachments
 
 _HELP_TEXT = """\
 🦞 **KiroCrew — Discord**
@@ -201,14 +209,24 @@ class DiscordDispatcher:
         scope_id = self._scope_id(user_id, thread_id)
         text = msg.text
 
+        # Attachments make this a content-bearing turn, not a control command.
+        # Otherwise a caption such as ``!help`` would intercept before ingestion
+        # and silently discard the attached file — the exact class of bug this
+        # path is meant to eliminate.
+        interpret_as_command = interpret_commands and not msg.attachments
+
         # Per-message mid-turn override (!queue/!steer) — see the Telegram
         # dispatcher for the full precedence rationale.
         override_mode = None
-        if interpret_commands and parse_command(text) is None:
+        if interpret_as_command and parse_command(text) is None:
             override_mode, text = parse_mid_turn_override(text)
 
         # ── Command intercept (no LLM session needed) ──
-        cmd = parse_command(text) if interpret_commands and override_mode is None else None
+        cmd = (
+            parse_command(text)
+            if interpret_as_command and override_mode is None
+            else None
+        )
         if cmd == "new":
             left_resumed = self._session_resume.leave_resumed_session(channel_id)
             self._conv.bump_gen(scope_id)
@@ -307,17 +325,29 @@ class DiscordDispatcher:
             self.client, channel_id, DISCORD_CAPABILITIES, session_key=session_key
         )
         self._active_renderers[session_key] = renderer
+        attachment_temp_paths: list[str] = []
 
         # Everything acquire-dependent runs INSIDE the try so the finally
         # always finalizes the renderer; release() is gated on _acquired.
         # Mirrors telegram/transport_dispatch.py.
         _acquired = False
         try:
-            await renderer.on_turn_start()
+            # Acquire before attachment I/O. A large download yields repeatedly;
+            # leaving the session idle in that window lets a later message run
+            # first and persist the conversation in reverse order.
             provider, is_new, resumed = await self.sessions.get_or_create(
                 session_key, agent=agent, channel_id=chan_id
             )
             _acquired = True
+            if msg.attachments:
+                attachment_result = await process_discord_attachments(
+                    self.client, msg.attachments
+                )
+                attachment_temp_paths = list(attachment_result.temp_paths)
+                text = append_attachment_context(text, attachment_result)
+            if not text:
+                return
+            await renderer.on_turn_start()
             # New-session bookkeeping belongs to THIS conversation's own session
             # only. A resumed dashboard session is pre-existing by definition, and
             # `get_or_create` returns is_new whenever its ACP session is merely
@@ -441,6 +471,9 @@ class DiscordDispatcher:
             self._active_renderers.pop(session_key, None)
             if _acquired:
                 self.sessions.release(session_key)
+            await asyncio.to_thread(
+                cleanup_attachments, attachment_temp_paths
+            )
 
         # Drain anything queued during the turn (queue_mode == "queue").
         if drain:
@@ -457,7 +490,7 @@ class DiscordDispatcher:
         assert self.client is not None
         channel_id = msg.conversation_id
         mode = override_mode or self.cfg.messaging.queue_mode
-        if mode != "queue":
+        if mode != "queue" and not msg.attachments:
             provider = self.sessions.get_provider(session_key)
             steer = getattr(provider, "steer", None)
             # Only steer when a turn is GENUINELY in flight (see the Telegram
@@ -485,7 +518,12 @@ class DiscordDispatcher:
                 return
         # queue mode (or !queue override, or steer unavailable). Atomic
         # enqueue + receipt under _receipt_lock — see the Telegram dispatcher.
-        if not await self._enqueue_with_receipt(session_key, channel_id, text):
+        if not await self._enqueue_with_receipt(
+            session_key,
+            channel_id,
+            text,
+            attachments=msg.attachments,
+        ):
             await self.handle_message(msg)
 
     async def _drain_queue(
@@ -494,61 +532,112 @@ class DiscordDispatcher:
         """Collapse every message queued during the just-finished turn into ONE
         combined turn (order preserved). See the Telegram dispatcher for the
         lock/ordering rationale."""
-        texts: list[str] = []
-        remainder: list[tuple[str, str, dict]] = []
-        async with self._receipt_lock:
-            while True:
-                item = self.sessions.dequeue(session_key)
-                if item is None:
-                    break
-                if len(texts) < _MAX_COLLAPSE:
-                    texts.append(item[1])
-                else:
-                    remainder.append(item)
-            for _ts, rtext, _kw in remainder:
-                self.sessions.enqueue(session_key, str(time.time()), rtext, force=True)
-            if texts:
-                await self._receipt_flip_locked(session_key, channel_id, texts, len(remainder))
-        if not texts:
-            return
-        if remainder:
-            logger.debug(
-                "discord: drain hit collapse cap=%d for %s; %d message(s) "
-                "deferred (in order) to the next turn",
-                _MAX_COLLAPSE,
-                session_key,
-                len(remainder),
+        # Iterate rather than recurse: one burst can span multiple
+        # attachment-capped turns, and messages arriving during a drained turn
+        # join the same FIFO pump instead of waiting for unrelated future input.
+        while True:
+            texts: list[str] = []
+            attachments: list[Any] = []
+            remainder: list[tuple[str, str, dict]] = []
+            defer_rest = False
+            async with self._receipt_lock:
+                while True:
+                    item = self.sessions.dequeue(session_key)
+                    if item is None:
+                        break
+                    item_attachments = list(item[2].get("attachments") or [])
+                    exceeds_attachment_cap = bool(
+                        texts
+                        and item_attachments
+                        and len(attachments) + len(item_attachments)
+                        > _MAX_COLLAPSED_ATTACHMENTS
+                    )
+                    if (
+                        not defer_rest
+                        and len(texts) < _MAX_COLLAPSE
+                        and not exceeds_attachment_cap
+                    ):
+                        texts.append(item[1])
+                        attachments.extend(item_attachments)
+                    else:
+                        # Once one message no longer fits, defer it and everything
+                        # behind it so queue order remains exact.
+                        defer_rest = True
+                        remainder.append(item)
+                for _ts, rtext, rkw in remainder:
+                    self.sessions.enqueue(
+                        session_key,
+                        str(time.time()),
+                        rtext,
+                        force=True,
+                        attachments=list(rkw.get("attachments") or []),
+                    )
+                if texts:
+                    await self._receipt_flip_locked(
+                        session_key,
+                        channel_id,
+                        [text or "[attachment]" for text in texts],
+                        len(remainder),
+                    )
+            if not texts:
+                return
+            if remainder:
+                logger.debug(
+                    "discord: drain deferred %d message(s) for %s "
+                    "to preserve collapse/attachment caps and FIFO order",
+                    len(remainder),
+                    session_key,
+                )
+            combined = "\n\n".join(texts)
+            await self.handle_message(
+                InboundMessage(
+                    channel_type="discord",
+                    user_id=user_id,
+                    conversation_id=channel_id,
+                    text=combined,
+                    thread_id=thread_id or None,
+                    attachments=attachments,
+                ),
+                drain=False,
+                interpret_commands=False,
             )
-        combined = "\n\n".join(texts)
-        await self.handle_message(
-            InboundMessage(
-                channel_type="discord",
-                user_id=user_id,
-                conversation_id=channel_id,
-                text=combined,
-                thread_id=thread_id or None,
-            ),
-            drain=False,
-            interpret_commands=False,
-        )
 
     # ── Mid-turn queue receipt (single, in-place, persistent record) ───────
 
-    async def _enqueue_with_receipt(self, session_key: str, channel_id: str, text: str) -> bool:
+    async def _enqueue_with_receipt(
+        self,
+        session_key: str,
+        channel_id: str,
+        text: str,
+        *,
+        attachments: list[Any] | None = None,
+    ) -> bool:
         """Atomically enqueue a mid-turn message and create/grow its collapsing
         receipt, under ``_receipt_lock``. Returns True if queued; False if the
         turn finished in the window (caller runs the message as a fresh turn)."""
         assert self.client is not None
         async with self._receipt_lock:
-            if not self.sessions.enqueue(session_key, str(time.time()), text, force=False):
+            if not self.sessions.enqueue(
+                session_key,
+                str(time.time()),
+                text,
+                force=False,
+                attachments=list(attachments or []),
+            ):
                 return False
+            receipt_text = text or "[attachment]"
             receipt = self._queue_receipts.get(session_key)
             if receipt is None:
-                msg_id = await self.client.send_message(channel_id, _receipt_text([text]))
+                msg_id = await self.client.send_message(
+                    channel_id, _receipt_text([receipt_text])
+                )
                 if msg_id is not None:
-                    self._queue_receipts[session_key] = _QueueReceipt(msg_id=msg_id, texts=[text])
+                    self._queue_receipts[session_key] = _QueueReceipt(
+                        msg_id=msg_id,
+                        texts=[receipt_text],
+                    )
                 return True
-            receipt.texts.append(text)
+            receipt.texts.append(receipt_text)
             try:
                 await self.client.edit_message(
                     channel_id, receipt.msg_id, _receipt_text(receipt.texts)

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from kiro_crew import platform_compat
 
@@ -190,20 +191,39 @@ def is_available(stt_config=None) -> bool:  # type: ignore[no-untyped-def]
     return _find_whisper(stt_config.whisper_path) is not None
 
 
+def _load_stt_config() -> Any:
+    """Load STT configuration without importing or reading config on the loop."""
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    return KiroCrewConfig.load().stt
+
+
+def _is_sensitive_audio_path(audio_path: str) -> bool:
+    """Run the filesystem-resolving sensitive-path guard off the event loop."""
+    from kiro_crew.security import is_sensitive_path
+
+    return is_sensitive_path(audio_path)
+
+
+def _redact_transcript(transcript: str) -> str:
+    """Apply transcript redaction without consuming event-loop time."""
+    from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+    transcript, _ = redact_exfiltration_urls(transcript)
+    transcript, _ = redact_credentials(transcript)
+    return transcript
+
+
 async def transcribe_audio(audio_path: str, stt_config=None) -> str | None:  # type: ignore[no-untyped-def]
     """Transcribe audio file. Returns text or None."""
     if stt_config is None:
-        from kiro_crew.config.loader import KiroCrewConfig
-
-        stt_config = KiroCrewConfig.load().stt
+        stt_config = await asyncio.to_thread(_load_stt_config)
 
     if not stt_config.enabled:
         logger.debug("STT disabled in config")
         return None
 
-    from kiro_crew.security import is_sensitive_path
-
-    if is_sensitive_path(audio_path):
+    if await asyncio.to_thread(_is_sensitive_audio_path, audio_path):
         logger.error("Refusing to read sensitive path: %s", audio_path)
         return None
 
@@ -211,17 +231,14 @@ async def transcribe_audio(audio_path: str, stt_config=None) -> str | None:  # t
     if provider == "transcribe":
         result = await _transcribe_aws(audio_path, stt_config)
     elif provider == "mlx":
-        ensure_ffmpeg_in_path()
+        await asyncio.to_thread(ensure_ffmpeg_in_path)
         result = await _transcribe_mlx(audio_path, stt_config)
     else:
-        ensure_ffmpeg_in_path()
+        await asyncio.to_thread(ensure_ffmpeg_in_path)
         result = await _transcribe_native(audio_path, stt_config)
 
     if result:
-        from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-
-        result, _ = redact_exfiltration_urls(result)
-        result, _ = redact_credentials(result)
+        result = await asyncio.to_thread(_redact_transcript, result)
     return result
 
 
@@ -256,6 +273,54 @@ TRANSCRIBE_SAMPLE_RATE_HZ = 48000
 _TRANSCRIBE_MAX_BYTES = 25 * 1024 * 1024  # 25 MB Transcribe API limit
 
 
+def _load_aws_transcribe_components() -> tuple[Any, Any]:
+    """Import optional AWS Transcribe components outside the event loop."""
+    from amazon_transcribe.client import TranscribeStreamingClient
+    from amazon_transcribe.handlers import TranscriptResultStreamHandler
+    from amazon_transcribe.model import TranscriptEvent
+
+    class TranscriptCollector(TranscriptResultStreamHandler):
+        def __init__(self, output_stream: Any, transcript_parts: list[str]) -> None:
+            super().__init__(output_stream)
+            self._transcript_parts = transcript_parts
+
+        async def handle_transcript_event(
+            self, transcript_event: TranscriptEvent
+        ) -> None:
+            for result in transcript_event.transcript.results:
+                if not result.is_partial and result.alternatives:
+                    self._transcript_parts.append(result.alternatives[0].transcript)
+
+    return TranscribeStreamingClient, TranscriptCollector
+
+
+def _find_ffmpeg() -> str | None:
+    """Return an ffmpeg binary after probing known install locations."""
+    ensure_ffmpeg_in_path()
+    return shutil.which("ffmpeg")
+
+
+def _make_temp_ogg() -> str:
+    """Create and close a temporary OGG file without leaking its descriptor."""
+    fd, path = tempfile.mkstemp(suffix=".ogg")
+    os.close(fd)
+    return path
+
+
+def _unlink_if_exists(path: str) -> None:
+    """Remove *path*, tolerating another cleanup path winning the race."""
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+
+def _read_audio_bytes(audio_path: str) -> bytes:
+    """Read at most one byte beyond AWS Transcribe's upload limit."""
+    with open(audio_path, "rb") as audio_file:
+        return audio_file.read(_TRANSCRIBE_MAX_BYTES + 1)
+
+
 async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: ignore[no-untyped-def]
     """Transcribe using AWS Transcribe Streaming API (ogg-opus)."""
     ext = os.path.splitext(audio_path)[1].lower()
@@ -269,9 +334,9 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
         logger.error("AWS Transcribe not available: install 'kirocrew[voice]'")
         return None
     try:
-        from amazon_transcribe.client import TranscribeStreamingClient
-        from amazon_transcribe.handlers import TranscriptResultStreamHandler
-        from amazon_transcribe.model import TranscriptEvent
+        TranscribeStreamingClient, TranscriptCollector = await asyncio.to_thread(
+            _load_aws_transcribe_components
+        )
     except ImportError:
         logger.error("AWS Transcribe not available: install 'kirocrew[voice]'")
         return None
@@ -280,15 +345,14 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
     tmp_ogg = None
     actual_path = audio_path
     if ext in (".webm",):
-        ensure_ffmpeg_in_path()
-        if not shutil.which("ffmpeg"):
+        ffmpeg_bin = await asyncio.to_thread(_find_ffmpeg)
+        if not ffmpeg_bin:
             logger.error("ffmpeg required to remux webm to ogg for Transcribe")
             return None
-        fd, tmp_ogg = tempfile.mkstemp(suffix=".ogg")
-        os.close(fd)
+        tmp_ogg = await asyncio.to_thread(_make_temp_ogg)
         try:
             proc = await asyncio.create_subprocess_exec(
-                "ffmpeg",
+                ffmpeg_bin,
                 "-y",
                 "-i",
                 audio_path,
@@ -308,30 +372,31 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
                 raise RuntimeError(f"ffmpeg exited with {proc.returncode}")
         except Exception:
             logger.exception("ffmpeg remux failed for %s", audio_path)
-            if tmp_ogg and os.path.exists(tmp_ogg):
-                os.unlink(tmp_ogg)
+            if tmp_ogg:
+                await asyncio.to_thread(_unlink_if_exists, tmp_ogg)
             return None
         actual_path = tmp_ogg
 
     transcript_parts: list[str] = []
-
-    class Handler(TranscriptResultStreamHandler):
-        async def handle_transcript_event(self, transcript_event: TranscriptEvent) -> None:
-            for result in transcript_event.transcript.results:
-                if not result.is_partial and result.alternatives:
-                    transcript_parts.append(result.alternatives[0].transcript)
-
     stream = None
     try:
-        file_size = os.path.getsize(actual_path)
-        if file_size > _TRANSCRIBE_MAX_BYTES:
-            logger.error("Audio file too large for Transcribe: %d bytes", file_size)
+        audio_bytes = await asyncio.to_thread(_read_audio_bytes, actual_path)
+        if len(audio_bytes) > _TRANSCRIBE_MAX_BYTES:
+            logger.error(
+                "Audio file too large for Transcribe: >%d bytes",
+                _TRANSCRIBE_MAX_BYTES,
+            )
             return None
 
         profile = stt_config.transcribe_profile or None
-        credential_resolver = _ProfileCredentialResolver(profile) if profile else None
+        credential_resolver = (
+            await asyncio.to_thread(_ProfileCredentialResolver, profile)
+            if profile
+            else None
+        )
 
-        client = TranscribeStreamingClient(
+        client = await asyncio.to_thread(
+            TranscribeStreamingClient,
             region=region,
             credential_resolver=credential_resolver,
         )
@@ -342,7 +407,6 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
         )
 
         async def write_chunks():
-            audio_bytes = Path(actual_path).read_bytes()
             chunk_size = 8192
             for i in range(0, len(audio_bytes), chunk_size):
                 await stream.input_stream.send_audio_event(
@@ -350,7 +414,7 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
                 )
             await stream.input_stream.end_stream()
 
-        handler = Handler(stream.output_stream)
+        handler = TranscriptCollector(stream.output_stream, transcript_parts)
         await asyncio.wait_for(
             asyncio.gather(write_chunks(), handler.handle_events()),
             timeout=stt_config.timeout_secs,
@@ -367,8 +431,8 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
                 await stream.input_stream.end_stream()
             except Exception:
                 pass
-        if tmp_ogg and os.path.exists(tmp_ogg):
-            os.unlink(tmp_ogg)
+        if tmp_ogg:
+            await asyncio.to_thread(_unlink_if_exists, tmp_ogg)
 
 
 def _collect_whisper_output(
@@ -406,7 +470,7 @@ async def _run_whisper_cli(
     up. ``build_args`` lets callers express their differing flags (the two CLIs
     use hyphenated vs underscored option names).
     """
-    out_dir = tempfile.mkdtemp()
+    out_dir = await asyncio.to_thread(tempfile.mkdtemp)
     proc = None
     try:
         clean_env = os.environ.copy()
@@ -420,7 +484,13 @@ async def _run_whisper_cli(
             env=clean_env,
         )
         _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
-        return _collect_whisper_output(proc.returncode, stderr, out_dir, label=label)
+        return await asyncio.to_thread(
+            _collect_whisper_output,
+            proc.returncode,
+            stderr,
+            out_dir,
+            label,
+        )
     except asyncio.TimeoutError:
         if proc is not None:
             try:
@@ -431,7 +501,7 @@ async def _run_whisper_cli(
         logger.error("%s transcription timed out after %ds", label, timeout_secs)
         return None
     finally:
-        shutil.rmtree(out_dir, ignore_errors=True)
+        await asyncio.to_thread(shutil.rmtree, out_dir, ignore_errors=True)
 
 
 # Defense in depth: ``mlx_model`` is read from config.json. The dashboard PUT
@@ -449,7 +519,7 @@ async def _transcribe_mlx(audio_path: str, stt_config) -> str | None:  # type: i
     the hyphenated flags (``--output-dir``/``--output-format``), which differ
     from the underscore flags used by the openai-whisper CLI.
     """
-    mlx_bin = _find_mlx_whisper()
+    mlx_bin = await asyncio.to_thread(_find_mlx_whisper)
     if not mlx_bin:
         logger.error("mlx_whisper not found — install: pipx install mlx-whisper")
         return None
@@ -481,7 +551,7 @@ async def _transcribe_mlx(audio_path: str, stt_config) -> str | None:  # type: i
 
 async def _transcribe_native(audio_path: str, stt_config) -> str | None:  # type: ignore[no-untyped-def]
     """Transcribe using the native openai-whisper binary."""
-    whisper_bin = _find_whisper(stt_config.whisper_path)
+    whisper_bin = await asyncio.to_thread(_find_whisper, stt_config.whisper_path)
     if not whisper_bin:
         logger.error("whisper not found — install: pip install openai-whisper")
         return None

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -10,6 +10,8 @@ turn + interaction routing (transport_dispatch.py). Mirrors test_telegram.py.
 from __future__ import annotations
 
 import asyncio
+import os
+import threading
 from types import SimpleNamespace
 from typing import Any
 
@@ -20,6 +22,7 @@ from kiro_crew.acp.types import (
     EVENT_COMPLETE,
     EVENT_TEXT_CHUNK,
 )
+from kiro_crew.discord.attachments import process_discord_attachments
 from kiro_crew.discord.client import (
     _INTENT_DIRECT_MESSAGES,
     _INTENT_GUILD_MESSAGES,
@@ -53,8 +56,11 @@ from kiro_crew.discord.transport_dispatch import (
     DiscordDispatcher,
     _receipt_text,
 )
+from kiro_crew.messaging.attachments import cleanup
 from kiro_crew.messaging.link import dashboard_mirror_key
 from kiro_crew.messaging.transport import InboundMessage
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
 
 # ── Fakes ──────────────────────────────────────────────────────────────────
 
@@ -69,6 +75,8 @@ class FakeClient:
         self.acked: list[str] = []
         self.reactions: list[tuple[str, str]] = []
         self.thread_channels: set[str] = set()
+        self.attachment_bodies: dict[str, bytes] = {}
+        self.attachment_downloads: list[str] = []
         self._mid = 100
 
     async def is_thread_channel(self, channel_id: str) -> bool:
@@ -115,6 +123,11 @@ class FakeClient:
 
     async def create_dm_channel(self, user_id: str) -> str:
         return f"dm-{user_id}"
+
+    async def download_attachment(self, url: str, dest: str) -> None:
+        self.attachment_downloads.append(url)
+        with open(dest, "wb") as fh:
+            fh.write(self.attachment_bodies[url])
 
     def final_text(self) -> Any:
         """Text the user ultimately sees on the live message: the last edit if
@@ -288,8 +301,10 @@ class _FakeHooks:
 class FakeCtx:
     def __init__(self) -> None:
         self.hooks = _FakeHooks()
+        self.messages: list[str] = []
 
     def build_message(self, text: str, is_new: bool, key: str, **kw: Any) -> Any:
+        self.messages.append(text)
         return text, None
 
 
@@ -496,7 +511,204 @@ class TestFindButtonLabel:
         assert _find_button_label(components, "opt:9") == ""
 
 
-# ── client.py Gateway intents ────────────────────────────────────────────
+# ── client.py Gateway + attachment download ──────────────────────────────
+
+
+class TestGatewayAttachmentNormalization:
+    @pytest.mark.asyncio
+    async def test_message_create_copies_attachments(self) -> None:
+        captured: list[DiscordInbound] = []
+
+        async def _capture(inbound: DiscordInbound) -> None:
+            captured.append(inbound)
+
+        client = DiscordClient(token="test", on_message=_capture)
+        raw_attachment = {
+            "filename": "photo.png",
+            "content_type": "image/png",
+            "size": len(_PNG),
+            "url": "https://cdn.discordapp.com/attachments/c/m/photo.png",
+        }
+        client._on_dispatch(
+            "MESSAGE_CREATE",
+            {
+                "channel_id": "c1",
+                "id": "m1",
+                "content": "caption",
+                "author": {"id": "u1", "username": "user"},
+                "attachments": [raw_attachment],
+            },
+        )
+        tasks = tuple(client._handler_tasks)
+        assert tasks
+        await asyncio.gather(*tasks)
+
+        assert captured[0].text == "caption"
+        assert captured[0].attachments == [raw_attachment]
+
+    @pytest.mark.asyncio
+    async def test_download_file_operations_run_off_loop(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop_thread = threading.get_ident()
+        operation_threads: dict[str, list[int]] = {
+            "open": [],
+            "write": [],
+            "close": [],
+        }
+        real_open = open
+
+        class _TrackedFile:
+            def __init__(self, inner: Any) -> None:
+                self._inner = inner
+
+            def write(self, chunk: bytes) -> int:
+                operation_threads["write"].append(threading.get_ident())
+                return self._inner.write(chunk)
+
+            def close(self) -> None:
+                operation_threads["close"].append(threading.get_ident())
+                self._inner.close()
+
+        def _tracked_open(*args: Any, **kwargs: Any) -> _TrackedFile:
+            operation_threads["open"].append(threading.get_ident())
+            return _TrackedFile(real_open(*args, **kwargs))
+
+        class _Content:
+            async def iter_chunked(self, size: int) -> Any:
+                assert size == 8192
+                yield b"first"
+                yield b"second"
+
+        class _Response:
+            status = 200
+            content = _Content()
+
+            async def __aenter__(self) -> "_Response":
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                return None
+
+            def raise_for_status(self) -> None:
+                return None
+
+        class _Session:
+            def get(self, *args: Any, **kwargs: Any) -> _Response:
+                return _Response()
+
+        async def _ensure_session() -> _Session:
+            return _Session()
+
+        client = DiscordClient(token="test")
+        monkeypatch.setattr(client, "_ensure_session", _ensure_session)
+        monkeypatch.setattr("builtins.open", _tracked_open)
+        dest = tmp_path / "download.bin"
+
+        await client.download_attachment(
+            "https://cdn.discordapp.com/attachments/c/m/download.bin",
+            str(dest),
+        )
+
+        assert dest.read_bytes() == b"firstsecond"
+        assert all(operation_threads.values())
+        assert all(
+            thread != loop_thread
+            for threads in operation_threads.values()
+            for thread in threads
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/file.png",
+            "https://cdn.discordapp.com.evil.example/file.png",
+            "http://cdn.discordapp.com/file.png",
+            "https://media.discordapp.net:444/file.png",
+        ],
+    )
+    async def test_download_refuses_non_discord_origin(
+        self, tmp_path: Any, url: str
+    ) -> None:
+        client = DiscordClient(token="test")
+        with pytest.raises(ValueError, match="Discord attachment URL"):
+            await client.download_attachment(url, str(tmp_path / "out"))
+        assert client._session is None
+
+
+class TestDiscordAttachmentAdapter:
+    @pytest.mark.asyncio
+    async def test_audio_is_returned_for_transcription(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = FakeClient()
+        url = "https://cdn.discordapp.com/attachments/c/m/voice.ogg"
+        client.attachment_bodies[url] = b"OggS" + b"\x00" * 32
+        transcribed: list[str] = []
+
+        async def _transcribe(path: str) -> str:
+            assert os.path.exists(path)
+            transcribed.append(path)
+            return "spoken words"
+
+        monkeypatch.setattr(
+            "kiro_crew.discord.attachments.stt_available", lambda: True
+        )
+        monkeypatch.setattr(
+            "kiro_crew.discord.attachments.transcribe_audio", _transcribe
+        )
+
+        result = await process_discord_attachments(
+            client,  # type: ignore[arg-type]
+            [
+                {
+                    "filename": "voice.ogg",
+                    "content_type": "audio/ogg",
+                    "size": 36,
+                    "url": url,
+                }
+            ],
+        )
+
+        assert transcribed == result.audio_paths
+        assert any("spoken words" in block for block in result.text_blocks)
+        cleanup(result.temp_paths)
+
+    @pytest.mark.asyncio
+    async def test_stt_availability_check_runs_off_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop_thread = threading.get_ident()
+        observed: list[int] = []
+        client = FakeClient()
+        url = "https://cdn.discordapp.com/attachments/c/m/voice.ogg"
+        client.attachment_bodies[url] = b"OggS" + b"\x00" * 32
+
+        def _available() -> bool:
+            observed.append(threading.get_ident())
+            return False
+
+        monkeypatch.setattr(
+            "kiro_crew.discord.attachments.stt_available", _available
+        )
+        result = await process_discord_attachments(
+            client,  # type: ignore[arg-type]
+            [
+                {
+                    "filename": "voice.ogg",
+                    "content_type": "audio/ogg",
+                    "size": 36,
+                    "url": url,
+                }
+            ],
+        )
+
+        assert observed and loop_thread not in observed
+        assert result.rejections == [
+            "[Audio attachment — transcription is unavailable]"
+        ]
+        cleanup(result.temp_paths)
 
 
 class _FakeWs:
@@ -555,6 +767,7 @@ class TestTransportAuth:
         assert DISCORD_CAPABILITIES.streaming is True
         assert DISCORD_CAPABILITIES.edit is True
         assert DISCORD_CAPABILITIES.reactions is True
+        assert DISCORD_CAPABILITIES.files is True
         assert DISCORD_CAPABILITIES.threads is True
 
 
@@ -685,6 +898,27 @@ class TestTransportReceive:
         t, dispatched, _ = self._transport(["u1"])
         await t.receive(DiscordInbound(channel_id="c1", user_id="u1", text=""))
         assert dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_attachment_only_message_dispatches(self) -> None:
+        t, dispatched, _ = self._transport(["u1"])
+        attachment = {
+            "filename": "photo.png",
+            "content_type": "image/png",
+            "size": len(_PNG),
+            "url": "https://cdn.discordapp.com/attachments/c/m/photo.png",
+        }
+        await t.receive(
+            DiscordInbound(
+                channel_id="c1",
+                user_id="u1",
+                text="",
+                attachments=[attachment],
+            )
+        )
+        assert len(dispatched) == 1
+        assert dispatched[0].text == ""
+        assert dispatched[0].attachments == [attachment]
 
     @pytest.mark.asyncio
     async def test_non_inbound_envelope_ignored(self) -> None:
@@ -899,6 +1133,240 @@ class TestDispatcher:
         await d.handle_message(self._msg("hello"))
         assert sess.released  # release still happened
         assert d._active_renderers == {}  # renderer entry cleaned up
+
+    @pytest.mark.asyncio
+    async def test_text_and_image_reach_prompt_then_temp_is_cleaned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop_thread = threading.get_ident()
+        cleanup_threads: list[int] = []
+
+        def _cleanup(paths: list[str]) -> None:
+            cleanup_threads.append(threading.get_ident())
+            cleanup(paths)
+
+        monkeypatch.setattr(
+            "kiro_crew.discord.transport_dispatch.cleanup_attachments",
+            _cleanup,
+        )
+        d, cli, _ = _dispatcher({"u1"})
+        url = "https://cdn.discordapp.com/attachments/c/m/photo.png"
+        cli.attachment_bodies[url] = _PNG
+        await d.handle_message(
+            InboundMessage(
+                channel_type="discord",
+                user_id="u1",
+                conversation_id="c1",
+                text="look at this",
+                attachments=[
+                    {
+                        "filename": "photo.png",
+                        "content_type": "image/png",
+                        "size": len(_PNG),
+                        "url": url,
+                    }
+                ],
+            )
+        )
+        await asyncio.sleep(0)
+
+        prompt = d.ctx_builder.messages[-1]
+        lines = prompt.splitlines()
+        assert lines[0] == "look at this"
+        assert lines[1].endswith(".png")
+        assert cli.attachment_downloads == [url]
+        assert not os.path.exists(lines[1])
+        assert cleanup_threads and loop_thread not in cleanup_threads
+
+    @pytest.mark.asyncio
+    async def test_attachment_turn_acquires_before_download_yields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, cli, sess = _dispatcher({"u1"})
+        d.cfg.messaging.queue_mode = "queue"
+        download_started = asyncio.Event()
+        finish_download = asyncio.Event()
+        url = "https://cdn.discordapp.com/attachments/c/m/slow.png"
+
+        real_get_or_create = sess.get_or_create
+        real_release = sess.release
+
+        async def _get_or_create(*args: Any, **kwargs: Any) -> Any:
+            result = await real_get_or_create(*args, **kwargs)
+            sess._busy = True
+            return result
+
+        def _release(key: str) -> None:
+            sess._busy = False
+            real_release(key)
+
+        async def _slow_download(download_url: str, dest: str) -> None:
+            cli.attachment_downloads.append(download_url)
+            download_started.set()
+            await finish_download.wait()
+            with open(dest, "wb") as fh:
+                fh.write(_PNG)
+
+        monkeypatch.setattr(sess, "get_or_create", _get_or_create)
+        monkeypatch.setattr(sess, "release", _release)
+        monkeypatch.setattr(cli, "download_attachment", _slow_download)
+
+        first = asyncio.create_task(
+            d.handle_message(
+                InboundMessage(
+                    channel_type="discord",
+                    user_id="u1",
+                    conversation_id="c1",
+                    text="first",
+                    attachments=[
+                        {
+                            "filename": "slow.png",
+                            "content_type": "image/png",
+                            "size": len(_PNG),
+                            "url": url,
+                        }
+                    ],
+                )
+            )
+        )
+        await asyncio.wait_for(download_started.wait(), timeout=1)
+
+        assert sess._busy, "session must be acquired before attachment download"
+        await d.handle_message(self._msg("second"))
+        assert [queued[1] for queued in sess.queued] == ["second"]
+
+        finish_download.set()
+        await first
+
+        assert d.ctx_builder.messages[0].splitlines()[0] == "first"
+        assert d.ctx_builder.messages[1] == "second"
+        assert sess.queued == []
+
+    @pytest.mark.asyncio
+    async def test_command_like_caption_does_not_discard_attachment(self) -> None:
+        d, cli, _ = _dispatcher({"u1"})
+        url = "https://cdn.discordapp.com/attachments/c/m/command.png"
+        cli.attachment_bodies[url] = _PNG
+        await d.handle_message(
+            InboundMessage(
+                channel_type="discord",
+                user_id="u1",
+                conversation_id="c1",
+                text="!help",
+                attachments=[
+                    {
+                        "filename": "command.png",
+                        "content_type": "image/png",
+                        "size": len(_PNG),
+                        "url": url,
+                    }
+                ],
+            )
+        )
+        await asyncio.sleep(0)
+
+        prompt = d.ctx_builder.messages[-1]
+        assert prompt.splitlines()[0] == "!help"
+        assert prompt.splitlines()[1].endswith(".png")
+        assert "KiroCrew — Discord" not in "\n".join(text for text, _ in cli.sent)
+
+    @pytest.mark.asyncio
+    async def test_attachment_rejection_is_not_silent(self) -> None:
+        d, cli, _ = _dispatcher({"u1"})
+        await d.handle_message(
+            InboundMessage(
+                channel_type="discord",
+                user_id="u1",
+                conversation_id="c1",
+                text="",
+                attachments=[
+                    {
+                        "filename": "archive.bin",
+                        "content_type": "application/octet-stream",
+                        "size": 10,
+                        "url": "https://cdn.discordapp.com/a.bin",
+                    }
+                ],
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert "unsupported type" in d.ctx_builder.messages[-1]
+        assert cli.attachment_downloads == []
+
+    @pytest.mark.asyncio
+    async def test_busy_attachment_waits_for_queued_turn_before_cleanup(self) -> None:
+        d, cli, sess = _dispatcher({"u1"})
+        url = "https://media.discordapp.net/attachments/c/m/queued.png"
+        attachment = {
+            "filename": "queued.png",
+            "content_type": "image/png",
+            "size": len(_PNG),
+            "url": url,
+        }
+        cli.attachment_bodies[url] = _PNG
+        sess._busy = True
+        await d.handle_message(
+            InboundMessage(
+                channel_type="discord",
+                user_id="u1",
+                conversation_id="c1",
+                text="",
+                attachments=[attachment],
+            )
+        )
+
+        assert cli.attachment_downloads == []
+        assert sess.queued[0][2]["attachments"] == [attachment]
+        sess._busy = False
+        await d._drain_queue(d._session_key("u1"), "u1", "c1")
+        await asyncio.sleep(0)
+
+        prompt_path = d.ctx_builder.messages[-1].splitlines()[0]
+        assert cli.attachment_downloads == [url]
+        assert prompt_path.endswith(".png")
+        assert not os.path.exists(prompt_path)
+
+    @pytest.mark.asyncio
+    async def test_drain_defers_messages_that_exceed_attachment_cap(self) -> None:
+        d, cli, sess = _dispatcher({"u1"})
+
+        def _batch(prefix: str) -> list[dict[str, Any]]:
+            batch: list[dict[str, Any]] = []
+            for i in range(10):
+                url = (
+                    "https://cdn.discordapp.com/attachments/c/m/"
+                    f"{prefix}-{i}.png"
+                )
+                cli.attachment_bodies[url] = _PNG
+                batch.append(
+                    {
+                        "filename": f"{prefix}-{i}.png",
+                        "content_type": "image/png",
+                        "size": len(_PNG),
+                        "url": url,
+                    }
+                )
+            return batch
+
+        first = _batch("first")
+        second = _batch("second")
+        sess.queued = [
+            ("t1", "first batch", {"attachments": first}),
+            ("t2", "second batch", {"attachments": second}),
+            ("t3", "after second", {"attachments": []}),
+        ]
+
+        await d._drain_queue(d._session_key("u1"), "u1", "c1")
+
+        assert cli.attachment_downloads == [
+            item["url"] for item in [*first, *second]
+        ]
+        assert sess.queued == []
+        assert len(d.ctx_builder.messages) == 2
+        assert d.ctx_builder.messages[0].splitlines()[0] == "first batch"
+        assert d.ctx_builder.messages[1].splitlines()[0] == "second batch"
+        assert "after second" in d.ctx_builder.messages[1]
 
     @pytest.mark.asyncio
     async def test_busy_steers_and_acks_with_reaction(self) -> None:

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -146,6 +147,129 @@ class TestTranscribeAudio:
         cfg = SttConfig(enabled=True, whisper_path="/nonexistent")
         result = await transcribe_audio("/tmp/test.webm", cfg)
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_whisper_discovery_runs_off_event_loop(self, tmp_path, monkeypatch):
+        from threading import get_ident
+
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(enabled=True)
+        loop_thread = get_ident()
+        discovery_threads = []
+
+        def discover_python_bin_dir():
+            discovery_threads.append(get_ident())
+            return ""
+
+        monkeypatch.setattr(
+            "kiro_crew.transcribe._python3_bin_dir", discover_python_bin_dir
+        )
+        monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [])
+        with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            result = await transcribe_audio(str(audio), cfg)
+
+        assert result is None
+        assert discovery_threads
+        assert discovery_threads[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_aws_audio_read_runs_off_event_loop(self, tmp_path, monkeypatch):
+        from threading import get_ident
+
+        from kiro_crew import transcribe as tr
+
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake audio")
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        loop_thread = get_ident()
+        read_threads = []
+
+        def read_audio(path):
+            assert path == str(audio)
+            read_threads.append(get_ident())
+            return b"fake audio"
+
+        input_stream = SimpleNamespace(
+            send_audio_event=AsyncMock(),
+            end_stream=AsyncMock(),
+        )
+        stream = SimpleNamespace(input_stream=input_stream, output_stream=object())
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def start_stream_transcription(self, **kwargs):
+                return stream
+
+        class FakeHandler:
+            def __init__(self, output_stream, transcript_parts):
+                pass
+
+            async def handle_events(self):
+                pass
+
+        monkeypatch.setattr(tr, "boto3", object())
+        monkeypatch.setattr(tr, "_read_audio_bytes", read_audio)
+        monkeypatch.setattr(
+            tr,
+            "_load_aws_transcribe_components",
+            lambda: (FakeClient, FakeHandler),
+        )
+
+        result = await tr._transcribe_aws(str(audio), cfg)
+
+        assert result is None
+        assert read_threads
+        assert read_threads[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_whisper_output_file_io_runs_off_event_loop(
+        self, tmp_path, monkeypatch
+    ):
+        from threading import get_ident
+
+        binary = tmp_path / "whisper"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        cfg = SttConfig(enabled=True, whisper_path=str(binary), timeout_secs=10)
+        loop_thread = get_ident()
+        io_threads = []
+
+        def make_output_dir():
+            io_threads.append(get_ident())
+            return str(output_dir)
+
+        def collect_output(*args, **kwargs):
+            io_threads.append(get_ident())
+            return "Hello world"
+
+        def remove_output_dir(*args, **kwargs):
+            io_threads.append(get_ident())
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        monkeypatch.setattr("kiro_crew.transcribe.tempfile.mkdtemp", make_output_dir)
+        monkeypatch.setattr(
+            "kiro_crew.transcribe._collect_whisper_output", collect_output
+        )
+        monkeypatch.setattr("kiro_crew.transcribe.shutil.rmtree", remove_output_dir)
+        with patch(
+            "kiro_crew.transcribe.asyncio.create_subprocess_exec",
+            return_value=mock_proc,
+        ):
+            result = await transcribe_audio(str(audio), cfg)
+
+        assert result == "Hello world"
+        assert len(io_threads) == 3
+        assert all(thread != loop_thread for thread in io_threads)
 
     @pytest.mark.asyncio
     async def test_successful_transcription(self, tmp_path):


### PR DESCRIPTION
## Problem

Discord `MESSAGE_CREATE` events dropped the payload's `attachments` array during normalization. The transport then rejected any message whose text was empty, so attachment-only DMs never reached the agent; captions reached the agent without their files.

## Why it matters

Discord users could not send screenshots, text files, documents, or voice messages to KiroCrew, and unsupported or failed files disappeared without an explanation. This left Discord behind Slack even though the shared attachment ingestion and ACP image-block path already existed.

## Fix (symptom → root cause → change)

- **Symptom:** attachment-only messages vanished; text-plus-file messages lost the file.
- **Root cause:** `DiscordClient` did not retain Discord attachment metadata, `DiscordTransport` treated empty text as an empty message, and the dispatcher had no channel adapter for the merged shared ingestion layer.
- **Change:** preserve Discord attachment metadata end to end; admit attachment-only messages; map Discord fields into `messaging.attachments.ingest_attachments`; download only from exact HTTPS `cdn.discordapp.com` / `media.discordapp.net` origins with redirects disabled and no auth header; transcribe normal `audio/*` voice attachments; append image paths, extracted text, transcripts, and rejection notes to the prompt; acquire the session before attachment I/O so later messages cannot overtake a download; preserve raw attachments while a busy turn queues them; split queued work at the shared 10-file ingestion cap and iteratively drain every deferred batch in FIFO order; clean all caller-owned temp paths after the consuming turn completes; and offload CDN file operations, STT availability probes, and cleanup from the gateway event loop.

## Tests

- `.venv/bin/python -m pytest -q -n0 test/test_discord*.py test/test_messaging_attachments.py test/test_no_blocking_call_on_loop.py` — 207 passed.
- Added regressions for Gateway payload copying, attachment-only dispatch, text-plus-image prompt preservation, command-like captions, Discord voice transcription, exact CDN-host refusal, visible rejection notes, session acquisition before slow downloads, busy-queue preservation, iterative FIFO queue draining at the shared attachment cap, post-turn temp cleanup, and worker-thread execution of download/STT/cleanup operations.
- `.venv/bin/isort --check-only src/kiro_crew test`
- `.venv/bin/flake8 --jobs 1 src/kiro_crew test`
- `.venv/bin/mypy src/kiro_crew/`

## Manual verification

- Confirmed the editable install resolves `kiro_crew` from this feature worktree.
- Checked Discord's official Message Resource contract: voice-message attachments use an `audio/*` content type and currently carry Opus in an OGG container, so no Slack-style `video/webm` override is needed.
- No live bot credentials were used; byte-real PNG/audio fixtures exercise the full payload-to-prompt and cleanup path.

Closes #923
