### PR TITLE
fix: tighten Search Everywhere double-Shift window to 250ms

### DIFF
--- a/website/src/components/CommandPalette.test.tsx
+++ b/website/src/components/CommandPalette.test.tsx
@@ -191,7 +191,7 @@ vi.mock('../store', () => ({
 }))
 
 import CommandPalette from './CommandPalette'
-import { useCommandPalette } from '../hooks/useCommandPalette'
+import { useCommandPalette, DOUBLE_SHIFT_WINDOW_MS } from '../hooks/useCommandPalette'
 import { SHORTCUTS_ENABLED_KEY } from '../hooks/useKeyboardShortcuts'
 import type { Result } from './commandPalette/types'
 
@@ -234,6 +234,33 @@ describe('useCommandPalette — global trigger', () => {
       fireEvent.keyDown(window, { key: 'Shift' })
     })
     expect(result.current.open).toBe(true)
+  })
+
+  it('two Shifts spaced BEYOND the double-tap window do not open (accidental tap)', () => {
+    const nowSpy = vi.spyOn(Date, 'now')
+    try {
+      const { result } = renderHook(() => useCommandPalette())
+      // Base off a NON-ZERO timestamp: t=0 collides with the hook's
+      // "no pending first tap" sentinel (lastShiftRef.current === 0), which
+      // would make the first tap silently fail to arm and pass this test for
+      // the wrong reason. With T0 > 0 the first tap genuinely arms.
+      const T0 = 1_000
+      nowSpy.mockReturnValue(T0)
+      act(() => fireEvent.keyDown(window, { key: 'Shift' }))
+      // Second tap one window+1ms later — too slow to count as a double-tap.
+      nowSpy.mockReturnValue(T0 + DOUBLE_SHIFT_WINDOW_MS + 1)
+      act(() => fireEvent.keyDown(window, { key: 'Shift' }))
+      expect(result.current.open).toBe(false)
+      // …but that slow second tap re-arms as a new first tap: a follow-up tap
+      // a real in-window gap later (half the window) still opens, so the
+      // gesture stays usable. A 0ms delta here would pass for any window ≥ 0
+      // and would not pin the 250ms boundary.
+      nowSpy.mockReturnValue(T0 + DOUBLE_SHIFT_WINDOW_MS + 1 + Math.floor(DOUBLE_SHIFT_WINDOW_MS / 2))
+      act(() => fireEvent.keyDown(window, { key: 'Shift' }))
+      expect(result.current.open).toBe(true)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('a key pressed between the two Shifts cancels the gesture', () => {

--- a/website/src/hooks/useCommandPalette.ts
+++ b/website/src/hooks/useCommandPalette.ts
@@ -33,8 +33,15 @@ import { SHORTCUTS_ENABLED_KEY } from './useKeyboardShortcuts'
  * trigger + visibility toggle.
  */
 
-/** Max gap between the two Shift keydowns to count as a double-tap. */
-export const DOUBLE_SHIFT_WINDOW_MS = 400
+/**
+ * Max gap between the two Shift keydowns to count as a double-tap. Kept
+ * deliberately tight (250ms): a wider window makes the palette pop open on
+ * incidental Shift taps (e.g. reaching for a capital, then hesitating) that
+ * were never meant as the gesture. 250ms is comfortably reachable as an
+ * intentional double-tap while cutting most accidental opens; ⌘K / Ctrl+K and
+ * the nav button remain as unambiguous alternatives.
+ */
+export const DOUBLE_SHIFT_WINDOW_MS = 250
 
 /** Live read of the global shortcuts toggle (default on; '0' means disabled). */
 const shortcutsEnabled = () => localStorage.getItem(SHORTCUTS_ENABLED_KEY) !== '0'


### PR DESCRIPTION
## Problem
The dashboard's "Search Everywhere" command palette opens on a double-Shift gesture with a 400ms double-tap window. That window is wide enough that incidental Shift presses — reaching for a capital and hesitating, or two quick Shifts during normal typing — pop the palette open unexpectedly.

## Why it matters
An unexpectedly-appearing modal interrupts whatever the user is doing (typing in the chat composer, navigating) and has to be dismissed, which is a small but repeated papercut. The gesture should require a deliberate double-tap, not fire on incidental key activity.

## Fix (symptom → root cause → change)
- **Symptom:** palette opens without the user intending the double-Shift gesture.
- **Root cause:** `DOUBLE_SHIFT_WINDOW_MS = 400` in `website/src/hooks/useCommandPalette.ts` is a generous window; two Shift keydowns that far apart are common during ordinary typing.
- **Change:** tighten the window to `250ms`. An intentional double-tap is comfortably reachable at 250ms while most accidental double-Shifts fall outside it. No logic change — only the constant and its explanatory comment. `⌘K` / `Ctrl+K` and the palette nav button remain unchanged as unambiguous alternatives.

## Tests
- New regression test in `website/src/components/CommandPalette.test.tsx`: asserts two Shift keydowns spaced *beyond* the window do **not** open the palette, and that the too-slow second tap re-arms so a follow-up tap within the window still opens (gesture stays usable). The test controls `Date.now` via `vi.spyOn` and bases the timeline off a non-zero timestamp (t=0 collides with the hook's "no pending tap" sentinel, which would make the assertion pass for the wrong reason). Mutation-tested: removing the window comparison from the hook makes this test fail, confirming it actually pins the boundary.
- Full frontend suite green: `tsc -b` clean, `vitest` 572 files / 6964 passed.

## Manual verification
N/A — unit coverage pins the window behaviour; the change is a single timing constant with no new UI surface.

## Screenshots
N/A — no visual change. This adjusts a keyboard-gesture timing constant only; nothing rendered changes.
