### PR TITLE
fix(desktop): rank the relocatable .cmd shim above the bundle's pip .exe

### DIFF
--- a/website/electron/find-bin.js
+++ b/website/electron/find-bin.js
@@ -49,24 +49,22 @@ function findKirocrewBin(
       path.resolve(dirname, "backend-dist", archBackend, "bin", "kirocrew")
     );
   }
-  // 0b. Windows layout: a pip/venv install exposes `kirocrew.exe` under
-  //     `Scripts\` (not the POSIX `bin/kirocrew` launcher). Probed before the
-  //     POSIX candidates so a native Windows source install resolves to an
-  //     absolute `.exe` that `spawn()` can launch without a shell. On POSIX
-  //     these are skipped entirely so mac/Linux behavior is unchanged.
+  // 0b. Windows SOURCE CHECKOUT: a pip/venv install exposes `kirocrew.exe`
+  //     under `Scripts\` (not the POSIX `bin/kirocrew` launcher). Probed before
+  //     the bundled candidates so a developer running from a checkout gets
+  //     their own venv, and as an absolute `.exe` that `spawn()` can launch
+  //     without a shell. On POSIX these are skipped entirely so mac/Linux
+  //     behavior is unchanged.
+  //
+  //     Only the checkout venvs are ranked here. The BUNDLE's own
+  //     Scripts\kirocrew.exe is ranked further down, below the .cmd shim --
+  //     see the note there.
   if (isWindows) {
     candidates.push(
-      // Bundled Windows backend (python-build-standalone → Scripts\kirocrew.exe)
-      path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe"),
-      path.resolve(dirname, "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe"),
       // Source checkout: repo-root `.venv` — electron/ is <repo>/website/electron,
       // so the venv is two levels up; one level up covers a <repo>/website venv.
       path.resolve(dirname, "..", "..", ".venv", "Scripts", "kirocrew.exe"),
-      path.resolve(dirname, "..", ".venv", "Scripts", "kirocrew.exe"),
-      // One-liner installer venv, and toolbox / local pip Scripts dirs.
-      path.join(home, ".kirocrew-app", ".venv", "Scripts", "kirocrew.exe"),
-      path.join(home, ".toolbox", "bin", "kirocrew.exe"),
-      path.join(home, ".local", "bin", "kirocrew.exe")
+      path.resolve(dirname, "..", ".venv", "Scripts", "kirocrew.exe")
     );
   }
   candidates.push(
@@ -77,6 +75,17 @@ function findKirocrewBin(
     //     stays platform-agnostic and testable; only a Windows bundle
     //     actually contains the .cmd. Keep in sync with
     //     build-desktop.sh's bin/kirocrew.cmd.
+    //
+    //     This MUST outrank backend-dist/.../Scripts/kirocrew.exe below.
+    //     `pip install` also drops a console-script .exe in the bundle's
+    //     Scripts\ dir, but distlib embeds the ABSOLUTE interpreter path of
+    //     the machine that built it, so inside a shipped bundle that .exe
+    //     points at a build-agent path (D:\a\KiroCrew\...) that does not
+    //     exist on the user's machine. The .cmd shim resolves the
+    //     interpreter via %~dp0 and is the only relocatable launcher of the
+    //     two. Ranking them the other way round both broke the build-time
+    //     resolver gate and, had the gate not caught it, would have shipped
+    //     an app whose backend could never start.
     path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "bin", "kirocrew.cmd"),
     path.resolve(dirname, "backend-dist", "kirocrew-backend", "bin", "kirocrew.cmd"),
     // 1. Legacy PyInstaller layout: a flat frozen executable at the root of the
@@ -91,12 +100,38 @@ function findKirocrewBin(
     //     with build-desktop.sh's BACKEND_OUT/bin/kirocrew path.
     path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "bin", "kirocrew"),
     path.resolve(dirname, "backend-dist", "kirocrew-backend", "bin", "kirocrew"),
-    path.resolve(dirname, "..", "bin", "kirocrew"),
-    // 2. Well-known install paths (toolbox, installer symlink, and venv)
+    path.resolve(dirname, "..", "bin", "kirocrew")
+  );
+  if (isWindows) {
+    // 1c. The bundle's pip console-script .exe. Ranked BELOW the .cmd shim
+    //     (distlib bakes the building machine's absolute interpreter path into
+    //     it, so in a shipped bundle it points at a path that does not exist)
+    //     but still ABOVE the user-level install paths below: a bundled app
+    //     must prefer its own backend over whatever happens to be installed on
+    //     the machine. It is correct for a bundle built where it runs (a local
+    //     `make desktop`), which is why it is probed at all.
+    candidates.push(
+      path.join(resourcesPath || "", "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe"),
+      path.resolve(dirname, "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe")
+    );
+  }
+  // 2. Well-known install paths (toolbox, installer symlink, and venv). Last,
+  //    so a packaged app never prefers a stray user-level install over the
+  //    backend it shipped with.
+  candidates.push(
     path.join(home, ".toolbox", "bin", "kirocrew"),
     path.join(home, ".local", "bin", "kirocrew"),
     path.join(home, ".kirocrew-app", ".venv", "bin", "kirocrew")
   );
+  if (isWindows) {
+    // Windows equivalents of the user-level paths above (one-liner installer
+    // venv, toolbox, and local pip Scripts dirs).
+    candidates.push(
+      path.join(home, ".kirocrew-app", ".venv", "Scripts", "kirocrew.exe"),
+      path.join(home, ".toolbox", "bin", "kirocrew.exe"),
+      path.join(home, ".local", "bin", "kirocrew.exe")
+    );
+  }
   for (const bin of candidates) {
     try {
       fs.accessSync(bin, fs.constants.X_OK);

--- a/website/electron/test/find-bin.test.js
+++ b/website/electron/test/find-bin.test.js
@@ -100,6 +100,58 @@ describe("findKirocrewBin", () => {
     assert.equal(result, bundledExe);
   });
 
+  // A real Windows bundle contains BOTH launchers: build-desktop.sh writes
+  // bin\kirocrew.cmd, and the `pip install` that populates the tree also drops
+  // a console-script Scripts\kirocrew.exe. Every Windows case above uses
+  // only() -- a one-candidate world -- so none of them could express which of
+  // the two wins. That gap let the two swap places and reach a nightly, where
+  // the build-time resolver gate failed with "the builder output layout and
+  // find-bin.js candidate list have drifted apart".
+  const present = (...targets) => {
+    const set = new Set(targets.map((t) => path.resolve(t)));
+    return {
+      accessSync: (p) => {
+        if (set.has(path.resolve(p))) return;
+        const e = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+      constants: { X_OK: fs.constants.X_OK },
+    };
+  };
+
+  it("prefers the relocatable bin\\kirocrew.cmd over the bundle's Scripts\\kirocrew.exe", () => {
+    // THE REGRESSION. pip's console-script .exe embeds the ABSOLUTE interpreter
+    // path of the machine that built it (distlib), so inside a shipped bundle it
+    // points at a build-agent path like D:\a\KiroCrew\... that does not exist on
+    // the user's machine. The .cmd shim resolves the interpreter through %~dp0
+    // and is the only relocatable launcher of the two -- so it must win whenever
+    // both are present, which in a real bundle is always.
+    const cmd = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "bin", "kirocrew.cmd");
+    const exe = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe");
+    const result = findKirocrewBin(present(cmd, exe), fakeOs, path, RESOURCES, DIRNAME, "x64", true);
+    assert.equal(result, cmd);
+  });
+
+  it("prefers the bundle's Scripts\\kirocrew.exe over a user-level install", () => {
+    // A packaged app must run the backend it shipped with, never whatever
+    // happens to be installed on the machine.
+    const exe = path.join(RESOURCES, "backend-dist", "kirocrew-backend", "Scripts", "kirocrew.exe");
+    const userLocal = path.join(HOME, ".local", "bin", "kirocrew.exe");
+    const result = findKirocrewBin(
+      present(exe, userLocal), fakeOs, path, RESOURCES, DIRNAME, "x64", true
+    );
+    assert.equal(result, exe);
+  });
+
+  it("still finds a user-level kirocrew.exe when nothing is bundled", () => {
+    const userLocal = path.join(HOME, ".local", "bin", "kirocrew.exe");
+    const result = findKirocrewBin(
+      present(userLocal), fakeOs, path, RESOURCES, DIRNAME, "x64", true
+    );
+    assert.equal(result, userLocal);
+  });
+
   it("does not probe Windows .exe candidates on POSIX", () => {
     const probed = [];
     const fakeFs = {


### PR DESCRIPTION
## Description

The nightly Windows desktop build has failed since #656 landed. Every run dies at the resolver-agreement gate:

```
ERROR: find-bin.js resolved
  'D:\a\KiroCrew\KiroCrew\website\electron\backend-dist\kirocrew-backend\Scripts\kirocrew.exe',
  expected the bundled launcher '.../kirocrew-backend/bin/kirocrew.cmd'.
  The builder output layout and find-bin.js candidate list have drifted apart.
```

A Windows bundle contains **both** launchers. `build_backend_windows` writes `bin\kirocrew.cmd`, and the `pip install` that populates the same tree also drops a console-script `Scripts\kirocrew.exe`. #656 added the bundled `.exe` as a Windows candidate and ranked it *above* the `.cmd`, so the resolver started returning the `.exe` and the gate failed.

### This is not just a gate mismatch

The `.exe` is the **wrong launcher to ship**. distlib bakes the absolute path of the *building* machine's interpreter into a Windows console script, so inside a distributed bundle that `.exe` points at a build-agent path (`D:\a\KiroCrew\...`) that exists on no user's machine. The `.cmd` shim resolves its interpreter through `%~dp0` and is the only relocatable launcher of the two.

So the gate was correct to fail, and it earned its keep here: had it not caught this, the installer would have shipped an app whose backend could never start. The fix is the ranking, not the gate.

### What changed

- The bundle's `Scripts\kirocrew.exe` drops **below** `bin\kirocrew.cmd`. It stays a candidate rather than being deleted — it is correct for a bundle built on the machine that runs it (a local `make desktop`), and for an older bundle predating the shim.
- It stays **above** the user-level install paths, so a packaged app still prefers its own backend over a stray `~/.local` install. Preserving that required moving the Windows user-level `.exe` paths down with it: they had been grouped with the checkout venvs, and leaving them there would have inverted the bundle-vs-user precedence that holds on `main` today. I verified that precedence on `main` before changing it.
- The source-checkout venv candidates stay where they were, so a developer running from a checkout still gets their own venv.

`main.js` already handles either resolution: it unwraps a `.cmd` to spawn `python.exe` directly (Node refuses `spawn()` of a `.cmd` without `shell: true`, CVE-2024-27980 hardening) and spawns a bare `.exe` as-is. No change needed there.

## Related Issues

Fixes the Windows leg of the nightly desktop build (regression from #656). Unrelated to #1125, which is Authenticode signing.

## Testing

- [x] Existing tests pass — `find-bin.test.js` 24/24; `test_build_desktop_launcher_symlink.py` + `test_build_desktop_rm_resilient.py` 11/11
- [x] New tests added for new functionality
- [x] Manual verification performed

**Why the existing suite missed this.** Every Windows case used a single-candidate fake `fs`, so none of them could express *which* launcher wins when both are present — which in a real bundle is always. That gap is precisely what let the two swap places and reach a nightly.

Adds a multi-candidate helper and three cases pinning the full precedence chain:

| case | expected |
|---|---|
| `.cmd` + bundle `.exe` both present (the failing case) | `.cmd` |
| bundle `.exe` vs user-level install | bundle `.exe` |
| nothing bundled | user-level install |

The first was **verified to fail against the unfixed resolver** and pass with the fix, so it is a real regression guard rather than a restatement of current behaviour.

Manual: reproduced the CI layout on disk (both launchers present) and confirmed the resolver now returns the `.cmd`, i.e. the gate's expected path. Also ran the full precedence matrix including the PATH fallback and confirmed POSIX still probes zero `.exe` candidates.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — the stale comment claiming the old ordering is corrected, and the reason the `.exe` cannot be trusted in a shipped bundle is recorded where the ranking decision lives
- [x] No secrets, credentials, or internal references in the diff
