### PR TITLE
test(dashboard): lock in credits-card account identity rendering

### DIFF
--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -933,6 +933,33 @@ describe('Kiro credits pill', () => {
     expect(screen.getByText('Overage used')).toBeInTheDocument()
     expect(screen.getByText(/across chat, agents, MCP/)).toBeInTheDocument()
   })
+
+  it('renders the resolved account identity on the card so the numbers are attributable', async () => {
+    // Regression guard for issue #632: the credits card must show WHICH account
+    // the numbers belong to. The backend resolves the signed-in kiro-cli account
+    // (email / account_type / start_url) and returns it on the usage payload; the
+    // card renders it as the identity header. Before that identity was surfaced
+    // the numbers were unattributable, which is how a wrong-account readout went
+    // unnoticed. Values here are placeholders, never a real credential.
+    const { api } = await import('../api/client')
+    vi.mocked(api.sessionsUsage).mockResolvedValue({
+      usage: {
+        credits_used: 3044, credits_covered: 3044, credits_overage: 0,
+        credits_plan: 10000, resets: '2026-07-01', plan: 'KIRO POWER',
+        email: 'dev@example.com', account_type: 'IamIdentityCenter',
+        start_url: 'https://example.awsapps.com/start',
+      },
+    } as never)
+    renderWithProviders(<App />, { route: '/chat' })
+    const pill = await screen.findByTitle(/Kiro credits: 3,044/)
+    fireEvent.click(pill)
+    // The identity header shows the resolved account email...
+    expect(await screen.findByText('dev@example.com')).toBeInTheDocument()
+    // ...and the sign-in descriptor, which includes the issuer host derived from
+    // the start URL, so an org account is obvious at a glance.
+    const signedIn = screen.getByText(/Signed in with/)
+    expect(signedIn.textContent).toContain('example.awsapps.com')
+  })
 })
 
 describe('Kiro credits pill — edge cases', () => {


### PR DESCRIPTION

## Description
Issue #632 has two parts: the Kiro Credits widget read from the wrong identity
source (the Kiro IDE account instead of the kiro-cli account KiroCrew drives),
and the card did not say which account the numbers belonged to. Both parts are
already fixed on `origin/main`, so this PR does not change runtime behavior - it
adds the one piece of regression coverage that was missing.

The source problem lives in `dashboard/handlers/kiro_usage_api.py::fetch_usage_limits`
and its wiring in `dashboard/handlers/sessions.py::_fetch_usage_bg`. Several
credentials can be readable at once - a Kiro IDE SSO cache under `~/.aws`
(`from_cli_store=False`) and kiro-cli's own auth store under `~/.local/share`
or `~/Library` (`from_cli_store=True`) - and an IDE token for a different
account can still be unexpired, so the old path served the IDE account's
numbers. The current code resolves kiro-cli's own identity first with
`_fetch_whoami` and passes its profile ARN as `expected_arn`: a candidate is
used only when its own `ListAvailableProfiles` ARN matches (ARN-anchored), or,
when the account has no ARN, only when it comes from kiro-cli's own store
(source-anchored). Either way the credential provably belongs to the kiro-cli
account. That landed in PR #940 (commit 83e016c8) and was refined by PR #954
(commit 7b76bef0). Correctly picking the source is what makes the number right;
a correctly labelled wrong number would still be wrong, so this is the half that
matters most, and it is the half that was already the most thoroughly tested.

The identity-on-the-card part landed in PR #791 (commit 8dcb7302): the backend
merges `email` / `account_type` / `start_url` (from whoami, only when the ARN
proves they belong to the billed account) and `account` (the profile display
name) into the usage cache, which `/api/sessions/usage` returns in full, and
`App.tsx` renders them as an identity header on the credits card - an avatar,
the email or org profile name, and a "Signed in with <type> - <issuer host>"
descriptor.

What was missing was a frontend test asserting that visible half. The
credential-selection logic is covered in `test_kiro_usage_api.py` (including
`test_foreign_credential_is_skipped_for_the_matching_one` and the
source-anchored `own=False` skips) and in `test_session_usage.py` (cross-account
safety), but no test opened the card and checked that the resolved account
identity is shown. This PR adds that regression guard to `website/src/test/App.test.tsx`:
with an account email, account type, and start URL on the usage payload, the
opened card renders the email and the "Signed in with" descriptor including the
issuer host derived from the start URL. The test would have failed before #791,
so it locks in the behavior the issue asked for.

The information shown is safe to display: an account email and the SSO issuer
host are account identifiers, not credentials. No bearer token, ARN, or any
secret is rendered - the private `_profile_arn` coupling field is stripped
server-side before the payload is ever cached or served, and every string leaf
is run through `redact_credentials` / `redact_exfiltration_urls`. The test uses
placeholder values (`dev@example.com`, `example.awsapps.com`), never a real
account.

The documented usage cache (the timed background refresh in
`api_sessions_usage`) is untouched; this change adds no production code and does
not alter cache semantics.

## Related Issues
Fixes #632

## Testing
- [x] Existing tests pass (targeted, not `make test` - see commands below)
- [x] New tests added for new functionality
- [ ] Manual verification performed

Commands run and observed output:

```
# Frontend, from website/
$ npx vitest run src/test/App.test.tsx --coverage=false --reporter=dot -t "Kiro credits pill"
  Test Files  1 passed (1)
       Tests  14 passed | 53 skipped (67)   # includes the new identity-card test

$ npx tsc --noEmit
  exit 0

$ npx eslint src/test/App.test.tsx --ext .ts,.tsx
  exit 0
```

The full pytest suite and `make test` were not run: this is a frontend
test-only change and the brief scopes gates to the files touched. The backend
usage tests referenced above were read, not re-run, since no backend file was
modified.

## Checklist
- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) - no documented behavior changed; the
      credits-card identity behavior is not described in any `docs/system-specs`
      module, so no spec update was required
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement
The upstream template carries a placeholder: the CLA wording is supplied by
OSPO and must not be invented. Left as-is pending that text.

## Research
Investigation order followed the mandated tiers. codedb/grep located the
server-side resolution: `dashboard/handlers/usage.py` serves billing from
`sessions.py:_usage_cache`, which `_fetch_usage_bg` populates by calling
`kiro_usage_api.fetch_usage_limits`. Reading `kiro_usage_api.py` end to end
showed the two candidate identity sources and how they differ: the Kiro IDE
JSON SSO cache under `~/.aws` versus kiro-cli's own SQLite store under
`~/.local/share` (Linux) or `~/Library/Application Support` (macOS). The correct
source is the one that provably belongs to the kiro-cli account - by matching
kiro-cli's whoami profile ARN, or by provenance from kiro-cli's own store. That
selection is exactly what `fetch_usage_limits(expected_arn=...)` implements now.

`git log` on the two handlers dated the fixes: #791 (2026-07-29) added the
account display, #940 (2026-07-31) fixed credential selection, #954 (2026-07-31)
stopped the overage-blind text scrape from clobbering the API value. Issue #632
was filed before all three (lower number), and the code matches its request
exactly, so the issue is already fixed. Per the brief, a truthful "already
fixed" is a valid outcome and no invented fix was made.

Alternatives considered and rejected: (1) forwarding `account`/`email` through
the `/api/usage/kiro` `billing` allowlist - rejected because that endpoint feeds
the telemetry usage chart, not the credits widget (the widget uses
`/api/sessions/usage`, which already returns the full cache), so changing it
would not touch the reported bug and would be an unrelated edit. (2) Adding a
duplicate backend test for source selection - rejected because
`test_kiro_usage_api.py` already covers the wrong-account skip and the
source-anchored path. The only real coverage gap was the frontend, so the change
is confined to it.

Blast radius: one test file. No production code changed, so no runtime caller is
affected. Deliberately not done: no spec file was created (AGENTS.md forbids new
markdown unless instructed and no documented behavior changed), and the
`/api/usage/kiro` allowlist was left alone.
