### PR TITLE
perf(mcp): stop a disabled server defeating the probe cache

### DIFF
--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -404,9 +404,21 @@ async def api_mcp_servers(request: web.Request) -> web.Response:
 
     # Also re-probe if a new server appeared (e.g. fresh install from AIM
     # Browse) so status transitions from "Unknown" to "ok"/"error" on the
-    # next page refresh without waiting out the 30-min TTL.
+    # next page refresh without waiting out the cache TTL.
+    #
+    # Only consider rows probe_all() would actually probe. It excludes
+    # consent-disabled servers on purpose (probing spawns the process), so a
+    # disabled row can never enter _mcp_probe_cache — while list_servers()
+    # deliberately returns it so the UI can render the row. Comparing the
+    # unfiltered list against the cache therefore treated every disabled
+    # server as "new" on EVERY request, bypassing the cache TTL and leaving a
+    # full spawn fan-out permanently in flight for anyone with one disabled
+    # server. Applying probe_all's own filter here keeps the freshness check
+    # and the cache contents talking about the same set.
     if not should_reprobe and not _mcp_probe_in_progress:
         for srv in servers:
+            if srv.disabled:
+                continue
             if srv.name not in cached_by_name:
                 should_reprobe = True
                 break

--- a/test/test_mcp_probe_treadmill.py
+++ b/test/test_mcp_probe_treadmill.py
@@ -1,0 +1,140 @@
+"""Regression: a disabled MCP server must not defeat the probe cache.
+
+``GET /api/mcp`` re-probes when a configured server is absent from
+``_mcp_probe_cache``, so a freshly installed server flips from "Unknown" to a
+real status on the next page load instead of waiting out the TTL.
+
+The cache is filled from ``probe_all()``, which deliberately excludes
+consent-disabled rows — probing spawns the server process, and that is exactly
+what consent gates. ``list_servers()`` deliberately INCLUDES them so the UI can
+render the row. Comparing the unfiltered list against the cache therefore
+classified every disabled server as "new" on every single request, so
+``should_reprobe`` was permanently true and a full spawn fan-out was always in
+flight for anyone with one disabled server. The freshness check must apply
+probe_all's own filter.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kiro_crew.dashboard.handlers import mcp as mcp_mod
+from kiro_crew.mcp_discovery import McpServerInfo
+
+
+def _request(state) -> object:
+    """Minimal stand-in for the aiohttp request the handler reads."""
+
+    class _App(dict):
+        pass
+
+    class _Req:
+        def __init__(self, app):
+            self.app = app
+
+    app = _App()
+    app["state"] = state
+    return _Req(app)
+
+
+class _State:
+    def __init__(self) -> None:
+        self._background_tasks: set = set()
+
+
+def _arrange(monkeypatch, tmp_path, servers, cache):
+    """Point the handler at a synthetic server list and a warm probe cache."""
+    import kiro_crew.mcp_discovery as disc
+
+    monkeypatch.setattr(disc, "list_servers", lambda *a, **k: list(servers))
+    # No mcp.json on disk: the disabled/kirocrewManaged overlay is a no-op, so
+    # `disabled` comes purely from the McpServerInfo rows above.
+    monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", tmp_path / "absent.json")
+    monkeypatch.setattr(mcp_mod, "_kirocrew_mcp_json", lambda: tmp_path / "absent-kc.json")
+    monkeypatch.setattr(mcp_mod, "_mcp_probe_cache", list(cache))
+    # Warm cache: the TTL branch must NOT be the thing that triggers a reprobe.
+    monkeypatch.setattr(mcp_mod, "_mcp_probe_ts", time.time())
+    monkeypatch.setattr(mcp_mod, "_mcp_probe_in_progress", False)
+
+    probe = AsyncMock(return_value=None)
+    monkeypatch.setattr(mcp_mod, "_bg_mcp_probe", probe)
+    return probe
+
+
+class TestDisabledServerDoesNotDefeatProbeCache:
+    @pytest.mark.asyncio
+    async def test_disabled_server_does_not_force_a_reprobe(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """A disabled row absent from the cache must not re-arm the probe.
+
+        Reverted (the check iterating every server rather than only probeable
+        ones), this schedules a background probe on a warm cache.
+        """
+        servers = [
+            McpServerInfo(name="enabled-one", command="/bin/true", status="ok"),
+            McpServerInfo(name="turned-off", command="/bin/true", disabled=True),
+        ]
+        # probe_all() would only ever have returned the enabled row.
+        cache = [{"name": "enabled-one", "status": "ok", "tools": [], "error": ""}]
+        probe = _arrange(monkeypatch, tmp_path, servers, cache)
+
+        state = _State()
+        await mcp_mod.api_mcp_servers(_request(state))
+
+        probe.assert_not_awaited()
+        assert not state._background_tasks
+        assert mcp_mod._mcp_probe_in_progress is False
+
+    @pytest.mark.asyncio
+    async def test_new_enabled_server_still_forces_a_reprobe(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The feature the check exists for must survive the fix.
+
+        An ENABLED server missing from the cache is genuinely new and still has
+        to trigger a probe — the fix narrows the check, it does not remove it.
+        """
+        servers = [
+            McpServerInfo(name="enabled-one", command="/bin/true", status="ok"),
+            McpServerInfo(name="just-installed", command="/bin/true"),
+        ]
+        cache = [{"name": "enabled-one", "status": "ok", "tools": [], "error": ""}]
+        _arrange(monkeypatch, tmp_path, servers, cache)
+
+        state = _State()
+        await mcp_mod.api_mcp_servers(_request(state))
+
+        # The handler creates a real asyncio task around the patched coroutine.
+        assert state._background_tasks, "a genuinely new server must re-arm the probe"
+        assert mcp_mod._mcp_probe_in_progress is True
+        for task in list(state._background_tasks):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_disabled_row_is_still_returned_to_the_ui(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Skipping disabled rows in the freshness check must not hide them.
+
+        The row still has to reach the response, otherwise the fix would trade
+        the spawn treadmill for a missing table entry.
+        """
+        servers = [
+            McpServerInfo(name="enabled-one", command="/bin/true", status="ok"),
+            McpServerInfo(name="turned-off", command="/bin/true", disabled=True),
+        ]
+        cache = [{"name": "enabled-one", "status": "ok", "tools": [], "error": ""}]
+        _arrange(monkeypatch, tmp_path, servers, cache)
+
+        resp = await mcp_mod.api_mcp_servers(_request(_State()))
+
+        import json as _json
+
+        rows = _json.loads(resp.text or "[]")
+        names = [r["name"] for r in rows]
+        assert "turned-off" in names, "a disabled server must still render a row"
+        assert "enabled-one" in names


### PR DESCRIPTION
# Problem

If you have **one disabled MCP server**, KiroCrew re-probes every MCP server on
*every* `GET /api/mcp` — spawning each enabled server as a subprocess for a full
`initialize` + `tools/list` handshake, just to render status badges. The 600-second
probe cache never takes effect.

The dashboard's MCP page sets no `staleTime` and refetches on mount and on window
focus, so in practice a spawn fan-out is permanently in flight.

# Why it matters

Continuous background subprocess churn on an ordinary install: every KiroCrew MCP
server pays its own cold-start import cost on each pass, and the fan-out competes
with the gateway for CPU. Nothing about it is visible to the user — the page looks
like it is just showing a list.

It needs only one disabled server to trigger, and disabling a server is the normal
way to decline an MCP install, so this is not an exotic configuration.

# Fix (symptom -> root cause -> change)

`api_mcp_servers` re-probes when a configured server is missing from
`_mcp_probe_cache`, so a freshly installed server flips from "Unknown" to a real
status on the next page load instead of waiting out the TTL. That check compared
two sets that were never the same set:

- `_mcp_probe_cache` is filled from `probe_all()`, which at
  `src/kiro_crew/mcp_discovery.py:1121` does
  `servers = [s for s in list_servers() if not s.disabled]`. Disabled rows are
  excluded **deliberately** — probing spawns the server process, and that is
  exactly what consent gates.
- The freshness check iterated the unfiltered `list_servers()`, which **includes**
  disabled rows on purpose so the UI can render them.

So a disabled server was absent from the cache by design, the check read that
absence as "a new server appeared", and `should_reprobe` was true on every request
regardless of the TTL.

The change applies `probe_all`'s own filter to the freshness check, so the two
sides finally describe the same population:

```python
for srv in servers:
    if srv.disabled:
        continue
    if srv.name not in cached_by_name:
        should_reprobe = True
        break
```

Three lines. No change to what is probed, what is cached, or what the API returns.

Basis: finding 30 from the `wf_000019` performance audit, which flagged this as
the one unambiguous logic defect among ~30 distinct findings.

# Tests

New `test/test_mcp_probe_treadmill.py`, three cases:

- `test_disabled_server_does_not_force_a_reprobe` — the actual guard. A warm cache
  holding only the enabled server, plus one disabled server, must **not** schedule
  a background probe. **Revert-verified**: restoring the unfiltered loop makes this
  fail, and it is the only one of the three that changes verdict, which is what
  pins the fix rather than the surrounding behaviour.
- `test_new_enabled_server_still_forces_a_reprobe` — guards against over-fixing.
  A genuinely new *enabled* server must still re-arm the probe; the fix narrows the
  check, it must not disable it.
- `test_disabled_row_is_still_returned_to_the_ui` — guards the other direction:
  skipping disabled rows in the freshness check must not drop them from the
  response, or the fix would trade the spawn treadmill for a missing table row.

The last two pass with and without the fix by design — they exist to catch a
future over-correction, not to prove this one.

# Manual verification

N/A — unit coverage is sufficient. The defect is a set-comparison bug fully
observable through whether a background probe task gets scheduled, which the tests
assert directly. No real server is spawned in any of them.

# Gates

`isort` and `flake8` clean. `mypy src/kiro_crew/` reports only the pre-existing
`faiss.write_index` overload error that reproduces unchanged on `origin/main`.

Tests: 1,627 passed across the MCP-matched scope (`-k mcp`), plus the 3 new cases.
One failure, `test_app_manager.py::TestBuiltinSecretForMcpServers::test_declares_backend_helper`,
was **verified pre-existing** by running it on a detached clean `origin/main`
worktree, where it fails identically.

Honest caveat on scope: the **full** 23k-test suite did not complete on this host.
It is not a hang in this change — 17 concurrent `pytest` processes from six other
worktrees were running `-n auto` simultaneously, starving the run, and the same
command completed in ~2 minutes on this repo earlier today. I ran the blast radius
under reduced parallelism instead rather than report a green I had not seen. CI's
own full run is the authority here, and the diff touches one function in one
handler.
