### PR TITLE
test: declare jsonschema so the config-validation guards run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,15 @@ dev = [
     "mypy==1.14.1",
     "black==24.10.0",
     "isort==6.0.0",
+    # Not a dev TOOL. kiro_crew.config.validation imports jsonschema behind a
+    # try/except and returns the config unvalidated when the import fails, so a
+    # run without it exercises none of the schema-validation path and silently
+    # SKIPS the 11 tests that cover it (pytest scores a skip as a pass). It is
+    # declared here so those guards actually run. Whether jsonschema should also
+    # be a runtime dependency -- making validation always-on for users rather
+    # than opt-in-by-accident -- is a separate, user-visible call and is
+    # deliberately not made here.
+    "jsonschema==4.26.0",
 ]
 
 [tool.black]


### PR DESCRIPTION
## Description

`src/kiro_crew/config/validation.py` imports `jsonschema` behind a `try`/`except ImportError` and sets `_HAS_JSONSCHEMA`. When the import fails, `validate_config_data()` returns early:

```python
if not _HAS_JSONSCHEMA:
    return data
```

`jsonschema` is not declared in `pyproject.toml`, `setup.cfg`, the `dev` dependency group, or the `voice` / `desktop` extras, and it does not arrive transitively — `import jsonschema` raises `ModuleNotFoundError` in an environment built from the repo's own dependencies. So CI has never had it, which means two things:

1. `validate_config_data()` is a no-op on every CI run, despite its docstring promising it *"mutates data in-place to remove invalid values"*.
2. The tests covering the schema path skip themselves rather than fail.

pytest scores a skip as a pass, so nothing objected. This is the same failure shape the Playwright suite guards against with `MAX_SKIPPED_SPECS = 0`; the Python suite has no equivalent ceiling, so a silently-skipping guard can sit there indefinitely.

The backend CI job installs with `--group dev`, so the `dev` group is the right home for it.

### Scope, and the follow-up this does not do

This PR makes the tests real. It changes nothing for users, because `jsonschema` stays out of the runtime dependencies.

That leaves a user-visible gap, and it is worth naming rather than leaving implied. For anyone who installs KiroCrew without `jsonschema`, `validate_config_data()` returns the config untouched and says nothing. Since the docstring promises it *"mutates data in-place to remove invalid values"*, a config with an out-of-range enum, an unrecognized key, or a wrong type is accepted silently and the loader falls back to defaults without telling anyone.

There are two ways to close that. I am proposing the second:

1. **Make `jsonschema` a runtime dependency.** Validation then runs for everyone, at the cost of a mandatory dependency on every install. That is a maintainer decision about the user-facing contract, so I have not made it.
2. **Keep it optional, but make the absence loud.** `validation.py:41-42` currently swallows the `ImportError` and sets `_HAS_JSONSCHEMA = False` with no output at all. The module already owns a logger on the loader's channel at line 46, chosen deliberately because "config-validation warnings are part of the loader's observable contract", and the existing validation warnings already use it. One warning there when validation is skipped costs a couple of lines and converts a silent no-op into something an operator can actually see.

I have deliberately not done (2) in this PR, for two reasons. It changes behaviour for users rather than fixing a test gap, so it does not belong in the same change. And the loader's warning channel is asserted by the test suite, so adding to it needs its own test pass to confirm nothing pinning the exact warning set breaks.

Happy to raise (2) as a follow-up PR, or to fold it in here if you would rather review one change than two.

## Related Issues

None. Found while auditing the test suite for guards that cannot fire in CI.

## Testing

- [x] Existing tests pass
- [ ] New tests added for new functionality (none: this enables 11 existing tests that were skipping)
- [x] Manual verification performed

Full suite, both arms, deselecting the two files CI also deselects (`test_script_hooks.py`, `test_cron_script.py`):

| arm | passed | skipped | failed |
|---|---|---|---|
| without `jsonschema` | 22791 | 146 | 14 |
| with `jsonschema` | **22802** | **135** | 14 |

Exactly 11 tests move from skipped to passing. The 14 failures are **identical in both arms** (compared by name, set difference empty in both directions), so they are pre-existing failures of my local sandbox — a `link(2)` syscall blocked by seccomp, a missing `qrcode`, and no available sandbox backend — and not a regression from this change.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) (not applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

