### PR TITLE
fix(dashboard): stop useLogSSE leaking EventSource on unmount

### DIFF
--- a/website/src/hooks/useLogSSE.test.ts
+++ b/website/src/hooks/useLogSSE.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useLogSSE } from './useLogSSE'
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+  readyState = 0
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: (() => void) | null = null
+  close = vi.fn()
+  url: string
+
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+}
+
+describe('useLogSSE', () => {
+  beforeEach(() => {
+    MockEventSource.instances = []
+    vi.stubGlobal('EventSource', MockEventSource)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('cleans up EventSource on unmount', () => {
+    const onMessage = vi.fn()
+    const { unmount } = renderHook(() => useLogSSE(onMessage))
+
+    expect(MockEventSource.instances).toHaveLength(1)
+    const sse = MockEventSource.instances[0]
+
+    unmount()
+    expect(sse.close).toHaveBeenCalled()
+  })
+
+  it('cancels pending reconnect timer on unmount during reconnect window', () => {
+    const onMessage = vi.fn()
+    const { unmount } = renderHook(() => useLogSSE(onMessage))
+
+    expect(MockEventSource.instances).toHaveLength(1)
+    const sse = MockEventSource.instances[0]
+
+    // Trigger an error - this schedules a reconnect in 3s
+    act(() => {
+      sse.onerror!()
+    })
+
+    // Unmount during the 3s reconnect window
+    unmount()
+
+    // Advance timers past the reconnect delay
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    // No new EventSource should have been created after the first one
+    expect(MockEventSource.instances).toHaveLength(1)
+  })
+
+  it('does not run message handler after unmount', () => {
+    const onMessage = vi.fn()
+    const { unmount } = renderHook(() => useLogSSE(onMessage))
+
+    const sse = MockEventSource.instances[0]
+    unmount()
+
+    // Simulate a message arriving after unmount
+    const event = { data: JSON.stringify({ level: 'info', msg: 'test' }) } as MessageEvent
+    sse.onmessage?.(event)
+
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not schedule reconnect after unmount when error fires post-close', () => {
+    const onMessage = vi.fn()
+    const { unmount } = renderHook(() => useLogSSE(onMessage))
+
+    const sse = MockEventSource.instances[0]
+    unmount()
+
+    // Simulate error firing after unmount (race condition)
+    act(() => {
+      sse.onerror!()
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    // Still only 1 instance - no reconnect happened
+    expect(MockEventSource.instances).toHaveLength(1)
+  })
+})

--- a/website/src/hooks/useLogSSE.ts
+++ b/website/src/hooks/useLogSSE.ts
@@ -2,29 +2,40 @@ import { useEffect, useRef, useCallback } from 'react'
 
 export function useLogSSE(onMessage: (data: { level: string; msg: string }) => void) {
   const ref = useRef<EventSource | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const disposedRef = useRef(false)
   const cb = useRef(onMessage)
   cb.current = onMessage
 
   const start = useCallback(() => {
+    if (disposedRef.current) return
     if (ref.current) return
     const sse = new EventSource('/api/logs')
     ref.current = sse
     sse.onmessage = (e) => {
+      if (disposedRef.current) return
       try { cb.current(JSON.parse(e.data)) } catch { /* ignore */ }
     }
     sse.onerror = () => {
       sse.close()
       ref.current = null
-      setTimeout(start, 3000)
+      if (disposedRef.current) return
+      timerRef.current = setTimeout(start, 3000)
     }
   }, [])
 
   const stop = useCallback(() => {
+    disposedRef.current = true
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
     ref.current?.close()
     ref.current = null
   }, [])
 
   useEffect(() => {
+    disposedRef.current = false
     start()
     return stop
   }, [start, stop])


### PR DESCRIPTION

## Description

`useLogSSE` schedules a reconnect via `setTimeout(start, 3000)` in its `onerror`
handler but never stores the timer handle. `stop()` (invoked by the effect cleanup
on unmount) only calls `ref.current?.close()` - it cannot cancel a pending
reconnect because it has no reference to the timer.

If the component unmounts during that 3-second window, `start()` fires after
unmount, opens an orphaned `EventSource` that nothing can ever close, and if that
connection also errors, the cycle repeats indefinitely - a resource leak and an
unbounded reconnect loop.

The fix in `website/src/hooks/useLogSSE.ts`:

1. Adds `timerRef` to store the `setTimeout` return value.
2. Adds `disposedRef` - a boolean guard set `true` by `stop()`.
3. `stop()` now calls `clearTimeout(timerRef.current)` before closing the ES.
4. `start()` and both event handlers (`onmessage`, `onerror`) bail early when
   `disposedRef.current` is true, guaranteeing no code runs after unmount.
5. The effect body resets `disposedRef` to `false` so remounts work correctly.

This makes cleanup total: the timer is cancelled, any live EventSource is closed,
and no handler can execute after unmount.

## Related Issues

Fixes #423

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality
- [ ] Manual verification performed

```
$ npx tsc --noEmit          -> exit 0
$ npx eslint src/hooks/useLogSSE.ts src/hooks/useLogSSE.test.ts  -> exit 0
$ npx vitest run src/hooks/useLogSSE.test.ts --coverage=false --reporter=dot
  Test Files  1 passed (1)
       Tests  4 passed (4)
    Duration  3.34s
```

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

(Placeholder - CLA wording is supplied by OSPO and must not be invented.)

## Research

**Investigation path:** Read `useLogSSE.ts` directly - the bug is exactly as
described in the issue. The `setTimeout` handle is never stored, and `stop()` has
no way to cancel it. No other callers of `start` or `stop` exist outside the hook
itself (the hook exports nothing besides its effect-driven lifecycle).

**Alternatives considered:**

- AbortController pattern: Would work but is heavier for this use case. A simple
  boolean ref (`disposedRef`) achieves the same "no execution after dispose"
  guarantee with less ceremony and no extra object allocation per mount.
- Returning a cleanup function from `start()`: Rejected because `start` is called
  both from the effect and from the reconnect timer - the cleanup semantics would
  differ depending on caller.

**Bounded reconnect (max attempts / backoff):** Deliberately out of scope. The
issue as filed is about the leak and infinite-loop on unmount. Reconnect bounding
is a separate UX/reliability concern - without the dispose guard the loop runs
after unmount (the actual bug), but while mounted an infinite-retry SSE is
standard browser behavior for server-sent events. A follow-up could add
exponential backoff or a max-attempts cap, but that is a feature enhancement, not
a fix for this leak.

**Blast radius:** `useLogSSE` is imported only by the Logs page component. The
hook's public API (signature and behavior while mounted) is unchanged. The only
behavioral change is that cleanup is now total on unmount.
