### PR TITLE
fix(dashboard): make transcript disclosure state survive row recycling

### DIFF
--- a/website/src/components/FileChangeChips.tsx
+++ b/website/src/components/FileChangeChips.tsx
@@ -1,6 +1,7 @@
-import { memo, useState } from 'react'
+import { memo } from 'react'
 import { FileDiff, ChevronDown, ChevronUp } from 'lucide-react'
 import type { FileChipStyle } from '../pages/chat/ChatSettings'
+import { useRowDisclosure } from '../pages/chat/rowDisclosure'
 import { colorForExt, fileIcon } from '../utils/fileIcons'
 
 import { i18nT } from '../i18n/t'
@@ -132,12 +133,13 @@ function ExpandedRow({ fc, added, removed, isArtifact, onClick }: { fc: FileChan
  *   shows the true total + aggregate stats while collapsed).                */
 const COLLAPSED_COUNT = 8
 
-function ExpandedList({ fileChanges, onOpenDiff, artifactPaths }: {
+function ExpandedList({ fileChanges, onOpenDiff, artifactPaths, disclosureKey }: {
   fileChanges: FileChangeEntry[]
   onOpenDiff?: (path: string, modified: string, original: string) => void
   artifactPaths?: Set<string>
+  disclosureKey?: string
 }) {
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   const n = fileChanges.length
   // Count once per file: reused by each row AND the header roll-up.
   const stats = fileChanges.map(fc => countLines(fc.before, fc.after))
@@ -203,13 +205,14 @@ function MinimalChip({ fc, onClick }: { fc: FileChangeEntry; onClick: () => void
  * Clicking any file opens the Monaco diff panel via
  * `onOpenDiff(path, after, before)`.
  */
-const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff, style = 'expanded', artifactPaths }: {
+const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff, style = 'expanded', artifactPaths, disclosureKey }: {
   fileChanges: FileChangeEntry[]
   onOpenDiff?: (path: string, modified: string, original: string) => void
   style?: FileChipStyle
   /** Paths the session tracks as documents/artifacts — badged in the expanded
    *  card so generated docs read distinctly from source-file edits. */
   artifactPaths?: Set<string>
+  disclosureKey?: string
 }) {
   if (!fileChanges?.length) return null
   // Minimal keeps the wrapping pill row; anything else uses the grouped card.
@@ -222,7 +225,7 @@ const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff,
       </div>
     )
   }
-  return <ExpandedList fileChanges={fileChanges} onOpenDiff={onOpenDiff} artifactPaths={artifactPaths} />
+  return <ExpandedList fileChanges={fileChanges} onOpenDiff={onOpenDiff} artifactPaths={artifactPaths} disclosureKey={disclosureKey} />
 })
 
 export default FileChangeChips

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -43,6 +43,7 @@ import { useTouchedFiles } from '../hooks/useTouchedFiles'
 import { useTheme } from '../hooks/useTheme'
 import CollapsibleToolGroup from './chat/CollapsibleToolGroup'
 import ThinkingBlock from './chat/ThinkingBlock'
+import { RowDisclosureProvider } from './chat/rowDisclosure'
 import type { DisplayItem, TurnItem } from './chat/types'
 import McpToolsPanel from './chat/McpToolsPanel'
 import { deriveLoadedMcpTools } from '../lib/mcpLoadedTools'
@@ -647,6 +648,27 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     return out
   }, [messages, activeSlot])
   const slotRunning = useAppSelector(s => s.chat.slotRunning)
+  // Turn disclosure ("N tool calls" / "Worked through N steps"), keyed by the
+  // virtualizer's stable row key. This lives HERE rather than in TurnBlock
+  // because the transcript is virtualised: a row is unmounted once it leaves
+  // the mounted window, which streaming does routinely as it scrolls content
+  // past, and row-local state would be destroyed every time. An entry exists
+  // only for a turn the user has explicitly toggled; absent means "use the
+  // default", so the automatic collapse-on-completion is untouched.
+  const [turnDisclosure, setTurnDisclosure] = useState<Record<string, boolean>>({})
+  const setTurnDisclosureFor = useCallback((key: string, expanded: boolean) => {
+    setTurnDisclosure(prev => (prev[key] === expanded ? prev : { ...prev, [key]: expanded }))
+  }, [])
+  // Same problem, same shape, for the per-tool-call pill (ToolCallLine): its
+  // expanded panel is also row-local and also dies when the virtualizer
+  // recycles the row. Keyed by the pill's own message key.
+  const [toolDisclosure, setToolDisclosure] = useState<Record<string, boolean>>({})
+  const setToolDisclosureFor = useCallback((key: string, expanded: boolean) => {
+    setToolDisclosure(prev => (prev[key] === expanded ? prev : { ...prev, [key]: expanded }))
+  }, [])
+  // Row keys are only unique within a slot, so carrying them across a slot
+  // switch would apply one session's choices to another's turns.
+  useEffect(() => { setTurnDisclosure({}); setToolDisclosure({}) }, [activeSlot])
   // Shared composer-busy rule (chatSlice.selectComposerBusy). Drives the
   // composer's busy/queue affordance so a message sent during a sub-agent run
   // reads as "will queue".
@@ -3719,7 +3741,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // one-shot entrance animation. clientTs keeps the key (and DOM) stable.
     const keyTs = (m.meta?.clientTs as string | undefined) || m.ts
     const key = keyTs ? `${m.role}-${keyTs}` : `${m.role}-${i}`
-    if (m.role === 'thinking') return m.content ? <ThinkingBlock key={key} content={m.content} /> : null
+    if (m.role === 'thinking') return m.content ? <ThinkingBlock key={key} content={m.content} disclosureKey={key} /> : null
     if (m.role === 'tool') {
       // Skip ✅/🚫 completion messages — completion shown via CircleCheckBig icon
       if (!m.content.startsWith('🔧')) return null
@@ -3735,7 +3757,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       if (spawnLaunch) return <SubagentRunCard key={key} launch={spawnLaunch} slot={activeSlot || ''} />
       // Animate tools in the trailing group (after last assistant/streaming text)
       const isInTrailingGroup = slotState === 'tool_running' && i > lastTextIdx
-      return <ToolCallLine key={key} message={m} running={isInTrailingGroup} onFileOpen={handleFileOpen} />
+      return <ToolCallLine key={key} message={m} running={isInTrailingGroup} onFileOpen={handleFileOpen} disclosure={toolDisclosure[key]} disclosureKey={key} onDisclosureChange={setToolDisclosureFor} />
     }
     if (m.role === 'file') {
       try {
@@ -3751,7 +3773,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // controls.
     if (m.role === 'nudge') {
       const ownLoop = nudgeMatchesLoop(m, autoNudgeLoop?.id)
-      return <NudgeCard key={key} message={m} onOpenLoop={ownLoop ? () => setAutoNudgeOpen(true) : undefined} />
+      return <NudgeCard key={key} message={m} disclosureKey={key} onOpenLoop={ownLoop ? () => setAutoNudgeOpen(true) : undefined} />
     }
     if (m.kind === 'stop_event' || m.meta?.kind === 'stop_event') return <StopEventCard key={m.meta?.id as string ?? key} message={m} />
     // A synthetic turn-recovery continuation (tool refusal / stalled turn /
@@ -3760,7 +3782,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // and the deny pattern rather than a full-width bubble of prompt prose.
     if (m.role === 'inject') {
       const recovery = parseRecoveryMessage(m.content)
-      if (recovery) return <RecoveryCard key={key} parsed={recovery} />
+      if (recovery) return <RecoveryCard key={key} parsed={recovery} disclosureKey={key} />
     }
     if (m.role === 'error') return <div key={key} className="bg-danger-subtle text-danger text-[13px] px-3 py-2 rounded-md border border-danger/15 self-center animate-scale-in">{m.content}</div>
     if (m.role === 'notice') return <div key={key} className="bg-card text-muted text-[13px] px-3 py-2 rounded-md border border-border self-center animate-scale-in">{m.content}</div>
@@ -3771,7 +3793,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     }
     // An injected workflow completion event renders as a compact status card
     // (with the full result folded away) instead of a wall of raw JSON.
-    if (isWorkflowCompletionMessage(m)) return <WorkflowCompletionCard key={key} message={m} onFileOpen={handleFileOpen} />
+    if (isWorkflowCompletionMessage(m)) return <WorkflowCompletionCard key={key} message={m} onFileOpen={handleFileOpen} disclosureKey={key} />
     const isUser = m.role === 'user'
     const isStreaming = m.role === 'streaming'
     const isInject = m.role === 'inject'
@@ -3839,7 +3861,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // apply-plan handler, so it belongs here for correctness. approve/send/
     // dismissApproval are NOT referenced in this renderer (user/approval rows go
     // through renderUserContentCb), so they are omitted to keep it stable.
-  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleArtifactOpen, handleFork, handleQuote, handleAsk, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId, artifactPaths, autoNudgeLoop])
+  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleArtifactOpen, handleFork, handleQuote, handleAsk, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId, artifactPaths, autoNudgeLoop, toolDisclosure, setToolDisclosureFor])
 
   const [mobileSessions, setMobileSessions] = useState(false)
   // Close mobile sessions panel when a session is selected
@@ -3942,6 +3964,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   })
 
   return (
+    <RowDisclosureProvider resetKey={activeSlot}>
     <TagPopoverProvider>
     <div ref={chatContainerRef} className="flex flex-1 min-h-0 h-full overflow-hidden relative">
       <AnimatePresence>
@@ -4316,6 +4339,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                         return (
                         <CollapsibleToolGroup
                           count={it.msgs.filter(m => m.role !== 'permission').length}
+                          disclosureKey={`ctg-g-${it.startIdx}`}
                           hasPermission={false}
                           isRunning={false}
                           permissionMeta={unresolvedPerms.at(-1)?.meta as Record<string, unknown> | undefined}
@@ -4331,7 +4355,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                       })() : renderMessage(it.idx, it.msg)}
                     </div>
                   }
-                  return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx}><TurnBlock turn={item} renderItem={renderTurnItem} collapseAll={chatConfig.collapseAllSteps} appToolCallIds={appToolCallIds} /></div>
+                  return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx}><TurnBlock turn={item} renderItem={renderTurnItem} collapseAll={chatConfig.collapseAllSteps} appToolCallIds={appToolCallIds} disclosure={turnDisclosure[vi.key]} onDisclosureChange={(next: boolean) => setTurnDisclosureFor(vi.key, next)} /></div>
                 }
                 return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx} className={`px-5 mx-auto w-full py-1`} style={{
                   maxWidth: 'var(--mc-content-width, 900px)',
@@ -4349,6 +4373,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 return (
                 <CollapsibleToolGroup
                   count={item.msgs.filter(m => m.role !== 'permission').length}
+                  disclosureKey={`ctg-${vi.key}`}
                   hasPermission={false}
                   isRunning={slotRunning && displayIdx === displayItems.length - 1}
                   permissionMeta={unresolvedGroupPerms.at(-1)?.meta as Record<string, unknown> | undefined}
@@ -4794,6 +4819,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       )}
     </div>
     </TagPopoverProvider>
+    </RowDisclosureProvider>
   )
 }
 

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -210,7 +210,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
       {!isStreaming && selectionActions.length > 0 && <SelectionToolbar containerRef={contentRef} actions={selectionActions} />}
     </div>
     {fileChanges && fileChanges.length > 0 && !isStreaming && (
-      <FileChangeChips fileChanges={fileChanges} onOpenDiff={onOpenDiff} style={fileChipStyle} artifactPaths={artifactPaths} />
+      <FileChangeChips fileChanges={fileChanges} onOpenDiff={onOpenDiff} style={fileChipStyle} artifactPaths={artifactPaths} disclosureKey={messageTs ? `fcc-${messageTs}` : undefined} />
     )}
     {!isStreaming && showFooter && turnStats && turnStats.elapsed_ms > 0 && (
       <div className="flex items-center gap-1 mt-1 text-[11px] text-muted/60 font-mono tabular-nums" data-testid="turn-stats" title={`Turn took ${fmtTurnElapsed(turnStats.elapsed_ms)}${(turnStats.credits ?? 0) > 0 ? ` and used ${fmtCredits(turnStats.credits!)} credits` : ''}${(turnStats.cost_usd ?? 0) > 0 ? ` ($${turnStats.cost_usd!.toFixed(4)} API cost)` : ''}`}>

--- a/website/src/pages/chat/CollapsibleToolGroup.tsx
+++ b/website/src/pages/chat/CollapsibleToolGroup.tsx
@@ -2,11 +2,13 @@ import { useState, useEffect, useRef, memo, type ReactNode } from 'react'
 import { CheckCircle, Handshake, Ban, Wrench, AlertTriangle } from 'lucide-react'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
 import { ToolInputText } from '../../components/ToolInputText'
+import { useRowDisclosure } from './rowDisclosure'
 
 import { i18nT } from '../../i18n/t'
 interface CollapsibleToolGroupProps {
   count: number
   autoExpand?: boolean
+  disclosureKey?: string
   hasPermission?: boolean
   isRunning?: boolean
   children: ReactNode
@@ -40,14 +42,14 @@ function extractPreview(meta?: Record<string, unknown>): string {
 }
 
 /** Collapsible row that wraps tool/thinking/permission messages — always collapsed unless autoExpand. */
-const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExpand, hasPermission, isRunning, children, permissionMeta, pendingPermCount, onApprove, onViewActivity, activityOpen }: CollapsibleToolGroupProps) {
-  const [expanded, setExpanded] = useState(!!autoExpand)
+const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExpand, disclosureKey, hasPermission, isRunning, children, permissionMeta, pendingPermCount, onApprove, onViewActivity, activityOpen }: CollapsibleToolGroupProps) {
+  const [expanded, setExpanded] = useRowDisclosure(disclosureKey, !!autoExpand)
   const userToggled = useRef(false)
   const [submitting, setSubmitting] = useState(false)
   const [localResolved, setLocalResolved] = useState<string | null>(null)
   const needsAttention = !!hasPermission && !localResolved
 
-  useEffect(() => { if (!userToggled.current) setExpanded(!!autoExpand) }, [autoExpand])
+  useEffect(() => { if (!userToggled.current) setExpanded(!!autoExpand) }, [autoExpand, setExpanded])
 
   // Reset approval state when permission props change (new approval arrives)
   useEffect(() => { setLocalResolved(null); setSubmitting(false) }, [hasPermission, pendingPermCount])
@@ -57,7 +59,7 @@ const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExp
   useEffect(() => {
     if (wasRunning.current && !isRunning && !userToggled.current) setExpanded(false)
     wasRunning.current = !!isRunning
-  }, [isRunning])
+  }, [isRunning, setExpanded])
 
   const decisionLabel: Record<string, ReactNode> = { approved: <><CheckCircle className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.approved')}</>, trust: <><Handshake className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.trusted')}</>, rejected: <><Ban className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.rejected')}</> }
   const labelNode = localResolved

--- a/website/src/pages/chat/NudgeCard.tsx
+++ b/website/src/pages/chat/NudgeCard.tsx
@@ -1,8 +1,9 @@
-import { memo, useState } from 'react'
+import { memo } from 'react'
 import { ChevronRight, RefreshCw } from 'lucide-react'
 import type { ChatMessage } from '../../types'
 
 import { i18nT } from '../../i18n/t'
+import { useRowDisclosure } from './rowDisclosure'
 /** Matches the `[auto-nudge cycle N]` prefix the gateway prepends to nudge turns. */
 const NUDGE_TAG_RE = /^\[auto-nudge cycle (\d+)\]\n?/
 
@@ -63,11 +64,13 @@ export function nudgeMatchesLoop(message: ChatMessage, activeLoopId?: string | n
 export default memo(function NudgeCard({
   message,
   onOpenLoop,
+  disclosureKey,
 }: {
   message: ChatMessage
   onOpenLoop?: () => void
+  disclosureKey?: string
 }) {
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   const { cycle, body } = parseNudgeMessage(message)
   const firstLine = body.split('\n').find(l => l.trim().length > 0)?.trim() ?? ''
   const label = cycle !== null ? `Auto-nudge · cycle ${cycle}` : i18nT('pages.chat.nudgeCard.auto_nudge')

--- a/website/src/pages/chat/RecoveryCard.tsx
+++ b/website/src/pages/chat/RecoveryCard.tsx
@@ -1,7 +1,8 @@
-import { memo, useState } from 'react'
+import { memo } from 'react'
 import { ChevronRight, RotateCcw, TriangleAlert } from 'lucide-react'
 
 import { i18nT } from '../../i18n/t'
+import { useRowDisclosure } from './rowDisclosure'
 
 /**
  * The synthetic-continuation prefixes the gateway prepends when it recovers a
@@ -131,8 +132,8 @@ export function parseRecoveryMessage(content: string): ParsedRecovery | null {
  * virtualized, so a scrolled-away row remounts collapsed. Same behaviour as
  * NudgeCard.
  */
-export default memo(function RecoveryCard({ parsed }: { parsed: ParsedRecovery }) {
-  const [expanded, setExpanded] = useState(false)
+export default memo(function RecoveryCard({ parsed, disclosureKey }: { parsed: ParsedRecovery; disclosureKey?: string }) {
+  const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   const { kind, title, detail, chip, body } = parsed
   // Severity split: a refusal or a stall means something was blocked or died and
   // the user may need to act, so it keeps the warning triangle. A transient

--- a/website/src/pages/chat/TaskProgressBar.tsx
+++ b/website/src/pages/chat/TaskProgressBar.tsx
@@ -1,8 +1,9 @@
-import { useState, useMemo, useCallback, memo } from 'react'
+import { useMemo, useCallback, memo } from 'react'
 import { ListTodo, ChevronDown, ChevronRight, CheckCircle2, Circle } from 'lucide-react'
 import { useAppSelector } from '../../store'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
 import type { TodoList } from '../../types'
+import { useRowDisclosure } from './rowDisclosure'
 
 import { i18nT } from '../../i18n/t'
 /** Rows rendered before the list scrolls internally — bounds DOM on long plans. */
@@ -19,8 +20,8 @@ const MAX_VISIBLE_ROWS = 12
  * present list is also hidden (there is nothing to show), but is distinct from
  * absent at the data layer.
  */
-const TaskProgressBar = memo(function TaskProgressBar({ slot }: { slot: string | null }) {
-  const [expanded, setExpanded] = useState(false)
+const TaskProgressBar = memo(function TaskProgressBar({ slot, disclosureKey }: { slot: string | null; disclosureKey?: string }) {
+  const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   // Select the primitive-bearing todo object for this slot only, so unrelated
   // slot churn in the slots array doesn't re-render the pill.
   const todo = useAppSelector(s =>
@@ -28,7 +29,7 @@ const TaskProgressBar = memo(function TaskProgressBar({ slot }: { slot: string |
   ) as TodoList | null
 
   const tasks = useMemo(() => todo?.tasks ?? [], [todo])
-  const toggle = useCallback(() => setExpanded(v => !v), [])
+  const toggle = useCallback(() => setExpanded(v => !v), [setExpanded])
 
   if (!slot || !todo || tasks.length === 0) return null
 

--- a/website/src/pages/chat/ThinkingBlock.tsx
+++ b/website/src/pages/chat/ThinkingBlock.tsx
@@ -1,6 +1,7 @@
-import { useState, memo } from 'react'
+import { memo } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
+import { useRowDisclosure } from './rowDisclosure'
 
 import { i18nT } from '../../i18n/t'
 /**
@@ -16,8 +17,10 @@ import { i18nT } from '../../i18n/t'
  * is rendered as dim pre-wrapped text rather than markdown -- thought streams
  * are often partial/ill-formed and shouldn't run through the markdown renderer.
  */
-function ThinkingBlock({ content }: { content: string }) {
-  const [expanded, setExpanded] = useState(false)
+function ThinkingBlock({ content, disclosureKey }: { content: string; disclosureKey?: string }) {
+  // Held outside the row: the transcript is virtualised, so this block is
+  // unmounted whenever its row leaves the mounted window.
+  const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   if (!content) return null
 
   return (

--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -31,7 +31,7 @@ const revealedToolIds = new Set<string>()
 /** Inline tool call pill. Click toggles an expanded panel below the pill that
  *  shows purpose / input / output (the same details that previously lived in
  *  the Activity sidebar's deprecated "Tools" tab). */
-export default memo(function ToolCallLine({ message, running: _running, slot, onFileOpen }: { message: ChatMessage; running: boolean; slot?: string; onFileOpen?: (path: string) => void }) {
+export default memo(function ToolCallLine({ message, running: _running, slot, onFileOpen, disclosure, disclosureKey, onDisclosureChange }: { message: ChatMessage; running: boolean; slot?: string; onFileOpen?: (path: string) => void; disclosure?: boolean; disclosureKey?: string; onDisclosureChange?: (key: string, expanded: boolean) => void }) {
   const dispatch = useAppDispatch()
   const label = message.content.replace(/^🔧\s*/, '')
   const toolCallId = message.meta?.tool_call_id as string | undefined
@@ -139,7 +139,26 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   // (manual toggle / focus signal) so the panel stays open if the user took
   // explicit control, and only auto-collapse when the approval resolves
   // *and* we were the ones who opened it.
-  const [expanded, setExpanded] = useState(() => hasPendingPerm)
+  const [localExpanded, setLocalExpanded] = useState(() => hasPendingPerm)
+  // Disclosure is HOST-OWNED when `disclosure` is supplied. The transcript is
+  // virtualised, so this pill is unmounted whenever its row leaves the mounted
+  // window, and state kept only here dies with it. `undefined` means the host
+  // holds no choice for this pill, so the local value applies.
+  const expanded = disclosure ?? localExpanded
+  // Both the notifier and the key are passed in already-stable, so memo() on
+  // this component still short-circuits.
+  const onDisclosureChangeRef = useRef(onDisclosureChange)
+  onDisclosureChangeRef.current = onDisclosureChange
+  const disclosureKeyRef = useRef(disclosureKey)
+  disclosureKeyRef.current = disclosureKey
+  // Write both channels: the local value keeps an uncontrolled host (split-view
+  // ChatPane, app-sdk) working, and the notification is what survives a remount.
+  const applyExpanded = useCallback((next: boolean) => {
+    setLocalExpanded(next)
+    const notify = onDisclosureChangeRef.current
+    const key = disclosureKeyRef.current
+    if (notify && key) notify(key, next)
+  }, [])
   const [pendingAutoExpand, setPendingAutoExpand] = useState(() => hasPendingPerm)
   const prevPendingRef = useRef(hasPendingPerm)
   useEffect(() => {
@@ -147,7 +166,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
     prevPendingRef.current = hasPendingPerm
     if (hasPendingPerm && !wasPending) {
       // Approval just became pending → auto-expand
-      setExpanded(true)
+      applyExpanded(true)
       setPendingAutoExpand(true)
     } else if (!hasPendingPerm && wasPending && pendingAutoExpand) {
       // Approval just resolved (approved/rejected/cancelled) and the user
@@ -158,12 +177,12 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
       // mid-flux height for the exit animation and the panel snaps shut
       // instead of animating cleanly.
       const raf = requestAnimationFrame(() => {
-        setExpanded(false)
+        applyExpanded(false)
         setPendingAutoExpand(false)
       })
       return () => cancelAnimationFrame(raf)
     }
-  }, [hasPendingPerm, pendingAutoExpand])
+  }, [hasPendingPerm, pendingAutoExpand, applyExpanded])
 
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -175,12 +194,12 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   const focusToolCallId = useAppSelector(s => s.chat.focusToolCallId)
   useEffect(() => {
     if (focusToolCallId && effectiveId && focusToolCallId === effectiveId) {
-      setExpanded(true)
+      applyExpanded(true)
       setPendingAutoExpand(false)
       requestAnimationFrame(() => containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' }))
       dispatch(clearFocusToolCallId())
     }
-  }, [focusToolCallId, effectiveId, dispatch])
+  }, [focusToolCallId, effectiveId, dispatch, applyExpanded])
 
   // File-op tool pills (read/edit/write) get a side-panel open affordance.
   // Extract the fs path from the tool's JSON args; the chip is gated on a
@@ -250,9 +269,9 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   // user can't hide the input they're being asked to approve.
   const onToggle = useCallback(() => {
     if (hasPendingPerm) return
-    setExpanded(e => !e)
+    applyExpanded(!expanded)
     setPendingAutoExpand(false)
-  }, [hasPendingPerm])
+  }, [hasPendingPerm, expanded, applyExpanded])
 
   const fmtTime = (t: number) => t ? new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : ''
 

--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo, type ReactNode } from 'react'
+import { useState, useRef, useEffect, useMemo, useCallback, type ReactNode } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
 import type { DisplayItem, TurnItem } from './types'
@@ -131,11 +131,31 @@ function findConclusionIdx(items: TurnItem[]): number {
  *  renders it for ChatEmbed with no Provider mounted, and a pane must scope the
  *  set to its OWN session key, not the globally-active slot.
  */
-export default function TurnBlock({ turn, renderItem, collapseAll = false, appToolCallIds = EMPTY_ID_SET }: { turn: Extract<DisplayItem, {kind:'turn'}>; renderItem: (item: TurnItem, i: number) => ReactNode; collapseAll?: boolean; appToolCallIds?: ReadonlySet<string> }) {
-  const [expanded, setExpanded] = useState(!turn.complete)
+export default function TurnBlock({ turn, renderItem, collapseAll = false, appToolCallIds = EMPTY_ID_SET, disclosure, onDisclosureChange }: { turn: Extract<DisplayItem, {kind:'turn'}>; renderItem: (item: TurnItem, i: number) => ReactNode; collapseAll?: boolean; appToolCallIds?: ReadonlySet<string>; disclosure?: boolean; onDisclosureChange?: (expanded: boolean) => void }) {
+  const [localExpanded, setLocalExpanded] = useState(!turn.complete)
+  // Disclosure is HOST-OWNED when `disclosure` is supplied, and that is what
+  // makes an explicit choice durable: the transcript is virtualised, so this
+  // row is unmounted whenever it leaves the mounted window and any state held
+  // here dies with it. `undefined` means the user has not chosen yet, so the
+  // local default below applies.
+  const expanded = disclosure ?? localExpanded
+  // An explicit click PINS the disclosure state, and the auto-collapse below
+  // honours that pin. `turn.complete` is not a stable property of the turn: it
+  // is derived from the slot's running flag, which ChatPage re-reconciles from
+  // every slots broadcast, so a broadcast that catches the slot momentarily
+  // idle between tool calls flips it true mid-turn. The pin is what keeps an
+  // incidental transport-level event from overriding a deliberate user
+  // gesture. CollapsibleToolGroup pins its own auto-collapse the same way.
+  const userToggled = useRef(false)
+  const toggle = useCallback(() => {
+    userToggled.current = true
+    const next = !expanded
+    if (onDisclosureChange) onDisclosureChange(next)
+    else setLocalExpanded(next)
+  }, [expanded, onDisclosureChange])
   const wasComplete = useRef(turn.complete)
   useEffect(() => {
-    if (turn.complete && !wasComplete.current) setExpanded(false)
+    if (turn.complete && !wasComplete.current && !userToggled.current) setLocalExpanded(false)
     wasComplete.current = turn.complete
   }, [turn.complete])
 
@@ -162,8 +182,17 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false, appTo
     // Only the non-visible-inline pre-conclusion items are actually collapsed.
     return beforeItems.some(it => !isVisibleInline(it, appToolCallIds) && msgIdxs(it).includes(currentMessageIdx))
   }, [turn.items, term, currentMessageIdx, collapseAll, appToolCallIds])
+  // Revealing a search match must win over the current disclosure state, and it
+  // has to travel the SAME channel the host owns, or a controlled row would
+  // stay collapsed and hide the <mark>. Held in a ref so an inline parent
+  // callback cannot re-fire this effect on every render.
+  const onDisclosureChangeRef = useRef(onDisclosureChange)
+  onDisclosureChangeRef.current = onDisclosureChange
   useEffect(() => {
-    if (matchInCollapsedSegment) setExpanded(true)
+    if (!matchInCollapsedSegment) return
+    const notify = onDisclosureChangeRef.current
+    if (notify) notify(true)
+    else setLocalExpanded(true)
   }, [matchInCollapsedSegment])
 
   // collapseAll mode: collapse everything except the last assistant message (original behavior)
@@ -202,7 +231,7 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false, appTo
 
     return (
       <>
-        <CollapseToggle expanded={expanded} onToggle={() => setExpanded(e => !e)}
+        <CollapseToggle expanded={expanded} onToggle={toggle}
           label={expanded ? 'Hide reasoning' : `Worked through ${stepCount} step${stepCount !== 1 ? 's' : ''}`} />
         {segs.map((seg, si) => seg.type === 'visible' ? (
           <div key={`v-${si}`}>{renderItem(seg.it, seg.idx)}</div>
@@ -238,7 +267,7 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false, appTo
 
   return (
     <>
-      <CollapseToggle expanded={expanded} onToggle={() => setExpanded(e => !e)}
+      <CollapseToggle expanded={expanded} onToggle={toggle}
         label={expanded ? 'Hide tool calls' : `${toolCount} tool call${toolCount !== 1 ? 's' : ''}`} />
       {segments.map((seg, si) => seg.type === 'visible' ? (
         <div key={si}>{renderItem(seg.it, seg.idx)}</div>

--- a/website/src/pages/chat/WorkflowCompletionCard.tsx
+++ b/website/src/pages/chat/WorkflowCompletionCard.tsx
@@ -13,7 +13,7 @@
  * based (not the WS `kind`, which is dropped when the message is persisted), so
  * it works live and when a conversation is reloaded from history.
  */
-import { memo, useState } from 'react'
+import { memo } from 'react'
 import { Workflow, CheckCircle2, AlertCircle, ChevronDown, PanelRight } from 'lucide-react'
 import { useAppDispatch } from '../../store'
 import { openActivityToTab } from '../../store/chatSlice'
@@ -22,6 +22,7 @@ import MarkdownRenderer from '../../components/MarkdownRenderer'
 import type { ChatMessage } from '../../types'
 
 import { i18nT } from '../../i18n/t'
+import { useRowDisclosure } from './rowDisclosure'
 const WF_COMPLETION_PREFIX = '[Workflow completion event]'
 // Name is backtick-delimited; allow any char except a backtick (including
 // newlines) so an unusual name doesn't make the header fail to parse. If it
@@ -66,12 +67,14 @@ export function parseWorkflowCompletion(content: string): ParsedCompletion | nul
 const WorkflowCompletionCard = memo(function WorkflowCompletionCard({
   message,
   onFileOpen,
+  disclosureKey,
 }: {
   message: ChatMessage
   onFileOpen?: (path: string) => void
+  disclosureKey?: string
 }) {
   const dispatch = useAppDispatch()
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   const parsed = parseWorkflowCompletion(message.content || '')
   if (!parsed) return null
 

--- a/website/src/pages/chat/rowDisclosure.tsx
+++ b/website/src/pages/chat/rowDisclosure.tsx
@@ -1,0 +1,126 @@
+/**
+ * Durable disclosure state for rows in the virtualised transcript.
+ *
+ * The chat log is virtualised: useVirtualChat renders a row only while
+ * `item.mounted` holds and unmounts it once the row leaves the window plus
+ * overscan band, which streaming does routinely as it scrolls content past. Any
+ * expand/collapse state held in `useState` inside a row is therefore destroyed
+ * every time that happens, and the user's choice is lost. Guarding the
+ * collapse cannot help, because a remount discards the guard along with the
+ * state it protects: the state has to outlive the row.
+ *
+ * This is an external store rather than context state so a toggle notifies only
+ * the ONE consumer subscribed to that key. Holding the map in provider state
+ * would re-render every consumer on every toggle, which matters because these
+ * are the rows whose render cost is already the most sensitive in the app.
+ *
+ * `useRowDisclosure` degrades to plain local state when no provider is present,
+ * so hosts that render transcript components outside ChatPage (split-view
+ * ChatPane, app-sdk's ChatMessageList) keep working untouched.
+ */
+import {
+  createContext, useCallback, useContext, useEffect, useRef, useState,
+  useSyncExternalStore, type ReactNode,
+} from 'react'
+
+type Listener = () => void
+
+export class RowDisclosureStore {
+  private values = new Map<string, boolean>()
+  private listeners = new Map<string, Set<Listener>>()
+
+  get = (key: string): boolean | undefined => this.values.get(key)
+
+  set = (key: string, value: boolean): void => {
+    if (this.values.get(key) === value) return
+    this.values.set(key, value)
+    const ls = this.listeners.get(key)
+    // Copy before iterating: a listener may unsubscribe during notification.
+    if (ls) for (const l of Array.from(ls)) l()
+  }
+
+  subscribe = (key: string, listener: Listener): (() => void) => {
+    let ls = this.listeners.get(key)
+    if (!ls) { ls = new Set(); this.listeners.set(key, ls) }
+    ls.add(listener)
+    return () => {
+      const cur = this.listeners.get(key)
+      if (!cur) return
+      cur.delete(listener)
+      if (cur.size === 0) this.listeners.delete(key)
+    }
+  }
+
+  /** Drop every recorded choice, notifying anything currently mounted. */
+  reset = (): void => {
+    const keys = Array.from(this.values.keys())
+    this.values.clear()
+    for (const k of keys) {
+      const ls = this.listeners.get(k)
+      if (ls) for (const l of Array.from(ls)) l()
+    }
+  }
+}
+
+const RowDisclosureContext = createContext<RowDisclosureStore | null>(null)
+
+/**
+ * Supplies the store to a transcript. `resetKey` is the slot key: row keys are
+ * only unique within a slot, so carrying choices across a switch would apply
+ * one session's state to another's rows.
+ */
+export function RowDisclosureProvider({ resetKey, children }: { resetKey?: string | null; children: ReactNode }) {
+  const storeRef = useRef<RowDisclosureStore | null>(null)
+  if (!storeRef.current) storeRef.current = new RowDisclosureStore()
+  const store = storeRef.current
+  // Reset in an effect, not during render: reset() notifies subscribers, and
+  // doing that mid-render would set state on other components while rendering.
+  useEffect(() => { store.reset() }, [resetKey, store])
+  return <RowDisclosureContext.Provider value={store}>{children}</RowDisclosureContext.Provider>
+}
+
+/**
+ * Disclosure state that survives the row being recycled.
+ *
+ * `key` identifies the control across unmounts and must be stable for the same
+ * logical row (a tool_call_id, a message key). Pass `undefined` when no stable
+ * identity is available and the hook falls back to local state. `fallback` is
+ * the value used until the user has made an explicit choice, so a control that
+ * was never touched keeps whatever default behaviour it had.
+ */
+export function useRowDisclosure(
+  key: string | undefined,
+  fallback: boolean,
+): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
+  const store = useContext(RowDisclosureContext)
+  const [local, setLocal] = useState(fallback)
+
+  const subscribe = useCallback((listener: Listener) => {
+    if (!store || !key) return () => {}
+    return store.subscribe(key, listener)
+  }, [store, key])
+
+  const getSnapshot = useCallback(
+    () => (store && key ? store.get(key) : undefined),
+    [store, key],
+  )
+  const stored = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  // When a store backs this control it is the ONLY source of truth. Falling
+  // back to the local shadow here would defeat reset(): the store clears but a
+  // stale local `true` would keep the control open across a slot switch.
+  // Without a store (unprovided host) the local value is all there is.
+  const backed = !!(store && key)
+  const expanded = backed ? (stored ?? fallback) : local
+
+  // Accepts the updater form as well, so migrating a `useState` call site is a
+  // one-line change rather than a rewrite of every toggle handler.
+  const expandedRef = useRef(expanded)
+  expandedRef.current = expanded
+  const set = useCallback((next: boolean | ((prev: boolean) => boolean)) => {
+    const value = typeof next === 'function' ? next(expandedRef.current) : next
+    if (store && key) store.set(key, value)
+    else setLocal(value)
+  }, [store, key])
+
+  return [expanded, set]
+}

--- a/website/src/test/ToolCallLine.disclosureDurable.test.tsx
+++ b/website/src/test/ToolCallLine.disclosureDurable.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * The per-tool-call pill's expanded panel must survive the virtualizer
+ * recycling its row.
+ *
+ * The transcript is virtualised, so a row is unmounted once it leaves the
+ * mounted window, which streaming does routinely as it scrolls content past.
+ * Expansion therefore cannot live in the pill. These tests mirror ChatPage's
+ * arrangement, where the host holds it keyed by the pill's message key.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { useCallback, useState } from 'react'
+import { renderWithProviders, createTestStore } from './helpers'
+import ToolCallLine from '../pages/chat/ToolCallLine'
+import type { RootState } from '../store'
+import type { ChatMessage } from '../types'
+
+type ChatState = RootState['chat']
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+}
+
+beforeEach(() => { localStorage.clear() })
+
+const KEY = 'row-tc_1'
+const toolMsg = (): ChatMessage => ({
+  role: 'tool', content: '🔧 Running: echo hello', cls: '',
+  meta: { tool_call_id: 'tc_1', purpose: 'Say hello' },
+})
+
+const store = () => createTestStore({
+  chat: {
+    messages: [toolMsg()],
+    toolLog: [{ type: 'tool', text: 'echo hello', purpose: 'Say hello', tool_call_id: 'tc_1', output: 'hello', ts: 1 }],
+    slotRunning: false,
+  } as unknown as ChatState,
+})
+
+/**
+ * Mirrors ChatPage: disclosure is host-owned and keyed, and the pill is only
+ * rendered while its row is mounted. The recycle button stands in for the row
+ * leaving the virtualizer's window and coming back.
+ */
+function Host() {
+  const [disclosure, setDisclosure] = useState<Record<string, boolean>>({})
+  const [mounted, setMounted] = useState(true)
+  const setFor = useCallback((key: string, expanded: boolean) => {
+    setDisclosure(prev => (prev[key] === expanded ? prev : { ...prev, [key]: expanded }))
+  }, [])
+  return (
+    <>
+      <button data-testid="recycle" onClick={() => setMounted(m => !m)}>recycle</button>
+      {mounted && (
+        <ToolCallLine
+          message={toolMsg()}
+          running={false}
+          disclosure={disclosure[KEY]}
+          disclosureKey={KEY}
+          onDisclosureChange={setFor}
+        />
+      )}
+    </>
+  )
+}
+
+/** The pill's own disclosure button, which is the one carrying aria-expanded. */
+const pill = () => screen.getAllByRole('button').find(b => b.hasAttribute('aria-expanded'))!
+const recycle = () => fireEvent.click(screen.getByTestId('recycle'))
+
+describe('ToolCallLine disclosure survives virtualizer recycling', () => {
+  it('keeps the panel open when the row unmounts and mounts again', () => {
+    renderWithProviders(<Host />, { store: store() })
+    expect(pill().getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(pill())
+    expect(pill().getAttribute('aria-expanded')).toBe('true')
+
+    recycle()   // row leaves the mounted window
+    expect(screen.getAllByRole('button').some(b => b.hasAttribute('aria-expanded'))).toBe(false)
+    recycle()   // user scrolls back to it
+
+    expect(pill().getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('keeps the panel closed across recycling when it was never opened', () => {
+    renderWithProviders(<Host />, { store: store() })
+    recycle()
+    recycle()
+    // No entry was recorded, so the default still applies.
+    expect(pill().getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('keeps an explicit re-collapse across recycling', () => {
+    renderWithProviders(<Host />, { store: store() })
+    fireEvent.click(pill())   // open
+    fireEvent.click(pill())   // close again
+    expect(pill().getAttribute('aria-expanded')).toBe('false')
+
+    recycle()
+    recycle()
+
+    expect(pill().getAttribute('aria-expanded')).toBe('false')
+  })
+})

--- a/website/src/test/TurnBlock.disclosureDurable.test.tsx
+++ b/website/src/test/TurnBlock.disclosureDurable.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Turn disclosure must survive the virtualizer unmounting the row.
+ *
+ * The transcript is virtualised: useVirtualChat renders a row only while
+ * `item.mounted` is true and unmounts it once it leaves the window + overscan
+ * band, which streaming does routinely as it scrolls content past. Disclosure
+ * state therefore cannot live in the row. These tests mirror ChatPage's
+ * arrangement, where the host holds the state keyed by the virtualizer's stable
+ * row key and passes it down.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import TurnBlock from '../pages/chat/TurnBlock'
+import { groupDisplayItems, applyRunningState } from '../pages/chat/groupDisplayItems'
+import { virtualKeyFor } from '../pages/ChatPage'
+import type { DisplayItem, TurnItem } from '../pages/chat/types'
+import type { ChatMessage } from '../types'
+
+const renderTurnItem = (it: TurnItem): ReactNode => (
+  <div key={it.kind === 'single' ? `m${it.msg.ts}` : `g${it.startIdx}`} />
+)
+
+/**
+ * Mirrors ChatPage: disclosure is held by the host, keyed by the row key, and
+ * `mounted` mirrors the virtualizer, where false means the row is not rendered.
+ */
+function Transcript({ messages, running, mounted }: { messages: ChatMessage[]; running: boolean; mounted: boolean }) {
+  const grouped = useMemo(() => groupDisplayItems(messages), [messages])
+  const items: DisplayItem[] = applyRunningState(grouped, running)
+  const [disclosure, setDisclosure] = useState<Record<string, boolean>>({})
+  const setFor = useCallback((key: string, expanded: boolean) => {
+    setDisclosure(prev => (prev[key] === expanded ? prev : { ...prev, [key]: expanded }))
+  }, [])
+  return (
+    <>
+      {items.map((item, i) => {
+        const k = virtualKeyFor(item, i, (m: ChatMessage) => `m${m.ts}`)
+        if (!mounted) return <div key={k} data-spacer />
+        if (item.kind === 'turn') {
+          return (
+            <div key={k}>
+              <TurnBlock
+                turn={item}
+                renderItem={renderTurnItem}
+                disclosure={disclosure[k]}
+                onDisclosureChange={(next: boolean) => setFor(k, next)}
+              />
+            </div>
+          )
+        }
+        return <div key={k}>{renderTurnItem(item)}</div>
+      })}
+    </>
+  )
+}
+
+let seq = 0
+const tool = (): ChatMessage => ({ role: 'tool', content: '🔧 Running: shell', ts: `${++seq}` })
+const text = (s: string): ChatMessage => ({ role: 'assistant', content: s, ts: `${++seq}` })
+const user = (s: string): ChatMessage => ({ role: 'user', content: s, ts: `${++seq}` })
+const aTurn = (): ChatMessage[] => { seq = 0; return [user('go'), tool(), text('a'), tool()] }
+const label = () => screen.getByRole('button').textContent
+
+describe('turn disclosure survives virtualizer unmount', () => {
+  it('keeps an expand when the row scrolls out of the mounted window and back', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={false} mounted={true} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(label()).toContain('Hide')
+
+    // Row leaves the mounted window, then the user scrolls back to it.
+    rerender(<Transcript messages={m} running={false} mounted={false} />)
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+    rerender(<Transcript messages={m} running={false} mounted={true} />)
+
+    expect(label()).toContain('Hide')
+  })
+
+  it('keeps an explicit collapse across an unmount too', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={false} mounted={true} />)
+    fireEvent.click(screen.getByRole('button'))   // expand
+    fireEvent.click(screen.getByRole('button'))   // collapse again
+    expect(label()).toContain('tool call')
+
+    rerender(<Transcript messages={m} running={false} mounted={false} />)
+    rerender(<Transcript messages={m} running={false} mounted={true} />)
+
+    expect(label()).toContain('tool call')
+    expect(label()).not.toContain('Hide')
+  })
+
+  it('survives an unmount combined with running-flag churn', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={false} mounted={true} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    // Agent resumes, the row scrolls away, a stale idle frame lands, row returns.
+    rerender(<Transcript messages={m} running={true} mounted={true} />)
+    rerender(<Transcript messages={m} running={true} mounted={false} />)
+    rerender(<Transcript messages={m} running={false} mounted={false} />)
+    rerender(<Transcript messages={m} running={false} mounted={true} />)
+
+    expect(label()).toContain('Hide')
+  })
+
+  it('still auto-collapses on completion when the user never touched it', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={true} mounted={true} />)
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+    rerender(<Transcript messages={m} running={false} mounted={true} />)
+    // No entry was ever recorded, so the default still applies.
+    expect(label()).toContain('tool call')
+    expect(label()).not.toContain('Hide')
+  })
+})

--- a/website/src/test/TurnBlock.disclosurePin.test.tsx
+++ b/website/src/test/TurnBlock.disclosurePin.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * TurnBlock disclosure state under running-flag churn.
+ *
+ * `turn.complete` is derived from the slot's running flag, which ChatPage
+ * re-reconciles from EVERY slots broadcast. A broadcast that catches the slot
+ * momentarily idle between tool calls flips `complete` true mid-turn, which
+ * fires TurnBlock's auto-collapse. These tests lock in that an explicit user
+ * click pins the disclosure state against that churn, while leaving the
+ * automatic collapse intact for a group the user never touched.
+ *
+ * These tests drive the REAL pipeline (groupDisplayItems + applyRunningState +
+ * TurnBlock) through ChatPage's own turn/loose dispatch, rather than poking
+ * TurnBlock's props directly, so the turn objects under test are shaped exactly
+ * the way production builds them.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useEffect, useMemo, type ReactNode } from 'react'
+import TurnBlock from '../pages/chat/TurnBlock'
+import { groupDisplayItems, applyRunningState } from '../pages/chat/groupDisplayItems'
+import { virtualKeyFor } from '../pages/ChatPage'
+import type { DisplayItem, TurnItem } from '../pages/chat/types'
+import type { ChatMessage } from '../types'
+
+/** Mount counter, so a re-render (state preserved) is distinguishable from a
+ *  remount (state destroyed). */
+const mounts: Record<string, number> = {}
+beforeEach(() => { for (const k of Object.keys(mounts)) delete mounts[k] })
+
+function Probe({ id }: { id: string }) {
+  useEffect(() => { mounts[id] = (mounts[id] ?? 0) + 1 }, [id])
+  return <span data-testid={`probe-${id}`} />
+}
+
+/** Stable content-derived row identity, never the array index. */
+const stableId = (it: TurnItem): string =>
+  it.kind === 'single' ? `m${it.msg.ts}` : `g${it.startIdx}`
+
+/** Mirrors ChatPage's renderTurnItem: a keyed wrapper around each row. */
+const renderTurnItem = (it: TurnItem): ReactNode => (
+  <div key={stableId(it)}><Probe id={stableId(it)} /></div>
+)
+
+/** Mirrors ChatPage's top-level dispatch: turns get a TurnBlock, loose items don't. */
+function Transcript({ messages, running }: { messages: ChatMessage[]; running: boolean }) {
+  const grouped = useMemo(() => groupDisplayItems(messages), [messages])
+  const items: DisplayItem[] = applyRunningState(grouped, running)
+  return (
+    <>
+      {items.map((item, i) => {
+        const k = virtualKeyFor(item, i, (m: ChatMessage) => `m${m.ts}`)
+        if (item.kind === 'turn') {
+          return <div key={k}><TurnBlock turn={item} renderItem={renderTurnItem} /></div>
+        }
+        return <div key={k}>{renderTurnItem(item)}</div>
+      })}
+    </>
+  )
+}
+
+let seq = 0
+const tool = (): ChatMessage => ({ role: 'tool', content: '🔧 Running: shell', ts: `${++seq}` })
+const text = (s: string): ChatMessage => ({ role: 'assistant', content: s, ts: `${++seq}` })
+const user = (s: string): ChatMessage => ({ role: 'user', content: s, ts: `${++seq}` })
+
+/** A turn long enough that flushTurn emits a `turn` object (items.length > 2). */
+const aTurn = (): ChatMessage[] => { seq = 0; return [user('go'), tool(), text('a'), tool()] }
+
+const label = () => screen.getByRole('button').textContent
+
+describe('TurnBlock — user disclosure survives running-flag churn', () => {
+  it('keeps the expand when a stale running:false frame lands mid-turn', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={false} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(label()).toContain('Hide')
+
+    // Agent resumes: running -> flat branch, toggle hidden.
+    rerender(<Transcript messages={m} running={true} />)
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+
+    // A slots broadcast observes the slot as momentarily idle. The message list
+    // is identical and the user never clicked again.
+    rerender(<Transcript messages={m} running={false} />)
+    expect(label()).toContain('Hide')
+  })
+
+  it('keeps the expand across repeated running-flag oscillation', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={false} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    for (let i = 0; i < 5; i++) {
+      rerender(<Transcript messages={m} running={true} />)
+      rerender(<Transcript messages={m} running={false} />)
+    }
+    expect(label()).toContain('Hide')
+  })
+
+  it('keeps the expand when the agent appends another step and finishes', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={false} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    rerender(<Transcript messages={[...m, tool()]} running={true} />)
+    rerender(<Transcript messages={[...m, tool()]} running={false} />)
+    expect(label()).toContain('Hide')
+  })
+
+  it('keeps an explicit collapse when the user collapsed it themselves', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={false} />)
+    fireEvent.click(screen.getByRole('button'))   // expand
+    fireEvent.click(screen.getByRole('button'))   // collapse again
+    expect(label()).toContain('tool call')
+
+    rerender(<Transcript messages={m} running={true} />)
+    rerender(<Transcript messages={m} running={false} />)
+    expect(label()).toContain('tool call')
+  })
+
+  it('does not disturb an earlier turn when a new turn starts', () => {
+    const m = aTurn()
+    const { rerender } = render(<Transcript messages={m} running={false} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    rerender(<Transcript messages={[...m, user('again'), tool(), text('b'), tool()]} running={true} />)
+    const labels = screen.queryAllByRole('button').map(b => b.textContent)
+    expect(labels.some(l => l?.includes('Hide'))).toBe(true)
+  })
+
+  it('still auto-collapses on completion when the user never touched it', () => {
+    const m = aTurn()
+    // Mount while running so `expanded` initialises true, then complete the turn.
+    const { rerender } = render(<Transcript messages={m} running={true} />)
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+    rerender(<Transcript messages={m} running={false} />)
+    // No user interaction, so the default collapse must still apply.
+    expect(label()).toContain('tool call')
+    expect(label()).not.toContain('Hide')
+  })
+})
+
+describe('TurnBlock — row identity across turn promotion', () => {
+  // KNOWN DEFECT (tracked separately): flushTurn only emits a `turn` object once
+  // the trailing group exceeds items.length > 2. Below that the items render
+  // loose; above it they are wrapped in TurnBlock. Inserting a component into
+  // the tree remounts everything beneath it, so row-local state dies once per
+  // turn. virtualKeyFor deliberately keeps the ROW key stable across the
+  // promotion, but a stable row key cannot prevent a remount caused by a
+  // changed child tree shape, which is exactly what this pins.
+  //
+  // `it.fails` asserts the defect is STILL present: when the promotion is made
+  // non-remounting this test starts failing and must be flipped to `it`.
+  it.fails('promoting loose items into a turn does not remount the row', () => {
+    seq = 0
+    const m: ChatMessage[] = [user('go'), tool()]
+    const firstId = `m${m[1].ts}`
+    const { rerender } = render(<Transcript messages={m} running={true} />)
+    expect(mounts[firstId]).toBe(1)
+
+    // Two more items push the trailing group over the promotion threshold.
+    rerender(<Transcript messages={[...m, text('thinking'), tool()]} running={true} />)
+    expect(mounts[firstId]).toBe(1)
+  })
+})

--- a/website/src/test/rowDisclosure.test.tsx
+++ b/website/src/test/rowDisclosure.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * The shared row-disclosure mechanism.
+ *
+ * Every expand/collapse control inside the virtualised transcript goes through
+ * useRowDisclosure, so proving durability here covers all of them rather than
+ * one component at a time. ThinkingBlock stands in as a real consumer.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+import { RowDisclosureProvider, useRowDisclosure } from '../pages/chat/rowDisclosure'
+import ThinkingBlock from '../pages/chat/ThinkingBlock'
+
+/** Minimal consumer, so the mechanism is testable without any one component. */
+function Probe({ id }: { id?: string }) {
+  const [open, setOpen] = useRowDisclosure(id, false)
+  return <button onClick={() => setOpen(v => !v)} aria-expanded={open}>{id ?? 'nokey'}</button>
+}
+
+/** `mounted` mirrors the virtualizer: false means the row is not rendered. */
+function Host({ children }: { children: (mounted: boolean) => React.ReactNode }) {
+  const [mounted, setMounted] = useState(true)
+  const [slot, setSlot] = useState('slot-a')
+  return (
+    <RowDisclosureProvider resetKey={slot}>
+      <button data-testid="recycle" onClick={() => setMounted(m => !m)}>recycle</button>
+      <button data-testid="switch-slot" onClick={() => setSlot('slot-b')}>switch</button>
+      {children(mounted)}
+    </RowDisclosureProvider>
+  )
+}
+
+const expandedOf = (name: string) => screen.getByRole('button', { name }).getAttribute('aria-expanded')
+const recycle = () => fireEvent.click(screen.getByTestId('recycle'))
+
+describe('useRowDisclosure', () => {
+  it('keeps a choice across an unmount and remount', () => {
+    render(<Host>{m => (m ? <Probe id="row-1" /> : null)}</Host>)
+    fireEvent.click(screen.getByRole('button', { name: 'row-1' }))
+    expect(expandedOf('row-1')).toBe('true')
+
+    recycle()
+    expect(screen.queryByRole('button', { name: 'row-1' })).toBeNull()
+    recycle()
+
+    expect(expandedOf('row-1')).toBe('true')
+  })
+
+  it('keeps an explicit collapse across an unmount too', () => {
+    render(<Host>{m => (m ? <Probe id="row-1" /> : null)}</Host>)
+    fireEvent.click(screen.getByRole('button', { name: 'row-1' }))
+    fireEvent.click(screen.getByRole('button', { name: 'row-1' }))
+    expect(expandedOf('row-1')).toBe('false')
+    recycle(); recycle()
+    expect(expandedOf('row-1')).toBe('false')
+  })
+
+  it('does not leak a choice between different keys', () => {
+    render(<Host>{m => (m ? <><Probe id="row-1" /><Probe id="row-2" /></> : null)}</Host>)
+    fireEvent.click(screen.getByRole('button', { name: 'row-1' }))
+    expect(expandedOf('row-1')).toBe('true')
+    expect(expandedOf('row-2')).toBe('false')
+    recycle(); recycle()
+    expect(expandedOf('row-1')).toBe('true')
+    expect(expandedOf('row-2')).toBe('false')
+  })
+
+  it('drops choices on a slot switch, since keys are only unique per slot', () => {
+    render(<Host>{m => (m ? <Probe id="row-1" /> : null)}</Host>)
+    fireEvent.click(screen.getByRole('button', { name: 'row-1' }))
+    expect(expandedOf('row-1')).toBe('true')
+    fireEvent.click(screen.getByTestId('switch-slot'))
+    expect(expandedOf('row-1')).toBe('false')
+  })
+
+  it('falls back to local state with no key, so unprovided hosts still work', () => {
+    render(<Probe />)   // no provider at all
+    expect(expandedOf('nokey')).toBe('false')
+    fireEvent.click(screen.getByRole('button', { name: 'nokey' }))
+    expect(expandedOf('nokey')).toBe('true')
+  })
+})
+
+describe('ThinkingBlock disclosure survives virtualizer recycling', () => {
+  const block = () => screen.getAllByRole('button').find(b => b.hasAttribute('aria-expanded'))!
+
+  it('keeps the reasoning open when the row is recycled', () => {
+    render(<Host>{m => (m ? <ThinkingBlock content="some reasoning" disclosureKey="think-1" /> : null)}</Host>)
+    expect(block().getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(block())
+    expect(block().getAttribute('aria-expanded')).toBe('true')
+
+    recycle()
+    expect(screen.getAllByRole('button').some(b => b.hasAttribute('aria-expanded'))).toBe(false)
+    recycle()
+
+    expect(block().getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('stays collapsed by default when never opened', () => {
+    render(<Host>{m => (m ? <ThinkingBlock content="some reasoning" disclosureKey="think-1" /> : null)}</Host>)
+    recycle(); recycle()
+    expect(block().getAttribute('aria-expanded')).toBe('false')
+  })
+})


### PR DESCRIPTION
## Problem

Expanding anything collapsible in the chat transcript while an agent is working
does not stick. A tool call, a thinking block, a workflow card: you open it, and
a moment later it closes on its own. Re-opening does not help, and it keeps
closing for as long as the turn runs. It looks intermittent, because whether it
happens depends on scroll position and streaming timing rather than on anything
the user did.

## Why it matters

Reading tool calls and reasoning as they stream is the main way a user follows
what an agent is doing during a long turn, and it is how they catch a wrong
command early. A disclosure control that discards an explicit click is worse
than one that never opened: the user keeps re-clicking, loses their place in the
transcript each time, and reasonably concludes the control is broken. It lands
at the moment attention matters most, mid-turn while work is in flight.

## Fix (symptoms → root cause → change)

This is a bug **class**, not one bug, and that is the important part of the
diagnosis.

The transcript is virtualised. `useVirtualChat` renders a row only while
`item.mounted` holds, and unmounts it once the row leaves the window plus
overscan band, which streaming does routinely as it scrolls content past. Every
collapsible control in the transcript kept its open/closed state in row-local
`useState`, so each recycle destroyed it. Nine controls had the defect:

`ThinkingBlock`, `ToolCallLine`, `TurnBlock`, `CollapsibleToolGroup`,
`NudgeCard`, `RecoveryCard`, `WorkflowCompletionCard`, `FileChangeChips`,
`TaskProgressBar`.

`ToolCallLine` already carried a comment naming "virtualizer recycling" as a
known hazard for a neighbouring concern, so the mechanism was known, just not
followed through to disclosure state.

A guard cannot fix this. A remount discards the guard along with the state it
protects, so the state has to outlive the row.

**Change: one shared mechanism.** `useRowDisclosure(key, fallback)` in
`website/src/pages/chat/rowDisclosure.tsx`, backed by an external store with
per-key subscriptions via `useSyncExternalStore`. Per-key subscription is a
deliberate choice over holding the map in provider state: the latter re-renders
every consumer on every toggle, and these are the rows whose render cost is the
most sensitive in the app. The hook degrades to plain local state when no
provider or key is present, so hosts that render transcript components outside
ChatPage (split-view `ChatPane`, app-sdk's `ChatMessageList`) keep working
untouched. An entry exists only once the user has made an explicit choice, so a
control that was never touched keeps its previous default behaviour. `ChatPage`
supplies the store and resets it on slot switch, since row keys are unique only
within a slot.

**A second, independent defect** in `TurnBlock` is also fixed. It collapsed on
any `turn.complete` false→true transition, and `complete` is derived from the
slot's running flag, which `ChatPage` re-reconciles from **every** slots
broadcast, accepting any `running: false` not shadowed by a locally pending
turn. A broadcast catching the slot momentarily idle between tool calls flipped
it true mid-turn and fired the collapse. An explicit click now pins that state.

## Tests

21 cases across four files. The mechanism is proven **once** rather than
re-proven per component: durability across unmount/remount, per-key isolation,
reset on slot switch, and the no-provider fallback. Component-level cases then
cover the tool pill and the turn-level toggle, including running-flag churn.

Writing the mechanism tests caught a real bug in the hook itself: `expanded =
stored ?? local` let a stale local `true` survive `reset()`, leaking a choice
across a slot switch. The store has to be the sole source of truth when
present. That case now guards it.

Six cases fail without the fix:

| Case | Locks in |
|---|---|
| hook: choice across unmount | the store outlives the row |
| tool pill recycled | the pill's panel survives a recycle |
| turn row scrolls away and back | turn-level disclosure survives a recycle |
| recycle combined with flag churn | both mechanisms together |
| stale `running:false` frame | one spurious frame does not discard an expand |
| repeated flag oscillation | five true/false cycles do not either |

Five more guard the **opposite** direction and pass in both states, covering
explicit collapse, an untouched control still auto-collapsing, per-key
isolation, and a new turn not disturbing an earlier one. Mutating either pin to
be too broad fails one of them, so the fix cannot be widened into disabling
intended behaviour unnoticed.

One `it.fails` case pins a **separate pre-existing defect** found while
diagnosing this: `flushTurn` only emits a `turn` object once the trailing group
exceeds `items.length > 2`, so crossing that threshold wraps the items in
`TurnBlock` and remounts every row beneath it. `it.fails` asserts the defect is
still present, so fixing the promotion turns the test red and forces the flip to
`it` rather than rotting silently. Follows existing in-repo precedent
(`website/src/i18n/memoBailout.test.tsx`).

## Manual verification

Reported from real use, and reproduced by hand across three separate controls
(the turn-level toggle, the tool pill, the thinking block). Each iteration was
built and synced to a live gateway for hands-on confirmation.

Diagnosis was instrumented rather than assumed. Mount counters separated a
re-render (state preserved) from a remount (state destroyed), which is what
identified the virtualizer recycle as the dominant path and ruled out an earlier
suspect: a 60 Hz style-recalc loop from a never-resolving spinner, measured and
**excluded** because it produces zero DOM mutations and so never re-renders
React. That is a real but separate CPU-waste issue, not folded in here.

Worth recording, because it explains the shape of this change. The first pass
fixed only the flag-churn mechanism and asserted the remount was "no longer
urgent once disclosure is pinned". That was wrong: a remount takes the guard
with it. The second pass fixed the remount for the wrong control, the
turn-level summary rather than the tool pill the report was about. Only after a
third report did enumerating **every** expandable control in the transcript
reveal this as a class, at which point a shared mechanism replaced the two
bespoke patches. Fixing controls one at a time was the error; the class fix is
the correction.

Two controls are migrated to the hook but intentionally **not keyed**, and fall
back to local state exactly as before: `TaskProgressBar` renders outside the
virtualised list so it was never exposed, and `KnowledgeBubbleChip` has no
stable identity at its call site.

Also worth flagging for reviewers: the migration initially introduced three new
`react-hooks/exhaustive-deps` warnings, because `setExpanded` is now a memoized
callback rather than a stable `useState` setter. `tsc` was clean throughout and
would not have caught it, and the warning ratchet would have failed the build.
Fixed by adding it to the three dependency arrays.

## Screenshots

Not applicable, and worth being explicit rather than silently dropping the
section. This changes **temporal** behaviour, not appearance: no pixel differs
in any single frame, because the bug is that a correctly-rendered open panel
closes a moment later. A still of either state looks identical before and after,
so it would be evidence of nothing. The behaviour over time is what the six
revert-verified cases capture, reproducing the exact frame sequences that
trigger it.

## Follow-ups (not in this PR)

1. **Converge the last two controls onto the hook.** `ToolCallLine` and
   `TurnBlock` still use ChatPage-state props from the earlier bespoke passes.
   Behaviourally equivalent to the hook, but two mechanisms for one job is
   worth collapsing.
2. **The running-flag oscillation itself.** `syncSlotRunningFromServer` accepts
   a `running: false` that contradicts an in-flight turn. Whether it should
   reject that is a separate question with its own blast radius, and it is a
   plausible cause of other transient UI churn. This PR makes the disclosure
   controls robust either way.
3. **The loose→turn promotion remount**, pinned by the `it.fails` case. Row
   identity across that promotion is structural. Disclosure no longer pays for
   it, but other row-local state remains exposed.
4. **The credits-pill spinner**, which burns 60 Hz of style recalc whenever
   `/api/sessions/usage` returns null because both `null` and `undefined` fall
   into the same falsy branch. Measured, unrelated to this bug, unfixed.
