### PR TITLE
fix(dashboard): constrain import wizard height so content pane scrolls

### DIFF
--- a/website/src/components/AgentImportFlow.tsx
+++ b/website/src/components/AgentImportFlow.tsx
@@ -421,7 +421,7 @@ export default function AgentImportFlow({
   const stageContent = (() => {
     if (scanQuery.isPending) {
       return (
-        <div className="flex min-h-[360px] flex-col items-center justify-center text-center">
+        <div className="flex flex-1 flex-col items-center justify-center text-center">
           <Loader2 className="lucide-inline animate-spin text-accent" />
           <h1 ref={headingRef} tabIndex={-1} className="mt-4 text-2xl font-semibold text-text-strong outline-none">
             {i18nT('components.agentImportFlow.scanning_for_agent_setup')}
@@ -432,7 +432,7 @@ export default function AgentImportFlow({
     }
     if (scanQuery.isError) {
       return (
-        <div className="flex min-h-[360px] flex-col items-center justify-center text-center">
+        <div className="flex flex-1 flex-col items-center justify-center text-center">
           <AlertTriangle className="lucide-inline text-danger" />
           <h1 ref={headingRef} tabIndex={-1} className="mt-4 text-2xl font-semibold text-text-strong outline-none">
             {i18nT('components.agentImportFlow.we_could_not_scan_agent_setup')}
@@ -448,7 +448,7 @@ export default function AgentImportFlow({
     }
     if (sources.length === 0) {
       return (
-        <div className="flex min-h-[360px] flex-col items-center justify-center text-center">
+        <div className="flex flex-1 flex-col items-center justify-center text-center">
           <FileSearch className="lucide-inline text-muted" />
           <h1 ref={headingRef} tabIndex={-1} className="mt-4 text-2xl font-semibold text-text-strong outline-none">
             {i18nT('components.agentImportFlow.no_supported_setup_found')}

--- a/website/src/components/OnboardingChapterShell.tsx
+++ b/website/src/components/OnboardingChapterShell.tsx
@@ -91,7 +91,7 @@ export function ShellAside({ copy }: { copy: ShellAsideCopy }) {
 // Exported for the Kiro CLI setup gate, which composes the same three pieces
 // (scrim + panel + section) around its own non-chapter content.
 export const SECTION_CLASS =
-  'flex min-h-[calc(100vh-248px)] min-w-0 flex-1 flex-col bg-card sm:min-h-0'
+  'flex min-h-[calc(100vh-248px)] min-w-0 flex-1 flex-col bg-card sm:min-h-0 sm:overflow-hidden'
 export const SCRIM_CLASS =
   'fixed inset-0 z-[120] flex min-h-0 overflow-y-auto bg-bg/70 backdrop-blur-sm p-0 text-text sm:items-center sm:justify-center sm:p-6'
 export const PANEL_CLASS =


### PR DESCRIPTION

## Description

The import wizard (`AgentImportFlow`) grew past the viewport on steps with long
content (e.g. the review step listing many skipped items). The footer buttons
scrolled out of view because the scrim itself scrolled rather than the wizard's
body pane.

Root cause: `SECTION_CLASS` in `OnboardingChapterShell.tsx` lacked
`overflow-hidden` at the `sm:` breakpoint. The panel already set a fixed height
(`sm:h-[min(760px,calc(100vh-48px))]`), and the section already used `flex-1`
with `sm:min-h-0` - but without `overflow-hidden` on the section, its flex-col
children could still grow past the allocated space. The existing scroll div
(`min-h-0 flex-1 overflow-y-auto`) never triggered because no ancestor
established a definite size context.

The fix adds `sm:overflow-hidden` to `SECTION_CLASS` so the section creates the
constraint its children already rely on. The header and footer stay pinned; only
the body pane scrolls.

A secondary symptom was inconsistent card height between steps: the
loading/error/empty states each pinned themselves to `min-h-[360px]` while the
real steps were content-driven. This made the card visibly resize as users moved
between stages. Replacing `min-h-[360px]` with `flex-1` makes every step fill
the same available space consistently.

## Related Issues

Fixes #640

## Testing

- [x] Existing tests pass (14 passed, 0 failed):
  ```
  npx vitest run src/components/AgentImportFlow.test.tsx --coverage=false --reporter=dot
  # Test Files  1 passed (1)
  #      Tests  14 passed (14)
  ```
- [x] TypeScript typecheck passes: `npx tsc --noEmit` exits 0
- [x] ESLint clean on both modified files
- [ ] Manual/visual verification performed

This is a layout bug whose fix is CSS-class-only (Tailwind utilities). The
existing test suite validates component behavior (button states, stage navigation,
API integration) but cannot verify visual layout. A meaningful assertion would
require an integration test with a real or headless browser measuring element
dimensions - something the existing test infrastructure does not provide. The fix
was verified by reasoning about the CSS flex model and by confirming it matches
the `DetailPanel` and `KiroPrerequisiteGate` patterns that already work correctly
in the same codebase.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) - no spec changes needed, this is a CSS-only fix
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under
the terms of the project license.

## Research

Investigation steps:

1. Read `ISSUE.md` - the report names `AgentImportFlow.tsx` and
   `OnboardingChapterShell.tsx`, describes the layout problem precisely (card grows
   past viewport, scrim scrolls, footer lost), and suggests clamping the card
   height. The card already has a clamped height (`sm:h-[...]`) so the issue was
   the missing overflow constraint one level down.

2. Read `OnboardingChapterShell.tsx` - traced the layout chain: SCRIM (overflow-y-auto)
   > PANEL (sm:h-[...], sm:flex-row, overflow-hidden) > ASIDE + SECTION (flex-1,
   min-h-0, flex-col). The section's children: header (shrink-0) + scroll div
   (min-h-0, flex-1, overflow-y-auto) + footer (shrink-0). The scroll div's
   overflow-y-auto cannot activate unless its parent establishes a definite height
   context - `overflow-hidden` on the section is the standard pattern.

3. Searched for existing patterns - `DetailPanel.tsx` uses
   `overflow-hidden flex flex-col` on its size-constrained container, confirming
   this is the established codebase pattern for "parent caps height, child scrolls."
   `KiroPrerequisiteGate.tsx` consumes the same `SECTION_CLASS` and its comment
   explicitly states "the panel height is fixed and the right column scrolls
   internally."

4. Considered alternatives:
   - Adding `h-full` to the section: rejected because `flex-1` + stretch already
     provides the height; the issue is the overflow context, not the height value.
   - Adding `max-h-[...]` to the section: rejected as redundant with the panel's
     fixed height.
   - Keeping `min-h-[360px]` on the per-step wrappers: rejected because
     step-specific minimums fight the card-owned height constraint and cause the
     resizing symptom the issue reports.

Blast radius: `SECTION_CLASS` is consumed by `OnboardingChapterShell` (used by
`AgentImportFlow` and `OnboardingFlow`) and by `KiroPrerequisiteGate`. Both
already intend the section to scroll internally - the gate's comment says so.
Adding `sm:overflow-hidden` is consistent with both consumers' documented intent.
No other component imports this constant.
