### PR TITLE
fix(subagent): close spawn-steer race with a typed retry contract

### DIFF
--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -519,6 +519,32 @@ Request: `{"task": "..."}`
 Response: `{"id": "abc123", "task": "...", "status": "spawned"}`
 Errors: 400 (missing task), 429 (capacity reached), 503 (subagents not available)
 
+### Steering a running run: `POST /api/spawn/{id}/steer`
+
+`SubagentManager.steer_run(agent_id, message)` injects `message` into a run's
+in-flight turn. It returns `(ok, detail)` with a typed `detail` on refusal, and
+the handler maps each to an HTTP code:
+
+| `detail` | HTTP | Meaning |
+|---|---|---|
+| `not_found` | 404 | No run with this id (`_agents` miss). |
+| `not_running: ...` | 409 | Run finished — use `spawn_continue`. |
+| `session_starting: ...` | 503 | **Transient.** The run exists and is executing but its session has not registered yet. Retryable. |
+| `no_session` | 502 | Session registered but not steerable (no provider / no `steer`). |
+| other | 502 | Provider-reported steer failure. |
+
+**Spawn-return-to-registration race**: `spawn_run` returns the run id the instant
+the record lands in `_agents`, but the session/provider is only registered later
+inside `_run_inner` (after spawn approval and `get_or_create`). A steer landing in
+that window used to fail with a bare `no_session`, indistinguishable from a real
+failure, so callers gave up instead of retrying. `steer_run` now waits on the
+run's real registration signal — `SubagentInfo._session_ready` (an `asyncio.Event`
+set once the provider is established in `_run_inner`, and unconditionally in
+`_run`'s teardown so a waiter never blocks past the run's lifetime) — bounded by
+`_STEER_SESSION_WAIT_SECS` (10 s). Within the cap the steer simply succeeds once
+the session comes up; past it, it returns the typed, retryable `session_starting`
+rather than a bare `no_session`. No sleeps: the wait is on the event, not a timer.
+
 ### Handler keywords (instant, no LLM)
 
 User-typed `spawn <task>`, `bg <task>`, `spawn list`, `spawn status` are intercepted by the handler for instant execution.

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -257,6 +257,10 @@ async def api_spawn_steer(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": detail, "code": "not_running"}, status=409
             )
+        if detail.startswith("session_starting"):
+            # Transient: the run's session has not registered yet. 503 is the
+            # retryable status — the caller (or LLM) should retry shortly.
+            return web.json_response({"error": detail, "code": "session_starting"}, status=503)
         return web.json_response(
             {"error": detail, "code": "steer_failed"}, status=502
         )

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -342,7 +342,10 @@ def _list_tools() -> list[dict[str, Any]]:
                 "Inject a message into a RUNNING subagent's in-flight turn "
                 "(course-correct without restarting it) — like steering a chat "
                 "session. Only works while the run is executing; for a finished "
-                "continuable run use spawn_continue instead."
+                "continuable run use spawn_continue instead. A steer issued in "
+                "the same breath as spawn_run briefly waits for the run's "
+                "session to come up; if it reports 'session_starting' the "
+                "session is not registered yet — retry in a few seconds."
             ),
             "inputSchema": {
                 "type": "object",

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -229,6 +229,16 @@ _RECOVERY_SLOT_WAIT_SECS = 60.0
 _REPORT_DRAIN_TIMEOUT = 30.0  # max seconds cancel_all() waits for shielded terminal reports to drain
 _STARTUP_TIMEOUT_SECS = 120  # max seconds a subagent may sit pre-first-turn with no runtime before the startup watchdog reaps it
 _ON_DONE_TIMEOUT = 1200.0  # outer cap: max total seconds for semaphore wait + injection
+# Max seconds steer_run waits for a just-spawned run's session to register
+# before returning the typed, retryable ``session_starting``. spawn_run returns
+# the run id the instant the record lands in ``_agents``, but the session/
+# provider is only registered later inside ``_run_inner`` (after spawn approval
+# and get_or_create). A steer landing in that window used to fail with a bare
+# ``no_session``; instead it now waits on the real registration signal
+# (``SubagentInfo._session_ready``) up to this bound so the common case (a fast
+# spawn) simply succeeds. Kept short so the caller's tool turn is never blocked
+# for long — a slower start still returns a typed retry hint rather than hanging.
+_STEER_SESSION_WAIT_SECS = 10.0
 
 # Continuation prompt sent when a transient backend error interrupted a turn
 # AFTER output had already streamed. Mirrors the main path's post-token
@@ -897,6 +907,15 @@ class SubagentInfo:
     # on the _shared_provider directly.
     _session_sharing: bool = False
     _shared_provider: Any = None  # AcpSessionProvider when _session_sharing=True
+    # Registration signal: set once _run_inner has established this run's
+    # session/provider (either the shared-runtime provider on ``_shared_provider``
+    # or a session registered in SessionManager), and unconditionally in
+    # ``_run``'s teardown so a waiter never blocks past the run's real lifetime.
+    # ``steer_run`` awaits it (bounded by ``_STEER_SESSION_WAIT_SECS``) to close
+    # the spawn-return-to-registration race instead of failing with a bare
+    # ``no_session``. Created without a bound loop (asyncio.Event, py3.10+); the
+    # first ``wait()``/``set()`` binds it to the running loop.
+    _session_ready: asyncio.Event = field(default_factory=asyncio.Event)
     # ── Turn-resilience state (subagent parity with the main-agent guards) ──
     # True when the user explicitly stopped this agent (DELETE /api/spawn/{id}).
     # Renders as a neutral "stopped" terminal state (not an error) and
@@ -2853,27 +2872,63 @@ class SubagentManager:
             conversation_key=conv_key,
         )
 
+    def _resolve_run_provider(self, info: "SubagentInfo") -> Any:
+        """Return the steerable provider for run *info*, or None if unresolved.
+
+        Shared-runtime runs steer through ``_shared_provider``; dedicated runs
+        look the session up in SessionManager. Returns None while the session
+        has not registered yet (the spawn-return-to-registration window) — the
+        caller distinguishes that transient state from a genuine failure.
+        """
+        if info._session_sharing and info._shared_provider is not None:
+            return info._shared_provider
+        session_key = info.conversation_key or f"subagent:{info.id}"
+        return self._sessions.get_provider(session_key)
+
     async def steer_run(self, agent_id: str, message: str) -> tuple[bool, str]:
         """Inject *message* into the RUNNING turn of run *agent_id*.
 
         Returns ``(ok, detail)``. Typed detail values on refusal:
         ``not_found`` (unknown id), ``not_running`` (run finished — use
-        spawn_continue), ``no_session`` (session not reachable), or the
+        spawn_continue), ``session_starting`` (the run exists and is executing
+        but its session has not registered yet — transient, retry in a few
+        seconds), ``no_session`` (session registered but not steerable), or the
         provider's failure reason.
+
+        A steer landing in the spawn-return-to-registration window waits on the
+        run's real registration signal (``_session_ready``) up to
+        ``_STEER_SESSION_WAIT_SECS`` before falling back to ``session_starting``,
+        so the common case (a fast spawn) simply succeeds rather than failing.
         """
         info = self._agents.get(agent_id)
         if info is None:
             return False, "not_found"
         if info.done:
             return False, "not_running: run finished — use spawn_continue"
-        provider: Any = None
-        if info._session_sharing and info._shared_provider is not None:
-            provider = info._shared_provider
-        else:
-            session_key = info.conversation_key or f"subagent:{info.id}"
-            provider = self._sessions.get_provider(session_key)
+        provider = self._resolve_run_provider(info)
         if provider is None or not hasattr(provider, "steer"):
-            return False, "no_session"
+            # The run is registered in _agents and not done, but its session may
+            # simply not have registered yet (spawn returns the id before
+            # _run_inner reaches get_or_create). Wait on the real registration
+            # signal, bounded, instead of failing blind — this removes the race
+            # for the common case where the session comes up within the cap.
+            if not info._session_ready.is_set():
+                try:
+                    await asyncio.wait_for(
+                        info._session_ready.wait(), timeout=_STEER_SESSION_WAIT_SECS
+                    )
+                except asyncio.TimeoutError:
+                    return False, (
+                        "session_starting: subagent session not registered yet"
+                        " — retry in a few seconds"
+                    )
+                # Registration (or teardown) fired: re-check terminal state and
+                # re-resolve the provider before steering.
+                if info.done:
+                    return False, "not_running: run finished — use spawn_continue"
+                provider = self._resolve_run_provider(info)
+            if provider is None or not hasattr(provider, "steer"):
+                return False, "no_session"
         try:
             ok = await provider.steer(message)
         except Exception as exc:  # pragma: no cover - provider-specific
@@ -3361,6 +3416,11 @@ class SubagentManager:
                 self._write_tombstone(info, "error")
             logger.exception("Subagent %s failed", info.id)
         finally:
+            # Release the registration signal unconditionally: a run that failed
+            # or was cancelled BEFORE reaching provider setup never set it, and a
+            # steer_run waiting on it must wake now (it re-checks info.done and
+            # returns not_running) rather than blocking the full wait cap.
+            info._session_ready.set()
             # Guard 3 of 3 — the terminal REPORT, owned by the finalize claim.
             # Taken (and the report task SPAWNED) before the teardown awaits
             # below, so a cancellation landing anywhere in teardown cannot
@@ -3815,6 +3875,10 @@ class SubagentManager:
                 )
             # Detect CC provider to skip permission event loop
             is_cc = self._is_cc_provider(client)
+        # The session/provider is now registered (shared arm set
+        # ``_shared_provider``; dedicated arm registered it in SessionManager):
+        # wake any steer_run waiting on the spawn-return-to-registration race.
+        info._session_ready.set()
         # Intentionally check info.agent (not resolved `agent`) so only
         # explicitly requested agents skip _SYSTEM_PREFIX (defense-in-depth).
         named_agent = bool(info.agent and _AGENT_NAME_RE.fullmatch(info.agent))

--- a/test/test_subagent_continuable.py
+++ b/test/test_subagent_continuable.py
@@ -15,6 +15,7 @@ Covers the hibernate-first lifecycle slice:
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -309,9 +310,77 @@ class TestSteerRun:
         sessions = _mock_sessions()
         sessions.get_provider = MagicMock(return_value=None)
         manager = _manager(sessions)
-        manager._agents["a1"] = SubagentInfo(id="a1", task="t")
+        # Registration is DONE (_session_ready set) but the provider is
+        # unreachable — a genuine no_session, not the startup race.
+        info = SubagentInfo(id="a1", task="t")
+        info._session_ready.set()
+        manager._agents["a1"] = info
         ok, detail = await manager.steer_run("a1", "hi")
         assert not ok and detail == "no_session"
+
+    @pytest.mark.asyncio
+    async def test_steer_before_registration_waits_then_succeeds(self) -> None:
+        # Drives the spawn-return-to-registration race deterministically: the
+        # run is in _agents and executing, but its session is not registered
+        # yet (_session_ready unset, get_provider returns None). The steer must
+        # NOT fail with a bare no_session — it parks on the registration signal.
+        sessions = _mock_sessions()
+        sessions.get_provider = MagicMock(return_value=None)
+        manager = _manager(sessions)
+        info = SubagentInfo(id="a1", task="t")
+        manager._agents["a1"] = info
+
+        task = asyncio.create_task(manager.steer_run("a1", "course correct"))
+        # One scheduler pass lets steer_run run its synchronous prologue and
+        # park on info._session_ready.wait(); everything before that await is
+        # non-blocking, so after a single yield the task is deterministically
+        # waiting rather than returned.
+        await asyncio.sleep(0)
+        assert not task.done()  # did not return no_session; it is waiting
+
+        # Registration completes: provider becomes reachable and the signal fires.
+        provider = AsyncMock()
+        provider.steer = AsyncMock(return_value=True)
+        sessions.get_provider = MagicMock(return_value=provider)
+        info._session_ready.set()
+
+        with patch("kiro_crew.subagent.sel"):
+            ok, detail = await task
+        assert ok and detail == "ok"
+        provider.steer.assert_awaited_once_with("course correct")
+
+    @pytest.mark.asyncio
+    async def test_steer_times_out_to_session_starting(self) -> None:
+        # Registration never completes within the (tiny, patched) cap: the
+        # steer returns the typed, retryable session_starting rather than a
+        # bare no_session. The event is never set, so the timeout is certain.
+        sessions = _mock_sessions()
+        sessions.get_provider = MagicMock(return_value=None)
+        manager = _manager(sessions)
+        manager._agents["a1"] = SubagentInfo(id="a1", task="t")
+        with patch("kiro_crew.subagent._STEER_SESSION_WAIT_SECS", 0.01):
+            ok, detail = await manager.steer_run("a1", "hi")
+        assert not ok and detail.startswith("session_starting")
+
+    @pytest.mark.asyncio
+    async def test_steer_wakes_as_not_running_if_run_ended_while_waiting(self) -> None:
+        # If the run finishes during the wait (teardown sets _session_ready
+        # unconditionally), the woken steer re-checks terminal state and
+        # reports not_running instead of steering a dead session.
+        sessions = _mock_sessions()
+        sessions.get_provider = MagicMock(return_value=None)
+        manager = _manager(sessions)
+        info = SubagentInfo(id="a1", task="t")
+        manager._agents["a1"] = info
+
+        task = asyncio.create_task(manager.steer_run("a1", "hi"))
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        info.done = True  # run ended
+        info._session_ready.set()  # teardown wakes the waiter
+        ok, detail = await task
+        assert not ok and detail.startswith("not_running")
 
 
 # ── release_conversation + TTL sweep ──


### PR DESCRIPTION

## Description

`spawn_run` returns a run id the instant the record lands in
`SubagentManager._agents`, but the run's ACP session/provider is only registered
later, inside `_run_inner`, after spawn approval and `SessionManager.get_or_create`.
A `spawn_steer` issued in that window found the run in `_agents` (so not
`not_found`) and not done (so not `not_running`), but `_sessions.get_provider(...)`
returned None - and `steer_run` (`src/kiro_crew/subagent.py`) collapsed that into a
bare `no_session`. That token is indistinguishable from a genuinely unsteerable
run, so the caller (an LLM) read it as "this run cannot be steered" and gave up
instead of retrying a few seconds later, which the issue confirms would have
succeeded. This is exactly the moment a parent most wants to steer - it just
realized the task text was wrong - so the failure mode is costly.

Root cause: `steer_run` had no way to distinguish "session has not registered
yet" (transient, retryable) from "session registered but not steerable" (a real
failure). The fix removes the race rather than only labeling it.

I chose to **remove the race** (option b) over a bare typed-error hint (option a)
and over a message queue. A typed hint alone still pushes a retry loop onto the
caller for the common case where the session comes up within a second or two; a
queue is the best UX but is materially more stateful (a bounded per-run buffer,
drop-on-complete semantics, a second injection path) than this bug warrants under
YAGNI. Waiting on the run's real registration signal is the smallest change that
makes an immediate steer simply succeed, and it degrades cleanly to the typed
hint only when the wait genuinely exceeds its bound.

Changes:

- `SubagentInfo._session_ready` - an `asyncio.Event`, set once `_run_inner` has
  established the provider (shared-runtime `_shared_provider`, or a session
  registered in `SessionManager`), and set **unconditionally** in `_run`'s
  teardown `finally` so a run that failed or was cancelled before provider setup
  never leaves a waiter blocked past its lifetime.
- `steer_run` resolves the provider through the new `_resolve_run_provider`
  helper; when the provider is not yet resolvable and the run is still live it
  waits on `_session_ready`, bounded by the module-level constant
  `_STEER_SESSION_WAIT_SECS` (10 s), then re-checks terminal state and re-resolves.
  Within the cap the steer succeeds; past it, it returns the typed, retryable
  `session_starting` instead of `no_session`. The wait is on the event, not a
  timer - no `sleep`-based fix.
- The HTTP handler `POST /api/spawn/{id}/steer`
  (`dashboard/handlers/messaging.py`) maps `session_starting` to a distinct
  retryable `503` (code `session_starting`), separate from the `502`
  `steer_failed` bucket.
- The `spawn_steer` MCP tool description (`mcp_core.py`) now tells the model that
  a steer issued in the same breath as `spawn_run` briefly waits, and that a
  `session_starting` result means "retry in a few seconds" - so user-facing prose
  matches the new contract.
- The subagent spec (`docs/system-specs/modules/subagent.md`) documents the full
  steer error contract (detail token -> HTTP code table) and the race, in the same
  commit, since the tool's error contract is documented behavior.

`no_session` is retained for its true meaning: the session registered but is not
steerable (no provider, or a provider without `steer`).

## Related Issues

Fixes #1113

## Testing

- [x] Existing tests pass (targeted; full suite is too slow for this sandbox)
- [x] New tests added for new functionality
- [ ] Manual verification performed

New and updated tests live in `test/test_subagent_continuable.py::TestSteerRun`:

- `test_no_session_reachable` - updated to represent the genuine case
  (`_session_ready` set, provider unreachable) and still asserts `no_session`.
- `test_steer_before_registration_waits_then_succeeds` - drives the race
  deterministically: steers while the run is in `_agents` but unregistered,
  asserts the call parks on the signal (does NOT return `no_session`), then
  completes registration and asserts the steer succeeds. The single
  `await asyncio.sleep(0)` is one scheduler pass to reach the await point (the
  prologue is fully synchronous), not a timed race - not `sleep`-based hoping.
- `test_steer_times_out_to_session_starting` - patches the cap tiny; the event is
  never set, so the timeout is certain and the call returns `session_starting`.
- `test_steer_wakes_as_not_running_if_run_ended_while_waiting` - the run ends
  during the wait (teardown sets the event); the woken steer reports `not_running`.

Commands run (venv at `/Users/diegogm/Dev/github/kc-venv`, `PYTHONPATH=src`):

```
python -m pytest test/test_subagent_continuable.py -n0 -q \
  -p no:cacheprovider --override-ini="addopts="
  -> 33 passed

python -m pytest test/test_steer_requeue.py test/test_mcp_core.py ...  -> 46 passed
python -m pytest test/test_subagent.py test/test_subagent_continuable.py \
  test/test_subagent_scale.py test/test_native_subagent_spawn.py         -> 221 passed
python -m pytest test/test_subagent_reap_race.py \
  test/test_subagent_turn_resilience.py test/test_subagent_persistence.py \
  test/test_queue_during_subagents.py                                     -> 118 passed

isort  --check-only <touched>   -> OK
flake8 <touched>                -> OK (clean)
mypy   <touched src>            -> Success: no issues found in 3 source files
```

Note on `black`: repo-wide `black --check` is deliberately DISABLED in CI
(`.github/workflows/ci.yml`, ~406-file bulk-format pass still pending), and the
touched files already fail `black` 24.10.0 on origin/main (pre-existing drift,
e.g. `1024 ** 3` is black-23 spacing). Running `black` on the whole files would
reformat hundreds of unrelated lines. I therefore hand-formatted only the lines I
added to black style and did NOT reformat unrelated code. Verified my diff adds
zero new `black` regions: `black --diff` region counts are identical between
origin/main and this branch for every touched file (subagent 54->54, mcp_core
8->8, messaging 4->4, test 6->6).

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text - it will be added here once Legal provides it. -->

## Research

Investigation path:

- Read the WORKER_BRIEF, the issue, and `AGENTS.md`; located `steer_run` and the
  `no_session` sites with `grep -rln` (used as a documented last resort; cbm/codedb
  MCP servers were not attached in this session, so lexical grep stood in for the
  codedb tier - noted in `LLM.log`).
- Traced the lifecycle to confirm the race: `spawn()` stores `info` in `_agents`
  then `asyncio.create_task(self._run(info))` and returns; `_run` -> `_run_inner`
  reaches `get_or_create` (dedicated arm) or `_create_shared_session` (shared arm)
  only after several awaits, so `get_provider(session_key)` is None in between.
  This matches the issue's "session not yet registered" diagnosis exactly.
- Read the provider-establishment block in `_run_inner`, the `_run` teardown
  `finally` (three-guard terminal-report machinery), the HTTP handler in
  `dashboard/handlers/messaging.py`, and the `spawn_steer` tool schema/handler in
  `mcp_core.py` before editing. Read `docs/system-specs/modules/subagent.md`.

Alternatives considered and rejected:

- **Bare typed hint only (issue option b):** simplest, but leaves the retry loop
  to the caller for the common fast-startup case; the issue itself notes callers
  give up rather than retry.
- **Message queue (issue option a):** best UX but the most state - a bounded
  buffer, drop-on-terminal semantics, and a distinct injection path. Overkill for
  a startup-only window; violates KISS/YAGNI here.
- **Sleep/poll loop:** explicitly disallowed and wrong - it wastes the window and
  is nondeterministic. The `asyncio.Event` is the real signal.

Blast radius: `steer_run` has one production caller (the `POST
/api/spawn/{id}/steer` handler) and the `TestSteerRun` tests. The new
`SubagentInfo` field is a defaulted `asyncio.Event` (constructed without a bound
loop on py3.10+; binds on first `wait()`/`set()`), so every existing `SubagentInfo(...)`
construction is unaffected - confirmed by running the wider subagent suites (221 +
118 passed). The teardown-`finally` `set()` is idempotent and cannot change any
terminal path.

Deliberately NOT done: no message-queue buffering, no change to `not_found` /
`not_running` semantics, no repo-wide `black` reformat, no touching the
`_STARTUP_TIMEOUT_SECS` watchdog (a separate concern).
