### PR TITLE
ci: let in-flight main runs finish instead of cancelling them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,13 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PRs cancel superseded revisions: only a PR's tip commit needs a verdict.
+  # main does not, so let an in-flight run finish instead of killing it.
+  # This does NOT produce a verdict per commit. The group still permits one
+  # pending run, and GitHub evicts that pending run when a newer one queues
+  # (longterm-arbiter.yml documents the same hazard). With a ~19min run and a
+  # ~1.4min median merge gap, main gets periodic verdicts instead of none.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-wheel:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,13 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PRs cancel superseded revisions: only a PR's tip commit needs a verdict.
+  # main does not, so let an in-flight run finish instead of killing it.
+  # This does NOT produce a verdict per commit. The group still permits one
+  # pending run, and GitHub evicts that pending run when a newer one queues
+  # (longterm-arbiter.yml documents the same hazard). With a ~19min run and a
+  # ~1.4min median merge gap, main gets periodic verdicts instead of none.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   scrub-lint:


### PR DESCRIPTION
## Description

`cancel-in-progress: true` sat above both the `pull_request` and the `push: main` trigger in `ci.yml` and `build.yml`, with no distinction between them. On a PR that is correct: a new revision supersedes the old one. On `main` it means each merge kills the run still in flight for the previous merge, and this repo merges fast.

Measured over the last 100 runs on `main`:

| workflow | cancelled | success | failure |
|---|---|---|---|
| `ci.yml` | **74** | 21 | 5 |
| `build.yml` | **38** | 22 | 0 |

The cost is attribution, not runner minutes. During a burst of merges no run completes at all, so those commits carry no verdict and the history cannot be bisected. #934 ran into this directly while trying to identify which commit broke the E2E job, and could not: *"their own CI runs were all `cancelled` ... so GitHub has no per-commit E2E result to bisect from."*

### What this does not do

It does not give `main` a verdict per commit, and the numbers say why. Measured over 2026-08-01T03:29Z to 2026-08-02T00:03Z:

| | |
|---|---|
| `ci.yml` duration on `main` | p50 **19 min**, p90 20, max 22 (n=14 completed) |
| merge inter-arrival on `main` | p50 **1.4 min**, p75 13.1 (n=59) |
| merges landing under 10 min after the previous | 71% |

So roughly 13 commits land per run duration. Separately, the shared group permits only one pending run, and GitHub evicts that pending run when a newer one queues. `longterm-arbiter.yml` already documents that same hazard in this repo.

What the change buys is periodic verdicts through a burst instead of none: coverage moves from about one verdict per burst to about one plus burst duration over 19 min. A four-hour burst goes from 1 verdict to roughly 13. That turns an unbisectable range into a window of about 13 commits.

### Cost

Capacity does not get worse. Today the killed run is replaced immediately by another 22-job run, so occupancy is about 22 jobs either way. This adds a *pending* run, and a pending run consumes no runners. That matters because `ci.yml` already notes a "~20 concurrent-job ceiling for public repos".

The real cost is latency: the head-of-`main` verdict can arrive up to one run duration later, because the newest commit may wait behind an in-flight run rather than pre-empting it.

Two caveats on the numbers above. 14 completed runs is a thin sample for the duration figure, and the merge-rate window is a single 21-hour stretch that includes a busy Saturday. Both are measured over that window rather than steady state.

### Not addressed here

A verdict per commit needs either a merge queue, or a concurrency group keyed per commit. Both trade against the job ceiling, and picking between them is a maintainer capacity decision rather than something this PR should presume. Happy to follow up on either if there is a preference.

`pages.yml` also runs on push to `main` and is deliberately **not** changed: it deploys, and there the newest deploy winning is the correct behaviour.

The conditional form is documented GitHub Actions syntax (workflow-syntax reference, "Only cancel in-progress jobs on specific branches"). Allowed expression contexts for `concurrency` are `github`, `inputs` and `vars`, and `github.event_name` is in the `github` context.

## Related Issues

No "Fixes" link. #934 is the evidence that the missing signal has a real cost, but this PR narrows that gap rather than closing it.

## Testing

- [x] Existing tests pass
- [ ] New tests added for new functionality (none: this is workflow configuration, not code)
- [x] Manual verification performed

Both files parse and the key resolves as intended (`yaml.safe_load`):

```
ci.yml    -> concurrency: {'group': '${{ github.workflow }}-${{ github.ref }}', 'cancel-in-progress': "${{ github.event_name == 'pull_request' }}"}
build.yml -> concurrency: {'group': '${{ github.workflow }}-${{ github.ref }}', 'cancel-in-progress': "${{ github.event_name == 'pull_request' }}"}
```

The behaviour itself cannot be verified before merge: GitHub evaluates the expression, and the effect on `push: main` only becomes observable once this is on `main`. The check to watch afterwards is the `cancelled` count on `main` falling, though it will not fall to zero because pending eviction remains.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) (not applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
