### PR TITLE
fix(chat): stop streaming rows remounting per chunk; constant-latency reveal

### DIFF
--- a/website/src/hooks/useSmoothStream.ts
+++ b/website/src/hooks/useSmoothStream.ts
@@ -9,54 +9,73 @@ import { useEffect, useRef, useState } from 'react'
  * sentence) and freezes in the gaps between bursts.
  *
  * This hook sits between the raw growing `content` and what the renderer sees.
- * It advances a "revealed" cursor toward the real content length at a steady,
- * adaptive rate via requestAnimationFrame:
- *   - a constant floor (BASE_CPS) keeps text flowing even when the model pauses;
- *   - a backlog term (CATCHUP) speeds up when the model races ahead, so the
- *     buffer never lags more than a few characters behind.
- * On stream end it flushes to the full content instantly.
+ * It is a constant-latency controller (the shape of an audio jitter buffer):
+ * the reveal aims to trail the live edge by a fixed time lag, so
  *
- * The emitted length is snapped back to the nearest word boundary so the
- * renderer never receives a half-streamed word (and the per-word reveal in
- * `rehypeStreamingReveal` stays clean). State updates are throttled to word
- * granularity — we only re-render when the snapped output actually changes,
- * not on every sub-word rAF frame.
+ *     rate = backlog / LAG_SECS
+ *
+ * which self-regulates against every failure mode the previous EMA + catch-up
+ * design fought piecemeal:
+ *   - a steady model at R chars/sec settles a standing backlog of R·LAG chars
+ *     and reveals at exactly R — smooth, with a constant ~LAG_SECS delay;
+ *   - a network burst raises the backlog, so the rate ramps up (slew-limited,
+ *     below) and the excess drains exponentially with time constant LAG_SECS —
+ *     drain time is inherently bounded (and MAX_CPS keeps the cascade at a
+ *     speed the eye can follow — see the constants below);
+ *   - a gap between bursts is absorbed by the standing backlog: the reveal
+ *     keeps flowing (decaying gently, never freezing) for up to ~LAG_SECS
+ *     before it can starve. The old design revealed straight to the live edge,
+ *     froze there, then surged on the next burst — the freeze→surge cycle the
+ *     eye reads as "chunks".
+ *
+ * The applied rate is additionally slew-limited (low-pass filtered), so burst
+ * arrivals read as smooth accelerations rather than step changes, and a MIN
+ * floor keeps text flowing even when the model idles. On stream end the same
+ * dynamics drain the remainder (exponential tail + MIN floor), so short/fast
+ * messages still animate fully.
+ *
+ * Emission is at char granularity — we re-render only when the floored reveal
+ * cursor actually advances, not on every rAF frame.
  *
  * When `enabled` is false the hook is a no-op pass-through (returns `content`
  * unchanged, no rAF loop), so `streamMode: 'immediate'` restores the exact
  * pre-existing behavior.
- *
- * Constants below correspond roughly to the demo's "word reveal @ speed ~48".
  */
 
 /** Floor reveal speed (chars/sec) so text still flows when the model idles or
  *  streams very slowly. */
 const MIN_CPS = 50
-/** Time constant (seconds) for the low-pass filter estimating the model's
- *  incoming token rate. The reveal rate tracks this, so it speeds up and slows
- *  down with the model automatically. */
-const RATE_TAU = 0.35
-/** Time constant (seconds) for draining residual backlog so the buffer
- *  converges to the live edge without overshooting. */
-const CATCHUP_TAU = 0.35
-/** Ceiling on reveal speed = the smoothness guarantee. Bounds how many chars
- *  (≈ words) can mount in one frame, so even a huge network burst fades in as a
- *  per-word wave instead of a single block. ~1.2 words/frame @60fps. Raising it
- *  reduces lag on very fast streams at the cost of burst smoothness. */
-const MAX_CPS = 400
-
-/** Largest index <= `idx` that sits on a word boundary, so we never emit a
- *  half-streamed word. Returns `s.length` when the whole string is consumed
- *  and `idx` when no preceding whitespace exists (e.g. one long unbroken run). */
-// function snapToWord(s: string, idx: number): number {
-//   if (idx >= s.length) return s.length
-//   if (idx <= 0) return 0
-//   const cut = Math.max(s.lastIndexOf(' ', idx - 1), s.lastIndexOf('\n', idx - 1))
-//   return cut >= 0 ? cut + 1 : idx
-// }
+/** The target time lag (seconds) behind the live edge. This single constant is
+ *  the smoothness/latency tradeoff: it is simultaneously the standing cushion
+ *  that bridges inter-burst gaps, the drain time constant for bursts, and the
+ *  perceived delay behind the raw stream. `speed` divides it (higher speed =
+ *  lower latency = closer tracking of the raw cadence). */
+const LAG_SECS = 0.4
+/** Ceiling on the reveal rate (chars/sec) — the smoothness guarantee. Bounds
+ *  how many chars can mount per frame (~10 @60fps, roughly 1.7 words), so a
+ *  fat burst reads as a fast per-word cascade the eye can follow, never a
+ *  blur. Matters most at stream START: the controller has no standing state
+ *  yet, and a large first chunk (typical after a long thinking/tool phase)
+ *  would otherwise demand backlog/lag = thousands of cps and the slew would
+ *  happily ramp there. `speed` multiplies it. */
+const MAX_CPS = 600
+/** Bounded-drain escape hatch: no backlog may take longer than about this to
+ *  drain (seconds). The effective ceiling is max(MAX_CPS, backlog/MAX_DRAIN_SECS),
+ *  so a pathological paste-like burst (a whole multi-KB code block in one
+ *  chunk) clears as a ~2.5s fast cascade instead of trailing at the cap for
+ *  8+ seconds — while ordinary bursts (≤ MAX_CPS × MAX_DRAIN_SECS ≈ 1.5K
+ *  chars) never engage it and stay under the smoothness ceiling. This bounded
+ *  drain is also what makes a hard cap safe against runaway lag on very fast
+ *  models (the failure the old design papered over with a 4x speed override). */
+const MAX_DRAIN_SECS = 2.5
+/** Slew time constant (seconds) for the APPLIED reveal rate. The desired rate
+ *  steps discontinuously when a burst lands; low-pass filtering the applied
+ *  rate turns those steps into smooth accelerations, so the reveal speeds up
+ *  and coasts down instead of jerking. */
+const RATE_SLEW_TAU = 0.15
 
 export function useSmoothStream(content: string, streaming: boolean, enabled: boolean, speed: number = 1): string {
-  // Emitted (snapped) character count. Initialized to full length so already-
+  // Emitted (floored) character count. Initialized to full length so already-
   // complete messages (history, variant switches) render instantly with no
   // animation — only genuine growth while streaming gets buffered.
   const [emitLen, setEmitLen] = useState(content.length)
@@ -64,17 +83,23 @@ export function useSmoothStream(content: string, streaming: boolean, enabled: bo
   const contentRef = useRef(content)
   const streamingRef = useRef(streaming)
   const revRef = useRef(content.length)   // float reveal progress (chars)
-  const emitRef = useRef(content.length)  // last committed snapped length
-  const lastTargetRef = useRef(content.length)  // target length seen last frame
-  const emaRef = useRef(MIN_CPS)          // smoothed incoming rate (chars/sec)
+  const emitRef = useRef(content.length)  // last committed floored length
+  const rateRef = useRef(0)               // slew-limited APPLIED reveal rate (chars/sec)
+  // True from the first streamed frame until the post-stream drain has fully
+  // caught up. Distinguishes "backlog left over from a live stream" (the rAF
+  // loop must finish revealing it smoothly) from "content changed on an idle,
+  // fully-revealed message" (variant switch / patch — render instantly).
+  const wasStreamingRef = useRef(false)
   contentRef.current = content
   streamingRef.current = streaming
+  if (streaming) wasStreamingRef.current = true
 
   // Pin to full length whenever the buffer is disabled.
   useEffect(() => {
     if (!enabled) {
       revRef.current = content.length
       emitRef.current = content.length
+      wasStreamingRef.current = false
       setEmitLen(content.length)
     }
   }, [enabled, content.length])
@@ -88,27 +113,35 @@ export function useSmoothStream(content: string, streaming: boolean, enabled: bo
   // it instantly (matching the "already-complete messages render instantly"
   // intent of the emitLen initializer). Genuine streaming growth is still
   // handled by the rAF loop below.
+  //
+  // CRUCIALLY this must NOT fire on the streaming→false transition itself:
+  // under the constant-latency controller the reveal deliberately trails the
+  // live edge by ~LAG_SECS of text, so at stream end there is ALWAYS unrevealed
+  // residue — snapping here would flash the last half-second of every message
+  // in as a block (the end-of-stream snap the old speed=4 override existed to
+  // hide). While `wasStreamingRef` is up the residue belongs to the drain loop,
+  // which reveals it at the slewed rate and lowers the flag when caught up.
   useEffect(() => {
     if (!enabled || streaming) return
+    if (wasStreamingRef.current) return
     if (content.length !== emitRef.current) {
       revRef.current = content.length
       emitRef.current = content.length
-      lastTargetRef.current = content.length
       setEmitLen(content.length)
     }
   }, [content, streaming, enabled])
 
-  // The rAF drain loop. Restarts whenever `enabled`/`streaming` flips; reads
-  // the latest content via ref so it doesn't restart on every delta.
+  // The rAF drain loop. Restarts whenever `enabled`/`speed` flips; reads the
+  // latest content via ref so it doesn't restart on every delta.
   useEffect(() => {
     if (!enabled) return
-    // Scale the reveal bounds by the speed preset (slow .5x … turbo 4x).
+    // Scale the latency target by the speed preset (slow .5x … turbo 4x):
+    // higher speed = smaller lag = tighter tracking of the raw stream.
     const minCps = MIN_CPS * speed
     const maxCps = MAX_CPS * speed
+    const lag = LAG_SECS / speed
     let raf = 0
     let last = 0
-    lastTargetRef.current = contentRef.current.length  // avoid a spurious first-frame burst
-    if (emaRef.current < minCps) emaRef.current = minCps
     const tick = (t: number) => {
       if (!last) last = t
       const dt = Math.min(0.1, (t - last) / 1000)  // clamp (tab refocus jumps)
@@ -120,35 +153,38 @@ export function useSmoothStream(content: string, streaming: boolean, enabled: bo
         // Content reset (demo loop restart or message switch) — reset buffer state
         revRef.current = target
         emitRef.current = target
-        emaRef.current = minCps
-        lastTargetRef.current = target
+        rateRef.current = 0
         setEmitLen(target)
       }
 
-      // 1. Estimate the model's incoming rate — a low-pass filter over the
-      //    chars that arrived this frame. Tracks fast/slow output automatically.
-      const arrived = target - lastTargetRef.current
-      lastTargetRef.current = target
-      const inst = arrived > 0 ? arrived / dt : 0
-      const a = 1 - Math.exp(-dt / RATE_TAU)
-      emaRef.current += a * (inst - emaRef.current)
-
-      // 2. Adaptive reveal rate: track the model (ema) + drain residual backlog,
-      //    then clamp to MAX_CPS — the per-frame smoothness guarantee.
+      // Constant-latency controller: reveal fast enough to hold the backlog at
+      // ~lag seconds of text — the rate tracks the model's rate with a
+      // constant delay. Clamped to the smoothness ceiling, except that no
+      // backlog may take longer than ~MAX_DRAIN_SECS to clear (see MAX_CPS /
+      // MAX_DRAIN_SECS above for why both halves exist).
       const backlog = target - revRef.current
-      let rate = Math.max(minCps, emaRef.current) + backlog / CATCHUP_TAU
-      if (rate > maxCps) rate = maxCps
-      if (backlog > 0) revRef.current = Math.min(target, revRef.current + rate * dt)
+      let desired = backlog > 0 ? Math.max(minCps, backlog / lag) : 0
+      const ceil = Math.max(maxCps, backlog / MAX_DRAIN_SECS)
+      if (desired > ceil) desired = ceil
+      // Slew-limit the applied rate: bursts become smooth accelerations.
+      const s = 1 - Math.exp(-dt / RATE_SLEW_TAU)
+      rateRef.current += s * (desired - rateRef.current)
+      if (backlog > 0) {
+        revRef.current = Math.min(target, revRef.current + rateRef.current * dt)
+      }
 
-      // 3. Emit at char granularity (no word snapping) for smooth per-char reveal.
+      // Emit at char granularity (no word snapping) for smooth per-char reveal.
       const caughtUp = revRef.current >= target
       const snapped = caughtUp ? target : Math.floor(revRef.current)
       if (snapped !== emitRef.current) { emitRef.current = snapped; setEmitLen(snapped) }
 
-      // Keep draining after the stream ends so short/fast messages animate fully.
+      // Keep draining after the stream ends so the trailing ~LAG_SECS of text
+      // (and short/fast messages) animate fully. Only once fully caught up does
+      // the message hand back to "idle" semantics (variant switches snap).
       if (streamingRef.current || !caughtUp) {
         raf = requestAnimationFrame(tick)
       } else {
+        wasStreamingRef.current = false
         raf = 0
       }
     }

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -292,6 +292,24 @@ export function virtualKeyFor(
   return turnLeadKey(it, msgKey)
 }
 
+/** React key for a message row's INNER bubble (the virtualizer row key is
+ *  virtualKeyFor). Prefer the optimistic client ts (stashed by the steer-echo
+ *  reconcile, and stamped at birth on streaming/thinking messages) over the
+ *  server ts, so a mid-stream ts overwrite never remounts the bubble.
+ *
+ *  Role-prefixed for cross-role uniqueness, EXCEPT that 'streaming' normalizes
+ *  to 'assistant': finalization (`_done` / `_segment`) mutates the SAME logical
+ *  message's role from streaming to assistant, and a role-sensitive key
+ *  remounted the bubble at end-of-turn — destroying useSmoothStream's drain
+ *  state, so the trailing unrevealed text (a standing ~LAG_SECS of it under the
+ *  constant-latency controller) snapped into view instead of finishing its
+ *  reveal. Exported for tests. */
+export function messageRowKey(m: ChatMessage, i: number): string {
+  const keyTs = (m.meta?.clientTs as string | undefined) || m.ts
+  const role = m.role === 'streaming' ? 'assistant' : m.role
+  return keyTs ? `${role}-${keyTs}` : `${role}-${i}`
+}
+
 /** Render user message content with file chips and image markdown. Handles:
  *  - Fresh messages: meta.files present, displayTxt has @relative/path tokens
  *  - Replayed history: no meta.files, content has [attached_file N] /full/path
@@ -3733,14 +3751,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   )
 
   const renderMessage = useCallback((i: number, m: ChatMessage) => {
-    // Prefer the optimistic client ts (stashed by the steer-echo reconcile in
-    // chatSlice.appendSlotMessage) over the server ts for the React key. A
-    // steered bubble is appended optimistically with a client ts, then the
-    // steer_push echo overwrites ts with the server ts — keying on ts alone
-    // would change the key mid-stream, remounting the bubble and replaying its
-    // one-shot entrance animation. clientTs keeps the key (and DOM) stable.
-    const keyTs = (m.meta?.clientTs as string | undefined) || m.ts
-    const key = keyTs ? `${m.role}-${keyTs}` : `${m.role}-${i}`
+    // Key identity rules (clientTs preference + streaming→assistant role
+    // normalization) live in messageRowKey — see its doc comment.
+    const key = messageRowKey(m, i)
     if (m.role === 'thinking') return m.content ? <ThinkingBlock key={key} content={m.content} disclosureKey={key} /> : null
     if (m.role === 'tool') {
       // Skip ✅/🚫 completion messages — completion shown via CircleCheckBig icon

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -120,7 +120,13 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
   // stream so the raw tag never renders.
   const { cleaned: steerCleaned, acks: steerAcks } = useMemo(() => extractSteeringAcks(text), [text])
   const [smooth] = useState(() => loadChatConfig().streamMode !== 'immediate')
-  const speed = 4 // force high speed smooth streaming to avoid lagging behind raw model output
+  // 1x = ~0.4s constant lag behind the live edge (see useSmoothStream's
+  // LAG_SECS). The old 4x override existed to stop the reveal lagging fast
+  // models under the previous catch-up design; the constant-latency controller
+  // bounds the lag for ANY model speed, and 4x only shrank the smoothing
+  // window to ~0.1s — smaller than typical inter-burst gaps, so the reveal
+  // starved between bursts and read as chunky.
+  const speed = 1
   const smoothedText = useSmoothStream(steerCleaned, isStreaming, smooth, speed)
 
   const planSteps = useMemo<PlanStepInput[] | null>(() => {

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -13,6 +13,21 @@ import type { McpAppRenderPayload } from '../lib/mcpAppSrcdoc'
 const SKIP_ROLES = new Set(['chunk', 'done'])
 const filterMessages = (msgs: ChatMessage[]) => msgs.filter(m => !SKIP_ROLES.has(m.role))
 
+/** Durable client-side identity for a message born WITHOUT a `ts` that will be
+ *  mutated across dispatches (streaming/thinking accumulation). ChatPage keys
+ *  rows by `meta.clientTs ?? ts` and falls back to a WeakMap id minted per
+ *  message OBJECT — but Immer replaces the object on every `content +=` commit,
+ *  so a ts-less accumulating message minted a NEW id (→ new React key → full
+ *  row remount) on every chunk flush. That remount reset useSmoothStream's
+ *  reveal cursor (text snapped in whole chunks) and restarted every CSS/Framer
+ *  animation in the row (widget-placeholder dots flashing in unison). Stamping
+ *  the identity once at append survives Immer's structural sharing for the
+ *  message's whole life, including the streaming→assistant finalization that
+ *  later sets a server `ts`. (This is the "durable id stamped in the reducer
+ *  at append" follow-up ChatPage's stableMsgKey comment pointed at.) */
+let bornKeySeq = 0
+const mintBornKey = (): string => `born-${Date.now()}-${bornKeySeq++}`
+
 /** The three keys that can pollute `Object.prototype` when used to index a
  *  plain-object map (`obj[key] = ...`). Slot ids, subagent ids, run ids, and
  *  session keys all flow in from WebSocket action payloads; a crafted payload
@@ -414,7 +429,7 @@ function applyNonActiveFrame(
       msg.content += content
       msg.rawText = msg.content
     } else {
-      msgs.push({ role: 'streaming', content, cls: 'msg msg-a', rawText: content })
+      msgs.push({ role: 'streaming', content, cls: 'msg msg-a', rawText: content, meta: { clientTs: mintBornKey() } })
     }
     if (seq !== undefined) run.lastChunkSeq = seq
     return
@@ -436,7 +451,7 @@ function applyNonActiveFrame(
     return
   }
   if (role === 'thinking') {
-    if (!msgs.some(m => m.role === 'thinking')) msgs.push({ role: 'thinking', content: '', cls: '' })
+    if (!msgs.some(m => m.role === 'thinking')) msgs.push({ role: 'thinking', content: '', cls: '', meta: { clientTs: mintBornKey() } })
     return
   }
   if (role === 'assistant') {
@@ -1063,7 +1078,7 @@ const chatSlice = createSlice({
     updateStreamingMessage(state, action: PayloadAction<string>) {
       const last = state.messages[state.messages.length - 1]
       if (last?.role === 'streaming') { last.content = action.payload }
-      else { state.messages.push({ role: 'streaming', content: action.payload, cls: 'msg msg-a' }) }
+      else { state.messages.push({ role: 'streaming', content: action.payload, cls: 'msg msg-a', meta: { clientTs: mintBornKey() } }) }
     },
     finalizeAssistant(state, action: PayloadAction<string | { content: string; ts?: string }>) {
       const payload = typeof action.payload === 'string' ? { content: action.payload } : action.payload
@@ -1710,7 +1725,7 @@ const chatSlice = createSlice({
         if (state.messages[i].role === 'thinking') { state.messages[i].content += content; return }
         if (state.messages[i].role === 'user') break
       }
-      state.messages.push({ role: 'thinking', content, cls: '' })
+      state.messages.push({ role: 'thinking', content, cls: '', meta: { clientTs: mintBornKey() } })
     },
     sseChatMessage(state, action: PayloadAction<{ slot: string; role: string; content: string; ts?: string; seq?: number; cls?: string; meta?: Record<string, unknown>; kind?: string; batched?: boolean }>) {
       const { slot, role, content, ts, seq, cls, meta, kind, batched } = action.payload
@@ -1780,7 +1795,7 @@ const chatSlice = createSlice({
           msg.content += content
           msg.rawText = msg.content
         } else {
-          state.messages.push({ role: 'streaming', content, cls: 'msg msg-a', rawText: content })
+          state.messages.push({ role: 'streaming', content, cls: 'msg msg-a', rawText: content, meta: { clientTs: mintBornKey() } })
         }
         if (seq !== undefined) state.lastChunkSeq = seq
         return
@@ -1825,7 +1840,7 @@ const chatSlice = createSlice({
       // Thinking — deduplicate, only keep one
       if (role === 'thinking') {
         if (state.messages.some(m => m.role === 'thinking')) return
-        state.messages.push({ role: 'thinking', content: '', cls: '' })
+        state.messages.push({ role: 'thinking', content: '', cls: '', meta: { clientTs: mintBornKey() } })
         return
       }
       // Replace streaming placeholder with final assistant message

--- a/website/src/test/chatSlice.streamingKeyStability.test.ts
+++ b/website/src/test/chatSlice.streamingKeyStability.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Streaming-row key stability across chunk dispatches (smooth-streaming regression).
+ *
+ * ChatPage keys virtual rows via stableMsgKey: `meta.clientTs ?? ts ?? <WeakMap
+ * id minted per message OBJECT>`. Streaming and thinking messages are born with
+ * no `ts`, and every chunk dispatch mutates their content — so Immer finalizes a
+ * NEW object per flush. Under the WeakMap fallback that minted a NEW id (→ new
+ * React key) per chunk, remounting the whole row ~60x/sec: useSmoothStream's
+ * reveal cursor reset each time (text snapped in whole chunks instead of the
+ * per-char reveal) and every CSS/Framer animation in the row restarted from
+ * phase 0 (widget-placeholder dots flashing in unison instead of breathing on
+ * their stagger).
+ *
+ * The fix stamps a durable `meta.clientTs` in the reducer at append. These
+ * tests deliberately drive the REAL reducer and mirror ChatPage's real resolver
+ * (including the WeakMap fallback), so they FAIL if the reducer stops stamping
+ * the birth identity — they cannot be satisfied by the test's own resolver.
+ */
+import { describe, it, expect } from 'vitest'
+import reducer, { sseChatMessage, sseThinkingChunk } from '../store/chatSlice'
+import { virtualKeyFor, messageRowKey } from '../pages/ChatPage'
+import type { ChatMessage } from '../types'
+import type { DisplayItem } from '../pages/chat/types'
+
+const SLOT = 'stream-key-slot'
+const initial = reducer(undefined, { type: '@@INIT' })
+const withSlot = { ...initial, activeSlot: SLOT }
+
+// Mirror of ChatPage's stableMsgKey — clientTs → ts → WeakMap-minted id. The
+// WeakMap fallback is the load-bearing part: it makes these tests fail when a
+// ts-less message's object identity churns without a stamped clientTs.
+function makeMsgKey() {
+  let seq = 0
+  const ids = new WeakMap<ChatMessage, string>()
+  return (m: ChatMessage): string => {
+    const explicit = (m.meta?.clientTs as string | undefined) || m.ts
+    if (explicit) return explicit
+    let id = ids.get(m)
+    if (!id) { id = `mid-${seq++}`; ids.set(m, id) }
+    return id
+  }
+}
+
+const single = (m: ChatMessage, idx: number): DisplayItem => ({ kind: 'single', msg: m, idx })
+
+const chunk = (state: ReturnType<typeof reducer>, content: string, seq: number) =>
+  reducer(state, sseChatMessage({ slot: SLOT, role: 'chunk', content, seq }))
+
+describe('streaming message identity across chunk dispatches', () => {
+  it('keeps the same virtual key while chunks accumulate (active slot)', () => {
+    const msgKey = makeMsgKey()
+    let state = chunk(withSlot, 'Hello ', 1)
+    const m1 = state.messages.find(m => m.role === 'streaming')!
+    const k1 = virtualKeyFor(single(m1, 0), 0, msgKey)
+
+    state = chunk(state, 'world', 2)
+    const m2 = state.messages.find(m => m.role === 'streaming')!
+    // Immer replaces the mutated message object — the identity the WeakMap
+    // fallback keyed on. The stamped clientTs is what keeps the key stable.
+    expect(m2).not.toBe(m1)
+    const k2 = virtualKeyFor(single(m2, 0), 0, msgKey)
+
+    expect(k2).toBe(k1)
+  })
+
+  it('keeps the same virtual key through streaming → assistant finalization', () => {
+    const msgKey = makeMsgKey()
+    let state = chunk(withSlot, 'Answer text', 1)
+    const streamingKey = virtualKeyFor(single(state.messages.find(m => m.role === 'streaming')!, 0), 0, msgKey)
+
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '', ts: '2026-08-01T22:00:00Z' }))
+    const done = state.messages.find(m => m.role === 'assistant')!
+    // Finalization sets a server ts, but clientTs outranks ts in the resolver,
+    // so the row (and its cached height) keeps its identity.
+    const doneKey = virtualKeyFor(single(done, 0), 0, msgKey)
+
+    expect(doneKey).toBe(streamingKey)
+  })
+
+  it('keeps the same virtual key while thinking content accumulates', () => {
+    const msgKey = makeMsgKey()
+    let state = reducer(withSlot, sseThinkingChunk({ slot: SLOT, content: 'pondering ' }))
+    const t1 = state.messages.find(m => m.role === 'thinking')!
+    const k1 = virtualKeyFor(single(t1, 0), 0, msgKey)
+
+    state = reducer(state, sseThinkingChunk({ slot: SLOT, content: 'more' }))
+    const t2 = state.messages.find(m => m.role === 'thinking')!
+    expect(t2).not.toBe(t1)
+    const k2 = virtualKeyFor(single(t2, 0), 0, msgKey)
+
+    expect(k2).toBe(k1)
+  })
+
+  it('keeps the same virtual key on the slot-routed (background pane) chunk path', () => {
+    const msgKey = makeMsgKey()
+    const bg = { ...initial, activeSlot: 'other-slot' }
+    let state = reducer(bg, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'bg ', seq: 1 }))
+    const m1 = state.slotMessages[SLOT]!.find(m => m.role === 'streaming')!
+    const k1 = virtualKeyFor(single(m1, 0), 0, msgKey)
+
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'text', seq: 2 }))
+    const m2 = state.slotMessages[SLOT]!.find(m => m.role === 'streaming')!
+    expect(m2).not.toBe(m1)
+    const k2 = virtualKeyFor(single(m2, 0), 0, msgKey)
+
+    expect(k2).toBe(k1)
+  })
+
+  it('mints distinct identities for distinct streaming messages', () => {
+    const msgKey = makeMsgKey()
+    let state = chunk(withSlot, 'first', 1)
+    const first = state.messages.find(m => m.role === 'streaming')!
+    const firstKey = virtualKeyFor(single(first, 0), 0, msgKey)
+
+    // Finalize, then start a second streamed answer.
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '' }))
+    state = chunk(state, 'second', 2)
+    const second = state.messages.find(m => m.role === 'streaming')!
+    const secondKey = virtualKeyFor(single(second, 1), 1, msgKey)
+
+    expect(secondKey).not.toBe(firstKey)
+  })
+})
+
+describe('messageRowKey — inner bubble identity across finalization', () => {
+  it('keeps the same key through streaming → assistant finalization (real reducer)', () => {
+    let state = chunk(withSlot, 'The answer', 1)
+    const streamingMsg = state.messages.find(m => m.role === 'streaming')!
+    const idx = state.messages.indexOf(streamingMsg)
+    const keyWhileStreaming = messageRowKey(streamingMsg, idx)
+
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '', ts: '2026-08-01T23:00:00Z' }))
+    const finalized = state.messages.find(m => m.role === 'assistant')!
+    // Same logical message: role flipped and a server ts landed, but the bubble
+    // must NOT remount — a remount here destroys useSmoothStream's drain state
+    // and snaps the trailing unrevealed text into view.
+    expect(messageRowKey(finalized, idx)).toBe(keyWhileStreaming)
+  })
+
+  it('still distinguishes different roles and different messages', () => {
+    const a = { role: 'user', content: 'q', cls: '', ts: 't1' }
+    const b = { role: 'assistant', content: 'a', cls: '', ts: 't1' }
+    const c = { role: 'assistant', content: 'a2', cls: '', ts: 't2' }
+    expect(messageRowKey(a, 0)).not.toBe(messageRowKey(b, 1))
+    expect(messageRowKey(b, 1)).not.toBe(messageRowKey(c, 2))
+  })
+})

--- a/website/src/test/useSmoothStream.dynamics.test.ts
+++ b/website/src/test/useSmoothStream.dynamics.test.ts
@@ -1,0 +1,225 @@
+/**
+ * useSmoothStream dynamics: the constant-latency controller.
+ *
+ * The reveal aims to trail the live edge by ~LAG_SECS of text (rate = backlog /
+ * lag, slew-limited). These tests drive the rAF loop with a manual, deterministic
+ * frame pump and pin the two properties the redesign exists for:
+ *
+ *  1. NO STARVATION: during a short gap in the incoming stream (shorter than the
+ *     standing lag) the reveal keeps flowing instead of freezing at the live
+ *     edge. The old EMA + fast-catch-up design revealed straight to the edge,
+ *     froze, then surged on the next burst — the freeze→surge cycle users saw
+ *     as "text showing up in chunks".
+ *
+ *  2. NO SNAPPING: a large single burst mounts over multiple frames as a smooth
+ *     ramp (slew-limited rate), never as one giant frame delta.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSmoothStream } from '../hooks/useSmoothStream'
+
+// ---- Manual rAF pump ----
+let rafQueue: Map<number, FrameRequestCallback>
+let rafId: number
+let now: number
+
+beforeEach(() => {
+  rafQueue = new Map()
+  rafId = 0
+  now = 0
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    rafQueue.set(++rafId, cb)
+    return rafId
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => { rafQueue.delete(id) })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** Advance one 16ms frame: run every queued rAF callback at the new timestamp. */
+function frame() {
+  now += 16
+  const cbs = [...rafQueue.values()]
+  rafQueue.clear()
+  act(() => { cbs.forEach(cb => cb(now)) })
+}
+
+const CHARS_PER_FRAME = 4 // ~250 cps steady feed
+
+describe('useSmoothStream constant-latency dynamics', () => {
+  it('keeps revealing through a short inter-burst gap (no freeze at the live edge)', () => {
+    let content = ''
+    const { result, rerender } = renderHook(
+      ({ c, s }) => useSmoothStream(c, s, true, 1),
+      { initialProps: { c: content, s: true } },
+    )
+
+    // Steady feed for 60 frames (~1s) to reach equilibrium: standing backlog of
+    // ~LAG_SECS worth of text, reveal rate tracking the input rate. 250 cps is
+    // deliberately BELOW the old design's 400 cps ceiling: under the old
+    // dynamics the reveal converged onto the live edge and froze during gaps
+    // (this test fails there); the controller instead holds a standing lag.
+    for (let i = 0; i < 60; i++) {
+      content += 'x'.repeat(CHARS_PER_FRAME)
+      rerender({ c: content, s: true })
+      frame()
+    }
+    const atEquilibrium = result.current.length
+    expect(atEquilibrium).toBeGreaterThan(0)
+    // The controller trails the live edge — there must be a standing backlog.
+    expect(atEquilibrium).toBeLessThan(content.length)
+
+    // GAP: the model goes quiet for 10 frames (~160ms, well under the ~400ms
+    // standing lag). The reveal must keep advancing on every frame.
+    const lens: number[] = [atEquilibrium]
+    for (let i = 0; i < 10; i++) {
+      frame() // no new content
+      lens.push(result.current.length)
+    }
+    for (let i = 1; i < lens.length; i++) {
+      expect(lens[i]).toBeGreaterThan(lens[i - 1])
+    }
+  })
+
+  it('tracks a fast model with bounded, non-growing lag (no runaway backlog)', () => {
+    // 500 cps is ABOVE the old design's 400 cps reveal ceiling at speed 1 — the
+    // old hook fell behind at ~100 chars/sec forever (the defect the hardcoded
+    // speed=4 override papered over). The controller has no ceiling: the rate
+    // tracks any input rate and the lag settles at ~LAG_SECS worth of text.
+    const fast = 8 // chars per 16ms frame ≈ 500 cps
+    let content = ''
+    const { result, rerender } = renderHook(
+      ({ c, s }) => useSmoothStream(c, s, true, 1),
+      { initialProps: { c: content, s: true } },
+    )
+    let backlogAt2s = 0
+    for (let i = 0; i < 250; i++) {
+      content += 'x'.repeat(fast)
+      rerender({ c: content, s: true })
+      frame()
+      if (i === 124) backlogAt2s = content.length - result.current.length
+    }
+    const backlogAt4s = content.length - result.current.length
+    // Lag must have settled (not kept growing) and stay near the design target
+    // (~0.4s × 500 cps = 200 chars).
+    expect(backlogAt4s).toBeLessThan(320)
+    expect(backlogAt4s - backlogAt2s).toBeLessThan(60)
+  })
+
+  it('ramps a large burst over multiple frames instead of snapping it in', () => {
+    let content = ''
+    const { result, rerender } = renderHook(
+      ({ c, s }) => useSmoothStream(c, s, true, 1),
+      { initialProps: { c: content, s: true } },
+    )
+
+    // Reach equilibrium on a modest feed.
+    for (let i = 0; i < 40; i++) {
+      content += 'x'.repeat(CHARS_PER_FRAME)
+      rerender({ c: content, s: true })
+      frame()
+    }
+
+    // One paste-like burst: 600 chars in a single delta.
+    const before = result.current.length
+    content += 'y'.repeat(600)
+    rerender({ c: content, s: true })
+    frame()
+    const firstDelta = result.current.length - before
+    // The slew-limited rate cannot jump: the first frame after the burst must
+    // mount only a small slice of it, not the whole block.
+    expect(firstDelta).toBeLessThan(120)
+
+    // And the burst must still drain in bounded time (~2s of frames).
+    for (let i = 0; i < 125 && result.current.length < content.length - 50; i++) frame()
+    expect(result.current.length).toBeGreaterThan(content.length - 60)
+  })
+
+  it('caps the reveal speed on a fat cold-start first chunk (no perceptual blur)', () => {
+    // A large FIRST chunk (typical after a long thinking/tool phase) used to
+    // demand backlog/lag = thousands of cps with no ceiling — smooth in the
+    // math, a blur to the eye. MAX_CPS bounds the cascade: 600 cps ≈ 10
+    // chars/frame at 60fps (a 1000-char burst is under the bounded-drain
+    // escape threshold, so the hard ceiling is what applies).
+    const { result, rerender } = renderHook(
+      ({ c, s }) => useSmoothStream(c, s, true, 1),
+      { initialProps: { c: '', s: true } },
+    )
+    const burst = 'x'.repeat(1000)
+    rerender({ c: burst, s: true })
+
+    let prev = result.current.length
+    let maxFrameDelta = 0
+    for (let i = 0; i < 40; i++) {
+      frame()
+      maxFrameDelta = Math.max(maxFrameDelta, result.current.length - prev)
+      prev = result.current.length
+    }
+    // ~10 chars/frame ceiling (+ integration slack). Without the cap this
+    // reaches 30+ chars/frame within the slew window.
+    expect(maxFrameDelta).toBeLessThanOrEqual(13)
+    // And it is still making brisk progress — the cap is a ceiling, not a crawl.
+    expect(result.current.length).toBeGreaterThan(200)
+  })
+
+  it('drains the residue smoothly after streaming ends — never snaps it in', () => {
+    let content = ''
+    const { result, rerender } = renderHook(
+      ({ c, s }) => useSmoothStream(c, s, true, 1),
+      { initialProps: { c: content, s: true } },
+    )
+    for (let i = 0; i < 30; i++) {
+      content += 'x'.repeat(CHARS_PER_FRAME)
+      rerender({ c: content, s: true })
+      frame()
+    }
+    // Stream ends with a standing backlog still unrevealed (the ~LAG_SECS
+    // cushion is the controller's design, so this residue ALWAYS exists).
+    const atEnd = result.current.length
+    expect(atEnd).toBeLessThan(content.length)
+    rerender({ c: content, s: false })
+    // The streaming→false commit itself must not snap (this discriminates
+    // against the unguarded grow-while-not-streaming effect, which pinned to
+    // full length the moment the prop flipped).
+    expect(result.current.length).toBe(atEnd)
+
+    // The residue drains over MULTIPLE frames, each revealing a bounded slice…
+    let prev = atEnd
+    let maxFrameDelta = 0
+    let framesToDrain = 0
+    for (let i = 0; i < 200 && result.current.length < content.length; i++) {
+      frame()
+      maxFrameDelta = Math.max(maxFrameDelta, result.current.length - prev)
+      prev = result.current.length
+      framesToDrain++
+    }
+    // …ending complete, having taken several frames (not one), with no
+    // single-frame block dump.
+    expect(result.current).toBe(content)
+    expect(framesToDrain).toBeGreaterThan(3)
+    expect(maxFrameDelta).toBeLessThan(60)
+  })
+
+  it('still snaps a variant switch on an idle, fully-drained message', () => {
+    let content = ''
+    const { result, rerender } = renderHook(
+      ({ c, s }) => useSmoothStream(c, s, true, 1),
+      { initialProps: { c: content, s: true } },
+    )
+    for (let i = 0; i < 20; i++) {
+      content += 'x'.repeat(CHARS_PER_FRAME)
+      rerender({ c: content, s: true })
+      frame()
+    }
+    rerender({ c: content, s: false })
+    for (let i = 0; i < 200 && result.current.length < content.length; i++) frame()
+    expect(result.current).toBe(content) // fully drained → idle semantics restored
+
+    // Variant switch on the idle message: render instantly, no animation.
+    const variant = 'a completely different regenerated answer'
+    rerender({ c: variant, s: false })
+    expect(result.current).toBe(variant)
+  })
+})


### PR DESCRIPTION
## Problem

Streaming text paints in whole-chunk jumps instead of the smooth per-character reveal, and the widget placeholder's "mesh flow" dots flash in unison instead of breathing on their staggered delays. Reported live on 2026-08-01.

## Why it matters

The streaming reveal is the single most-watched surface in the product — every response renders through it. Chunky paint reads as jank/breakage and undermines confidence in the app, and the regression shipped silently inside a scroll-repair PR.

## Fix (symptoms → root cause → change)

**Symptoms → root cause.** Both symptoms are one mechanism: the streaming row remounts on every chunk flush. #383 (`96b33ad3`) keyed virtualizer rows via `stableMsgKey`, which mints a WeakMap id **per message object** for ts-less messages, on the assumption that object identity is stable under Immer's structural sharing. That holds across renders but not across dispatches: every `chunk` reducer run mutates `msg.content`, so Immer finalizes a NEW object per flush → WeakMap miss → new React key → full row unmount/remount ~per frame. Each remount resets `useSmoothStream`'s reveal cursor (text snaps in whole chunks) and restarts every CSS/Framer animation in the row (dots flash together).

**Changes.**
1. **`chatSlice.ts`** — stamp a durable `meta.clientTs` (`mintBornKey()`) at all six ts-less streaming/thinking push sites. `meta.clientTs` is already `stableMsgKey`'s top-priority source, and it survives both Immer object replacement and the finalization that later sets a server `ts`.
2. **`ChatPage.tsx`** — extract the inner bubble key as `messageRowKey()` (exported for tests) and normalize `streaming` → `assistant` in it: finalization mutates the same logical message's role, and a role-sensitive key remounted the bubble at end-of-turn, snapping the trailing unrevealed text into view.
3. **`useSmoothStream.ts`** — replace the EMA + fast-catch-up dynamics with a **constant-latency controller** (`rate = backlog / LAG_SECS`, slew-limited). The old design had per-burst surge/stall cycles, froze at the live edge between bursts, and papered over runaway lag with a hardcoded 4x speed override (which shrank the smoothing window below typical inter-burst gaps — itself a chunkiness source). New envelope: floor 50 cps, tracks the model's own rate with a constant ~0.4 s delay, hard ceiling 600 cps (~10 chars/frame — a cascade the eye can follow), bounded-drain escape (≤ ~2.5 s) for multi-KB paste-like bursts. Post-stream residue drains smoothly via a `wasStreaming` gate instead of snapping; variant switches on idle messages still render instantly.
4. **`AssistantMessage.tsx`** — `speed` 4 → 1 (the override is obsolete under bounded lag).

## Tests

12 new tests across two suites; each verified to FAIL against the pre-fix code:

- `chatSlice.streamingKeyStability.test.ts` — drives the **real reducer**: virtual key stable across chunk dispatches (active + background-slot paths), stable through `streaming → assistant` finalization, thinking-message accumulation, distinct identities for distinct messages; `messageRowKey` stability across finalize.
- `useSmoothStream.dynamics.test.ts` — deterministic manual rAF pump: no freeze in inter-burst gaps, bounded non-growing lag at 500 cps, slew-limited burst ramp (no single-frame block dump), cold-start speed cap (≤13 chars/frame on a 1 KB first chunk), smooth no-snap end-of-stream drain, variant-switch snap preserved.

Full frontend suite: 6,903 passed, `tsc -b` clean. (One pre-existing failure on clean `main`: `src/i18n/keyReference.test.ts` flags `PrivacyPanel.tsx` — unrelated to this diff.)

## Manual verification

Verified live on a dev gateway against real kiro-cli streaming: smooth per-char reveal on plain prose, staggered dot breathing on widget placeholders, no end-of-stream snap, capped cold-start cascade. Screenshots are omitted deliberately: every change here is motion behavior — a still frame cannot distinguish the fixed and broken states (identical at rest). Can attach a screen recording on request.
