### PR TITLE
fix(autonudge): offload blocking _save() in remove() to executor

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -508,9 +508,7 @@ class AutoNudgeService:
             # worker thread, and await it so a persistence failure still
             # propagates to the caller before the loop is reported armed.
             payload = self._serialize_state()
-            await asyncio.get_running_loop().run_in_executor(
-                None, self._write_state, payload
-            )
+            await asyncio.get_running_loop().run_in_executor(None, self._write_state, payload)
             self._arm_timer(loop)
         self._emit("added", loop)
         logger.info("AutoNudge: added loop %s on slot %s (idle=%ds)", loop.id, slot_key, idle_secs)
@@ -633,7 +631,9 @@ class AutoNudgeService:
 
     async def remove(self, loop_id: str) -> None:
         async with self._lock:
-            self.remove_sync(loop_id)
+            self.remove_sync(loop_id, persist=False)
+            payload = self._serialize_state()
+            await asyncio.get_running_loop().run_in_executor(None, self._write_state, payload)
 
     def get_by_slot(self, slot_key: str) -> NudgeLoop | None:
         return self._find_by_slot(slot_key)

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -1261,8 +1261,8 @@ class TestAutonudgeUpdateConcurrency:
             timer = svc._timers[loop_obj.id]
             await asyncio.sleep(0.15)  # delivered; parked inside the persist
             assert loop_obj.id in svc._firing
-            svc.notify_turn_complete("chat-9-7")   # queues a deferred re-arm
-            svc.notify_user_input("chat-9-7")      # user takes priority
+            svc.notify_turn_complete("chat-9-7")  # queues a deferred re-arm
+            svc.notify_user_input("chat-9-7")  # user takes priority
             assert not timer.cancelled(), "user input cancelled the firing task"
             gate.set()
             await asyncio.wait_for(asyncio.shield(timer), timeout=5)
@@ -1315,9 +1315,7 @@ class TestAutonudgeUpdateConcurrency:
         svc = AutoNudgeService(base_dir=tmp_path, on_fire=on_fire)
         await svc.start()
         try:
-            loop_obj = await svc.add(
-                slot_key="slack:1700000000.1", message="go", idle_secs=15
-            )
+            loop_obj = await svc.add(slot_key="slack:1700000000.1", message="go", idle_secs=15)
             # Re-arm with a zero delay so exactly ONE fire starts promptly; the
             # channel self-re-arm afterwards uses the real 15s idle gap, so the
             # test observes a single, deterministic fire window.
@@ -1553,10 +1551,18 @@ class TestSentinelPathRepair:
                 {
                     "version": 1,
                     "loops": [
-                        {"id": "bad", "slot_key": "chat-1-1", "message": "m",
-                         "stop_sentinel_path": 12345},
-                        {"id": "good", "slot_key": "chat-2-2", "message": "m",
-                         "stop_sentinel_path": str(current / "workspace" / ".stop-ok")},
+                        {
+                            "id": "bad",
+                            "slot_key": "chat-1-1",
+                            "message": "m",
+                            "stop_sentinel_path": 12345,
+                        },
+                        {
+                            "id": "good",
+                            "slot_key": "chat-2-2",
+                            "message": "m",
+                            "stop_sentinel_path": str(current / "workspace" / ".stop-ok"),
+                        },
                     ],
                 }
             ),
@@ -1728,5 +1734,51 @@ class TestSentinelPathRepair:
             await svc._timers["abc123"]
             assert fired == [], "loop fired despite the sentinel being present"
             assert "abc123" not in svc._loops, "sentinel did not remove the loop"
+        finally:
+            svc.stop()
+
+
+class TestRemoveOffloadsIO:
+    """remove() must not block the event loop with a synchronous _save()."""
+
+    @pytest.mark.asyncio
+    async def test_remove_persists_off_the_event_loop(self, tmp_path, monkeypatch):
+        """_save() fsyncs on the loop thread; remove() must offload like update()."""
+        svc = AutoNudgeService(base_dir=tmp_path)
+        await svc.start()
+        try:
+            loop_obj = await svc.add(slot_key="chat-1-rm", message="go", idle_secs=15)
+            svc._cancel_timer(loop_obj.id)
+            loop_thread = threading.get_ident()
+            seen: list[int] = []
+            real_write = svc._write_state
+
+            def _spy(payload):
+                seen.append(threading.get_ident())
+                return real_write(payload)
+
+            monkeypatch.setattr(svc, "_write_state", _spy)
+            monkeypatch.setattr(
+                svc, "_save", lambda: pytest.fail("blocking _save called on the loop")
+            )
+            await svc.remove(loop_obj.id)
+            assert seen, "remove() never persisted"
+            assert seen[-1] != loop_thread, "_write_state ran on the event loop thread"
+            assert loop_obj.id not in svc._loops, "loop was not removed"
+        finally:
+            svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_remove_persists_removal_to_disk(self, tmp_path):
+        """After remove(), the on-disk store should no longer contain the loop."""
+        svc = AutoNudgeService(base_dir=tmp_path)
+        await svc.start()
+        try:
+            loop_obj = await svc.add(slot_key="chat-1-rm2", message="go", idle_secs=15)
+            svc._cancel_timer(loop_obj.id)
+            await svc.remove(loop_obj.id)
+            on_disk = json.loads((tmp_path / "autonudge.json").read_text(encoding="utf-8"))
+            ids = [lp["id"] for lp in on_disk["loops"]]
+            assert loop_obj.id not in ids, "removed loop still on disk"
         finally:
             svc.stop()


### PR DESCRIPTION

## Description

The `async remove()` method in `src/kiro_crew/autonudge.py` called
`remove_sync(loop_id)` with the default `persist=True`, which invoked
`self._save()` directly on the asyncio event loop. `_save()` calls
`_write_state()`, which performs a blocking `os.fsync()`. On slow or
network-backed storage this freezes the gateway event loop, stalling
chat, heartbeat, and liveness until the syscall returns.

The root cause is that `remove()` was the only async CRUD method that
did not offload its persistence to a thread executor. `_add_locked()`
and `_update_locked()` already snapshot under the service lock and then
call `await loop.run_in_executor(None, self._write_state, payload)`.
`remove()` simply forwarded to the synchronous `remove_sync()` helper
without the same treatment.

The fix makes `remove()` call `remove_sync(loop_id, persist=False)` to
perform the in-memory mutation, then serialize the state under the lock
and offload `_write_state` to the default executor - the same pattern
used by every other async persistence path in the module.

## Related Issues

Fixes #425

## Testing

- [x] Existing tests pass
- [x] New tests added for the fix

```
$ PYTHONPATH=src python -m pytest test/test_autonudge.py -n0 -q
74 passed, 4 warnings in 2.98s

$ PYTHONPATH=src python -m pytest test/test_autonudge_stop_auth.py -n0 -q
23 passed, 2 warnings in 0.53s
```

Lint gates:
```
black --check: pass (after formatting)
isort --check-only: pass
flake8: pass (0 issues)
mypy: Success: no issues found in 1 source file
```

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

(Placeholder - CLA wording supplied by OSPO.)

## Research

Investigation confirmed the bug as described in the issue. The three async CRUD
methods (`add`, `update`, `remove`) were examined:

- `_add_locked()` (line ~510): already offloads via `run_in_executor` - correct.
- `_update_locked()` (line ~596): already offloads via `run_in_executor` - correct.
- `_persist_locked()` (line ~518): shared helper that offloads - correct.
- `remove()` (line ~636): called `remove_sync(loop_id)` which calls `self._save()`
  synchronously on the event loop - BUG.

The existing test class `TestAutonudgeUpdateChokepoint` at line 935 already
asserts the same property for `update()`, proving this is a recognized hazard
in the codebase. The fix mirrors that exact pattern.

Alternatives considered:
- Using `_persist_locked()` directly: rejected because `remove()` already
  holds `self._lock` via `async with`, and `_persist_locked()` also acquires
  it, which would deadlock. Inlining the body of `_persist_locked()` (snapshot
  + offload) is what the other `_*_locked` methods do.
- Making `remove_sync` async: rejected because it is also called from
  synchronous contexts (e.g. `_add_locked` with `persist=False`) and changing
  its signature would be a larger refactor.

Blast radius: `remove_sync(persist=True)` is called from exactly one place -
the `async remove()` method. The `persist=False` path is used by `_add_locked`
when replacing an existing loop. No other callers are affected.

No spec file exists at `docs/system-specs/modules/autonudge.md` so no spec
update is needed.
