### PR TITLE
perf(boot): stop blocking the boot path and the import graph

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -49,8 +49,8 @@ from kiro_crew.config.loader import (
 from kiro_crew.config.paths import _default_home, _legacy_home
 from kiro_crew.constants import BANNER, env_flag_enabled
 from kiro_crew.crash_guard import install as _install_crash_guard
-from kiro_crew.dashboard.origin import parse_dashboard_url
 from kiro_crew.dashboard.state import set_build_info
+from kiro_crew.dashboard.urls import parse_dashboard_url
 from kiro_crew.env import git_build_info
 from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
 from kiro_crew.history import ConversationLog, HistoryConsolidator

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -145,6 +145,20 @@ _WORKSPACE_DIR_NAME = "kirocrew-workspace"
 # ``None`` means "not yet resolved this process".
 _resolved_home: Path | None = None
 
+# Memo for ``config_dir()``: ``(raw KIROCREW_HOME, _resolved_home at the time,
+# result)``. ``config_dir()`` is called from 323 sites and each uncached call
+# does a ``Path.resolve()`` + ``mkdir`` and, on the default path, a breadcrumb
+# read/write plus the leftover-archive sweep — measured 94.9us per call. Keying
+# on the RAW env value keeps the override honoured the moment it changes
+# (``KIROCREW_HOME`` is repointed per test by the suite's isolation fixture, and
+# by pods/worktrees at runtime), and keying on ``_resolved_home`` by identity
+# ties the default-path entry to the resolution cache below — so clearing
+# ``_resolved_home`` (which the test suite does per test) invalidates this memo
+# too instead of pinning a stale home. In a real process both keys are stable
+# after the first call, which is what makes the breadcrumb write and the archive
+# sweep effectively once-per-process rather than once-per-call.
+_config_dir_memo: tuple[str | None, Path | None, Path] | None = None
+
 
 def _default_home() -> Path:
     """Resolve the default (non-override) data root: ``~/.kiro/crew``."""
@@ -458,9 +472,15 @@ def _valid_override_home() -> Path | None:
 
 
 def config_dir() -> Path:
+    global _config_dir_memo
+    override_raw = os.environ.get("KIROCREW_HOME")
+    memo = _config_dir_memo
+    if memo is not None and memo[0] == override_raw and memo[1] is _resolved_home:
+        return memo[2]
     p = _valid_override_home()
     if p is not None:
         p.mkdir(parents=True, exist_ok=True)
+        _config_dir_memo = (override_raw, _resolved_home, p)
         return p
     if os.environ.get("KIROCREW_HOME"):
         logger.warning(
@@ -473,11 +493,11 @@ def config_dir() -> Path:
     # Best-effort + idempotent; guarded so a breadcrumb failure never blocks the
     # data-home resolution the whole app depends on.
     _write_recovery_breadcrumb(d)
-    # One-shot (but re-checked every call, so a leftover created or missed
-    # between starts is still caught) removal of an ungated archive/backup an
-    # earlier release of this migration could have left behind. Default path
-    # only — see _sweep_ungated_archive_leftovers.
+    # Removal of an ungated archive/backup an earlier release of this migration
+    # could have left behind. Default path only — see
+    # _sweep_ungated_archive_leftovers.
     _sweep_ungated_archive_leftovers()
+    _config_dir_memo = (override_raw, _resolved_home, d)
     return d
 
 

--- a/src/kiro_crew/dashboard/__init__.py
+++ b/src/kiro_crew/dashboard/__init__.py
@@ -11,7 +11,43 @@ The package is split into:
 
 from __future__ import annotations
 
-from kiro_crew.dashboard.server import start_api_server, start_dashboard
-from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _fmt_duration
+import importlib
+from typing import TYPE_CHECKING
+
+# Lazy attribute access (PEP 562) so importing anything under this package —
+# e.g. ``dashboard.urls`` for the two URL helpers the CLI needs, or
+# ``dashboard.origin`` from mcp_core / cli_doctor — does NOT eagerly pull
+# ``dashboard.server`` and, through it, the entire handler tree. Importing
+# ``dashboard.origin`` measured 605ms / 1124 modules with the eager exports
+# below, paid by every CLI invocation and every MCP stdio subprocess even
+# though no dashboard is ever served in those processes. Submodules load on
+# first attribute access; ``from kiro_crew.dashboard import <submodule>``
+# (server.py does this for channel_slots, chat, handlers, ...) is unaffected —
+# the import system falls back to importing the submodule when the attribute
+# lookup misses. Same pattern as ``mcp_gateway/__init__.py``.
+_LAZY = {
+    "start_api_server": ("server", "start_api_server"),
+    "start_dashboard": ("server", "start_dashboard"),
+    "DashboardState": ("state", "DashboardState"),
+    "_ChatSlot": ("state", "_ChatSlot"),
+    "_fmt_duration": ("state", "_fmt_duration"),
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(f"{__name__}.{target[0]}")
+    return getattr(module, target[1])
+
+
+def __dir__():
+    return sorted(__all__)
+
+
+if TYPE_CHECKING:  # names for static type checkers only
+    from kiro_crew.dashboard.server import start_api_server, start_dashboard
+    from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _fmt_duration
 
 __all__ = ["start_api_server", "start_dashboard", "DashboardState", "_ChatSlot", "_fmt_duration"]

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -26,7 +26,6 @@ from kiro_crew.embeddings import (
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-from kiro_crew.vector_memory import SemanticRejectCode
 
 from ._shared import _get_memory, _is_restricted_session
 
@@ -213,6 +212,16 @@ async def api_memory_semantic_write(request: web.Request) -> web.Response:
     err = await asyncio.to_thread(store.set_semantic, key, value, confidence, source)
     if err is not None:
         code, message = err
+        # Imported here, not at module scope: ``vector_memory`` pulls
+        # snowballstemmer plus the optional numpy/faiss imports (measured 175ms
+        # and ~200 modules) and this enum is the module's ONLY use of it, on one
+        # error branch. The enum itself belongs in ``vector_memory_constants``
+        # (the dependency-free split-out this module's other constants already
+        # live in), but relocating it edits ``vector_memory.py``, which is owned
+        # by another change in flight — deferring the import keeps the cost off
+        # the import path without touching that file.
+        from kiro_crew.vector_memory import SemanticRejectCode
+
         sk = request.headers.get("X-Session-Key", "")
         _sel().log_api_access(
             caller=sk, operation="semantic.write", outcome="rejected",

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -256,16 +256,39 @@ def _changelog_path() -> Path | None:
     return None
 
 
+#: Cached CHANGELOG.md body, keyed on ``(path, st_mtime_ns, st_size)``.
+#: ``GET /api/changelog`` read and decoded the whole file on the event loop on
+#: every request (the About panel re-fetches on each open, and the file grows
+#: with every release). The stat signature keeps a dev-install edit visible
+#: immediately, so the endpoint stays as live as it was.
+_changelog_cache: tuple[tuple[str, int, int], str] | None = None
+
+
+def _read_changelog() -> str:
+    """Return CHANGELOG.md's contents, re-reading only when the file changes."""
+    global _changelog_cache
+    path = _changelog_path()
+    if path is None:
+        return ""
+    try:
+        st = path.stat()
+        key = (str(path), st.st_mtime_ns, st.st_size)
+    except OSError:
+        return ""
+    cached = _changelog_cache
+    if cached is not None and cached[0] == key:
+        return cached[1]
+    try:
+        content = path.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+    _changelog_cache = (key, content)
+    return content
+
+
 async def api_changelog(request: web.Request) -> web.Response:
     """GET /api/changelog — read full CHANGELOG.md from project or bundle."""
-    path = _changelog_path()
-    content = ""
-    if path is not None:
-        try:
-            content = path.read_text(encoding="utf-8")
-        except Exception:
-            content = ""
-    return web.json_response({"content": content})
+    return web.json_response({"content": _read_changelog()})
 
 
 async def _build_frontend(proj: str, state: DashboardState) -> None:

--- a/src/kiro_crew/dashboard/handlers_channel.py
+++ b/src/kiro_crew/dashboard/handlers_channel.py
@@ -92,22 +92,49 @@ async def _get_channel_body(request: web.Request):
 # ── List / Get ──
 
 
-async def api_channel_presets(request: web.Request) -> web.Response:
-    """Return channel presets from config.json, falling back to built-in defaults.
+#: Cached ``channel_presets`` value, keyed on config.json's
+#: ``(path, st_mtime_ns, st_size)``. The handler used to read, decode and
+#: JSON-parse the whole config file on the event loop on every call so that an
+#: edit lands without a gateway restart. The stat signature preserves that
+#: contract exactly while making the repeat calls (the channel UI refetches on
+#: every panel open) free.
+_presets_cache: tuple[tuple[str, int, int], object] | None = None
 
-    Reads ``~/.kiro/crew/config.json`` fresh on each call so users can edit the
-    ``channel_presets`` key without restarting the gateway.
-    """
+
+def _load_presets() -> object:
+    """Return ``channel_presets`` from config.json, re-reading only on change."""
+    global _presets_cache
+    path = config_path()
+    try:
+        st = path.stat()
+        key = (str(path), st.st_mtime_ns, st.st_size)
+    except OSError:
+        # Missing config — built-in defaults, nothing to cache against.
+        return _DEFAULT_PRESETS
+    cached = _presets_cache
+    if cached is not None and cached[0] == key:
+        return cached[1]
     config: dict = {}
     try:
-        parsed = json.loads(config_path().read_text(encoding="utf-8"))
+        parsed = json.loads(path.read_text(encoding="utf-8"))
         if isinstance(parsed, dict):
             config = parsed
     except (OSError, json.JSONDecodeError):
-        # Missing or malformed config — fall through to defaults
+        # Malformed config — fall through to defaults
         pass
     presets = config.get("channel_presets", _DEFAULT_PRESETS)
-    return web.json_response({"presets": presets})
+    _presets_cache = (key, presets)
+    return presets
+
+
+async def api_channel_presets(request: web.Request) -> web.Response:
+    """Return channel presets from config.json, falling back to built-in defaults.
+
+    Picks up an edit to the ``channel_presets`` key without a gateway restart:
+    the read is cached on config.json's stat signature, so a changed file is
+    re-read on the next call.
+    """
+    return web.json_response({"presets": _load_presets()})
 
 
 async def api_channels_list(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/origin.py
+++ b/src/kiro_crew/dashboard/origin.py
@@ -8,34 +8,57 @@ construction, and per-request origin validation so that ``server.py``
 The only user-facing config is ``dashboard.url`` — a single URL like
 ``http://my-host.example.com:8080``.  Everything else (port, bind
 address, allowed origins) is derived from it.
+
+This module holds the checks that inspect a live ``web.Request``. The
+request-independent URL / host / origin-set arithmetic lives in the stdlib-only
+:mod:`kiro_crew.dashboard.urls` leaf and is re-exported below, so ``from
+kiro_crew.dashboard.origin import ...`` keeps working for every existing caller
+while CLI and MCP-stdio callers can import the leaf directly and skip the
+``aiohttp`` stack.
 """
 
 from __future__ import annotations
 
-import ipaddress
 import logging
-import os
-import socket
-from urllib.parse import parse_qs, quote, urlparse
 
-from aiohttp import web
+# ``socket`` is not used directly here anymore (the hostname helpers moved to
+# ``urls``), but it is re-exported on purpose: callers and tests patch
+# ``origin.socket.gethostname`` / ``.gethostbyname``, and because this is the one
+# shared stdlib module object, patching it through this name still reaches the
+# helpers in ``urls``.
+import socket  # noqa: F401
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+# Re-exported for backwards compatibility — every name that used to be defined
+# in this module is still importable from it.
+from kiro_crew.dashboard.urls import (  # noqa: F401
+    _BIND_ALL,
+    _BIND_LOCAL,
+    _CANONICALIZABLE_LOOPBACK_HOSTS,
+    _DEFAULT_PORT,
+    _ENV_BIND,
+    _ensure_scheme,
+    _host_without_port,
+    bind_address_for,
+    build_allowed_hosts,
+    build_allowed_origins,
+    build_dashboard_url,
+    dashboard_origin,
+    devspaces_proxy_url,
+    format_dashboard_urls,
+    is_local_only,
+    is_loopback,
+    machine_hostname,
+    parse_dashboard_url,
+    resolve_dashboard_host,
+    should_canonicalize_host,
+)
+
+if TYPE_CHECKING:  # aiohttp is needed for annotations only
+    from aiohttp import web
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_PORT = 5476
-
-_BIND_LOCAL = "127.0.0.1"
-_BIND_ALL = "0.0.0.0"
-
-# Loopback hostnames that all resolve to the same machine but are *distinct
-# browser origins* (origin = scheme://host:port). The dashboard SPA stores user
-# settings (theme, zoom, layout, ...) in per-origin localStorage, so a user who
-# reaches the dashboard on more than one of these names gets a separate, empty
-# settings bucket each time — settings appear to "reset". We canonicalize
-# navigations among this set onto a single host (see should_canonicalize_host).
-_CANONICALIZABLE_LOOPBACK_HOSTS = frozenset(
-    {"127.0.0.1", "::1", "localhost", "kirocrew.localhost"}
-)
 
 #: Liveness/readiness probe paths. Orchestrators (Kubernetes kubelet, Docker
 #: HEALTHCHECK behind a remapped port, load balancers) address these by pod /
@@ -46,29 +69,6 @@ _CANONICALIZABLE_LOOPBACK_HOSTS = frozenset(
 #: agree (see handlers.core._liveness_payload), so a rebound request gets
 #: only the liveness bit an attacker can infer from the TCP connect anyway.
 PROBE_PATHS = frozenset({"/api/health", "/api/live", "/api/ready"})
-
-
-# ---------------------------------------------------------------------------
-# Hostname / IP helpers
-# ---------------------------------------------------------------------------
-
-
-def machine_hostname() -> str | None:
-    """Return the machine hostname, or ``None`` on failure."""
-    try:
-        return socket.gethostname()
-    except Exception:
-        return None
-
-
-def is_loopback(host: str) -> bool:
-    """Return ``True`` if *host* is a loopback address (127.0.0.1, ::1, etc.)."""
-    if host in ("localhost", "127.0.0.1", "::1", "kirocrew.localhost"):
-        return True
-    try:
-        return ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        return False
 
 
 #: Headers that proxies/tunnels attach when forwarding a request. Browsers
@@ -138,396 +138,6 @@ def is_https_request(request: web.Request) -> bool:
     if proto == "https" and is_loopback(request.remote or ""):
         return True
     return False
-
-
-# ---------------------------------------------------------------------------
-# Dashboard URL parsing
-# ---------------------------------------------------------------------------
-
-
-def parse_dashboard_url(url: str) -> tuple[str, int]:
-    """Parse ``dashboard.url`` into ``(hostname, port)``.
-
-    Returns ``("", _DEFAULT_PORT)`` when *url* is empty.
-    ``KIROCREW_PORT`` env var always overrides the port (dev mode).
-    """
-    if not url:
-        host, port = "", _DEFAULT_PORT
-    else:
-        url = _ensure_scheme(url)
-        # urlparse raises ValueError on a malformed IPv6 literal
-        # ("http://[::1"), and .port raises ValueError on a non-integer port
-        # ("http://host:notaport"). dashboard.url is a user-editable config
-        # field parsed unguarded during gateway startup (SlackGateway.
-        # _init_dashboard, cli_server, cli_doctor, mcp_core), so one typo aborted
-        # the whole boot. Degrade to defaults instead — mirrors dashboard_origin().
-        try:
-            parsed = urlparse(url)
-            host = parsed.hostname or ""
-            port = parsed.port or _DEFAULT_PORT
-        except ValueError:
-            logger.warning("Ignoring malformed dashboard_url: %s", url)
-            host, port = "", _DEFAULT_PORT
-    env_port = os.environ.get("KIROCREW_PORT")
-    if env_port:
-        try:
-            port = int(env_port)
-        except ValueError:
-            logger.warning(
-                "KIROCREW_PORT=%r is not a valid integer; using port %d from config",
-                env_port,
-                port,
-            )
-    return host, port
-
-
-def _ensure_scheme(url: str) -> str:
-    """Prepend ``http://`` if *url* has no scheme."""
-    return url if "://" in url else f"http://{url}"
-
-
-def dashboard_origin(url: str) -> str:
-    """Return the browser-facing origin for *url*, or ``""`` if invalid.
-
-    Reuses the same scheme-defaulting logic as :func:`parse_dashboard_url`
-    so that bare hostnames (``myhost:8080``) are normalised to ``http://``.
-    Default ports (80 for http, 443 for https) are stripped to match
-    browser ``Origin`` header behaviour.
-    """
-    if not url:
-        return ""
-    url = _ensure_scheme(url)
-    try:
-        parsed = urlparse(url)
-        scheme = parsed.scheme
-        host = parsed.hostname or ""
-        port = parsed.port
-    except ValueError:
-        logger.warning("Ignoring malformed dashboard_url: %s", url)
-        return ""
-    if not host:
-        return ""
-    if scheme not in ("http", "https"):
-        logger.warning("Ignoring non-HTTP dashboard_url scheme: %s", scheme)
-        return ""
-    # urlparse strips [] from IPv6 — re-wrap to match browser Origin header
-    if ":" in host:
-        host = f"[{host}]"
-    default_port = {"http": 80, "https": 443}.get(scheme)
-    if port == default_port:
-        port = None
-    return f"{scheme}://{host}:{port}" if port else f"{scheme}://{host}"
-
-
-# ---------------------------------------------------------------------------
-# Remote-proxy detection (OSS: no managed proxy)
-# ---------------------------------------------------------------------------
-
-
-def devspaces_proxy_url(port: int) -> str | None:
-    """Return the managed-proxy base URL, or ``None`` (always ``None`` in OSS).
-
-    Symbol preserved for callers (``is_local_only``, ``format_dashboard_urls``,
-    ``build_allowed_origins``); there is no managed reverse-proxy in the public
-    build, so this always returns ``None``.  Users behind their own proxy add
-    its origin via ``dashboard.url`` or ``KIROCREW_CORS_ORIGINS``.
-    """
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Local-only mode resolution
-# ---------------------------------------------------------------------------
-
-
-def is_local_only(dashboard_host: str, slack_connected: bool) -> bool:
-    """Determine whether the dashboard should bind to loopback only.
-
-    Always returns ``True`` (bind ``127.0.0.1``) in the public build.
-    To expose the dashboard beyond loopback, run your own reverse proxy
-    (e.g. Caddy/nginx with TLS) and add its origin via ``dashboard.url``
-    or ``KIROCREW_CORS_ORIGINS``.
-    """
-    # A managed proxy could require a 0.0.0.0 binding; there is none in OSS
-    # (devspaces_proxy_url always returns None), so we always bind loopback.
-    # Safety: slack_connected=True guarantees start_dashboard() mounts
-    # token_auth_middleware before any non-loopback binding is used.
-    if devspaces_proxy_url(0) is not None and slack_connected:
-        logger.info("Managed proxy detected: binding 0.0.0.0 (token auth via Slack)")
-        return False
-    return True
-
-
-#: Explicit bind-address override for container/orchestrated deployments.
-#: See :func:`bind_address_for`.
-_ENV_BIND = "KIROCREW_BIND"
-
-
-def bind_address_for(local_only: bool) -> str:
-    """Return the TCP bind address string for aiohttp.
-
-    ``KIROCREW_BIND`` (env) overrides the bind ADDRESS only — nothing else.
-    It exists for containers: inside Docker, published ports (``-p``) map to
-    the container's bridge interface, so a loopback-bound gateway is
-    unreachable from the host even though the operator explicitly asked for
-    the port to be exposed. The official image sets ``KIROCREW_BIND=0.0.0.0``;
-    binding all interfaces *inside the container's network namespace* exposes
-    nothing on the host beyond what ``-p`` explicitly publishes.
-
-    Deliberately narrow:
-
-    * ``local_only`` semantics are UNCHANGED — dashboard URLs, the CSRF
-      origin allowlist, host canonicalization, and the strict internal-path
-      rules keep their loopback behavior (correct for the common
-      ``-p 5476:5476`` + ``http://localhost:5476`` mapping). Only the TCP
-      bind widens.
-    * Safe by construction: ``token_auth_middleware`` is mounted
-      unconditionally in BOTH server paths (``start_dashboard`` and
-      ``start_api_server``, which both resolve their bind through this
-      function), so a wider bind never exposes an unauthenticated surface
-      beyond the three ``PROBE_PATHS`` liveness probes (token-exempt by
-      design, secret-free payloads). CSRF ``check_origin`` and the
-      DNS-rebinding ``check_host`` barrier apply to every request except
-      those same probe paths (orchestrators address pods by IP — see
-      ``PROBE_PATHS``), and the ``is_direct_local_request`` gates (secret
-      reveal, channel config writes) treat bridge peers as remote —
-      fail-closed.
-    * The value must parse as an IP address (``0.0.0.0``, ``::``, or a
-      specific interface address). Anything else is ignored with a warning
-      and the normal local-only resolution applies — a typo can only ever
-      *narrow* exposure back to loopback, never widen it.
-    """
-    override = os.environ.get(_ENV_BIND, "").strip()
-    if override:
-        try:
-            ipaddress.ip_address(override)
-        except ValueError:
-            logger.warning(
-                "Ignoring %s=%r: not a valid IP address; binding loopback",
-                _ENV_BIND,
-                override,
-            )
-        else:
-            logger.info(
-                "%s=%s: binding this address instead of loopback. Every client "
-                "must still present a valid dashboard token (token auth is "
-                "always mounted); config writes remain restricted to direct "
-                "local sessions.",
-                _ENV_BIND,
-                override,
-            )
-            return override
-    return _BIND_LOCAL if local_only else _BIND_ALL
-
-
-# ---------------------------------------------------------------------------
-# Dashboard host / URL helpers
-# ---------------------------------------------------------------------------
-
-
-def resolve_dashboard_host(local_only: bool, configured_host: str = "") -> str:
-    """Return the hostname users should use to reach the dashboard."""
-    if configured_host:
-        return configured_host
-    if local_only:
-        # Canonical loopback host is plain ``localhost``. It resolves in every
-        # browser and through SSH port-forwards, so a dev who tunnels into a
-        # Linux devdesk and opens the dashboard in Safari can always reach it.
-        # ``kirocrew.localhost`` (and other ``*.localhost`` names) are NOT
-        # resolved by Safari / the macOS system resolver — RFC 6761's loopback
-        # rule is a SHOULD that only Chrome/Firefox and the Linux stub resolver
-        # honor — so canonicalizing onto ``kirocrew.localhost`` would 302 those
-        # users to a host their browser can't resolve. ``*.localhost`` stays
-        # trusted in build_allowed_origins() for the multi-instance embedded-pane
-        # iframes; it is just not the single host the emitters + 302 converge on.
-        return "localhost"
-    return machine_hostname() or "localhost"
-
-
-def _host_without_port(host_header: str) -> str:
-    """Return the host from a ``Host`` header value, IPv6-bracket aware.
-
-    Mirrors the rest of this file's IPv6 handling (``is_loopback``,
-    ``dashboard_origin``, ``build_allowed_origins`` all treat ``::1`` as
-    first-class). A naive ``split(":")[0]`` would yield ``"["`` for an
-    ``[::1]:7777`` Host and silently defeat the loopback match.
-
-        ``[::1]:7777`` -> ``::1``   ``localhost:7777`` -> ``localhost``
-        ``[::1]``      -> ``::1``   ``127.0.0.1``      -> ``127.0.0.1``
-    """
-    h = (host_header or "").strip()
-    if h.startswith("["):
-        end = h.find("]")
-        return h[1:end] if end != -1 else h[1:]
-    return h.split(":")[0]
-
-
-def should_canonicalize_host(
-    request_host: str,
-    canonical_host: str,
-    *,
-    method: str,
-    sec_fetch_dest: str | None,
-) -> bool:
-    """Return True if a request should be 302-redirected to *canonical_host*.
-
-    Converges loopback aliases (127.0.0.1 / localhost / kirocrew.localhost) onto
-    a single origin so the SPA's per-origin localStorage settings are not split
-    across hostnames (see _CANONICALIZABLE_LOOPBACK_HOSTS). Conservative on every
-    axis so it can never touch a request that isn't a same-machine top-level
-    page navigation:
-
-    * only GET/HEAD (never a mutating request),
-    * only true top-level document navigations (``Sec-Fetch-Dest: document`` —
-      absent/empty/websocket/XHR are left alone, so APIs and WebSockets and
-      sub-resource fetches are never redirected),
-    * only when both the request host and the canonical host are in the
-      canonicalizable loopback set (real hostnames / reverse-proxy vhosts are
-      never redirected),
-    * only when they actually differ.
-
-    The caller passes the port-stripped comparison via *request_host*'s host part;
-    this helper strips any ``:port`` itself for safety.
-    """
-    if method not in ("GET", "HEAD"):
-        return False
-    if sec_fetch_dest != "document":
-        return False
-    host = _host_without_port(request_host or "")
-    if host not in _CANONICALIZABLE_LOOPBACK_HOSTS:
-        return False
-    if canonical_host not in _CANONICALIZABLE_LOOPBACK_HOSTS:
-        return False
-    return host != canonical_host
-
-
-def build_dashboard_url(base_url: str, token: str = "", *, local_only: bool = True) -> str:
-    """Build the authenticated dashboard URL."""
-    if local_only is not True and not token:
-        raise ValueError("token is required when dashboard is not local-only")
-    return f"{base_url}?token={quote(token, safe='')}" if token else base_url
-
-
-def format_dashboard_urls(
-    authed_url: str,
-    *,
-    port: int,
-    local_only: bool = True,
-    has_custom_host: bool = False,
-) -> list[str]:
-    """Return startup log lines describing how to reach the dashboard."""
-    parsed_query = urlparse(authed_url).query
-    _qs = f"?{parsed_query}" if parsed_query else ""
-    if local_only is not True and "token" not in parse_qs(parsed_query):
-        raise ValueError("token is required when dashboard is not local-only")
-    _is_remote = bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_CLIENT"))
-
-    if _is_remote:
-        mh = machine_hostname() or "localhost"
-        lines: list[str] = [
-            f"👻 Dashboard: ssh -NL {port}:localhost:{port} {mh}",
-            f"             then open http://localhost:{port}{_qs}",
-        ]
-    else:
-        lines = ["👻 Dashboard:", f"   {authed_url}"]
-
-    if local_only and not has_custom_host and not _is_remote:
-        mh_local = machine_hostname()
-        if mh_local and mh_local != "localhost":
-            try:
-                ip = socket.gethostbyname(mh_local)
-                if ip and ip != "127.0.0.1":
-                    lines.append(f"👻 Remote:    ssh -NL {port}:localhost:{port} {mh_local}")
-            except Exception:
-                pass
-
-    proxy = devspaces_proxy_url(port)
-    if proxy and not local_only:
-        lines.append(f"👻 Proxy:     {proxy}{_qs}")
-
-    if _is_remote:
-        lines.append("👻 Run 24/7:  see docs/remote-desktop-setup.md for systemd service setup")
-
-    return lines
-
-
-# ---------------------------------------------------------------------------
-# Allowed-origin set
-# ---------------------------------------------------------------------------
-
-
-def build_allowed_origins(
-    port: int, local_only: bool, configured_host: str = "", dashboard_url: str = ""
-) -> set[str]:
-    """Compute the set of allowed origins for the dashboard.
-
-    When *dashboard_url* is provided, its origin (scheme + host + port)
-    is added as-is so that reverse-proxy setups (e.g. Caddy with TLS on
-    a custom domain) pass the CSRF check without code changes.
-    """
-    origins: set[str] = {
-        f"http://127.0.0.1:{port}",
-        f"http://localhost:{port}",
-        f"http://kirocrew.localhost:{port}",
-    }
-    if os.environ.get("KIROCREW_HOME"):
-        origins.add("http://localhost:3000")
-        origins.add("http://127.0.0.1:3000")
-    if configured_host:
-        origins.add(f"http://{configured_host}:{port}")
-    if dashboard_url:
-        origin = dashboard_origin(dashboard_url)
-        if origin:
-            origins.add(origin)
-    if not local_only:
-        mh = machine_hostname()
-        if mh:
-            origins.add(f"http://{mh}:{port}")
-    # Managed-proxy origin (None in OSS; see devspaces_proxy_url)
-    proxy = devspaces_proxy_url(port)
-    if proxy:
-        origins.add(proxy)
-    # Manual CORS override for future environments
-    for _co in os.environ.get("KIROCREW_CORS_ORIGINS", "").split(","):
-        if _co.strip():
-            origins.add(_co.strip())
-    # Extra loopback ports the operator explicitly trusts — typically the
-    # local end of an SSH tunnel (``-L 8777:localhost:7777`` makes the browser
-    # send Origin ``http://localhost:8777``). This replaces the previous
-    # blanket "trust any loopback port" behaviour (CSE SEC-016): only the bound
-    # port and these opted-in ports are accepted, so a malicious local web page
-    # on an arbitrary port can no longer pass the CSRF origin check.
-    for _p in os.environ.get("KIROCREW_ALLOWED_LOOPBACK_PORTS", "").split(","):
-        _p = _p.strip()
-        if _p.isdigit():
-            origins.add(f"http://127.0.0.1:{_p}")
-            origins.add(f"http://localhost:{_p}")
-            origins.add(f"http://[::1]:{_p}")
-            origins.add(f"http://kirocrew.localhost:{_p}")
-    return origins
-
-
-def build_allowed_hosts(allowed_origins: set[str]) -> set[str]:
-    """Derive the ``Host``-header allowlist from the CSRF origin allowlist.
-
-    DNS-rebinding defense-in-depth: the ``Host`` header must name a
-    host we actually serve. We reuse the SAME source of truth as the CSRF Origin
-    check (``allowed_origins``) so the two layers can never drift — every origin
-    the dashboard trusts contributes its hostname. The comparison is
-    port-independent (hostname only), so an SSH-tunnel local port such as
-    ``localhost:8777`` still matches ``localhost``. The canonical loopback names
-    are always included as a floor so local tooling / doctor / mcp-core are never
-    rejected.
-    """
-    hosts: set[str] = {"localhost", "127.0.0.1", "::1", "kirocrew.localhost"}
-    for origin in allowed_origins:
-        try:
-            parsed_host = urlparse(origin).hostname
-        except ValueError:
-            parsed_host = None
-        if parsed_host:
-            hosts.add(parsed_host.lower())
-    return hosts
 
 
 # ---------------------------------------------------------------------------

--- a/src/kiro_crew/dashboard/urls.py
+++ b/src/kiro_crew/dashboard/urls.py
@@ -1,0 +1,453 @@
+"""Dashboard URL / host / origin-set helpers — stdlib-only leaf module.
+
+Split out of :mod:`kiro_crew.dashboard.origin` so callers that only need URL
+and host arithmetic can import them WITHOUT pulling ``aiohttp``. The helpers
+here take plain strings and ints; everything that inspects a live
+``web.Request`` (CSRF, Host barrier, direct-local and HTTPS detection) stays in
+``origin``, which re-exports every name below so existing import paths keep
+working.
+
+Why it matters: ``kirocrew`` CLI invocations and every MCP stdio subprocess
+import ``parse_dashboard_url`` on the way to resolving the dashboard port.
+Reaching it through ``origin`` cost ~605ms and 1124 modules — the ``aiohttp``
+stack plus (before ``dashboard/__init__`` went lazy) the entire handler tree —
+for two lines of URL parsing. Keep this module stdlib-only.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from urllib.parse import parse_qs, quote, urlparse
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PORT = 5476
+
+_BIND_LOCAL = "127.0.0.1"
+_BIND_ALL = "0.0.0.0"
+
+# Loopback hostnames that all resolve to the same machine but are *distinct
+# browser origins* (origin = scheme://host:port). The dashboard SPA stores user
+# settings (theme, zoom, layout, ...) in per-origin localStorage, so a user who
+# reaches the dashboard on more than one of these names gets a separate, empty
+# settings bucket each time — settings appear to "reset". We canonicalize
+# navigations among this set onto a single host (see should_canonicalize_host).
+_CANONICALIZABLE_LOOPBACK_HOSTS = frozenset(
+    {"127.0.0.1", "::1", "localhost", "kirocrew.localhost"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Hostname / IP helpers
+# ---------------------------------------------------------------------------
+
+
+def machine_hostname() -> str | None:
+    """Return the machine hostname, or ``None`` on failure."""
+    try:
+        return socket.gethostname()
+    except Exception:
+        return None
+
+
+def is_loopback(host: str) -> bool:
+    """Return ``True`` if *host* is a loopback address (127.0.0.1, ::1, etc.)."""
+    if host in ("localhost", "127.0.0.1", "::1", "kirocrew.localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Dashboard URL parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_dashboard_url(url: str) -> tuple[str, int]:
+    """Parse ``dashboard.url`` into ``(hostname, port)``.
+
+    Returns ``("", _DEFAULT_PORT)`` when *url* is empty.
+    ``KIROCREW_PORT`` env var always overrides the port (dev mode).
+    """
+    if not url:
+        host, port = "", _DEFAULT_PORT
+    else:
+        url = _ensure_scheme(url)
+        # urlparse raises ValueError on a malformed IPv6 literal
+        # ("http://[::1"), and .port raises ValueError on a non-integer port
+        # ("http://host:notaport"). dashboard.url is a user-editable config
+        # field parsed unguarded during gateway startup (SlackGateway.
+        # _init_dashboard, cli_server, cli_doctor, mcp_core), so one typo aborted
+        # the whole boot. Degrade to defaults instead — mirrors dashboard_origin().
+        try:
+            parsed = urlparse(url)
+            host = parsed.hostname or ""
+            port = parsed.port or _DEFAULT_PORT
+        except ValueError:
+            logger.warning("Ignoring malformed dashboard_url: %s", url)
+            host, port = "", _DEFAULT_PORT
+    env_port = os.environ.get("KIROCREW_PORT")
+    if env_port:
+        try:
+            port = int(env_port)
+        except ValueError:
+            logger.warning(
+                "KIROCREW_PORT=%r is not a valid integer; using port %d from config",
+                env_port,
+                port,
+            )
+    return host, port
+
+
+def _ensure_scheme(url: str) -> str:
+    """Prepend ``http://`` if *url* has no scheme."""
+    return url if "://" in url else f"http://{url}"
+
+
+def dashboard_origin(url: str) -> str:
+    """Return the browser-facing origin for *url*, or ``""`` if invalid.
+
+    Reuses the same scheme-defaulting logic as :func:`parse_dashboard_url`
+    so that bare hostnames (``myhost:8080``) are normalised to ``http://``.
+    Default ports (80 for http, 443 for https) are stripped to match
+    browser ``Origin`` header behaviour.
+    """
+    if not url:
+        return ""
+    url = _ensure_scheme(url)
+    try:
+        parsed = urlparse(url)
+        scheme = parsed.scheme
+        host = parsed.hostname or ""
+        port = parsed.port
+    except ValueError:
+        logger.warning("Ignoring malformed dashboard_url: %s", url)
+        return ""
+    if not host:
+        return ""
+    if scheme not in ("http", "https"):
+        logger.warning("Ignoring non-HTTP dashboard_url scheme: %s", scheme)
+        return ""
+    # urlparse strips [] from IPv6 — re-wrap to match browser Origin header
+    if ":" in host:
+        host = f"[{host}]"
+    default_port = {"http": 80, "https": 443}.get(scheme)
+    if port == default_port:
+        port = None
+    return f"{scheme}://{host}:{port}" if port else f"{scheme}://{host}"
+
+
+# ---------------------------------------------------------------------------
+# Remote-proxy detection (OSS: no managed proxy)
+# ---------------------------------------------------------------------------
+
+
+def devspaces_proxy_url(port: int) -> str | None:
+    """Return the managed-proxy base URL, or ``None`` (always ``None`` in OSS).
+
+    Symbol preserved for callers (``is_local_only``, ``format_dashboard_urls``,
+    ``build_allowed_origins``); there is no managed reverse-proxy in the public
+    build, so this always returns ``None``.  Users behind their own proxy add
+    its origin via ``dashboard.url`` or ``KIROCREW_CORS_ORIGINS``.
+    """
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Local-only mode resolution
+# ---------------------------------------------------------------------------
+
+
+def is_local_only(dashboard_host: str, slack_connected: bool) -> bool:
+    """Determine whether the dashboard should bind to loopback only.
+
+    Always returns ``True`` (bind ``127.0.0.1``) in the public build.
+    To expose the dashboard beyond loopback, run your own reverse proxy
+    (e.g. Caddy/nginx with TLS) and add its origin via ``dashboard.url``
+    or ``KIROCREW_CORS_ORIGINS``.
+    """
+    # A managed proxy could require a 0.0.0.0 binding; there is none in OSS
+    # (devspaces_proxy_url always returns None), so we always bind loopback.
+    # Safety: slack_connected=True guarantees start_dashboard() mounts
+    # token_auth_middleware before any non-loopback binding is used.
+    if devspaces_proxy_url(0) is not None and slack_connected:
+        logger.info("Managed proxy detected: binding 0.0.0.0 (token auth via Slack)")
+        return False
+    return True
+
+
+#: Explicit bind-address override for container/orchestrated deployments.
+#: See :func:`bind_address_for`.
+_ENV_BIND = "KIROCREW_BIND"
+
+
+def bind_address_for(local_only: bool) -> str:
+    """Return the TCP bind address string for aiohttp.
+
+    ``KIROCREW_BIND`` (env) overrides the bind ADDRESS only — nothing else.
+    It exists for containers: inside Docker, published ports (``-p``) map to
+    the container's bridge interface, so a loopback-bound gateway is
+    unreachable from the host even though the operator explicitly asked for
+    the port to be exposed. The official image sets ``KIROCREW_BIND=0.0.0.0``;
+    binding all interfaces *inside the container's network namespace* exposes
+    nothing on the host beyond what ``-p`` explicitly publishes.
+
+    Deliberately narrow:
+
+    * ``local_only`` semantics are UNCHANGED — dashboard URLs, the CSRF
+      origin allowlist, host canonicalization, and the strict internal-path
+      rules keep their loopback behavior (correct for the common
+      ``-p 5476:5476`` + ``http://localhost:5476`` mapping). Only the TCP
+      bind widens.
+    * Safe by construction: ``token_auth_middleware`` is mounted
+      unconditionally in BOTH server paths (``start_dashboard`` and
+      ``start_api_server``, which both resolve their bind through this
+      function), so a wider bind never exposes an unauthenticated surface
+      beyond the three ``PROBE_PATHS`` liveness probes (token-exempt by
+      design, secret-free payloads). CSRF ``check_origin`` and the
+      DNS-rebinding ``check_host`` barrier apply to every request except
+      those same probe paths (orchestrators address pods by IP — see
+      ``PROBE_PATHS``), and the ``is_direct_local_request`` gates (secret
+      reveal, channel config writes) treat bridge peers as remote —
+      fail-closed.
+    * The value must parse as an IP address (``0.0.0.0``, ``::``, or a
+      specific interface address). Anything else is ignored with a warning
+      and the normal local-only resolution applies — a typo can only ever
+      *narrow* exposure back to loopback, never widen it.
+    """
+    override = os.environ.get(_ENV_BIND, "").strip()
+    if override:
+        try:
+            ipaddress.ip_address(override)
+        except ValueError:
+            logger.warning(
+                "Ignoring %s=%r: not a valid IP address; binding loopback",
+                _ENV_BIND,
+                override,
+            )
+        else:
+            logger.info(
+                "%s=%s: binding this address instead of loopback. Every client "
+                "must still present a valid dashboard token (token auth is "
+                "always mounted); config writes remain restricted to direct "
+                "local sessions.",
+                _ENV_BIND,
+                override,
+            )
+            return override
+    return _BIND_LOCAL if local_only else _BIND_ALL
+
+
+# ---------------------------------------------------------------------------
+# Dashboard host / URL helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_dashboard_host(local_only: bool, configured_host: str = "") -> str:
+    """Return the hostname users should use to reach the dashboard."""
+    if configured_host:
+        return configured_host
+    if local_only:
+        # Canonical loopback host is plain ``localhost``. It resolves in every
+        # browser and through SSH port-forwards, so a dev who tunnels into a
+        # Linux devdesk and opens the dashboard in Safari can always reach it.
+        # ``kirocrew.localhost`` (and other ``*.localhost`` names) are NOT
+        # resolved by Safari / the macOS system resolver — RFC 6761's loopback
+        # rule is a SHOULD that only Chrome/Firefox and the Linux stub resolver
+        # honor — so canonicalizing onto ``kirocrew.localhost`` would 302 those
+        # users to a host their browser can't resolve. ``*.localhost`` stays
+        # trusted in build_allowed_origins() for the multi-instance embedded-pane
+        # iframes; it is just not the single host the emitters + 302 converge on.
+        return "localhost"
+    return machine_hostname() or "localhost"
+
+
+def _host_without_port(host_header: str) -> str:
+    """Return the host from a ``Host`` header value, IPv6-bracket aware.
+
+    Mirrors the rest of this file's IPv6 handling (``is_loopback``,
+    ``dashboard_origin``, ``build_allowed_origins`` all treat ``::1`` as
+    first-class). A naive ``split(":")[0]`` would yield ``"["`` for an
+    ``[::1]:7777`` Host and silently defeat the loopback match.
+
+        ``[::1]:7777`` -> ``::1``   ``localhost:7777`` -> ``localhost``
+        ``[::1]``      -> ``::1``   ``127.0.0.1``      -> ``127.0.0.1``
+    """
+    h = (host_header or "").strip()
+    if h.startswith("["):
+        end = h.find("]")
+        return h[1:end] if end != -1 else h[1:]
+    return h.split(":")[0]
+
+
+def should_canonicalize_host(
+    request_host: str,
+    canonical_host: str,
+    *,
+    method: str,
+    sec_fetch_dest: str | None,
+) -> bool:
+    """Return True if a request should be 302-redirected to *canonical_host*.
+
+    Converges loopback aliases (127.0.0.1 / localhost / kirocrew.localhost) onto
+    a single origin so the SPA's per-origin localStorage settings are not split
+    across hostnames (see _CANONICALIZABLE_LOOPBACK_HOSTS). Conservative on every
+    axis so it can never touch a request that isn't a same-machine top-level
+    page navigation:
+
+    * only GET/HEAD (never a mutating request),
+    * only true top-level document navigations (``Sec-Fetch-Dest: document`` —
+      absent/empty/websocket/XHR are left alone, so APIs and WebSockets and
+      sub-resource fetches are never redirected),
+    * only when both the request host and the canonical host are in the
+      canonicalizable loopback set (real hostnames / reverse-proxy vhosts are
+      never redirected),
+    * only when they actually differ.
+
+    The caller passes the port-stripped comparison via *request_host*'s host part;
+    this helper strips any ``:port`` itself for safety.
+    """
+    if method not in ("GET", "HEAD"):
+        return False
+    if sec_fetch_dest != "document":
+        return False
+    host = _host_without_port(request_host or "")
+    if host not in _CANONICALIZABLE_LOOPBACK_HOSTS:
+        return False
+    if canonical_host not in _CANONICALIZABLE_LOOPBACK_HOSTS:
+        return False
+    return host != canonical_host
+
+
+def build_dashboard_url(base_url: str, token: str = "", *, local_only: bool = True) -> str:
+    """Build the authenticated dashboard URL."""
+    if local_only is not True and not token:
+        raise ValueError("token is required when dashboard is not local-only")
+    return f"{base_url}?token={quote(token, safe='')}" if token else base_url
+
+
+def format_dashboard_urls(
+    authed_url: str,
+    *,
+    port: int,
+    local_only: bool = True,
+    has_custom_host: bool = False,
+) -> list[str]:
+    """Return startup log lines describing how to reach the dashboard."""
+    parsed_query = urlparse(authed_url).query
+    _qs = f"?{parsed_query}" if parsed_query else ""
+    if local_only is not True and "token" not in parse_qs(parsed_query):
+        raise ValueError("token is required when dashboard is not local-only")
+    _is_remote = bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_CLIENT"))
+
+    if _is_remote:
+        mh = machine_hostname() or "localhost"
+        lines: list[str] = [
+            f"👻 Dashboard: ssh -NL {port}:localhost:{port} {mh}",
+            f"             then open http://localhost:{port}{_qs}",
+        ]
+    else:
+        lines = ["👻 Dashboard:", f"   {authed_url}"]
+
+    if local_only and not has_custom_host and not _is_remote:
+        mh_local = machine_hostname()
+        if mh_local and mh_local != "localhost":
+            try:
+                ip = socket.gethostbyname(mh_local)
+                if ip and ip != "127.0.0.1":
+                    lines.append(f"👻 Remote:    ssh -NL {port}:localhost:{port} {mh_local}")
+            except Exception:
+                pass
+
+    proxy = devspaces_proxy_url(port)
+    if proxy and not local_only:
+        lines.append(f"👻 Proxy:     {proxy}{_qs}")
+
+    if _is_remote:
+        lines.append("👻 Run 24/7:  see docs/remote-desktop-setup.md for systemd service setup")
+
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Allowed-origin set
+# ---------------------------------------------------------------------------
+
+
+def build_allowed_origins(
+    port: int, local_only: bool, configured_host: str = "", dashboard_url: str = ""
+) -> set[str]:
+    """Compute the set of allowed origins for the dashboard.
+
+    When *dashboard_url* is provided, its origin (scheme + host + port)
+    is added as-is so that reverse-proxy setups (e.g. Caddy with TLS on
+    a custom domain) pass the CSRF check without code changes.
+    """
+    origins: set[str] = {
+        f"http://127.0.0.1:{port}",
+        f"http://localhost:{port}",
+        f"http://kirocrew.localhost:{port}",
+    }
+    if os.environ.get("KIROCREW_HOME"):
+        origins.add("http://localhost:3000")
+        origins.add("http://127.0.0.1:3000")
+    if configured_host:
+        origins.add(f"http://{configured_host}:{port}")
+    if dashboard_url:
+        origin = dashboard_origin(dashboard_url)
+        if origin:
+            origins.add(origin)
+    if not local_only:
+        mh = machine_hostname()
+        if mh:
+            origins.add(f"http://{mh}:{port}")
+    # Managed-proxy origin (None in OSS; see devspaces_proxy_url)
+    proxy = devspaces_proxy_url(port)
+    if proxy:
+        origins.add(proxy)
+    # Manual CORS override for future environments
+    for _co in os.environ.get("KIROCREW_CORS_ORIGINS", "").split(","):
+        if _co.strip():
+            origins.add(_co.strip())
+    # Extra loopback ports the operator explicitly trusts — typically the
+    # local end of an SSH tunnel (``-L 8777:localhost:7777`` makes the browser
+    # send Origin ``http://localhost:8777``). This replaces the previous
+    # blanket "trust any loopback port" behaviour (CSE SEC-016): only the bound
+    # port and these opted-in ports are accepted, so a malicious local web page
+    # on an arbitrary port can no longer pass the CSRF origin check.
+    for _p in os.environ.get("KIROCREW_ALLOWED_LOOPBACK_PORTS", "").split(","):
+        _p = _p.strip()
+        if _p.isdigit():
+            origins.add(f"http://127.0.0.1:{_p}")
+            origins.add(f"http://localhost:{_p}")
+            origins.add(f"http://[::1]:{_p}")
+            origins.add(f"http://kirocrew.localhost:{_p}")
+    return origins
+
+
+def build_allowed_hosts(allowed_origins: set[str]) -> set[str]:
+    """Derive the ``Host``-header allowlist from the CSRF origin allowlist.
+
+    DNS-rebinding defense-in-depth: the ``Host`` header must name a
+    host we actually serve. We reuse the SAME source of truth as the CSRF Origin
+    check (``allowed_origins``) so the two layers can never drift — every origin
+    the dashboard trusts contributes its hostname. The comparison is
+    port-independent (hostname only), so an SSH-tunnel local port such as
+    ``localhost:8777`` still matches ``localhost``. The canonical loopback names
+    are always included as a floor so local tooling / doctor / mcp-core are never
+    rejected.
+    """
+    hosts: set[str] = {"localhost", "127.0.0.1", "::1", "kirocrew.localhost"}
+    for origin in allowed_origins:
+        try:
+            parsed_host = urlparse(origin).hostname
+        except ValueError:
+            parsed_host = None
+        if parsed_host:
+            hosts.add(parsed_host.lower())
+    return hosts

--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -28,6 +28,13 @@ HARD_SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv",
                   "dist", "build", "out", "target"}
 DEFAULT_MAX_FILES = 5000
 
+# How many discovered files a scan processes between ``scan_paused`` re-reads.
+# The check used to run per file, i.e. one on-loop sqlite SELECT against
+# ``sources`` for every discovered file (up to ``max_files``). Re-reading on this
+# interval keeps a mid-scan pause responsive while bounding the query count at
+# ceil(files / _PAUSE_RECHECK_FILES) + 1.
+_PAUSE_RECHECK_FILES = 100
+
 # Extra skip dirs per source type
 SOURCE_TYPE_SKIP_DIRS: dict[str, set[str]] = {
     "obsidian_vault": {".obsidian", ".trash"},
@@ -118,9 +125,24 @@ class FolderWatcher:
 
         # 5. Process discovered files
         namespace = props.get("namespace", "default")
-        for file_path, mtime in discovered:
-            # Check pause between files
-            if self._is_paused(source_id):
+        # Pause is a user-driven cancel, so it must still land mid-scan — but
+        # re-reading ``sources.properties`` once per file cost one on-loop sqlite
+        # SELECT per discovered file (up to max_files, 10,000 by default). Check
+        # once up front, then only every _PAUSE_RECHECK_FILES files: a pause
+        # still takes effect within a bounded number of files instead of costing
+        # a query per file.
+        paused = self._is_paused(source_id)
+        # ``last_seen`` touches for unchanged files are accumulated and flushed
+        # as a single executemany instead of one UPDATE per file. They carry no
+        # per-row logic and were already committed in the batch commit below, so
+        # deferring them to the flush changes nothing an in-scan reader can see.
+        last_seen_batch: list[tuple[str, str, str]] = []
+        for idx, (file_path, mtime) in enumerate(discovered):
+            if idx and idx % _PAUSE_RECHECK_FILES == 0:
+                paused = self._is_paused(source_id)
+            if paused:
+                self._flush_last_seen(last_seen_batch)
+                self.store.db.commit()
                 return {**stats, "status": "paused"}
 
             state = existing.get(file_path)
@@ -133,7 +155,7 @@ class FolderWatcher:
 
             if state and state.get("status") == "done" and mtime <= state.get("mtime", 0):
                 # Unchanged — just update last_seen
-                self._update_last_seen(source_id, file_path, now)
+                last_seen_batch.append((now, source_id, file_path))
                 continue
 
             # mtime changed or new/interrupted file — check content hash
@@ -167,6 +189,7 @@ class FolderWatcher:
                 self._update_state(source_id, file_path, content_hash, mtime, json.dumps(item_ids), now, "done", commit=False)
                 ingested_paths.append(file_path)
 
+        self._flush_last_seen(last_seen_batch)
         self.store.db.commit()  # Batch commit for all non-crash-recovery updates
         # Targeted cross-source dedup for each newly ingested/changed file, so a folder
         # copy collapses any matching one-shot upload. O(k*n) over the k changed files
@@ -236,6 +259,20 @@ class FolderWatcher:
         self.store.db.execute(
             "UPDATE folder_file_state SET last_seen = ? WHERE source_id = ? AND file_path = ?",
             (now, source_id, file_path))
+
+    def _flush_last_seen(self, batch: list[tuple[str, str, str]]):
+        """Apply accumulated ``(now, source_id, file_path)`` last_seen touches.
+
+        One executemany instead of one execute per unchanged file. Clears
+        *batch* so a caller can flush more than once in a scan (the pause
+        early-return does).
+        """
+        if not batch:
+            return
+        self.store.db.executemany(
+            "UPDATE folder_file_state SET last_seen = ? WHERE source_id = ? AND file_path = ?",
+            batch)
+        batch.clear()
 
     def _is_paused(self, source_id: str) -> bool:
         """Check if source has scan_paused flag set."""

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -25,48 +25,109 @@ import`` note there.
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 import os
 import threading
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.paths import config_dir
 from kiro_crew.metrics.recorder import MetricsRecorder
 
+if TYPE_CHECKING:  # real types for annotations; never imported at runtime
+    from opentelemetry.sdk.metrics import MeterProvider as _MeterProviderT
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader as _ReaderT
+
 # KiroCrew declares opentelemetry-sdk as a required dependency, so
-# this guard is defense-in-depth — not for a genuinely optional dep, but for a
-# partial / --no-deps / broken env-closure install where the SDK is absent. This
-# module is on the eager boot chain (cli.py -> dashboard -> ... -> history.py ->
-# skills.py -> get_recorder), so an unconditional top-level import here would
-# brick the ENTIRE gateway (and `kirocrew --version`) even though telemetry
-# defaults off. Degrade to the existing no-op MetricsRecorder(None) path instead
-# of crashing at import time.
+# the availability probe below is defense-in-depth — not for a genuinely
+# optional dep, but for a partial / --no-deps / broken env-closure install where
+# the SDK is absent. This module is on the eager boot chain (cli.py -> dashboard
+# -> ... -> history.py -> skills.py -> get_recorder), so an unconditional
+# top-level import here would brick the ENTIRE gateway (and `kirocrew
+# --version`) even though telemetry defaults off. Degrade to the existing no-op
+# MetricsRecorder(None) path instead of crashing at import time.
 #
-# local_exporter is imported INSIDE the guard: its JsonlMetricExporter
+# The SDK is NOT imported at module scope: executing
+# ``opentelemetry.sdk.metrics`` + ``.export`` + ``.view`` + ``.resources`` costs
+# ~57ms and ~120 extra modules on EVERY entry point (CLI invocations, MCP stdio
+# subprocesses, `kirocrew --version`) while telemetry is off by default and the
+# SDK is never used. ``importlib.util.find_spec`` answers the availability
+# question for ~0.9ms without executing the package, so the eager cost is paid
+# only by hosts that actually opt in. The real imports happen in ``_load_otel``,
+# called from ``_build_recorder`` after the consent gate.
+#
+# local_exporter is loaded in the same lazy step: its JsonlMetricExporter
 # subclasses the OTel SDK's MetricExporter base class, so the module itself
-# cannot load without opentelemetry. It is only used on the enabled path
-# (after the _OTEL_AVAILABLE check in _build_recorder), so guarding the
-# import preserves the degrade contract. recorder.py is annotation-only on
+# cannot load without opentelemetry. It is only used on the enabled path, so
+# deferring it preserves the degrade contract. recorder.py is annotation-only on
 # OTel symbols (TYPE_CHECKING import) and stays loadable either way.
-try:
-    from opentelemetry.sdk.metrics import MeterProvider
-    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-    from opentelemetry.sdk.metrics.view import (
-        ExplicitBucketHistogramAggregation,
-        View,
-    )
-    from opentelemetry.sdk.resources import Resource
 
-    from kiro_crew.metrics.local_exporter import JsonlMetricExporter
 
-    _OTEL_AVAILABLE = True
-except ImportError:
-    MeterProvider = PeriodicExportingMetricReader = None  # type: ignore[assignment,misc]
-    ExplicitBucketHistogramAggregation = View = Resource = None  # type: ignore[assignment,misc]
-    JsonlMetricExporter = None  # type: ignore[assignment,misc]
-    _OTEL_AVAILABLE = False
+def _otel_importable() -> bool:
+    """Whether the OTel metrics SDK can be imported, without importing it.
+
+    ``find_spec`` on a dotted name imports the PARENT packages
+    (``opentelemetry``, ``opentelemetry.sdk``) but not the metrics SDK itself,
+    which is where the cost and the module-count blow-up live. It raises
+    (rather than returning ``None``) when a parent is unimportable, so both
+    outcomes are folded into ``False`` here — same contract as the ImportError
+    guard this replaced.
+    """
+    try:
+        return importlib.util.find_spec("opentelemetry.sdk.metrics") is not None
+    except (ImportError, AttributeError, ValueError):
+        return False
+
+
+_OTEL_AVAILABLE = _otel_importable()
+
+# Resolved on first use by ``_load_otel``. Kept as module globals (rather than
+# locals in ``_build_recorder``) because tests substitute them by name —
+# ``_load_otel`` only fills the ones that are still None, so a monkeypatched
+# stand-in is never overwritten by the real class. Typed ``Any`` because they
+# are lazily bound; the TYPE_CHECKING aliases above carry the real types for
+# the annotations that need them.
+MeterProvider: Any = None
+PeriodicExportingMetricReader: Any = None
+ExplicitBucketHistogramAggregation: Any = None
+View: Any = None
+Resource: Any = None
+JsonlMetricExporter: Any = None
+
+
+def _load_otel() -> bool:
+    """Import the OTel metrics SDK into the module globals. True on success."""
+    global MeterProvider, PeriodicExportingMetricReader
+    global ExplicitBucketHistogramAggregation, View, Resource, JsonlMetricExporter
+    try:
+        from opentelemetry.sdk.metrics import MeterProvider as _MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader as _Reader
+        from opentelemetry.sdk.metrics.view import (
+            ExplicitBucketHistogramAggregation as _BucketAggregation,
+        )
+        from opentelemetry.sdk.metrics.view import View as _View
+        from opentelemetry.sdk.resources import Resource as _Resource
+
+        from kiro_crew.metrics.local_exporter import JsonlMetricExporter as _JsonlMetricExporter
+    except ImportError:
+        return False
+    # Fill only what is still unset, so a test's substitute survives.
+    if MeterProvider is None:
+        MeterProvider = _MeterProvider
+    if PeriodicExportingMetricReader is None:
+        PeriodicExportingMetricReader = _Reader
+    if ExplicitBucketHistogramAggregation is None:
+        ExplicitBucketHistogramAggregation = _BucketAggregation
+    if View is None:
+        View = _View
+    if Resource is None:
+        Resource = _Resource
+    if JsonlMetricExporter is None:
+        JsonlMetricExporter = _JsonlMetricExporter
+    return True
+
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +200,7 @@ _HISTOGRAM_BUCKETS_MS: dict[str, list[float]] = {
 _lock = threading.Lock()
 _recorder: Optional[MetricsRecorder] = None
 _initialized = False
-_provider: Optional["MeterProvider"] = None
+_provider: Optional["_MeterProviderT"] = None
 
 # Env-var opt-in (rec #14: easy opt-in). ``KIROCREW_TELEMETRY`` lets a host turn
 # LOCAL metrics on (or force them off) without editing ~/.kiro/crew/config.json —
@@ -185,6 +246,12 @@ def _build_recorder() -> MetricsRecorder:
     if not _consent_enabled(cfg):
         return MetricsRecorder(None)
 
+    # Consent granted — now pay for the SDK import (deferred from module scope
+    # so the default-off path never does).
+    if not _load_otel():
+        logger.warning("opentelemetry not importable; telemetry disabled")
+        return MetricsRecorder(None)
+
     # PeriodicExportingMetricReader starts its daemon ticker thread inside
     # __init__, so if any later step (MeterProvider construction, etc.) raises,
     # the reader is already ticking. Hoist it here so the except can reap it —
@@ -211,7 +278,7 @@ def _build_recorder() -> MetricsRecorder:
         otlp_reader = _build_otlp_reader(cfg)
         if otlp_reader is not None:
             readers.append(otlp_reader)
-        _provider = MeterProvider(
+        provider = MeterProvider(
             metric_readers=readers,
             resource=Resource.create({"service.name": _SERVICE_NAME}),
             # One View per instrument, from _HISTOGRAM_BUCKETS_MS. Deliberately
@@ -229,12 +296,13 @@ def _build_recorder() -> MetricsRecorder:
                 for name, bounds in _HISTOGRAM_BUCKETS_MS.items()
             ],
         )
+        _provider = provider
         logger.info(
             "telemetry enabled; local JSONL sink at %s (otlp=%s)",
             directory,
             "on" if len(readers) > 1 else "off",
         )
-        return MetricsRecorder(_provider.get_meter(_SCOPE))
+        return MetricsRecorder(provider.get_meter(_SCOPE))
     except Exception as exc:
         logger.warning("telemetry init failed; metrics disabled: %s", exc)
         # Reap the reader's already-started daemon thread if it outlived a
@@ -249,7 +317,7 @@ def _build_recorder() -> MetricsRecorder:
         return MetricsRecorder(None)
 
 
-def _build_otlp_reader(cfg: object) -> Optional["PeriodicExportingMetricReader"]:
+def _build_otlp_reader(cfg: object) -> Optional["_ReaderT"]:
     """Build the opt-in OTLP/HTTP metric reader, or None when not configured.
 
     Egress is OFF by default (rec #1): this returns None unless
@@ -263,6 +331,11 @@ def _build_otlp_reader(cfg: object) -> Optional["PeriodicExportingMetricReader"]
     """
     endpoint = str(getattr(cfg, "otlp_endpoint", "") or "").strip()
     if not endpoint:
+        return None
+    # Callable directly (not only via _build_recorder), so make sure the lazily
+    # imported SDK symbols this needs are bound.
+    if not _load_otel():
+        logger.warning("opentelemetry not importable; OTLP egress disabled")
         return None
     try:
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import (

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -866,6 +866,10 @@ class GatewayOrchestrator:
         self._wecom_client: "WeComClient | None" = None  # set by maybe_start_wecom
         self._model_download_task: "asyncio.Task[bool] | None" = None
         self._auto_migrate_task: "asyncio.Task[None] | None" = None
+        # Boot-time update check, started fire-and-forget after the signal
+        # handlers are installed (see start()). Cancelled on shutdown so a
+        # stalled git fetch cannot hold the process open.
+        self._update_check_task: "asyncio.Task[None] | None" = None
         self._mcp_gateway_manager: GatewayManager | None = None
 
     def _count_in_flight_work(self) -> int:
@@ -4975,6 +4979,10 @@ class GatewayOrchestrator:
         # Cancel background auto-migration if still in flight
         if self._auto_migrate_task is not None and not self._auto_migrate_task.done():
             self._auto_migrate_task.cancel()
+        # Cancel the boot update check if still in flight — its git subprocesses
+        # can take ~70s to time out and nothing downstream needs the result.
+        if self._update_check_task is not None and not self._update_check_task.done():
+            self._update_check_task.cancel()
 
         if cleanup_tasks:
             await asyncio.gather(*cleanup_tasks, return_exceptions=True)
@@ -5448,11 +5456,13 @@ class GatewayOrchestrator:
 
         await self._start_channel_transports()
 
-        # Check for updates before printing URLs
-        print("👻 Checking for updates…")
-        await self._check_for_updates()
-
         # ── Signal handlers ──
+        # Installed BEFORE the update check (below) is started. The check runs
+        # five sequential git subprocesses whose timeouts sum to ~70s, so while
+        # it was inline-awaited here a stalled network left the gateway with no
+        # SIGINT/SIGTERM handler for over a minute: Ctrl-C did nothing and the
+        # process looked wedged. Handlers first means the boot is interruptible
+        # from this point on regardless of what the check does.
         loop = asyncio.get_running_loop()
         _shutting_down = False
 
@@ -5487,6 +5497,20 @@ class GatewayOrchestrator:
                         signal.signal(sig, _sigint_fallback)
                     except (ValueError, OSError):
                         pass  # not in main thread
+
+        # Update check — fire-and-forget, NOT awaited. It runs five sequential
+        # git subprocesses (fetch/rev-parse/...) whose timeouts sum to ~70s, and
+        # nothing later in boot depends on its result: it only flips
+        # _update_info / pushes a dashboard refresh, or applies an auto-update
+        # that restarts the process. Awaiting it delayed the dashboard URL by up
+        # to ~70s on a stalled network. handlers_system.api_status treats the
+        # same check as fire-and-forget for the same reason. Registered in
+        # _background_tasks so the task is not GC'd mid-flight and is reaped on
+        # shutdown with the rest.
+        print("👻 Checking for updates…")
+        self._update_check_task = asyncio.create_task(self._check_for_updates())
+        self._background_tasks.add(self._update_check_task)
+        self._update_check_task.add_done_callback(self._background_tasks.discard)
 
         # Wait for MCP probe to finish before warming sessions —
         # kiro-cli reads MCP config at spawn time, so sessions must

--- a/test/test_dashboard_origin.py
+++ b/test/test_dashboard_origin.py
@@ -232,7 +232,13 @@ class TestParseDashboardUrlMalformed:
         assert port == 9090
 
 
-_MOD = "kiro_crew.dashboard.origin"
+# Patch target for TestFormatDashboardUrls below. format_dashboard_urls lives in
+# dashboard.urls (the stdlib-only leaf module the CLI imports); dashboard.origin
+# only re-exports it for back-compat. Collaborators are resolved in the defining
+# module's namespace, so patching "...origin.machine_hostname" is INERT here — it
+# rebinds origin's copy while format_dashboard_urls keeps calling urls'. Point at
+# the defining module so the patches actually take effect.
+_MOD = "kiro_crew.dashboard.urls"
 
 
 class TestBuildDashboardUrl:

--- a/test/test_perf_boot_path.py
+++ b/test/test_perf_boot_path.py
@@ -1,0 +1,588 @@
+"""Regression tests for the boot-path / import-cost remediation.
+
+Each test here pins one specific cost that was measured on the startup path and
+fails if the corresponding fix is reverted:
+
+* the gateway's boot update check must not be inline-awaited, and the SIGINT /
+  SIGTERM handlers must be installed before it starts;
+* the OpenTelemetry SDK must not be imported while telemetry is off;
+* ``config_dir()`` must be memoized, making its breadcrumb write and archive
+  sweep once-per-resolution instead of once-per-call;
+* importing ``dashboard.origin`` / ``dashboard.urls`` must not pull the dashboard
+  handler tree or aiohttp;
+* importing ``dashboard.handlers.memory`` must not pull ``vector_memory``;
+* a folder scan must not issue one ``sources`` query and one ``last_seen``
+  UPDATE per discovered file;
+* the changelog and channel-preset reads must be cached on a stat signature.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import kiro_crew
+from kiro_crew.config import paths
+from kiro_crew.dashboard import handlers_channel
+from kiro_crew.dashboard.handlers import updates
+from kiro_crew.slack.gateway import GatewayOrchestrator
+
+_SRC = str(Path(kiro_crew.__file__).resolve().parents[1])
+
+
+def _probe(snippet: str) -> dict:
+    """Run *snippet* in a clean interpreter, returning the JSON it prints.
+
+    Import-graph assertions need a fresh process: pytest has already imported
+    most of the package, so ``sys.modules`` in-process says nothing about what a
+    given import actually pulls.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _SRC + os.pathsep + env.get("PYTHONPATH", "")
+    # Coverage's subprocess hook would otherwise import extra modules and
+    # pollute the module-count assertions.
+    env.pop("COV_CORE_SOURCE", None)
+    env.pop("COVERAGE_PROCESS_START", None)
+    # parse_dashboard_url honours KIROCREW_PORT; keep the probe deterministic.
+    env.pop("KIROCREW_PORT", None)
+    proc = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    assert proc.returncode == 0, f"probe failed:\n{proc.stdout}\n{proc.stderr}"
+    # The data-home conflict warning goes to stderr; only stdout is parsed.
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+# ── Gateway boot: update check off the critical path ───────────────────────
+
+
+class TestGatewayUpdateCheckIsBackgrounded:
+    """``_check_for_updates`` runs five sequential git subprocesses whose
+    timeouts sum to ~70s. Inline-awaiting it during ``start()`` delayed the
+    dashboard URL by that long on a stalled network AND did so before the signal
+    handlers existed, so Ctrl-C did nothing and the gateway looked wedged."""
+
+    def test_update_check_is_not_awaited_inline(self) -> None:
+        src = inspect.getsource(GatewayOrchestrator.run)
+        assert "await self._check_for_updates()" not in src, (
+            "the boot update check must not be inline-awaited — it blocks the "
+            "boot for up to ~70s on a stalled network"
+        )
+        assert "asyncio.create_task(self._check_for_updates())" in src
+
+    def test_signal_handlers_installed_before_update_check(self) -> None:
+        src = inspect.getsource(GatewayOrchestrator.run)
+        handlers_at = src.index("loop.add_signal_handler(sig, _on_signal)")
+        check_at = src.index("asyncio.create_task(self._check_for_updates())")
+        assert handlers_at < check_at, (
+            "SIGINT/SIGTERM handlers must be installed before the update check "
+            "starts, or an early Ctrl-C is ignored"
+        )
+
+    def test_update_check_task_is_tracked_and_cancelled(self) -> None:
+        run_src = inspect.getsource(GatewayOrchestrator.run)
+        assert "self._background_tasks.add(self._update_check_task)" in run_src, (
+            "the fire-and-forget task must be strongly referenced or it can be "
+            "garbage-collected mid-flight"
+        )
+        shutdown_src = inspect.getsource(GatewayOrchestrator._shutdown)
+        assert "self._update_check_task.cancel()" in shutdown_src
+
+
+# ── Telemetry: no OTel SDK import while telemetry is off ───────────────────
+
+
+class TestOtelSdkImportIsDeferred:
+    """The OTel metrics SDK costs ~57ms and ~120 modules to import. The metrics
+    provider sits on the eager boot chain (cli -> ... -> skills -> get_recorder)
+    while telemetry is default-off, so the SDK must not load until a host opts
+    in."""
+
+    def test_provider_import_does_not_load_otel_sdk(self) -> None:
+        result = _probe(
+            "import json, sys\n"
+            "import kiro_crew.metrics.provider as p\n"
+            "print(json.dumps({\n"
+            "    'sdk': 'opentelemetry.sdk.metrics' in sys.modules,\n"
+            "    'available': p._OTEL_AVAILABLE,\n"
+            "}))\n"
+        )
+        assert result["sdk"] is False, (
+            "importing metrics.provider must not import the OTel metrics SDK"
+        )
+        # The availability probe must still work — it is what keeps a partial
+        # install degrading to the no-op recorder instead of crashing.
+        assert result["available"] is True
+
+    def test_disabled_recorder_does_not_load_otel_sdk(self) -> None:
+        result = _probe(
+            "import json, sys\n"
+            "import kiro_crew.metrics.provider as p\n"
+            "rec = p.get_recorder()\n"
+            "print(json.dumps({\n"
+            "    'sdk': 'opentelemetry.sdk.metrics' in sys.modules,\n"
+            "    'enabled': rec.enabled,\n"
+            "}))\n"
+        )
+        assert result["enabled"] is False  # default-off consent gate
+        assert result["sdk"] is False, (
+            "a disabled recorder must not pay for the OTel SDK import"
+        )
+
+    def test_enabled_recorder_still_loads_the_sdk(self, tmp_path: Path) -> None:
+        """The deferral must not break the opt-in path."""
+        result = _probe(
+            "import json, sys\n"
+            "import kiro_crew.metrics.provider as p\n"
+            f"import os; os.environ['KIROCREW_HOME'] = {str(tmp_path)!r}\n"
+            "os.environ['KIROCREW_TELEMETRY'] = '1'\n"
+            "rec = p.get_recorder()\n"
+            "print(json.dumps({\n"
+            "    'sdk': 'opentelemetry.sdk.metrics' in sys.modules,\n"
+            "    'enabled': rec.enabled,\n"
+            "}))\n"
+        )
+        assert result["enabled"] is True
+        assert result["sdk"] is True
+
+
+# ── config_dir(): memoized resolution ─────────────────────────────────────
+
+
+class TestConfigDirMemo:
+    """``config_dir()`` is called from 323 sites and measured 94.9us per call —
+    a ``Path.resolve()`` + ``mkdir`` and, on the default path, a breadcrumb
+    read/write plus the leftover-archive sweep, every time."""
+
+    def test_repeat_calls_do_not_redo_breadcrumb_or_sweep(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr(paths, "_resolved_home", None)
+        monkeypatch.setattr(paths, "_config_dir_memo", None, raising=False)
+
+        calls = {"breadcrumb": 0, "sweep": 0}
+        real_breadcrumb = paths._write_recovery_breadcrumb
+        real_sweep = paths._sweep_ungated_archive_leftovers
+
+        def _breadcrumb(d: Path) -> None:
+            calls["breadcrumb"] += 1
+            real_breadcrumb(d)
+
+        def _sweep() -> None:
+            calls["sweep"] += 1
+            real_sweep()
+
+        monkeypatch.setattr(paths, "_write_recovery_breadcrumb", _breadcrumb)
+        monkeypatch.setattr(paths, "_sweep_ungated_archive_leftovers", _sweep)
+
+        first = paths.config_dir()
+        for _ in range(50):
+            assert paths.config_dir() == first
+
+        assert calls["breadcrumb"] == 1, "breadcrumb write must be once per resolution"
+        assert calls["sweep"] == 1, "archive sweep must be once per resolution"
+
+    def test_override_change_is_honoured(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The memo must not pin a stale home when KIROCREW_HOME is repointed —
+        pods, worktrees and the test suite all repoint it at runtime."""
+        monkeypatch.setattr(paths, "_config_dir_memo", None, raising=False)
+        a, b = tmp_path / "a", tmp_path / "b"
+        monkeypatch.setenv("KIROCREW_HOME", str(a))
+        assert paths.config_dir() == a.resolve()
+        assert paths.config_dir() == a.resolve()  # memo hit
+        monkeypatch.setenv("KIROCREW_HOME", str(b))
+        assert paths.config_dir() == b.resolve()
+
+    def test_clearing_resolved_home_invalidates_the_memo(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The suite's isolation fixture resets ``_resolved_home`` per test; the
+        memo is keyed on it so a default-path result cannot outlive that reset."""
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "h1"))
+        monkeypatch.setattr(paths, "_resolved_home", None)
+        monkeypatch.setattr(paths, "_config_dir_memo", None, raising=False)
+        first = paths.config_dir()
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "h2"))
+        monkeypatch.setattr(paths, "_resolved_home", None)
+        second = paths.config_dir()
+
+        assert second != first
+        assert second == (tmp_path / "h2" / ".kiro" / "crew")
+
+
+# ── dashboard package: lazy exports + stdlib-only URL leaf ────────────────
+
+
+class TestDashboardImportIsLeaf:
+    """``dashboard/__init__`` eagerly imported ``server``, so reaching
+    ``parse_dashboard_url`` through ``dashboard.origin`` pulled the whole handler
+    tree (measured 605ms / 1124 modules) into every CLI invocation and every MCP
+    stdio subprocess."""
+
+    def test_importing_urls_pulls_no_handler_tree_and_no_aiohttp(self) -> None:
+        result = _probe(
+            "import json, sys\n"
+            "from kiro_crew.dashboard.urls import parse_dashboard_url\n"
+            "print(json.dumps({\n"
+            "    'server': 'kiro_crew.dashboard.server' in sys.modules,\n"
+            "    'handlers': 'kiro_crew.dashboard.handlers' in sys.modules,\n"
+            "    'aiohttp': 'aiohttp' in sys.modules,\n"
+            "    'parsed': list(parse_dashboard_url('http://h:9999')),\n"
+            "}))\n"
+        )
+        assert result["server"] is False
+        assert result["handlers"] is False
+        assert result["aiohttp"] is False, "the URL leaf must stay stdlib-only"
+        assert result["parsed"] == ["h", 9999]
+
+    def test_importing_origin_pulls_no_handler_tree(self) -> None:
+        result = _probe(
+            "import json, sys\n"
+            "import kiro_crew.dashboard.origin as o\n"
+            "print(json.dumps({\n"
+            "    'server': 'kiro_crew.dashboard.server' in sys.modules,\n"
+            "    'handlers': 'kiro_crew.dashboard.handlers' in sys.modules,\n"
+            "    'aiohttp': 'aiohttp' in sys.modules,\n"
+            "    'modules': len(sys.modules),\n"
+            "    'reexports_ok': all(hasattr(o, n) for n in (\n"
+            "        'parse_dashboard_url', 'dashboard_origin', 'build_allowed_origins',\n"
+            "        'build_allowed_hosts', 'bind_address_for', 'is_loopback',\n"
+            "        'machine_hostname', 'resolve_dashboard_host', 'is_local_only',\n"
+            "        'build_dashboard_url', 'format_dashboard_urls',\n"
+            "        'should_canonicalize_host', 'devspaces_proxy_url', 'socket',\n"
+            "    )),\n"
+            "}))\n"
+        )
+        assert result["server"] is False, (
+            "dashboard/__init__ must not eagerly import server"
+        )
+        assert result["handlers"] is False
+        assert result["aiohttp"] is False, (
+            "origin's aiohttp import must stay under TYPE_CHECKING — the CSRF "
+            "helpers only need it for annotations, and CLI / MCP-stdio callers "
+            "import this module for URL parsing alone"
+        )
+        assert result["modules"] < 400, (
+            f"dashboard.origin pulled {result['modules']} modules; it was 1124 "
+            "before the split and must stay a leaf"
+        )
+        assert result["reexports_ok"] is True, (
+            "origin must keep re-exporting every name it used to define"
+        )
+
+    def test_lazy_package_attributes_still_resolve(self) -> None:
+        result = _probe(
+            "import json\n"
+            "from kiro_crew.dashboard import (start_dashboard, start_api_server,\n"
+            "    DashboardState, _ChatSlot, _fmt_duration)\n"
+            "import kiro_crew.dashboard as d\n"
+            "print(json.dumps({\n"
+            "    'callables': all(callable(x) for x in (start_dashboard,\n"
+            "        start_api_server, DashboardState, _ChatSlot, _fmt_duration)),\n"
+            "    'raises': not hasattr(d, 'definitely_not_a_real_attribute'),\n"
+            "}))\n"
+        )
+        assert result["callables"] is True
+        assert result["raises"] is True
+
+    def test_memory_handler_does_not_import_vector_memory(self) -> None:
+        """``handlers/memory`` needed ``vector_memory`` (snowballstemmer plus the
+        optional numpy/faiss imports, ~175ms) for one enum on one error branch."""
+        result = _probe(
+            "import json, sys\n"
+            "import kiro_crew.dashboard.handlers.memory  # noqa: F401\n"
+            "print(json.dumps({\n"
+            "    'vector_memory': 'kiro_crew.vector_memory' in sys.modules,\n"
+            "    'snowballstemmer': 'snowballstemmer' in sys.modules,\n"
+            "}))\n"
+        )
+        assert result["vector_memory"] is False
+        assert result["snowballstemmer"] is False
+
+
+# ── folder_watcher: bounded pause checks + batched last_seen ───────────────
+
+
+class _CountingDb:
+    """sqlite connection wrapper that counts statements by SQL fragment."""
+
+    def __init__(self, db) -> None:
+        self._db = db
+        self.select_sources = 0
+        self.last_seen_execute = 0
+        self.last_seen_executemany = 0
+
+    def execute(self, sql, *args, **kwargs):
+        if "FROM sources WHERE id" in sql:
+            self.select_sources += 1
+        if "SET last_seen" in sql:
+            self.last_seen_execute += 1
+        return self._db.execute(sql, *args, **kwargs)
+
+    def executemany(self, sql, seq, *args, **kwargs):
+        seq = list(seq)
+        if "SET last_seen" in sql:
+            self.last_seen_executemany += 1
+        return self._db.executemany(sql, seq, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+
+class TestFolderWatcherScanQueryCount:
+    """A scan re-read ``sources.properties`` and issued a ``last_seen`` UPDATE
+    once per discovered file — up to 10,000 on-loop sqlite ops per scan."""
+
+    @pytest.mark.asyncio
+    async def test_pause_check_and_last_seen_are_not_per_file(
+        self, tmp_path: Path
+    ) -> None:
+        from kiro_crew.knowledge.folder_watcher import (
+            _PAUSE_RECHECK_FILES,
+            FolderWatcher,
+        )
+        from kiro_crew.knowledge.store import KnowledgeStore
+
+        n_files = 40
+        assert n_files < _PAUSE_RECHECK_FILES  # so one up-front check suffices
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        for i in range(n_files):
+            (vault / f"note{i}.md").write_text(f"Note {i}", encoding="utf-8")
+
+        store = KnowledgeStore(tmp_path / "knowledge.db")
+        pipeline = MagicMock()
+        pipeline._dedup_enabled = False
+        fw = FolderWatcher(store, pipeline)
+        source_id = store.add_source("t", "local_folder", str(vault), properties={})
+        source = {
+            "id": source_id,
+            "uri": str(vault),
+            "source_type": "local_folder",
+            "properties": "{}",
+        }
+
+        # First pass records every file so the second pass takes the unchanged
+        # (last_seen-only) branch for all of them.
+        async def _ingest(file_path, source_id, namespace, props, old_ids):
+            return ["item-" + Path(file_path).name]
+
+        fw._ingest_file = _ingest  # type: ignore[assignment]
+        first = await fw.scan_source(source)
+        assert first["new"] == n_files
+
+        counting = _CountingDb(store.db)
+        # ``KnowledgeStore.db`` is a read-only property backed by a per-thread
+        # connection; the scan runs on this thread, so swap the thread-local.
+        store._thread_local.conn = counting
+        await fw.scan_source(source)
+
+        assert counting.select_sources <= 2, (
+            f"{counting.select_sources} sources queries for {n_files} files — "
+            "the pause check must not run per file"
+        )
+        assert counting.last_seen_execute == 0, (
+            "last_seen touches must be batched, not issued one per file"
+        )
+        assert counting.last_seen_executemany == 1
+
+    @pytest.mark.asyncio
+    async def test_last_seen_is_still_written(self, tmp_path: Path) -> None:
+        """The batching must not drop the touches it defers."""
+        from kiro_crew.knowledge.folder_watcher import FolderWatcher
+        from kiro_crew.knowledge.store import KnowledgeStore
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "note.md").write_text("Note", encoding="utf-8")
+
+        store = KnowledgeStore(tmp_path / "knowledge.db")
+        pipeline = MagicMock()
+        pipeline._dedup_enabled = False
+        fw = FolderWatcher(store, pipeline)
+
+        async def _ingest(file_path, source_id, namespace, props, old_ids):
+            return ["item-1"]
+
+        fw._ingest_file = _ingest  # type: ignore[assignment]
+        source_id = store.add_source("t", "local_folder", str(vault), properties={})
+        source = {
+            "id": source_id,
+            "uri": str(vault),
+            "source_type": "local_folder",
+            "properties": "{}",
+        }
+        await fw.scan_source(source)
+        store.db.execute(
+            "UPDATE folder_file_state SET last_seen = ? WHERE source_id = ?",
+            ("1999-01-01", source_id),
+        )
+        store.db.commit()
+
+        await fw.scan_source(source)  # unchanged file -> batched last_seen touch
+
+        row = store.db.execute(
+            "SELECT last_seen FROM folder_file_state WHERE source_id = ?",
+            (source_id,),
+        ).fetchone()
+        assert row["last_seen"] != "1999-01-01", "batched last_seen was never flushed"
+
+    @pytest.mark.asyncio
+    async def test_pause_still_stops_a_scan(self, tmp_path: Path) -> None:
+        """Bounding the re-check must not remove the pause path."""
+        from kiro_crew.knowledge.folder_watcher import FolderWatcher
+        from kiro_crew.knowledge.store import KnowledgeStore
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        for i in range(5):
+            (vault / f"note{i}.md").write_text(f"Note {i}", encoding="utf-8")
+
+        store = KnowledgeStore(tmp_path / "knowledge.db")
+        fw = FolderWatcher(store, MagicMock())
+        source_id = store.add_source(
+            "t", "local_folder", str(vault), properties={"scan_paused": True}
+        )
+        source = {
+            "id": source_id,
+            "uri": str(vault),
+            "source_type": "local_folder",
+            "properties": "{}",
+        }
+
+        stats = await fw.scan_source(source)
+
+        assert stats["status"] == "paused"
+        assert stats["new"] == 0
+
+
+# ── Cached file reads: changelog + channel presets ─────────────────────────
+
+
+class TestChangelogReadIsCached:
+    """``GET /api/changelog`` read and decoded the whole file on the event loop
+    on every request."""
+
+    @pytest.mark.asyncio
+    async def test_repeat_reads_hit_the_disk_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        changelog = proj / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n\n## [1.0.0]\n", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        monkeypatch.setattr(updates, "_changelog_cache", None, raising=False)
+
+        reads = {"n": 0}
+        real_read = Path.read_text
+
+        def _counting_read(self, *a, **k):
+            if self.name == "CHANGELOG.md":
+                reads["n"] += 1
+            return real_read(self, *a, **k)
+
+        monkeypatch.setattr(Path, "read_text", _counting_read)
+
+        first = await updates.api_changelog(MagicMock())
+        for _ in range(10):
+            await updates.api_changelog(MagicMock())
+
+        assert json.loads(first.body)["content"].startswith("# Changelog")
+        assert reads["n"] == 1, f"CHANGELOG.md was read {reads['n']} times, expected 1"
+
+    @pytest.mark.asyncio
+    async def test_edit_is_picked_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cache is keyed on the stat signature, so a dev-install edit must
+        still be visible without a restart."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        changelog = proj / "CHANGELOG.md"
+        changelog.write_text("first\n", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        monkeypatch.setattr(updates, "_changelog_cache", None, raising=False)
+
+        assert json.loads((await updates.api_changelog(MagicMock())).body)[
+            "content"
+        ] == "first\n"
+
+        changelog.write_text("second edition\n", encoding="utf-8")
+        st = changelog.stat()
+        os.utime(changelog, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+
+        assert json.loads((await updates.api_changelog(MagicMock())).body)[
+            "content"
+        ] == "second edition\n"
+
+
+class TestChannelPresetsReadIsCached:
+    """``/api/channels/presets`` re-read and re-parsed config.json on every call
+    so that an edit lands without a restart. The stat-keyed cache keeps that
+    contract without the per-call read."""
+
+    @pytest.mark.asyncio
+    async def test_repeat_reads_hit_the_disk_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({"channel_presets": [{"id": "a"}]}), encoding="utf-8")
+        monkeypatch.setattr(handlers_channel, "config_path", lambda: cfg)
+        monkeypatch.setattr(handlers_channel, "_presets_cache", None, raising=False)
+
+        reads = {"n": 0}
+        real_read = Path.read_text
+
+        def _counting_read(self, *a, **k):
+            if self == cfg:
+                reads["n"] += 1
+            return real_read(self, *a, **k)
+
+        monkeypatch.setattr(Path, "read_text", _counting_read)
+
+        for _ in range(10):
+            resp = await handlers_channel.api_channel_presets(MagicMock())
+
+        assert json.loads(resp.body)["presets"] == [{"id": "a"}]
+        assert reads["n"] == 1, f"config.json was read {reads['n']} times, expected 1"
+
+    @pytest.mark.asyncio
+    async def test_edit_is_picked_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({"channel_presets": [{"id": "a"}]}), encoding="utf-8")
+        monkeypatch.setattr(handlers_channel, "config_path", lambda: cfg)
+        monkeypatch.setattr(handlers_channel, "_presets_cache", None, raising=False)
+
+        resp = await handlers_channel.api_channel_presets(MagicMock())
+        assert json.loads(resp.body)["presets"] == [{"id": "a"}]
+
+        cfg.write_text(
+            json.dumps({"channel_presets": [{"id": "b"}, {"id": "c"}]}),
+            encoding="utf-8",
+        )
+        st = cfg.stat()
+        os.utime(cfg, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+
+        resp = await handlers_channel.api_channel_presets(MagicMock())
+        assert json.loads(resp.body)["presets"] == [{"id": "b"}, {"id": "c"}]


### PR DESCRIPTION
# Problem

Two things make KiroCrew slow before it does any work.

**Boot blocks on a network call, un-interruptibly.** `start()` inline-awaited
`_check_for_updates()`, which runs five sequential `git` subprocesses whose
timeouts sum to roughly 70 seconds — and it did so *before* the SIGINT/SIGTERM
handlers were installed and before the dashboard URL printed. On a stalled or
firewalled network the gateway looked wedged and Ctrl-C did nothing for over a
minute.

**Every entry point pays for the dashboard.** `cli.py` imported
`parse_dashboard_url` from `kiro_crew.dashboard.origin`, and
`dashboard/__init__.py` eagerly re-exported `dashboard.server` — so importing two
pure-stdlib URL helpers pulled the entire handler tree and aiohttp. That cost is
paid by every CLI invocation and every MCP stdio subprocess, none of which ever
serve a dashboard. On top of that, the OpenTelemetry SDK was imported at module
scope even though telemetry defaults off, `config_dir()` re-did a
`Path.resolve()` + `mkdir` + breadcrumb write + archive sweep on all 323 call
sites, and the folder watcher issued a `_is_paused` check and a `last_seen`
UPDATE per file scanned.

# Why it matters

The boot delay is the user-visible one: up to ~70s to first URL on a bad
network, with no working Ctrl-C. The import cost is smaller per call but is
multiplied across every `kirocrew` command and every MCP server spawn, so it
shows up as general sluggishness rather than one slow thing.

# Fix (symptom -> root cause -> change)

1. **Update check backgrounded.** Signal handlers are now installed *first*, then
   the check is started with `asyncio.create_task`, registered in
   `_background_tasks`, and cancelled on shutdown so a stalled `git fetch` cannot
   hold the process open. Nothing later in boot consumes its result —
   `handlers_system.api_status` already treated the same check as
   fire-and-forget.
2. **URL helpers extracted to a leaf module.** The stdlib-only helpers moved from
   `dashboard/origin.py` into a new `dashboard/urls.py` (imports only
   `ipaddress`/`logging`/`os`/`socket`/`urllib`). `origin.py` keeps the
   aiohttp-dependent request-inspection functions (`check_origin`, `check_host`,
   `is_direct_local_request`, `is_https_request`) and re-exports the moved names
   for back-compat. `cli.py` now imports from `urls`.
3. **Dashboard package made lazy** via PEP 562 `__getattr__`, so importing any
   submodule no longer drags in `server`. Same pattern already used by
   `mcp_gateway/__init__.py`. `TYPE_CHECKING` imports preserve the static types.
4. **OTel SDK import deferred.** `importlib.util.find_spec` answers the
   availability question without executing the package; the real imports happen
   in `_load_otel()`, called from `_build_recorder` after the consent gate. The
   degrade-to-no-op contract for partial installs is preserved.
5. **`config_dir()` memoized** on `(raw KIROCREW_HOME, _resolved_home identity)`,
   which keeps per-test and per-pod overrides honoured while making the
   breadcrumb write and archive sweep effectively once-per-process.
6. **Folder watcher**: `_is_paused` hoisted out of the per-file loop, `last_seen`
   batched into one `executemany`.
7. **Changelog and channel-presets reads cached** rather than re-read per
   request.

Basis: findings 19, 25, 29, 38, 42 and 52 from the `wf_000019` performance audit.

# Tests

New `test/test_perf_boot_path.py`, 20 tests across six classes. They assert
**structure and behaviour, not wall-clock**, so they are stable in CI:

- `TestGatewayUpdateCheckIsBackgrounded` — the check is not awaited inline,
  signal handlers are installed before it, and the task is tracked and cancelled.
- `TestOtelSdkImportIsDeferred` — importing `provider` and building a *disabled*
  recorder load no OTel SDK module; an *enabled* recorder still does.
- `TestConfigDirMemo` — repeat calls skip the breadcrumb/sweep, an override
  change is honoured, and clearing `_resolved_home` invalidates the memo.
- `TestDashboardImportIsLeaf` — importing `urls` pulls no handler tree and no
  aiohttp; importing `origin` stays under a module ceiling; the lazy package
  attributes still resolve; the memory handler no longer imports `vector_memory`.
- `TestFolderWatcherScanQueryCount` — query count per scan via a counting DB
  double.
- `TestChangelogReadIsCached` / `TestChannelPresetsReadIsCached` — one read, not
  one per call.

# Manual verification

N/A — unit coverage is sufficient here. Every change is either a structural
assertion the new tests pin directly, or covered by the existing suites for the
touched modules.

One regression was found and fixed during review rather than by CI, and it is
worth flagging to reviewers because it is a hazard inherent to the extraction:
`test_dashboard_origin.py` patched `kiro_crew.dashboard.origin.machine_hostname`
/ `.devspaces_proxy_url`, but `format_dashboard_urls` now resolves those names in
the `urls` namespace, so the patches became **silently inert** — four tests in
that class failed outright and four more kept passing only because the real
values happened to satisfy their assertions. `_MOD` is repointed at the defining
module with a comment explaining why. The two other patch styles in the repo were
audited and both still work: `origin.is_loopback` (production resolves it through
the `origin` module) and `origin.socket.*` (patches the shared `socket` module
object, which is why `origin.py` keeps `import socket  # noqa: F401`).

# Gates

`isort`, `flake8` clean. `mypy src/kiro_crew/` reports only the pre-existing
`faiss.write_index` overload error that reproduces unchanged on `origin/main`.
Full backend suite: **23,018 passed**, 83 skipped, 5 xfailed. Six failures, all
verified pre-existing on a clean `origin/main` checkout:
`test_dashboard_origin.py::TestParseDashboardUrlMalformed` (3, ambient dashboard
URL in this environment) and `test_embedding_space_reconcile.py` (3, arrived with
#961).
