### PR TITLE
ci: surface PR merge conflicts as a label in the pulls list

### DIFF
--- a/.github/workflows/pr-merge-conflict-label.yml
+++ b/.github/workflows/pr-merge-conflict-label.yml
@@ -1,0 +1,105 @@
+name: PR Merge-Conflict Label
+
+# Mirrors GitHub's OWN per-PR mergeability onto a single "merge conflict"
+# label. GitHub already shows a conflict on the PR page and blocks the merge
+# button, but it does NOT surface conflicts in the /pulls list -- so a reviewer
+# scanning open PRs cannot tell which green-looking PR is actually unmergeable.
+# A label renders on every row of that list, closing the gap.
+#
+# This workflow is read-only against PR content: it only reads the computed
+# `mergeable` field and toggles a label. It never checks out or executes PR
+# code, recomputes mergeability itself, or re-runs any checks. It also never
+# blocks merge (GitHub already blocks a conflicting merge) -- the label is
+# purely a visibility signal.
+on:
+  schedule:
+    # Backstop sweep. A PR flips MERGEABLE -> CONFLICTING purely because its
+    # base branch advanced, and GitHub emits NO pull_request event for that,
+    # so a periodic sweep is the only way to catch the base-moved case.
+    - cron: "*/30 * * * *"
+  push:
+    # A merge into the default branch is the usual cause of other open PRs
+    # becoming conflicted -- re-sweep immediately so the labels stay fresh
+    # without waiting for the next scheduled run.
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  # Collapse an overlapping sweep (e.g. a push landing during a scheduled run)
+  # into one. The sweep is idempotent, so cancelling an in-flight run is safe.
+  group: pr-merge-conflict-label
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Sync merge-conflict label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync "merge conflict" label across open pull requests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          LABEL: "merge conflict"
+        run: |
+          set -euo pipefail
+
+          # Ensure the label exists (idempotent).
+          existing="$(gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name')"
+          if ! grep -Fxq "$LABEL" <<<"$existing"; then
+            gh label create "$LABEL" --repo "$REPO" \
+              --color "D93F0B" \
+              --description "Branch has merge conflicts with its base — author must resolve before merge"
+          fi
+
+          # Enumerate open PRs with GitHub's own mergeability + current labels.
+          prs="$(gh pr list --repo "$REPO" --state open --limit 300 \
+            --json number,mergeable,labels)"
+
+          add_label() {
+            jq -n --arg label "$LABEL" '{labels: [$label]}' \
+              | gh api --method POST "repos/$REPO/issues/$1/labels" --input - >/dev/null
+          }
+          remove_label() {
+            local encoded
+            encoded="$(jq -rn --arg value "$LABEL" '$value | @uri')"
+            gh api --method DELETE "repos/$REPO/issues/$1/labels/$encoded" >/dev/null
+          }
+
+          echo "$prs" | jq -c '.[]' | while read -r pr; do
+            number="$(jq -r '.number' <<<"$pr")"
+            mergeable="$(jq -r '.mergeable' <<<"$pr")"
+            has_label="$(jq -r --arg l "$LABEL" 'any(.labels[]?; .name == $l)' <<<"$pr")"
+
+            # GitHub computes mergeability lazily, so a freshly-listed PR is
+            # often UNKNOWN. Re-query it once -- a node read nudges GitHub to
+            # compute it. Anything still UNKNOWN is left untouched this pass and
+            # settles on a later sweep. Only a definitive CONFLICTING/MERGEABLE
+            # ever adds or removes the label; UNKNOWN never does.
+            if [ "$mergeable" = "UNKNOWN" ]; then
+              mergeable="$(gh pr view "$number" --repo "$REPO" \
+                --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")"
+            fi
+
+            case "$mergeable" in
+              CONFLICTING)
+                if [ "$has_label" != "true" ]; then
+                  add_label "$number"
+                  echo "PR #$number: CONFLICTING -> added '$LABEL'"
+                fi
+                ;;
+              MERGEABLE)
+                if [ "$has_label" = "true" ]; then
+                  remove_label "$number"
+                  echo "PR #$number: MERGEABLE -> removed '$LABEL'"
+                fi
+                ;;
+              *)
+                echo "PR #$number: mergeability UNKNOWN -> unchanged"
+                ;;
+            esac
+          done


### PR DESCRIPTION
## Problem
GitHub shows a PR's merge-conflict state on the **PR page** (the red "Merge conflicts" box) and disables the merge button, but it does **not** surface conflicts in the **`/pulls` list**. A reviewer scanning open PRs therefore can't tell which otherwise-green PR is actually unmergeable, and a conflict introduced purely by the base branch advancing can sit unnoticed until someone tries to merge.

## Why it matters
Conflicts discovered at merge time waste a review cycle: the PR looks ready, gets attention/approval, then can't land. Surfacing the state in the list lets the author fix it earlier and lets reviewers skip PRs that aren't actually mergeable.

## Fix (symptom → root cause → change)
- **Symptom:** conflicting PRs look ready in the list.
- **Root cause:** the list view has no native conflict indicator, and the base-advanced case emits no `pull_request` event, so nothing flips an existing signal.
- **Change:** a new standalone workflow `pr-merge-conflict-label.yml` mirrors GitHub's **own** computed `mergeable` field onto a single `merge conflict` label, which renders on every row of `/pulls`.
  - Triggers: `schedule` every 30 min (backstop for the base-advanced case, which has no event) + `push` to `main` (immediate re-sweep after the usual cause of new conflicts) + `workflow_dispatch`.
  - One job, one `gh pr list --json number,mergeable,labels` call; `UNKNOWN` PRs (GitHub computes mergeability lazily) are re-queried once via `gh pr view`, and anything still unknown is left for the next sweep. Only a definitive `CONFLICTING`/`MERGEABLE` adds/removes the label.
  - **Visibility only** — it never blocks merge (GitHub already blocks a conflicting merge) and is deliberately decoupled from the `PR Readiness` verdict (which is about automated validation, not mergeability).

### Cost / blast radius
Bounded by merge frequency plus 48 tiny runs/day: a **single** runner that loops all open PRs internally and writes a label **only** to the ones whose state actually changed. No per-PR runner fan-out, no checkout, no re-run of any checks. Least-privilege (`contents: read`, `issues`/`pull-requests: write`), no third-party actions.

## Tests
N/A — no application code. The workflow is validated by YAML parse + bash `-n` syntax check locally, and the `gh pr list --json mergeable` field behavior was confirmed against the live repo before writing (returns definitive `CONFLICTING`/`MERGEABLE` plus lazily-computed `UNKNOWN`, which the sweep handles).

## Manual verification
- `gh pr list --repo kirodotdev/KiroCrew --state open --json number,mergeable` confirmed the field is populated with `CONFLICTING`/`MERGEABLE`/`UNKNOWN` values on the real repo.
- YAML parses; the embedded run script passes `bash -n`.
- Post-merge: run once via `workflow_dispatch` and confirm the `merge conflict` label appears on currently-conflicting PRs and is absent on mergeable ones.
