### PR TITLE
ci: run the Electron test suite on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,6 +766,33 @@ jobs:
           path: website/build/coverage/
           if-no-files-found: error
 
+  electron-test:
+    name: Electron Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/electron/package-lock.json
+
+      # ELECTRON_SKIP_BINARY_DOWNLOAD: the suite is `node --test` over the main
+      # process's pure-logic modules -- it never launches Electron -- so the
+      # ~100MB prebuilt binary is dead weight here. Skipping it takes the
+      # install from minutes to ~30s. Anything that needs a REAL Electron
+      # runtime belongs in ota-test.yml, which packages actual app bundles.
+      - name: Install dependencies
+        working-directory: website/electron
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+        run: npm ci --no-audit --no-fund
+
+      - name: Unit tests
+        working-directory: website/electron
+        run: npm test
+
   e2e:
     name: E2E (stub ACP backend, offline)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The **428-test Electron main-process suite** (`website/electron/test/*.test.js`) gates nothing on a pull request.

`npm test` for that directory appears in exactly one workflow — `ota-test.yml` — whose triggers are:

```yaml
on:
  workflow_dispatch:
  workflow_call:
  schedule:
    - cron: "40 8 * * *"
```

No `pull_request`. That workflow also documents itself as *"not an automatic merge block"*.

## Why it matters

Everything those tests cover runs only after merge, if at all:

- auto-update install timing and error phases (`auto-update*.test.js`)
- the screen-capture handler (`display-media.test.js`)
- the microphone permission handlers (`permission-handler.test.js`)
- gateway liveness / recovery / stop (`gateway-*.test.js`)
- bundle-location classification, instance-guard, local-token, zoom, badge…

Concretely: **#1108** landed a permission-handler fix that had denied all voice input in the packaged app. Its 20 new tests gated nothing on that PR. The same class of regression can land again unnoticed.

## Fix

One `electron-test` job in `ci.yml`, modelled on the existing `frontend-test` job — same SHA-pinned actions, same node-20 + npm cache shape, cache keyed on `website/electron/package-lock.json`.

`ELECTRON_SKIP_BINARY_DOWNLOAD=1` on the install is the one non-obvious bit. The suite is `node --test` over the main process's **pure-logic modules** and never launches Electron, so the ~100 MB prebuilt binary is dead weight.

**Measured locally**, not assumed:

| | |
|---|---|
| `npm ci` with binary skipped | **32s** |
| `npm test` | **8s**, 428/428 pass, 0 fail, 0 skipped |
| `node_modules/electron/dist` | absent — binary genuinely not fetched |

Anything that needs a *real* Electron runtime stays in `ota-test.yml`, which packages actual app bundles. This job is deliberately the cheap unit lane.

## Why no registration was needed

`pr-readiness.yml` aggregates at the **workflow** level:

```yaml
workflow_specs=(
  "ci.yml|CI"
  "build.yml|Build"
  "code-review.yml|Code Review"
)
```

So a new job inside `ci.yml` is picked up automatically. I also checked that nothing else under `.github/` enumerates individual job names — `grep -rn "Frontend Tests" .github/` returns hits only inside `ci.yml` itself.

The job emits no coverage artifact, so `coverage-combine` and `coverage-gate` are untouched.

## Tests

No product code changed — this is CI configuration. The verification is that the job's own commands succeed, measured above. YAML validated by parsing (`js-yaml` → 12 jobs, `electron-test` structurally correct), not by eyeballing.

## Manual verification

The real proof is this PR's own check run: `Electron Tests` should appear and pass. If it doesn't appear at all, the job isn't wired correctly and this PR should not merge.

## Screenshots

N/A — CI configuration, no user-visible surface.

## Not included

Running the suite on Windows and macOS runners. The main process ships on all three, and several tests encode platform-conditional behaviour, so cross-OS coverage has real value — but it triples the job count for a lane that has never run on PRs at all. Worth a follow-up once this one has some history.
