### PR TITLE
fix(artifacts): broadcast artifact_update after widget auto-registration

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -1638,7 +1638,19 @@ def _schedule_widget_registration(
     # unlike ``_collect_session_docs``). WidgetFrame's fallback create also sends
     # the bare key, so this keeps auto-registered and star-created artifacts in
     # the same bucket — the one the tab can actually see.
-    task = asyncio.create_task(register_widgets_off_loop(text, message_ts, slot.key))
+
+    async def _register_and_notify() -> list[str]:
+        slugs = await register_widgets_off_loop(text, message_ts, slot.key)
+        # Broadcast artifact_update for each newly registered widget so the
+        # frontend's in-session Artifacts tab refreshes immediately rather than
+        # waiting for the react-query staleness window. Without this, the tab
+        # has no signal that a widget was just auto-registered (registration
+        # bypasses the HTTP handler that normally broadcasts).
+        for s in slugs:
+            state.push_artifact_update(s, 1)
+        return slugs
+
+    task = asyncio.create_task(_register_and_notify())
     state._background_tasks.add(task)
     task.add_done_callback(state._background_tasks.discard)
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -2577,6 +2577,40 @@ class TestFlushSegment:
         asyncio.run(_run())
         assert called is False, f"{mode} session must not register widget artifacts"
 
+    def test_flush_segment_broadcasts_artifact_update_after_registration(
+        self, tmp_path, monkeypatch
+    ):
+        """Auto-registered widgets must broadcast artifact_update so the
+        frontend's in-session Artifacts tab refreshes without waiting for
+        the react-query staleness window.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.push_artifact_update = MagicMock()
+        slot = state.get_or_create_slot("s1")
+
+        async def _fake_register(text, message_ts, session_key):
+            return ["abc123", "def456"]
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.register_widgets_off_loop", _fake_register
+        )
+
+        from kiro_crew.dashboard.chat import _flush_segment
+
+        async def _run():
+            _flush_segment(state, slot, '<mcwidget title="W">body</mcwidget>')
+            await asyncio.sleep(0)
+            for t in list(state._background_tasks):
+                await t
+
+        asyncio.run(_run())
+
+        assert state.push_artifact_update.call_count == 2
+        state.push_artifact_update.assert_any_call("abc123", 1)
+        state.push_artifact_update.assert_any_call("def456", 1)
+
 
 class TestRunChatSegmentFlush:
     """Tests for segment flush behavior in _run_chat()."""

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -516,6 +516,12 @@ export function useWebSocket() {
                 queryClient.invalidateQueries({ queryKey: ['artifact-comments', slug] })
               }
               queryClient.invalidateQueries({ queryKey: ['artifacts'] })
+              // Session-scoped queries use different key prefixes that the
+              // broad ['artifacts'] invalidation does not reach. Invalidate
+              // them so the in-session Artifacts tab picks up auto-registered
+              // widgets immediately after the backend broadcasts.
+              queryClient.invalidateQueries({ queryKey: ['session-artifact-records'] })
+              queryClient.invalidateQueries({ queryKey: ['session-artifacts'] })
             }
             break
           }

--- a/website/src/test/useWebSocket.artifactUpdate.test.ts
+++ b/website/src/test/useWebSocket.artifactUpdate.test.ts
@@ -152,4 +152,12 @@ describe('useWebSocket artifact_update frame', () => {
     expect(keys).not.toContain(JSON.stringify(['artifacts']))
     expect(onDeleted).not.toHaveBeenCalled()
   })
+
+  it('invalidates session-scoped artifact queries so the Artifacts tab refreshes', () => {
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    send({ slug: 'widget-abc', version: 1, deleted: false })
+    const keys = spy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys).toContain(JSON.stringify(['session-artifact-records']))
+    expect(keys).toContain(JSON.stringify(['session-artifacts']))
+  })
 })


### PR DESCRIPTION

## Description

When the agent emits an `<mcwidget>` in chat, the backend auto-registers it as an unpinned artifact via `register_widgets_off_loop` called from `_schedule_widget_registration` in `chat_runner.py`. This registration bypasses the HTTP artifact handler (`handlers/artifacts.py`) which is normally responsible for broadcasting `artifact_update` over WebSocket. The frontend's in-session Artifacts tab (`SessionArtifactsTab` in `ActivityViewer.tsx`) uses React Query keys `['session-artifact-records', slot]` and `['session-artifacts', slot]` with no auto-refetch interval - they rely entirely on explicit invalidation signals.

The root cause is a two-part gap:

1. Widget auto-registration calls `store.create()` directly and never broadcasts an `artifact_update` WS event afterward. The existing `_fire_change` listener on the store is wired only for Knowledge Library ingestion, not for WS notification.
2. Even when `artifact_update` events arrive from other mutation paths, the frontend handler only invalidates `['artifacts']` (which prefix-matches the library section B query `['artifacts', 'panel-library']`) but not the session-scoped query keys. React Query prefix matching does not cover keys that start with a different string.

The net effect: auto-registered widget artifacts are invisible in the Artifacts tab until the user navigates away and back (triggering a remount/refetch) or the React Query staleness window (default 0 for these queries, but gated on component mount) kicks in. If the tab is already open when the segment finalizes, widgets never appear.

The fix wraps the detached registration task in a coroutine that broadcasts `artifact_update` for each newly registered slug after `register_widgets_off_loop` completes, and adds invalidation of the session-scoped query keys in the frontend's WS `artifact_update` handler.

## Related Issues

Fixes #802

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality

Backend:
```
pytest TestFlushSegment (7 passed) - includes new test_flush_segment_broadcasts_artifact_update_after_registration
pytest test_widget_artifacts.py (30 passed) - existing, confirms no regression
```

Frontend:
```
npx vitest run src/test/useWebSocket.artifactUpdate.test.ts (6 passed) - includes new test asserting session-scoped invalidation
npx tsc --noEmit: exit 0
npx eslint src/hooks/useWebSocket.ts: 0 errors
```

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Pending OSPO text.

## Research

The issue is extremely sparse - just a title and one sentence ("There seems to be a gap of what agent decides to put into artifacts tab.") with no repro steps, version, or artifact kind. The investigation focused on establishing the contract first:

**Contract established from docs/system-specs/modules/artifacts.md:**
- Every `<mcwidget>` the agent emits is auto-registered as an unpinned artifact via `widget_artifacts.register_widgets_off_loop`
- Registration happens at segment finalize time in `chat_runner._flush_segment`
- The in-session Artifacts tab queries `?touched_by=<slot>` which matches artifacts by origin session_key OR any lifecycle event's session_id
- The `artifact_update` WS event is the live-refresh mechanism for all artifact mutations

**Investigation path:**
1. Read the full artifact system spec - understood the two-input model (real artifacts + session documents)
2. Traced `_flush_segment` -> `_schedule_widget_registration` -> `register_widgets_off_loop` - confirmed registration works correctly and the session_key attribution is the bare slot key
3. Traced the WS `artifact_update` handler in `useWebSocket.ts` - found it only invalidates `['artifacts']` and slug-scoped keys
4. Confirmed `SessionArtifactsTab` uses differently-prefixed keys (`['session-artifact-records']`, `['session-artifacts']`) that the broad invalidation cannot reach
5. Confirmed `_schedule_widget_registration` has no broadcast mechanism - the task fires, completes, and only discards itself from the background_tasks set

**Alternatives considered:**
- Adding a `refetchInterval` to the session-artifact queries: rejected because polling is wasteful and the latency would still be non-zero. The existing WS push model is correct; it just had a gap in coverage.
- Using `_fire_change` (the store's change listener): rejected because that listener is designed for Knowledge Library ingestion and runs in the executor thread, not on the event loop where `push_artifact_update` needs to run.
- Merging the registration into the HTTP handler path: rejected because the spec explicitly says registration must be fire-and-forget with no added latency to segment flushes.

**Blast radius:** `push_artifact_update` is a fire-and-forget WS broadcast; the added calls mirror what the HTTP create handler already does. The frontend invalidation is additive (two more prefixes) and triggers React Query's standard stale-while-revalidate path. No new imports, no new dependencies.
