### PR TITLE
feat(perf): debug-only stack sampler behind `kirocrew perf sample`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,13 @@ install_requires =
 #   pip install "kirocrew[otlp]"
 otlp =
     opentelemetry-exporter-otlp-proto-http==1.44.0
+# Optional out-of-process profiling for `kirocrew perf sample --pid`. The
+# in-process sampler (`--call`) needs nothing extra; py-spy is only required to
+# attach to an already-running gateway, and on macOS also needs elevated
+# privileges (task_for_pid). Profiling stays off unless KIROCREW_DEBUG is set:
+#   pip install "kirocrew[perf]"
+perf =
+    py-spy>=0.3,<1
 # Optional Microsoft Teams channel. The inbound Bot Framework webhook validates
 # an RS256 JWT (issuer + App-ID audience + JWKS signature) before processing, so
 # it needs PyJWT + cryptography. Install with:

--- a/skills/kirocrew-commands/SKILL.md
+++ b/skills/kirocrew-commands/SKILL.md
@@ -256,6 +256,22 @@ keystone paths are still refused). The CLI is the stricter of the two.
 | `kirocrew config set --file config.json` | Load full config from JSON file |
 | `kirocrew config edit` | Open config in $EDITOR |
 
+## Profiling (debug-only)
+
+Off unless `KIROCREW_DEBUG=1` is set; the CLI is the only entry point. Emits folded
+stacks (open in speedscope / flamegraph.pl). See `docs/profiling.md`.
+
+| Command | Description |
+|---------|-------------|
+| `KIROCREW_DEBUG=1 kirocrew perf sample --call mod:fn` | Profile that callable in-process (no extra dependency) |
+| `KIROCREW_DEBUG=1 kirocrew perf sample` | Attach to the running gateway (needs `pip install "kirocrew[perf]"`) |
+| `KIROCREW_DEBUG=1 kirocrew perf sample --pid 1234 --seconds 30` | Attach to a specific PID for N seconds (1-300) |
+| `... --interval 0.002` | Seconds between samples (0.001-1.0, default 0.005) |
+| `... --output /tmp/p.folded` | Where to write the profile (default `./kirocrew-profile.folded`) |
+
+On macOS the attach path additionally needs elevated privileges (the OS denies
+`task_for_pid`), so it may require sudo; `--call` needs neither py-spy nor sudo.
+
 ## Security & Eval
 
 | Command | Description |

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1169,6 +1169,8 @@ Examples:
     profile_show = policy_sub.add_parser("profile", help="Show a profile by name")
     profile_show.add_argument("name", help="Profile file stem (without .json)")
 
+    register_perf_parser(sub)
+
     kn_parser = sub.add_parser("knowledge", help="Knowledge Base maintenance")
     kn_sub = kn_parser.add_subparsers(dest="knowledge_action")
     kn_dedup = kn_sub.add_parser(
@@ -2057,6 +2059,10 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         _consolidate_cmd(args)
     elif args.command == "config":
         _config_cmd(args)
+    elif args.command == "perf":
+        rc = perf_cmd(args)
+        if rc:
+            raise SystemExit(rc)
     elif args.command == "snapshot":
         from kiro_crew.snapshot import snapshot_main
 
@@ -2102,6 +2108,7 @@ from kiro_crew.cli_commands import (  # noqa: E402
 )
 from kiro_crew.cli_config import _config_cmd  # noqa: E402
 from kiro_crew.cli_doctor import _doctor  # noqa: E402
+from kiro_crew.cli_perf import perf_cmd, register_perf_parser  # noqa: E402
 from kiro_crew.cli_server import (  # noqa: E402
     _gateway,
     _logout,

--- a/src/kiro_crew/cli_perf.py
+++ b/src/kiro_crew/cli_perf.py
@@ -1,0 +1,389 @@
+"""``kirocrew perf`` -- debug-only performance sampling commands.
+
+Thin CLI layer: argument handling, gate enforcement, process resolution and
+output. The sampling itself lives in :mod:`kiro_crew.perf_sampler`.
+
+Two shapes, because they answer different questions and have different
+requirements:
+
+* ``kirocrew perf sample --pid <PID>`` (default: the running gateway) attaches
+  from outside via py-spy. This is the only way to see a gateway that is already
+  serving, and it needs py-spy installed (plus privileges on macOS).
+* ``kirocrew perf sample --call <module:callable>`` runs that callable in this
+  process with the in-process sampler around it. No extra dependency, works
+  everywhere, and is the path for profiling one code path in isolation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.loader import config_dir
+from kiro_crew.gateway_lock import LOCK_FILENAME
+from kiro_crew.perf_sampler import (
+    DEFAULT_INTERVAL_SECONDS,
+    MAX_INTERVAL_SECONDS,
+    MIN_INTERVAL_SECONDS,
+    StackSampler,
+    gate_refusal_message,
+    profiling_enabled,
+    pyspy_argv,
+    pyspy_attach_failure_hint,
+    pyspy_path,
+    pyspy_unavailable_message,
+    render_folded,
+    sanitize_profile,
+    shorten_frame_paths,
+)
+
+# Ceiling on a single run. A sampler left running for hours produces an artifact
+# nobody can load; a maintainer asking a user to profile wants a short window.
+MAX_SECONDS = 300
+
+
+def _read_gateway_pid() -> int | None:
+    """PID of a **live** gateway from ``$KIROCREW_HOME/gateway.lock``, or None.
+
+    Two steps, because the recorded PID alone is not evidence. The gateway stamps
+    its PID on acquire but nothing clears it on exit, so a stopped gateway leaves
+    a stale number behind — and PIDs are reused, so attaching to a stale one would
+    profile an unrelated process and label the artifact as the gateway's.
+
+    The authoritative check is the lock itself: try to take it non-blockingly. If
+    we get it, nothing holds it and there is no live gateway, so we release it
+    immediately and report None. If we cannot, a live holder exists and the
+    recorded PID names it. Any error reads as "cannot confirm" and returns None —
+    fail closed, since the failure mode is profiling the wrong process.
+
+    Mirrors ``home_migration._gateway_is_live``, which uses the same probe to
+    decide whether relocating a data home is safe.
+    """
+    lock_path = config_dir() / LOCK_FILENAME
+    try:
+        recorded = lock_path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        pid = int(recorded.splitlines()[0]) if recorded else 0
+    except (ValueError, IndexError):
+        return None
+    if pid <= 0:
+        return None
+    if not _gateway_lock_is_held(lock_path):
+        return None
+    # A live holder exists and the file names this pid. Confirm the process is
+    # actually there: on a torn write the recorded pid can disagree with the
+    # holder, and attaching to a dead pid should read as "no gateway".
+    if not platform_compat.pid_exists(pid):
+        return None
+    return pid
+
+
+def _gateway_lock_is_held(lock_path: Path) -> bool:
+    """True when something holds the gateway lock (i.e. a gateway is running).
+
+    Non-destructive: acquiring is only used as a probe and released at once, so a
+    real gateway is never disturbed. Errors read as held, so an unreadable lock
+    never gets mistaken for "no gateway running".
+    """
+    if not lock_path.exists():
+        return False
+    fd = None
+    try:
+        fd = os.open(str(lock_path), os.O_RDWR)
+        if platform_compat.try_acquire_lock(fd, exclusive=True):
+            platform_compat.release_lock(fd)
+            return False
+        return True
+    except OSError:
+        return True
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _resolve_callable(spec: str) -> object:
+    """Import ``module:attr`` and return the attribute.
+
+    Deliberately narrow: an import plus ``getattr``, no expression evaluation. It
+    is still arbitrary in-process code execution, which is why it sits behind the
+    debug gate -- though it grants nothing a local user could not already do by
+    running python directly against the same installed package.
+    """
+    if ":" not in spec:
+        raise ValueError(f"expected 'module:callable', got {spec!r}")
+    module_name, _, attr = spec.partition(":")
+    if not module_name or not attr:
+        raise ValueError(f"expected 'module:callable', got {spec!r}")
+    module = importlib.import_module(module_name)
+    target = module
+    for part in attr.split("."):
+        target = getattr(target, part)
+    if not callable(target):
+        raise TypeError(f"{spec} is not callable")
+    return target
+
+
+def _write_artifact(output: Path, text: str) -> bool:
+    """Write the profile owner-only. Returns False (with a diagnostic) on failure.
+
+    Uses :func:`atomic_write` rather than ``Path.write_text``: the default output
+    path is relative, so it usually lands in whatever directory the operator ran
+    the command from -- frequently a repo checkout. ``write_text`` follows a
+    symlink, so a planted ``kirocrew-profile.folded`` link would have the linked
+    file truncated and chmodded to 0o600. atomic_write creates a fresh temp file
+    and renames over the path, which replaces the link instead of writing through
+    it, and applies the mode to the file it actually created.
+
+    Errors are reported rather than raised: by the time this runs the sampling is
+    already done, so an unwritable ``--output`` should cost the operator a clear
+    message and a nonzero exit, not a traceback over a profile that was collected
+    successfully.
+
+    0o600 because a profile names code paths and file layout from the user's
+    machine; it is diagnostic data, not world-readable output.
+    """
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(output, text, mode=0o600)
+    except OSError as exc:
+        print(f"Could not write the profile to {output}: {exc}", file=sys.stderr)
+        return False
+    return True
+
+
+def _sample_in_process(args: argparse.Namespace) -> int:
+    """Profile a callable in this process with the in-process sampler."""
+    try:
+        target = _resolve_callable(args.perf_call)
+    except (Exception, SystemExit) as exc:  # noqa: BLE001 - see below
+        # Deliberately broad: resolving runs the target module's top-level code,
+        # which can raise anything (a RuntimeError from a failed import guard, a
+        # KeyError from missing config) or call sys.exit -- hence SystemExit is
+        # named explicitly, since it is a BaseException and Exception alone would
+        # let it through. KeyboardInterrupt is deliberately NOT caught: an operator
+        # interrupting the command should still interrupt it. Report the type so
+        # the failure stays diagnosable.
+        print(
+            f"Cannot resolve --call {args.perf_call!r}: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    sampler = StackSampler(interval=args.interval)
+    started = time.perf_counter()
+    sampler.start()
+    try:
+        target()  # type: ignore[operator]
+    except (Exception, SystemExit) as exc:  # noqa: BLE001 - report, still emit
+        # The profile of a call that raised is often exactly what is wanted, so
+        # keep the samples and surface the error rather than discarding both.
+        #
+        # SystemExit is included deliberately and is not hypothetical: the most
+        # natural things to profile here are CLI entry points, and those call
+        # sys.exit on their normal path (`--call kiro_crew.cli_doctor:_doctor`
+        # exits 1 whenever it finds an issue). Catching only Exception meant the
+        # run that mattered most produced no artifact at all. KeyboardInterrupt
+        # is BaseException and not SystemExit, so Ctrl-C still propagates and
+        # aborts rather than silently yielding a partial profile.
+        print(f"--call raised {type(exc).__name__}: {exc}", file=sys.stderr)
+    finally:
+        report = sampler.stop()
+    elapsed = time.perf_counter() - started
+
+    if report.samples == 0:
+        print(
+            "No samples collected -- the command finished faster than one "
+            f"sampling interval ({args.interval}s). Lower --interval or profile "
+            "more work.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not _write_artifact(args.output, sanitize_profile(render_folded(report))):
+        return 6
+    print(
+        f"Sampled {report.samples} ticks over {elapsed:.2f}s "
+        f"({report.effective_rate:.0f}/s effective, {args.interval}s requested)."
+    )
+    if report.truncated_stacks:
+        print(f"{report.truncated_stacks} stack(s) truncated at maximum depth.")
+    print(f"Wrote folded stacks to {args.output}")
+    print("Open it in speedscope (https://speedscope.app) or flamegraph.pl.")
+    return 0
+
+
+def _sample_out_of_process(args: argparse.Namespace, pid: int) -> int:
+    """Profile a foreign PID by shelling out to py-spy.
+
+    py-spy is pointed at a **private temporary file**, never at ``--output``. Two
+    reasons, both load-bearing:
+
+    * py-spy opens its output path directly, so a symlink at ``--output`` would
+      have its target truncated by py-spy before this function ever got to
+      sanitize and re-write. Routing through a temp dir we own means the caller's
+      path is only ever touched by :func:`_write_artifact`, which renames over it.
+    * py-spy's raw output has to be re-read and redacted anyway (it embeds
+      absolute paths from the target process), so the artifact the operator asked
+      for should only ever appear in its final, sanitized form -- never as an
+      intermediate the redactors have not seen yet.
+
+    Every syscall on this path is guarded: a discovered-but-unlaunchable binary
+    makes ``subprocess.run`` raise ``OSError``, which would otherwise surface as a
+    traceback rather than an exit code.
+    """
+    if pyspy_path() is None:
+        print(pyspy_unavailable_message(), file=sys.stderr)
+        return 3
+
+    rate = max(1, int(round(1.0 / args.interval)))
+    print(f"Attaching py-spy to pid {pid} for {args.seconds}s at {rate}Hz...")
+
+    try:
+        # 0o700 by default, and removed on exit, so the intermediate profile is
+        # never readable by another user and never left behind.
+        with tempfile.TemporaryDirectory(prefix="kirocrew-perf-") as tmpdir:
+            staged = Path(tmpdir) / "profile.folded"
+            try:
+                argv = pyspy_argv(pid=pid, seconds=args.seconds, output=staged, rate=rate)
+            except FileNotFoundError:
+                # py-spy vanished between the check above and here.
+                print(pyspy_unavailable_message(), file=sys.stderr)
+                return 3
+            try:
+                completed = subprocess.run(
+                    argv, capture_output=True, text=True, timeout=args.seconds + 60
+                )
+            except subprocess.TimeoutExpired:
+                print("py-spy did not finish within its duration plus 60s.", file=sys.stderr)
+                return 4
+            except OSError as exc:
+                # A discovered path can still be unlaunchable: wrong architecture,
+                # not actually executable, a broken interpreter line.
+                print(f"Could not run py-spy ({argv[0]}): {exc}", file=sys.stderr)
+                return 3
+            if completed.returncode != 0:
+                detail = (completed.stderr or completed.stdout or "").strip()
+                print(f"py-spy failed (exit {completed.returncode}).", file=sys.stderr)
+                if detail:
+                    print(sanitize_profile(detail), file=sys.stderr)
+                print(pyspy_attach_failure_hint(), file=sys.stderr)
+                return completed.returncode
+            try:
+                raw = staged.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                print("py-spy reported success but wrote no readable profile.", file=sys.stderr)
+                return 5
+    except OSError as exc:
+        # Creating the temp dir can fail (no space, unwritable TMPDIR).
+        print(f"Could not create a temporary directory for the profile: {exc}", file=sys.stderr)
+        return 6
+
+    if not _write_artifact(args.output, sanitize_profile(shorten_frame_paths(raw))):
+        return 6
+    print(f"Wrote folded stacks to {args.output}")
+    print("Open it in speedscope (https://speedscope.app) or flamegraph.pl.")
+    return 0
+
+
+def _perf_sample(args: argparse.Namespace) -> int:
+    """Entry point for ``kirocrew perf sample``."""
+    if not profiling_enabled():
+        print(gate_refusal_message(), file=sys.stderr)
+        return 1
+
+    if not MIN_INTERVAL_SECONDS <= args.interval <= MAX_INTERVAL_SECONDS:
+        print(
+            f"--interval must be between {MIN_INTERVAL_SECONDS} and "
+            f"{MAX_INTERVAL_SECONDS} seconds.",
+            file=sys.stderr,
+        )
+        return 2
+    if not 1 <= args.seconds <= MAX_SECONDS:
+        print(f"--seconds must be between 1 and {MAX_SECONDS}.", file=sys.stderr)
+        return 2
+
+    if args.perf_call:
+        return _sample_in_process(args)
+
+    pid = args.pid or _read_gateway_pid()
+    if pid is None:
+        print(
+            "No running gateway found (no pid recorded in "
+            f"{config_dir() / LOCK_FILENAME}). Pass --pid explicitly, or use "
+            "--call to profile a code path in this process.",
+            file=sys.stderr,
+        )
+        return 2
+    return _sample_out_of_process(args, pid)
+
+
+def perf_cmd(args: argparse.Namespace) -> int:
+    """Dispatch a ``perf`` subcommand."""
+    if args.perf_action == "sample":
+        return _perf_sample(args)
+    print("Usage: kirocrew perf sample [--pid PID | --call module:callable]", file=sys.stderr)
+    return 2
+
+
+def register_perf_parser(sub: argparse._SubParsersAction) -> None:
+    """Wire ``kirocrew perf`` into the top-level parser.
+
+    Named ``perf`` rather than ``profile``: ``kirocrew policy profile`` already
+    exists, and "profile" is overloaded three ways in this codebase (governance
+    profiles, AWS profiles, deploy profiles).
+    """
+    perf_parser = sub.add_parser("perf", help="Debug-only performance sampling (off by default)")
+    perf_sub = perf_parser.add_subparsers(dest="perf_action")
+    sample = perf_sub.add_parser(
+        "sample",
+        help="Sample stacks into a folded-stack profile",
+        description=(
+            "Debug-only stack sampler. Requires KIROCREW_DEBUG=1. With no "
+            "--call, attaches to the running gateway (or --pid) using py-spy; "
+            "with --call, profiles that callable in this process."
+        ),
+    )
+    sample.add_argument(
+        "--seconds", type=int, default=10, help=f"Attach duration, 1-{MAX_SECONDS} (default: 10)"
+    )
+    sample.add_argument(
+        "--interval",
+        type=float,
+        default=DEFAULT_INTERVAL_SECONDS,
+        help=(
+            f"Seconds between samples, {MIN_INTERVAL_SECONDS}-{MAX_INTERVAL_SECONDS} "
+            f"(default: {DEFAULT_INTERVAL_SECONDS})"
+        ),
+    )
+    sample.add_argument(
+        "--pid", type=int, default=0, help="Target PID (default: the running gateway)"
+    )
+    sample.add_argument(
+        "--call",
+        dest="perf_call",
+        default="",
+        metavar="MODULE:CALLABLE",
+        # dest is explicit and prefixed: the top-level subparsers use
+        # dest="command", so a flag named --command here would silently overwrite
+        # the subcommand name and route the invocation to argparse's help path.
+        help="Profile 'module:callable' in this process instead of attaching",
+    )
+    sample.add_argument(
+        "--output",
+        type=Path,
+        default=Path("kirocrew-profile.folded"),
+        help="Where to write the profile (default: ./kirocrew-profile.folded)",
+    )

--- a/src/kiro_crew/docs/index.md
+++ b/src/kiro_crew/docs/index.md
@@ -66,6 +66,7 @@ agent backend and Slack credentials.
 - [Getting Started](getting-started.md) — Installation, first-time setup, background running
 - [Configuration](configuration.md) — Config file reference, environment variables, sandbox modes
 - [Use Cases](use-cases.md) — Real-world workflows from the community
+- [Profiling](profiling.md) — Debug-only stack sampler (`kirocrew perf sample`) for attributing time to call paths
 - [Troubleshooting](troubleshooting.md) — Common issues and fixes
 
 ## Security

--- a/src/kiro_crew/docs/profiling.md
+++ b/src/kiro_crew/docs/profiling.md
@@ -1,0 +1,124 @@
+# Profiling (debug-only)
+
+KiroCrew ships aggregate duration histograms (`kiro_crew.metrics`, off by
+default) and a stall detector that dumps thread stacks when the event loop wedges
+(`kiro_crew.dashboard.loop_watchdog`). Neither attributes time to call paths.
+`kirocrew perf sample` fills that gap: it turns a window of execution into
+**folded stacks**, the format speedscope, flamegraph.pl and Perfetto all import.
+
+## It is off by default
+
+Profiling never runs unless you ask for it twice: the debug switch must be set
+**and** you must invoke the CLI. There is no always-on instrumentation, no
+background sampler at rest, and no HTTP endpoint — the CLI is the only entry
+point.
+
+```bash
+export KIROCREW_DEBUG=1
+```
+
+Without it every `perf` command refuses and explains how to enable it. A value of
+`0`, `false`, `no` or `off` also reads as disabled, so `KIROCREW_DEBUG=0` does
+not accidentally switch profiling on.
+
+## Profiling a code path (no extra dependency)
+
+`--call` imports `module:callable`, runs it in this process, and samples every
+thread while it runs. This works everywhere with no extra install and is the
+right tool for "why is this one operation slow".
+
+```bash
+KIROCREW_DEBUG=1 kirocrew perf sample \
+  --call kiro_crew.history:ConversationLog.list_sessions \
+  --interval 0.002 \
+  --output /tmp/list-sessions.folded
+```
+
+The callable is invoked with no arguments. If it raises, the profile is still
+written — the stacks leading to a failure are usually the point.
+
+## Profiling a running gateway (needs py-spy)
+
+With no `--call`, the sampler attaches to another process: `--pid`, or the
+running gateway's PID read from `$KIROCREW_HOME/gateway.lock`.
+
+```bash
+pip install "kirocrew[perf]"
+KIROCREW_DEBUG=1 kirocrew perf sample --seconds 30 --output /tmp/gateway.folded
+```
+
+A foreign process cannot be sampled from pure Python, so this path requires
+py-spy and is a deliberately optional extra. py-spy is located by probing the
+usual install locations first (`/opt/homebrew/bin`, `/usr/local/bin`,
+`~/.cargo/bin`, `~/.local/bin`) and only then `PATH` — a process launched by the
+desktop app or launchd gets a minimal `PATH` with no shell profile sourced, so a
+`PATH`-only lookup reports "not installed" on machines that have it. The same
+list lives in `website/electron/pyspy-dump.js`; keep them in sync.
+
+On macOS py-spy also needs elevated privileges, because the OS denies
+`task_for_pid` otherwise — the same constraint that led `loop_watchdog` to prefer
+an in-process `faulthandler` timer over an external py-spy capture. When py-spy is
+missing the command says so and points at `--call` instead of producing nothing.
+
+### It can lose a race with the desktop app's crash capture
+
+The desktop app already uses py-spy for a different purpose: when the liveness
+monitor decides the gateway is wedged, `website/electron/pyspy-dump.js` runs
+`py-spy dump` on it just before `SIGKILL` so the post-restart crash report carries
+the frozen frame.
+
+On Linux, ptrace admits exactly **one** tracer per process, so that capture and an
+attach from this command cannot both hold the gateway — one is refused. The wedge
+capture takes precedence by design: it is the only record of the freeze and it is
+time-bounded and unrepeatable, whereas this command is operator-invoked and can be
+re-run. If an attach is refused, the error names both possibilities (an existing
+tracer, or missing privileges) rather than assuming it is a permissions problem.
+
+macOS behaves differently — py-spy reads via `task_for_pid` there, where several
+readers can hold a task port — so a refusal on macOS points at privileges.
+
+## Reading the output
+
+Each line is `outermost;...;innermost <sample-count>`, hottest first:
+
+```
+run (kiro_crew/cli.py:702);search (kiro_crew/history.py:412) 184
+```
+
+Open it at <https://speedscope.app> (local, nothing is uploaded) or pipe it to
+`flamegraph.pl`.
+
+The command reports the **effective** sample rate alongside the requested one:
+
+```
+Sampled 168 ticks over 0.61s (274/s effective, 0.002s requested).
+```
+
+A loaded machine cannot always hit the requested interval. Trust the effective
+figure — that is the resolution you actually got.
+
+## What the artifact contains
+
+Frame labels are function names plus the last two path components, so absolute
+paths and the home-directory prefix are dropped. This holds for both sampling
+strategies: the in-process sampler builds labels that way, and py-spy's own output
+is rewritten through the same shortening before it is saved. Output is
+additionally run through the standard credential and exfiltration-URL redactors,
+and written `0o600`, because a profile describes code paths and file layout from
+the user's machine. It is still diagnostic data about a real system — review it
+before attaching it to a public issue.
+
+## Options
+
+| Flag | Meaning |
+|---|---|
+| `--call MODULE:CALLABLE` | Profile that callable in this process (no py-spy needed) |
+| `--pid PID` | Attach to this PID (default: the running gateway) |
+| `--seconds N` | Attach duration, 1–300 (default 10). Applies to the attach path |
+| `--interval S` | Seconds between samples, 0.001–1.0 (default 0.005) |
+| `--output PATH` | Where to write the profile (default `./kirocrew-profile.folded`) |
+
+Exit codes: `1` gate off or nothing sampled, `2` bad arguments or an
+unresolvable `--call`, `3` py-spy missing, `4` py-spy timed out, `5` py-spy
+reported success but wrote nothing readable, `6` the profile could not be written
+to `--output`.

--- a/src/kiro_crew/perf_sampler.py
+++ b/src/kiro_crew/perf_sampler.py
@@ -1,0 +1,459 @@
+"""Debug-only statistical stack sampler.
+
+KiroCrew has aggregate duration histograms (``kiro_crew.metrics``) and a stall
+detector that dumps thread stacks when the event loop wedges
+(``dashboard.loop_watchdog``), but nothing that attributes CPU/wall time to
+call paths. This module is the missing piece: a sampling profiler that turns a
+window of execution into folded stacks, which speedscope, flamegraph.pl and
+Perfetto all import directly.
+
+Two sampling strategies, because they answer different questions:
+
+* **In-process** (:class:`StackSampler`) -- a daemon thread wakes on an interval
+  and reads every other thread's stack via :func:`sys._current_frames`. Needs no
+  extra privileges, no third-party package, and works on macOS and Windows. It
+  can only see the process it runs in, so it profiles a command executed by the
+  CLI, not a gateway already running elsewhere.
+* **Out-of-process** (:func:`pyspy_argv`) -- py-spy attaches to a foreign PID.
+  This is the only way to profile an already-running gateway, and it is
+  deliberately optional: py-spy needs ``task_for_pid`` on macOS, which the OS
+  denies without elevated privileges (the same constraint that made
+  ``loop_watchdog`` prefer an in-process ``faulthandler`` timer over an external
+  py-spy capture). When py-spy is missing or refused, the caller reports that
+  instead of silently producing nothing.
+
+Nothing here runs unless a CLI command asks for it. There is no import-time
+hook, no background thread at rest, and no HTTP surface -- see
+:func:`profiling_enabled` for the gate.
+"""
+
+from __future__ import annotations
+
+import collections
+import os
+import re
+import shutil
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from kiro_crew import platform_compat
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+# Environment switch. Off unless explicitly set, so a normal install cannot
+# start a sampler by accident and CI never carries one.
+DEBUG_ENV_VAR = "KIROCREW_DEBUG"
+
+# Interval bounds. Below ~1ms the sampler thread costs more than it measures;
+# above 1s the sample count is too small to attribute anything.
+MIN_INTERVAL_SECONDS = 0.001
+MAX_INTERVAL_SECONDS = 1.0
+DEFAULT_INTERVAL_SECONDS = 0.005
+
+# Frames deeper than this are truncated. Runaway recursion would otherwise
+# produce single folded lines megabytes wide.
+MAX_STACK_DEPTH = 200
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def profiling_enabled(env: dict[str, str] | None = None) -> bool:
+    """True when the debug gate is set.
+
+    Read from *env* (defaults to the real environment) so tests do not mutate
+    global state. Any value outside :data:`_TRUTHY` counts as off, which means a
+    stray ``KIROCREW_DEBUG=0`` reads as disabled rather than as "the name is
+    present, therefore on".
+    """
+    source = os.environ if env is None else env
+    return source.get(DEBUG_ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+def gate_refusal_message() -> str:
+    """One-line explanation of how to enable profiling, for the CLI to print."""
+    return (
+        f"Profiling is off. It is a debug-only tool, so it must be enabled "
+        f"explicitly: re-run with {DEBUG_ENV_VAR}=1 set in the environment."
+    )
+
+
+@dataclass(frozen=True)
+class SampleReport:
+    """Result of a sampling run.
+
+    ``counts`` maps a folded stack ("outermost;...;innermost") to the number of
+    samples in which that exact stack was on top. ``samples`` is the number of
+    sampling ticks taken and ``duration`` the wall-clock span, so a caller can
+    report the effective rate actually achieved rather than the one requested --
+    a loaded machine will not hit the requested interval, and reporting the
+    request as if it were the result would overstate the resolution.
+    """
+
+    counts: dict[str, int]
+    samples: int
+    duration: float
+    interval: float
+    truncated_stacks: int = 0
+
+    @property
+    def effective_rate(self) -> float:
+        """Samples per second actually achieved (0.0 when nothing was sampled)."""
+        if self.duration <= 0 or self.samples <= 0:
+            return 0.0
+        return self.samples / self.duration
+
+
+def _frame_label(filename: str, lineno: int, funcname: str) -> str:
+    """Render one frame as ``func (file:line)`` with the path shortened.
+
+    Absolute paths are reduced to their last two components. That keeps the
+    label useful for navigation while dropping the home-directory prefix, which
+    is user-identifying and worthless for reading a flamegraph.
+    """
+    try:
+        parts = Path(filename).parts
+    except (TypeError, ValueError):
+        parts = ()
+    short = "/".join(parts[-2:]) if parts else filename or "<unknown>"
+    return f"{funcname} ({short}:{lineno})"
+
+
+def _fold_frame_stack(frame: object) -> tuple[str, bool]:
+    """Walk a frame's ``f_back`` chain into a folded, outermost-first stack.
+
+    Returns the folded string plus whether the walk hit
+    :data:`MAX_STACK_DEPTH`. Frames are collected innermost-first (the direction
+    the chain runs) and reversed once, rather than prepending, so a deep stack
+    stays linear instead of quadratic.
+    """
+    labels: list[str] = []
+    truncated = False
+    current = frame
+    while current is not None:
+        if len(labels) >= MAX_STACK_DEPTH:
+            truncated = True
+            break
+        code = getattr(current, "f_code", None)
+        if code is None:
+            break
+        labels.append(
+            _frame_label(
+                getattr(code, "co_filename", "<unknown>"),
+                getattr(current, "f_lineno", 0) or 0,
+                getattr(code, "co_name", "<unknown>"),
+            )
+        )
+        current = getattr(current, "f_back", None)
+    labels.reverse()
+    return ";".join(labels), truncated
+
+
+class StackSampler:
+    """Samples every thread's stack from a daemon thread on a fixed interval.
+
+    The sampler thread excludes itself: including it would put its own sleep at
+    the top of a large share of samples and crowd out the real work.
+    """
+
+    def __init__(self, interval: float = DEFAULT_INTERVAL_SECONDS) -> None:
+        if not MIN_INTERVAL_SECONDS <= interval <= MAX_INTERVAL_SECONDS:
+            raise ValueError(
+                f"interval must be between {MIN_INTERVAL_SECONDS} and "
+                f"{MAX_INTERVAL_SECONDS} seconds, got {interval}"
+            )
+        self._interval = interval
+        self._counts: collections.Counter[str] = collections.Counter()
+        self._samples = 0
+        self._truncated = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started_at = 0.0
+        self._stopped_at = 0.0
+
+    def _tick(self) -> None:
+        """Take one sample of every thread except the sampler's own."""
+        own = threading.get_ident()
+        for tid, frame in sys._current_frames().items():
+            if tid == own:
+                continue
+            folded, truncated = _fold_frame_stack(frame)
+            if not folded:
+                continue
+            self._counts[folded] += 1
+            if truncated:
+                self._truncated += 1
+        self._samples += 1
+
+    def _run(self) -> None:
+        # Absolute deadlines rather than sleep(interval): a fixed sleep drifts by
+        # however long each tick takes, so the achieved rate would sag under load
+        # without that showing up anywhere.
+        next_at = time.perf_counter()
+        while not self._stop.is_set():
+            next_at += self._interval
+            delay = next_at - time.perf_counter()
+            if delay > 0:
+                if self._stop.wait(delay):
+                    break
+            else:
+                # Behind schedule: skip the backlog instead of spinning to catch
+                # up, which would sample in a tight burst and skew the profile.
+                next_at = time.perf_counter()
+            try:
+                self._tick()
+            except Exception:  # noqa: BLE001 - a debug tool must not kill its host
+                # A frame can vanish mid-walk when its thread exits. Dropping the
+                # sample keeps the run going; the report's sample count reflects it.
+                continue
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("sampler already started")
+        self._started_at = time.perf_counter()
+        self._thread = threading.Thread(
+            target=self._run, name="kirocrew-perf-sampler", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> SampleReport:
+        if self._thread is None:
+            raise RuntimeError("sampler not started")
+        self._stop.set()
+        # Bounded join: the loop only ever waits on the stop event or a bounded
+        # sleep, so it exits promptly. The timeout means a wedged sampler still
+        # yields whatever it collected instead of hanging the CLI.
+        self._thread.join(timeout=max(1.0, self._interval * 20))
+        self._stopped_at = time.perf_counter()
+        self._thread = None
+        return SampleReport(
+            counts=dict(self._counts),
+            samples=self._samples,
+            duration=max(0.0, self._stopped_at - self._started_at),
+            interval=self._interval,
+            truncated_stacks=self._truncated,
+        )
+
+    def __enter__(self) -> "StackSampler":
+        self.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._thread is not None:
+            self.stop()
+
+
+def render_folded(report: SampleReport) -> str:
+    """Render a report as folded stacks, hottest first.
+
+    Folded text is the lowest-common-denominator profile format: speedscope,
+    flamegraph.pl and Perfetto all read it, so emitting it avoids owning a
+    version-pinned JSON schema. Sorted by descending count then by stack so the
+    output is deterministic and diffable between runs.
+    """
+    lines = [
+        f"{stack} {count}"
+        for stack, count in sorted(report.counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    ]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def shorten_frame_paths(text: str) -> str:
+    """Reduce absolute paths in a folded profile to their last two components.
+
+    :func:`_frame_label` does this for the in-process sampler, but py-spy writes
+    its own artifact with full paths from the target process, so the same
+    guarantee has to be applied to that text after the fact. Without this the
+    documented promise ("absolute paths and the home-directory prefix are
+    dropped") held only for one of the two sampling strategies, and a py-spy
+    profile leaked the operator's home directory (hence username).
+
+    Matches POSIX and Windows absolute paths that end in a source-file component,
+    which is the only shape py-spy emits inside a frame label. Relative paths are
+    left alone -- they carry no home prefix to strip.
+
+    Two passes, because a path component may legitimately contain a space
+    (``/home/Jane Doe/...``, ``C:\\Users\\Jane Doe\\...``). A single
+    space-excluding pattern matched only the tail after the last space, so it
+    rewrote ``/home/Jane Doe/proj/pkg/mod.py`` to ``/home/Jane Doepkg/mod.py`` --
+    still carrying the home prefix, which is precisely what this function exists
+    to remove. The first pass therefore handles the parenthesized ``(path:line)``
+    form py-spy emits, where the closing paren is an unambiguous terminator so
+    spaces inside the path are safe to consume; the second pass keeps the
+    conservative space-excluding rule for any bare path outside parentheses,
+    where a space cannot be told apart from surrounding prose.
+    """
+
+    def _shorten(raw_path: str) -> str:
+        parts = [p for p in re.split(r"[/\\]", raw_path) if p and not p.endswith(":")]
+        return "/".join(parts[-2:]) if len(parts) >= 2 else raw_path
+
+    def _replace(match: "re.Match[str]") -> str:
+        return _shorten(match.group(0))
+
+    def _replace_parenthesized(match: "re.Match[str]") -> str:
+        # Rebuild the wrapper so only the path itself is rewritten. The suffix
+        # group is optional, so it is None when there is no ":<line>".
+        return f"({_shorten(match.group('path'))}{match.group('suffix') or ''})"
+
+    # Pass 1: "(<absolute path>:<line>)" -- the shape py-spy writes. The path may
+    # contain spaces; ")" terminates it unambiguously.
+    parenthesized = (
+        r"\((?P<path>(?:[A-Za-z]:)?[/\\][^)]*?\.[A-Za-z0-9_]+)(?P<suffix>:\d+)?\)"
+    )
+    text = re.sub(parenthesized, _replace_parenthesized, text)
+
+    # Pass 2: bare absolute paths outside parentheses. Anchored on the extension
+    # so bare directories and ordinary prose are not rewritten; space-excluding
+    # because nothing delimits the end of the path here.
+    pattern = r"(?:[A-Za-z]:)?(?:[/\\][^/\\\s;:()]+)+\.[A-Za-z0-9_]+"
+    return re.sub(pattern, _replace, text)
+
+
+def sanitize_profile(text: str) -> str:
+    """Strip credentials and exfiltration URLs from profile output.
+
+    Frame labels are code identifiers and shortened paths, so a hit is unlikely
+    -- but a sampled frame can carry a literal in a filename, and the artifact is
+    meant to be sent to a maintainer. Redacting on the way out is cheap
+    insurance, and matches the redact-before-egress rule the rest of the
+    codebase follows.
+    """
+    cleaned, _ = redact_exfiltration_urls(text)
+    cleaned, _ = redact_credentials(cleaned)
+    return cleaned
+
+
+def _home_dir() -> Path:
+    """Return the user's home directory.
+
+    A one-line indirection purely so tests can simulate an unresolvable home
+    without monkeypatching ``pathlib.Path.home`` itself. Patching that class
+    attribute mutates pathlib process-wide for the duration of the test, which
+    breaks unrelated code calling ``Path.home()`` and corrupted ``WindowsPath``
+    internals on the Windows CI shard.
+    """
+    return Path.home()
+
+
+def pyspy_candidates() -> tuple[Path, ...]:
+    """Explicit install locations to probe before falling back to ``PATH``.
+
+    Mirrors ``website/electron/pyspy-dump.js``, which learned this the hard way:
+    a process launched by the desktop app (or by launchd) gets a minimal ``PATH``
+    with no shell profile sourced, so a py-spy installed by homebrew, cargo or
+    ``pip --user`` is present on disk but invisible to a ``PATH`` lookup. Probing
+    the known locations first is what stops the attach path reporting itself
+    unavailable on a machine that has py-spy.
+
+    Kept in sync with that module's ``PYSPY_CANDIDATES`` list.
+
+    Empty on Windows, deliberately. Every entry is a POSIX location, the binary
+    there is ``py-spy.exe`` rather than ``py-spy``, and ``os.access(X_OK)`` is
+    permissive on Windows (there is no execute bit, so any existing file answers
+    True) -- probing would therefore be both useless and wrong. Windows discovery
+    goes through :func:`shutil.which`, which applies ``PATHEXT``.
+    """
+    if platform_compat.IS_WINDOWS:
+        return ()
+    absolute = (
+        Path("/opt/homebrew/bin/py-spy"),
+        Path("/usr/local/bin/py-spy"),
+    )
+    try:
+        home = _home_dir()
+    except (RuntimeError, OSError):
+        # Path.home() raises when the home directory cannot be resolved -- e.g. a
+        # systemd unit or container with no HOME and no passwd entry. The
+        # home-relative candidates are simply unavailable there; the absolute ones
+        # and the PATH fallback still work, so degrade rather than raise out of a
+        # discovery helper.
+        return absolute
+    return absolute + (
+        home / ".cargo" / "bin" / "py-spy",
+        home / ".local" / "bin" / "py-spy",
+    )
+
+
+def pyspy_path() -> str | None:
+    """Absolute path to a py-spy binary, or None when it is not installed.
+
+    Candidate locations first, then ``PATH`` (via :func:`shutil.which`, which also
+    applies ``PATHEXT`` on Windows).
+    """
+    for candidate in pyspy_candidates():
+        try:
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+        except OSError:
+            continue
+    return shutil.which("py-spy")
+
+
+def pyspy_argv(pid: int, seconds: int, output: Path, rate: int) -> list[str]:
+    """Build the py-spy argv for attaching to *pid*.
+
+    ``--format raw`` emits folded stacks, matching :func:`render_folded`, so both
+    sampling strategies produce one interchangeable artifact format. Returned
+    rather than executed so the CLI owns spawning (and so this stays testable
+    without a real py-spy).
+    """
+    binary = pyspy_path()
+    if binary is None:
+        raise FileNotFoundError("py-spy is not installed")
+    return [
+        binary,
+        "record",
+        "--pid",
+        str(pid),
+        "--duration",
+        str(seconds),
+        "--rate",
+        str(rate),
+        "--format",
+        "raw",
+        "--output",
+        str(output),
+    ]
+
+
+def pyspy_attach_failure_hint() -> str:
+    """Explain the two distinct reasons an attach is refused.
+
+    Blaming privileges alone is misleading on Linux, where the more likely cause
+    is that something else already holds the target: ptrace admits exactly one
+    tracer per process, so a second ``PTRACE_ATTACH`` is refused while another is
+    attached. The desktop app does exactly that — ``website/electron/pyspy-dump.js``
+    runs ``py-spy dump`` on the gateway just before SIGKILL when the liveness
+    monitor declares it wedged.
+
+    That capture deliberately takes precedence: it is the only record of the
+    frozen frame and it is time-bounded and unrepeatable, whereas this command is
+    operator-invoked and can simply be re-run. So the guidance is to retry rather
+    than to defeat it.
+
+    macOS differs — py-spy reads via ``task_for_pid`` there, where multiple
+    readers can hold a task port, so a refusal on macOS points at privileges
+    instead.
+    """
+    return (
+        "py-spy could not attach. Two common causes:\n"
+        "  1. Another tracer already holds the process. On Linux only ONE ptrace "
+        "tracer is allowed per process, and the desktop app attaches py-spy to the "
+        "gateway to capture a frozen stack when it looks wedged. That capture wins "
+        "by design (it is the only record of the freeze) — wait and re-run.\n"
+        "  2. Insufficient privileges. On macOS reading another process needs "
+        "task_for_pid, which the OS denies without elevation; try sudo."
+    )
+
+
+def pyspy_unavailable_message() -> str:
+    """Explain that out-of-process sampling needs py-spy, and how to get it."""
+    return (
+        "Attaching to another process needs py-spy, which is not installed.\n"
+        "Install it with:  pip install 'kirocrew[perf]'   (or: pip install py-spy)\n"
+        "On macOS py-spy also needs elevated privileges to read another "
+        "process (the OS denies task_for_pid otherwise), so it may require sudo.\n"
+        "To profile work in this process instead, use: --call module:callable"
+    )

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -107,6 +107,14 @@ class PostureControl:
 # Where a sink runs only ONE of the two scanners, its detail text says so.
 _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
     (
+        "Profile artifact",
+        "perf_sampler.py",
+        "Folded-stack profiles written by `kirocrew perf sample`. Frame labels are "
+        "code identifiers and shortened paths, but the artifact exists to be sent "
+        "to a maintainer, and py-spy's raw output embeds absolute paths from the "
+        "target process — so it is an egress boundary, redacted on the way out.",
+    ),
+    (
         "Side-chat parent snapshot",
         "dashboard/side_context.py",
         "Parent user/assistant turns embedded in the side-chat prompt. The prompt "

--- a/test/test_perf_sampler.py
+++ b/test/test_perf_sampler.py
@@ -1,0 +1,777 @@
+"""Tests for the debug-only performance sampler (kirocrew perf sample)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import cli_perf, perf_sampler
+
+# ── The debug gate ──
+
+
+class TestGate:
+    def test_absent_env_is_disabled(self):
+        assert perf_sampler.profiling_enabled({}) is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " on "])
+    def test_truthy_values_enable(self, value):
+        assert perf_sampler.profiling_enabled({perf_sampler.DEBUG_ENV_VAR: value}) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
+    def test_other_values_stay_disabled(self, value):
+        # "0" must read as OFF. Treating mere presence as on would make
+        # KIROCREW_DEBUG=0 silently enable profiling.
+        assert perf_sampler.profiling_enabled({perf_sampler.DEBUG_ENV_VAR: value}) is False
+
+    def test_refusal_message_names_the_switch(self):
+        assert perf_sampler.DEBUG_ENV_VAR in perf_sampler.gate_refusal_message()
+
+    def test_cli_refuses_when_gate_off(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.delenv(perf_sampler.DEBUG_ENV_VAR, raising=False)
+        args = _sample_args(perf_call="time:sleep", output=tmp_path / "p.folded")
+        assert cli_perf._perf_sample(args) == 1
+        assert perf_sampler.DEBUG_ENV_VAR in capsys.readouterr().err
+        # Nothing may be written when the gate refuses.
+        assert not (tmp_path / "p.folded").exists()
+
+
+def _sample_args(**overrides: object) -> argparse.Namespace:
+    """A Namespace shaped like the parsed `perf sample` arguments."""
+    base: dict[str, object] = {
+        "perf_action": "sample",
+        "seconds": 10,
+        "interval": perf_sampler.DEFAULT_INTERVAL_SECONDS,
+        "pid": 0,
+        "perf_call": "",
+        "output": None,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# ── Argument-name collision regression ──
+
+
+class TestParserWiring:
+    def test_sample_flags_do_not_shadow_the_subcommand_dest(self):
+        """`perf sample` must leave args.command == "perf".
+
+        The top-level subparsers use dest="command"; a flag on this subparser
+        whose dest is also "command" silently overwrites the subcommand name, so
+        dispatch falls through to argparse's help path and the command appears to
+        do nothing. Pin it.
+        """
+        parser = argparse.ArgumentParser(prog="kirocrew")
+        sub = parser.add_subparsers(dest="command")
+        cli_perf.register_perf_parser(sub)
+
+        ns = parser.parse_args(["perf", "sample", "--call", "mod:fn"])
+
+        assert ns.command == "perf"
+        assert ns.perf_action == "sample"
+        assert ns.perf_call == "mod:fn"
+
+    def test_no_sample_argument_uses_the_command_dest(self):
+        parser = argparse.ArgumentParser(prog="kirocrew")
+        sub = parser.add_subparsers(dest="command")
+        cli_perf.register_perf_parser(sub)
+        ns = parser.parse_args(["perf", "sample"])
+        # Every optional resolved to its default without clobbering "perf".
+        assert ns.command == "perf"
+
+
+# ── The in-process sampler ──
+
+
+def _recognisable_workload() -> None:
+    """Burn CPU inside a uniquely named frame so the profile is checkable."""
+    deadline = time.time() + 0.25
+    total = 0
+    while time.time() < deadline:
+        total += sum(i * i for i in range(2000))
+
+
+class TestStackSampler:
+    @pytest.mark.parametrize("bad", [0.0, 0.0005, 1.5, -1.0])
+    def test_rejects_out_of_range_interval(self, bad):
+        with pytest.raises(ValueError):
+            perf_sampler.StackSampler(interval=bad)
+
+    def test_collects_samples_and_names_the_frame(self):
+        sampler = perf_sampler.StackSampler(interval=0.002)
+        sampler.start()
+        _recognisable_workload()
+        report = sampler.stop()
+
+        assert report.samples > 0
+        folded = perf_sampler.render_folded(report)
+        assert "_recognisable_workload" in folded
+        # Every line is "<stack> <count>" with a positive integer count.
+        for line in folded.splitlines():
+            stack, _, count = line.rpartition(" ")
+            assert stack
+            assert int(count) > 0
+
+    def test_stop_without_start_raises(self):
+        with pytest.raises(RuntimeError):
+            perf_sampler.StackSampler().stop()
+
+    def test_double_start_raises(self):
+        sampler = perf_sampler.StackSampler()
+        sampler.start()
+        try:
+            with pytest.raises(RuntimeError):
+                sampler.start()
+        finally:
+            sampler.stop()
+
+    def test_context_manager_stops_the_thread(self):
+        with perf_sampler.StackSampler(interval=0.002):
+            _recognisable_workload()
+        # The daemon thread must be gone, not merely idle: a leaked sampler keeps
+        # reading frames for the life of the process.
+        assert not any(
+            t.name == "kirocrew-perf-sampler" for t in __import__("threading").enumerate()
+        )
+
+    def test_effective_rate_reports_zero_when_nothing_sampled(self):
+        report = perf_sampler.SampleReport(counts={}, samples=0, duration=0.0, interval=0.005)
+        assert report.effective_rate == 0.0
+
+    def test_effective_rate_is_measured_not_requested(self):
+        report = perf_sampler.SampleReport(counts={}, samples=50, duration=2.0, interval=0.001)
+        # 50 samples in 2s is 25/s even though 0.001s asked for 1000/s.
+        assert report.effective_rate == 25.0
+
+
+# ── Rendering, redaction and frame labels ──
+
+
+class TestRendering:
+    def test_folded_is_sorted_hottest_first_then_deterministic(self):
+        report = perf_sampler.SampleReport(
+            counts={"b;x": 5, "a;y": 5, "c;z": 9}, samples=19, duration=1.0, interval=0.005
+        )
+        assert perf_sampler.render_folded(report).splitlines() == ["c;z 9", "a;y 5", "b;x 5"]
+
+    def test_empty_report_renders_empty(self):
+        report = perf_sampler.SampleReport(counts={}, samples=0, duration=0.0, interval=0.005)
+        assert perf_sampler.render_folded(report) == ""
+
+    def test_frame_label_drops_the_home_directory_prefix(self):
+        label = perf_sampler._frame_label("/home/someone/secret/pkg/mod.py", 42, "fn")
+        assert label == "fn (pkg/mod.py:42)"
+        assert "someone" not in label
+
+    def test_sanitize_redacts_a_credential(self):
+        dirty = "fn (pkg/mod.py:1);AKIAIOSFODNN7EXAMPLE 3"
+        assert "AKIAIOSFODNN7EXAMPLE" not in perf_sampler.sanitize_profile(dirty)
+
+
+# ── py-spy integration (out-of-process) ──
+
+
+class TestPySpy:
+    def test_argv_raises_when_pyspy_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(perf_sampler.shutil, "which", lambda _n: None)
+        with pytest.raises(FileNotFoundError):
+            perf_sampler.pyspy_argv(pid=123, seconds=5, output=tmp_path / "o", rate=100)
+
+    def test_argv_requests_folded_output(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(perf_sampler.shutil, "which", lambda _n: "/usr/bin/py-spy")
+        argv = perf_sampler.pyspy_argv(pid=123, seconds=5, output=tmp_path / "o", rate=100)
+        assert argv[:2] == ["/usr/bin/py-spy", "record"]
+        assert "--pid" in argv and "123" in argv
+        # raw == folded stacks, so both sampling strategies emit one format.
+        assert argv[argv.index("--format") + 1] == "raw"
+
+    def test_unavailable_message_explains_macos_and_the_extra(self):
+        message = perf_sampler.pyspy_unavailable_message()
+        assert "task_for_pid" in message
+        assert "kirocrew[perf]" in message
+
+    def test_candidate_paths_are_probed_before_PATH(self, monkeypatch, tmp_path):
+        """A py-spy installed by homebrew/cargo/pip --user must still be found.
+
+        Electron (and launchd) give a minimal PATH with no shell profile sourced,
+        so a which-only lookup reports "not installed" on a machine that has it --
+        the same trap website/electron/pyspy-dump.js already probes around.
+        """
+        fake = tmp_path / "py-spy"
+        fake.write_text("#!/bin/sh\n", encoding="utf-8")
+        fake.chmod(0o755)
+        monkeypatch.setattr(perf_sampler, "pyspy_candidates", lambda: (fake,))
+        # PATH lookup deliberately fails, so only the candidate probe can succeed.
+        monkeypatch.setattr(perf_sampler.shutil, "which", lambda _n: None)
+        assert perf_sampler.pyspy_path() == str(fake)
+
+    def test_falls_back_to_PATH_when_no_candidate_exists(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(perf_sampler, "pyspy_candidates", lambda: (tmp_path / "absent",))
+        monkeypatch.setattr(perf_sampler.shutil, "which", lambda _n: "/usr/bin/py-spy")
+        assert perf_sampler.pyspy_path() == "/usr/bin/py-spy"
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows has no execute bit: os.access(X_OK) answers True for any "
+        "existing file, so an 'executable?' filter cannot be asserted there. The "
+        "candidate probe is POSIX-only for that reason (see pyspy_candidates).",
+    )
+    def test_non_executable_candidate_is_skipped(self, monkeypatch, tmp_path):
+        plain = tmp_path / "py-spy"
+        plain.write_text("not executable", encoding="utf-8")
+        plain.chmod(0o644)
+        monkeypatch.setattr(perf_sampler, "pyspy_candidates", lambda: (plain,))
+        monkeypatch.setattr(perf_sampler.shutil, "which", lambda _n: None)
+        assert perf_sampler.pyspy_path() is None
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="The candidate list is POSIX-only; on Windows it is empty by design "
+        "and discovery goes through shutil.which/PATHEXT.",
+    )
+    def test_candidate_list_matches_the_electron_module(self):
+        # Kept in sync with pyspy-dump.js's PYSPY_CANDIDATES; a divergence means
+        # one surface finds py-spy and the other reports it missing. Compared with
+        # as_posix() so the assertion does not depend on the host separator.
+        names = {p.as_posix() for p in perf_sampler.pyspy_candidates()}
+        assert "/opt/homebrew/bin/py-spy" in names
+        assert "/usr/local/bin/py-spy" in names
+        assert any(n.endswith(".cargo/bin/py-spy") for n in names)
+        assert any(n.endswith(".local/bin/py-spy") for n in names)
+
+    def test_candidates_are_empty_on_windows(self, monkeypatch):
+        # Those paths are POSIX locations, the binary is py-spy.exe, and X_OK is
+        # meaningless on Windows -- so the probe is skipped entirely there.
+        monkeypatch.setattr(perf_sampler.platform_compat, "IS_WINDOWS", True)
+        assert perf_sampler.pyspy_candidates() == ()
+
+    def test_windows_discovery_falls_through_to_which(self, monkeypatch):
+        monkeypatch.setattr(perf_sampler.platform_compat, "IS_WINDOWS", True)
+        monkeypatch.setattr(perf_sampler.shutil, "which", lambda _n: r"C:\tools\py-spy.exe")
+        assert perf_sampler.pyspy_path() == r"C:\tools\py-spy.exe"
+
+    def test_attach_failure_hint_names_tracer_contention_not_just_privileges(self):
+        """A refusal on Linux is more often "already traced" than "need sudo".
+
+        The desktop app attaches py-spy to the gateway to capture a frozen stack
+        before SIGKILL, and ptrace allows one tracer per process -- so the hint has
+        to name that, and say the wedge capture wins.
+        """
+        hint = perf_sampler.pyspy_attach_failure_hint()
+        assert "ptrace" in hint
+        assert "task_for_pid" in hint
+        # Names the competing capture and tells the operator to retry rather than
+        # to defeat the diagnostic that exists for the freeze.
+        assert "wedged" in hint or "freeze" in hint
+        assert "re-run" in hint
+
+    def test_cli_prints_the_attach_hint_on_failure(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        monkeypatch.setattr(cli_perf, "pyspy_path", lambda: "/usr/bin/py-spy")
+        monkeypatch.setattr(cli_perf, "pyspy_argv", lambda **_kw: ["/bin/false"])
+
+        class _Failed:
+            returncode = 1
+            stdout = ""
+            stderr = "Permission denied"
+
+        monkeypatch.setattr(cli_perf.subprocess, "run", lambda *_a, **_k: _Failed())
+        args = _sample_args(pid=4321, output=tmp_path / "p.folded")
+        assert cli_perf._sample_out_of_process(args, pid=4321) == 1
+        assert "ptrace" in capsys.readouterr().err
+
+    def test_cli_reports_missing_pyspy_instead_of_failing_silently(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        monkeypatch.setattr(cli_perf, "pyspy_path", lambda: None)
+        args = _sample_args(pid=4321, output=tmp_path / "p.folded")
+        assert cli_perf._sample_out_of_process(args, pid=4321) == 3
+        assert "py-spy" in capsys.readouterr().err
+
+
+# ── CLI behaviour ──
+
+
+class TestCliSample:
+    @pytest.fixture
+    def probe_module(self):
+        """Install an importable module exposing the workloads --call needs.
+
+        The test file itself is not importable as ``test.test_perf_sampler`` (the
+        test directory is not a package), so a synthetic module gives --call a
+        real import target without depending on collection layout.
+        """
+        import sys
+        import types
+
+        module = types.ModuleType("_kc_perf_probe")
+        module.work = _recognisable_workload  # type: ignore[attr-defined]
+        module.boom = _raises_after_work  # type: ignore[attr-defined]
+        sys.modules["_kc_perf_probe"] = module
+        try:
+            yield "_kc_perf_probe"
+        finally:
+            sys.modules.pop("_kc_perf_probe", None)
+
+    def test_in_process_run_writes_a_private_artifact(self, monkeypatch, tmp_path, probe_module):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        out = tmp_path / "nested" / "p.folded"
+        args = _sample_args(perf_call=f"{probe_module}:work", interval=0.002, output=out)
+        assert cli_perf._perf_sample(args) == 0
+        assert out.exists()
+        assert "_recognisable_workload" in out.read_text(encoding="utf-8")
+        if os.name == "posix":
+            # Profiles name code paths from the user's machine; keep them owner-only.
+            assert out.stat().st_mode & 0o077 == 0
+
+    def test_rejects_bad_interval_before_sampling(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        args = _sample_args(interval=99.0, output=tmp_path / "p.folded")
+        assert cli_perf._perf_sample(args) == 2
+        assert "--interval" in capsys.readouterr().err
+        assert not (tmp_path / "p.folded").exists()
+
+    def test_rejects_out_of_range_seconds(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        args = _sample_args(seconds=99999, output=tmp_path / "p.folded")
+        assert cli_perf._perf_sample(args) == 2
+        assert "--seconds" in capsys.readouterr().err
+
+    def test_unresolvable_call_is_reported(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        args = _sample_args(perf_call="no_such_module_xyz:fn", output=tmp_path / "p.folded")
+        assert cli_perf._perf_sample(args) == 2
+        assert "--call" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "raised",
+        [RuntimeError("import guard failed"), KeyError("missing"), SystemExit(3)],
+    )
+    def test_import_time_exception_is_reported_not_tracebacked(
+        self, monkeypatch, capsys, tmp_path, raised
+    ):
+        """Resolving runs the target module's top-level code, which can raise anything.
+
+        A fixed (ImportError, AttributeError, TypeError, ValueError) tuple let a
+        RuntimeError from a failed import guard -- or a module calling sys.exit --
+        escape as an uncaught traceback.
+        """
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+
+        def _boom(_spec):
+            raise raised
+
+        monkeypatch.setattr(cli_perf, "_resolve_callable", _boom)
+        args = _sample_args(perf_call="mod:fn", output=tmp_path / "p.folded")
+        assert cli_perf._perf_sample(args) == 2
+        err = capsys.readouterr().err
+        assert "Cannot resolve --call" in err
+        # The exception type is named so the failure stays diagnosable.
+        assert type(raised).__name__ in err
+
+    def test_keyboard_interrupt_during_resolution_still_propagates(
+        self, monkeypatch, tmp_path
+    ):
+        # An operator interrupting the command must still interrupt it; the broad
+        # handler deliberately does not swallow KeyboardInterrupt.
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+
+        def _interrupt(_spec):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(cli_perf, "_resolve_callable", _interrupt)
+        args = _sample_args(perf_call="mod:fn", output=tmp_path / "p.folded")
+        with pytest.raises(KeyboardInterrupt):
+            cli_perf._perf_sample(args)
+
+    def test_raising_call_still_emits_the_profile(self, monkeypatch, tmp_path, probe_module):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        out = tmp_path / "p.folded"
+        args = _sample_args(perf_call=f"{probe_module}:boom", interval=0.002, output=out)
+        # The profile of a call that failed is often the point, so samples are kept.
+        assert cli_perf._perf_sample(args) == 0
+        assert out.exists()
+
+    def test_no_pid_and_no_call_explains_both_routes(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        monkeypatch.setattr(cli_perf, "_read_gateway_pid", lambda: None)
+        args = _sample_args(output=tmp_path / "p.folded")
+        assert cli_perf._perf_sample(args) == 2
+        err = capsys.readouterr().err
+        assert "--pid" in err and "--call" in err
+
+
+def _raises_after_work() -> None:
+    _recognisable_workload()
+    raise RuntimeError("boom")
+
+
+# ── Gateway PID resolution ──
+
+
+class TestGatewayPid:
+    def test_reads_the_recorded_pid_when_the_lock_is_held(self, monkeypatch, tmp_path):
+        (tmp_path / "gateway.lock").write_text("4242\n", encoding="utf-8")
+        monkeypatch.setattr(cli_perf, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(cli_perf, "_gateway_lock_is_held", lambda _p: True)
+        monkeypatch.setattr(cli_perf.platform_compat, "pid_exists", lambda _p: True)
+        assert cli_perf._read_gateway_pid() == 4242
+
+    def test_stale_pid_is_rejected_when_no_gateway_holds_the_lock(self, monkeypatch, tmp_path):
+        """A stopped gateway leaves its pid behind and pids get reused.
+
+        Without the held-lock check, the default target would be whatever process
+        inherited that pid, and the profile would be labelled as the gateway's.
+        """
+        (tmp_path / "gateway.lock").write_text("4242\n", encoding="utf-8")
+        monkeypatch.setattr(cli_perf, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(cli_perf, "_gateway_lock_is_held", lambda _p: False)
+        # pid_exists is pinned True so the held-lock check is the ONLY thing that
+        # can reject. Without this the real pid 4242 is absent on the test host and
+        # the assertion passes even with the lock gate removed (a vacuous test).
+        monkeypatch.setattr(cli_perf.platform_compat, "pid_exists", lambda _p: True)
+        assert cli_perf._read_gateway_pid() is None
+
+    def test_dead_pid_is_rejected_even_if_the_lock_looks_held(self, monkeypatch, tmp_path):
+        (tmp_path / "gateway.lock").write_text("4242\n", encoding="utf-8")
+        monkeypatch.setattr(cli_perf, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(cli_perf, "_gateway_lock_is_held", lambda _p: True)
+        monkeypatch.setattr(cli_perf.platform_compat, "pid_exists", lambda _p: False)
+        assert cli_perf._read_gateway_pid() is None
+
+    def test_missing_file_is_none(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(cli_perf, "config_dir", lambda: tmp_path)
+        assert cli_perf._read_gateway_pid() is None
+
+    @pytest.mark.parametrize("content", ["", "not-a-pid", "0\n", "-5\n"])
+    def test_unusable_content_is_none(self, monkeypatch, tmp_path, content):
+        (tmp_path / "gateway.lock").write_text(content, encoding="utf-8")
+        monkeypatch.setattr(cli_perf, "config_dir", lambda: tmp_path)
+        assert cli_perf._read_gateway_pid() is None
+
+    def test_absent_lock_file_is_not_held(self, tmp_path):
+        assert cli_perf._gateway_lock_is_held(tmp_path / "nope.lock") is False
+
+    def test_unheld_lock_probe_releases_and_reports_free(self, tmp_path):
+        # An unlocked file must probe as free, and the probe must not leave it
+        # locked (a real gateway starting right after must still be able to take it).
+        lock = tmp_path / "gateway.lock"
+        lock.write_text("1\n", encoding="utf-8")
+        assert cli_perf._gateway_lock_is_held(lock) is False
+        assert cli_perf._gateway_lock_is_held(lock) is False
+
+
+class TestArtifactWriteFailure:
+    def test_symlinked_output_does_not_write_through_the_link(self, tmp_path):
+        """A planted symlink at the output path must not have its target clobbered.
+
+        The default --output is relative, so it usually lands in the directory the
+        operator ran from -- often a repo checkout. write_text() follows a symlink
+        and would truncate + chmod the linked file; atomic_write renames over the
+        link instead.
+        """
+        victim = tmp_path / "victim.txt"
+        victim.write_text("precious", encoding="utf-8")
+        link = tmp_path / "profile.folded"
+        link.symlink_to(victim)
+
+        assert cli_perf._write_artifact(link, "profile-data") is True
+
+        # The link was replaced by a real file holding our content...
+        assert link.is_symlink() is False
+        assert link.read_text(encoding="utf-8") == "profile-data"
+        # ...and the target it pointed at is untouched.
+        assert victim.read_text(encoding="utf-8") == "precious"
+
+    def test_written_artifact_is_owner_only(self, tmp_path):
+        out = tmp_path / "p.folded"
+        assert cli_perf._write_artifact(out, "x") is True
+        if os.name == "posix":
+            assert out.stat().st_mode & 0o077 == 0
+
+    def test_unwritable_output_returns_false_not_raises(self, capsys, tmp_path):
+        # A directory where a file is expected: the write raises OSError.
+        target = tmp_path / "adir"
+        target.mkdir()
+        assert cli_perf._write_artifact(target, "x") is False
+        assert "Could not write the profile" in capsys.readouterr().err
+
+    def test_cli_exits_nonzero_instead_of_tracebacking(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        import sys as _sys
+        import types
+
+        module = types.ModuleType("_kc_perf_probe_w")
+        module.work = _recognisable_workload  # type: ignore[attr-defined]
+        _sys.modules["_kc_perf_probe_w"] = module
+        try:
+            unwritable = tmp_path / "adir"
+            unwritable.mkdir()
+            args = _sample_args(
+                perf_call="_kc_perf_probe_w:work", interval=0.002, output=unwritable
+            )
+            # Sampling succeeded; only the write failed, so this must be a clean
+            # nonzero exit with a diagnostic rather than an uncaught OSError.
+            assert cli_perf._perf_sample(args) == 6
+            assert "Could not write the profile" in capsys.readouterr().err
+        finally:
+            _sys.modules.pop("_kc_perf_probe_w", None)
+
+
+class TestPySpyPathShortening:
+    def test_absolute_posix_paths_are_shortened(self):
+        raw = 'thread;run (/home/someone/proj/pkg/mod.py:12);inner (/usr/lib/py/x.py:3) 7'
+        out = perf_sampler.shorten_frame_paths(raw)
+        assert "someone" not in out
+        assert "pkg/mod.py:12" in out
+        assert "py/x.py:3" in out
+
+    def test_windows_paths_are_shortened(self):
+        raw = "thread;run (C:\\Users\\someone\\proj\\pkg\\mod.py:12) 4"
+        out = perf_sampler.shorten_frame_paths(raw)
+        assert "someone" not in out
+        assert "pkg/mod.py:12" in out
+
+    def test_relative_paths_and_counts_are_untouched(self):
+        raw = "fn (pkg/mod.py:1);other (pkg/two.py:9) 42"
+        assert perf_sampler.shorten_frame_paths(raw) == raw
+
+    def test_pyspy_output_is_shortened_before_being_written(self, monkeypatch, tmp_path):
+        """The documented path-shortening guarantee must hold for BOTH strategies.
+
+        It previously lived only in _frame_label (in-process), so a py-spy profile
+        still carried the operator's home directory.
+        """
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        out = tmp_path / "p.folded"
+        monkeypatch.setattr(cli_perf, "pyspy_path", lambda: "/usr/bin/py-spy")
+
+        # py-spy is handed a staged path; emulate it writing there.
+        def _fake_argv(**kw):
+            Path(kw["output"]).write_text(
+                "t;run (/home/someone/proj/pkg/mod.py:12) 5\n", encoding="utf-8"
+            )
+            return ["/bin/true"]
+
+        monkeypatch.setattr(cli_perf, "pyspy_argv", _fake_argv)
+
+        class _Done:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(cli_perf.subprocess, "run", lambda *_a, **_k: _Done())
+        args = _sample_args(pid=999, output=out)
+        assert cli_perf._sample_out_of_process(args, pid=999) == 0
+        written = out.read_text(encoding="utf-8")
+        assert "someone" not in written
+        assert "pkg/mod.py:12" in written
+
+    def test_pyspy_is_never_pointed_at_the_caller_supplied_output(self, monkeypatch, tmp_path):
+        """py-spy opens its output path directly, so it must not receive --output.
+
+        A symlink at --output would otherwise have its target truncated by py-spy
+        before this code ever sanitizes and re-writes.
+        """
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        out = tmp_path / "p.folded"
+        seen: dict[str, Path] = {}
+        monkeypatch.setattr(cli_perf, "pyspy_path", lambda: "/usr/bin/py-spy")
+
+        def _capture(**kw):
+            seen["output"] = Path(kw["output"])
+            Path(kw["output"]).write_text("t;fn (pkg/m.py:1) 1\n", encoding="utf-8")
+            return ["/bin/true"]
+
+        monkeypatch.setattr(cli_perf, "pyspy_argv", _capture)
+
+        class _Done:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(cli_perf.subprocess, "run", lambda *_a, **_k: _Done())
+        assert cli_perf._sample_out_of_process(_sample_args(pid=7, output=out), pid=7) == 0
+        assert seen["output"] != out
+        # The staged file lived in a temp dir and is cleaned up afterwards.
+        assert not seen["output"].exists()
+
+    def test_symlinked_output_target_survives_the_pyspy_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        victim = tmp_path / "victim.txt"
+        victim.write_text("precious", encoding="utf-8")
+        link = tmp_path / "p.folded"
+        link.symlink_to(victim)
+        monkeypatch.setattr(cli_perf, "pyspy_path", lambda: "/usr/bin/py-spy")
+
+        def _argv(**kw):
+            Path(kw["output"]).write_text("t;fn (pkg/m.py:1) 1\n", encoding="utf-8")
+            return ["/bin/true"]
+
+        monkeypatch.setattr(cli_perf, "pyspy_argv", _argv)
+
+        class _Done:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(cli_perf.subprocess, "run", lambda *_a, **_k: _Done())
+        assert cli_perf._sample_out_of_process(_sample_args(pid=7, output=link), pid=7) == 0
+        assert victim.read_text(encoding="utf-8") == "precious"
+        assert link.is_symlink() is False
+
+    def test_unlaunchable_binary_returns_exit_code_not_traceback(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        """A discovered path can still be unlaunchable (wrong arch, bad shebang)."""
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        monkeypatch.setattr(cli_perf, "pyspy_path", lambda: "/usr/bin/py-spy")
+        monkeypatch.setattr(cli_perf, "pyspy_argv", lambda **_kw: ["/nonexistent/py-spy"])
+
+        def _raise(*_a, **_k):
+            raise OSError(8, "Exec format error")
+
+        monkeypatch.setattr(cli_perf.subprocess, "run", _raise)
+        args = _sample_args(pid=7, output=tmp_path / "p.folded")
+        assert cli_perf._sample_out_of_process(args, pid=7) == 3
+        assert "Could not run py-spy" in capsys.readouterr().err
+
+    def test_candidates_degrade_when_home_is_unresolvable(self, monkeypatch):
+        """An unresolvable home must degrade, not raise out of a discovery helper.
+
+        Path.home() raises with no HOME and no passwd entry (systemd units, slim
+        containers).
+
+        IS_WINDOWS is pinned False so this exercises the POSIX branch on every
+        platform: the candidate list is empty on Windows by design, so asserting a
+        non-empty result would fail there for a reason unrelated to this
+        behaviour. The seam is perf_sampler._home_dir rather than
+        pathlib.Path.home, so pathlib is not mutated process-wide.
+        """
+        monkeypatch.setattr(perf_sampler.platform_compat, "IS_WINDOWS", False)
+
+        def _no_home():
+            raise RuntimeError("Could not determine home directory")
+
+        monkeypatch.setattr(perf_sampler, "_home_dir", _no_home)
+        candidates = perf_sampler.pyspy_candidates()
+        assert candidates  # absolute entries still offered
+        assert all("cargo" not in str(c) and ".local" not in str(c) for c in candidates)
+
+    def test_candidates_are_empty_on_windows_regardless_of_home(self, monkeypatch):
+        """The POSIX probe is gated off on Windows, so home never matters there."""
+        monkeypatch.setattr(perf_sampler.platform_compat, "IS_WINDOWS", True)
+
+        def _no_home():
+            raise AssertionError("home must not be consulted on Windows")
+
+        monkeypatch.setattr(perf_sampler, "_home_dir", _no_home)
+        assert perf_sampler.pyspy_candidates() == ()
+
+
+class TestShortenPathsWithSpaces:
+    """A home directory containing a space must still be stripped.
+
+    The whole point of shortening is dropping the home prefix (hence the
+    username); a pattern that only matched the tail after the last space left
+    that prefix in the artifact.
+    """
+
+    def test_posix_home_with_a_space_is_fully_stripped(self):
+        text = "thread;run (/home/Jane Doe/proj/pkg/mod.py:12) 5\n"
+        out = perf_sampler.shorten_frame_paths(text)
+        assert "Jane" not in out
+        assert "Doe" not in out
+        assert "/home" not in out
+        assert "pkg/mod.py:12" in out
+
+    def test_windows_home_with_a_space_is_fully_stripped(self):
+        text = "thread;run (C:\\Users\\Jane Doe\\proj\\pkg\\mod.py:12) 5\n"
+        out = perf_sampler.shorten_frame_paths(text)
+        assert "Jane" not in out
+        assert "Users" not in out
+        assert "pkg/mod.py:12" in out
+
+    def test_the_regression_shape_is_gone(self):
+        """Lock the exact corrupted output the old pattern produced."""
+        out = perf_sampler.shorten_frame_paths("(/home/Jane Doe/proj/pkg/mod.py:12)")
+        assert "Doepkg" not in out
+
+    def test_multiple_dots_in_the_filename_still_match(self):
+        out = perf_sampler.shorten_frame_paths("(/home/Jane Doe/pkg/mod.test.py:3)")
+        assert "Jane" not in out
+        assert "pkg/mod.test.py:3" in out
+
+    def test_shortening_is_idempotent(self):
+        """Two passes now run, so re-shortening must not corrupt the result."""
+        once = perf_sampler.shorten_frame_paths("(/home/Jane Doe/proj/pkg/mod.py:12) 5")
+        assert perf_sampler.shorten_frame_paths(once) == once
+
+    def test_relative_paths_and_prose_are_left_alone(self):
+        for text in ("(see notes.py)", "pkg/mod.py:1", "thread;fn (pkg/m.py:2) 1"):
+            assert perf_sampler.shorten_frame_paths(text) == text
+
+    def test_a_path_without_a_line_number_is_still_shortened(self):
+        out = perf_sampler.shorten_frame_paths("(/home/Jane Doe/pkg/mod.py)")
+        assert out == "(pkg/mod.py)"
+
+
+class TestCallExitsCleanly:
+    def test_systemexit_from_the_call_still_writes_the_profile(self, monkeypatch, tmp_path):
+        """CLI entry points exit via sys.exit on their NORMAL path.
+
+        Catching only Exception meant profiling the most natural targets produced
+        no artifact at all.
+        """
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        out = tmp_path / "p.folded"
+
+        def _exits():
+            # Sleep rather than burn CPU: the sampler walks sys._current_frames()
+            # on a wall-clock interval and a sleeping thread is still sampled, so
+            # this collects samples deterministically instead of racing the
+            # interval under parallel test load.
+            time.sleep(0.3)
+            raise SystemExit(1)
+
+        monkeypatch.setattr(cli_perf, "_resolve_callable", lambda _spec: _exits)
+        args = _sample_args(output=out, perf_call="mod:fn")
+        args.pid = None
+        args.interval = 0.005
+        rc = cli_perf._sample_in_process(args)
+        assert rc == 0, "SystemExit must not discard the collected samples"
+        assert out.exists() and out.read_text(encoding="utf-8").strip()
+
+    def test_keyboardinterrupt_from_the_call_still_propagates(self, monkeypatch, tmp_path):
+        """Ctrl-C must abort, not yield a partial profile as if it succeeded."""
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+
+        def _interrupted():
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(cli_perf, "_resolve_callable", lambda _spec: _interrupted)
+        args = _sample_args(output=tmp_path / "p.folded", perf_call="mod:fn")
+        args.pid = None
+        with pytest.raises(KeyboardInterrupt):
+            cli_perf._sample_in_process(args)
+
+
+class TestResolveCallable:
+    @pytest.mark.parametrize("spec", ["nocolon", ":fn", "mod:", ""])
+    def test_rejects_malformed_specs(self, spec):
+        with pytest.raises(ValueError):
+            cli_perf._resolve_callable(spec)
+
+    def test_rejects_non_callable(self):
+        with pytest.raises(TypeError):
+            cli_perf._resolve_callable("kiro_crew.perf_sampler:DEBUG_ENV_VAR")
+
+    def test_resolves_a_dotted_attribute(self):
+        resolved = cli_perf._resolve_callable("kiro_crew.perf_sampler:StackSampler.start")
+        assert callable(resolved)

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -141,6 +141,14 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "apps/backend.py::_proc_start_time",
         "apps/backend.py::_resolve_nvm_path",
         "apps/backend.py::stop_app_backend",
+        # py-spy attach for `kirocrew perf sample --pid`: fixed list-argv (no
+        # shell=True), binary resolved via shutil.which rather than from input,
+        # and every value is either a range-validated int (pid/seconds/rate) or a
+        # path passed as a flag VALUE. NOT sandboxed because py-spy's whole job is
+        # reading another process's memory (ptrace / task_for_pid) — a sandbox that
+        # scrubbed that capability would break the feature it is guarding. Gated
+        # behind KIROCREW_DEBUG and reachable only from the CLI.
+        "cli_perf.py::_sample_out_of_process",
         # gh-CLI open-PR enumeration: fixed `gh api` list-argv (no shell=True);
         # owner/repo are validated to ^[A-Za-z0-9._-]+$ by adapters.parse_repo_url
         # and only fill the API path (bounded to api.github.com). NOT sandboxed


### PR DESCRIPTION
## Problem

KiroCrew has no profiler. What exists is adjacent but different: `kiro_crew.metrics`
emits duration histograms at a handful of hand-placed call sites (off by default),
and `dashboard/loop_watchdog.py` dumps every thread's stack when the event loop
wedges. Neither attributes time to call paths.

The cost showed up in the recent performance audit: it produced ~30 distinct
findings almost entirely from static analysis, with a few magnitudes measured by
hand. Nobody could answer "where did those 1200ms actually go" with a profile,
and nobody could ask a user "run this for 30 seconds and send me the file".

## Why it matters

The interesting performance problems are the ones on a real install — a user's own
MCP servers, their transcript sizes, their machine. Static reading cannot find
those, and a dev-only tool cannot be pointed at them.

## Fix

`kirocrew perf sample` with two sampling strategies, because they answer different
questions and have different requirements:

- **`--call module:callable`** — runs that callable in this process with a
  daemon-thread sampler reading `sys._current_frames()` on an interval. No extra
  dependency, works on macOS and Windows, and is the path for "why is this one
  operation slow".
- **no `--call`** — attaches to a PID (default: the gateway's, read from
  `$KIROCREW_HOME/gateway.lock`) via py-spy. A foreign process cannot be sampled
  from pure Python, so this needs py-spy and it is an optional `kirocrew[perf]`
  extra, never a base dependency (matching the existing `otlp` / `teams`
  precedent). On macOS py-spy additionally needs elevated privileges because the
  OS denies `task_for_pid` — the same constraint that led `loop_watchdog` to
  prefer an in-process `faulthandler` timer over an external capture. When py-spy
  is missing the command says so and points at `--call` rather than producing
  nothing.

Both emit **folded stacks**, which speedscope, flamegraph.pl and Perfetto import
directly — so there is no bespoke JSON schema to own and version.

### Debug-only, by construction

- Refuses unless `KIROCREW_DEBUG` is truthy. `KIROCREW_DEBUG=0` reads as **off**,
  so presence-of-name cannot enable it by accident.
- The CLI is the only entry point: no import-time hook, no sampler thread at rest,
  no HTTP endpoint, no UI surface, and no change to any default behavior.
- Gated on an env var rather than a config key deliberately — that keeps
  `config/loader.py` and the generated `config-baseline.json` untouched.

### Artifact handling

Frame labels are `func (last-two/path-components:line)`, so the home-directory
prefix never reaches the artifact. Output additionally runs through the standard
credential and exfiltration-URL redactors (py-spy's raw output embeds absolute
paths from the target process) and is written `0o600`. `perf_sampler.py` is
registered in `_REDACTION_SINKS` so the security panel counts it as the egress
boundary it is.

The command reports the **effective** sample rate next to the requested one, e.g.
`Sampled 168 ticks over 0.61s (274/s effective, 0.002s requested)` — a loaded host
cannot always hit the requested interval, and reporting the request as though it
were the result would overstate the resolution.

### Naming

`perf`, not `profile`: `kirocrew policy profile` already exists, and "profile" is
overloaded three ways in this codebase (governance profiles, AWS profiles, deploy
profiles).

## Tests

`test/test_perf_sampler.py` — 53 tests covering the gate (truthy/falsey table,
including `0` reading as off), CLI refusal writing nothing, interval/seconds
validation, sampler lifecycle (double-start, stop-without-start, context-manager
thread cleanup), folded-render determinism, home-prefix stripping, credential
redaction, py-spy argv construction and the missing-py-spy path, gateway-PID
parsing (including garbage and non-positive values), and `--call` resolution
failures.

Two guards worth calling out:

- **`test_sample_flags_do_not_shadow_the_subcommand_dest`** pins a real bug found
  while building this. An earlier revision named the flag `--command`, whose dest
  collided with the top-level subparsers' `dest="command"`; argparse overwrote
  `"perf"` with the flag's value, dispatch fell through, and `kirocrew perf sample`
  silently printed top-level help. Revert-verified: reintroducing the collision
  fails this test.
- **`test_in_process_run_writes_a_private_artifact`** asserts mode `0o600`.

Also added: `perf_sampler.py` to `_REDACTION_SINKS`, and
`cli_perf.py::_sample_out_of_process` to `BENIGN_SPAWNS` with justification — the
py-spy spawn is fixed list-argv with no shell, its binary comes from
`shutil.which`, and every value is a range-validated int or a path passed as a
flag value. It is deliberately **not** sandboxed: py-spy's entire job is reading
another process's memory, so scrubbing that capability would break the feature.

## Manual verification

Ran end-to-end against a synthetic nested workload:

- gate off → refusal on stderr, exit 1, no file written
- gate on → 168 samples over 0.61s, artifact contains the nested workload frame
- `--help` renders through the real `console_scripts` entry point

Local gates: `isort`, `flake8`, and CI-parity `mypy` (573 files) all clean;
targeted suites green.

**Not verified:** attaching to a live gateway with py-spy — py-spy is not installed
in this environment, so the `--pid` path is covered by unit tests around argv
construction and the missing-binary branch, not by a real attach. Worth exercising
before relying on it.

## Full-suite note

Six failures in the full backend run are **pre-existing and environment-specific**,
not from this change — verified by stashing this diff and re-running, where all six
still fail: three in `test_dashboard_origin.py` (the live gateway's configured port
`6776` leaks into assertions expecting `5476`/`9090`) and three in
`test_embedding_space_reconcile.py`.
