### PR TITLE
feat: chat header alignment, panel icons, sidebar collapse morph

### DIFF
--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -370,6 +370,9 @@ export default [
               // `api.fetch`, never `prefetch`). A leading `^` opts out of the dotted
               // prefix, which is what is wanted here — `i18nT`, not `obj.i18nT`.
               '^i18nT$', '^t$',
+              // Icon component factory: the string argument is a React DevTools
+              // displayName, not user-visible copy.
+              '^makePanelIcon$',
               // A per-app `request` wrapper takes an ENDPOINT PATH — the same class as
               // the `fetch` exclusion above, and the only thing standing between a
               // route string and the fetch it performs. Anchored, so it cannot match a

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -26,7 +26,7 @@ import { ZoomProvider } from './hooks/ZoomProvider'
 import { api, isAuthBannerShown } from './api/client'
 import { safeSetItem } from './utils/safeStorage'
 import { gcOrphanedStorage } from './utils/storageGc'
-import { Rocket, Menu, Bell, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, AudioWaveform, ChevronUp, MoreHorizontal, Coins, PanelLeftClose, LayoutGrid, Lightbulb, ExternalLink, SquareTerminal, Bot } from 'lucide-react'
+import { Rocket, Menu, Bell, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, AudioWaveform, ChevronUp, MoreHorizontal, Coins, ArrowLeftToLine, LayoutGrid, Lightbulb, ExternalLink, SquareTerminal, Bot } from 'lucide-react'
 import { GithubIcon, DiscordIcon } from './components/BrandIcon'
 import { Toggle } from './components/ui'
 import OnboardingFlow from './components/OnboardingFlow'
@@ -1915,19 +1915,29 @@ export default function App() {
         <div className="shrink-0 flex flex-col gap-0.5 px-2 pt-2">
           {/* mb-1.5 (6px) + the container's gap-0.5 (2px) = 8px between the
               header and the first nav item, without widening the 2px item gaps. */}
-          <div className={`flex items-center mb-1.5 ${effectiveCollapsed ? 'justify-start' : ''}`}>
+          <div className={`relative flex items-center mb-1.5 ${effectiveCollapsed ? 'justify-start' : ''}`}>
             {/* One persistent click target that toggles the rail. The logo
                 never unmounts, so it stays perfectly still across collapse/
                 expand (no swap, no shift). Only the brand text + collapse arrow
                 animate — fading in on expand and out on collapse via
                 AnimatePresence. No hover tint on the row; on hover only the
                 logo rotates (group-hover). */}
-            {/* No overflow-hidden here: the 40px logo's hover-rotate paints a
-                few px past its box, and clipping it looked cut off. Rotation is
-                a transform so it doesn't affect the header's layout height (row
-                stays 40px, collapse-icon alignment unchanged); horizontal spill
-                on collapse is still clipped by the rail (motion.nav) and the
-                brand text clips itself via `truncate`. */}
+            {/* No overflow-hidden here: the logo's hover-rotate paints a few
+                px past its box, and clipping it looked cut off. Rotation is a
+                transform so it doesn't affect the header's layout height
+                (row height tracks the logo, collapse-icon alignment
+                unchanged); horizontal spill on collapse is still clipped by
+                the rail (motion.nav) and the brand text clips itself via
+                `truncate`.
+                Logo is DUAL-SIZE: w-7 (28px) expanded — 1px card border +
+                pt-2 + 14 puts the header row's center on the 23px shared
+                control baseline — and w-10 (40px) collapsed, where the
+                icons-only rail keeps the full brand mark (a branding
+                logoClass overrides both). The collapse arrow no longer centers
+                in the row — it pins to top-[6px] so its center stays on the
+                23px shared control baseline (chat title row, its sessions
+                toggle, and the activity strip icons) while the two-line
+                brand block makes the row taller. */}
             <button
               type="button"
               className="group relative flex items-center gap-2 w-full p-0 bg-transparent border-none cursor-pointer text-left"
@@ -1937,7 +1947,7 @@ export default function App() {
               aria-expanded={!effectiveCollapsed}
             >
               <span className="flex items-center gap-2.5 min-w-0">
-                <img src={avatar} alt="" aria-hidden="true" className={`${branding?.logoClass ?? 'w-10 h-10'} rounded-md shrink-0 object-contain transition-transform duration-300 group-hover:rotate-[-8deg]`} />
+                <img src={avatar} alt="" aria-hidden="true" className={`${branding?.logoClass ?? (effectiveCollapsed ? 'w-10 h-10' : 'w-7 h-7')} rounded-md shrink-0 object-contain transition-all duration-300 group-hover:rotate-[-8deg]`} />
                 <AnimatePresence initial={false}>
                   {!effectiveCollapsed && (
                     <motion.span
@@ -1946,8 +1956,20 @@ export default function App() {
                       animate={{ opacity: 1, x: 0 }}
                       exit={{ opacity: 0, x: -6, transition: { duration: 0.12, ease: 'easeIn' } }}
                       transition={{ duration: 0.2, ease: 'easeOut' }}
-                      className="text-sm font-bold tracking-[.08em] text-text-strong whitespace-nowrap truncate min-w-0"
-                    >{botName}</motion.span>
+                      className="text-[13px] font-bold tracking-[.14em] uppercase whitespace-nowrap truncate min-w-0"
+                    >
+                      {/* Last word of the bot name carries the accent (KIRO
+                          CREW: muted brand, accent product); single-word names
+                          render all-muted. */}
+                      {botName.includes(' ') ? (
+                        <>
+                          <span className="text-muted">{botName.slice(0, botName.lastIndexOf(' ') + 1)}</span>
+                          <span className="text-accent/90">{botName.slice(botName.lastIndexOf(' ') + 1)}</span>
+                        </>
+                      ) : (
+                        <span className="text-muted">{botName}</span>
+                      )}
+                    </motion.span>
                   )}
                 </AnimatePresence>
               </span>
@@ -1965,14 +1987,19 @@ export default function App() {
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1, transition: { duration: 0.18, ease: 'easeOut', delay: 0.12 } }}
                     exit={{ opacity: 0, transition: { duration: 0.12, ease: 'easeIn' } }}
-                    className="absolute right-0 inset-y-0 my-auto h-4 flex items-center text-muted pointer-events-none"
+                    className="absolute right-0 top-[6px] h-4 flex items-center text-muted pointer-events-none"
                   >
-                    <PanelLeftClose size={16} />
+                    {/* Arrow-to-edge, not a hide-panel glyph: the rail
+                        collapses to an icon rail rather than hiding. */}
+                    <ArrowLeftToLine size={15} />
                   </motion.span>
                 )}
               </AnimatePresence>
             </button>
           </div>
+          {/* Hairline under the expanded header (collapsed rail has none —
+              the big logo alone separates well). */}
+          {!effectiveCollapsed && <div aria-hidden="true" className="h-px bg-border shrink-0 mt-0.5 mb-[7px]" />}
           {NAV_ITEMS.filter(n => n.group === 'Main').map(n => <div key={n.id}>{renderNavRow(n)}</div>)}
           {/* Apps section header. "Explore" (the App Store) rides the header
               row in accent when expanded; collapsed it becomes a regular

--- a/website/src/apps/issue-radar/components/RefSheet.tsx
+++ b/website/src/apps/issue-radar/components/RefSheet.tsx
@@ -15,7 +15,8 @@
 // window — matching ConnectRepoModal.
 import { useCallback, useRef } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
-import { ChevronLeft, CircleDot, ExternalLink, GitPullRequest, Loader2, PanelRightOpen, X } from 'lucide-react'
+import { ChevronLeft, CircleDot, ExternalLink, GitPullRequest, Loader2, X } from 'lucide-react'
+import { PanelRightSolid } from '../../../components/icons/panels'
 import Clickable from '../../../components/Clickable'
 import { useDialogFocusTrap } from '../../../hooks/useDialogFocusTrap'
 import { useIssueRadar } from '../context'
@@ -143,9 +144,9 @@ export default function RefSheet() {
                     onClick={openInWorkspace}
                     aria-label={i18nT('apps.issueRadar.components.refSheet.open_this_item_in_the_workspace')}
                     title={i18nT('apps.issueRadar.components.refSheet.open_in_the_list_detail_column')}
-                    className={ICON_BTN}
+                    className={`pi-morph ${ICON_BTN}`}
                   >
-                    <PanelRightOpen className="lucide-inline" aria-hidden="true" />
+                    <PanelRightSolid className="lucide-inline" aria-hidden="true" />
                   </button>
                 )}
                 <a

--- a/website/src/components/BottomTerminalPanel.tsx
+++ b/website/src/components/BottomTerminalPanel.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence, Reorder } from 'framer-motion'
 import { usePointerDrag } from '../hooks/usePointerDrag'
 import { useLocation } from 'react-router-dom'
-import { TerminalSquare, Plus, X, ChevronDown, PanelRight } from 'lucide-react'
+import { TerminalSquare, Plus, X, ChevronDown } from 'lucide-react'
+import { PanelRightSolid } from './icons/panels'
 import CliPanel, { disposeTerminalSession, useDeleteTerminalSession } from './CliPanel'
 import { useTerminalTitle } from '../utils/terminalRegistry'
 import { usePanelTabs } from '../hooks/usePanelTabs'
@@ -31,7 +32,7 @@ function TabChip({ tab, active, onSelect, onClose, onTransfer, canTransfer }: {
   onTransfer: () => void; canTransfer: boolean
 }) {
   const transferCls = canTransfer
-    ? `shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`
+    ? `pi-morph shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`
     : 'shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full bg-transparent border-none text-muted opacity-30 cursor-not-allowed'
   return (
     <div
@@ -59,7 +60,7 @@ function TabChip({ tab, active, onSelect, onClose, onTransfer, canTransfer }: {
           title={canTransfer ? i18nT('components.bottomTerminalPanel.move_to_side_panel') : i18nT('components.bottomTerminalPanel.open_a_chat_page_to_move_this_terminal_there')}
           aria-label={i18nT('components.bottomTerminalPanel.move_to_side_panel')}
         >
-          <PanelRight size={12} />
+          <PanelRightSolid size={12} />
         </button>
         <button
           onClick={(e) => { e.stopPropagation(); onClose() }}

--- a/website/src/components/Modal.tsx
+++ b/website/src/components/Modal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { X } from 'lucide-react'
 
@@ -64,7 +65,15 @@ export default function Modal({ open, onClose, title, footer, headerActions, max
         transition: SPRING,
       }
 
-  return (
+  // Portal to document.body: the overlay layers below are position:fixed, and
+  // fixed positioning escapes ancestor OVERFLOW but not ancestor CLIP-PATH,
+  // TRANSFORM, or FILTER -- those are paint/containing-block operations applied
+  // to the whole subtree, fixed descendants included. Modals are mounted deep
+  // inside arbitrary containers (e.g. ChatSidebar, whose OverlayDrawer wrapper
+  // keeps a resting `clip-path: inset(0 0 0 0)` from the collapse morph, which
+  // would confine the "full-screen" modal to the sidebar rect). Rendering at
+  // body level immunizes every modal against any fancy container for good.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <>
@@ -106,6 +115,7 @@ export default function Modal({ open, onClose, title, footer, headerActions, max
           </div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   )
 }

--- a/website/src/components/OverlayDrawer.tsx
+++ b/website/src/components/OverlayDrawer.tsx
@@ -4,17 +4,24 @@ interface Props {
   open: boolean
   width: number
   dragging?: boolean
-  /** When true, the panel fades as it collapses (content fade) — the visible
-   *  border-box morph into the expand button is handled by a dedicated element
-   *  in ChatPage; this just collapses the panel cleanly for layout reflow. */
+  /** Morph mode: the panel's visible window (clip-path) collapses into
+   *  `morphTarget` and expands back out — the content itself never moves or
+   *  deforms. The outer width still animates for layout reflow. */
   morph?: boolean
+  /** Container-space rect the panel deforms into (the sidebar toggle button). */
+  morphTarget?: { x: number; y: number; size: number }
+  /** Panel pixel height, for the vertical squash ratio. */
+  contentH?: number
   className?: string
   children: React.ReactNode
 }
 
+// Near-linear on purpose: a strong ease-out front-loads the travel, which
+// visually freezes the near edges while the far edges are still sweeping.
 const EASE = [0.32, 0.72, 0, 1] as const
+const DUR = 0.24
 
-export default function OverlayDrawer({ open, width, dragging, morph, className, children }: Props) {
+export default function OverlayDrawer({ open, width, dragging, morph, morphTarget, contentH, className, children }: Props) {
   const reduce = useReducedMotion()
   // Gesture end settles from the live presentation value via a critically
   // damped spring (no overshoot, no visible jump) — never a fixed ease tween.
@@ -22,24 +29,52 @@ export default function OverlayDrawer({ open, width, dragging, morph, className,
   const settle = reduce
     ? { duration: 0.2 }
     : { type: 'spring' as const, bounce: 0, duration: 0.35 }
+  // The panel never moves or deforms — only its VISIBLE WINDOW morphs: a
+  // clip-path inset animates between the full panel rect and the toggle
+  // button's rect, so collapsing looks like the panel's visibility converging
+  // into the button and expanding like it pouring back out (iPadOS-style
+  // masked container transform). Pure px strings so Framer can interpolate.
+  const clips = morph && !reduce && morphTarget && contentH && width > 0 && contentH > 0
+    ? {
+        full: 'inset(0px 0px 0px 0px round 12px)',
+        button: `inset(${morphTarget.y}px ${width - morphTarget.x - morphTarget.size}px ${contentH - morphTarget.y - morphTarget.size}px ${morphTarget.x}px round 6px)`,
+      }
+    : null
   return (
     <AnimatePresence initial={false}>
       {open && (
         <motion.div
           key="drawer"
-          initial={morph ? { width: 0, opacity: 0 } : { width: 0 }}
-          animate={morph ? { width, opacity: 1 } : { width }}
-          exit={morph ? { width: 0, opacity: 0 } : { width: 0 }}
+          initial={{ width: 0 }}
+          animate={{ width }}
+          exit={{ width: 0 }}
           transition={
             dragging
               ? { duration: 0 }
               : morph && !reduce
-                ? { width: { duration: 0.32, ease: EASE }, opacity: { duration: 0.12, ease: EASE } }
+                ? { width: { duration: DUR, ease: EASE } }
                 : settle
           }
-          className={`shrink-0 pb-2 overflow-hidden ${className || ''}`}
+          className={`shrink-0 pb-2 ${clips ? 'relative z-[60] overflow-visible' : 'overflow-hidden'} ${className || ''}`}
         >
-          {children}
+          {clips ? (
+            /* Fixed pixel width so the width collapse never reflows the
+               content mid-motion. The clip-path is the only visible boundary
+               (the outer is overflow-visible + z-[60], so the still-wide
+               panel paints over the chat pane while the layout column
+               closes). The final clipped chip — a button-sized patch of
+               empty panel header under the real toggle — fades in the last
+               ~15% so the unmount never pops. */
+            <motion.div
+              style={{ width, height: '100%' }}
+              initial={{ clipPath: clips.button, opacity: 1 }}
+              animate={{ clipPath: clips.full, opacity: 1 }}
+              exit={{ clipPath: clips.button, opacity: [1, 1, 0], transition: { duration: DUR, ease: EASE, opacity: { duration: DUR, times: [0, 0.85, 1] } } }}
+              transition={dragging ? { duration: 0 } : { duration: DUR, ease: EASE }}
+            >
+              {children}
+            </motion.div>
+          ) : children}
         </motion.div>
       )}
     </AnimatePresence>

--- a/website/src/components/SplitGlyph.tsx
+++ b/website/src/components/SplitGlyph.tsx
@@ -1,6 +1,9 @@
-import { PanelRight, PanelBottom } from 'lucide-react'
+import { PanelRightLight, PanelBottomLight } from './icons/panels'
 
-/** Split-direction icon: a right panel = split right, a bottom panel = split down. */
+/** Split-direction icon: a right panel = split right, a bottom panel = split down.
+ *  Uses the thick-pane (open) variants: the glyph depicts the pane the split
+ *  will occupy, not a panel's open/closed state — and it is a pure indicator,
+ *  so its enclosing controls deliberately carry no `pi-morph`. */
 export function SplitGlyph({ down }: { down?: boolean }) {
-  return down ? <PanelBottom size={12} /> : <PanelRight size={12} />
+  return down ? <PanelBottomLight size={12} /> : <PanelRightLight size={12} />
 }

--- a/website/src/components/icons/panels.tsx
+++ b/website/src/components/icons/panels.tsx
@@ -1,0 +1,129 @@
+import type { CSSProperties, SVGProps } from 'react'
+
+/**
+ * Hand-rolled panel / sidebar icons — KiroCrew's replacement for lucide's
+ * PanelLeft / PanelLeftClose / PanelRight / PanelRightClose / PanelBottom.
+ *
+ * Each glyph is an outlined frame with the pane drawn as a filled rounded
+ * block. State is carried by the pane, never by embedded arrows:
+ *   - THIN + solid pane  -> the panel is CLOSED / can be summoned; "view in
+ *     panel" affordances use it because they open the panel
+ *   - THICK + dimmed pane -> the panel is OPEN; clicking tucks it away
+ *
+ * Hover morph is OPT-IN: an enclosing control carrying the `pi-morph` class
+ * (button / [role="button"] / a) previews its click's outcome on hover — the
+ * pane smoothly morphs to the opposite state's geometry and fill. Apply
+ * `pi-morph` only where the icon is a live toggle/opener for the panel it
+ * depicts; leave it off pure indicators (e.g. SplitGlyph's split-direction
+ * glyph), where a state-preview would be false.
+ *
+ * Geometry has ONE source of truth: PANE_GEOMETRY below. The component emits
+ * both the resting and hover-target values as CSS custom properties, and the
+ * `.pi-pane` rules in index.css are pure mechanism (they only reference the
+ * variables). The rect's SVG attributes carry the resting values too, as the
+ * fallback for browsers without SVG geometry-property CSS support.
+ *
+ * The dimmed fill uses fillOpacity on currentColor, so it tracks the button's
+ * text color through hover/theme changes with no extra states.
+ *
+ * The glyph deliberately fills more of the 24px viewBox than lucide's panel
+ * icons (frame 19x17.5 vs 18x15): at the 12-16px sizes these render at, the
+ * stock proportions were hard to read.
+ *
+ * API is lucide-compatible (size + spread SVG props incl. className), so these
+ * drop into existing <PanelLeft size={16}/> call sites unchanged.
+ */
+type PanelIconProps = SVGProps<SVGSVGElement> & { size?: number | string }
+
+const FRAME = { x: 2.5, y: 3.25, width: 19, height: 17.5, rx: 3 } as const
+
+/** Pane rect per side and state — the single source of truth for pane
+ *  geometry. The pane hugs its frame edge and grows inward: thin = panel
+ *  closed, thick = panel open. */
+const PANE_GEOMETRY = {
+  left: {
+    closed: { x: 4.5, y: 5.25, width: 2.4, height: 13.5, rx: 1.2 },
+    open: { x: 4.5, y: 5.25, width: 6.5, height: 13.5, rx: 1.4 },
+  },
+  right: {
+    closed: { x: 17.1, y: 5.25, width: 2.4, height: 13.5, rx: 1.2 },
+    open: { x: 13, y: 5.25, width: 6.5, height: 13.5, rx: 1.4 },
+  },
+  bottom: {
+    closed: { x: 4.5, y: 16.35, width: 15, height: 2.4, rx: 1.2 },
+    open: { x: 4.5, y: 13.25, width: 15, height: 5.5, rx: 1.4 },
+  },
+} as const
+
+/** Dimmed "already open" pane fill — low enough to read as not-solid, high
+ *  enough to stay legible on dim muted-gray themes. */
+const LIGHT_OPACITY = 0.45
+
+type PaneRect = { x: number; y: number; width: number; height: number; rx: number }
+
+/** Rest + hover-target geometry as CSS custom properties consumed by the
+ *  `.pi-pane` rules in index.css. */
+function paneVars(rest: PaneRect, hover: PaneRect, open: boolean): CSSProperties {
+  return {
+    '--pi-x': `${rest.x}px`,
+    '--pi-y': `${rest.y}px`,
+    '--pi-w': `${rest.width}px`,
+    '--pi-h': `${rest.height}px`,
+    '--pi-rx': `${rest.rx}px`,
+    '--pi-o': open ? LIGHT_OPACITY : 1,
+    '--pi-hx': `${hover.x}px`,
+    '--pi-hy': `${hover.y}px`,
+    '--pi-hw': `${hover.width}px`,
+    '--pi-hh': `${hover.height}px`,
+    '--pi-hrx': `${hover.rx}px`,
+    '--pi-ho': open ? 1 : LIGHT_OPACITY,
+  } as CSSProperties
+}
+
+function makePanelIcon(side: keyof typeof PANE_GEOMETRY, open: boolean, displayName: string) {
+  const rest = PANE_GEOMETRY[side][open ? 'open' : 'closed']
+  const hover = PANE_GEOMETRY[side][open ? 'closed' : 'open']
+  const vars = paneVars(rest, hover, open)
+  function PanelIcon({ size = 24, style, ...props }: PanelIconProps) {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        style={style ? { ...vars, ...style } : vars}
+        {...props}
+      >
+        <rect {...FRAME} />
+        <rect
+          className="pi-pane"
+          {...rest}
+          fill="currentColor"
+          fillOpacity={open ? LIGHT_OPACITY : undefined}
+          stroke="none"
+        />
+      </svg>
+    )
+  }
+  PanelIcon.displayName = displayName
+  return PanelIcon
+}
+
+/** Left sidebar is HIDDEN — thin solid pane says "click to summon it". */
+export const PanelLeftSolid = makePanelIcon('left', false, 'PanelLeftSolid')
+/** Left sidebar is OPEN — thick dimmed pane says "already out; click to tuck away". */
+export const PanelLeftLight = makePanelIcon('left', true, 'PanelLeftLight')
+/** Right panel is CLOSED / "open in panel" affordances — thin solid pane. */
+export const PanelRightSolid = makePanelIcon('right', false, 'PanelRightSolid')
+/** Right panel is OPEN — thick dimmed pane; clicking closes it. */
+export const PanelRightLight = makePanelIcon('right', true, 'PanelRightLight')
+/** Bottom dock is CLOSED / "send to bottom dock" affordances — thin solid pane. */
+export const PanelBottomSolid = makePanelIcon('bottom', false, 'PanelBottomSolid')
+/** Bottom dock is OPEN — thick dimmed pane; also the split-down direction glyph. */
+export const PanelBottomLight = makePanelIcon('bottom', true, 'PanelBottomLight')

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1496,6 +1496,23 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
 /* lucide-react icons — inline sizing to match surrounding text */
 .lucide-inline { display: inline-block; width: 1em; height: 1em; vertical-align: -0.125em; flex-shrink: 0; }
 
+/* ── Panel icon pane morph (components/icons/panels.tsx) ──
+   Pure mechanism: all geometry arrives as CSS custom properties emitted by the
+   icon component (PANE_GEOMETRY is the single source of truth). Resting values
+   also exist as SVG attributes, the fallback for browsers without SVG
+   geometry-property CSS support (they render static icons, no morph).
+   The hover morph — previewing the click's outcome by flipping the pane to the
+   opposite state — is OPT-IN via the `pi-morph` class on the enclosing
+   control: apply it to live panel toggles/openers, never to pure indicators
+   (e.g. SplitGlyph's split-direction glyph). */
+.pi-pane {
+  transition: x .18s ease, y .18s ease, width .18s ease, height .18s ease, rx .18s ease, fill-opacity .18s ease;
+  x: var(--pi-x); y: var(--pi-y); width: var(--pi-w); height: var(--pi-h); rx: var(--pi-rx); fill-opacity: var(--pi-o);
+}
+:is(button, [role="button"], a).pi-morph:hover .pi-pane {
+  x: var(--pi-hx); y: var(--pi-hy); width: var(--pi-hw); height: var(--pi-hh); rx: var(--pi-hrx); fill-opacity: var(--pi-ho);
+}
+
 /* ── Search highlights ── */
 .search-match {
   background-color: var(--search-highlight);

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -135,7 +135,8 @@ import OverlayDrawer from '../components/OverlayDrawer'
 import { loadChatConfig, CONTENT_WIDTH, type ChatConfig } from './chat/ChatSettings'
 import { useKnowledgeFetch, extractKnowledgeQuery, expandKnowledgeBlock } from './chat/useKnowledgeFetch'
 import { KnowledgePicker } from './chat/KnowledgePicker'
-import { BookOpen, EyeOff, Loader, PanelLeftOpen, PanelLeftClose, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, PanelRight, Paperclip } from 'lucide-react'
+import { BookOpen, EyeOff, Loader, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, Paperclip } from 'lucide-react'
+import { PanelLeftSolid, PanelLeftLight, PanelRightSolid } from '../components/icons/panels'
 
 import InfoTip from '../components/InfoTip'
 import { FileCard } from '../components/FileCard'
@@ -4278,8 +4279,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   useEffect(() => { if (!isMobile) setMobileSessions(false) }, [isMobile])
   // Swipe from left edge to open sidebar, swipe left on backdrop to close
   const chatContainerRef = useRef<HTMLDivElement>(null)
-  // Measured container height — used to size the sidebar border-box morph
-  // (the panel rect it grows from / shrinks into the expand button).
+  // Measured container height — sizes the sidebar border-box morph (the panel
+  // rect the box shrinks from on collapse and grows back to on expand).
   const [containerH, setContainerH] = useState(0)
   useEffect(() => {
     const el = chatContainerRef.current
@@ -4388,46 +4389,22 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
           />
         )}
       </AnimatePresence>
-      {/* Sidebar collapse/expand control. Two stacked pieces, both in the
-          stable container (not inside the morphing panel):
-          1. Morph border-box: a crisp bordered box (no content, so border &
-             radius stay sharp) that grows from the button's rect to the
-             panel's rect on open and shrinks back on collapse — the panel's
-             border becoming the button's box.
-          2. Icon button: fixed at the button's spot, flips icon + action.
-          Desktop, non-embed, with sessions only. */}
-      {!isMobile && embedMode !== 'chat' && embedMode !== 'sessions' && filteredSlots.length > 0 && (() => {
-        const RADIUS = 12 // same as the panel's rounded-xl — constant through the morph
-        const PANEL = { top: 0, left: 0, width: sidebarWidth, height: Math.max(0, containerH - 8), borderRadius: RADIUS, opacity: 1 }
-        const BTN = { top: 12, left: 8, width: 34, height: 34, borderRadius: RADIUS, opacity: 1 }
-        const MORPH = { duration: 0.32, ease: [0.32, 0.72, 0, 1] as const }
-        return (
-          <>
-            <AnimatePresence initial={false}>
-              {!sidebarOpen && (
-                <motion.div
-                  key="sidebar-morph-box"
-                  aria-hidden="true"
-                  className="absolute z-[60] bg-bg-elevated border border-border shadow-md pointer-events-none"
-                  initial={PANEL}
-                  animate={BTN}
-                  exit={{ ...PANEL, opacity: 0 }}
-                  transition={MORPH}
-                />
-              )}
-            </AnimatePresence>
-            <button
-              type="button"
-              onClick={() => window.dispatchEvent(new CustomEvent('toggle-pin-chat-sidebar'))}
-              className="absolute top-[12px] left-2 z-[61] w-[34px] h-[34px] rounded-xl flex items-center justify-center cursor-pointer text-muted hover:text-text transition-colors bg-transparent border-none"
-              title={sidebarOpen ? i18nT('pages.chatPage.hide_sessions') : i18nT('pages.chatPage.show_sessions')}
-              aria-label={sidebarOpen ? i18nT('pages.chatPage.hide_sessions_sidebar') : i18nT('pages.chatPage.show_sessions_sidebar')}
-            >
-              {sidebarOpen ? <PanelLeftClose size={16} /> : <PanelLeftOpen size={16} />}
-            </button>
-          </>
-        )
-      })()}
+      {/* Sidebar toggle — absolute in the stable container in BOTH states
+          (only the icon flips), so collapsing cannot drag it sideways with
+          the reflowing content pane. The collapse/expand motion itself is the
+          panel deforming into/out of this button's rect (OverlayDrawer morph
+          mode, morphTarget below). Desktop, non-embed, with sessions only. */}
+      {!isMobile && embedMode !== 'chat' && embedMode !== 'sessions' && filteredSlots.length > 0 && (
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new CustomEvent('toggle-pin-chat-sidebar'))}
+          className="pi-morph absolute top-[9px] left-2 z-[61] w-7 h-7 rounded-md flex items-center justify-center cursor-pointer text-muted hover:text-text hover:bg-bg-hover transition-colors bg-transparent border-none"
+          title={sidebarOpen ? i18nT('pages.chatPage.hide_sessions') : i18nT('pages.chatPage.show_sessions')}
+          aria-label={sidebarOpen ? i18nT('pages.chatPage.hide_sessions_sidebar') : i18nT('pages.chatPage.show_sessions_sidebar')}
+        >
+          {sidebarOpen ? <PanelLeftLight size={16} /> : <PanelLeftSolid size={16} />}
+        </button>
+      )}
       {embedMode === 'chat' ? null : embedMode === 'sessions' ? (
         <div className="flex-1 min-w-0 h-full overflow-hidden [&_.sidebar-inner]:!w-full [&_.sidebar-inner]:!border-0 [&_.sidebar-inner]:!rounded-none [&_.sidebar-inner]:!shrink [&_.sidebar-inner]:!bg-bg [&_.sidebar-resize-handle]:!hidden">
           <ChatSidebar
@@ -4445,7 +4422,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
           />
         </div>
       ) : (
-      <OverlayDrawer open={sidebarOpen} width={isMobile ? window.innerWidth : sidebarWidth} dragging={sidebarDragging} morph={!isMobile} className={isMobile ? 'mobile-sessions-overlay fixed top-[42px] bottom-0 left-0 z-50 bg-bg-elevated !py-0 rounded-r-xl shadow-lg max-w-[calc(100vw-2.5rem)] [&>*]:!rounded-none [&>*]:!border-0 [&>*]:!m-0' : ''}>
+      <OverlayDrawer open={sidebarOpen} width={isMobile ? window.innerWidth : sidebarWidth} dragging={sidebarDragging} morph={!isMobile} morphTarget={{ x: 8, y: 9, size: 28 }} contentH={Math.max(0, containerH - 8)} className={isMobile ? 'mobile-sessions-overlay fixed top-[42px] bottom-0 left-0 z-50 bg-bg-elevated !py-0 rounded-r-xl shadow-lg max-w-[calc(100vw-2.5rem)] [&>*]:!rounded-none [&>*]:!border-0 [&>*]:!m-0' : ''}>
         <ChatSidebar
           slots={filteredSlots}
           activeSlot={activeSlot}
@@ -4519,14 +4496,27 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 in index.css) so the overlay never paints over the scroller's scrollbar
                 track — otherwise the thumb is hidden/un-grabbable when scrolled to top. */}
             <div className="absolute top-0 left-0 right-1.5 z-10 pointer-events-none" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
-              <div className={`relative pr-5 pt-1 pb-2 flex items-center gap-2 bg-bg pointer-events-none ${!sidebarOpen && !isMobile ? 'pl-14' : 'pl-5'}`}>
+              {/* The row's left padding GLIDES between its open (20px) and
+                  collapsed (60px, clearing the stationary toggle + divider)
+                  values on the same 320ms curve as the panel — an instant
+                  class flip here reads as the title jumping sideways at the
+                  start of the slide. */}
+              <div className={`relative pr-1.5 pt-[9px] pb-2 flex items-center gap-2 bg-bg pointer-events-none transition-[padding-left] duration-[240ms] [transition-timing-function:cubic-bezier(.32,.72,0,1)] ${!isMobile && embedMode !== 'chat' && filteredSlots.length > 0 && !sidebarOpen ? 'pl-[60px]' : 'pl-5'}`}>
+                {/* Divider between toggle and title — ALWAYS mounted and
+                    absolute (zero width, no flex-gap participation) so it can
+                    never change the row's layout; it rides the row (title
+                    side) and only fades. left-[52px] = the collapsed pane's
+                    view of container x 44 (button 8+28 + 8px gap). */}
+                {!isMobile && embedMode !== 'chat' && filteredSlots.length > 0 && (
+                  <span aria-hidden="true" className={`absolute left-[52px] top-[13px] w-px h-5 bg-border transition-opacity ${sidebarOpen ? 'opacity-0 duration-100' : 'opacity-100 duration-150 delay-[90ms]'}`} />
+                )}
                 {embedMode !== 'chat' && isMobile && (
                   <button className="p-1 rounded-md text-muted hover:text-text cursor-pointer bg-transparent border-none pointer-events-auto" onClick={() => setMobileSessions(p => !p)} aria-label={i18nT('pages.chatPage.toggle_sessions')}>
                     {effectiveMode === 'orchestrator' ? <MessageSquareDot size={16} /> : <MessageSquare size={16} />}
                   </button>
                 )}
                 <div className="group/header flex items-stretch gap-0.5 pointer-events-auto">
-                <div className="rounded-l-md rounded-r-[2px] px-1.5 py-0.5 group-hover/header:bg-bg-hover transition-colors">
+                <div className="flex items-center rounded-l-md rounded-r-[2px] px-1.5 py-0.5 group-hover/header:bg-bg-hover transition-colors">
                 <ChatHeaderMenu
                   activeSlot={activeSlot}
                   agent={currentSlot?.agent}
@@ -4561,7 +4551,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               {/* Trailing controls grouped under a single ml-auto so multiple
                   right-aligned items don't each absorb free space (two ml-auto
                   siblings split the gap, parking the split icon mid-header). */}
-              <div className="ml-auto flex items-center gap-1.5 pr-1.5 pointer-events-none">
+              <div className="ml-auto flex items-center gap-1.5 pointer-events-none">
               {/* Pop-out control, promoted to the title bar (menu items remain for
                   sidebar parity). Mirrors the split-view pattern to its left: a
                   dimmed icon to act, an accent chip when the state is active.
@@ -4588,12 +4578,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                   the button does nothing. */}
               {!embedMode && !popout && !activityOpen && (
                 <Clickable
-                  className="flex items-center justify-center w-7 h-7 rounded-md transition-colors bg-transparent border-none shrink-0 pointer-events-auto text-muted hover:text-text hover:bg-bg-hover cursor-pointer"
+                  className="pi-morph flex items-center justify-center w-7 h-7 rounded-md transition-colors bg-transparent border-none shrink-0 pointer-events-auto text-muted hover:text-text hover:bg-bg-hover cursor-pointer"
                   onClick={toggleAct}
                   title={i18nT('pages.chatPage.open_activity_panel')}
                   aria-label={i18nT('pages.chatPage.open_activity_panel')}
                 >
-                  <PanelRight size={15} />
+                  <PanelRightSolid size={15} />
                 </Clickable>
               )}
               {!embedMode && splitFeatureEnabled && (splitAnchorForActive && !activeIsSplitAnchor ? (

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -535,10 +535,9 @@ interface ChatSidebarProps {
    *  When provided, this fires AFTER the switchSlot dispatch so consumers
    *  can react to user-driven selection (e.g. to navigate the URL). */
   onSelectSlot?: (key: string) => void
-  /** When true, the sidebar is externally collapsible — a persistent toggle
-   *  button lives in the chat container at the top-left, so the header
-   *  reserves left space for it. Omitted in embed/sessions mode where the
-   *  sidebar is the whole view. */
+  /** When true, ChatPage floats a hide-sidebar button over this header's
+   *  top-left (open state), so the header reserves left space for it.
+   *  Omitted in embed/sessions mode where the sidebar is the whole view. */
   collapsible?: boolean
   /** Split View (session grid) opt-in feature. When `splitEnabled`, a pinned
    *  "Split View" entry renders at the top; clicking it calls `onOpenSplit`.
@@ -2706,14 +2705,17 @@ function ChatSidebar({
         <div className="w-[2px] h-full bg-transparent group-hover/drag:bg-accent group-active/drag:bg-accent-hover transition-colors duration-200" />
       </div>
 
-      {/* Header — per Figma (node 3108:9725): all elements (collapse icon,
-          "Sessions" title, kebab, New button) centered on one line at ~28px
-          from the panel top (mt-2 ≈ panel 8px pad, then centered in a 40px row),
-          matching the left-menu header baseline. Equal top/right gap so the New
-          button sits equidistant from the panel's top and right edges. */}
-      <div className="flex justify-between items-center pl-2 pr-3.5 mt-2 h-10">
-        <div className={`flex items-center gap-1.5 min-w-0 flex-1 ${collapsible && !isMobile ? 'pl-8' : ''}`}>
-          {!tinyHeader && <span className="sessions-panel-title text-sm font-medium text-muted tracking-[.04em] truncate">{i18nT('pages.chatSidebar.sessions')}</span>}
+      {/* Header — all elements ("Sessions" title, kebab, New button) centered
+          on one line 23px from the panel top (1px card border + mt-0.5, then
+          centered in a 40px row) — the shared control baseline: the nav rail
+          header, chat title row, and activity strip icons center on the same
+          line.
+          px-2 is symmetric so the New button ends 9px from the card's right
+          edge (8 + 1px border) — the same as its 9px gap to the top edge
+          (1px border + mt-0.5 + 6px of the h-10 row around the h-7 button). */}
+      <div className="flex justify-between items-center px-2 mt-0.5 h-10">
+        <div className={`flex items-center gap-1.5 min-w-0 flex-1 ${collapsible && !isMobile ? 'pl-9' : 'pl-1.5'}`}>
+          {!tinyHeader && <span className="sessions-panel-title text-sm font-semibold text-text-strong tracking-[.04em] truncate">{i18nT('pages.chatSidebar.sessions')}</span>}
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           <DropdownMenu>

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -2,7 +2,8 @@ import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } fro
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { usePointerDrag } from '../../hooks/usePointerDrag'
 import { Reorder } from 'framer-motion'
-import { FileText, Bot, Workflow, ScrollText, MessageSquare, TerminalSquare, GitCompare, GitPullRequest, Package, Plus, X, Hash, Pen, Columns2, PanelRightClose, Component, PanelBottom, Globe, CircleDot, Folder } from 'lucide-react'
+import { FileText, Bot, Workflow, ScrollText, MessageSquare, TerminalSquare, GitCompare, GitPullRequest, Package, Plus, X, Hash, Pen, Columns2, Component, Globe, CircleDot, Folder } from 'lucide-react'
+import { PanelRightLight, PanelBottomSolid } from '../../components/icons/panels'
 import ActivityViewer from './ActivityViewer'
 import DiffPanel from '../../components/DiffPanel'
 import DetailPanel from '../../components/DetailPanel'
@@ -383,12 +384,12 @@ export default function SidePanel({
       <div className="side-panel-strip flex items-center gap-1.5 shrink-0 p-2 rounded-tl-xl bg-bg-elevated">
         {/* Collapse the panel (far-left), separated from the tabs by a hairline. */}
         <button
-          className="flex items-center justify-center w-7 h-7 rounded-md text-muted hover:text-text hover:bg-bg-hover transition-colors bg-transparent border-none cursor-pointer shrink-0"
+          className="pi-morph flex items-center justify-center w-7 h-7 rounded-md text-muted hover:text-text hover:bg-bg-hover transition-colors bg-transparent border-none cursor-pointer shrink-0"
           onClick={onClose}
           title={i18nT('pages.chat.sidePanel.close_panel')}
           aria-label={i18nT('pages.chat.sidePanel.close_panel')}
         >
-          <PanelRightClose size={15} />
+          <PanelRightLight size={15} />
         </button>
         <span aria-hidden="true" className="w-px h-5 bg-border shrink-0" />
         {/* Pinned views (Changes / Files / Artifacts): always present, fixed at
@@ -733,11 +734,11 @@ function TabChip({ tab, active, onSelect, onClose, closable = true, onTransfer, 
           {onTransfer && (
             <button
               onClick={(e) => { e.stopPropagation(); onTransfer() }}
-              className={`shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
+              className={`pi-morph shrink-0 flex items-center justify-center w-[18px] h-[18px] rounded-full transition-all bg-transparent border-none cursor-pointer text-muted hover:text-text hover:bg-bg-hover ${active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'}`}
               title={i18nT('pages.chat.sidePanel.move_to_bottom_panel')}
               aria-label={i18nT('pages.chat.sidePanel.move_to_bottom_panel')}
             >
-              <PanelBottom size={12} />
+              <PanelBottomSolid size={12} />
             </button>
           )}
           {closable && (

--- a/website/src/pages/chat/SubagentRunCard.tsx
+++ b/website/src/pages/chat/SubagentRunCard.tsx
@@ -14,7 +14,8 @@
  * the Subagents side panel.
  */
 import { memo } from 'react'
-import { Bot, Loader2, CheckCircle2, AlertCircle, Clock, Square, PanelRight } from 'lucide-react'
+import { Bot, Loader2, CheckCircle2, AlertCircle, Clock, Square } from 'lucide-react'
+import { PanelRightSolid } from '../../components/icons/panels'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { openActivityToTab, selectSubagent } from '../../store/chatSlice'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
@@ -218,7 +219,7 @@ const SubagentRunCard = memo(function SubagentRunCard({
         onClick={open}
         title={i18nT('pages.chat.subagentRunCard.open_in_the_subagents_panel')}
         data-testid="subagent-run-card"
-        className="group w-full text-left rounded-md bg-accent/10 border border-accent/20 hover:bg-accent/15 hover:border-accent/40 transition-colors px-3 py-2 flex items-start gap-2"
+        className="pi-morph group w-full text-left rounded-md bg-accent/10 border border-accent/20 hover:bg-accent/15 hover:border-accent/40 transition-colors px-3 py-2 flex items-start gap-2"
       >
         <span className="shrink-0 mt-0.5">
           {counts.running > 0
@@ -265,7 +266,7 @@ const SubagentRunCard = memo(function SubagentRunCard({
             {i18nT('pages.chat.subagentRunCard.open_subagents_panel')}
           </div>
         </div>
-        <PanelRight
+        <PanelRightSolid
           size={14}
           className="text-muted shrink-0 mt-0.5 opacity-60 group-hover:opacity-100 transition-opacity"
         />

--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -4,7 +4,8 @@ import { shallowEqual } from 'react-redux'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { clearFocusToolCallId, mcpAppKey } from '../../store/chatSlice'
 import { useSimplifiedToolNames } from '../../hooks/useSimplifiedToolNames'
-import { LoaderCircle, CircleSlash, CircleDot, Lock, PanelRight } from 'lucide-react'
+import { LoaderCircle, CircleSlash, CircleDot, Lock } from 'lucide-react'
+import { PanelRightSolid } from '../../components/icons/panels'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { ChatMessage } from '../../types'
 import { ToolDetails } from './ToolDetails'
@@ -382,14 +383,14 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
           on hover; the icon inherits the button's currentColor. */}
       {showFileOpen && filePath && (
         <button
-          className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[12px] leading-tight bg-bg-hover text-muted hover:text-accent hover:bg-accent/10 cursor-pointer transition-colors focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:outline-none"
+          className="pi-morph shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[12px] leading-tight bg-bg-hover text-muted hover:text-accent hover:bg-accent/10 cursor-pointer transition-colors focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:outline-none"
           style={{ marginTop: '1px' }}
           onClick={(e) => { e.stopPropagation(); onFileOpen!(filePath) }}
           title={`Open ${filePath} in side panel`}
           aria-label={`Open ${filePath} in side panel`}
         >
           <span className="max-w-[240px] truncate">{basename}</span>
-          <PanelRight size={12} className="shrink-0" />
+          <PanelRightSolid size={12} className="shrink-0" />
         </button>
       )}
       </div>

--- a/website/src/pages/chat/WorkflowCompletionCard.tsx
+++ b/website/src/pages/chat/WorkflowCompletionCard.tsx
@@ -14,7 +14,8 @@
  * it works live and when a conversation is reloaded from history.
  */
 import { memo } from 'react'
-import { Workflow, CheckCircle2, AlertCircle, ChevronDown, PanelRight } from 'lucide-react'
+import { Workflow, CheckCircle2, AlertCircle, ChevronDown } from 'lucide-react'
+import { PanelRightSolid } from '../../components/icons/panels'
 import { useAppDispatch } from '../../store'
 import { openActivityToTab } from '../../store/chatSlice'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
@@ -113,9 +114,9 @@ const WorkflowCompletionCard = memo(function WorkflowCompletionCard({
               onClick={() => dispatch(openActivityToTab('workflows'))}
               title={i18nT('pages.chat.workflowCompletionCard.open_in_the_workflows_panel')}
               aria-label={i18nT('pages.chat.workflowCompletionCard.open_in_the_workflows_panel')}
-              className="flex items-center gap-1 text-[11px] text-accent hover:text-accent-hover bg-transparent border-none cursor-pointer px-1.5 py-1 rounded hover:bg-accent/10 transition-colors"
+              className="pi-morph flex items-center gap-1 text-[11px] text-accent hover:text-accent-hover bg-transparent border-none cursor-pointer px-1.5 py-1 rounded hover:bg-accent/10 transition-colors"
             >
-              <PanelRight size={13} />
+              <PanelRightSolid size={13} />
               <span className="hidden sm:inline">{i18nT('pages.chat.workflowCompletionCard.panel')}</span>
             </button>
             {body && (

--- a/website/src/pages/chat/WorkflowRunCard.tsx
+++ b/website/src/pages/chat/WorkflowRunCard.tsx
@@ -14,7 +14,8 @@
  * panel still has the full run history from the backend.
  */
 import { memo } from 'react'
-import { Workflow, Loader2, CheckCircle2, AlertCircle, PanelRight } from 'lucide-react'
+import { Workflow, Loader2, CheckCircle2, AlertCircle } from 'lucide-react'
+import { PanelRightSolid } from '../../components/icons/panels'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { openActivityToTab } from '../../store/chatSlice'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
@@ -79,7 +80,7 @@ const WorkflowRunCard = memo(function WorkflowRunCard({
         type="button"
         onClick={open}
         title={i18nT('pages.chat.workflowRunCard.open_in_the_workflows_panel')}
-        className="group w-full text-left rounded-md bg-accent/10 border border-accent/20 hover:bg-accent/15 hover:border-accent/40 transition-colors px-3 py-2 flex items-start gap-2"
+        className="pi-morph group w-full text-left rounded-md bg-accent/10 border border-accent/20 hover:bg-accent/15 hover:border-accent/40 transition-colors px-3 py-2 flex items-start gap-2"
       >
         <span className="shrink-0 mt-0.5">
           {status === 'running' && <Loader2 size={15} className="text-accent animate-spin" />}
@@ -107,7 +108,7 @@ const WorkflowRunCard = memo(function WorkflowRunCard({
             {runId} {i18nT('pages.chat.workflowRunCard.open_workflows_panel')}
           </div>
         </div>
-        <PanelRight
+        <PanelRightSolid
           size={14}
           className="text-muted shrink-0 mt-0.5 opacity-60 group-hover:opacity-100 transition-opacity"
         />

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -185,10 +185,10 @@ describe('App routing', () => {
     expect(screen.getByText('Sessions')).toBeInTheDocument()
     expect(screen.getByText('Agent Capabilities')).toBeInTheDocument()
     expect(screen.getByText('Settings')).toBeInTheDocument()
-    // The App Store rides the Apps section header as an accent link.
+    // The App Store now rides the Apps section header as an accent link.
     expect(screen.getByText('Explore')).toBeInTheDocument()
     // The bottom-pinned community row: two stacked GitHub links under one mark,
-    // plus the icon-only Discord link.
+    // plus the icon-only Discord link. The kiro.dev link was removed.
     expect(screen.getByText('Star us')).toBeInTheDocument()
     expect(screen.getByText('Report issue')).toBeInTheDocument()
     expect(screen.getByLabelText('Star KiroCrew on GitHub')).toBeInTheDocument()
@@ -198,23 +198,24 @@ describe('App routing', () => {
   })
 
   it('renders the registry-derived Artifacts and Knowledge nav items', () => {
-    // Both Artifacts and Knowledge are registered unconditionally in
-    // `surfaces/builtins.tsx`, so they must always appear in the
-    // registry-driven rail (`NAV_ITEMS = getBuiltinSurfaces().map(...)`).
-    // Asserting them by label catches a hardcoded-array regression (an array
-    // that omits Artifacts and Knowledge) that the isolated surfaces.test.tsx
-    // cannot.
+    // Regression guard for the aaf7cfe stale-branch merge, which reverted the
+    // registry-driven rail (`NAV_ITEMS = getBuiltinSurfaces().map(...)`) back
+    // to a hardcoded array that omitted Artifacts and Knowledge. Both are
+    // registered unconditionally in `surfaces/builtins.tsx`, so they must
+    // always appear in the rail. Asserting them by label catches a future
+    // hardcoded-array regression that the isolated surfaces.test.tsx cannot.
     renderWithProviders(<App />, { route: '/chat' })
     expect(screen.getByText('Artifacts')).toBeInTheDocument()
     expect(screen.getByText('Knowledge')).toBeInTheDocument()
   })
 
   it('does not double-render Secretary when the builtin Secretary app is enabled', async () => {
-    // Secretary registers a surface (so its attention badge wires through
-    // `selectSurfaceBadgeCount`) but is rendered as a nav item by `appNavItems`
-    // from `api.listApps()`, not by NAV_ITEMS. With `appOnly: true` on the
-    // Secretary surface, `getBuiltinSurfaces()` excludes it from NAV_ITEMS so it
-    // appears exactly once even when api.listApps() returns it.
+    // Regression for the Surface registry refactor: Secretary registers a
+    // surface (so its attention badge wires through `selectSurfaceBadgeCount`)
+    // but is rendered as a nav item by `appNavItems` from `api.listApps()`,
+    // not by NAV_ITEMS. With `appOnly: true` on the Secretary surface,
+    // `getBuiltinSurfaces()` excludes it from NAV_ITEMS so it should appear
+    // exactly once even when api.listApps() returns it.
     const { api } = await import('../api/client')
     ;(api.listApps as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       {
@@ -235,9 +236,9 @@ describe('App routing', () => {
   })
 
   it('collapses a long Apps list behind a "more" toggle so the nav cannot grow unbounded', async () => {
-    // With many enabled apps the rail would grow past the viewport, so the Apps
-    // group shows up to APPS_NAV_LIMIT (6) and hides the rest behind a
-    // "show more" toggle.
+    // Regression for the nav-overflow bug: with many enabled apps the rail used
+    // to grow past the viewport. The Apps group now shows up to APPS_NAV_LIMIT
+    // (6) and hides the rest behind a "show more" toggle.
     const { api } = await import('../api/client')
     const manyApps = Array.from({ length: 10 }, (_, i) => ({
       name: `app${i}`,
@@ -283,12 +284,12 @@ describe('App routing', () => {
   })
 
   it('refetches the Apps nav when the gateway reconnects (post-update recovery)', async () => {
-    // The empty-rail-after-update case: the dashboard fetches /api/apps once on
-    // mount, and right after a `kirocrew update` restart that first fetch can
-    // come back empty while the gateway is still warming. When the WebSocket
-    // reconnects, the Apps nav must refetch and self-heal — otherwise it stays
-    // empty until a manual reload (Browse, lazy-fetched, keeps working, which is
-    // why apps still show in the App Store).
+    // Regression for the empty-rail-after-update bug: the dashboard fetches
+    // /api/apps once on mount, and right after a `kirocrew update` restart that
+    // first fetch can come back empty while the gateway is still warming. When
+    // the WebSocket reconnects, the Apps nav must refetch and self-heal —
+    // previously it stayed empty until a manual reload (Browse, lazy-fetched,
+    // kept working, which is why apps still showed in the App Store).
     const { api } = await import('../api/client')
     const lateApp = {
       name: 'late', displayName: 'Late App', enabled: true, origin: 'installed',
@@ -312,8 +313,8 @@ describe('App routing', () => {
   })
 
   it('retries the initial Apps-nav fetch after a transient failure', async () => {
-    // The mount fetch can reject while the gateway is mid-restart; that failure
-    // must not be swallowed (empty rail). refreshAppNav retries with bounded
+    // The mount fetch can reject while the gateway is mid-restart; the failure
+    // used to be swallowed (empty rail). refreshAppNav now retries with bounded
     // backoff so the apps appear without a manual reload.
     vi.useFakeTimers()
     try {
@@ -415,11 +416,11 @@ describe('App routing', () => {
   })
 
   it('dismisses the collapsed overflow-toggle hover label when the toggle is pressed', async () => {
-    // Pressing the Apps overflow toggle in the collapsed rail must dismiss its
-    // portaled "N more" / "Show less" flyout. Two causes would otherwise leave
-    // it on screen: expanding re-flows the list so the row moves out from under
-    // a stationary cursor (no mouseleave is dispatched), and the click's own
-    // focus re-arms the label. Activation must dismiss it.
+    // Regression: pressing the Apps overflow toggle in the collapsed rail left
+    // its portaled "N more" / "Show less" flyout on screen until the user
+    // clicked elsewhere. Two causes: expanding re-flows the list so the row
+    // moves out from under a stationary cursor (no mouseleave is dispatched),
+    // and the click's own focus re-armed the label. Activation must dismiss it.
     const { fireEvent } = await import('@testing-library/react')
     const { api } = await import('../api/client')
     const manyApps = Array.from({ length: 10 }, (_, i) => ({
@@ -457,8 +458,9 @@ describe('App routing', () => {
   it('renders Kiro Crew branding', () => {
     localStorage.removeItem('mc-nav') // expanded sidebar shows the brand text
     renderWithProviders(<App />, { route: '/chat' })
-    // Brand (logo + name) lives in the sidebar menu row.
-    expect(screen.getAllByText('Kiro Crew').length).toBeGreaterThan(0)
+    // Brand (logo + name) moved from the top bar into the sidebar menu row.
+    // The wordmark renders as two colored segments ('Kiro ' + 'Crew').
+    expect(screen.getAllByText('Crew').length).toBeGreaterThan(0)
     localStorage.removeItem('mc-nav')
   })
 
@@ -479,10 +481,10 @@ describe('App routing', () => {
 
   it('resizes the sidebar and main body together with a quick shell transition', () => {
     localStorage.removeItem('mc-nav')
-    // The width transition must be unconditional — including with Activity open.
-    // Gating it on a 180ms pulse AND the Activity panel being closed makes the
-    // sidebar snap instead of animate whenever Activity is open (or a slow frame
-    // eats the pulse).
+    // Regression (PR #94): the width transition was gated on a 180ms pulse AND
+    // the Activity panel being closed, so the sidebar snapped instead of
+    // animating whenever Activity was open (or a slow frame ate the pulse).
+    // The transition must now be unconditional — including with Activity open.
     const store = createTestStore()
     store.dispatch(openActivityPanel())
     renderWithProviders(<App />, { route: '/chat', store })
@@ -506,9 +508,9 @@ describe('App routing', () => {
     renderWithProviders(<App />, { route: '/chat' })
 
     const nav = screen.getByRole('navigation', { name: 'Main navigation' })
-    // Brand (logo + name) lives in the rail's menu row; the collapse control is
-    // an arrow-left-to-line button.
-    expect(within(nav).getByText('Kiro Crew')).toBeInTheDocument()
+    // Brand (logo + name) now lives in the rail's menu row, replacing the old
+    // hamburger; the collapse control is an arrow-left-to-line button.
+    expect(within(nav).getByText('Crew')).toBeInTheDocument()
     const collapse = within(nav).getByRole('button', { name: 'Collapse sidebar' })
     expect(within(nav).queryByRole('button', { name: 'Toggle sidebar' })).not.toBeInTheDocument()
     expect(within(nav).queryByText('Main')).not.toBeInTheDocument()
@@ -540,9 +542,9 @@ describe('App routing', () => {
     safeSetItem('mc-nav', '1')
     renderWithProviders(<App />, { route: '/chat' })
 
-    // Request a Feature is its own pill in the header's right-side actions
-    // cluster; it stays visible regardless of the sidebar's collapsed/expanded
-    // state.
+    // Request a Feature moved out of the brand region into its own pill in the
+    // header's right-side actions cluster; it stays visible regardless of the
+    // sidebar's collapsed/expanded state.
     expect(screen.getByRole('button', { name: 'Request a Feature' })).toBeInTheDocument()
 
     const nav = screen.getByRole('navigation', { name: 'Main navigation' })
@@ -555,8 +557,8 @@ describe('App routing', () => {
 
   it('renders connection status', () => {
     renderWithProviders(<App />, { route: '/chat' })
-    // Connection is a colored dot in the unified readout capsule (no "Offline"
-    // text -- the capsule's red tint is the disconnected signal).
+    // Connection is a colored dot in the unified readout capsule ("Offline"
+    // text was removed -- the capsule's red tint is the disconnected signal).
     expect(screen.getByLabelText('Gateway offline')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
# Chat header alignment, hand-rolled panel icons, sidebar collapse morph

## Problem

Four related polish gaps in the chat chrome:

- The chat page header was visually misaligned: title-row trailing icons ended ~32px from the window edge while the topbar bell sits 12px in, and the sessions toggle, chat title, Sessions header, nav-rail header, and activity strip icons all sat on different vertical lines.
- lucide's `PanelLeft`/`PanelRight`/`PanelBottom` glyphs are near-identical at the 12-16px sizes we render, so open-vs-closed state and "which panel" were hard to read.
- Hiding or showing the sessions sidebar was a plain slide, and the toggle jumped between two different positions across the transition, so the control you clicked was not the control you landed on.
- The nav rail's brand header felt thin for an app brand: a small logo and a bold name that competed with nav labels.

## Why it matters

The header is the most-looked-at chrome in the app. Controls that drift off each other's baselines read as unpolished, panel toggles whose icons don't communicate state force users to click to find out, and the brand block is the first thing every screenshot of the product shows.

## Fix (symptoms, root cause, change)

**Alignment**: each surface derived control positions from its own local padding with no shared reference. The fix anchors everything to the activity strip's icon center (23px from container top): the chat title row gets `pt-[9px]` and its trailing icons end at the bell's 12px inset; the Sessions header aligns via `mt-0.5` with a heading-weight title; the nav rail collapse icon becomes `ArrowLeftToLine`.

**Panel icons**: new hand-rolled, lucide-compatible glyphs (`website/src/components/icons/panels.tsx`) replace all lucide `Panel*` usages app-wide. An outlined frame with a filled pane encodes state: **thin solid pane = panel closed** (click summons), **thick dimmed pane = panel open** (click tucks away). Hovering a toggle/opener previews the click's outcome by morphing the pane to the opposite state (pure CSS transitions on SVG geometry properties, no JS). Two design guards from review: geometry has a **single source of truth** (`PANE_GEOMETRY` emits CSS custom properties; `index.css` is pure mechanism, so a future tweak can't desync the static glyph from its morph), and the morph is **opt-in** via a `pi-morph` class on the enclosing control, applied at true toggles/openers and omitted from pure indicators (`SplitGlyph` renders the thick variants statically). The icon factory's `displayName` strings are excluded from the i18n string gate by callee (`eslint.i18n.config.js`); they are React DevTools names, not user copy.

**Sidebar collapse morph**: the sessions sidebar now collapses and expands as an iPadOS-style container transform (`OverlayDrawer` morph mode). The panel content never moves or deforms; a `clip-path` inset window animates between the full panel rect and the toggle button's 28px rect, so the bar visually collapses into (and expands out of) the button. The toggle is one stationary floating button at the same spot in both states, flipping only its icon. The title row reserves space for it with a `padding-left` glide on the same 240ms swift-out curve (`cubic-bezier(.32,.72,0,1)`), and an always-mounted divider fades in and out instead of remounting. Framer interpolates the clip only between structurally identical pixel strings; reduced motion and mobile fall back to the plain drawer with no morph.

**Brand header**: the rail's expanded header becomes a single brand line: 28px logo (40px collapsed) and a 13px uppercase muted wordmark with the last word in the theme accent (`KIRO CREW`).

## Tests

- Full vitest website suite green (593 files / 7413 tests passed, 3 skipped), `tsc -b` clean, i18n gate chain green (pseudolocale parity, key references, extraction baseline, source strings).
- `src/test/App.test.tsx` brand assertions updated to match the segmented wordmark rendering.
- No new tests: the change is presentational (class strings, SVG components, CSS clip-path/transitions) with render coverage via the existing suite.

## Manual verification

Verified visually on a live dev build across: sidebar collapse/expand morph in both directions (including drag-resize and reduced motion fallbacks), nav rail expanded/collapsed, activity panel open/closed, icon hover morphs on every swapped call site (floating sessions toggle, strip close, view-in-panel chips, run cards, terminal transfers), and title-row icons flush against the topbar bell.

## Screenshot

<img width="2040" height="61" alt="Screenshot 2026-08-02 at 3 50 12 PM" src="https://github.com/user-attachments/assets/fcb8dfbf-1781-46f9-a531-95d001d0d975" />

## Video

https://github.com/user-attachments/assets/12e5f4eb-e0cc-4c0e-9656-dad4b7cb1db0