### PR TITLE
fix(telemetry): record real turn duration in the usage row store

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -157,7 +157,6 @@ from kiro_crew.security import (
 from kiro_crew.sel import sel
 from kiro_crew.session import SessionClosingError
 from kiro_crew.slack.handler import post_linked_approval, resolve_linked_approval
-from kiro_crew.stats import Stats
 from kiro_crew.validation import ValidationError, infer_use_case, validate_ask_user_question
 from kiro_crew.widget_artifacts import register_widgets_off_loop
 
@@ -4339,19 +4338,6 @@ async def _run_chat(
                 except (TypeError, ValueError):
                     _turn_elapsed_ms = int((time.monotonic() - _turn_t0) * 1000)
                 if _u.input_tokens or _u.output_tokens or _u.credits:
-                    stats = Stats()
-                    stats.inc_input_tokens(_u.input_tokens)
-                    stats.inc_output_tokens(_u.output_tokens)
-                    if _u.cache_creation_tokens:
-                        stats.inc_cache_creation_tokens(_u.cache_creation_tokens)
-                    if _u.cache_read_tokens:
-                        stats.inc_cache_read_tokens(_u.cache_read_tokens)
-                    if _u.cost_usd:
-                        stats.inc_cost_usd(_u.cost_usd)
-                    if _u.num_turns:
-                        stats.inc_turns(_u.num_turns)
-                    if _u.duration_ms:
-                        stats.inc_duration_ms(_u.duration_ms)
                     try:
                         _provider_name = cfg.agent.provider  # type: ignore[possibly-undefined]
                     except (NameError, AttributeError):
@@ -4384,6 +4370,10 @@ async def _run_chat(
                         agent=read_effective_agent(client) or slot.agent or "",
                         context_used=_ctx_used,
                         context_window=_ctx_window,
+                        # Same wall clock the turn-duration histogram below is
+                        # given, so the row store and the histogram can never
+                        # disagree about one turn. acp reports 0 here.
+                        elapsed_ms=_turn_elapsed_ms,
                         model_source=client,
                     )
                 # ── Turn-completion histogram (OTel M2) ──

--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -424,6 +424,10 @@ async def _run_hook_inner(
         )
     result_text = ""
     _complete_event: object | None = None
+    # Wall clock for the webhook agent turn: acp leaves TurnUsage.duration_ms
+    # at 0, so without this the row records a literal 0. Started after the
+    # context build so prompt assembly is not charged to the turn.
+    _turn_t0 = time.monotonic()
     async for event in client.stream(full_message):
         if event.kind == EVENT_TEXT_CHUNK:
             result_text += event.text
@@ -454,6 +458,7 @@ async def _run_hook_inner(
             agent=read_effective_agent(client) or agent or "",
             context_used=_used,
             context_window=_window,
+            elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
             model_source=client,
         )
     except Exception:

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -417,6 +417,7 @@ def _build_token_record(
     agent: str = "",
     context_used: int = 0,
     context_window: int = 0,
+    elapsed_ms: int = 0,
 ) -> dict[str, Any]:
     """Build the JSONL token-usage record dict (no I/O).
 
@@ -425,6 +426,18 @@ def _build_token_record(
     ``context_window`` record context-window occupancy (read from the provider
     via :func:`read_context_tokens` at the call site). All four are additive and
     default to empty/0, so pre-existing shards and existing callers stay valid.
+
+    ``elapsed_ms`` is the caller's locally measured wall clock for the turn and
+    is the FALLBACK for ``duration_ms``: the provider-reported value wins when
+    non-zero, otherwise the local measurement is recorded. Both are needed
+    because the acp provider always reports ``TurnUsage.duration_ms == 0``
+    (nothing assigns it — only claude_code filled it in, and that provider is
+    gone), so a provider-only read wrote a literal 0 into every real row and
+    left the row store unable to answer "how long did this turn take".
+
+    This mirrors the precedence the OTEL emit path already uses
+    (``chat_runner._attach_turn_stats``: ``value = duration_ms or elapsed_ms``),
+    so the histogram and the row store cannot disagree about one turn.
     """
     # Usage lives on event.usage (TurnUsage). Fall back to the event itself when
     # it isn't a real TurnUsage (legacy / non-AcpEvent producers, test doubles).
@@ -448,7 +461,7 @@ def _build_token_record(
         "cost": getattr(u, "cost_usd", 0.0),
         "credits": credits,
         "turns": getattr(u, "num_turns", 0),
-        "duration_ms": getattr(u, "duration_ms", 0),
+        "duration_ms": getattr(u, "duration_ms", 0) or _coerce_int(elapsed_ms),
         # Additive per-turn fields (issue #647): context occupancy + dispatch
         # origin. Old shards lack these keys; readers must tolerate their
         # absence. context_* are int-coerced so a bad value can't break json.dumps.
@@ -480,6 +493,7 @@ def persist_token_record(
     agent: str = "",
     context_used: int = 0,
     context_window: int = 0,
+    elapsed_ms: int = 0,
     model_source: object = None,
 ) -> None:
     """Append a token usage record to today's shard under
@@ -490,6 +504,10 @@ def persist_token_record(
     ``surface`` / ``agent`` tag the dispatch origin and resolved agent, and
     ``context_used`` / ``context_window`` record context-window occupancy — all
     additive and defaulted so existing callers stay valid.
+
+    ``elapsed_ms`` is the caller's locally measured turn wall clock, used only
+    when the provider reports no duration. Every dispatch surface owns its own
+    measurement because there is no global turn boundary to hang one clock on.
 
     ``model_source`` is a provider/client used ONLY to fill ``model`` when the
     caller could not resolve one (several dispatch surfaces never pick a model
@@ -513,6 +531,7 @@ def persist_token_record(
                 agent=agent,
                 context_used=context_used,
                 context_window=context_window,
+                elapsed_ms=elapsed_ms,
             ),
             now,
         )
@@ -530,6 +549,7 @@ async def persist_token_record_async(
     agent: str = "",
     context_used: int = 0,
     context_window: int = 0,
+    elapsed_ms: int = 0,
     model_source: object = None,
 ) -> None:
     """Async variant: builds the record on-loop, offloads the file write.
@@ -539,7 +559,8 @@ async def persist_token_record_async(
     co-resident coroutines for the IO window. These are best-effort analytics
     (no fsync, exceptions swallowed), so off-loop write loses no durability.
     See :func:`persist_token_record` for the ``surface`` / ``agent`` /
-    ``context_used`` / ``context_window`` / ``model_source`` fields.
+    ``context_used`` / ``context_window`` / ``elapsed_ms`` / ``model_source``
+    fields.
     """
     try:
         model = _resolve_model(model, model_source)
@@ -554,6 +575,7 @@ async def persist_token_record_async(
             agent=agent,
             context_used=context_used,
             context_window=context_window,
+            elapsed_ms=elapsed_ms,
         )
         await asyncio.to_thread(_write_token_record, record, now)
     except Exception:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2000,6 +2000,11 @@ class GatewayOrchestrator:
                             interactive=False,
                             agent=agent,
                         )
+                        # Wall clock for the cron agent turn: acp never assigns
+                        # TurnUsage.duration_ms, so the row falls back to this.
+                        # Brackets only the model turn — session acquisition and
+                        # the episodic-query embed above are setup, not the turn.
+                        _turn_t0 = time.monotonic()
                         result_text = await stream_and_collect(
                             client,
                             full_message,
@@ -2037,6 +2042,7 @@ class GatewayOrchestrator:
                                 agent=read_effective_agent(client) or agent or "",
                                 context_used=_used,
                                 context_window=_window,
+                                elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
                                 model_source=client,
                             )
                         except Exception:
@@ -2086,6 +2092,9 @@ class GatewayOrchestrator:
                     minimal_context=job.minimal_context,
                 )
 
+                # Wall clock for the cron agent turn — see the sequential site
+                # above. acp reports no duration, so this is the row's fallback.
+                _turn_t0 = time.monotonic()
                 result_text = await stream_and_collect(
                     client,
                     full_message,
@@ -2123,6 +2132,7 @@ class GatewayOrchestrator:
                         agent=read_effective_agent(client) or job.agent_id or "",
                         context_used=_used,
                         context_window=_window,
+                        elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
                         model_source=client,
                     )
                 except Exception:
@@ -2570,6 +2580,10 @@ class GatewayOrchestrator:
                 # the user's ``auto_approve_tools`` MUST NOT widen the heartbeat
                 # allowlist — ``llm_helpers._resolve_permission`` consults
                 # ``hooks.on_tool_call()`` BEFORE ``on_tool_approval``.
+                #
+                # Clock started outside wait_for so BOTH the success path and the
+                # TimeoutError branch below can report the real elapsed time.
+                _turn_t0 = time.monotonic()
                 result_text = await asyncio.wait_for(
                     stream_and_collect(
                         client,
@@ -2597,6 +2611,7 @@ class GatewayOrchestrator:
                         agent=read_effective_agent(client) or "kirocrew-heartbeat",
                         context_used=_used,
                         context_window=_window,
+                        elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
                         model_source=client,
                     )
                 except Exception:
@@ -2614,6 +2629,35 @@ class GatewayOrchestrator:
                     HEARTBEAT_TASK_TIMEOUT_SECS,
                     task_text[:80],
                 )
+                # ── Timeout spend is REAL spend (issue #874 follow-up). ──
+                # Before this, a timed-out heartbeat wrote no row at all, so
+                # every cancelled turn silently dropped whatever it had already
+                # cost. Record it here, BEFORE the session reset below tears the
+                # client down and takes its last-turn usage with it.
+                #
+                # No new schema field: the record has never carried a
+                # success/failure outcome for ANY surface, so a timeout row is
+                # no less honest than any other row. The duration recorded is
+                # the real elapsed time, which for a timeout is ~the ceiling.
+                try:
+
+                    _used, _window = read_context_tokens(client)
+                    await persist_token_record_async(
+                        session_key,
+                        "",
+                        provider_last_turn_usage(client),
+                        provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                        surface="heartbeat",
+                        agent=read_effective_agent(client) or "kirocrew-heartbeat",
+                        context_used=_used,
+                        context_window=_window,
+                        elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
+                        model_source=client,
+                    )
+                except Exception:
+                    logger.debug(
+                        "usage row (heartbeat timeout) persist failed", exc_info=True
+                    )
                 try:
                     await self.sessions.reset(session_key)
                 except Exception:
@@ -2727,6 +2771,10 @@ class GatewayOrchestrator:
             full_msg, _ = await run_in_embed_pool(
                 self.ctx_builder.build_message, tagged, is_new, key, provider_type=_provider
             )
+            # Clock started outside wait_for so BOTH the success path and the
+            # TimeoutError branch below can report the real elapsed time. acp
+            # never assigns TurnUsage.duration_ms, so the row needs this.
+            _turn_t0 = time.monotonic()
             response = await asyncio.wait_for(
                 stream_and_collect(
                     client,
@@ -2756,10 +2804,47 @@ class GatewayOrchestrator:
                     agent=read_effective_agent(client) or _get_agent_for_session(key),
                     context_used=_used,
                     context_window=_window,
+                    elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
                     model_source=client,
                 )
             except Exception:
                 logger.debug("usage row (monitor) persist failed", exc_info=True)
+        except asyncio.TimeoutError:
+            # ── Timeout spend is REAL spend (issue #874 follow-up). ──
+            # A timed-out nudge turn previously fell through to the generic
+            # handler below and wrote no row at all, silently dropping whatever
+            # the cancelled turn had already cost. Record it, then bail as
+            # before. Runs before the `finally` cancels/releases the session.
+            #
+            # No new schema field: the record has never carried a
+            # success/failure outcome for ANY surface, so a timeout row is no
+            # less honest than any other row.
+            logger.warning(
+                "AutoNudge: slack nudge turn timed out after %ss for %s (loop %s)",
+                _NUDGE_TURN_TIMEOUT,
+                key,
+                loop.id,
+            )
+            try:
+
+                _used, _window = read_context_tokens(client)
+                await persist_token_record_async(
+                    key,
+                    "",
+                    provider_last_turn_usage(client),
+                    provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                    surface="monitor",
+                    agent=read_effective_agent(client) or _get_agent_for_session(key),
+                    context_used=_used,
+                    context_window=_window,
+                    elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
+                    model_source=client,
+                )
+            except Exception:
+                logger.debug(
+                    "usage row (monitor timeout) persist failed", exc_info=True
+                )
+            return False
         except Exception:
             logger.exception("AutoNudge: slack nudge turn failed for %s (loop %s)", key, loop.id)
             return False

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -3709,6 +3709,14 @@ class SubagentManager:
                     msg = _TRANSIENT_CONTINUE_MSG if _had_activity else full_message
 
         _complete_event: LLMEvent | None = None
+        # Wall clock for THIS subagent's own turn. Deliberately started here,
+        # at the subagent's own stream, not on the parent side: under session
+        # sharing this subagent reuses the parent's runtime, so a parent-side
+        # clock would charge the child for the parent's elapsed time. acp
+        # leaves TurnUsage.duration_ms at 0, so the row needs this.
+        # Includes transient-retry backoff, which is real wall time the caller
+        # waited for this turn.
+        _turn_t0 = time.monotonic()
         async for event in _stream_with_transient_retry():
             # Refresh the activity clock for EVERY event kind (thinking chunks,
             # tool-call updates, etc.) before dispatch, so idle-stall detection
@@ -3970,6 +3978,7 @@ class SubagentManager:
                 agent=agent or read_effective_agent(client) or "",
                 context_used=_used,
                 context_window=_window,
+                elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
                 model_source=client,
             )
         except Exception:

--- a/src/kiro_crew/task_executor.py
+++ b/src/kiro_crew/task_executor.py
@@ -342,6 +342,12 @@ async def execute_task(
             result_text = ""
             _chunk_count = 0
             _complete_event: LLMEvent | None = None
+            # Wall clock for THIS turn only. The acp provider never assigns
+            # TurnUsage.duration_ms, so the record builder falls back to this
+            # local measurement (elapsed_ms). Bracket ONLY the stream: the prompt
+            # build and episodic-query embed above are turn setup, not the turn,
+            # and this loop re-runs per attempt so each row measures its own turn.
+            _turn_t0 = _time.monotonic()
             async for event in client.stream(full_prompt):
                 if event.kind == EVENT_TEXT_CHUNK:
                     result_text += event.text
@@ -549,6 +555,7 @@ async def execute_task(
                     agent=read_effective_agent(client) or agent or "",
                     context_used=_used,
                     context_window=_window,
+                    elapsed_ms=int((_time.monotonic() - _turn_t0) * 1000),
                     model_source=client,
                 )
             except Exception:
@@ -854,6 +861,10 @@ async def self_review(
             agent=agent or None,
             cwd=str(run.work_dir) if run.work_dir else None,
         )
+        # Wall clock for the review turn (see execute_task): the acp provider
+        # reports no duration, so this local measurement is the fallback. Bracket
+        # ONLY the model stream, not open_task_session / diff fetch / prompt build.
+        _review_t0 = _time.monotonic()
         result = await stream_and_collect_json(client, prompt)
 
         # ── Per-turn usage row (issue #647): self-review is a separate model turn. ──
@@ -880,6 +891,7 @@ async def self_review(
                 agent=read_effective_agent(client) or agent or "",
                 context_used=_used,
                 context_window=_window,
+                elapsed_ms=int((_time.monotonic() - _review_t0) * 1000),
                 model_source=client,
             )
         except Exception:

--- a/src/kiro_crew/workflows/agent_exec.py
+++ b/src/kiro_crew/workflows/agent_exec.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+import time
 from typing import Any, Callable, Optional
 
 from kiro_crew.llm_helpers import ToolApprovalPolicy, provider_last_turn_usage, stream_and_collect
@@ -75,6 +76,11 @@ def build_agent_fn(
             model=opts.get("model") or default_model,
             cwd=opts.get("cwd") or cwd,
         )
+        # Wall clock for THIS agent turn only (not the whole workflow run):
+        # acp leaves TurnUsage.duration_ms at 0, so without this the row's
+        # duration_ms is a literal 0. Started after get_or_create so session
+        # setup is not charged to the turn.
+        _turn_t0 = time.monotonic()
         try:
             text = await stream_and_collect(
                 provider,
@@ -83,32 +89,54 @@ def build_agent_fn(
                 max_turns=_MAX_TURNS_PER_STEP,
             )
             # ── Per-turn usage row (issue #647): attribute workflow spend. ──
+            # Best-effort analytics that must never break the workflow run — but
+            # the guards are deliberately NARROW. A single wide try around the
+            # import + context read + persist used to swallow ANY of them at
+            # debug, so one import failure or a context-read failure silently
+            # dropped the ENTIRE row (the workflow surface wrote zero rows).
+            #
+            # The import stays function-local on purpose: kiro_crew.dashboard.
+            # handlers.usage pulls in the slack handler chain, so a module-scope
+            # import can raise ImportError under some import orders. A genuine
+            # failure here is a real wiring bug, so surface it (warning) instead
+            # of hiding it — while still not aborting the run.
             try:
-                # circular import: reached while kiro_crew.slack.handler is still
-                # initialising (dashboard/handlers/files.py imports is_tracked_channel
-                # from it), so a module-scope import raises ImportError under the
-                # suite's import order.
                 from kiro_crew.dashboard.handlers.usage import (
                     persist_token_record_async,
                     read_context_tokens,
                     read_effective_agent,
                 )
-
-                _used, _window = read_context_tokens(provider)
-                await persist_token_record_async(
-                    key,
-                    opts.get("model") or default_model or "",
-                    provider_last_turn_usage(provider),
-                    provider="acp",
-                    surface="workflow",
-                    agent=(read_effective_agent(provider)
-                           or opts.get("agent") or default_agent or ""),
-                    context_used=_used,
-                    context_window=_window,
-                    model_source=provider,
+            except ImportError:
+                logger.warning(
+                    "workflow usage row skipped: usage handlers unimportable",
+                    exc_info=True,
                 )
-            except Exception:
-                logger.debug("usage row (workflow) persist failed", exc_info=True)
+            else:
+                # Context occupancy is enrichment only. Guard it on its OWN so a
+                # read failure degrades to (0, 0) instead of taking the row down.
+                try:
+                    _used, _window = read_context_tokens(provider)
+                except Exception:
+                    logger.debug("workflow context-token read failed", exc_info=True)
+                    _used, _window = 0, 0
+                # Only the persist stays in a best-effort try: a write failure
+                # must not break the workflow run, but nothing else hides here.
+                try:
+                    await persist_token_record_async(
+                        key,
+                        opts.get("model") or default_model or "",
+                        provider_last_turn_usage(provider),
+                        provider="acp",
+                        surface="workflow",
+                        agent=(read_effective_agent(provider)
+                               or opts.get("agent") or default_agent or ""),
+                        context_used=_used,
+                        context_window=_window,
+                        elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
+                        model_source=provider,
+                    )
+                except Exception:
+                    logger.debug("workflow usage row persist failed", exc_info=True)
             # Issue #2: Apply output redaction to prevent credential leakage
             # in workflow results stored in history or injected into parent chat.
             text, _ = redact_credentials(text)

--- a/test/test_turn_duration_hooks.py
+++ b/test/test_turn_duration_hooks.py
@@ -1,0 +1,103 @@
+"""Turn wall-clock (``elapsed_ms``) recorded by the webhook hooks surface.
+
+The acp provider never assigns ``TurnUsage.duration_ms`` (it stays 0), so
+``_run_hook_inner`` measures the turn locally and passes ``elapsed_ms`` to
+``persist_token_record_async``, which records ``duration_ms`` = the provider
+value when non-zero ELSE ``elapsed_ms``.
+
+Both tests drive the real persist path and capture the built record at
+``_write_token_record``, so the fallback (local clock fills a 0-duration turn)
+and its precedence (a provider-reported duration still wins) are exercised end
+to end — the negative control is what keeps the positive assertion honest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, AcpEvent, TurnUsage
+from kiro_crew.dashboard.handlers import usage
+from kiro_crew.dashboard.handlers.hooks import _run_hook_inner
+
+# A provider-reported duration no sub-second test turn could ever produce
+# (~16 min). A record showing it proves the provider value won over the local
+# wall clock; a record NOT showing it in the 0-duration case proves the local
+# clock is genuinely the fallback source.
+_PROVIDER_SENTINEL_MS = 987_654
+
+# Long enough that int((monotonic delta) * 1000) is reliably > 0 (a sub-ms turn
+# would floor to 0), short enough to keep the test fast. asyncio.sleep ensures at
+# least this much wall time elapses inside the streamed turn.
+_TURN_DELAY_S = 0.02
+
+
+class _FakeClient:
+    """Minimal stand-in for the ACP client ``_run_hook_inner`` streams from."""
+
+    def __init__(self, complete_event: AcpEvent) -> None:
+        self._complete_event = complete_event
+        # read_effective_agent / _resolve_model walk the wrapper chain for these.
+        self._agent = "kirocrew"
+        self._model = "claude-test"
+
+    async def stream(self, _message: str):
+        yield AcpEvent(kind=EVENT_TEXT_CHUNK, text="hello ")
+        # A real turn takes time; sleeping makes the measured wall clock non-zero.
+        await asyncio.sleep(_TURN_DELAY_S)
+        yield self._complete_event
+
+
+class _FakeSessions:
+    def __init__(self, client: _FakeClient) -> None:
+        self._client = client
+
+    async def get_or_create(self, _session_key: str, agent: str | None = None):
+        # is_new=False so _run_hook_inner skips context building (no embed pool).
+        return (self._client, False, False)
+
+    def record_success(self, _session_key: str) -> None:
+        pass
+
+
+class _FakeState:
+    def __init__(self, client: _FakeClient) -> None:
+        self.sessions = _FakeSessions(client)
+        self.context_builder = None
+
+
+def _drive(monkeypatch, complete_event: AcpEvent) -> dict:
+    """Run one webhook turn, returning the record handed to the writer.
+
+    ``persist_token_record_async`` builds the record on-loop (applying the
+    duration-or-elapsed precedence) then offloads the write to
+    ``_write_token_record`` — intercept there to read the final record without
+    touching a shard.
+    """
+    captured: dict = {}
+
+    def _capture(record: dict, _now: object) -> None:
+        captured["record"] = record
+
+    monkeypatch.setattr(usage, "_write_token_record", _capture)
+    asyncio.run(
+        _run_hook_inner(_FakeState(_FakeClient(complete_event)), "hook:test:1", "go", None)
+    )
+    return captured["record"]
+
+
+def test_webhook_turn_records_local_wall_clock(monkeypatch):
+    """acp reports duration_ms=0 -> the row falls back to the local turn clock."""
+    complete = AcpEvent(kind=EVENT_COMPLETE, usage=TurnUsage(duration_ms=0, credits=1.0))
+    record = _drive(monkeypatch, complete)
+
+    assert record["surface"] == "webhook"
+    assert record["duration_ms"] > 0, "local wall clock must fill a 0-duration turn"
+
+
+def test_provider_duration_wins_over_local_clock(monkeypatch):
+    """Negative control: a provider-reported duration is NOT overwritten by the
+    local clock, so the positive test above cannot pass vacuously."""
+    complete = AcpEvent(kind=EVENT_COMPLETE, usage=TurnUsage(duration_ms=_PROVIDER_SENTINEL_MS))
+    record = _drive(monkeypatch, complete)
+
+    assert record["duration_ms"] == _PROVIDER_SENTINEL_MS

--- a/test/test_turn_duration_recorded.py
+++ b/test/test_turn_duration_recorded.py
@@ -1,0 +1,160 @@
+"""Every dispatch surface must record a REAL turn duration.
+
+Regression guard for the row-store half of the ``duration_ms: 0`` defect. The
+OTEL histogram was fixed separately (per-instrument buckets); the row store kept
+reading ``TurnUsage.duration_ms``, which the acp provider never assigns, so every
+real row in ``<data home>/usage/tokens/*.jsonl`` carried a literal 0 and the
+Telemetry page could not answer "how long did this turn take".
+
+The fix threads a caller-measured ``elapsed_ms`` into the record builder as the
+FALLBACK for ``duration_ms``. These tests lock in three properties:
+
+1. the fallback fires when the provider reports nothing (the acp reality),
+2. a provider that DOES report still wins (so the fallback is not a clobber),
+3. every persist call site actually passes a measured value — the property that
+   would silently rot as new dispatch surfaces are added.
+
+Property 3 is enforced structurally (AST over the real source), not by mocking
+each surface: a mock-per-surface suite passes happily while a NEW surface added
+next quarter forgets the argument entirely.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from datetime import datetime
+
+import pytest
+
+from kiro_crew.acp.types import TurnUsage
+from kiro_crew.dashboard.handlers.usage import _build_token_record
+
+SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+
+
+class _Ev:
+    """Minimal stand-in for an AcpEvent carrying usage."""
+
+    def __init__(self, usage: TurnUsage) -> None:
+        self.usage = usage
+
+
+def _record(usage: TurnUsage, **kw: object) -> dict:
+    return _build_token_record("slot-1", "claude-opus-5", _Ev(usage), "acp",
+                               datetime.now().astimezone(), **kw)  # type: ignore[arg-type]
+
+
+# ─────────────────────── builder semantics ───────────────────────
+
+def test_local_wall_clock_is_recorded_when_provider_reports_nothing():
+    """The acp reality: usage.duration_ms is 0, so elapsed_ms must land."""
+    rec = _record(TurnUsage(input_tokens=10, output_tokens=5), elapsed_ms=227589)
+    assert rec["duration_ms"] == 227589
+
+
+def test_provider_reported_duration_wins_over_local_clock():
+    """Negative control: the fallback must not clobber a real provider value.
+
+    Without this, `test_local_wall_clock_is_recorded...` would still pass if the
+    implementation unconditionally overwrote duration_ms with elapsed_ms.
+    """
+    rec = _record(TurnUsage(input_tokens=10, output_tokens=5, duration_ms=999),
+                  elapsed_ms=227589)
+    assert rec["duration_ms"] == 999
+
+
+def test_omitting_elapsed_keeps_old_behaviour():
+    """Back-compat: a caller that passes nothing still gets 0, not a crash."""
+    rec = _record(TurnUsage(input_tokens=10, output_tokens=5))
+    assert rec["duration_ms"] == 0
+
+
+@pytest.mark.parametrize("junk", ["bogus", None, object()])
+def test_non_numeric_elapsed_cannot_break_serialization(junk):
+    """A bad value must degrade to 0, never raise into the dispatch path.
+
+    These records are best-effort analytics appended as JSON; a TypeError here
+    would surface inside a live turn.
+    """
+    rec = _record(TurnUsage(input_tokens=1, output_tokens=1), elapsed_ms=junk)
+    assert rec["duration_ms"] == 0
+
+
+# ─────────────────── every call site is wired ───────────────────
+
+# Files that persist a usage row, and how many call sites each owns. A new
+# surface MUST be added here deliberately, which is the point: the counts make
+# an unnoticed drift fail loudly instead of silently recording zeros.
+EXPECTED_SITES = {
+    "dashboard/chat_runner.py": 1,
+    "dashboard/handlers/hooks.py": 1,
+    "slack/gateway.py": 6,          # 2 cron + heartbeat + its timeout
+                                    #          + monitor + its timeout
+    "task_executor.py": 2,          # task step + self-review
+    "subagent.py": 1,
+    "workflows/agent_exec.py": 1,
+}
+
+
+def _persist_calls(tree: ast.AST) -> list[ast.Call]:
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", "")
+        if name in ("persist_token_record", "persist_token_record_async"):
+            out.append(node)
+    return out
+
+
+@pytest.mark.parametrize("rel,count", sorted(EXPECTED_SITES.items()))
+def test_every_persist_site_passes_a_measured_duration(rel, count):
+    """Structural: no dispatch surface may omit elapsed_ms.
+
+    Deliberately an AST walk over the real source rather than a mock per
+    surface — the failure mode being guarded is a FUTURE surface that never
+    passes the argument, which no amount of mocking existing ones would catch.
+    """
+    path = SRC / rel
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    calls = _persist_calls(tree)
+    assert len(calls) == count, (
+        f"{rel}: expected {count} persist call site(s), found {len(calls)}. "
+        "If a surface was added or removed, update EXPECTED_SITES deliberately."
+    )
+    for call in calls:
+        kwargs = {kw.arg for kw in call.keywords if kw.arg}
+        assert "elapsed_ms" in kwargs, (
+            f"{rel}:{call.lineno} persists a usage row without elapsed_ms, so "
+            "its duration_ms will be a literal 0 on the acp provider."
+        )
+
+
+def test_the_structural_check_can_actually_fail():
+    """Negative control for the AST walk itself.
+
+    Without this, a bug in _persist_calls that found ZERO calls would make the
+    per-file assertions vacuous everywhere.
+    """
+    tree = ast.parse(
+        "async def f():\n"
+        "    await persist_token_record_async('k', 'm', ev, surface='x')\n"
+    )
+    calls = _persist_calls(tree)
+    assert len(calls) == 1
+    assert "elapsed_ms" not in {kw.arg for kw in calls[0].keywords if kw.arg}
+
+
+# ───────────────── the dead Stats block is gone ─────────────────
+
+def test_chat_runner_no_longer_builds_the_dead_stats_object():
+    """The per-turn Stats() was constructed, incremented, and never read.
+
+    It also fed ``inc_duration_ms(usage.duration_ms)`` — the same structurally
+    zero field — so it was doubly dead. Guard against it being reintroduced.
+    """
+    src = (SRC / "dashboard" / "chat_runner.py").read_text(encoding="utf-8")
+    assert "stats = Stats()" not in src
+    assert "from kiro_crew.stats import Stats" not in src

--- a/test/test_turn_duration_slack.py
+++ b/test/test_turn_duration_slack.py
@@ -1,0 +1,227 @@
+"""Turn wall clock + timeout-spend recording on the Slack dispatch surface.
+
+``gateway.py`` now measures a local ``time.monotonic()`` wall clock for each
+background dispatch turn and passes it as ``elapsed_ms`` to
+``persist_token_record_async``. The acp provider never assigns
+``TurnUsage.duration_ms`` (it stays 0), so without this the row store recorded
+``duration_ms=0`` for every real turn; the record builder now falls back to the
+caller's ``elapsed_ms`` when the provider reports nothing (issue #647 / #874
+follow-up).
+
+The two ``asyncio.wait_for`` timeout branches (slack heartbeat and the monitor
+auto-nudge) previously wrote NO row at all on timeout, silently dropping the
+spend the cancelled turn had already incurred. They now record it.
+
+These tests drive the monitor path (``GatewayOrchestrator._fire_slack_nudge``)
+end to end because it is a directly-callable method. Its timeout branch has the
+same shape as the heartbeat one -- read the provider's accumulated usage off the
+still-alive client, then persist with the measured elapsed -- and both go
+through the identical ``persist_token_record_async(..., elapsed_ms=...)`` seam.
+The heartbeat runner is a closure nested inside ``_init_heartbeat`` and is not
+callable in isolation, so it is covered by code review + this shared-shape test
+rather than driven directly here.
+
+Assertions read the real usage shard written under the per-test isolated
+``KIROCREW_HOME`` (the autouse ``_isolate_kirocrew_home`` conftest fixture), so
+they exercise the full chain gateway -> persist -> ``_build_token_record``
+precedence, not a mock of it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.acp.types import TurnUsage
+from kiro_crew.autonudge import NudgeLoop
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard.handlers.usage import _token_usage_dir
+from kiro_crew.slack import gateway as gw
+
+
+class _StepClock:
+    """Deterministic stand-in for the ``time`` module in ``gateway.py``.
+
+    ``gateway.py`` reads ``time.monotonic()`` once to open the turn
+    (``_turn_t0``) and once more when it builds the persist kwargs. The first
+    read returns ``start`` and every later read returns ``later``, so the
+    recorded elapsed is exactly ``(later - start) * 1000`` ms regardless of how
+    many reads happen -- decoupling the asserted duration from real wall time.
+    Any other attribute (e.g. ``time.time``) proxies to the real module so an
+    unrelated call in the exercised path still behaves.
+    """
+
+    def __init__(self, start: float, later: float) -> None:
+        self._start = start
+        self._later = later
+        self._opened = False
+
+    def monotonic(self) -> float:
+        if not self._opened:
+            self._opened = True
+            return self._start
+        return self._later
+
+    def __getattr__(self, name: str):
+        return getattr(time, name)
+
+
+def _fake_client() -> SimpleNamespace:
+    """A minimal provider/client stub for the usage readers.
+
+    ``read_context_tokens`` calls the two accessors; ``read_effective_agent``
+    walks the wrapper chain and picks up ``_agent``. ``provider_last_turn_usage``
+    is patched per test, so nothing here needs a ``last_prompt_stats``.
+    """
+    return SimpleNamespace(
+        context_used_tokens=lambda: 4096,
+        context_window_tokens=lambda: 200000,
+        _agent="kirocrew-monitor",
+    )
+
+
+def _fake_sessions(client: object) -> MagicMock:
+    s = MagicMock()
+    s.is_busy = MagicMock(return_value=False)
+    s.get_channel = MagicMock(return_value="C123")
+    s.get_thread = MagicMock(return_value="111.222")
+    s.get_or_create = AsyncMock(return_value=(client, True, False))
+    s.cancel_current = AsyncMock()
+    s.release = MagicMock()
+    return s
+
+
+def _build_orchestrator(client: object) -> gw.GatewayOrchestrator:
+    """Construct a real orchestrator, then swap in the collaborators the
+    monitor nudge path touches."""
+    cfg = KiroCrewConfig()
+    creds = {"KIROCREW_OWNER_ID": "U_OWNER"}
+    with patch.object(cfg, "load_credentials", return_value=creds):
+        orch = gw.GatewayOrchestrator(
+            cfg, no_dashboard=True, no_crons=True, no_open=True
+        )
+    orch.sessions = _fake_sessions(client)
+    orch.slack = MagicMock()
+    orch.slack.post_message = AsyncMock()
+    orch.ctx_builder = SimpleNamespace(
+        hooks=object(), build_message=lambda *a, **k: ("MSG", None)
+    )
+    orch.conv_log = None
+    orch.autonudge_svc = None
+
+    # The approval callback is never invoked (stream_and_collect is stubbed);
+    # replace it with a harmless async approver so building it can't reach into
+    # unset dashboard state.
+    async def _approve(_event: object) -> bool:
+        return True
+
+    orch._interactive_approval = lambda _source: _approve
+    return orch
+
+
+def _monitor_rows() -> list[dict]:
+    """All ``surface == "monitor"`` records in the isolated usage shard(s)."""
+    rows: list[dict] = []
+    shard_dir = _token_usage_dir()
+    if not shard_dir.exists():
+        return rows
+    for shard in shard_dir.glob("*.jsonl"):
+        for line in shard.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            if rec.get("surface") == "monitor":
+                rows.append(rec)
+    return rows
+
+
+def test_monitor_turn_records_local_wall_clock(monkeypatch):
+    """Normal path: acp reports no duration, so the row records the gateway's
+    local wall clock -- a non-zero ``duration_ms``."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+
+    monkeypatch.setattr(gw, "time", _StepClock(1000.0, 1005.0))  # 5000 ms
+    monkeypatch.setattr(
+        gw, "provider_last_turn_usage", lambda _c: TurnUsage(credits=0.42)
+    )
+
+    async def _stream_ok(*_a, **_k):
+        return "hello from the nudge turn"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_ok)
+
+    loop = NudgeLoop(id="loop-normal", slot_key="slack:111.222", message="check it")
+    result = asyncio.run(orch._fire_slack_nudge(loop))
+
+    assert result is True
+    rows = _monitor_rows()
+    assert len(rows) == 1
+    rec = rows[0]
+    assert rec["duration_ms"] == 5000
+    assert rec["duration_ms"] > 0
+    assert rec["credits"] == pytest.approx(0.42)
+
+
+def test_monitor_timeout_records_previously_dropped_row(monkeypatch):
+    """Timeout path: the turn is cancelled by ``wait_for``, but the spend it had
+    already incurred is now recorded (previously the row was never written)."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+
+    monkeypatch.setattr(gw, "time", _StepClock(1000.0, 1000.5))  # 500 ms
+    monkeypatch.setattr(
+        gw, "provider_last_turn_usage", lambda _c: TurnUsage(credits=0.17)
+    )
+    monkeypatch.setattr(gw, "_NUDGE_TURN_TIMEOUT", 0.05)
+
+    async def _stream_hang(*_a, **_k):
+        await asyncio.sleep(1.0)
+        return "never returned"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_hang)
+
+    loop = NudgeLoop(id="loop-timeout", slot_key="slack:111.222", message="slow")
+    result = asyncio.run(orch._fire_slack_nudge(loop))
+
+    assert result is False  # the timeout branch bails after recording
+    rows = _monitor_rows()
+    assert len(rows) == 1  # previously ZERO rows were written on timeout
+    assert rows[0]["credits"] == pytest.approx(0.17)
+    assert rows[0]["duration_ms"] == 500
+
+
+def test_provider_duration_wins_over_local_clock(monkeypatch):
+    """Negative control: when the provider DOES report a duration it wins over
+    the local clock, so the normal-path assertion above is not vacuous."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+
+    # The local clock would record 1234 ms ...
+    monkeypatch.setattr(gw, "time", _StepClock(1000.0, 1001.234))
+    # ... but a provider-reported 5000 ms duration must win.
+    monkeypatch.setattr(
+        gw,
+        "provider_last_turn_usage",
+        lambda _c: TurnUsage(credits=0.42, duration_ms=5000),
+    )
+
+    async def _stream_ok(*_a, **_k):
+        return "done"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_ok)
+
+    loop = NudgeLoop(id="loop-neg", slot_key="slack:111.222", message="fast")
+    result = asyncio.run(orch._fire_slack_nudge(loop))
+
+    assert result is True
+    rows = _monitor_rows()
+    assert len(rows) == 1
+    assert rows[0]["duration_ms"] == 5000  # provider wins
+    assert rows[0]["duration_ms"] != 1234  # not the local-clock fallback

--- a/test/test_turn_duration_subagent.py
+++ b/test/test_turn_duration_subagent.py
@@ -1,0 +1,177 @@
+"""Turn wall-clock for the subagent dispatch surface (``subagent.py``).
+
+The record builder falls back to a caller-measured ``elapsed_ms`` for
+``duration_ms`` because the acp provider always reports
+``TurnUsage.duration_ms == 0`` (nothing assigns it). These tests pin the
+SUBAGENT surface's half of that contract: ``_run_inner`` measures its OWN turn
+wall clock (``_turn_t0``, started at the subagent's own stream — never the
+parent's under session sharing) and passes it as ``elapsed_ms`` to
+``persist_token_record_async``.
+
+Two tests, the second a negative control so the first cannot pass vacuously:
+
+1. provider reports no duration  -> the row records the local wall clock (> 0).
+2. provider reports a duration   -> that value WINS; the local clock is ignored.
+
+Capture happens at ``usage._write_token_record`` so the REAL
+``persist_token_record_async`` and ``_build_token_record`` run — the assertions
+see the genuine ``duration_ms or elapsed_ms`` precedence, not a re-implemented
+copy of it. Subagent-registry and ``KIROCREW_HOME`` isolation come from the
+autouse conftest fixtures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.acp.types import TurnUsage
+from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK
+from kiro_crew.subagent import SubagentManager
+
+# Implausibly large: no unit-test turn runs ~16 minutes, so a row carrying this
+# value can only have come from the provider, never from the local wall clock.
+_PROVIDER_DURATION_MS = 987654
+
+# Real time forced to pass inside the turn so the local clock is measurably
+# non-zero. asyncio.sleep floors the elapsed wall time at >= this many seconds.
+_TURN_SLEEP_SECS = 0.03
+
+
+def _text_event(text: str) -> SimpleNamespace:
+    return SimpleNamespace(kind=EVENT_TEXT_CHUNK, text=text)
+
+
+def _complete_event(usage: TurnUsage | None = None) -> SimpleNamespace:
+    """An EVENT_COMPLETE. With no ``usage`` it mirrors the real acp stream,
+    where nothing assigns ``duration_ms`` and the row must fall back to the
+    caller's ``elapsed_ms``."""
+    ev = SimpleNamespace(kind=EVENT_COMPLETE, stop_reason="end_turn")
+    if usage is not None:
+        ev.usage = usage
+    return ev
+
+
+def _mock_sessions(stream_factory) -> MagicMock:
+    sessions = MagicMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    provider = AsyncMock()
+    provider.start = AsyncMock()
+    provider.shutdown = AsyncMock()
+    provider.context_usage_pct = lambda: 0.0
+    provider.stream = MagicMock(side_effect=stream_factory)
+    sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    sessions.record_success = MagicMock()
+    sessions.get_agent = MagicMock(return_value="")
+    sessions.get_approval_policy = MagicMock(return_value="auto")
+    sessions.has_session = MagicMock(return_value=True)
+    sessions._provider = provider
+    return sessions
+
+
+def _mock_ctx_builder() -> MagicMock:
+    ctx = MagicMock()
+    ctx.build_message = MagicMock(return_value=("built_message", None))
+    ctx.hooks.on_tool_call = MagicMock()
+    ctx.hooks.auto_approve_subagent_spawn = True
+    ctx.hooks.auto_approve_subagent_tools = False
+    return ctx
+
+
+def _manager(sessions: MagicMock) -> SubagentManager:
+    mgr = SubagentManager(sessions=sessions, ctx_builder=_mock_ctx_builder())
+    # Force the dedicated-process path (deterministic under MagicMock sessions).
+    # The clock lives in _run_inner, which is entered once per subagent turn on
+    # BOTH paths, so this exercises the same measurement the shared path uses.
+    mgr._should_use_session_sharing = MagicMock(return_value=False)
+    return mgr
+
+
+async def _spawn_and_capture(stream_factory) -> list[dict]:
+    """Drive one subagent turn and return the token records it persisted.
+
+    The three ``read_*`` helpers are pinned so nothing depends on the mock
+    provider's internals; only ``_write_token_record`` is replaced (to capture),
+    leaving the real persist + record-builder precedence under test.
+    """
+    captured: list[dict] = []
+    mgr = _manager(_mock_sessions(stream_factory))
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch(
+            "kiro_crew.dashboard.handlers.usage._write_token_record",
+            side_effect=lambda record, now: captured.append(record),
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.usage.read_context_tokens",
+            return_value=(0, 0),
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.usage.read_effective_agent",
+            return_value="kirocrew",
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.usage.read_effective_model",
+            return_value="claude-opus-5",
+        ),
+    ):
+        info = mgr.spawn("measure my turn")
+        assert info is not None
+        await mgr._tasks[info.id]
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_subagent_turn_records_local_wall_clock():
+    """acp reports no duration -> the subagent row records its OWN wall clock."""
+
+    def stream_factory(msg, *a, **kw):
+        async def _gen():
+            yield _text_event("working ")
+            # Guarantee measurable wall time between _turn_t0 and the persist.
+            await asyncio.sleep(_TURN_SLEEP_SECS)
+            yield _complete_event()  # no usage -> duration_ms unset (acp shape)
+
+        return _gen()
+
+    records = await _spawn_and_capture(stream_factory)
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["surface"] == "subagent"
+    # The fallback fired: a real, positive local measurement — not the literal
+    # 0 the provider-only read used to write into every row.
+    assert rec["duration_ms"] > 0
+    # Tie it to the real clock: >= the forced sleep, minus scheduling slop.
+    assert rec["duration_ms"] >= 20
+
+
+@pytest.mark.asyncio
+async def test_provider_reported_duration_wins_over_local_clock():
+    """Negative control: a provider-reported duration WINS and the local clock
+    is ignored — so the positive test cannot pass vacuously. A broken "always
+    write elapsed_ms" implementation would record ~30ms here, not the provider
+    value."""
+
+    def stream_factory(msg, *a, **kw):
+        async def _gen():
+            yield _text_event("working ")
+            # Local clock would read ~30ms here; the row must NOT use it.
+            await asyncio.sleep(_TURN_SLEEP_SECS)
+            yield _complete_event(TurnUsage(duration_ms=_PROVIDER_DURATION_MS))
+
+        return _gen()
+
+    records = await _spawn_and_capture(stream_factory)
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["surface"] == "subagent"
+    # Provider value recorded verbatim — NOT the ~30ms local measurement.
+    assert rec["duration_ms"] == _PROVIDER_DURATION_MS

--- a/test/test_turn_duration_task_runner.py
+++ b/test/test_turn_duration_task_runner.py
@@ -1,0 +1,182 @@
+"""Turn wall-clock accounting for the task_runner dispatch surface (issue #647).
+
+``task_executor`` persists a per-turn usage row at two sites — the main
+execution turn in :func:`execute_task` and the separate model turn in
+:func:`self_review`. The acp provider never assigns ``TurnUsage.duration_ms``
+(only the removed claude_code provider did), so each site now measures its own
+wall clock and passes it as the ``elapsed_ms`` fallback. ``_build_token_record``
+records ``duration_ms = provider value when non-zero, ELSE elapsed_ms``.
+
+These tests prove, per site:
+  * the row records a non-zero duration sourced from the local clock when the
+    provider is silent (the acp reality), and
+  * a negative control — a provider-reported duration still WINS over the local
+    clock — so the positive assertion cannot pass vacuously.
+
+The REAL ``persist_token_record_async`` runs (so the precedence in
+``_build_token_record`` is exercised for real); only the disk append
+(``_write_token_record``) is intercepted, so no usage shard is written.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew import task_executor
+from kiro_crew.acp.types import TurnUsage
+from kiro_crew.dashboard.handlers import usage
+from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
+from kiro_crew.task_models import Project, Task
+
+# A turn long enough that ``int(elapsed_s * 1000)`` is unambiguously >= 1 on any
+# host (asyncio.sleep is a lower bound), yet trivially short for the suite.
+_TURN_SLEEP_S = 0.02
+# A provider-reported duration the ~20 ms local clock can never coincide with,
+# so "provider wins" is distinguishable from "local clock was used".
+_PROVIDER_MS = 987654
+
+
+def _complete_event(duration_ms: int) -> LLMEvent:
+    """An EVENT_COMPLETE carrying a provider ``duration_ms`` (0 == silent)."""
+    return LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage(duration_ms=duration_ms))
+
+
+def _intercept_usage(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Run the REAL persist path but capture the built record instead of writing.
+
+    Patches the record's disk append and the client-reading helpers (which would
+    otherwise need a live provider). Returns the list capturing each record.
+    """
+    captured: list[dict] = []
+    monkeypatch.setattr(usage, "_write_token_record", lambda record, now: captured.append(record))
+    monkeypatch.setattr(usage, "read_context_tokens", lambda *a, **k: (100, 1000))
+    monkeypatch.setattr(usage, "read_effective_agent", lambda *a, **k: "agentX")
+    monkeypatch.setattr(usage, "read_effective_model", lambda *a, **k: "test-model")
+    fake_config = MagicMock()
+    fake_config.load.return_value = SimpleNamespace(agent=SimpleNamespace(provider="acp"))
+    monkeypatch.setattr(task_executor, "KiroCrewConfig", fake_config)
+    return captured
+
+
+def _make_run(task: Task) -> Project:
+    run = Project(spec_path="spec.md", spec_content="body")
+    run.task_id = "task-test"
+    run.tasks = [task]
+    run.branch_name = ""  # no git branch -> skip diff/commit/revert paths
+    run.work_dir = ""
+    return run
+
+
+class _StreamClient:
+    """Fake ACP client whose stream sleeps (a measurable turn) then completes."""
+
+    def __init__(self, event: LLMEvent) -> None:
+        self._event = event
+
+    async def stream(self, _prompt: str):
+        await asyncio.sleep(_TURN_SLEEP_S)
+        yield self._event
+
+
+def _make_sessions(client: object) -> MagicMock:
+    sessions = MagicMock()
+    sessions.open_task_session = AsyncMock(return_value=(client, True, False))
+    sessions.record_success = MagicMock()
+    sessions.check_context_usage = MagicMock()
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    sessions.record_failure = AsyncMock()
+    return sessions
+
+
+async def _run_execute_task(monkeypatch: pytest.MonkeyPatch, provider_ms: int) -> dict:
+    """Drive one ``execute_task`` turn; return its single captured usage row."""
+    captured = _intercept_usage(monkeypatch)
+    monkeypatch.setattr(task_executor, "check_context", AsyncMock())
+    monkeypatch.setattr(task_executor, "build_task_prompt", AsyncMock(return_value="PROMPT"))
+
+    task = Task(index=1, title="do the thing", description="desc")
+    run = _make_run(task)
+    client = _StreamClient(_complete_event(provider_ms))
+    sessions = _make_sessions(client)
+
+    ok = await task_executor.execute_task(
+        run,
+        task,
+        sessions,
+        None,  # ctx -> no episodic embed
+        "agentX",  # agent
+        None,  # on_tool_approval
+        False,  # auto_test -> skip run_tests
+        None,  # test_cmd
+        "",  # work_dir
+        AsyncMock(),  # on_notify (unused on the happy path)
+        "task-test:task1",
+    )
+    assert ok is True
+    assert len(captured) == 1, "execute_task must persist exactly one row per turn"
+    return captured[0]
+
+
+async def _run_self_review(monkeypatch: pytest.MonkeyPatch, provider_ms: int) -> dict:
+    """Drive one ``self_review`` turn; return its single captured usage row."""
+    captured = _intercept_usage(monkeypatch)
+
+    async def _review_stream(*_a, **_k):
+        await asyncio.sleep(_TURN_SLEEP_S)
+        return {"ok": True}
+
+    monkeypatch.setattr(task_executor, "stream_and_collect_json", _review_stream)
+    monkeypatch.setattr(
+        task_executor,
+        "provider_last_turn_usage",
+        MagicMock(return_value=_complete_event(provider_ms)),
+    )
+
+    task = Task(index=1, title="do the thing", description="desc")
+    run = _make_run(task)
+    sessions = MagicMock()
+    sessions.open_task_session = AsyncMock(return_value=(MagicMock(), True, False))
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+
+    ok = await task_executor.self_review(run, task, sessions, "agentX", "task-test:task1")
+    assert ok is True
+    assert len(captured) == 1, "self_review must persist exactly one row per turn"
+    return captured[0]
+
+
+@pytest.mark.asyncio
+async def test_execute_task_records_local_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Provider silent (the acp reality) -> the row's duration is the local clock.
+    record = await _run_execute_task(monkeypatch, provider_ms=0)
+    assert record["surface"] == "task_runner"
+    assert isinstance(record["duration_ms"], int)
+    assert record["duration_ms"] >= 1, "execute_task turn must record a non-zero local duration"
+
+
+@pytest.mark.asyncio
+async def test_execute_task_provider_duration_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Negative control: a provider-reported duration WINS over the local clock,
+    # so the positive test above cannot be passing vacuously.
+    record = await _run_execute_task(monkeypatch, provider_ms=_PROVIDER_MS)
+    assert record["duration_ms"] == _PROVIDER_MS
+
+
+@pytest.mark.asyncio
+async def test_self_review_records_local_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    record = await _run_self_review(monkeypatch, provider_ms=0)
+    assert record["surface"] == "task_runner"
+    assert isinstance(record["duration_ms"], int)
+    assert record["duration_ms"] >= 1, "self_review turn must record a non-zero local duration"
+
+
+@pytest.mark.asyncio
+async def test_self_review_provider_duration_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Negative control for the review turn (see execute_task counterpart).
+    record = await _run_self_review(monkeypatch, provider_ms=_PROVIDER_MS)
+    assert record["duration_ms"] == _PROVIDER_MS

--- a/test/test_turn_duration_workflow.py
+++ b/test/test_turn_duration_workflow.py
@@ -1,0 +1,187 @@
+"""Workflow surface: per-turn usage row survives, and carries a real duration.
+
+Guards two independent fixes in ``kiro_crew.workflows.agent_exec.build_agent_fn``:
+
+1. **The swallowed-row bug (regression).** The usage-row block used to wrap the
+   function-local import, the context-token read, AND the persist in one wide
+   ``try/except Exception: logger.debug(...)``. A failure in the *enrichment*
+   step (the context read) therefore jumped past the persist and the workflow
+   surface wrote **zero** rows. :func:`test_context_read_failure_still_writes_row`
+   injects exactly that failure; it FAILS on the old wide try (no row) and passes
+   now that the context read is guarded on its own with a ``(0, 0)`` fallback.
+2. **The turn wall clock.** acp never assigns ``TurnUsage.duration_ms`` (only the
+   removed claude_code provider did), so the row's ``duration_ms`` was a literal
+   0. ``agent_fn`` now measures a local monotonic clock and passes it as
+   ``elapsed_ms``; the record builder uses it only as a FALLBACK — a
+   provider-reported duration still wins.
+
+These tests never touch disk: they patch ``usage._write_token_record`` to
+capture the exact record ``_build_token_record`` produced, so the real
+duration/precedence logic is exercised with zero shard pollution.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import kiro_crew.dashboard.handlers.usage as usage_mod
+import kiro_crew.workflows.agent_exec as agent_exec
+from kiro_crew.acp.types import TurnUsage
+from kiro_crew.workflows.agent_exec import build_agent_fn
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeProvider:
+    """Bare provider double — no context/agent accessors, so the real
+    ``read_context_tokens`` yields ``(0, 0)`` and ``read_effective_agent`` yields
+    ``""`` (falls back to the step's agent)."""
+
+    def __init__(self, key: str = "k") -> None:
+        self.key = key
+
+
+class FakeSessions:
+    """Minimal SessionManager double recording releases."""
+
+    def __init__(self) -> None:
+        self.released: list[str] = []
+
+    async def get_or_create(self, key, *, agent=None, model=None, cwd=None, **kw):
+        return FakeProvider(key), True, False
+
+    def release(self, key, *, cleanup=False):
+        self.released.append(key)
+
+
+class _FakeTime:
+    """Stand-in for the ``time`` module in agent_exec (only ``monotonic`` used).
+
+    Patched onto ``agent_exec.time`` alone so agent_fn's turn clock is
+    deterministic WITHOUT disturbing asyncio's real event-loop clock.
+    """
+
+    def __init__(self, *values: float) -> None:
+        self._values = list(values)
+        self._i = 0
+
+    def monotonic(self) -> float:
+        v = self._values[min(self._i, len(self._values) - 1)]
+        self._i += 1
+        return v
+
+
+@pytest.fixture(autouse=True)
+def _fast_stream(monkeypatch):
+    """stream_and_collect → echo the prompt (no real model / kiro-cli)."""
+
+    async def fake_stream(provider, message, **kw):
+        return f"reply:{message}"
+
+    monkeypatch.setattr(agent_exec, "stream_and_collect", fake_stream)
+
+
+@pytest.fixture
+def captured_rows(monkeypatch):
+    """Capture every record handed to the shard writer, without disk I/O.
+
+    ``persist_token_record_async`` resolves ``_write_token_record`` as a
+    usage-module global at call time (then runs it via ``asyncio.to_thread``), so
+    patching the module attribute captures the REAL record ``_build_token_record``
+    built — exercising the actual duration precedence — with zero file writes.
+    """
+    rows: list[dict] = []
+    monkeypatch.setattr(
+        usage_mod, "_write_token_record", lambda record, now: rows.append(record)
+    )
+    return rows
+
+
+async def test_context_read_failure_still_writes_row(captured_rows, monkeypatch):
+    """REGRESSION: a failing context-token read must NOT take the whole row down.
+
+    Old wide try: ``read_context_tokens`` shared one ``except Exception`` with the
+    persist, so this RuntimeError skipped the persist and the workflow surface
+    wrote zero rows. This asserts a row is STILL written (context degraded to
+    0/0) — it fails on the old behavior, passes on the narrowed guards.
+    """
+    boom = MagicMock(side_effect=RuntimeError("context read boom"))
+    monkeypatch.setattr(usage_mod, "read_context_tokens", boom)
+
+    sessions = FakeSessions()
+    fn = build_agent_fn(
+        sessions, run_id="wf_reg", default_agent="researcher", default_model="m1"
+    )
+
+    out = await fn("do work", {})
+
+    assert out == "reply:do work"          # the workflow run completed normally
+    assert boom.called                     # the failing read path WAS exercised
+    assert len(captured_rows) == 1         # ...and a usage row was STILL written
+    row = captured_rows[0]
+    assert row["surface"] == "workflow"
+    assert row["agent"] == "researcher"    # fell back from empty read_effective_agent
+    assert row["context_used"] == 0        # degraded to the (0, 0) fallback
+    assert row["context_window"] == 0
+
+
+async def test_row_records_local_wall_clock_when_provider_reports_none(
+    captured_rows, monkeypatch
+):
+    """duration_ms is the locally measured wall clock when the provider reports
+    none (the acp case: TurnUsage.duration_ms == 0)."""
+    # Deterministic turn clock: t0=1000.0, persist-time=1000.250 → 250 ms.
+    monkeypatch.setattr(agent_exec, "time", _FakeTime(1000.0, 1000.25))
+    monkeypatch.setattr(
+        agent_exec, "provider_last_turn_usage", lambda p: TurnUsage(duration_ms=0)
+    )
+
+    sessions = FakeSessions()
+    fn = build_agent_fn(sessions, run_id="wf_dur", default_model="m1")
+
+    await fn("hi", {})
+
+    assert len(captured_rows) == 1
+    assert captured_rows[0]["duration_ms"] == 250
+
+
+async def test_provider_reported_duration_wins_over_local_clock(
+    captured_rows, monkeypatch
+):
+    """Negative control: a provider-reported duration WINS — the local clock is a
+    fallback, never an override."""
+    # The local clock would compute 250 ms; the provider reports 999999.
+    monkeypatch.setattr(agent_exec, "time", _FakeTime(1000.0, 1000.25))
+    monkeypatch.setattr(
+        agent_exec,
+        "provider_last_turn_usage",
+        lambda p: TurnUsage(duration_ms=999999),
+    )
+
+    sessions = FakeSessions()
+    fn = build_agent_fn(sessions, run_id="wf_neg", default_model="m1")
+
+    await fn("hi", {})
+
+    assert len(captured_rows) == 1
+    assert captured_rows[0]["duration_ms"] == 999999  # provider value, not 250
+
+
+async def test_persist_failure_does_not_break_workflow_run(monkeypatch):
+    """A persist write failure is best-effort: it must never propagate out and
+    break the workflow run, and the ephemeral session is still torn down."""
+
+    async def boom(*a, **kw):
+        raise RuntimeError("shard write exploded")
+
+    monkeypatch.setattr(usage_mod, "persist_token_record_async", boom)
+
+    sessions = FakeSessions()
+    fn = build_agent_fn(sessions, run_id="wf_pf", default_model="m1")
+
+    out = await fn("still works", {})
+
+    assert out == "reply:still works"        # run completed despite the raise
+    assert sessions.released == ["wf:wf_pf:0"]  # ephemeral session cleaned up


### PR DESCRIPTION
## Problem

Every real row in the per-turn usage shards (`<data home>/usage/tokens/*.jsonl`)
carries `duration_ms: 0`. Measured on a live gateway right before this change:
**0 of 50 real rows had a duration**. The Telemetry page therefore cannot answer
"how long did this turn take" from the row store, and no latency question can be
asked of it at all.

## Why it matters

The row store is the only per-turn record with full attribution (slot, agent,
model, surface, context occupancy). With duration structurally absent, cost and
latency cannot be correlated per turn — you can see what a turn cost but not what
it cost *per second*, and slow surfaces cannot be told from cheap ones. The OTEL
histogram was fixed earlier, so the two sinks also disagreed about the same turn.

Separately, timed-out background turns recorded **nothing at all**, so spend that
was genuinely incurred was silently dropped.

## Fix (symptom → root cause → change)

The builder read `TurnUsage.duration_ms`. Nothing in the tree assigns that field
— only the removed `claude_code` provider ever filled it in, so on acp (the only
provider now) it is **structurally always 0**:

```python
# acp/types.py
duration_ms: int = 0        # never assigned anywhere
```

The OTEL emit path had already worked around this with a locally measured wall
clock. The row store was never wired to the same value:

```python
# before — dashboard/handlers/usage.py
"duration_ms": getattr(u, "duration_ms", 0),                      # always 0
# after
"duration_ms": getattr(u, "duration_ms", 0) or _coerce_int(elapsed_ms),
```

`elapsed_ms` is a new keyword on `_build_token_record` and both persist entry
points, used as the **fallback** — a provider-reported value still wins. That is
the same precedence the OTEL path already uses
(`chat_runner._attach_turn_stats`: `value = duration_ms or elapsed_ms`), so the
histogram and the row store can no longer disagree about one turn.

**Why per-site clocks rather than one:** there is no global turn boundary to hang
a single clock on. Each of the 12 call sites across 6 modules measures its own
turn and brackets only the model turn — session acquisition, prompt assembly and
episodic-query embeds are setup, not turn time. `task_executor` is the clearest
case: it is not one row per step (2 on success, 3 on the review-failure branch),
and the self-review turn is a separate model call that must not inherit the task
turn's clock.

### Also in this change

- **Timeout spend is no longer discarded.** The slack heartbeat and monitor turns
  run under `asyncio.wait_for`. On timeout they wrote no row at all. Both now
  record before teardown reclaims the client — placement matters, since the
  client's last-turn usage goes away with it.
  *No new schema field:* the record has never carried a success/failure outcome
  for **any** surface, so a timeout row is no less honest than any other row, and
  the duration recorded is the real elapsed time.

- **Removed a dead per-turn `Stats()`** in `chat_runner`. It was constructed and
  incremented but never read, and it fed `inc_duration_ms(usage.duration_ms)` —
  the same structurally-zero field — so it was doubly dead. Verified unread
  before deleting (the `stats` name at `_attach_turn_stats` is a different local
  in another scope). Its now-unused import goes with it.

## Tests

`test/test_turn_duration_recorded.py` plus four per-surface behavioural files
(26 tests total).

- **Builder semantics** — the fallback fires when the provider reports nothing.
- **Negative control** — a provider-reported duration still *wins*. Without this,
  the positive test would also pass an implementation that unconditionally
  clobbered `duration_ms`.
- **Back-compat** — a caller passing nothing still gets 0, not a crash.
- **Robustness** — non-numeric input degrades to 0 rather than raising into a
  live turn (these rows are best-effort analytics appended as JSON).
- **Structural coverage** — an AST walk asserts every persist call site passes
  `elapsed_ms`, with per-file counts. Deliberately *not* a mock-per-surface
  suite: the failure mode worth guarding is a **future** dispatch surface that
  forgets the argument and silently records zeros, which mocking the existing
  ones would never catch. The walk carries its own negative control so it cannot
  pass vacuously. It already earned its keep — it caught a miscount in this PR's
  own expected site table.
- **Per-surface end-to-end** — hooks / subagent / task_runner / workflow drive
  the *real* persist path and capture at `_write_token_record`, so they observe
  the genuine precedence rather than a re-implemented copy of it.

## Manual verification

Full suite: 22956 passed. 21 failures, all pre-existing and environment-only on
this host (it cannot `unshare(CLONE_NEWUSER)`). Triaged by the rule that raw
counts drift: the **non-sandbox** failure set is 9 and was confirmed
**byte-identical on a detached clean `main`** at the same base commit — same 9
tests, all in files this PR does not touch (beacon, deploy, dev_fleet,
gateway_lock, issue_radar, source_providers).

Gates green: `isort --check-only`, `flake8 -j 1`, `mypy` (574 source files, no
issues).

No frontend changes, so `tsc` / `vitest` are not applicable.

## Screenshots

N/A — no user-visible UI change in this PR. The Telemetry page reads these rows,
but this change only populates a field that was already rendered; a screenshot of
real non-zero durations needs live traffic through the new code, which is covered
by the QA pass rather than a static capture.
