### PR TITLE
fix: seven localized backend/dashboard defects (#423-#429)

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -633,7 +633,30 @@ class AutoNudgeService:
 
     async def remove(self, loop_id: str) -> None:
         async with self._lock:
-            self.remove_sync(loop_id)
+            existed = loop_id in self._loops
+            # Remove in-memory but SKIP the blocking save: _save() -> _write_state
+            # fsyncs, and a wedged disk must not freeze the event loop. Snapshot
+            # under THIS lock hold (serialization vs the post-fire write). Keep
+            # the removal INLINE (not a separate task) so _cancel_timer's
+            # "never cancel the current task" self-guard still applies when
+            # _timer removes its own loop. (#425)
+            self.remove_sync(loop_id, persist=False)
+            if existed:
+                payload = self._serialize_state()
+                fut = asyncio.get_running_loop().run_in_executor(None, self._write_state, payload)
+                try:
+                    await asyncio.shield(fut)
+                except asyncio.CancelledError:
+                    # Caller cancelled mid-write: the executor thread can't be
+                    # cancelled and is still fsyncing. shield re-raised on us
+                    # immediately, so DRAIN the write to completion before this
+                    # `async with` exits and releases _lock — otherwise a waiter
+                    # (add()/update()/_persist_locked) could acquire the lock and
+                    # race a second os.replace(), clobbering newer state with this
+                    # stale removal snapshot ("lost update after restart"). Then
+                    # propagate the cancellation. (#425)
+                    await asyncio.shield(fut)
+                    raise
 
     def get_by_slot(self, slot_key: str) -> NudgeLoop | None:
         return self._find_by_slot(slot_key)

--- a/src/kiro_crew/channel_history.py
+++ b/src/kiro_crew/channel_history.py
@@ -209,8 +209,13 @@ class ChannelHistory:
             return None
         from kiro_crew.hooks import is_sensitive_path
 
+        history_root = self._history_dir.resolve()
         path = (self._history_dir / f"{channel_id}.jsonl").resolve()
-        if not str(path).startswith(str(self._history_dir.resolve())):
+        # Boundary-aware containment: a bare str.startswith has no trailing
+        # separator, so a sibling dir sharing the prefix (e.g. ".../hist-evil"
+        # vs ".../hist") would pass. is_relative_to compares path components.
+        # (#428)
+        if not path.is_relative_to(history_root):
             logger.warning("Refusing unsafe history path for channel %s", channel_id)
             return None
         if is_sensitive_path(str(path)):

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -2329,18 +2329,20 @@ class CronService:
             await asyncio.wait_for(self._execute(job), timeout=timeout)
         except asyncio.TimeoutError:
             # NB: Timeout bypasses _cron_callback's except block entirely —
-            # which also means it bypasses all Slack notification logic. From
-            # the user's perspective, timeouts are silent (log + dashboard
-            # status update only). Adding a timeout Slack alert is a separate
-            # feature and is intentionally out of scope for failure dedup.
+            # which also means it bypasses all Slack notification logic. Adding
+            # a timeout Slack alert is a separate feature and is intentionally
+            # out of scope here.
             # Clear failure dedup state so a subsequent real error isn't
-            # suppressed as a dup of the pre-timeout failure.
+            # suppressed as a dup of the pre-timeout failure, but STILL count
+            # the timeout toward the auto-pause threshold: a job that times out
+            # on every run must eventually auto-pause instead of running forever
+            # with zero user signal. (#424)
             job.last_status = "error"
             job.last_error = f"Timed out after {timeout}s"
             job.last_run_ts = time.time()
             job.last_failure_hash = ""
             job.last_failure_at = 0.0
-            job.consecutive_failures = 0
+            job.record_failure()
             logger.error("Cron job '%s' timed out after %ds", job.name, timeout)
 
     async def _execute(self, job: CronJob) -> None:

--- a/src/kiro_crew/knowledge/embedder.py
+++ b/src/kiro_crew/knowledge/embedder.py
@@ -9,6 +9,7 @@ degraded UX. Knowledge and vector memory share one loaded model instance
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import struct
 import time
@@ -155,9 +156,47 @@ def floats_to_bytes(vec: list[float]) -> bytes:
 
 
 def bytes_to_floats(data: bytes) -> list[float]:
-    """Deserialize binary BLOB back to float list."""
-    n = len(data) // 4
-    return list(struct.unpack(f"{n}f", data))
+    """Deserialize a stored embedding blob back to a float list.
+
+    Tolerates both encodings and never raises on a corrupt/legacy row: a
+    legacy JSON-encoded list is decoded first, then the compact binary form
+    (struct-packed floats). A blob whose length is not a multiple of 4, or
+    that is otherwise unparseable, yields ``[]`` rather than a ``struct.error``
+    — so one bad row can't abort a whole dedup sweep. Mirrors the guards in
+    ``knowledge/retrieval._bytes_to_floats``. (#429)
+    """
+    if not data:
+        return []
+    # Legacy JSON-encoded embedding takes precedence: if the blob is valid JSON
+    # it IS a JSON embedding (real packed-float bytes are ~never valid JSON), so
+    # decode it here and NEVER fall through to the binary path — otherwise a
+    # rejected-but-valid JSON blob whose byte length happens to be a multiple of
+    # 4 would be misread as packed floats. Return [] for any malformed JSON
+    # (non-list, non-numeric/boolean elements, or values that overflow float())
+    # so one bad row is skipped instead of aborting the dedup sweep. (#429)
+    try:
+        parsed = json.loads(data)
+    except (json.JSONDecodeError, TypeError, ValueError, UnicodeDecodeError):
+        parsed = None
+    else:
+        if isinstance(parsed, list):
+            try:
+                if all(
+                    isinstance(x, (int, float)) and not isinstance(x, bool) for x in parsed
+                ):
+                    return [float(x) for x in parsed]
+            except (ValueError, OverflowError):
+                pass
+        return []
+    # Not JSON: compact binary form (struct-packed floats). A byte length that is
+    # not a multiple of 4 is the corrupt case that used to raise struct.error.
+    if isinstance(data, (bytes, bytearray)) and len(data) % 4 == 0:
+        try:
+            n = len(data) // 4
+            return list(struct.unpack(f"{n}f", data))
+        except struct.error:
+            pass
+    return []
 
 
 def embed_signature(model: str, content_budget: int = _EMBED_CONTENT_BUDGET) -> str:

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -26,6 +26,7 @@ from kiro_crew.acp.types import (
     STOP_REASON_CANCELLED,
     STOP_REASON_END_TURN,
 )
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.effort import (
     EFFORT_LEVELS,
@@ -89,7 +90,7 @@ def _write_cli_overlay(work_dir: Path, model: str, effort: str) -> None:
             model_cfg.pop(other_key, None)
     model_defaults[model] = model_cfg
     existing["chat.modelDefaults"] = model_defaults
-    cli_json.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    atomic_write(cli_json, json.dumps(existing, indent=2))  # atomic: readers never see a partial file (#426)
 
 
 def _write_tool_search_overlay(work_dir: Path, enabled: bool) -> None:
@@ -135,7 +136,7 @@ def _write_tool_search_overlay(work_dir: Path, enabled: bool) -> None:
         # later build flips the global default on.
         existing.pop("toolSearch.minPct", None)
         existing.pop("toolSearch.minTokens", None)
-    cli_json.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    atomic_write(cli_json, json.dumps(existing, indent=2))  # atomic: readers never see a partial file (#426)
 
 
 def _clear_cli_overlay_effort(work_dir: Path, model: str) -> None:
@@ -170,7 +171,7 @@ def _clear_cli_overlay_effort(work_dir: Path, model: str) -> None:
         if not model_cfg:
             model_defaults.pop(model, None)
     try:
-        cli_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        atomic_write(cli_json, json.dumps(data, indent=2))  # atomic (#426)
     except OSError:
         logger.debug("ACP effort overlay clear failed", exc_info=True)
 

--- a/src/kiro_crew/stats.py
+++ b/src/kiro_crew/stats.py
@@ -19,8 +19,15 @@ class Stats:
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._init_counters()
+                    # Build into a local and FULLY initialize it before
+                    # publishing to ``cls._instance``. Publishing first would
+                    # let a second thread on the lock-free fast path above
+                    # observe a non-None but half-built instance (no ``_mu`` /
+                    # ``_c`` yet) and raise AttributeError on the next
+                    # ``.inc()`` / ``.snapshot()``. (#427)
+                    inst = super().__new__(cls)
+                    inst._init_counters()
+                    cls._instance = inst
         return cls._instance
 
     def _init_counters(self) -> None:

--- a/test/test_acp_overlay_atomic_426.py
+++ b/test/test_acp_overlay_atomic_426.py
@@ -1,0 +1,47 @@
+"""Regression: ACP cli.json overlays must be written atomically (#426).
+
+A plain ``write_text`` truncates-then-writes, so a crash or concurrent read
+mid-write yields an empty/partial file and kiro-cli drops the effort / Tool
+Search settings. The overlay writers now route through ``atomic_write``
+(temp file + ``os.replace``), so readers only ever see a complete file and no
+``.tmp`` residue is left behind.
+"""
+
+from __future__ import annotations
+
+import json
+
+from kiro_crew.providers import acp as acp_mod
+from kiro_crew.providers.acp import _write_cli_overlay, _write_tool_search_overlay
+
+
+def _cli_json(work_dir):
+    return work_dir / ".kiro" / "settings" / "cli.json"
+
+
+def test_cli_overlay_writes_valid_json_no_temp_residue(tmp_path):
+    _write_cli_overlay(tmp_path, "claude-opus-5", "high")
+    cli = _cli_json(tmp_path)
+    data = json.loads(cli.read_text(encoding="utf-8"))  # complete + parseable
+    assert "chat.modelDefaults" in data
+    assert list(cli.parent.glob("*.tmp")) == []
+
+
+def test_tool_search_overlay_merges_atomically(tmp_path):
+    _write_cli_overlay(tmp_path, "claude-opus-5", "high")
+    _write_tool_search_overlay(tmp_path, True)
+    cli = _cli_json(tmp_path)
+    data = json.loads(cli.read_text(encoding="utf-8"))
+    # Both overlays present; second write did not clobber the first.
+    assert "chat.modelDefaults" in data
+    assert list(cli.parent.glob("*.tmp")) == []
+
+
+def test_overlay_routes_through_atomic_write(tmp_path, monkeypatch):
+    calls: list = []
+    real = acp_mod.atomic_write
+    monkeypatch.setattr(
+        acp_mod, "atomic_write", lambda p, c, **k: (calls.append(p), real(p, c, **k))[1]
+    )
+    _write_cli_overlay(tmp_path, "gpt-5.6-sol", "medium")
+    assert calls, "overlay write must go through atomic_write"

--- a/test/test_autonudge_remove_offload_425.py
+++ b/test/test_autonudge_remove_offload_425.py
@@ -1,0 +1,52 @@
+"""Regression: async remove() must offload persistence, not fsync on the loop (#425).
+
+``remove()`` called ``remove_sync(persist=True)`` -> ``_save()`` -> ``_write_state``
+which does a blocking ``os.fsync`` directly on the event loop. It must instead
+snapshot under the lock and offload the write to an executor (as update() does).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.autonudge import AutoNudgeService
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch):
+    monkeypatch.setenv("KIROCREW_AUTONUDGE", "1")
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return AutoNudgeService(base_dir=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_remove_offloads_persist_without_blocking_save(svc, monkeypatch):
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=15)
+
+    save_called = {"v": False}
+    monkeypatch.setattr(svc, "_save", lambda: save_called.__setitem__("v", True))
+
+    writes: list[dict] = []
+    orig_write = svc._write_state
+    monkeypatch.setattr(
+        svc, "_write_state", lambda payload: (writes.append(payload), orig_write(payload))[1]
+    )
+
+    await svc.remove(loop.id)
+
+    assert loop.id not in svc._loops
+    assert save_called["v"] is False, "blocking _save() must not run on the event loop"
+    assert writes, "removal must still be persisted (via the offloaded write)"
+
+
+@pytest.mark.asyncio
+async def test_remove_missing_loop_is_noop(svc, monkeypatch):
+    await svc.start()
+    writes: list[dict] = []
+    monkeypatch.setattr(svc, "_write_state", lambda payload: writes.append(payload))
+    await svc.remove("does-not-exist")
+    assert writes == []

--- a/test/test_channel_history_containment_428.py
+++ b/test/test_channel_history_containment_428.py
@@ -1,0 +1,36 @@
+"""Regression: channel-history path containment must be boundary-aware (#428).
+
+A bare ``str.startswith`` has no trailing-separator boundary, so a sibling
+directory that merely shares the prefix (``.../hist-evil`` vs ``.../hist``)
+would pass. ``Path.is_relative_to`` compares path components instead.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.channel_history import ChannelHistory
+
+
+def test_observe_path_accepts_child(tmp_path) -> None:
+    hist = tmp_path / "hist"
+    hist.mkdir()
+    h = ChannelHistory(history_dir=hist)
+    p = h._observe_path("C123")
+    assert p is not None
+    assert p == (hist / "C123.jsonl")
+
+
+def test_observe_path_rejects_sibling_sharing_prefix(tmp_path) -> None:
+    hist = tmp_path / "hist"
+    hist.mkdir()
+    (tmp_path / "hist-evil").mkdir()
+    h = ChannelHistory(history_dir=hist)
+    # Escapes to the sibling dir that shares the "hist" string prefix; the old
+    # startswith guard accepted this, is_relative_to refuses it.
+    assert h._observe_path("../hist-evil/x") is None
+
+
+def test_observe_path_rejects_parent_escape(tmp_path) -> None:
+    hist = tmp_path / "hist"
+    hist.mkdir()
+    h = ChannelHistory(history_dir=hist)
+    assert h._observe_path("../../etc/passwd") is None

--- a/test/test_cron_dedup.py
+++ b/test/test_cron_dedup.py
@@ -441,7 +441,9 @@ class TestCronFailurePersistence:
         # Failure dedup state cleared — next real error will trigger fresh alert
         assert job.last_failure_hash == ""
         assert job.last_failure_at == 0.0
-        assert job.consecutive_failures == 0
+        # ...but the timeout still counts toward the auto-pause threshold (#424):
+        # started at 3, one timeout -> 4.
+        assert job.consecutive_failures == 4
 
     def test_timeout_persists_cleared_state(self, tmp_path) -> None:
         """Verify _run_job_isolated persists the cleared failure state to disk."""
@@ -473,7 +475,8 @@ class TestCronFailurePersistence:
         svc2._load()
         assert svc2._jobs[0].last_failure_hash == ""
         assert svc2._jobs[0].last_failure_at == 0.0
-        assert svc2._jobs[0].consecutive_failures == 0
+        # Timeout counted toward auto-pause and was persisted (#424): 3 -> 4.
+        assert svc2._jobs[0].consecutive_failures == 4
 
     def test_save_load_round_trip(self, tmp_path) -> None:
         from kiro_crew.cron import CronService

--- a/test/test_cron_timeout_autopause_424.py
+++ b/test/test_cron_timeout_autopause_424.py
@@ -1,0 +1,59 @@
+"""Regression: cron timeouts must count toward auto-pause (#424).
+
+The ``asyncio.TimeoutError`` handler in ``_execute_with_timeout`` reset
+``consecutive_failures`` to 0 on every timeout, so a job that timed out on
+every run never accumulated toward ``_AUTO_PAUSE_THRESHOLD`` — it ran forever
+with zero user signal. Timeouts must now increment the counter and eventually
+auto-pause.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from kiro_crew import cron as cron_mod
+from kiro_crew.cron import _AUTO_PAUSE_THRESHOLD, CronJob, CronService
+
+
+@pytest.mark.asyncio
+async def test_repeated_timeouts_accumulate_and_autopause(tmp_path, monkeypatch):
+    svc = CronService(base_dir=tmp_path)
+    job = CronJob(id="j1", name="slow", message="hi", timeout_secs=1)
+
+    async def _timeout_immediately(coro, timeout):
+        coro.close()  # avoid "coroutine was never awaited" warning
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(cron_mod.asyncio, "wait_for", _timeout_immediately)
+
+    for i in range(_AUTO_PAUSE_THRESHOLD):
+        assert not job.auto_paused
+        await svc._execute_with_timeout(job)
+        assert job.consecutive_failures == i + 1
+        assert job.last_status == "error"
+
+    # Threshold reached: the job auto-paused instead of running forever silently.
+    assert job.auto_paused is True
+    assert job.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_timeout_clears_failure_dedup_hash(tmp_path, monkeypatch):
+    svc = CronService(base_dir=tmp_path)
+    job = CronJob(id="j2", name="slow", message="hi", timeout_secs=1)
+    job.last_failure_hash = "stale"
+    job.last_failure_at = 123.0
+
+    async def _timeout_immediately(coro, timeout):
+        coro.close()
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(cron_mod.asyncio, "wait_for", _timeout_immediately)
+    await svc._execute_with_timeout(job)
+    # Dedup state cleared so a later distinct error isn't suppressed...
+    assert job.last_failure_hash == ""
+    assert job.last_failure_at == 0.0
+    # ...but the failure still counted.
+    assert job.consecutive_failures == 1

--- a/test/test_embedder_decode_429.py
+++ b/test/test_embedder_decode_429.py
@@ -1,0 +1,52 @@
+"""Regression: bytes_to_floats must not raise on corrupt/legacy blobs (#429).
+
+A blob whose length isn't a multiple of 4 used to raise ``struct.error`` and
+abort the whole dedup sweep; a legacy JSON-encoded embedding was mis-decoded as
+garbage floats. It now returns ``[]`` (skippable) / decodes JSON correctly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.knowledge.embedder import bytes_to_floats, floats_to_bytes
+
+
+def test_binary_roundtrip() -> None:
+    vec = [0.1, 0.2, 0.3, 0.4]
+    out = bytes_to_floats(floats_to_bytes(vec))
+    assert out == pytest.approx(vec)
+
+
+def test_short_binary_roundtrip() -> None:
+    # A short (8-byte) vector must still round-trip — no >=16 floor.
+    vec = [1.5, -2.5]
+    assert bytes_to_floats(floats_to_bytes(vec)) == pytest.approx(vec)
+
+
+def test_non_multiple_of_four_returns_empty() -> None:
+    # 3 bytes: used to raise struct.error and abort the sweep.
+    assert bytes_to_floats(b"\x01\x02\x03") == []
+
+
+def test_empty_returns_empty() -> None:
+    assert bytes_to_floats(b"") == []
+
+
+def test_legacy_json_blob_decoded() -> None:
+    blob = json.dumps([1.0, 2.0, 3.0]).encode("utf-8")
+    assert bytes_to_floats(blob) == [1.0, 2.0, 3.0]
+
+
+def test_non_numeric_json_returns_empty() -> None:
+    # A JSON list of non-numbers must not flow into dedup mean-pooling.
+    assert bytes_to_floats(json.dumps(["bad"]).encode("utf-8")) == []
+
+
+def test_overflowing_int_json_returns_empty() -> None:
+    # A 309-digit integer overflows float(); must return [] rather than raise
+    # OverflowError and abort the dedup sweep.
+    blob = json.dumps([int("1" + "0" * 309)]).encode("utf-8")
+    assert bytes_to_floats(blob) == []

--- a/test/test_stats_race_427.py
+++ b/test/test_stats_race_427.py
@@ -1,0 +1,39 @@
+"""Regression: Stats.__new__ must fully initialize before publishing (#427).
+
+Publishing ``cls._instance`` before ``_init_counters()`` let a second thread on
+the lock-free fast path observe a half-built instance (no ``_mu`` / ``_c``) and
+raise AttributeError on the next ``.snapshot()`` / ``.inc_*()``.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from kiro_crew.stats import Stats
+
+
+def test_new_publishes_only_after_init() -> None:
+    # Force __new__ down its build path under contention.
+    Stats._instance = None
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(32)
+
+    def worker() -> None:
+        try:
+            barrier.wait()
+            # A half-built singleton would raise AttributeError here.
+            Stats().snapshot()
+            Stats().inc_message_received()
+        except BaseException as exc:  # noqa: BLE001 -- capture any race fallout
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(32)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"half-built singleton observed: {errors!r}"
+    # Fully-initialized: counters exist and increments landed.
+    assert "messages_received" in Stats().snapshot()
+    Stats().reset()

--- a/website/src/hooks/useLogSSE.test.ts
+++ b/website/src/hooks/useLogSSE.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useLogSSE } from './useLogSSE'
+
+/**
+ * Regression coverage for the reconnect-timer leak (#423).
+ *
+ * On error, useLogSSE schedules setTimeout(start, 3000). If the component
+ * unmounts (or stop() runs) during that 3s window, the pending reconnect must
+ * be cancelled — otherwise it fires afterward, opens a NEW EventSource on the
+ * now-orphaned ref that nothing can close, and can spin an unbounded reconnect
+ * loop with no owner.
+ */
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+  url: string
+  closed = false
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+  close() {
+    this.closed = true
+  }
+}
+
+afterEach(() => {
+  MockEventSource.instances = []
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('useLogSSE reconnect-timer cleanup', () => {
+  it('does NOT reconnect after unmount during the error backoff window', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('EventSource', MockEventSource as unknown as typeof EventSource)
+
+    const { unmount } = renderHook(() => useLogSSE(() => {}))
+    expect(MockEventSource.instances).toHaveLength(1)
+
+    // Stream errors -> schedules a reconnect in 3s.
+    act(() => { MockEventSource.instances[0].onerror?.() })
+    expect(MockEventSource.instances[0].closed).toBe(true)
+
+    // Unmount during the 3s window must clear the pending reconnect.
+    unmount()
+    act(() => { vi.advanceTimersByTime(5000) })
+
+    // No second EventSource was ever opened -> no leak, no orphaned loop.
+    expect(MockEventSource.instances).toHaveLength(1)
+  })
+
+  it('reconnects after 3s while still mounted', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('EventSource', MockEventSource as unknown as typeof EventSource)
+
+    renderHook(() => useLogSSE(() => {}))
+    expect(MockEventSource.instances).toHaveLength(1)
+
+    act(() => { MockEventSource.instances[0].onerror?.() })
+    act(() => { vi.advanceTimersByTime(3000) })
+
+    // A fresh stream was opened by the scheduled reconnect.
+    expect(MockEventSource.instances).toHaveLength(2)
+  })
+})

--- a/website/src/hooks/useLogSSE.ts
+++ b/website/src/hooks/useLogSSE.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react'
 
 export function useLogSSE(onMessage: (data: { level: string; msg: string }) => void) {
   const ref = useRef<EventSource | null>(null)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const cb = useRef(onMessage)
   cb.current = onMessage
 
@@ -15,11 +16,16 @@ export function useLogSSE(onMessage: (data: { level: string; msg: string }) => v
     sse.onerror = () => {
       sse.close()
       ref.current = null
-      setTimeout(start, 3000)
+      // Store the reconnect handle so stop()/unmount can cancel it. Without
+      // this, a reconnect scheduled during the 3s error window fires after
+      // unmount, opens a new EventSource on the orphaned ref, and leaks — with
+      // an unbounded reconnect loop that no one can close. (#423)
+      timer.current = setTimeout(start, 3000)
     }
   }, [])
 
   const stop = useCallback(() => {
+    if (timer.current) { clearTimeout(timer.current); timer.current = null }
     ref.current?.close()
     ref.current = null
   }, [])


### PR DESCRIPTION
## Problem
Seven independent, localized defects surfaced by a code review of `main` (issues #423–#429). Each is a real reachable bug with a correct in-repo pattern to mirror:

- **#423** `useLogSSE` never stored its reconnect `setTimeout` handle, so an error during the 3s backoff followed by unmount/`stop()` fired a reconnect that opened a new `EventSource` on an orphaned ref — a leaked connection plus an unbounded reconnect loop with no owner.
- **#424** the cron timeout handler reset `consecutive_failures = 0` every timeout, so a job timing out on *every* run never reached `_AUTO_PAUSE_THRESHOLD` — it ran forever with no auto-pause and no signal.
- **#425** `autonudge.remove()` called the blocking `_save()` (`os.fsync`) directly on the event loop.
- **#426** the ACP `cli.json` overlay writers used a truncating `write_text`; a crash or concurrent read mid-write left kiro-cli an empty/partial file.
- **#427** `Stats.__new__` published the singleton *before* `_init_counters()`, so a racing thread could observe a half-built instance and `AttributeError` on `.inc()`/`.snapshot()`.
- **#428** `channel_history._observe_path` used a bare `str.startswith` for path containment, which accepts a sibling dir sharing the prefix (`.../hist-evil` vs `.../hist`).
- **#429** `embedder.bytes_to_floats` had no length/JSON guard; one corrupt or legacy row raised `struct.error` and aborted the entire dedup sweep.

## Why it matters
These span data loss (dropped kiro-cli settings), a silent-failure safety-net hole (cron never auto-pauses), event-loop stalls on slow disks, a concurrency crash, a weak path-containment guard, and a sweep-aborting decode — all low-risk to fix and each with a sibling implementation already in the tree.

## Fix (symptom → root cause → change)
- **#423** leak/loop → timer handle discarded → store it in a `timer` ref and `clearTimeout` it in `stop()`.
- **#424** never auto-pauses → counter reset on timeout → call `job.record_failure()` (still clearing the dedup hash so a later distinct error isn't suppressed).
- **#425** loop stall → `remove_sync(persist=True)` fsyncs on the loop → snapshot under the lock and offload `_write_state` to an executor, mirroring `_update_locked`.
- **#426** partial file → non-atomic `write_text` → route all three overlay writes through `atomic_write` (temp + `os.replace`), matching `rewriter.py`.
- **#427** AttributeError under contention → publish-before-init → build into a local, `_init_counters()`, then publish `cls._instance` last.
- **#428** sibling accepted → prefix string check → `Path.is_relative_to`, mirroring `subagent_persistence._agent_dir`.
- **#429** sweep aborts → unguarded `struct.unpack` → JSON fallback + `len % 4 == 0` guard, returning `[]` on corrupt input (dedup already skips empties). (The `>=16` floor from `retrieval._bytes_to_floats` is intentionally omitted so short-vector round-trips stay lossless.)

## Tests
One regression test file per fix (7 new files):
- `test_stats_race_427.py` — 32-thread hammer on a reset singleton; no AttributeError.
- `test_channel_history_containment_428.py` — sibling-prefix + parent-escape rejected, child accepted.
- `test_embedder_decode_429.py` — binary/short round-trip, non-mult-of-4 → `[]`, empty → `[]`, legacy JSON decoded.
- `test_autonudge_remove_offload_425.py` — `remove()` does not call `_save()` but still persists via the offloaded write; missing-loop is a no-op.
- `test_acp_overlay_atomic_426.py` — overlays produce valid JSON, leave no `.tmp` residue, and route through `atomic_write`.
- `test_cron_timeout_autopause_424.py` — repeated timeouts accumulate to auto-pause; dedup hash still cleared.
- `useLogSSE.test.ts` — no reconnect after unmount during the backoff window; reconnects after 3s while mounted.

## Manual verification
N/A — unit coverage is sufficient. All gates run locally green: 317 backend tests (targeted + affected `test_autonudge`/`test_acp_*`/`test_cron`), `isort`, `flake8`, `mypy` (no faiss → CI-parity), plus `tsc -b` and vitest.

## Screenshots
N/A — no user-visible UI change (#423 is a log-stream hook; behavior only, nothing visual).
