### PR TITLE
fix(dashboard): keep a surfaced channel tab mirroring its channel session until the user forks it

### DIFF
--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -27,6 +27,14 @@ Design notes:
   never reads — so it would reopen on the next pass. Continuity with the live
   channel session is not worth that; picking the conversation up with its full
   history (which this does) is the point.
+* **Mirror until forked.** A surfaced slot the user has NOT written to from the
+  dashboard is a pure mirror of the channel transcript, and the no-split
+  rationale above does not yet apply — so the reconciler keeps appending new
+  channel turns into it, keeping the tab current instead of freezing it at
+  surface time. The first dashboard-authored turn forks the conversation and
+  disarms the mirror permanently; from then on the two transcripts diverge
+  exactly as the previous note describes. Fork detection is fail-safe: ANY
+  window change the mirror did not make itself disarms it.
 * **Recency-bounded.** Only sessions modified within the dashboard's configured
   ``restore_window_minutes`` become slots, so a long DM history does not turn
   into hundreds of tabs. Pinned and foldered sessions are exempt from the
@@ -96,6 +104,9 @@ class _Transcript(NamedTuple):
     messages: list[dict[str, Any]]
     disk_older: int
     disk_window: int
+    #: True when the slot's own on-disk lines are all copies of channel turns —
+    #: the precondition for arming the mirror (see :func:`is_pure_mirror`).
+    pure_mirror: bool = True
 
 
 def channel_label(session_key: str) -> str:
@@ -127,6 +138,77 @@ def _redact(text: str) -> str:
     text, _ = redact_exfiltration_urls(text)
     text, _ = redact_credentials(text)
     return text
+
+
+def _mirror_identity(msg: dict[str, Any]) -> tuple[str, str, str]:
+    """Cross-file match identity for one transcript message.
+
+    Slot copies of channel turns are stored REDACTED (``surface_channel_session``
+    redacts on seed), while the channel file holds the raw text — comparing raw
+    identities would mis-classify every redacted turn as dashboard-authored.
+    Redacting both sides makes the comparison stable regardless of which side a
+    message is read from (the redactors are idempotent on their own output, and
+    redacting an already-redacted slot line is a no-op either way).
+    """
+    return (
+        str(msg.get("role", "")),
+        _redact(str(msg.get("content", ""))),
+        str(msg.get("ts", "")),
+    )
+
+
+def is_pure_mirror(
+    slot_messages: list[dict[str, Any]],
+    channel_messages: list[dict[str, Any]],
+) -> bool:
+    """True when *slot_messages* holds nothing the channel transcript lacks.
+
+    A pure-mirror slot is one the user has never written to from the dashboard:
+    every turn it carries is a copy of a channel turn. Only such a slot may be
+    kept in sync by :func:`mirror_new_messages` — the moment the slot holds a
+    dashboard-authored turn the conversation has forked, and appending further
+    channel turns would interleave two diverged transcripts.
+
+    Pure and side-effect free so the fork rule is directly testable.
+    """
+    channel = {_mirror_identity(m) for m in channel_messages}
+    return all(_mirror_identity(m) in channel for m in slot_messages)
+
+
+def mirror_new_messages(
+    slot_messages: list[dict[str, Any]],
+    channel_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Channel turns a pure-mirror slot is missing, in append order.
+
+    Only turns at or after the slot's newest ordered timestamp are candidates:
+    the seed window is a capped TAIL of the transcript (:func:`hydrate_window`),
+    so turns older than the window were deliberately not seeded and must not be
+    appended after newer ones — that would scramble the visible order. Turns
+    whose timestamp cannot be parsed to an instant are skipped for the same
+    reason: they cannot be placed. Empty-content lines are dropped to match the
+    seed, and duplicates are dropped on the redaction-stable identity.
+
+    Pure and side-effect free so the ordering rules are directly testable.
+    """
+    have = {_mirror_identity(m) for m in slot_messages}
+    threshold = max(
+        (k for m in slot_messages if (k := _ts_sort_key(m))[0] == 0),
+        default=None,
+    )
+    out: list[dict[str, Any]] = []
+    for m in channel_messages:
+        if not m.get("content"):
+            continue
+        key = _ts_sort_key(m)
+        if key[0] != 0:
+            continue
+        if threshold is not None and key < threshold:
+            continue
+        if _mirror_identity(m) in have:
+            continue
+        out.append(m)
+    return sorted(out, key=_ts_sort_key)
 
 
 def eligible_channel_sessions(
@@ -289,6 +371,7 @@ def surface_channel_session(
     *,
     disk_older: int = 0,
     disk_window: int = 0,
+    mirror: bool = False,
 ) -> "_ChatSlot | None":
     """Create the dashboard slot for one channel session.
 
@@ -300,6 +383,12 @@ def surface_channel_session(
     that caller's split of the slot's OWN on-disk lines into the frozen prefix
     the window does not carry and the region it re-serializes — see
     :func:`frozen_prefix_len` for why a save needs both.
+
+    *mirror* arms mirror-until-forked on the new slot: the reconciler keeps
+    appending new channel turns into it until the first dashboard-authored turn
+    forks the conversation. Pass it only when the slot's own on-disk transcript
+    is a pure mirror (:func:`is_pure_mirror`) — arming it on a forked slot would
+    interleave two diverged transcripts.
     """
     session_key = session_info.get("key", "")
     if not session_key or not is_channel_session_key(session_key):
@@ -357,10 +446,85 @@ def surface_channel_session(
     # Not dirty: a surfaced conversation the user never touches costs no write.
     # The first real dashboard turn is what persists it under the slot key.
     slot._dirty = False
+    if mirror:
+        # Arm mirror-until-forked. The rebind question is settled by
+        # construction (this call just seeded the slot from the transcripts),
+        # so mark the check done too.
+        slot._channel_mirror_key = session_key
+        slot._channel_mirror_len = len(slot.messages)
+        slot._channel_mirror_mtime = float(session_info.get("modified", 0) or 0)
+        slot._channel_mirror_checked = True
     logger.info(
         "Surfaced %s session %s as slot %s", channel_label(session_key), session_key, slot_name
     )
     return slot
+
+
+def _apply_mirror(
+    slot: "_ChatSlot",
+    session_info: dict[str, Any],
+    channel_messages: list[dict[str, Any]],
+) -> int:
+    """Append the channel turns a pure-mirror *slot* is missing. Returns count.
+
+    Runs on the event loop (slot mutation). The appended turns are treated
+    exactly like seeded ones: content is redacted, ``_resumed_count`` counts
+    them as history rather than novel dashboard turns, and the dirty flag is
+    preserved — mirroring alone never persists the slot, matching the seed's
+    "a conversation the user never touches costs no write" rule. When the
+    conversation does get picked up on the dashboard, the ordinary save
+    re-serializes the whole window and the mirrored turns persist with it.
+    """
+    new = mirror_new_messages(slot.messages, channel_messages)
+    dirty_was = slot._dirty
+    had_reader = slot._has_reader
+    for m in new:
+        role = m.get("role", "assistant")
+        slot.append(
+            role,
+            _redact(m.get("content", "")),
+            f"msg msg-{'a' if role != 'user' else 'u'}",
+            ts=m.get("ts", ""),
+            # broadcast=False for the same reason as the seed: these are
+            # copies of channel history, not dashboard-originated turns. An
+            # attached stream reader still receives them via the pending
+            # queue; everyone else gets the sidebar refresh from
+            # push_slots_update.
+            broadcast=False,
+        )
+    if new and not had_reader:
+        # No live stream is consuming the pending queue — drop the copies so
+        # they cannot pile up across passes (the seed drains for the same
+        # reason). With a reader attached the queue is being consumed; leave
+        # it so the open tab shows the new turns live.
+        slot.drain()
+    slot._dirty = dirty_was
+    slot._resumed_count += len(new)
+    slot._channel_mirror_len = len(slot.messages)
+    slot._channel_mirror_mtime = float(session_info.get("modified", 0) or 0)
+    return len(new)
+
+
+def _mirror_intact(slot: "_ChatSlot") -> bool:
+    """True while *slot*'s window shows no sign of a non-mirror mutation.
+
+    Two invariants hold on a slot only the mirror has touched:
+
+    - ``len(messages) == _channel_mirror_len`` — the mirror recorded the length
+      after its last action, so any append since then is someone else's.
+    - ``_resumed_count == len(messages)`` — seed and mirror both count their
+      turns as resumed history. A plain append leaves ``_resumed_count`` behind,
+      and regenerate/rewind reset it to 0 — so a NET-ZERO edit (regenerate
+      replaces a message without changing the count) still breaks this
+      invariant even though the length check alone would miss it.
+
+    Either signal disarms; degrading to the frozen-copy behaviour is always
+    safe, mirroring into a diverged transcript never is.
+    """
+    return (
+        len(slot.messages) == slot._channel_mirror_len
+        and slot._resumed_count == len(slot.messages)
+    )
 
 
 async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) -> int:
@@ -404,7 +568,38 @@ async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) 
     eligible = eligible_channel_sessions(candidates, metadata=metadata, cutoff=cutoff)
     # Skip transcript reads for sessions that already own a slot — the steady state.
     pending = [s for s in eligible if channel_slot_name(s.get("key", "")) not in state._slots]
-    if not pending:
+    # Existing slots that may need a mirror sync. Everything here is a cheap
+    # in-memory check; the transcript read only happens for slots that are
+    # armed AND stale, or restored slots awaiting their one-time rebind check.
+    mirror_pending: list[dict[str, Any]] = []
+    for s in eligible:
+        key = s.get("key", "")
+        slot = state._slots.get(channel_slot_name(key))
+        if slot is None:
+            continue
+        if slot._channel_mirror_key == key:
+            if not _mirror_intact(slot):
+                # A non-mirror mutation happened — an append (the user picked
+                # the conversation up on the dashboard) or an in-place edit
+                # like regenerate. Forked: stop mirroring for good. Fail-safe:
+                # ANY untracked window change (including a trim) disarms,
+                # degrading to the old frozen-copy behaviour rather than
+                # risking an interleave.
+                slot._channel_mirror_key = ""
+                continue
+            if float(s.get("modified", 0) or 0) <= slot._channel_mirror_mtime:
+                continue  # channel file unchanged since the last sync
+            mirror_pending.append(s)
+        elif not slot._channel_mirror_checked:
+            # Restored after a restart — the restore path knows nothing about
+            # mirroring, so settle it once here. Only when the whole file is in
+            # the window can purity be judged from memory; a longer file may
+            # hide dashboard-authored turns in the frozen prefix, so fail safe.
+            if slot._disk_older_count > 0:
+                slot._channel_mirror_checked = True
+                continue
+            mirror_pending.append(s)
+    if not pending and not mirror_pending:
         return 0
 
     def _load_messages() -> dict[str, _Transcript]:
@@ -415,18 +610,46 @@ async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) 
                 slot_msgs = log.read_messages(slot_history_key(key))
             except Exception:
                 slot_msgs = []
+            chan_ok = True
             try:
                 chan_msgs = log.read_messages(key)
             except Exception:
                 chan_msgs = []
+                chan_ok = False
             merged = merge_transcripts(slot_msgs, chan_msgs)
             # Split the slot's own on-disk lines here, in the executor, while
             # both sides are still separable — after the merge they are not.
             older = frozen_prefix_len(slot_msgs, hydrate_window(merged))
-            out[key] = _Transcript(merged, older, max(0, len(slot_msgs) - older))
+            out[key] = _Transcript(
+                merged,
+                older,
+                max(0, len(slot_msgs) - older),
+                # A failed channel read proves nothing about purity — do not
+                # arm the mirror on it. The slot surfaces without a mirror and
+                # unchecked, so the rebind path re-judges it on a later pass.
+                chan_ok and is_pure_mirror(slot_msgs, chan_msgs),
+            )
         return out
 
-    transcripts = await loop.run_in_executor(None, _load_messages)
+    def _load_mirror_transcripts() -> dict[str, list[dict[str, Any]]]:
+        out: dict[str, list[dict[str, Any]]] = {}
+        for s in mirror_pending:
+            key = s.get("key", "")
+            try:
+                out[key] = log.read_messages(key)
+            except Exception:
+                # Omit the key entirely: an empty transcript would look like a
+                # successful sync and advance the watermark having copied
+                # nothing, permanently skipping these messages if the channel
+                # file never changes again. Absent key = untouched state,
+                # retried on the next pass.
+                logger.debug("channel mirror: read failed for %s", key, exc_info=True)
+        return out
+
+    transcripts = await loop.run_in_executor(None, _load_messages) if pending else {}
+    mirror_transcripts = (
+        await loop.run_in_executor(None, _load_mirror_transcripts) if mirror_pending else {}
+    )
 
     surfaced = 0
     for s in pending:
@@ -440,11 +663,41 @@ async def reconcile_channel_slots(state: "DashboardState", window_minutes: int) 
                 transcript.messages,
                 disk_older=transcript.disk_older,
                 disk_window=transcript.disk_window,
+                mirror=transcript.pure_mirror,
             ):
                 surfaced += 1
         except Exception:
             logger.warning("channel reconcile: failed to surface %s", key, exc_info=True)
-    if surfaced:
+
+    mirrored = 0
+    for s in mirror_pending:
+        key = s.get("key", "")
+        slot = state._slots.get(channel_slot_name(key))
+        if slot is None:
+            continue
+        chan_msgs = mirror_transcripts.get(key)
+        if chan_msgs is None:
+            # Read failed in the executor — leave the slot untouched (not
+            # checked, watermark not advanced) so the next pass retries.
+            continue
+        try:
+            if not slot._channel_mirror_checked:
+                # One-time rebind after restore: arm only when nothing in the
+                # window is dashboard-authored. Either way the question is
+                # settled — never re-read this transcript on later passes.
+                slot._channel_mirror_checked = True
+                if not is_pure_mirror(slot.messages, chan_msgs):
+                    continue
+                slot._channel_mirror_key = key
+                slot._channel_mirror_len = len(slot.messages)
+            elif not _mirror_intact(slot):
+                # Forked between the eligibility check and the executor read.
+                slot._channel_mirror_key = ""
+                continue
+            mirrored += _apply_mirror(slot, s, chan_msgs)
+        except Exception:
+            logger.warning("channel reconcile: failed to mirror %s", key, exc_info=True)
+    if surfaced or mirrored:
         state.push_slots_update()
     return surfaced
 

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -830,6 +830,10 @@ class _ChatSlot:
         "forked_from",
         "_fork_lock",
         "_tab_id",
+        "_channel_mirror_key",
+        "_channel_mirror_len",
+        "_channel_mirror_mtime",
+        "_channel_mirror_checked",
         "_disk_older_count",
         "_disk_window_len",
         "_frozen_prefix_cache",
@@ -1008,6 +1012,14 @@ class _ChatSlot:
         self.forked_from: str | None = None  # parent slot key if this is a fork
         self._fork_lock: asyncio.Lock = asyncio.Lock()  # serialises concurrent forks on this slot
         self._tab_id: str = ""  # permanent tab identity for cross-restart session chaining
+        # Channel-slot mirroring (see channel_slots.py). While a surfaced
+        # channel slot has NO dashboard-authored turns, the reconciler keeps
+        # copying new channel messages into it so the tab stays current. The
+        # first non-mirror append forks the conversation and stops the mirror.
+        self._channel_mirror_key: str = ""  # channel session key mirrored into this slot
+        self._channel_mirror_len: int = 0  # len(messages) after the last mirror action
+        self._channel_mirror_mtime: float = 0.0  # channel `modified` at the last sync
+        self._channel_mirror_checked: bool = False  # one-time rebind check done
         self._disk_older_count: int = (
             0  # count of disk messages OLDER than in-memory window (stable, set at restore/resume)
         )

--- a/test/test_channel_slots.py
+++ b/test/test_channel_slots.py
@@ -640,3 +640,373 @@ class TestImmediateDispatcherSurface:
         asyncio.run(channel_slots.surface_dispatcher_session(dispatcher))
 
         assert not called
+
+
+class TestMirrorHelpers:
+    """Pure-function rules for mirror-until-forked."""
+
+    def test_is_pure_mirror_is_redaction_stable(self) -> None:
+        """Slot copies are stored redacted while the channel file is raw.
+
+        Comparing raw identities would mis-classify every redacted turn as
+        dashboard-authored and permanently disarm the mirror.
+        """
+        raw = "creds AKIAIOSFODNN7EXAMPLE leaked"
+        chan = [{"role": "user", "content": raw, "ts": "2026-07-30T00:00:00Z"}]
+        slot = [
+            {
+                "role": "user",
+                "content": channel_slots._redact(raw),
+                "ts": "2026-07-30T00:00:00Z",
+            }
+        ]
+        assert channel_slots.is_pure_mirror(slot, chan)
+
+    def test_a_dashboard_authored_turn_breaks_purity(self) -> None:
+        chan = [{"role": "user", "content": "on slack", "ts": "2026-07-30T00:00:00Z"}]
+        slot = chan + [
+            {"role": "user", "content": "from the dashboard", "ts": "2026-07-30T00:01:00Z"}
+        ]
+        assert not channel_slots.is_pure_mirror(slot, chan)
+
+    def test_an_empty_slot_is_a_pure_mirror(self) -> None:
+        assert channel_slots.is_pure_mirror([], [{"role": "user", "content": "x", "ts": "t"}])
+
+    def test_new_messages_are_ordered_and_deduped(self) -> None:
+        slot = [{"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}]
+        chan = [
+            {"role": "assistant", "content": "third", "ts": "2026-07-30T00:02:00Z"},
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "assistant", "content": "second", "ts": "2026-07-30T00:01:00Z"},
+        ]
+        out = channel_slots.mirror_new_messages(slot, chan)
+        assert [m["content"] for m in out] == ["second", "third"]
+
+    def test_pre_window_history_is_not_replayed(self) -> None:
+        """The seed window is a capped tail; older turns must never append
+        AFTER newer ones — that would scramble the visible order."""
+        slot = [{"role": "user", "content": "newest", "ts": "2026-07-30T00:05:00Z"}]
+        chan = [
+            {"role": "user", "content": "ancient", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "user", "content": "newest", "ts": "2026-07-30T00:05:00Z"},
+            {"role": "user", "content": "after", "ts": "2026-07-30T00:06:00Z"},
+        ]
+        assert [m["content"] for m in channel_slots.mirror_new_messages(slot, chan)] == ["after"]
+
+    def test_unplaceable_and_empty_turns_are_skipped(self) -> None:
+        slot = [{"role": "user", "content": "a", "ts": "2026-07-30T00:00:00Z"}]
+        chan = slot + [
+            {"role": "user", "content": "no ts at all"},
+            {"role": "user", "content": "garbled", "ts": "not-a-timestamp"},
+            {"role": "user", "content": "", "ts": "2026-07-30T00:01:00Z"},
+            {"role": "user", "content": "kept", "ts": "2026-07-30T00:02:00Z"},
+        ]
+        assert [m["content"] for m in channel_slots.mirror_new_messages(slot, chan)] == ["kept"]
+
+
+class TestMirrorUntilForked:
+    """End-to-end reconcile behaviour: a surfaced slot stays current until the
+    user picks the conversation up on the dashboard."""
+
+    def _surface(self, dashboard_state: Any, log: _FakeLog) -> Any:
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        return dashboard_state._slots["slack_1.1"]
+
+    def test_new_channel_turns_flow_into_the_surfaced_slot(self, dashboard_state: Any) -> None:
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        slot = self._surface(dashboard_state, log)
+        assert [m["content"] for m in slot.messages] == ["first"]
+        assert slot._channel_mirror_key == "slack:1.1"
+
+        log.transcripts["slack:1.1"].append(
+            {"role": "assistant", "content": "second", "ts": "2026-07-30T00:01:00Z"}
+        )
+        sess["modified"] = NOW
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert [m["content"] for m in slot.messages] == ["first", "second"]
+
+    def test_mirroring_alone_never_marks_the_slot_dirty(self, dashboard_state: Any) -> None:
+        """Same rule as the seed: a conversation the user never touches costs
+        no write. The mirrored turns persist with the first real save."""
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        slot = self._surface(dashboard_state, log)
+        log.transcripts["slack:1.1"].append(
+            {"role": "assistant", "content": "second", "ts": "2026-07-30T00:01:00Z"}
+        )
+        sess["modified"] = NOW
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert len(slot.messages) == 2
+        assert slot._dirty is False
+        # Counted as history, not novel dashboard turns.
+        assert slot._resumed_count == len(slot.messages)
+
+    def test_mirrored_content_is_redacted(self, dashboard_state: Any) -> None:
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "hello", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        slot = self._surface(dashboard_state, log)
+        log.transcripts["slack:1.1"].append(
+            {
+                "role": "assistant",
+                "content": "creds AKIAIOSFODNN7EXAMPLE leaked",
+                "ts": "2026-07-30T00:01:00Z",
+            }
+        )
+        sess["modified"] = NOW
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert len(slot.messages) == 2
+        assert "AKIAIOSFODNN7EXAMPLE" not in slot.messages[1]["content"]
+
+    def test_a_dashboard_turn_forks_and_stops_the_mirror(self, dashboard_state: Any) -> None:
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        slot = self._surface(dashboard_state, log)
+
+        # The user picks the conversation up on the dashboard.
+        slot.append("user", "picked up here", "msg msg-u")
+        log.transcripts["slack:1.1"].append(
+            {"role": "user", "content": "meanwhile on slack", "ts": "2026-07-30T00:02:00Z"}
+        )
+        sess["modified"] = NOW
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        contents = [m["content"] for m in slot.messages]
+        assert "meanwhile on slack" not in contents
+        assert slot._channel_mirror_key == ""
+
+        # And it stays off: later passes never re-arm a forked slot.
+        sess["modified"] = NOW + 60
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert "meanwhile on slack" not in [m["content"] for m in slot.messages]
+
+    def test_a_forked_on_disk_transcript_never_arms_the_mirror(
+        self, dashboard_state: Any
+    ) -> None:
+        """A slot re-surfaced from a fork file that holds dashboard replies is
+        already diverged — seeding merges, but mirroring must not arm."""
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "on slack", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        log.transcripts["dashboard:slack_1.1"] = [
+            {"role": "user", "content": "on slack", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "user", "content": "from the dashboard", "ts": "2026-07-30T00:01:00Z"},
+        ]
+        slot = self._surface(dashboard_state, log)
+        assert slot._channel_mirror_key == ""
+
+        log.transcripts["slack:1.1"].append(
+            {"role": "user", "content": "later on slack", "ts": "2026-07-30T00:02:00Z"}
+        )
+        sess["modified"] = NOW
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert "later on slack" not in [m["content"] for m in slot.messages]
+
+    def test_restored_pure_slot_rearms_and_catches_up(self, dashboard_state: Any) -> None:
+        """After a gateway restart the restore path rebuilds the slot without
+        mirror state; the reconciler settles it once and catches the tab up."""
+        sess = _session("slack:1.1")
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "assistant", "content": "second", "ts": "2026-07-30T00:01:00Z"},
+        ]
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        slot = dashboard_state.get_or_create_slot(name="slack_1.1")
+        slot.append("user", "first", "msg msg-u", ts="2026-07-30T00:00:00Z", broadcast=False)
+        slot._dirty = False
+
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert [m["content"] for m in slot.messages] == ["first", "second"]
+        assert slot._channel_mirror_key == "slack:1.1"
+        assert slot._channel_mirror_checked is True
+
+    def test_restored_slot_with_a_frozen_prefix_never_arms(self, dashboard_state: Any) -> None:
+        """Purity can only be judged when the whole file is in the window — a
+        frozen prefix may hide dashboard-authored turns, so fail safe."""
+        sess = _session("slack:1.1")
+        log = _FakeLog([sess], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        slot = dashboard_state.get_or_create_slot(name="slack_1.1")
+        slot._disk_older_count = 3
+
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert slot._channel_mirror_key == ""
+        assert slot._channel_mirror_checked is True
+        # Settled without a transcript read, and never re-read on later passes.
+        assert log.message_reads == []
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert log.message_reads == []
+
+    def test_unchanged_channel_file_costs_no_transcript_read(self, dashboard_state: Any) -> None:
+        """Steady state stays cheap: the watermark gates the disk IO."""
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        self._surface(dashboard_state, log)
+        reads_after_surface = len(log.message_reads)
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert len(log.message_reads) == reads_after_surface
+
+    def test_mirror_pass_broadcasts_the_slots_update(self, dashboard_state: Any) -> None:
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        slot = self._surface(dashboard_state, log)
+        pushes: list[int] = []
+        dashboard_state.push_slots_update = lambda: pushes.append(1)  # type: ignore[method-assign]
+        log.transcripts["slack:1.1"].append(
+            {"role": "assistant", "content": "second", "ts": "2026-07-30T00:01:00Z"}
+        )
+        sess["modified"] = NOW
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert len(slot.messages) == 2
+        assert pushes, "a mirror-only pass must still refresh the sidebar"
+
+
+class TestMirrorForkAndFailureModes:
+    """Regression guards for the two review findings: net-zero edits must fork,
+    and failed reads must not count as successful syncs."""
+
+    def _surface(self, dashboard_state: Any, log: _FakeLog) -> Any:
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        return dashboard_state._slots["slack_1.1"]
+
+    def test_a_net_zero_edit_forks_the_mirror(self, dashboard_state: Any) -> None:
+        """Regenerate replaces a message WITHOUT changing the count and resets
+        _resumed_count to 0 — the length check alone misses it, and mirroring
+        on would interleave channel turns into the diverged branch."""
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"},
+            {"role": "assistant", "content": "reply", "ts": "2026-07-30T00:00:30Z"},
+        ]
+        slot = self._surface(dashboard_state, log)
+        assert slot._channel_mirror_key == "slack:1.1"
+
+        # Simulate regenerate: in-place replacement, same count, resumed reset.
+        slot.messages[-1]["content"] = "regenerated reply"
+        slot._resumed_count = 0
+
+        log.transcripts["slack:1.1"].append(
+            {"role": "user", "content": "meanwhile on slack", "ts": "2026-07-30T00:02:00Z"}
+        )
+        sess["modified"] = NOW
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert "meanwhile on slack" not in [m["content"] for m in slot.messages]
+        assert slot._channel_mirror_key == ""
+
+    def test_a_failed_mirror_read_is_retried_not_recorded(self, dashboard_state: Any) -> None:
+        """A transient read failure must not advance the watermark — otherwise
+        an unchanged channel file is never retried and its turns stay missing."""
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        slot = self._surface(dashboard_state, log)
+        log.transcripts["slack:1.1"].append(
+            {"role": "assistant", "content": "second", "ts": "2026-07-30T00:01:00Z"}
+        )
+        sess["modified"] = NOW
+
+        fail_once = {"armed": True}
+        orig_read = log.read_messages
+
+        def flaky(key: str) -> list[dict[str, Any]]:
+            if fail_once["armed"] and key == "slack:1.1":
+                fail_once["armed"] = False
+                raise OSError("transient")
+            return orig_read(key)
+
+        log.read_messages = flaky  # type: ignore[method-assign]
+
+        # Failing pass: nothing copied, mirror still armed, watermark untouched.
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert [m["content"] for m in slot.messages] == ["first"]
+        assert slot._channel_mirror_key == "slack:1.1"
+
+        # Next pass with the SAME modified stamp must retry and catch up.
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert [m["content"] for m in slot.messages] == ["first", "second"]
+
+    def test_a_failed_channel_read_at_surface_does_not_arm(self, dashboard_state: Any) -> None:
+        """Purity cannot be judged from a failed read — surface unarmed and let
+        the rebind path settle it once the read succeeds."""
+        sess = _session("slack:1.1", modified=NOW - 60)
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        fail_once = {"armed": True}
+        orig_read = log.read_messages
+
+        def flaky(key: str) -> list[dict[str, Any]]:
+            if fail_once["armed"] and key == "slack:1.1":
+                fail_once["armed"] = False
+                raise OSError("transient")
+            return orig_read(key)
+
+        log.read_messages = flaky  # type: ignore[method-assign]
+        slot = self._surface(dashboard_state, log)
+        assert slot._channel_mirror_key == ""
+        assert slot._channel_mirror_checked is False
+
+        # Rebind pass with a working read arms the mirror and catches up.
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert [m["content"] for m in slot.messages] == ["first"]
+        assert slot._channel_mirror_key == "slack:1.1"
+
+    def test_a_failed_rebind_read_is_retried(self, dashboard_state: Any) -> None:
+        """A restored slot whose rebind read fails must stay unchecked so a
+        later pass can still settle it."""
+        sess = _session("slack:1.1")
+        log = _FakeLog([sess], {})
+        log.transcripts["slack:1.1"] = [
+            {"role": "user", "content": "first", "ts": "2026-07-30T00:00:00Z"}
+        ]
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        slot = dashboard_state.get_or_create_slot(name="slack_1.1")
+
+        fail_once = {"armed": True}
+        orig_read = log.read_messages
+
+        def flaky(key: str) -> list[dict[str, Any]]:
+            if fail_once["armed"] and key == "slack:1.1":
+                fail_once["armed"] = False
+                raise OSError("transient")
+            return orig_read(key)
+
+        log.read_messages = flaky  # type: ignore[method-assign]
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert slot._channel_mirror_checked is False
+
+        asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30))
+        assert slot._channel_mirror_key == "slack:1.1"
+        assert [m["content"] for m in slot.messages] == ["first"]


### PR DESCRIPTION
# Problem

A Slack/Discord conversation surfaced into the dashboard goes silently stale. The channel-slot reconciler seeds the tab once at surface time and then skips any session that already owns a slot, so channel turns arriving after that moment never reach the dashboard copy. Observed in production: a Discord DM session's live file held 68 messages while its dashboard tab froze at 42 — 26 messages (several hours of conversation) were invisible on the dashboard, with no indication the transcript was incomplete.

# Why it matters

The whole point of surfacing channel sessions is "your Slack/Discord conversations show up in the dashboard, ready to continue." A tab that freezes hours after it is created misrepresents what the conversation contains — the user reads a stale transcript believing it is current, and picking the conversation up from the dashboard means replying with missing context.

# Fix (symptoms -> root cause -> change)

The reconciler's steady-state is a deliberate no-op for sessions that already own a slot. The module's "one history key, no split" design note explains why the slot is never *linked* to the channel session — a dashboard reply would split one conversation across two transcripts. But that rationale only applies **after** the slot holds a dashboard-authored turn. Until then the slot is a pure mirror of the channel transcript, and appending new channel turns is lossless.

The reconciler now mirrors until forked:

- **Arm at surface.** When the slot's own on-disk lines are all copies of channel turns (`is_pure_mirror`, compared on a redaction-stable identity since slot copies are stored redacted), the new slot is armed for mirroring.
- **Mirror on later passes.** For armed slots, new channel turns are appended (`mirror_new_messages`) — ordered by timestamp, deduped, capped at the slot's newest ordered turn so pre-window history is never replayed out of order. A `modified`-time watermark gates the disk read, so the steady state costs nothing.
- **Re-arm once after a restart.** The restore path knows nothing about mirroring, so the reconciler settles restored slots with a one-time purity check — only when the whole file is visible in the window (`_disk_older_count == 0`); a frozen prefix could hide dashboard-authored turns, so it fails safe to no-mirror.
- **Disarm permanently on any non-mirror mutation** (`_mirror_intact`): a length change (dashboard append) or a broken `_resumed_count == len(messages)` invariant (regenerate/rewind replace messages without changing the count). From that moment the conversation is forked and behaves exactly as before this change.
- **Failed reads are not syncs.** A failed channel-file read is omitted from the pass entirely — no watermark advance, no rebind settlement, no mirror arming — so the next pass retries instead of permanently skipping messages.

Mirrored turns follow the seed's rules: content redacted, counted as history via `_resumed_count`, and the dirty flag preserved — an untouched conversation still costs no write; the first real save persists the window as usual.

# Tests

19 new tests in `test/test_channel_slots.py` (18 revert-verified failing without the fix):

- `TestMirrorHelpers` — purity is redaction-stable; a dashboard-authored turn breaks purity; new messages are ordered/deduped; pre-window history is never replayed; unplaceable (bad/absent ts) and empty turns are skipped.
- `TestMirrorUntilForked` — new channel turns flow into the surfaced slot; mirroring never marks the slot dirty and counts turns as resumed; mirrored content is redacted; a dashboard turn forks and permanently stops the mirror; a forked on-disk transcript never arms; a restored pure slot re-arms and catches up; a restored slot with a frozen prefix never arms and settles without a read; an unchanged channel file costs no transcript read; a mirror-only pass still broadcasts the sidebar update.
- `TestMirrorForkAndFailureModes` — a net-zero edit (regenerate) forks the mirror; a failed mirror read is retried, not recorded; a failed channel read at surface does not arm; a failed rebind read is retried.

# Manual verification

Reproduced the production symptom on this host's real session files (`discord_kirocrew_direct_*`: 68 live vs 42 dashboard messages, 26 missing, 0 dashboard-authored) — the exact state the mirror phase now converges. No UI changes; the fix is entirely in the reconciler's pass, exercised end-to-end by the async reconcile tests.

# Screenshots

N/A — backend-only change, no user-visible UI surface modified (the sidebar/tab rendering is untouched; only the transcript contents stay current).
