### PR TITLE
fix(i18n): resolve the PrivacyPanel shell label key statically

### DIFF
--- a/website/src/pages/settings/PrivacyPanel.tsx
+++ b/website/src/pages/settings/PrivacyPanel.tsx
@@ -7,20 +7,38 @@ const COMMANDS = [
   'kirocrew telemetry disable',
 ] as const
 
+/**
+ * Catalog key per shell, as a literal map indexed at the `i18nT()` call site.
+ *
+ * The rows below used to carry the key themselves and pass the destructured
+ * `labelKey` into `i18nT()`. `scripts/check-i18n-keys.mjs` resolves only
+ * file-scope bindings, so the call site was unresolvable and the gate failed on
+ * its dynamic-site ratchet. The three keys were still checked even then, via
+ * that gate's `labelKey` data-field rule — what was exempt was the call site,
+ * not the keys. Indexing an `as const` map with a non-literal index resolves to
+ * the union of all three values, so each is verified at the point of use. Same
+ * shape as `STATUS_LABEL_KEY` in `pages/chat/McpToolsPanel.tsx`.
+ */
+const SHELL_LABEL_KEY = {
+  macosLinux: 'privacyDisclosure.shellMacOSLinuxLabel',
+  powerShell: 'privacyDisclosure.shellPowerShellLabel',
+  windowsCmd: 'privacyDisclosure.shellWindowsCmdLabel',
+} as const
+
 const SHELL_COMMANDS = [
   {
-    labelKey: 'privacyDisclosure.shellMacOSLinuxLabel',
+    kind: 'macosLinux',
     command: 'export KIROCREW_TELEMETRY_DISABLED=1',
   },
   {
-    labelKey: 'privacyDisclosure.shellPowerShellLabel',
+    kind: 'powerShell',
     command: "$env:KIROCREW_TELEMETRY_DISABLED = '1'",
   },
   {
-    labelKey: 'privacyDisclosure.shellWindowsCmdLabel',
+    kind: 'windowsCmd',
     command: 'set KIROCREW_TELEMETRY_DISABLED=1',
   },
-] as const
+] as const satisfies readonly { kind: keyof typeof SHELL_LABEL_KEY, command: string }[]
 
 /** Durable disclosure surface. This page explains controls but does not ask for
  * consent or gate use of the application. */
@@ -71,9 +89,9 @@ export function PrivacyPanel() {
               {command}
             </code>
           ))}
-          {SHELL_COMMANDS.map(({ labelKey, command }) => (
+          {SHELL_COMMANDS.map(({ kind, command }) => (
             <div key={command} className="flex max-w-full flex-col items-start gap-1">
-              <span className="text-[12px] font-medium text-muted">{i18nT(labelKey)}</span>
+              <span className="text-[12px] font-medium text-muted">{i18nT(SHELL_LABEL_KEY[kind])}</span>
               <code className="max-w-full overflow-x-auto text-[13px] text-text bg-bg border border-border rounded-md px-2.5 py-1.5 select-all">
                 {command}
               </code>


### PR DESCRIPTION
## Problem

`main` is red, and every PR cut from it inherits the failure.

`website/scripts/check-i18n-keys.mjs` exits 1 on a **completely unmodified checkout** of `main`:

```
1 file(s) gained translation call sites whose key cannot be resolved statically:
  pages/settings/PrivacyPanel.tsx: 0 → 1
```

That gate is whole-repo by design (`ci.yml` says so explicitly) and reads no base ref, so the failure is not diff-scoped. One root cause takes down two required jobs — **Frontend Lint & Type Check** (via `npm run i18n:check`) and **Frontend Tests** (via `src/i18n/keyReference.test.ts`, `expected 1 to be +0`) — and **Coverage Gate** falls over downstream with no report to read.

## Why it matters

`PR Readiness` aggregates CI, so **no PR against `main` can reach `readiness: passed` until this is fixed**. At the time of writing, 11 open PRs are already failing on this exact signature across 5 different authors, none of whom touched i18n — including a documentation-only PR (#1094). The remaining open PRs will join on their next push or rerun, because the gate does not depend on what the PR changed.

## Fix

**Symptom** → `check-i18n-keys.mjs` reports `pages/settings/PrivacyPanel.tsx: 0 → 1` on a clean tree.

**Root cause** → `PrivacyPanel`'s shell rows carried their own catalog key and passed the *destructured* `labelKey` parameter into `i18nT()`. The gate's resolver walks only **file-scope** bindings (`collectFileScopeConsts`, deliberately scoped that way so a shadowed name falls through to "dynamic" rather than resolving to the wrong outer binding), so a destructured parameter is unresolvable. The site was recorded as a dynamic call site, `dynamic-keys-baseline.json` does not list that file, and the per-file ratchet fired on `0 → 1`.

Worth being precise about what was and was not exempt: the three keys themselves were still verified even before this change, via the gate's `KEY_BEARING_PROPERTIES` rule for `labelKey: '<literal>'` data fields. What was exempt was the **call site**, and the failure was the ratchet.

How it landed green: this line arrived in #1012, whose last CI run predates the gate (#1046) by ~7 hours. The repo does not require branches to be up to date, so GitHub never re-ran #1012 after its base advanced — the gate never evaluated that diff.

**Change** → move the keys into a `SHELL_LABEL_KEY` literal map indexed at the call site, which is the shape the gate's own failure message points at. A non-literal index resolves to the **union of all three values**, so each one is verified at the point of use.

```ts
const SHELL_LABEL_KEY = {
  macosLinux: 'privacyDisclosure.shellMacOSLinuxLabel',
  powerShell: 'privacyDisclosure.shellPowerShellLabel',
  windowsCmd: 'privacyDisclosure.shellWindowsCmdLabel',
} as const
// ...
{i18nT(SHELL_LABEL_KEY[kind])}
```

The `satisfies readonly { kind: keyof typeof SHELL_LABEL_KEY, command: string }[]` clause moves a typo'd `kind` from an error at the index expression to an error at the declaration site. Structurally identical to `STATUS_LABEL_KEY` in `pages/chat/McpToolsPanel.tsx`, which is on `main` and green.

### No baseline edit — deliberately

`dynamic-keys-baseline.json` is **untouched**, and that is the point. The fix drives PrivacyPanel's count to 0, which matches the already-committed ledger exactly (`surfaces/registry.ts: 1`, `_total: 1`). Because the file was never in `base.files`, `shrank` cannot fire either.

The alternative — running `check-i18n-keys.mjs --update` to raise `_total` from 1 to 2 — is what that file's own `_comment` forbids ("Ratchet DOWN … never raise it"), and it would leave the call site permanently exempt from every existence check the gate performs. Four in-flight PRs currently carry exactly that one-line raise as a local workaround; once this merges they should drop it (the gate will then report `1 → 0` and fail on `shrank` until they do). Each of those PRs is behind `main` and needs a rebase regardless.

## Tests

No new test — existing coverage already locks this in, and a new one would duplicate it:

- **`src/i18n/keyReference.test.ts`** → `wiring > gates the real tree at zero dangling references` spawns the real gate against the real `website/` and asserts `status === 0`. **This is the assertion that is currently failing on `main`**, so reintroducing an unresolvable call site in this file is a red test by construction. It passes on this branch.
- **`src/test/PrivacyPanel.test.tsx`** → `shows persistent and labelled cross-platform telemetry controls` pins the exact English text of all three labels (`macOS / Linux`, `Windows PowerShell`, `Windows Command Prompt`) and the label→command parent nesting. Unmodified and passing, which is the evidence that rendered output did not change.
- The `as const` map shape itself is covered by `keyReference.test.ts`'s `key resolution beyond the plain literal` fixtures (`INDEXED[st]` → both entries).

Local run: `34 test files / 436 tests passed` (`src/test/PrivacyPanel.test.tsx` + all of `src/i18n/`).

## Manual verification

N/A for rendering — the diff changes no element, class, `key=` prop, or aria attribute, and the surface has no interactive controls, so the DOM and a11y tree are byte-identical. The three keys resolve to the same strings in `en.manual.json`. `PrivacyPanel.test.tsx` asserting unchanged rendered text is stronger evidence than a screenshot here.

Gate verification, run locally in `node:20-bookworm`:

| gate | before (pristine `main`) | after |
|---|---|---|
| `node scripts/check-i18n-keys.mjs` | **exit 1** — `PrivacyPanel.tsx: 0 → 1` | exit 0 — `5765 static key references all resolve, 1 dynamic site(s) at baseline (99.98% static coverage)` |
| `npm run i18n:check` (6 sub-checks) | exit 1 | exit 0 |
| `npx tsc -b` | exit 0 | exit 0 |
| `npx eslint src/ --max-warnings 1116` | exit 0 | exit 0 (298 warnings) |
| `vitest src/i18n/ src/test/PrivacyPanel.test.tsx` | 1 failed / 435 passed | 436 passed |

## Screenshots

N/A — no user-visible change. Same three labels, same commands, same DOM order; see Manual verification.

## Progress map — i18n remediation program

This PR is **not** a phase item. It is an out-of-band fix to unblock a red `main`, filed separately precisely so it can merge ahead of the four in-flight phase PRs.

| Phase | State |
|---|---|
| Phase 0 — gates & guardrails | ✅ merged (#898, #911, #913/#922, #914, #921, #924) |
| Phase 0.5 — i18next 26 upgrade | ✅ merged (#915) |
| Phase 1 — string extraction, batches 1–5 | ✅ #932, #949, #956, #959, #964 merged · batch 1 real content in flight (#1040) |
| Phase 2a — script/font support | 🔄 in flight (#982) |
| Phase 2b — bidi isolation, line-height/height units | ⬜ local only, no PR |
| Phase 3 — de-fragmentation & key-reference safety | ✅ #1046 (gate), #1048 (item 1) merged · items 2+ not started |
| Phase 4 — locale-aware formatting | ✅ #1009 merged · 🔄 formatter convergence in flight (#1047) |
| Phase 5 — ratchet model | ✅ merged (#1060) |
| Phase 6 — structural cleanup (7 items, 945 sites) | ⬜ not started |
| Phase 7 | ⬜ not started |
| Docs — AGENTS contract | 🔄 in flight (#1022) |

**This PR:** repairs the Phase 3 gate (#1046) against a violation that merged after it, restoring a green `main` for all phases.

Tracks #1004
