### PR TITLE
fix(i18n): resolve the PrivacyPanel shell label keys statically

### DIFF
--- a/website/src/pages/settings/PrivacyPanel.tsx
+++ b/website/src/pages/settings/PrivacyPanel.tsx
@@ -7,17 +7,27 @@ const COMMANDS = [
   'kirocrew telemetry disable',
 ] as const
 
+// Keys held in an indexed `as const` map of full literals rather than inline on each
+// SHELL_COMMANDS entry: check-i18n-keys.mjs resolves a map access to the map's value
+// set, but cannot follow a key destructured out of an array of objects, which would
+// exempt the call site from key-existence verification.
+const SHELL_LABEL_KEY = {
+  macos: 'privacyDisclosure.shellMacOSLinuxLabel',
+  powershell: 'privacyDisclosure.shellPowerShellLabel',
+  cmd: 'privacyDisclosure.shellWindowsCmdLabel',
+} as const
+
 const SHELL_COMMANDS = [
   {
-    labelKey: 'privacyDisclosure.shellMacOSLinuxLabel',
+    shell: 'macos',
     command: 'export KIROCREW_TELEMETRY_DISABLED=1',
   },
   {
-    labelKey: 'privacyDisclosure.shellPowerShellLabel',
+    shell: 'powershell',
     command: "$env:KIROCREW_TELEMETRY_DISABLED = '1'",
   },
   {
-    labelKey: 'privacyDisclosure.shellWindowsCmdLabel',
+    shell: 'cmd',
     command: 'set KIROCREW_TELEMETRY_DISABLED=1',
   },
 ] as const
@@ -71,9 +81,11 @@ export function PrivacyPanel() {
               {command}
             </code>
           ))}
-          {SHELL_COMMANDS.map(({ labelKey, command }) => (
+          {SHELL_COMMANDS.map(({ shell, command }) => (
             <div key={command} className="flex max-w-full flex-col items-start gap-1">
-              <span className="text-[12px] font-medium text-muted">{i18nT(labelKey)}</span>
+              <span className="text-[12px] font-medium text-muted">
+                {i18nT(SHELL_LABEL_KEY[shell])}
+              </span>
               <code className="max-w-full overflow-x-auto text-[13px] text-text bg-bg border border-border rounded-md px-2.5 py-1.5 select-all">
                 {command}
               </code>


### PR DESCRIPTION
## Problem: the gate is red on clean `main`

`website/scripts/check-i18n-keys.mjs` fails on unmodified `origin/main`:

```
1 file(s) gained translation call sites whose key cannot be resolved statically:
  pages/settings/PrivacyPanel.tsx: 0 → 1
```

The same failure surfaces through vitest as
`src/i18n/keyReference.test.ts > wiring > gates the real tree at zero dangling references`,
so every PR inherits a red Frontend Lint & Type Check gate regardless of its own diff.

## Why the shape defeated the resolver

`PrivacyPanel` held its three shell label keys inline on the entries of a module-level
`SHELL_COMMANDS` array and destructured them in the JSX:

```tsx
const SHELL_COMMANDS = [
  { labelKey: 'privacyDisclosure.shellMacOSLinuxLabel', command: '…' },
  …
] as const

{SHELL_COMMANDS.map(({ labelKey, command }) => (
  <span>{i18nT(labelKey)}</span>
))}
```

The resolver in `check-i18n-keys.mjs` follows string literals, `const` bindings,
`as const` map property/element access and finite ternaries. It does not follow a key
destructured out of an array of objects, so it could not compute the possibility set for
that `i18nT()` call — and a key the gate cannot resolve is a key it cannot verify exists,
which exempts the site from every existence check above it. That is precisely the
condition the ratchet is built to refuse.

## Fix: the shape the gate's own message prescribes

Move the keys into an indexed `as const` map of **full literal** key strings and index it
with a short discriminator carried on each entry:

```tsx
const SHELL_LABEL_KEY = {
  macos: 'privacyDisclosure.shellMacOSLinuxLabel',
  powershell: 'privacyDisclosure.shellPowerShellLabel',
  cmd: 'privacyDisclosure.shellWindowsCmdLabel',
} as const

{SHELL_COMMANDS.map(({ shell, command }) => (
  <span>{i18nT(SHELL_LABEL_KEY[shell])}</span>
))}
```

This matches the two shapes the failure message names as references —
`UPDATE_ERROR_KEYS` in `pages/settings/AboutPanel.tsx` and `STATUS_LABEL_KEY` in
`pages/chat/McpToolsPanel.tsx`. Per the resolver's `ElementAccessExpression` branch, a
non-literal index resolves to the map's entire value set, so all three keys are now
individually checked rather than one site being skipped.

## Scope

One file, `website/src/pages/settings/PrivacyPanel.tsx`.

- **No user-visible English changed** — the same three keys resolve to the same three
  catalog strings, rendered in the same order.
- **No catalog key added, removed, or renamed** in any of the 11 locale files.
- Nothing outside this component was touched.

## Verification (Node 24, from `website/`)

| Check | Result |
|---|---|
| `node scripts/check-i18n-keys.mjs` | exit 0 — `OK: 5765 static key references all resolve, 1 dynamic site(s) at baseline (99.98% static coverage)` |
| `npx tsc -b` | clean |
| `npx eslint src/pages/settings/PrivacyPanel.tsx` | clean |
| `npm run i18n:check` | exit 0 — 1848 untranslated strings, at/below the 1854 baseline |
| `npx vitest run src/i18n` | 431/432 pass, incl. `keyReference.test.ts` |
| `npx vitest run src/test/PrivacyPanel.test.tsx src/test/SettingsPage.test.tsx` | 16/16 pass |

The single remaining vitest failure is `src/i18n/format.test.ts > fmtUnit`, which asserts
`Intl.DurationFormat` is absent. Node 24 ships it, so the assertion fails there on clean
`main` as well; it is unrelated to this diff (which touches no formatting code) and is
deliberately left alone.

**Revert-verified:** with `PrivacyPanel.tsx` restored to its `origin/main` content the gate
fails again with the original message; restoring the fix returns it to exit 0.
