### PR TITLE
fix(mcp-gateway): graceful gatewayd shutdown + forward declared env

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2791,6 +2791,19 @@ class McpGatewayConfig:
             "per-session. Managed from Settings -> Shared MCP gateway.",
         ),
     )
+    forward_declared_env: bool = field(
+        default=False,
+        metadata=_meta(
+            "Forward Declared Env",
+            "Apply a pooled server's declared NON-SECRET env to its shared "
+            "backend. Default False -- opt-in. Only the keys already folded "
+            "into the pool key (i.e. non-secret keys; rotating-secret prefixes "
+            "AWS_SECRET/AWS_SESSION/OAUTH are excluded) are forwarded, so every "
+            "session sharing a backend agrees on their values. Secrets are "
+            "never forwarded; a server that needs a per-session secret keeps "
+            "reading it from disk or stays poolable:false.",
+        ),
+    )
     prewarm_count: int = field(
         default=0,
         metadata=_meta(
@@ -4555,6 +4568,7 @@ class KiroCrewConfig:
                     s for s in mcp_gateway_data.get("poolable_servers", []) if isinstance(s, str)
                 ],
                 prewarm_count=max(0, _safe_int(mcp_gateway_data.get("prewarm_count", 0), 0)),
+                forward_declared_env=bool(mcp_gateway_data.get("forward_declared_env", False)),
                 read_buffer_limit_bytes=max(
                     1024,
                     _safe_int(

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -502,6 +502,20 @@ class Backend:
     def dead_reason(self) -> Optional[str]:
         return self._dead_reason
 
+    @property
+    def has_inflight_requests(self) -> bool:
+        """True while this backend has a forwarded request awaiting a reply, or
+        an initialize handshake still in flight.
+
+        Used by gatewayd's graceful-shutdown drain to wait on *real* work
+        rather than on the mere presence of a (possibly idle) pooled bridge
+        connection: a pooled stub's bridge connection is long-lived and never
+        self-closes, so draining on the connection set would always burn the
+        full grace window (see issue #1078). ``refcount`` is deliberately NOT
+        consulted here -- it counts attached stubs, not outstanding requests.
+        """
+        return bool(self._pending_requests) or self._init_state == "in_flight"
+
     @staticmethod
     def _now() -> float:
         return time.monotonic()

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -49,7 +49,12 @@ from kiro_crew.mcp_gateway import credwatch, socketsec, transport
 from kiro_crew.mcp_gateway.apps import sweep_spool as apps_sweep_spool
 from kiro_crew.mcp_gateway.backend import Backend, BackendGone, spawn_backend
 from kiro_crew.mcp_gateway.breaker import CircuitBreaker
-from kiro_crew.mcp_gateway.manager import _scrub_sensitive_env
+from kiro_crew.mcp_gateway.hashing import is_scrubbed_env_key
+from kiro_crew.mcp_gateway.manager import (
+    _POOL_SHUTDOWN_SECS,
+    _SHUTDOWN_DRAIN_SECS,
+    _scrub_sensitive_env,
+)
 from kiro_crew.mcp_gateway.pool import (
     DRAIN_DEADLINE_SECS,
     READ_BUFFER_LIMIT_BYTES,
@@ -130,8 +135,10 @@ _WRITE_REPLY_TIMEOUT_SECS = 30.0
 
 # Graceful-shutdown grace: in-flight connection handlers get this long to
 # finish their current JSON-RPC round-trip before gatewayd cancels them
-# and tears down the pool.
-_SHUTDOWN_DRAIN_SECS = 10.0
+# and tears down the pool. Imported from ``manager`` (single source of truth)
+# so it can never invert against the supervisor's SIGTERM->SIGKILL grace --
+# see manager._SHUTDOWN_GRACE_SECS and issue #1078. ``_POOL_SHUTDOWN_SECS`` is
+# likewise imported and passed to ``pool.shutdown_all`` below.
 
 # Interval between per-backend heartbeat sweeps. A backend
 # that is gone, or wedged with an in-flight request outstanding past
@@ -592,13 +599,17 @@ async def run_gatewayd(
         if server is not None:
             server.close()
 
-        # Phase 1: let in-flight handlers drain cleanly. ``return_exceptions``
-        # because a handler that was already errored will raise from the
-        # gather; that's not a shutdown failure.
-        if connections:
-            drain_deadline = time.monotonic() + _SHUTDOWN_DRAIN_SECS
-            while connections and time.monotonic() < drain_deadline:
-                await asyncio.sleep(0.05)
+        # Phase 1: let in-flight work drain cleanly. Drain on the condition
+        # that actually matters -- no backend has an outstanding request --
+        # instead of "the connection set is empty". A pooled stub's bridge
+        # connection is long-lived and never self-closes, so with pooling
+        # active ``connections`` is essentially never empty and draining on it
+        # always burned the full window (issue #1078). Polling
+        # ``pool.has_inflight_requests()`` lets an idle daemon shut down at once
+        # while still giving genuine in-flight tool calls time to finish.
+        drain_deadline = time.monotonic() + _SHUTDOWN_DRAIN_SECS
+        while pool.has_inflight_requests() and time.monotonic() < drain_deadline:
+            await asyncio.sleep(0.05)
 
         # Phase 2: cancel whatever is still in-flight.
         for task in list(connections):
@@ -659,7 +670,7 @@ async def run_gatewayd(
             with contextlib.suppress(Exception):
                 await asyncio.to_thread(hot_keys.flush)
 
-        await pool.shutdown_all()
+        await pool.shutdown_all(timeout=_POOL_SHUTDOWN_SECS)
         # Clean shutdown drained every backend; drop the out-of-band reap list
         # so a supervising manager never killpg's now-dead pids.
         with contextlib.suppress(OSError):
@@ -912,6 +923,23 @@ def env_target_resolver(pool_key: PoolKey) -> Optional[tuple[str, list[str], dic
     # environment doesn't leak into Python-based MCP backends (import conflicts).
     env.pop("PYTHONPATH", None)
     env.pop("PYTHONHOME", None)
+    # Forward the server's declared NON-SECRET env when the rewriter published
+    # it (config ``mcp_gateway.forward_declared_env``; default off). The entry
+    # is keyed by the SAME ``effective_env_hash`` the stub registered, so only
+    # sessions that agree on those values share this backend -- applying them at
+    # spawn cannot cause cross-tenant divergence. Secret-prefixed keys are never
+    # published (see hashing.ENV_SCRUB_PREFIXES), so a rotating credential never
+    # lands here; the mapping is per-server, so one server's declared env cannot
+    # bleed into another's backend. See issue #1078.
+    env_base = "MC_MCP_ENV_" + pool_key.server_name.upper().replace("-", "_")
+    forwarded_raw = os.environ.get(env_base + "__" + pool_key.effective_env_hash)
+    if forwarded_raw:
+        with contextlib.suppress(json.JSONDecodeError):
+            forwarded = json.loads(forwarded_raw)
+            if isinstance(forwarded, dict):
+                for fk, fv in forwarded.items():
+                    if not is_scrubbed_env_key(str(fk)):
+                        env[str(fk)] = str(fv)
     if pool_key.channel_id:
         env["KIROCREW_CHANNEL_ID"] = pool_key.channel_id
     return command, args, env, pool_key.work_dir

--- a/src/kiro_crew/mcp_gateway/hashing.py
+++ b/src/kiro_crew/mcp_gateway/hashing.py
@@ -32,3 +32,41 @@ def hash_command(command: str, args: list[str]) -> str:
         h.update(a.encode("utf-8"))
         h.update(b"\0")
     return h.hexdigest()
+
+
+#: Env-key prefixes for rotating secrets. Keys starting with any of these are
+#: EXCLUDED from :func:`hash_effective_env` so an otherwise-identical pair of
+#: stubs still pools together across a credential rotation (the hash would
+#: otherwise change on every rotation and split the pool). This is also the
+#: single source of truth for env FORWARDING: the rewriter forwards exactly the
+#: keys that are NOT scrub-prefixed (the same keys that were hashed), so the
+#: forwarded set is provably identical to the hashed set and cannot drift.
+#: Secret-prefixed keys are never hashed and never forwarded.
+ENV_SCRUB_PREFIXES: tuple[str, ...] = ("AWS_SECRET", "AWS_SESSION", "OAUTH")
+
+
+def is_scrubbed_env_key(key: str) -> bool:
+    """True if ``key`` is a rotating-secret key excluded from both the effective
+    env hash and env forwarding (see :data:`ENV_SCRUB_PREFIXES`)."""
+    return any(key.startswith(p) for p in ENV_SCRUB_PREFIXES)
+
+
+def hash_effective_env(env_pairs: dict[str, str]) -> str:
+    """Sorted ``K=V\\0``-delimited SHA-256, skipping scrub-prefixed keys.
+
+    Single source of truth for the ``effective_env_hash`` dimension of
+    :class:`kiro_crew.mcp_gateway.pool.PoolKey`. The stub hashes its declared
+    env through this to register a pool key; the rewriter hashes the same env to
+    build the ``MC_MCP_ENV_<SERVER>__<hash>`` forwarding entry that
+    ``gatewayd.env_target_resolver`` looks up by that same key. Both call THIS
+    function so the mapping can never drift between writer and reader.
+    """
+    h = hashlib.sha256()
+    for k in sorted(env_pairs):
+        if is_scrubbed_env_key(k):
+            continue
+        h.update(k.encode("utf-8"))
+        h.update(b"=")
+        h.update(str(env_pairs[k]).encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()

--- a/src/kiro_crew/mcp_gateway/manager.py
+++ b/src/kiro_crew/mcp_gateway/manager.py
@@ -59,8 +59,25 @@ _LIVENESS_PING_INTERVAL_SECS = 30.0
 # threshold raced with run_chaos.py and produced spurious
 # "gatewayd_pid_changed_unexpectedly" during legitimate chaos tests.
 _LIVENESS_MAX_CONSECUTIVE_FAILURES = 3
-# SIGTERM → SIGKILL grace period on shutdown.
-_SHUTDOWN_GRACE_SECS = 5.0
+# --- Shutdown budgets (single source of truth) ---------------------------
+# These three are the ONLY place the graceful-shutdown timing is declared.
+# gatewayd imports ``_SHUTDOWN_DRAIN_SECS`` and ``_POOL_SHUTDOWN_SECS`` from
+# here so the daemon's own drain window and the supervisor's SIGTERM grace can
+# never be configured to invert (issue #1078: a 5s grace killed the daemon
+# while it was still inside its own 10s drain, so pool.shutdown_all() never
+# ran and the daemon was SIGKILLed on every restart).
+#
+# The daemon's graceful drain window: in-flight backend requests get this long
+# to finish before gatewayd cancels handlers and tears down the pool.
+_SHUTDOWN_DRAIN_SECS = 10.0
+# Budget for ``pool.shutdown_all()`` after the drain completes.
+_POOL_SHUTDOWN_SECS = 5.0
+# Safety margin so the supervisor never races the daemon's own teardown.
+_SHUTDOWN_GRACE_MARGIN_SECS = 3.0
+# SIGTERM -> SIGKILL grace period on shutdown. DERIVED so the supervisor's
+# grace ALWAYS covers the daemon's drain + pool-shutdown budget; this makes the
+# historical budget inversion impossible to reintroduce by editing one number.
+_SHUTDOWN_GRACE_SECS = _SHUTDOWN_DRAIN_SECS + _POOL_SHUTDOWN_SECS + _SHUTDOWN_GRACE_MARGIN_SECS
 # Respawn backoff: start here, double up to max.
 _RESPAWN_BACKOFF_START_SECS = 1.0
 _RESPAWN_BACKOFF_MAX_SECS = 60.0

--- a/src/kiro_crew/mcp_gateway/pool.py
+++ b/src/kiro_crew/mcp_gateway/pool.py
@@ -1070,6 +1070,19 @@ class BackendPool:
         """
         return list(self._backends.values()) + [e.backend for e in self._draining]
 
+    def has_inflight_requests(self) -> bool:
+        """True if ANY current backend (active or draining) has an in-flight
+        request.
+
+        Lock-free snapshot via :meth:`all_backends` (mirroring the abort
+        handler's iteration). gatewayd's graceful-shutdown drain polls this so
+        idle pooled bridge connections no longer hold shutdown hostage: the
+        drain now waits on the condition that actually matters -- outstanding
+        backend work -- instead of on an ever-populated connection set (issue
+        #1078).
+        """
+        return any(b.has_inflight_requests for b in self.all_backends())
+
     async def shutdown_all(self, timeout: float = 5.0) -> None:
         """Shut down every registered backend and clear the pool.
 

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -26,7 +26,11 @@ from typing import Any
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
-from kiro_crew.mcp_gateway.hashing import hash_command
+from kiro_crew.mcp_gateway.hashing import (
+    hash_command,
+    hash_effective_env,
+    is_scrubbed_env_key,
+)
 from kiro_crew.mcp_utils import mcp_server_alias
 
 logger = logging.getLogger(__name__)
@@ -68,6 +72,8 @@ def _build_stub_entry(
     work_dir: Path,
     sandbox_mode: str,
     approval_mode: str,
+    target_env: dict[str, str] | None = None,
+    forward_declared_env: bool = False,
     sidecars_written: set[str] | None = None,
 ) -> dict[str, Any]:
     """Return the rewritten ``mcpServers[name]`` entry.
@@ -116,20 +122,62 @@ def _build_stub_entry(
         "--socket", str(socket_path),
     ]
     if env_pairs:
-        # Operational hazard signal: the declared env is folded into the
-        # PoolKey hash (so differing-env sessions never share a backend) but is
-        # NOT applied to the pooled backend — gatewayd spawns it with the
-        # daemon's own scrubbed environment (env_target_resolver never reads
-        # the sidecar). A server that genuinely depends on its declared env
-        # (e.g. a credential) will misbehave when pooled; keep it non-poolable
-        # until per-server env forwarding lands. Warn so the operator sees it.
-        logger.warning(
-            "rewriter: pooled server %r for agent %r declares a non-empty env "
-            "(%d keys); the declared env is NOT applied to the shared pooled "
-            "backend (spawned with the daemon's scrubbed env). Set poolable:false "
-            "if this server depends on that env.",
-            server_name, agent_name, len(env_pairs),
-        )
+        # The declared env is folded into the PoolKey hash (so differing-env
+        # sessions never share a backend). Whether it is APPLIED to the pooled
+        # backend now depends on the opt-in ``forward_declared_env`` flag:
+        #
+        #   * flag off (default): the declared env is NOT applied -- gatewayd
+        #     spawns the backend with the daemon's own scrubbed environment
+        #     (env_target_resolver finds no forwarding entry). A server that
+        #     genuinely depends on its declared env should stay poolable:false.
+        #   * flag on: the NON-SECRET declared keys are forwarded (published
+        #     below, keyed by effective_env_hash). Secret-prefixed keys
+        #     (hashing.ENV_SCRUB_PREFIXES) are never forwarded -- those servers
+        #     keep reading the secret from disk or stay poolable:false.
+        secret_keys = [k for k in env_pairs if is_scrubbed_env_key(str(k))]
+        forwardable = {
+            str(k): str(v) for k, v in env_pairs.items() if not is_scrubbed_env_key(str(k))
+        }
+        if forward_declared_env and target_env is not None and forwardable:
+            # Publish exactly the hashed (non-secret) keys, keyed by the SAME
+            # effective_env_hash the stub registers, so env_target_resolver can
+            # look it back up per (server, env) -- the env analogue of the
+            # MC_MCP_TARGET_<SERVER>__<command_args_hash> command mapping. The
+            # forwarded set is provably identical to the hashed set because
+            # both derive from hashing.ENV_SCRUB_PREFIXES.
+            env_key = "MC_MCP_ENV_" + server_name.replace("-", "_").upper()
+            hashed_key = env_key + "__" + hash_effective_env(forwardable)
+            target_env[hashed_key] = json.dumps(forwardable, sort_keys=True)
+            if secret_keys:
+                logger.warning(
+                    "rewriter: forwarding %d non-secret env key(s) for pooled "
+                    "server %r (agent %r); %d secret-prefixed key(s) are NOT "
+                    "forwarded and are dropped from the pooled backend -- set "
+                    "poolable:false if this server needs them.",
+                    len(forwardable),
+                    server_name,
+                    agent_name,
+                    len(secret_keys),
+                )
+        else:
+            # Operational hazard signal: the declared env is folded into the
+            # PoolKey hash but is NOT applied to the pooled backend -- gatewayd
+            # spawns it with the daemon's own scrubbed environment
+            # (env_target_resolver never forwards it). A server that genuinely
+            # depends on its declared env (e.g. a credential) will misbehave
+            # when pooled; keep it non-poolable, or enable
+            # mcp_gateway.forward_declared_env to forward the non-secret keys.
+            logger.warning(
+                "rewriter: pooled server %r for agent %r declares a non-empty "
+                "env (%d keys); the declared env is NOT applied to the shared "
+                "pooled backend (spawned with the daemon's scrubbed env). Set "
+                "poolable:false if this server depends on that env, or enable "
+                "mcp_gateway.forward_declared_env to forward the non-secret "
+                "keys.",
+                server_name,
+                agent_name,
+                len(env_pairs),
+            )
         # JSON-encode env so values containing ',' or '=' round-trip
         # intact. A prior CSV serialisation ``K=V,K2=V2`` silently
         # truncated any value with a ',' in it — e.g. JAVA_OPTS='-Xmx1g,-Xms512m'
@@ -274,6 +322,7 @@ def _rewrite_single_spec(
     poolable_servers: frozenset[str],
     inject_servers: dict[str, Any] | None = None,
     target_env: dict[str, str] | None = None,
+    forward_declared_env: bool = False,
     sidecars_written: set[str] | None = None,
 ) -> tuple[dict[str, Any], int]:
     """Return ``(new_spec, wrapped_count)``. Idempotent.
@@ -351,6 +400,8 @@ def _rewrite_single_spec(
             work_dir=work_dir,
             sandbox_mode=sandbox_mode,
             approval_mode=approval_mode,
+            target_env=target_env,
+            forward_declared_env=forward_declared_env,
             sidecars_written=sidecars_written,
         )
         wrapped += 1
@@ -420,6 +471,8 @@ def _rewrite_single_spec(
             work_dir=work_dir,
             sandbox_mode=sandbox_mode,
             approval_mode=approval_mode,
+            target_env=target_env,
+            forward_declared_env=forward_declared_env,
             sidecars_written=sidecars_written,
         )
         wrapped += 1
@@ -483,6 +536,7 @@ def rewrite_agents(
     sandbox_mode: str = "auto",
     approval_mode: str = "interactive",
     poolable_servers: frozenset[str] | None = None,
+    forward_declared_env: bool = False,
 ) -> tuple[dict[str, int], dict[str, str]]:
     """Populate ``overlay_dir`` with rewritten copies of ``source_dir/*.json``.
 
@@ -503,16 +557,24 @@ def rewrite_agents(
         poolable_servers: Server names from ``config.mcp_gateway.poolable_servers``.
             A stdio server is pooled when its name is in this set OR its entry
             sets ``poolable: true``. ``None`` is treated as an empty set.
+        forward_declared_env: When True (config
+            ``mcp_gateway.forward_declared_env``; default off), the NON-SECRET
+            declared env of each pooled server is published into ``target_env``
+            as ``MC_MCP_ENV_<SERVER>__<effective_env_hash>`` so
+            ``gatewayd.env_target_resolver`` applies it at spawn. Secret-prefixed
+            keys (``hashing.ENV_SCRUB_PREFIXES``) are never forwarded.
 
     Returns:
         A ``(results, target_env)`` tuple:
 
         * ``results``: mapping ``{agent_filename: wrapped_server_count}``.
           Agents with no MCP servers are omitted.
-        * ``target_env``: mapping ``{MC_MCP_TARGET_<SERVER>: "cmd arg arg"}``
-          suitable for ``GatewaySpec.mcp_target_env``. Gatewayd consults
-          these when a stub registers, to find the real backend command
-          to spawn for a new pool key.
+        * ``target_env``: mapping of gateway-process env vars suitable for
+          ``GatewaySpec.mcp_target_env``. Always carries
+          ``MC_MCP_TARGET_<SERVER>[__<command_args_hash>]`` (the backend command
+          gatewayd spawns per pool key); when ``forward_declared_env`` is set it
+          also carries ``MC_MCP_ENV_<SERVER>__<effective_env_hash>`` (the
+          forwarded non-secret declared env).
     """
     pool_set = poolable_servers or frozenset()
     if not source_dir.is_dir():
@@ -591,6 +653,7 @@ def rewrite_agents(
             poolable_servers=pool_set,
             inject_servers=settings_poolable,
             target_env=target_env,
+            forward_declared_env=forward_declared_env,
             sidecars_written=written_sidecars,
         )
         _collect_target_env(new_spec.get("mcpServers", {}), target_env)

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -36,7 +36,11 @@ from kiro_crew import platform_compat
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.mcp_caller import CallerContext, _parent_pid
 from kiro_crew.mcp_gateway import transport
-from kiro_crew.mcp_gateway.hashing import hash_command
+from kiro_crew.mcp_gateway.hashing import (
+    ENV_SCRUB_PREFIXES,
+    hash_command,
+    hash_effective_env,
+)
 from kiro_crew.mcp_gateway.pool import READ_BUFFER_LIMIT_BYTES, PoolKey
 
 logger = logging.getLogger(__name__)
@@ -49,7 +53,10 @@ _HANDSHAKE_TIMEOUT_SECS = 3.0
 _ENSURE_BACKEND_TIMEOUT_SECS = 25.0
 # Scrub-prefixed env keys (rotating secrets) are dropped before hashing
 # so otherwise-identical stubs pool together across credential rotations.
-_ENV_SCRUB_PREFIXES = ("AWS_SECRET", "AWS_SESSION", "OAUTH")
+# Single source of truth lives in ``hashing`` so the rewriter's forwarded set
+# is provably identical to this hashed set (see issue #1078). Kept as a
+# module-level alias for backward compatibility with callers/tests.
+_ENV_SCRUB_PREFIXES = ENV_SCRUB_PREFIXES
 # Content-hash cap for ``binary_version``. Every shipped MCP is <1 MiB, so
 # 4 MiB covers them with margin. Larger binaries
 # (npm/Node/Java runtimes) are NOT hashed synchronously on the cold-start
@@ -192,16 +199,13 @@ def _parse_auto_approve(raw: str) -> list[str]:
 
 
 def _hash_effective_env(env_pairs: dict[str, str]) -> str:
-    """Sorted ``K=V\\0``-delimited SHA-256, skipping scrub-prefixed keys."""
-    h = hashlib.sha256()
-    for k in sorted(env_pairs):
-        if any(k.startswith(p) for p in _ENV_SCRUB_PREFIXES):
-            continue
-        h.update(k.encode("utf-8"))
-        h.update(b"=")
-        h.update(env_pairs[k].encode("utf-8"))
-        h.update(b"\0")
-    return h.hexdigest()
+    """Sorted ``K=V\\0``-delimited SHA-256, skipping scrub-prefixed keys.
+
+    Thin wrapper over :func:`kiro_crew.mcp_gateway.hashing.hash_effective_env`
+    (the single source of truth shared with the rewriter). Kept as a
+    module-level name for backward compatibility with callers/tests.
+    """
+    return hash_effective_env(env_pairs)
 
 
 def _hash_permission_profile(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -4896,6 +4896,7 @@ class GatewayOrchestrator:
                     sandbox_mode=self._cfg.agent.sandbox,
                     approval_mode=self._cfg.agent.approval_mode,
                     poolable_servers=frozenset(cfg_gw.poolable_servers),
+                    forward_declared_env=cfg_gw.forward_declared_env,
                 ),
             )
         except Exception:

--- a/test/test_mcp_gateway_shutdown_env_1078.py
+++ b/test/test_mcp_gateway_shutdown_env_1078.py
@@ -1,0 +1,288 @@
+"""Regression tests for issue #1078.
+
+Two independent MCP gateway defects:
+
+Gap 1 - gatewayd was SIGKILLed on every restart with attached stubs, because
+the supervisor's SIGTERM->SIGKILL grace (5s) was shorter than the daemon's own
+graceful drain (10s) + pool.shutdown_all() (5s), and the drain waited on the
+(never-empty) pooled connection set instead of on real in-flight work.
+
+Gap 2 - a pooled server's declared, non-secret env was never forwarded to the
+shared backend; there was no env analogue of the command's
+MC_MCP_TARGET_<SERVER>__<hash> reverse-lookup.
+
+The tests here never spawn or kill a real process tree - the process layer is
+mocked and only call ORDER is asserted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.mcp_gateway import manager as manager_mod
+from kiro_crew.mcp_gateway.backend import Backend
+from kiro_crew.mcp_gateway.gatewayd import env_target_resolver
+from kiro_crew.mcp_gateway.hashing import hash_effective_env, is_scrubbed_env_key
+from kiro_crew.mcp_gateway.manager import GatewayManager, GatewaySpec
+from kiro_crew.mcp_gateway.pool import BackendPool, PoolKey
+from kiro_crew.mcp_gateway.rewriter import rewrite_agents
+
+# --- Gap 1: shutdown budgets + drain condition ------------------------------
+
+
+def test_shutdown_grace_covers_daemon_drain_and_pool_budget() -> None:
+    """The supervisor grace MUST always cover the daemon's drain window plus
+    pool.shutdown_all(). This is the exact inversion that produced the SIGKILL
+    on every restart; deriving grace from the two budgets makes it impossible
+    to reintroduce by editing one number."""
+    assert (
+        manager_mod._SHUTDOWN_GRACE_SECS
+        >= manager_mod._SHUTDOWN_DRAIN_SECS + manager_mod._POOL_SHUTDOWN_SECS
+    )
+
+
+def test_gatewayd_shares_the_same_budgets_as_the_supervisor() -> None:
+    """gatewayd must not carry its own copies of the drain / pool budgets -
+    they are imported from manager so writer and reader can never drift."""
+    from kiro_crew.mcp_gateway import gatewayd as gatewayd_mod
+
+    assert gatewayd_mod._SHUTDOWN_DRAIN_SECS is manager_mod._SHUTDOWN_DRAIN_SECS
+    assert gatewayd_mod._POOL_SHUTDOWN_SECS is manager_mod._POOL_SHUTDOWN_SECS
+
+
+@dataclass
+class _FakePoolKey:
+    server_name: str = "kirocrew-core"
+    agent_name: str = "kirocrew"
+
+    def human_readable(self) -> str:
+        return f"{self.agent_name}:{self.server_name}"
+
+
+def _make_backend() -> Backend:
+    from unittest.mock import MagicMock
+
+    process = MagicMock()
+    process.returncode = None
+    process.pid = 9999
+    return Backend(
+        pool_key=_FakePoolKey(),  # type: ignore[arg-type]
+        process=process,
+        stdin=MagicMock(),
+        stdout=MagicMock(),
+        created_at=0.0,
+        last_used_at=0.0,
+    )
+
+
+def test_backend_has_inflight_requests_reflects_pending_and_init() -> None:
+    from kiro_crew.mcp_gateway.backend import _PendingRequest
+
+    backend = _make_backend()
+    assert backend.has_inflight_requests is False
+
+    backend._pending_requests["gw-1"] = _PendingRequest(  # type: ignore[call-arg]
+        original_id=1, stub_uuid="stub-A", method="tools/call"
+    )
+    assert backend.has_inflight_requests is True
+
+    backend._pending_requests.clear()
+    assert backend.has_inflight_requests is False
+
+    backend._init_state = "in_flight"
+    assert backend.has_inflight_requests is True
+
+
+def test_pool_has_inflight_requests_aggregates_over_backends(monkeypatch) -> None:
+    pool = BackendPool(max_backends=4)
+
+    # No backends -> nothing in flight: an idle daemon drains at once.
+    monkeypatch.setattr(pool, "all_backends", lambda: [])
+    assert pool.has_inflight_requests() is False
+
+    @dataclass
+    class _B:
+        has_inflight_requests: bool
+
+    monkeypatch.setattr(pool, "all_backends", lambda: [_B(False), _B(False)])
+    assert pool.has_inflight_requests() is False
+
+    monkeypatch.setattr(pool, "all_backends", lambda: [_B(False), _B(True)])
+    assert pool.has_inflight_requests() is True
+
+
+class _FakeProc:
+    """Records the order of SIGTERM/SIGKILL without touching a real process."""
+
+    def __init__(self, *, exits_on_term: bool) -> None:
+        self.returncode = None
+        self.pid = 4242
+        self.calls: list[str] = []
+        self._exits_on_term = exits_on_term
+        self._killed = False
+
+    def send_signal(self, sig) -> None:  # noqa: ANN001 - sig type is signal.Signals
+        self.calls.append("SIGTERM")
+        if self._exits_on_term:
+            self.returncode = 0
+
+    def kill(self) -> None:
+        self.calls.append("SIGKILL")
+        self._killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        while self.returncode is None and not self._killed:
+            await asyncio.sleep(0.005)
+        return self.returncode if self.returncode is not None else 0
+
+
+def _manager(tmp_path: Path) -> GatewayManager:
+    spec = GatewaySpec(socket_path=tmp_path / "gw.sock")
+    return GatewayManager(spec)
+
+
+@pytest.mark.asyncio
+async def test_terminate_sends_sigterm_first_and_skips_kill_when_graceful(
+    tmp_path: Path,
+) -> None:
+    mgr = _manager(tmp_path)
+    proc = _FakeProc(exits_on_term=True)
+    mgr._process = proc  # type: ignore[assignment]
+
+    await mgr._terminate_process(grace_secs=0.1)
+
+    # Graceful: the daemon exited on SIGTERM, so we never escalate to SIGKILL.
+    assert proc.calls == ["SIGTERM"]
+
+
+@pytest.mark.asyncio
+async def test_terminate_escalates_to_sigkill_only_after_sigterm_times_out(
+    tmp_path: Path,
+) -> None:
+    mgr = _manager(tmp_path)
+    proc = _FakeProc(exits_on_term=False)
+    mgr._process = proc  # type: ignore[assignment]
+
+    await mgr._terminate_process(grace_secs=0.05)
+
+    # SIGTERM is always attempted BEFORE any escalation.
+    assert proc.calls == ["SIGTERM", "SIGKILL"]
+
+
+# --- Gap 2: forward declared non-secret env to pooled backends --------------
+
+
+def _write_agent(source_dir: Path, name: str, servers: dict) -> None:
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / f"{name}.json").write_text(
+        json.dumps({"name": name, "mcpServers": servers}), encoding="utf-8"
+    )
+
+
+def _run_rewriter(tmp_path: Path, forward: bool) -> dict:
+    source_dir = tmp_path / "agents"
+    # Two poolable servers with DIFFERENT declared env, so we can assert one
+    # server's env never bleeds into the other's forwarding entry.
+    _write_agent(
+        source_dir,
+        "agent-a",
+        {
+            "srv-one": {
+                "command": "/bin/echo",
+                "args": ["--stdio"],
+                "poolable": True,
+                # placeholder feature flag (non-secret) + a placeholder secret
+                "env": {"TOOL_FLAG_ONE": "on", "AWS_SECRET_PLACEHOLDER": "REDACTED"},
+            },
+            "srv-two": {
+                "command": "/bin/echo",
+                "args": ["--stdio"],
+                "poolable": True,
+                "env": {"TOOL_FLAG_TWO": "two"},
+            },
+        },
+    )
+    _rewrite, target_env = rewrite_agents(
+        source_dir=source_dir,
+        overlay_dir=tmp_path / "overlay",
+        socket_path=tmp_path / "gw.sock",
+        work_dir=tmp_path / "wd",
+        forward_declared_env=forward,
+    )
+    return target_env
+
+
+def test_rewriter_does_not_forward_env_when_flag_disabled(tmp_path: Path) -> None:
+    target_env = _run_rewriter(tmp_path, forward=False)
+    assert not any(k.startswith("MC_MCP_ENV_") for k in target_env), target_env
+
+
+def test_rewriter_forwards_only_nonsecret_env_when_enabled(tmp_path: Path) -> None:
+    target_env = _run_rewriter(tmp_path, forward=True)
+
+    env_keys = {k: v for k, v in target_env.items() if k.startswith("MC_MCP_ENV_")}
+    assert env_keys, "expected a forwarded env entry per server"
+
+    # srv-one: the non-secret flag is forwarded; the secret-prefixed key is not.
+    one = json.loads(next(v for k, v in env_keys.items() if "SRV_ONE" in k))
+    assert one == {"TOOL_FLAG_ONE": "on"}
+    assert not any(is_scrubbed_env_key(k) for k in one)
+
+    # The forwarded set is provably identical to the hashed set: the key's hash
+    # suffix equals hash_effective_env(forwarded) and no leakage from srv-two.
+    key_one = next(k for k in env_keys if "SRV_ONE" in k)
+    assert key_one.endswith("__" + hash_effective_env({"TOOL_FLAG_ONE": "on"}))
+    assert "TOOL_FLAG_TWO" not in one
+
+    two = json.loads(next(v for k, v in env_keys.items() if "SRV_TWO" in k))
+    assert two == {"TOOL_FLAG_TWO": "two"}
+
+
+def _pool_key(server: str, env_hash: str) -> PoolKey:
+    return PoolKey(
+        server_name=server,
+        agent_name="agent-a",
+        command_args_hash="cah",
+        effective_env_hash=env_hash,
+        work_dir="/tmp/wd",
+        binary_version="1.0",
+        os_uid=1000,
+        sandbox_mode="none",
+        autoapprove_set_hash="aah",
+        approval_mode="reads",
+        trust_all_tools=False,
+        user_identity="tester",
+        channel_id=None,
+        config_snapshot_hash="csh",
+    )
+
+
+def test_resolver_applies_forwarded_env_to_the_right_server_only(monkeypatch) -> None:
+    # srv-one has a published command AND a forwarded non-secret env.
+    monkeypatch.setenv("MC_MCP_TARGET_SRV_ONE", "/bin/echo --stdio")
+    monkeypatch.setenv(
+        "MC_MCP_ENV_SRV_ONE__hashone",
+        json.dumps({"TOOL_FLAG_ONE": "on", "AWS_SECRET_PLACEHOLDER": "REDACTED"}),
+    )
+    # srv-two has a command but NO forwarded env entry.
+    monkeypatch.setenv("MC_MCP_TARGET_SRV_TWO", "/bin/echo --stdio")
+
+    resolved_one = env_target_resolver(_pool_key("srv-one", "hashone"))
+    assert resolved_one is not None
+    _cmd, _args, env_one, _wd = resolved_one
+    # Declared non-secret key reaches its OWN backend...
+    assert env_one.get("TOOL_FLAG_ONE") == "on"
+    # ...but a secret-prefixed key is dropped even if it slipped into the JSON.
+    assert "AWS_SECRET_PLACEHOLDER" not in env_one
+
+    # A different server's backend must NOT inherit srv-one's declared env.
+    resolved_two = env_target_resolver(_pool_key("srv-two", "hashtwo"))
+    assert resolved_two is not None
+    _c2, _a2, env_two, _w2 = resolved_two
+    assert "TOOL_FLAG_ONE" not in env_two


### PR DESCRIPTION

## Description

This PR fixes two independent MCP gateway pooling gaps reported in #1078. They
are logically separate; Gap 1 changes the shutdown path for everyone, Gap 2 is
entirely behind a new default-off flag.

Gap 1 - gatewayd was SIGKILLed on every restart that had attached stubs. The
root cause was two inverted shutdown budgets. The supervisor in
`mcp_gateway/manager.py` sent SIGTERM and waited `_SHUTDOWN_GRACE_SECS = 5.0`
before escalating to SIGKILL, but the daemon's own graceful path in
`mcp_gateway/gatewayd.py::run_gatewayd` drained for up to
`_SHUTDOWN_DRAIN_SECS = 10.0` and only then ran `pool.shutdown_all()` (another
5s). So the supervisor killed the daemon while it was still inside its own drain
window, and `pool.shutdown_all()` never ran - pooled backends were reaped by the
`<socket>.backends` pidfile fallback instead of being drained cleanly, and
in-flight tool calls were cut. Worse, the drain loop waited for the `connections`
set to empty, but a pooled stub's bridge connection is long-lived and never
self-closes, so with pooling active the drain always burned the full 10s.

The fix makes the two budgets impossible to invert by deriving them from one
source of truth in `manager.py`: `_SHUTDOWN_GRACE_SECS` is now
`_SHUTDOWN_DRAIN_SECS + _POOL_SHUTDOWN_SECS + _SHUTDOWN_GRACE_MARGIN_SECS`, and
`gatewayd` imports the drain and pool budgets from `manager` rather than
declaring its own. The named module-level grace constant therefore always covers
the daemon's full graceful path. The drain loop now polls the condition that
actually matters - `pool.has_inflight_requests()` - instead of the connection
set, so an idle daemon shuts down at once while genuine in-flight calls still get
their window. That required a new `Backend.has_inflight_requests` property (true
while a forwarded request is outstanding or the initialize handshake is in
flight) and a lock-free `BackendPool.has_inflight_requests()` aggregate over
active plus draining backends. All process control stays on `platform_compat`;
the existing `_terminate_process` already signals its own child through the
asyncio process API and escalates via `platform_compat.kill_process_tree_async`.

Gap 2 - an agent's declared per-server `env` was never applied to the shared
pooled backend. For command+args a reverse-lookup already existed (the rewriter
publishes `MC_MCP_TARGET_<SERVER>__<command_args_hash>` and
`gatewayd.env_target_resolver` looks it back up by the same hash), but there was
no env analogue, so `env_target_resolver` spawned the backend with only
`_scrub_sensitive_env(os.environ)`. The fix forwards exactly the non-secret keys
- the same keys that are folded into `effective_env_hash`. To guarantee the
forwarded set is provably identical to the hashed set, the scrub-prefix list and
the effective-env hash moved into the dependency-free `hashing` leaf module
(`ENV_SCRUB_PREFIXES`, `is_scrubbed_env_key`, `hash_effective_env`); `stub` and
`rewriter` now both call it. Behind a new default-off config flag
`mcp_gateway.forward_declared_env`, the rewriter publishes the non-secret env as
`MC_MCP_ENV_<SERVER>__<effective_env_hash>` and `env_target_resolver` applies it
keyed by that same hash. Because those keys are part of the PoolKey, every
session sharing a backend already agrees on their values, so applying them at
spawn cannot cause cross-tenant divergence. Secret-prefixed keys
(`AWS_SECRET*`, `AWS_SESSION*`, `OAUTH*`) are never published and are
defensively dropped again in the resolver; the mapping is per-server, so one
server's declared env can never reach another server's backend.

## Related Issues

Fixes #1078

## Testing

- [x] Existing tests pass (targeted subsets; the full 840-file suite was not run per the worker brief)
- [x] New tests added for new functionality
- [ ] Manual verification performed

Commands run in the worktree (shared dependency venv, `PYTHONPATH=src`):

```
# new regression tests
pytest test/test_mcp_gateway_shutdown_env_1078.py     -> 9 passed
# new tests + adjacent suites that import the touched modules
pytest test/test_mcp_gateway_shutdown_env_1078.py \
       test/test_mcp_gateway_rewriter.py \
       test/test_mcp_gateway_stub_hash.py \
       test/test_mcp_gateway_bluegreen.py \
       test/test_mcp_gateway_poolkey.py \
       test/test_config_loader.py \
       test/test_config_schema.py                     -> 269 passed, 6 skipped
pytest test/test_mcp_gateway_control_plane.py \
       test/test_mcp_gateway_prewarm.py \
       test/test_mcp_gateway_wedge_ping_gate.py       -> passed (no regressions)
pytest -k "mcp_gateway or stub"                       -> 275 passed, 10 skipped, 6 failed

black  (touched files) -> my added lines are clean; 0 new violations
isort  (touched files) -> pass
flake8 (touched files) -> pass
mypy   (touched src)   -> Success: no issues found in 8 source files
```

The 6 failures are all in `test/test_mcp_gateway_transport.py` and are
pre-existing and environmental, not caused by this change: they fail with
`OSError: AF_UNIX path too long` because the CI worktree path is deep enough to
exceed the ~104-byte `sun_path` limit when the test binds a real unix socket.
`transport.py` is not modified by this PR.

Note on formatting: `mcp_gateway/{backend,gatewayd,manager,rewriter,stub}.py`
and `slack/gateway.py` are already not fully black-clean on `origin/main`
(verified against a pristine checkout), so a whole-file `black` run would rewrap
many unrelated pre-existing lines. To avoid an unrelated-refactor diff, only the
new lines were formatted; `black --diff` confirms it proposes no changes to any
line this PR adds. `hashing.py`, `pool.py`, `config/loader.py`, and the new test
file are fully black-clean.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

Documentation: both behaviors are documented only in code (the updated
docstrings and the operator-facing warning in `rewriter._build_stub_entry`) and
in the new config field's `_meta` description, which is what the Settings UI
renders. There is no separate spec-prose contract to update - `mcp-apps.md`
covers the MCP Apps rendering feature, not the pooling shutdown/env lifecycle,
and `config.md` does not enumerate individual `mcp_gateway` fields.

## Contribution License Agreement

The upstream template carries a placeholder: the CLA wording is supplied by
OSPO and must not be invented. Left as-is pending that text.

## Research

Investigation started from the two precise root causes named in the issue. I
read the issue in full, then traced the shutdown path and the env path through
the code.

Shutdown path: `manager.py` (`_SHUTDOWN_GRACE_SECS`, `_terminate_process`,
`_reap_orphaned_backends`) and `gatewayd.py` (`run_gatewayd`'s `finally`,
`_SHUTDOWN_DRAIN_SECS`, `pool.shutdown_all`). The inversion the issue describes
was exactly present: 5s supervisor grace against a 10s drain plus a 5s pool
shutdown, with the drain gated on `connections` (never empty under pooling). I
confirmed `gatewayd` already imports `_scrub_sensitive_env` from `manager`, so
importing the two budgets from `manager` adds no new import cycle and gives a
single source of truth. For the drain condition I looked at how in-flight work is
tracked: `Backend._pending_requests` plus the `_init_state == "in_flight"`
handshake state; `BackendPool.all_backends()` already gives a lock-free snapshot
across active and draining backends (it is what the abort handler iterates), so
the aggregate reuses it.

Env path: `rewriter._build_stub_entry` reads the declared `env`, writes it to a
`0600` sidecar, and clears it on the wrapper; `stub._hash_effective_env` folds it
into `effective_env_hash` (skipping the scrub prefixes) and the Register frame
carries only the hash; `gatewayd.env_target_resolver` never read it back. The
command side already had the `MC_MCP_TARGET_<SERVER>__<hash>` symmetry via
`hashing.hash_command`, so I mirrored it for env by moving the env hash and the
scrub-prefix list into `hashing` (making the forwarded set provably equal to the
hashed set, per the issue's requirement) and publishing
`MC_MCP_ENV_<SERVER>__<effective_env_hash>`.

Alternatives considered and rejected: (1) forwarding the declared env via the
existing sidecar path read from the daemon - rejected because the daemon would
have to locate a per-(agent,server) sidecar with no reverse index, and the
sidecar can hold secrets, whereas the hash-keyed env var carries only the
non-secret subset already agreed across the pool; (2) forwarding all keys and
scrubbing at spawn - rejected because a lossy secret hash is non-injective, so a
shared backend cannot reconstruct per-session secrets safely; (3) rewrapping the
whole files with black - rejected as an unrelated refactor (see the formatting
note above).

Blast radius: `hashing`, `manager`, `pool`, `backend` are imported widely, but
the changes are additive (new symbols / a derived constant / a new property) and
existing call sites are unchanged. `stub._hash_effective_env` and
`_ENV_SCRUB_PREFIXES` are preserved as module-level aliases for backward
compatibility. `env_target_resolver`'s behavior is unchanged when the new flag is
off (no `MC_MCP_ENV_*` var is ever published), so Gap 2 is inert by default.

Deliberately not done: the issue flags a human security review for the
credential-adjacent env handling in Gap 2 - that review is left to the reviewer.
No change to the `_terminate_process` signal mechanics (already cross-platform),
and no touching of the unrelated transport socket tests.
