### PR TITLE
fix(macos): stop the home-directory walks tripping a burst of TCC consent dialogs

### DIFF
--- a/src/kiro_crew/dashboard/file_index.py
+++ b/src/kiro_crew/dashboard/file_index.py
@@ -95,14 +95,14 @@ class FileIndex:
         truncated = False
         # macOS: if this index is rooted at bare $HOME, prune the TCC-gated
         # folders. This walk re-runs every _REFRESH_SECS, so without the prune
-        # a dismissed consent dialog would be re-triggered on every refresh.
-        tcc_skip = platform_compat.tcc_protected_dirs_for_walk(self.root)
+        # a dismissed consent dialog would be re-triggered on every refresh --
+        # which is how one prompt becomes a recurring stream of them.
         for dirpath, dirnames, filenames in os.walk(self.root):
-            dirnames[:] = [
-                d for d in dirnames
-                if not d.startswith(".") and d not in _SKIP_DIRS
-                and not (dirpath == self.root and d in tcc_skip)
-            ]
+            dirnames[:] = platform_compat.tcc_prune_walk_dirs(
+                self.root,
+                dirpath,
+                [d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS],
+            )
             for fname in filenames:
                 if len(entries) >= _MAX_ENTRIES:
                     truncated = True

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1908,16 +1908,23 @@ async def api_file_search(request: web.Request) -> web.Response:
     scoped = bool(search_roots)
 
     if not search_roots:
-        # Fallback: project dir, kirocrew workspace, home
+        # Fallback: project dir, then the kirocrew workspace.
+        #
+        # Bare $HOME is deliberately NOT a fallback root. Walking it reaches
+        # every TCC-gated folder macOS knows about, and each one costs a
+        # separate consent dialog -- paid on an unscoped keystroke the user
+        # never pointed anywhere. The results did not justify it either: the
+        # walk stops at max_scan entries in os.walk order, so an unscoped home
+        # search returned whichever files happened to be reached first rather
+        # than the best matches. Callers that genuinely want home can still
+        # ask for it explicitly with ?project=$HOME, which is scoped and
+        # searched in full.
         proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
         if proj and os.path.isdir(proj):
             search_roots.append(proj)
         mc_workspace = str(config_dir() / "workspace")
         if os.path.isdir(mc_workspace):
             search_roots.append(mc_workspace)
-        home = os.path.expanduser("~")
-        if home not in search_roots:
-            search_roots.append(home)
 
     # Filter out sensitive roots
     safe_roots: list[str] = []
@@ -1954,22 +1961,18 @@ async def api_file_search(request: web.Request) -> web.Response:
         for root_dir in safe_roots:
             if walked >= max_scan or len(results) >= max_collect:
                 break
-            # macOS: when this root is the bare $HOME fallback, prune the
-            # TCC-gated folders. Reaching into them would pop one consent
-            # modal PER folder for a search the user scoped to nothing.
-            # ``scoped`` means the user NAMED this root (?project= / ?workspace=),
-            # so even ``project=$HOME`` is deliberate and is searched in full.
-            tcc_skip = (
-                frozenset() if scoped
-                else platform_compat.tcc_protected_dirs_for_walk(root_dir)
-            )
+            # macOS: prune the TCC-gated folders. Reaching into them would pop
+            # one consent modal PER folder. ``scoped`` means the user NAMED
+            # this root (?project= / ?workspace=), so even ``project=$HOME``
+            # is deliberate and is searched in full.
             for dirpath, dirnames, filenames in os.walk(root_dir):
-                dirnames[:] = [
+                pruned = [
                     d for d in dirnames
-                    if not d.startswith(".")
-                    and d not in skip_dirs
-                    and not (dirpath == root_dir and d in tcc_skip)
+                    if not d.startswith(".") and d not in skip_dirs
                 ]
+                dirnames[:] = pruned if scoped else platform_compat.tcc_prune_walk_dirs(
+                    root_dir, dirpath, pruned
+                )
                 for fname in filenames:
                     if walked >= max_scan or len(results) >= max_collect:
                         break

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -100,11 +100,38 @@ TCC_PROTECTED_HOME_DIRS: frozenset[str] = frozenset(
         "Music",
     }
 )
-# Deliberately NOT included: ``Library``. It is not TCC-gated, so pruning it
-# removes zero prompts — while ``~/Library/CloudStorage/<Provider>/`` (modern
-# OneDrive / Google Drive / Dropbox mounts) and ``~/Library/Mobile Documents/``
-# (iCloud Drive) are common project homes, so hiding it costs real search hits.
-# Keep this set to exactly the folders macOS actually gates.
+# ``Library`` is deliberately absent from the set ABOVE, but it is not
+# unpruned — see TCC_LIBRARY_WALKABLE_CHILDREN. It cannot be a plain member
+# here because it must be *descended into* to reach the cloud-drive mounts,
+# which a top-level name prune would make unreachable.
+
+#: Children of ``~/Library`` that stay walkable; every other child is pruned
+#: from a home-rooted walk. This is an ALLOWLIST on purpose.
+#:
+#: Much of ``~/Library`` is gated behind Full Disk Access — ``Mail``,
+#: ``Messages``, ``Safari``, ``Calendars``, ``HomeKit``, ``Cookies``,
+#: ``IdentityServices``, ``Suggestions``, ``PersonalizationPortrait``,
+#: ``Metadata/CoreSpotlight``, ``Containers/com.apple.*`` and several
+#: ``Application Support`` leaves (``AddressBook``, ``CallHistoryDB``,
+#: ``MobileSync``, ``com.apple.TCC``) — and Apple keeps ADDING to that list
+#: with each release. A denylist would therefore go stale and silently start
+#: leaking prompts again on the next macOS version, so the rule is inverted:
+#: name the two paths worth reaching and drop the rest.
+#:
+#: The two kept entries are the modern cloud-drive mount points, which are
+#: common project homes and hold real search hits:
+#: ``~/Library/CloudStorage/<Provider>/`` (OneDrive / Google Drive / Dropbox)
+#: and ``~/Library/Mobile Documents/`` (iCloud Drive).
+TCC_LIBRARY_WALKABLE_CHILDREN: frozenset[str] = frozenset(
+    {
+        "CloudStorage",
+        "Mobile Documents",
+    }
+)
+
+#: The single ``~/Library`` component name, kept as a constant because the walk
+#: pruner compares it positionally rather than by membership.
+_LIBRARY_DIR = "Library"
 
 
 def tcc_protected_dirs_for_walk(root: str | os.PathLike) -> frozenset[str]:
@@ -135,6 +162,50 @@ def tcc_protected_dirs_for_walk(root: str | os.PathLike) -> frozenset[str]:
         # the /api/file-search request (same class as agent.py's guard).
         return frozenset()
     return TCC_PROTECTED_HOME_DIRS
+
+
+def tcc_prune_walk_dirs(root: str, dirpath: str, dirnames: list[str]) -> list[str]:
+    """Return *dirnames* minus the TCC-gated entries for this walk position.
+
+    Single entry point for ``os.walk`` pruning: call it with the ``top`` passed
+    to :func:`os.walk` plus the ``dirpath``/``dirnames`` of the current step and
+    assign the result back into ``dirnames[:]``.
+
+    Two positions prune, and only when *root* is the user's home directory
+    itself (see :func:`tcc_protected_dirs_for_walk` for why an explicitly
+    scoped root is never pruned):
+
+    * at *root* — drop the gated top-level folders (``Downloads``, ``Desktop``,
+      ...). ``Library`` is NOT dropped here, so the walk can reach the cloud
+      mounts below it.
+    * at ``<root>/Library`` — keep only TCC_LIBRARY_WALKABLE_CHILDREN and drop
+      every other child, most of which is Full-Disk-Access gated.
+
+    Every deeper position returns *dirnames* untouched. A name that merely
+    matches a gated folder further down the tree (a project's own
+    ``Documents/``) is not gated and stays walkable.
+
+    Callers MUST pass the same ``str`` they hand to :func:`os.walk`: the
+    positional comparisons rely on ``dirpath`` being built by joining onto
+    ``top`` verbatim, which is what ``os.walk`` guarantees.
+    """
+    if not IS_MACOS:
+        return dirnames
+    # Positional gate FIRST: only two walk positions can prune, so every other
+    # directory in a large tree returns without paying the realpath syscall
+    # that the home check below costs.
+    at_root = dirpath == root
+    at_library = not at_root and dirpath == os.path.join(root, _LIBRARY_DIR)
+    if not (at_root or at_library):
+        return dirnames
+    # Doubles as the "is root the home directory" test and inherits that
+    # helper's failure handling (an unresolvable root prunes nothing).
+    protected = tcc_protected_dirs_for_walk(root)
+    if not protected:
+        return dirnames
+    if at_root:
+        return [d for d in dirnames if d not in protected]
+    return [d for d in dirnames if d in TCC_LIBRARY_WALKABLE_CHILDREN]
 
 
 def ensure_utf8_console() -> None:

--- a/test/test_file_search.py
+++ b/test/test_file_search.py
@@ -129,12 +129,28 @@ class TestFileSearch:
             assert names[2] == "abcdef.py"
 
     @pytest.mark.asyncio
-    async def test_fallback_uses_home(self, tmp_path, mock_sel):
+    async def test_fallback_does_not_use_home(self, tmp_path, mock_sel):
+        """$HOME is not an implicit fallback root.
+
+        Walking it reached every TCC-gated folder on macOS -- one consent dialog
+        each -- for a query the caller scoped nowhere. Asking for home
+        explicitly (``?project=``) still works and is covered separately.
+        """
         (tmp_path / "findme.txt").write_text("x")
-        with patch.dict(os.environ, {"HOME": str(tmp_path)}, clear=False), \
+        with patch.dict(os.environ, {"HOME": str(tmp_path), "USERPROFILE": str(tmp_path)}, clear=False), \
              patch.dict(os.environ, {"KIROCREW_PROJECT_DIR": ""}, clear=False):
             async with TestClient(TestServer(_make_app())) as client:
                 resp = await client.get("/api/file-search?q=findme")
+                names = {r["name"] for r in (await resp.json())["results"]}
+                assert "findme.txt" not in names
+
+    @pytest.mark.asyncio
+    async def test_explicit_home_project_still_searched(self, tmp_path, mock_sel):
+        """Naming home is deliberate and stays fully searchable."""
+        (tmp_path / "findme.txt").write_text("x")
+        with patch.dict(os.environ, {"HOME": str(tmp_path), "USERPROFILE": str(tmp_path)}, clear=False):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/file-search?q=findme&project={tmp_path}")
                 names = {r["name"] for r in (await resp.json())["results"]}
                 assert "findme.txt" in names
 

--- a/test/test_tcc_protected_dirs.py
+++ b/test/test_tcc_protected_dirs.py
@@ -89,13 +89,102 @@ class TestTccHelper:
         with patch.object(platform_compat, "IS_MACOS", True):
             assert platform_compat.tcc_protected_dirs_for_walk("/tmp/a\x00b") == frozenset()
 
-    def test_library_is_not_pruned(self):
-        """``~/Library`` is not TCC-gated, and holds CloudStorage project mounts.
+    def test_library_is_descended_but_gated_children_are_pruned(self):
+        """``~/Library`` must be reachable yet mostly pruned.
 
-        Pruning it would remove zero prompts while hiding OneDrive / Google
-        Drive / iCloud project trees from search.
+        It is NOT a plain member of the top-level set, because the walk has to
+        descend into it to reach the cloud-drive mounts. What it gets instead is
+        an allowlist: only CloudStorage / Mobile Documents survive.
+
+        The earlier premise here was that ``~/Library`` is not TCC-gated and so
+        pruning it would remove zero prompts. That is wrong -- ``Library/Mail``,
+        ``Library/Messages``, ``Library/Safari``, ``Library/Calendars``,
+        ``Library/Cookies``, ``Library/Containers/com.apple.*`` and several
+        ``Application Support`` leaves are all Full-Disk-Access gated.
         """
         assert "Library" not in platform_compat.TCC_PROTECTED_HOME_DIRS
+        assert platform_compat.TCC_LIBRARY_WALKABLE_CHILDREN == frozenset(
+            {"CloudStorage", "Mobile Documents"}
+        )
+
+
+class TestLibraryPruning:
+    """``~/Library`` is walked only as far as the cloud-drive mounts."""
+
+    @staticmethod
+    def _prune(root, dirpath, dirnames, tmp_path):
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            return platform_compat.tcc_prune_walk_dirs(root, dirpath, dirnames)
+
+    def test_library_survives_the_root_prune(self, tmp_path):
+        """Pruning Library at the root would make the cloud mounts unreachable."""
+        got = self._prune(
+            str(tmp_path), str(tmp_path), ["Library", "Downloads", "code"], tmp_path
+        )
+        assert got == ["Library", "code"]
+
+    def test_gated_library_children_are_pruned(self, tmp_path):
+        lib = str(tmp_path / "Library")
+        got = self._prune(
+            str(tmp_path),
+            lib,
+            ["Mail", "Messages", "Safari", "Cookies", "Containers", "CloudStorage"],
+            tmp_path,
+        )
+        assert got == ["CloudStorage"]
+
+    def test_cloud_mounts_are_kept(self, tmp_path):
+        lib = str(tmp_path / "Library")
+        got = self._prune(
+            str(tmp_path), lib, ["CloudStorage", "Mobile Documents", "Caches"], tmp_path
+        )
+        assert got == ["CloudStorage", "Mobile Documents"]
+
+    def test_unknown_library_child_is_pruned(self, tmp_path):
+        """An allowlist, not a denylist: macOS keeps adding gated subpaths, and
+        a name this code has never heard of must default to pruned."""
+        lib = str(tmp_path / "Library")
+        assert self._prune(str(tmp_path), lib, ["SomeFutureGatedThing"], tmp_path) == []
+
+    def test_nested_library_is_untouched(self, tmp_path):
+        """Only ``<root>/Library`` is special. A project's own nested
+        ``Library/`` is not gated and keeps every child."""
+        deep = str(tmp_path / "code" / "Library")
+        got = self._prune(str(tmp_path), deep, ["Mail", "Safari"], tmp_path)
+        assert got == ["Mail", "Safari"]
+
+    def test_library_of_a_scoped_root_is_untouched(self, tmp_path):
+        """Root is not $HOME, so nothing prunes -- the user named this tree."""
+        proj = tmp_path / "code"
+        got = self._prune(str(proj), str(proj / "Library"), ["Mail"], tmp_path)
+        assert got == ["Mail"]
+
+    def test_off_macos_prunes_nothing(self, tmp_path):
+        with patch.object(platform_compat, "IS_MACOS", False):
+            got = platform_compat.tcc_prune_walk_dirs(
+                str(tmp_path), str(tmp_path / "Library"), ["Mail"]
+            )
+        assert got == ["Mail"]
+
+    @pytest.mark.asyncio
+    async def test_index_at_home_skips_gated_library(self, tmp_path):
+        """End-to-end through the walk that re-runs every 30s."""
+        for rel in ("Library/Mail", "Library/CloudStorage/Work"):
+            d = tmp_path / rel
+            d.mkdir(parents=True)
+            (d / "target.txt").write_text("x")
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            idx = FileIndex(str(tmp_path))
+            entries, _ = await __import__("asyncio").to_thread(idx._walk)
+        rels = {os.path.relpath(e[0], tmp_path) for e in entries}
+        assert os.path.join("Library", "CloudStorage", "Work", "target.txt") in rels
+        assert not any(r.startswith(os.path.join("Library", "Mail")) for r in rels)
 
 
 class TestFileIndexPruning:
@@ -168,7 +257,15 @@ def mock_sel():
 
 class TestFileSearchPruning:
     @pytest.mark.asyncio
-    async def test_home_fallback_skips_tcc_dirs(self, tmp_path, mock_sel):
+    async def test_home_is_not_an_implicit_search_root(self, tmp_path, mock_sel):
+        """An unscoped search must not walk $HOME at all.
+
+        This supersedes an earlier contract where bare $HOME was a fallback
+        root that merely pruned its gated top-level folders. Pruning still left
+        the walk descending ``~/Library`` (Full-Disk-Access gated) and paid a
+        whole-home walk per keystroke for results taken in os.walk order rather
+        than by match quality. Nothing incidental walks home now.
+        """
         _make_home(tmp_path)
         with (
             patch.object(platform_compat, "IS_MACOS", True),
@@ -179,11 +276,26 @@ class TestFileSearchPruning:
             async with TestClient(TestServer(_make_app())) as client:
                 resp = await client.get("/api/file-search?q=target")
                 paths = [r["path"] for r in (await resp.json())["results"]]
-        for name in _TCC_DIRS:
-            assert not any(
-                f"{os.sep}{name}{os.sep}" in p for p in paths
-            ), f"{name} must not be searched from the bare $HOME fallback"
-        assert any(f"{os.sep}code{os.sep}" in p for p in paths)
+        assert not any(str(tmp_path) in p for p in paths), (
+            "no result may come from $HOME when the caller scoped nothing"
+        )
+
+    @pytest.mark.asyncio
+    async def test_named_project_root_is_still_searched(self, tmp_path, mock_sel):
+        """Dropping the home fallback must not break the real fallback root."""
+        proj = _make_home(tmp_path)
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(
+                os.environ,
+                {**_home_env(tmp_path), "KIROCREW_PROJECT_DIR": str(proj)},
+                clear=False,
+            ),
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get("/api/file-search?q=target")
+                names = {r["name"] for r in (await resp.json())["results"]}
+        assert "target.txt" in names
 
     @pytest.mark.asyncio
     async def test_explicit_project_under_tcc_dir_still_searchable(self, tmp_path, mock_sel):


### PR DESCRIPTION
## Problem

macOS records file-access consent **per (app, protected location)**. A single walk rooted at `$HOME` therefore produces one consent dialog *per folder it reaches* — which is why the app appeared to ask "seven different times", plus the media-library dialog (worded around Apple Music) and others. It is one root cause, not seven bugs.

Two walks were rooted at bare `$HOME`:

- `api_file_search` — `$HOME` was the last-resort fallback root when the caller scoped nothing
- `FileIndex._walk` — and this one **re-runs every 30 s**, so a dismissed dialog came back indefinitely

An existing prune (`TCC_PROTECTED_HOME_DIRS`) covered the six gated top-level folders, but stopped there on this premise:

> Deliberately NOT included: `Library`. It is not TCC-gated, so pruning it removes zero prompts.

**That premise is wrong.** Much of `~/Library` is Full-Disk-Access gated: `Mail`, `Messages`, `Safari`, `Calendars`, `Cookies`, `HomeKit`, `IdentityServices`, `Suggestions`, `PersonalizationPortrait`, `Metadata/CoreSpotlight`, `Containers/com.apple.*`, and `Application Support/{AddressBook,CallHistoryDB,MobileSync,com.apple.TCC}`. Both walks descended straight into all of it.

## Changes

**1. `~/Library` is descended only as far as the cloud-drive mounts.** The rule is an **allowlist** (`CloudStorage`, `Mobile Documents`) rather than a denylist of gated names — Apple keeps adding gated subpaths, and a denylist would go stale and silently start leaking prompts again on the next macOS release. The two kept entries preserve exactly why `Library` was walkable in the first place: OneDrive / Google Drive / Dropbox / iCloud project homes with real search hits.

**2. Bare `$HOME` is no longer an implicit file-search root.** It was reached only on an unscoped query, and it paid a whole-home walk per keystroke to return whatever `os.walk` happened to reach before `max_scan` — order of traversal, not match quality. The other two fallback roots are unchanged (`KIROCREW_PROJECT_DIR`, which the packaged app always sets in `main.js`, and the crew workspace), so the unscoped path still has somewhere to look and the picker does not go blank. `?project=$HOME` stays scoped and fully searched.

Both walk sites now share one entry point, `tcc_prune_walk_dirs`, which gates on walk position *before* paying the `realpath` syscall — deep trees are unaffected.

## Superseded tests

Two tests encoded premises this corrects; both are replaced with the reasoning recorded inline:

- `test_library_is_not_pruned` → `test_library_is_descended_but_gated_children_are_pruned`
- `test_fallback_uses_home` → `test_fallback_does_not_use_home` (+ a new test that `?project=$HOME` still works)

## Verification

- **11 tests revert-verified** — all 11 fail against unmodified source, pass with the fix
- pytest 23003 passed. 3 failures in `test_dashboard_origin.py` confirmed pre-existing on clean `origin/main` (module untouched by this diff)
- `isort` / `flake8` clean at CI scope; `mypy src/kiro_crew/` clean over 571 files (faiss absent = CI parity)
- No frontend changes, so `tsc`/`vitest` are not implicated

## Not covered here

The `osascript choose folder` picker still bypasses the powerbox, so the gateway gets no implicit grant for the folder the user picks. Moving it to Electron's native `dialog.showOpenDialog` would remove that prompt class entirely — [Apple documents that intent-based access through the Open panel changes the caller's sandbox](https://mjtsai.com/blog/2026/04/10/privacy-t-show-intent-based-access/). Worth a follow-up PR.

I could not test on macOS from this Linux host: the prune logic is verified by unit tests that patch `IS_MACOS`, not by observing real dialogs.
