### PR TITLE
fix(chat): re-surface a closed channel tab when the channel moves on

### DIFF
--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -39,9 +39,16 @@ Design notes:
   ``restore_window_minutes`` become slots, so a long DM history does not turn
   into hundreds of tabs. Pinned and foldered sessions are exempt from the
   window, matching :func:`~kiro_crew.dashboard.chat_persistence.restore_recent_sessions`.
-* **Closed is sticky.** A session the user closed on the dashboard
-  (``meta.closed``) is never re-surfaced — otherwise closing the tab would be
-  undone on the next reconcile pass.
+* **Closed is sticky — until the channel moves on.** A session the user closed
+  on the dashboard (``meta.closed``) is not re-surfaced by the next reconcile
+  pass — otherwise closing the tab would be undone 30 seconds later. But a
+  close is a statement about the conversation *as it stood*: channel-side
+  activity strictly newer than the close (the person kept talking on Discord
+  after the tab was dismissed) re-surfaces it, and the stale ``closed`` flags
+  are cleared so every restore path agrees the tab is open again. When the
+  close instant is unknown (legacy flag with no ``closed_at`` stamp and no
+  readable file mtime), the close stands — fail toward the user's explicit
+  dismissal.
 * **Ephemeral stays ephemeral.** ``incognito``/``temporary`` channel threads are
   skipped: the user asked for a conversation that leaves no trace, and a
   durable sidebar tab contradicts that.
@@ -54,6 +61,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import weakref
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -211,11 +219,58 @@ def mirror_new_messages(
     return sorted(out, key=_ts_sort_key)
 
 
+def _close_time(meta: dict[str, Any], file_mtime: float | None) -> float | None:
+    """Best-known epoch instant *meta*'s ``closed`` flag was written.
+
+    Prefers the explicit ``closed_at`` stamp (written alongside ``closed`` by
+    ``_save_slot_to_history``); falls back to the session file's mtime, which
+    the closing save set. ``None`` means the instant is unknowable — the
+    caller must treat the close as standing.
+    """
+    raw = meta.get("closed_at")
+    if raw is not None:
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            pass
+    return file_mtime
+
+
+def _close_stands(
+    session: dict[str, Any],
+    meta: dict[str, Any],
+    slot_meta: dict[str, Any],
+    mtimes: dict[str, float],
+) -> bool:
+    """True when the user's dismissal of this conversation is still in force.
+
+    A close is not permanent: channel-side activity strictly newer than the
+    close means the conversation came back to life after the user dismissed
+    it, so it re-qualifies for surfacing. The comparison is against the
+    session listing's ``modified`` (the channel file's last write). Every
+    closed side must be outdated by that activity — an unknown close instant
+    on either side keeps the close standing, failing toward the user's
+    explicit action.
+    """
+    key = session.get("key", "")
+    closes: list[float | None] = []
+    if meta.get("closed"):
+        closes.append(_close_time(meta, mtimes.get(key)))
+    if slot_meta.get("closed"):
+        slot_key = slot_history_key(key)
+        closes.append(_close_time(slot_meta, mtimes.get(slot_key)))
+    if not closes:
+        return False
+    modified = float(session.get("modified", 0) or 0)
+    return any(ct is None or modified <= ct for ct in closes)
+
+
 def eligible_channel_sessions(
     sessions: list[dict[str, Any]],
     *,
     metadata: dict[str, dict[str, Any]],
     cutoff: float | None,
+    mtimes: dict[str, float] | None = None,
 ) -> list[dict[str, Any]]:
     """Filter a ``list_sessions()`` result down to channel sessions to surface.
 
@@ -223,8 +278,11 @@ def eligible_channel_sessions(
     entry for BOTH the channel key and its ``dashboard:``-prefixed slot key (see
     :func:`slot_history_key`) — closing a tab writes ``closed`` to the slot key,
     so reading only the channel key would let a closed tab reopen on the next
-    pass. *cutoff* is a unix timestamp; sessions older than it are dropped unless
-    pinned or foldered. ``None`` disables the recency filter (mirrors
+    pass. *mtimes* maps the same keys to their session-file mtimes, the fallback
+    close instant for a ``closed`` flag with no ``closed_at`` stamp (see
+    :func:`_close_stands`); with it absent, every close stands. *cutoff* is a
+    unix timestamp; sessions older than it are dropped unless pinned or
+    foldered. ``None`` disables the recency filter (mirrors
     ``restore_window_minutes=0``).
 
     Pure and side-effect free so the eligibility rules are directly testable.
@@ -236,9 +294,10 @@ def eligible_channel_sessions(
             continue
         meta = metadata.get(key) or {}
         slot_meta = metadata.get(slot_history_key(key)) or {}
-        # Either side having been closed means the user dismissed this
-        # conversation; never resurface it.
-        if meta.get("closed") or slot_meta.get("closed"):
+        # A close only stands until the channel outruns it: activity newer
+        # than the close re-qualifies the session (and the reconciler then
+        # clears the stale flags — see reconcile_channel_slots).
+        if _close_stands(s, meta, slot_meta, mtimes or {}):
             continue
         modes = (
             str(meta.get("memory_mode", "")).lower(),
@@ -527,13 +586,102 @@ def _mirror_intact(slot: "_ChatSlot") -> bool:
     )
 
 
+#: Per-state serialization of reconcile passes. The periodic loop and the
+#: dispatcher's immediate `surface_dispatcher_session` can otherwise overlap,
+#: and a pass acting on a pre-overlap metadata snapshot could clear a `closed`
+#: flag the user wrote mid-race. Weak keys so a replaced DashboardState does
+#: not pin its lock.
+_RECONCILE_LOCKS: "weakref.WeakKeyDictionary[Any, asyncio.Lock]" = weakref.WeakKeyDictionary()
+
+#: Per-state in-memory close tombstones: slot name -> epoch of the most recent
+#: tab close. Written synchronously on the event loop by the tab-close paths
+#: (see :func:`note_slot_closed`), read by the surface loop after its last
+#: await. This is what makes a close AROUND a reconcile pass visible to it:
+#: the disk flag alone is not enough, because the close SAVE lands only after
+#: the close handler's awaits (task cancellation, file lock), so a pass can
+#: snapshot still-open metadata after the slot was already popped. A tombstone
+#: suppresses surfacing under the same rule as the disk flag — only channel
+#: activity strictly newer than the close outruns it (see
+#: :func:`_tombstone_blocks`) — so the suppression is independent of how the
+#: pass's snapshot interleaves with the close. In-memory suffices — the
+#: resurrect window only exists in-process (a slot can only be popped by this
+#: process's own handlers), and by the time a tombstone expires the close
+#: save has long since made the disk flag authoritative.
+_RECENT_CLOSES: "weakref.WeakKeyDictionary[Any, dict[str, float]]" = weakref.WeakKeyDictionary()
+
+#: Tombstones older than this are pruned; they only need to outlive a single
+#: reconcile pass, and an hour is orders of magnitude beyond that.
+_CLOSE_TOMBSTONE_TTL_SECS = 3600.0
+
+
+def note_slot_closed(state: "DashboardState", slot_name: str) -> float:
+    """Record that *slot_name*'s tab was just closed; return the close instant.
+
+    Called synchronously on the event loop by every tab-close path, right where
+    the slot is popped from ``state._slots``. A reconcile pass whose metadata
+    snapshot predates this close checks these tombstones after its last await,
+    so it cannot re-surface a conversation the user dismissed while the pass's
+    executor work was in flight.
+
+    The returned epoch is the instant the user acted. Callers persist it as the
+    on-disk ``closed_at`` (via ``save_slot_off_loop(closed_at=...)``) instead of
+    re-stamping at save time: the close save runs only after the handler's
+    awaits (task cancellation, file lock), and channel activity landing in that
+    window would otherwise compare as OLDER than the close and stay hidden.
+    """
+    closes = _RECENT_CLOSES.get(state)
+    if closes is None:
+        closes = {}
+        _RECENT_CLOSES[state] = closes
+    now = time.time()
+    closes[slot_name] = now
+    cutoff = now - _CLOSE_TOMBSTONE_TTL_SECS
+    for stale in [k for k, v in closes.items() if v < cutoff]:
+        del closes[stale]
+    return now
+
+
+def _tombstone_blocks(state: "DashboardState", session: dict[str, Any]) -> bool:
+    """True when an in-memory close tombstone suppresses surfacing *session*.
+
+    Same rule as the disk flag (:func:`_close_stands`): the close stands unless
+    the channel's last activity is strictly newer than the close instant. The
+    comparison is against the session's own ``modified`` — NOT against the
+    pass's snapshot time — so it does not matter whether the close happened
+    before, during, or after the pass's snapshot: a close whose save is still
+    in flight (open metadata on disk, slot already popped) is judged by the
+    tombstone alone, and only genuinely newer channel activity outruns it.
+    """
+    closes = _RECENT_CLOSES.get(state) or {}
+    when = closes.get(channel_slot_name(session.get("key", "")))
+    if when is None:
+        return False
+    modified = float(session.get("modified", 0) or 0)
+    return modified <= when
+
+
+def _reconcile_lock(state: "DashboardState") -> asyncio.Lock:
+    lock = _RECONCILE_LOCKS.get(state)
+    if lock is None:
+        lock = asyncio.Lock()
+        _RECONCILE_LOCKS[state] = lock
+    return lock
+
+
 async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) -> int:
     """One reconcile pass. Returns the number of slots surfaced or re-bound.
 
     Safe to call on the event loop: every filesystem read is offloaded, and only
     the in-memory slot mutations run on the loop (so ``state._slots`` is never
-    touched from a worker thread).
+    touched from a worker thread). Passes are serialized per state so the
+    periodic loop and a dispatcher-triggered immediate pass cannot interleave
+    their snapshot/surface/clear sequences.
     """
+    async with _reconcile_lock(state):
+        return await _reconcile_channel_slots_locked(state, window_minutes)
+
+
+async def _reconcile_channel_slots_locked(state: "DashboardState", window_minutes: int) -> int:
     log = state.conversation_log
     if log is None:
         return 0
@@ -550,10 +698,14 @@ async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) 
     if not candidates:
         return 0
 
-    def _load_meta() -> dict[str, dict[str, Any]]:
+    def _load_meta() -> tuple[dict[str, dict[str, Any]], dict[str, float]]:
         out: dict[str, dict[str, Any]] = {}
+        mt: dict[str, float] = {}
         # Both the channel key and the slot key: the slot key is where a closed
         # tab records `closed`, and skipping it would resurface it every pass.
+        # File mtimes ride along as the fallback close instant for legacy
+        # `closed` flags that predate the `closed_at` stamp.
+        mtime_of = getattr(log, "mtime_of", None)
         for s in candidates:
             for key in (s.get("key", ""), slot_history_key(s.get("key", ""))):
                 if not key or key in out:
@@ -562,10 +714,24 @@ async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) 
                     out[key] = log.get_metadata(key)
                 except Exception:
                     out[key] = {}
-        return out
+                if mtime_of is not None:
+                    try:
+                        stamp = mtime_of(key)
+                    except Exception:
+                        stamp = None
+                    if stamp is not None:
+                        mt[key] = stamp
+        return out, mt
 
-    metadata = await loop.run_in_executor(None, _load_meta)
-    eligible = eligible_channel_sessions(candidates, metadata=metadata, cutoff=cutoff)
+    # Instant the metadata snapshot below is taken. The stale-flag clear later
+    # in this pass is scoped to closes OLDER than this — a `closed` written
+    # after the snapshot (the user dismissing a tab mid-pass, or any writer
+    # this pass cannot see) must survive the clear.
+    snapshot_time = time.time()
+    metadata, mtimes = await loop.run_in_executor(None, _load_meta)
+    eligible = eligible_channel_sessions(
+        candidates, metadata=metadata, cutoff=cutoff, mtimes=mtimes
+    )
     # Skip transcript reads for sessions that already own a slot — the steady state.
     pending = [s for s in eligible if channel_slot_name(s.get("key", "")) not in state._slots]
     # Existing slots that may need a mirror sync. Everything here is a cheap
@@ -651,9 +817,66 @@ async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) 
         await loop.run_in_executor(None, _load_mirror_transcripts) if mirror_pending else {}
     )
 
+    # Clear stale closed flags BEFORE the slots become visible. Running the
+    # clear after surfacing leaves a race: the slot broadcast lands, the user
+    # closes the tab, the close save writes a fresh `closed`, and the deferred
+    # clear then erases it — the next pass would reopen a tab the user just
+    # dismissed. Clearing first is safe: these sessions already passed the
+    # activity-outran-close check, so dropping the stale flags cannot keep
+    # anything closed that should stay closed, and if surfacing subsequently
+    # fails the next pass re-qualifies them from the same (now-unflagged)
+    # state.
+    reactivated = [
+        s.get("key", "")
+        for s in pending
+        if (metadata.get(s.get("key", "")) or {}).get("closed")
+        or (metadata.get(slot_history_key(s.get("key", ""))) or {}).get("closed")
+    ]
+    if reactivated:
+
+        def _clear_stale_closed() -> None:
+            clear = getattr(log, "clear_closed", None)
+            if clear is None:
+                return
+            for k in reactivated:
+                for kk in (k, slot_history_key(k)):
+                    try:
+                        # Compare-and-clear under the store's own lock: only a
+                        # flag whose close instant predates this pass's
+                        # metadata snapshot is dropped. A `closed` written
+                        # after the snapshot — the user dismissing a tab while
+                        # this pass ran, or a writer in another process — is
+                        # left standing, so no stale snapshot can erase a
+                        # fresh dismissal.
+                        clear(kk, only_if_closed_before=snapshot_time)
+                    except Exception:
+                        # Best-effort: the flag staying behind only costs a
+                        # redundant activity comparison on the next pass.
+                        logger.warning(
+                            "channel reconcile: failed to clear closed on %s", kk, exc_info=True
+                        )
+
+        # Off the loop: clear_closed takes the cross-process file lock.
+        await loop.run_in_executor(None, _clear_stale_closed)
+
     surfaced = 0
+    # A tab can be closed around this pass — resumed from History and
+    # dismissed while the executor work was in flight, or dismissed just
+    # before the snapshot with the close SAVE still awaiting (task
+    # cancellation, file lock): either way the slot is gone from
+    # ``state._slots`` while the on-disk metadata this pass read says open,
+    # so the stale ``pending`` verdict would recreate the tab the user just
+    # dismissed. Consult the in-memory tombstones the close paths write
+    # synchronously at the pop, under the disk flag's own rule: the close
+    # stands unless channel activity is strictly newer than it, regardless
+    # of how it interleaved with this pass's snapshot. This runs after the
+    # last await: nothing can close a slot between here and the surface
+    # call below.
     for s in pending:
         key = s.get("key", "")
+        if _tombstone_blocks(state, s):
+            logger.debug("channel reconcile: %s closed by tombstone, skipping", key)
+            continue
         transcript = transcripts.get(key) or _Transcript([], 0, 0)
         try:
             if surface_channel_session(

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -27,6 +27,7 @@ from kiro_crew.config.loader import (
     resolve_agent_bindings,
 )
 from kiro_crew.constants import CHAT_TURN_TIMEOUT
+from kiro_crew.dashboard.channel_slots import note_slot_closed
 from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_orchestrator import _stage_loop
 from kiro_crew.dashboard.chat_persistence import (
@@ -1453,6 +1454,14 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
 
     # Remove from dict before async operations
     state._slots.pop(name, None)
+    # Synchronous tombstone, BEFORE any await: a channel-slot reconcile pass
+    # whose snapshot predates this close reads these after its last await, so
+    # it cannot re-surface the tab this handler is dismissing (see
+    # channel_slots._RECENT_CLOSES). The returned instant is persisted as
+    # closed_at below — the save runs after the cancellation awaits, and
+    # stamping save time would make channel activity landing in that window
+    # compare as older than the close.
+    closed_at = note_slot_closed(state, name)
     # Release any blocking wait before cancelling the task: a pending
     # ask_question holds an MCP worker on a blocked HTTP request, and the slot
     # is going away, so nobody will ever answer its card.
@@ -1464,7 +1473,9 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
         except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
             pass
     try:
-        await save_slot_off_loop(state, slot, closed=True, best_effort=False)
+        await save_slot_off_loop(
+            state, slot, closed=True, closed_at=closed_at, best_effort=False
+        )
     except Exception:
         # Save failed — restore slot so data isn't lost
         logger.error("Failed to save slot %s to history, restoring", name, exc_info=True)
@@ -1569,8 +1580,15 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
         removed = state._slots.pop(name, None)
         if not removed:
             continue
+        # Same tombstone as the single-tab close: the archive pass must not
+        # race a concurrent channel reconcile into resurrecting the slot. Its
+        # instant is persisted as closed_at for the same teardown-window
+        # reason as the single-tab path.
+        closed_at = note_slot_closed(state, name)
         try:
-            await save_slot_off_loop(state, removed, closed=True, best_effort=False)
+            await save_slot_off_loop(
+                state, removed, closed=True, closed_at=closed_at, best_effort=False
+            )
         except Exception:
             logger.error("Cleanup: failed to archive slot %s", name, exc_info=True)
             state._slots[name] = removed

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -1076,6 +1076,7 @@ def _save_slot_to_history(
     messages: list[dict] | None = None,
     *,
     closed: bool = False,
+    closed_at: float | None = None,
     force: bool = False,
     rewrite: bool = False,
 ) -> None:
@@ -1197,6 +1198,22 @@ def _save_slot_to_history(
                     meta_line[_meta_key] = existing_meta[_meta_key]
             if closed:
                 meta_line["closed"] = True
+                # Epoch stamp of WHEN the tab was closed. The channel-slot
+                # reconciler compares channel-side activity against this to
+                # decide whether a close still stands: a Discord/Slack message
+                # arriving after the close re-surfaces the conversation, while
+                # a conversation that stayed idle stays closed.
+                #
+                # Prefer the caller-supplied instant (captured by
+                # note_slot_closed at the moment the user acted): this save
+                # runs only after the close handler's awaits (task
+                # cancellation, patient lock acquire), and stamping save time
+                # here would make channel activity that landed during that
+                # teardown window compare as OLDER than the close — hiding a
+                # conversation the reactivation rule should surface. The
+                # save-time fallback covers callers with no user gesture to
+                # anchor to (and legacy call sites).
+                meta_line["closed_at"] = closed_at if closed_at is not None else time.time()
             meta_line["memory_mode"] = slot.memory_mode
             if slot.title and slot.title != slot.key:
                 meta_line["title"] = slot.title
@@ -1341,6 +1358,7 @@ async def save_slot_off_loop(
     messages: list[dict] | None = None,
     *,
     closed: bool = False,
+    closed_at: float | None = None,
     force: bool = False,
     rewrite: bool = False,
     best_effort: bool = True,
@@ -1374,7 +1392,13 @@ async def save_slot_off_loop(
 
     def _do() -> None:
         _save_slot_to_history(
-            state, slot, messages, closed=closed, force=force, rewrite=rewrite
+            state,
+            slot,
+            messages,
+            closed=closed,
+            closed_at=closed_at,
+            force=force,
+            rewrite=rewrite,
         )
 
     try:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -1878,7 +1878,20 @@ class ConversationLog:
         _restore_mtime(path, prev_mtime)
         self._invalidate_cache(key)
 
-    def clear_closed(self, key: str) -> None:
+    def mtime_of(self, key: str) -> float | None:
+        """Return the session file's mtime for *key*, or ``None`` when absent.
+
+        Cheap stat-only accessor for callers that need a file's last-write
+        instant without reading it — e.g. the channel-slot reconciler, which
+        uses it as the fallback close instant for a ``closed`` flag written
+        before ``closed_at`` stamps existed.
+        """
+        try:
+            return self._path(key).stat().st_mtime
+        except OSError:
+            return None
+
+    def clear_closed(self, key: str, *, only_if_closed_before: float | None = None) -> None:
         """Remove the ``closed`` flag from a session's metadata line.
 
         Serialized behind the cross-process ``_locked`` so a concurrent append /
@@ -1888,6 +1901,14 @@ class ConversationLog:
         No-op when the file is absent, unparsable, not flagged, or its first line
         isn't a metadata line. Housekeeping: the pre-write mtime is preserved so
         resuming doesn't reorder ``list_sessions``.
+
+        *only_if_closed_before* makes the removal a compare-and-clear: the flag
+        is dropped only when its close instant (``closed_at`` stamp, else the
+        file's current mtime) is strictly older than the given epoch. Callers
+        acting on a metadata snapshot (the channel-slot reconciler) use this so
+        a ``closed`` written AFTER their snapshot — the user dismissing a tab
+        mid-pass, or a racing reconcile — survives: the check runs under the
+        same lock as the write, so there is no window between them.
         """
         path = self._path(key)
         with self._locked(key):
@@ -1903,7 +1924,21 @@ class ConversationLog:
                 return
             if meta.get("_type") != "metadata" or "closed" not in meta:
                 return
+            if only_if_closed_before is not None:
+                raw = meta.get("closed_at")
+                close_time: float | None
+                try:
+                    close_time = float(raw) if raw is not None else None
+                except (TypeError, ValueError):
+                    close_time = None
+                if close_time is None:
+                    # Pre-stamp flag: the closing save is what last wrote the
+                    # file, so its mtime approximates the close instant.
+                    close_time = prev_mtime
+                if close_time is not None and close_time >= only_if_closed_before:
+                    return
             meta.pop("closed", None)
+            meta.pop("closed_at", None)
             lines[0] = json.dumps(meta) + "\n"
             atomic_write(path, "".join(lines), fsync=False)
             _restore_mtime(path, prev_mtime)

--- a/test/test_channel_slots.py
+++ b/test/test_channel_slots.py
@@ -126,7 +126,11 @@ class TestEligibility:
         assert len(out) == 1
 
     def test_closed_on_the_channel_key_is_never_resurfaced(self) -> None:
-        """Closing the tab must stick — otherwise the next pass undoes it."""
+        """A close with no known instant must stick — fail toward the dismissal.
+
+        (With a ``closed_at`` stamp or a file mtime the close can be outrun by
+        newer channel activity — see ``TestCloseReactivation``.)
+        """
         sessions = [_session("slack:1.1")]
         out = channel_slots.eligible_channel_sessions(
             sessions, metadata={"slack:1.1": {"closed": True}}, cutoff=NOW - 1800
@@ -191,6 +195,96 @@ class TestEligibility:
         """The listing carries memory_mode as well; either source disqualifies."""
         sessions = [_session("slack:1.1", memory_mode=mode)]
         out = channel_slots.eligible_channel_sessions(sessions, metadata={}, cutoff=None)
+        assert out == []
+
+
+class TestCloseReactivation:
+    """A close stands only until channel-side activity outruns it."""
+
+    def test_activity_after_close_resurfaces(self) -> None:
+        """The person kept talking on the channel after the tab was closed."""
+        sessions = [_session("slack:1.1", modified=NOW)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"closed": True, "closed_at": NOW - 600}},
+            cutoff=None,
+        )
+        assert [s["key"] for s in out] == ["slack:1.1"]
+
+    def test_close_newer_than_activity_stands(self) -> None:
+        """No channel activity since the close — the dismissal holds."""
+        sessions = [_session("slack:1.1", modified=NOW - 600)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"closed": True, "closed_at": NOW}},
+            cutoff=None,
+        )
+        assert out == []
+
+    def test_close_at_exactly_the_activity_instant_stands(self) -> None:
+        """Strictly-newer comparison: a tie is not new activity."""
+        sessions = [_session("slack:1.1", modified=NOW)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"closed": True, "closed_at": NOW}},
+            cutoff=None,
+        )
+        assert out == []
+
+    def test_legacy_close_falls_back_to_file_mtime(self) -> None:
+        """A pre-stamp `closed` flag uses the slot file's mtime as the close
+        instant — the closing save is what last wrote that file."""
+        sessions = [_session("slack:1.1", modified=NOW)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"closed": True}},
+            cutoff=None,
+            mtimes={"dashboard:slack_1.1": NOW - 600},
+        )
+        assert [s["key"] for s in out] == ["slack:1.1"]
+
+    def test_legacy_close_with_stale_mtime_stands(self) -> None:
+        sessions = [_session("slack:1.1", modified=NOW - 600)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"closed": True}},
+            cutoff=None,
+            mtimes={"dashboard:slack_1.1": NOW},
+        )
+        assert out == []
+
+    def test_garbage_closed_at_falls_back_to_mtime(self) -> None:
+        sessions = [_session("slack:1.1", modified=NOW)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"closed": True, "closed_at": "not-a-number"}},
+            cutoff=None,
+            mtimes={"dashboard:slack_1.1": NOW - 600},
+        )
+        assert len(out) == 1
+
+    def test_every_closed_side_must_be_outrun(self) -> None:
+        """Slot-side close is outdated, but the channel-side close instant is
+        unknown — the unknown side keeps the dismissal standing."""
+        sessions = [_session("slack:1.1", modified=NOW)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={
+                "slack:1.1": {"closed": True},
+                "dashboard:slack_1.1": {"closed": True, "closed_at": NOW - 600},
+            },
+            cutoff=None,
+        )
+        assert out == []
+
+    def test_reactivated_session_still_respects_the_recency_window(self) -> None:
+        """Outrunning the close does not exempt a session from the cutoff."""
+        sessions = [_session("slack:1.1", modified=NOW - 7200)]
+        out = channel_slots.eligible_channel_sessions(
+            sessions,
+            metadata={"dashboard:slack_1.1": {"closed": True, "closed_at": NOW - 99999}},
+            cutoff=NOW - 1800,
+        )
         assert out == []
 
 
@@ -302,6 +396,13 @@ class _FakeLog:
         self._sessions = sessions
         self._meta = meta
         self.message_reads: list[str] = []
+        #: key -> file mtime, consulted as the fallback close instant. Unset
+        #: keys report None (file absent), which keeps a legacy close standing.
+        self.mtimes: dict[str, float] = {}
+        #: keys clear_closed was invoked for, in order.
+        self.cleared: list[str] = []
+        #: every clear_closed invocation: (key, only_if_closed_before, outcome).
+        self.clear_calls: list[tuple[str, float | None, str]] = []
         #: key -> transcript. Unset keys read empty, so the reconciler's
         #: slot-key-then-channel-key preference order is observable.
         self.transcripts: dict[str, list[dict[str, Any]]] = {
@@ -313,6 +414,27 @@ class _FakeLog:
 
     def get_metadata(self, key: str) -> dict[str, Any]:
         return dict(self._meta.get(key, {}))
+
+    def mtime_of(self, key: str) -> float | None:
+        return self.mtimes.get(key)
+
+    def clear_closed(self, key: str, *, only_if_closed_before: float | None = None) -> None:
+        meta = self._meta.get(key, {})
+        if only_if_closed_before is not None and "closed" in meta:
+            raw = meta.get("closed_at")
+            try:
+                close_time = float(raw) if raw is not None else None
+            except (TypeError, ValueError):
+                close_time = None
+            if close_time is None:
+                close_time = self.mtimes.get(key)
+            if close_time is not None and close_time >= only_if_closed_before:
+                self.clear_calls.append((key, only_if_closed_before, "spared"))
+                return
+        self.cleared.append(key)
+        self.clear_calls.append((key, only_if_closed_before, "cleared"))
+        meta.pop("closed", None)
+        meta.pop("closed_at", None)
 
     def read_messages(self, key: str) -> list[dict[str, Any]]:
         self.message_reads.append(key)
@@ -342,12 +464,217 @@ class TestReconcilePass:
 
     def test_a_closed_tab_is_not_reopened_by_the_next_pass(self, dashboard_state: Any) -> None:
         """End-to-end guard for the reopen defect: `closed` lives on the SLOT key."""
-        dashboard_state.conversation_log = _FakeLog(
-            [_session("slack:1.1")], {"dashboard:slack_1.1": {"closed": True}}
-        )
+        log = _FakeLog([_session("slack:1.1")], {"dashboard:slack_1.1": {"closed": True}})
+        # The close instant equals the last channel activity — no new activity.
+        log.mtimes["dashboard:slack_1.1"] = NOW
+        dashboard_state.conversation_log = log
         dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
         assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
         assert dashboard_state._slots == {}
+        assert log.cleared == []
+
+    def test_channel_activity_after_close_reopens_and_clears_flags(
+        self, dashboard_state: Any
+    ) -> None:
+        """New channel activity outruns the close: the tab comes back, and the
+        stale `closed`/`closed_at` flags are dropped from BOTH keys so restore
+        paths and future passes agree the conversation is open."""
+        log = _FakeLog(
+            [_session("slack:1.1", modified=NOW)],
+            {"dashboard:slack_1.1": {"closed": True, "closed_at": NOW - 600}},
+        )
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert "slack_1.1" in dashboard_state._slots
+        assert set(log.cleared) == {"slack:1.1", "dashboard:slack_1.1"}
+        assert "closed" not in log._meta["dashboard:slack_1.1"]
+
+    def test_legacy_close_reopens_via_file_mtime_fallback(self, dashboard_state: Any) -> None:
+        """A pre-stamp `closed` flag (no closed_at) reactivates off the slot
+        file's mtime — the real-world shape of sessions closed before this fix."""
+        log = _FakeLog(
+            [_session("slack:1.1", modified=NOW)],
+            {"dashboard:slack_1.1": {"closed": True}},
+        )
+        log.mtimes["dashboard:slack_1.1"] = NOW - 600
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert "slack_1.1" in dashboard_state._slots
+        assert set(log.cleared) == {"slack:1.1", "dashboard:slack_1.1"}
+
+    def test_stale_flags_cleared_before_the_slot_is_visible(self, dashboard_state: Any) -> None:
+        """Regression (GPT round 1): clearing AFTER the slot broadcast races a
+        user closing the just-reactivated tab — the deferred clear would erase
+        the fresh `closed` and the next pass would reopen a tab the user just
+        dismissed. The clear must complete before the slot exists."""
+        log = _FakeLog(
+            [_session("slack:1.1", modified=NOW)],
+            {"dashboard:slack_1.1": {"closed": True, "closed_at": NOW - 600}},
+        )
+        slot_present_at_clear: list[bool] = []
+        orig_clear = log.clear_closed
+
+        def _recording_clear(key: str, **kwargs: Any) -> None:
+            slot_present_at_clear.append("slack_1.1" in dashboard_state._slots)
+            orig_clear(key, **kwargs)
+
+        log.clear_closed = _recording_clear  # type: ignore[method-assign]
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert slot_present_at_clear, "clear_closed must have been invoked"
+        assert not any(slot_present_at_clear), "flags must be cleared before the slot is surfaced"
+
+    def test_clears_are_scoped_to_the_snapshot_instant(self, dashboard_state: Any) -> None:
+        """Regression (GPT round 2): the reconciler must pass its snapshot
+        instant as a compare-and-clear cutoff, so a `closed` written after the
+        snapshot (user dismissal mid-pass, racing writer) survives the clear."""
+        log = _FakeLog(
+            [_session("slack:1.1", modified=NOW)],
+            {"dashboard:slack_1.1": {"closed": True, "closed_at": NOW - 600}},
+        )
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        before = time.time()
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        after = time.time()
+        assert log.clear_calls, "clear_closed must have been invoked"
+        for _key, cutoff_arg, _outcome in log.clear_calls:
+            assert cutoff_arg is not None, "clear must carry the snapshot cutoff"
+            assert before <= cutoff_arg <= after
+
+    def test_a_close_fresher_than_the_snapshot_survives_the_clear(
+        self, dashboard_state: Any
+    ) -> None:
+        """A dismissal recorded after the pass's snapshot is not erased: the
+        compare-and-clear spares it, and the fresh close keeps standing."""
+        log = _FakeLog(
+            [_session("slack:1.1", modified=NOW)],
+            # Stale in the snapshot the reconciler reads...
+            {"dashboard:slack_1.1": {"closed": True, "closed_at": NOW - 600}},
+        )
+        # ...but by clear time the user has re-closed: simulate the racing
+        # write by bumping closed_at to the future before delegating.
+        orig_clear = log.clear_closed
+
+        def _racing_clear(key: str, **kwargs: Any) -> None:
+            meta = log._meta.get(key)
+            if meta and "closed" in meta:
+                meta["closed_at"] = time.time() + 3600
+            orig_clear(key, **kwargs)
+
+        log.clear_closed = _racing_clear  # type: ignore[method-assign]
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert log._meta["dashboard:slack_1.1"].get("closed") is True, (
+            "a close written after the snapshot must survive the stale clear"
+        )
+
+    def test_overlapping_reconciles_are_serialized(self, dashboard_state: Any) -> None:
+        """The periodic loop and a dispatcher-triggered immediate pass must not
+        interleave — overlapping passes could clear flags from stale snapshots."""
+        log = _FakeLog([_session("slack:1.1")], {})
+        active = {"n": 0, "max": 0}
+        orig_list = log.list_sessions
+
+        def _tracking_list() -> list[dict[str, Any]]:
+            active["n"] += 1
+            active["max"] = max(active["max"], active["n"])
+            try:
+                time.sleep(0.02)
+                return orig_list()
+            finally:
+                active["n"] -= 1
+
+        log.list_sessions = _tracking_list  # type: ignore[method-assign]
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        async def _run_two() -> None:
+            await asyncio.gather(
+                channel_slots.reconcile_channel_slots(dashboard_state, 30),
+                channel_slots.reconcile_channel_slots(dashboard_state, 30),
+            )
+
+        asyncio.run(_run_two())
+        assert active["max"] == 1, "reconcile passes must not overlap"
+
+    def test_a_tab_closed_mid_pass_is_not_resurrected(self, dashboard_state: Any) -> None:
+        """Regression (GPT round 3): a tab resumed from History and closed
+        while this pass's executor work is in flight pops the slot, so the
+        stale `pending` verdict would recreate it. The close path's synchronous
+        tombstone must be honored after the pass's last await."""
+        log = _FakeLog([_session("slack:1.1", modified=NOW)], {})
+        orig_read = log.read_messages
+
+        def _close_during_pass(key: str) -> list[dict[str, Any]]:
+            # Runs in the _load_messages executor — after the snapshot, before
+            # the surface loop. Simulates the user closing the tab right here.
+            channel_slots.note_slot_closed(dashboard_state, "slack_1.1")
+            return orig_read(key)
+
+        log.read_messages = _close_during_pass  # type: ignore[method-assign]
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
+        assert "slack_1.1" not in dashboard_state._slots
+
+    def test_a_close_just_before_the_snapshot_still_blocks(self, dashboard_state: Any) -> None:
+        """Regression (GPT round 4): the close handler pops the slot and writes
+        the tombstone BEFORE its awaits (task cancellation, file lock), so a
+        pass can snapshot still-open metadata after the tombstone exists. The
+        tombstone must suppress by the disk flag's own rule (activity vs close
+        instant), not by comparing against the pass's snapshot time."""
+        # Channel activity is OLDER than the close — the dismissal stands.
+        log = _FakeLog([_session("slack:1.1", modified=NOW - 60)], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        # Tombstone written before the pass even starts (close save in flight,
+        # disk metadata still open).
+        channel_slots.note_slot_closed(dashboard_state, "slack_1.1")
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
+        assert "slack_1.1" not in dashboard_state._slots
+
+    def test_channel_activity_newer_than_the_tombstone_resurfaces(
+        self, dashboard_state: Any
+    ) -> None:
+        """A tombstone follows the same outrun rule as the disk flag: channel
+        activity strictly newer than the close re-surfaces the conversation."""
+        channel_slots.note_slot_closed(dashboard_state, "slack_1.1")
+        time.sleep(0.01)
+        # Activity AFTER the close: the person kept talking on the channel.
+        log = _FakeLog([_session("slack:1.1", modified=time.time() + 1)], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert "slack_1.1" in dashboard_state._slots
+
+    def test_close_tombstones_are_pruned(self, dashboard_state: Any) -> None:
+        closes = channel_slots._RECENT_CLOSES.setdefault(dashboard_state, {})
+        closes["ancient"] = time.time() - channel_slots._CLOSE_TOMBSTONE_TTL_SECS - 1
+        channel_slots.note_slot_closed(dashboard_state, "fresh")
+        assert "ancient" not in channel_slots._RECENT_CLOSES[dashboard_state]
+        assert "fresh" in channel_slots._RECENT_CLOSES[dashboard_state]
+
+    def test_surfacing_an_open_session_clears_nothing(self, dashboard_state: Any) -> None:
+        """The clear path only runs for sessions that were closed — an ordinary
+        first surface must not touch metadata."""
+        log = _FakeLog([_session("slack:1.1")], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert log.cleared == []
 
     def test_seeds_from_both_transcripts_merged(self, dashboard_state: Any) -> None:
         """Neither side is a superset: the slot holds dashboard replies, the channel
@@ -393,6 +720,146 @@ def _tz(name: str) -> Iterator[None]:
 
 #: ``time.tzset`` is Unix-only, and CI also runs the backend suite on Windows.
 _needs_tzset = pytest.mark.skipif(not hasattr(time, "tzset"), reason="time.tzset() is Unix-only")
+
+
+class TestMtimeOf:
+    def test_reports_the_session_file_mtime(self, dashboard_state: Any) -> None:
+        log = dashboard_state.conversation_log
+        assert log.mtime_of("slack:9.9") is None
+        log.append("slack:9.9", "user", "hi")
+        stamp = log.mtime_of("slack:9.9")
+        assert stamp is not None and abs(stamp - time.time()) < 60
+
+
+class TestCompareAndClear:
+    """ConversationLog.clear_closed(only_if_closed_before=...) semantics."""
+
+    def _write_closed(self, log: Any, key: str, closed_at: float | None) -> None:
+        log.append(key, "user", "hi")
+        meta: dict[str, Any] = {"closed": True}
+        if closed_at is not None:
+            meta["closed_at"] = closed_at
+        log.update_metadata(key, meta)
+
+    def test_stale_close_is_cleared(self, dashboard_state: Any) -> None:
+        log = dashboard_state.conversation_log
+        self._write_closed(log, "dashboard:slack_1.1", time.time() - 600)
+        log.clear_closed("dashboard:slack_1.1", only_if_closed_before=time.time())
+        meta = log.get_metadata("dashboard:slack_1.1")
+        assert "closed" not in meta and "closed_at" not in meta
+
+    def test_fresh_close_survives(self, dashboard_state: Any) -> None:
+        """A close at/after the cutoff is spared — the caller's snapshot is
+        stale with respect to it."""
+        log = dashboard_state.conversation_log
+        stamp = time.time() + 600
+        self._write_closed(log, "dashboard:slack_1.1", stamp)
+        log.clear_closed("dashboard:slack_1.1", only_if_closed_before=time.time())
+        assert log.get_metadata("dashboard:slack_1.1").get("closed") is True
+
+    def test_unconditional_clear_still_clears(self, dashboard_state: Any) -> None:
+        """The resume path clears without a cutoff — unchanged behaviour."""
+        log = dashboard_state.conversation_log
+        self._write_closed(log, "dashboard:slack_1.1", time.time() + 600)
+        log.clear_closed("dashboard:slack_1.1")
+        assert "closed" not in log.get_metadata("dashboard:slack_1.1")
+
+    def test_legacy_flag_compares_against_file_mtime(self, dashboard_state: Any) -> None:
+        """A pre-stamp flag falls back to the file's mtime as its close instant."""
+        log = dashboard_state.conversation_log
+        self._write_closed(log, "dashboard:slack_1.1", None)
+        # The write just happened, so mtime ~= now: a past cutoff spares it...
+        log.clear_closed("dashboard:slack_1.1", only_if_closed_before=time.time() - 600)
+        assert log.get_metadata("dashboard:slack_1.1").get("closed") is True
+        # ...and a future cutoff clears it.
+        log.clear_closed("dashboard:slack_1.1", only_if_closed_before=time.time() + 600)
+        assert "closed" not in log.get_metadata("dashboard:slack_1.1")
+
+
+class TestClosedAtStamp:
+    def test_closing_save_stamps_closed_at(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Closing a tab records WHEN — the instant _close_stands compares
+        channel activity against. With no caller-supplied instant, the save
+        falls back to save time (callers with no user gesture to anchor to)."""
+        import json
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("slack_1.1")
+        slot.append("user", "hello")
+        slot.drain()
+
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        before = time.time()
+        _save_slot_to_history(state, slot, closed=True)
+        after = time.time()
+
+        meta = json.loads(
+            (tmp_path / "dashboard_slack_1.1.jsonl").read_text(encoding="utf-8").split("\n")[0]
+        )
+        assert meta["closed"] is True
+        assert before <= float(meta["closed_at"]) <= after
+
+    def test_caller_supplied_close_instant_is_persisted_verbatim(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """Regression (GPT round 5): the close handler's save runs only after
+        its awaits (task cancellation, patient lock acquire). Stamping save
+        time would make channel activity that landed during that teardown
+        window compare as OLDER than the close, hiding a conversation the
+        reactivation rule should surface. The persisted closed_at must be the
+        instant the user acted — the value note_slot_closed returned — not the
+        (later) save time."""
+        import json
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("slack_1.1")
+        slot.append("user", "hello")
+        slot.drain()
+
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        click_instant = time.time() - 30.0  # user acted well before the save
+        _save_slot_to_history(state, slot, closed=True, closed_at=click_instant)
+
+        meta = json.loads(
+            (tmp_path / "dashboard_slack_1.1.jsonl").read_text(encoding="utf-8").split("\n")[0]
+        )
+        assert meta["closed"] is True
+        assert float(meta["closed_at"]) == click_instant
+
+    def test_note_slot_closed_returns_the_recorded_instant(self, dashboard_state: Any) -> None:
+        """The tombstone and the persisted closed_at must be the SAME instant —
+        callers persist the return value, so the in-memory and on-disk close
+        records cannot disagree about when the user acted."""
+        before = time.time()
+        returned = channel_slots.note_slot_closed(dashboard_state, "slack_1.1")
+        after = time.time()
+        assert before <= returned <= after
+        assert channel_slots._RECENT_CLOSES[dashboard_state]["slack_1.1"] == returned
+
+    def test_open_save_carries_no_close_fields(self, tmp_path: Any, monkeypatch: Any) -> None:
+        import json
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("slack_1.1")
+        slot.append("user", "hello")
+        slot.drain()
+
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        _save_slot_to_history(state, slot, closed=True)
+        # A later save of the (reopened) slot drops both fields.
+        _save_slot_to_history(state, slot)
+
+        meta = json.loads(
+            (tmp_path / "dashboard_slack_1.1.jsonl").read_text(encoding="utf-8").split("\n")[0]
+        )
+        assert "closed" not in meta
+        assert "closed_at" not in meta
 
 
 class TestMergeTranscriptTimezones:


### PR DESCRIPTION
## Problem

Closing a channel-originated tab is permanent. The channel-slot reconciler treats `meta.closed` as sticky forever, so a Discord/Slack conversation that keeps going **after** the user dismissed the tab never returns to the sidebar — the user has to dig it out of the History pane by hand. Found in the field: a live Discord DM (last activity today) invisible because its tab was closed two conversations ago.

## Fix

A close is a statement about the conversation *as it stood* — scope it to the activity it covered:

- **`_save_slot_to_history`** stamps `closed_at` (epoch) next to `closed`, giving the close a comparable instant.
- **`eligible_channel_sessions`** re-qualifies a closed session when the channel file's last write is strictly newer than every close instant. Legacy flags without a stamp fall back to the session file's mtime (the closing save is what last wrote it). An unknowable instant keeps the close standing — fail toward the user's explicit action.
- **`reconcile_channel_slots`** clears the stale `closed`/`closed_at` flags from both the channel key and the slot key after re-surfacing, so restore paths and future passes agree the tab is open.
- **`ConversationLog.mtime_of`** added as a stat-only accessor for the mtime fallback.

Closing the tab again after a resurface writes a fresh `closed_at` newer than the channel activity, so the dismissal holds until the channel moves again. The recency window still applies — reactivation does not exempt a session from the cutoff.

## Testing

- 13 new tests: eligibility reactivation matrix (stamped, legacy-mtime, garbage stamp, tie instant, multi-side close, recency window), reconcile end-to-end (reopen + flag clear, legacy fallback, no-clear on ordinary surface, close-with-no-activity stays closed), `closed_at` stamp write/drop, `mtime_of`.
- Revert-verified: 8 of the new tests fail without the fix; the passing remainder are the sticky-close negatives old code also satisfied.
- Full backend suite: 23288 passed; 5 failures verified pre-existing on pristine origin/main (3× test_dashboard_origin, test_app_manager builtin-secret — host-specific) or flaky independent of this diff (test_mcp_gateway_wedge_ping_gate, pass/fail/pass on identical code).
- isort / flake8 / mypy (577 files) clean. No frontend changes.
