### PR TITLE
feat(signing): pin the CLI manifest signing key

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Cryptographic material must be checked out BYTE-FOR-BYTE identical on every
+# platform. The CLI manifest trust root is compared byte-for-byte in two places:
+# publish-cli.yml reconciles it against `aws kms get-public-key` output before
+# signing, and test_cli_manifest_signature.py asserts it equals the base64 copy
+# pinned in cli.sh's CLI_MANIFEST_PUBLIC_KEY_B64.
+#
+# With no attribute, git's automatic text detection rewrites LF to CRLF on a
+# Windows checkout, so both comparisons fail there and only there. Marking the
+# file non-text disables newline conversion entirely.
+*.pem -text

--- a/cli.sh
+++ b/cli.sh
@@ -38,11 +38,14 @@ PIN_VERSION=""
 
 # Offline trust root for CLI artifact manifests. These two values are replaced
 # together during the operational KMS-key enablement documented in
-# packaging/signing/README.md. They deliberately ship unconfigured in the
-# repository contract: until a non-exportable signing key is provisioned and
-# its public half is pinned here, the installer refuses before any network I/O.
-CLI_MANIFEST_KEY_ID="UNCONFIGURED"
-CLI_MANIFEST_PUBLIC_KEY_B64="UNCONFIGURED"
+# packaging/signing/README.md, and must stay in lockstep with
+# packaging/signing/cli-manifest-public.pem -- KEY_ID is the SHA-256 of that
+# PEM's DER encoding, so a mismatched pair fails closed before any network I/O.
+# Never edit these in place to rotate: schema v1 pins exactly one key, so an
+# in-place swap breaks every already-deployed installer. Rotation requires the
+# dual-trust sequence in packaging/signing/README.md.
+CLI_MANIFEST_KEY_ID="sha256:d3a83f0c1ff84a2cbee6bd34d889d8725af34358148a6c18ed3ecbbbcceec06b"
+CLI_MANIFEST_PUBLIC_KEY_B64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQm9qQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FZOEFNSUlCaWdLQ0FZRUF0MnR0NnZ3ZFZ4Z0tWbTRGQVdkeApwZjZFckx3Y2ljUHlHUGh2SXdXRTRqNmg1YjlwMzFiaktMaWlEakxvK3VpQUJPL21vUjdJUUtoaUNSaXY0d0dTCk1mYnd2ZnNhLy8xNlVBbkNURkRDb1pId0IwVm93cTRYWjZ1NHBrdTFqNlBlRXBMNjVqRXZvcjd1a29HS2xiOVMKQlBva01aN0VtYlpWbmJiSWJBVXYrZ0NWajRCWDRpam5GWkJEMmNPcmtkQWdGR3UraU9jRHVlRDNqTExicXVhUwp0K0tLWXltQ2VxaitPazZ0OFBMQ2VRZmYrWVc4YS9wRU03Wm1tMTJ0Y3BRdEF0OHVCSVdkZE9qaTN1c3BhVlA3CkZJUlhzNnJIajIwTDd0dE9kMGpmKzRWQ0ZtV09FWE4rNWc0YS8rNkcrc3lxeDk4VlR2RVF5cDZVdWZnb0FoQkMKLzFVNG5XajdmMVRFQkV4dXBSRXFUK1lmUmp6aFJUR2NGN0czRUp3MmZjUU1taElIdFpVanM3endVY3NmblhDMwpGQzJBR3pBZnExSGV0WHU5amFOQWZSdjdLZXYxT2hvVmMzYUlONEd3UkpZRDNPNUFSQk5SRGpQUVFWUHBaVW5rCjB1WVdpZExSVDVRUVZMYnlSLzJFKytqTWFyRXBkVXRkZGY1anlwZW5pbFhUQWdNQkFBRT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
 
 while [ $# -gt 0 ]; do
   case "$1" in

--- a/packaging/signing/cli-manifest-public.pem
+++ b/packaging/signing/cli-manifest-public.pem
@@ -1,2 +1,11 @@
-# UNCONFIGURED: replace with a PEM-encoded RSA public key (3072 bits or stronger).
-# The corresponding private key must remain non-exportable in AWS KMS.
+-----BEGIN PUBLIC KEY-----
+MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAt2tt6vwdVxgKVm4FAWdx
+pf6ErLwcicPyGPhvIwWE4j6h5b9p31bjKLiiDjLo+uiABO/moR7IQKhiCRiv4wGS
+Mfbwvfsa//16UAnCTFDCoZHwB0Vowq4XZ6u4pku1j6PeEpL65jEvor7ukoGKlb9S
+BPokMZ7EmbZVnbbIbAUv+gCVj4BX4ijnFZBD2cOrkdAgFGu+iOcDueD3jLLbquaS
+t+KKYymCeqj+Ok6t8PLCeQff+YW8a/pEM7Zmm12tcpQtAt8uBIWddOji3uspaVP7
+FIRXs6rHj20L7ttOd0jf+4VCFmWOEXN+5g4a/+6G+syqx98VTvEQyp6UufgoAhBC
+/1U4nWj7f1TEBExupREqT+YfRjzhRTGcF7G3EJw2fcQMmhIHtZUjs7zwUcsfnXC3
+FC2AGzAfq1HetXu9jaNAfRv7Kev1OhoVc3aIN4GwRJYD3O5ARBNRDjPQQVPpZUnk
+0uYWidLRT5QQVLbyR/2E++jMarEpdUtddf5jypenilXTAgMBAAE=
+-----END PUBLIC KEY-----


### PR DESCRIPTION
## What

Pins the offline trust root for CLI artifact manifests, replacing the `UNCONFIGURED` placeholders in `cli.sh` and `packaging/signing/cli-manifest-public.pem`.

This is Step 4 of the CLI Signing KMS Bootstrap runbook (tracking #1116, contract introduced by #995).

## Why

Nightly CLI publishing has been failing at the `Refuse partial CLI signing configuration` guard (run [30731924645](https://github.com/kirodotdev/KiroCrew/actions/runs/30731924645)) because the signing key did not exist. It now does, and both remaining blockers are addressed:

| Blocker | State |
|---|---|
| KMS signing key | **Created** - `alias/kirocrew-cli-manifest`, `RSA_3072` / `SIGN_VERIFY`, `Origin: AWS_KMS` |
| Key policy grant | **Applied** - `kms:Sign` + `kms:GetPublicKey` only, to `kirocrew-signing-invoker` |
| `prod` var `CLI_MANIFEST_SIGNING_KEY_ARN` | **Set** |
| Public key pin | **This PR** |

Both were required. Setting the variable alone only moves the failure from the workflow guard into `cli-manifest.py`, which raises `CLI manifest public key is not configured` on an `UNCONFIGURED` pin.

## Key material handling

The private half was generated inside KMS and is non-exportable (`Origin: AWS_KMS`). It was never generated locally, exported, committed, or pasted into CI. Everything in this diff is public material.

The bootstrap grant is least-privilege (no `kms:*`, no `kms:Decrypt`, no wildcard principal) and the publisher role's OIDC trust policy was not modified.

## Verification

- `aws kms sign` on the new key, signature verified locally against the extracted PEM: `Verified OK`
- `CLI_MANIFEST_KEY_ID` re-derived from the pinned PEM's DER encoding: matches
- `CLI_MANIFEST_PUBLIC_KEY_B64` base64-decodes to the pinned PEM byte-for-byte: matches
- `test/test_cli_manifest_signature.py`: 24 passed
- `sh -n cli.sh`: clean

## Also: `.gitattributes` for the PEM

`Backend Tests (Windows)` shard 1 failed on the first push:

```
test_installer_and_repository_public_key_are_one_fail_closed_contract
AssertionError: assert b'...KEY-----\n' == b'...KEY-----\r\n'
```

The repo had no `.gitattributes`, so git's automatic text detection rewrote the PEM to CRLF on the Windows checkout while `CLI_MANIFEST_PUBLIC_KEY_B64` encodes the LF bytes. The test reads the PEM with `read_bytes()`, so it sees the difference; everything reading it with `read_text()` was shielded by universal newlines. The `UNCONFIGURED` branch never reached that byte comparison, which is why pinning a real key is what surfaced it.

Fixed with `*.pem -text` rather than by normalizing inside the assertion. These bytes are load-bearing in two separate byte-for-byte comparisons, one of which is `publish-cli.yml` reconciling this file against `aws kms get-public-key` output before it signs. A trust root whose bytes depend on the checkout platform is the actual defect; the assertion was right to catch it. That PEM is currently the only tracked `.pem`, so the glob has no unintended reach.

## Follow-up (not in this PR)

The key was created by hand per the runbook, so it now lives outside the IaC that owns the role it grants: `kirocrew-signing-invoker` is defined in `KiroCrewPublishCDK` `lib/cdsigner-stack.ts` (stack `KiroCrewCdSigner`). Worth codifying with `kms.Key` + `grantSign` by **importing** the existing key. Do not let CDK replace it: schema v1 pins exactly one key, and an in-place swap breaks every deployed installer.

Note for #1116: that issue mentions a secret named `REGISTRY_SIGNING_KEY`. No such secret exists or is referenced by any workflow. The real contract is the `AWS_SIGNING_ROLE_ARN` secret plus the `CLI_MANIFEST_SIGNING_KEY_ARN` prod variable.

