### PR TITLE
feat(voice): insert dictation transcript at the cursor

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -276,6 +276,11 @@ interface ChatInputProps {
   voiceSampleRef?: { current: AudioSample }
   /** Latest partial hypothesis, rendered muted in the dictation panel. */
   voicePartial?: string
+  /** Live composer caret, updated by ChatInput so ChatPage's dictation handler
+   *  can splice the transcript in at the cursor instead of appending. */
+  voiceCaretRef?: React.MutableRefObject<{ start: number; end: number } | null>
+  /** Caret offset to restore after a dictation-driven value update lands. */
+  voicePendingCaretRef?: React.MutableRefObject<number | null>
   /** Chat-level controls in input bar */
   agentName?: string
   agentSource?: string
@@ -466,6 +471,8 @@ function ChatInput({
   voiceDictationPanel = false,
   voiceSampleRef,
   voicePartial = '',
+  voiceCaretRef,
+  voicePendingCaretRef,
   onClearVoiceError,
   agentName,
   agentSource,
@@ -686,6 +693,50 @@ function ChatInput({
   const approvalBtnClass = 'inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[color-mix(in_srgb,var(--warn)_12%,transparent)] border border-border text-text text-[12px] cursor-pointer font-body hover:bg-[color-mix(in_srgb,var(--warn)_25%,transparent)] hover:text-text hover:border-border-strong transition-colors disabled:opacity-50'
 
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  // Publish the live caret so ChatPage's dictation handler can splice a
+  // transcript in at the cursor instead of appending. Written on every caret
+  // move (typing, click, selection); the value persists through blur (clicking
+  // the mic button), which is exactly when a batch transcript needs it.
+  const recordCaret = useCallback(() => {
+    const ta = inputRef.current
+    if (ta && voiceCaretRef) voiceCaretRef.current = { start: ta.selectionStart ?? 0, end: ta.selectionEnd ?? 0 }
+  }, [voiceCaretRef])
+  // Restore the caret after a dictation transcript lands in `value`. The update
+  // arrives via the parent (onChange → ChatPage setInput → value prop), so the
+  // parent can't set the DOM selection itself. rAF mirrors applyPickedToken:
+  // wait for the controlled value to commit before moving the caret. Cheap on
+  // ordinary edits — it no-ops unless a dictation splice armed a pending caret.
+  useLayoutEffect(() => {
+    const pendingRef = voicePendingCaretRef
+    const pos = pendingRef?.current
+    if (!pendingRef || pos == null) {
+      // No dictation restore pending: keep voiceCaretRef in sync with the live
+      // selection, but ONLY once it has been established by a real interaction.
+      // Guard on an already-non-null ref so an untouched textarea holding an
+      // existing draft doesn't publish offset 0 here (which would make the next
+      // batch transcript prepend at 0 instead of using the append fallback that
+      // a null ref provides).
+      const el = inputRef.current
+      if (el && voiceCaretRef && voiceCaretRef.current) voiceCaretRef.current = { start: el.selectionStart ?? 0, end: el.selectionEnd ?? 0 }
+      return
+    }
+    pendingRef.current = null
+    const raf = requestAnimationFrame(() => {
+      const el = inputRef.current
+      if (!el) return
+      const p = Math.min(pos, el.value.length)
+      // Restore the caret WITHOUT taking focus: a batch transcript can land while
+      // the user is focused in another field/session, and stealing focus would
+      // corrupt their typing there. setSelectionRange works on an unfocused
+      // element, so the caret is correct the moment the composer is (re)focused.
+      el.setSelectionRange(p, p)
+      if (voiceCaretRef) voiceCaretRef.current = { start: p, end: p }
+    })
+    // Cancel the frame if the slot switches (autoFocusKey) or value changes
+    // again before it fires — otherwise the callback would stamp this slot's
+    // caret onto whatever composer is mounted next.
+    return () => cancelAnimationFrame(raf)
+  }, [value, voicePendingCaretRef, voiceCaretRef, autoFocusKey])
   // Dictation-panel gate. Three independent conditions must hold: the setting
   // is on, the browser has WebGL2, and the OS is not asking for reduced motion
   // (the hook covers the latter two). A mic error always falls through to
@@ -1809,6 +1860,7 @@ function ChatInput({
    *  Covers drag-select that ends mid-token, touch/long-press handles on mobile,
    *  and any other non-keyboard way selection could split a token. */
   const handleSelectSnap = useCallback(() => {
+    recordCaret()
     if (!pasteBlocks.length) return
     const ta = inputRef.current
     if (!ta) return
@@ -1832,7 +1884,7 @@ function ChatInput({
     if (newSs === ss && newSe === se) return
     const dir = ta.selectionDirection || 'forward'
     ta.setSelectionRange(Math.min(newSs, newSe), Math.max(newSs, newSe), dir as 'forward' | 'backward' | 'none')
-  }, [pasteBlocks])
+  }, [pasteBlocks, recordCaret])
 
   /** Prune paste blocks whose token was deleted from the textarea. */
   useEffect(() => {
@@ -2257,6 +2309,7 @@ function ChatInput({
             const skillQ = fileQ === null ? matchSkillToken(before) : null
             if (skillQ !== null) { setSkillPickerOpen(true); setSkillQuery(skillQ) }
             else { setSkillPickerOpen(false); setSkillQuery('') }
+            recordCaret()
           }}
           onKeyDown={handleKeyDown}
           {...ime.composition}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1347,6 +1347,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // never be transcribed.
   const [voiceSetupOpen, setVoiceSetupOpen] = useState(false)
   const frozenInputRef = useRef<string | null>(null)
+  // Caret snapshot taken alongside frozenInputRef, so a streaming partial (and
+  // the final that replaces it) keeps inserting at the same spot. The batch
+  // path leaves both null and reads the LIVE composer caret instead.
+  const frozenCaretRef = useRef<{ start: number; end: number } | null>(null)
+  // Live composer caret, kept current by ChatInput (onSelect / click / typing).
+  // Dictation splices the transcript in HERE instead of always appending at end.
+  const voiceCaretRef = useRef<{ start: number; end: number } | null>(null)
+  // Caret offset ChatInput should restore after a dictation-driven value update
+  // lands (set by the splice below, consumed + cleared inside ChatInput).
+  const voicePendingCaretRef = useRef<number | null>(null)
   // Drops late-arriving partials/finals for the CURRENT slot after a send.
   // `stop()` is async (up to 5s for backend close) — without this guard, a
   // delayed onFinal would repopulate the composer with text the user already
@@ -1371,6 +1381,33 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // the live composer; a background slot gets it appended to its persisted draft
   // (recoverable, shown on return) instead of leaking into the active session or
   // being dropped. Mirrors handleOptimizeResult's cross-slot routing.
+  // Splice a dictation transcript into `base` at the caret (frozen snapshot
+  // when streaming, else the live caret), returning the new value and the caret
+  // offset to restore. Falls back to appending when no caret is known (e.g. the
+  // composer was never focused).
+  const spliceDictation = useCallback((base: string, text: string): { value: string; caret: number } => {
+    const caret = frozenCaretRef.current ?? voiceCaretRef.current
+    // An empty transcript (e.g. a silent streaming partial) must NOT mutate the
+    // draft: splicing "" across a selection would delete the selected range.
+    // Leave the base untouched and collapse the caret to the insertion point.
+    if (!text) return { value: base, caret: caret ? Math.min(caret.start, base.length) : base.length }
+    if (!caret) {
+      const value = base ? (base.endsWith(' ') ? base + text : base + ' ' + text) : text
+      return { value, caret: value.length }
+    }
+    const start = Math.min(caret.start, base.length)
+    const end = Math.min(caret.end, base.length)
+    const before = base.slice(0, start)
+    const after = base.slice(end)
+    // Leading space only when joining onto a non-space char, so mid-sentence
+    // dictation doesn't glue onto the preceding word.
+    // Leading/trailing space uses whitespace-class checks (not only ' ') so a
+    // caret beside a newline or tab doesn't get an unwanted literal space.
+    const lead = before && !/\s$/.test(before) && !/^\s/.test(text) ? ' ' : ''
+    const trail = after && !/^\s/.test(after) && !/\s$/.test(text) ? ' ' : ''
+    const insert = lead + text
+    return { value: before + insert + trail + after, caret: before.length + insert.length }
+  }, [])
   const applyVoiceText = useCallback((text: string, sessionId: string | null) => {
     // Disarmed after a send (streaming) — the transcript was already sent, so
     // drop it for EVERY route. Checked FIRST (before the cross-slot branch) so a
@@ -1404,13 +1441,23 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       saveDrafts()
       return
     }
-    // Foreground: streaming seeds frozenInputRef in onPartial (the pre-dictation
-    // snapshot); the batch path never fires onPartial so it's null — fall back
-    // to the live composer text so the transcript APPENDS to what the user typed
-    // instead of overwriting it.
-    setInput(append(frozenInputRef.current ?? inputRef.current ?? ''))
+    // Foreground: streaming seeds frozenInputRef/frozenCaretRef in onPartial
+    // (the pre-dictation snapshot); the batch path never fires onPartial so both
+    // are null — fall back to the live composer text + caret so the transcript
+    // inserts at the cursor instead of overwriting (or blindly appending to)
+    // what the user typed.
+    const spliced = spliceDictation(frozenInputRef.current ?? inputRef.current ?? '', text)
+    // Only arm the caret restore when the value actually changes. If a streaming
+    // final equals the last partial, setInput is a no-op and the restore effect
+    // (keyed on `value`) never fires — leaving a stale pending caret that would
+    // hijack the user's NEXT edit.
+    if (spliced.value !== inputRef.current) {
+      setInput(spliced.value)
+      voicePendingCaretRef.current = spliced.caret
+    }
     frozenInputRef.current = null
-  }, [saveDrafts])
+    frozenCaretRef.current = null
+  }, [saveDrafts, spliceDictation])
   const voice = useVoiceInput(
     applyVoiceText,
     {
@@ -1423,12 +1470,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         // half-word into the wrong session.
         if (sessionId && sessionId !== activeSlotRef.current) return
         if (sttDisarmedRef.current) return
-        // Snapshot BEFORE setInput so the updater stays pure (no ref
-        // mutation inside a function React may invoke twice).
-        if (frozenInputRef.current === null) frozenInputRef.current = inputRef.current
-        const base = frozenInputRef.current
-        setInput(base ? (base.endsWith(' ') ? base + text : base + ' ' + text) : text)
-      }, []),
+        // Snapshot the pre-dictation text AND caret on the first partial
+        // (before setInput, so the updater stays pure — no ref mutation inside a
+        // function React may invoke twice) so every later partial and the final
+        // insert at the same spot, replacing the growing hypothesis.
+        if (frozenInputRef.current === null) {
+          frozenInputRef.current = inputRef.current
+          frozenCaretRef.current = voiceCaretRef.current
+        }
+        const spliced = spliceDictation(frozenInputRef.current ?? '', text)
+        if (spliced.value !== inputRef.current) {
+          setInput(spliced.value)
+          voicePendingCaretRef.current = spliced.caret
+        }
+      }, [spliceDictation]),
       // Semantic endpointing (stt.endpointing) judged the utterance complete:
       // auto-submit. The composer already holds the streamed transcript via
       // onPartial, and send() reads inputRef.current + stops the live capture
@@ -1481,6 +1536,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       // finals — otherwise onPartial sees a non-null ref, skips
       // re-snapshotting, and text typed between sessions is dropped.
       frozenInputRef.current = null
+      frozenCaretRef.current = null
     } else if (streamEnabledRef.current) {
       // Manual stop of a STREAMING recording: streamStop() drains the socket
       // asynchronously and a final can still arrive. The dictated text is
@@ -1507,6 +1563,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // are preserved rather than clobbered by a stale snapshot.
   useEffect(() => {
     frozenInputRef.current = null
+    frozenCaretRef.current = null
+    // Drop the previous slot's caret so dictating in a freshly switched-to slot
+    // (without touching its composer) appends to that slot's draft instead of
+    // inserting at the old slot's offset.
+    voiceCaretRef.current = null
     // Streaming ONLY: disarm so a delayed streaming final arriving after this
     // switch is dropped instead of appended. Its live partial was already
     // flushed into the outgoing slot's draft, so appending the full final on
@@ -5036,6 +5097,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               voiceDictationPanel={sttDictationPanel}
               voiceSampleRef={voice.sampleRef}
               voicePartial={voiceOwned ? voice.partial : ''}
+              voiceCaretRef={voiceCaretRef}
+              voicePendingCaretRef={voicePendingCaretRef}
               onVoiceToggle={voiceInputSupported ? toggleVoice : undefined}
               onVoicePrewarm={voiceInputSupported ? voice.prewarm : undefined}
               agentName={currentSlot?.agent || 'default'}

--- a/website/src/test/ChatPage.sendDuringDictation.test.tsx
+++ b/website/src/test/ChatPage.sendDuringDictation.test.tsx
@@ -219,4 +219,51 @@ describe('ChatPage — sending while dictating', () => {
     await waitFor(() => expect(api.sendChat).toHaveBeenCalled())
     expect(voice.toggle).not.toHaveBeenCalled()
   })
+
+  it('inserts a batch transcript at the caret, not appended to the end', async () => {
+    // Cursor-position dictation: with the caret in the MIDDLE of existing text,
+    // the transcript splices in at the caret (with a joining space) rather than
+    // appending to the end or overwriting. Guards the append→splice change.
+    setStt(false)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    expect(typeof voice.onText).toBe('function')
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /voice input/i })) })
+    // Type a sentence, then place the caret right after "Hello" (offset 5).
+    await act(async () => { fireEvent.change(ta, { target: { value: 'Hello world' } }) })
+    await act(async () => { ta.setSelectionRange(5, 5); fireEvent.select(ta) })
+
+    await act(async () => { voice.onText?.('there') })
+    expect(ta.value).toBe('Hello there world')
+  })
+
+  it('adds a joining space when dictating right before existing text', async () => {
+    // Guards the gluing bug: caret at the very start of "world" + dictate
+    // "hello" must yield "hello world", not "helloworld".
+    setStt(false)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /voice input/i })) })
+    await act(async () => { fireEvent.change(ta, { target: { value: 'world' } }) })
+    await act(async () => { ta.setSelectionRange(0, 0); fireEvent.select(ta) })
+    await act(async () => { voice.onText?.('hello') })
+    expect(ta.value).toBe('hello world')
+  })
+
+  it('leaves the draft untouched on an empty transcript (no selection deletion)', async () => {
+    // An empty transcript with an active selection must NOT delete the selected
+    // text (guards the empty-partial splice bug).
+    setStt(false)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /voice input/i })) })
+    await act(async () => { fireEvent.change(ta, { target: { value: 'keep me' } }) })
+    await act(async () => { ta.setSelectionRange(0, 7); fireEvent.select(ta) })
+    await act(async () => { voice.onText?.('') })
+    expect(ta.value).toBe('keep me')
+  })
 })


### PR DESCRIPTION
## Problem
Voice dictation inserted the transcript at the **end** of the composer instead of at the cursor. Dictating into the middle of an existing draft forced the user to manually cut/paste the words into place.

## Why it matters
Dictation is only ergonomic if it behaves like every OS-level dictation surface — the text lands where the caret is. Appending-at-end makes mid-draft dictation unusable and surprises anyone who moved their cursor before speaking.

## Fix (symptom → root cause → change)
- **Symptom:** the transcript always appended to the end of the composer.
- **Root cause:** `applyVoiceText` / `onPartial` only ever appended the transcript to a base string; the composer caret was never consulted.
- **Change:**
  - `ChatInput` publishes the live caret into `voiceCaretRef` (updated on select / click / type; it persists through the blur that clicking the mic button causes, which is exactly when a batch transcript needs it).
  - `ChatPage.spliceDictation` inserts the transcript at that caret (`before + text + after`), adding a joining space only when butting onto a non-space char, and falls back to appending when no caret is known (composer never focused).
  - After the controlled value commits, `ChatInput` restores the caret from `voicePendingCaretRef` via a rAF `setSelectionRange` — the same idiom the existing `@`/`$` token pickers use.
  - Batch (mlx/whisper) and streaming both route through the splice; streaming snapshots the caret alongside the pre-dictation text so each partial replaces in place. The off-screen-slot draft path still appends (there is no live caret for a hidden composer).

Stacked on `fix/voice-input-per-slot-state` (#1120), whose `applyVoiceText` structure this builds on.

## Tests
- New `ChatPage.sendDuringDictation` case: type `Hello world`, place the caret after `Hello`, dictate `there` → composer becomes `Hello there world` (not `Hello world there`).
- Existing voice suites (dictation panel, send-during-dictation, prewarm) still pass — 17 pre-existing + 1 new.

## Manual verification
Exercised live in the Amazon-internal edition build: with a cursor mid-draft, a dictated phrase now lands at the cursor rather than the end.

## Screenshots
N/A — no visual / layout / theme change. The change is *where* dictated text lands in the textarea, which a still frame can't convey; the behavior is locked by the unit test above.
