### PR TITLE
fix(apps): carry a builtin's agents and skills through discovery

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,6 +29,9 @@ recursive-include src/kiro_crew/static *
 # --- Other package_data directories ------------------------------------------
 recursive-include src/kiro_crew/config *
 recursive-include src/kiro_crew/apps *.json
+# ATTRIBUTION.md / README.md under a builtin app carry the upstream-author credit
+# for apps ported from third-party work; Apache-2.0 attribution must ship.
+recursive-include src/kiro_crew/apps *.md
 recursive-include src/kiro_crew/eval/scenarios *.json
 recursive-include src/kiro_crew/docs *.md
 recursive-include src/kiro_crew/tests_fixtures *

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,6 +124,12 @@ kiro_crew =
     apps/builtins/*/backend/**/*
     apps/builtins/*/skills/**/*
     apps/builtins/*/scripts/**/*
+    apps/builtins/*/agents/*.json
+    apps/builtins/*/prompts/*.md
+    # ATTRIBUTION.md / README.md carry the upstream-author credit for the builtin
+    # apps ported from third-party work — Apache-2.0 attribution has to reach the
+    # installed package, not just the repository.
+    apps/builtins/*/*.md
     builtin_skills/**/*
     deploy/skills/**/*
     eval/scenarios/*.json

--- a/src/kiro_crew/apps/discovery.py
+++ b/src/kiro_crew/apps/discovery.py
@@ -56,6 +56,16 @@ def _manifest_to_builtin_dict(manifest: AppManifest) -> dict[str, Any]:
     if backend_d:
         d["backend"] = backend_d
 
+    # Agents and skills. These are typed fields rather than ``extra``, so they
+    # have to be copied explicitly — omitting them silently stripped both from
+    # the persisted ``app.json``, and ``bridges.register_app`` re-reads that
+    # stripped file, so a builtin's declared agents were never symlinked into
+    # ``~/.kiro/agents`` and its skills were never registered.
+    if manifest.agents:
+        d["agents"] = list(manifest.agents)
+    if manifest.skills:
+        d["skills"] = list(manifest.skills)
+
     # MCP servers
     if manifest.mcpServers:
         d["mcpServers"] = manifest.mcpServers

--- a/test/test_builtin_discovery.py
+++ b/test/test_builtin_discovery.py
@@ -236,3 +236,82 @@ class TestHiddenBuiltins:
         assert "deploy-web" not in shipped, (
             "deploy-web builtin should no longer exist — folded into Artifacts core"
         )
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsAndSkillsSurviveDiscovery:
+    """``agents`` / ``skills`` are typed ``AppManifest`` fields, not ``extra``.
+
+    So ``_manifest_to_builtin_dict`` has to copy them EXPLICITLY. When it did
+    not, both were silently stripped from the dict that ``register_builtin_apps``
+    persists as the installed ``app.json`` — and ``bridges.register_app``
+    re-reads that stripped file, so a builtin's declared agents were never
+    symlinked into ``~/.kiro/agents`` and its skills were never registered. The
+    manifest looked correct on disk in the package and the app was simply inert.
+
+    A round-trip assertion is the only thing that catches this: every per-field
+    unit test passed while the aggregate dict was missing two keys.
+    """
+
+    def test_declared_agents_and_skills_reach_discovery_output(self, tmp_path: Path) -> None:
+        manifest = _valid_manifest("agentful-app")
+        manifest["agents"] = ["agents/one.json", "agents/two.json"]
+        manifest["skills"] = ["skills/the-skill"]
+        _write_manifest(tmp_path / "agentful-app", manifest)
+
+        apps = discover_builtin_apps(tmp_path)
+        assert len(apps) == 1
+        assert apps[0]["agents"] == ["agents/one.json", "agents/two.json"]
+        assert apps[0]["skills"] == ["skills/the-skill"]
+
+    def test_absent_agents_and_skills_stay_absent(self, tmp_path: Path) -> None:
+        """Omit the keys rather than emitting empty lists.
+
+        ``register_builtin_apps`` merges this dict over existing state, so an
+        empty list would be a meaningful value that could clear a real one.
+        """
+        _write_manifest(tmp_path / "plain-app", _valid_manifest("plain-app"))
+
+        apps = discover_builtin_apps(tmp_path)
+        assert "agents" not in apps[0]
+        assert "skills" not in apps[0]
+
+    def test_shipped_manifests_keep_their_agents_and_skills(self) -> None:
+        """The regression this guards, on the real shipped manifests.
+
+        An app that dispatches to its own agents by name does so as its PRIMARY
+        function, so a stripped ``agents`` list is not a degraded feature but a
+        dead one — and the failure is silent, because the manifest on disk in the
+        package still looks correct.
+
+        Derived from what the packaged ``app.json`` files actually declare rather
+        than a hardcoded app list: the invariant is "whatever a manifest declares
+        survives discovery", which is what makes this hold for every builtin
+        including ones added later. A named list would instead have to be edited
+        by the very change most likely to break the round-trip.
+        """
+        import kiro_crew.apps.builtins as builtins_pkg
+
+        builtins_dir = Path(builtins_pkg.__file__).resolve().parent
+        shipped = {a["name"]: a for a in discover_builtin_apps()}
+
+        checked = 0
+        for manifest_path in sorted(builtins_dir.glob("*/app.json")):
+            declared = json.loads(manifest_path.read_text(encoding="utf-8"))
+            name = declared.get("name")
+            for field in ("agents", "skills"):
+                if not declared.get(field):
+                    continue
+                assert name in shipped, f"{name} builtin not discovered"
+                assert shipped[name].get(field) == declared[field], (
+                    f"{name} declares {field} in its manifest but discovery "
+                    f"dropped or altered them"
+                )
+                checked += 1
+
+        assert checked, (
+            "no shipped builtin declares agents or skills, so this guard proved "
+            "nothing — if that is now genuinely true, delete it"
+        )


### PR DESCRIPTION
## What

`_manifest_to_builtin_dict` rebuilds an app manifest into the dict that `register_builtin_apps` persists as the installed `app.json`, copying each field explicitly. `agents` and `skills` are typed `AppManifest` fields rather than `extra`, so they were never copied.

`bridges.register_app` re-reads that persisted file — so a builtin's declared agents were never symlinked into `~/.kiro/agents`, and its declared skills were never registered.

## Why it matters

The failure is silent and total. The manifest on disk in the package still looks correct, so an app whose primary function is dispatching to its own agents simply ships inert with no error anywhere.

**This is live on `main` today:** `code-review-sage` declares `skills` in its manifest, and they are being dropped.

## The guard

A round-trip assertion is the only thing that catches this — every per-field unit test passed while the aggregate dict was missing two keys.

It is derived from what the packaged `app.json` files actually declare, rather than a hardcoded list of app names. That way it holds for builtins added later without needing to be edited by the very change most likely to break the round-trip. It also asserts it checked something, so it can't quietly pass by matching nothing.

Verified it fails with the fix reverted (catches `code-review-sage`) and passes with it applied.

## Also included

The files such a manifest points at were missing from `package_data` — for the same reason nobody noticed the fields were dropped. Adds `agents/*.json`, `prompts/*.md`, and `ATTRIBUTION.md` / `README.md`, the last of which carries upstream-author credit for ported apps and which Apache-2.0 attribution requires reach the installed package, not just the repository.

## Context

First of four PRs splitting #969 (40k insertions / 157 files), which is too large to review well. This is the shared-platform slice; the three app PRs stack on top of it. #969 stays open for reference.

This one lands first because it is independently valuable — it fixes a current bug — and because two of the three apps would ship inert without it.

## Test plan

- `pytest test/test_builtin_discovery.py` — 14 passed
- Guard verified to fail without the fix
- `flake8`, `isort`, `mypy` clean; `tsc --noEmit` clean
- `black` and `scrub-lint` failures confirmed pre-existing on pristine `main` (repo is not black-formatted; scrub-lint's remaining check is the git-history author rewrite, tracked separately)