### PR TITLE
fix(gateway): quarantine stray auth staging path instead of crashing

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -641,9 +641,7 @@ def _project_identity_database(source: Path, destination: Path) -> bool:
                     if not table_rows:
                         continue
                     placeholders = ",".join("?" * len(table_rows[0]))
-                    staged.executemany(
-                        f'INSERT INTO "{table}" VALUES ({placeholders})', table_rows
-                    )
+                    staged.executemany(f'INSERT INTO "{table}" VALUES ({placeholders})', table_rows)
     except sqlite3.Error:
         with contextlib.suppress(OSError):
             os.unlink(str(destination))
@@ -721,10 +719,27 @@ def _auth_store_mappings(
 
 
 def _ensure_auth_staging_parent(home: Path) -> Path:
-    """Create the fixed sandbox-hidden parent before agent sessions can start."""
+    """Create the fixed sandbox-hidden parent before agent sessions can start.
+
+    If the staging path exists but is not a usable directory (a stray regular
+    file, a dangling symlink, or a symlink to a directory), move it aside to a
+    timestamped quarantine name and recreate the directory fresh.  The stray
+    content is never deleted - it might be user data.
+    """
 
     staging_parent = home / _AUTH_STAGING_RELATIVE
-    staging_parent.mkdir(parents=True, exist_ok=True)
+    # Quarantine a non-directory entry BEFORE mkdir so the call cannot raise
+    # FileExistsError.  lexists catches dangling symlinks that exist on disk
+    # but whose target is gone (where .exists() returns False).
+    if staging_parent.is_symlink() or (staging_parent.exists() and not staging_parent.is_dir()):
+        _quarantine_stray_staging_path(staging_parent)
+    try:
+        staging_parent.mkdir(parents=True, exist_ok=True)
+    except (FileExistsError, NotADirectoryError):
+        # Race or an entry that slipped past the pre-check (e.g. a component
+        # of the parent chain is a file).  Quarantine and retry once.
+        _quarantine_stray_staging_path(staging_parent)
+        staging_parent.mkdir(parents=True, exist_ok=True)
     if staging_parent.is_symlink() or not staging_parent.is_dir():
         raise OSError("Kiro auth staging root is not a private directory")
     if platform_compat.IS_POSIX:
@@ -732,6 +747,36 @@ def _ensure_auth_staging_parent(home: Path) -> Path:
     else:
         platform_compat.restrict_to_owner(str(staging_parent))
     return staging_parent
+
+
+def _quarantine_stray_staging_path(path: Path) -> None:
+    """Move a non-directory staging path aside with a WARNING log line."""
+
+    timestamp = time.strftime("%Y%m%dT%H%M%S")
+    quarantine_name = f"{path.name}.corrupt-{timestamp}"
+    quarantine_dest = path.parent / quarantine_name
+    # Ensure the parent directory exists so rename can succeed.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.rename(quarantine_dest)
+    except OSError as exc:
+        logger.error(
+            "Cannot quarantine stray auth staging path %s: %s - "
+            "remove it manually to restore gateway boot",
+            path,
+            exc,
+        )
+        raise OSError(
+            f"Kiro auth staging path {path} is not a directory and could "
+            f"not be quarantined: {exc}"
+        ) from exc
+    logger.warning(
+        "Quarantined non-directory auth staging path %s -> %s; "
+        "the gateway will recreate the directory. If you need the "
+        "original content, find it at the quarantine path.",
+        path,
+        quarantine_dest,
+    )
 
 
 def _prepare_auth_workspace(
@@ -1937,9 +1982,7 @@ class KiroPrerequisiteService:
             # cannot even resolve itself without its real-home registry — so the
             # isolated probe reported such CLIs signed-out even though a real
             # session authenticates fine.
-            whoami = await self._audited_identity_probe(
-                self._viable_binary, isolate_home=False
-            )
+            whoami = await self._audited_identity_probe(self._viable_binary, isolate_home=False)
             if whoami.ok:
                 await asyncio.to_thread(self._mark_setup_complete)
             self._status = PrerequisiteStatus(

--- a/test/test_ensure_auth_staging.py
+++ b/test/test_ensure_auth_staging.py
@@ -1,0 +1,80 @@
+"""Tests for _ensure_auth_staging_parent resilience to non-directory paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kiro_crew.kiro_prerequisite import _ensure_auth_staging_parent
+
+
+class TestEnsureAuthStagingParent:
+    """_ensure_auth_staging_parent must boot even when the staging path is stray."""
+
+    def test_creates_fresh_directory(self, tmp_path: Path) -> None:
+        """Normal case: path does not exist yet, mkdir creates it."""
+        result = _ensure_auth_staging_parent(tmp_path)
+        assert result.is_dir()
+        assert not result.is_symlink()
+
+    def test_existing_directory_is_kept(self, tmp_path: Path) -> None:
+        """A real existing directory is left intact."""
+        staging = tmp_path / ".kiro" / "crew-auth-staging"
+        staging.mkdir(parents=True)
+        result = _ensure_auth_staging_parent(tmp_path)
+        assert result == staging
+        assert result.is_dir()
+
+    def test_regular_file_is_quarantined(self, tmp_path: Path) -> None:
+        """A stray regular file at the staging path is moved aside."""
+        staging = tmp_path / ".kiro" / "crew-auth-staging"
+        staging.parent.mkdir(parents=True, exist_ok=True)
+        staging.write_text("stray content")
+        assert staging.is_file()
+
+        result = _ensure_auth_staging_parent(tmp_path)
+
+        assert result.is_dir()
+        assert not result.is_symlink()
+        # The stray file was quarantined, not deleted
+        quarantined = list(staging.parent.glob("crew-auth-staging.corrupt-*"))
+        assert len(quarantined) == 1
+        assert quarantined[0].read_text() == "stray content"
+
+    def test_dangling_symlink_is_quarantined(self, tmp_path: Path) -> None:
+        """A dangling symlink at the staging path is moved aside."""
+        staging = tmp_path / ".kiro" / "crew-auth-staging"
+        staging.parent.mkdir(parents=True, exist_ok=True)
+        staging.symlink_to("/nonexistent/target/that/does/not/exist")
+        assert staging.is_symlink()
+        assert not staging.exists()  # dangling
+
+        result = _ensure_auth_staging_parent(tmp_path)
+
+        assert result.is_dir()
+        assert not result.is_symlink()
+        # The dangling symlink was quarantined, not deleted
+        quarantined = list(staging.parent.glob("crew-auth-staging.corrupt-*"))
+        assert len(quarantined) == 1
+        assert quarantined[0].is_symlink()
+
+    def test_symlink_to_directory_is_quarantined(self, tmp_path: Path) -> None:
+        """A symlink pointing to a real directory is still quarantined.
+
+        The post-mkdir guard already catches this case, but verify the
+        pre-mkdir quarantine handles it too (the path must be a real
+        directory, not a symlink to one).
+        """
+        real_dir = tmp_path / "real_target"
+        real_dir.mkdir()
+        staging = tmp_path / ".kiro" / "crew-auth-staging"
+        staging.parent.mkdir(parents=True, exist_ok=True)
+        staging.symlink_to(real_dir)
+        assert staging.is_symlink()
+        assert staging.is_dir()  # resolves to a directory
+
+        result = _ensure_auth_staging_parent(tmp_path)
+
+        assert result.is_dir()
+        assert not result.is_symlink()
+        quarantined = list(staging.parent.glob("crew-auth-staging.corrupt-*"))
+        assert len(quarantined) == 1


### PR DESCRIPTION

## Description

Gateway boot crashes with `FileExistsError: [Errno 17] File exists` when
`~/.kiro/crew-auth-staging` exists but is not a real directory - for example a
stray regular file left by a failed operation, or a dangling symlink whose
target was removed. Every subsequent boot fails the same way until a human
removes the path by hand.

The root cause is in `_ensure_auth_staging_parent` (src/kiro_crew/kiro_prerequisite.py).
It calls `staging_parent.mkdir(parents=True, exist_ok=True)`, which only tolerates
an existing directory - a regular file or dangling symlink at the path still raises
`FileExistsError` from within `mkdir`. The existing post-mkdir guard
(`is_symlink() or not is_dir()`) only catches the symlink-to-directory case; the
file and dangling-symlink shapes die earlier, inside mkdir, with the raw exception.

This PR adds a pre-mkdir check: if the path exists as a symlink or non-directory
entry, it is moved aside to a timestamped quarantine name
(`crew-auth-staging.corrupt-<YYYYmmddTHHMMSS>`) with a WARNING log line, then the
directory is created fresh. A try/except around mkdir handles any race between the
check and the system call by quarantining and retrying once. The stray content is
never deleted - it might be user data - and the log line names the quarantine path
so the user can recover it.

The choice to REPAIR the path (quarantine + recreate) rather than refuse the feature
is deliberate: the auth staging directory is a hard boot-time prerequisite. Refusing
would leave the gateway permanently broken, which is the exact symptom we are
fixing. Moving aside is the least destructive option that restores boot.

## Related Issues

Fixes #561

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality

Commands run:

```
PYTHONPATH=src python -m pytest test/test_ensure_auth_staging.py test/test_kiro_prerequisite.py -n0 -q
  -> 133 passed, 1 skipped

black --check src/kiro_crew/kiro_prerequisite.py test/test_ensure_auth_staging.py -> pass
isort --check-only src/kiro_crew/kiro_prerequisite.py test/test_ensure_auth_staging.py -> pass
flake8 src/kiro_crew/kiro_prerequisite.py test/test_ensure_auth_staging.py -> pass
mypy src/kiro_crew/kiro_prerequisite.py -> Success: no issues found
```

New test file `test/test_ensure_auth_staging.py` covers five cases: fresh creation,
existing directory (no-op), regular file quarantine, dangling symlink quarantine,
and symlink-to-directory quarantine. All use `tmp_path` and never touch real
`~/.kiro`.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

(Pending OSPO text.)

## Research

Investigation path:

1. Read the issue - it names the file (`kiro_prerequisite.py`), the function
   (`_ensure_auth_staging_parent`), and the exception (`FileExistsError`).
2. Read `docs/system-specs/modules/security.md` line 945 - confirms the
   `~/.kiro/crew-auth-staging` parent is the fixed sandbox-hidden directory and
   is on the sensitive-path floor.
3. Read the source - confirmed `staging_parent.mkdir(parents=True, exist_ok=True)`
   at line 729. The `exist_ok=True` only tolerates an existing directory per
   Python docs.
4. Checked callers: `_ensure_auth_staging_parent` is called in
   `KiroPrerequisiteService.__init__` (construction time, during gateway boot) and
   in `_prepare_auth_workspace`. Both paths propagate the exception uncaught.
5. Considered alternatives: (a) wrapping in a bare try/except and logging -
   rejected because auth staging is a hard prerequisite and silencing the error
   would leave sign-in broken in a confusing way. (b) Deleting the stray path -
   rejected because it might contain user data. (c) The chosen approach:
   quarantine (rename) + recreate - preserves data, restores boot, emits an
   actionable log line.
6. No spec update needed: `security.md` describes the staging path as a fixed
   directory without specifying error-recovery behavior.
