### PR TITLE
feat(i18n): gate untranslated text at render time under the en-XA pseudolocale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,6 +644,41 @@ jobs:
         working-directory: website
         run: npx playwright install --with-deps chromium
 
+      - name: i18n render-time gate (en-XA + shipped locales)
+        # Phase 5 of the i18n plan. Every other i18n gate reads SOURCE or CATALOG
+        # JSON, so three defect classes are invisible to all of them: a string that
+        # was never extracted (ordinary TypeScript to a scanner), a sentence
+        # assembled from several keys (several correct lookups), and English in a
+        # title/aria-label (never in the text flow). This renders the real SPA under
+        # the en-XA pseudolocale and reads them off the DOM.
+        #
+        # It lives in this job to reuse the Chromium install on the step above --
+        # its own job would re-download the browser for a ~5min script. It needs no
+        # gateway, no token and no backend: the script serves the build over
+        # loopback and answers every /api/** call from fixtures, like the
+        # capture-*.mjs harnesses. It builds its OWN bundle rather than reusing
+        # `npm run build` above, because en-XA is DEV-only and a production build
+        # tree-shakes the catalog out entirely.
+        #
+        # Two runs, one per tree: [vs-base] renders the BASE commit with the same
+        # scanner and fails on any per-surface increase, reading no committed number.
+        # That is what makes the ledger's upward-only ceilings legitimate under
+        # website/AGENTS.md's rule -- there is nothing to re-snapshot a regression
+        # into. The base ref must be fetched first because this checkout is shallow;
+        # the script EXITS NON-ZERO if a configured ref cannot be resolved rather
+        # than skipping itself green, for the reason the frontend-lint job documents.
+        working-directory: website
+        env:
+          I18N_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
+        run: |
+          if [ -n "$I18N_BASE_REF" ]; then
+            git fetch --depth=1 origin "${I18N_BASE_REF#origin/}" \
+              || { echo "::error::could not fetch base ref ${I18N_BASE_REF#origin/}; the diff-scoped render gate cannot run"; exit 1; }
+            git update-ref "refs/remotes/$I18N_BASE_REF" FETCH_HEAD \
+              || { echo "::error::could not update $I18N_BASE_REF; the diff-scoped render gate cannot run"; exit 1; }
+          fi
+          npm run i18n:render
+
       - name: Run E2E (smoke + Playwright)
         # KIROCREW_E2E=1 is set by `setup.py test_e2e` itself. KIROCREW_E2E_REQUIRE=1
         # turns environment-resolution misses (missing website dir, Playwright CLI,

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -5,6 +5,12 @@ coverage
 *.tsbuildinfo
 .vite
 
+# The DEV-mode bundle the i18n render gate builds (scripts/check-i18n-render.mjs).
+# A separate output dir on purpose: it is NOT shippable — `import.meta.env.DEV` is
+# true, so it carries the en-XA pseudolocale catalog and dev-only tooling. The bare
+# `dist` rule above does not cover it.
+dist-dev
+
 # Electron
 electron/dist
 electron/node_modules

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -373,6 +373,7 @@ committed number can always be re-snapshotted past.
 | catalog QA violations, per check | `CEILINGS` in `src/i18n/qa.test.ts` | `check-source-strings.mjs` **[changed-values]** — QA on any value you added or changed |
 | unextracted JSX strings | `--baseline=N` in `package.json` | **[added-lines]** — same population, no ledger |
 | host-locale calls | `BASELINE` in `src/i18n/localeFormatting.test.ts` | that file's own **[added-lines]** / **[vs-base]** — a `toLocale*`/`localeCompare` on a line you wrote, or a touched file whose count grew vs the base ref |
+| render-time defects, per surface | `src/i18n/render-baseline.json` | `check-i18n-render.mjs` **[vs-base]** — renders the base commit and fails on any per-surface increase |
 
 For these four, a decrease is reported and tolerated: you do not re-snapshot anything,
 and a change that improves one of these numbers without editing it will pass.
@@ -416,6 +417,87 @@ none of them caused this.
 
 To see the QA worklist the deleted allowlist used to hold:
 `I18N_QA_REPORT=1 npx vitest run src/i18n/qa.test.ts`.
+
+### The render-time gate: what a source scan structurally cannot see
+
+Every gate above reads **source** (an eslint pass over `src`) or **catalog JSON**. Three
+defect classes are invisible to all of them, not by oversight but by construction:
+
+| Defect | Why the static gates miss it |
+|---|---|
+| a string that was never extracted | it is ordinary TypeScript — `` `${h}h ${m}m ${s}s` `` in `useUptime.ts` reads as arithmetic, and shipped for months |
+| a sentence assembled from several keys | it is several *correct* `t()` calls; only the rendered line shows the seam |
+| English in `title` / `aria-label` / `placeholder` | attribute text never enters the text flow, so nothing that walks prose sees it |
+
+`npm run i18n:render` (`scripts/check-i18n-render.mjs`) closes them. It renders the real
+built SPA under the **`en-XA` pseudolocale**, where `gen-pseudolocale.mjs` has already
+guaranteed the two properties the whole check rests on: every catalog value is wrapped in
+`[` … `]`, and every ASCII letter outside a preserved region is accented. So inside one
+inline run, a `]…[` seam **is** a surviving concatenation, and plain Latin **is** text
+that never reached a catalog. It needs no gateway, no token and no backend — it serves
+the build over loopback and answers every `/api/**` call from fixtures, exactly like the
+`capture-*.mjs` harnesses.
+
+Four things to know before you touch it:
+
+1. **It builds its own bundle, with `NODE_ENV=development`.** `en-XA` is DEV-only in
+   three independent places (`index.ts` tree-shakes the catalog, `isRestorableLanguage()`
+   refuses the stored code, `DETECTABLE_CODES` hides it), all keyed on
+   `import.meta.env.DEV`. `vite build --mode development` is **not** enough — Vite derives
+   DEV from `NODE_ENV`, not from `--mode`. Get this wrong and the gate does not fail, it
+   renders English and passes; `assertPseudoActive()` exists so that can never be silent.
+2. **A crashed surface is exit 2, not findings.** If a fixture is the wrong shape the
+   error boundary replaces the panel with its own English message, and a naive scan would
+   report *that* as untranslated copy. Any uncaught page error aborts the run instead.
+3. **DNT integrity runs only in real locales.** The pseudolocale accents DNT terms too
+   (`GitHub` → `ĞìţĤùƀ`), so asserting them under `en-XA` would report all 19 as mangled.
+   It is zero-tolerance, and it deliberately accepts an all-lowercase hit as the command
+   (`git push`, `docker run`) rather than a mangled product name.
+4. **Enforcement is `[vs-base]`, not the ledger.** The gate renders the BASE commit
+   with the same scanner and fails on any per-surface increase, reading no committed
+   number — so there is nothing to re-snapshot and nothing to absorb a regression
+   with. `src/i18n/render-baseline.json` (three buckets: `text`, `layout`, `latent`,
+   keyed per surface, upward-only) is a **debt record and the push-to-`main` backstop**,
+   where there is no base to diff against. It is allowed to sit above reality; a
+   decrease is reported, never required. Goal is 0 for every entry.
+
+   Per-surface keys alone would *not* have satisfied the rule at the top of this
+   section. A finer ledger only shrinks the range you can trade within — it is still a
+   committed number, and `--update` still absorbs anything. The measured proof: inflate
+   `settings-about.text` from 28 to 100, add 18 real defects, and the ledger reports an
+   *improvement* while `[vs-base]` fails with `28 -> 46 (+18)`.
+
+`latent` holds `ellipsis-with-flex-parent` on its own — ~544 sites where
+`text-overflow: ellipsis` cannot apply because a flex child's `min-width` is still `auto`,
+so the truncation those sites think they have does nothing. Real, but a uniform `min-w-0`
+cleanup that would otherwise bury the handful of actual overflows in `layout`.
+
+The base tree is exported with `git archive`, never `git worktree add`. A worktree
+registers itself in the repo, so a run killed mid-flight leaves a stale registration that
+breaks every later run — and the obvious recovery, `git worktree prune`, removes the
+registration of any worktree whose path is not visible from where it runs, which in a
+container that mounts the checkout elsewhere means the caller's own. `git archive` touches
+no repo state, needs no cleanup, and works on CI's shallow checkout.
+
+**Regenerate the ledger on Linux + the pinned Chromium, not on your laptop.** `layout` and
+`latent` are pixel measurements, so they depend on the platform's font metrics and on which
+faces are installed. A macOS-regenerated ledger will not match CI, and if it lands *lower*
+than CI measures, `main` goes red on a file nobody edited. `[vs-base]` is immune (both
+sides are measured in the same run on the same box), which is another reason it carries
+enforcement — but `--update` is not. Use the same image CI does:
+
+```sh
+docker run --rm --ipc=host -v "$PWD":/w -w /w/website \
+  mcr.microsoft.com/playwright:v1.58.2-jammy \
+  node scripts/check-i18n-render.mjs --build --update
+```
+
+The analysis is in `scripts/lib/render-scan.mjs`, which runs in **two** runtimes from one
+copy: Node (so `renderScan.test.ts` can unit-test the string logic) and the browser (via
+`browserBundle()`, which strips the `export` keywords and injects it with
+`addScriptTag`). Keep it import-free, or the browser half stops loading. Its tests also
+lock the pseudolocale invariants it borrows, so a change to the generator's delimiters
+fails a test instead of quietly making the gate find nothing.
 
 **Gotcha — the settings-search extractor.** `scripts/settingsExtract.ts` parses
 Settings panels to generate `settingsRegistry.gen.ts` (which powers

--- a/website/package.json
+++ b/website/package.json
@@ -29,6 +29,7 @@
     "lint:theme-colors": "node scripts/check-theme-colors.mjs",
     "lint:i18n": "node scripts/check-i18n-strings.mjs",
     "i18n:pseudo": "node scripts/gen-pseudolocale.mjs",
+    "i18n:render": "node scripts/check-i18n-render.mjs --build",
     "i18n:check": "node scripts/gen-pseudolocale.mjs --check && node scripts/check-i18n-keys.mjs && node scripts/i18n-codemod.mjs --check --baseline=3 && node scripts/i18n-plural-codemod.mjs --check && node scripts/check-source-strings.mjs && npm run lint:i18n",
     "pretest": "npm run jscpd"
   },

--- a/website/scripts/check-i18n-render.mjs
+++ b/website/scripts/check-i18n-render.mjs
@@ -1,0 +1,707 @@
+#!/usr/bin/env node
+/**
+ * Phase 5 — the render-time i18n gate.
+ *
+ * ## What this catches that nothing else can
+ *
+ * Every other i18n gate in this repo reads source or catalog JSON:
+ *   - `check-i18n-strings.mjs` runs eslint over `src` — it sees a string literal.
+ *   - `check-source-strings.mjs` / `qa.test.ts` read catalog values.
+ *   - `catalogParity` / `deadKeys` / `glossary` compare catalogs to each other.
+ *
+ * None of them can see the rendered page, and three whole defect classes live only
+ * there. A hardcoded `"6m 38s"` built by `useUptime.ts` is ordinary TypeScript to a
+ * source scanner. A sentence assembled from three catalog keys is three correct
+ * lookups. An English `aria-label` never enters the text flow at all. This gate
+ * renders the real built SPA under the `en-XA` pseudolocale and reads them off the
+ * DOM, which is why the plan calls it "the rendered proof of Phases 1-3, not a
+ * catalog assertion".
+ *
+ * ## How it runs with no gateway and no credentials
+ *
+ * It serves the REAL build over loopback (`lib/serve-dist.mjs`) and answers every
+ * `/api/**` call from fixtures (`lib/stub-dashboard-api.mjs`), the same mechanism
+ * the `capture-*.mjs` harnesses use. No token, no Python backend, no model calls.
+ *
+ * ## The one build requirement
+ *
+ * `en-XA` is DEV-only in three independent places (`index.ts` tree-shakes the
+ * catalog out, `isRestorableLanguage()` refuses the stored code, `DETECTABLE_CODES`
+ * hides it), all keyed on `import.meta.env.DEV`. `vite build --mode development` is
+ * NOT enough — Vite derives DEV from `NODE_ENV`, not from `--mode` — so the bundle
+ * this gate needs is built with `NODE_ENV=development`. Verified: without it the
+ * accented catalog is absent from `dist/assets/*.js` entirely and every surface
+ * renders English, which would make the gate silently pass. `assertPseudoActive()`
+ * below exists so that failure mode can never be silent again.
+ *
+ * ## Enforcement shape (post-#1060 doctrine)
+ *
+ *   - `dnt` findings are ZERO TOLERANCE. The catalog-level DNT check
+ *     (`glossary.test.ts`) already passes, so any render-level violation is new.
+ *   - **[vs-base] is the gate.** With `I18N_BASE_REF` set, this renders the BASE
+ *     commit too — same scanner, same surfaces, same locales, only the bundle
+ *     differs — and fails on any per-surface increase. It reads no committed
+ *     number, so there is nothing to re-snapshot and nothing to absorb a
+ *     regression with. That is what licenses the ledger below to be upward-only
+ *     under `website/AGENTS.md`'s rule.
+ *   - the LEDGER (`src/i18n/render-baseline.json`) is a debt record and the
+ *     backstop for a push to `main`, where there is no base to diff. Upward-only,
+ *     keyed per surface, allowed to sit above reality; a decrease is reported,
+ *     never required. Goal 0 for every entry.
+ *
+ * A finer ledger alone would NOT have been enough, and it is worth being precise
+ * about why: per-surface keys only shrink the range a regression can hide within.
+ * Measured — inflate `settings-about.text` from 28 to 100, add 18 real defects, and
+ * the ledger reports an *improvement* while [vs-base] fails with `28 -> 46 (+18)`.
+ *
+ * Usage:
+ *   npm run i18n:render                                   # build + gate (+ vs-base)
+ *   node scripts/check-i18n-render.mjs --build --update    # build + reseed ledger
+ *   node scripts/check-i18n-render.mjs                     # gate an existing dist-dev
+ *   node scripts/check-i18n-render.mjs --no-vs-base        # ledger only, skip base render
+ *   node scripts/check-i18n-render.mjs --surface chat --locale en-XA --verbose
+ *   I18N_BASE_REF=origin/main node scripts/check-i18n-render.mjs --build
+ *
+ * Exit codes: 0 clean · 1 regression · 2 cannot run (build missing, no browser,
+ * pseudolocale not active).
+ */
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, symlinkSync } from 'node:fs'
+import { spawnSync, execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { serveDist } from './lib/serve-dist.mjs'
+import { stubDashboardApi, logPageProblems, json } from './lib/stub-dashboard-api.mjs'
+import { SURFACES, LOCALES, VIEWPORTS } from './lib/i18n-surfaces.mjs'
+import { browserBundle } from './lib/render-scan.mjs'
+
+const SCAN_SRC = fileURLToPath(new URL('./lib/render-scan.mjs', import.meta.url))
+const LEDGER = fileURLToPath(new URL('../src/i18n/render-baseline.json', import.meta.url))
+const GLOSSARY = fileURLToPath(new URL('../src/i18n/glossary.json', import.meta.url))
+/** Repo root — `website/`'s parent, where every git call is rooted. */
+const REPO = fileURLToPath(new URL('../..', import.meta.url))
+
+const argv = process.argv.slice(2)
+const has = f => argv.includes(f)
+const opt = (f, d) => {
+  const i = argv.indexOf(f)
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : d
+}
+
+const BUILD = has('--build')
+const NO_VS_BASE = has('--no-vs-base')
+const UPDATE = has('--update')
+const VERBOSE = has('--verbose')
+const DIST = fileURLToPath(new URL(`../${opt('--dist', 'dist-dev')}/`, import.meta.url))
+const ONLY_SURFACE = opt('--surface', '')
+const ONLY_LOCALE = opt('--locale', '')
+
+const die = msg => {
+  console.error(`\n[i18n-render] ${msg}\n`)
+  process.exit(2)
+}
+
+/**
+ * Fixture values are deliberately digit-shaped or non-Latin.
+ *
+ * Anything word-shaped in a fixture renders into the page and is indistinguishable
+ * from a hardcoded English string, so it would show up as a leak the branch cannot
+ * fix. The shared stub's defaults (`user: 'owner'`, agents `kirocrew`/`oncall`) are
+ * overridden below for exactly that reason.
+ *
+ * The two non-obvious shapes are load-bearing, and both error-boundary the WHOLE
+ * app shell rather than degrading:
+ *   - a chat slot with no `key`: the command palette's recents provider maps
+ *     `slots.map(s => s.key.startsWith('dashboard_'))`, so a keyless slot throws on
+ *     every route that mounts the palette — which is all of them.
+ *   - `/api/security/denied-commands` as an array: SecurityPanel guards `dc?.builtins`
+ *     in one place but reads `dc.builtins.length` unguarded in another, and `[]` is
+ *     truthy, so the panel throws instead of rendering empty.
+ */
+const SLOT_KEY = '0100'
+
+const FIXTURE_SLOTS = [{
+  key: SLOT_KEY,
+  title: '0101',
+  running: false,
+  last_message: '0102',
+  messages: 2,
+  agent: '0001',
+  memory_mode: 'persistent',
+  project: '/0002',
+  model: '',
+  reasoning_effort: '',
+  modified: 1750000000,
+  source_links: [],
+  source_links_total: 0,
+}]
+
+const FIXTURE_OVERRIDES = async (language, path, route) => {
+  // `stubDashboardApi` treats a TRUTHY return as "handled". `json()` resolves to
+  // undefined (that is what `route.fulfill()` returns), so an override must await
+  // it and return true explicitly — returning the promise falls through to the
+  // shared arm and Playwright throws "Route is already handled".
+  const done = async body => { await json(route, body); return true }
+  // LanguageProvider treats the boot payload as authoritative over the
+  // localStorage fast-path, so a payload with no `language` reverts the UI to
+  // English mid-boot and turns a localised pass into an English one.
+  if (path === '/api/theme/boot') return done({ mode: 'dark', theme: '', language })
+  if (path === '/api/auth/me') return done({ user: '0000', app: '' })
+  if (path === '/api/agents' || path === '/api/chat/agents') {
+    return done([{ name: '0001', source: 'builtin' }])
+  }
+  if (path === '/api/recent-projects') return done({ dirs: ['/0002'] })
+  if (path === '/api/dashboard/branding') return done({ bot_name: 'Kiro', avatar: '' })
+  if (path === '/api/chat/slots') return done(FIXTURE_SLOTS)
+  if (path.startsWith('/api/chat/slots/')) {
+    return done({ key: SLOT_KEY, messages: [], running: false, agent: '0001' })
+  }
+  if (path === '/api/security/denied-commands') {
+    return done({ builtins: [], user_added: [], policy_pinned: [] })
+  }
+  if (path === '/api/security/posture') return done({ posture: {} })
+  return false
+}
+
+/**
+ * Run a DEV-mode vite build and return only whether it worked.
+ *
+ * Output is CAPTURED, not inherited: vite prints a line per emitted asset, and this
+ * gate runs two builds, so inheriting would bury the actual findings under ~200 lines
+ * of asset table in the CI log. On failure the tail is printed, which is the only time
+ * any of it is useful.
+ */
+function runViteDevBuild(cwd, outDir, label) {
+  const vite = fileURLToPath(new URL('../node_modules/vite/bin/vite.js', import.meta.url))
+  if (!existsSync(vite)) die(`cannot find vite at ${vite}; run \`npm ci\` in website/ first.`)
+  const started = Date.now()
+  const res = spawnSync(
+    process.execPath,
+    [vite, 'build', '--mode', 'development', '--outDir', outDir, '--emptyOutDir'],
+    {
+      cwd,
+      // The ONLY thing that makes `import.meta.env.DEV` true in a build. `--mode
+      // development` alone is not enough: Vite derives DEV from NODE_ENV, and with
+      // just the mode flag the en-XA catalog is tree-shaken out and every surface
+      // renders English.
+      env: { ...process.env, NODE_ENV: 'development' },
+      encoding: 'utf-8',
+    },
+  )
+  if (res.status !== 0) {
+    console.error(`${res.stdout || ''}\n${res.stderr || ''}`.trim().split('\n').slice(-25).join('\n'))
+    die(`[${label}] vite build failed (exit ${res.status})`)
+  }
+  console.log(`[i18n-render] [${label}] built in ${((Date.now() - started) / 1000).toFixed(0)}s`)
+}
+
+/**
+ * Build the bundle this gate needs, in-process.
+ *
+ * This lives here rather than in an npm script because the requirement is a
+ * NODE_ENV, and `"NODE_ENV=development vite build"` in package.json is shell
+ * syntax that cmd.exe does not understand — no other script in this file needs a
+ * shell, and adding `cross-env` for one line is not worth a dependency. Spawning
+ * vite's JS entry through `process.execPath` also avoids the `.bin` shim, which is
+ * the same Windows ENOENT trap `check-source-strings.mjs` hit with `npx`.
+ */
+function buildDevBundle(outDir) {
+  runViteDevBuild(fileURLToPath(new URL('..', import.meta.url)), outDir, 'HEAD')
+}
+
+/**
+ * Decide whether to run the diff-scoped half, and against which commit.
+ *
+ * Mirrors `check-i18n-strings.mjs`'s contract deliberately, including the parts that
+ * look defensive:
+ *   - no `I18N_BASE_REF` means there is genuinely no base (a push to `main`), so the
+ *     ledger runs alone.
+ *   - a ref that IS configured but cannot be resolved is a HARD failure, never a
+ *     green skip. `ci.yml` records having watched a sibling gate skip itself green on
+ *     a failed fetch and silently stop checking for a whole PR.
+ *   - prefer the merge base so commits that landed on the base branch after this one
+ *     forked are not attributed to this branch; fall back to the base tip, because CI
+ *     checks out at depth 1 and fetches the base at depth 1 too, so the two have no
+ *     shared history and `merge-base` fails there.
+ */
+function resolveBaseScope() {
+  if (NO_VS_BASE) return { run: false, reason: '--no-vs-base' }
+  if (ONLY_SURFACE || ONLY_LOCALE) return { run: false, reason: 'partial run (--surface/--locale)' }
+  if (UPDATE) return { run: false, reason: '--update only reseeds the ledger' }
+  const baseRef = process.env.I18N_BASE_REF
+  if (!baseRef) {
+    return { run: false, reason: 'I18N_BASE_REF is unset, so there is no branch to diff (push to main)' }
+  }
+
+  const git = args => execFileSync('git', args, { cwd: REPO, encoding: 'utf-8' }).trim()
+  try {
+    git(['rev-parse', '--verify', `${baseRef}^{commit}`])
+  } catch {
+    die(`cannot resolve ${baseRef}. The diff-scoped render gate needs the base ref; fetch it\n`
+      + '    before running this script, or unset I18N_BASE_REF to check only the ledger.')
+  }
+
+  let sha
+  try {
+    sha = git(['merge-base', baseRef, 'HEAD'])
+  } catch {
+    sha = git(['rev-parse', `${baseRef}^{commit}`])
+  }
+  if (sha === git(['rev-parse', 'HEAD'])) {
+    return { run: false, reason: 'HEAD is the base commit' }
+  }
+
+  // Nothing renderable changed, so the base render is guaranteed identical and the
+  // second build+sweep would be ~2.5 minutes of CI for a known answer. Scoped to what
+  // can actually alter a rendered surface: app source, the catalogs, the build config.
+  const changed = git(['diff', '--name-only', `${sha}`, 'HEAD']).split('\n').filter(Boolean)
+  const renderable = changed.filter(f => /^website\/(src\/|index\.html|vite\.config|tailwind|postcss|package\.json)/.test(f))
+  if (!renderable.length) {
+    return { run: false, reason: `no renderable file changed vs ${sha.slice(0, 8)} (${changed.length} file(s) in diff)` }
+  }
+  return { run: true, sha, changed: renderable.length }
+}
+
+/**
+ * Build the base commit's bundle from a read-only export of its tree.
+ *
+ * `git archive` rather than `git worktree add`, deliberately and after being burned:
+ * a worktree REGISTERS itself in the repo, so it needs cleanup, and a run killed
+ * mid-flight leaves a stale registration that breaks every later run. The obvious
+ * recovery — `git worktree prune` — is far too blunt: it removes the registration of
+ * ANY worktree whose path is not visible from where it runs, which in a container
+ * that mounts the checkout at a different path means the caller's own worktree. It
+ * did exactly that to me once. `git archive` touches no repo state at all, needs no
+ * cleanup, cannot corrupt anything, and works on the shallow clone CI checks out.
+ *
+ * Only `website/` is exported: nothing in its build config reaches outside it.
+ * `node_modules` is symlinked rather than installed — a second `npm ci` would cost
+ * minutes, and the base's dependency set only matters if the lockfile changed, which
+ * a render gate is not the right place to police.
+ */
+function buildBaseBundle(sha) {
+  const dir = join(tmpdir(), `i18n-render-base-${sha.slice(0, 12)}`)
+  rmSync(dir, { recursive: true, force: true })
+  mkdirSync(dir, { recursive: true })
+  console.log(`[i18n-render] [vs-base] exporting base tree ${sha.slice(0, 8)}`)
+
+  const tarball = join(dir, 'base.tar')
+  try {
+    const out = execFileSync('git', ['archive', '--format=tar', '-o', tarball, sha, 'website'],
+      { cwd: REPO, stdio: 'pipe' })
+    void out
+    execFileSync('tar', ['-xf', tarball, '-C', dir], { stdio: 'pipe' })
+    rmSync(tarball, { force: true })
+  } catch (err) {
+    die(`could not export base tree ${sha}: ${err.message}`)
+  }
+
+  const baseWeb = join(dir, 'website')
+  if (!existsSync(join(baseWeb, 'package.json'))) {
+    die(`base tree ${sha} has no website/ — cannot render it`)
+  }
+  // `junction`, not `dir`, on Windows: creating a directory SYMLINK there needs
+  // elevated privileges or Developer Mode, so a plain `dir` link fails with EPERM on
+  // a stock Windows dev box and takes the whole gate down with exit 2. A junction
+  // needs no privilege. It requires an absolute target, which this already is.
+  symlinkSync(
+    join(fileURLToPath(new URL('..', import.meta.url)), 'node_modules'),
+    join(baseWeb, 'node_modules'),
+    process.platform === 'win32' ? 'junction' : 'dir',
+  )
+
+  runViteDevBuild(baseWeb, 'dist-dev', `base ${sha.slice(0, 8)}`)
+  TEMP_DIRS.push(dir)
+  return join(baseWeb, 'dist-dev')
+}
+
+/** Exported base trees to delete on exit. Plain directories — no repo state involved. */
+const TEMP_DIRS = []
+process.on('exit', () => {
+  for (const dir of TEMP_DIRS) {
+    try { rmSync(dir, { recursive: true, force: true }) } catch { /* best effort */ }
+  }
+})
+
+async function main() {
+  if (BUILD) buildDevBundle(opt('--dist', 'dist-dev'))
+  if (!existsSync(new URL('index.html', `file://${DIST}`))) {
+    die(`no build at ${DIST}\n  Build the DEV bundle first (en-XA is stripped from a production build):\n`
+      + '    npm run i18n:render        # builds, then gates\n'
+      + '    node scripts/check-i18n-render.mjs --build')
+  }
+
+  let chromium
+  try {
+    ({ chromium } = await import('playwright'))
+  } catch {
+    die('playwright is not installed. Run `npx playwright install --with-deps chromium`.')
+  }
+
+  const scanScript = browserBundle(readFileSync(SCAN_SRC, 'utf-8'))
+  const dnt = JSON.parse(readFileSync(GLOSSARY, 'utf-8')).dnt
+  const surfaces = ONLY_SURFACE ? SURFACES.filter(s => s.id === ONLY_SURFACE) : SURFACES
+  const locales = ONLY_LOCALE ? LOCALES.filter(l => l.code === ONLY_LOCALE) : LOCALES
+  if (!surfaces.length) die(`unknown --surface ${ONLY_SURFACE}`)
+  if (!locales.length) die(`unknown --locale ${ONLY_LOCALE}`)
+
+  const browser = await chromium.launch()
+  let head
+  let baseAll = null
+  try {
+    head = await sweep(browser, DIST, { scanScript, dnt, surfaces, locales, label: 'HEAD' })
+
+    // The diff-scoped half. Everything about it is derived at runtime from two
+    // trees; nothing is read from a committed number, which is the whole point.
+    const scope = resolveBaseScope()
+    if (scope.run) {
+      const baseDist = buildBaseBundle(scope.sha)
+      // Deliberately the SAME scanScript, surfaces and locales as the HEAD run —
+      // they come from this checkout, not from the base tree. Only the BUNDLE is
+      // base's. If the base tree's own scanner were used instead, any change to the
+      // detector would read as a product regression (or mask one).
+      baseAll = (await sweep(browser, baseDist, {
+        scanScript, dnt, surfaces, locales, label: `base ${scope.sha.slice(0, 8)}`,
+      })).all
+    } else if (scope.reason) {
+      console.log(`[i18n-render] [vs-base] skipped — ${scope.reason}`)
+    }
+  } finally {
+    await browser.close()
+  }
+
+  report(head.all)
+  const partial = !!(ONLY_SURFACE || ONLY_LOCALE)
+  process.exit(reconcile(head.all, baseAll, { partial }))
+}
+
+/**
+ * Render every surface in every locale against ONE bundle and return the findings.
+ *
+ * Factored out so the HEAD and base runs are provably the same measurement: a
+ * difference between them can then only come from the bundles, never from how they
+ * were measured.
+ */
+async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label }) {
+  const { srv, base } = await serveDist(dist)
+  /** @type {Array<{surface: string, locale: string, viewport: string, finding: object}>} */
+  const all = []
+  let pseudoSeen = false
+
+  try {
+    for (const locale of locales) {
+      for (const viewport of VIEWPORTS) {
+        const context = await browser.newContext({
+          viewport: { width: viewport.width, height: viewport.height },
+          // Pin the browser tags too. Detection is only consulted when no explicit
+          // choice is stored, but leaving the runner's own locale in play makes the
+          // gate's result depend on the machine it ran on.
+          locale: locale.code === 'en-XA' ? 'en-US' : locale.code,
+          // Layout animations change measured widths mid-flight, and every width
+          // this gate reports would otherwise be a race.
+          reducedMotion: 'reduce',
+        })
+        await context.addInitScript(code => {
+          localStorage.setItem('mc-lang', code)
+          localStorage.setItem('mc-onboarded', '1')
+          localStorage.setItem('mc-import-onboarded', '1')
+        }, locale.code)
+
+        const page = await context.newPage()
+        if (VERBOSE) logPageProblems(page)
+        // A crashed surface is the gate's most dangerous failure mode, because it
+        // does not look like a failure: React's error boundary replaces the panel
+        // with its own English message, the scan dutifully reports that message as
+        // untranslated copy, and the ledger absorbs a number that has nothing to do
+        // with the product. Treat any uncaught page error as INFRASTRUCTURE broken
+        // (exit 2) rather than as findings.
+        const pageErrors = []
+        page.on('pageerror', err => pageErrors.push(String(err.message || err)))
+        await stubDashboardApi(page, {
+          theme: 'dark',
+          extra: (path, route) => FIXTURE_OVERRIDES(locale.code, path, route),
+        })
+
+        for (const surface of surfaces) {
+          pageErrors.length = 0
+          await page.goto(base + surface.url, { waitUntil: 'domcontentloaded' })
+          // Wait for the shell to actually paint. A fixed sleep raced the first
+          // render and made the gate report zero findings on a surface it never
+          // saw — the quietest possible false pass. The predicate is deliberately
+          // locale-agnostic (text VOLUME, not any particular string) so it works
+          // identically under the pseudolocale and under zh-CN.
+          try {
+            await page.waitForFunction(
+              () => document.body.innerText.trim().length > 100, { timeout: 15000 },
+            )
+          } catch {
+            die(`[${label}] ${surface.url} rendered nothing in 15s — the fixtures are probably `
+              + 'the wrong shape for this surface (see lib/boot-api.mjs for the two shapes that '
+              + 'error-boundary the whole shell). Re-run with --verbose to see the page errors.')
+          }
+          // Panels that fetch after mount need a beat more; a half-rendered surface
+          // under-reports rather than failing loudly.
+          await page.waitForTimeout(surface.settle || 250)
+          // Every width this gate reports is a text measurement, and text measures
+          // differently in the fallback face than in the real one. Scanning before
+          // the webfonts land made the layout bucket differ by 2 between identical
+          // runs (artifacts.layout 4 vs 2), which would have made the whole gate
+          // flaky rather than wrong. Two rAF ticks after that let the resulting
+          // reflow finish before anything is read.
+          await page.evaluate(() => document.fonts.ready)
+          await page.evaluate(() => new Promise(r => requestAnimationFrame(
+            () => requestAnimationFrame(() => r(null)),
+          )))
+          if (pageErrors.length) {
+            die(`[${label}] ${surface.url} (${locale.code}) threw while rendering, so its `
+              + 'findings would be the error boundary\'s own English copy rather than the '
+              + `product's:\n${pageErrors.slice(0, 3).map(e => `      ${e}`).join('\n')}`
+              + '\n    Fix the fixture shape in FIXTURE_OVERRIDES, or drop the surface from '
+              + 'lib/i18n-surfaces.mjs with a comment saying why.')
+          }
+          await page.addScriptTag({ content: scanScript })
+
+          if (locale.mode === 'pseudo' && !pseudoSeen) {
+            pseudoSeen = await assertPseudoActive(page, surface)
+          }
+          const findings = await page.evaluate(
+            o => window.__I18N_SCAN.scanDocument(o),
+            { mode: locale.mode, minLetters: 1, dnt: locale.mode === 'real' ? dnt : [] },
+          )
+          for (const finding of findings) {
+            all.push({ surface: surface.id, locale: locale.code, viewport: viewport.id, finding })
+          }
+        }
+        await context.close()
+      }
+    }
+  } finally {
+    srv.close()
+  }
+
+  if (locales.some(l => l.mode === 'pseudo') && !pseudoSeen) {
+    die(`[${label}] the en-XA catalog never rendered — this build is not a DEV build, so the `
+      + 'text assertions would have passed against English.\n'
+      + '    node scripts/check-i18n-render.mjs --build')
+  }
+  return { all }
+}
+
+/**
+ * Prove the pseudolocale is live before trusting a single text assertion.
+ *
+ * Without this the gate's most likely failure is also its quietest: a production
+ * bundle renders plain English, every string is un-accented but also outside any
+ * `[` … `]` unit... and the scan happily reports whatever English text it finds as
+ * leaks, or — if the ledger was recorded the same way — reports nothing at all.
+ */
+async function assertPseudoActive(page, surface) {
+  try {
+    await page.waitForFunction(
+      () => /[\u00C0-\u024F]/.test(document.body.innerText)
+        && document.body.innerText.includes('['),
+      { timeout: 10000 },
+    )
+    return true
+  } catch {
+    if (VERBOSE) console.log(`[i18n-render] no accented text on ${surface.id}`)
+    return false
+  }
+}
+
+/** Group findings and print the prescriptive output Phase 5 item 3 requires. */
+function report(all) {
+  if (!all.length) {
+    console.log('[i18n-render] no findings')
+    return
+  }
+  /** @type {Map<string, {count: number, worst: {locale: string, ratio: number}, sample: object}>} */
+  const bySignature = new Map()
+  for (const { locale, finding } of all) {
+    const key = `${finding.kind}/${finding.signature}`
+    const prev = bySignature.get(key)
+    const ratio = finding.ratio || 0
+    if (!prev) {
+      bySignature.set(key, { count: 1, worst: { locale, ratio }, sample: finding })
+    } else {
+      prev.count++
+      if (ratio > prev.worst.ratio) prev.worst = { locale, ratio }
+    }
+  }
+  console.log('\n[i18n-render] findings by signature\n')
+  for (const [key, v] of [...bySignature].sort((a, b) => b[1].count - a[1].count)) {
+    console.log(`  ${String(v.count).padStart(5)}  ${key}`)
+    console.log(`         worst: ${v.worst.locale}${v.worst.ratio ? ` @ ${v.worst.ratio}x` : ''}`)
+    console.log(`         e.g.:  ${v.sample.path}`)
+    console.log(`                ${JSON.stringify(v.sample.text)}`)
+    if (v.sample.fixedAncestor) console.log(`         ancestor: ${v.sample.fixedAncestor}`)
+    console.log(`         fix:   ${v.sample.fix}\n`)
+  }
+  if (VERBOSE) {
+    console.log('[i18n-render] every finding\n')
+    for (const { surface, locale, viewport, finding } of all) {
+      console.log(`  ${surface} ${locale} ${viewport} ${finding.signature} ${finding.path}`)
+      console.log(`      ${JSON.stringify(finding.text)}${finding.detail ? ` -- ${finding.detail}` : ''}`)
+    }
+  }
+}
+
+/**
+ * Ledger buckets.
+ *
+ *   text   — never reached a catalog, or was assembled from several keys.
+ *   layout — the text does not fit RIGHT NOW, in some shipped locale.
+ *   latent — a pattern that is silently broken but not yet visible, which today
+ *            means `ellipsis-with-flex-parent`: `text-overflow` cannot apply while
+ *            a flex child's `min-width` is `auto`, so the truncation those sites
+ *            think they have does nothing and the text pushes its sibling out
+ *            instead. It is kept separate because there are ~460 of them and
+ *            folding them into `layout` would bury the handful of real overflows
+ *            under a uniform `min-w-0` cleanup that belongs to its own PR.
+ */
+const BUCKETS = ['text', 'layout', 'latent']
+
+const bucketOf = finding => {
+  if (finding.kind !== 'layout') return 'text'
+  return finding.signature === 'ellipsis-with-flex-parent' ? 'latent' : 'layout'
+}
+
+/** Compare against the ledger, or rewrite it under `--update`. */
+/**
+ * Two independent checks, in decreasing order of strength.
+ *
+ * 1. **[vs-base]** — the real gate. Renders the base tree with the SAME scanner and
+ *    fails on any per-surface increase. It reads no committed number, so there is
+ *    nothing to re-snapshot and nothing to absorb a regression with: the bypass that
+ *    made the old bidirectional ratchets decorative (`195904c` shipped 113
+ *    untranslated strings while RAISING `_total`, green) does not exist here.
+ * 2. **ledger** — upward-only, per surface. With [vs-base] carrying enforcement this
+ *    is a debt record and a backstop for the push-to-`main` case where there is no
+ *    base to diff. It is allowed to sit above reality; a decrease is reported, never
+ *    required.
+ */
+function reconcile(all, baseAll, { partial }) {
+  const tally = records => {
+    const c = {}
+    for (const s of SURFACES) c[s.id] = Object.fromEntries(BUCKETS.map(b => [b, 0]))
+    const dnt = []
+    for (const { surface, finding, locale } of records) {
+      if (finding.kind === 'dnt') { dnt.push({ surface, locale, finding }); continue }
+      c[surface][bucketOf(finding)]++
+    }
+    return { counts: c, dnt }
+  }
+
+  const { counts, dnt: dntFindings } = tally(all)
+  const zero = () => Object.fromEntries(BUCKETS.map(b => [b, 0]))
+  const totals = c => Object.fromEntries(
+    BUCKETS.map(b => [b, Object.values(c).reduce((n, x) => n + x[b], 0)]),
+  )
+
+  if (UPDATE) {
+    if (partial) die('--update needs the full run; drop --surface/--locale')
+    const ledger = {
+      _comment: 'Phase 5 render-time gate. Findings from rendering the real DEV build under '
+        + 'en-XA (text) and the shipped locales (layout/latent). This is a DEBT RECORD, not '
+        + 'the enforcement: [vs-base] renders the base tree and fails on any per-surface '
+        + 'increase without reading this file, so nothing here can absorb a regression. '
+        + 'Upward-only and keyed per surface; a decrease is reported, never required. The '
+        + 'goal for every entry is 0. Regenerate with `--update` and only commit a decrease.',
+      _total: totals(counts),
+      surfaces: counts,
+    }
+    writeFileSync(LEDGER, `${JSON.stringify(ledger, null, 2)}\n`)
+    const t = ledger._total
+    console.log(`[i18n-render] ledger written: text=${t.text} layout=${t.layout} latent=${t.latent}`)
+    return 0
+  }
+
+  if (!existsSync(LEDGER)) die(`no ledger at ${LEDGER}. Seed it with --update.`)
+  const ledger = JSON.parse(readFileSync(LEDGER, 'utf-8'))
+  let failed = false
+
+  if (dntFindings.length) {
+    failed = true
+    console.error(`\n[i18n-render] [dnt] ${dntFindings.length} do-not-translate violation(s) — zero tolerance\n`)
+    for (const { surface, locale, finding } of dntFindings.slice(0, 20)) {
+      console.error(`  ${surface} (${locale}): ${finding.detail}`)
+      console.error(`      ${finding.path}\n`)
+    }
+  }
+
+  // ---- [vs-base]: the strict, stateless half --------------------------------
+  if (baseAll) {
+    const { counts: baseCounts } = tally(baseAll)
+    const grew = []
+    const shrank = []
+    for (const s of SURFACES) {
+      for (const bucket of BUCKETS) {
+        const now = counts[s.id][bucket]
+        const was = baseCounts[s.id][bucket]
+        if (now > was) grew.push(`${s.id}.${bucket}: ${was} -> ${now} (+${now - was})`)
+        else if (now < was) shrank.push(`${s.id}.${bucket}: ${was} -> ${now} (-${was - now})`)
+      }
+    }
+    if (grew.length) {
+      failed = true
+      console.error('\n[i18n-render] [vs-base] this branch ADDS render-time i18n defects:\n')
+      for (const g of grew) console.error(`  ${g}`)
+      console.error('\n  These are measured against the base commit, not against a committed'
+        + '\n  number — there is nothing to re-snapshot. Fix the findings above.\n')
+    } else {
+      const bt = totals(baseCounts)
+      const ht = totals(counts)
+      console.log(`[i18n-render] [vs-base] OK — no surface got worse `
+        + `(base text=${bt.text}/layout=${bt.layout}/latent=${bt.latent} → `
+        + `head text=${ht.text}/layout=${ht.layout}/latent=${ht.latent})`)
+      if (shrank.length) {
+        console.log('\n[i18n-render] [vs-base] this branch FIXES:\n')
+        for (const s of shrank) console.log(`  ${s}`)
+        console.log('')
+      }
+    }
+  }
+
+  // ---- ledger: upward-only debt record --------------------------------------
+  const regressions = []
+  const improvements = []
+  for (const s of SURFACES) {
+    if (partial && ONLY_SURFACE && s.id !== ONLY_SURFACE) continue
+    const ceiling = (ledger.surfaces && ledger.surfaces[s.id]) || zero()
+    for (const bucket of BUCKETS) {
+      const now = counts[s.id][bucket]
+      const was = ceiling[bucket] || 0
+      // A partial run cannot see every locale, so it can only ever under-count.
+      // Reporting an "improvement" from that would invite a bogus ledger drop.
+      if (partial && now < was) continue
+      if (now > was) regressions.push(`${s.id}.${bucket}: ${was} -> ${now}`)
+      else if (now < was) improvements.push(`${s.id}.${bucket}: ${was} -> ${now}`)
+    }
+  }
+
+  if (regressions.length) {
+    failed = true
+    console.error('\n[i18n-render] these surfaces exceed the ledger (upward-only):\n')
+    for (const r of regressions) console.error(`  ${r}`)
+    console.error('\n  Fix the findings above. Do NOT run --update to absorb them.\n')
+  }
+  if (improvements.length) {
+    // NOT a failure. An upward-only ledger fails on growth only; failing on a
+    // decrease is the bidirectional behaviour #1060 removed, and it would turn any
+    // merge that fixes strings — #1040, say — into a red main until someone
+    // remembered to re-run --update.
+    console.log('\n[i18n-render] ledger sits above reality — lower it when convenient:\n')
+    for (const i of improvements) console.log(`  ${i}`)
+    console.log('\n  node scripts/check-i18n-render.mjs --build --update\n')
+  }
+  if (!failed) {
+    const t = totals(counts)
+    console.log(`[i18n-render] OK — text=${t.text} layout=${t.layout} latent=${t.latent} (goal 0)`)
+  }
+  return failed ? 1 : 0
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(2)
+})

--- a/website/scripts/lib/i18n-surfaces.mjs
+++ b/website/scripts/lib/i18n-surfaces.mjs
@@ -1,0 +1,78 @@
+/**
+ * The surfaces the Phase 5 render gate asserts on.
+ *
+ * WHY A REGISTRY AND NOT "every route". The gate renders each entry once per
+ * locale, so cost is linear in this list. More importantly the ledger is keyed on
+ * `id`, which makes a per-surface ceiling meaningful: adding untranslated copy to
+ * `/schedule` raises `schedule`'s own number and fails, even if some other surface
+ * improved in the same branch. A single global total would let that trade happen
+ * silently — which is exactly the bidirectional-ratchet failure #1060 removed.
+ *
+ * SELECTION. Ranked by catalog text volume x traffic x label density. Every entry
+ * is reachable by URL alone: the settings/capabilities/developer sub-panels are
+ * query-param driven, so the gate needs no click choreography and cannot fail
+ * because a selector moved. Modal and portal surfaces (command palette, credits
+ * modal, composer dropdowns) are deliberately NOT here — they need interaction, and
+ * a gate that flakes on a dropdown that did not open is a gate people disable.
+ * `fixed-overlay-off-viewport` still covers the portals that mount on load.
+ *
+ * `settle` is extra idle time in ms for surfaces that fetch after first paint.
+ */
+export const SURFACES = [
+  { id: 'chat', url: '/chat', settle: 400 },
+  { id: 'settings-display', url: '/settings?tab=display' },
+  { id: 'settings-overview', url: '/settings?tab=overview' },
+  { id: 'schedule', url: '/schedule' },
+  { id: 'settings-chat', url: '/settings?tab=chat' },
+  { id: 'settings-privacy', url: '/settings?tab=privacy' },
+  { id: 'settings-computer-use', url: '/settings?tab=computer-use' },
+  { id: 'settings-security', url: '/settings?tab=security' },
+  { id: 'settings-notifications', url: '/settings?tab=notifications' },
+  { id: 'settings-about', url: '/settings?tab=about' },
+  { id: 'capabilities-crews', url: '/capabilities?tab=crews' },
+  { id: 'capabilities-mcp', url: '/capabilities?tab=mcp' },
+  { id: 'capabilities-skills', url: '/capabilities?tab=skills' },
+  { id: 'projects', url: '/projects' },
+  { id: 'knowledge', url: '/knowledge' },
+  { id: 'artifacts', url: '/artifacts' },
+  { id: 'apps', url: '/apps' },
+  { id: 'notifications', url: '/notifications' },
+  { id: 'logs', url: '/logs' },
+  { id: 'developer-system', url: '/developer?tab=system' },
+]
+
+/**
+ * Locales the gate renders.
+ *
+ * `en-XA` is the only one the text assertions run against — it is the locale where
+ * un-accented Latin is provably untranslated. The real locales are there for the
+ * layout and DNT halves, which the pseudolocale cannot answer:
+ *
+ *   - `de` is the widest Latin script shipped (long compounds, the classic overflow
+ *     source), so it grades the pseudolocale's synthetic padding against a real one.
+ *   - `bn` is the tall script. The plan names `th`/`hi`/`ar` for vertical growth;
+ *     of those only `hi` ships, and `bn` has the taller line box, so both Indic
+ *     locales are cheaper to reason about than either alone. `ar` is deliberately
+ *     absent: no RTL locale ships until Track C.
+ *   - `zh-CN` exercises the CJK font fallback, which a pseudolocale cannot simulate.
+ *
+ * DNT integrity runs ONLY here and never on `en-XA`: `gen-pseudolocale.mjs` accents
+ * every ASCII letter outside a preserved region, and DNT terms are not preserved,
+ * so in the pseudolocale all 19 render mangled by design.
+ */
+export const LOCALES = [
+  { code: 'en-XA', mode: 'pseudo' },
+  { code: 'de', mode: 'real' },
+  { code: 'zh-CN', mode: 'real' },
+  { code: 'bn', mode: 'real' },
+]
+
+/**
+ * Viewports. The narrow one is where fixed-width ancestors actually bite; the wide
+ * one is the default desktop shell and the only place the topbar readout capsule and
+ * the rail community row are laid out at all.
+ */
+export const VIEWPORTS = [
+  { id: 'wide', width: 1440, height: 900 },
+  { id: 'narrow', width: 1024, height: 768 },
+]

--- a/website/scripts/lib/render-scan.mjs
+++ b/website/scripts/lib/render-scan.mjs
@@ -1,0 +1,579 @@
+/**
+ * Render-time i18n scanner — the DOM half of the Phase 5 gate.
+ *
+ * Every other i18n gate in this repo reads SOURCE (an eslint pass over `src`) or
+ * CATALOG JSON. Both are blind to the same two things: a string that is never
+ * extracted at all reads as ordinary TypeScript, and a sentence assembled from
+ * three catalog keys reads as three correct lookups. Only the rendered page shows
+ * either one. This file is that check.
+ *
+ * It runs against the `en-XA` pseudolocale, where `gen-pseudolocale.mjs` has
+ * already given us two properties we can assert on cheaply:
+ *
+ *   1. every catalog value is wrapped in `[` … `]`, so a `]…[` seam inside one
+ *      inline run is a surviving concatenation; and
+ *   2. every ASCII letter outside a preserved region is accented, so any plain
+ *      Latin letter outside a `[` … `]` unit is text that never reached a catalog.
+ *
+ * DUAL TARGET. The same source runs in two places, and there is deliberately only
+ * one copy of the logic:
+ *   - Node, via `import` — `renderScan.test.ts` exercises the pure text functions.
+ *   - the browser, via `browserBundle()` — `check-i18n-render.mjs` strips the
+ *     `export` keywords and injects the result with `page.addScriptTag`.
+ * Because of the second target this file must stay import-free and top-level-side-
+ * effect-free, and every export must be a plain `export function` / `export const`
+ * that `STRIP_EXPORT` can rewrite. Nothing here may reference module scope that
+ * would not survive being pasted into a page.
+ */
+
+// ---------------------------------------------------------------------------
+// Pseudolocale constants — must match scripts/gen-pseudolocale.mjs
+// ---------------------------------------------------------------------------
+
+/** The wrapper `transform()` puts around every catalog value. */
+export const UNIT_OPEN = '['
+export const UNIT_CLOSE = ']'
+
+/** The padding glyph (U+00B7). Filler, never copy — discounted everywhere. */
+export const PSEUDO_PAD = '·'
+
+/**
+ * IBM/W3C expansion budget, copied from `gen-pseudolocale.mjs:expansionRatio`.
+ * Used to grade an overflow: a 2.4x-wide short label is within the pseudolocale's
+ * own padding budget, so it is advisory, while exceeding it is a real finding.
+ */
+export function expansionBudget(length) {
+  if (length <= 10) return 2.5
+  if (length <= 20) return 1.9
+  if (length <= 30) return 1.7
+  if (length <= 50) return 1.5
+  if (length <= 70) return 1.35
+  return 1.3
+}
+
+// ---------------------------------------------------------------------------
+// Text-level analysis (pure — unit-tested in Node)
+// ---------------------------------------------------------------------------
+
+/**
+ * Split rendered text into catalog units and the text outside them.
+ *
+ * Units are recognised by the wrapper the transform actually guarantees — "starts
+ * `[`, ends `]`" — NOT by balanced-bracket depth: real copy carries its own
+ * unbalanced brackets (`"[ Paste #"` pseudolocalises to `[[ Þàşţè #···]`) and depth
+ * counting misreports it. Two adjacent units are separated by a `]…[` seam.
+ *
+ * Splitting INSIDE a text node matters: `{t('a')}{t('b')}` gives React two text
+ * nodes, but `` {`${t('a')} ${t('b')}`} `` and `t('a') + t('b')` give it one.
+ * Counting nodes alone would miss the second shape entirely.
+ */
+export function splitUnits(text) {
+  const first = text.indexOf(UNIT_OPEN)
+  const last = text.lastIndexOf(UNIT_CLOSE)
+  // No wrapper at all, or a `[` with nothing closing it: none of this came from a
+  // catalog, so the whole string is orphan text.
+  if (first < 0 || last < first) return { units: [], orphans: text ? [text] : [] }
+
+  const units = []
+  const orphans = []
+  if (first > 0) orphans.push(text.slice(0, first))
+  if (last < text.length - 1) orphans.push(text.slice(last + 1))
+
+  const inner = text.slice(first, last + 1)
+  const seam = /\][^[\]]*\[/g
+  let cursor = 0
+  let m = seam.exec(inner)
+  while (m) {
+    units.push(inner.slice(cursor, m.index + 1))
+    const between = m[0].slice(1, -1)
+    if (between) orphans.push(between)
+    cursor = m.index + m[0].length - 1
+    m = seam.exec(inner)
+  }
+  units.push(inner.slice(cursor))
+  return { units, orphans }
+}
+
+/** True when `s` carries no meaning — whitespace and pseudolocale padding only. */
+export function isFiller(s) {
+  return s.split(PSEUDO_PAD).join('').trim() === ''
+}
+
+/**
+ * Tokens that are plain Latin in EVERY language and must not count as a leak.
+ *
+ * Two populations, and they are excluded for opposite reasons:
+ *
+ *   - DNT terms (`glossary.json`) are proper nouns a translator must leave alone.
+ *     Note the asymmetry this creates: `gen-pseudolocale.mjs` does NOT preserve
+ *     them, so in `en-XA` they render accented (`GitHub` -> `ĞìţĤùƀ`). A plain
+ *     `GitHub` in an en-XA render therefore means the string never went through the
+ *     catalog at all — it IS a leak. We exclude them anyway, because the same term
+ *     legitimately appears in fixture data and in DNT-by-provenance third-party
+ *     metadata, and a gate that cries wolf on the word "GitHub" will be ignored.
+ *     Consequence, stated plainly: a hardcoded string whose every word is a DNT
+ *     term is invisible to this gate.
+ *   - Language endonyms are deliberately never translated (`languages.ts`), and
+ *     they all render on `/settings?tab=display`, one of the gated surfaces.
+ */
+export const ALWAYS_LATIN = [
+  // glossary.json `dnt`
+  'AWS', 'Discord', 'Docker', 'Git', 'GitHub', 'GitLab', 'JSON', 'Kiro', 'KiroCrew',
+  'MCP', 'Markdown', 'Node.js', 'OAuth', 'Playwright', 'Python', 'Slack',
+  'TypeScript', 'YAML', 'npm',
+  // language endonyms from SUPPORTED_LANGUAGES
+  'English', 'Espanol', 'Español', 'Francais', 'Français', 'Portugues', 'Português',
+  'Deutsch', 'Italiano', 'Pseudolocale',
+]
+
+/**
+ * Regions `gen-pseudolocale.mjs` passes through byte-identical, so they are Latin in
+ * the pseudolocale BY DESIGN and are not leaks.
+ *
+ * Same four shapes as that file's `PRESERVE` array, but deliberately in a DIFFERENT
+ * ORDER. The generator carves all four in ONE pass where the outermost match wins;
+ * stripping them one regex at a time is not equivalent, because a pattern that sits
+ * INSIDE another destroys its host. `https://<your-host>` is the live case: strip
+ * `<your-host>` first and the surviving `https://` no longer matches the URL
+ * pattern, orphaning `https` as a phantom leak. Broadest-first restores
+ * outermost-wins for the shapes that actually nest here.
+ *
+ * `renderScan.test.ts` asserts this over every committed en-XA value, so a new
+ * preserved shape fails that test instead of flooding the ledger.
+ */
+export const PRESERVED_REGIONS = [
+  /https?:\/\/\S+/g, // urls — may CONTAIN a <…> or {{…}} region, so strip first
+  /\{\{[^}]*\}\}/g, // i18next interpolation
+  /\$t\([^)]*\)/g, // i18next nesting
+  /<[^>]+>/g, // markup, and the URL-shaped <…> values in this catalog
+]
+
+/**
+ * Strip everything that is legitimately un-accented, then report the Latin that is
+ * left over.
+ *
+ * Order matters. The `ALWAYS_LATIN` pass runs before the letter-run scan so that
+ * `Node.js` cannot leave a bare `js` behind, and the longest terms are removed
+ * first so `GitHub` is not half-consumed by `Git`.
+ */
+export function latinLeaks(text, opts) {
+  const minLetters = opts && opts.minLetters ? opts.minLetters : 1
+  const allow = (opts && opts.allow) || ALWAYS_LATIN
+  let rest = text
+  for (const term of [...allow].sort((a, b) => b.length - a.length)) {
+    rest = rest.split(term).join(' ')
+  }
+  // Preserved regions normally sit INSIDE a unit and so never reach this function,
+  // but an interpolated value React renders as its own text node arrives here bare.
+  for (const rx of PRESERVED_REGIONS) rest = rest.replace(rx, ' ')
+  const runs = rest.match(/[A-Za-z]+/g) || []
+  return runs.filter(r => r.length >= minLetters)
+}
+
+/** Punctuation that, at the START of orphan text, continues the sentence before it. */
+const CONTINUATION = /^[)\]}:;,.!?…）】」]/
+
+/**
+ * Delimiter pairs checked for a dangling open bracket. `[`/`]` is excluded on
+ * purpose: those are the pseudolocale's own wrapper, so every unit carries exactly
+ * one of each and counting them says nothing.
+ */
+const DELIMITER_PAIRS = [['(', ')'], ['{', '}'], ['（', '）'], ['【', '】'], ['「', '」']]
+
+const countOf = (haystack, needle) => haystack.split(needle).length - 1
+
+/**
+ * Grade one inline run's text.
+ *
+ * Returns `{ fragments, leaks }`. `fragments` is non-empty when the run was
+ * assembled from more than one catalog unit, or when orphan text continues a
+ * sentence a unit started. `leaks` is the plain-Latin text with no catalog origin.
+ *
+ * Deliberately NOT gated on `units.length > 0`. The predecessor implementation
+ * skipped any run with no bracketed unit, which inverted the gate's sensitivity:
+ * the more untranslated a surface was, the less it reported, and a component with
+ * zero catalog usage produced zero findings. That hole is why the hardcoded
+ * `"6m 38s"` duration in `useUptime.ts` survived every gate.
+ */
+export function gradeRun(text, opts) {
+  const { units, orphans } = splitUnits(text)
+  const live = orphans.filter(o => !isFiller(o))
+  const fragments = []
+  const leaks = []
+
+  if (units.length >= 2) {
+    fragments.push({ signal: 'multi-unit', detail: `${units.length} catalog units in one run` })
+  }
+
+  for (const orphan of live) {
+    const trimmed = orphan.trim()
+    if (units.length > 0) {
+      if (CONTINUATION.test(trimmed)) {
+        fragments.push({ signal: 'continuation-punctuation', detail: trimmed.slice(0, 40) })
+      }
+      for (const [open, close] of DELIMITER_PAIRS) {
+        const opened = units.reduce((n, u) => n + countOf(u, open) - countOf(u, close), 0)
+        if (opened > 0 && trimmed.includes(close)) {
+          fragments.push({ signal: 'dangling-delimiter', detail: `${open}…${close}` })
+          break
+        }
+      }
+    }
+    for (const run of latinLeaks(orphan, opts)) leaks.push(run)
+  }
+  return { fragments, leaks, units, orphans: live }
+}
+
+/**
+ * DNT terms must survive translation byte-identical. Only meaningful in a REAL
+ * locale — `en-XA` accents them by construction, so running this against the
+ * pseudolocale would report all 19 as mangled.
+ */
+export function dntViolations(text, terms) {
+  const out = []
+  for (const term of terms) {
+    // Match LOOSELY, then require the hit to be byte-exact. Searching for the exact
+    // term would find only the cases that are already correct; the finding we want
+    // is the near-miss. Alphanumerics are matched literally and every separator
+    // becomes optional, so `Node.js` also matches `Node js` and `NodeJS` — both of
+    // which then fail the equality test and are reported.
+    const loose = [...term]
+      .map(ch => (/[A-Za-z0-9]/.test(ch) ? ch : '[^\\p{L}\\p{N}]?'))
+      .join('')
+    const rx = new RegExp(`(^|[^\\p{L}\\p{N}])(${loose})([^\\p{L}\\p{N}]|$)`, 'giu')
+    let m = rx.exec(text)
+    while (m) {
+      // An all-lowercase hit is the COMMAND or package, not the product: `git push`,
+      // `docker run`, `python -m`, `npm i`. Prose about denied commands is full of
+      // them, and calling `git` a mangled `Git` is how a gate earns a blanket
+      // suppression. What is left is the class DNT actually protects against —
+      // wrong internal capitalisation or spacing: `Github`, `NodeJS`, `Node JS`,
+      // `YAml`. A term translated away entirely is invisible to any render check,
+      // since the word simply is not there to find.
+      if (m[2] !== term && m[2] !== term.toLowerCase()) out.push({ term, found: m[2] })
+      m = rx.exec(text)
+    }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// DOM traversal (browser-only — `scanDocument` runs inside the page)
+// ---------------------------------------------------------------------------
+
+/**
+ * Elements text flows through, so their content joins the surrounding run.
+ *
+ * Seeded from the tag set the happy-dom predecessor used, but in a real browser we
+ * prefer the computed `display`, which is correct for CSS-overridden inline-ness
+ * and for `display:contents`. The tag list survives only as the fallback for
+ * elements with no box at all.
+ */
+const INLINE_TAGS = 'SPAN STRONG B EM I CODE A SMALL KBD SAMP MARK U ABBR SUB SUP LABEL TIME BDI BDO SVG IMG Q CITE VAR DFN S DEL INS WBR BR'
+
+/** Attributes that carry user-visible prose but never appear in the text flow. */
+const TEXT_ATTRS = ['title', 'aria-label', 'placeholder', 'alt', 'aria-placeholder']
+
+/**
+ * Walk the document and return every render-time i18n finding.
+ *
+ * Runs inside the page. `opts` arrives structured-cloned, so it may hold only
+ * JSON-shaped values.
+ *
+ * @param {{
+ *   mode: 'pseudo' | 'real',
+ *   minLetters?: number,
+ *   allow?: string[],
+ *   dnt?: string[],
+ *   maxFindings?: number,
+ * }} opts
+ */
+export function scanDocument(opts) {
+  const mode = opts.mode
+  const inlineTags = new Set(INLINE_TAGS.split(' '))
+  const findings = []
+  const push = f => {
+    if (findings.length < (opts.maxFindings || 4000)) findings.push(f)
+  }
+
+  // -- shared predicates ----------------------------------------------------
+
+  const visible = el => {
+    if (typeof el.checkVisibility !== 'function') return true
+    return el.checkVisibility({
+      contentVisibilityAuto: true, opacityProperty: true, visibilityProperty: true,
+    })
+  }
+
+  /**
+   * Opaque-data subtrees. Code, terminal output, file paths and hashes are Latin in
+   * every language, and the mono font stack is how this codebase marks them. Read
+   * the COMPUTED family, not the class list: `.msg-content pre` sets the font in
+   * `index.css`, where no `font-mono` token appears.
+   */
+  const isOpaque = el => {
+    if (el.closest('code, pre, kbd, samp, [data-i18n-opaque]')) return true
+    const fam = getComputedStyle(el).fontFamily || ''
+    return /mono/i.test(fam)
+  }
+
+  /**
+   * Virtuoso sizes its inner container past its viewport by design, so its
+   * scrollWidth/scrollHeight carry no information about text fit.
+   */
+  const inVirtualList = el => !!el.closest('[data-testid="virtuoso"]')
+
+  const describe = el => {
+    const parts = []
+    let cur = el
+    for (let i = 0; i < 4 && cur && cur !== document.body; i++) {
+      const id = cur.getAttribute && cur.getAttribute('data-testid')
+      let seg = cur.tagName.toLowerCase()
+      if (id) seg += `[${id}]`
+      else if (cur.parentElement) {
+        const sibs = [...cur.parentElement.children].filter(c => c.tagName === cur.tagName)
+        if (sibs.length > 1) seg += `:nth(${sibs.indexOf(cur)})`
+      }
+      parts.unshift(seg)
+      cur = cur.parentElement
+    }
+    return parts.join('>')
+  }
+
+  const clip = s => (s.length > 90 ? `${s.slice(0, 87)}…` : s)
+
+  // -- 1/2. inline runs: fragments + plain-Latin leaks -----------------------
+
+  const isInline = node => {
+    if (node.nodeType === 3) return true
+    if (node.nodeType !== 1) return false
+    if (!visible(node)) return false
+    const d = getComputedStyle(node).display
+    if (d === 'contents') return true
+    return d.startsWith('inline') || inlineTags.has(node.tagName)
+  }
+
+  for (const el of document.body.querySelectorAll('*')) {
+    if (!visible(el) || inVirtualList(el) || isOpaque(el)) continue
+
+    // Group DIRECT children into maximal inline runs; a block child ends the run.
+    let run = []
+    const flush = () => {
+      if (!run.length) return
+      const text = run.map(n => (n.nodeType === 3 ? n.textContent : n.textContent || '')).join('')
+      run = []
+      if (!text.trim()) return
+      const graded = gradeRun(text, opts)
+      if (mode === 'pseudo') {
+        for (const frag of graded.fragments) {
+          push({
+            kind: 'fragment', signature: frag.signal, path: describe(el),
+            text: clip(text), detail: frag.detail,
+            fix: frag.signal === 'multi-unit'
+              ? 'Merge the adjacent catalog keys into one key with {{vars}} — see AGENTS.md "merge, not join".'
+              : 'Move the orphan punctuation/word inside the catalog value.',
+          })
+        }
+        for (const leak of graded.leaks) {
+          push({
+            kind: 'latin-leak', signature: 'untranslated-text', path: describe(el),
+            text: clip(text), detail: leak,
+            fix: `Extract "${leak}" into the catalog and render it with t().`,
+          })
+        }
+      }
+    }
+    for (const node of el.childNodes) {
+      if (isInline(node)) run.push(node)
+      else flush()
+    }
+    flush()
+
+    // Attribute prose is outside the text flow, so the run walk above cannot see
+    // it. This is the class that hid ThinkingBlock's English title/aria-label.
+    for (const attr of TEXT_ATTRS) {
+      const v = el.getAttribute && el.getAttribute(attr)
+      if (!v || !v.trim()) continue
+      if (mode !== 'pseudo') continue
+      const graded = gradeRun(v, opts)
+      for (const leak of graded.leaks) {
+        push({
+          kind: 'latin-leak', signature: 'untranslated-attribute', path: describe(el),
+          text: clip(`@${attr}=${v}`), detail: leak,
+          fix: `Extract the ${attr} text into the catalog and render it with t().`,
+        })
+      }
+    }
+  }
+
+  // -- 3. DNT integrity (real locales only) ---------------------------------
+
+  if (mode === 'real' && opts.dnt && opts.dnt.length) {
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+    for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+      const parent = n.parentElement
+      if (!parent || !visible(parent) || isOpaque(parent)) continue
+      const text = (n.textContent || '').normalize('NFC')
+      if (!text.trim()) continue
+      // Prose only. A text node that is a single whitespace-free token is an
+      // IDENTIFIER — an agent name, a slug, a filename, a config key — and the
+      // casing convention there is the machine's, not the translator's. Without
+      // this, the agent named `kirocrew` reads as a mangled `KiroCrew` on every
+      // surface that lists it. The accepted blind spot: a genuinely mistranslated
+      // DNT term standing alone in its own element is missed.
+      if (!/\s/.test(text.trim())) continue
+      for (const v of dntViolations(text, opts.dnt)) {
+        push({
+          kind: 'dnt', signature: 'dnt-mangled', path: describe(parent),
+          text: clip(text), detail: `${v.term} rendered as ${v.found}`,
+          fix: `Restore "${v.term}" verbatim in this catalog value — it is on the do-not-translate list.`,
+        })
+      }
+    }
+  }
+
+  // -- 4. overflow, with the prescriptive signature ------------------------
+
+  /** Nearest ancestor whose width cannot give, and why. */
+  const fixedAncestor = el => {
+    let cur = el.parentElement
+    for (let i = 0; i < 12 && cur && cur !== document.body; i++) {
+      const cs = getComputedStyle(cur)
+      if (/px$/.test(cs.flexBasis)) return `${describe(cur)} (flex-basis:${cs.flexBasis})`
+      if (/px$/.test(cs.maxWidth)) return `${describe(cur)} (max-width:${cs.maxWidth})`
+      if (/px$/.test(cs.minWidth) && cs.minWidth !== '0px') return `${describe(cur)} (min-width:${cs.minWidth})`
+      if (cs.width === cs.maxWidth && /px$/.test(cs.width)) return `${describe(cur)} (fixed width:${cs.width})`
+      cur = cur.parentElement
+    }
+    return ''
+  }
+
+  /** Longest unbreakable token, measured with a Range rather than guessed. */
+  const longestTokenWidth = el => {
+    const node = [...el.childNodes].find(n => n.nodeType === 3 && n.textContent.trim())
+    if (!node) return 0
+    const text = node.textContent
+    let best = 0
+    const rx = /\S+/g
+    let m = rx.exec(text)
+    const range = document.createRange()
+    while (m) {
+      range.setStart(node, m.index)
+      range.setEnd(node, m.index + m[0].length)
+      best = Math.max(best, range.getBoundingClientRect().width)
+      m = rx.exec(text)
+    }
+    range.detach && range.detach()
+    return best
+  }
+
+  for (const el of document.body.querySelectorAll('*')) {
+    if (!visible(el) || inVirtualList(el) || isOpaque(el)) continue
+    const cs = getComputedStyle(el)
+    // The element is itself a scroll container, so horizontal overflow is the
+    // designed behaviour, not a layout failure.
+    if (cs.overflowX === 'auto' || cs.overflowX === 'scroll') continue
+    // Only elements that own text directly. Without this every ancestor of one
+    // overflowing leaf reports the same finding.
+    const own = [...el.childNodes].filter(n => n.nodeType === 3 && n.textContent.trim())
+    if (!own.length) continue
+
+    // Visually-hidden patterns — skip links, `sr-only`, collapsed readouts — are
+    // clamped to ~1px or pushed off-screen rather than `display:none`, so
+    // checkVisibility() correctly reports them as visible. Measuring them yields a
+    // 1px box "overflowing" by 196x: pure noise that drowns the real findings.
+    const rect = el.getBoundingClientRect()
+    if (el.clientWidth < 8 || el.clientHeight < 4) continue
+    if (rect.right < 0 || rect.bottom < 0) continue
+
+    const client = Math.max(el.clientWidth, 1)
+    // scrollWidth rounds up while clientWidth truncates, so sub-pixel layouts
+    // report a 1px delta with nothing wrong.
+    const overflowing = el.scrollWidth - el.clientWidth > 1
+    const ratio = el.scrollWidth / client
+    const source = own.map(n => n.textContent).join('').trim()
+    const budget = expansionBudget(source.length)
+
+    const clips = cs.overflowX === 'hidden' || cs.overflowX === 'clip'
+    const ellipsis = cs.textOverflow === 'ellipsis'
+    const named = !!(el.title || el.getAttribute('aria-label') || el.closest('[title]'))
+
+    // The highest-value signature in this codebase, and it does not need the
+    // element to be overflowing YET: an ellipsis on a flex child whose min-width
+    // is still `auto` silently does nothing (CSS Flexbox 4.5), so the text will
+    // push its sibling out instead of truncating.
+    const parentCs = el.parentElement ? getComputedStyle(el.parentElement) : null
+    if (ellipsis && parentCs && /flex/.test(parentCs.display) && cs.minWidth === 'auto') {
+      push({
+        kind: 'layout', signature: 'ellipsis-with-flex-parent', path: describe(el),
+        text: clip(source), ratio: Number(ratio.toFixed(2)), fixedAncestor: fixedAncestor(el),
+        fix: 'Add `min-w-0` to this flex child — text-overflow:ellipsis cannot apply while min-width is auto.',
+      })
+    }
+
+    if (!overflowing) continue
+
+    let signature = clips ? 'clipped-without-title' : 'whole-toolbar-overflow'
+    let fix = 'Let the container grow, or wrap the label.'
+    if (clips && named) {
+      // Truncation with the full text reachable is a legitimate pattern — 325
+      // `truncate` sites rely on it. Only advisory, and only past budget.
+      if (ratio <= budget) continue
+      signature = 'over-budget-truncation'
+      fix = `Truncation is fine, but ${ratio.toFixed(2)}x exceeds the ${budget}x budget for a ${source.length}-char source — shorten the source or widen the container.`
+    } else if (clips) {
+      fix = 'Text is silently clipped with no `title`/`aria-label` carrying the full string — add one, or let it wrap.'
+    } else if (longestTokenWidth(el) > client && cs.overflowWrap === 'normal' && cs.wordBreak === 'normal') {
+      signature = 'unbreakable-token'
+      fix = 'One token is wider than the box; no wrapping can fix it. Add `overflow-wrap:anywhere`.'
+    } else if (cs.whiteSpace === 'nowrap' || cs.whiteSpace === 'pre') {
+      signature = 'nowrap-overflow'
+      fix = 'Remove `whitespace-nowrap`, or give the container room for the longest locale.'
+    }
+    push({
+      kind: 'layout', signature, path: describe(el), text: clip(source),
+      ratio: Number(ratio.toFixed(2)), budget, fixedAncestor: fixedAncestor(el), fix,
+    })
+  }
+
+  // Portaled overlays (nav flyouts, composer dropdowns) are `position:fixed` and
+  // `nowrap`: they overflow the VIEWPORT, not a parent, so scrollWidth never fires.
+  for (const el of document.body.querySelectorAll('*')) {
+    if (!visible(el) || isOpaque(el)) continue
+    if (getComputedStyle(el).position !== 'fixed') continue
+    const r = el.getBoundingClientRect()
+    if (r.width === 0) continue
+    if (r.right <= window.innerWidth + 1 && r.left >= -1) continue
+    push({
+      kind: 'layout', signature: 'fixed-overlay-off-viewport', path: describe(el),
+      text: clip((el.textContent || '').trim()),
+      ratio: Number((r.width / window.innerWidth).toFixed(2)), fixedAncestor: '',
+      fix: 'A fixed overlay extends past the viewport in this locale — clamp its max-width or flip its anchor side.',
+    })
+  }
+
+  return findings
+}
+
+// __BROWSER_BUNDLE_CUT__
+
+// ---------------------------------------------------------------------------
+// Browser bundling (Node-only — everything below the cut is excluded from the
+// injected script)
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite this module into a plain script for `page.addScriptTag`.
+ *
+ * `page.evaluate` cannot close over module scope, so the analysis has to reach the
+ * page somehow. Pasting a second copy into a template string is how the two halves
+ * drift apart — instead we take THIS file's own source, strip the `export`
+ * keywords, and cut everything below the marker (which is Node-only and whose own
+ * body contains the rewriting regex). One implementation, two runtimes.
+ */
+export function browserBundle(source) {
+  const body = source.split('// __BROWSER_BUNDLE_CUT__')[0]
+    .replace(/^export (function|const|class)/gm, '$1')
+  return `(() => {\n${body}\nwindow.__I18N_SCAN = { scanDocument };\n})()`
+}
+

--- a/website/src/i18n/render-baseline.json
+++ b/website/src/i18n/render-baseline.json
@@ -1,0 +1,110 @@
+{
+  "_comment": "Phase 5 render-time gate. Findings from rendering the real DEV build under en-XA (text) and the shipped locales (layout/latent). UPWARD-ONLY and keyed per surface: a number may only go DOWN. The goal for every entry is 0. Regenerate with `node scripts/check-i18n-render.mjs --update` and only ever commit a decrease. DNT findings are not ledgered — they are zero-tolerance.",
+  "_total": {
+    "text": 2108,
+    "layout": 3,
+    "latent": 544
+  },
+  "surfaces": {
+    "chat": {
+      "text": 104,
+      "layout": 2,
+      "latent": 64
+    },
+    "settings-display": {
+      "text": 90,
+      "layout": 0,
+      "latent": 32
+    },
+    "settings-overview": {
+      "text": 34,
+      "layout": 0,
+      "latent": 16
+    },
+    "schedule": {
+      "text": 248,
+      "layout": 0,
+      "latent": 16
+    },
+    "settings-chat": {
+      "text": 258,
+      "layout": 0,
+      "latent": 88
+    },
+    "settings-privacy": {
+      "text": 48,
+      "layout": 0,
+      "latent": 16
+    },
+    "settings-computer-use": {
+      "text": 28,
+      "layout": 0,
+      "latent": 16
+    },
+    "settings-security": {
+      "text": 494,
+      "layout": 0,
+      "latent": 16
+    },
+    "settings-notifications": {
+      "text": 224,
+      "layout": 0,
+      "latent": 80
+    },
+    "settings-about": {
+      "text": 28,
+      "layout": 0,
+      "latent": 16
+    },
+    "capabilities-crews": {
+      "text": 136,
+      "layout": 0,
+      "latent": 40
+    },
+    "capabilities-mcp": {
+      "text": 126,
+      "layout": 0,
+      "latent": 16
+    },
+    "capabilities-skills": {
+      "text": 56,
+      "layout": 0,
+      "latent": 16
+    },
+    "projects": {
+      "text": 14,
+      "layout": 0,
+      "latent": 16
+    },
+    "knowledge": {
+      "text": 62,
+      "layout": 0,
+      "latent": 16
+    },
+    "artifacts": {
+      "text": 14,
+      "layout": 0,
+      "latent": 16
+    },
+    "apps": {
+      "text": 14,
+      "layout": 0,
+      "latent": 16
+    },
+    "notifications": {
+      "text": 58,
+      "layout": 0,
+      "latent": 16
+    },
+    "logs": {
+      "text": 22,
+      "layout": 0,
+      "latent": 16
+    },
+    "developer-system": {
+      "text": 50,
+      "layout": 1,
+      "latent": 16
+    }
+  }
+}

--- a/website/src/i18n/renderScan.test.ts
+++ b/website/src/i18n/renderScan.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for the render gate's analysis layer (`scripts/lib/render-scan.mjs`).
+ *
+ * The gate itself needs a browser and a DEV build, so it runs in CI rather than in
+ * vitest. That leaves its REASONING untested unless it is tested here: whether a
+ * `]…[` seam is really a concatenation, whether a word is really un-accented, which
+ * exclusions apply. Those are pure string functions, and a wrong answer in one of
+ * them either hides a defect forever or floods the ledger with noise.
+ *
+ * The other half of the job is locking the invariants the gate BORROWS from
+ * `gen-pseudolocale.mjs`. The scanner assumes every catalog value is `[`-wrapped and
+ * that no single value contains a `]…[` seam of its own. If the generator ever
+ * changed its delimiters, the gate would not fail — it would silently find nothing.
+ * So we assert those properties against the committed catalog too.
+ */
+import { describe, it, expect } from 'vitest'
+import enXA from './locales/en-XA.json'
+import glossary from './glossary.json'
+import {
+  splitUnits, isFiller, latinLeaks, gradeRun, dntViolations, expansionBudget,
+  browserBundle, ALWAYS_LATIN, PSEUDO_PAD,
+} from '../../scripts/lib/render-scan.mjs'
+
+const flat = (obj, prefix = '', out = {}) => {
+  for (const [k, v] of Object.entries(obj)) {
+    if (v && typeof v === 'object') flat(v, `${prefix}${k}.`, out)
+    else out[`${prefix}${k}`] = v
+  }
+  return out
+}
+const VALUES = Object.values(flat(enXA))
+
+describe('splitUnits', () => {
+  it('treats a single bracketed value as one unit with no orphans', () => {
+    const { units, orphans } = splitUnits('[Şèşşìøñş ····]')
+    expect(units).toEqual(['[Şèşşìøñş ····]'])
+    expect(orphans).toEqual([])
+  })
+
+  it('splits two adjacent values at the `]…[` seam', () => {
+    const { units, orphans } = splitUnits('[Şţàŕ ùş]·[Ŕèþøŕţ ìşşùè]')
+    expect(units).toHaveLength(2)
+    expect(orphans).toEqual(['·'])
+  })
+
+  it('reports text with no wrapper at all as pure orphan', () => {
+    // The case the predecessor detector dropped: a run with zero catalog units was
+    // skipped entirely, so a fully hardcoded component reported nothing.
+    expect(splitUnits('6m 38s')).toEqual({ units: [], orphans: ['6m 38s'] })
+  })
+
+  it('does not use bracket DEPTH, so copy carrying its own brackets survives', () => {
+    // "[ Paste #" pseudolocalises to a value with an extra `[` inside it.
+    const { units, orphans } = splitUnits('[[ Þàşţè # ···]')
+    expect(units).toEqual(['[[ Þàşţè # ···]'])
+    expect(orphans).toEqual([])
+  })
+
+  it('keeps leading and trailing text outside the units', () => {
+    const { orphans } = splitUnits('Total: [ṽàĺùè] items')
+    expect(orphans).toEqual(['Total: ', ' items'])
+  })
+})
+
+describe('isFiller', () => {
+  it('discounts padding and whitespace', () => {
+    expect(isFiller(` ${PSEUDO_PAD}${PSEUDO_PAD} `)).toBe(true)
+    expect(isFiller('·x·')).toBe(false)
+  })
+})
+
+describe('latinLeaks', () => {
+  it('finds un-accented words', () => {
+    expect(latinLeaks('Chat')).toEqual(['Chat'])
+  })
+
+  it('finds single-letter unit symbols', () => {
+    // `8h 49m 29s` under a translated heading is a real shipped defect. A >=3-letter
+    // threshold (what the predecessor used) misses every one of these.
+    expect(latinLeaks('8h 49m 29s')).toEqual(['h', 'm', 's'])
+  })
+
+  it('ignores accented pseudolocale text', () => {
+    expect(latinLeaks('Şèşşìøñş')).toEqual([])
+  })
+
+  it('ignores do-not-translate terms and language endonyms', () => {
+    expect(latinLeaks('GitHub')).toEqual([])
+    expect(latinLeaks('Node.js')).toEqual([])
+    expect(latinLeaks('Español')).toEqual([])
+  })
+
+  it('removes longer terms first, so GitHub does not leave a bare Hub', () => {
+    expect(ALWAYS_LATIN).toContain('Git')
+    expect(ALWAYS_LATIN).toContain('GitHub')
+    // `and` is correctly reported — it is untranslated copy. The point is that no
+    // fragment of either DNT term survives to be reported alongside it.
+    expect(latinLeaks('GitHub and Git')).toEqual(['and'])
+  })
+
+  it('ignores the markup and nesting regions the generator preserves', () => {
+    expect(latinLeaks('<your-host>')).toEqual([])
+    expect(latinLeaks('kirocrew app install <path>'.replace(/kirocrew/, ''))).toEqual(['app', 'install'])
+    expect(latinLeaks('$t(app.name)')).toEqual([])
+  })
+
+  it('strips a nested preserved region without orphaning its host', () => {
+    // `https://<your-host>` is a real committed value. Stripping `<your-host>` first
+    // leaves `https://`, which no longer matches the URL pattern.
+    expect(latinLeaks('https://<your-host>')).toEqual([])
+  })
+
+  it('ignores interpolation placeholders and URLs, which pass through un-accented', () => {
+    expect(latinLeaks('{{count}}')).toEqual([])
+    expect(latinLeaks('https://github.com/owner/repo')).toEqual([])
+  })
+
+  it('honours a raised minLetters', () => {
+    expect(latinLeaks('8h 49m', { minLetters: 3 })).toEqual([])
+  })
+})
+
+describe('gradeRun', () => {
+  it('flags a run built from two catalog units', () => {
+    const { fragments } = gradeRun('[Şţàŕ ùş]·[Ŕèþøŕţ ìşşùè]')
+    expect(fragments.map(f => f.signal)).toContain('multi-unit')
+  })
+
+  it('flags orphan punctuation that continues a translated sentence', () => {
+    const { fragments } = gradeRun('[Ŕèàðý]: ')
+    expect(fragments.map(f => f.signal)).toContain('continuation-punctuation')
+  })
+
+  it('flags a closing delimiter the units left open', () => {
+    const { fragments } = gradeRun('[Ŕèàðý (ɱøðè])')
+    expect(fragments.map(f => f.signal)).toContain('dangling-delimiter')
+  })
+
+  it('reports leaks in a run with NO catalog unit at all', () => {
+    // The regression guard for the predecessor's `units.length === 0` skip, which
+    // made the gate blinder the more untranslated a surface was.
+    const { leaks, fragments } = gradeRun('Cron Jobs')
+    expect(leaks).toEqual(['Cron', 'Jobs'])
+    expect(fragments).toEqual([])
+  })
+
+  it('reports a hardcoded suffix beside a translated unit', () => {
+    const { leaks } = gradeRun('[Ùþţìɱè ···] 6m 38s')
+    expect(leaks).toEqual(['m', 's'])
+  })
+
+  it('stays silent on a correctly translated single unit', () => {
+    const { leaks, fragments } = gradeRun('[Şèşşìøñş ············]')
+    expect(leaks).toEqual([])
+    expect(fragments).toEqual([])
+  })
+})
+
+describe('dntViolations', () => {
+  const dnt = glossary.dnt
+
+  it('accepts the exact term', () => {
+    expect(dntViolations('Open GitHub to continue', dnt)).toEqual([])
+  })
+
+  it('reports wrong internal capitalisation', () => {
+    expect(dntViolations('Open Github to continue', dnt))
+      .toEqual([{ term: 'GitHub', found: 'Github' }])
+  })
+
+  it('reports a separator turned into a space', () => {
+    expect(dntViolations('Requires Node js 24', dnt))
+      .toEqual([{ term: 'Node.js', found: 'Node js' }])
+  })
+
+  it('accepts an all-lowercase hit as the command, not the product', () => {
+    // Prose about denied commands is full of `git push` / `docker run`.
+    expect(dntViolations('Blockiert git push und docker run', dnt)).toEqual([])
+  })
+
+  it('does not match a term inside a longer word', () => {
+    expect(dntViolations('Visit GitLab now', dnt)).toEqual([])
+  })
+})
+
+describe('expansionBudget', () => {
+  it('matches the generator table it is copied from', () => {
+    expect(expansionBudget(5)).toBe(2.5)
+    expect(expansionBudget(20)).toBe(1.9)
+    expect(expansionBudget(30)).toBe(1.7)
+    expect(expansionBudget(50)).toBe(1.5)
+    expect(expansionBudget(70)).toBe(1.35)
+    expect(expansionBudget(200)).toBe(1.3)
+  })
+})
+
+describe('browserBundle', () => {
+  const bundle = browserBundle(
+    'export const A = 1\nexport function scanDocument() { return A }\n'
+    + '// __BROWSER_BUNDLE_CUT__\nexport function browserBundle() { throw new Error("node only") }\n',
+  )
+
+  it('strips export keywords so the source runs as a plain script', () => {
+    expect(bundle).not.toMatch(/^export /m)
+    expect(bundle).toContain('const A = 1')
+  })
+
+  it('cuts everything below the marker, keeping Node-only code out of the page', () => {
+    expect(bundle).not.toContain('node only')
+  })
+
+  it('publishes scanDocument on window', () => {
+    expect(bundle).toContain('window.__I18N_SCAN = { scanDocument }')
+  })
+})
+
+describe('the pseudolocale invariants the scanner depends on', () => {
+  it('wraps every catalog value in the delimiters the scanner looks for', () => {
+    const bad = VALUES.filter(v => typeof v === 'string' && !(v.startsWith('[') && v.endsWith(']')))
+    expect(bad).toEqual([])
+  })
+
+  it('never puts a `]…[` seam inside a single value', () => {
+    // This is what makes "a seam means two keys were concatenated" sound. If the
+    // generator ever emitted a seam of its own, the gate would report every value
+    // containing one as a fragment.
+    const bad = VALUES.filter(v => typeof v === 'string' && /\][^[\]]*\[/.test(v))
+    expect(bad).toEqual([])
+  })
+
+  it('leaves no un-accented Latin the scanner would read as a leak', () => {
+    // Bounds the gate's own false-positive floor: whatever survives here is text the
+    // generator deliberately preserved (placeholders, markup, URLs) and every one of
+    // those is excluded by `latinLeaks`. A non-empty result means a NEW preserved
+    // shape appeared and the exclusion list has to learn about it.
+    const offenders = []
+    for (const v of VALUES) {
+      if (typeof v !== 'string') continue
+      const inner = v.slice(1, -1)
+      if (latinLeaks(inner).length) offenders.push(v)
+    }
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
Tracks #1004

## The gap this closes

Every i18n gate we have reads **source** (an eslint pass over `src`) or **catalog JSON**. Three defect classes are invisible to all of them — not by oversight, by construction:

| Defect | Why every static gate misses it |
|---|---|
| a string that was never extracted | it is ordinary TypeScript. The hardcoded `` `${h}h ${m}m ${s}s` `` in `useUptime.ts` shipped for months past an eslint gate, a codemod and six catalog assertions |
| a sentence assembled from several keys | it is several *correct* `t()` calls. Only the rendered line shows the seam |
| English in `title` / `aria-label` / `placeholder` | attribute text never enters the text flow, so nothing that walks prose can see it |

`eslint.i18n.config.js` says so in its own words — single-word copy is "precisely the class the `en-XA` pseudolocale in this PR catches by construction, which is why a render-time detector ships alongside the static ones". That detector never landed. This is it.

## How it works

`npm run i18n:render` renders the real built SPA under the **`en-XA` pseudolocale** and reads the defects off the DOM. `gen-pseudolocale.mjs` already guarantees the two properties the whole check rests on: every catalog value is wrapped in `[` … `]`, and every ASCII letter outside a preserved region is accented. So inside one inline run, a `]…[` seam **is** a surviving concatenation, and plain Latin **is** text that never reached a catalog.

No gateway, no token, no Python backend: it serves the build over loopback (`lib/serve-dist.mjs`) and answers every `/api/**` call from fixtures (`lib/stub-dashboard-api.mjs`), the same mechanism the `capture-*.mjs` harnesses use. 20 surfaces × 4 locales × 2 viewports in **112s** per tree; with the base render that is ~5.5 min including both builds, inside the `e2e` job's 25-minute budget. It runs in that job to reuse the Chromium install already on the step above.

## Findings on main

| kind | count | measurable before? |
|---|---|---|
| untranslated visible text | 1512 | no |
| untranslated `title`/`aria-label`/`placeholder` | 522 | **no — no gate has ever seen attribute text** |
| surviving concatenations | 74 | no |
| real overflow / clipping | 3 | no |
| latent `ellipsis-with-flex-parent` | 544 | no |
| DNT violations at render | **0** | catalog-level only |

Two real examples: `title="Gateway connected · click to collapse readouts"` (an English tooltip on the topbar), and `[Şţàŕ ùş]·[Ŕèþøŕţ ìşşùè]` — two keys joined with `·`, the merge-not-join defect.

Output is prescriptive per the plan's item 3: every finding carries a signature, the worst locale, the overflow ratio, the nearest fixed-size ancestor, and a one-line fix.

## Five things that are load-bearing and non-obvious

1. **It builds its own bundle with `NODE_ENV=development`.** `en-XA` is DEV-only in three independent places (`index.ts` tree-shakes the catalog, `isRestorableLanguage()` refuses the stored code, `DETECTABLE_CODES` hides it), all keyed on `import.meta.env.DEV`. **`vite build --mode development` is not enough** — Vite derives DEV from `NODE_ENV`, not from `--mode`. I verified this empirically: with only the mode flag the accented catalog is absent from `dist/assets/*.js` entirely and every surface renders English. That failure mode does not look like a failure, so `assertPseudoActive()` exists to make it impossible to hit silently.
2. **A crashed surface is exit 2, not findings.** With the wrong fixture shape React's error boundary replaces the panel with its own English message and a naive scan reports *that* as untranslated product text. Two surfaces did exactly this before I caught it: a chat slot with no `key` crashes the command palette's `slots.map(s => s.key.startsWith('dashboard_'))` on every route, and `/api/security/denied-commands` returning `[]` crashes `SecurityPanel`'s unguarded `dc.builtins.length` (`[]` is truthy). Both are now fixtured, and any uncaught page error aborts the run.
3. **DNT integrity runs only in real locales.** The pseudolocale accents DNT terms too (`GitHub` → `ĞìţĤùƀ`), so asserting them under `en-XA` would report all 19 as mangled. It is zero-tolerance, and it deliberately accepts an all-lowercase hit as the CLI name rather than a mangled product name — prose about denied commands is full of them, and calling `git` a mangled `Git` is how a gate earns a blanket suppression.
4. **Widths are read after `document.fonts.ready` plus two rAF ticks.** Without it the layout bucket differed by 2 between identical runs. That fix also corrected the true overflow count from 7 to 3 — four were fallback-font artifacts.
5. **The base tree is exported with `git archive`, never `git worktree add`.** A worktree registers itself in the repo, so a run killed mid-flight leaves a stale registration that breaks every later run — and the obvious recovery, `git worktree prune`, removes the registration of *any* worktree whose path is not visible from where it runs, which in a container that mounts the checkout elsewhere means the caller's own. I hit exactly that while building this. `git archive` touches no repo state, needs no cleanup, and works on CI's shallow checkout.

## Enforcement is diff-scoped, not the ledger

Follows #1060's doctrine. `dnt` is zero-tolerance. The real gate is **`[vs-base]`**: with `I18N_BASE_REF` set, the script renders the **base commit** too — same scanner, same surfaces, same locales, only the bundle differs — and fails on any per-surface increase, reading **no committed number**. There is nothing to re-snapshot and nothing to absorb a regression with.

A per-surface ledger alone would **not** have been enough, and it is worth being precise about why: finer keys only shrink the range a regression can hide within, and `--update` still absorbs anything. Measured — inflate `settings-about.text` from 28 to 100, add 18 real defects, and the **ledger reports an *improvement*** while `[vs-base]` fails with `28 -> 46 (+18)`. That is the `195904c` bypass (which shipped 113 untranslated strings while *raising* `_total`, green) closed for this gate.

`src/i18n/render-baseline.json` is therefore a **debt record** and the backstop for a push to `main`, where there is no base to diff. Upward-only, keyed per surface, allowed to sit above reality; a decrease is reported, never required. Goal is 0 for every entry.

An earlier revision of this PR claimed per-surface keys satisfied the rule on their own. They do not, and `website/AGENTS.md` now says so explicitly rather than leaving the weaker claim in the doctrine.

`latent` is its own bucket because 544 `ellipsis-with-flex-parent` sites (where `text-overflow` cannot apply while a flex child's `min-width` is `auto`, so the truncation those sites think they have does nothing) would otherwise bury the 3 real overflows under a uniform `min-w-0` cleanup that belongs in its own PR.

## Verification

- 33 new unit tests; full suite **570 files / 6928 tests green** under Node 20 (CI's version)
- typecheck, `i18n:check`, `lint:i18n` (1848 ≤ 1854 baseline), jscpd 0 clones — clean
- **Deterministic**: identical totals across 3 consecutive full sweeps, *and* across two independently built bundles (base `ea34065` vs head produced byte-identical numbers — this PR changes no rendered component)
- **`[vs-base]` is strictly stronger than the ledger**: proven by the inflated-ceiling test above
- **Actually blocks**: injected a hardcoded string + tooltip into `AboutPanel`, rebuilt → `settings-about.text: 28 -> 46`, exit 1. Reverted.
- **Stable across a real main advance**: rebased onto `ea34065` (#1091, which rewrites `PrivacyPanel` and adds an onboarding privacy step — both gated surfaces) and the numbers are unchanged, confirming #1091's new strings are properly translated

The analysis lives in **one** copy that runs in two runtimes: Node, so `renderScan.test.ts` can unit-test the string logic, and the browser via `browserBundle()`, which strips the `export` keywords and injects it with `addScriptTag`. Those tests also lock the pseudolocale invariants the gate borrows, so changing the generator's delimiters fails a test instead of quietly making the gate find nothing. One of them caught a real gap while I was writing it: `latinLeaks` orphaned `https` out of the committed value `https://<your-host>` because stripping `<…>` first destroys its URL host.

## Where this sits in the plan

| Phase | State |
|---|---|
| 0 — guards, style guides, en-XA generation | merged (#898, #911, #914, #921, #922) |
| 0.5 — i18next 26 / react-i18next 17 | merged (#915) |
| 1 — remove visible English | batches 2–5 merged; batch 1 open in #1040 |
| 2a — script font stacks | merged (#982) |
| 2b — bidi isolation | not started (local only) |
| 3 — de-fragment | item 1 merged (#1048); items 2–4 not started |
| 4 — locale-aware formatting | seam merged (#1009); batch 2 open in #1047 |
| **5 — render-time gate** | **this PR** |
| 6 — structural cleanup | not started; #1099 is a partial slice |
| 7 — contributor tooling | not started |

Within Phase 5:

| Item | State |
|---|---|
| 1 — no bidi pseudolocale (decision, nothing to build) | honoured — no RTL locale ships until Track C |
| 2 — per-locale runs, 4 assertions on the top ~20 surfaces | **in this PR** (all four: overflow, bracket integrity, plain-Latin leak, DNT) |
| 3 — eight prescriptive finding signatures | **6 of 8 in this PR** |

The two deferred signatures are #5 (vertical growth in tall scripts) and #6 (short-source ratio > 2). Both need to match the same element across locale runs, and this codebase has very few `data-testid`s, so a tag-chain key collides heavily. Shipping them on a colliding key would produce a signal nobody could trust. They want either testids on the gated surfaces or an index-extended path — worth its own change.

## Not covered, stated plainly

- **Interactive surfaces.** Command palette, credits modal and the composer dropdowns need clicks; a gate that flakes because a dropdown did not open is a gate people disable. The `fixed-overlay-off-viewport` check still covers portals that mount on load.
- **A string whose every word is a DNT term** is invisible — the exclusion list cannot tell it from fixture data or third-party metadata.
- **Single-token DNT text** is skipped, because an agent named `kirocrew` is an identifier, not a mangled `KiroCrew`.
- It renders fixture data, so it verifies the rendering and catalog layers, not gateway-to-UI wiring.
