### PR TITLE
fix(stats): publish singleton only after full initialization

### DIFF
--- a/src/kiro_crew/stats.py
+++ b/src/kiro_crew/stats.py
@@ -19,8 +19,9 @@ class Stats:
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._init_counters()
+                    inst = super().__new__(cls)
+                    inst._init_counters()
+                    cls._instance = inst  # publish only after fully initialized
         return cls._instance
 
     def _init_counters(self) -> None:

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -136,6 +136,71 @@ class TestStats(unittest.TestCase):
 
     # -- thread safety --
 
+    def test_singleton_publish_after_init(self) -> None:
+        """Regression test for #427: singleton must be fully initialized before publish.
+
+        This test deterministically triggers the race by injecting a barrier into
+        _init_counters that forces the following interleaving:
+
+        Thread A                          Thread B
+        --------                          --------
+        __new__: acquires lock
+        __new__: creates instance
+        __new__: calls _init_counters
+          _init_counters: barrier.wait()
+                                          __new__: lock-free check sees non-None
+                                          __new__: returns half-built instance
+                                          snapshot(): AttributeError on _mu/_c
+          _init_counters: finishes
+
+        If the singleton is published before _init_counters completes, thread B
+        sees a half-built instance and snapshot() raises AttributeError. The fix
+        is to assign cls._instance only after _init_counters returns.
+        """
+        # Reset singleton so we can create a fresh one
+        Stats._instance = None
+
+        barrier = threading.Barrier(2)
+        results: list[object] = [None, None]  # [thread_b_result_or_error, thread_a_instance]
+
+        original_init_counters = Stats._init_counters
+
+        def slow_init_counters(self: Stats) -> None:
+            # Signal thread B that we're inside _init_counters but not done
+            barrier.wait()
+            # Give thread B time to grab the half-built instance and call snapshot
+            import time
+
+            time.sleep(0.05)
+            original_init_counters(self)
+
+        def thread_a() -> None:
+            with patch.object(Stats, "_init_counters", slow_init_counters):
+                results[1] = Stats()
+
+        def thread_b() -> None:
+            barrier.wait()  # Wait for thread A to be inside _init_counters
+            try:
+                inst = Stats()
+                # Try to use the instance - this will fail if it's half-built
+                results[0] = inst.snapshot()
+            except AttributeError as e:
+                results[0] = e
+
+        t_a = threading.Thread(target=thread_a)
+        t_b = threading.Thread(target=thread_b)
+
+        t_a.start()
+        t_b.start()
+        t_a.join(timeout=5)
+        t_b.join(timeout=5)
+
+        # With the fix, thread B should get a fully initialized instance (dict result)
+        # Without the fix, thread B gets AttributeError
+        assert isinstance(
+            results[0], dict
+        ), f"Expected snapshot dict, got {type(results[0]).__name__}: {results[0]}"
+
     def test_thread_safety(self) -> None:
         s = Stats()
         barrier = threading.Barrier(10)


### PR DESCRIPTION

## Description

The `Stats.__new__` method in `src/kiro_crew/stats.py` contained a broken double-checked-locking pattern. It assigned `cls._instance` to the newly created object and then called `_init_counters()` on it:

```python
cls._instance = super().__new__(cls)   # published FIRST
cls._instance._init_counters()         # initialized SECOND
```

This is a classic publish-before-init race. A second thread hitting the lock-free `if cls._instance is None` check in the window between those two statements would see a non-None instance and immediately return it - while `self._mu` and `self._c` did not yet exist. Any subsequent call to `inc()` or `snapshot()` on that half-built instance would raise `AttributeError`.

The fix builds into a local variable, initializes it, and only then assigns to the class attribute:

```python
inst = super().__new__(cls)
inst._init_counters()
cls._instance = inst  # publish only after fully initialized
```

This makes the ordering structurally impossible to violate: the local `inst` is invisible to other threads until the assignment to `cls._instance`, which happens only after `_init_counters()` has returned. No window exists for a second thread to observe a half-initialized instance.

## Related Issues

Fixes #427

## Testing

- [x] Existing tests pass (13 passed in test_stats.py)
- [x] New test added for the race condition

Commands run:
```
cd /Users/diegogm/Dev/github/kc-wt/fix-427
PYTHONPATH=src python -m pytest test/test_stats.py -n0 -q -p no:cacheprovider --override-ini="addopts="
# Result: 13 passed, 2 warnings in 0.40s
```

The new test `test_singleton_publish_after_init` deterministically triggers the race by injecting a barrier into `_init_counters`. Thread A enters `_init_counters` and hits the barrier; thread B wakes, sees the already-assigned `cls._instance`, and immediately tries to use it. Before the fix, thread B got `AttributeError: 'Stats' object has no attribute '_mu'`. After the fix, thread B blocks on the lock and receives a fully initialized instance.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) - no module spec exists for stats
- [x] No secrets, credentials, or internal references in the diff

Lint/type gates:
```
black --check: pass
isort --check-only: pass
flake8: pass
mypy: pass (no issues found in 1 source file)
```

## Contribution License Agreement

(Placeholder - CLA wording supplied by OSPO)

## Research

I confirmed the bug by reading `src/kiro_crew/stats.py` lines 18-24. The code matched the issue description exactly - `cls._instance` was assigned before `_init_counters()`.

I checked for a module spec in `docs/system-specs/modules/` - none exists for stats, so no documentation update is needed.

I examined `test/test_stats.py` and found existing tests for the singleton pattern and thread safety of counter increments, but no test for the publish-before-init race. I added a deterministic test that uses a `threading.Barrier` plus a patched slow `_init_counters` to force the interleaving. The test failed before the fix and passes after.

Blast radius: `Stats` is used throughout the codebase via `Stats().inc_*()` calls. The change is purely in the construction order - the singleton contract and all public methods remain identical. The fix is minimal and surgical: two lines reordered, one local variable introduced.

Alternative considered: moving all initialization into `__new__` itself. Rejected because `_init_counters` is a sensible factorization and the local-variable approach is the canonical fix for this pattern.
