### PR TITLE
feat(channels): tell Slack and Discord users when their context was auto-compacted

### DIFF
--- a/src/kiro_crew/dashboard/chat_compaction_notice.py
+++ b/src/kiro_crew/dashboard/chat_compaction_notice.py
@@ -1,0 +1,188 @@
+"""Auto-compaction notice delivery for channel-originated sessions.
+
+``SessionManager`` fires its compact callback for EVERY session it compacts, but
+the dashboard's handler only knows how to append to a chat slot — so a session
+living on Slack or Discord had its context compacted silently: no notice, and no
+explanation for the summarized history the user sees afterwards. This module is
+the channel leg of that notice.
+
+Delivery reuses the two existing outbound paths rather than adding a third:
+
+* **Slack** — ``state.slack_client.post_message`` into the thread persisted by
+  the inbound leg (``SessionMap.get_slack_link``), the same resolution the
+  linked-thread auth-error notice uses. Slack is deliberately absent from the
+  ``channel_transports`` registry, so it cannot ride the ladder below.
+* **every other channel** — the governed cross-surface ladder
+  (``chat_runner._resolve_channel_target``), which vets the send against the
+  ``channels`` governance scope, records a SEL decision for grant AND denial,
+  and checks ``supports_proactive_send`` before handing off to
+  ``Transport.send_message``. The target is the session's ``origin`` link,
+  recorded by the transport's inbound path.
+
+Best-effort by construction: the compaction itself already succeeded and the
+session keeps running, so a failed or impossible delivery is logged and
+swallowed rather than surfaced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from kiro_crew.messaging.link import SLACK_NAMESPACE, channel_namespace_of
+from kiro_crew.platform.context import PlatformCompositionError
+from kiro_crew.platform.governance_profiles import vet_and_audit
+
+logger = logging.getLogger(__name__)
+
+#: Notices are plain text: a channel session may be read on a client with no
+#: markdown rendering, and the dashboard's own notice copy does not transfer
+#: (it references UI affordances the channel user does not have).
+CHANNEL_COMPACT_NOTICE = (
+    "Context reached {pct:.0f}% and was auto-compacted. Earlier turns are now a "
+    "summary; this conversation continues where it left off."
+)
+CHANNEL_COMPACT_FAILED_NOTICE = (
+    "Context reached {pct:.0f}% but auto-compact failed. It retries after a "
+    "cooldown — send {cmd} to compact now, or {new_cmd} to start fresh."
+)
+
+#: Manual fallbacks differ per channel: the bang-prefixed transports own their
+#: commands locally, while the reply-token channels use slash commands. Keyed by
+#: channel namespace with a conservative default for a transport that has not
+#: been checked.
+_MANUAL_COMMANDS: dict[str, tuple[str, str]] = {
+    "slack": ("`!compact`", "`!new`"),
+    "discord": ("`!compact`", "`!new`"),
+}
+_DEFAULT_COMMANDS = ("/compact", "/new")
+
+
+def notice_text(namespace: str, pct: float, *, success: bool) -> str:
+    """Render the notice for *namespace* at *pct* usage."""
+    if success:
+        return CHANNEL_COMPACT_NOTICE.format(pct=pct)
+    compact_cmd, new_cmd = _MANUAL_COMMANDS.get(namespace, _DEFAULT_COMMANDS)
+    return CHANNEL_COMPACT_FAILED_NOTICE.format(pct=pct, cmd=compact_cmd, new_cmd=new_cmd)
+
+
+async def deliver_channel_compaction_notice(
+    state: Any, key: str, pct: float, *, success: bool
+) -> None:
+    """Post the auto-compact notice into the conversation behind *key*.
+
+    Silent no-op for a key that is not channel-originated (``cron:``,
+    ``heartbeat``, ``subagent:`` and friends have no user watching a
+    conversation), and for a channel session whose reply target cannot be
+    resolved.
+    """
+    namespace = channel_namespace_of(key)
+    if not namespace:
+        return
+    if namespace == SLACK_NAMESPACE:
+        await _deliver_slack(state, key, notice_text(namespace, pct, success=success))
+        return
+    await _deliver_via_transport(state, key, pct, success=success)
+
+
+def _channel_egress_permitted(session_key: str, channel_type: str) -> bool:
+    """Vet an outbound notice against the ``channels`` governance scope.
+
+    The non-Slack leg inherits this from ``_resolve_channel_target``. Slack is
+    deliberately absent from ``channel_transports`` and so never reaches that
+    ladder, which would leave its notice as the one unvetted, unaudited egress
+    in this module. Fail-closed: a degraded evaluation denies rather than
+    degrading to permit, matching the ladder and the other ``channels``-scope
+    gates. ``vet_and_audit`` records a SEL decision for both grant and denial.
+
+    Synchronous by design — callers run it through ``asyncio.to_thread`` because
+    the gate reads the profile directory.
+    """
+    try:
+        decision = vet_and_audit(
+            "channels",
+            channel_type,
+            session_key=session_key,
+            tool_name="chat.compaction_notice",
+            fail_closed=True,
+        )
+    except PlatformCompositionError:
+        # An invalid governance ceiling is not an ordinary skip: the ladder
+        # deliberately re-raises rather than degrading, and so does this gate.
+        raise
+    except Exception:
+        logger.debug(
+            "compact notice: governance check failed for %s; denying (fail-closed)",
+            session_key,
+            exc_info=True,
+        )
+        return False
+    # Default False: a Decision without ``permitted`` is an unusable answer from
+    # a gate and must not read as permission.
+    return bool(getattr(decision, "permitted", False))
+
+
+async def _deliver_slack(state: Any, key: str, text: str) -> None:
+    """Post into the Slack thread the session is bound to."""
+    client = getattr(state, "slack_client", None)
+    sessions = getattr(state, "sessions", None)
+    if client is None or sessions is None:
+        return
+    try:
+        thread_ts, channel_id = sessions.get_slack_link(key)
+    except Exception:
+        logger.debug("compact notice: slack link lookup failed for %s", key, exc_info=True)
+        return
+    if not channel_id:
+        return
+    # Off-loop: the gate walks the profile directory (iterdir + stat, with a
+    # possible reload), which is unbounded on slow or networked storage.
+    if not await asyncio.to_thread(_channel_egress_permitted, key, SLACK_NAMESPACE):
+        return
+    try:
+        # thread_ts is optional: a session bound to a channel without a thread
+        # (post_message treats None as a top-level post) still gets the notice.
+        await client.post_message(channel_id, text, thread_ts or None)
+    except Exception:
+        logger.debug("compact notice: slack delivery failed for %s", key, exc_info=True)
+
+
+async def _deliver_via_transport(state: Any, key: str, pct: float, *, success: bool) -> None:
+    """Send through the governed cross-surface ladder (Discord and friends).
+
+    The notice text is rendered from the RESOLVED channel type rather than the
+    key's namespace, so a ``unified:`` DM bucket still quotes the right manual
+    command for the channel it actually lives on.
+    """
+    sessions = getattr(state, "sessions", None)
+    if sessions is None:
+        return
+    try:
+        link = sessions.get_origin_link(key)
+    except Exception:
+        logger.debug("compact notice: origin lookup failed for %s", key, exc_info=True)
+        return
+    if link is None:
+        return
+    # Lazy: chat_runner imports state at module scope, so a top-level import
+    # here would close the cycle.
+    from kiro_crew.dashboard.chat_runner import _resolve_channel_target
+
+    # Off-loop: the ladder's governance gate walks the profile directory
+    # (iterdir + stat, with a possible reload), which is unbounded on slow or
+    # networked storage. A notice is never worth stalling the loop for.
+    target = await asyncio.to_thread(_resolve_channel_target, state, key, link)
+    if target is None:
+        return
+    resolved, transport = target
+    text = notice_text(resolved.channel_type, pct, success=success)
+    try:
+        await transport.send_message(resolved.channel_id, text, thread_id=resolved.thread_id)
+    except Exception:
+        logger.debug(
+            "compact notice: %s delivery failed for %s",
+            resolved.channel_type,
+            key,
+            exc_info=True,
+        )

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -25,6 +25,7 @@ from kiro_crew.acp.types import STOP_REASON_CANCELLED
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import DASHBOARD_PORT, config_dir
 from kiro_crew.constants import OPTIONS_RE_LINE
+from kiro_crew.dashboard.chat_compaction_notice import deliver_channel_compaction_notice
 from kiro_crew.dashboard.side_state import SideState
 from kiro_crew.knowledge.store import KnowledgeStore
 from kiro_crew.messaging.link import SLACK_NAMESPACE, ChannelLink
@@ -1828,6 +1829,10 @@ class DashboardState:
 
         async def _on_compacted(key: str, pct: float, *, success: bool) -> None:
             if not key.startswith("dashboard:"):
+                # A Slack or Discord session has no slot to append to, so the
+                # notice used to be dropped and the user saw summarized history
+                # with no explanation. Route it to its own conversation instead.
+                await self._notify_channel_compaction(key, pct, success=success)
                 return
             slot_key = key[len("dashboard:") :]
             slot = self.get_slot(slot_key)
@@ -1864,6 +1869,20 @@ class DashboardState:
                     )
 
         self.sessions.set_compact_callback(_on_compacted)
+
+    async def _notify_channel_compaction(self, key: str, pct: float, *, success: bool) -> None:
+        """Deliver the auto-compact notice to a channel-originated session.
+
+        Isolated from the dashboard leg: a channel that is unreachable, ungoverned
+        or unregistered must not turn a successful compaction into an exception on
+        the session manager's background task.
+        """
+        try:
+            await deliver_channel_compaction_notice(self, key, pct, success=success)
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Failed to deliver channel compact notice for %s", key
+            )
 
     def wire_session_recycle_callback(self) -> None:
         """Register the dashboard's recycle-notification callback.

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -371,6 +371,21 @@ class DiscordDispatcher:
             is_new_own_session = is_new and resumed_key is None
             if is_new_own_session:
                 await self.sessions.set_channel(session_key, chan_id)
+            if resumed_key is None:
+                # Record the conversation's REAL send target so unattended
+                # output about the session — the auto-compact notice — can reach
+                # the user. `chan_id` above is the legacy namespaced bucket and
+                # carries the user id for a DM, which is not a postable channel.
+                # Skipped for a resumed dashboard session: its own surface owns
+                # the notice, and stamping it here would bind a dashboard entry
+                # to Discord.
+                # An in-memory dict assignment on the session manager, not a
+                # persisted field: the target is only needed while the session
+                # is live, so no disk I/O and no cross-thread state land on this
+                # turn path.
+                self.sessions.set_origin_link(
+                    session_key, ChannelLink("discord", channel_id=channel_id)
+                )
             # Publish this turn's session identity so managed MCP tools resolve
             # X-Session-Key; one shared writer lives in messaging.identity. (#232)
             await publish_turn_identity(self.sessions, session_key)

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -316,6 +316,10 @@ class _RecycleCallback(Protocol):
 # Circuit breaker: force-reset after this many consecutive failures
 _CIRCUIT_BREAKER_THRESHOLD = 5
 
+# Cap on remembered per-session channel notice targets. reset()/remove() evict
+# their own entries, so this only bounds sessions dropped by some other path.
+_MAX_ORIGIN_LINKS = 512
+
 # Background session recycle thresholds (more aggressive than chat compaction)
 _BG_RECYCLE_PCT = 70.0  # recycle at 70% — well before overflow
 _BG_BLIND_RECYCLE_PROMPTS = 40  # recycle after 40 prompts if no metadata
@@ -616,6 +620,9 @@ class SessionManager:
         # cold-start).
         self._recycling: dict[str, "_Session"] = {}
         self._compact_cooldown_until: dict[str, float] = {}
+        # Per-session channel conversation to send unattended output to (the
+        # auto-compact notice). In-memory on purpose: see set_origin_link.
+        self._origin_links: dict[str, ChannelLink] = {}
         self._background_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
         self._on_compacted: _CompactCallback | None = None
         self._on_recycled: _RecycleCallback | None = None
@@ -2408,6 +2415,7 @@ class SessionManager:
             # The new process is a fresh start — drop any stale failure
             # cooldown so it isn't inherited.
             self._compact_cooldown_until.pop(key, None)
+            self._origin_links.pop(key, None)
         if session:
             # Capture PID and child tree before shutdown clears them
             client = getattr(session.provider, "_client", None)
@@ -2793,6 +2801,7 @@ class SessionManager:
         async with self._lock:
             session = self._sessions.pop(key, None)
             self._compact_cooldown_until.pop(key, None)
+            self._origin_links.pop(key, None)
         if session:
             await session.provider.shutdown()
             # Reap any companion subagent runtime keyed by this parent (the
@@ -3398,6 +3407,33 @@ class SessionManager:
     def mirror_accepts_inbound(self, key: str) -> bool:
         """True iff this session's mirror is a session-resume (two-way) binding."""
         return self._session_map.mirror_accepts_inbound(key)
+
+    def set_origin_link(self, key: str, link: ChannelLink) -> None:
+        """Record the channel conversation this session was started from.
+
+        Called by a transport's inbound path with the conversation's real send
+        target, so unattended output about the session (the auto-compact notice)
+        can reach the user.
+
+        Held in memory, NOT persisted, and that is deliberate: the target is only
+        ever needed to talk about a LIVE session, and sessions themselves are
+        in-memory — a gateway restart takes the session with it, so there is
+        nothing left to compact or explain. Keeping it here also keeps the
+        recording free of disk I/O and of cross-thread mutation, both of which a
+        session-map field would have put on the transport's turn path.
+        """
+        key = self._fold_key(key)
+        self._origin_links[key] = link
+        # Bound the map for the pathological case where sessions are dropped
+        # without reset()/remove() (which evict their own entries). FIFO, since
+        # dict preserves insertion order and the oldest key is the least likely
+        # to still be live.
+        while len(self._origin_links) > _MAX_ORIGIN_LINKS:
+            self._origin_links.pop(next(iter(self._origin_links)), None)
+
+    def get_origin_link(self, key: str) -> ChannelLink | None:
+        """Return the channel conversation this session was started from, or None."""
+        return self._origin_links.get(self._fold_key(key))
 
     def find_mirror_sessions(
         self,

--- a/test/test_channel_compaction_notice.py
+++ b/test/test_channel_compaction_notice.py
@@ -1,0 +1,410 @@
+"""Auto-compaction notice on channel-originated sessions (Slack + Discord).
+
+Before this, ``SessionManager``'s compact callback was dashboard-only: it
+returned early for any key that did not start with ``dashboard:``, so a Slack
+thread or Discord DM was compacted in silence. These tests pin the channel leg:
+
+  * the notice text (copy, pct rounding, per-channel manual command);
+  * Slack delivery into the session's persisted thread, gated on the
+    ``channels`` governance scope;
+  * non-Slack delivery through the governed cross-surface ladder, using the
+    session's ``origin`` link as the target;
+  * every no-target / no-transport / governance-denial / delivery-failure path
+    degrading to a logged no-op — a compaction that SUCCEEDED must never
+    surface as an error;
+  * the origin-link store itself: in-memory on ``SessionManager`` (NOT
+    persisted), evicted with the session, and bounded;
+  * the wiring in ``DashboardState.wire_session_compact_callback``.
+
+All against fakes — no real transport, session manager, or network.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.dashboard.chat_compaction_notice import (
+    deliver_channel_compaction_notice,
+    notice_text,
+)
+from kiro_crew.messaging.link import ChannelLink
+
+
+class _SlackClient:
+    def __init__(self, fail: bool = False) -> None:
+        self.posted: list[tuple[str, str, str | None]] = []
+        self.fail = fail
+
+    async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> str:
+        if self.fail:
+            raise RuntimeError("slack down")
+        self.posted.append((channel, text, thread_ts))
+        return "ts-posted"
+
+
+class _Transport:
+    def __init__(self, fail: bool = False, max_chars: int = 2000) -> None:
+        self.sent: list[tuple[str, str, str | None]] = []
+        self.fail = fail
+        self.capabilities = SimpleNamespace(
+            supports_proactive_send=True, max_message_chars=max_chars
+        )
+
+    async def send_message(
+        self, conversation_id: str, content: str, thread_id: str | None = None
+    ) -> str:
+        if self.fail:
+            raise RuntimeError("discord down")
+        self.sent.append((conversation_id, content, thread_id))
+        return "mid-1"
+
+
+class _Sessions:
+    def __init__(
+        self,
+        *,
+        slack_link: tuple[str | None, str | None] = (None, None),
+        origin: ChannelLink | None = None,
+        raise_on_lookup: bool = False,
+    ) -> None:
+        self._slack_link = slack_link
+        self._origin = origin
+        self._raise = raise_on_lookup
+
+    def get_slack_link(self, key: str) -> tuple[str | None, str | None]:
+        if self._raise:
+            raise RuntimeError("map unreadable")
+        return self._slack_link
+
+    def get_origin_link(self, key: str) -> ChannelLink | None:
+        if self._raise:
+            raise RuntimeError("map unreadable")
+        return self._origin
+
+
+def _state(
+    *,
+    slack_client: Any = None,
+    sessions: Any = None,
+    transport: Any = None,
+) -> Any:
+    return SimpleNamespace(
+        slack_client=slack_client,
+        sessions=sessions or _Sessions(),
+        channel_transports={"discord": transport} if transport is not None else {},
+        get_channel_transport=lambda ct: (
+            transport if transport is not None and ct == "discord" else None
+        ),
+    )
+
+
+@contextmanager
+def _permit_governance():
+    """Permit BOTH governance gates on the notice path.
+
+    There are two, resolved differently: this module's Slack gate holds
+    ``vet_and_audit`` as a module-scope name, while ``chat_runner``'s transport
+    ladder imports it inside the function (so it must be patched at its source).
+    A test that patched only one would leave the other reading the host's real
+    governance profile.
+    """
+    permit = SimpleNamespace(permitted=True)
+    with patch(
+        "kiro_crew.dashboard.chat_compaction_notice.vet_and_audit", return_value=permit
+    ), patch("kiro_crew.platform.governance_profiles.vet_and_audit", return_value=permit):
+        yield
+
+
+class TestNoticeText:
+    def test_success_copy_rounds_pct(self) -> None:
+        text = notice_text("discord", 91.7, success=True)
+        assert "92%" in text
+        assert "auto-compacted" in text
+
+    def test_failure_copy_quotes_bang_commands_on_discord(self) -> None:
+        text = notice_text("discord", 90.0, success=False)
+        assert "!compact" in text
+        assert "!new" in text
+
+    def test_failure_copy_quotes_bang_commands_on_slack(self) -> None:
+        assert "!compact" in notice_text("slack", 90.0, success=False)
+
+    def test_failure_copy_falls_back_to_slash_commands(self) -> None:
+        """An unchecked transport gets the conservative slash form, not a wrong bang."""
+        text = notice_text("webex", 90.0, success=False)
+        assert "/compact" in text
+        assert "!compact" not in text
+
+    def test_no_emoji_in_notices(self) -> None:
+        for success in (True, False):
+            text = notice_text("discord", 90.0, success=success)
+            assert all(ord(ch) < 0x2190 for ch in text), text
+
+
+@pytest.mark.asyncio
+class TestSlackDelivery:
+    async def test_posts_into_persisted_thread(self) -> None:
+        client = _SlackClient()
+        state = _state(
+            slack_client=client,
+            sessions=_Sessions(slack_link=("ts-1", "C123")),
+        )
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 92.0, success=True)
+
+        assert len(client.posted) == 1
+        channel, text, thread_ts = client.posted[0]
+        assert (channel, thread_ts) == ("C123", "ts-1")
+        assert "92%" in text
+
+    async def test_posts_top_level_when_no_thread(self) -> None:
+        client = _SlackClient()
+        state = _state(slack_client=client, sessions=_Sessions(slack_link=("", "C123")))
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 90.0, success=True)
+
+        assert client.posted[0][2] is None
+
+    async def test_noop_without_client(self) -> None:
+        state = _state(sessions=_Sessions(slack_link=("ts-1", "C123")))
+        with _permit_governance():
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 90.0, success=True)
+
+    async def test_noop_without_channel(self) -> None:
+        client = _SlackClient()
+        state = _state(slack_client=client, sessions=_Sessions(slack_link=("ts-1", None)))
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 90.0, success=True)
+
+        assert client.posted == []
+
+    async def test_governance_denial_blocks_the_post(self) -> None:
+        """Slack is absent from the transport ladder, so it needs its own gate."""
+        client = _SlackClient()
+        state = _state(slack_client=client, sessions=_Sessions(slack_link=("ts-1", "C123")))
+
+        with patch(
+            "kiro_crew.dashboard.chat_compaction_notice.vet_and_audit",
+            return_value=SimpleNamespace(permitted=False),
+        ):
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 90.0, success=True)
+
+        assert client.posted == []
+
+    async def test_decision_without_permitted_is_denial(self) -> None:
+        """An unusable answer from the gate must not read as permission."""
+        client = _SlackClient()
+        state = _state(slack_client=client, sessions=_Sessions(slack_link=("ts-1", "C123")))
+
+        with patch(
+            "kiro_crew.dashboard.chat_compaction_notice.vet_and_audit",
+            return_value=SimpleNamespace(),
+        ):
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 90.0, success=True)
+
+        assert client.posted == []
+
+    async def test_governance_error_fails_closed(self) -> None:
+        client = _SlackClient()
+        state = _state(slack_client=client, sessions=_Sessions(slack_link=("ts-1", "C123")))
+
+        with patch(
+            "kiro_crew.dashboard.chat_compaction_notice.vet_and_audit",
+            side_effect=RuntimeError("profile unreadable"),
+        ):
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 90.0, success=True)
+
+        assert client.posted == []
+
+    async def test_swallows_post_failure(self) -> None:
+        state = _state(
+            slack_client=_SlackClient(fail=True),
+            sessions=_Sessions(slack_link=("ts-1", "C123")),
+        )
+        # A failed notice must not propagate into the compaction task.
+        with _permit_governance():
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 90.0, success=True)
+
+    async def test_swallows_map_failure(self) -> None:
+        client = _SlackClient()
+        state = _state(slack_client=client, sessions=_Sessions(raise_on_lookup=True))
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(state, "slack:ts-1", 90.0, success=True)
+
+        assert client.posted == []
+
+
+@pytest.mark.asyncio
+class TestTransportDelivery:
+    async def test_sends_to_origin_conversation(self) -> None:
+        transport = _Transport()
+        state = _state(
+            transport=transport,
+            sessions=_Sessions(origin=ChannelLink("discord", channel_id="chan-9")),
+        )
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(
+                state, "discord:kirocrew:direct:u1", 93.0, success=True
+            )
+
+        assert len(transport.sent) == 1
+        conversation, text, thread = transport.sent[0]
+        assert (conversation, thread) == ("chan-9", None)
+        assert "93%" in text
+
+    async def test_unified_bucket_uses_resolved_channel_for_hint(self) -> None:
+        """A ``unified:`` key still quotes Discord's bang command, not ``/compact``."""
+        transport = _Transport()
+        state = _state(
+            transport=transport,
+            sessions=_Sessions(origin=ChannelLink("discord", channel_id="chan-9")),
+        )
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(
+                state, "unified:kirocrew:direct:u1", 90.0, success=False
+            )
+
+        assert "!compact" in transport.sent[0][1]
+
+    async def test_noop_without_origin(self) -> None:
+        transport = _Transport()
+        state = _state(transport=transport, sessions=_Sessions(origin=None))
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(
+                state, "discord:kirocrew:direct:u1", 90.0, success=True
+            )
+
+        assert transport.sent == []
+
+    async def test_noop_when_transport_unregistered(self) -> None:
+        state = _state(sessions=_Sessions(origin=ChannelLink("discord", channel_id="chan-9")))
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(
+                state, "discord:kirocrew:direct:u1", 90.0, success=True
+            )
+
+    async def test_noop_when_governance_denies(self) -> None:
+        transport = _Transport()
+        state = _state(
+            transport=transport,
+            sessions=_Sessions(origin=ChannelLink("discord", channel_id="chan-9")),
+        )
+
+        # The ladder resolves vet_and_audit at its source (function-local import).
+        with patch(
+            "kiro_crew.platform.governance_profiles.vet_and_audit",
+            return_value=SimpleNamespace(permitted=False),
+        ):
+            await deliver_channel_compaction_notice(
+                state, "discord:kirocrew:direct:u1", 90.0, success=True
+            )
+
+        assert transport.sent == []
+
+    async def test_swallows_send_failure(self) -> None:
+        transport = _Transport(fail=True)
+        state = _state(
+            transport=transport,
+            sessions=_Sessions(origin=ChannelLink("discord", channel_id="chan-9")),
+        )
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(
+                state, "discord:kirocrew:direct:u1", 90.0, success=True
+            )
+
+
+@pytest.mark.asyncio
+class TestNonChannelKeys:
+    @pytest.mark.parametrize(
+        "key",
+        ["cron:daily-digest", "heartbeat", "subagent:abc", "hook:webhook-1", "_bg"],
+    )
+    async def test_no_delivery_for_non_channel_session(self, key: str) -> None:
+        client = _SlackClient()
+        transport = _Transport()
+        state = _state(
+            slack_client=client,
+            transport=transport,
+            sessions=_Sessions(
+                slack_link=("ts-1", "C123"),
+                origin=ChannelLink("discord", channel_id="chan-9"),
+            ),
+        )
+
+        with _permit_governance():
+            await deliver_channel_compaction_notice(state, key, 95.0, success=True)
+
+        assert client.posted == []
+        assert transport.sent == []
+
+
+class TestOriginLinkStore:
+    """The notice target lives in memory on SessionManager, not in SessionMap.
+
+    Its lifetime is the SESSION's: a target is only ever needed to talk about a
+    live session, and a gateway restart takes the session with it. Keeping it out
+    of the session map also keeps disk I/O and cross-thread state off the
+    transport's turn path.
+    """
+
+    def _manager(self, tmp_path):
+        from kiro_crew.config.loader import KiroCrewConfig
+        from kiro_crew.session import SessionManager
+
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            return SessionManager(KiroCrewConfig())
+
+    def test_round_trip(self, tmp_path) -> None:
+        mgr = self._manager(tmp_path)
+        link = ChannelLink("discord", channel_id="chan-9")
+        mgr.set_origin_link("discord:kirocrew:direct:u1", link)
+        assert mgr.get_origin_link("discord:kirocrew:direct:u1") == link
+
+    def test_absent_returns_none(self, tmp_path) -> None:
+        assert self._manager(tmp_path).get_origin_link("discord:nope") is None
+
+    def test_overwrites_previous_target(self, tmp_path) -> None:
+        mgr = self._manager(tmp_path)
+        mgr.set_origin_link("discord:k", ChannelLink("discord", channel_id="c1"))
+        mgr.set_origin_link("discord:k", ChannelLink("discord", channel_id="c2"))
+        got = mgr.get_origin_link("discord:k")
+        assert got is not None and got.channel_id == "c2"
+
+    def test_not_persisted_to_the_session_map(self, tmp_path) -> None:
+        """No session-map write means no whole-map rewrite on a turn path."""
+        mgr = self._manager(tmp_path)
+        mgr.set_origin_link("discord:k", ChannelLink("discord", channel_id="c1"))
+        assert not hasattr(mgr._session_map, "set_origin_link")
+        assert mgr._session_map._data.get("discord:k") is None
+
+    @pytest.mark.asyncio
+    async def test_evicted_with_the_session(self, tmp_path) -> None:
+        mgr = self._manager(tmp_path)
+        mgr.set_origin_link("discord:k", ChannelLink("discord", channel_id="c1"))
+        await mgr.remove("discord:k")
+        assert mgr.get_origin_link("discord:k") is None
+
+    def test_bounded_against_unevicted_growth(self, tmp_path) -> None:
+        from kiro_crew.session import _MAX_ORIGIN_LINKS
+
+        mgr = self._manager(tmp_path)
+        for i in range(_MAX_ORIGIN_LINKS + 10):
+            mgr.set_origin_link(f"discord:k{i}", ChannelLink("discord", channel_id=str(i)))
+        assert len(mgr._origin_links) == _MAX_ORIGIN_LINKS
+        # FIFO: the oldest keys went first, the newest survive.
+        assert mgr.get_origin_link("discord:k0") is None
+        assert mgr.get_origin_link(f"discord:k{_MAX_ORIGIN_LINKS + 9}") is not None

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -252,6 +252,44 @@ class TestCompactCallbackWiring:
         await cb("cron:daily-digest", 95.0, success=True)
 
         assert len(slot.messages) == baseline
+
+    @pytest.mark.asyncio
+    async def test_callback_routes_channel_keys_to_channel_notice(
+        self, state: DashboardState
+    ) -> None:
+        """A Slack/Discord session has no slot, so the notice goes to its channel."""
+        slot = state.get_or_create_slot("chat-1")
+        baseline = len(slot.messages)
+        cb = self._captured_callback(state)
+
+        with patch(
+            "kiro_crew.dashboard.state.deliver_channel_compaction_notice",
+            new_callable=AsyncMock,
+        ) as deliver:
+            await cb("slack:1785370133.085469", 92.0, success=True)
+            await cb("discord:kirocrew:direct:u1", 93.0, success=False)
+
+        assert [c.args[1] for c in deliver.await_args_list] == [
+            "slack:1785370133.085469",
+            "discord:kirocrew:direct:u1",
+        ]
+        assert deliver.await_args_list[1].kwargs["success"] is False
+        # The channel leg must not also write into an unrelated dashboard slot.
+        assert len(slot.messages) == baseline
+
+    @pytest.mark.asyncio
+    async def test_channel_notice_failure_does_not_propagate(
+        self, state: DashboardState
+    ) -> None:
+        """The compaction already succeeded; a broken channel must not raise."""
+        cb = self._captured_callback(state)
+
+        with patch(
+            "kiro_crew.dashboard.state.deliver_channel_compaction_notice",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("transport exploded"),
+        ):
+            await cb("slack:1785370133.085469", 92.0, success=True)
 
     @pytest.mark.asyncio
     async def test_callback_noop_when_slot_missing(self, state: DashboardState) -> None:

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -207,6 +207,7 @@ class FakeSessions:
         self.queued: list = []
         self._gp = FakeProvider()
         self.mirror_links: dict[str, Any] = {}
+        self.origin_links: dict[str, Any] = {}
         self.inbound_mirror_keys: set[str] = set()
 
     async def get_or_create(self, key: str, *, agent: Any = None, channel_id: Any = None) -> Any:
@@ -254,6 +255,12 @@ class FakeSessions:
 
     def get_mirror_link(self, key: str) -> Any:
         return self.mirror_links.get(key)
+
+    def set_origin_link(self, key: str, link: Any) -> None:
+        self.origin_links[key] = link
+
+    def get_origin_link(self, key: str) -> Any:
+        return self.origin_links.get(key)
 
     def find_mirror_sessions(self, link: Any, *, inbound_only: bool = False) -> list[str]:
         return [

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -90,6 +90,7 @@ class _Provider:
 class _Sessions:
     def __init__(self) -> None:
         self.mirror_links: dict[str, ChannelLink] = {}
+        self.origin_links: dict[str, ChannelLink] = {}
         self.inbound_keys: set[str] = set()
         self.last_key = ""
         self.provider = _Provider()
@@ -106,6 +107,12 @@ class _Sessions:
             self.inbound_keys.add(key)
         else:
             self.inbound_keys.discard(key)
+
+    def set_origin_link(self, key: str, link: ChannelLink) -> None:
+        self.origin_links[key] = link
+
+    def get_origin_link(self, key: str) -> ChannelLink | None:
+        return self.origin_links.get(key)
 
     def get_mirror_link(self, key: str) -> ChannelLink | None:
         return self.mirror_links.get(key)
@@ -777,6 +784,20 @@ async def test_own_session_still_gets_new_session_bookkeeping() -> None:
 
     assert [key for key, _ in getattr(sessions, "set_channel_calls", [])] == [sessions.last_key]
     assert [key for key, _ in getattr(log, "titles_set", [])] == [sessions.last_key]
+
+
+@pytest.mark.asyncio
+async def test_own_session_records_the_origin_conversation() -> None:
+    """The auto-compact notice needs the REAL channel, not the DM's user-id bucket."""
+    log = _log()
+    dispatcher, _, sessions = _dispatcher({"u1"}, log)
+    sessions.is_new_result = True
+
+    await dispatcher.handle_message(_message("hello there", channel_id="c1"))
+
+    link = sessions.get_origin_link(sessions.last_key)
+    assert link is not None
+    assert (link.channel_type, link.channel_id) == ("discord", "c1")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`SessionManager` fires its compact callback for **every** session it compacts, but the only registered handler is the dashboard's, and it returned early for any key that is not a `dashboard:` slot:

```python
async def _on_compacted(key, pct, *, success):
    if not key.startswith("dashboard:"):
        return          # <- Slack and Discord fell off here
```

So a Slack thread or Discord conversation crossing `session.autocompact_pct` (default 90) had its context compacted **in silence**. The user saw summarized history with no explanation, and on a *failed* compact got no hint that `!compact` / `!new` exist. The dashboard, by contrast, gets a notice plus a context-bar reset.

## Why it matters

Compaction is the moment a conversation visibly loses detail. Explaining it is what separates "the agent forgot what we agreed" from "the context was summarized, here's how to start fresh". Discord and Telegram warn at `soft_threshold_pct` (80) *before* compaction, and Slack has neither a soft nudge nor a hard force — so on both channels the event that actually changes the conversation was the one nobody was told about.

## Fix (symptom -> root cause -> change)

The symptom is a missing message; the root cause is a handler that could only write to a chat slot, and a channel session has none. So the callback now routes channel-originated keys to a channel leg, which reuses the two outbound paths that already exist rather than adding a third:

- **Slack** — `state.slack_client.post_message` into the thread the inbound leg already persists on every turn (`SessionMap.get_slack_link`). Same resolution the linked-thread auth-error notice uses. Slack is deliberately absent from `channel_transports`, so it cannot ride the ladder below — which also meant it needed its own governance gate (see below).
- **Every other channel** — the governed cross-surface ladder (`chat_runner._resolve_channel_target`), which vets the send against the `channels` governance scope, records a SEL decision for **grant and denial**, and checks `supports_proactive_send` before handing to `Transport.send_message`.

Non-Slack delivery needs the conversation's real send target, so `SessionManager` gains an **in-memory** `_origin_links` map, recorded by the transport's inbound path. It is deliberately **not persisted**: a notice target is only ever needed to talk about a **live** session, and sessions are in-memory, so a gateway restart takes the session and its target together and leaves nothing to compact or explain. Keeping it out of the session map also keeps disk I/O and cross-thread state off the transport's turn path (see Review rounds — this is where three rounds of review converged). Entries are evicted in `reset()` and `remove()` beside the existing `_compact_cooldown_until` cleanup, with a FIFO cap (`_MAX_ORIGIN_LINKS = 512`) bounding any session dropped by another path.

Discord records the target per turn. The pre-existing `slack_channel_id` stamp could not be reused because it is a namespaced bucket (`discord:<id>`) that carries the **user id** for a DM, which is not a postable channel. Recording is skipped for a resumed dashboard session, whose own surface owns the notice.

Both governance gates are awaited through `asyncio.to_thread`, because each reads the profile directory (`iterdir` + `stat`, with a possible reload) — unbounded on slow or networked storage, and a notice is never worth stalling the loop for.

Notice copy is plain text (no emoji, no markdown assumptions) and the manual-command hint is per channel — `!compact` / `!new` for Slack and Discord, conservative `/compact` for a transport that has not been checked. The hint is rendered from the **resolved** channel type, so a `unified:` DM bucket still quotes the right command.

## Failure behavior

The compaction itself already succeeded and the session keeps running, so every degenerate path is a logged no-op, never an exception on the session manager's background task: no client, no resolvable target, unregistered transport, governance denial, governance evaluation error (fail-closed), map read failure, and send failure. `PlatformCompositionError` is the one exception that propagates — an invalid governance ceiling is not an ordinary skip, matching the ladder's own contract. The dashboard leg is unchanged and unaffected.

## Tests

`test/test_channel_compaction_notice.py` (new, 31 cases) plus wiring tests in `test_dashboard_state_ws.py` and an origin-recording test in `test_discord_sessions.py`:

- notice copy: pct rounding, per-channel manual command, slash fallback, no emoji
- Slack: posts into the persisted thread, top-level when threadless, no-op without client/channel, swallows post and map failures
- Slack governance: denial blocks the post, a `Decision` without `permitted` is treated as denial, an evaluation error fails closed
- transport: sends to the origin conversation, `unified:` bucket uses the resolved channel's command, no-op without origin / unregistered transport / governance denial, swallows send failure
- non-channel keys (`cron:`, `heartbeat:`, `subagent:`, `hook:`, `_bg`) deliver nothing
- origin-link store: round trip, overwrite, **not** written to `SessionMap`, evicted with the session, FIFO-bounded
- routing: channel keys reach the channel leg with the right key and `success` flag; a channel-leg exception does not propagate

Revert-verified: the three governance tests fail with the gate line removed; the eviction and cap tests fail with the eviction and cap removed; `test_callback_routes_channel_keys_to_channel_notice` and `test_own_session_records_the_origin_conversation` fail against `origin/main`'s versions of `state.py` and `transport_dispatch.py`.

## Manual verification

N/A — unit coverage is sufficient. Every branch is a pure function of injected fakes (transport, Slack client, session manager, governance decision); there is no UI surface and no rendering to eyeball. Reproducing a real 90%-context compaction on a live Slack thread would exercise `SessionManager` code this PR does not touch.

## Gates

- Targeted scope: 372 tests pass across channel / dashboard / session-map / session-manager / Discord. The full backend suite passed at 23321 on an earlier head of this branch; the 4 failures there (`test_app_manager::test_declares_backend_helper`, 3 in `test_dashboard_origin::TestParseDashboardUrlMalformed`) reproduce on a clean `origin/main` tree in the same worktree — pre-existing, unrelated to this diff.
- `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test`, `mypy src/kiro_crew/` (578 files, CI-parity venv without faiss) all clean.
- No frontend files touched, so `tsc -b` / vitest scope is unchanged.

## Deliberately out of scope

Telegram (and the other transports) still compact silently. The origin store and the transport ladder are generic, so closing that gap is a one-line `set_origin_link` stamp per dispatcher — but each one needs its own inbound-path reading to pick the right send target, so they are follow-ups rather than blind copies. Design review and Arbiter both flagged this and both rated it a fine follow-up.

Arbiter also suggested a broader sweep — offloading `SessionMap._save` and caching the governance ladder's filesystem reads for **all** existing callers. Both are pre-existing patterns this PR no longer contributes to, and both are better done once at their own layer.

## Review rounds

**Round 1 (`f4542eeb`)** — GPT: governance-ladder scan and the session-map write both on the event loop; function-local import in `state.py`. Fixed by `asyncio.to_thread` on both and hoisting the import.

**Round 2 (`0db3905b`)** — GPT: (a) the Slack notice bypassed channel governance entirely — accepted, added `_channel_egress_permitted`; (b) the round-1 `to_thread` on `set_origin_link` races `_save()`, since `SessionMap` has no lock and the loop's single-threaded execution *was* the serialization — accepted, reverted to synchronous.

**Round 3 (`940be86c`)** — GPT: the now-synchronous whole-map write stalls the loop, "revert this write". Rounds 1 and 3 both want the write off the loop; round 2 establishes it cannot leave while `SessionMap` is unsynchronized. Both are correct, so no *placement* of a session-map write satisfies them, and the literal prescription would have deleted the Discord half of the feature. The premise went instead: **the target is no longer persisted at all**, which removes the contested write rather than relocating it. Also hoisted the two platform imports to module scope (verified cycle-free); the one remaining function-local import is `chat_runner`, which is genuinely circular and documented as such.

**Round 4 (`3862d118`)** — GPT, Opus 5, Design and Arbiter all pass. Design's advisory CONCERNS was that this description and a test docstring still documented the round-1/2 persisted design; both are corrected here.
