### PR TITLE
fix(chat): remember which Change / Issue tab a session had open

### DIFF
--- a/website/src/components/IssuePanel.tsx
+++ b/website/src/components/IssuePanel.tsx
@@ -274,11 +274,14 @@ export default function IssuePanel({
   issues,
   selectedUrl,
   onSelect,
+  onReconcile,
   onAddToChat,
 }: {
   issues: PullRequestLink[]
   selectedUrl: string
   onSelect: (url: string) => void
+  // See PullRequestPanel: the self-normalizing path must not be persisted.
+  onReconcile?: (url: string) => void
   onAddToChat?: (text: string) => void
 }) {
   const cappedIssues = issues.slice(0, MAX_PULL_REQUEST_SOURCES)
@@ -289,8 +292,8 @@ export default function IssuePanel({
   const forceRefreshRef = useRef(false)
 
   useEffect(() => {
-    if (selected && selected.url !== selectedUrl) onSelect(selected.url)
-  }, [selected, selectedUrl, onSelect])
+    if (selected && selected.url !== selectedUrl) (onReconcile || onSelect)(selected.url)
+  }, [selected, selectedUrl, onSelect, onReconcile])
 
   useEffect(() => { setTab('description') }, [selected?.url])
 

--- a/website/src/components/PullRequestPanel.tsx
+++ b/website/src/components/PullRequestPanel.tsx
@@ -746,11 +746,18 @@ export default function PullRequestPanel({
   sources,
   selectedUrl,
   onSelect,
+  onReconcile,
   onAddToChat,
 }: {
   sources: PullRequestLink[]
   selectedUrl: string
   onSelect: (url: string) => void
+  // Called when this panel normalizes an out-of-range selection on its own,
+  // rather than the user picking a tab. Kept separate from onSelect because the
+  // parent persists an explicit choice and must NOT persist this one: a
+  // transcript that lacks the remembered url may simply be a cached one that is
+  // still being refetched. Defaults to onSelect for callers that do not care.
+  onReconcile?: (url: string) => void
   onAddToChat: (text: string) => void
 }) {
   const cappedSources = sources.slice(0, MAX_PULL_REQUEST_SOURCES)
@@ -762,8 +769,8 @@ export default function PullRequestPanel({
   const queryClient = useQueryClient()
 
   useEffect(() => {
-    if (selected && selected.url !== selectedUrl) onSelect(selected.url)
-  }, [selected, selectedUrl, onSelect])
+    if (selected && selected.url !== selectedUrl) (onReconcile || onSelect)(selected.url)
+  }, [selected, selectedUrl, onSelect, onReconcile])
 
   useEffect(() => {
     setTab('changes')

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -117,11 +117,18 @@ import { loadFileDrafts, saveFileDrafts as persistFileDrafts, setFileDraft } fro
 import { loadPasteDrafts, savePasteDrafts as persistPasteDrafts, setPasteDraft } from '../utils/chatPasteDrafts'
 import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, promptPreview, pinHandoffY, pinPushTravel, DEFAULT_PINNED_CARD_H } from '../utils/pinnedPrompt'
 import {
+  adoptSourceSelections,
+  commitSourceSelection,
+  isSourceSelectionKey,
   loadSeenPullRequestLinks,
+  loadSourceSelections,
   partitionSourceLinks,
   persistSeenPullRequestLinks,
   PullRequestLinkIndex,
   recordNewPullRequestLinks,
+  type SourceLinkKind,
+  sourceSelection,
+  withSourceSelection,
 } from '../utils/pullRequestLinks'
 import { deriveFollowUpOptions } from '../utils/deriveFollowUpOptions'
 import OverlayDrawer from '../components/OverlayDrawer'
@@ -1441,8 +1448,163 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     () => partitionSourceLinks(indexedSourceLinks),
     [indexedSourceLinks],
   )
-  const [selectedSourceUrl, setSelectedSourceUrl] = useState('')
-  const [selectedIssueUrl, setSelectedIssueUrl] = useState('')
+  // Which Change / Issue tab is focused, PER SLOT and persisted (see
+  // pullRequestLinks.SourceSelections). Per-slot because a single shared value
+  // reconciles to the first link of whichever transcript is active, so switching
+  // A→B→A dropped A's selection; persisted because the panel tab strip itself
+  // survives reloads (mc-panel-tabs:<slot>) and a strip that comes back focused
+  // on a tab the user never chose is the bug this closes.
+  //
+  // React state holds this window's view for rendering; commitSourceSelection
+  // does the durable write, merging ONE slot into a freshly read snapshot so a
+  // second chat window (a popped-out session shares this localStorage) cannot
+  // publish its stale view of the slots it is not looking at. That means this
+  // window's map can lag another window's writes to OTHER slots — harmless,
+  // since only the active slot is ever read, and far better than losing them.
+  const [sourceSelections, setSourceSelections] = useState(loadSourceSelections)
+  const selectedSourceUrl = sourceSelection(sourceSelections, activeSlot, 'change')
+  const selectedIssueUrl = sourceSelection(sourceSelections, activeSlot, 'issue')
+  // Fields whose durable write storage REFUSED, per slot. Storage then holds an
+  // older url than the user's live choice, so adoption must not take it back
+  // (see adoptSourceSelections). A ref, not state: it changes nothing on screen
+  // and must not re-render.
+  const unpersistedSelectionsRef = useRef<Record<string, Partial<Record<SourceLinkKind, boolean>>>>({})
+  // Fields whose on-screen value is a provisional fallback rather than a real
+  // choice. The value is the link count seen when the fallback was taken, so the
+  // storage re-read below can retry only once the transcript has actually GROWN
+  // rather than on every render. Cleared by an explicit pick or a successful
+  // restore.
+  const provisionalFallbackRef = useRef<Record<string, Partial<Record<SourceLinkKind, number>>>>({})
+  const selectSource = useCallback((kind: SourceLinkKind, url: string) => {
+    const slot = activeSlotRef.current
+    setSourceSelections(previous => withSourceSelection(previous, slot, kind, url))
+    const outcome = commitSourceSelection(slot, kind, url)
+    if (!slot) return
+    // An explicit choice supersedes any provisional fallback for this field.
+    const provisional = { ...provisionalFallbackRef.current[slot] }
+    delete provisional[kind]
+    provisionalFallbackRef.current = { ...provisionalFallbackRef.current, [slot]: provisional }
+    const failed = { ...unpersistedSelectionsRef.current[slot] }
+    // 'failed' means storage refused the write and still holds an older url;
+    // 'unchanged' means storage already agrees. Both are explicit writes, so the
+    // ledger records exactly whether this selection reached storage.
+    if (outcome === 'failed') failed[kind] = true
+    else delete failed[kind]
+    unpersistedSelectionsRef.current = { ...unpersistedSelectionsRef.current, [slot]: failed }
+  }, [])
+  const selectSourceUrl = useCallback((url: string) => selectSource('change', url), [selectSource])
+  const selectIssueUrl = useCallback((url: string) => selectSource('issue', url), [selectSource])
+  // A RECONCILED pick is derived from the transcript, not chosen by the user, and
+  // is deliberately IN-MEMORY ONLY — it never writes to storage.
+  //
+  // Persisting it bought nothing and cost correctness. The fallback is
+  // deterministic (`sourceLinks[0]`), so a session where the user never picked a
+  // tab recomputes the same answer on return without any stored value; the only
+  // case persistence changes is a choice that DIFFERS from the first link, which
+  // is exactly what an explicit click already records. Meanwhile every write from
+  // here could destroy a real choice, because the fallback also fires whenever the
+  // transcript on screen is provisional — `switchSlot.pending` serves a cached
+  // transcript with `slotLoading` already false while the fetch is still in
+  // flight, and a transcript missing a url is not proof the url is gone.
+  //
+  // The slot is marked provisional so the reconciliation effects know to look in
+  // storage once for a better answer (see the effects below).
+  const reconcileSelection = useCallback((kind: SourceLinkKind, url: string, seen = 0) => {
+    const slot = activeSlotRef.current
+    setSourceSelections(previous => withSourceSelection(previous, slot, kind, url))
+    if (!slot) return
+    provisionalFallbackRef.current = {
+      ...provisionalFallbackRef.current,
+      [slot]: { ...provisionalFallbackRef.current[slot], [kind]: seen },
+    }
+  }, [])
+  // The panels normalize their own selection when the remembered url is not among
+  // the tabs they render, and that is NOT a user choice — route it to the
+  // in-memory path so it cannot overwrite storage. Before this split the panels
+  // were handed the persisting callback, which made their normalize a durable
+  // write and defeated the whole in-memory-only rule.
+  const reconcileSourceUrl = useCallback(
+    (url: string) => reconcileSelection('change', url, sourceLinks.length),
+    [reconcileSelection, sourceLinks.length],
+  )
+  const reconcileIssueUrl = useCallback(
+    (url: string) => reconcileSelection('issue', url, issueLinks.length),
+    [reconcileSelection, issueLinks.length],
+  )
+
+  // Re-read storage for a slot whose on-screen value is a provisional fallback.
+  //
+  // Without this the fallback would stick for the life of the document: nothing
+  // else re-reads storage in the window that wrote it — loadSourceSelections runs
+  // only in the useState initializer, and the `storage` event never fires in the
+  // writing document — so the user would keep seeing the fallback instead of the
+  // tab they left open until a reload.
+  //
+  // Retried only when the transcript has GROWN since the fallback was taken. A
+  // transcript is append-only within a slot, so growth is the only way a
+  // previously-absent url can appear, and gating on it keeps this off the
+  // per-render (and per-streaming-chunk) path. Membership in `links` is the
+  // "the fetch proved it still exists" condition.
+  const restoreFromStorage = useCallback((
+    kind: SourceLinkKind,
+    links: readonly { url: string }[],
+  ): boolean => {
+    const slot = activeSlotRef.current
+    if (!slot) return false
+    const seen = provisionalFallbackRef.current[slot]?.[kind]
+    if (seen === undefined || links.length <= seen) return false
+
+    const stored = sourceSelection(loadSourceSelections(), slot, kind)
+    if (stored && links.some(link => link.url === stored)) {
+      const provisional = { ...provisionalFallbackRef.current[slot] }
+      delete provisional[kind]
+      provisionalFallbackRef.current = { ...provisionalFallbackRef.current, [slot]: provisional }
+      setSourceSelections(previous => withSourceSelection(previous, slot, kind, stored))
+      return true
+    }
+    // Not there yet — wait for further growth rather than re-reading every render.
+    provisionalFallbackRef.current = {
+      ...provisionalFallbackRef.current,
+      [slot]: { ...provisionalFallbackRef.current[slot], [kind]: links.length },
+    }
+    return false
+  }, [])
+
+  // Adopt a sibling window's writes. `storage` fires in every OTHER document on
+  // this origin, so the window that did NOT write is the one that needs to
+  // re-read. Without this, a window carries its mount-time view until reload and
+  // two windows focused on the same session would each show their own last
+  // choice. The event's newValue is ignored in favour of a full re-read, so the
+  // loader's own validation and bounds apply to whatever a sibling wrote.
+  //
+  // The urls THIS window's transcript offers go in with the read: adoption is
+  // conditional on them for the active slot, which is what keeps two windows
+  // with divergent transcripts from overwriting each other in a loop (see
+  // adoptSourceSelections). Read through a ref because the listener is
+  // registered once and must see the current transcript at event time.
+  const availableSourceUrls = useMemo(() => ({
+    change: sourceLinks.map(source => source.url),
+    issue: issueLinks.map(issue => issue.url),
+  }), [sourceLinks, issueLinks])
+  const availableSourceUrlsRef = useRef(availableSourceUrls)
+  availableSourceUrlsRef.current = availableSourceUrls
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.storageArea && event.storageArea !== localStorage) return
+      // key === null is a storage.clear(), which does concern us. Otherwise
+      // match the store's key prefix — the selection lives in one key per
+      // (slot, kind), so there is no single literal to compare against.
+      if (event.key !== null && !isSourceSelectionKey(event.key)) return
+      setSourceSelections(previous => adoptSourceSelections(
+        previous,
+        activeSlotRef.current,
+        availableSourceUrlsRef.current,
+        unpersistedSelectionsRef.current,
+      ))
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
 
   // Add and focus the per-slot Changes / Issues tabs for newly detected URLs,
   // but leave panel visibility under explicit user control. Both kinds share one
@@ -1465,36 +1627,54 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // An uncached slot temporarily has no messages while its history hydrates.
     // Preserve the persisted strip until that source-of-truth load settles.
     if (slotLoading) return
+    // A previous provisional render may have fallen back in memory while storage
+    // still holds the tab the user chose; look there first once links appear.
+    if (restoreFromStorage('change', sourceLinks)) return
     if (sourceLinks.length === 0) {
       // Changes is a permanently pinned tab (SidePanel.syncPinned) — never
       // auto-close it here. Just clear the source selection; the tab stays put
       // and renders its empty state until sources are detected again.
-      setSelectedSourceUrl('')
+      //
+      // Two guards, both load-bearing:
+      //  - transcript LOADED, not merely empty. switchSlot.rejected (a dropped
+      //    history fetch) empties `messages` AND drops slotLoading in one reducer
+      //    pass, so the guard above does not hold; since the selection is durable,
+      //    clearing there would outlive the failure and lose the tab on retry.
+      //  - something to clear. commitSourceSelection enumerates storage to decide
+      //    whether the value already matches, and these effects re-run on every
+      //    streaming chunk (the link index hands back a fresh array per chunk), so
+      //    an unconditional clear costs a full enumeration per chunk for every
+      //    session that never mentions a pull request — the common case.
+      if (messages.length && selectedSourceUrl) reconcileSelection('change', '')
       return
     }
+    // First-wins fallback ONLY when the remembered url is gone from the
+    // transcript: while it is still present, selectedSourceUrl already carries
+    // the restored per-slot choice and this reconciliation leaves it alone.
     if (!sourceLinks.some(source => source.url === selectedSourceUrl)) {
-      setSelectedSourceUrl(sourceLinks[0].url)
+      // Storage may still hold the tab the user actually chose — absent from an
+      // earlier PROVISIONAL transcript but present now that the fetch landed.
+      // Look there once before falling back, gated on the url being in THIS
+      // transcript (that gate IS the "the fetch proved it exists" condition).
+      reconcileSelection('change', sourceLinks[0].url, sourceLinks.length)
     }
-    // React to indexed sources, selection, and hydration completion only;
-    // tabsCtl changes identity as tabs move and must not retrigger source
-    // reconciliation.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sourceLinks, selectedSourceUrl, slotLoading])
+    // reconcileSourceUrl reads the active slot through a ref, so it is stable and
+    // this effect reacts only to sources, selection, and hydration state.
+  }, [sourceLinks, selectedSourceUrl, slotLoading, messages.length, reconcileSelection, restoreFromStorage])
 
   useEffect(() => {
     // Same first-wins / clear-on-empty reconciliation as the Changes selection
-    // above, and the same hydration guard: an uncached slot has no messages
-    // while its history loads, so an early clear would drop a valid selection.
+    // above, including the loaded-transcript guard on the clear.
     if (slotLoading) return
+    if (restoreFromStorage('issue', issueLinks)) return
     if (issueLinks.length === 0) {
-      setSelectedIssueUrl('')
+      if (messages.length && selectedIssueUrl) reconcileSelection('issue', '')
       return
     }
     if (!issueLinks.some(issue => issue.url === selectedIssueUrl)) {
-      setSelectedIssueUrl(issueLinks[0].url)
+      reconcileSelection('issue', issueLinks[0].url, issueLinks.length)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [issueLinks, selectedIssueUrl, slotLoading])
+  }, [issueLinks, selectedIssueUrl, slotLoading, messages.length, reconcileSelection, restoreFromStorage])
 
   const addSourceCommentToChat = useCallback((text: string) => {
     setInput(previous => previous.trim() ? `${previous.trimEnd()}\n\n${text}` : text)
@@ -4879,8 +5059,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               files={touchedFiles.files} onFileOpen={handleFileOpen} onFileRemove={touchedFiles.removeFile} onFilesClear={touchedFiles.clearBySource}
               onArtifactOpen={handleArtifactOpen}
               projectDir={currentSlot?.project || undefined} navLinks={chatNav.links} navResolving={chatNav.resolving}
-              sources={sourceLinks} selectedSourceUrl={selectedSourceUrl} onSelectSource={setSelectedSourceUrl}
-              issues={issueLinks} selectedIssueUrl={selectedIssueUrl} onSelectIssue={setSelectedIssueUrl}
+              sources={sourceLinks} selectedSourceUrl={selectedSourceUrl} onSelectSource={selectSourceUrl} onReconcileSource={reconcileSourceUrl}
+              issues={issueLinks} selectedIssueUrl={selectedIssueUrl} onSelectIssue={selectIssueUrl} onReconcileIssue={reconcileIssueUrl}
               onAddSourceToChat={addSourceCommentToChat}
               onSubmitComments={submitComments} onFileSave={handleFileSave} onClose={toggleAct}
               inlinePreviewPath={inlinePreviewPath} onInlinePreviewChange={setInlinePreviewPath}
@@ -4914,8 +5094,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 files={touchedFiles.files} onFileOpen={handleFileOpen} onFileRemove={touchedFiles.removeFile} onFilesClear={touchedFiles.clearBySource}
                 onArtifactOpen={handleArtifactOpen}
                 projectDir={currentSlot?.project || undefined} navLinks={chatNav.links} navResolving={chatNav.resolving}
-                sources={sourceLinks} selectedSourceUrl={selectedSourceUrl} onSelectSource={setSelectedSourceUrl}
-              issues={issueLinks} selectedIssueUrl={selectedIssueUrl} onSelectIssue={setSelectedIssueUrl}
+                sources={sourceLinks} selectedSourceUrl={selectedSourceUrl} onSelectSource={selectSourceUrl} onReconcileSource={reconcileSourceUrl}
+              issues={issueLinks} selectedIssueUrl={selectedIssueUrl} onSelectIssue={selectIssueUrl} onReconcileIssue={reconcileIssueUrl}
               onAddSourceToChat={addSourceCommentToChat}
                 onSubmitComments={submitComments} onFileSave={handleFileSave} onClose={toggleAct}
                 inlinePreviewPath={inlinePreviewPath} onInlinePreviewChange={setInlinePreviewPath}

--- a/website/src/pages/chat/ActivityViewer.tsx
+++ b/website/src/pages/chat/ActivityViewer.tsx
@@ -994,14 +994,14 @@ function ArtifactListRow({ row, busy, onOpen, onToggleStar }: {
   )
 }
 
-export default function ActivityViewer({ subagents, toolLog, open, onToggle, slot, files, onFileOpen, onArtifactOpen, onFileRemove, navLinks, navResolving, view, sources, selectedSourceUrl, onSelectSource, issues, selectedIssueUrl, onSelectIssue, onAddToChat, onFileSave, onSubmitComments, openDocPaths, previewPath, onPreviewPathChange }: {
+export default function ActivityViewer({ subagents, toolLog, open, onToggle, slot, files, onFileOpen, onArtifactOpen, onFileRemove, navLinks, navResolving, view, sources, selectedSourceUrl, onSelectSource, onReconcileSource, issues, selectedIssueUrl, onSelectIssue, onReconcileIssue, onAddToChat, onFileSave, onSubmitComments, openDocPaths, previewPath, onPreviewPathChange }: {
   subagents: Record<string, SubagentActivity>; toolLog: ToolActivity[]; open: boolean; onToggle: () => void; slot: string
   files?: TouchedFile[]; onFileOpen?: (path: string) => void; onArtifactOpen?: (slug: string) => void; onFileRemove?: (path: string) => void; onFilesClear?: (source: 'history' | 'tool') => void
   projectDir?: string
   navLinks?: ExtractedLink[]; navResolving?: boolean
-  sources?: PullRequestLink[]; selectedSourceUrl?: string; onSelectSource?: (url: string) => void; onAddToChat?: (text: string) => void
+  sources?: PullRequestLink[]; selectedSourceUrl?: string; onSelectSource?: (url: string) => void; onReconcileSource?: (url: string) => void; onAddToChat?: (text: string) => void
   /** Issue links mentioned in this session, plus the Issues tab's own selection. */
-  issues?: PullRequestLink[]; selectedIssueUrl?: string; onSelectIssue?: (url: string) => void
+  issues?: PullRequestLink[]; selectedIssueUrl?: string; onSelectIssue?: (url: string) => void; onReconcileIssue?: (url: string) => void
   /** Save handler for the Files-tab inline file preview (opening a file keeps
    *  it in the Files tab instead of spawning a document tab). */
   onFileSave?: (filePath: string, content: string) => Promise<void>
@@ -1198,6 +1198,7 @@ export default function ActivityViewer({ subagents, toolLog, open, onToggle, slo
               sources={sources!}
               selectedUrl={selectedSourceUrl || ''}
               onSelect={onSelectSource || (() => {})}
+              onReconcile={onReconcileSource}
               onAddToChat={onAddToChat || (() => {})}
             />
           ) : (
@@ -1216,6 +1217,7 @@ export default function ActivityViewer({ subagents, toolLog, open, onToggle, slo
               issues={issues!}
               selectedUrl={selectedIssueUrl || ''}
               onSelect={onSelectIssue || (() => {})}
+              onReconcile={onReconcileIssue}
               onAddToChat={onAddToChat}
             />
           ) : (

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -64,12 +64,14 @@ interface SidePanelProps {
   sources?: PullRequestLink[]
   selectedSourceUrl?: string
   onSelectSource?: (url: string) => void
+  onReconcileSource?: (url: string) => void
   /** Issue links mentioned in this session (the `kind: 'issue'` half of the
    *  extractor's output). Separate props — not a merged list — so the Changes
    *  and Issues tabs each keep their own selection. */
   issues?: PullRequestLink[]
   selectedIssueUrl?: string
   onSelectIssue?: (url: string) => void
+  onReconcileIssue?: (url: string) => void
   onAddSourceToChat?: (text: string) => void
   onSubmitComments?: (message: string) => void
   onFileSave: (filePath: string, content: string) => Promise<void>
@@ -182,8 +184,8 @@ export function measureSidePanelReservedW(): number {
 
 export default function SidePanel({
   tabsCtl, slot, files, onFileOpen, onArtifactOpen, onFileRemove, onFilesClear,
-  projectDir, navLinks, navResolving, sources, selectedSourceUrl, onSelectSource,
-  issues, selectedIssueUrl, onSelectIssue,
+  projectDir, navLinks, navResolving, sources, selectedSourceUrl, onSelectSource, onReconcileSource,
+  issues, selectedIssueUrl, onSelectIssue, onReconcileIssue,
   onAddSourceToChat, onSubmitComments, onFileSave, onClose,
   inlinePreviewPath, onInlinePreviewChange, expanded, fillWidth,
 }: SidePanelProps) {
@@ -491,9 +493,11 @@ export default function SidePanel({
                   sources={sources}
                   selectedSourceUrl={selectedSourceUrl}
                   onSelectSource={onSelectSource}
+                  onReconcileSource={onReconcileSource}
                   issues={issues}
                   selectedIssueUrl={selectedIssueUrl}
                   onSelectIssue={onSelectIssue}
+                  onReconcileIssue={onReconcileIssue}
                   onAddToChat={onAddSourceToChat}
                   // The Files/Artifacts/Changes tabs are permanent (pinned).
                   // Files opens its file inline (kept in the Files tab, with a

--- a/website/src/test/ChatPage.sourceSelection.test.tsx
+++ b/website/src/test/ChatPage.sourceSelection.test.tsx
@@ -1,0 +1,418 @@
+/**
+ * TRUE regression test for the focused Change / Issue tab surviving a session
+ * round-trip.
+ *
+ * The Changes panel renders one tab per pull request the transcript mentions.
+ * The focused one used to live in a single component-local `useState('')` in
+ * ChatPage, so it was neither per-slot nor persisted: switching sessions (or
+ * reloading) reconciled it back to the FIRST link in the transcript, discarding
+ * whichever PR the user had actually opened.
+ *
+ * SidePanel is mocked to echo the selected urls into the DOM, so these tests
+ * assert the real selection ChatPage passes down — not just what it persisted.
+ * Reverting the per-slot/persisted selection in ChatPage.tsx fails them.
+ */
+import { useEffect } from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { appendMessage } from '../store/chatSlice'
+import { ThemeProvider } from '../hooks/useTheme'
+import { __resetPanelTabs } from '../hooks/usePanelTabs'
+import type { ChatMessage, ChatSlot } from '../types'
+import type { RootState } from '../store'
+
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../components/ChatInput', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: () => null }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../components/PendingQuestionCard', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat', () => ({ ChatFooter: () => null, AssistantMessage: () => null, McpInfoButton: () => null }))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ contentWidth: 'compact' }),
+  CONTENT_WIDTH: { compact: { messages: '900px', input: '916px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } },
+}))
+
+// Echo the selection props, and expose the select callbacks as buttons so a
+// test can drive a real user selection without the whole panel tree.
+//
+// This mock MIRRORS the real PullRequestPanel's self-normalizing effect: when the
+// selected url is not among the tabs it renders, it reports the first one back to
+// the parent. That behaviour is the reason onReconcileSource exists, so a mock
+// without it cannot catch the parent wiring that path to a persisting callback —
+// which is exactly how a durable-overwrite regression went unnoticed here.
+vi.mock('../pages/chat/SidePanel', () => ({
+  // Named (uppercase) rather than an inline arrow: react-hooks/rules-of-hooks
+  // rejects a hook called inside a function named `default`.
+  default: function MockSidePanel({ selectedSourceUrl, selectedIssueUrl, sources, onSelectSource, onReconcileSource }: {
+    selectedSourceUrl?: string
+    selectedIssueUrl?: string
+    sources?: Array<{ url: string }>
+    onSelectSource?: (url: string) => void
+    onReconcileSource?: (url: string) => void
+  }) {
+    const rendered = (sources ?? []).slice(0, 64)
+    const selected = rendered.find(source => source.url === selectedSourceUrl) || rendered[0]
+    useEffect(() => {
+      if (selected && selected.url !== selectedSourceUrl) {
+        (onReconcileSource || onSelectSource)?.(selected.url)
+      }
+    }, [selected, selectedSourceUrl, onSelectSource, onReconcileSource])
+    return (
+      <div>
+        <span data-testid="selected-source">{selectedSourceUrl}</span>
+        <span data-testid="selected-issue">{selectedIssueUrl}</span>
+        {(sources ?? []).map(source => (
+          <button key={source.url} aria-label={`pick ${source.url}`} onClick={() => onSelectSource?.(source.url)} />
+        ))}
+      </div>
+    )
+  },
+  CHAT_PANE_MIN_W: 320,
+  sidePanelFillWidth: () => false,
+}))
+
+vi.mock('../hooks/usePanelState', () => ({
+  usePanelState: () => ({ isOpen: false, openPanel: vi.fn(), closePanel: vi.fn() }),
+  useDiffPanel: () => ({ isOpen: false, filePath: '', original: '', modified: '', openDiff: vi.fn(), closeDiff: vi.fn() }),
+}))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+
+vi.mock('../api/client', () => ({
+  api: Object.fromEntries(
+    ['sessions', 'chatSlotDetail', 'createChatSlot', 'deleteChatSlot', 'resumeChatSlot',
+     'deleteSession', 'agentDetail', 'approveChatSlot', 'chatSlotAgent', 'chatSlotModel',
+     'chatSlotWorkspace', 'models', 'planAction', 'planFromChat', 'renameSlot',
+     'resolveApproval', 'screenshot', 'slackChannels', 'slackLink', 'spawnList',
+     'stopChatSlot', 'uploadFiles', 'voiceSynthesize', 'workspaces', 'chatSlots',
+     'notifications', 'status', 'sendChat', 'dashboardConfig'].map(k => [
+      k, vi.fn().mockResolvedValue(k === 'chatSlotDetail' ? { messages: [], has_more: false } : {}),
+    ]),
+  ),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch
+
+import ChatPage from '../pages/ChatPage'
+
+// One key per (slot, kind) — see the store's header comment on why there is no
+// shared blob. Helpers keep the tests reading in terms of a session's selection.
+const selKey = (slot: string, kind: 'change' | 'issue' = 'change') => `mc-pr-source-sel:${kind}:${slot}`
+const seedSelection = (slot: string, url: string, kind: 'change' | 'issue' = 'change') =>
+  localStorage.setItem(selKey(slot, kind), JSON.stringify({ u: url, t: Date.now() }))
+const readSelection = (slot: string, kind: 'change' | 'issue' = 'change'): string => {
+  try {
+    return JSON.parse(localStorage.getItem(selKey(slot, kind)) || 'null')?.u ?? ''
+  } catch {
+    return ''
+  }
+}
+const PR_ONE = 'https://github.com/acme/widgets/pull/11'
+const PR_TWO = 'https://github.com/acme/widgets/pull/12'
+
+const slot = (key: string): ChatSlot => ({
+  key, title: key, messages: 0, running: false, mode: '', created: '', last_ts: '',
+  pending_approval: false, waiting_for_input: false, last_activity_ts: undefined,
+})
+const allSlots = [slot('chat-1'), slot('chat-2')]
+
+// Agent-authored: under first-mention attribution only agent-surfaced PRs
+// become Change sources. All urls go in ONE message so the extracted source
+// order is fixed by the message text, independent of transcript hydration.
+const transcript = (...urls: string[]): ChatMessage[] =>
+  [{ role: 'assistant', content: `opened ${urls.join(' and ')}`, cls: '' }]
+
+function renderChatPage(activeSlot: string, messages: ChatMessage[]) {
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' }, connected: false, slots: allSlots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as unknown as RootState['dashboard'],
+    chat: {
+      activeSlot, messages, slotRunning: false, slotStopping: false, slotState: 'idle',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      lastChunkSeq: undefined, history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: true, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+      slotMessages: {}, slotLoading: false,
+    } as unknown as RootState['chat'],
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { ...view, store }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetPanelTabs()
+})
+
+describe('focused source tab persistence', () => {
+  it('falls back to the first source when the slot has no remembered tab', async () => {
+    renderChatPage('chat-2', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+  })
+
+  it('restores the tab the user had open instead of the first source', async () => {
+    seedSelection('chat-2', PR_TWO)
+    renderChatPage('chat-2', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_TWO)
+    })
+  })
+
+  it('persists a user selection so the next mount comes back to it', async () => {
+    const { unmount } = renderChatPage('chat-2', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+
+    await act(async () => { screen.getByLabelText(`pick ${PR_TWO}`).click() })
+    await waitFor(() => {
+      expect(readSelection('chat-2')).toBe(PR_TWO)
+    })
+
+    unmount()
+    renderChatPage('chat-2', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_TWO)
+    })
+  })
+
+  it('keeps each slot on its own tab when switching sessions', async () => {
+    seedSelection('chat-1', PR_ONE)
+    seedSelection('chat-2', PR_TWO)
+    const { unmount } = renderChatPage('chat-2', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_TWO)
+    })
+    unmount()
+
+    // Same two links in the other session: a single shared selection would
+    // still satisfy the "is it in the list" check and leak chat-2's tab here.
+    renderChatPage('chat-1', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+  })
+
+  it('shows the first source but keeps the stored one when the transcript lacks it', async () => {
+    // A transcript that does not carry the remembered url is not proof the url
+    // is gone — switchSlot.pending renders a CACHED copy with slotLoading
+    // already false while the real fetch is in flight. So the panel falls back
+    // to a valid tab, but the stored selection is left alone; once the full
+    // transcript arrives carrying PR 12 it is restored rather than lost.
+    seedSelection('chat-2', PR_TWO)
+    renderChatPage('chat-2', transcript(PR_ONE))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+    await act(async () => {})
+
+    expect(readSelection('chat-2')).toBe(PR_TWO)
+  })
+
+  it('keeps the remembered tab when a history fetch fails', async () => {
+    // switchSlot.rejected (dropped/failed history fetch) empties `messages` AND
+    // clears slotLoading in one reducer pass, so the hydration guard does not
+    // hold. Because the selection is durable now, clearing here would outlive
+    // the failure and lose the tab on the user's retry.
+    seedSelection('chat-2', PR_TWO)
+    renderChatPage('chat-2', [])
+    await act(async () => {})
+
+    expect(readSelection('chat-2')).toBe(PR_TWO)
+  })
+
+  it('picks up a sibling window changing the tab for the session on screen', async () => {
+    renderChatPage('chat-2', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+
+    // A second window (a popped-out session shares this origin's localStorage)
+    // moves chat-2 to PR 12. Only the OTHER document gets the storage event, so
+    // write the value first and then dispatch it by hand, exactly as the browser
+    // would deliver it here.
+    seedSelection('chat-2', PR_TWO)
+    await act(async () => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: selKey('chat-2'),
+        newValue: localStorage.getItem(selKey('chat-2')),
+        storageArea: localStorage,
+      }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_TWO)
+    })
+  })
+
+  it('ignores a storage event for an unrelated key', async () => {
+    renderChatPage('chat-2', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+
+    seedSelection('chat-2', PR_TWO)
+    await act(async () => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: 'mc-something-else',
+        newValue: 'x',
+        storageArea: localStorage,
+      }))
+    })
+
+    // Still on PR 11: the listener must not re-read on every unrelated write.
+    expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+  })
+
+  it('does not adopt or re-commit a url this window has no tab for', async () => {
+    // A sibling window on the same session has a newer transcript and selects a
+    // PR this window has never seen. Adopting it would make this window's own
+    // reconciliation overwrite the sibling's choice, which the sibling would
+    // overwrite back — an unbounded cross-window write loop. This window must
+    // keep its own selection AND leave storage exactly as the sibling wrote it.
+    renderChatPage('chat-2', transcript(PR_ONE))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+
+    seedSelection('chat-2', PR_TWO)
+    await act(async () => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: selKey('chat-2'),
+        newValue: localStorage.getItem(selKey('chat-2')),
+        storageArea: localStorage,
+      }))
+    })
+    await act(async () => {})
+
+    expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    // The sibling's value is untouched — no answering write, so no ping-pong.
+    expect(readSelection('chat-2')).toBe(PR_TWO)
+  })
+  it('never persists a reconciled pick, so a fresh slot stores nothing', async () => {
+    // Reconciliation is in-memory only. Persisting sourceLinks[0] bought nothing
+    // — the fallback is deterministic, so a return visit recomputes the same tab
+    // — while every write from that path risked destroying a real choice.
+    renderChatPage('chat-2', transcript(PR_ONE, PR_TWO))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+    await act(async () => {})
+
+    expect(readSelection('chat-2')).toBe('')
+  })
+
+  it('restores the stored tab once the transcript carries it, without a remount', async () => {
+    // The provisional-render path, in ONE document: switchSlot.pending serves a
+    // cached transcript with slotLoading already false, so the panel falls back in
+    // memory while storage still holds PR 12. Nothing else re-reads storage in the
+    // window that wrote it — loadSourceSelections runs only in the useState
+    // initializer and the `storage` event never fires in the writing document — so
+    // without the one re-read the fallback would stick until a reload. The
+    // transcript is grown IN PLACE here; a remount would prove nothing, because a
+    // fresh mount reads storage anyway.
+    seedSelection('chat-2', PR_TWO)
+    const { store } = renderChatPage('chat-2', transcript(PR_ONE))
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_ONE)
+    })
+    expect(readSelection('chat-2')).toBe(PR_TWO)
+
+    // The fetch lands and the transcript now carries PR 12.
+    await act(async () => {
+      store.dispatch(appendMessage({ role: 'assistant', content: `opened ${PR_TWO}`, cls: '' }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(PR_TWO)
+    })
+  })
+
+  it('does not delete the stored tab when the transcript has no sources', async () => {
+    // Same reasoning applied to the clear branch: a stale cached transcript can
+    // be nonempty and still carry no links, which is not proof they are gone.
+    seedSelection('chat-2', PR_TWO)
+    renderChatPage('chat-2', [{ role: 'assistant', content: 'no links here', cls: '' }])
+    await act(async () => {})
+
+    expect(readSelection('chat-2')).toBe(PR_TWO)
+  })
+
+  it('leaves a stored tab alone when it sits beyond the rendered cap', async () => {
+    // The panels render only the first MAX_PULL_REQUEST_SOURCES (64) tabs, so a
+    // remembered url past that point is not reachable as a tab and the panel
+    // normalizes to tab 0. That normalize must not be persisted: this fires even
+    // for a fully-settled transcript, so it is the one trigger that does not need
+    // a provisional render to destroy a real choice.
+    const many = Array.from({ length: 70 }, (_, i) => `https://github.com/o/r/pull/${i + 1}`)
+    const beyondCap = many[68]
+    seedSelection('chat-2', beyondCap)
+    renderChatPage('chat-2', [{ role: 'assistant', content: many.join(' '), cls: '' }])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-source')).toHaveTextContent(many[0])
+    })
+    await act(async () => {})
+
+    expect(readSelection('chat-2')).toBe(beyondCap)
+  })
+
+  it('does not touch storage for a session with no pull requests', async () => {
+    // The reconciliation effects re-run on every streaming chunk (the link index
+    // hands back a fresh array each time), and commitSourceSelection enumerates
+    // all of localStorage to decide whether the value already matches. An
+    // unconditional clear therefore cost a full enumeration per chunk for every
+    // session that never mentions a pull request — the common case. The clear is
+    // gated on there being a selection to clear.
+    const keySpy = vi.spyOn(Storage.prototype, 'key')
+    try {
+      renderChatPage('chat-2', [{ role: 'assistant', content: 'no links here', cls: '' }])
+      await act(async () => {})
+      expect(keySpy).not.toHaveBeenCalled()
+    } finally {
+      keySpy.mockRestore()
+    }
+  })
+})

--- a/website/src/test/pullRequestLinks.test.ts
+++ b/website/src/test/pullRequestLinks.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import type { ChatMessage } from '../types'
 import {
+  adoptSourceSelections,
+  commitSourceSelection,
   extractPullRequestLinks,
+  isSourceSelectionKey,
   loadSeenPullRequestLinks,
+  loadSourceSelections,
   MAX_PULL_REQUEST_SOURCES,
   persistSeenPullRequestLinks,
   PullRequestLinkIndex,
   recordNewPullRequestLinks,
+  sourceSelection,
+  withSourceSelection,
 } from '../utils/pullRequestLinks'
 
 // Default to assistant-authored messages: under first-mention attribution only
@@ -301,6 +307,305 @@ describe('extractPullRequestLinks', () => {
     localStorage.setItem('mc-pr-source-seen-v1', JSON.stringify({ slot: ['not-an-array'] }))
     expect(loadSeenPullRequestLinks()).toEqual(new Map())
     localStorage.clear()
+  })
+})
+
+describe('per-slot focused source tab', () => {
+  const prA = 'https://github.com/acme/widgets/pull/11'
+  const prB = 'https://github.com/acme/widgets/pull/12'
+  const issue = 'https://github.com/acme/widgets/issues/9'
+
+  afterEach(() => { localStorage.clear() })
+
+  it('keeps each slot and each kind independent', () => {
+    let sel = withSourceSelection({}, 'slot-a', 'change', prB)
+    sel = withSourceSelection(sel, 'slot-a', 'issue', issue)
+    sel = withSourceSelection(sel, 'slot-b', 'change', prA)
+
+    expect(sourceSelection(sel, 'slot-a', 'change')).toBe(prB)
+    expect(sourceSelection(sel, 'slot-a', 'issue')).toBe(issue)
+    expect(sourceSelection(sel, 'slot-b', 'change')).toBe(prA)
+    // A slot that never selected anything reads as "no selection", so the
+    // caller's first-wins fallback applies.
+    expect(sourceSelection(sel, 'slot-c', 'change')).toBe('')
+    expect(sourceSelection(sel, null, 'change')).toBe('')
+  })
+
+  it('returns the same object when nothing changes so a state update bails', () => {
+    const sel = withSourceSelection({}, 'slot-a', 'change', prB)
+    expect(withSourceSelection(sel, 'slot-a', 'change', prB)).toBe(sel)
+    // No slot, and clearing a slot that has nothing stored, are both no-ops —
+    // the latter keeps PR-free sessions from each accumulating an empty entry.
+    expect(withSourceSelection(sel, null, 'change', prA)).toBe(sel)
+    expect(withSourceSelection(sel, 'slot-z', 'change', '')).toBe(sel)
+  })
+
+  it('restores the selection a slot had before it was left', () => {
+    expect(commitSourceSelection('slot-a', 'change', prB)).toBe('persisted')
+    expect(commitSourceSelection('slot-a', 'issue', issue)).toBe('persisted')
+
+    // Fresh mount (reload / route change): slot-a comes back on PR 12, not on
+    // whichever link the transcript happens to mention first.
+    const restored = loadSourceSelections()
+    expect(sourceSelection(restored, 'slot-a', 'change')).toBe(prB)
+    expect(sourceSelection(restored, 'slot-a', 'issue')).toBe(issue)
+  })
+
+  it('writes one key per (slot, kind) so a write can never touch another field', () => {
+    // The concurrency invariant: nothing is stored as a shared blob, so a write
+    // has no other field in scope to drop. Two windows can only collide on the
+    // exact same key.
+    commitSourceSelection('slot-a', 'change', prA)
+    commitSourceSelection('slot-a', 'issue', issue)
+    commitSourceSelection('slot-b', 'change', prB)
+
+    const keys: string[] = []
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index)
+      if (key?.startsWith('mc-pr-source-sel:')) keys.push(key)
+    }
+    keys.sort()
+    expect(keys).toEqual([
+      'mc-pr-source-sel:change:slot-a',
+      'mc-pr-source-sel:change:slot-b',
+      'mc-pr-source-sel:issue:slot-a',
+    ])
+    for (const key of keys) expect(isSourceSelectionKey(key)).toBe(true)
+    expect(isSourceSelectionKey('mc-panel-tabs:slot-a')).toBe(false)
+  })
+
+  it('survives two windows committing different slots', () => {
+    // Cross-document safety is STRUCTURAL here, not timing-dependent: with one
+    // key per field there is no read-modify-write for a concurrent document to
+    // interleave with, so no ordering of two windows' writes can drop a field
+    // neither of them named. (A single-threaded test cannot reproduce the real
+    // interleaving — the gap between another document's read and its write — so
+    // the invariant is pinned by the one-key-per-field test above; this case
+    // covers the ordinary two-window outcome.)
+    commitSourceSelection('slot-a', 'change', prA)
+    commitSourceSelection('slot-b', 'change', prB)
+
+    const merged = loadSourceSelections()
+    expect(sourceSelection(merged, 'slot-a', 'change')).toBe(prA)
+    expect(sourceSelection(merged, 'slot-b', 'change')).toBe(prB)
+  })
+
+  it('fails closed on malformed or non-canonical persisted selections', () => {
+    localStorage.setItem('mc-pr-source-sel:change:slot-a', '{not-json')
+    localStorage.setItem('mc-pr-source-sel:change:slot-b', JSON.stringify(['not-an-object']))
+    localStorage.setItem('mc-pr-source-sel:change:slot-c', JSON.stringify({ u: 42 }))
+    // Wrong host, and a canonical-looking url with a query tail, are both refused.
+    localStorage.setItem('mc-pr-source-sel:change:slot-d', JSON.stringify({ u: 'https://evil.example/acme/widgets/pull/3' }))
+    localStorage.setItem('mc-pr-source-sel:change:slot-e', JSON.stringify({ u: `${prA}?tab=files` }))
+    // An unknown kind segment is not a field this store owns.
+    localStorage.setItem('mc-pr-source-sel:bogus:slot-f', JSON.stringify({ u: prA }))
+    expect(loadSourceSelections()).toEqual({})
+  })
+
+  it('removes the key when a selection is cleared', () => {
+    expect(commitSourceSelection('slot-a', 'change', prA)).toBe('persisted')
+    expect(commitSourceSelection('slot-a', 'change', '')).toBe('persisted')
+    expect(loadSourceSelections()).toEqual({})
+    expect(localStorage.getItem('mc-pr-source-sel:change:slot-a')).toBeNull()
+  })
+
+  it('caps stored slots by write recency, pruning the oldest', () => {
+    // Recency is the stored timestamp, not key order — independent keys have no
+    // insertion order to trim by. Stamps are forced so the test does not depend
+    // on wall-clock resolution.
+    const now = Date.now()
+    for (let index = 0; index < 40; index += 1) {
+      localStorage.setItem(
+        `mc-pr-source-sel:change:slot-${index}`,
+        JSON.stringify({ u: `https://github.com/acme/widgets/pull/${index + 1}`, t: now + index }),
+      )
+    }
+    const restored = loadSourceSelections()
+    expect(Object.keys(restored)).toHaveLength(32)
+    expect(sourceSelection(restored, 'slot-39', 'change')).toBe('https://github.com/acme/widgets/pull/40')
+    expect(sourceSelection(restored, 'slot-0', 'change')).toBe('')
+  })
+
+  it('keeps a re-selected slot when the cap has to drop one', () => {
+    // Re-selecting a tab in an OLD session must move it out of the eviction
+    // queue, so the cap never evicts the session the user is actively reading.
+    // Seeded in the PAST (oldest first) so the fresh commits below are newest.
+    const past = Date.now() - 100_000
+    for (let index = 0; index < 32; index += 1) {
+      localStorage.setItem(
+        `mc-pr-source-sel:change:slot-${index}`,
+        JSON.stringify({ u: `https://github.com/acme/widgets/pull/${index + 1}`, t: past + index }),
+      )
+    }
+    // Touch the oldest slot, then add a 33rd so the cap has to drop exactly one.
+    expect(commitSourceSelection('slot-0', 'change', prB)).toBe('persisted')
+    expect(commitSourceSelection('slot-32', 'change', prA)).toBe('persisted')
+
+    const restored = loadSourceSelections()
+    expect(Object.keys(restored)).toHaveLength(32)
+    expect(sourceSelection(restored, 'slot-0', 'change')).toBe(prB)
+    expect(sourceSelection(restored, 'slot-32', 'change')).toBe(prA)
+    // The now-oldest untouched slot falls outside the cap on READ. Its key is
+    // deliberately left in place: deleting another slot's key by snapshot can
+    // race a sibling window that just refreshed it, so nothing prunes here.
+    expect(sourceSelection(restored, 'slot-1', 'change')).toBe('')
+    expect(localStorage.getItem('mc-pr-source-sel:change:slot-1')).not.toBeNull()
+  })
+
+  it('keeps a fresh selection visible when the clock steps backwards', () => {
+    // A stamp taken straight from a clock that has moved BACKWARD (NTP step,
+    // resumed VM, user setting the date) would sort below 32 older slots, so the
+    // read cap would hide the selection the user just made and the tab would
+    // reset on reload. The written stamp is clamped above whatever is stored.
+    const future = Date.now() + 10_000_000
+    for (let index = 0; index < 32; index += 1) {
+      localStorage.setItem(
+        `mc-pr-source-sel:change:slot-${index}`,
+        JSON.stringify({ u: `https://github.com/acme/widgets/pull/${index + 1}`, t: future + index }),
+      )
+    }
+    expect(commitSourceSelection('slot-new', 'change', prA)).toBe('persisted')
+
+    const restored = loadSourceSelections()
+    expect(Object.keys(restored)).toHaveLength(32)
+    expect(sourceSelection(restored, 'slot-new', 'change')).toBe(prA)
+  })
+
+  it('merges a commit into fresh storage instead of republishing a stale snapshot', () => {
+    // Two chat windows on one origin (a popped-out session shares this
+    // localStorage). Window B mounted BEFORE window A made its selection, so
+    // B's in-memory snapshot does not know about slot-a. Writing B's whole map
+    // back would delete slot-a; committing one slot against fresh storage keeps
+    // both.
+    expect(commitSourceSelection('slot-a', 'change', prA)).toBe('persisted')
+    expect(commitSourceSelection('slot-b', 'change', prB)).toBe('persisted')
+
+    const restored = loadSourceSelections()
+    expect(sourceSelection(restored, 'slot-a', 'change')).toBe(prA)
+    expect(sourceSelection(restored, 'slot-b', 'change')).toBe(prB)
+  })
+
+  it('reports whether a commit reached storage', () => {
+    expect(commitSourceSelection('slot-a', 'change', prA)).toBe('persisted')
+    // Re-committing the same value writes again, on purpose: the rewrite is what
+    // refreshes recency (see the capped-out re-selection test below), so
+    // 'unchanged' now means only "no write was attempted at all".
+    expect(commitSourceSelection('slot-a', 'change', prA)).toBe('persisted')
+    expect(commitSourceSelection('slot-z', 'change', '')).toBe('unchanged')
+    expect(commitSourceSelection(null, 'change', prB)).toBe('unchanged')
+  })
+
+  it('refreshes recency when a capped-out slot is re-selected', () => {
+    // Aged-out slots keep their keys but are excluded on read. Re-picking the url
+    // already stored for such a slot has to rewrite it, or the click can never
+    // pull the slot back inside the cap and the tab resets on every reload.
+    const aged = 'slot-aged'
+    commitSourceSelection(aged, 'change', prA)
+    // Push it out of the cap with MAX_PERSISTED_SOURCE_SLOTS newer slots.
+    for (let i = 0; i < 32; i += 1) {
+      commitSourceSelection(`slot-new-${i}`, 'change', `https://github.com/o/r/pull/${i + 100}`)
+    }
+    expect(loadSourceSelections()[aged]).toBeUndefined()
+
+    // The user clicks the tab for the url that is ALREADY stored for that slot.
+    expect(commitSourceSelection(aged, 'change', prA)).toBe('persisted')
+    expect(loadSourceSelections()[aged]?.change).toBe(prA)
+  })
+
+  it('reports failed when storage refuses the write', () => {    // 'failed' must be distinguishable from 'unchanged': only the former means
+    // storage now DISAGREES with what the caller intended.
+    const setItem = Storage.prototype.setItem
+    Storage.prototype.setItem = () => {
+      throw new DOMException('full', 'QuotaExceededError')
+    }
+    try {
+      expect(commitSourceSelection('slot-a', 'change', prA)).toBe('failed')
+    } finally {
+      Storage.prototype.setItem = setItem
+    }
+  })
+
+  it('does not adopt a stored value whose own write was refused', () => {
+    // The user moved slot-a to PR 12 but the write was dropped, so storage still
+    // holds PR 11 — a value that IS in this window's transcript, so the
+    // availability rule alone would take it back and silently revert the tab.
+    commitSourceSelection('slot-a', 'change', prA)
+    const mine = withSourceSelection(loadSourceSelections(), 'slot-a', 'change', prB)
+
+    const naive = adoptSourceSelections(mine, 'slot-a', { change: [prA, prB] })
+    expect(sourceSelection(naive, 'slot-a', 'change')).toBe(prA)
+
+    const guarded = adoptSourceSelections(mine, 'slot-a', { change: [prA, prB] }, { 'slot-a': { change: true } })
+    expect(guarded).toBe(mine)
+    expect(sourceSelection(guarded, 'slot-a', 'change')).toBe(prB)
+  })
+
+  it('honors a refused write for a slot that is not on screen', () => {
+    // A refused write is equally lost whether or not the user happens to be
+    // looking at that session, so the ledger is not scoped to the active slot.
+    commitSourceSelection('slot-b', 'change', prB)
+    const mine = withSourceSelection(loadSourceSelections(), 'slot-b', 'change', prA)
+
+    // slot-a is on screen; slot-b's own write was refused, so storage still
+    // holds prB while this window has moved on to prA.
+    const adopted = adoptSourceSelections(
+      mine, 'slot-a', { change: [prA, prB] }, { 'slot-b': { change: true } },
+    )
+    expect(sourceSelection(adopted, 'slot-b', 'change')).toBe(prA)
+    // Without the ledger entry the sibling's stored value wins for that slot.
+    const unguarded = adoptSourceSelections(mine, 'slot-a', { change: [prA, prB] })
+    expect(sourceSelection(unguarded, 'slot-b', 'change')).toBe(prB)
+  })
+
+  it('adopts a sibling window write, including for the active slot', () => {
+    // This window mounted with slot-a on PR 11; a sibling then moved slot-a to
+    // PR 12 and picked a tab in slot-b. Both windows see both PRs, so PR 12 is
+    // usable here and the sibling's choice wins.
+    const mine = withSourceSelection({}, 'slot-a', 'change', prA)
+    commitSourceSelection('slot-a', 'change', prB)
+    commitSourceSelection('slot-b', 'change', prA)
+
+    const adopted = adoptSourceSelections(mine, 'slot-a', { change: [prA, prB] })
+    expect(sourceSelection(adopted, 'slot-a', 'change')).toBe(prB)
+    expect(sourceSelection(adopted, 'slot-b', 'change')).toBe(prA)
+  })
+
+  it('refuses an active-slot value this window cannot show', () => {
+    // The loop guard. Two windows on the SAME session with DIVERGENT transcripts
+    // (a sibling has a newer message mentioning another PR). Adopting a url this
+    // window has no tab for would make its reconciliation overwrite the
+    // sibling's choice, which the sibling then overwrites back — an unbounded
+    // cross-window write loop. Keeping our own value ends it: nothing changed
+    // here, so nothing gets committed.
+    const mine = withSourceSelection({}, 'slot-a', 'change', prA)
+    commitSourceSelection('slot-a', 'change', prB)
+
+    const adopted = adoptSourceSelections(mine, 'slot-a', { change: [prA] })
+    expect(adopted).toBe(mine)
+    expect(sourceSelection(adopted, 'slot-a', 'change')).toBe(prA)
+  })
+
+  it('keeps the active slot when storage has no entry for it', () => {
+    // Stands in for a dropped write (safeSetItem false under quota pressure):
+    // storage never learned about this window's own selection. Adopting the
+    // storage view wholesale would yank the tab the user is looking at.
+    const mine = withSourceSelection({}, 'slot-a', 'change', prA)
+    commitSourceSelection('slot-b', 'change', prB)
+
+    const adopted = adoptSourceSelections(mine, 'slot-a', { change: [prA] })
+    expect(sourceSelection(adopted, 'slot-a', 'change')).toBe(prA)
+    expect(sourceSelection(adopted, 'slot-b', 'change')).toBe(prB)
+    // A slot this window is NOT showing gets no such protection — the sibling's
+    // view of it is the truth, and this window's reconciliation never writes it.
+    expect(sourceSelection(adoptSourceSelections(mine, 'slot-b', { change: [prB] }), 'slot-a', 'change')).toBe('')
+  })
+
+  it('returns the same object when a sibling write changes nothing here', () => {
+    commitSourceSelection('slot-a', 'change', prA)
+    const mine = loadSourceSelections()
+    expect(adoptSourceSelections(mine, 'slot-a', { change: [prA] })).toBe(mine)
+    // An unrelated key being cleared leaves storage identical, so still a bail.
+    expect(adoptSourceSelections(mine, null)).toBe(mine)
   })
 })
 

--- a/website/src/utils/pullRequestLinks.ts
+++ b/website/src/utils/pullRequestLinks.ts
@@ -435,6 +435,309 @@ export function loadSeenPullRequestLinks(): Map<string, Set<string>> {
   return new Map(restored)
 }
 
+/* ── Per-slot selected source tab (which Change / Issue tab is focused) ────
+ * The Changes and Issues panels each render one tab per detected url, and the
+ * focused one is per chat slot. Kept HERE (persisted, keyed by slot) rather than
+ * as a single component-local value so that leaving a session and returning —
+ * including across a reload, where the panel tab strip itself rehydrates from
+ * mc-panel-tabs:<slot> — restores the tab the user was reading instead of
+ * snapping back to the first pull request in the transcript. Not stored on the
+ * PanelTab itself: the selection must survive while the Changes tab does not yet
+ * exist (the strip is created by SidePanel.syncPinned, which only runs while the
+ * panel subtree is mounted), and patchTab silently no-ops on an absent tab.
+ *
+ * ONE KEY PER (slot, kind), never a shared blob. The dashboard can run several
+ * chat windows against one origin (a popped-out session is a second document
+ * sharing this localStorage), and localStorage offers no cross-document
+ * atomicity: with a single blob, two windows reconciling at the same moment both
+ * read it and the later write silently drops whatever the other had just added.
+ * A one-field key makes every write a single scalar setItem with nothing to
+ * merge, so two windows can only ever collide on the exact same field — which is
+ * last-writer-wins by nature rather than collateral loss. usePanelTabs stores the
+ * tab strip the same way, for the same reason ("Per-slot writes mean a GC'd slot
+ * key is never resurrected by an unrelated slot's mutation").
+ *
+ * Recency for the slot cap therefore cannot come from key insertion order, so
+ * each value carries the epoch millis it was written and the cap is applied on
+ * read (and pruned after a write). */
+
+const SOURCE_SELECTION_PREFIX = 'mc-pr-source-sel:'
+
+/** True for a `storage` event key belonging to this store, so a window can tell
+ *  a sibling's selection write from every other key on the origin. */
+export function isSourceSelectionKey(key: string): boolean {
+  return key.startsWith(SOURCE_SELECTION_PREFIX)
+}
+
+/** `mc-pr-source-sel:<kind>:<slot>` — kind first so the slot is the whole
+ *  remainder and needs no escaping, whatever characters a slot key contains. */
+function selectionStorageKey(slot: string, kind: SourceLinkKind): string {
+  return `${SOURCE_SELECTION_PREFIX}${kind}:${slot}`
+}
+
+function parseSelectionStorageKey(key: string): { slot: string; kind: SourceLinkKind } | null {
+  if (!isSourceSelectionKey(key)) return null
+  const rest = key.slice(SOURCE_SELECTION_PREFIX.length)
+  const split = rest.indexOf(':')
+  if (split <= 0) return null
+  const kind = rest.slice(0, split)
+  const slot = rest.slice(split + 1)
+  if (!slot || slot.length > MAX_PERSISTED_SLOT_LENGTH) return null
+  if (kind !== 'change' && kind !== 'issue') return null
+  return { slot, kind }
+}
+
+/** Focused source url per slot, split by kind (one Changes tab + one Issues
+ *  tab per slot, each with its own selection). */
+export type SourceSelections = Record<string, Partial<Record<SourceLinkKind, string>>>
+
+/** Set one slot's selection for one kind, returning the SAME object when
+ *  nothing changes so a React state update bails instead of re-rendering.
+ *  Clearing ('' url) is a no-op when there is nothing stored for that slot, so
+ *  the many sessions that never mention a pull request do not each accumulate
+ *  an empty entry. In-memory only — durability goes through
+ *  commitSourceSelection, which writes one field at a time. */
+export function withSourceSelection(
+  selections: SourceSelections,
+  slot: string | null,
+  kind: SourceLinkKind,
+  url: string,
+): SourceSelections {
+  if (!slot) return selections
+  const current = selections[slot]
+  if ((current?.[kind] ?? '') === url) return selections
+  if (!url && !current) return selections
+  return { ...selections, [slot]: { ...current, [kind]: url } }
+}
+
+/** Read one slot's selection for one kind. '' when nothing is remembered. */
+export function sourceSelection(
+  selections: SourceSelections,
+  slot: string | null,
+  kind: SourceLinkKind,
+): string {
+  return (slot && selections[slot]?.[kind]) || ''
+}
+
+const SOURCE_KINDS: readonly SourceLinkKind[] = ['change', 'issue']
+
+interface StoredSelection {
+  slot: string
+  kind: SourceLinkKind
+  url: string
+  /** Epoch millis of the write. Carries the recency the slot cap trims by, which
+   *  independent keys cannot express as insertion order. */
+  at: number
+}
+
+/** Enumerate and validate every stored field. localStorage is untrusted input,
+ *  so a malformed key, a non-canonical url, or an unparseable value is skipped
+ *  rather than trusted. A restored url is additionally compared against the live
+ *  transcript before it selects anything, so this validation is bounding rather
+ *  than authorization. */
+function readStoredSelections(): StoredSelection[] {
+  if (typeof localStorage === 'undefined') return []
+  const out: StoredSelection[] = []
+  try {
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index)
+      if (!key) continue
+      const parsedKey = parseSelectionStorageKey(key)
+      if (!parsedKey) continue
+      let value: unknown
+      try {
+        value = JSON.parse(localStorage.getItem(key) ?? 'null')
+      } catch {
+        continue
+      }
+      if (!value || typeof value !== 'object' || Array.isArray(value)) continue
+      const { u, t } = value as { u?: unknown; t?: unknown }
+      if (typeof u !== 'string' || !u || u.length > MAX_PERSISTED_SOURCE_URL_LENGTH) continue
+      if (!isCanonicalStoredUrl(u)) continue
+      out.push({ ...parsedKey, url: u, at: typeof t === 'number' && Number.isFinite(t) ? t : 0 })
+    }
+  } catch {
+    // Enumerating storage can throw in locked-down environments.
+    return out
+  }
+  return out
+}
+
+/** Slots ordered newest-write-first. A slot's recency is its most recent field,
+ *  so the two kinds of one session are capped together rather than competing. */
+function slotsByRecency(stored: readonly StoredSelection[]): string[] {
+  const newest = new Map<string, number>()
+  for (const entry of stored) {
+    newest.set(entry.slot, Math.max(newest.get(entry.slot) ?? 0, entry.at))
+  }
+  return [...newest.entries()].sort((a, b) => b[1] - a[1]).map(([slot]) => slot)
+}
+
+/** Restore the per-slot focused-tab selections, capped to the most recently
+ *  written slots.
+ *
+ *  The cap is applied HERE, on read, and nothing deletes another slot's key.
+ *  Deleting by snapshot cannot be made safe across documents: the set of doomed
+ *  slots is computed from a walk, and a sibling window can refresh one of them
+ *  before the removals run — so a "prune the tail" pass can delete a selection
+ *  that just became live. (Re-reading each key immediately before removing it
+ *  only shrinks that window, which is the same reasoning that made the old
+ *  single-blob read-modify-write unsafe.) The only removal this store performs is
+ *  the one the calling document owns: clearing its own field.
+ *
+ *  The cost is that keys accumulate — two at most per session that ever had a
+ *  selection, roughly a hundred bytes each. usePanelTabs takes the same trade for
+ *  the tab strip (no cap; a key is removed only when its own bucket empties), and
+ *  this is orders of magnitude smaller than the per-session `vc_heights_*` caches
+ *  that safeStorage's reclaim tiers exist for. */
+export function loadSourceSelections(): SourceSelections {
+  const stored = readStoredSelections()
+  const keep = new Set(slotsByRecency(stored).slice(0, MAX_PERSISTED_SOURCE_SLOTS))
+  const out: SourceSelections = {}
+  for (const entry of stored) {
+    if (!keep.has(entry.slot)) continue
+    out[entry.slot] = { ...out[entry.slot], [entry.kind]: entry.url }
+  }
+  return out
+}
+
+/**
+ * Outcome of a durable write. `unchanged` and `failed` are deliberately
+ * distinct: both mean "storage was not written", but only `failed` means storage
+ * now DISAGREES with what the caller intended, which is what
+ * `adoptSourceSelections` needs to know to avoid adopting a stale value back
+ * over a live selection.
+ */
+export type CommitOutcome = 'persisted' | 'unchanged' | 'failed'
+
+/**
+ * Write ONE (slot, kind) through to its OWN storage key.
+ *
+ * There is deliberately nothing to merge here: the value is a scalar under a key
+ * no other field shares, so this is a single setItem with no read-modify-write
+ * for a concurrent window to interleave with. That is what makes several chat
+ * windows on one origin safe — see the store's header comment. Two windows can
+ * still race the exact same field, which is last-writer-wins by nature; what
+ * cannot happen any more is one window's write dropping a field it never touched.
+ *
+ * NOT free to call speculatively. It enumerates storage to clamp the stamp, and
+ * a valid url is always written through (see the recency note below), so callers
+ * must skip it when they know nothing changed — the reconciliation effects gate
+ * their clear on there being a selection to clear rather than calling this on
+ * every render. `unchanged` therefore means "no write was attempted at all"
+ * (no slot, an over-long or non-canonical url, or a clear with nothing stored),
+ * never "the value already matched".
+ */
+export function commitSourceSelection(
+  slot: string | null,
+  kind: SourceLinkKind,
+  url: string,
+): CommitOutcome {
+  if (!slot || slot.length > MAX_PERSISTED_SLOT_LENGTH) return 'unchanged'
+  if (typeof localStorage === 'undefined') return 'unchanged'
+  const key = selectionStorageKey(slot, kind)
+  const stored = readStoredSelections()
+  const current = stored.find(entry => entry.slot === slot && entry.kind === kind)?.url ?? ''
+
+  if (!url) {
+    if (!current) return 'unchanged'
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      return 'failed'
+    }
+    return 'persisted'
+  }
+  // Re-selecting the SAME url is deliberately NOT a no-op: it rewrites the entry
+  // to refresh recency. The read cap hides all but the most recent slots, so a
+  // slot that has aged out is excluded on load and the panel shows the fallback.
+  // If re-picking the value already stored there did nothing, the user's click
+  // could never bring that slot back inside the cap and the tab would reset on
+  // every reload — the exact failure this store exists to prevent.
+  if (url.length > MAX_PERSISTED_SOURCE_URL_LENGTH || !isCanonicalStoredUrl(url)) return 'unchanged'
+  // Never stamp below what is already stored. A clock that steps BACKWARD (an
+  // NTP correction, a resumed VM, a user setting the date) would otherwise put a
+  // brand-new selection at the bottom of the recency order, where the read cap
+  // hides it behind 32 older slots and the tab resets on the next reload.
+  const newest = stored.reduce((max, entry) => Math.max(max, entry.at), 0)
+  const at = Math.max(Date.now(), newest + 1)
+  if (!safeSetItem(key, JSON.stringify({ u: url, t: at }))) return 'failed'
+  return 'persisted'
+}
+
+function sameSelections(a: SourceSelections, b: SourceSelections): boolean {
+  const slots = new Set([...Object.keys(a), ...Object.keys(b)])
+  for (const slot of slots) {
+    for (const kind of SOURCE_KINDS) {
+      if ((a[slot]?.[kind] ?? '') !== (b[slot]?.[kind] ?? '')) return false
+    }
+  }
+  return true
+}
+
+/**
+ * Re-read storage and fold another window's writes into this window's map.
+ *
+ * Meant for the `storage` event, which fires in every OTHER document on the
+ * origin when one of them writes — so a window learns about a sibling's change
+ * instead of carrying its mount-time view until reload. Storage is the merged
+ * truth for slots this window is not showing (every window commits through
+ * `commitSourceSelection`), so those are taken wholesale.
+ *
+ * The ACTIVE slot is the one that needs a rule, because it is the only slot this
+ * window's own reconciliation also writes to. It is merged per KIND, and a stored
+ * value replaces this window's own only when both hold:
+ *
+ *   - It is in `available` — the urls this window's transcript currently offers
+ *     for that kind. Two windows can show the same session with DIFFERENT
+ *     transcripts (one has received a newer message mentioning another pull
+ *     request). Adopting a url this window has no tab for makes its own
+ *     reconciliation immediately overwrite the sibling's choice, discarding
+ *     whichever selection the user actually made. (Whether that exchange also
+ *     repeats depends on how the two transcripts diverged; the selection loss
+ *     does not.) Refusing an unusable value ends it: this window keeps its own,
+ *     its reconciliation sees nothing to change, and it writes nothing.
+ *   - That kind is not in `unpersisted[slot]` — the fields whose own write storage
+ *     REFUSED (`safeSetItem` returns false once nothing reclaimable is left).
+ *     Storage then holds an older url (or none) for a field the user has already
+ *     moved, and without this the next sibling event would quietly revert it. The
+ *     ledger is honored for EVERY slot, not just the active one: a refused write
+ *     is equally lost whether or not the user happens to be looking at that
+ *     session right now.
+ *
+ * Returns the SAME object when nothing differs, so a state update bails.
+ */
+export function adoptSourceSelections(
+  previous: SourceSelections,
+  activeSlot: string | null,
+  available: Partial<Record<SourceLinkKind, readonly string[]>> = {},
+  unpersisted: Record<string, Partial<Record<SourceLinkKind, boolean>>> = {},
+): SourceSelections {
+  const stored = loadSourceSelections()
+  const next: SourceSelections = { ...stored }
+  // Slots this window holds a refused write for, plus the active slot (whose
+  // transcript gates adoption). Everything else is taken from storage as-is.
+  const reconcile = new Set([...Object.keys(unpersisted), ...(activeSlot ? [activeSlot] : [])])
+  for (const slot of reconcile) {
+    const incoming = stored[slot]
+    const own = previous[slot]
+    const refused = unpersisted[slot] ?? {}
+    const merged: Partial<Record<SourceLinkKind, string>> = {}
+    for (const kind of SOURCE_KINDS) {
+      const candidate = incoming?.[kind] ?? ''
+      // The transcript check applies only to the slot on screen — it is the one
+      // whose reconciliation would answer an unusable value with a write.
+      const showable = slot !== activeSlot || (available[kind] ?? []).includes(candidate)
+      const usable = Boolean(candidate) && !refused[kind] && showable
+      const value = usable ? candidate : (own?.[kind] ?? '')
+      if (value) merged[kind] = value
+    }
+    if (Object.keys(merged).length) next[slot] = merged
+    else delete next[slot]
+  }
+  return sameSelections(previous, next) ? previous : next
+}
+
 /** Persist recent per-slot seen sources without allowing unbounded growth. */
 export function persistSeenPullRequestLinks(
   seenBySlot: Map<string, Set<string>>,


### PR DESCRIPTION
# Remember which Change / Issue tab a session had open

## Problem

The Changes side panel renders one tab per pull request (and one per issue) that a
chat transcript mentions. Leave a session and come back, or reload, and the focused
tab was gone — the panel reopened on whichever pull request happened to be
mentioned first, not the one you were reading.

## Why it matters

The panel is where PR review actually happens, so the tab you had open is the thing
you were working on. Losing it on every session switch means re-finding your place
by hand, and it is worst exactly when it hurts most: a session with many PRs, where
scanning the tab strip is slowest.

## Fix (symptom → root cause → change)

The focused tab lived in a single `useState('')` in `ChatPage` — not keyed by chat
slot, and not persisted. The tab *strip* already survived (`mc-panel-tabs:<slot>`),
which is why the panel reappeared but focused on a tab nobody picked. On a slot
switch the shared value failed the "is this url still in the transcript" check and
snapped to `sourceLinks[0]`.

The selection is now persisted per `(slot, kind)` in `localStorage`, and the design
is shaped by two constraints that took several review rounds to pin down:

**One key per `(slot, kind)`, never a shared blob.** `localStorage` has no
cross-document atomicity, so a load-modify-store lets two windows both read and the
later write drop a slot it never touched. Every write is a single scalar `setItem`
with nothing to merge — the same approach `usePanelTabs` already uses for the strip.
Because independent keys carry no insertion order, the 32-slot cap is applied on
**read** only, ordered by a stored timestamp; nothing prunes another slot's key.
The written stamp is clamped to `max(Date.now(), newest + 1)` so a backward clock
step cannot sort a fresh selection below the cap and hide it.

**Only an explicit click persists; reconciliation is in-memory.** Deriving a tab
from the transcript must never write, because `switchSlot.pending` serves a *cached*
transcript with `slotLoading` already `false` on an instant switch — so a transcript
that lacks the remembered url is not proof the url is gone, and a write there
destroys a real choice. That applies to three separate paths, all of which reach the
same fallback:

- the reconciliation effects in `ChatPage`,
- the clear branch, when a transcript legitimately has no links,
- and the panels themselves, which normalize an out-of-range selection to tab 0 via
  their own effect. `PullRequestPanel` / `IssuePanel` now take a separate
  `onReconcile` callback for that path, so the parent can persist a click without
  persisting a normalize. The panels cap at `MAX_PULL_REQUEST_SOURCES`, so this one
  fires even for a fully-settled transcript.

Because the in-memory fallback would otherwise stick for the life of the document
(nothing else re-reads storage in the window that wrote it — `loadSourceSelections`
runs only in the `useState` initializer, and the `storage` event never fires in the
writing document), `restoreFromStorage` re-reads once per provisional fallback,
retried only when the transcript has **grown**. Transcripts are append-only, so
growth is the only way a previously-absent url can appear, and gating on it keeps
this off the per-streaming-chunk path.

A `storage` listener folds in a sibling window's writes. It re-reads storage rather
than trusting `event.newValue`, so the loader's validation applies, and adoption of
the active slot is conditional on the incoming url existing in *this* window's
transcript — otherwise two windows with divergent transcripts discard each other's
choice.

## Tests

`website/src/test/pullRequestLinks.test.ts` (61 cases) covers the store: per-key
writes, recency ordering, the read-only cap, clock-skew clamping, the refused-write
ledger, and adoption.

`website/src/test/ChatPage.sourceSelection.test.tsx` (14 cases) covers the wiring —
per-slot isolation, the round-trip, the failed-history-fetch clear, cross-window
adoption, and four that lock in the in-memory rule: a reconciled pick stores
nothing; a reconciled clear does not delete a stored key; a stored tab beyond the
rendered cap is not overwritten; and the stored tab is restored once the transcript
carries it, **without a remount**.

The `SidePanel` mock deliberately mirrors the real panel's self-normalizing effect.
Without that, the mock cannot exercise the panel→parent callback at all, and a
durable-overwrite regression passes every test in the file.

Every assertion was revert-verified: with the guard reverted, exactly the named
tests fail.

## Manual verification

N/A — unit coverage is sufficient and this change has no visual surface. The tab
strip, its styling, and the panel contents are unchanged; only which tab is focused
after a session round-trip differs, which is what the tests assert.

## Screenshots

None — no user-visible UI change. Nothing is added, moved, or restyled.
