### PR TITLE
feat(skills): audit when consolidation proposes no skill candidate

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -3555,6 +3555,24 @@ class HistoryConsolidator:
                                     "reason": "creation_failed",
                                 },
                             )
+        else:
+            # Eligible session ran the skill-gen prompt, but the model returned
+            # no new-skill candidate. Emit a lightweight audit trail so
+            # operators can distinguish "asked, model declined" from "never
+            # asked" — previously this branch left no SEL event or log line,
+            # making it impossible to tell from the audit log whether skill
+            # generation was ever attempted during a consolidation.
+            logger.info(
+                "Auto-skill: model proposed no skill candidate for session %s",
+                key,
+            )
+            sel().log_tool_invocation(
+                session_key=key,
+                tool_name="auto_skill_create",
+                tool_kind="skills",
+                outcome="skipped",
+                metadata={"reason": "no_candidate_proposed"},
+            )
 
         # Refine path (only if explicitly enabled)
         if not self._auto_refine_enabled:

--- a/test/test_skill_update_flow.py
+++ b/test/test_skill_update_flow.py
@@ -364,6 +364,57 @@ def test_process_dup_still_rejects(monkeypatch):
     assert rej and rej[0]["metadata"]["existing"] == "auto/deploy-helper"
 
 
+def test_process_no_candidate_emits_skipped_audit(monkeypatch):
+    """When the model returns no new_skill, emit a 'skipped' audit event.
+
+    Regression test for the observability gap: an eligible session that ran the
+    skill-gen prompt but got no candidate previously left NO SEL event, making
+    'asked, model declined' indistinguishable from 'never asked' in the audit
+    log. The else-branch in _process_auto_skills now records it.
+    """
+    loader = FakeLoader()
+    c = _mk(loader)
+    # _dedupe_candidate must never be consulted — there is no candidate.
+    monkeypatch.setattr(
+        c, "_dedupe_candidate",
+        lambda *a, **k: pytest.fail("dedupe called for a null candidate"),
+    )
+    recorded: list[dict] = []
+    ctx = _sel_recorder(recorded)
+    try:
+        # result carries a history_entry but new_skill is absent (model declined).
+        c._process_auto_skills({"history_entry": "did some work"}, "sess")
+    finally:
+        ctx.stop()
+    assert loader.staged == []
+    skipped = [
+        r for r in recorded
+        if r.get("tool_name") == "auto_skill_create"
+        and r.get("outcome") == "skipped"
+        and r.get("metadata", {}).get("reason") == "no_candidate_proposed"
+    ]
+    assert len(skipped) == 1
+    assert skipped[0]["session_key"] == "sess"
+
+
+def test_process_null_new_skill_emits_skipped_audit(monkeypatch):
+    """A literal ``new_skill: null`` is treated the same as an absent key."""
+    loader = FakeLoader()
+    c = _mk(loader)
+    recorded: list[dict] = []
+    ctx = _sel_recorder(recorded)
+    try:
+        c._process_auto_skills({"new_skill": None}, "sess")
+    finally:
+        ctx.stop()
+    assert loader.staged == []
+    assert any(
+        r.get("outcome") == "skipped"
+        and r.get("metadata", {}).get("reason") == "no_candidate_proposed"
+        for r in recorded
+    )
+
+
 def test_process_new_stages_as_new(monkeypatch):
     loader = FakeLoader()
     c = _mk(loader)  # approval_required=True → stages


### PR DESCRIPTION
## Problem
When memory consolidation runs the auto-skill-generation prompt for an eligible
session (≥ `auto_min_tool_calls`, non-sensitive) but the model returns
`new_skill: null`, `_process_auto_skills` did nothing and emitted no log or audit
event. Every *write* decision (staged / created / duplicate / rejected) already
produced a SEL `auto_skill_create` event, but the "model declined" path was
completely silent.

## Why it matters
The silence made the audit trail unable to distinguish **"asked, model declined"**
from **"never asked."** Investigating whether skill generation ever ran during
recent consolidations required scanning 40+ MB of `security_events.jsonl` and
still could not answer the question — the absence of events was ambiguous. An
operator has no way to confirm the feature is exercising its code path.

## Fix (symptom → root cause → change)
- **Symptom:** no audit/log evidence that consolidation attempted skill-gen.
- **Root cause:** `_process_auto_skills` only logged inside the
  `if isinstance(new_skill, dict):` branch; the null/declined case fell through
  with no observability.
- **Change:** add an `else:` branch that emits a `logger.info` line plus a
  lightweight SEL event (`tool_name=auto_skill_create`, `tool_kind=skills`,
  `outcome=skipped`, `metadata.reason=no_candidate_proposed`). The call matches
  the shape and threading of the five sibling SEL calls already in the function
  (it runs on the worker thread via the existing `asyncio.to_thread`
  invocation, so no event-loop blocking). Eligible sessions that produce no
  candidate now always leave exactly one trace; non-eligible sessions
  (below threshold / sensitive) legitimately remain silent.

## Tests
- `test_process_no_candidate_emits_skipped_audit` — result with no `new_skill`
  key: asserts a single `skipped` / `no_candidate_proposed` SEL event, nothing
  staged, and that `_dedupe_candidate` is never consulted.
- `test_process_null_new_skill_emits_skipped_audit` — literal `new_skill: null`
  is treated the same as an absent key.

## Manual verification
N/A — unit coverage is sufficient. (A live end-to-end consolidation could not be
triggered from the CLI in the dev container: spawning the agent runtime fails on
`unshare(CLONE_NEWUSER) → EPERM`. The new branch is exercised by the two
regression tests instead.)

## Screenshots
N/A — no user-visible UI change (backend audit logging only).
