### PR TITLE
fix(channel_history): use is_relative_to for path containment check

### DIFF
--- a/src/kiro_crew/channel_history.py
+++ b/src/kiro_crew/channel_history.py
@@ -106,7 +106,14 @@ class ChannelHistory:
             except OSError:
                 logger.warning("Failed to remove history file %s", path, exc_info=True)
 
-    def push(self, channel_id: str, user: str, text: str, thread_ts: str | None = None, msg_ts: str | None = None) -> None:
+    def push(
+        self,
+        channel_id: str,
+        user: str,
+        text: str,
+        thread_ts: str | None = None,
+        msg_ts: str | None = None,
+    ) -> None:
         """Record a message in the channel buffer.
 
         Called on every message event in the gateway, not just @mentions.
@@ -128,7 +135,9 @@ class ChannelHistory:
 
         # Build entry — observe channels use wall clock for persistence
         wall_ts = time.time() if is_observe else None
-        entry = HistoryEntry(user=user, text=text, thread_ts=thread_ts, msg_ts=msg_ts, wall_ts=wall_ts)
+        entry = HistoryEntry(
+            user=user, text=text, thread_ts=thread_ts, msg_ts=msg_ts, wall_ts=wall_ts
+        )
         buf.append(entry)
 
         # Persist to disk for observe channels
@@ -209,8 +218,9 @@ class ChannelHistory:
             return None
         from kiro_crew.hooks import is_sensitive_path
 
+        history_root = self._history_dir.resolve()
         path = (self._history_dir / f"{channel_id}.jsonl").resolve()
-        if not str(path).startswith(str(self._history_dir.resolve())):
+        if not path.is_relative_to(history_root):
             logger.warning("Refusing unsafe history path for channel %s", channel_id)
             return None
         if is_sensitive_path(str(path)):

--- a/test/test_channel_history.py
+++ b/test/test_channel_history.py
@@ -358,3 +358,59 @@ class TestChannelHistoryContext:
         msg, _ = builder.build_message("hello", False, channel_id="C123")
 
         assert msg.startswith("hello")
+
+
+class TestObservePathContainment:
+    """Tests that _observe_path rejects path-traversal attacks."""
+
+    def test_normal_channel_id_accepted(self, tmp_path):
+        """A plain channel ID resolves inside history_dir."""
+        h = ChannelHistory(history_dir=tmp_path)
+        result = h._observe_path("C0VALID")
+        assert result is not None
+        assert result.parent == tmp_path
+
+    def test_sibling_prefix_rejected(self, tmp_path, monkeypatch):
+        """A channel_id that resolves to a sibling dir sharing the name prefix is refused.
+
+        This is the exact bug: /a/hist vs /a/hist-evil passes startswith but
+        must NOT pass is_relative_to.
+        """
+        # Create a sibling directory whose name starts with the history_dir name
+        evil_dir = tmp_path / "history-evil"
+        evil_dir.mkdir()
+        evil_file = evil_dir / "payload.jsonl"
+        evil_file.touch()
+
+        history_dir = tmp_path / "history"
+        history_dir.mkdir()
+
+        h = ChannelHistory(history_dir=history_dir)
+        # Craft a channel_id that after joining resolves outside history_dir
+        # Using relative traversal: go up, then into sibling
+        result = h._observe_path("../history-evil/payload")
+        assert result is None
+
+    def test_dot_dot_traversal_rejected(self, tmp_path):
+        """A channel_id with ../ components is rejected."""
+        history_dir = tmp_path / "channels"
+        history_dir.mkdir()
+
+        h = ChannelHistory(history_dir=history_dir)
+        result = h._observe_path("../../etc/passwd")
+        assert result is None
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        """A symlinked history_dir still guards against escape after resolve."""
+        real_dir = tmp_path / "real_history"
+        real_dir.mkdir()
+        link_dir = tmp_path / "link_history"
+        link_dir.symlink_to(real_dir)
+
+        h = ChannelHistory(history_dir=link_dir)
+        # A normal ID works fine (resolved path is under the resolved root)
+        assert h._observe_path("C0NORMAL") is not None
+
+        # Traversal out of the resolved root is still blocked
+        result = h._observe_path("../secret")
+        assert result is None


### PR DESCRIPTION

## Description

`ChannelHistory._observe_path` guards against path-traversal attacks by
verifying that the resolved JSONL file path lives inside `self._history_dir`.
The guard used `str(path).startswith(str(root))` which has no trailing-separator
boundary - a sibling directory sharing the name prefix (e.g. root `/a/hist` vs
resolved path `/a/hist-evil/x.jsonl`) satisfies the check and is accepted.

The fix replaces the string comparison with `Path.is_relative_to(root)`, which
performs a proper path-component check. Both the path and root are `.resolve()`d
before comparison, so symlink escapes are also covered. `is_relative_to` is
available since Python 3.9; the project floor is 3.10 (`setup.cfg`
`python_requires = >=3.10`).

## Related Issues

Fixes #428

## Testing

- [x] Existing tests pass
- [x] New tests added for the containment guard

```
$ PYTHONPATH=src python -m pytest test/test_channel_history.py -n0 -q
32 passed in 1.20s
```

```
$ black --check src/kiro_crew/channel_history.py test/test_channel_history.py
All done! 1 file reformatted (after initial fix).
$ isort --check-only ... -> pass
$ flake8 ... -> pass
$ mypy src/kiro_crew/channel_history.py -> Success: no issues found in 1 source file
```

- [ ] Manual verification performed

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) - spec does not document this internal guard
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

(Pending OSPO text.)

## Research

**Approach:** The issue precisely names the file, function, and fix. Confirmed
by reading `src/kiro_crew/channel_history.py` line 213, verifying the
`startswith` check lacks a trailing-separator boundary.

**Spec check:** Read `docs/system-specs/modules/channel-history.md`. The spec
does not document the path containment implementation detail, so no spec update
is needed.

**Python floor:** `setup.cfg` declares `python_requires = >=3.10`.
`Path.is_relative_to` landed in 3.9, so it is available.

**Other instances of the same weak idiom (out of scope, follow-up):**

- `src/kiro_crew/providers/cleanup.py:29` - `str(resolved).startswith(str(root) + os.sep)` (has trailing sep, but still weaker than is_relative_to)
- `src/kiro_crew/deploy/handlers.py:729` - same pattern with `+ os.sep`
- `src/kiro_crew/deploy/handlers.py:2091` - same
- `src/kiro_crew/apps/builtins/dev_fleet/server.py:553` - same

The `+ os.sep` variants are less vulnerable (they require an exact separator
boundary) but are still weaker than `is_relative_to` since they don't handle
edge cases like the root path itself.

**Blast radius:** `_observe_path` is called only from `_append_to_disk` and
`_load_from_disk` within the same module. The `channel_id` is platform-supplied
(Slack channel IDs) so exploitation requires compromised upstream input, but the
fix eliminates the vector regardless.

**Alternative considered:** Adding `+ os.sep` to the startswith check. Rejected
because `is_relative_to` is the canonical Python idiom, already used elsewhere
in the repo (`subagent_persistence.py`), and handles all edge cases without
string manipulation.
