### PR TITLE
fix(voice): scope STT recording state per session slot

### DIFF
--- a/website/src/hooks/useVoiceInput.ts
+++ b/website/src/hooks/useVoiceInput.ts
@@ -24,14 +24,27 @@ const WARM_IDLE_MS = 15000
 
 interface Opts {
   streaming?: boolean
-  onPartial?: (text: string) => void
+  onPartial?: (text: string, sessionId: string | null) => void
   /** Fired when streaming semantic endpointing judges the utterance complete. */
   onEndpoint?: () => void
+  /** Id of the session/slot that currently owns the mic. Snapshotted the
+   *  instant a recording starts so the resulting transcript can be attributed
+   *  to the slot that initiated it — even if the user switches sessions before
+   *  the (async) transcription finishes. */
+  sessionId?: string | null
 }
 
-export function useVoiceInput(onText: (text: string) => void, opts: Opts = {}) {
+export function useVoiceInput(onText: (text: string, sessionId: string | null) => void, opts: Opts = {}) {
   const [recording, setRecording] = useState(false)
   const [transcribing, setTranscribing] = useState(false)
+  // The slot that owns the current voice session — set when a recording
+  // actually starts (not optimistically on click) and held through its
+  // transcription, then cleared when the session ends. Recording/transcribing
+  // UI is scoped to this slot so a session's busy state never shows in another
+  // session. Sessions are exclusive (one shared mic, and the caller blocks a
+  // new start while one is in flight), so a single owner is sufficient — no
+  // per-session map or request token is needed. Null when idle.
+  const [sessionOwner, setSessionOwner] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [level, setLevel] = useState(0)
   const [deviceLabel, setDeviceLabel] = useState('')
@@ -56,14 +69,23 @@ export function useVoiceInput(onText: (text: string) => void, opts: Opts = {}) {
   const warmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const clearError = useCallback(() => setError(null), [])
 
+  // Live active-session id, mirrored every render so start() can snapshot the
+  // slot that owns a recording at the exact moment capture begins.
+  const sessionIdRef = useRef<string | null>(opts.sessionId ?? null)
+  sessionIdRef.current = opts.sessionId ?? null
+  // The session captured when the CURRENT streaming run started, so its
+  // partials + final are attributed to the originating slot. (The batch path
+  // snapshots a plain local in start() instead — see below.)
+  const streamSessionRef = useRef<string | null>(null)
+
   const streamEnabled = !!opts.streaming && streamingSupported
   const optsPartial = opts.onPartial
   const streamOnPartial = useCallback(
-    (text: string) => { setPartial(text); optsPartial?.(text) },
+    (text: string) => { setPartial(text); optsPartial?.(text, streamSessionRef.current) },
     [optsPartial],
   )
   const streamOnFinal = useCallback(
-    (text: string) => { setPartial(''); if (text) onText(text) },
+    (text: string) => { setPartial(''); if (text) onText(text, streamSessionRef.current) },
     [onText],
   )
   const optsEndpoint = opts.onEndpoint
@@ -170,9 +192,35 @@ export function useVoiceInput(onText: (text: string) => void, opts: Opts = {}) {
 
   const start = useCallback(async () => {
     setError(null)
-    if (streamEnabled) { await streamStart(); return }
+    if (streamEnabled) {
+      // Re-entrancy guard for the async startup window (mirrors the batch path
+      // below): a second slot's click during streamStart() must not open a
+      // second stream or reassign ownership. Capture the session at click time
+      // for partial/final attribution, and assign sessionOwner only AFTER the
+      // stream actually starts — so a mid-startup slot switch can't misattribute
+      // this stream to the slot now on screen.
+      if (startingRef.current) return
+      startingRef.current = true
+      const streamSession = sessionIdRef.current
+      streamSessionRef.current = streamSession
+      try {
+        await streamStart()
+        // Aborted by a slot switch during startup — stop the stream rather than
+        // capture invisibly for a slot that is no longer on screen.
+        if (streamSession !== sessionIdRef.current) { streamStop(); return }
+        setSessionOwner(streamSession)
+      } finally {
+        startingRef.current = false
+      }
+      return
+    }
     if (!voiceInputSupported || startingRef.current) return
     startingRef.current = true
+    // Attribute this recording's transcript to the slot that owns the mic RIGHT
+    // NOW. Captured as a local (not the ref) so a second recording started in
+    // another slot before this one's async transcription returns can't reassign
+    // the attribution out from under it.
+    const sessionAtStart = sessionIdRef.current
     if (warmTimerRef.current) { clearTimeout(warmTimerRef.current); warmTimerRef.current = null }
     let stream: MediaStream | null = null
     try {
@@ -181,6 +229,20 @@ export function useVoiceInput(onText: (text: string) => void, opts: Opts = {}) {
       // meter + device label exactly once.
       stream = await acquireWarm()
       warmRef.current = null // ownership transfers to the recorder; releaseWarm now no-ops
+      // The user switched slots while the mic was being acquired. Abort instead
+      // of starting a recording the now-active slot can neither see nor stop —
+      // it would capture invisibly until the user returned to the originating
+      // slot. (sessionAtStart is this recording's slot; sessionIdRef.current is
+      // the live active slot.)
+      if (sessionAtStart !== sessionIdRef.current) {
+        stream.getTracks().forEach(t => t.stop())
+        levelStopRef.current?.()
+        levelStopRef.current = null
+        setLevel(0)
+        setDeviceLabel('')
+        startingRef.current = false
+        return
+      }
       const mimeType = pickMimeType()
       const mr = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
       chunksRef.current = []
@@ -193,7 +255,7 @@ export function useVoiceInput(onText: (text: string) => void, opts: Opts = {}) {
         stream?.getTracks().forEach(t => t.stop())
         const ext = mimeType.includes('mp4') ? 'mp4' : mimeType.includes('ogg') ? 'ogg' : 'webm'
         const blob = new Blob(chunksRef.current, { type: mimeType || 'audio/webm' })
-        if (blob.size < 100) return
+        if (blob.size < 100) { setSessionOwner(null); return }
         setTranscribing(true)
         try {
           const res = await api.sttTranscribe(blob, ext)
@@ -201,17 +263,28 @@ export function useVoiceInput(onText: (text: string) => void, opts: Opts = {}) {
             // eslint-disable-next-line no-console -- surface STT failures for debugging
             console.error('[voice] STT error:', res.error)
             setError(`Transcription failed: ${res.error}`)
-          } else if (res.text) onText(res.text)
+          } else if (res.text) onText(res.text, sessionAtStart)
         } catch (err) {
           // eslint-disable-next-line no-console -- surface transcription failures for debugging
           console.error('[voice] transcription failed:', err)
           setError(i18nT('hooks.useVoiceInput.transcription_request_failed'))
         }
+        // Session over (recording ended, transcription done) — release ownership
+        // so another slot can start. Exclusivity (one session at a time) is
+        // enforced by the caller, so there is never a second in-flight request
+        // whose state this could clobber.
         setTranscribing(false)
+        setSessionOwner(null)
       }
       mr.start()
       mediaRef.current = mr
       setRecording(true)
+      // Ownership is assigned HERE — when capture actually begins — not
+      // optimistically on click. If the user switched slots during the
+      // getUserMedia await, sessionAtStart still points at the slot that
+      // initiated this recording, so its audio/transcript can never be
+      // misattributed to the slot now on screen.
+      setSessionOwner(sessionAtStart)
     } catch (e) {
       if (warmTimerRef.current) { clearTimeout(warmTimerRef.current); warmTimerRef.current = null }
       levelStopRef.current?.()
@@ -221,13 +294,14 @@ export function useVoiceInput(onText: (text: string) => void, opts: Opts = {}) {
       stream?.getTracks().forEach(t => t.stop())
       warmRef.current = null
       warmPromiseRef.current = null
+      setSessionOwner(null)
       setError(humanizeMicError(e))
     }
     startingRef.current = false
   }, [onText, streamEnabled, streamStart, acquireWarm])
 
   const stop = useCallback(() => {
-    if (streamEnabled) { streamStop(); return }
+    if (streamEnabled) { streamStop(); setSessionOwner(null); return }
     setPartial('')
     levelStopRef.current?.()
     levelStopRef.current = null
@@ -241,5 +315,5 @@ export function useVoiceInput(onText: (text: string) => void, opts: Opts = {}) {
   const isRecording = streamEnabled ? streamRecording : recording
   const toggle = useCallback(() => { if (isRecording) stop(); else start() }, [isRecording, start, stop])
 
-  return { recording: isRecording, transcribing, toggle, prewarm, error, level, deviceLabel, clearError, partial, sampleRef }
+  return { recording: isRecording, transcribing, sessionOwner, streamEnabled, toggle, prewarm, error, level, deviceLabel, clearError, partial, sampleRef }
 }

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1325,25 +1325,81 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // never be transcribed.
   const [voiceSetupOpen, setVoiceSetupOpen] = useState(false)
   const frozenInputRef = useRef<string | null>(null)
-  // Drops late-arriving partials/finals from a previous slot or stopped
-  // session. `stop()` is async (up to 5s for backend close) — without
-  // this guard, a delayed onFinal would overwrite text the user has
-  // already typed in the new slot.
+  // Drops late-arriving partials/finals for the CURRENT slot after a send.
+  // `stop()` is async (up to 5s for backend close) — without this guard, a
+  // delayed onFinal would repopulate the composer with text the user already
+  // sent. Cross-SLOT safety is handled separately by session-scoped routing
+  // (see applyVoiceText + voice.sessionOwner).
   const sttDisarmedRef = useRef(false)
+  // The hook's EFFECTIVE streaming mode: streaming is only truly active when the
+  // config asks for it AND the browser supports it (AudioWorklet/WS). Mirrored
+  // from voice.streamEnabled (set by the effect below, once `voice` exists) so
+  // the disarm + cross-slot-routing decisions gate on what the hook ACTUALLY
+  // runs, not the raw config. Keying those on the config alone would, in a
+  // browser without AudioWorklet, treat a batch-fallback session as streaming
+  // and disarm/drop its (only) transcript.
+  const streamEnabledRef = useRef(false)
   // Forward ref to send() (defined far below) so the streaming endpointer's
   // auto-submit callback — wired into the voice hook here, above send — can
   // fire it. Kept fresh by an effect after send is declared.
   const sendRef = useRef<((optionText?: string, targetSlot?: string) => void) | null>(null)
+  // Deliver a finished transcript to the slot that INITIATED the recording,
+  // using the session id useVoiceInput snapshotted at record-start (falling back
+  // to the active slot for the ordinary same-slot case). Same-slot splices into
+  // the live composer; a background slot gets it appended to its persisted draft
+  // (recoverable, shown on return) instead of leaking into the active session or
+  // being dropped. Mirrors handleOptimizeResult's cross-slot routing.
+  const applyVoiceText = useCallback((text: string, sessionId: string | null) => {
+    // Disarmed after a send (streaming) — the transcript was already sent, so
+    // drop it for EVERY route. Checked FIRST (before the cross-slot branch) so a
+    // late final can't slip the already-sent text back into the originating
+    // slot's draft.
+    if (sttDisarmedRef.current) return
+    const target = sessionId ?? activeSlotRef.current
+    const append = (base: string) => (base ? (base.endsWith(' ') ? base + text : base + ' ' + text) : text)
+    // Splice into the LIVE composer only when the target slot is both the active
+    // slot AND the slot the composer's `input` currently belongs to. On a slot
+    // switch, activeSlotRef updates synchronously in render, but the composer's
+    // draft-restore + composerSlotRef advance run in LATER effects — splicing in
+    // that unsettled window would let the pending draft restore overwrite the
+    // transcript. Otherwise route to the target slot's persisted draft.
+    const onScreen = target === activeSlotRef.current && composerSlotRef.current === target
+    if (!onScreen) {
+      // Off-screen (or not-yet-settled) delivery is BATCH ONLY. Streaming splices
+      // its live hypothesis into `input`, which is flushed into the draft on
+      // switch, so a cross-slot append would double it — a streaming final that
+      // lands off its slot is dropped (pre-existing behaviour). Batch has no
+      // partial, so appending to the slot's draft is unambiguous.
+      if (!target || streamEnabledRef.current) return
+      const next = append(drafts.current[target] ?? '')
+      setDraft(drafts.current, target, next)
+      // Mid-switch guard: if the composer still belongs to `target` (activeSlot
+      // has advanced in render but the outgoing-slot persist effect hasn't run
+      // yet), that effect will flush inputRef.current into drafts[target] and
+      // would overwrite this transcript with the pre-transcript input. Carry the
+      // appended value into inputRef too so the flush preserves the transcript.
+      if (composerSlotRef.current === target) inputRef.current = next
+      saveDrafts()
+      return
+    }
+    // Foreground: streaming seeds frozenInputRef in onPartial (the pre-dictation
+    // snapshot); the batch path never fires onPartial so it's null — fall back
+    // to the live composer text so the transcript APPENDS to what the user typed
+    // instead of overwriting it.
+    setInput(append(frozenInputRef.current ?? inputRef.current ?? ''))
+    frozenInputRef.current = null
+  }, [saveDrafts])
   const voice = useVoiceInput(
-    useCallback((text: string) => {
-      if (sttDisarmedRef.current) return
-      const base = frozenInputRef.current ?? ''
-      setInput(base ? (base.endsWith(' ') ? base + text : base + ' ' + text) : text)
-      frozenInputRef.current = null
-    }, []),
+    applyVoiceText,
     {
       streaming: sttStreaming,
-      onPartial: useCallback((text: string) => {
+      sessionId: activeSlot,
+      onPartial: useCallback((text: string, sessionId: string | null) => {
+        // Streaming partials only fire while the originating slot is on screen
+        // (switching slots stops the stream), so a partial attributed to any
+        // other slot is a late straggler — drop it rather than smear a
+        // half-word into the wrong session.
+        if (sessionId && sessionId !== activeSlotRef.current) return
         if (sttDisarmedRef.current) return
         // Snapshot BEFORE setInput so the updater stays pure (no ref
         // mutation inside a function React may invoke twice).
@@ -1371,8 +1427,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // Same reason as voiceRef: send() deliberately keeps a minimal dep array (with
   // an exhaustive-deps suppression), so reading `sttStreaming` directly there
   // would close over the value from the render that created that send().
-  const sttStreamingRef = useRef(sttStreaming)
-  useEffect(() => { sttStreamingRef.current = sttStreaming }, [sttStreaming])
+  // Keep streamEnabledRef in sync with the hook's EFFECTIVE streaming mode (see
+  // its declaration above). send()/the slot-switch effect/toggleVoice read it to
+  // decide whether a draining final should be disarmed — which must reflect what
+  // the hook actually runs, not the raw config.
+  useEffect(() => { streamEnabledRef.current = voice.streamEnabled }, [voice.streamEnabled])
   // Re-arm when the user explicitly (re)starts recording — wrap toggle.
   // Depend on the individual stable members actually read so this callback
   // is only re-created when they change. `[voice]` would recreate every
@@ -1388,27 +1447,59 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       return
     }
     if (!voice.recording) {
+      // Exclusive sessions: the mic is a single shared device, so refuse to
+      // START a new recording while another session's transcription is still
+      // in flight (voice.transcribing). This is what keeps voice single-session
+      // — no two recordings/transcriptions ever overlap — so the busy state
+      // needs only a single owner and can never be misattributed. Stopping an
+      // in-progress recording (the else path) is always allowed.
+      if (voice.transcribing) return
       sttDisarmedRef.current = false
       // Reset stale snapshot from a prior session that ended without
       // finals — otherwise onPartial sees a non-null ref, skips
       // re-snapshotting, and text typed between sessions is dropped.
       frozenInputRef.current = null
+    } else if (streamEnabledRef.current) {
+      // Manual stop of a STREAMING recording: streamStop() drains the socket
+      // asynchronously and a final can still arrive. The dictated text is
+      // already in the composer (onPartial writes each hypothesis into `input`),
+      // so disarm to drop that draining final — otherwise it rebuilds from the
+      // stale pre-dictation frozenInputRef and clobbers any text typed while the
+      // socket drains. (Batch is untouched: its onstop transcript is the ONLY
+      // copy and must land, so it is never disarmed here.)
+      sttDisarmedRef.current = true
     }
     voice.toggle()
     // Depend on the individual stable members actually read, not the whole
     // `voice` object — `[voice]` would recreate this callback every render and
     // re-render every child that receives `toggleVoice` (see comment above).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [voice.recording, voice.toggle, sttEnabled, sttConfigLoaded, sttAvailable])
-  // Stop any in-flight recording and drop the frozen prefix when the user
-  // switches slots so a late-arriving transcript can't leak into the wrong
-  // session. Disarm first so any in-flight final from the previous slot is
-  // silently dropped when it eventually arrives.
+  }, [voice.recording, voice.transcribing, voice.toggle, sttEnabled, sttConfigLoaded, sttAvailable])
+  // Stop any in-flight recording and clear the streaming prefix when the user
+  // switches slots. The mic is a single shared device, so a recording can't
+  // follow the user to another session; a BATCH transcript is still delivered
+  // to the originating slot via applyVoiceText's session-scoped routing (which
+  // prevents cross-slot leakage precisely — no blanket disarm needed here).
+  // Clearing frozenInputRef here means a streaming final that lands after a
+  // switch-and-return rebases on the LIVE input, so edits made after returning
+  // are preserved rather than clobbered by a stale snapshot.
   useEffect(() => {
     frozenInputRef.current = null
-    sttDisarmedRef.current = true
+    // Streaming ONLY: disarm so a delayed streaming final arriving after this
+    // switch is dropped instead of appended. Its live partial was already
+    // flushed into the outgoing slot's draft, so appending the full final on
+    // return would duplicate the dictated text ("hello hello"). Batch is NOT
+    // disarmed — its single final is routed to the originating slot's draft by
+    // applyVoiceText. (Cross-slot streaming delivery is a follow-up; streaming
+    // is opt-in and off by default.)
+    if (streamEnabledRef.current) sttDisarmedRef.current = true
     if (voiceRef.current.recording) voiceRef.current.toggle()
   }, [activeSlot])
+  // True when the current voice session (owned by the slot where recording
+  // actually started — see useVoiceInput's sessionOwner) is the slot on screen.
+  // Gates the recording/transcribing UI so a session transcribing in the
+  // background never shows a busy/locked mic in the session the user switched to.
+  const voiceOwned = voice.sessionOwner === activeSlot
   // (Streaming-off teardown now lives in useVoiceInput — see its effect on
   // [streamEnabled, streamRecording, streamStop]. Routing through voice.toggle
   // here is racy because `useVoiceInput` flips its returned `recording` to the
@@ -2669,7 +2760,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // would throw away the entire recording, which is the opposite of the bug
     // being fixed. Batch therefore keeps its pre-existing behaviour untouched:
     // capture continues, and the transcript lands when the user stops.
-    if (voiceRef.current.recording && sttStreamingRef.current) {
+    if (voiceRef.current.recording && streamEnabledRef.current) {
       sttDisarmedRef.current = true
       frozenInputRef.current = null
       voiceRef.current.toggle()
@@ -4867,15 +4958,15 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               dragOver={dragOver}
               onDragOver={e => { e.preventDefault(); e.stopPropagation(); setDragOver(true) }}
               onDragLeave={e => { if (e.currentTarget === e.target) setDragOver(false) }}
-              voiceRecording={voice.recording}
-              voiceTranscribing={voice.transcribing}
+              voiceRecording={voiceOwned && voice.recording}
+              voiceTranscribing={voiceOwned && voice.transcribing}
               voiceError={voice.error}
-              voiceLevel={voice.level}
-              voiceDeviceLabel={voice.deviceLabel}
+              voiceLevel={voiceOwned ? voice.level : 0}
+              voiceDeviceLabel={voiceOwned ? voice.deviceLabel : ''}
               onClearVoiceError={voice.clearError}
               voiceDictationPanel={sttDictationPanel}
               voiceSampleRef={voice.sampleRef}
-              voicePartial={voice.partial}
+              voicePartial={voiceOwned ? voice.partial : ''}
               onVoiceToggle={voiceInputSupported ? toggleVoice : undefined}
               onVoicePrewarm={voiceInputSupported ? voice.prewarm : undefined}
               agentName={currentSlot?.agent || 'default'}

--- a/website/src/test/ChatPage.sendDuringDictation.test.tsx
+++ b/website/src/test/ChatPage.sendDuringDictation.test.tsx
@@ -46,12 +46,14 @@ const voice = vi.hoisted(() => {
 })
 voice.toggle = vi.fn(() => { voice.recording = !voice.recording })
 vi.mock('../hooks/useVoiceInput', () => ({
-  useVoiceInput: (onText: (t: string) => void, opts?: { onPartial?: (t: string) => void }) => {
+  useVoiceInput: (onText: (t: string) => void, opts?: { onPartial?: (t: string) => void; streaming?: boolean }) => {
     voice.onPartial = opts?.onPartial ?? null
     voice.onText = onText
     return ({
     recording: voice.recording,
     transcribing: false,
+    sessionOwner: null,
+    streamEnabled: !!opts?.streaming,
     toggle: voice.toggle,
     prewarm: vi.fn(),
     error: null,


### PR DESCRIPTION
## Problem
Voice input (STT) uses a single `useVoiceInput` instance hoisted to `ChatPage`, so its `recording` / `transcribing` state is page-global. While one session is transcribing, switching to **any other session** shows that session's mic disabled with a "Transcribing…" spinner and a "Transcribing, please wait" placeholder — one session's voice work locks the mic in every session. Switching slots mid-transcription also **discarded** the transcript entirely.

## Why it matters
Multi-session users can't dictate in one chat and keep working in another — the mic appears stuck everywhere until the (sometimes slow) transcription finishes, and any transcript produced after a switch is silently lost. It reads as a broken/hung mic across the whole app.

## Fix (symptom → root cause → change)
- **Symptom:** every session's mic is busy/locked while one transcribes; transcript lost on switch.
- **Root cause:** one hook instance ⇒ one set of busy flags shared by all slots, and a blanket "drop the transcript on slot switch" guard.
- **Change (exclusive single-session model):**
  - `useVoiceInput` snapshots the **owning session id** the instant a recording starts (a local capture for the batch path so a later recording can't reassign it; `streamSessionRef` for streaming) and returns it alongside the transcript via `onText` / `onPartial`.
  - The hook tracks a single `sessionOwner`, assigned when capture **actually begins** (not optimistically on click) and cleared when the session ends — so if the user switches slots during the `getUserMedia` await, the audio can never be misattributed to the slot now on screen.
  - `ChatPage` gates the `voiceRecording` / `voiceTranscribing` / `voiceLevel` / `voicePartial` / `voiceError` props on `voiceOwned = voice.sessionOwner === activeSlot`, so a background session never shows a busy/locked mic elsewhere.
  - `toggleVoice` refuses to **start** a new recording while one is transcribing (`voice.transcribing`). The mic is a single shared device, so sessions are **exclusive** — no two recordings/transcriptions ever overlap. That exclusivity is what lets a single `sessionOwner` be correct with no per-session map or request token.
  - On completion a **batch** transcript is routed to the slot that started it: spliced into the live composer when that slot is on screen, otherwise appended to that slot's persisted draft (recoverable on disk, shown on return) instead of leaking into the active session or being dropped. Mirrors the prompt optimizer's cross-slot routing (`handleOptimizeResult` + `setDraft`).
  - `sttDisarmedRef` is kept for its same-slot job (dropping a late **streaming** partial/final after send — the check is hoisted to the top of `applyVoiceText` so it covers every route); only the blanket slot-switch disarm is removed.

Scope notes — recording itself still stops on a slot switch (single shared mic). **Cross-slot delivery is batch-only**: streaming splices a live hypothesis into the composer that gets flushed to the draft on switch, so appending a streaming final cross-slot would double the text — a streaming final that lands after leaving its slot keeps the pre-existing drop behaviour. Cross-slot streaming delivery is a follow-up; streaming (AWS Transcribe) is opt-in and off by default, and the enabled provider here (mlx/whisper) is batch.

## Tests
No new tests were needed to change behaviour; the existing voice suites lock in the invariants this change must preserve:
- `ChatPage.sendDuringDictation` — the post-send disarm (streaming) still drops a late partial, and batch capture is **not** disarmed on send (transcript still lands). Confirms `sttDisarmedRef`'s same-slot role and the new `onText`/`onPartial(text, sessionId)` signatures.
- `useVoiceInput.prewarm`, `ChatInput.dictation` — hook lifecycle + dictation UI unaffected.

All green (full `ChatInput` + `ChatPage` set: 375 tests), plus `tsc --noEmit` and `eslint` on the two changed files clean.

## Manual verification
N/A for the routing/gating logic (unit-covered above). End-to-end mic behaviour across two live sessions needs a real microphone + STT provider and can't run headless; the gating is pure prop derivation and the routing is exercised by the existing suites.

## Screenshots
N/A — no visual/layout change. The fix is behavioural: the existing mic button's disabled/spinner state is no longer shown on non-owning sessions. No new or changed panel, component, layout, or theme.
