### PR TITLE
fix(dashboard): restore sidebar rows as lazy stub slots

### DIFF
--- a/src/kiro_crew/dashboard/chat.py
+++ b/src/kiro_crew/dashboard/chat.py
@@ -88,6 +88,7 @@ from kiro_crew.dashboard.chat_persistence import (  # noqa: F401
     _build_history_prefix,
     _rehydrate_slot_from_history,
     _save_slot_to_history,
+    materialize_slot,
     restore_open_slots,
     restore_open_slots_async,
     restore_recent_sessions,

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -32,6 +32,7 @@ from kiro_crew.dashboard.chat_orchestrator import _stage_loop
 from kiro_crew.dashboard.chat_persistence import (
     _attach_variants,
     get_reasoning_effort_values,
+    materialize_slot,
     save_slot_off_loop,
 )
 from kiro_crew.dashboard.chat_runner import _context_usage_payload, _run_chat
@@ -345,6 +346,9 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
 
     slot._has_reader = not ws_mode  # Only block SSE broadcast if HTTP SSE reader
     slot._file_changes = []  # Reset file-change accumulator for the new turn
+    # ── Materialize stub slots before a turn starts (on-demand load) ──
+    if slot._stub:
+        materialize_slot(state, slot)
     # ── Sweep orphaned permissions from prior turns ──
     _sweep_stale_permissions(slot)
 
@@ -602,6 +606,10 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     if not slot:
         return web.json_response({"error": "not found"}, status=404)
 
+    # Materialize stub slots on first detail access (user activated the tab).
+    if slot._stub:
+        materialize_slot(state, slot)
+
     limit_raw = request.query.get("limit")
     before = request.query.get("before")
 
@@ -757,9 +765,7 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
             # One code for BOTH reasons on purpose: a distinct code per reason
             # would turn this 404 into an existence oracle for slots the caller
             # may not know about. The prose stays in `error` for logs.
-            return web.json_response(
-                {"error": "not found", "code": "slot_not_found"}, status=404
-            )
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
         # Pin title if explicitly provided (prevents auto-title from overwriting)
         title = (body.get("title") or "").strip()[:200] if isinstance(body, dict) else ""
         if title:
@@ -871,14 +877,10 @@ def _unblock_pending_waits(state: DashboardState, slot: _ChatSlot) -> None:
     _reject_pending_approvals(slot)
     cancelled = state.cancel_questions_for_slot(slot.key)
     if cancelled:
-        logger.info(
-            "Stop: cancelled %d pending question(s) on slot %s", cancelled, slot.key
-        )
+        logger.info("Stop: cancelled %d pending question(s) on slot %s", cancelled, slot.key)
 
 
-async def _reset_slot_session(
-    state: DashboardState, slot: _ChatSlot, session_key: str
-) -> None:
+async def _reset_slot_session(state: DashboardState, slot: _ChatSlot, session_key: str) -> None:
     """Reset a slot's agent session, releasing anything blocked on the old one.
 
     The switch handlers (agent, model, bulk model, reasoning effort, workspace)

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -197,9 +197,7 @@ def _restore_open_slots_steps(state: DashboardState) -> "Iterator[int]":
         # separators; reject any that do, warn so an attempted breakout is
         # visible, and keep restoring the rest.
         if "/" in raw or "\\" in raw:
-            logger.warning(
-                "restore_open_slots: rejecting key with path separators: %r", raw
-            )
+            logger.warning("restore_open_slots: rejecting key with path separators: %r", raw)
             continue
         # Fold to the canonical (filename-charset) key. Snapshots written
         # before slot-key normalization landed may carry a raw display-style
@@ -210,24 +208,15 @@ def _restore_open_slots_steps(state: DashboardState) -> "Iterator[int]":
         if raw in state._slots:
             continue
         try:
-            slot = _rehydrate_slot_from_history(state, raw, kiro_model_map=kiro_model_map)
+            slot = _create_stub_slot(state, raw, kiro_model_map=kiro_model_map)
         except Exception:
-            logger.debug("restore_open_slots: rehydrate failed for %s", raw, exc_info=True)
-            # Roll back any partial slot leaked by _rehydrate_slot_from_history.
-            # It calls state.get_or_create_slot() BEFORE its fallible work
-            # (read_messages, redaction, slot.append), so a failure there
-            # leaves an empty slot registered in state._slots. Without this
-            # pop, restore_recent_sessions runs next, hits its
-            # `if slot_name in state._slots: continue` dedup guard, and skips
-            # the proper restore — the user would see a tab with the right
-            # title/agent but empty or wrong message history.
+            logger.debug("restore_open_slots: stub creation failed for %s", raw, exc_info=True)
+            # Roll back any partial slot leaked by _create_stub_slot.
+            # It calls state.get_or_create_slot() BEFORE its fallible work,
+            # so a failure leaves an empty slot registered in state._slots.
             state._slots.pop(raw, None)
-            # _rehydrate_slot_from_history also adds `dashboard:{slot_name}`
-            # to _restricted_keys before that fallible work for any
-            # non-persistent memory_mode. Roll it back too, else a later
-            # get_or_create_slot(slot_name) (default memory_mode='persistent')
-            # silently inherits restricted status, blocking
-            # consolidation/lessons for what should be a normal session.
+            # _create_stub_slot also adds `dashboard:{slot_name}`
+            # to _restricted_keys for any non-persistent memory_mode.
             state._restricted_keys.discard(f"dashboard:{raw}")
             continue
         if slot is not None:
@@ -313,6 +302,151 @@ def _attach_variants(slot: _ChatSlot, m: dict) -> None:
             if isinstance(v, dict)
         ]
         slot.messages[-1]["variant_idx"] = m.get("variant_idx", 0)
+
+
+def _create_stub_slot(
+    state: DashboardState,
+    slot_name: str,
+    *,
+    kiro_model_map: dict[str, str] | None = None,
+) -> _ChatSlot | None:
+    """Create a lightweight stub slot for sidebar rendering without loading messages.
+
+    Reads only the metadata line and a bounded tail preview - no full transcript
+    read, no per-message redaction pass. The slot's ``_stub`` flag is True;
+    callers that need messages must call :func:`materialize_slot` first.
+
+    Returns None if the session does not exist or is closed (same contract as
+    :func:`_rehydrate_slot_from_history`).
+    """
+    if not state.conversation_log:
+        return None
+    slot_name = _normalize_slot_key(slot_name)
+    if slot_name in state._slots:
+        return state._slots[slot_name]
+    history_key = _history_key_for(slot_name)
+    meta = state.conversation_log.get_metadata(history_key)
+    if not meta:
+        return None
+    if meta.get("closed"):
+        return None
+    try:
+        _restore_cfg = KiroCrewConfig.load()
+    except Exception:
+        _restore_cfg = None
+    if kiro_model_map is None:
+        kiro_model_map = _build_kiro_model_map()
+    slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
+    # Populate sidebar-visible metadata from the metadata line.
+    raw_title = meta.get("title") or slot_name
+    raw_title, _ = redact_exfiltration_urls(raw_title)
+    raw_title, _ = redact_credentials(raw_title)
+    slot.title = raw_title
+    slot._titled = bool(meta.get("title"))
+    if meta.get("created_at"):
+        slot.created_at = meta["created_at"]
+    if meta.get("agent"):
+        slot.agent = meta["agent"]
+    if meta.get("model"):
+        _prov = _restore_cfg.agent.provider if _restore_cfg else ""
+        slot.model = model_registry.canonicalize_for_provider(
+            _normalize_model(meta["model"]), _prov
+        )
+    elif slot.agent:
+        try:
+            mc = _restore_cfg.agents.get(slot.agent) if _restore_cfg else None
+            kiro_name = mc.kiro_agent if mc and mc.kiro_agent else slot.agent
+            slot.model = kiro_model_map.get(kiro_name, "")
+        except Exception:
+            logger.debug("Failed to resolve model for stub slot %s", slot_name, exc_info=True)
+    if meta.get("reasoning_effort"):
+        slot.reasoning_effort = _validate_reasoning_effort(meta["reasoning_effort"])
+    if meta.get("workspace"):
+        slot.workspace = meta["workspace"]
+    if meta.get("project"):
+        slot.project = meta["project"]
+    if meta.get("mode"):
+        slot.mode = meta["mode"]
+    if meta.get("folder_id"):
+        slot.folder_id = meta["folder_id"]
+    if meta.get("app"):
+        slot._app = meta["app"]
+    _artifact_meta = meta.get("artifact")
+    if isinstance(_artifact_meta, str) and ARTIFACT_SLUG_RE.match(_artifact_meta):
+        slot._artifact = _artifact_meta
+    if meta.get("pinned"):
+        slot.pinned = True
+    if meta.get("color_index") is not None:
+        slot.color_index = meta["color_index"]
+    raw_tags = meta.get("tags")
+    if isinstance(raw_tags, list):
+        slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
+    mm = meta.get("memory_mode", "persistent")
+    slot.memory_mode = mm
+    if mm != "persistent":
+        state._restricted_keys.add(f"dashboard:{slot_name}")
+    if meta.get("forked_from") is not None:
+        slot.forked_from = meta["forked_from"]
+    tab_id = meta.get("tab_id")
+    if not tab_id:
+        tab_id = uuid.uuid4().hex[:12]
+        update_metadata_off_loop(state.conversation_log, history_key, {"tab_id": tab_id})
+    slot._tab_id = tab_id
+    # Cheap tail preview for sidebar last_message (bounded backward seek).
+    preview = state.conversation_log.last_message_preview(history_key)
+    # Redact the preview (it came from raw disk content).
+    if preview:
+        preview, _ = redact_exfiltration_urls(preview)
+        preview, _ = redact_credentials(preview)
+        preview = (preview[:80] + "\u2026") if len(preview) > 80 else preview
+    slot._stub = True
+    slot._stub_last_msg = preview
+    # Use metadata created_at as a fallback timestamp for the sidebar.
+    slot._stub_last_ts = meta.get("created_at", "")
+    slot._stub_message_count = 0
+    slot._dirty = False
+    logger.info("Created stub slot %s (%s)", slot_name, slot.title)
+    return slot
+
+
+def materialize_slot(state: DashboardState, slot: _ChatSlot) -> None:
+    """Materialize a stub slot into a full slot by loading its message history.
+
+    Reads and redacts the transcript, populating ``slot.messages`` and clearing
+    the ``_stub`` flag. Safe to call on an already-materialized slot (no-op).
+    Must be called on the event loop thread (it mutates slot state).
+    """
+    if not slot._stub:
+        return
+    if not state.conversation_log:
+        slot._stub = False
+        return
+    history_key = _history_key_for(slot.key)
+    messages = state.conversation_log.read_messages_chained(history_key)
+    slot._disk_older_count = max(0, len(messages) - 500)
+    for m in messages[-500:]:
+        role = m.get("role", "assistant")
+        cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
+        content = m.get("content", "")
+        # Content redaction on load - same policy as _rehydrate_slot_from_history.
+        if role != "user":
+            content, _ = redact_exfiltration_urls(content)
+            content, _ = redact_credentials(content)
+        slot.append(
+            role,
+            content,
+            cls,
+            ts=m.get("ts", ""),
+            broadcast=False,
+            meta=(m["meta"] if isinstance(m.get("meta"), dict) else None),
+        )
+        _attach_variants(slot, m)
+    slot.drain()
+    slot._resumed_count = len(slot.messages)
+    slot._disk_window_len = len(slot.messages)
+    slot._dirty = False
+    slot._stub = False
+    logger.info("Materialized stub slot %s (%d messages)", slot.key, len(slot.messages))
 
 
 def _rehydrate_slot_from_history(
@@ -455,9 +589,7 @@ def _rehydrate_slot_from_history(
         # resolution in api_send_message). update_metadata enters _locked
         # (flock + os.close), a blocking-on-loop-prohibited op, so backfill the
         # tab_id off the loop rather than on it.
-        update_metadata_off_loop(
-            state.conversation_log, history_key, {"tab_id": tab_id}
-        )
+        update_metadata_off_loop(state.conversation_log, history_key, {"tab_id": tab_id})
     slot._tab_id = tab_id
     # Use read_messages_chained (not read_messages) so the loaded window walks
     # the tab_id ancestry across forks, matching restore_recent_sessions.
@@ -582,7 +714,7 @@ def _restore_recent_sessions_steps(
                 continue
         slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
         # Titles can be LLM-generated (auto-title) and are surfaced on the
-        # dashboard — apply the same redaction as assistant content. Matches
+        # dashboard - apply the same redaction as assistant content. Matches
         # the treatment in _rehydrate_slot_from_history above.
         raw_title = s.get("title", slot_name)
         raw_title, _ = redact_exfiltration_urls(raw_title)
@@ -647,42 +779,23 @@ def _restore_recent_sessions_steps(
         if not tab_id:
             tab_id = uuid.uuid4().hex[:12]
             # restore_recent_sessions runs during on_startup (event loop live)
-            # — keep the _locked flock/os.close off the loop via the off-loop
+            # - keep the _locked flock/os.close off the loop via the off-loop
             # backfill helper.
-            update_metadata_off_loop(
-                state.conversation_log, key, {"tab_id": tab_id}
-            )
+            update_metadata_off_loop(state.conversation_log, key, {"tab_id": tab_id})
         slot._tab_id = tab_id
-        messages = state.conversation_log.read_messages_chained(key)
-        slot._disk_older_count = max(0, len(messages) - 500)
-        for m in messages[-500:]:
-            role = m.get("role", "assistant")
-            cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
-            content = m.get("content", "")
-            # CONTENT is redacted on load; META is deferred to the emit sites.
-            # See the equivalent loop in _rehydrate_slot_from_history for the
-            # measured rationale (content ~0.4s / ~204 readers, meta ~5.5s /
-            # 31 readers that touch only control fields outside the emit sites).
-            if role != "user":
-                content, _ = redact_exfiltration_urls(content)
-                content, _ = redact_credentials(content)
-            slot.append(
-                role,
-                content,
-                cls,
-                ts=m.get("ts", ""),
-                broadcast=False,
-                meta=(m["meta"] if isinstance(m.get("meta"), dict) else None),
-            )
-            _attach_variants(slot, m)
-        slot.drain()
-        slot._resumed_count = len(slot.messages)
-        # Loaded window is the on-disk window region; older lines (counted in
-        # _disk_older_count above) are the frozen prefix saves never rewrite.
-        slot._disk_window_len = len(slot.messages)
+        # Create as stub: cheap tail preview for sidebar, no full transcript read.
+        preview = state.conversation_log.last_message_preview(key)
+        if preview:
+            preview, _ = redact_exfiltration_urls(preview)
+            preview, _ = redact_credentials(preview)
+            preview = (preview[:80] + "\u2026") if len(preview) > 80 else preview
+        slot._stub = True
+        slot._stub_last_msg = preview
+        slot._stub_last_ts = meta.get("created_at", "")
+        slot._stub_message_count = 0
         slot._dirty = False
         restored += 1
-        logger.info("Restored session %s (%s)", slot_name, slot.title)
+        logger.info("Restored session %s (%s) as stub", slot_name, slot.title)
         # One yield point per restored session (see _restore_open_slots_steps).
         yield restored
     _sync_dashboard_slots(state)
@@ -899,12 +1012,7 @@ def _frozen_prefix_and_foreign_appends(
     except OSError:
         return ("", [], [])
     cache = slot._frozen_prefix_cache
-    if (
-        cache is not None
-        and cache[0] == mtime
-        and cache[1] == size
-        and cache[2] == disk_older
-    ):
+    if cache is not None and cache[0] == mtime and cache[1] == size and cache[2] == disk_older:
         # File is byte-identical to our last write → prefix AND the foreign
         # lines that write preserved are both served from cache. Returning the
         # cached foreign lines (a copy, so the caller cannot mutate the cache)
@@ -1244,14 +1352,10 @@ def _save_slot_to_history(
             # foreign lines so a concurrent cross-process append (landed between
             # this save's pre-lock ``window`` snapshot and the lock) is preserved
             # rather than clobbered by the meta+frozen+window replace.
-            window_entries = [
-                e for m in window if (e := _build_message_entry(m)) is not None
-            ]
+            window_entries = [e for m in window if (e := _build_message_entry(m)) is not None]
             window_lines = [json.dumps(e) + "\n" for e in window_entries]
-            frozen_prefix, foreign_lines, dedup_dropped = (
-                _frozen_prefix_and_foreign_appends(
-                    slot, path, disk_older, window_entries, collect_foreign=not rewrite
-                )
+            frozen_prefix, foreign_lines, dedup_dropped = _frozen_prefix_and_foreign_appends(
+                slot, path, disk_older, window_entries, collect_foreign=not rewrite
             )
             # A fresh-``ts`` disk copy folded into the window by the bounded
             # (role, content) tiebreak is redundant with a window entry, so the
@@ -1261,23 +1365,15 @@ def _save_slot_to_history(
             # the trade-off loses no data permanently (arbiter long-term item 2b).
             if dedup_dropped:
                 try:
-                    base = (
-                        state.conversation_log._dir
-                        if state.conversation_log
-                        else None
-                    )
-                    _archive_lines(
-                        history_key, dedup_dropped, reason="foreign-dedup", base=base
-                    )
+                    base = state.conversation_log._dir if state.conversation_log else None
+                    _archive_lines(history_key, dedup_dropped, reason="foreign-dedup", base=base)
                 except Exception:
                     logger.warning(
                         "Failed to archive foreign-dedup drops for %s",
                         history_key,
                         exc_info=True,
                     )
-            payload = (
-                meta_str + frozen_prefix + "".join(window_lines) + "".join(foreign_lines)
-            )
+            payload = meta_str + frozen_prefix + "".join(window_lines) + "".join(foreign_lines)
 
             # Rewrite paths (rewind/regenerate/fork) intentionally TRUNCATE the
             # window, so the dropped tail must be archived first to stay
@@ -1373,9 +1469,7 @@ async def save_slot_off_loop(
     """
 
     def _do() -> None:
-        _save_slot_to_history(
-            state, slot, messages, closed=closed, force=force, rewrite=rewrite
-        )
+        _save_slot_to_history(state, slot, messages, closed=closed, force=force, rewrite=rewrite)
 
     try:
         loop = asyncio.get_running_loop()

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -23,7 +23,7 @@ from kiro_crew.browser.setup import (
 )
 from kiro_crew.constants import CHAT_TURN_TIMEOUT
 from kiro_crew.cron import CronStoreBusy
-from kiro_crew.dashboard.chat_persistence import _rehydrate_slot_from_history
+from kiro_crew.dashboard.chat_persistence import _rehydrate_slot_from_history, materialize_slot
 from kiro_crew.dashboard.chat_utils import _remove_queued_by_id
 from kiro_crew.dashboard.origin import is_direct_local_request, is_loopback
 from kiro_crew.dashboard.state import (
@@ -179,14 +179,10 @@ async def api_spawn_continue(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except Exception:
-        return web.json_response(
-            {"error": "invalid JSON", "code": "invalid_json"}, status=400
-        )
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     task = str(body.get("task", "") or "").strip()
     if not task:
-        return web.json_response(
-            {"error": "task is required", "code": "task_required"}, status=400
-        )
+        return web.json_response({"error": "task is required", "code": "task_required"}, status=400)
     parent_session = str(body.get("parent_session", "") or "")
     agent = str(body.get("agent", "") or "")
     model = str(body.get("model", "") or "")
@@ -212,19 +208,11 @@ async def api_spawn_continue(request: web.Request) -> web.Response:
         )
     if info.done and info.error:
         if info.error.startswith("conversation_busy"):
-            return web.json_response(
-                {"error": info.error, "code": "conversation_busy"}, status=409
-            )
+            return web.json_response({"error": info.error, "code": "conversation_busy"}, status=409)
         if info.error.startswith("conversation_gone"):
-            return web.json_response(
-                {"error": info.error, "code": "conversation_gone"}, status=404
-            )
-        return web.json_response(
-            {"error": info.error, "code": "spawn_rejected"}, status=400
-        )
-    return web.json_response(
-        {"id": info.id, "conversation": conv_id, "status": "spawned"}
-    )
+            return web.json_response({"error": info.error, "code": "conversation_gone"}, status=404)
+        return web.json_response({"error": info.error, "code": "spawn_rejected"}, status=400)
+    return web.json_response({"id": info.id, "conversation": conv_id, "status": "spawned"})
 
 
 async def api_spawn_steer(request: web.Request) -> web.Response:
@@ -239,9 +227,7 @@ async def api_spawn_steer(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except Exception:
-        return web.json_response(
-            {"error": "invalid JSON", "code": "invalid_json"}, status=400
-        )
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     message = str(body.get("message", "") or "").strip()
     if not message:
         return web.json_response(
@@ -250,16 +236,10 @@ async def api_spawn_steer(request: web.Request) -> web.Response:
     ok, detail = await state.subagents.steer_run(agent_id, message)
     if not ok:
         if detail == "not_found":
-            return web.json_response(
-                {"error": detail, "code": "not_found"}, status=404
-            )
+            return web.json_response({"error": detail, "code": "not_found"}, status=404)
         if detail.startswith("not_running"):
-            return web.json_response(
-                {"error": detail, "code": "not_running"}, status=409
-            )
-        return web.json_response(
-            {"error": detail, "code": "steer_failed"}, status=502
-        )
+            return web.json_response({"error": detail, "code": "not_running"}, status=409)
+        return web.json_response({"error": detail, "code": "steer_failed"}, status=502)
     return web.json_response({"id": agent_id, "status": "steered"})
 
 
@@ -279,12 +259,8 @@ async def api_spawn_release(request: web.Request) -> web.Response:
     ok, detail = state.subagents.release_conversation(conv_id)
     if not ok:
         if detail.startswith("conversation_busy"):
-            return web.json_response(
-                {"error": detail, "code": "conversation_busy"}, status=409
-            )
-        return web.json_response(
-            {"error": detail, "code": "conversation_gone"}, status=404
-        )
+            return web.json_response({"error": detail, "code": "conversation_busy"}, status=409)
+        return web.json_response({"error": detail, "code": "conversation_gone"}, status=404)
     return web.json_response({"conversation": conv_id, "status": "released"})
 
 
@@ -1171,6 +1147,9 @@ async def api_send_message(request: web.Request) -> web.Response:
                     (slot is not None and not was_loaded),
                 )
                 if slot:
+                    # Materialize stub if needed before injecting messages.
+                    if slot._stub:
+                        materialize_slot(state, slot)
                     label = job_name or "cron"
                     label, _ = redact_exfiltration_urls(label)
                     label, _ = redact_credentials(label)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -847,6 +847,10 @@ class _ChatSlot:
         "_native_subagent_tracker",
         "_native_subagent_output",
         "_pending_steers",
+        "_stub",
+        "_stub_last_msg",
+        "_stub_last_ts",
+        "_stub_message_count",
     )
 
     def __init__(
@@ -1073,6 +1077,13 @@ class _ChatSlot:
         # STOP, error). Without this, a steer swallowed by a dying turn
         # vanished with no trace (2026-07-17 incident; see the requeue site).
         self._pending_steers: list[str] = []
+        # Stub support: a stub slot holds metadata for sidebar rendering
+        # without materializing the full message list.  Materialized on demand
+        # when the tab is activated (detail endpoint or send).
+        self._stub: bool = False
+        self._stub_last_msg: str = ""
+        self._stub_last_ts: str = ""
+        self._stub_message_count: int = 0
 
     @property
     def _plan_stage_count(self) -> int:
@@ -1422,6 +1433,56 @@ class _ChatSlot:
         return links
 
     def to_dict(self, *, include_check_status: bool = False) -> dict:
+        # Fast path for stub slots: return sidebar-only projection without
+        # scanning messages (which are empty for stubs).
+        if self._stub:
+            return {
+                "key": self.key,
+                "title": _redact(self.display_title),
+                "agent": self.agent,
+                "model": self.model,
+                "reasoning_effort": self.reasoning_effort,
+                "mode": self.mode,
+                "surface": self.mode,
+                "workspace": self.workspace,
+                "project": self.project,
+                "artifact": self._artifact,
+                "messages": self._stub_message_count,
+                "running": False,
+                "queue_depth": 0,
+                "stopping": False,
+                "pending_approval": False,
+                "pending_approval_info": None,
+                "last_activity_ts": self._stub_last_ts,
+                "waiting_for_input": False,
+                "stop_state": "idle",
+                "created": self.created_at,
+                "last_ts": self._stub_last_ts,
+                "last_message": self._stub_last_msg,
+                "source_links": [],
+                "source_links_total": 0,
+                "todo": None,
+                "has_options": False,
+                "options": [],
+                "prompt_preview": "",
+                "trust": False,
+                "trust_reads": False,
+                "trusted_patterns_count": 0,
+                "slack_linked": self._slack_linked,
+                "slack_channel": self._slack_channel,
+                "slack_thread_ts": self._slack_thread_ts,
+                "folder_id": self.folder_id,
+                "pinned": self.pinned,
+                "tags": list(self.tags),
+                "color_index": self.color_index,
+                "color_theme": self.color_theme,
+                "theme_consent": self.theme_consent,
+                "theme_consent_sha": self.theme_consent_sha,
+                "memory_mode": self.memory_mode,
+                "forked_from": self.forked_from,
+                "linked_session_key": self.linked_session_key,
+                "app": self._app,
+            }
         last_ts = self.messages[-1].get("ts", "") if self.messages else ""
         # Single reverse scan for last_msg, options, and last_activity_ts.
         last_msg = ""

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -7646,7 +7646,11 @@ class TestRegenerateAndVariants:
         ]
         slot.messages[-1]["variant_idx"] = 1
         slot.drain()
-        from kiro_crew.dashboard.chat import _save_slot_to_history, restore_recent_sessions
+        from kiro_crew.dashboard.chat import (
+            _save_slot_to_history,
+            materialize_slot,
+            restore_recent_sessions,
+        )
 
         _save_slot_to_history(state, slot)
         # Clear in-memory state and restore via production path
@@ -7654,6 +7658,14 @@ class TestRegenerateAndVariants:
         restore_recent_sessions(state, window_minutes=9999)
         restored_slot = state._slots.get("s1")
         assert restored_slot is not None
+        # restore_recent_sessions now yields a lazy STUB (no transcript read) so
+        # startup does not materialize every sidebar row. Messages -- and with
+        # them the variant payload -- arrive when the tab is activated, which is
+        # what materialize_slot does on the production path.
+        assert restored_slot._stub is True
+        assert restored_slot.messages == []
+        materialize_slot(state, restored_slot)
+        assert restored_slot._stub is False
         ai = [m for m in restored_slot.messages if m.get("role") == "assistant"][0]
         assert "variants" in ai
         assert len(ai["variants"]) == 2

--- a/test/test_display_time_redaction.py
+++ b/test/test_display_time_redaction.py
@@ -20,6 +20,7 @@ The `system` role is the crux of the emit-site half: the write path never redact
 it, the old load path did, and the emit paths did not — so `system` content
 reached disk raw and was cleaned only in memory.
 """
+
 from __future__ import annotations
 
 import json
@@ -218,13 +219,19 @@ def test_restore_recent_sessions_does_not_broadcast_either(tmp_path, monkeypatch
 
     monkeypatch.setattr(state2, "get_or_create_slot", _spy)
 
-    from kiro_crew.dashboard.chat_persistence import restore_recent_sessions
+    from kiro_crew.dashboard.chat_persistence import materialize_slot, restore_recent_sessions
 
     restored = restore_recent_sessions(state2, window_minutes=0)
     assert restored == 1, "precondition: the session was restored"
     slot = state2._slots.get("chat-1-nb2")
-    assert slot is not None and slot.messages, "precondition: messages were replayed"
-    assert seen == [], f"restore_recent_sessions broadcast {len(seen)} message(s)"
+    assert slot is not None, "precondition: the stub slot was created"
+    assert (
+        seen == []
+    ), f"restore_recent_sessions broadcast {len(seen)} message(s) during stub creation"
+    # Materialization must also not broadcast.
+    materialize_slot(state2, slot)
+    assert slot.messages, "precondition: messages were loaded by materialize"
+    assert seen == [], f"materialize_slot broadcast {len(seen)} message(s)"
 
 
 def test_rehydrate_does_not_broadcast_replayed_messages(tmp_path, monkeypatch) -> None:
@@ -459,15 +466,11 @@ def test_oauth_url_gate_still_blocks_a_tampered_url() -> None:
     from kiro_crew.dashboard.chat_utils import _redact_meta_for_role
 
     # 1. Non-http(s) scheme: must never reach an <a href>.
-    out = _redact_meta_for_role(
-        "mcp_oauth", {"oauth_url": "javascript:alert(document.cookie)"}
-    )
+    out = _redact_meta_for_role("mcp_oauth", {"oauth_url": "javascript:alert(document.cookie)"})
     assert out["oauth_url"] == "", "javascript: URL survived the scheme gate"
 
     # 2. An embedded real credential still blanks it.
-    out = _redact_meta_for_role(
-        "mcp_oauth", {"oauth_url": f"https://ex.com/cb?tok={SECRET}"}
-    )
+    out = _redact_meta_for_role("mcp_oauth", {"oauth_url": f"https://ex.com/cb?tok={SECRET}"})
     assert out["oauth_url"] == "", "credential-bearing URL survived the cred gate"
 
 

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -263,18 +263,18 @@ def test_restore_open_slots_rolls_back_partial_slot_on_rehydrate_failure(tmp_pat
 
     state2 = _make_state(tmp_path / "sessions")
 
-    # Patch _rehydrate_slot_from_history so that it leaks a partial slot
+    # Patch _create_stub_slot so that it leaks a partial slot
     # (mirroring the real partial-state path) and then raises. Without the
     # rollback in restore_open_slots, the partial slot would persist.
     from kiro_crew.dashboard import chat_persistence as cp_mod
 
-    def _failing_rehydrate(state_arg, slot_name):
+    def _failing_stub(state_arg, slot_name, **kwargs):
         # Mimic the real failure mode: register an empty slot via
         # get_or_create_slot, then bomb on the fallible work.
         state_arg.get_or_create_slot(slot_name, app="")
-        raise RuntimeError("simulated read_messages failure (e.g. disk EIO)")
+        raise RuntimeError("simulated stub creation failure (e.g. disk EIO)")
 
-    monkeypatch.setattr(cp_mod, "_rehydrate_slot_from_history", _failing_rehydrate)
+    monkeypatch.setattr(cp_mod, "_create_stub_slot", _failing_stub)
     restored = restore_open_slots(state2)
 
     # Rehydrate raised, so nothing was successfully restored.
@@ -328,9 +328,7 @@ def test_rehydrate_slot_restores_persisted_tab_id_for_fork_chaining(tmp_path, mo
 
     # Legacy-session path: no tab_id in meta -> one is generated and written back.
     _seed_session(state, "chat-2-legacy-no-tab-id")
-    snapshot_path.write_text(
-        json.dumps({"keys": ["chat-2-legacy-no-tab-id"], "ts": 0.0})
-    )
+    snapshot_path.write_text(json.dumps({"keys": ["chat-2-legacy-no-tab-id"], "ts": 0.0}))
     state3 = _make_state(tmp_path / "sessions")
     restored = restore_open_slots(state3)
     assert restored == 1
@@ -344,15 +342,11 @@ def test_rehydrate_slot_restores_persisted_tab_id_for_fork_chaining(tmp_path, mo
 
 
 def test_rehydrate_slot_uses_chained_read_with_500_message_window(tmp_path, monkeypatch):
-    """Chained read + 500-message window on rehydrate.
+    """Chained read + 500-message window on materialize.
 
-    ``_rehydrate_slot_from_history`` previously called
-    ``conversation_log.read_messages(history_key)`` (no chain, capped at 200
-    in-memory). ``restore_recent_sessions`` uses
-    ``read_messages_chained(key)`` (capped at 500). Because
-    ``restore_open_slots`` runs FIRST in start_dashboard and dedupes by key,
-    every long-running session lost 200+ messages of visible window on every
-    gateway restart.
+    ``materialize_slot`` must call ``read_messages_chained`` (not
+    ``read_messages``) so the loaded window walks the tab_id ancestry
+    across forks, matching the behavior previously done at restore time.
 
     This test pins:
       1. ``read_messages_chained`` is the call used (not ``read_messages``).
@@ -382,36 +376,41 @@ def test_rehydrate_slot_uses_chained_read_with_500_message_window(tmp_path, monk
         flat_calls.append(key)
         return real_flat(key, *args, **kwargs)
 
-    with patch.object(state2.conversation_log, "read_messages_chained", _spy_chained), \
-            patch.object(state2.conversation_log, "read_messages", _spy_flat):
-        restored = restore_open_slots(state2)
-
+    # First restore creates stubs (no message read).
+    restored = restore_open_slots(state2)
     assert restored == 1
+    slot = state2._slots["chat-1-long"]
+    assert slot._stub is True
+
+    # Materialize triggers the actual read.
+    from kiro_crew.dashboard.chat_persistence import materialize_slot
+
+    with (
+        patch.object(state2.conversation_log, "read_messages_chained", _spy_chained),
+        patch.object(state2.conversation_log, "read_messages", _spy_flat),
+    ):
+        materialize_slot(state2, slot)
+
+    assert slot._stub is False
     history_key = _history_key_for("chat-1-long")
     assert history_key in chained_calls, (
-        f"rehydrate did NOT call read_messages_chained "
+        f"materialize did NOT call read_messages_chained "
         f"(called: chained={chained_calls!r}, flat={flat_calls!r}). "
         "Forked-session ancestry would be invisible to the in-memory window."
     )
     assert history_key not in flat_calls, (
-        "rehydrate still called the non-chained read_messages, "
+        "materialize still called the non-chained read_messages, "
         "which caps at 200 and does not walk fork ancestry."
     )
 
 
 def test_rehydrate_slot_loads_full_500_message_window(tmp_path, monkeypatch):
-    """Functional window-cap pin: rehydrate loads the full window.
+    """Functional window-cap pin: materialize loads the full window.
 
-    Seeds 250 messages — strictly more than the old 200 cap and well below
-    the new 500 cap — then rehydrates and asserts ALL 250 were loaded into
-    the slot. This pin is durable against refactors that the previous
-    inspect-the-source approach was brittle to (extracting 500 to a named
-    constant, reformatting, etc. would silently break a string-match
-    assertion). 250 keeps the test fast (sub-second seeding) while still
-    proving the cap is materially > 200.
-
-    Pre-fix (200 cap), this test would see only the last 200 of 250
-    messages restored. With the 500 cap, all 250 land.
+    Seeds 250 messages - strictly more than the old 200 cap and well below
+    the new 500 cap - then restores as stub and materializes, asserting ALL
+    250 were loaded into the slot. This pin is durable against refactors that
+    the previous inspect-the-source approach was brittle to.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
@@ -423,17 +422,25 @@ def test_rehydrate_slot_loads_full_500_message_window(tmp_path, monkeypatch):
         log.append(history_key, "user", f"msg-{i:03d}")
 
     snapshot_path = tmp_path / "open_slots.json"
-    snapshot_path.write_text(
-        json.dumps({"keys": ["chat-1-bigwindow"], "ts": 0.0})
-    )
+    snapshot_path.write_text(json.dumps({"keys": ["chat-1-bigwindow"], "ts": 0.0}))
 
     state2 = _make_state(tmp_path / "sessions")
     restored = restore_open_slots(state2)
     assert restored == 1
     slot = state2._slots["chat-1-bigwindow"]
+    # Stub has no messages loaded.
+    assert slot._stub is True
+    assert len(slot.messages) == 0
+
+    # Materialize loads the full window.
+    from kiro_crew.dashboard.chat_persistence import materialize_slot
+
+    materialize_slot(state2, slot)
+
+    assert slot._stub is False
     assert len(slot.messages) == 250, (
-        f"rehydrate loaded {len(slot.messages)} of 250 seeded "
-        "messages — likely still using the old 200-message cap. "
+        f"materialize loaded {len(slot.messages)} of 250 seeded "
+        "messages - likely still using the old 200-message cap. "
         "The window must be >= 250 (current target: 500)."
     )
     # Verify ordering (oldest first, newest last) — defensive, in case a
@@ -499,16 +506,16 @@ def test_restore_open_slots_rollback_also_discards_restricted_keys(tmp_path, mon
     state2 = _make_state(tmp_path / "sessions")
     from kiro_crew.dashboard import chat_persistence as cp_mod
 
-    def _failing_rehydrate(state_arg, slot_name):
+    def _failing_stub(state_arg, slot_name, **kwargs):
         # Mimic the real failure mode for an INCOGNITO session: register the
-        # slot, mark it restricted (matching what _rehydrate_slot_from_history
+        # slot, mark it restricted (matching what _create_stub_slot
         # does for non-persistent memory_mode), THEN bomb on the fallible
         # downstream work.
         state_arg.get_or_create_slot(slot_name, app="")
         state_arg._restricted_keys.add(f"dashboard:{slot_name}")
-        raise RuntimeError("simulated read_messages_chained failure (e.g. disk EIO)")
+        raise RuntimeError("simulated stub creation failure (e.g. disk EIO)")
 
-    monkeypatch.setattr(cp_mod, "_rehydrate_slot_from_history", _failing_rehydrate)
+    monkeypatch.setattr(cp_mod, "_create_stub_slot", _failing_stub)
     restored = restore_open_slots(state2)
 
     assert restored == 0
@@ -774,9 +781,7 @@ def test_restore_open_slots_async_matches_sync_result(tmp_path, monkeypatch):
 
     sync_state = _make_state(tmp_path / "sessions")
     async_state = _make_state(tmp_path / "sessions")
-    assert restore_open_slots(sync_state) == asyncio.run(
-        restore_open_slots_async(async_state)
-    )
+    assert restore_open_slots(sync_state) == asyncio.run(restore_open_slots_async(async_state))
     assert set(sync_state._slots) == set(async_state._slots) == {"chat-1-same", "chat-2-same"}
 
 
@@ -918,9 +923,7 @@ def test_flush_during_async_restore_does_not_truncate_snapshot(tmp_path, monkeyp
             observed.append(len(json.loads(snapshot.read_text())["keys"]))
         return await real_sleep(delay, *a, **kw)
 
-    with patch(
-        "kiro_crew.dashboard.chat_persistence.asyncio.sleep", side_effect=flushing_sleep
-    ):
+    with patch("kiro_crew.dashboard.chat_persistence.asyncio.sleep", side_effect=flushing_sleep):
         restored = asyncio.run(restore_open_slots_async(state2))
 
     assert restored == 8
@@ -928,9 +931,9 @@ def test_flush_during_async_restore_does_not_truncate_snapshot(tmp_path, monkeyp
     # Assert on the INTERMEDIATE states, not just the final one. Without the guard
     # the file transiently reads 1, 2, 3 … tabs; it only ends up complete because
     # the restore happens to finish. A kill in that window is what loses tabs.
-    assert all(n == len(keys) for n in observed), (
-        f"snapshot was truncated mid-restore: sizes {observed} (expected all {len(keys)})"
-    )
+    assert all(
+        n == len(keys) for n in observed
+    ), f"snapshot was truncated mid-restore: sizes {observed} (expected all {len(keys)})"
     assert set(json.loads(snapshot.read_text())["keys"]) == set(keys)
 
 
@@ -939,9 +942,7 @@ def test_restoring_flag_clears_and_reenables_persistence(tmp_path, monkeypatch):
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
     _seed_session(state, "chat-1-flag")
-    (tmp_path / "open_slots.json").write_text(
-        json.dumps({"keys": ["chat-1-flag"], "ts": 0.0})
-    )
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": ["chat-1-flag"], "ts": 0.0}))
 
     state2 = _make_state(tmp_path / "sessions")
     assert state2.restoring_open_slots is False
@@ -962,9 +963,7 @@ def test_restoring_flag_cleared_even_if_restore_raises(tmp_path, monkeypatch):
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
     _seed_session(state, "chat-1-boom")
-    (tmp_path / "open_slots.json").write_text(
-        json.dumps({"keys": ["chat-1-boom"], "ts": 0.0})
-    )
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": ["chat-1-boom"], "ts": 0.0}))
 
     state2 = _make_state(tmp_path / "sessions")
     with patch(

--- a/test/test_session_restore.py
+++ b/test/test_session_restore.py
@@ -81,7 +81,12 @@ class TestRestoreRecentSessions:
                 {"role": "user", "content": "hello", "ts": "2026-03-23T10:00:00"},
                 {"role": "assistant", "content": "hi there", "ts": "2026-03-23T10:00:01"},
             ],
-            meta={"title": "Test Chat", "agent": "kirocrew", "workspace": "myws", "mode": "orchestrator"},
+            meta={
+                "title": "Test Chat",
+                "agent": "kirocrew",
+                "workspace": "myws",
+                "mode": "orchestrator",
+            },
         )
         # Touch the file to make it recent
         path = tmp_path / "dashboard_chat1.jsonl"
@@ -96,10 +101,19 @@ class TestRestoreRecentSessions:
         assert slot.agent == "kirocrew"
         assert slot.workspace == "myws"
         assert slot.mode == "orchestrator"
+        # Restore creates stubs; messages load on demand via materialize_slot.
+        assert slot._stub is True
+        assert len(slot.messages) == 0
+        assert slot._dirty is False
+
+        # Materialize loads the full message window.
+        from kiro_crew.dashboard.chat_persistence import materialize_slot
+
+        materialize_slot(state, slot)
+        assert slot._stub is False
         assert len(slot.messages) == 2
         assert slot.messages[0]["content"] == "hello"
         assert slot.messages[1]["content"] == "hi there"
-        assert slot._dirty is False
         assert slot._resumed_count == 2
 
     def test_restores_mode_empty_by_default(self, tmp_path, monkeypatch):
@@ -187,7 +201,7 @@ class TestRestoreRecentSessions:
         assert state._slots["existing"].messages[0]["content"] == "already here"
 
     def test_limits_to_500_messages(self, tmp_path, monkeypatch):
-        """Only the last 500 messages are loaded from a session."""
+        """Only the last 500 messages are loaded on materialize."""
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         messages = [
             {"role": "user", "content": f"msg {i}", "ts": f"2026-03-23T10:{i:04d}"}
@@ -201,6 +215,11 @@ class TestRestoreRecentSessions:
         restored = restore_recent_sessions(state, window_minutes=60)
         assert restored == 1
         slot = state._slots["big"]
+        assert slot._stub is True
+
+        from kiro_crew.dashboard.chat_persistence import materialize_slot
+
+        materialize_slot(state, slot)
         assert len(slot.messages) == 500
         assert slot.messages[0]["content"] == "msg 100"
         assert slot._disk_older_count == 100  # 600 total - 500 loaded = 100 older on disk
@@ -237,6 +256,9 @@ class TestRestoreRecentSessions:
         restored = restore_recent_sessions(state, window_minutes=60)
         assert restored == 1
         assert "mychat" in state._slots
+        from kiro_crew.dashboard.chat_persistence import materialize_slot
+
+        materialize_slot(state, state._slots["mychat"])
         assert state._slots["mychat"].messages[0]["content"] == "hi"
 
     def test_dashboard_colon_key_derives_correct_slot_name(self, tmp_path, monkeypatch):
@@ -270,6 +292,9 @@ class TestRestoreRecentSessions:
         restored = restore_recent_sessions(state, window_minutes=60)
         assert restored == 1
         assert "mychat" in state._slots
+        from kiro_crew.dashboard.chat_persistence import materialize_slot
+
+        materialize_slot(state, state._slots["mychat"])
         assert state._slots["mychat"].messages[0]["content"] == "colon test"
 
     def test_redacts_credentials_in_restored_messages(self, tmp_path, monkeypatch):
@@ -300,6 +325,10 @@ class TestRestoreRecentSessions:
         restored = restore_recent_sessions(state, window_minutes=60)
         assert restored == 1
         slot = state._slots["redact"]
+        # Materialize to load messages for the emit-path assertion.
+        from kiro_crew.dashboard.chat_persistence import materialize_slot
+
+        materialize_slot(state, slot)
         # User content is preserved as-is, on load and on emit.
         assert slot.messages[0]["content"] == "show me the key"
 

--- a/test/test_stub_slot_restore.py
+++ b/test/test_stub_slot_restore.py
@@ -1,0 +1,200 @@
+"""Tests for lazy stub slot restoration (issue #895).
+
+Pins two properties:
+1. Startup restore creates stub slots without reading messages (no full
+   materialization for sidebar-only rows).
+2. materialize_slot loads the full transcript on demand when a tab is activated.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard.chat_persistence import (
+    materialize_slot,
+    restore_open_slots,
+    restore_recent_sessions,
+)
+from kiro_crew.dashboard.chat_utils import _history_key_for
+
+
+def _seed_session(state, slot_name: str, n_messages: int = 3) -> None:
+    """Seed a session with metadata and messages."""
+    log = state.conversation_log
+    assert log is not None
+    history_key = _history_key_for(slot_name)
+    log.update_metadata(history_key, {"title": f"Title {slot_name}", "agent": "kirocrew"})
+    for i in range(n_messages):
+        log.append(history_key, "user" if i % 2 == 0 else "assistant", f"msg-{i}")
+
+
+class TestStubSlotRestore:
+    """Restore creates stubs that do not read messages."""
+
+    def test_restore_open_slots_creates_stubs(self, tmp_path, monkeypatch):
+        """restore_open_slots must NOT call read_messages_chained."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        state = _make_state(tmp_path / "sessions")
+        _seed_session(state, "chat-1-test", n_messages=10)
+
+        snapshot_path = tmp_path / "open_slots.json"
+        snapshot_path.write_text(json.dumps({"keys": ["chat-1-test"], "ts": 0.0}))
+
+        state2 = _make_state(tmp_path / "sessions")
+        chained_calls: list[str] = []
+        real_chained = state2.conversation_log.read_messages_chained
+
+        def _spy_chained(key, *a, **kw):
+            chained_calls.append(key)
+            return real_chained(key, *a, **kw)
+
+        with patch.object(state2.conversation_log, "read_messages_chained", _spy_chained):
+            restored = restore_open_slots(state2)
+
+        assert restored == 1
+        slot = state2._slots["chat-1-test"]
+        assert slot._stub is True
+        assert len(slot.messages) == 0
+        # The critical assertion: no transcript was read during restore.
+        assert chained_calls == [], (
+            f"restore_open_slots called read_messages_chained {len(chained_calls)} "
+            "time(s) - stubs must not read transcripts"
+        )
+
+    def test_restore_recent_sessions_creates_stubs(self, tmp_path, monkeypatch):
+        """restore_recent_sessions must NOT call read_messages_chained."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path / "sessions")
+        _seed_session(state, "chat-1-recent", n_messages=5)
+        # Touch the file to make it recent
+        (tmp_path / "sessions" / "dashboard_chat-1-recent.jsonl").touch()
+
+        state2 = _make_state(tmp_path / "sessions")
+        chained_calls: list[str] = []
+        real_chained = state2.conversation_log.read_messages_chained
+
+        def _spy_chained(key, *a, **kw):
+            chained_calls.append(key)
+            return real_chained(key, *a, **kw)
+
+        with patch.object(state2.conversation_log, "read_messages_chained", _spy_chained):
+            restored = restore_recent_sessions(state2, window_minutes=60)
+
+        assert restored == 1
+        slot = list(state2._slots.values())[0]
+        assert slot._stub is True
+        assert len(slot.messages) == 0
+        assert chained_calls == [], (
+            "restore_recent_sessions called read_messages_chained - "
+            "stubs must not read transcripts"
+        )
+
+    def test_stub_to_dict_returns_sidebar_fields(self, tmp_path, monkeypatch):
+        """to_dict on a stub returns metadata without scanning messages."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        state = _make_state(tmp_path / "sessions")
+        _seed_session(state, "chat-1-stub", n_messages=5)
+
+        snapshot_path = tmp_path / "open_slots.json"
+        snapshot_path.write_text(json.dumps({"keys": ["chat-1-stub"], "ts": 0.0}))
+
+        state2 = _make_state(tmp_path / "sessions")
+        restore_open_slots(state2)
+        slot = state2._slots["chat-1-stub"]
+
+        d = slot.to_dict()
+        assert d["title"] == "Title chat-1-stub"
+        assert d["agent"] == "kirocrew"
+        assert d["running"] is False
+        assert d["pending_approval"] is False
+        assert d["folder_id"] == ""
+
+    def test_stub_restricted_keys_seeded(self, tmp_path, monkeypatch):
+        """Stubs seed _restricted_keys for non-persistent memory_mode."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        state = _make_state(tmp_path / "sessions")
+        log = state.conversation_log
+        assert log is not None
+        history_key = _history_key_for("chat-1-incog")
+        log.update_metadata(history_key, {"title": "Incog", "memory_mode": "incognito"})
+        log.append(history_key, "user", "secret stuff")
+
+        snapshot_path = tmp_path / "open_slots.json"
+        snapshot_path.write_text(json.dumps({"keys": ["chat-1-incog"], "ts": 0.0}))
+
+        state2 = _make_state(tmp_path / "sessions")
+        restore_open_slots(state2)
+        # Privacy-critical: restricted_keys must be seeded from metadata even
+        # for stubs, so consolidation is blocked for non-persistent sessions.
+        assert "dashboard:chat-1-incog" in state2._restricted_keys
+
+
+class TestMaterializeSlot:
+    """materialize_slot loads the full transcript on demand."""
+
+    def test_materialize_loads_messages(self, tmp_path, monkeypatch):
+        """After materialize, slot has full message history."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        state = _make_state(tmp_path / "sessions")
+        _seed_session(state, "chat-1-mat", n_messages=6)
+
+        snapshot_path = tmp_path / "open_slots.json"
+        snapshot_path.write_text(json.dumps({"keys": ["chat-1-mat"], "ts": 0.0}))
+
+        state2 = _make_state(tmp_path / "sessions")
+        restore_open_slots(state2)
+        slot = state2._slots["chat-1-mat"]
+        assert slot._stub is True
+        assert len(slot.messages) == 0
+
+        materialize_slot(state2, slot)
+        assert slot._stub is False
+        assert len(slot.messages) == 6
+        assert slot._resumed_count == 6
+        assert slot._disk_window_len == 6
+
+    def test_materialize_noop_on_non_stub(self, tmp_path, monkeypatch):
+        """materialize_slot is a no-op on an already-materialized slot."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        state = _make_state(tmp_path / "sessions")
+        _seed_session(state, "chat-1-full", n_messages=3)
+
+        snapshot_path = tmp_path / "open_slots.json"
+        snapshot_path.write_text(json.dumps({"keys": ["chat-1-full"], "ts": 0.0}))
+
+        state2 = _make_state(tmp_path / "sessions")
+        restore_open_slots(state2)
+        slot = state2._slots["chat-1-full"]
+        materialize_slot(state2, slot)
+        count_after_first = len(slot.messages)
+
+        # Second call is a no-op.
+        materialize_slot(state2, slot)
+        assert len(slot.messages) == count_after_first
+
+    def test_materialize_redacts_content(self, tmp_path, monkeypatch):
+        """Content redaction happens during materialize, not at restore."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        state = _make_state(tmp_path / "sessions")
+        log = state.conversation_log
+        assert log is not None
+        history_key = _history_key_for("chat-1-redact")
+        log.update_metadata(history_key, {"title": "Redact Test"})
+        log.append(history_key, "assistant", "key: AKIAIOSFODNN7EXAMPLE")
+
+        snapshot_path = tmp_path / "open_slots.json"
+        snapshot_path.write_text(json.dumps({"keys": ["chat-1-redact"], "ts": 0.0}))
+
+        state2 = _make_state(tmp_path / "sessions")
+        restore_open_slots(state2)
+        slot = state2._slots["chat-1-redact"]
+        assert slot._stub is True
+
+        materialize_slot(state2, slot)
+        # Credential must be redacted in loaded content.
+        assert "AKIAIOSFODNN7EXAMPLE" not in slot.messages[0]["content"]
+        assert "[REDACTED" in slot.messages[0]["content"]


### PR DESCRIPTION

## Description

The dashboard startup restore (`restore_open_slots` and `restore_recent_sessions`) was materializing a full `_ChatSlot` for every restored session - reading the entire transcript via `read_messages_chained`, redacting content on all 500 messages, and appending them to the slot - even though the sidebar only needs metadata (title, agent, model, folder, pinned status, etc.) and a last-message preview.

The root cause is in `_restore_open_slots_steps` and `_restore_recent_sessions_steps` in `chat_persistence.py`: both called `_rehydrate_slot_from_history` which performs the full N-message read and redaction pass per tab. The issue comment's profiling shows this costs ~7s for 35 tabs (83% in GIL-bound redaction, only 3% in actual file I/O), blocking the event loop for the duration.

This PR implements Stage 2 from the issue: lazy stub slot materialization. Both restore paths now create lightweight stub slots that hold only metadata and a bounded tail preview for the sidebar `last_message` field. The full transcript is loaded on demand via `materialize_slot()` when the user activates a tab (detail endpoint or message send).

The three seams identified in the issue are addressed:
- `_restricted_keys` is seeded from metadata at stub creation time - the privacy gate is maintained.
- `reseed_slot_counter` operates on slot keys (which stubs have) not messages - unchanged.
- Control-plane addressing (`_slots.get(name)`) resolves stubs; every site that needs messages calls `materialize_slot` first.

Stage 1 (offloading reads to `asyncio.to_thread`) is deliberately omitted because the issue comment's profiling proves it would move only ~0.33s (3% - the file I/O) off the loop while leaving ~5.9s of GIL-holding CPU work still blocking it. The structural fix subsumes it entirely. The broader pattern of sync data-home calls on the loop is #1057, not this issue.

## Related Issues

Fixes #895

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality

Commands run:
```
PYTHONPATH=src python -m pytest test/test_stub_slot_restore.py test/test_open_slots_persistence.py test/test_session_restore.py test/test_display_time_redaction.py test/test_artifact_companion.py test/test_cron_origin_injection.py test/test_dashboard_file_io.py -n0 -q -p no:cacheprovider --override-ini="addopts="
181 passed

black --check (9 files): pass
isort --check-only (9 files): pass
flake8 (9 files): pass
mypy (5 source files): Success, no issues
```

New test file `test/test_stub_slot_restore.py` covers:
- `restore_open_slots` creates stubs without calling `read_messages_chained`
- `restore_recent_sessions` creates stubs without calling `read_messages_chained`
- `to_dict` on a stub returns correct sidebar fields
- `_restricted_keys` is seeded for non-persistent stubs (privacy pin)
- `materialize_slot` loads full messages on demand
- `materialize_slot` is a no-op on already-materialized slots
- `materialize_slot` redacts credentials in content

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Pending OSPO text.

## Research

Investigation started with `chat_persistence.py` - the two restore generators `_restore_open_slots_steps` and `_restore_recent_sessions_steps`. Both called `_rehydrate_slot_from_history` which reads the full transcript and redacts content on each message.

The issue comment measured the cost breakdown:
- 59.8% in `redact_credentials` (GIL-bound regex + sliding window classifier)
- 3.4% in `json` parse
- 3.0% in file I/O
- 0.5% in slot operations

This invalidates the naive `asyncio.to_thread` approach (Stage 1 as originally specified) since it would only move 3% off the loop.

The existing cheap primitives are:
- `ConversationLog.list_sessions()` - reads only the first line per file (metadata)
- `ConversationLog.last_message_preview()` - bounded backward tail seek
- `ConversationLog.get_metadata()` - mtime-cached first-line read

The sidebar `to_dict()` needs: title, agent, model, last_msg, last_ts, folder_id, pinned, tags, color_index, running state, pending_approval. All except last_msg and last_ts come from the metadata line. last_msg and last_ts can be derived from `last_message_preview` (bounded) and metadata's `created_at`.

Callers that need messages (beyond the restore): `api_chat_slot_detail` (tab activation), the SSE send path (new message), cron origin injection via `messaging.py`, and `_rehydrate_slot_from_history` (on-demand cold-slot resolution). The first three are wired to call `materialize_slot`; the fourth already does full rehydration (it is the on-demand path, not the bulk startup path).

Blast radius: `state._slots` consumers that read `.messages` directly could see empty lists on stubs. Audited: `_save_slot_to_history` early-returns on empty window (safe). The `to_dict` fast-path prevents any message-scanning code from running on stubs. All API endpoints that return message content (`/api/chat/slots/{slot}`) materialize first.

Alternatives rejected:
- `to_thread` alone: only moves 3% off loop per measurements
- Removing content redaction at load: already rejected in favor of display-time for meta (previous #885 fix), content stays on-load because it has ~204 read sites
- Background materialization: adds complexity without benefit since the tab activator needs messages synchronously for the response
