### PR TITLE
fix(mcp-gateway): resolve the stub's data home per-platform, not via $HOME

### DIFF
--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -67,11 +67,39 @@ _BINARY_HASH_CAP_BYTES = 4 * 1024 * 1024
 _CONFIG_SNAPSHOT_PLACEHOLDER = "0" * 64
 
 
+def _crew_home() -> Path:
+    """Data home the stub resolves its paths under.
+
+    ``Path.home()`` rather than ``os.environ["HOME"]``: that variable is
+    normally unset on Windows (which uses ``USERPROFILE``), so the previous
+    fallback evaluated to ``Path("")`` and every derived path became RELATIVE to
+    the stub's cwd. For the socket that is worse than untidy on Windows, where
+    the pipe name is a hash of this path -- a daemon and a stub started from
+    different working directories would hash to different pipe names and never
+    meet. ``Path.home()`` consults the right variable on each platform.
+
+    Never raises. ``Path.home()`` raises ``RuntimeError`` when no home can be
+    resolved at all, and both callers are on paths that must not fail: the
+    socket default is an argparse default (a raise there kills the stub before
+    it can degrade to a per-session exec) and the log path is used by
+    ``log_fallback``, whose handler catches ``OSError`` only.
+
+    Deliberately not ``config.paths.config_dir()``: this module is on the stub's
+    cold-start path and stays import-light.
+    """
+    home = os.environ.get("KIROCREW_HOME")
+    if home:
+        return Path(home)
+    try:
+        base = Path.home()
+    except RuntimeError:
+        base = Path(os.environ.get("USERPROFILE") or os.environ.get("HOME") or ".")
+    return base / ".kiro" / "crew"
+
+
 def _default_socket_path() -> str:
     """Resolve the default gateway socket under KIROCREW_HOME (0700 dir)."""
-    home = os.environ.get("KIROCREW_HOME")
-    base = Path(home) if home else Path(os.environ.get("HOME", "")) / ".kiro" / "crew"
-    return str(base / "mc-mcp-gateway.sock")
+    return str(_crew_home() / "mc-mcp-gateway.sock")
 
 
 def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
@@ -689,9 +717,7 @@ async def run_bridge(
 
 
 def _fallback_log_path() -> Path:
-    home = os.environ.get("KIROCREW_HOME")
-    base = Path(home) if home else Path(os.environ.get("HOME", "")) / ".kiro" / "crew"
-    return base / "logs" / "stub_fallback.jsonl"
+    return _crew_home() / "logs" / "stub_fallback.jsonl"
 
 
 def log_fallback(

--- a/test/test_mcp_gateway_stub_paths.py
+++ b/test/test_mcp_gateway_stub_paths.py
@@ -1,0 +1,89 @@
+"""The stub's path resolution must produce ABSOLUTE paths on every platform.
+
+Both the default socket path and the fallback audit log derive from one data
+home. That home used to fall back to ``os.environ["HOME"]``, which is normally
+unset on Windows (it uses ``USERPROFILE``), so the expression evaluated to
+``Path("")`` and every derived path became relative to the stub's cwd.
+
+That is not cosmetic. The Windows pipe name is a hash of the socket path, so a
+daemon and a stub started from different working directories would hash to two
+different pipe names and never meet -- silently, with a gateway nothing can
+reach. The fallback log landing in an arbitrary cwd also quietly destroys the
+main signal for "did pooling actually engage".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.mcp_gateway.stub import (
+    _crew_home,
+    _default_socket_path,
+    _fallback_log_path,
+)
+
+
+def _clear_home_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reproduce a Windows environment: no KIROCREW_HOME and no HOME."""
+    monkeypatch.delenv("KIROCREW_HOME", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
+
+
+def test_kirocrew_home_wins_when_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    assert _crew_home() == tmp_path
+    assert _default_socket_path() == str(tmp_path / "mc-mcp-gateway.sock")
+    assert _fallback_log_path() == tmp_path / "logs" / "stub_fallback.jsonl"
+
+
+def test_home_is_absolute_without_any_home_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regression. With HOME unset the old expression yielded ``Path("")``,
+    making every derived path relative to whatever cwd the stub inherited."""
+    _clear_home_env(monkeypatch)
+    assert _crew_home().is_absolute(), "data home must never be cwd-relative"
+
+
+def test_socket_default_is_absolute_without_any_home_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Load-bearing on Windows: the pipe name is a hash of this path, so a
+    cwd-relative value lets two processes derive different pipe names."""
+    _clear_home_env(monkeypatch)
+    assert Path(_default_socket_path()).is_absolute()
+
+
+def test_fallback_log_is_absolute_without_any_home_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_home_env(monkeypatch)
+    assert _fallback_log_path().is_absolute()
+
+
+def test_unresolvable_home_degrades_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``Path.home()`` raises RuntimeError when no home can be resolved at all,
+    and neither caller may raise: the socket value is an argparse default (a
+    raise there kills the stub before it can degrade to a per-session exec) and
+    the log path is used by ``log_fallback``, whose handler catches ``OSError``
+    only -- so a RuntimeError would escape the one function documented as
+    never allowed to break the exec that keeps kiro-cli working.
+    """
+    _clear_home_env(monkeypatch)
+    monkeypatch.delenv("USERPROFILE", raising=False)
+
+    def _no_home() -> Path:
+        raise RuntimeError("could not determine home directory")
+
+    monkeypatch.setattr(Path, "home", staticmethod(_no_home))
+
+    # Must not raise, and must still yield a usable path.
+    assert _crew_home().parts, "a degraded home must still be a usable path"
+    assert _default_socket_path().endswith("mc-mcp-gateway.sock")
+    assert _fallback_log_path().name == "stub_fallback.jsonl"


### PR DESCRIPTION
## What

The stub derived both its default socket path and its fallback audit log from
`Path(os.environ.get("HOME", "")) / ".kiro" / "crew"`. `HOME` is normally unset on
Windows (it uses `USERPROFILE`), so that expression evaluates to `Path("")` and every
derived path becomes **relative to whatever working directory the stub inherited**.

Both sites had the identical expression, so this extracts one `_crew_home()` helper
using `Path.home()`, which consults the right variable on each platform.

## Why it matters

**Socket path** — the Windows pipe name is a sha256 of the socket path, so a daemon and
a stub started from different working directories derive **different pipe names and
never meet** — no error, just a gateway nothing can reach. Production passes `--socket`
explicitly at all three call sites, so this is latent rather than active, but the
default is exactly what a first manual Windows run uses.

**Fallback log** — a non-empty `stub_fallback.jsonl` is how an operator learns the stub
degraded to a per-session exec instead of pooling. Landing it in an arbitrary cwd
destroys the main signal for "did pooling actually engage", and an operator looking
under the data home would not find the file at all.

Found while writing the manual Windows test plan for #1042, not by a reviewer.

## `_crew_home()` cannot raise

`Path.home()` raises `RuntimeError` when no home is resolvable, and neither caller may
raise:

- the socket value is an **argparse default**, so a raise there kills the stub before it
  can degrade to a per-session exec;
- the log path is used by `log_fallback`, whose handler catches `OSError` only — a
  `RuntimeError` would escape the one function documented as never allowed to break the
  exec that keeps kiro-cli working.

The degraded branch falls back to `USERPROFILE`, then `HOME`, then the old relative
behaviour, so the worst case is what shipped before rather than a crash.

Deliberately not `config.paths.config_dir()`: this module is on the stub's cold-start
path and stays import-light.

## Testing

New `test/test_mcp_gateway_stub_paths.py` asserts the property that matters and is
platform-independent: **the resolved paths must be absolute with no home variables
set**. Mutation-verified — restoring the old expression fails three of the five on
`data home must never be cwd-relative`. The `RuntimeError` path is covered by patching
`Path.home` to raise.

Full local suite: 23,303 passed, no failures beyond the known environment-dependent set
(sandbox userns, docker, `gh` binary, `qrcode` module). `scripts/scrub-lint.sh` clean.
