### PR TITLE
fix(electron): stop the permission check denying a media check with no mediaType

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -46,6 +46,10 @@ const { findConfiguredDashboardPort } = require("./data-home");
 const { createTokenRetryHandler } = require("./token-retry");
 const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
 const { createDisplayMediaHandler } = require("./display-media");
+const {
+  createPermissionRequestHandler,
+  createPermissionCheckHandler,
+} = require("./permission-handler");
 const { createWindowOpenHandler } = require("./external-scheme");
 const { initAutoUpdate } = require("./auto-update");
 const {
@@ -1960,23 +1964,14 @@ app.whenReady().then(async () => {
   // permission *check* can report `media` as denied for the renderer's
   // navigator.mediaDevices.getUserMedia(), so the mic button silently no-ops
   // in the packaged app even though it works in a plain browser (Chromium
-  // prompts there). Scope the grant to the `media` permission type only
-  // (what getUserMedia needs for the mic) and deny every other permission
-  // type (geolocation, clipboard, notifications, MIDI, …) per least
-  // privilege. Screen capture uses its own setDisplayMediaRequestHandler and
-  // is unaffected. On macOS we also proactively trigger the OS microphone
-  // (TCC) permission prompt.
-  const isAppOrigin = (wc) => {
-    try { return new URL(wc?.getURL?.() || "").hostname === "localhost"; } catch { return false; }
-  };
-  session.defaultSession.setPermissionRequestHandler((wc, permission, callback, details) => {
-    const isAudioOnly = details?.mediaTypes?.includes("audio") && !details?.mediaTypes?.includes("video");
-    callback(permission === "media" && isAppOrigin(wc) && isAudioOnly);
-  });
-  session.defaultSession.setPermissionCheckHandler((wc, permission, _origin, details) => {
-    if (permission === "media") return isAppOrigin(wc) && details?.mediaType === "audio";
-    return false;
-  });
+  // prompts there). The handlers grant `media` for the app origin and deny
+  // every other permission type (geolocation, clipboard, notifications,
+  // MIDI, …) per least privilege. Screen capture uses its own
+  // setDisplayMediaRequestHandler and is unaffected. See permission-handler.js
+  // for why the audio grant must NOT require a populated details.mediaTypes.
+  // On macOS we also proactively trigger the OS microphone (TCC) prompt.
+  session.defaultSession.setPermissionRequestHandler(createPermissionRequestHandler());
+  session.defaultSession.setPermissionCheckHandler(createPermissionCheckHandler());
   if (process.platform === "darwin") {
     systemPreferences.askForMediaAccess("microphone").catch(() => {
       /* best effort — older macOS or TCC denied */

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -78,6 +78,7 @@
       "remote-token.js",
       "token-retry.js",
       "display-media.js",
+      "permission-handler.js",
       "external-scheme.js",
       "validation.js",
       "context-menu.js",

--- a/website/electron/permission-handler.js
+++ b/website/electron/permission-handler.js
@@ -1,0 +1,173 @@
+// Renderer permission gating for the KiroCrew Electron app.
+//
+// Why this exists: without an explicit handler, Electron's default permission
+// *check* can report `media` as denied for the renderer's getUserMedia(), so
+// the chat input's mic button silently no-ops in the packaged app even though
+// it works in a plain browser (Chromium prompts there). These handlers grant
+// the microphone and deny everything else, per least privilege. Screen capture
+// has its own seam (display-media.js) and is unaffected.
+//
+// ── The bug this module fixes ────────────────────────────────────────────────
+//
+// Voice input was denied in the packaged app while working in Chrome at the
+// SAME origin, with the SAME macOS (TCC) grant, on the SAME device — proving by
+// isolation that the denial came from this layer and not from the OS. The
+// renderer saw `NotAllowedError` from getUserMedia even though
+// navigator.permissions.query({name:'microphone'}) reported "granted" and
+// device labels were populated (Chromium only exposes labels post-grant).
+//
+// The original CHECK handler had two independent defects:
+//
+//     setPermissionCheckHandler((wc, permission, _origin, details) => {
+//       if (permission === "media") return isAppOrigin(wc) && details?.mediaType === "audio";
+//       return false;
+//     });
+//
+//   1. `wc` MAY BE NULL. Electron passes a null webContents for permission
+//      checks that don't originate from a live frame. The old isAppOrigin then
+//      ran `new URL("")`, threw, and returned false — a deny. Meanwhile
+//      `_origin`, the origin STRING Electron supplies for exactly this case,
+//      was discarded. That is the bug this module's two-source origin check
+//      closes.
+//   2. `mediaType === "audio"` is an exact match, so any other value — notably
+//      'unknown', which Chromium uses on some paths — also denied.
+//
+// Either defect alone produces the observed asymmetry: permissions.query()
+// arrives with a real frame and mediaType 'audio' (granted), while
+// getUserMedia's internal check arrives without one (denied). The fix covers
+// both, so it holds regardless of which fired.
+//
+// ── The rule ─────────────────────────────────────────────────────────────────
+//
+// Deny only when video is EXPLICITLY requested. Audio-only and unspecified both
+// pass. That keeps the camera gated while making the mic robust to absent or
+// renamed detail fields. Non-`media` permissions are still denied wholesale.
+//
+// A denial logs one line to the main-process console, because diagnosing this
+// previously required attaching a debugger to the main process — the handlers
+// were silent, so a deny was indistinguishable from an OS refusal.
+//
+// Pure logic with the origin lookup injected, so both handlers are unit
+// testable without a live Electron session — mirroring display-media.js.
+"use strict";
+
+/**
+ * True when the request belongs to the app's own dashboard.
+ *
+ * Checks TWO sources because neither is always present:
+ *   - `wc.getURL()` — available for frame-originated requests.
+ *   - `origin` — the string Electron passes to the CHECK handler, and the ONLY
+ *     signal when `wc` is null. Ignoring it is what denied the microphone.
+ *
+ * Both are parsed as URLs and compared on hostname; never substring-matched, so
+ * `http://localhost.evil.example/` cannot pass. The shell always loads
+ * `http://localhost:<port>` (main.js BACKEND_URL) and remote hosts are SSH
+ * forwards onto that same loopback port, so hostname is a stable identity.
+ *
+ * @param {{ getURL?: () => string } | null | undefined} wc
+ * @param {string} [origin] - securityOrigin string, when Electron supplies one
+ * @returns {boolean}
+ */
+function isAppOrigin(wc, origin) {
+  let fromWc;
+  try {
+    fromWc = wc?.getURL?.();
+  } catch {
+    fromWc = undefined; // a destroyed webContents throws on getURL()
+  }
+  for (const candidate of [fromWc, origin]) {
+    if (!candidate || typeof candidate !== "string") continue;
+    try {
+      if (new URL(candidate).hostname === "localhost") return true;
+    } catch {
+      // Unparseable — try the next source rather than denying outright.
+    }
+  }
+  return false;
+}
+
+/**
+ * Does this request explicitly ask for video (camera)?
+ *
+ * Only an explicit "video" entry counts. An absent or non-array `mediaTypes`
+ * is NOT treated as a video request — see the fail-open rationale above.
+ *
+ * @param {{ mediaTypes?: Array<string> } | null | undefined} details
+ * @returns {boolean}
+ */
+function requestsVideo(details) {
+  const types = details?.mediaTypes;
+  return Array.isArray(types) && types.includes("video");
+}
+
+/** One-line breadcrumb so a denial is visible without attaching a debugger. */
+function logDeny(kind, permission, wc, origin, details) {
+  // eslint-disable-next-line no-console -- see module header: silent denials
+  // cost two debugging sessions.
+  console.warn(
+    `[permission] ${kind} DENY permission=${permission}`,
+    `wcUrl=${(() => { try { return wc?.getURL?.() || "<none>"; } catch { return "<throws>"; } })()}`,
+    `origin=${origin || "<none>"}`,
+    `details=${JSON.stringify(details ?? null)}`,
+  );
+}
+
+/**
+ * Build the handler for session.setPermissionRequestHandler().
+ *
+ * Grants `media` for the app origin unless video is explicitly requested.
+ * Denies every other permission type (geolocation, clipboard, notifications,
+ * MIDI, …).
+ *
+ * @param {object} [deps]
+ * @param {(wc: unknown, origin?: string) => boolean} [deps.isAppOrigin] - injectable for tests
+ * @param {(...args: unknown[]) => void} [deps.onDeny] - injectable for tests
+ * @returns {(wc: unknown, permission: string, callback: (granted: boolean) => void, details?: object) => void}
+ */
+function createPermissionRequestHandler(deps = {}) {
+  const originOk = deps.isAppOrigin || isAppOrigin;
+  const onDeny = deps.onDeny || logDeny;
+  return function handlePermissionRequest(wc, permission, callback, details) {
+    // The REQUEST handler has no origin string of its own; details may carry a
+    // requesting URL on some Electron versions, so offer it as the fallback.
+    const origin = details?.securityOrigin || details?.requestingUrl;
+    const granted =
+      permission === "media" && originOk(wc, origin) && !requestsVideo(details);
+    if (!granted) onDeny("request", permission, wc, origin, details);
+    return callback(granted);
+  };
+}
+
+/**
+ * Build the handler for session.setPermissionCheckHandler().
+ *
+ * Mirrors the request handler so a synchronous check cannot disagree with the
+ * async grant — a disagreement is what made navigator.permissions.query()
+ * report "granted" while getUserMedia failed. `details.mediaType` is the
+ * singular sibling of `mediaTypes`; "video" is refused, anything else
+ * (including an absent value) is allowed for the app origin.
+ *
+ * @param {object} [deps]
+ * @param {(wc: unknown, origin?: string) => boolean} [deps.isAppOrigin] - injectable for tests
+ * @param {(...args: unknown[]) => void} [deps.onDeny] - injectable for tests
+ * @returns {(wc: unknown, permission: string, origin?: string, details?: object) => boolean}
+ */
+function createPermissionCheckHandler(deps = {}) {
+  const originOk = deps.isAppOrigin || isAppOrigin;
+  const onDeny = deps.onDeny || logDeny;
+  return function handlePermissionCheck(wc, permission, origin, details) {
+    const granted =
+      permission === "media" &&
+      originOk(wc, origin) &&
+      details?.mediaType !== "video";
+    if (!granted) onDeny("check", permission, wc, origin, details);
+    return granted;
+  };
+}
+
+module.exports = {
+  isAppOrigin,
+  requestsVideo,
+  createPermissionRequestHandler,
+  createPermissionCheckHandler,
+};

--- a/website/electron/test/permission-handler.test.js
+++ b/website/electron/test/permission-handler.test.js
@@ -1,0 +1,199 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  isAppOrigin,
+  requestsVideo,
+  createPermissionRequestHandler,
+  createPermissionCheckHandler,
+} = require("../permission-handler");
+
+/** webContents stub whose getURL() returns `url`. */
+const wcAt = (url) => ({ getURL: () => url });
+/** A destroyed webContents: getURL() throws. */
+const wcDestroyed = () => ({ getURL: () => { throw new Error("Object has been destroyed"); } });
+
+const APP = wcAt("http://localhost:5476/chat/x?token=abc");
+const ORIGIN = "http://localhost:5476";
+const allowAll = { isAppOrigin: () => true, onDeny: () => {} };
+const quiet = { onDeny: () => {} };
+
+/** Invoke the request handler and return what it passed to callback(). */
+function grant(handler, wc, permission, details) {
+  let granted;
+  handler(wc, permission, (v) => { granted = v; }, details);
+  return granted;
+}
+
+describe("isAppOrigin — two sources", () => {
+  it("accepts the webContents URL on any port", () => {
+    assert.equal(isAppOrigin(APP), true);
+    assert.equal(isAppOrigin(wcAt("http://localhost:6777/")), true);
+  });
+
+  it("FALLS BACK to the origin string when webContents is null", () => {
+    // THE BUG: Electron passes a null webContents for checks that don't come
+    // from a live frame. The old code ran new URL("") -> threw -> denied, while
+    // discarding the origin string provided for exactly this case.
+    assert.equal(isAppOrigin(null, ORIGIN), true);
+    assert.equal(isAppOrigin(undefined, "http://localhost:5476/"), true);
+    assert.equal(isAppOrigin({}, ORIGIN), true);
+  });
+
+  it("falls back when webContents getURL() throws (destroyed)", () => {
+    assert.equal(isAppOrigin(wcDestroyed(), ORIGIN), true);
+    assert.equal(isAppOrigin(wcDestroyed(), undefined), false);
+  });
+
+  it("denies when BOTH sources are absent or foreign", () => {
+    assert.equal(isAppOrigin(null, undefined), false);
+    assert.equal(isAppOrigin(null, ""), false);
+    assert.equal(isAppOrigin(wcAt("http://evil.example/"), "http://evil.example"), false);
+    assert.equal(isAppOrigin(null, "http://evil.example"), false);
+  });
+
+  it("compares hostname, never a substring (no localhost.evil bypass)", () => {
+    assert.equal(isAppOrigin(null, "http://localhost.evil.example/"), false);
+    assert.equal(isAppOrigin(wcAt("http://notlocalhost/"), undefined), false);
+    assert.equal(isAppOrigin(null, "http://evil.example/?x=http://localhost"), false);
+  });
+
+  it("tolerates unparseable values by trying the other source", () => {
+    assert.equal(isAppOrigin(wcAt("not a url"), ORIGIN), true);
+    assert.equal(isAppOrigin(wcAt("not a url"), "also not a url"), false);
+    assert.equal(isAppOrigin(null, 42), false);
+  });
+});
+
+describe("requestsVideo", () => {
+  it("is true ONLY for an explicit video entry", () => {
+    assert.equal(requestsVideo({ mediaTypes: ["video"] }), true);
+    assert.equal(requestsVideo({ mediaTypes: ["audio", "video"] }), true);
+  });
+
+  it("treats absent / empty / non-array mediaTypes as NOT video", () => {
+    for (const d of [{}, { mediaTypes: [] }, { mediaTypes: undefined }, { mediaTypes: "audio" }, undefined, null]) {
+      assert.equal(requestsVideo(d), false, `${JSON.stringify(d)} must not read as video`);
+    }
+  });
+});
+
+describe("createPermissionCheckHandler", () => {
+  it("GRANTS the real observed payload: live frame, NO mediaType at all", () => {
+    // THE VERIFIED CAUSE. Captured from Electron 33.4.11 in the packaged app:
+    //   CHECK media wcIsNull=false origin=http://localhost:5476/ mediaType=undefined
+    // Electron issues a first `media` check whose details carry no mediaType —
+    // only embeddingOrigin / isMainFrame / requestingUrl — then a second with
+    // mediaType:"audio". The shipped `mediaType === "audio"` exact match denied
+    // the FIRST one, so getUserMedia rejected with NotAllowedError before the
+    // audio-specific check was ever reached.
+    const h = createPermissionCheckHandler(quiet);
+    const observed = {
+      embeddingOrigin: "http://localhost:5476/",
+      isMainFrame: true,
+      requestingUrl: "http://localhost:5476/chat/x?token=redacted&sid=chat-70",
+    };
+    assert.equal(h(APP, "media", "http://localhost:5476/", observed), true);
+    // …and the follow-up check that did carry mediaType.
+    assert.equal(h(APP, "media", "http://localhost:5476/", { ...observed, mediaType: "audio" }), true);
+  });
+
+  it("grants mic when webContents is null but origin is ours", () => {
+    // Not the cause observed here (wcIsNull was false), but Electron documents
+    // a nullable webContents, and the old isAppOrigin threw on it.
+    const h = createPermissionCheckHandler(quiet);
+    assert.equal(h(null, "media", ORIGIN, { mediaType: "audio" }), true);
+    assert.equal(h(null, "media", ORIGIN, { mediaType: "unknown" }), true);
+    assert.equal(h(null, "media", ORIGIN, {}), true);
+    assert.equal(h(null, "media", ORIGIN, undefined), true);
+  });
+
+  it("grants a non-'audio' mediaType such as 'unknown' (the other defect)", () => {
+    const h = createPermissionCheckHandler(quiet);
+    assert.equal(h(APP, "media", ORIGIN, { mediaType: "unknown" }), true);
+  });
+
+  it("refuses video, keeping the camera gated", () => {
+    const h = createPermissionCheckHandler(quiet);
+    assert.equal(h(APP, "media", ORIGIN, { mediaType: "video" }), false);
+    assert.equal(h(null, "media", ORIGIN, { mediaType: "video" }), false);
+  });
+
+  it("denies non-media permissions and foreign origins", () => {
+    const h = createPermissionCheckHandler(quiet);
+    for (const p of ["geolocation", "notifications", "midi", "clipboard-read", "unknown"]) {
+      assert.equal(h(APP, p, ORIGIN, {}), false, `${p} must be denied`);
+    }
+    assert.equal(h(wcAt("http://evil.example/"), "media", "http://evil.example", { mediaType: "audio" }), false);
+    assert.equal(h(null, "media", undefined, { mediaType: "audio" }), false);
+  });
+});
+
+describe("createPermissionRequestHandler", () => {
+  it("grants audio-only and unspecified mediaTypes", () => {
+    const h = createPermissionRequestHandler(allowAll);
+    assert.equal(grant(h, APP, "media", { mediaTypes: ["audio"] }), true);
+    assert.equal(grant(h, APP, "media", {}), true);
+    assert.equal(grant(h, APP, "media", undefined), true);
+  });
+
+  it("denies video and every non-media permission", () => {
+    const h = createPermissionRequestHandler(allowAll);
+    assert.equal(grant(h, APP, "media", { mediaTypes: ["video"] }), false);
+    assert.equal(grant(h, APP, "geolocation", { mediaTypes: ["audio"] }), false);
+  });
+
+  it("uses details.securityOrigin when webContents is null", () => {
+    const h = createPermissionRequestHandler(quiet);
+    assert.equal(grant(h, null, "media", { mediaTypes: ["audio"], securityOrigin: ORIGIN }), true);
+    assert.equal(grant(h, null, "media", { mediaTypes: ["audio"] }), false);
+  });
+
+  it("invokes the callback exactly once, granted or not", () => {
+    const h = createPermissionRequestHandler(allowAll);
+    let calls = 0;
+    h(APP, "geolocation", () => { calls += 1; }, {});
+    h(APP, "media", () => { calls += 1; }, {});
+    assert.equal(calls, 2);
+  });
+});
+
+describe("check and request handlers agree", () => {
+  it("never lets a check veto a grant the request handler would give", () => {
+    // The observed contradiction: permissions.query() said "granted" while
+    // getUserMedia was refused. Same inputs must yield the same verdict.
+    const check = createPermissionCheckHandler(quiet);
+    const req = createPermissionRequestHandler(quiet);
+    const cases = [
+      [APP, ORIGIN, "audio"], [APP, ORIGIN, "unknown"], [APP, ORIGIN, undefined],
+      [null, ORIGIN, "audio"], [null, ORIGIN, "unknown"], [APP, ORIGIN, "video"],
+      [null, undefined, "audio"],
+    ];
+    for (const [wc, origin, mediaType] of cases) {
+      const asCheck = check(wc, "media", origin, { mediaType });
+      const asReq = grant(req, wc, "media", {
+        mediaTypes: mediaType ? [mediaType] : undefined,
+        securityOrigin: origin,
+      });
+      assert.equal(asCheck, asReq, `disagreement for wc=${!!wc} origin=${origin} mediaType=${mediaType}`);
+    }
+  });
+});
+
+describe("denial logging", () => {
+  it("emits exactly one breadcrumb per denial and none on grant", () => {
+    const seen = [];
+    const deps = { onDeny: (...a) => seen.push(a) };
+    const check = createPermissionCheckHandler(deps);
+    check(APP, "media", ORIGIN, { mediaType: "audio" });   // grant
+    assert.equal(seen.length, 0);
+    check(null, "media", undefined, { mediaType: "audio" }); // deny
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0][0], "check");
+  });
+
+  it("survives a destroyed webContents while logging", () => {
+    const h = createPermissionCheckHandler();
+    // Real logDeny path with a throwing getURL() must not raise.
+    assert.equal(h(wcDestroyed(), "media", undefined, { mediaType: "audio" }), false);
+  });
+});


### PR DESCRIPTION
## Problem

Voice input is denied in the packaged app. The renderer gets `NotAllowedError` from `getUserMedia`, surfaced as *"Microphone permission denied. Allow mic access in your OS and browser settings."* — pointing at the OS, where nothing is wrong.

**Isolated by test.** Same dashboard, same origin, same macOS (TCC) grant, same device:

| | mic |
|---|---|
| Chrome at `http://localhost:5476` | ✅ works |
| Packaged Electron app | ❌ `NotAllowedError` |

A browser has no `setPermissionCheckHandler`. That difference put the cause in this layer.

## Root cause — measured, not inferred

Instrumenting **both** handlers in the running app (`--inspect=9229`, real module loaded) produced:

```
CHECK media wcIsNull=false origin=http://localhost:5476/           mediaType=undefined  => true
CHECK media wcIsNull=false origin=http://localhost:5476/chat/...   mediaType="audio"    => true
```

Electron issues a **first `media` check carrying no `mediaType` at all** — `details` holds only `embeddingOrigin`, `isMainFrame`, `requestingUrl` — followed by a second that does. The shipped handler demanded an exact match:

```js
setPermissionCheckHandler((wc, permission, _origin, details) => {
  if (permission === "media") return isAppOrigin(wc) && details?.mediaType === "audio";
  return false;
});
```

`undefined === "audio"` is `false`, so **the first check denied** and `getUserMedia` rejected before the audio-specific check was ever reached.

That also explains the contradiction in the renderer: `navigator.permissions.query({name:'microphone'})` reported **`granted`** (it resolves through the path that carries `mediaType: "audio"`) while `getUserMedia` failed on the next line.

**Fix:** deny only when video is **explicitly** requested, instead of requiring positive proof of audio. The camera stays gated; the mic stops depending on an optional field being populated.

### Also corrected — but not the cause here

`wc` is nullable per Electron's API, and the old `isAppOrigin` ran `new URL("")` on it, threw, and returned `false` while discarding the `origin` string supplied for exactly that case. **`wcIsNull` was `false` in every observed check**, so this latent path did not fire in this bug. Closed anyway, with the origin fallback.

## Verification

**Verified against the real failure**, not just in unit tests: this module was loaded into the running packaged app via `--inspect` and the microphone worked. The same run showed `speaker-selection` still correctly **denied**, so least-privilege on non-media permissions is intact.

- 20 tests, including the **captured real-world payload** (live frame, no `mediaType`)
- **Mutation-checked**: restoring only `mediaType === "audio"` fails 4 of 20
- 427/427 electron tests green, rebased onto current main

## Changes

| File | Change |
|---|---|
| `website/electron/permission-handler.js` | **New.** Both handlers extracted with the origin lookup injected, matching how `display-media.js` isolates the screen-capture handler |
| `website/electron/main.js` | 23 inline lines → two factory calls |
| `website/electron/test/permission-handler.test.js` | **New.** 20 tests |
| `website/electron/package.json` | `permission-handler.js` added to electron-builder's explicit `files` list |

- Origin is checked against **both** `wc.getURL()` and the `origin` string, tolerating a destroyed `webContents` whose `getURL()` throws. Both parsed as URLs and compared on **hostname, never substring** — `http://localhost.evil.example/` cannot pass (tested).
- The check handler now **mirrors** the request handler, so a synchronous check cannot veto a grant the async path would give.
- **One log line on any denial.** The handlers were silent, so a deny was indistinguishable from an OS refusal. That silence cost two debugging sessions and a debugger attach to the main process.

Non-`media` permissions (geolocation, clipboard, notifications, MIDI, `speaker-selection`, …) remain denied wholesale.

## Why this wasn't caught

1. **No test existed** for these handlers. `display-media.js` was extracted and tested for the *screen* equivalent; the mic handlers stayed inline in `main.js`.
2. **The electron suite doesn't run on PRs.** `npm test` for `website/electron` appears in exactly one workflow — `ota-test.yml` — which self-describes as "nightly and on demand… not an automatic merge block." So these 427 tests, including the 20 here, gate nothing on a pull request. Worth a separate discussion; CI is unchanged in this PR.
3. **No E2E coverage of real Electron permission plumbing.** These 20 tests verify logic against a model of Electron's behaviour; if that model drifts in a future Electron version they will still pass. `ota-test.yml` proves the shape is feasible (it launches real app bundles), but it isn't a PR gate.
