### PR TITLE
fix(dashboard): apply simplifiedToolNames to session-list status

### DIFF
--- a/website/src/components/CommandPalette.test.tsx
+++ b/website/src/components/CommandPalette.test.tsx
@@ -202,6 +202,9 @@ afterEach(() => {
   H.storeState.dashboard.slots = []
   H.storeState.dashboard.unreadSlots = []
   H.storeState.chat.slotStatusDetail = {}
+  // localStorage is file-scoped, not per-test: a chat-config write (e.g. the
+  // simplifiedToolNames toggle test) would otherwise persist into siblings.
+  localStorage.removeItem('mc-chat-config')
   queryClient.clear()
 })
 
@@ -327,6 +330,27 @@ describe('CommandPalette — render', () => {
     H.storeState.chat.slotStatusDetail = {
       'chat-1': { kind: 'tool', text: 'Running: read /workspace/src/app.ts', ts: 1 },
     }
+    rerender(<CommandPalette open onClose={vi.fn()} />)
+
+    await waitFor(() => expect(H.recentsProvider.search).toHaveBeenCalledTimes(2))
+  })
+
+  it('refreshes recents when the simplified-tool-names preference changes', async () => {
+    // Rows render the tool status through toolStatusLabel, so the preference is
+    // part of the live state the query key covers — otherwise a running row keeps
+    // its pre-toggle label until the next status tick or staleTime expiry.
+    H.storeState.dashboard.slots = [
+      { key: 'chat-1', title: 'Live session', running: true, messages: 2 },
+    ]
+    H.storeState.chat.slotStatusDetail = {
+      'chat-1': { kind: 'tool', text: 'Reading the app entrypoint', ts: 1 },
+    }
+    const { rerender } = render(<CommandPalette open onClose={vi.fn()} />, { wrapper })
+    await screen.findByText('Recent Session')
+    expect(H.recentsProvider.search).toHaveBeenCalledTimes(1)
+
+    localStorage.setItem('mc-chat-config', JSON.stringify({ simplifiedToolNames: false }))
+    window.dispatchEvent(new Event('mc-config-changed'))
     rerender(<CommandPalette open onClose={vi.fn()} />)
 
     await waitFor(() => expect(H.recentsProvider.search).toHaveBeenCalledTimes(2))

--- a/website/src/components/CommandPalette.tsx
+++ b/website/src/components/CommandPalette.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { useAppSelector } from '../store'
 import { useListKeyboardNav } from '../hooks/useListKeyboardNav'
+import { useSimplifiedToolNames } from '../hooks/useSimplifiedToolNames'
 import type { Result, ResourceProvider } from './commandPalette/types'
 import { registerProvider } from './commandPalette/providers'
 import { usePaletteActions } from './commandPalette/paletteActions'
@@ -342,6 +343,11 @@ export default function CommandPalette({
   const slots = useAppSelector((s) => s.dashboard.slots)
   const unreadSlots = useAppSelector((s) => s.dashboard.unreadSlots)
   const slotStatusDetail = useAppSelector((s) => s.chat.slotStatusDetail ?? {})
+  // Rows render a tool status through toolStatusLabel, so the purpose-vs-raw-title
+  // preference is part of the live state the key has to cover: without it, toggling
+  // the setting between two opens leaves a running row on its pre-toggle label until
+  // the next status tick or staleTime expiry.
+  const simplifiedToolNames = useSimplifiedToolNames()
   const liveFingerprint = useMemo(
     () =>
       activeProvider.id === 'recents'
@@ -354,9 +360,9 @@ export default function CommandPalette({
                   slotStatusDetail[s.key]?.kind ?? ''
                 }:${slotStatusDetail[s.key]?.text ?? ''}:${slotStatusDetail[s.key]?.ts ?? ''}`,
             )
-            .join('|') + `#${unreadSlots.join(',')}`
+            .join('|') + `#${unreadSlots.join(',')}#${simplifiedToolNames ? 1 : 0}`
         : '',
-    [activeProvider.id, slots, unreadSlots, slotStatusDetail],
+    [activeProvider.id, slots, unreadSlots, slotStatusDetail, simplifiedToolNames],
   )
   const { data: results = [], isLoading: loading } = useQuery({
     queryKey: ['palette', 'search', activeProvider.id, debouncedQuery, liveFingerprint],

--- a/website/src/components/commandPalette/providers/recentsProvider.test.ts
+++ b/website/src/components/commandPalette/providers/recentsProvider.test.ts
@@ -15,7 +15,7 @@ import {
 type MockState = {
   dashboard: { slots: ChatSlot[]; unreadSlots: string[] }
   chat: {
-    slotStatusDetail: Record<string, { kind?: string; text?: string; ts?: number }>
+    slotStatusDetail: Record<string, { kind?: string; text?: string; toolName?: string; ts?: number }>
   }
 }
 
@@ -209,10 +209,23 @@ describe('sessionStatus — running detail', () => {
       label: 'Thinking…',
     })
   })
+
+  it('shows the raw tool title when simplifiedToolNames is off', () => {
+    // Same preference the inline tool pill obeys, so the palette row and the
+    // transcript agree instead of the row always showing the purpose.
+    const detail = { kind: 'tool', text: 'Reading the app entrypoint', toolName: 'fs_read /workspace/src/app.ts' }
+    expect(sessionStatus(slot({ running: true }), [], detail, false)).toMatchObject({
+      label: 'fs_read /workspace/src/app.ts',
+    })
+    expect(sessionStatus(slot({ running: true }), [], detail, true)).toMatchObject({
+      label: 'Reading the app entrypoint',
+    })
+  })
 })
 
 describe('useRecentsProvider — live status bridge', () => {
   beforeEach(() => {
+    localStorage.clear()
     vi.clearAllMocks()
     mocks.state.dashboard.slots = []
     mocks.state.dashboard.unreadSlots = []
@@ -239,6 +252,26 @@ describe('useRecentsProvider — live status bridge', () => {
       statusStyle: 'dot',
       statusPulse: true,
       statusLabel: 'Running: read /workspace/src/app.ts',
+    })
+  })
+
+  it('renders the raw tool title when the user turned simplified tool names off', async () => {
+    localStorage.setItem('mc-chat-config', JSON.stringify({ simplifiedToolNames: false }))
+    mocks.state.dashboard.slots = [slot({ key: 'dashboard_live', running: true })]
+    mocks.state.chat.slotStatusDetail = {
+      dashboard_live: {
+        kind: 'tool',
+        text: 'Reading the app entrypoint',
+        toolName: 'fs_read /workspace/src/app.ts',
+        ts: 123,
+      },
+    }
+
+    const { result } = renderHook(() => useRecentsProvider())
+    const rows = await result.current.search('')
+
+    expect(rows.find((row) => row.id === 'recents:cur:dashboard_live')).toMatchObject({
+      statusLabel: 'fs_read /workspace/src/app.ts',
     })
   })
 })

--- a/website/src/components/commandPalette/providers/recentsProvider.ts
+++ b/website/src/components/commandPalette/providers/recentsProvider.ts
@@ -4,10 +4,12 @@ import { useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { api } from '../../../api/client'
+import { useSimplifiedToolNames } from '../../../hooks/useSimplifiedToolNames'
 import { useAppDispatch, useAppSelector } from '../../../store'
 import { createSlot, resumeFromHistory, switchSlot } from '../../../store/chatSlice'
 import type { ChatSlot, ChatFolder, CronJob } from '../../../types'
 import type { Result, ResourceProvider } from '../types'
+import { toolStatusLabel } from '../../../utils/toolStatusLabel'
 
 import { i18nT } from '../../../i18n/t'
 import { fmtDateFields, fmtRelative, toDate } from '../../../i18n/format'
@@ -170,7 +172,10 @@ function shortMsg(slot: ChatSlot): string {
 export function sessionStatus(
   slot: ChatSlot,
   unread: string[],
-  statusDetail?: { text?: string },
+  statusDetail?: { kind?: string; text?: string; toolName?: string },
+  // Defaults to the ChatSettings default (on) so callers that don't care about
+  // the preference keep the purpose-first behavior.
+  simplifiedToolNames = true,
 ): {
   style?: 'pill' | 'dot'
   colorVar?: string
@@ -193,7 +198,9 @@ export function sessionStatus(
       style: 'dot',
       colorVar: '--accent',
       pulse: true,
-      label: statusDetail?.text || i18nT('components.commandPalette.providers.recentsProvider.thinking'),
+      label:
+        toolStatusLabel(statusDetail, simplifiedToolNames) ||
+        i18nT('components.commandPalette.providers.recentsProvider.thinking'),
     }
   }
   if (unread.includes(slot.key) || slot.waiting_for_input) {
@@ -214,6 +221,7 @@ export function useRecentsProvider(): ResourceProvider {
   const slots = useAppSelector((s) => s.dashboard.slots)
   const unread = useAppSelector((s) => s.dashboard.unreadSlots)
   const slotStatusDetail = useAppSelector((s) => s.chat.slotStatusDetail ?? {})
+  const simplifiedToolNames = useSimplifiedToolNames()
 
   return useMemo(() => {
     const { ordered: orderedSlots, hasEmptyNew } = prepareCurrentSlots(slots)
@@ -260,7 +268,7 @@ export function useRecentsProvider(): ResourceProvider {
           // An untitled slot that already has messages is a real conversation
           // and keeps its normal row treatment.
           const isNew = isEmptyNewSlot(s)
-          const st = isNew ? {} : sessionStatus(s, unread, slotStatusDetail[s.key])
+          const st = isNew ? {} : sessionStatus(s, unread, slotStatusDetail[s.key], simplifiedToolNames)
           return {
             id: `recents:cur:${s.key}`,
             providerId: 'recents',
@@ -360,5 +368,5 @@ export function useRecentsProvider(): ResourceProvider {
         return [...current, ...planned, ...older]
       },
     }
-  }, [dispatch, navigate, queryClient, slots, unread, slotStatusDetail])
+  }, [dispatch, navigate, queryClient, slots, unread, slotStatusDetail, simplifiedToolNames])
 }

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -23,12 +23,14 @@ import { computeRecentRank, recencyTintShadow, clampTintCount } from '../utils/r
 import { computeActiveSubtree, folderIsHidden, folderOffersHide } from '../utils/folderVisibility'
 import { groupHistoryByFolder } from '../utils/groupHistoryByFolder'
 import { slotChannelLabel, slotChannelNamespace } from '../utils/channelOrigin'
+import { toolStatusLabel } from '../utils/toolStatusLabel'
 import { SearchInput, Input, Btn, IconButton, IconButtonGroup } from '../components/ui'
 import { useProvider } from '../providers'
 import ModelDropdownList from '../components/ModelDropdownList'
 import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
 import { useSessionPalette } from '../hooks/useSessionPalette'
 import { useMoveSlotToFolder } from '../hooks/useMoveSlotToFolder'
+import { useSimplifiedToolNames } from '../hooks/useSimplifiedToolNames'
 import { useSessionActions } from '../hooks/useSessionActions'
 import { useChatPopouts } from '../hooks/useChatPopouts'
 import { useImeGuard } from '../hooks/useImeGuard'
@@ -67,11 +69,15 @@ import { i18nT } from '../i18n/t'
  *  English literal by the websocket layer (a plain `.ts` module the i18n codemod
  *  never scans), so it must be localized at render time. The two fixed phases
  *  (`thinking`/`streaming`) map to catalog keys; a `tool` phase or a
- *  server-supplied status carries its own dynamic text and is passed through. */
-function slotStatusText(detail?: { kind?: string; text?: string }): string {
+ *  server-supplied status carries its own dynamic text and is passed through.
+ *
+ *  A `tool` phase honors the user's `simplifiedToolNames` preference (purpose vs
+ *  raw tool title) via toolStatusLabel, so the row agrees with the inline tool
+ *  pill in the transcript rather than always showing the purpose. */
+function slotStatusText(detail: { kind?: string; text?: string; toolName?: string } | undefined, simplifiedToolNames: boolean): string {
   if (detail?.kind === 'streaming') return i18nT('pages.chatSidebar.streaming')
   if (detail?.kind === 'thinking' && detail.text === 'Thinking…') return i18nT('pages.chatSidebar.thinking')
-  return detail?.text || i18nT('pages.chatSidebar.thinking')
+  return toolStatusLabel(detail, simplifiedToolNames) || i18nT('pages.chatSidebar.thinking')
 }
 /** Telegram-style relative time: time today, "Yesterday hh:mm", weekday+time this week,
  *  short date this year, full date otherwise.
@@ -752,6 +758,8 @@ function ChatSidebar({
   // not merely because a reducer produced a new map wrapper. Without it, any
   // write to one slot's detail re-renders the entire sidebar.
   const slotStatusDetail = useAppSelector(s => s.chat.slotStatusDetail, shallowEqual)
+  // Purpose-vs-raw-tool-title preference, shared with the inline tool pills.
+  const simplifiedToolNames = useSimplifiedToolNames()
   // Presence in this map means "this session is in an active goal loop".
   const goalLoops = useAppSelector(s => s.chat.goalLoops)
   // Live subagent activity per slot, for the sidebar row's "N agents running"
@@ -2074,7 +2082,7 @@ function ChatSidebar({
       : subagentCount > 0
         ? subagentLabel
         : s.running
-          ? slotStatusText(slotStatusDetail[s.key])
+          ? slotStatusText(slotStatusDetail[s.key], simplifiedToolNames)
           : (s.last_message || '')
     const ci = s.color_index != null && s.color_index >= 0 && s.color_index < paletteColors.length ? s.color_index : null
     const rowColor = ci != null ? paletteColors[ci] : null
@@ -2301,7 +2309,7 @@ function ChatSidebar({
                 <span className="truncate">{subagentLabel}</span>
               </div>
             ) : s.running ? (
-              <div className="text-[12px] text-accent leading-snug truncate mt-0.5 flex items-center gap-1"><span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse shrink-0" />{slotStatusText(slotStatusDetail[s.key])}</div>
+              <div className="text-[12px] text-accent leading-snug truncate mt-0.5 flex items-center gap-1"><span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse shrink-0" />{slotStatusText(slotStatusDetail[s.key], simplifiedToolNames)}</div>
             ) : s.last_message ? (
               <div className="text-[12px] text-muted leading-snug truncate mt-0.5">{s.last_message}</div>
             ) : null}

--- a/website/src/test/ChatSidebar.toolStatusSetting.test.tsx
+++ b/website/src/test/ChatSidebar.toolStatusSetting.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Chat sidebar row status honors the `simplifiedToolNames` preference:
+ * the running-session subtitle is the same tool label the inline pill shows
+ * in the transcript — the agent's purpose when simplified names are on, the
+ * raw tool title when they're off. Before this, the row always showed the
+ * purpose, so turning the setting off left the two surfaces disagreeing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+
+// Mutable chat config: the sidebar reads `simplifiedToolNames` through
+// useSimplifiedToolNames -> loadChatConfig. tagColumnsEnabled stays off so the
+// rows render as one flat lane and stay easy to query.
+const cfg = vi.hoisted(() => ({
+  value: { tagColumnsEnabled: false, confirmCloseSession: false, simplifiedToolNames: true } as Record<string, unknown>,
+}))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => cfg.value,
+  saveChatConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: () => vi.fn().mockResolvedValue([]),
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+const TOOL_DETAIL = {
+  kind: 'tool',
+  text: 'Looking up the mic permission handler',
+  toolName: 'grep --include=*.ts setPermissionCheckHandler',
+  ts: 1,
+}
+
+function renderSidebar(slots: any[], chat: Record<string, unknown>) {
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: { activeSlot: null, slotStatusDetail: {}, subagents: {}, slotActivity: {}, goalLoops: {}, ...chat } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  return render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  cfg.value = { tagColumnsEnabled: false, confirmCloseSession: false, simplifiedToolNames: true }
+})
+afterEach(() => vi.clearAllMocks())
+
+describe('chat sidebar — tool status honors simplifiedToolNames', () => {
+  const slots = [{ key: 'k', title: 'sess', running: true, messages: 5, last_message: 'stale' }]
+
+  it('shows the agent purpose when the setting is on', () => {
+    const { getByText, queryByText } = renderSidebar(slots, { slotStatusDetail: { k: TOOL_DETAIL } })
+    expect(getByText(/Looking up the mic permission handler/)).toBeTruthy()
+    expect(queryByText(/setPermissionCheckHandler/)).toBeNull()
+  })
+
+  it('shows the raw tool title when the setting is off', () => {
+    cfg.value = { ...cfg.value, simplifiedToolNames: false }
+    const { getByText, queryByText } = renderSidebar(slots, { slotStatusDetail: { k: TOOL_DETAIL } })
+    expect(getByText(/setPermissionCheckHandler/)).toBeTruthy()
+    expect(queryByText(/Looking up the mic permission handler/)).toBeNull()
+  })
+
+  it('still localizes the fixed thinking phase with the setting off', () => {
+    // Only the `tool` phase carries two forms; thinking/streaming must keep
+    // going through the catalog rather than falling into the tool branch.
+    cfg.value = { ...cfg.value, simplifiedToolNames: false }
+    const { getByText } = renderSidebar(slots, {
+      slotStatusDetail: { k: { kind: 'thinking', text: 'Thinking…', ts: 1 } },
+    })
+    expect(getByText(/Thinking…/)).toBeTruthy()
+  })
+
+  it('composes the goal-loop detail from the same setting-aware label', () => {
+    cfg.value = { ...cfg.value, simplifiedToolNames: false }
+    const { getByText } = renderSidebar(slots, {
+      goalLoops: { k: { cycle_count: 3, max_cycles: 24 } },
+      slotStatusDetail: { k: TOOL_DETAIL },
+    })
+    expect(getByText('Loop 3/24')).toBeTruthy()
+    expect(getByText(/setPermissionCheckHandler/)).toBeTruthy()
+  })
+})

--- a/website/src/test/toolStatusLabel.test.ts
+++ b/website/src/test/toolStatusLabel.test.ts
@@ -1,0 +1,40 @@
+/**
+ * toolStatusLabel: the purpose-vs-raw-tool-title selection shared by every
+ * session-list surface (sidebar rows, command-palette recents) so a row agrees
+ * with the inline tool pill in the transcript.
+ */
+import { describe, it, expect } from 'vitest'
+import { toolStatusLabel } from '../utils/toolStatusLabel'
+
+describe('toolStatusLabel', () => {
+  const toolDetail = { kind: 'tool', text: 'Looking up the mic permission handler', toolName: 'grep' }
+
+  it('returns the agent purpose when simplified names are on', () => {
+    expect(toolStatusLabel(toolDetail, true)).toBe('Looking up the mic permission handler')
+  })
+
+  it('returns the raw tool title when simplified names are off', () => {
+    expect(toolStatusLabel(toolDetail, false)).toBe('grep')
+  })
+
+  it('falls back to the purpose in raw mode when no tool title was recorded', () => {
+    // Details restored from before toolName was carried, or a status whose
+    // tool title was empty: showing the purpose beats blanking the row.
+    expect(toolStatusLabel({ kind: 'tool', text: 'Reading gateway.log' }, false)).toBe('Reading gateway.log')
+  })
+
+  it('passes non-tool phases through unchanged in both modes', () => {
+    for (const simplified of [true, false]) {
+      expect(toolStatusLabel({ kind: 'thinking', text: 'Thinking…' }, simplified)).toBe('Thinking…')
+      expect(toolStatusLabel({ kind: 'streaming', text: 'Streaming' }, simplified)).toBe('Streaming')
+      // Server-supplied chat_status carries only `text`, never a tool title.
+      expect(toolStatusLabel({ kind: 'thinking', text: 'Compacting…' }, simplified)).toBe('Compacting…')
+    }
+  })
+
+  it('returns empty string when there is nothing to show (caller owns fallback copy)', () => {
+    expect(toolStatusLabel(undefined, true)).toBe('')
+    expect(toolStatusLabel({}, true)).toBe('')
+    expect(toolStatusLabel({ kind: 'tool' }, false)).toBe('')
+  })
+})

--- a/website/src/utils/toolStatusLabel.ts
+++ b/website/src/utils/toolStatusLabel.ts
@@ -1,0 +1,29 @@
+/** The pair of labels a live `tool` status carries — the same pair an inline
+ *  tool pill chooses between (see ToolCallLine's `toolLabel`). */
+export type ToolStatusDetail = { kind?: string; text?: string; toolName?: string }
+
+/**
+ * Resolve a live session status to the label the user's `simplifiedToolNames`
+ * preference asks for, so a session-list row agrees with the inline tool pill
+ * instead of always showing the purpose.
+ *
+ * The websocket layer stores both forms on every `tool` status (see the
+ * `tool_call` case in useWebSocket): `text` is the agent-written purpose
+ * (already falling back to the tool title when the agent supplied none) and
+ * `toolName` is the raw tool title. Non-tool phases — `thinking`, `streaming`,
+ * a server-supplied `chat_status` — carry a single label and pass through
+ * unchanged, so a caller can route every status through this one function.
+ *
+ * Returns `''` when there is nothing to show; the caller owns the fallback copy
+ * (which is localized, and therefore not this module's business).
+ */
+export function toolStatusLabel(
+  detail: ToolStatusDetail | undefined,
+  simplifiedToolNames: boolean,
+): string {
+  if (!detail) return ''
+  // Raw mode: prefer the tool title, but fall back to `text` for statuses that
+  // predate `toolName` (restored/legacy details) rather than blanking the row.
+  if (detail.kind === 'tool' && !simplifiedToolNames) return detail.toolName || detail.text || ''
+  return detail.text || ''
+}


### PR DESCRIPTION
## Problem

The **Simplified Tool Call Names** setting only governed inline tool pills in the transcript. Session-list rows — the chat sidebar and the command palette's Recents group — always rendered the agent-written *purpose*, so with the setting off the two surfaces disagreed about the same running tool call: the transcript showed `grep --include=*.ts setPermissionCheckHandler` while the sidebar row beside it read "Looking up the mic permission handler".

## Why it matters

The setting exists because some users want to see exactly what the agent is running, not a paraphrase of it. Turning it off half-worked: the surface people watch to see *which of their sessions is doing what* kept paraphrasing. Worse, the sidebar is the only tool-status readout for **background** sessions — the ones whose transcript you are not looking at — so the setting was ineffective precisely where the label matters most.

## Fix (symptoms → root cause → change)

Both labels were already in the store. `useWebSocket`'s `tool_call` handler writes **`text`** (the agent purpose, already falling back to the tool title when the agent supplied none) *and* **`toolName`** (the raw title) — the same pair `ToolCallLine` picks between for the pill. The session list simply read `text` unconditionally; there was no missing data, only a missing selection.

- New `website/src/utils/toolStatusLabel.ts` — one pure selector holding that choice, so a third session-list surface can't drift from the first two.
- `ChatSidebar.slotStatusText` and `recentsProvider.sessionStatus` route through it.
- Only the `tool` phase branches. `thinking` / `streaming` / server-supplied `chat_status` carry a single label and keep resolving through the i18n catalog — no new user-visible literal is introduced (the labels are dynamic agent text; both fallbacks stay on catalog keys).
- In raw mode a status with no recorded `toolName` (restored from an older session) falls back to the purpose rather than blanking the row.
- `CommandPalette.liveFingerprint` folds in the preference. React Query re-invokes `search()` only on a **key** change — a re-memoized provider identity alone does nothing (the contract the comment on that block already states) — so without this, toggling the setting between two palette opens left a running row on its pre-toggle label until the next status tick or the 10s `staleTime` expiry.

`simplifiedToolNames` defaults to **on**, so this is a no-op for anyone who has not flipped the toggle.

## Tests

11 new/changed assertions, all of which fail against the pre-fix code:

- `website/src/test/toolStatusLabel.test.ts` — the selector: purpose when on, raw title when off, purpose-fallback when `toolName` is absent, non-tool phases unchanged in **both** modes, `''` when there is nothing to show (callers own the localized fallback).
- `website/src/test/ChatSidebar.toolStatusSetting.test.tsx` — sidebar rows in both modes, that `thinking` still localizes with the setting off, and that the goal-loop composed subtitle uses the same setting-aware label.
- `recentsProvider.test.ts` — `sessionStatus` in both modes, plus a `useRecentsProvider` row rendering the raw title.
- `CommandPalette.test.tsx` — the fingerprint discriminator: a preference toggle re-invokes `search()`. **Verified it discriminates** — reverting only the `liveFingerprint` change makes this test fail (key byte-identical, entry still fresh, no remount), and restoring it makes it pass. Also added `localStorage.removeItem('mc-chat-config')` to the file's `afterEach`: storage is file-scoped, not per-test, so the new write would otherwise persist into siblings.

## Manual verification

N/A — unit coverage is sufficient and is the stronger evidence here. The affected pixels are one text run per row whose two states are asserted directly in the DOM; reproducing it live would require an agent turn mid-tool-call in a running session, which the DOM tests stage deterministically instead.

## Screenshots

N/A — no layout, component, or theme change. The diff alters *which of two existing strings* fills an existing text node; row structure, styling, and the pulsing-dot treatment are untouched.

## Local review

Both reviewer lanes mirrored locally before push (per `prepare-pr`):

- **gpt-5.6-sol** (mirror of `codex-review.yml`): no findings.
- **claude-opus-5** (mirror of `claude-review.yml` + base-ref `AUTOSDE.yaml` / `website/AUTOSDE.yaml` / `AGENTS.md`): 0 blocking (all matching `blocking: true` rules pass — `frontend-security` confirmed `toolName` reaches the DOM as an auto-escaped React text child and is already `sanitizeLlmOutput`-ed at the WS boundary). One non-blocking finding — the `liveFingerprint` gap above — **fixed rather than deferred**.
- A focused verifier confirmed the fix closes that finding with no new Critical/High, and flagged the `localStorage` cleanup gap, also fixed.

Gates green on `d5b10b3c`: 571 files / 6940 tests, `tsc -b` clean, eslint under the warning ceiling, jscpd 0 clones.
