### PR TITLE
fix(acp): thread channel_id through AcpRuntime.create_session

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -538,8 +538,7 @@ class AcpRuntime:
             # from the windowless gateway (0 on POSIX, so no effect there).
             start_new_session=platform_compat.IS_POSIX,
             creationflags=(
-                platform_compat.CREATE_NEW_PROCESS_GROUP
-                | platform_compat._SUBPROCESS_NO_WINDOW
+                platform_compat.CREATE_NEW_PROCESS_GROUP | platform_compat._SUBPROCESS_NO_WINDOW
             ),
             env=env,
             profile=RLIMIT_PROFILE_SESSION_HOST,
@@ -1102,6 +1101,7 @@ class AcpRuntime:
         cwd: str | Path | None = None,
         agent: str | None = None,
         mcp_servers: list[dict[str, Any]] | None = None,
+        channel_id: str | None = None,
     ) -> AcpSessionHandle:
         """Create a new ACP session on this runtime. Returns a session handle."""
         if not self._initialized:
@@ -1113,7 +1113,7 @@ class AcpRuntime:
         # is written anywhere. Empty when the gateway is disabled.
         if mcp_servers is None:
             mcp_servers = pooled_session_servers(
-                self._mcp_gateway_overlay, agent or self._agent
+                self._mcp_gateway_overlay, agent or self._agent, channel_id
             )
         params = build_session_new_params(
             cwd if cwd else self._work_dir,

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -492,6 +492,11 @@ class AcpProvider(LLMProvider):
         )
         mcp_gateway_socket = getattr(self._client, "_mcp_gateway_socket", None)
 
+        # Channel id for pool-key partitioning (so sessions in different channels
+        # do not collapse onto one pooled backend). None for channel-less origins
+        # (CLI, cron) — the pool key's channel component stays absent.
+        channel_id: str | None = getattr(self._client, "_channel_id", None) or None
+
         # Check for session resume
         resume_sid = getattr(self._client, "_resume_session_id", "")
 
@@ -598,6 +603,7 @@ class AcpProvider(LLMProvider):
                     handle = await runtime.create_session(
                         cwd=work_dir,
                         agent=agent or None,
+                        channel_id=channel_id,
                     )
                 except AcpRuntimeError as exc:
                     if runtime.saw_not_logged_in():

--- a/test/test_acp_runtime_channel_pool.py
+++ b/test/test_acp_runtime_channel_pool.py
@@ -1,0 +1,186 @@
+"""Tests for channel-scoped MCP pool partitioning via AcpRuntime.create_session.
+
+Verifies that channel_id is threaded to pooled_session_servers so sessions in
+different channels get different pool keys (different --channel-id args on the
+broker stubs), and that channel-less sessions (CLI/cron) leave it absent.
+
+Fixes #1056.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.acp.runtime import AcpRuntime
+from kiro_crew.acp.types import METHOD_SESSION_NEW
+
+
+def _make_initialized_runtime() -> AcpRuntime:
+    """An initialized AcpRuntime wired to a fake subprocess (no real process)."""
+    rt = AcpRuntime(work_dir="/tmp", mcp_gateway_overlay="/fake/overlay")
+    reader = asyncio.StreamReader()
+    proc = MagicMock()
+    proc.stdout = reader
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.returncode = None
+    proc.pid = 9999
+    rt._process = proc
+    rt._pid = 9999
+    rt._initialized = True
+    return rt
+
+
+@pytest.mark.asyncio
+async def test_create_session_passes_channel_id_to_pool(monkeypatch):
+    """Two sessions with different channel_ids get different pool keys.
+
+    The pool key is determined by the --channel-id flag in the MCP stub args
+    returned by pooled_session_servers. If channel_id is correctly forwarded,
+    two calls with different channels produce different server entries.
+    """
+    rt = _make_initialized_runtime()
+    captured_calls: list[tuple] = []
+
+    def _fake_pooled(overlay_dir, agent, channel_id=None):
+        captured_calls.append((overlay_dir, agent, channel_id))
+        # Return a minimal stub entry so the test proceeds
+        return []
+
+    monkeypatch.setattr("kiro_crew.acp.runtime.pooled_session_servers", _fake_pooled)
+
+    async def _fake_send(method, params, timeout=30.0):
+        if method == METHOD_SESSION_NEW:
+            return {"sessionId": f"sid-{len(captured_calls)}"}
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+    # Session in channel A
+    await rt.create_session(cwd="/w", agent="kirocrew", channel_id="channel-A")
+    # Session in channel B
+    await rt.create_session(cwd="/w", agent="kirocrew", channel_id="channel-B")
+
+    assert len(captured_calls) == 2
+    # Each call must pass the correct channel_id
+    assert captured_calls[0][2] == "channel-A"
+    assert captured_calls[1][2] == "channel-B"
+    # The two calls have DIFFERENT channel_ids - proving partitioning
+    assert captured_calls[0][2] != captured_calls[1][2]
+
+
+@pytest.mark.asyncio
+async def test_create_session_no_channel_leaves_pool_unscoped(monkeypatch):
+    """A session with no channel (CLI/cron origin) passes None, preserving the
+    channel-less pool key path - no bogus channel is injected."""
+    rt = _make_initialized_runtime()
+    captured_calls: list[tuple] = []
+
+    def _fake_pooled(overlay_dir, agent, channel_id=None):
+        captured_calls.append((overlay_dir, agent, channel_id))
+        return []
+
+    monkeypatch.setattr("kiro_crew.acp.runtime.pooled_session_servers", _fake_pooled)
+
+    async def _fake_send(method, params, timeout=30.0):
+        if method == METHOD_SESSION_NEW:
+            return {"sessionId": "sid-no-channel"}
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+    # No channel_id passed (default)
+    await rt.create_session(cwd="/w", agent="kirocrew")
+    assert len(captured_calls) == 1
+    assert captured_calls[0][2] is None
+
+
+@pytest.mark.asyncio
+async def test_create_session_explicit_mcp_servers_skips_pool(monkeypatch):
+    """When caller supplies explicit mcp_servers, pooled_session_servers is not
+    called at all, regardless of channel_id."""
+    rt = _make_initialized_runtime()
+    pooled_called = []
+
+    def _fake_pooled(overlay_dir, agent, channel_id=None):
+        pooled_called.append(True)
+        return []
+
+    monkeypatch.setattr("kiro_crew.acp.runtime.pooled_session_servers", _fake_pooled)
+
+    async def _fake_send(method, params, timeout=30.0):
+        if method == METHOD_SESSION_NEW:
+            return {"sessionId": "sid-explicit"}
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+    await rt.create_session(
+        cwd="/w", agent="kirocrew", mcp_servers=[{"name": "custom"}], channel_id="ch-X"
+    )
+    # pooled_session_servers must NOT have been called
+    assert pooled_called == []
+
+
+@pytest.mark.asyncio
+async def test_provider_threads_channel_id_to_runtime(monkeypatch, tmp_path):
+    """End-to-end: AcpProvider._start_kiro_runtime_impl extracts channel_id from
+    self._client and passes it to runtime.create_session, which forwards it to
+    pooled_session_servers. Two providers with different channels produce
+    different pool scoping."""
+    from kiro_crew.providers.acp import AcpProvider
+
+    captured_channel_ids: list[str | None] = []
+
+    def _fake_pooled(overlay_dir, agent, channel_id=None):
+        captured_channel_ids.append(channel_id)
+        return []
+
+    monkeypatch.setattr("kiro_crew.acp.runtime.pooled_session_servers", _fake_pooled)
+
+    # Mock spawn() so no real process is created
+    async def _fake_spawn(self):
+        self._process = MagicMock()
+        self._process.pid = 7777
+        self._process.returncode = None
+        self._process.stdin = MagicMock()
+        self._process.stdin.write = MagicMock()
+        self._process.stdin.drain = AsyncMock()
+        self._process.stdout = asyncio.StreamReader()
+        self._process.stderr = asyncio.StreamReader()
+        self._pid = 7777
+        self._initialized = True
+        self._spawn_monotonic = 0.0
+
+    monkeypatch.setattr(AcpRuntime, "spawn", _fake_spawn)
+
+    # Mock _send_and_await on runtime
+    async def _fake_send(self, method, params, timeout=30.0):
+        if method == METHOD_SESSION_NEW:
+            return {"sessionId": "sid-provider-test"}
+        return {}
+
+    monkeypatch.setattr(AcpRuntime, "_send_and_await", _fake_send)
+
+    # Mock session_pid tracking to avoid file writes
+    monkeypatch.setattr("kiro_crew.acp.runtime._track_pid", lambda pid: None)
+    monkeypatch.setattr("kiro_crew.acp.runtime._track_session_pid", lambda pid: None)
+    monkeypatch.setattr("kiro_crew.acp.runtime.register_protected_pid", lambda pid: None)
+
+    # Create a provider with a channel_id
+    provider = AcpProvider(
+        work_dir=str(tmp_path),
+        channel_id="slack-channel-123",
+        mcp_gateway_overlay=str(tmp_path / "overlay"),
+    )
+
+    phases: dict[str, float] = {}
+    await provider._start_kiro_runtime_impl(phases)
+
+    # The channel_id from the AcpClient must have reached pooled_session_servers
+    assert len(captured_channel_ids) == 1
+    assert captured_channel_ids[0] == "slack-channel-123"


### PR DESCRIPTION

## Description

`AcpRuntime.create_session()` never received a `channel_id` parameter, so its call to `pooled_session_servers()` always used the `None` default. This meant every runtime-path session registered with `PoolKey.channel_id = None` regardless of which channel originated it, collapsing all sessions onto a single pooled MCP backend. Channel-scoped pool isolation - the property that sessions in different Slack/WeCom/Telegram channels each get their own backend instance - was only achieved on the `AcpClient` path.

The root cause is in `providers/acp.py::_start_kiro_runtime_impl`: it extracts most attributes from the placeholder `AcpClient` (work_dir, agent, sandbox_mode, extra_env, mcp_gateway_overlay) but never extracts `_channel_id`. The fix adds `channel_id` to `AcpRuntime.create_session()`'s signature and threads it to `pooled_session_servers`, matching how `AcpClient` already works. In `_start_kiro_runtime_impl`, `_channel_id` is now extracted from `self._client` and passed to `create_session()`.

Sessions with no channel (CLI, cron, background tasks) continue to pass `None`, which leaves the `--channel-id` flag absent from the stub args and preserves the existing channel-less pool key. No bogus channel is injected.

## Related Issues

Fixes #1056

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality

Commands run and observed output:

```
pytest test/test_acp_runtime_channel_pool.py -n0 -q: 4 passed
pytest test/test_acp_runtime.py -n0 -q: 155 passed, 2 skipped
black --check: pass
isort --check-only: pass
flake8: pass
mypy: Success: no issues found in 2 source files
```

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under
the terms of the project license.

## Research

Investigation approach: read the issue (which pinpointed the exact files and functions), then traced the call graph from `AcpProvider.__init__` through `_start_kiro_runtime_impl` to `AcpRuntime.create_session()` to `pooled_session_servers()`. Confirmed that `AcpClient` passes `self._channel_id` correctly (line 1435 of `acp/client.py`) while the runtime path defaulted to `None`.

Alternatives considered: threading the channel_id into the `AcpRuntime` constructor (so it would be stored once). Rejected because a single runtime can host multiple sessions from different channels (multiplexed design) - the channel is a per-session property, not a per-process one.

Blast radius: `create_session()` is called in `_start_kiro_runtime_impl` (the provider cold-start) and in `test_acp_runtime.py`'s existing tests. All callers that do not pass `channel_id` get `None` (the previous behavior), so existing callers are unaffected. The test confirming this is `test_create_session_no_channel_leaves_pool_unscoped`.

No spec update needed: the `session_servers.py` docstring already documents the `channel_id` parameter and its `None` semantics. The runtime path now honors what was already documented.
