### PR TITLE
fix(skills): make image-authoring discoverable, add excalidraw route

### DIFF
--- a/src/kiro_crew/builtin_skills/image-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/image-authoring/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: image-authoring
+description: Author images and diagrams as code — SVG, Pillow, Excalidraw, mermaid. Load when asked to draw, illustrate, or make an image, icon, logo, poster, or diagram.
+---
+
 # Image Authoring
 
 Create images by **authoring them as code** — there is no text-to-image model
@@ -38,6 +43,7 @@ the user can correct course before you draw.
 | Texture, gradient art, pixel art, noise, filters, compositing | **Python + Pillow** (raster) |
 | Raster copy of an SVG (user needs .png) | Convert: rsvg-convert → inkscape → magick → Playwright screenshot |
 | Flowchart, architecture, data chart | Prefer mermaid / widgets; else SVG or Pillow |
+| Hand-drawn / whiteboard-style diagram, sketch aesthetic | **Excalidraw scene** — see below |
 
 Check tool availability before relying on it (`python3 -c "import PIL"`,
 `which rsvg-convert`).
@@ -79,6 +85,35 @@ For raster: edit the kept script/HTML and re-run — never hand-patch pixels.
 - "colors feel dull" → adjust gradient stops / palette variables only.
 - "more detail on X" → add children inside X's group, keep siblings intact.
 - Ambiguous region? Ask one short clarifying question instead of guessing.
+
+## Excalidraw scenes
+
+The dashboard renders an ```excalidraw fence (and a saved `.excalidraw` file) as
+inline SVG. Reach for it when the hand-drawn whiteboard look is the point;
+mermaid stays better when you want automatic layout, and a widget when you want
+real HTML. Unlike mermaid, this fence is specific to this dashboard — emit it
+deliberately, it is not a convention a reader will know from elsewhere.
+
+Emit scene JSON: `{"type":"excalidraw","version":2,"elements":[…],"appState":{…}}`.
+The renderer is a **viewer, not the editor**, so author around these differences:
+
+- **Fonts are not bundled.** `fontFamily` 1/5/8 (the hand-drawn ids) resolve to
+  whatever the *viewer's* machine aliases to CSS `cursive`, which varies per box
+  and can be illegible. Use `2` (sans) or `3` (mono) unless the hand-drawn face
+  matters more than legibility. Shapes stay sketchy either way — that comes from
+  rough.js, not the font.
+- **Bound text is approximated.** `containerId` is not resolved to its container.
+  Position each text element absolutely, giving it the container's `x` and
+  `width` with `textAlign: "center"` to centre a label.
+- **Keep `seed` stable** across edits. rough.js derives its jitter from it, so
+  new seeds make the whole diagram wobble on re-render.
+- **Images** need a raster `data:image/*;base64` URL in `files`. SVG data URLs
+  are rejected; `embeddable` / `iframe` elements are skipped.
+- Set `appState.viewBackgroundColor` — the scene is painted on its own canvas
+  rather than composited onto the chat surface, so it does not follow the theme.
+
+Malformed JSON falls back to showing the source, so a broken scene costs the
+reader the picture but never the content.
 
 ## Style hints that raise quality
 

--- a/test/test_image_authoring_skill.py
+++ b/test/test_image_authoring_skill.py
@@ -1,0 +1,69 @@
+"""The image-authoring skill must stay discoverable and keep its Excalidraw route.
+
+Locks two joints:
+
+(1) Every packaged builtin skill carries the frontmatter fields ``skills/README.md``
+    documents as required — ``name`` and ``description``. Without them
+    ``SkillsLoader.list_skills`` falls back to ``meta.get("description", name)``, so
+    the skill appears in the lazy-load catalog as nothing but its own directory name
+    and ``skill_search`` has no text to match on. image-authoring shipped that way
+    and was effectively unreachable: the only route to it was typing its exact name.
+
+    ``triggers`` is deliberately NOT asserted here. ``skills/README.md`` documents it
+    as optional, and whether a skill should auto-inject is a per-skill judgement
+    about trigger overlap (see the PR #353 arbiter note in ``skills.py``) rather than
+    something a blanket test should force.
+
+(2) image-authoring names the ``excalidraw`` fence. The dashboard renders it
+    (``MarkdownRenderer`` -> ``ExcalidrawBlock``), but that fence is specific to this
+    project, so an agent only emits one if this skill says the option exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.skills import SkillsLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+BUILTIN_SKILLS_DIR = ROOT / "src" / "kiro_crew" / "builtin_skills"
+IMAGE_AUTHORING = BUILTIN_SKILLS_DIR / "image-authoring" / "SKILL.md"
+
+
+def _builtin_skill_files() -> list[Path]:
+    """Every packaged builtin SKILL.md, including nested ones (kirocrew-dev/…)."""
+    return sorted(BUILTIN_SKILLS_DIR.rglob("SKILL.md"))
+
+
+def _skill_id(path: Path) -> str:
+    """Skill key as the loader sees it — the dir path relative to the builtin root."""
+    return str(path.parent.relative_to(BUILTIN_SKILLS_DIR))
+
+
+class TestBuiltinSkillFrontmatter:
+    """Required frontmatter is what makes a packaged skill findable at all."""
+
+    def test_builtin_skills_are_discovered(self):
+        assert _builtin_skill_files(), f"no SKILL.md found under {BUILTIN_SKILLS_DIR}"
+
+    @pytest.mark.parametrize("skill_file", _builtin_skill_files(), ids=_skill_id)
+    def test_name_and_description_present(self, skill_file: Path):
+        # The loader's own parser, not a reimplementation of it.
+        meta = SkillsLoader._parse_frontmatter(skill_file)
+        skill = _skill_id(skill_file)
+        assert meta, f"{skill}: no YAML frontmatter — nothing to show in the catalog"
+        assert meta.get("name"), f"{skill}: missing required 'name'"
+        assert meta.get("description"), f"{skill}: missing required 'description'"
+
+
+class TestImageAuthoringSkill:
+    """The Excalidraw route stays named in the skill that owns diagram technique."""
+
+    def test_names_the_excalidraw_fence(self):
+        content = IMAGE_AUTHORING.read_text(encoding="utf-8")
+        assert "excalidraw" in content.lower(), (
+            "image-authoring must name the excalidraw option; the dashboard renders "
+            "the fence but no agent will emit one it was never told about"
+        )


### PR DESCRIPTION
## Description

`image-authoring` was the only one of the 12 packaged builtin skills with **no YAML
frontmatter**, so it carried neither field `skills/README.md` documents as required.
`SkillsLoader.list_skills` falls back to `meta.get("description", name)`, which left its
catalog entry as nothing but its own directory name — the lazy-load block had no summary
to show and `skill_search` had no text to match. The trigger vocabulary the body already
lists in prose ("draw", "illustrate", "logo", "poster") is invisible to the loader, so
the only route in was typing `$image-authoring`, i.e. already knowing it exists.

This adds `name` + `description` **only**. `triggers` stays absent on purpose: it is
documented as optional, and picking a vocabulary that does not collide with `widgets`
(`chart, table, visual, dashboard`) or `frontend-design-workflow` (`mockup, redesign,
visual change`) is a separate judgement — with `_MIN_TRIGGER_OVERLAP = 0.7` and the
`max_triggered` cap, a broad token like `draw` competes on ordinary phrasing, which is
the overlap the PR #353 arbiter blocked. That decision is #1109, not this PR. **So this
changes auto-trigger behaviour by exactly nothing** — only catalog visibility.

It also documents the ` ```excalidraw ` fence. #1064 made it renderable, but nothing told
an agent it exists: unlike mermaid, the fence has no presence outside this project, so a
model never infers it. Asked to "draw an architecture diagram" today, an agent follows the
technique table straight to mermaid or hand-rolled SVG and the renderer is never reached.
The notes cover the viewer's documented divergences from excalidraw.com — no bundled fonts
(so `fontFamily` 1/5/8 land on whatever the *viewer's* box aliases to CSS `cursive`),
approximated bound text, stable `seed`s, raster-only images.

Found while authoring a diagram by hand: I only produced a legible scene because I read
`excalidrawScene.ts` first. My untutored first attempt used `fontFamily: 1`, which is
correct for excalidraw.com and wrong here. That delta is what the new section encodes.

## Related Issues

Refs #1109 (whether the skill should auto-trigger, and on what vocabulary — deliberately
out of scope here). Follows up #1064, which added the renderer.

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality
- [x] Manual verification performed

`test/test_image_authoring_skill.py` (14 cases) asserts `name` + `description` across
**all** builtins, so the next skill cannot ship unreachable the same way. It deliberately
does **not** assert `triggers`.

- **Negative control:** restoring the pre-fix `SKILL.md` from `origin/main` fails exactly
  2 cases (`no YAML frontmatter`, and the excalidraw assertion) and passes 12 — the test
  catches the real defect rather than passing vacuously.
- 201 passed across `test_skills.py`, `test_skill_discover.py`,
  `test_agent_template_skills.py`, `test_skill_providers.py` — the new frontmatter does not
  disturb catalog or trigger behaviour.
- `isort`, `flake8`, `black --check` clean. `mypy src/kiro_crew/` → no issues in 577 files.
- Developed in a git worktree off `origin/main` per `kirocrew-worktree-dev`, rebased onto
  `2de95d16`, single flat commit.

**Deviation worth flagging:** I skipped `npx tsc -b` and `npx vitest run`. This touches zero
frontend files, so a fresh `npm ci` buys no signal — but CI runs them, so please treat CI as
the authority there.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff