### PR TITLE
feat(mcp-apps): reveal tool arguments progressively via tool-input-partial

### DIFF
--- a/website/src/components/McpAppFrame.tsx
+++ b/website/src/components/McpAppFrame.tsx
@@ -8,6 +8,7 @@ import {
   buildAllowAttribute,
   type McpAppRenderPayload,
 } from '../lib/mcpAppSrcdoc'
+import { planReveal, prefersReducedMotion, hasRevealed, markRevealed } from './mcpAppReveal'
 
 /** Inline height for a rendered MCP App before it reports its own size. */
 const DEFAULT_HEIGHT = 480
@@ -25,6 +26,10 @@ const M_REQUEST_DISPLAY_MODE = 'ui/request-display-mode'
 const M_OPEN_LINK = 'ui/open-link'
 const N_INITIALIZED = 'ui/notifications/initialized'
 const N_TOOL_INPUT = 'ui/notifications/tool-input'
+/** Incomplete arguments, "may change" — the notification a streaming-aware app
+ *  redraws from. Posted in ascending prefixes ahead of N_TOOL_INPUT; see
+ *  `mcpAppReveal.ts` for why the pacing is the host's and not the model's. */
+const N_TOOL_INPUT_PARTIAL = 'ui/notifications/tool-input-partial'
 const N_TOOL_RESULT = 'ui/notifications/tool-result'
 const N_SIZE_CHANGED = 'ui/notifications/size-changed'
 const N_HOST_CONTEXT_CHANGED = 'ui/notifications/host-context-changed'
@@ -456,6 +461,17 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
   // replacement document must never wield the host-held callback_secret).
   const loadCountRef = useRef<number>(0)
   const navigatedRef = useRef<boolean>(false)
+  // Pending progressive-reveal step. Held in a ref so unmount (and app
+  // navigation) can cancel a reveal mid-flight instead of posting into a torn
+  // down frame.
+  const revealTimerRef = useRef<number | null>(null)
+  // Whether this app document has already completed its init handshake. A
+  // SECOND `initialized` must not be serviced: the spool is already marked
+  // revealed by then, so the duplicate would take the no-plan branch and post
+  // the complete input + result immediately while the first reveal's timer is
+  // still armed — the remaining partials would then land AFTER the result and
+  // leave a partial-aware app rendering a truncated prefix permanently.
+  const initializedRef = useRef<boolean>(false)
 
   useEffect(() => {
     const handler = (e: MessageEvent) => {
@@ -525,25 +541,67 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
           }
           return
 
-        case N_INITIALIZED:
+        case N_INITIALIZED: {
           // App finished its own init handshake → deliver the tool invocation
           // context: the ORIGINATING tools/call arguments and result content
           // captured by the gateway at interception time, so apps that
           // initialize from their inputs get real state.
-          post({
-            jsonrpc: '2.0',
-            method: N_TOOL_INPUT,
-            params: { arguments: toolInputRef.current ?? {} },
-          })
-          post({
-            jsonrpc: '2.0',
-            method: N_TOOL_RESULT,
-            params: {
-              content: Array.isArray(resultContentRef.current) ? resultContentRef.current : [],
-              structuredContent: structuredRef.current ?? null,
-            },
-          })
+          //
+          // Exactly once per app document: a duplicate would race the in-flight
+          // reveal and invert the notification ordering (see initializedRef).
+          if (initializedRef.current) return
+          initializedRef.current = true
+          const args = toolInputRef.current ?? {}
+          const postResult = () => {
+            post({
+              jsonrpc: '2.0',
+              method: N_TOOL_RESULT,
+              params: {
+                content: Array.isArray(resultContentRef.current) ? resultContentRef.current : [],
+                structuredContent: structuredRef.current ?? null,
+              },
+            })
+          }
+          const postComplete = () => {
+            post({ jsonrpc: '2.0', method: N_TOOL_INPUT, params: { arguments: args } })
+            // Ordering is a contract: the result may only land once the app has
+            // been told the arguments are complete.
+            postResult()
+          }
+          // Reveal the arguments progressively when they have a revealable
+          // shape, the user has not asked for reduced motion, and this spool has
+          // not already animated in this page session (a remounted transcript
+          // frame must not replay history's draw-on).
+          const plan =
+            prefersReducedMotion() || hasRevealed(spoolIdRef.current)
+              ? null
+              : planReveal(args)
+          if (!plan) {
+            postComplete()
+            return
+          }
+          markRevealed(spoolIdRef.current)
+          const step = (i: number) => {
+            revealTimerRef.current = null
+            // The bridge dies with the app document; a reveal in flight when the
+            // app navigates must stop rather than post into the replacement.
+            if (navigatedRef.current) return
+            if (i >= plan.frames.length) {
+              postComplete()
+              return
+            }
+            post({
+              jsonrpc: '2.0',
+              method: N_TOOL_INPUT_PARTIAL,
+              params: { arguments: plan.frames[i] },
+            })
+            revealTimerRef.current = window.setTimeout(() => step(i + 1), plan.stepMs)
+          }
+          // First frame goes out synchronously, so the app paints immediately
+          // and the reveal reads as drawing rather than as a delayed start.
+          step(0)
           return
+        }
 
         case N_SIZE_CHANGED: {
           const params = msg.params as { width?: number; height?: number } | undefined
@@ -716,7 +774,13 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
       }
     }
     window.addEventListener('message', handler)
-    return () => window.removeEventListener('message', handler)
+    return () => {
+      window.removeEventListener('message', handler)
+      if (revealTimerRef.current !== null) {
+        window.clearTimeout(revealTimerRef.current)
+        revealTimerRef.current = null
+      }
+    }
   }, [])
 
   // Push a partial hostContext update into the app. Mirrors the inbound bridge's

--- a/website/src/components/mcpAppReveal.ts
+++ b/website/src/components/mcpAppReveal.ts
@@ -1,0 +1,200 @@
+/** Host-side progressive reveal of tool-call arguments.
+ *
+ *  SEP-1865 gives apps two input notifications: `tool-input-partial`
+ *  ("Partial tool call arguments (incomplete, may change)") and `tool-input`
+ *  ("Complete tool call arguments"). Apps built for streaming hosts listen on
+ *  the partial one and redraw per delta — excalidraw's `ontoolinputpartial`
+ *  parses a possibly-truncated element array and draws whatever parsed.
+ *
+ *  WHAT THIS IS, PRECISELY: the pacing here is the HOST'S, not the model's.
+ *  kiro-cli 2.16.0 announces a tool call early (`tool_call_chunk`, carrying
+ *  only title/kind with `args:{}`) and then delivers arguments WHOLE — it emits
+ *  no argument deltas, and the binary carries no `tool_input_partial` /
+ *  `input_delta` symbol. So we cannot forward a real token-paced stream; we
+ *  take the complete arguments and reveal them in ascending prefixes.
+ *
+ *  This is not a fake of a feature the app can detect: the notification, its
+ *  shape and its "may change" contract are exactly what a genuinely streaming
+ *  host sends, and excalidraw's own dev harness (`dev-mock.ts`) fakes it the
+ *  same way. The single difference is that the cadence is uniform rather than
+ *  tracking generation speed. If a future CLI emits argument deltas, the
+ *  frames simply come from the wire instead of from `planReveal`.
+ *
+ *  Only ARRAY-shaped arguments are revealable: a prefix of a list of diagram
+ *  elements is a meaningful intermediate state, whereas a prefix of a string or
+ *  a subset of unrelated scalar keys is noise. When nothing qualifies we return
+ *  null and the caller posts the complete input immediately, which is exactly
+ *  the pre-existing behaviour.
+ */
+
+/** Wall-clock budget for the whole reveal. Deliberately short: the reveal is
+ *  gated on argument SHAPE, not on app capability, so an app that ignores
+ *  `tool-input-partial` still waits this long for its complete input and result.
+ *  A capability gate is not available — `ui/initialize` params do carry
+ *  `appCapabilities`, but excalidraw (the reference partial-aware consumer)
+ *  declares `capabilities: {}`, so gating on a declared capability would switch
+ *  the animation off for the very app that implements it. Keeping the budget
+ *  small is the honest trade instead. */
+export const REVEAL_BUDGET_MS = 700
+/** Upper bound on posted frames. A 4000-element diagram must not become 4000
+ *  postMessage round-trips; past ~two dozen steps the motion reads identically. */
+export const REVEAL_MAX_FRAMES = 24
+/** Floor on the gap between frames, so a short list still animates visibly
+ *  instead of flashing through in three frames' worth of milliseconds. */
+export const REVEAL_MIN_STEP_MS = 45
+/** Cap on the encoded size of the WHOLE arguments object.
+ *
+ *  It must be the whole object, not just the revealed array: every frame is
+ *  `{...toolInput, [key]: prefix}`, so each frame structured-clones every
+ *  SIBLING argument too. Measuring only the array would let a small array
+ *  beside a multi-megabyte sibling ship (frames x sibling) bytes through
+ *  postMessage. At this cap the worst case is ~24 x 256KB. */
+export const REVEAL_MAX_SOURCE_BYTES = 256_000
+
+/** How the revealed array was carried in the arguments object. Servers differ:
+ *  excalidraw passes `elements` as a JSON *string*, others pass a real array. */
+type RevealEncoding = 'array' | 'json-string'
+
+export interface RevealPlan {
+  /** The argument key being revealed progressively. */
+  key: string
+  /** Successive partial `arguments` objects, in order. Deliberately EXCLUDES
+   *  the complete value: the final state is delivered by the real `tool-input`
+   *  notification, keeping "partial ⇒ may change" and "input ⇒ complete" true. */
+  frames: Record<string, unknown>[]
+  /** Delay between frames, in milliseconds. */
+  stepMs: number
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** Decode an argument value to an array if it is one, either natively or as a
+ *  JSON string. Returns null for anything else. */
+function decodeArray(value: unknown): { items: unknown[]; encoding: RevealEncoding } | null {
+  if (Array.isArray(value)) return { items: value, encoding: 'array' }
+  if (typeof value === 'string') {
+    // Cheap prefilters BEFORE parsing: skip values that cannot be an array
+    // literal, and skip anything already past the size cap — parsing a
+    // multi-megabyte untrusted string just to discover it is too big to reveal
+    // is itself the main-thread cost the cap exists to avoid.
+    const trimmed = value.trim()
+    if (!trimmed.startsWith('[')) return null
+    if (trimmed.length > REVEAL_MAX_SOURCE_BYTES) return null
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+      if (Array.isArray(parsed)) return { items: parsed, encoding: 'json-string' }
+    } catch {
+      // Not JSON — nothing to reveal. (Unlike the APP side, the host always
+      // holds complete arguments, so a parse failure here is a genuine
+      // non-array value rather than mid-stream truncation.)
+    }
+  }
+  return null
+}
+
+function encodeItems(items: unknown[], encoding: RevealEncoding): unknown {
+  return encoding === 'json-string' ? JSON.stringify(items) : items
+}
+
+/** Evenly spaced prefix lengths over `1 .. total-1`, at most `REVEAL_MAX_FRAMES`
+ *  of them, strictly increasing and never including `total`. */
+function prefixLengths(total: number): number[] {
+  const steps = Math.min(REVEAL_MAX_FRAMES, total - 1)
+  const out: number[] = []
+  for (let i = 1; i <= steps; i++) {
+    const len = Math.max(1, Math.round((i * (total - 1)) / steps))
+    if (out[out.length - 1] !== len) out.push(len)
+  }
+  return out
+}
+
+/** Build a reveal plan for a tool call's arguments, or null when the payload has
+ *  no meaningfully revealable array. */
+export function planReveal(toolInput: unknown): RevealPlan | null {
+  if (!isPlainObject(toolInput)) return null
+
+  // Size-gate the WHOLE arguments object FIRST, before scanning or decoding any
+  // value. Every frame carries all sibling arguments, so the per-frame cost is
+  // driven by the total payload rather than by the revealed array alone.
+  let encodedBytes: number
+  try {
+    encodedBytes = (JSON.stringify(toolInput) ?? '').length
+  } catch {
+    // Circular or non-serialisable arguments. structured clone would still copy
+    // them, but we cannot bound the per-frame cost, so decline the reveal and
+    // let the caller deliver the payload whole.
+    return null
+  }
+  if (encodedBytes > REVEAL_MAX_SOURCE_BYTES) return null
+
+  // Pick the LARGEST array-valued argument: for a diagram call that is the
+  // element list, not an incidental two-entry options array. Iteration follows
+  // key order and the comparison is strictly-greater, so the choice is stable.
+  let best: { key: string; items: unknown[]; encoding: RevealEncoding } | null = null
+  for (const key of Object.keys(toolInput)) {
+    const decoded = decodeArray(toolInput[key])
+    if (!decoded) continue
+    if (!best || decoded.items.length > best.items.length) {
+      best = { key, items: decoded.items, encoding: decoded.encoding }
+    }
+  }
+  // Fewer than two items yields no intermediate state worth showing.
+  if (!best || best.items.length < 2) return null
+
+  const lengths = prefixLengths(best.items.length)
+  if (lengths.length === 0) return null
+
+  const frames = lengths.map((len) => ({
+    ...toolInput,
+    [best.key]: encodeItems(best.items.slice(0, len), best.encoding),
+  }))
+
+  return {
+    key: best.key,
+    frames,
+    stepMs: Math.max(REVEAL_MIN_STEP_MS, Math.round(REVEAL_BUDGET_MS / frames.length)),
+  }
+}
+
+/** Honour the OS/browser reduced-motion preference: a user who has asked for
+ *  less motion gets the complete payload at once rather than a draw-on. */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  } catch {
+    return false
+  }
+}
+
+/** Spools already revealed in this page session.
+ *
+ *  A transcript frame can unmount and remount (virtualisation, navigating back
+ *  to an old conversation). Replaying the draw-on every time would animate
+ *  history on every scroll, so each spool animates at most once per page. */
+const revealedSpools = new Set<string>()
+/** Bound the set: transcripts are unbounded, this cache must not be. */
+const REVEALED_CAP = 256
+
+export function hasRevealed(spoolId: string): boolean {
+  return revealedSpools.has(spoolId)
+}
+
+export function markRevealed(spoolId: string): void {
+  // Evict the OLDEST entry, not the whole set: clearing wholesale would let
+  // every already-seen app re-animate after the 257th render, which is exactly
+  // the history-replay this cache exists to prevent. Set preserves insertion
+  // order, so the first key is the oldest.
+  if (revealedSpools.size >= REVEALED_CAP) {
+    const oldest = revealedSpools.values().next()
+    if (!oldest.done) revealedSpools.delete(oldest.value)
+  }
+  revealedSpools.add(spoolId)
+}
+
+/** Test seam — reveal state is module-level, so tests must be able to reset it. */
+export function __resetRevealedForTests(): void {
+  revealedSpools.clear()
+}

--- a/website/src/test/McpAppFrame.test.tsx
+++ b/website/src/test/McpAppFrame.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderWithProviders } from './helpers'
 import { act } from '@testing-library/react'
 import McpAppFrame from '../components/McpAppFrame'
 import type { McpAppRenderPayload } from '../lib/mcpAppSrcdoc'
+import { __resetRevealedForTests } from '../components/mcpAppReveal'
 
 function payload(over: Partial<McpAppRenderPayload> = {}): McpAppRenderPayload {
   return {
@@ -37,6 +38,13 @@ function dispatchFromApp(data: unknown, source: unknown) {
 }
 
 describe('McpAppFrame', () => {
+  // The progressive-reveal "already animated" cache is module-level (it must
+  // outlive a remounted transcript frame), so tests have to reset it or the
+  // first animating test would suppress every later one sharing a spool id.
+  beforeEach(() => {
+    __resetRevealedForTests()
+  })
+
   it('renders a sandboxed iframe WITHOUT allow-same-origin', () => {
     const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
     const iframe = container.querySelector('iframe')!
@@ -122,6 +130,179 @@ describe('McpAppFrame', () => {
     expect(win.postMessage.mock.calls[1][0].params.content).toEqual([
       { type: 'text', text: 'opened' },
     ])
+  })
+
+  // ---- progressive reveal (host-paced tool-input-partial) -------------------
+
+  /** A JSON-string element array, the shape excalidraw's create_view sends. */
+  function elementsArg(n: number): string {
+    return JSON.stringify(Array.from({ length: n }, (_, i) => ({ id: `e${i}` })))
+  }
+
+  it('reveals array arguments as tool-input-partial, then the complete input, then the result', () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const { container } = renderWithProviders(
+        <McpAppFrame
+          payload={payload({
+            tool_input: { elements: elementsArg(5) },
+            result_content: [{ type: 'text', text: 'drawn' }],
+          })}
+        />,
+      )
+      const win = stubContentWindow(container.querySelector('iframe')!)
+
+      dispatchFromApp({ jsonrpc: '2.0', method: 'ui/notifications/initialized' }, win)
+
+      // The first partial is synchronous: the app paints immediately instead of
+      // waiting out a step interval before anything appears.
+      expect(win.postMessage).toHaveBeenCalledTimes(1)
+      expect(win.postMessage.mock.calls[0][0].method).toBe('ui/notifications/tool-input-partial')
+
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      const methods = win.postMessage.mock.calls.map((c) => c[0].method)
+      // Every partial precedes the completion pair, and the result is LAST —
+      // an app must never see a result before its arguments are complete.
+      expect(methods.slice(-2)).toEqual([
+        'ui/notifications/tool-input',
+        'ui/notifications/tool-result',
+      ])
+      expect(new Set(methods.slice(0, -2))).toEqual(new Set(['ui/notifications/tool-input-partial']))
+      expect(methods.filter((m) => m === 'ui/notifications/tool-input-partial').length).toBe(4)
+
+      // Partials grow monotonically and stay short of the full array.
+      const counts = win.postMessage.mock.calls
+        .filter((c) => c[0].method === 'ui/notifications/tool-input-partial')
+        .map((c) => (JSON.parse(c[0].params.arguments.elements as string) as unknown[]).length)
+      expect(counts).toEqual([1, 2, 3, 4])
+
+      // The COMPLETE notification carries the whole payload, unmodified.
+      const complete = win.postMessage.mock.calls.at(-2)![0]
+      expect((JSON.parse(complete.params.arguments.elements as string) as unknown[]).length).toBe(5)
+      expect(win.postMessage.mock.calls.at(-1)![0].params.content).toEqual([
+        { type: 'text', text: 'drawn' },
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a duplicate initialized so no partial can land after the result', () => {
+    // Both local reviewers found this: without the guard, the second
+    // `initialized` sees the spool already marked revealed, takes the no-plan
+    // branch and posts complete-input + result immediately, while chain 1's
+    // timer keeps firing partials afterwards — a partial-aware app would repaint
+    // a truncated prefix over the finished diagram and stay there.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const { container } = renderWithProviders(
+        <McpAppFrame payload={payload({ tool_input: { elements: elementsArg(8) } })} />,
+      )
+      const win = stubContentWindow(container.querySelector('iframe')!)
+      const init = { jsonrpc: '2.0', method: 'ui/notifications/initialized' }
+
+      dispatchFromApp(init, win)
+      dispatchFromApp(init, win) // duplicate, mid-reveal
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      const methods = win.postMessage.mock.calls.map((c) => c[0].method)
+      // Exactly one completion pair, and it is the LAST thing posted.
+      expect(methods.filter((m) => m === 'ui/notifications/tool-input').length).toBe(1)
+      expect(methods.filter((m) => m === 'ui/notifications/tool-result').length).toBe(1)
+      expect(methods.slice(-2)).toEqual([
+        'ui/notifications/tool-input',
+        'ui/notifications/tool-result',
+      ])
+      // No partial after the complete input.
+      const completeAt = methods.indexOf('ui/notifications/tool-input')
+      expect(methods.slice(completeAt).includes('ui/notifications/tool-input-partial')).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips the reveal entirely when the user prefers reduced motion', () => {
+    // The stub must be a COMPLETE MediaQueryList: the theme provider subscribes
+    // with mql.addEventListener during render, and a bare {matches} object
+    // throws there — wedging React's act queue for every later test in the file.
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(() => false),
+      })),
+    )
+    try {
+      const { container } = renderWithProviders(
+        <McpAppFrame payload={payload({ tool_input: { elements: elementsArg(6) } })} />,
+      )
+      const win = stubContentWindow(container.querySelector('iframe')!)
+      dispatchFromApp({ jsonrpc: '2.0', method: 'ui/notifications/initialized' }, win)
+
+      expect(win.postMessage.mock.calls.map((c) => c[0].method)).toEqual([
+        'ui/notifications/tool-input',
+        'ui/notifications/tool-result',
+      ])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('does not replay the reveal when the same spool remounts', () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const p = payload({ tool_input: { elements: elementsArg(5) } })
+      const first = renderWithProviders(<McpAppFrame payload={p} />)
+      const win1 = stubContentWindow(first.container.querySelector('iframe')!)
+      dispatchFromApp({ jsonrpc: '2.0', method: 'ui/notifications/initialized' }, win1)
+      act(() => {
+        vi.runAllTimers()
+      })
+      first.unmount()
+
+      // Same spool id → history must not animate again on a scroll-back remount.
+      const second = renderWithProviders(<McpAppFrame payload={p} />)
+      const win2 = stubContentWindow(second.container.querySelector('iframe')!)
+      dispatchFromApp({ jsonrpc: '2.0', method: 'ui/notifications/initialized' }, win2)
+      expect(win2.postMessage.mock.calls.map((c) => c[0].method)).toEqual([
+        'ui/notifications/tool-input',
+        'ui/notifications/tool-result',
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels an in-flight reveal on unmount instead of posting into a dead frame', () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const { container, unmount } = renderWithProviders(
+        <McpAppFrame payload={payload({ tool_input: { elements: elementsArg(20) } })} />,
+      )
+      const win = stubContentWindow(container.querySelector('iframe')!)
+      dispatchFromApp({ jsonrpc: '2.0', method: 'ui/notifications/initialized' }, win)
+      const afterFirstFrame = win.postMessage.mock.calls.length
+
+      unmount()
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(win.postMessage.mock.calls.length).toBe(afterFirstFrame)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('relays tools/call to POST /api/mcp-apps/call and posts back the result', async () => {

--- a/website/src/test/mcpAppReveal.test.ts
+++ b/website/src/test/mcpAppReveal.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  planReveal,
+  prefersReducedMotion,
+  hasRevealed,
+  markRevealed,
+  __resetRevealedForTests,
+  REVEAL_MAX_FRAMES,
+  REVEAL_MAX_SOURCE_BYTES,
+  REVEAL_MIN_STEP_MS,
+} from '../components/mcpAppReveal'
+
+/** N distinct element-ish objects, the shape a diagram tool actually sends. */
+function elements(n: number): { id: string }[] {
+  return Array.from({ length: n }, (_, i) => ({ id: `e${i}` }))
+}
+
+describe('planReveal', () => {
+  it('returns null for payloads with nothing array-shaped to reveal', () => {
+    expect(planReveal(null)).toBeNull()
+    expect(planReveal('a string')).toBeNull()
+    expect(planReveal([1, 2, 3])).toBeNull() // top level must be the arguments OBJECT
+    expect(planReveal({ url: 'https://example.com/a.pdf' })).toBeNull()
+    expect(planReveal({ prose: 'not json at all' })).toBeNull()
+  })
+
+  it('returns null for a single-element array — there is no intermediate state', () => {
+    expect(planReveal({ elements: elements(1) })).toBeNull()
+    expect(planReveal({ elements: JSON.stringify(elements(1)) })).toBeNull()
+  })
+
+  it('reveals a JSON-STRING encoded array as growing JSON strings', () => {
+    // excalidraw's create_view passes `elements` as a JSON string, and its
+    // parsePartialElements tolerates truncation — so frames must stay strings.
+    const plan = planReveal({ elements: JSON.stringify(elements(4)) })!
+    expect(plan.key).toBe('elements')
+    expect(plan.frames.length).toBe(3)
+    for (const frame of plan.frames) {
+      expect(typeof frame.elements).toBe('string')
+    }
+    const lengths = plan.frames.map((f) => (JSON.parse(f.elements as string) as unknown[]).length)
+    expect(lengths).toEqual([1, 2, 3])
+  })
+
+  it('reveals a NATIVE array as growing arrays', () => {
+    const plan = planReveal({ elements: elements(3) })!
+    const lengths = plan.frames.map((f) => (f.elements as unknown[]).length)
+    expect(lengths).toEqual([1, 2])
+    expect(Array.isArray(plan.frames[0].elements)).toBe(true)
+  })
+
+  it('never emits the COMPLETE array in a partial frame', () => {
+    // The completeness contract: `tool-input-partial` means "may change",
+    // `tool-input` means complete. A partial equal to the whole payload would
+    // make an app that only listens to partials believe it had the final state.
+    const total = 8
+    const plan = planReveal({ elements: elements(total) })!
+    for (const frame of plan.frames) {
+      expect((frame.elements as unknown[]).length).toBeLessThan(total)
+    }
+  })
+
+  it('preserves the other arguments untouched in every frame', () => {
+    const plan = planReveal({ elements: elements(3), title: 'Arch diagram', theme: 'dark' })!
+    for (const frame of plan.frames) {
+      expect(frame.title).toBe('Arch diagram')
+      expect(frame.theme).toBe('dark')
+    }
+  })
+
+  it('reveals the LARGEST array, not an incidental small one', () => {
+    const plan = planReveal({ tags: ['a', 'b'], elements: elements(9) })!
+    expect(plan.key).toBe('elements')
+  })
+
+  it('caps frame count and keeps prefixes strictly increasing for a big diagram', () => {
+    const plan = planReveal({ elements: elements(500) })!
+    expect(plan.frames.length).toBeLessThanOrEqual(REVEAL_MAX_FRAMES)
+    const lengths = plan.frames.map((f) => (f.elements as unknown[]).length)
+    for (let i = 1; i < lengths.length; i++) {
+      expect(lengths[i]).toBeGreaterThan(lengths[i - 1])
+    }
+    expect(lengths[lengths.length - 1]).toBeLessThan(500)
+  })
+
+  it('declines payloads too large to re-encode per frame', () => {
+    // One oversized element is enough: the guard is about encoded bytes, not count.
+    const huge = [{ id: 'a', blob: 'x'.repeat(REVEAL_MAX_SOURCE_BYTES + 10) }, { id: 'b' }]
+    expect(planReveal({ elements: JSON.stringify(huge) })).toBeNull()
+    expect(planReveal({ elements: huge })).toBeNull()
+  })
+
+  it('counts SIBLING arguments against the size cap, not just the revealed array', () => {
+    // Every frame is {...toolInput, [key]: prefix}, so each frame clones every
+    // sibling too. A small array beside a huge sibling would otherwise ship
+    // (frames x sibling) bytes through postMessage.
+    const plan = planReveal({
+      elements: elements(25),
+      backdrop: 'y'.repeat(REVEAL_MAX_SOURCE_BYTES + 10),
+    })
+    expect(plan).toBeNull()
+  })
+
+  it('declines circular arguments instead of throwing', () => {
+    const circular: Record<string, unknown> = { elements: elements(4) }
+    circular.self = circular
+    expect(() => planReveal(circular)).not.toThrow()
+    expect(planReveal(circular)).toBeNull()
+  })
+
+  it('never schedules frames faster than the minimum step', () => {
+    const plan = planReveal({ elements: elements(400) })!
+    expect(plan.stepMs).toBeGreaterThanOrEqual(REVEAL_MIN_STEP_MS)
+  })
+})
+
+describe('revealed-spool cache', () => {
+  afterEach(() => {
+    __resetRevealedForTests()
+  })
+
+  it('evicts the OLDEST entry at the cap, not the whole set', () => {
+    // Clearing wholesale would let every already-seen app re-animate after the
+    // cap is crossed — the exact history-replay this cache prevents.
+    __resetRevealedForTests()
+    markRevealed('first')
+    for (let i = 0; i < 300; i++) markRevealed(`spool-${i}`)
+    // 'first' is gone (evicted as oldest), but recent entries survive.
+    expect(hasRevealed('first')).toBe(false)
+    expect(hasRevealed('spool-299')).toBe(true)
+    expect(hasRevealed('spool-298')).toBe(true)
+  })
+})
+
+describe('prefersReducedMotion', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reports the reduce preference when the media query matches', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }))
+    expect(prefersReducedMotion()).toBe(true)
+  })
+
+  it('defaults to false when matchMedia is unavailable or throws', () => {
+    vi.stubGlobal('matchMedia', undefined)
+    expect(prefersReducedMotion()).toBe(false)
+    vi.stubGlobal('matchMedia', vi.fn().mockImplementation(() => { throw new Error('nope') }))
+    expect(prefersReducedMotion()).toBe(false)
+  })
+})


### PR DESCRIPTION
# Problem

MCP Apps that are built to animate their own rendering never animated in KiroCrew. Excalidraw's app wires `app.ontoolinputpartial` (`src/mcp-app.tsx:804`) and ships a `parsePartialElements()` that deliberately tolerates a mid-stream truncated JSON array — its own dev harness (`dev-mock.ts:110`) drives it with growing element-array prefixes. Our host never sent `ui/notifications/tool-input-partial`, so on `initialized` the app received the finished argument payload in one frame and the diagram simply appeared, fully formed.

# Why it matters

The draw-on reveal is the visible difference between "a picture arrived" and "the assistant is drawing this for you" — it is the feature these apps were written for, and the MCP Apps spec calls it out explicitly ("preload this resource before the tool is even called, enabling features like streaming tool inputs to the app"). We were shipping a finished consumer with the producing half missing.

# Fix (symptom → root cause → change)

**Symptom:** diagrams render in a single frame; the app's partial handler never fires.

**Root cause:** `McpAppFrame`'s `ui/notifications/initialized` branch posted the complete `tool-input` immediately. `tool-input-partial` was never in the host's vocabulary at all.

**Change:** the host now holds the payload back and posts ascending prefixes of an array-valued argument as `tool-input-partial`, then the complete `tool-input`, then `tool-result`.

**On honesty of the mechanism** — this is host-paced, not model-paced, and the code says so at `mcpAppReveal.ts:9-16`. I settled the question against the shipped kiro-cli 2.16.0 binary rather than guessing: it emits `tool_call_chunk` early (carrying only `title`/`kind` with `args:{}`) and then delivers arguments **whole**; there is no `tool_input_partial` / `input_delta` / `partial_input` symbol anywhere in it. So the frames are constructed host-side from the complete arguments. What reaches the app — the method, the shape, the "may change" contract — is exactly what a genuinely streaming host sends, and the app cannot distinguish it; only the cadence is uniform rather than tracking generation. If a future CLI emits deltas, `step()` is fed from the wire and the planner drops out with no change to the reveal policy.

**What is deliberately NOT here: early mount.** The app still mounts after the tool completes. Mounting before the tool returns is blocked structurally — gatewayd has no push channel to the dashboard; the only render signal is the opaque marker `[kirocrew-mcp-app:<spool_id>]` embedded in the tool *result* text (`mcp_gateway/apps.py:51`), consumed at `dashboard/chat_runner.py:3330` on `EVENT_TOOL_RESULT`. Adding one collides with a deliberate invariant stated in `mcp_gateway/backend.py` — *"A FAILED tool call must never spawn an app render (nor mint a live spool capability)"* — since early mount necessarily mints that capability before the call's outcome is known. That needs a restricted pre-call capability design, not a rendering PR. The animation works without it because `create_view` returns quickly.

`planReveal()` is a pure, total planner (returns `null`, never throws): it picks the largest array-valued argument, handling both a native array and excalidraw's JSON-**string** `elements`. On `null` — no array, one element, reduced motion, oversized or circular payload — behaviour is byte-identical to before.

## Notable decisions

- **Partials never carry the complete array.** A partial equal to the whole payload would tell an app that only listens to partials that it had final state, breaking the partial/complete distinction.
- **`prefers-reduced-motion` is honoured** — the payload is delivered whole. This is the codebase's canonical mechanism (`ThemeExperienceLayer.tsx:85`, `lib/disintegrate.ts:38`, and others).
- **A spool animates at most once per page**, so scrolling back through a transcript does not replay history's draw-on.
- **Budget is 700ms, deliberately short.** The reveal is gated on argument *shape*, not app *capability*, so an app that ignores partials waits that long for its input. A real capability gate is not viable: `ui/initialize` params **do** carry `appCapabilities`, but excalidraw — the reference partial-aware consumer — declares `capabilities: {}`, so gating on a declared capability would switch the animation off for the one app that implements it. Keeping the delay imperceptible is the honest trade.
- **Bounded work:** ≤24 frames regardless of element count, and payloads over 256KB decline the reveal outright.

# Tests

`website/src/test/mcpAppReveal.test.ts` (15) — planner contract: JSON-string vs native array encoding, largest-array selection, monotonic prefixes, **no partial ever equal to the complete array**, sibling arguments preserved per frame, frame cap + strict increase at 500 elements, the whole-object size cap (including the sibling case), circular input declining rather than throwing, `stepMs` floor, oldest-entry cache eviction, and reduced-motion detection.

`website/src/test/McpAppFrame.test.tsx` (51 total, 5 new) — host wiring: the full partial→complete→result sequence with ordering asserted, reduced-motion skip, no replay on remount of the same spool, cancellation on unmount, and the duplicate-`initialized` interleave. The interleave test is **mutation-verified**: with the guard removed it fails with two `tool-input` posts.

# Manual verification

Not yet done, and it is genuinely needed here — see Screenshots. Automated coverage locks the host-side protocol sequence, but it cannot show that excalidraw's canvas actually draws element-by-element from these frames.

Gates run locally: `npm run build` ✓, full vitest 575 files / 6995 tests ✓, `tsc --noEmit` ✓, and on the backend `isort` / `flake8` / `mypy` (580 files) ✓ — no Python is touched by this diff.

# Screenshots

**Outstanding — a still frame cannot evidence this change.** This is a motion change, so the correct artifact is a short GIF/video of the draw-on, captured from a live dashboard render of `excalidraw/create_view` against this branch's build. That needs the feature branch built and served, which is a live-plane action I have not taken unilaterally. Flagging it explicitly rather than omitting the section: please treat this PR as incomplete evidence-wise until the recording is attached.
