### PR TITLE
fix: pin a tall prompt by its bottom edge, not its top

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -115,7 +115,7 @@ import { toSlug } from '../utils/shareUrl'
 import { DRAFT_SAVE_DEBOUNCE_MS, loadDrafts, saveDrafts as persistDrafts, setDraft } from '../utils/chatDrafts'
 import { loadFileDrafts, saveFileDrafts as persistFileDrafts, setFileDraft } from '../utils/chatFileDrafts'
 import { loadPasteDrafts, savePasteDrafts as persistPasteDrafts, setPasteDraft } from '../utils/chatPasteDrafts'
-import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, promptPreview } from '../utils/pinnedPrompt'
+import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, promptPreview, pinHandoffY, pinPushTravel, DEFAULT_PINNED_CARD_H } from '../utils/pinnedPrompt'
 import {
   loadSeenPullRequestLinks,
   partitionSourceLinks,
@@ -1957,6 +1957,15 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const pinEnabledRef = useRef(true)
   const [pinned, setPinned] = useState<{ idx: number; text: string; full: string; push: number; bannerH: number } | null>(null)
   const [pinExpanded, setPinExpanded] = useState(false)
+  // Collapsed card height — the hand-off line is derived from it, so it must be
+  // known even while nothing is pinned (no card mounted to measure). Seeded with
+  // the computed default and then reported by PinnedPrompt itself, which is the
+  // only place the SETTLED height is knowable: measuring the card from here would
+  // sample the expand/collapse morph mid-flight and drag the line with it.
+  const pinCollapsedHRef = useRef(DEFAULT_PINNED_CARD_H)
+  const onPinCollapsedHeight = useCallback((h: number) => {
+    if (h > 0) pinCollapsedHRef.current = h
+  }, [])
   // Recompute which prompt is pinned, and how far the incoming prompt has
   // pushed it out, from the current scroll position.
   const updatePinnedPrompt = useCallback(() => {
@@ -1970,34 +1979,50 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     const items = el.querySelectorAll('[data-display-index]')
     const foldY = pinFoldRef.current?.getBoundingClientRect().top
       ?? el.getBoundingClientRect().top
-    // First row whose bottom is still below the fold = the topmost row not yet
-    // fully scrolled past it.
-    let foldIdx = -1
-    let foldRowTop = 0
+    // A prompt hands over to the banner only once it is entirely behind the band
+    // (bottom edge at or above the band's bottom), so a prompt taller than the
+    // band scrolls away line by line instead of collapsing the moment it is sent.
+    const handoffY = pinHandoffY(foldY, pinCollapsedHRef.current)
+    // First row whose bottom is still below that line = the topmost row not yet
+    // fully scrolled behind the band.
+    let handoffIdx = -1
     for (const item of items) {
       const htmlItem = item as HTMLElement
-      const rect = htmlItem.getBoundingClientRect()
-      if (rect.bottom > foldY) {
-        foldIdx = parseInt(htmlItem.getAttribute('data-display-index') || '0', 10)
-        foldRowTop = rect.top
+      if (htmlItem.getBoundingClientRect().bottom > handoffY) {
+        handoffIdx = parseInt(htmlItem.getAttribute('data-display-index') || '0', 10)
         break
       }
     }
 
-    if (!pinEnabledRef.current || foldIdx < 0) { setPinned(null); return }
+    if (!pinEnabledRef.current || handoffIdx < 0) { setPinned(null); return }
     const list = displayItemsRef.current
-    const pinIdx = findPinnedPromptIdx(list, foldIdx, foldRowTop < foldY)
+    const pinIdx = findPinnedPromptIdx(list, handoffIdx)
     const pinItem = pinIdx >= 0 ? list[pinIdx] : undefined
     if (!pinItem || pinItem.kind !== 'single') { setPinned(null); return }
     // The incoming prompt pushes the banner out; when its row is not mounted it
-    // is still far below the fold, so there is nothing to push against yet.
+    // is still far below the fold, so there is nothing to push against yet. Its
+    // TOP edge against the fold drives the push (see computePinPush) — an earlier
+    // line than the hand-off, so a tall prompt shoves the card fully out while it
+    // scrolls in, and only takes the pin once its own bottom clears the band.
     const nextIdx = findNextPromptIdx(list, pinIdx)
     const nextEl = nextIdx >= 0
       ? el.querySelector(`[data-display-index="${nextIdx}"]`) as HTMLElement | null
       : null
     const nextTop = nextEl ? nextEl.getBoundingClientRect().top : null
-    const bannerH = pinCardRef.current?.getBoundingClientRect().height ?? 0
+    // Measure the live card when it is mounted, and otherwise fall back to the
+    // last SETTLED collapsed height PinnedPrompt reported: the push threshold
+    // below has to be decidable even while nothing is mounted, or dropping the
+    // banner would zero the height, zero the push, re-mount it, and oscillate at
+    // frame rate.
+    const measured = pinCardRef.current?.getBoundingClientRect().height ?? 0
+    const bannerH = measured > 0 ? measured : pinCollapsedHRef.current
     const push = computePinPush(bannerH, foldY, nextTop)
+    // Fully pushed out: DROP the banner instead of rendering it clipped to
+    // nothing. A tall incoming prompt holds this state for its whole length (it
+    // takes the pin only once its own bottom clears the band), and a card clipped
+    // to zero still shows a hairline of its bottom edge under sub-pixel rounding
+    // and browser zoom — a bubble fragment parked over the prompt being read.
+    if (push >= pinPushTravel(bannerH)) { setPinned(null); return }
     const full = pinItem.msg.content
     const text = promptPreview(full)
     setPinned(prev => (prev && prev.idx === pinIdx && prev.push === push
@@ -4219,6 +4244,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                   onToggleExpanded={() => setPinExpanded(p => !p)}
                   onJump={() => scrollToPinnedPrompt(pinned.idx)}
                   cardRef={pinCardRef}
+                  onCollapsedHeight={onPinCollapsedHeight}
                 />
               )}
             </div>
@@ -4360,12 +4386,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx} className={`px-5 mx-auto w-full py-1`} style={{
                   maxWidth: 'var(--mc-content-width, 900px)',
                   // The pinned banner is styled as this row's own bubble and sits
-                  // at the exact position and width the bubble had when it crossed
-                  // the fold, so leaving both visible is what betrays them as two
-                  // containers. Hide the real one (visibility, NOT display — the
-                  // virtualizer must keep measuring its height or the transcript
-                  // would reflow under the reader) and the bubble appears to simply
-                  // stop travelling and stick.
+                  // at the exact position and width the bubble had when its bottom
+                  // edge reached the band's bottom, so leaving both visible is what
+                  // betrays them as two containers. Hide the real one (visibility,
+                  // NOT display — the virtualizer must keep measuring its height or
+                  // the transcript would reflow under the reader) and the bubble
+                  // appears to simply stop travelling and stick. A row is only ever
+                  // hidden once it is entirely behind the band, so a tall prompt
+                  // never leaves a visible hole above the response.
                   visibility: pinned?.idx === displayIdx ? 'hidden' : undefined,
                 }}>{item.kind === 'group' ? (() => {
                 const unresolvedGroupPerms = item.msgs.filter(m => m.role === 'permission' && !m.meta?.resolved)

--- a/website/src/pages/chat/PinnedPrompt.tsx
+++ b/website/src/pages/chat/PinnedPrompt.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { i18nT } from '../../i18n/t'
+import { ROW_PAD_Y } from '../../utils/pinnedPrompt'
 
 interface PinnedPromptProps {
   /** One-line preview of the pinned prompt. */
@@ -17,16 +18,23 @@ interface PinnedPromptProps {
   onJump: () => void
   /** Ref on the card — measured for the push geometry. */
   cardRef: React.Ref<HTMLDivElement>
+  /**
+   * Reports the card's SETTLED collapsed height. ChatPage derives the hand-off
+   * line from it (`pinHandoffY`), so it must never come from measuring the card
+   * while the expand/collapse morph below is animating `height` — that samples an
+   * expanded-size height and moves the line by the difference.
+   */
+  onCollapsedHeight?: (h: number) => void
 }
 
 /**
  * Vertical padding a transcript row puts around its bubble (`py-1` on the
  * message row wrapper in ChatPage). The pinned band reproduces it so the card
  * sits the same distance below the fold as a bubble sits below its row top —
- * which is also what makes the hand-off land on the exact same pixel.
+ * which is also what makes the hand-off land on the exact same pixel. Imported
+ * from the geometry module because the hand-off line is derived from the same
+ * value (see `pinHandoffY`).
  */
-const ROW_PAD_Y = 4
-
 /** Expand/collapse height-morph — matches the left-nav collapse
  *  (`grid-template-columns 150ms cubic-bezier(0.2,0,0,1)` in App.tsx). The
  *  chevron rotate below uses the same values so the two move as one. */
@@ -34,16 +42,20 @@ const MORPH_MS = 150
 const MORPH_EASE = 'cubic-bezier(0.2,0,0,1)'
 
 /**
- * The most recent prompt at or above the fold, pinned under the session title.
+ * The most recent prompt that has scrolled fully behind the band, pinned under
+ * the session title.
  *
  * The card is a pixel-for-pixel copy of the user bubble's own box — same
  * `px-5 mx-auto` content column, right-aligned, `max-w-[550px]`, `px-4 py-1.5
  * rounded-xl bg-card text-sm` with an inner `my-1.5 leading-relaxed` paragraph —
  * because the transcript row it represents is hidden while it is pinned (see
- * ChatPage's row `visibility`). The two are the same size at the same place at
- * the moment of hand-off, so the bubble appears to stop travelling and stick
- * rather than being replaced. Keep these values in sync with `UserMessage`'s
- * `bubble` and with `MD_COMPONENTS.p` in MarkdownRenderer.
+ * ChatPage's row `visibility`). For a one-line prompt the two are the same size
+ * at the same place at the moment of hand-off, so the bubble appears to stop
+ * travelling and stick rather than being replaced. A taller prompt hands over
+ * once its bottom edge reaches the band's bottom (`pinHandoffY`), i.e. once it is
+ * completely covered by the band, so the swap still happens out of sight. Keep
+ * these values in sync with `UserMessage`'s `bubble` and with `MD_COMPONENTS.p`
+ * in MarkdownRenderer.
  *
  * Deliberate details that protect that equality:
  *   - No `border`. The bubble has none, so a 1px border made the card 2px taller
@@ -65,7 +77,7 @@ const MORPH_EASE = 'cubic-bezier(0.2,0,0,1)'
  *     overflows at W minus the chevron.
  */
 export default function PinnedPrompt({
-  text, fullText, pushUp, bannerH, expanded, onToggleExpanded, onJump, cardRef,
+  text, fullText, pushUp, bannerH, expanded, onToggleExpanded, onJump, cardRef, onCollapsedHeight,
 }: PinnedPromptProps) {
   const textRef = useRef<HTMLParagraphElement | null>(null)
   const boxRef = useRef<HTMLDivElement | null>(null)
@@ -85,9 +97,26 @@ export default function PinnedPrompt({
   useLayoutEffect(() => {
     const el = boxRef.current
     if (!el) return
+    // A toggle landing INSIDE the previous morph leaves that morph's inline
+    // height/transition in place — React runs the old effect's cleanup first, and
+    // it only detaches the listener. Reading the box now would report the
+    // animating value as the natural height (the bug this reporting exists to
+    // avoid), so measure where the box visually is, then strip the leftovers so
+    // the next read is the true natural height.
+    const inflight = !!el.style.height
+    const current = inflight ? el.getBoundingClientRect().height : null
+    if (inflight) { el.style.height = ''; el.style.transition = ''; el.style.overflow = '' }
     const target = el.getBoundingClientRect().height
-    const from = lastBoxH.current
+    const from = current ?? lastBoxH.current
     lastBoxH.current = target
+    // `target` is the natural height React has just committed, read with no inline
+    // override in play — i.e. the settled collapsed height whenever this runs
+    // collapsed (mount, and every collapse). Reporting it from here is what keeps
+    // ChatPage from having to measure the card itself: a measurement taken during
+    // the 150ms morph reads an intermediate, up-to-expanded-size height, and the
+    // hand-off line derived from it would jump by the difference — hiding a
+    // transcript row that is still on screen.
+    if (!expanded) onCollapsedHeight?.(target)
     if (from == null || Math.abs(from - target) < 0.5) return
     el.style.overflow = 'hidden'
     el.style.height = `${from}px`
@@ -103,7 +132,7 @@ export default function PinnedPrompt({
     }
     el.addEventListener('transitionend', done)
     return () => el.removeEventListener('transitionend', done)
-  }, [expanded])
+  }, [expanded, onCollapsedHeight])
 
   useEffect(() => {
     // While expanded the text wraps and stops overflowing, so re-measuring would
@@ -111,13 +140,24 @@ export default function PinnedPrompt({
     // Hold the collapsed-state verdict instead; it is re-taken on collapse.
     if (expanded) return
     const el = textRef.current
+    const box = boxRef.current
     if (!el) return
-    const measure = () => setTruncated(el.scrollWidth > el.clientWidth + 1)
+    const measure = () => {
+      setTruncated(el.scrollWidth > el.clientWidth + 1)
+      // Re-report the collapsed height whenever the box itself resizes. The layout
+      // effect above only runs on expand/collapse, so a host font-size or zoom
+      // change would otherwise leave ChatPage's hand-off line on a stale height
+      // until the next remount. Skipped while an inline height is set — that is
+      // the morph animating, and its intermediate values are not the settled
+      // height (this also re-reports once `transitionend` clears it).
+      if (box && !box.style.height) onCollapsedHeight?.(box.getBoundingClientRect().height)
+    }
     measure()
     const ro = new ResizeObserver(measure)
     ro.observe(el)
+    if (box) ro.observe(box)
     return () => ro.disconnect()
-  }, [text, expanded])
+  }, [text, expanded, onCollapsedHeight])
 
   const showChevron = truncated || expanded
 
@@ -140,7 +180,10 @@ export default function PinnedPrompt({
         // Height must be CONTINUOUS through pushUp === 0, or the clip box jumps
         // the moment the push starts. Carrying both paddings (ROW_PAD_Y * 2)
         // makes this formula equal the natural height at rest and shrink smoothly
-        // from there.
+        // from there. pushUp travels ROW_PAD_Y + bannerH (see computePinPush), so
+        // it bottoms out at a ROW_PAD_Y-tall, empty, transparent strip with the
+        // card entirely clipped away — no fragment of it survives the no-banner
+        // stretch that a tall incoming prompt opens up.
         height: bannerH > 0
           ? Math.max(0, ROW_PAD_Y * 2 + bannerH - pushUp)
           : undefined,

--- a/website/src/test/pinnedPrompt.test.ts
+++ b/website/src/test/pinnedPrompt.test.ts
@@ -4,6 +4,10 @@ import {
   findNextPromptIdx,
   computePinPush,
   promptPreview,
+  pinHandoffY,
+  pinPushTravel,
+  ROW_PAD_Y,
+  DEFAULT_PINNED_CARD_H,
 } from '../utils/pinnedPrompt'
 import type { DisplayItem } from '../pages/chat/types'
 
@@ -14,29 +18,56 @@ const assistant = (idx: number): DisplayItem =>
 const turn = (): DisplayItem =>
   ({ kind: 'turn', items: [], complete: true } as unknown as DisplayItem)
 
+describe('pinHandoffY', () => {
+  it('is the bottom edge of the band, not the fold line', () => {
+    expect(pinHandoffY(100, 46.75)).toBe(100 + ROW_PAD_Y * 2 + 46.75)
+  })
+
+  it('falls back to the computed one-line card height before any measurement', () => {
+    expect(DEFAULT_PINNED_CARD_H).toBeCloseTo(46.75, 2)
+  })
+
+  it('a one-line prompt hands over exactly as its bubble top reaches the card top', () => {
+    // Row = ROW_PAD_Y + bubble + ROW_PAD_Y, and a one-line bubble is cardH tall.
+    // Pinning at rowBottom <= handoffY therefore fires at bubbleTop === foldY +
+    // ROW_PAD_Y — the card's own top — i.e. the old top-edge rule, unchanged.
+    const foldY = 100, cardH = 46.75
+    const handoffY = pinHandoffY(foldY, cardH)
+    const rowBottomAtHandoff = handoffY
+    const bubbleTop = rowBottomAtHandoff - ROW_PAD_Y - cardH
+    expect(bubbleTop).toBe(foldY + ROW_PAD_Y)
+  })
+})
+
 describe('findPinnedPromptIdx', () => {
   it('returns -1 with no prompts', () => {
-    expect(findPinnedPromptIdx([], 0, false)).toBe(-1)
-    expect(findPinnedPromptIdx([assistant(0), turn()], 1, true)).toBe(-1)
+    expect(findPinnedPromptIdx([], 0)).toBe(-1)
+    expect(findPinnedPromptIdx([assistant(0), turn()], 2)).toBe(-1)
   })
 
-  it('pins the fold row itself once its top has crossed the fold', () => {
+  it('pins the previous prompt while the straddling row is itself a prompt', () => {
+    // p2 straddles the hand-off line — still readable in the transcript, so the
+    // banner keeps showing p1 (this is the tall-prompt fix).
     const items = [user('p1', 0), turn(), user('p2', 2), turn()]
-    expect(findPinnedPromptIdx(items, 2, true)).toBe(2)
+    expect(findPinnedPromptIdx(items, 2)).toBe(0)
   })
 
-  it('pins the previous prompt while the fold row starts below the fold', () => {
+  it('pins a prompt once the row after it is the straddling one', () => {
     const items = [user('p1', 0), turn(), user('p2', 2), turn()]
-    expect(findPinnedPromptIdx(items, 2, false)).toBe(0)
+    expect(findPinnedPromptIdx(items, 3)).toBe(2)
   })
 
   it('skips non-prompt rows walking upward', () => {
     const items = [user('p1', 0), turn(), assistant(2), turn()]
-    expect(findPinnedPromptIdx(items, 3, true)).toBe(0)
+    expect(findPinnedPromptIdx(items, 3)).toBe(0)
   })
 
   it('pins nothing above the first prompt', () => {
-    expect(findPinnedPromptIdx([user('p1', 0), turn()], 0, false)).toBe(-1)
+    expect(findPinnedPromptIdx([user('p1', 0), turn()], 0)).toBe(-1)
+  })
+
+  it('pins nothing when no row is below the hand-off line', () => {
+    expect(findPinnedPromptIdx([user('p1', 0), turn()], -1)).toBe(-1)
   })
 })
 
@@ -55,20 +86,56 @@ describe('findNextPromptIdx', () => {
 describe('computePinPush', () => {
   const bannerH = 52
   const foldY = 100
+  // The card sits ROW_PAD_Y below the fold, so it must travel that much further
+  // than its own height to clear the band completely.
+  const travel = ROW_PAD_Y + bannerH
 
   it('does not push while the incoming prompt is below the banner', () => {
-    expect(computePinPush(bannerH, foldY, foldY + bannerH)).toBe(0)
+    expect(computePinPush(bannerH, foldY, foldY + travel)).toBe(0)
     expect(computePinPush(bannerH, foldY, foldY + 400)).toBe(0)
   })
 
   it('pushes so the banner bottom tracks the incoming prompt top', () => {
-    // gap 30 → banner bottom sits 30px below the fold → pushed 22px
-    expect(computePinPush(bannerH, foldY, foldY + 30)).toBe(22)
+    // gap 30 → banner bottom sits 30px below the fold → pushed travel-30
+    expect(computePinPush(bannerH, foldY, foldY + 30)).toBe(travel - 30)
   })
 
-  it('is fully pushed out exactly when the incoming prompt reaches the fold', () => {
-    expect(computePinPush(bannerH, foldY, foldY)).toBe(bannerH)
-    expect(computePinPush(bannerH, foldY, foldY - 200)).toBe(bannerH)
+  it('clears the band completely when the incoming prompt top reaches the fold', () => {
+    // Card top = foldY + ROW_PAD_Y, so a push of exactly `travel` puts its BOTTOM
+    // on the fold line: nothing of it is left inside the band. A push of only
+    // `bannerH` would strand a ROW_PAD_Y-tall strip of the card's bottom edge
+    // visible over the incoming prompt for the whole no-banner stretch.
+    expect(computePinPush(bannerH, foldY, foldY)).toBe(travel)
+    expect(computePinPush(bannerH, foldY, foldY - 200)).toBe(travel)
+    expect(travel).toBeGreaterThan(bannerH)
+  })
+
+  it('leaves a no-banner stretch for a prompt taller than the band', () => {
+    // A tall prompt's top is already above the fold (card fully pushed out) while
+    // its own bottom is still below the hand-off line, so it has not taken the
+    // pin yet — that stretch shows no banner, by design. The push reaching
+    // `pinPushTravel` is ChatPage's signal to DROP the banner for its duration,
+    // so nothing of the outgoing card can survive it.
+    const handoffY = pinHandoffY(foldY, bannerH)
+    const tallTop = foldY - 300
+    const push = computePinPush(bannerH, foldY, tallTop)
+    expect(push).toBe(travel)
+    expect(push).toBeGreaterThanOrEqual(pinPushTravel(bannerH))
+    expect(tallTop + 600).toBeGreaterThan(handoffY) // 600px-tall row: bottom still below
+  })
+
+  it('does not report a completed push while any of the card is still in the band', () => {
+    // The drop threshold must not fire early: one pixel short of the fold, a
+    // pixel of card is still legitimately visible and the banner stays mounted.
+    const push = computePinPush(bannerH, foldY, foldY + 1)
+    expect(push).toBeLessThan(pinPushTravel(bannerH))
+  })
+
+  it('hands off in one frame for a one-line incoming prompt', () => {
+    // Its row is ROW_PAD_Y + bannerH + ROW_PAD_Y tall, so top-reaches-fold and
+    // bottom-reaches-hand-off-line are the same instant — no gap for short prompts.
+    expect(computePinPush(bannerH, foldY, foldY)).toBe(travel)
+    expect(foldY + ROW_PAD_Y * 2 + bannerH).toBe(pinHandoffY(foldY, bannerH))
   })
 
   it('no push when the incoming row is unmounted or the banner unmeasured', () => {

--- a/website/src/utils/pinnedPrompt.ts
+++ b/website/src/utils/pinnedPrompt.ts
@@ -2,17 +2,59 @@ import type { DisplayItem } from '../pages/chat/types'
 
 /**
  * Geometry + selection helpers for the pinned-prompt banner (the most recent
- * user prompt at or above the chat fold, shown as a sticky band under the
- * session title).
+ * user prompt that has scrolled fully behind the chat fold, shown as a sticky
+ * band under the session title).
  *
- * These mirror native `position: sticky` stacking semantics, which is what the
- * design calls for: a prompt scrolls with the transcript until its top reaches
- * the fold, sticks there, and is pushed out by the NEXT prompt as that prompt's
- * top border meets it. The banner cannot be a real sticky element because the
- * transcript is virtualized — a row scrolled far above the window unmounts, so
- * the sticky node would vanish. Instead the banner is an overlay driven by the
- * same math.
+ * The hand-off is **bottom-edge driven**: a prompt scrolls with the transcript
+ * until its bubble's BOTTOM edge reaches the bottom of the banner band, i.e.
+ * until the row is entirely hidden behind the band; only then does it collapse
+ * into the banner. It is then pushed out by the NEXT prompt as that prompt's top
+ * border meets it (`computePinPush`) — a separate, earlier line, so a tall prompt
+ * shows no banner at all while it is being read.
+ *
+ * Why the bottom edge and not the top (the original sticky-style rule): a prompt
+ * taller than the band — an essay, a pasted stack trace — satisfies "top has
+ * reached the fold" the instant it is sent, so it would collapse into a one-line
+ * banner before the user could read it, and its still-laid-out (but hidden) row
+ * left a prompt-sized hole above the response. Tracking the bottom edge means a
+ * tall prompt stays fully readable and scrolls away line by line. For a
+ * one-line prompt the two rules fire on the same pixel (its bubble height equals
+ * the collapsed card height), so short-prompt behaviour is unchanged.
+ *
+ * The banner cannot be a real sticky element because the transcript is
+ * virtualized — a row scrolled far above the window unmounts, so the sticky node
+ * would vanish. Instead the banner is an overlay driven by the same math.
  */
+
+/**
+ * Vertical padding around the bubble inside a row (`py-1` on both the transcript
+ * message row in ChatPage and the pinned band in PinnedPrompt). Single-sourced
+ * here because the hand-off line is derived from it.
+ */
+export const ROW_PAD_Y = 4
+
+/**
+ * Height of the COLLAPSED banner card, used only until the real card has been
+ * measured once (nothing is pinned on first load, so there is no card to read).
+ * One line of `text-sm` (14px) at `leading-relaxed` (1.625 → 22.75px) plus the
+ * paragraph's `my-1.5` (6+6) and the box's `py-1.5` (6+6) = 46.75px. A different
+ * host font size only skews the very first hand-off of a session; every
+ * subsequent one uses the measured height.
+ */
+export const DEFAULT_PINNED_CARD_H = 46.75
+
+/**
+ * Viewport Y of the hand-off line: the BOTTOM edge of the banner band. A prompt
+ * pins once its row bottom has risen to or above this line (the row is then
+ * completely covered by the band, so the swap is invisible), and un-pins the
+ * moment it drops back below it.
+ *
+ * @param foldY         viewport Y of the fold sentinel = the band's top edge
+ * @param collapsedCardH measured height of the collapsed banner card
+ */
+export function pinHandoffY(foldY: number, collapsedCardH: number): number {
+  return foldY + ROW_PAD_Y * 2 + collapsedCardH
+}
 
 /** Only user-typed prompts pin. `nudge` opens a turn too but is machine-injected. */
 function isPrompt(item: DisplayItem | undefined): boolean {
@@ -22,17 +64,19 @@ function isPrompt(item: DisplayItem | undefined): boolean {
 /**
  * Display index of the prompt that should be pinned, or -1 for none.
  *
- * @param items          the flattened display list
- * @param foldIdx        display index of the first row whose bottom is below the fold
- * @param foldIdxCrossed true when that row's own top has already passed the fold
- *                       (i.e. it is straddling it, not starting below it)
+ * Rows are laid out in order, so their bottom edges increase monotonically with
+ * index: the rows already fully above the hand-off line are exactly the prefix
+ * before `handoffIdx`. The pinned prompt is therefore the last prompt STRICTLY
+ * before it — the row straddling the line is still readable in the transcript
+ * and must not be swapped for the banner yet.
+ *
+ * @param items      the flattened display list
+ * @param handoffIdx display index of the first row whose bottom is still below
+ *                   the hand-off line (see `pinHandoffY`)
  */
-export function findPinnedPromptIdx(
-  items: DisplayItem[],
-  foldIdx: number,
-  foldIdxCrossed: boolean,
-): number {
-  const start = Math.min(foldIdxCrossed ? foldIdx : foldIdx - 1, items.length - 1)
+export function findPinnedPromptIdx(items: DisplayItem[], handoffIdx: number): number {
+  if (handoffIdx < 0) return -1
+  const start = Math.min(handoffIdx - 1, items.length - 1)
   for (let i = start; i >= 0; i--) {
     if (isPrompt(items[i])) return i
   }
@@ -50,19 +94,52 @@ export function findNextPromptIdx(items: DisplayItem[], afterIdx: number): numbe
 /**
  * How far (px) to translate the banner UP so the incoming prompt pushes it out.
  *
- * The banner's bottom edge tracks the incoming prompt's top edge exactly, so the
+ * The banner's bottom edge tracks the incoming prompt's TOP edge exactly, so the
  * two never overlap: the push starts when the incoming top reaches the banner's
- * bottom (`gap === bannerH`) and completes when it reaches the fold (`gap === 0`),
- * at which point the caller swaps the banner to the incoming prompt.
+ * bottom (`gap === ROW_PAD_Y + bannerH`, the card's own bottom, since the card
+ * sits ROW_PAD_Y below the fold) and completes when it reaches the fold
+ * (`gap === 0`), by which point the card is entirely above the fold.
+ *
+ * The travel is therefore `ROW_PAD_Y + bannerH`, NOT `bannerH`: the card starts
+ * ROW_PAD_Y below the fold, so a `bannerH` travel strands its last ROW_PAD_Y of
+ * height inside the band. That was invisible while the push completed on the same
+ * frame as the hand-off (the incoming card replaced it instantly), but once the
+ * two lines separated for tall prompts it became a 4px strip of the outgoing
+ * bubble's bottom edge parked over the incoming prompt for the whole no-banner
+ * stretch — flickering in size with every sub-pixel scroll.
+ *
+ * Note this is a DIFFERENT line from the one that decides which prompt is pinned
+ * (`pinHandoffY`, driven by the incoming prompt's BOTTOM edge), and deliberately
+ * so. For a prompt taller than the band the two separate: the card is fully
+ * pushed out while the prompt's top is still rising, and the prompt only takes
+ * the pin later, once its bottom clears the band. The stretch between them —
+ * where no banner is shown at all while the tall prompt is read — is intended:
+ * the band would otherwise slide up across the prompt's own text, since by then
+ * the only part of it beside the band is its last line. For a one-line prompt the
+ * two lines coincide and the hand-off is instantaneous, as before.
  *
  * @param nextTop viewport-relative top of the incoming prompt row, or null when
  *                that row is not mounted (i.e. still far below the fold)
  */
+/**
+ * Total distance the banner must travel to leave the band COMPLETELY: its own
+ * height plus the `ROW_PAD_Y` it sits below the fold. Once `computePinPush`
+ * returns this, no part of the card is inside the band any more and ChatPage
+ * drops the banner outright rather than rendering a fully-clipped one — a card
+ * clipped to zero still leaves a 1-2px slice of its bottom edge under sub-pixel
+ * rounding and browser zoom, parked over the incoming prompt for the whole
+ * stretch while it is read.
+ */
+export function pinPushTravel(bannerH: number): number {
+  return ROW_PAD_Y + bannerH
+}
+
 export function computePinPush(bannerH: number, foldY: number, nextTop: number | null): number {
   if (nextTop == null || bannerH <= 0) return 0
+  const travel = pinPushTravel(bannerH)
   const gap = nextTop - foldY
-  if (gap >= bannerH) return 0
-  return Math.max(0, Math.min(bannerH, bannerH - gap))
+  if (gap >= travel) return 0
+  return Math.max(0, Math.min(travel, travel - gap))
 }
 
 /**


### PR DESCRIPTION
<!-- pinned-prompt-tall-handoff -->
## Problem

Follow-up to #950. When a user prompt is **taller than the chat pane**, the pinned-prompt banner behaved wrongly the moment the prompt was sent:

- The prompt collapsed into the one-line banner immediately, so **the user could never read their own prompt** — its top edge had already crossed the trigger line by the time it rendered.
- Its row stayed laid out but hidden, leaving a **prompt-sized blank hole** between the prompt and Kiro's response.

Two further artifacts surfaced while fixing it, both reported from live use:

- A **fragment of the previous prompt's bubble** (its bottom edge — rounded corner, hairline ring, clipped chevron) parked at the top of the transcript for the entire time the next prompt was being read.
- On a tall incoming prompt the banner **slid up and then came back**, showing the same prompt text twice.

## Why it matters

The pinned banner is on by default for every chat. A long pasted prompt — a stack trace, a spec, an essay — is exactly when you most want to see what you asked, and it was the one case that hid it. The leftover bubble fragment reads as a rendering bug in the middle of the primary surface.

## Fix (symptom → root cause → change)

**Root cause:** the hand-off was driven by the prompt's **top** edge crossing the fold. For a bubble taller than the band that predicate is true the instant the prompt exists, so "has scrolled out of view" and "is taller than the viewport" were indistinguishable.

**Change — track the bottom edge.** A prompt now pins only once its row is *entirely* behind the banner band:

```
pinHandoffY = foldY + ROW_PAD_Y * 2 + collapsedCardH   // the band's BOTTOM edge
```

A tall prompt scrolls away line by line and collapses only when its last line is covered; because the row is fully above the band at the swap, the hole above the response is gone too. A one-line bubble is exactly the collapsed card's height, so both rules fire on the same pixel and **short-prompt behaviour is bit-identical** (asserted by a test).

`findPinnedPromptIdx` lost its `foldIdxCrossed` argument: the straddling row is never the pinned one any more, so the pinned prompt is always the last prompt strictly before the row that crosses the hand-off line.

**The push keeps its own, earlier line — deliberately.** How far the outgoing banner slides is still driven by the incoming prompt's **top** against the fold. That separation is the point: a tall prompt shoves the previous banner clear out of view and then shows **no banner at all** while it is being read, rather than sliding the old card up across its own text.

Two follow-ons make that stretch genuinely empty:

- `computePinPush` travels `ROW_PAD_Y + bannerH`, not `bannerH`. The card sits `ROW_PAD_Y` below the fold, so travelling only its own height stranded a 4px strip of its bottom edge inside the band — invisible while the push used to complete on the same frame as the hand-off, but parked over the incoming prompt once the two lines separated.
- Once the push completes, `ChatPage` **drops the banner from the DOM** instead of rendering it clipped to nothing. A card clipped to zero still paints a hairline under sub-pixel rounding and browser zoom. The drop predicate reduces algebraically to `nextTop <= foldY`, independent of the measured height, so it cannot oscillate frame to frame.

**Collapsed height is now reported by the child.** The hand-off line needs the collapsed card height even when no card is mounted, and `ChatPage` measuring the card was unsound: the expand/collapse morph animates the card's height for 150 ms *after* `expanded` flips, so a scroll or streaming tick in that window cached an expanded-size height, moved the hand-off line down by the difference, and hid a transcript row that was still on screen. `PinnedPrompt` now reports the settled height from its FLIP layout effect, which already reads the natural height before it starts animating, and strips an interrupted morph's inline height first so a double-toggle of the chevron cannot report an animating value either. Its `ResizeObserver` re-reports on a host font-size / zoom change.

## Tests

`website/src/test/pinnedPrompt.test.ts` — 21 tests (was 14), all green:

- `pinHandoffY` is the band's **bottom** edge, and a one-line prompt hands over exactly as its bubble top reaches the card top — locking in that short prompts did not change.
- `findPinnedPromptIdx` pins the *previous* prompt while the straddling row is itself a prompt (the tall-prompt case), and takes the pin once the row after it straddles.
- `computePinPush` clears the band completely at the fold (`travel > bannerH`), leaves a no-banner stretch for a prompt taller than the band, hands off in one frame for a one-line prompt, and does **not** report a completed push while any of the card is still in the band (guards the drop threshold against firing early).

Not covered by unit tests: the reported collapsed height. jsdom has no layout engine, so every `getBoundingClientRect().height` is 0 and the `h > 0` guard makes the path untestable without mocking layout — called out rather than papered over.

## Manual verification

Verified interactively against the Vite dev server on the reporter's own session, through four rounds: a tall pasted prompt now stays fully readable and scrolls away line by line; the hole above the response is gone; the band is empty while the tall prompt and its response are read; the prompt takes the pin as its bottom reaches the band. One-line prompts were re-checked for the pixel-perfect hand-off.

The residual bubble fragment was diagnosed by decoding the reporter's screenshot pixel-by-pixel (column/row colour profiles) rather than by eye — that is what established it was the card's bottom edge and not, as first assumed, a layout feedback loop.

## Screenshots

None. Every surface here is a **scroll-motion** behaviour — a still frame cannot distinguish the fixed states from the broken ones, and the meaningful evidence (the fragment) is a 4px slice whose absence is what "correct" looks like. Driving the scroll to record it needs the browser-operate toggle, which was not enabled for this session; the behaviour was verified live by the reporter instead across four review rounds.

## Local review

Both mirrored gates ran before the push: `gpt-5.6-sol` (codex-review contract) returned no findings; `claude-opus-5` (claude-review + base-ref `AUTOSDE.yaml`) returned no blocking findings, all six matching blocking frontend rules satisfied. The Opus pass found the mid-morph height-caching defect described above and a verifier confirmed it closed, plus the narrower double-toggle variant — both fixed in this commit.
