### PR TITLE
docs: adopt the Amazon Open Source Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,5 @@
 # Code of Conduct
 
-This project has adopted the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
-
-For more information see the [Code of Conduct FAQ](https://www.contributor-covenant.org/faq) or
-contact the maintainers with any additional questions or comments.
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/scripts/scrub-allowlist.txt
+++ b/scripts/scrub-allowlist.txt
@@ -112,6 +112,15 @@ src/kiro_crew/cli_cloud.py:.*aws\.amazon\.com/cli
 src/kiro_crew/cloud/aws.py:.*docs\.aws\.amazon\.com
 src/kiro_crew/cloud/ssm.py:.*docs\.aws\.amazon\.com
 
+# Code-of-conduct enforcement contact. ``opensource-codeofconduct@amazon.com`` is
+# the PUBLISHED intake for the Amazon Open Source Code of Conduct
+# (https://aws.github.io/code-of-conduct), printed in that public policy and in
+# every Amazon-published OSS repo that adopts it. It is a public-facing address,
+# not an employee alias or an internal coupling, and the policy is unusable
+# without naming where reports go. Line-anchored so a NEW @amazon.com address
+# anywhere in this file is still caught.
+CODE_OF_CONDUCT.md:.*opensource-codeofconduct@amazon\.com
+
 # Live public AWS service class-name string the dashboard credit pill calls
 # (CodeWhisperer RTS GetUsageLimits) — a functional API identifier, not a leak.
 src/kiro_crew/dashboard/handlers/kiro_usage_api.py:.*codewhisperer


### PR DESCRIPTION
Adopts the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct) in place of the Contributor Covenant, mirroring [strands-agents/harness-sdk](https://github.com/strands-agents/harness-sdk/blob/main/CODE_OF_CONDUCT.md).

## Why

The previous text adopted the Contributor Covenant and directed readers to "contact the maintainers" without naming an address, so the policy described an escalation path that did not exist. The Amazon Open Source Code of Conduct is Contributor Covenant derived and routes enforcement to `opensource-codeofconduct@amazon.com`, which is a monitored inbox.

## What changed

`CODE_OF_CONDUCT.md` body text is byte-identical to upstream. The one deviation is the heading level: upstream opens with an H2 inherited from the `amazon-archives/__template_Apache-2.0` template, and this keeps the existing H1 since the file stands alone.

`scripts/scrub-allowlist.txt` gains one entry, because the scrub-lint gate blocks `@amazon.com` addresses in the public tree and correctly flagged the new contact:

```
CODE_OF_CONDUCT.md:.*opensource-codeofconduct@amazon\.com
```

That address is the published intake printed in the public policy itself, not an employee alias or an internal coupling, and the policy is unusable without naming where reports go. There is existing precedent in the same file for public `aws.amazon.com` documentation URLs.

The entry is anchored on both the filename and the literal address. Since the allowlist is applied as a plain `grep -v` to both the internal-marker scan and the employee-alias scan, a path-only entry would have dropped every line of this file from both gates. Verified by appending a different `someone@amazon.com` line to `CODE_OF_CONDUCT.md` and confirming the gate still fails on it.

## Testing

`./scripts/scrub-lint.sh --no-history` passes locally. Documentation and CI config only, with no code, build, or runtime surface touched.

## Not in this PR

Two related gaps found while comparing against Strands, left alone deliberately:

- `CONTRIBUTING.md` has no Code of Conduct, Security issue notifications, or Licensing sections, so no prose in the repo links to this file.
- `SECURITY.md` routes vulnerability reports to `security@kirocrew.dev` and commits to a 48 hour acknowledgement and a 7 day fix for critical issues. Strands routes to the AWS vulnerability reporting page with no SLA. Worth a separate decision.