### PR TITLE
fix(installer): prefer supported Python 3.12 over 3.13

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -125,10 +125,12 @@ command -v curl    >/dev/null 2>&1 || err "curl is required"
 command -v openssl >/dev/null 2>&1 || err "openssl is required to verify the signed manifest"
 # KiroCrew needs Python >=3.10 at runtime (contextlib.aclosing, etc.) even
 # though older published wheels' METADATA claimed >=3.9 -- pip would install
-# fine on 3.9 and then crash on first run. Pick the best interpreter, newest
-# first; plain python3 only counts if it is itself >=3.10.
+# fine on 3.9 and then crash on first run. Prefer 3.12 (the version CI builds
+# and tests on), then fall back to other supported minors, then 3.13+ only as
+# a last resort (numpy<2 and other deps may lack wheels for bleeding-edge
+# interpreters). Plain python3 only counts if it is itself >=3.10.
 PY=""
-for c in python3.13 python3.12 python3.11 python3.10 python3; do
+for c in python3.12 python3.11 python3.10 python3.13 python3; do
   command -v "$c" >/dev/null 2>&1 || continue
   if "$c" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
     PY="$c"; break

--- a/ensure-python.sh
+++ b/ensure-python.sh
@@ -32,10 +32,11 @@ _pyver() {
     "$1" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null
 }
 
-# First usable system python >= 3.9, preferring newer explicit minors.
+# First usable system python >= 3.10, preferring the supported/tested version
+# (3.12) over newer minors that may lack dep wheels or have API changes.
 _find_system_python() {
     local c resolved
-    for c in python3.13 python3.12 python3.11 python3.10 python3 python; do
+    for c in python3.12 python3.11 python3.10 python3.13 python3 python; do
         resolved="$(command -v "$c" 2>/dev/null)" || continue
         if _py_ok "$resolved"; then
             echo "$resolved"


### PR DESCRIPTION

## Description

The cli.sh and ensure-python.sh scripts were selecting the newest available Python interpreter (3.13 first), but the project is built and tested exclusively on Python 3.10 and 3.12. This caused problems on machines with Python 3.13 installed - while the issue originally noted that numpy<2 lacks cp313 wheels, the numpy constraint has since been relaxed to `<3` (per the comment on the issue). However, the interpreter discovery order remained wrong, and on distros where only bare `python3` exists pointing to 3.14, the loop would select an entirely untested interpreter.

Root cause: Both `cli.sh` line 128 and `ensure-python.sh` line 38 had `python3.13` first in their for-loop candidates, contradicting the project's own `TARGET_PY="${KIROCREW_PYTHON_VERSION:-3.12}"` declaration in ensure-python.sh.

This PR reorders the interpreter selection loops to prefer 3.12 first (the CI target), then 3.11, 3.10, and only fall back to 3.13+ as a last resort. The selection still accepts 3.13 when no supported interpreter exists, so users on bleeding-edge distros are not hard-blocked. This matches the existing order already used by install.sh, minimal_install.sh, setup.sh, and cloud-install.sh.

## Related Issues

Fixes #86

## Testing

- [x] Syntax verification with `bash -n` on both modified files
- [x] shellcheck passes with no warnings (shellcheck 0.11.0)
- [x] Manual verification with fake python shims in isolated PATH

Shell verification harness output (fabricated PATH with fake interpreters):
```
=== Test 1: Both 3.12 and 3.13 available - should pick 3.12 ===
Selected: python3.12
PASS: Correctly selected 3.12 over 3.13

=== Test 2: Only 3.13 available - should pick 3.13 as fallback ===
Selected: python3.13
PASS: Correctly fell back to 3.13

=== Test 3: 3.10, 3.11, 3.12, 3.13 all available - should pick 3.12 ===
Selected: python3.12
PASS: Correctly selected 3.12 when all available
```

Not run (intentionally):
- The actual installer scripts were not executed against the host machine per instructions
- No Python backend tests exist for shell installer behavior; shell-level verification was used instead

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) - comments in changed files updated to explain the preference order
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The upstream template carries a placeholder: the CLA wording is supplied by OSPO and must not be invented. Left as-is pending that text.

## Research

**Files enumerated for interpreter selection loops:**
- `cli.sh:128` - had 3.13 first - CHANGED
- `ensure-python.sh:38` - had 3.13 first - CHANGED  
- `install.sh:182` - already prefers 3.12 first - no change needed
- `minimal_install.sh:48` - already prefers 3.12 first - no change needed
- `setup.sh:46` - already prefers 3.12 first - no change needed
- `cloud-install.sh:62` - already prefers 3.12 first - no change needed
- `bin/kirocrew` - no selection loop, only uses python3 as a realpath fallback - no change needed
- `docker/Dockerfile` - uses `python:3.12-slim-trixie` base image, already pinned - no change needed
- `packaging/build-desktop.sh` - hardcodes python3.12 for PBS trees - no change needed

**Queries used:**
- `grep -r 'python3\.(1[0-4]|[0-9])' --include='*.sh'` to enumerate all interpreter references
- Read setup.cfg and pyproject.toml to confirm `python_requires = >=3.10` with no upper bound

**Alternatives considered:**
1. Adding `requires-python = ">=3.10,<3.13"` upper bound - rejected because it would hard-block users already on 3.13/3.14, which is more disruptive than a preference order change
2. Deriving the preference dynamically from pyproject.toml at install time - rejected as over-engineered; the preference order can be updated when CI changes its target

**Blast radius:** Only installer/bootstrap scripts - no runtime code changes. The fix is consistent with 4 other scripts in the repo that already had the correct order.
