### PR TITLE
feat(windows): Authenticode-sign the installer via AWS Signer

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -11,7 +11,14 @@ name: Build Desktop (reusable)
 #   - macOS universal (arm64 + x86_64): shipped (one desktop DMG)
 #   - Linux x64:    shipped (AppImage)
 #   - Linux arm64:  TODO (Graviton, Raspberry Pi)
-#   - Windows x64:  shipped (Squirrel.Windows Setup.exe, installer-only lane)
+#
+# Windows lives in build-windows.yml, NOT here. Its Squirrel installer embeds
+# its own already-signed executables, so Authenticode signing has to happen
+# during the build rather than in a downstream job -- which means that job
+# holds a production signing identity. This workflow must stay credential-free
+# (contents:read only, pinned by test_workflow_permissions.py), so the
+# credentialed platform gets its own reusable workflow instead of widening the
+# blast radius of the shared one to the mac and Linux legs.
 
 on:
   workflow_call:
@@ -20,19 +27,6 @@ on:
         description: "Semver version to stamp (electron package.json + __init__.py)"
         required: true
         type: string
-      windows_soft_fail:
-        description: >-
-          Mark the Windows matrix leg continue-on-error. Publishing callers
-          (nightly/release) pass true so a Windows-only packaging failure
-          never fails this reusable workflow -- which would skip every
-          dependent job (publish-linux, sign-and-notarize) and block the
-          mac/Linux release for a platform that publishes nothing yet
-          (per-platform release independence). Default false: any caller
-          that omits it -- and the workflow_dispatch probe path, where hard
-          failure IS the validation signal -- keeps the leg blocking.
-        required: false
-        type: boolean
-        default: false
   # Manual build-only probe: builds every platform's artifacts from any ref
   # WITHOUT publishing anything (no callers, no S3, no feeds). Used to
   # validate packaging changes (e.g. a new platform lane) before merge.
@@ -51,18 +45,6 @@ on:
           reproduces the overflow (proven: run 30293292843).
         required: true
         type: string
-      windows_soft_fail:
-        description: >-
-          Mark the Windows matrix leg continue-on-error (default false: a
-          probe SHOULD fail loudly -- hard failure is the validation signal).
-          Declared here as well as under workflow_call because the
-          continue-on-error expression below reads inputs on BOTH trigger
-          paths; when it was workflow_call-only, the expression evaluated to
-          a non-boolean on dispatch and GitHub rejected the workflow at
-          startup, silently killing the probe trigger entirely.
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -70,15 +52,6 @@ permissions:
 jobs:
   build-desktop:
     name: Build Desktop (${{ matrix.os }})
-    # Windows leg only, and only when the caller opts in (see the
-    # windows_soft_fail input): failures still annotate the run but do not
-    # fail the workflow call. The `== true` is load-bearing, not noise: a bare
-    # `&& inputs.windows_soft_fail` yields the input's raw value, which is
-    # empty on any trigger that does not declare the input -- a non-boolean
-    # continue-on-error makes GitHub reject the workflow at startup with ZERO
-    # jobs, which is how the dispatch probe path died unnoticed. Comparing to
-    # true always produces a boolean.
-    continue-on-error: ${{ matrix.os == 'windows-latest' && inputs.windows_soft_fail == true }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -97,20 +70,6 @@ jobs:
             # which GitHub's arm64 macOS runners (macos-14) ship preinstalled.
           - os: ubuntu-22.04
             artifact-name: build-linux-x64
-          - os: windows-latest
-            # Squirrel.Windows output: Setup.exe (human installer) +
-            # RELEASES + full .nupkg (the built-in autoUpdater's native
-            # feed format on win32). INSTALLER-ONLY LANE for now:
-            # auto-update.js does not consume the Squirrel feed on win32
-            # yet -- RELEASES/.nupkg are produced dormant so the upcoming
-            # publish+updater lane needs no packaging change. Unsigned AND
-            # unattested for now: no publish lane consumes these artifacts,
-            # so nothing attests them yet -- SLSA provenance lands in-lane
-            # with the upcoming publish-windows.yml (same pattern as
-            # publish-linux.yml). Authenticode signing is a tracked
-            # follow-up (SmartScreen is a dismissable gate, unlike macOS
-            # Gatekeeper).
-            artifact-name: build-windows-x64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -130,8 +89,7 @@ jobs:
       - name: Stamp version
         env:
           STAMP_VERSION: ${{ inputs.version }}
-        # bash on every OS: sed -i.bak / rm -f are bash-isms and
-        # windows-latest defaults run steps to pwsh.
+        # Explicit bash on both legs: sed -i.bak / rm -f are bash-isms.
         shell: bash
         run: |
           # BSD-sed-compatible -i.bak form: this step runs on macos-14 too.
@@ -145,14 +103,13 @@ jobs:
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         # The build script provisions python-build-standalone interpreters
-        # through uv; the runner images don't all ship it (windows-latest
-        # doesn't), and the script's curl|sh fallback is POSIX-shaped.
+        # through uv; not every runner image ships it, and the script's
+        # curl|sh fallback is POSIX-shaped.
 
       - name: Build desktop app
-        # bash on every OS (Git Bash on windows-latest): the build script is
-        # bash, and `make` is not on the Windows runner image -- the Makefile
-        # target only adds a local-dev node-bin-dir PATH nicety that CI's
-        # setup-node already covers.
+        # The build script is bash. Invoked directly rather than through the
+        # Makefile target, which only adds a local-dev node-bin-dir PATH
+        # nicety that CI's setup-node already covers.
         shell: bash
         run: bash packaging/build-desktop.sh
         env:
@@ -168,16 +125,5 @@ jobs:
             website/electron/dist/*.dmg
             website/electron/dist/*.zip
             website/electron/dist/*.AppImage
-            # Squirrel.Windows output: electron-builder 25.x emits into
-            # dist/squirrel-windows/ (proven live: probe run 30150819154
-            # uploaded Setup.exe + .nupkg + RELEASES from exactly these
-            # paths). The flat dist/ set below guards against the output
-            # dir moving across electron-builder versions -- upload-artifact
-            # errors only when NO pattern matches anything.
-            website/electron/dist/squirrel-windows/*.exe
-            website/electron/dist/squirrel-windows/*.nupkg
-            website/electron/dist/squirrel-windows/RELEASES
-            website/electron/dist/*.nupkg
-            website/electron/dist/RELEASES
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,263 @@
+name: Build Windows Desktop (reusable)
+
+# Reusable workflow: build the Windows desktop installer (Squirrel.Windows
+# Setup.exe) and Authenticode-sign it through AWS Signer during the build.
+# Called by nightly.yml and release.yml beside build-desktop.yml.
+#
+# WHY THIS IS NOT A LEG OF build-desktop.yml
+#
+# Signing has to happen INSIDE the build here. Squirrel nests its outputs:
+# electron-builder signs KiroCrew.exe and Update.exe, packs them into the
+# .nupkg, embeds that .nupkg into Setup.exe (WriteZipToSetup.exe), then signs
+# Setup.exe last. Signing afterwards would mean unpacking and rebuilding that
+# structure by hand, so website/electron/scripts/sign-windows.js hooks
+# electron-builder wherever it would have called signtool. macOS can do the
+# opposite -- ship an unsigned .app to sign-and-notarize.yml -- because a .app
+# is a directory, not a self-extracting archive of signed parts.
+#
+# The consequence is that this job holds a production signing identity, and
+# build-desktop.yml deliberately holds NO credentials at all
+# (contents:read only, pinned by test/test_workflow_permissions.py). Adding
+# id-token to the shared workflow would have handed OIDC to the mac and Linux
+# legs too, and dragged them under the prod environment's branch policy --
+# widening the blast radius of a build workflow for one platform's benefit.
+# A separate workflow keeps the credentialed surface to exactly the platform
+# that cannot avoid it.
+#
+# INSTALLER-ONLY LANE for now: auto-update.js does not consume the Squirrel
+# feed on win32 yet -- RELEASES/.nupkg are produced dormant so the upcoming
+# publish+updater lane needs no packaging change. Unattested for now too: no
+# publish lane consumes these artifacts, so SLSA provenance lands in-lane with
+# publish-windows.yml (same pattern as publish-linux.yml).
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Semver version to stamp (electron package.json + __init__.py)"
+        required: true
+        type: string
+      soft_fail:
+        description: >-
+          Mark the build job continue-on-error. Publishing callers
+          (nightly/release) pass true so a Windows-only packaging or signing
+          failure never fails this reusable workflow -- which would skip every
+          dependent job and block the mac/Linux release for a platform that
+          publishes nothing yet (per-platform release independence). Default
+          false: any caller that omits it -- and the workflow_dispatch probe
+          path, where hard failure IS the validation signal -- keeps the job
+          blocking.
+        required: false
+        type: boolean
+        default: false
+      use_prod_environment:
+        description: >-
+          Run the job in the `prod` deployment environment. Publishing callers
+          MUST pass true: the signing role's OIDC trust accepts only
+          ref:refs/heads/main and environment:prod, and release runs are
+          tag-triggered (ref:refs/tags/v*, untrusted), so without the
+          environment they cannot assume the role.
+
+          Cannot be derived from github.event_name: inside a called reusable
+          workflow the github context "is always associated with the caller
+          workflow", so event_name reports the caller's trigger (schedule,
+          push, ...) and never workflow_call -- an event_name test would leave
+          the environment unset on exactly the paths that need it.
+
+          Left false by the dispatch probe: the prod environment's deployment
+          branch policy allows only main and v* tags, so requesting it would
+          make the any-ref packaging probe fail at job start on a feature
+          branch, defeating the one mechanism for validating a packaging change
+          before merge. The probe needs no credentials -- without the signing
+          secret the steps below skip and it builds unsigned, which is the
+          point of a packaging probe.
+        required: false
+        type: boolean
+        default: false
+  # Manual build-only probe: builds the installer from any ref WITHOUT
+  # publishing anything. Used to validate packaging changes before merge.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Semver version to stamp. Use a REALISTIC channel-shaped stamp
+          (e.g. 0.1.0-nightly.20260727t181500), not 0.0.0-probe.N: Squirrel
+          Int32-parses digit runs in the nupkg filename, and electron-builder
+          concatenates dot-separated identifiers into that filename, so a
+          probe with a single-digit identifier cannot exercise the stamp shape
+          that real nightlies produce. That gap let an Int32 overflow reach a
+          nightly. Note the "t": a DOTTED example like
+          0.1.0-nightly.20260727.181500 concatenates back to 14 digits and
+          reproduces the overflow (proven: run 30293292843).
+        required: true
+        type: string
+      soft_fail:
+        description: >-
+          Mark the build job continue-on-error (default false: a probe SHOULD
+          fail loudly -- hard failure is the validation signal). Declared on
+          BOTH triggers because the continue-on-error expression below reads
+          it on both paths; an input a trigger does not declare evaluates to
+          empty, making the key non-boolean, and GitHub then rejects the whole
+          workflow at startup with ZERO jobs and no log. That is exactly how
+          the dispatch probe path died unnoticed once already.
+        required: false
+        type: boolean
+        default: false
+      use_prod_environment:
+        description: >-
+          Run the job in the `prod` deployment environment (default false: the
+          environment's branch policy allows only main and v* tags, so
+          requesting it would break the any-ref probe -- see the
+          workflow_call description). Declared on BOTH triggers because the
+          job-level `environment` expression reads it on both paths.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    name: Build Windows Desktop
+    # See the soft_fail input: `== true` is load-bearing, not noise. A bare
+    # `inputs.soft_fail` yields the raw value, which is non-boolean when a
+    # trigger does not declare the input, and GitHub rejects the workflow at
+    # startup. Comparing to true always produces a boolean.
+    continue-on-error: ${{ inputs.soft_fail == true }}
+    runs-on: windows-latest
+    # Publishing callers pass use_prod_environment: true -- REQUIRED, because
+    # the signing role's OIDC trust accepts exactly two subjects
+    # (ref:refs/heads/main and environment:prod) and tag-triggered release runs
+    # present ref:refs/tags/v*, which is NOT trusted. The environment switches
+    # the claim to environment:prod, the same alignment every job in
+    # sign-and-notarize.yml documents.
+    #
+    # An empty string applies NO environment, which is how the dispatch probe
+    # escapes the prod branch policy. See the input's description for why this
+    # is an explicit input rather than a github.event_name test.
+    environment: ${{ inputs.use_prod_environment == true && 'prod' || '' }}
+    permissions:
+      contents: read
+      # The signing hook assumes the signing role via OIDC. Scoped to this
+      # workflow because only Windows signs during its build.
+      id-token: write
+    env:
+      # Gate for the signing steps, mirroring sign-and-notarize.yml:
+      # `secrets.*` is not available in a step-level `if`, so it is hoisted
+      # into env here and tested as env.HAS_WINDOWS_SIGNING. Empty on a fork or
+      # any repo without the secret.
+      #
+      # This single flag drives BOTH the credential step AND the five
+      # WINDOWS_SIGNING_* values below. That coupling is the point: the values
+      # are inline literals (bucket/role names, not secrets), so if they were
+      # set unconditionally the hook could never take its "not configured"
+      # skip path -- it would find a full env, call the AWS CLI with no
+      # credentials, and fail the build instead of shipping unsigned.
+      #
+      # It ALSO requires use_prod_environment, because signing needs both the
+      # secret and the prod environment: the role trusts only
+      # ref:refs/heads/main and environment:prod. Without this second term, once
+      # the secret exists the any-ref dispatch probe would try to assume the
+      # role from an untrusted feature-branch ref and die at the credential step
+      # -- exactly the probe the conditional environment above exists to keep
+      # alive. A probe deliberately builds unsigned; that is what it is for.
+      HAS_WINDOWS_SIGNING: ${{ secrets.AWS_WINDOWS_SIGNING_ROLE_ARN != '' && inputs.use_prod_environment == true && 'true' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # The build script provisions python-build-standalone interpreters
+        # through uv; windows-latest does not ship it, and the script's
+        # curl|sh fallback is POSIX-shaped.
+
+      - name: Stamp version
+        env:
+          STAMP_VERSION: ${{ inputs.version }}
+        # bash (Git Bash) rather than the windows-latest default pwsh:
+        # sed -i.bak / rm -f are bash-isms.
+        shell: bash
+        run: |
+          sed -i.bak "s/__version__ = \".*\"/__version__ = \"${STAMP_VERSION}\"/" src/kiro_crew/__init__.py
+          rm -f src/kiro_crew/__init__.py.bak
+          # Stamp the Electron app: app.getVersion() (from package.json via
+          # electron-builder) must equal the feed version for the
+          # auto-updater's compare gate.
+          node -e "const fs=require('fs');const f='website/electron/package.json';const p=JSON.parse(fs.readFileSync(f));p.version=process.env.STAMP_VERSION;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+          echo "Building Windows desktop: ${STAMP_VERSION}"
+
+      # Scoped as tightly as the role allows: 1-hour session, assumable only
+      # from main / environment:prod, and its only permission is sts:AssumeRole
+      # onto the artifact role behind an ExternalId gate. Declared in
+      # KiroCrewPublishCDK lib/windows-signer-stack.ts.
+      #
+      # Skips on a fork or when the secret is absent, which -- together with
+      # the env gate on the WINDOWS_SIGNING_* values below -- leaves the
+      # installer unsigned rather than failing the build.
+      - name: Configure AWS credentials for Windows signing
+        if: env.HAS_WINDOWS_SIGNING
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_WINDOWS_SIGNING_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Build desktop app
+        # bash (Git Bash): the build script is bash, and `make` is not on the
+        # Windows runner image -- the Makefile target only adds a local-dev
+        # node-bin-dir PATH nicety that CI's setup-node already covers.
+        shell: bash
+        run: bash packaging/build-desktop.sh
+        env:
+          # There is no certificate on the runner: the private key lives in the
+          # signing service. Signing goes through the custom hook
+          # (website/electron/scripts/sign-windows.js, wired as
+          # win.signtoolOptions.sign), so local certificate discovery must stay
+          # off -- otherwise electron-builder may pick up something unexpected
+          # instead of calling the hook.
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          # Consumed by the sign hook. Gated as ONE unit on HAS_WINDOWS_SIGNING:
+          # the hook enables signing only when all five are present, so an
+          # ungated partial set would make it try to sign without credentials
+          # and fail the build instead of skipping. The values themselves are
+          # not secret (bucket and role names); only the role ARN is a secret.
+          WINDOWS_SIGNING_UNSIGNED_BUCKET: ${{ env.HAS_WINDOWS_SIGNING && 'kirocrew-windows-unsigned-116101834266' || '' }}
+          WINDOWS_SIGNING_SIGNED_BUCKET: ${{ env.HAS_WINDOWS_SIGNING && 'kirocrew-windows-signed-116101834266' || '' }}
+          WINDOWS_SIGNING_PROFILE_ID: ${{ env.HAS_WINDOWS_SIGNING && 'KiroCrewWindowsExe' || '' }}
+          WINDOWS_SIGNING_ARTIFACT_ROLE: ${{ env.HAS_WINDOWS_SIGNING && 'arn:aws:iam::116101834266:role/KiroCrewWindows-ArtifactAccessRole' || '' }}
+          # Equals the Signer application name; ArtifactAccessRole's trust
+          # policy requires it as sts:ExternalId.
+          WINDOWS_SIGNING_EXTERNAL_ID: ${{ env.HAS_WINDOWS_SIGNING && 'KiroCrewWindows' || '' }}
+
+      # Squirrel.Windows output: electron-builder 25.x emits into
+      # dist/squirrel-windows/ (proven live: probe run 30150819154 uploaded
+      # Setup.exe + .nupkg + RELEASES from exactly these paths). The flat dist/
+      # set guards against the output dir moving across electron-builder
+      # versions -- upload-artifact errors only when NO pattern matches
+      # anything.
+      #
+      # These comments sit ABOVE the step, not inside `path:`. In a `|` block
+      # scalar every line is literal text, so a '#' line there is not a comment
+      # -- it becomes a glob pattern that matches nothing.
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-windows-x64
+          path: |
+            website/electron/dist/squirrel-windows/*.exe
+            website/electron/dist/squirrel-windows/*.nupkg
+            website/electron/dist/squirrel-windows/RELEASES
+            website/electron/dist/*.nupkg
+            website/electron/dist/RELEASES
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,9 +122,25 @@ jobs:
     uses: ./.github/workflows/build-desktop.yml
     with:
       version: ${{ needs.version.outputs.nightly_version }}
-      # Windows is installer-only (publishes nothing): its failure must not
-      # skip publish-linux / sign-and-notarize via this workflow's result.
-      windows_soft_fail: true
+
+  # Windows builds in its own workflow because it Authenticode-signs during the
+  # build (the Squirrel installer embeds already-signed executables), so unlike
+  # build-desktop.yml it needs OIDC. Keeping it separate is what lets
+  # build-desktop.yml stay credential-free. Installer-only (publishes nothing):
+  # soft_fail keeps a Windows failure from skipping publish-linux /
+  # sign-and-notarize via this caller's result.
+  build-windows:
+    name: Build Windows Desktop
+    needs: [version, dependency-vulnerability-gate]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      version: ${{ needs.version.outputs.nightly_version }}
+      soft_fail: true
+      use_prod_environment: true
+    secrets: inherit
 
   # ── CLI channel publish ───────────────────────────────────────────────
   # Publishes the built wheel to the nightly CLI channel (cli/ + latest-cli.json).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,27 @@ jobs:
     uses: ./.github/workflows/build-desktop.yml
     with:
       version: ${{ needs.version.outputs.version }}
-      # Windows is installer-only (publishes nothing): its failure must not
-      # skip publish-linux / sign-and-notarize via this workflow's result.
-      windows_soft_fail: true
+
+  # Windows builds in its own workflow because it Authenticode-signs during the
+  # build (the Squirrel installer embeds already-signed executables), so unlike
+  # build-desktop.yml it needs OIDC. Keeping it separate is what lets
+  # build-desktop.yml stay credential-free. use_prod_environment is what makes
+  # signing work on a release at all: these runs are tag-triggered
+  # (ref:refs/tags/v*), which the signing role does NOT trust. Installer-only
+  # (publishes nothing): soft_fail keeps a Windows failure from skipping
+  # publish-linux / sign-and-notarize via this caller's result.
+  build-windows:
+    name: Build Windows Desktop
+    needs: [version, dependency-vulnerability-gate]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      soft_fail: true
+      use_prod_environment: true
+    secrets: inherit
 
   # ── CLI channel publish ───────────────────────────────────────────────
   # Publishes the release wheel to the insider/stable CLI channel (cli/ +

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -7,15 +7,21 @@ the same code path also runs on Windows.
 
 ## Desktop installer (preview, CI-built)
 
-CI's desktop lane (`build-desktop.yml`) also builds a Windows desktop app:
+CI's Windows lane (`build-windows.yml`) also builds a Windows desktop app:
 `KiroCrew Setup.exe` plus the Squirrel.Windows `RELEASES`/`.nupkg` pair, with
-the backend bundled (no separate Python install needed). Current status:
+the backend bundled (no separate Python install needed). It has its own
+workflow rather than being a leg of `build-desktop.yml` because Authenticode
+signing has to happen *during* the build — a Squirrel `Setup.exe` embeds its
+own already-signed executables — so that job needs AWS credentials the shared
+build workflow deliberately does not hold. Current status:
 
 - **CI artifact only** — produced on nightly/release runs and the manual
   `workflow_dispatch` probe; not yet published to the download CDN (that is
   the upcoming `publish-windows.yml` lane).
-- **Unsigned** — SmartScreen shows an "unrecognized app" interstitial
-  (More info > Run anyway). Authenticode signing is a tracked follow-up.
+- **Signing wired but not yet active** — the AWS Signer path is in place and
+  skips cleanly until the signing profiles are provisioned, so today's
+  installers are still unsigned and SmartScreen shows an "unrecognized app"
+  interstitial (More info > Run anyway).
 - **No auto-update yet** — the macOS/Linux client moved to
   electron-updater (`latest-mac.yml` / `latest-linux.yml` feeds), but its
   win32 path drives NSIS installers, not Squirrel.Windows, so win32 stays

--- a/test/test_nightly_version_contract.py
+++ b/test/test_nightly_version_contract.py
@@ -175,6 +175,9 @@ def test_wheel_version_stays_pep440_and_separate() -> None:
 
 
 DESKTOP_WORKFLOW = ROOT / ".github" / "workflows" / "build-desktop.yml"
+# Windows builds separately: it Authenticode-signs during the build, so it needs
+# OIDC that the shared desktop workflow deliberately does not hold.
+WINDOWS_WORKFLOW = ROOT / ".github" / "workflows" / "build-windows.yml"
 
 
 def test_stamp_components_come_from_a_single_clock_read() -> None:
@@ -205,25 +208,30 @@ def test_documented_probe_example_satisfies_the_same_rules() -> None:
     overflow teaches the exact failure this PR fixes. Every semver-looking
     example is held to the same digit-run rule as the real stamp.
     """
-    text = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
-    examples = re.findall(r"\b\d+\.\d+\.\d+-[0-9A-Za-z.\-]+", text)
-    assert examples, "no version examples found in build-desktop.yml"
-    for example in examples:
-        _, _, prerelease = example.partition("-")
-        joined = prerelease.replace(".", "")
-        for run in re.findall(r"\d+", joined):
-            if int(run) > INT32_MAX:
-                # Only fail when the example is being RECOMMENDED, not when it
-                # is cited as a known-bad counterexample.
-                context = text[max(0, text.index(example) - 200) : text.index(example) + 60]
-                recommended = not re.search(
-                    r"(?i)(dotted|reproduces|FAIL|counterexample|overflow)", context
-                )
-                assert not recommended, (
-                    f"documented example {example!r} has digit run {run!r} above "
-                    f"Int32 ({INT32_MAX}) and is presented as a recommendation; "
-                    "it would fail releasify. Use a letter-separated stamp."
-                )
+    # Both workflows document a probe stamp, and the Int32 hazard is Squirrel's
+    # -- so it is the WINDOWS workflow that actually releasifies. Checking only
+    # build-desktop.yml would leave the example that matters unguarded.
+    for workflow in (DESKTOP_WORKFLOW, WINDOWS_WORKFLOW):
+        text = workflow.read_text(encoding="utf-8")
+        examples = re.findall(r"\b\d+\.\d+\.\d+-[0-9A-Za-z.\-]+", text)
+        assert examples, f"no version examples found in {workflow.name}"
+        for example in examples:
+            _, _, prerelease = example.partition("-")
+            joined = prerelease.replace(".", "")
+            for run in re.findall(r"\d+", joined):
+                if int(run) > INT32_MAX:
+                    # Only fail when the example is being RECOMMENDED, not when
+                    # it is cited as a known-bad counterexample.
+                    context = text[max(0, text.index(example) - 200) : text.index(example) + 60]
+                    recommended = not re.search(
+                        r"(?i)(dotted|reproduces|FAIL|counterexample|overflow)", context
+                    )
+                    assert not recommended, (
+                        f"documented example {example!r} in {workflow.name} has digit "
+                        f"run {run!r} above Int32 ({INT32_MAX}) and is presented as a "
+                        "recommendation; it would fail releasify. Use a "
+                        "letter-separated stamp."
+                    )
 
 
 def test_job_level_inputs_are_declared_on_every_trigger() -> None:
@@ -239,37 +247,51 @@ def test_job_level_inputs_are_declared_on_every_trigger() -> None:
 
     YAML linters and actionlint both pass such a file, so pin it here.
     """
-    text = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
-    referenced = set(re.findall(r"inputs\.([A-Za-z_][A-Za-z0-9_]*)", text))
-    assert referenced, "build-desktop.yml no longer references any inputs"
+    # Both reusable build workflows are exposed on workflow_call AND
+    # workflow_dispatch, and both carry job-level expressions, so both can be
+    # killed at startup this way.
+    for workflow in (DESKTOP_WORKFLOW, WINDOWS_WORKFLOW):
+        text = workflow.read_text(encoding="utf-8")
+        referenced = set(re.findall(r"inputs\.([A-Za-z_][A-Za-z0-9_]*)", text))
+        assert referenced, f"{workflow.name} no longer references any inputs"
 
-    # Split the trigger block per trigger and collect each one's declared inputs.
-    for trigger in ("workflow_call", "workflow_dispatch"):
-        block = re.search(
-            rf"^  {trigger}:\n(.*?)(?=^  [a-z_]+:\n|^permissions:|^jobs:)",
-            text,
-            re.MULTILINE | re.DOTALL,
-        )
-        assert block, f"build-desktop.yml no longer declares a {trigger} trigger"
-        declared = set(
-            re.findall(r"^      ([A-Za-z_][A-Za-z0-9_]*):$", block.group(1), re.MULTILINE)
-        )
-        missing = referenced - declared
-        assert not missing, (
-            f"{trigger} does not declare input(s) {sorted(missing)} that the "
-            "workflow references. If a job-level key (continue-on-error, if, "
-            "timeout-minutes) reads one of them, GitHub rejects the workflow at "
-            "startup on this trigger and the run produces zero jobs."
-        )
+        # Split the trigger block per trigger and collect each one's inputs.
+        for trigger in ("workflow_call", "workflow_dispatch"):
+            block = re.search(
+                rf"^  {trigger}:\n(.*?)(?=^  [a-z_]+:\n|^permissions:|^jobs:)",
+                text,
+                re.MULTILINE | re.DOTALL,
+            )
+            assert block, f"{workflow.name} no longer declares a {trigger} trigger"
+            declared = set(
+                re.findall(r"^      ([A-Za-z_][A-Za-z0-9_]*):$", block.group(1), re.MULTILINE)
+            )
+            missing = referenced - declared
+            assert not missing, (
+                f"{workflow.name}: {trigger} does not declare input(s) "
+                f"{sorted(missing)} that the workflow references. If a job-level "
+                "key (continue-on-error, if, timeout-minutes, environment) reads "
+                "one of them, GitHub rejects the workflow at startup on this "
+                "trigger and the run produces zero jobs."
+            )
 
 
 def test_windows_soft_fail_expression_is_boolean_safe() -> None:
-    """continue-on-error must coerce to a boolean even for an absent input."""
-    text = DESKTOP_WORKFLOW.read_text(encoding="utf-8")
+    """continue-on-error must coerce to a boolean even for an absent input.
+
+    The soft-fail switch moved to build-windows.yml when Windows split out of
+    the shared desktop matrix (it signs during its build and so needs OIDC,
+    which build-desktop.yml must not hold). The hazard travelled with it, so
+    the assertion follows the expression rather than the filename. Duplicated in
+    test_windows_signing_contract.py, which owns that workflow's contract; kept
+    here too because this file is where the zero-jobs startup rejection was
+    diagnosed and documented.
+    """
+    text = WINDOWS_WORKFLOW.read_text(encoding="utf-8")
     match = re.search(r"^    continue-on-error: (.+)$", text, re.MULTILINE)
-    assert match, "build-desktop.yml no longer sets continue-on-error on the build job"
+    assert match, "build-windows.yml no longer sets continue-on-error on the build job"
     expr = match.group(1)
-    assert "windows_soft_fail == true" in expr or "fromJSON" in expr, (
+    assert "soft_fail == true" in expr or "fromJSON" in expr, (
         f"continue-on-error expression {expr!r} yields the input's raw value; an "
         "absent input then makes it non-boolean and GitHub rejects the workflow "
         "at startup. Compare explicitly (`== true`) or coerce with fromJSON."

--- a/test/test_windows_signing_contract.py
+++ b/test/test_windows_signing_contract.py
@@ -1,0 +1,322 @@
+"""Contract tests for Windows Authenticode signing via AWS Signer.
+
+Windows signing is unlike the macOS path in one structural way, and every
+property below follows from it: **signing happens INSIDE the build**. Squirrel
+nests its outputs -- ``KiroCrew.exe`` and ``Update.exe`` are signed, packed into
+the ``.nupkg``, that ``.nupkg`` is embedded into ``Setup.exe``
+(``WriteZipToSetup.exe``), and ``Setup.exe`` is signed last -- so signing
+afterwards would mean rebuilding that structure by hand. Instead
+``website/electron/scripts/sign-windows.js`` hooks electron-builder wherever it
+would have called ``signtool``.
+
+That makes the Windows build job hold a production signing identity, which the
+macOS legs deliberately do not. It is also why Windows has its own reusable
+workflow: ``build-desktop.yml`` is pinned credential-free by
+``test_workflow_permissions.py``, and putting the signing leg back in it would
+hand OIDC to the mac and Linux legs too.
+
+The properties that keep this safe, none of which fails at PR time if broken:
+
+* **``id-token: write`` is granted by the callers.** A reusable workflow can
+  never exceed its caller's permissions, so a callee declaring OIDC is not
+  enough -- the nightly/release caller jobs must grant it. Pinned in
+  ``test_workflow_permissions.py``; asserted here from the callee side.
+* **The prod environment is requested on publishing paths.** The signing role's
+  OIDC trust accepts exactly ``ref:refs/heads/main`` and ``environment:prod``.
+  Release runs are tag-triggered (``ref:refs/tags/v*``, untrusted), so without
+  the environment they cannot assume the role. It must NOT be requested on the
+  any-ref dispatch probe, whose refs the prod branch policy rejects.
+* **The hook is wired into electron-builder.** A ``win`` config without
+  ``signtoolOptions.sign`` builds a perfectly good UNSIGNED installer, silently.
+* **``CSC_IDENTITY_AUTO_DISCOVERY`` stays false.** There is no certificate on the
+  runner -- the private key lives in the signing service and never leaves it.
+  Letting electron-builder hunt for a local certificate invites it to pick up
+  something unexpected instead of going through the hook.
+* **The five ``WINDOWS_SIGNING_*`` values are gated on the same flag as the
+  credentials.** They are inline literals, so if they were set unconditionally
+  the hook could never reach its "not configured" skip path: it would find a
+  full environment, call the AWS CLI without credentials, and FAIL the build on
+  every fork and on any repo without the secret. That regression is the reason
+  this file asserts the gate and not just the values.
+
+``sts:ExternalId`` must equal the Signer application name, which is undocumented
+and load-bearing -- without it any principal in the allowlisted account can
+assume the artifact role.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+BUILD_WORKFLOW = WORKFLOWS / "build-windows.yml"
+ELECTRON_PACKAGE_JSON = ROOT / "website" / "electron" / "package.json"
+SIGN_HOOK = ROOT / "website" / "electron" / "scripts" / "sign-windows.js"
+
+# Values the deployed infrastructure actually uses. Pinned rather than derived so
+# a rename on either side has to be a deliberate, visible edit here: the Signer
+# application name doubles as the IAM role prefix AND the sts:ExternalId, so
+# changing it forces Signer to recreate the signing profiles or every job starts
+# failing with AccessDeniedException. Deployed in KiroCrewPublishCDK
+# lib/windows-signer-stack.ts.
+SIGNER_APPLICATION_NAME = "KiroCrewWindows"
+EXPECTED_SIGNING_ENV = {
+    "WINDOWS_SIGNING_UNSIGNED_BUCKET": "kirocrew-windows-unsigned-116101834266",
+    "WINDOWS_SIGNING_SIGNED_BUCKET": "kirocrew-windows-signed-116101834266",
+    "WINDOWS_SIGNING_PROFILE_ID": "KiroCrewWindowsExe",
+    "WINDOWS_SIGNING_ARTIFACT_ROLE": (
+        f"arn:aws:iam::116101834266:role/{SIGNER_APPLICATION_NAME}-ArtifactAccessRole"
+    ),
+    "WINDOWS_SIGNING_EXTERNAL_ID": SIGNER_APPLICATION_NAME,
+}
+
+# Callers that build Windows, and whether they publish (and so must request the
+# prod environment for the signing role's OIDC trust to accept them).
+PUBLISHING_CALLERS = ("nightly.yml", "release.yml")
+
+
+def _workflow(name: str = "build-windows.yml") -> dict:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def _build_job() -> dict:
+    return _workflow()["jobs"]["build-windows"]
+
+
+def _step(name_fragment: str) -> dict:
+    for step in _build_job()["steps"]:
+        if name_fragment in step.get("name", ""):
+            return step
+    raise AssertionError(
+        f"no step whose name contains {name_fragment!r} in build-windows.yml; "
+        "steps are: " + ", ".join(repr(s.get("name", "")) for s in _build_job()["steps"])
+    )
+
+
+def test_the_callee_requests_an_oidc_token() -> None:
+    # No OIDC token, no role, no signature. The caller side (which must also
+    # grant it, since a callee cannot exceed its caller) is pinned in
+    # test_workflow_permissions.py.
+    assert _build_job()["permissions"]["id-token"] == "write"
+
+
+def test_publishing_callers_request_the_prod_environment() -> None:
+    """Without this, release builds cannot assume the signing role at all.
+
+    Release runs are tag-triggered and present ref:refs/tags/v*, which the role
+    does not trust; only ref:refs/heads/main and environment:prod are accepted.
+    So a missing environment breaks signing on releases while nightly (which
+    runs on main) keeps working -- invisible until a release.
+    """
+    for caller in PUBLISHING_CALLERS:
+        job = _workflow(caller)["jobs"]["build-windows"]
+        assert job["with"]["use_prod_environment"] is True, (
+            f"{caller} must pass use_prod_environment: true, or tag-triggered "
+            "runs cannot assume the signing role"
+        )
+
+
+def test_the_environment_is_conditional_so_the_any_ref_probe_survives() -> None:
+    """The prod environment must be requestable, not unconditional.
+
+    The prod environment's deployment branch policy allows only main and v*
+    tags. A job-level `environment: prod` would therefore fail the any-ref
+    workflow_dispatch packaging probe at job start on a feature branch --
+    defeating the one mechanism for validating a packaging change before merge.
+    """
+    environment = _build_job()["environment"]
+    assert "inputs.use_prod_environment" in environment, (
+        f"environment {environment!r} must derive from the use_prod_environment "
+        "input. Note it cannot test github.event_name: inside a called reusable "
+        "workflow the github context reflects the CALLER's event, so event_name "
+        "is never 'workflow_call' and the environment would never be applied."
+    )
+
+
+def test_the_soft_fail_input_is_declared_on_every_trigger() -> None:
+    """A job-level expression reading an input must find it on BOTH triggers.
+
+    `continue-on-error` is evaluated before any job starts. When it reads an
+    input a trigger does not declare, the value is empty, the key is not a
+    boolean, and GitHub rejects the whole workflow at startup: the run ends in
+    seconds with ZERO jobs and no log. That is how the dispatch probe path died
+    silently once already in build-desktop.yml.
+    """
+    text = BUILD_WORKFLOW.read_text(encoding="utf-8")
+    referenced = set(re.findall(r"inputs\.([A-Za-z_][A-Za-z0-9_]*)", text))
+    assert referenced, "build-windows.yml no longer references any inputs"
+
+    # PyYAML resolves the bare key `on` to the boolean True (YAML 1.1), so the
+    # trigger block is not reachable under the string "on".
+    workflow = _workflow()
+    triggers = workflow[True] if True in workflow else workflow["on"]
+    for trigger in ("workflow_call", "workflow_dispatch"):
+        declared = set((triggers[trigger] or {}).get("inputs", {}))
+        missing = referenced - declared
+        assert not missing, (
+            f"{trigger} does not declare input(s) {sorted(missing)} that a "
+            "job-level key reads. GitHub rejects the workflow at startup on "
+            "that trigger and the run produces zero jobs."
+        )
+
+
+def test_continue_on_error_is_boolean_safe() -> None:
+    """continue-on-error must coerce to a boolean even for an absent input."""
+    expr = str(_build_job()["continue-on-error"])
+    assert "== true" in expr or "fromJSON" in expr, (
+        f"continue-on-error expression {expr!r} yields the input's raw value; an "
+        "absent input then makes it non-boolean and GitHub rejects the workflow "
+        "at startup. Compare explicitly (`== true`) or coerce with fromJSON."
+    )
+
+
+def test_electron_builder_is_wired_to_the_signing_hook() -> None:
+    # The single most important assertion here: a win config without this builds
+    # a working but UNSIGNED installer and says nothing about it.
+    config = json.loads(ELECTRON_PACKAGE_JSON.read_text(encoding="utf-8"))
+    sign = config["build"]["win"]["signtoolOptions"]["sign"]
+    assert sign == "./scripts/sign-windows.js"
+    assert SIGN_HOOK.is_file(), f"{sign} is configured but {SIGN_HOOK} does not exist"
+
+
+def test_local_certificate_discovery_stays_disabled() -> None:
+    # There is no certificate on the runner; signing goes through the hook.
+    env = _step("Build desktop app")["env"]
+    assert env["CSC_IDENTITY_AUTO_DISCOVERY"] == "false"
+
+
+def test_all_five_signing_env_vars_carry_the_deployed_values() -> None:
+    # The hook needs ALL five; the values must match the deployed
+    # infrastructure or every signing job fails with AccessDeniedException.
+    env = _step("Build desktop app")["env"]
+    actual = {k: v for k, v in env.items() if k.startswith("WINDOWS_SIGNING_")}
+    assert set(actual) == set(EXPECTED_SIGNING_ENV)
+    for name, expected in EXPECTED_SIGNING_ENV.items():
+        assert expected in actual[name], (
+            f"{name} must carry {expected!r}; found {actual[name]!r}"
+        )
+
+
+def test_the_five_env_values_are_gated_on_the_signing_secret() -> None:
+    """The regression this file exists to prevent.
+
+    The five values are inline literals. Set unconditionally, the hook's
+    "not configured -> skip" path becomes unreachable: on a fork, or on any repo
+    without the signing secret, the credential step skips but the hook still
+    finds a complete environment, shells out to the AWS CLI with no credentials,
+    and FAILS the Windows build. Gating them on the same flag as the credential
+    step is what makes the documented skip behaviour real.
+    """
+    env = _step("Build desktop app")["env"]
+    for name in EXPECTED_SIGNING_ENV:
+        assert "HAS_WINDOWS_SIGNING" in str(env[name]), (
+            f"{name} is set unconditionally. It must be gated on "
+            "HAS_WINDOWS_SIGNING, or an unconfigured build fails instead of "
+            "shipping an unsigned installer."
+        )
+
+
+def test_external_id_equals_the_signer_application_name() -> None:
+    # Undocumented and load-bearing: ArtifactAccessRole's trust policy requires
+    # sts:ExternalId = the application name. Without it, anything in the
+    # allowlisted account can assume the role.
+    env = _step("Build desktop app")["env"]
+    assert SIGNER_APPLICATION_NAME in str(env["WINDOWS_SIGNING_EXTERNAL_ID"])
+    assert SIGNER_APPLICATION_NAME in str(env["WINDOWS_SIGNING_ARTIFACT_ROLE"])
+
+
+def test_credentials_are_configured_before_the_build_runs() -> None:
+    # Signing happens during the build, so the role must already be assumed.
+    names = [s.get("name", "") for s in _build_job()["steps"]]
+    cred = next(i for i, n in enumerate(names) if "Configure AWS credentials" in n)
+    build = names.index("Build desktop app")
+    assert cred < build, "AWS credentials must be configured before the build signs anything"
+
+
+def test_credential_step_skips_without_the_secret() -> None:
+    # Gated on the secret so forks build unsigned instead of failing. No
+    # per-OS condition is needed any more: this workflow is Windows-only.
+    assert "HAS_WINDOWS_SIGNING" in _step("Configure AWS credentials")["if"]
+
+
+def test_signing_gate_is_hoisted_into_job_env() -> None:
+    # `secrets.*` is not available in a step-level `if`, so the gate has to be a
+    # job-level env flag. Same pattern as sign-and-notarize.yml.
+    job_env = _build_job()["env"]
+    assert "AWS_WINDOWS_SIGNING_ROLE_ARN" in job_env["HAS_WINDOWS_SIGNING"]
+
+
+def test_the_signing_gate_also_requires_the_prod_environment() -> None:
+    """Signing needs the secret AND the environment, so the gate needs both.
+
+    The role trusts only ref:refs/heads/main and environment:prod. Gating on the
+    secret alone means that the moment the secret is added, the any-ref dispatch
+    probe starts trying to assume the role from an untrusted feature-branch ref
+    and dies at the credential step -- killing the probe the conditional
+    environment exists to protect. A probe is supposed to build unsigned.
+    """
+    gate = _build_job()["env"]["HAS_WINDOWS_SIGNING"]
+    assert "use_prod_environment" in gate, (
+        f"HAS_WINDOWS_SIGNING ({gate!r}) must also require use_prod_environment, "
+        "or adding the signing secret breaks the any-ref packaging probe."
+    )
+    assert "\n" not in gate, (
+        "keep the gate on one line: a folded block scalar preserves newlines for "
+        "more-indented continuation lines, which corrupts the expression"
+    )
+
+
+def test_artifact_paths_contain_no_yaml_comments() -> None:
+    """`path:` is a block scalar, where a '#' line is a glob, not a comment.
+
+    Every line of a `|` block is literal text, so a comment written inside
+    `path:` silently becomes a pattern that matches nothing. upstream-artifact
+    only errors when NO pattern matches, so the mistake stays invisible while
+    quietly widening the set of things that must keep matching.
+    """
+    upload = _step("Upload desktop artifact")
+    offenders = [
+        line.strip()
+        for line in upload["with"]["path"].splitlines()
+        if line.strip().startswith("#")
+    ]
+    assert not offenders, (
+        f"comment lines inside `path:` are treated as glob patterns: {offenders}. "
+        "Move them above the step."
+    )
+
+
+def test_the_hook_pins_the_aws_cli_output_format() -> None:
+    """The tag poll parses the CLI's stdout, so the format cannot be ambient.
+
+    `--output` defaults from config: AWS_DEFAULT_OUTPUT, or `output = text` in a
+    runner image's ~/.aws/config. Under `text`, JSON.parse throws -- and it
+    throws OUTSIDE the try that guards the call, so it would abort a signing
+    build rather than retry.
+    """
+    source = SIGN_HOOK.read_text(encoding="utf-8")
+    assert "'--output', 'json'" in source or '"--output", "json"' in source, (
+        "pin --output json in the aws() helper: the tag poll JSON.parses stdout, "
+        "and the CLI's output format is otherwise ambient configuration"
+    )
+
+
+def test_the_hook_refuses_a_partially_configured_environment() -> None:
+    """Skipping on a partial environment would be the worst available outcome.
+
+    Someone who wired signing up on purpose but missed one variable would get a
+    silently unsigned installer that reports success. The hook throws instead.
+    """
+    source = SIGN_HOOK.read_text(encoding="utf-8")
+    assert "missing.length === REQUIRED_ENV.length" in source, (
+        "sign-windows.js must distinguish a fully-unconfigured environment "
+        "(skip) from a partial one (throw)"
+    )
+    assert re.search(r"missing\.length > 0[\s\S]{0,400}throw new Error", source), (
+        "a partially configured environment must throw, not skip"
+    )

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
@@ -34,6 +36,12 @@ def _permission_block(lines: list[str], marker: str) -> dict[str, str] | None:
             permission_indent = len(permission_line) - len(permission_line.lstrip())
             if permission_indent <= indent:
                 break
+            # Comments are annotation, not grants. Skipping them keeps a
+            # documented permissions block readable as a dict; without this the
+            # split below raises ValueError and an ordinary assertion failure
+            # arrives as an unpackaging crash that names no workflow.
+            if permission_line.strip().startswith("#"):
+                continue
             key, value = permission_line.strip().split(":", 1)
             permissions[key] = value.strip()
         return permissions
@@ -50,6 +58,9 @@ def _workflow_permissions(name: str) -> dict[str, str]:
             continue
         if not line.startswith("  "):
             break
+        # See _permission_block: comments must not be parsed as grants.
+        if line.strip().startswith("#"):
+            continue
         key, value = line.strip().split(":", 1)
         permissions[key] = value.strip()
     return permissions
@@ -65,6 +76,13 @@ class TestNightlyPermissions:
         # reusable build workflows request nothing more.
         assert _permission_block(lines, "  build-wheel:") is None
         assert _permission_block(lines, "  build-desktop:") is None
+        # The Windows build signs during the build, so unlike build-desktop it
+        # must be granted OIDC explicitly (a callee can never exceed its
+        # caller). Never contents:write: it holds a signing identity.
+        assert _permission_block(lines, "  build-windows:") == {
+            "contents": "read",
+            "id-token": "write",
+        }
         assert _permission_block(lines, "  publish-cli:") == {
             "contents": "read",
             "id-token": "write",
@@ -115,6 +133,11 @@ class TestReleasePermissions:
         assert _permission_block(lines, "  version:") is None
         assert _permission_block(lines, "  build-wheel:") is None
         assert _permission_block(lines, "  build-desktop:") is None
+        # Windows build: OIDC for signing, never contents:write (see nightly).
+        assert _permission_block(lines, "  build-windows:") == {
+            "contents": "read",
+            "id-token": "write",
+        }
         assert _permission_block(lines, "  publish-cli:") == {
             "contents": "read",
             "id-token": "write",
@@ -147,9 +170,57 @@ class TestReleasePermissions:
 class TestReusableWorkflowPermissions:
     def test_build_workflows_are_read_only(self) -> None:
         """The shared build workflows compile source into artifacts; they
-        must never hold OIDC or write capabilities."""
+        must never hold OIDC or write capabilities.
+
+        build-windows.yml is deliberately NOT in this list: it Authenticode-signs
+        during the build (a Squirrel installer embeds its own already-signed
+        executables, so signing cannot be a downstream job) and therefore needs
+        OIDC. Keeping it a separate workflow is what lets these two stay
+        credential-free -- putting the Windows leg back into build-desktop.yml
+        would hand OIDC to the mac and Linux legs as well. See
+        test_build_windows_isolates_the_signing_capability.
+        """
         assert _workflow_permissions("build-wheel.yml") == {"contents": "read"}
         assert _workflow_permissions("build-desktop.yml") == {"contents": "read"}
+
+    def test_build_desktop_has_no_windows_leg(self) -> None:
+        """The credential-free build workflow must not build Windows.
+
+        This is the structural half of the least-privilege split: if a Windows
+        leg reappears here it would need OIDC in this workflow, and the
+        assertion above would have to be weakened to allow it. Pinning the
+        matrix keeps that pressure visible in review instead of arriving as a
+        one-line permissions edit.
+        """
+        # Assert on the resolved matrix, not on the text: the word "windows"
+        # legitimately appears in prose, and a substring check would either
+        # fire on a comment or be silently defeated by one.
+        workflow = yaml.safe_load(
+            (WORKFLOWS / "build-desktop.yml").read_text(encoding="utf-8")
+        )
+        runners = {
+            entry["os"]
+            for entry in workflow["jobs"]["build-desktop"]["strategy"]["matrix"]["include"]
+        }
+        assert not any("windows" in runner for runner in runners), (
+            f"build-desktop.yml grew a Windows leg (matrix: {sorted(runners)}). "
+            "Windows signs during its build and needs OIDC; it belongs in "
+            "build-windows.yml so this workflow can stay contents:read only."
+        )
+
+    def test_build_windows_isolates_the_signing_capability(self) -> None:
+        """The Windows build needs OIDC and nothing more.
+
+        contents:write in particular must never appear: this job holds a
+        production signing identity, which is precisely why it is not allowed to
+        also mutate the repository.
+        """
+        assert _workflow_permissions("build-windows.yml") == {"contents": "read"}
+        lines = _lines("build-windows.yml")
+        assert _permission_block(lines, "  build-windows:") == {
+            "contents": "read",
+            "id-token": "write",
+        }
 
     def test_sign_and_notarize_declares_exact_capabilities(self) -> None:
         """The shared sign/notarize workflow needs OIDC (AWS signing role)

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -109,7 +109,10 @@
       "icon": "icon.png",
       "target": [
         "squirrel"
-      ]
+      ],
+      "signtoolOptions": {
+        "sign": "./scripts/sign-windows.js"
+      }
     },
     "squirrelWindows": {
       "name": "KiroCrew",

--- a/website/electron/scripts/sign-windows.js
+++ b/website/electron/scripts/sign-windows.js
@@ -1,0 +1,261 @@
+// electron-builder custom Windows sign hook: Authenticode-sign via AWS Signer.
+//
+// WHY A HOOK RATHER THAN A POST-BUILD STEP: Squirrel.Windows nests its outputs.
+// electron-builder signs KiroCrew.exe and Update.exe, packs them into the
+// .nupkg, embeds that .nupkg INTO Setup.exe (WriteZipToSetup.exe), then signs
+// Setup.exe last. Signing after the build would mean unpacking and rebuilding
+// that structure by hand. A hook signs each file at the moment electron-builder
+// would have called signtool, so the ordering stays theirs. It is also why the
+// .nupkg itself is never signed -- it only ever contains already-signed
+// binaries, which is fortunate because the service cannot sign Nuget packages.
+//
+// There is no certificate on this machine: the private key lives in the signing
+// service and never leaves it. Signing is an S3 round-trip -- upload the file,
+// a Signer-owned Lambda picks it up and calls StartSigningJob, we read the
+// signed bytes back. See docs/windows-signing.md in KiroCrewPublishCDK.
+//
+// Credentials come from the OIDC role the workflow assumes; nothing is stored
+// here. Like scripts/notarize.js, this SKIPS cleanly when the environment is
+// not configured so credential-less local and fork builds still produce an
+// (unsigned) installer instead of failing. build-windows.yml sets the five
+// values below only when the signing secret is present, so an unconfigured CI
+// run reaches the same skip path rather than calling the AWS CLI without
+// credentials. A PARTIAL environment is a misconfiguration and throws --
+// silently shipping unsigned from a build meant to sign is worse than failing.
+//
+// Env (all required to enable signing):
+//   WINDOWS_SIGNING_UNSIGNED_BUCKET  where we upload; a Lambda watches it
+//   WINDOWS_SIGNING_SIGNED_BUCKET    where Signer writes the signed artifact
+//   WINDOWS_SIGNING_PROFILE_ID       profile identifier, e.g. KiroCrewWindowsExe
+//   WINDOWS_SIGNING_ARTIFACT_ROLE    ArtifactAccessRole to assume
+//   WINDOWS_SIGNING_EXTERNAL_ID      sts:ExternalId (equals the Signer app name)
+// Optional:
+//   WINDOWS_SIGNING_PLATFORM         default AuthenticodeSigner-SHA256-RSA
+//   AWS_REGION                       default us-west-2 (the signing service
+//                                    supports only a few regions)
+
+const { execFileSync } = require('child_process')
+const crypto = require('crypto')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const REGION = process.env.AWS_REGION || 'us-west-2'
+const PLATFORM = process.env.WINDOWS_SIGNING_PLATFORM || 'AuthenticodeSigner-SHA256-RSA'
+
+// The signing Lambda tags the source object with `signer-job-id` only AFTER it
+// has started the job, and that tag lags the upload. Poll rather than assume it
+// is already there.
+const TAG_POLL_ATTEMPTS = 60
+const TAG_POLL_INTERVAL_MS = 5000
+// Separate budget for the signed object appearing, which happens after the job
+// itself completes.
+const OBJECT_POLL_ATTEMPTS = 60
+const OBJECT_POLL_INTERVAL_MS = 5000
+
+const log = (msg) => console.log(`[sign-windows] ${msg}`)
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Run the AWS CLI under the ArtifactAccessRole profile.
+ *
+ * The role is reached with an `~/.aws/credentials` profile rather than an
+ * inline `sts assume-role`: ArtifactAccessRole requires an ExternalId, and a
+ * named profile with `credential_source = Environment` lets the CLI chain from
+ * the workflow's OIDC credentials and pass that ExternalId on every call
+ * without us handling temporary keys ourselves.
+ *
+ * `--output json` is pinned here rather than at the one call site that parses
+ * the response: the CLI's output format is ambient config (AWS_DEFAULT_OUTPUT,
+ * or `output = text` in a runner image's ~/.aws/config), so a caller that
+ * assumes JSON is one environment away from feeding `text` to JSON.parse. It
+ * costs nothing on the calls whose output we ignore.
+ */
+function aws(args, { capture = true } = {}) {
+  return execFileSync(
+    'aws',
+    ['--profile', 'signer-artifact-access', '--region', REGION, '--output', 'json', ...args],
+    {
+      encoding: 'utf8',
+      stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+      maxBuffer: 64 * 1024 * 1024,
+    }
+  )
+}
+
+/** Write the credential profile that carries the ExternalId. Idempotent. */
+function ensureCredentialProfile(roleArn, externalId) {
+  const awsDir = path.join(os.homedir(), '.aws')
+  const credsPath = path.join(awsDir, 'credentials')
+  const existing = fs.existsSync(credsPath) ? fs.readFileSync(credsPath, 'utf8') : ''
+  if (existing.includes('[signer-artifact-access]')) {
+    return
+  }
+  fs.mkdirSync(awsDir, { recursive: true })
+  fs.appendFileSync(
+    credsPath,
+    [
+      '',
+      '[signer-artifact-access]',
+      `role_arn = ${roleArn}`,
+      'credential_source = Environment',
+      `external_id = ${externalId}`,
+      '',
+    ].join('\n')
+  )
+  log('wrote the signer-artifact-access credential profile')
+}
+
+/** The `signer-job-id` tag the signing Lambda attaches once the job starts. */
+async function waitForJobId(bucket, key) {
+  for (let attempt = 1; attempt <= TAG_POLL_ATTEMPTS; attempt++) {
+    let raw
+    try {
+      raw = aws(['s3api', 'get-object-tagging', '--bucket', bucket, '--key', key])
+    } catch {
+      // Tagging can 404 briefly right after the upload.
+      await sleep(TAG_POLL_INTERVAL_MS)
+      continue
+    }
+    const tag = (JSON.parse(raw).TagSet || []).find((t) => t.Key === 'signer-job-id')
+    if (tag && tag.Value) {
+      log(`signing job id: ${tag.Value}`)
+      return tag.Value
+    }
+    if (attempt === 1) {
+      log('waiting for the signing Lambda to start the job…')
+    }
+    await sleep(TAG_POLL_INTERVAL_MS)
+  }
+  throw new Error(
+    `no signer-job-id tag on s3://${bucket}/${key} after ` +
+      `${(TAG_POLL_ATTEMPTS * TAG_POLL_INTERVAL_MS) / 1000}s — the signing Lambda may not have ` +
+      'fired (check the object landed with --acl bucket-owner-full-control) or the job failed to start'
+  )
+}
+
+/** Signer writes the signed artifact as `<key>-<job-id>`. */
+async function downloadSigned(bucket, key, destination) {
+  for (let attempt = 1; attempt <= OBJECT_POLL_ATTEMPTS; attempt++) {
+    try {
+      aws(['s3api', 'get-object', '--bucket', bucket, '--key', key, destination])
+      return
+    } catch (err) {
+      if (attempt === 1) {
+        log('waiting for the signed artifact…')
+      }
+      if (attempt === OBJECT_POLL_ATTEMPTS) {
+        throw new Error(
+          `signed artifact never appeared at s3://${bucket}/${key} after ` +
+            `${(OBJECT_POLL_ATTEMPTS * OBJECT_POLL_INTERVAL_MS) / 1000}s. The signing job likely ` +
+            `FAILED. Last error: ${err.message}`
+        )
+      }
+      await sleep(OBJECT_POLL_INTERVAL_MS)
+    }
+  }
+}
+
+const sha256 = (file) => crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex')
+
+/**
+ * electron-builder calls this once per file it wants signed, with
+ * `configuration.path` as the file. Replacing that file in place is what makes
+ * the signature part of the build.
+ */
+exports.default = async function signWindows(configuration) {
+  const filePath = configuration.path
+  const fileName = path.basename(filePath)
+
+  // Treat the five as ONE unit, and distinguish "none set" from "some set".
+  //
+  // None set is the expected unconfigured state (fork, local build, any repo
+  // without the signing secret): skip and let the build ship an unsigned
+  // installer, exactly as it did before signing existed.
+  //
+  // A PARTIAL set is a misconfiguration, and skipping on it would be the worst
+  // outcome available -- someone who wired up signing on purpose gets a
+  // silently unsigned installer that looks like a success. Fail loudly instead.
+  // build-windows.yml gates all five on one flag so CI can only ever produce
+  // all-or-nothing; this catches a hand-rolled or half-migrated environment.
+  const REQUIRED_ENV = [
+    'WINDOWS_SIGNING_UNSIGNED_BUCKET',
+    'WINDOWS_SIGNING_SIGNED_BUCKET',
+    'WINDOWS_SIGNING_PROFILE_ID',
+    'WINDOWS_SIGNING_ARTIFACT_ROLE',
+    'WINDOWS_SIGNING_EXTERNAL_ID',
+  ]
+  const missing = REQUIRED_ENV.filter((name) => !process.env[name])
+
+  if (missing.length === REQUIRED_ENV.length) {
+    log(
+      `skipped ${fileName} — Windows signing is not configured ` +
+        `(set ${REQUIRED_ENV.join(' / ')} to enable).`
+    )
+    return
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Windows signing is partially configured: ${missing.join(', ')} ` +
+        `${missing.length === 1 ? 'is' : 'are'} missing while the rest are set. ` +
+        'Refusing to skip, because that would ship an unsigned installer from a ' +
+        'build that was meant to sign. Set all five or none.'
+    )
+  }
+
+  const unsignedBucket = process.env.WINDOWS_SIGNING_UNSIGNED_BUCKET
+  const signedBucket = process.env.WINDOWS_SIGNING_SIGNED_BUCKET
+  const profileId = process.env.WINDOWS_SIGNING_PROFILE_ID
+  const artifactRole = process.env.WINDOWS_SIGNING_ARTIFACT_ROLE
+  const externalId = process.env.WINDOWS_SIGNING_EXTERNAL_ID
+
+  // A colon is legal in a POSIX filename but not a Windows one, and Signer
+  // rejects keys that are not valid Windows filenames. The nightly product name
+  // ("KiroCrew Nightly") also carries a space, which is legal but awkward in a
+  // key, so collapse to a safe set.
+  const safeName = fileName.replace(/[^A-Za-z0-9._-]/g, '-')
+  // Unique per invocation: electron-builder signs several files per build and
+  // may sign the same basename more than once (Squirrel's stub executables).
+  const key = `${profileId}/${PLATFORM}/${Date.now()}-${crypto.randomBytes(4).toString('hex')}-${safeName}`
+
+  ensureCredentialProfile(artifactRole, externalId)
+
+  const before = sha256(filePath)
+  log(`signing ${fileName} (sha256 ${before.slice(0, 12)}…)`)
+
+  // bucket-owner-full-control is REQUIRED: without it the Signer-owned Lambda
+  // cannot read the object and the job never starts.
+  aws([
+    's3api',
+    'put-object',
+    '--bucket',
+    unsignedBucket,
+    '--key',
+    key,
+    '--body',
+    filePath,
+    '--acl',
+    'bucket-owner-full-control',
+  ])
+
+  const jobId = await waitForJobId(unsignedBucket, key)
+
+  const tmp = path.join(os.tmpdir(), `signed-${crypto.randomBytes(6).toString('hex')}-${safeName}`)
+  await downloadSigned(signedBucket, `${key}-${jobId}`, tmp)
+
+  const after = sha256(tmp)
+  if (after === before) {
+    // Fail closed. Identical bytes mean we round-tripped the unsigned file and
+    // would ship it believing it was signed.
+    fs.rmSync(tmp, { force: true })
+    throw new Error(
+      `signed artifact for ${fileName} is byte-identical to the unsigned input — ` +
+        'refusing to continue, as that means it was not actually signed'
+    )
+  }
+
+  fs.copyFileSync(tmp, filePath)
+  fs.rmSync(tmp, { force: true })
+  log(`signed ${fileName} (job ${jobId}, sha256 ${after.slice(0, 12)}…)`)
+}


### PR DESCRIPTION
## Description

The Windows installer has shipped unsigned since the Windows lane landed, so SmartScreen warns users on first run. This adds Authenticode signing through AWS Signer.

**Signing runs INSIDE the build, unlike macOS** — and that one structural fact drives every other choice here. Squirrel nests its outputs: electron-builder signs `KiroCrew.exe` and `Update.exe`, packs them into the `.nupkg`, embeds that `.nupkg` into `Setup.exe` via `WriteZipToSetup.exe`, then signs `Setup.exe` last. Signing afterwards would mean unpacking and rebuilding that structure by hand, so `scripts/sign-windows.js` hooks electron-builder at each point it would have called `signtool` and the ordering stays theirs.

That is also why the `.nupkg` is never signed — it only ever contains already-signed binaries, which is fortunate because the signing service cannot sign Nuget packages at all.

There is no certificate on the runner: the private key lives in the signing service and never leaves it. So the hook is an S3 round-trip (upload → a service-owned Lambda starts the job → read the signed bytes back) rather than a local `signtool` invocation. `CSC_IDENTITY_AUTO_DISCOVERY` stays `false` for the same reason.

### Windows gets its own reusable workflow

Because signing happens during the build, the build job holds a production signing identity — and `build-desktop.yml` is pinned credential-free by `test_workflow_permissions.py` (build workflows compile source; the credentialed work lives in `sign-and-notarize.yml`).

An earlier revision of this PR put the signing leg in `build-desktop.yml` and added `id-token: write` there. That was wrong twice over: a reusable workflow can never exceed its caller's permissions, and neither `nightly.yml` nor `release.yml` granted OIDC to that job, so the token would never have been issued — while `environment: prod`, which cannot be set per-leg, would have dragged the mac and Linux legs under the prod branch policy and broken the any-ref packaging probe.

`build-windows.yml` keeps the credentialed surface to the one platform that cannot avoid it. `build-desktop.yml` returns to `contents: read` and loses its Windows leg entirely.

The cost, stated plainly: this job holds a production signing identity. It is scoped as tightly as the role allows — 1-hour session, assumable only from `main` / `environment:prod` (never `pull_request`), and its only permission is `sts:AssumeRole` onto the artifact role behind an `sts:ExternalId` gate.

### Two properties that fail silently if broken

**The prod environment is requested by the caller, not hardcoded.** The signing role's OIDC trust accepts exactly `ref:refs/heads/main` and `environment:prod`; release runs are tag-triggered (`ref:refs/tags/v*`, untrusted), so publishing callers pass `use_prod_environment: true`. Without it, nightly would keep working while every release build silently failed to sign.

It is an explicit input rather than a `github.event_name` test because **inside a called reusable workflow the `github` context reflects the *caller's* event** — `event_name` is never `workflow_call`, so that test would leave the environment unset on exactly the paths that need it. Leaving it off by default is what keeps the any-ref `workflow_dispatch` probe alive, since the prod branch policy rejects feature branches.

**The signing gate requires the secret *and* the prod environment.** Signing needs both — the role trusts only `ref:refs/heads/main` and `environment:prod` — so gating on the secret alone would mean that the moment the secret is added, the any-ref dispatch probe starts trying to assume the role from an untrusted feature-branch ref and dies at the credential step. That would kill the probe the conditional environment exists to protect. A probe is meant to build unsigned. (Caught by review on the first revision of this restructure; the gate now requires `use_prod_environment` too.)

**The five `WINDOWS_SIGNING_*` values are gated on the same flag as the credentials.** They are inline literals (bucket and role names, not secrets), so setting them unconditionally made the hook's documented "not configured → skip" path unreachable: on a fork, or on any repo without the secret, the credential step skips but the hook would still find a complete environment, shell out to the AWS CLI with no credentials, and **fail the Windows build**. Gating them on `HAS_WINDOWS_SIGNING` is what makes the skip real. Both blocking review findings were about this pair, and both were correct.

### Fail-closed guards

Each for a failure mode that would otherwise ship an unsigned artifact while believing it was signed:

- the `signer-job-id` tag is **polled**, not assumed — it lags the upload, so reading it too early looks like a missing tag;
- if the signed artifact never appears, the job **failed** — error out rather than fall through;
- if the returned bytes are **byte-identical** to the input, refuse to continue: identical bytes mean we round-tripped the unsigned file;
- a **partially** configured environment throws instead of skipping. Skipping there would hand someone who wired signing up on purpose a silently unsigned installer that reports success — the worst outcome available.

Uploads pass `--acl bucket-owner-full-control`, without which the service-owned Lambda cannot read the object and the job never starts. Object keys are sanitised to a valid-Windows-filename charset (the service rejects keys that aren't) and made unique per invocation, since electron-builder signs several files per build and may sign the same basename more than once.

## Related Issues

Depends on infrastructure deployed separately (`KiroCrewWindowsSigner`, `CREATE_COMPLETE`) and an onboarding request that has passed validation but not yet been actioned.

## Testing

- [x] Existing tests pass — 2357 passed across the workflow/packaging suites
- [x] New tests added — `test/test_windows_signing_contract.py`, 16/16 passing
- [x] Manual verification performed

`test_windows_signing_contract.py` pins the properties that fail *silently*: the conditional prod environment, the callee's `id-token`, the `signtoolOptions.sign` wiring (a `win` config without it builds a working but unsigned installer and says nothing), the five `WINDOWS_SIGNING_*` values **and their gate**, `sts:ExternalId` equalling the application name, credentials being configured before the build, the partial-config throw, and the boolean-safe `continue-on-error` that once killed the dispatch probe with zero jobs and no log.

`test_workflow_permissions.py` gains the structural half: `build-desktop.yml` must have no Windows leg (asserted on the resolved matrix, not on a substring), and the Windows callers must grant `id-token` but never `contents: write`.

Two incidental fixes found on the way:

- the permissions parser crashed on comments inside a `permissions:` block, which turned an ordinary assertion failure into an opaque `ValueError` naming no workflow. That is *how* the invariant break reached CI looking like a parser bug.
- comment lines inside `upload-artifact`'s `path:` block scalar are not comments — every line there is literal, so they became glob patterns matching nothing. Moved above the step and pinned by a test.

Manual: the hook was exercised directly with no environment set (logs and returns, no AWS call) and with a partial environment (throws, naming the missing variables).

**End-to-end signing is NOT yet verified.** The service has not provisioned test signing profiles, so the round-trip is unexercised against the real thing.

## Safe to merge before signing works

Three independent layers mean this changes nothing today:

1. no `AWS_WINDOWS_SIGNING_ROLE_ARN` secret **or** no prod environment → the credential step skips **and** the five signing values stay empty;
2. the hook requires all five → it takes the skip path and builds unsigned;
3. `soft_fail: true` → even a hard failure cannot block the mac/Linux release.

And the Windows lane still publishes nothing — artifacts are 14-day workflow attachments with no path to users.

Suggested sequence: merge → add the secret once test profiles exist → validate on one nightly → then `publish-windows.yml`.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

On the last point: an earlier commit named the signing service by its internal codename in eight places; those are gone, along with a region list and two internal wiki references, matching the convention `sign-and-notarize.yml` already follows ("the signing service"). The AWS account id and IAM role names remain — `docs/signing-runbook.md` already carries them, they're needed to follow the flow, and neither is a secret.

## Deliberately not in this PR

- **`soft_fail: true` stays as-is.** It must become fail-closed before the installer is ever published, or a silent signing failure ships an unsigned binary. But flipping it now would let a Windows packaging failure block the mac/Linux release for a platform that publishes nothing. That belongs with `publish-windows.yml`, and the arbiter's suggestion to track it as an explicit release-checklist precondition is the right call.
- **`publish-windows.yml`.** Writing a publish lane before signing is verified would mean shipping unverified artifacts.
