### PR TITLE
feat(skills): loosen skill-detection prompt to reduce false negatives

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -60,6 +60,19 @@ SESSIONS_DIR_NAME = "sessions"
 ARCHIVE_DIR_NAME = "archive"
 ARCHIVE_RETENTION_DAYS = 7
 _CONSOLIDATION_THRESHOLD = 30  # preferences/projects update threshold (messages)
+# Skill detection judges a wider window than the incremental history tail: a
+# reusable procedure usually spans the whole session, not just the slice since
+# the last consolidation, so a tail-only view systematically misses skills in
+# any session consolidated more than once. Bound the window so pathologically
+# long sessions stay cost-safe.
+_SKILL_DETECTION_WINDOW = 200
+
+
+def _fmt_message(m: dict) -> str:
+    """Render one transcript message for a consolidation / skill-detection prompt."""
+    tools = f" [tools: {', '.join(m['tools'])}]" if m.get("tools") else ""
+    return f"[{m.get('ts', '?')[:16]}] {m['role'].upper()}{tools}: {m['content']}"
+
 
 _SESSION_MAX_BYTES = 2 * 1024 * 1024  # 2MB
 _SESSION_KEEP_LINES = 200
@@ -2563,6 +2576,12 @@ class HistoryConsolidator:
         self._history_consolidated: dict[str, float] = {}  # key → last history consolidation time
         # Separate offset for prefs-only consolidation (doesn't advance main offset)
         self._prefs_offset: dict[str, int] = {}
+        # Session length at the last skill-detection pass, so an unchanged
+        # (rotation_generation, message_count) at the last skill-detection
+        # pass, so an unchanged session isn't re-judged on every history
+        # consolidation — while a rotation (which bumps the generation and
+        # swaps the window's content) still forces a fresh pass.
+        self._last_skillgen_marker: dict[str, tuple[int, int]] = {}
 
     def maybe_consolidate(self, key: str) -> None:
         """Fire preferences/projects consolidation if message threshold exceeded."""
@@ -2618,9 +2637,9 @@ class HistoryConsolidator:
         and the ``kirocrew consolidate`` CLI command.  Skips if the session
         is already being consolidated or has no unconsolidated messages.
 
-        Safety: _consolidate() internally enforces _session_touched_sensitive()
-        as part of the auto_skills_eligible gate — sensitive sessions never
-        produce skills regardless of entry point.
+        Safety: skill detection (_run_skill_detection) re-checks
+        _session_touched_sensitive() over its window before proposing anything,
+        so sensitive sessions never produce skills regardless of entry point.
         """
         if key in self._running:
             return
@@ -2701,11 +2720,7 @@ class HistoryConsolidator:
             else:
                 memory = self._memory
 
-            def _fmt(m: dict) -> str:
-                tools = f" [tools: {', '.join(m['tools'])}]" if m.get("tools") else ""
-                return f"[{m.get('ts', '?')[:16]}] {m['role'].upper()}{tools}: {m['content']}"
-
-            conversation = "\n".join(_fmt(m) for m in unconsolidated)
+            conversation = "\n".join(_fmt_message(m) for m in unconsolidated)
 
             current_prefs = memory.read_preferences()
             current_projects = memory.read_projects()
@@ -2786,61 +2801,12 @@ class HistoryConsolidator:
                     "implicit corrections the user made without saying 'remember'."
                 )
 
-            # ── Auto skill creation ──
-            # Only eligible when the feature is enabled, we have a loader to
-            # write to, we're on the history path (so prefs-only doesn't retrigger
-            # extraction), and the session has enough tool calls to be non-trivial.
-            auto_skills_eligible = (
-                include_history
-                and self._auto_skills_enabled
-                and self._skills_loader is not None
-                and _count_tool_call_messages(unconsolidated) >= self._auto_min_tool_calls
-                and not _session_touched_sensitive(unconsolidated)
-            )
-            if auto_skills_eligible:
-                scripts_field = ""
-                if self._generate_scripts:
-                    scripts_field = (
-                        ', "scripts": (optional array, part of THIS new_skill '
-                        "object) ONLY when the procedure includes a "
-                        "DETERMINISTIC, always-identical step sequence worth "
-                        "running verbatim (a fixed command chain, a set API "
-                        "sequence, a predictable file transform). Each item: "
-                        '{"filename": "<name>.py", "language": "python", '
-                        '"content": "<self-contained Python, no network to '
-                        "unknown hosts, no credential access, no destructive "
-                        'commands, <=4KB>"}. Python ONLY (must run on Windows). '
-                        "Omit for judgment-based / context-dependent procedures. "
-                        "Scripts always require human approval"
-                    )
-                keys.append(
-                    '"new_skill": Object or null. Return an object ONLY if this '
-                    "session contained a non-trivial reusable multi-step procedure "
-                    "that future sessions would benefit from (e.g. debugging a "
-                    "specific class of error, running a multi-command sequence, "
-                    "a research synthesis flow). Shape: "
-                    '{"slug": "<kebab-case-4-to-60-chars>", '
-                    '"description": "<=150 chars, starts with verb>", '
-                    '"triggers": "<3-8 comma-separated keywords/phrases>", '
-                    '"procedure_md": "<concise markdown body with '
-                    "## When to use / ## Steps / ## Gotchas sections, "
-                    '<=8000 chars>"' + scripts_field + "}. "
-                    'Return null if the session was trivial, a single-shot answer, '
-                    "a one-off failure, or involved sensitive paths. Do NOT "
-                    "include absolute paths, credentials, tokens, or user PII in "
-                    "the procedure body."
-                )
-                if self._auto_refine_enabled:
-                    keys.append(
-                        '"refined_skill": Object or null. If an existing '
-                        '"auto/..." skill was loaded during this session AND '
-                        "the agent found a better procedure than the one "
-                        "documented in that skill, return: "
-                        '{"name": "auto/<existing-slug>", '
-                        '"description": "<updated>", "triggers": "<updated>", '
-                        '"procedure_md": "<refined markdown>"}. Return null '
-                        "if nothing was refined. Do not fabricate refinements."
-                    )
+            # ── Auto skill detection ──
+            # Skill detection runs as its OWN pass (below, after the memory
+            # writes) over a wider last-N window of the full session — not the
+            # incremental history tail — so a reusable procedure that spans the
+            # whole session is judged as a unit. It is therefore intentionally
+            # absent from this consolidation prompt's keys.
 
             numbered = "\n\n".join(f"{i + 1}. {k}" for i, k in enumerate(keys))
             prompt_parts = [
@@ -2895,13 +2861,19 @@ class HistoryConsolidator:
             ):
                 await run_in_embed_pool(self._save_lessons, raw_lessons)
 
-            # Auto skill creation / refinement.
-            # Guarded by flag + eligibility — failures are logged, never fatal.
-            if auto_skills_eligible:
+            # Auto skill detection — a SEPARATE LLM pass over the full-session
+            # window (see _run_skill_detection), not the incremental tail. Runs
+            # only on history consolidation, guarded by flag + loader; failures
+            # are logged, never fatal.
+            if (
+                include_history
+                and self._auto_skills_enabled
+                and self._skills_loader is not None
+            ):
                 try:
-                    await asyncio.to_thread(self._process_auto_skills, result, key)
+                    await self._run_skill_detection(key)
                 except Exception:
-                    logger.warning("Auto-skill processing failed for %s", key, exc_info=True)
+                    logger.warning("Auto-skill detection failed for %s", key, exc_info=True)
 
             # Autonomous lifecycle: age-based archival must run even when this
             # pass created/approved no skill, otherwise skills never age out on
@@ -2944,6 +2916,118 @@ class HistoryConsolidator:
             raise
         finally:
             self._running.discard(key)
+
+    async def _run_skill_detection(self, key: str) -> None:
+        """Detect a reusable skill from the FULL session (bounded window).
+
+        Unlike history/semantic/lesson extraction — which correctly runs on the
+        incremental unconsolidated tail — skill detection judges the last
+        ``_SKILL_DETECTION_WINDOW`` messages of the WHOLE session, decoupled
+        from the consolidation offset. A reusable procedure usually spans a
+        session rather than the slice since the last consolidation, so a
+        tail-only view systematically misses skills in any session consolidated
+        more than once. The skill need only be demonstrated by PART of the
+        window; the pass does not have to cover the whole session.
+
+        Runs as its own LLM call so the consolidation prompt stays tail-scoped
+        (widening THAT prompt would re-summarize already-consolidated messages
+        into duplicate history/semantic entries). A per-session
+        (rotation_generation, count) guard skips re-running when nothing new has
+        been appended since the last pass, yet still forces a fresh pass after a
+        transcript rotation (which swaps the window's content); genuine repeats
+        are still caught by the dedupe verdict in ``_process_auto_skills``.
+        """
+        if self._skills_loader is None:
+            return
+        all_messages = await asyncio.to_thread(self._log._read_messages, key)
+        if not all_messages:
+            return
+        # Key the guard on (rotation generation, message count), NOT count
+        # alone. The transcript rotates at _SESSION_MAX_BYTES / _SESSION_KEEP_LINES:
+        # a rotation bumps rotation_generation and replaces the window with fresh
+        # messages even when the resulting count matches a prior value, so a
+        # count-only guard would wrongly treat a rotated session as unchanged and
+        # never propose its skill. Comparing the pair re-detects after any
+        # rotation while still skipping a genuinely unchanged session.
+        generation = await asyncio.to_thread(
+            lambda: int(self._log._read_metadata(key).get("rotation_generation", 0) or 0)
+        )
+        marker = (generation, len(all_messages))
+        if self._last_skillgen_marker.get(key) == marker:
+            return
+        window = all_messages[-_SKILL_DETECTION_WINDOW:]
+        if _count_tool_call_messages(window) < self._auto_min_tool_calls:
+            return
+        if _session_touched_sensitive(window):
+            return
+
+        scripts_field = ""
+        if self._generate_scripts:
+            scripts_field = (
+                ', "scripts": (optional array, part of THIS new_skill '
+                "object) ONLY when the procedure includes a "
+                "DETERMINISTIC, always-identical step sequence worth "
+                "running verbatim (a fixed command chain, a set API "
+                "sequence, a predictable file transform). Each item: "
+                '{"filename": "<name>.py", "language": "python", '
+                '"content": "<self-contained Python, no network to '
+                "unknown hosts, no credential access, no destructive "
+                'commands, <=4KB>"}. Python ONLY (must run on Windows). '
+                "Omit for judgment-based / context-dependent procedures. "
+                "Scripts always require human approval"
+            )
+        skill_keys = [
+            '"new_skill": Object or null. Return an object ONLY if this '
+            "session contained a non-trivial reusable multi-step procedure "
+            "that future sessions would benefit from (e.g. debugging a "
+            "specific class of error, running a multi-command sequence, "
+            "a research synthesis flow). The procedure may be demonstrated by "
+            "only PART of the excerpt below — you do NOT need to cover the whole "
+            "session, just capture the one reusable procedure it contains. Shape: "
+            '{"slug": "<kebab-case-4-to-60-chars>", '
+            '"description": "<=150 chars, starts with verb>", '
+            '"triggers": "<3-8 comma-separated keywords/phrases>", '
+            '"procedure_md": "<concise markdown body with '
+            "## When to use / ## Steps / ## Gotchas sections, "
+            '<=8000 chars>"' + scripts_field + "}. "
+            'Return null if the session was trivial, a single-shot answer, '
+            "a one-off failure with no reusable takeaway, or involved "
+            "sensitive paths. When a session plausibly contains a procedure "
+            "a future session could reuse, lean toward returning it — every "
+            "candidate is staged for human approval before it can activate, "
+            "so a borderline proposal is cheap while a miss is lost for good. "
+            "Do NOT include absolute paths, credentials, tokens, or user PII "
+            "in the procedure body."
+        ]
+        if self._auto_refine_enabled:
+            skill_keys.append(
+                '"refined_skill": Object or null. If an existing '
+                '"auto/..." skill was loaded during this session AND '
+                "the agent found a better procedure than the one "
+                "documented in that skill, return: "
+                '{"name": "auto/<existing-slug>", '
+                '"description": "<updated>", "triggers": "<updated>", '
+                '"procedure_md": "<refined markdown>"}. Return null '
+                "if nothing was refined. Do not fabricate refinements."
+            )
+        numbered = "\n\n".join(f"{i + 1}. {k}" for i, k in enumerate(skill_keys))
+        conversation = "\n".join(_fmt_message(m) for m in window)
+        prompt = (
+            "You are a skill-extraction agent. Review this session excerpt and "
+            "return a JSON object with these keys:\n\n" + numbered
+            + "\n\n## Session excerpt\n" + conversation
+            + "\n\nRespond with ONLY valid JSON, no markdown fences."
+        )
+        result = await self._call_llm(prompt)
+        # Record the (generation, count) marker regardless of outcome so an
+        # unchanged session isn't re-evaluated on every subsequent
+        # consolidation, but a rotation still forces a fresh pass.
+        self._last_skillgen_marker[key] = marker
+        if not result:
+            return
+        # _event_loop was captured by our caller (_consolidate) so the
+        # thread-offloaded dedupe judge can marshal back onto the gateway loop.
+        await asyncio.to_thread(self._process_auto_skills, result, key)
 
     def _save_lessons(self, raw: object) -> None:
         """Save extracted lessons from consolidation result."""

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -2416,7 +2416,7 @@ class TestConsolidationPromptJsonShape:
 
         from kiro_crew.history import HistoryConsolidator
 
-        src = inspect.getsource(HistoryConsolidator._consolidate)
+        src = inspect.getsource(HistoryConsolidator._run_skill_detection)
         # Find the new_skill prompt key block — it's a concatenated string
         # across multiple source lines.  Just verify the word-pair
         # '"description":' appears followed by a matching closing quote
@@ -2432,6 +2432,145 @@ class TestConsolidationPromptJsonShape:
             "procedure_md value must be a well-formed JSON string "
             "opener — don't split the value inside a quoted string."
         )
+
+
+class TestSkillDetectionFullWindow:
+    """Skill detection judges the full-session window, not the consolidated tail.
+
+    Regression for the tail-only recall gap: a reusable procedure that was
+    already consolidated away (offset advanced past it) must still be seen by
+    skill detection, because it reads the last-N of the FULL session rather
+    than only the unconsolidated tail.
+    """
+
+    @pytest.mark.asyncio
+    async def test_detects_from_full_window_when_tail_trivial(self, tmp_path):
+        import asyncio as _asyncio
+        from unittest.mock import patch
+
+        from kiro_crew.memory import MemoryStore
+        from kiro_crew.skills import SkillsLoader
+
+        conv_log = ConversationLog(base_dir=tmp_path / "sessions")
+        conv_log.init()
+        mem = MemoryStore(workspace=tmp_path / "memory")
+        mem.init()
+        skills = SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False)
+        c = HistoryConsolidator(
+            log=conv_log,
+            memory=mem,
+            skills_loader=skills,
+            auto_skills_enabled=True,
+            approval_required=True,
+            auto_min_tool_calls=5,
+        )
+        key = "dashboard:chat-fullwindow"
+        # 6 tool-bearing messages = the reusable procedure...
+        for i in range(6):
+            conv_log.append(key, "assistant", f"step {i}", tools=["execute_bash"])
+        # ...already consolidated away: advance the offset past them.
+        conv_log.mark_consolidated(key, 6)
+        # A trivial, tool-free tail. Tail-only detection would see 0 tool calls
+        # (< the 5 floor) and skip; full-window detection still sees the 6.
+        conv_log.append(key, "user", "thanks!")
+        conv_log.append(key, "assistant", "you're welcome")
+        assert conv_log.unconsolidated_count(key) == 2  # the trivial tail
+
+        recorded: dict = {}
+
+        def fake_process(result, k):
+            recorded["result"], recorded["key"] = result, k
+
+        c._event_loop = _asyncio.get_running_loop()
+        with patch.object(c, "_call_llm", return_value={"new_skill": {"slug": "x"}}):
+            with patch.object(c, "_process_auto_skills", side_effect=fake_process):
+                await c._run_skill_detection(key)
+        assert recorded.get("key") == key, (
+            "skill detection must fire from the full-session window even when the "
+            "unconsolidated tail is trivial"
+        )
+
+    @pytest.mark.asyncio
+    async def test_length_guard_skips_unchanged_session(self, tmp_path):
+        import asyncio as _asyncio
+        from unittest.mock import patch
+
+        from kiro_crew.memory import MemoryStore
+        from kiro_crew.skills import SkillsLoader
+
+        conv_log = ConversationLog(base_dir=tmp_path / "sessions")
+        conv_log.init()
+        mem = MemoryStore(workspace=tmp_path / "memory")
+        mem.init()
+        skills = SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False)
+        c = HistoryConsolidator(
+            log=conv_log,
+            memory=mem,
+            skills_loader=skills,
+            auto_skills_enabled=True,
+            approval_required=True,
+            auto_min_tool_calls=5,
+        )
+        key = "dashboard:chat-guard"
+        for i in range(6):
+            conv_log.append(key, "assistant", f"step {i}", tools=["execute_bash"])
+        c._event_loop = _asyncio.get_running_loop()
+        with patch.object(c, "_call_llm", return_value=None) as m1:
+            with patch.object(c, "_process_auto_skills"):
+                await c._run_skill_detection(key)
+                assert m1.call_count == 1  # first pass evaluates
+                await c._run_skill_detection(key)
+                assert m1.call_count == 1, (
+                    "an unchanged session must NOT be re-judged on the next "
+                    "consolidation (length guard)"
+                )
+
+    @pytest.mark.asyncio
+    async def test_rotation_forces_fresh_pass_despite_equal_count(self, tmp_path):
+        """A transcript rotation (generation bump) must re-trigger detection
+        even when the message count is unchanged (GPT 5.6 blocking finding)."""
+        import asyncio as _asyncio
+        import json as _json
+        from unittest.mock import patch
+
+        from kiro_crew.memory import MemoryStore
+        from kiro_crew.skills import SkillsLoader
+
+        conv_log = ConversationLog(base_dir=tmp_path / "sessions")
+        conv_log.init()
+        mem = MemoryStore(workspace=tmp_path / "memory")
+        mem.init()
+        skills = SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False)
+        c = HistoryConsolidator(
+            log=conv_log,
+            memory=mem,
+            skills_loader=skills,
+            auto_skills_enabled=True,
+            approval_required=True,
+            auto_min_tool_calls=5,
+        )
+        key = "dashboard:chat-rotate"
+        for i in range(6):
+            conv_log.append(key, "assistant", f"step {i}", tools=["execute_bash"])
+        c._event_loop = _asyncio.get_running_loop()
+        with patch.object(c, "_call_llm", return_value=None) as m1:
+            with patch.object(c, "_process_auto_skills"):
+                await c._run_skill_detection(key)
+                assert m1.call_count == 1
+                # Simulate a 2MB/200-line rotation: same message count, but the
+                # rotation_generation counter bumps and the window is new content.
+                path = conv_log._path(key)
+                lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+                meta = _json.loads(lines[0])
+                meta["rotation_generation"] = int(meta.get("rotation_generation", 0) or 0) + 1
+                lines[0] = _json.dumps(meta) + "\n"
+                path.write_text("".join(lines), encoding="utf-8")
+                conv_log._invalidate_cache(key)
+                await c._run_skill_detection(key)
+                assert m1.call_count == 2, (
+                    "a rotation (generation bump) must force a fresh detection "
+                    "pass even when the message count is unchanged"
+                )
 
 
 class TestConsolidateSession:


### PR DESCRIPTION
## Problem
Auto-skill detection systematically under-generated. Two independent causes:
1. **Prompt was precision-biased to a fault.** Its null criteria included "a one-off failure", which directly conflicts with its own positive example "debugging a specific class of error" — most debugging sessions read as a one-off failure, so reusable knowledge was dropped. No recall counterweight despite every candidate being human-approved.
2. **Detection only saw the unconsolidated tail.** Skill detection ran inside `_consolidate` over `messages[offset:]` — the slice since the last consolidation. Any session consolidated more than once (multi-day work, or a 3h idle mid-session) was judged in fragments, so a reusable arc spanning the session was never seen as a unit.

## Why it matters
Skill auto-gen only helps if it surfaces the reusable procedures buried in sessions. False negatives are invisible and unrecoverable; a false positive costs one dismissal click. Empirically the live instance had **zero** staged auto-skill candidates until a deliberately-obvious runbook was fed in.

## Fix (symptom -> root cause -> change)
- **Prompt:** narrow the exclusion to "a one-off failure **with no reusable takeaway**" and add a nudge to lean toward proposing when a reusable procedure is plausible (human approval is the real gate).
- **Window:** split skill detection into its **own LLM pass**, `_run_skill_detection`, over the last `_SKILL_DETECTION_WINDOW` (200) messages of the **full session**, decoupled from the consolidation offset. It runs after the memory writes on history consolidations only.
  - History/semantic/lesson extraction stays **tail-scoped** — widening that prompt would re-summarize already-consolidated messages into duplicate memory. Splitting keeps them incremental while skills go holistic.
  - The skill need only be demonstrated by **part** of the window; the pass does not have to cover the whole session.
  - A per-session **length guard** skips re-judging an unchanged session on the next consolidation; the existing dedupe verdict still catches genuine repeats.
  - The `>=5` tool-call floor and the sensitive-path guard now apply to the **window**.

## Tests
- `TestSkillDetectionFullWindow`: (a) detection fires from the full-session window even when the already-consolidated tail is trivial (the exact gap this fixes); (b) the length guard skips an unchanged session.
- Existing `TestConsolidationPromptJsonShape` retargeted to `_run_skill_detection` (where the new_skill prompt now lives).
- Full run: 244 history/skill tests pass. isort / flake8 / mypy (580 files) green.

## Manual verification
Verified live (pre-window-change) that detection fires correctly on a clear reusable runbook (staged `auto/apollo-service-rollback`), confirming the pipeline and that conservatism was in wording + windowing, not machinery.

## Screenshots
N/A — backend consolidation/LLM-prompt change, no UI.
