### PR TITLE
fix(acp): write cli.json overlay atomically via atomic_write

### DIFF
--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -26,6 +26,7 @@ from kiro_crew.acp.types import (
     STOP_REASON_CANCELLED,
     STOP_REASON_END_TURN,
 )
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.effort import (
     EFFORT_LEVELS,
@@ -89,7 +90,7 @@ def _write_cli_overlay(work_dir: Path, model: str, effort: str) -> None:
             model_cfg.pop(other_key, None)
     model_defaults[model] = model_cfg
     existing["chat.modelDefaults"] = model_defaults
-    cli_json.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    atomic_write(cli_json, json.dumps(existing, indent=2))
 
 
 def _write_tool_search_overlay(work_dir: Path, enabled: bool) -> None:
@@ -135,7 +136,7 @@ def _write_tool_search_overlay(work_dir: Path, enabled: bool) -> None:
         # later build flips the global default on.
         existing.pop("toolSearch.minPct", None)
         existing.pop("toolSearch.minTokens", None)
-    cli_json.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    atomic_write(cli_json, json.dumps(existing, indent=2))
 
 
 def _clear_cli_overlay_effort(work_dir: Path, model: str) -> None:
@@ -170,7 +171,7 @@ def _clear_cli_overlay_effort(work_dir: Path, model: str) -> None:
         if not model_cfg:
             model_defaults.pop(model, None)
     try:
-        cli_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        atomic_write(cli_json, json.dumps(data, indent=2))
     except OSError:
         logger.debug("ACP effort overlay clear failed", exc_info=True)
 

--- a/test/test_acp_provider.py
+++ b/test/test_acp_provider.py
@@ -957,3 +957,85 @@ class TestLoadSessionWithRetry:
         assert got is None
         assert rt.load_session.await_count == 1  # bail as soon as the runtime is dead
         assert sleep_mock.await_count == 0
+
+
+class TestCliOverlayAtomicity:
+    """Regression tests for #426: cli.json overlay must be written atomically."""
+
+    def test_write_cli_overlay_uses_atomic_write(self, tmp_path):
+        from kiro_crew.providers.acp import _write_cli_overlay
+
+        with patch("kiro_crew.providers.acp.atomic_write") as aw:
+            _write_cli_overlay(tmp_path, "claude-sonnet-4-20250514", "high")
+
+        aw.assert_called_once()
+        path_arg, content_arg = aw.call_args[0]
+        assert str(path_arg).endswith("cli.json")
+        # Content must be valid JSON with the expected structure
+        import json
+
+        data = json.loads(content_arg)
+        assert "chat.modelDefaults" in data
+        assert "claude-sonnet-4-20250514" in data["chat.modelDefaults"]
+
+    def test_write_tool_search_overlay_uses_atomic_write(self, tmp_path):
+        from kiro_crew.providers.acp import _write_tool_search_overlay
+
+        with patch("kiro_crew.providers.acp.atomic_write") as aw:
+            _write_tool_search_overlay(tmp_path, True)
+
+        aw.assert_called_once()
+        path_arg, content_arg = aw.call_args[0]
+        assert str(path_arg).endswith("cli.json")
+        import json
+
+        data = json.loads(content_arg)
+        assert data["toolSearch.enabled"] is True
+        assert data["toolSearch.minPct"] == 0
+        assert data["toolSearch.minTokens"] == 0
+
+    def test_clear_cli_overlay_effort_uses_atomic_write(self, tmp_path):
+        from kiro_crew.providers.acp import _clear_cli_overlay_effort, _write_cli_overlay
+
+        # First write an overlay so there's something to clear
+        _write_cli_overlay(tmp_path, "claude-sonnet-4-20250514", "high")
+
+        with patch("kiro_crew.providers.acp.atomic_write") as aw:
+            _clear_cli_overlay_effort(tmp_path, "claude-sonnet-4-20250514")
+
+        aw.assert_called_once()
+        path_arg, content_arg = aw.call_args[0]
+        assert str(path_arg).endswith("cli.json")
+        import json
+
+        data = json.loads(content_arg)
+        # Effort should be cleared
+        model_cfg = data.get("chat.modelDefaults", {}).get("claude-sonnet-4-20250514", {})
+        for key in ("output_config", "reasoning"):
+            sub = model_cfg.get(key, {})
+            assert "effort" not in sub
+
+    def test_overlay_never_leaves_partial_content(self, tmp_path):
+        """Verify that a reader never sees truncated/empty JSON.
+
+        atomic_write uses temp-file + os.replace, so the target path
+        transitions from absent/old to complete-new in one rename.  This
+        test confirms the contract by checking that after the real
+        atomic_write, the file is always valid JSON.
+        """
+        from kiro_crew.providers.acp import _write_cli_overlay, _write_tool_search_overlay
+
+        _write_cli_overlay(tmp_path, "claude-sonnet-4-20250514", "high")
+        cli_json = tmp_path / ".kiro" / "settings" / "cli.json"
+        import json
+
+        # Must be valid JSON after each write
+        data = json.loads(cli_json.read_text(encoding="utf-8"))
+        assert "chat.modelDefaults" in data
+
+        # Overwrite with tool-search - still valid
+        _write_tool_search_overlay(tmp_path, True)
+        data = json.loads(cli_json.read_text(encoding="utf-8"))
+        assert data["toolSearch.enabled"] is True
+        # Previous effort key preserved
+        assert "chat.modelDefaults" in data


### PR DESCRIPTION

## Description

The workspace CLI overlay at `<work_dir>/.kiro/settings/cli.json` is read by kiro-cli at spawn and rewritten live by `change_effort()` while a session is running. Three writers in `src/kiro_crew/providers/acp.py` - `_write_cli_overlay`, `_write_tool_search_overlay`, and `_clear_cli_overlay_effort` - used plain `Path.write_text()` which truncates the file before writing. A crash or a concurrent kiro-cli read mid-write would yield an empty or partially-written file, causing kiro-cli to silently drop effort and Tool Search settings or error on malformed JSON.

The root cause is a missing atomic-write pattern that the rest of the codebase already follows for bind-mounted overlay files (e.g. `rewriter.py` uses `atomic_write`). This PR replaces all three `write_text` calls with `atomic_write()` from `src/kiro_crew/atomic_write.py`, which writes to a unique temp file via `mkstemp` and then does an `os.replace` - ensuring readers only ever see a complete, valid JSON file. The helper already handles cross-platform concerns via `platform_compat.fchmod_safe`.

## Related Issues

Fixes #426

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality

Commands run and results:

```
PYTHONPATH=src python -m pytest test/test_acp_provider.py -n0 -q -p no:cacheprovider --override-ini="addopts="
54 passed, 2 warnings in 2.26s

black --check src/kiro_crew/providers/acp.py test/test_acp_provider.py
2 files would be left unchanged.

isort --check-only src/kiro_crew/providers/acp.py test/test_acp_provider.py
(clean - no output)

flake8 src/kiro_crew/providers/acp.py test/test_acp_provider.py
(clean - no output)

mypy src/kiro_crew/providers/acp.py
Success: no issues found in 1 source file
```

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under
the terms of the project's license.

## Research

Investigation approach: read the issue (which precisely identified the three call sites), confirmed the bug by reading `providers/acp.py` L88-171 and verifying all three paths use `write_text`. Read `atomic_write.py` to confirm its API is a drop-in replacement (it takes `path, content` positional args, handles `encoding="utf-8"` internally, and already routes permissions through `platform_compat.fchmod_safe`).

Blast radius: the three functions are called from `AcpProvider.change_effort()`, `AcpProvider._prepare_spawn()` (via `_write_tool_search_overlay`), and `AcpProvider._on_session_end()` (via `_clear_cli_overlay_effort`). No other callers. The `atomic_write` helper is already used throughout the codebase and carries no new dependency.

Alternatives considered: (1) Using `fsync=True` for extra durability - rejected because the existing pattern in `rewriter.py` does not fsync, and the issue only requires crash-atomicity (complete or absent), not durability against power loss. (2) Adding a `mode=0o600` for secrets - rejected because the overlay is not a secret (it contains model/effort preferences) and other overlay writers do not restrict permissions.

No spec update needed: the acp-client.md spec mentions the overlay exists but does not document write semantics - the fix makes the implementation match the implicit contract (readers always see valid JSON) without changing any API or schema.
