### PR TITLE
fix(i18n): stop cross-tab boot race and repaint memoized subtrees

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -94,8 +94,16 @@ route it through the catalog or it will render as English in every language.
   Preferred for new code — it subscribes to language changes.
 - **Anywhere a hook is illegal** (render callbacks, plain helpers, non-component
   modules): `import { i18nT } from '../i18n/t'` then `i18nT('key')`. It reads the
-  current language but does NOT subscribe; `LanguageProvider` remounts the tree on
-  a language change so these re-evaluate.
+  current language but does NOT subscribe; `LanguageProvider` re-renders the tree
+  (via `cloneElement`, preserving state) on a language change so these re-evaluate.
+- **Inside a `React.memo`/`useMemo` boundary that uses `i18nT()`:** the central
+  re-render does NOT reach you - `memo` bails out on shallow-equal props and
+  `i18nT()` output is not a prop, so the subtree keeps stale strings after a
+  switch. Call `useI18nRevision()` (from `../i18n/useI18nRevision`) once at the top
+  of such a component: it reads the provider's `active` language from context, so a
+  switch changes the context value and forces the memo boundary to re-render. It
+  does not disable memoization - the component still skips renders while its props
+  AND the language are unchanged.
 - **Never `import { t } from 'i18next'`** — `t` is a very common local identifier
   here (`.map(t => …)` over tabs/turns/tasks/themes) and a bare `t` gets shadowed,
   turning the call into `SomeObject(...)`.

--- a/website/src/apps/workflows/WorkflowRunTree.tsx
+++ b/website/src/apps/workflows/WorkflowRunTree.tsx
@@ -23,6 +23,7 @@ import { sanitizeLlmOutput } from '../../utils/sanitize'
 import { groupByPhase, latestBudget, type WfEvent } from './runModel'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 export interface WorkflowRunTreeProps {
   events: WfEvent[]
   /** Terminal status of the run; drives the per-phase fallback when no agents
@@ -73,6 +74,7 @@ const WorkflowRunTree = memo(function WorkflowRunTree({
   error,
   maxLogs = 6,
 }: WorkflowRunTreeProps) {
+  useI18nRevision()
   const phases = useMemo(() => groupByPhase(events), [events])
   const budget = useMemo(() => latestBudget(events), [events])
   const logLines = useMemo(

--- a/website/src/apps/workflows/WorkflowSourcePanel.tsx
+++ b/website/src/apps/workflows/WorkflowSourcePanel.tsx
@@ -20,6 +20,7 @@ import { FileCode, Pencil, Play, ChevronRight } from 'lucide-react'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 const CORE_API_BASE = '/api/workflows'
 
 interface RerunOk {
@@ -47,6 +48,7 @@ const WorkflowSourcePanel = memo(function WorkflowSourcePanel({
   source,
   sourceError,
 }: WorkflowSourcePanelProps) {
+  useI18nRevision()
   const [open, setOpen] = useState(false)
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState<string>('')

--- a/website/src/components/ArtifactBody.tsx
+++ b/website/src/components/ArtifactBody.tsx
@@ -11,6 +11,7 @@ import type { FileType } from './FileRenderers'
 import type { Artifact, ArtifactComment } from '../types'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 // Extracted from ArtifactDetailPage so the full-page route and the chat
 // side-panel Artifacts tab share one renderer (markdown/text/json/svg natively
 // via ContentRenderer; widget/html via the sandboxed iframe).
@@ -93,6 +94,7 @@ export const ArtifactBodyNative = memo(function ArtifactBodyNative({
    *  own unless told to run flush. */
   flush?: boolean
 }) {
+  useI18nRevision()
   const fileType = fileTypeForKind(kind)
   const ext = extForKind(kind)
   const isRichType = fileType === 'json' || fileType === 'svg' || fileType === 'html' || fileType === 'image' || fileType === 'csv' || fileType === 'pdf'

--- a/website/src/components/CodeBlock.tsx
+++ b/website/src/components/CodeBlock.tsx
@@ -4,6 +4,7 @@ import { copyCode } from '../utils/clipboard'
 import { highlightAsync } from '../utils/highlightClient'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 export function HighlightedCode({ code, lang, className }: { code: string; lang: string | undefined; className: string }) {
   const [html, setHtml] = useState('')
   // Reset to plain text the instant the code changes, so a stale highlight from
@@ -44,6 +45,7 @@ export const CodeBlock = memo(function CodeBlock(
     code: string; lang?: string; complete: boolean; headerActions?: React.ReactNode
   },
 ) {
+  useI18nRevision()
   const [copied, setCopied] = useState(false)
   const copy = () => { copyCode(code); setCopied(true); setTimeout(() => setCopied(false), 1500) }
 

--- a/website/src/components/CommentsSidebar.tsx
+++ b/website/src/components/CommentsSidebar.tsx
@@ -9,6 +9,7 @@ import { useAutoGrowTextarea } from '../hooks/useAutoGrowTextarea'
 
 import { i18nT } from '../i18n/t'
 import { fmtDateFields } from '../i18n/format'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 /** Short relative-ish timestamp for a comment row. */
 function fmtTs(ts: string): string {
   if (!ts) return ''
@@ -330,6 +331,7 @@ const SIDEBAR_DEFAULT_STYLE: React.CSSProperties = { height: 'calc(100vh - 240px
  *  widget, where text-selection anchoring isn't available inside the
  *  sandboxed iframe — comments degrade to whole-artifact). */
 export const CommentsSidebar = memo(function CommentsSidebar(props: CommentsSidebarProps) {
+  useI18nRevision()
   const {
     comments, loading, remoteSyncError, onAdd, onReply, onResolve,
     onMarkReview, onDelete, onRefresh, onAskAgent, onClose, restrictActions, hideResolve, hideDelete,

--- a/website/src/components/ContentRenderer.tsx
+++ b/website/src/components/ContentRenderer.tsx
@@ -21,6 +21,7 @@ import { monacoLang, useIsDark } from './MonacoCodeBlock'
 import { kirocrewDark, kirocrewLight } from './monacoTheme'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 // Route through ensureMonacoLocal() so Monaco loads from the locally-bundled
 // package instead of the default cdn.jsdelivr.net loader (blocked by CSP
 // connect-src). Mirrors DiffPanel/MarkdownPanel/MonacoCodeBlock.
@@ -158,6 +159,7 @@ export const ContentRenderer = memo(function ContentRenderer({
    *  the host surface (side-panel tab body) already frames the content. */
   flush?: boolean
 }) {
+  useI18nRevision()
   const inner = (
     <>
       {isRichType && fileType === 'image' && filePath && <ImageViewer filePath={filePath} />}

--- a/website/src/components/FileCard.tsx
+++ b/website/src/components/FileCard.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react'
 import { Music, Video, Image, Paperclip, ArrowDown } from 'lucide-react'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 export interface FileData {
   filename: string
   description?: string
@@ -11,6 +12,7 @@ export interface FileData {
 
 /** Renders a file embed card — inline audio/video player or download link. */
 export const FileCard = memo(function FileCard({ file }: { file: FileData }) {
+  useI18nRevision()
   const url = `/api/outbox/${encodeURIComponent(file.filename)}`
   const mime = (file.content_type || '') as string
 

--- a/website/src/components/FileChangeChips.tsx
+++ b/website/src/components/FileChangeChips.tsx
@@ -5,6 +5,7 @@ import { useRowDisclosure } from '../pages/chat/rowDisclosure'
 import { colorForExt, fileIcon } from '../utils/fileIcons'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 export interface FileChangeEntry {
   path: string
   before: string
@@ -214,6 +215,7 @@ const FileChangeChips = memo(function FileChangeChips({ fileChanges, onOpenDiff,
   artifactPaths?: Set<string>
   disclosureKey?: string
 }) {
+  useI18nRevision()
   if (!fileChanges?.length) return null
   // Minimal keeps the wrapping pill row; anything else uses the grouped card.
   if (style === 'minimal') {

--- a/website/src/components/FileRenderers.tsx
+++ b/website/src/components/FileRenderers.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useMemo, useCallback, useRef } from 'react'
 import DOMPurify from 'dompurify'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 import { ExcalidrawBlock } from './ExcalidrawBlock'
 /* ── extension helpers ── */
 const IMG_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.svg', '.ico'])
@@ -39,6 +40,7 @@ function extOf(fp: string) { const i = fp.lastIndexOf('.'); return i >= 0 ? fp.s
 
 /* ── Image viewer ── */
 export const ImageViewer = memo(function ImageViewer({ filePath }: { filePath: string }) {
+  useI18nRevision()
   return (
     <div className="flex items-center justify-center h-full overflow-auto p-4 bg-bg-elevated rounded-md border border-border">
       <img

--- a/website/src/components/MarkdownPanel.tsx
+++ b/website/src/components/MarkdownPanel.tsx
@@ -174,6 +174,7 @@ import { monacoLang, useIsDark } from './MonacoCodeBlock'
 import { kirocrewDark, kirocrewLight } from './monacoTheme'
 import type { IDisposable } from 'monaco-editor'
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 const MonacoDiffEditor = lazy(async () => {
   const { ensureMonacoLocal } = await import('../utils/monacoLocal')
   await ensureMonacoLocal()
@@ -610,6 +611,7 @@ const CommentOverlayBlock = memo(function CommentOverlayBlock({ popover, addComm
   popover: { x: number; y: number } | null; addComment: (text: string) => void; setPopover: (v: null) => void
   onSubmitComments?: (message: string) => void; comments: InlineComment[]; editComment: (id: string, text: string) => void; removeComment: (id: string) => void; submitAllComments: (extraPrompt?: string) => void; containerRef?: React.RefObject<HTMLElement | null>; scrollRef?: React.RefObject<HTMLElement | null>
 }) {
+  useI18nRevision()
   return (
     <>
       {popover && (

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -144,6 +144,7 @@ const sp = (node?: HastElement) => {
 }
 
 const MermaidBlock = memo(function MermaidBlock({ code }: { code: string }) {
+  useI18nRevision()
   const ref = useRef<HTMLDivElement>(null)
   const id = useId().replace(/:/g, '_')
   const renderedRef = useRef('')
@@ -1091,6 +1092,7 @@ import WidgetFrame from './WidgetFrame'
 import WidgetPlaceholder from './WidgetPlaceholder'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 /** Try to extract a file path from chat text immediately preceding a diff
  * block. Tools sometimes emit "Created /path/to/file:" or "Modified ..."
  * before a bare diff with no +++/--- headers; this hint lets DiffBlock's

--- a/website/src/components/MarkdownToc.tsx
+++ b/website/src/components/MarkdownToc.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useCallback, useEffect, useRef } from 'react'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 export interface TocEntry { level: number; text: string; index: number }
 
 /** Extract TOC entries from rendered DOM headings — guarantees consistency with what the user sees */
@@ -76,6 +77,7 @@ const tickWidth = (depth: number) => TICK_WIDTH[Math.min(depth, TICK_WIDTH.lengt
  * inside a `position: relative` ancestor that shares that viewport's box.
  */
 const MarkdownOutlineRail = memo(function MarkdownOutlineRail({ containerRef }: { containerRef: React.RefObject<HTMLElement | null> }) {
+  useI18nRevision()
   const [entries, setEntries] = useState<TocEntry[]>([])
   const [active, setActive] = useState(0)
   const [expanded, setExpanded] = useState(false)

--- a/website/src/components/MonacoCodeBlock.tsx
+++ b/website/src/components/MonacoCodeBlock.tsx
@@ -6,6 +6,7 @@ import RunInTerminalBtn, { SHELL_LANGS } from './RunInTerminalBtn'
 import { useTerminalEnabled } from '../utils/terminalRegistry'
 
 import { i18nT } from '../i18n/t'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 const Editor = lazy(async () => {
   const { ensureMonacoLocal } = await import('../utils/monacoLocal')
   await ensureMonacoLocal()
@@ -45,6 +46,7 @@ export function lineCount(code: string): number {
 const MonacoCodeBlock = memo(function MonacoCodeBlock(
   { code, lang, complete }: { code: string; lang?: string; complete: boolean },
 ) {
+  useI18nRevision()
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(code)
   const [copied, setCopied] = useState(false)

--- a/website/src/i18n/LanguageProvider.test.tsx
+++ b/website/src/i18n/LanguageProvider.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 
 import { LanguageProvider, useLanguage } from './LanguageProvider'
 import { LANG_STORAGE_KEY } from './detect'
+import { i18nT } from './t'
 import { api } from '../api/client'
 
 /** Fresh QueryClient per test so the ['theme-boot'] cache never leaks across cases. */
@@ -240,5 +241,150 @@ describe('LanguageProvider — an empty server value must not erase a local choi
     wrap(<Probe />, { language: '' })
     await waitFor(() => expect(screen.getByTestId('resolved')).toHaveTextContent('en'))
     expect(screen.getByTestId('choice')).toHaveTextContent('(auto)')
+  })
+})
+
+describe('LanguageProvider — cross-tab switch survives a delayed boot response', () => {
+  /**
+   * Regression: the `onStorage` handler (cross-tab sync) set `language` without
+   * setting `userChose`, so a slow `/api/theme/boot` response arriving after a
+   * cross-tab switch could overwrite it. The fix sets `userChose.current = true`
+   * in the storage handler, blocking boot adoption the same way a local pick does.
+   */
+  it('a cross-tab switch is not reverted by a delayed boot response', async () => {
+    // Simulate: tab A set localStorage to zh-CN (cross-tab switch), then boot
+    // responds with language: 'en'.
+    //
+    // We control the boot response timing by making themeBoot a deferred promise.
+    let resolveBoot!: (value: unknown) => void
+    const bootPromise = new Promise(resolve => { resolveBoot = resolve })
+    vi.spyOn(api, 'themeBoot').mockReturnValue(bootPromise as never)
+    vi.spyOn(api, 'updateThemeConfig').mockResolvedValue({} as never)
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <LanguageProvider><Probe /></LanguageProvider>
+      </QueryClientProvider>,
+    )
+
+    // Before boot resolves, simulate a cross-tab language change via StorageEvent
+    await act(async () => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: LANG_STORAGE_KEY,
+        newValue: 'zh-CN',
+        storageArea: localStorage,
+      }))
+    })
+
+    await waitFor(() => expect(screen.getByTestId('choice')).toHaveTextContent('zh-CN'))
+
+    // NOW let boot resolve with a DIFFERENT language. Wait until the boot query
+    // has actually COMMITTED its data: waitFor wraps each poll in act(), so once
+    // the cache holds the response the adopt effect it schedules has run to
+    // completion (including any cascading setState). Only then is the final
+    // assertion race-free - a plain expect right after resolveBoot would observe
+    // the still-true initial value before adoption had a chance to revert it.
+    resolveBoot({ language: 'en' })
+    await waitFor(() => expect(qc.getQueryData(['theme-boot'])).toEqual({ language: 'en' }))
+
+    // The adopt effect has now run. With the fix it was blocked by `userChose`;
+    // without it, the delayed boot reverts the cross-tab choice to 'en'.
+    expect(screen.getByTestId('choice')).toHaveTextContent('zh-CN')
+  })
+
+  it('a delayed boot IS adopted when no cross-tab switch preceded it', async () => {
+    // Control proving the deferred-boot adoption path is live and observable:
+    // with no prior explicit choice, the same delayed 'en' boot response IS
+    // adopted. This is the exact code path the test above must suppress, so if
+    // adoption silently stopped working this control fails instead.
+    let resolveBoot!: (value: unknown) => void
+    const bootPromise = new Promise(resolve => { resolveBoot = resolve })
+    vi.spyOn(api, 'themeBoot').mockReturnValue(bootPromise as never)
+    vi.spyOn(api, 'updateThemeConfig').mockResolvedValue({} as never)
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <LanguageProvider><Probe /></LanguageProvider>
+      </QueryClientProvider>,
+    )
+
+    await act(async () => {
+      resolveBoot({ language: 'en' })
+      await bootPromise
+    })
+    await waitFor(() => expect(screen.getByTestId('choice')).toHaveTextContent('en'))
+  })
+})
+
+describe('LanguageProvider — memoized components repaint on language switch', () => {
+  /**
+   * Guards that the `useI18nRevision()` hook correctly threads the language
+   * through memo boundaries. A memo'd component using i18nT should display
+   * translated text after a language switch, not stale English.
+   */
+  it('a memo-wrapped component repaints when language changes', async () => {
+    const { memo: reactMemo } = await import('react')
+    const { useI18nRevision: rev } = await import('./useI18nRevision')
+
+    const MemoChild = reactMemo(function MemoChild({ id }: { id: number }) {
+      rev()
+      return <span data-testid="memo-text">{i18nT('pages.settings.displayPanel.view')}{id}</span>
+    })
+
+    function Parent() {
+      const { setLanguage } = useLanguage()
+      return (
+        <div>
+          <MemoChild id={1} />
+          <button onClick={() => setLanguage('zh-CN')}>switch</button>
+        </div>
+      )
+    }
+
+    vi.spyOn(api, 'themeBoot').mockResolvedValue({} as never)
+    vi.spyOn(api, 'updateThemeConfig').mockResolvedValue({} as never)
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <LanguageProvider><Parent /></LanguageProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('memo-text')).toHaveTextContent('View'))
+    await userEvent.click(screen.getByText('switch'))
+    await waitFor(() => {
+      expect(screen.getByTestId('memo-text').textContent).not.toContain('View')
+    })
+  })
+
+  it('a pre-set locale in storage renders translated on first paint', async () => {
+    localStorage.setItem(LANG_STORAGE_KEY, 'zh-CN')
+
+    const { memo: reactMemo } = await import('react')
+    const { useI18nRevision: rev } = await import('./useI18nRevision')
+
+    const MemoChild = reactMemo(function MemoChild({ id }: { id: number }) {
+      rev()
+      return <span data-testid="memo-text">{i18nT('pages.settings.displayPanel.view')}{id}</span>
+    })
+
+    function Parent() {
+      return <MemoChild id={1} />
+    }
+
+    vi.spyOn(api, 'themeBoot').mockResolvedValue({ language: 'zh-CN' } as never)
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <LanguageProvider><Parent /></LanguageProvider>
+      </QueryClientProvider>,
+    )
+
+    // Should render Chinese on first paint, no English flash
+    await waitFor(() => {
+      expect(screen.getByTestId('memo-text').textContent).toMatch(/[一-鿿]/)
+    })
   })
 })

--- a/website/src/i18n/LanguageProvider.tsx
+++ b/website/src/i18n/LanguageProvider.tsx
@@ -109,6 +109,13 @@ export interface LanguageContextValue {
    * reconciles it on its own. Showing the failure is what makes that recoverable.
    */
   syncFailed: boolean
+  /**
+   * The i18next catalog language currently active in the runtime. Changes only
+   * AFTER `changeLanguage()` resolves, so reading it guarantees the catalog is
+   * loaded. Exposed so memoized descendants can subscribe to language switches
+   * without migrating every `i18nT()` call to `useTranslation()`.
+   */
+  active: string
 }
 
 const LanguageContext = createContext<LanguageContextValue | null>(null)
@@ -261,9 +268,15 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
   // Cross-tab sync: switching language in one tab updates the others without a
   // reload. Same StorageEvent pattern as useUIMode.
+  //
+  // Sets `userChose` so that a delayed boot response cannot overwrite a
+  // cross-tab switch — the storage event represents an explicit user action in
+  // another tab, so it outranks the server value for the same reason a local
+  // picker click does.
   useEffect(() => {
     const onStorage = (e: StorageEvent) => {
       if (e.key !== LANG_STORAGE_KEY) return
+      userChose.current = true
       setLanguageState(e.newValue ?? AUTO_LANGUAGE)
     }
     window.addEventListener('storage', onStorage)
@@ -292,7 +305,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   )
 
   return (
-    <LanguageContext.Provider value={{ language, resolved, detected, setLanguage, syncFailed }}>
+    <LanguageContext.Provider value={{ language, resolved, detected, setLanguage, syncFailed, active }}>
       {refreshed}
     </LanguageContext.Provider>
   )
@@ -309,11 +322,13 @@ export function useLanguage(): LanguageContextValue {
   const ctx = useContext(LanguageContext)
   if (ctx) return ctx
   const stored = readStoredLanguage()
+  const res = resolveLanguage(stored)
   return {
     language: stored,
-    resolved: resolveLanguage(stored),
+    resolved: res,
     detected: resolveLanguage(AUTO_LANGUAGE),
     setLanguage: () => {},
     syncFailed: false,
+    active: res,
   }
 }

--- a/website/src/i18n/memoBailout.test.tsx
+++ b/website/src/i18n/memoBailout.test.tsx
@@ -31,6 +31,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import { LanguageProvider, useLanguage } from './LanguageProvider'
 import { i18nT } from './t'
+import { useI18nRevision } from './useI18nRevision'
 import { api } from '../api/client'
 
 const KEY = 'pages.settings.displayPanel.view'
@@ -46,6 +47,7 @@ function Leaf({ testid }: { testid: string }) {
  * `<PastedChip block={r.block} />`.
  */
 const MemoLeaf = memo(function MemoLeaf({ block }: { block: { id: number } }) {
+  useI18nRevision()
   return <span data-testid="memoized">{i18nT(KEY)}{block.id}</span>
 })
 
@@ -98,18 +100,12 @@ describe('D11 — memo() boundary under a language change', () => {
   })
 
   /**
-   * `it.fails` because this is a KNOWN DEFECT, not an aspiration.
-   *
-   * The suite stays green while the bug exists, and turns red the moment someone
-   * fixes it — at which point flip this to `it()` and delete this comment. That is
-   * the opposite of `skip`, which would let the fix land unnoticed and let the
-   * defect silently return later.
-   *
-   * The fix is not in this file: make the language a tracked input, either by
-   * having `i18nT` subscribe (`useSyncExternalStore` over i18next's
-   * `languageChanged` event) or by routing call sites through `useTranslation`.
+   * Fixed: `useI18nRevision()` subscribes the memo'd component to language
+   * changes via LanguageContext. When `active` changes, the context value
+   * changes, React re-renders the consumer even through a memo boundary, and
+   * `i18nT()` re-evaluates against the new catalog.
    */
-  it.fails('the memoized leaf does NOT switch — D11, known defect', async () => {
+  it('the memoized leaf switches on language change', async () => {
     mount()
     await waitFor(() => expect(screen.getByTestId('memoized')).toHaveTextContent('View'))
     await userEvent.click(screen.getByText('zh'))

--- a/website/src/i18n/useI18nRevision.ts
+++ b/website/src/i18n/useI18nRevision.ts
@@ -1,0 +1,45 @@
+/**
+ * Language-change subscription for memoized components.
+ *
+ * ## The problem
+ *
+ * `React.memo` bails out when props are shallow-equal. Standalone `i18nT()`
+ * reads the current catalog but does NOT subscribe to language changes, so a
+ * memoized subtree whose props haven't changed keeps its stale strings after a
+ * switch.
+ *
+ * ## The fix
+ *
+ * This hook reads the `active` field from `LanguageContext`. When the language
+ * changes, `active` changes, the context value changes, and React re-renders
+ * the consuming component - including its memoized boundary. The hook's return
+ * value is intentionally unused; the side effect of subscribing to the context
+ * is what matters.
+ *
+ * ## Usage
+ *
+ * Add a single line at the top of any `memo()`-wrapped component that uses
+ * `i18nT()`:
+ *
+ * ```tsx
+ * const MyComponent = memo(function MyComponent(props) {
+ *   useI18nRevision()
+ *   // ... existing code with i18nT() calls
+ * })
+ * ```
+ *
+ * This does NOT remove memoization - the component still skips renders when its
+ * own props are unchanged AND the language is unchanged. It only adds the
+ * language as an additional tracked dependency.
+ */
+
+import { useLanguage } from './LanguageProvider'
+
+/**
+ * Subscribe to language changes so `i18nT()` re-evaluates inside a memoized
+ * component. Returns the active language for callers that need it, but most
+ * just call it for the subscription side-effect.
+ */
+export function useI18nRevision(): string {
+  return useLanguage().active
+}

--- a/website/src/pages/ArtifactDetailPage.tsx
+++ b/website/src/pages/ArtifactDetailPage.tsx
@@ -37,6 +37,7 @@ import type { Artifact, ArtifactEvent, ArtifactComment, CommentAnchor, ChatSlot 
 
 import { i18nT } from '../i18n/t'
 import { fmtDateFields } from '../i18n/format'
+import { useI18nRevision } from '../i18n/useI18nRevision'
 /**
  * The artifact's active companion session: the bound slot for `slug`, or the most
  * recently active one if a race or a History-page resume left more than one.
@@ -123,6 +124,7 @@ const ActivityTimeline = memo(function ActivityTimeline({
   events: ArtifactEvent[]
   navigateToSlot: (slotKey: string) => void
 }) {
+  useI18nRevision()
   if (!events.length) {
     return (
       <div className="text-[12px] text-muted">{i18nT('pages.artifactDetailPage.no_lifecycle_events_yet')}</div>

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -16,6 +16,7 @@ import { useSmoothStream } from '../../hooks/useSmoothStream'
 import type { PlanStepInput } from '../../api/client'
 import { OPTION_MARKER_RE } from '../../utils/optionsMarker'
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 const PLAN_HEADER_RE = /📋\s*Plan for:/i
 const STAGE_RE = /^Stage\s+\d+\s*:/m
 
@@ -97,6 +98,7 @@ function SteerAckChip({ summary }: { summary: string }) {
 }
 
 const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, onFileOpen, onArtifactOpen, planTaskId, onApplyPlan, slotRunning, onSpeak, timestamp, showFooter = true, onRegenerate, variants, variantIdx, onSwitchVariant, isRegenerating, onFork, onPlanFromHere, forkIndex, onQuote, onAsk, messageTs, slotKey, slotTitle, mode, fileChanges, onOpenDiff, fileChipStyle, artifactPaths, turnStats }: { content: string; isStreaming: boolean; onFileOpen?: (path: string) => void; onArtifactOpen?: (slug: string) => void; planTaskId?: string; onApplyPlan?: (steps: PlanStepInput[]) => Promise<boolean>; slotRunning?: boolean; onSpeak?: (content: string) => void; timestamp?: string; showFooter?: boolean; onRegenerate?: () => void; variants?: { content: string; ts?: string }[]; variantIdx?: number; onSwitchVariant?: (index: number) => void; isRegenerating?: boolean; onFork?: (index: number) => void | Promise<void>; onPlanFromHere?: (index: number) => void | Promise<void>; forkIndex?: number; onQuote?: (text: string, rect: DOMRect) => void; onAsk?: (text: string, rect: DOMRect) => void; messageTs?: string; slotKey?: string; slotTitle?: string; mode?: string; fileChanges?: FileChangeEntry[]; onOpenDiff?: (path: string, modified: string, original: string) => void; fileChipStyle?: FileChipStyle; artifactPaths?: Set<string>; turnStats?: TurnStats }) {
+  useI18nRevision()
   const [applied, setApplied] = useState(false)
   const [copied, setCopied] = useState(false)
   const [linkCopied, setLinkCopied] = useState(false)

--- a/website/src/pages/chat/ChatFooter.tsx
+++ b/website/src/pages/chat/ChatFooter.tsx
@@ -3,6 +3,7 @@ import { Hourglass, Search, Lightbulb, Settings, Zap, Check, Sparkles, Brain, Pe
 import { motion } from 'framer-motion'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 import { GHOST_POSE_ICONS } from '../../components/GhostPoses'
 import { getThemeBranding } from '../../themeBranding'
 import ErrorBoundary from '../../components/ErrorBoundary'
@@ -209,6 +210,7 @@ export function useStreamIdle(tick: number, active: boolean, ms: number = STREAM
 }
 
 const ChatFooter = memo(function ChatFooter({ running, stopping, state, lastRole, regenerating, stopState, streamTick = 0 }: { running: boolean; stopping: boolean; state: string; lastRole: string; regenerating?: boolean; stopState?: StopState; streamTick?: number }) {
+  useI18nRevision()
   const loader = resolveLoader(useThemeSlug())
   // Text is only ACTIVELY streaming while the slot says so AND chunks keep
   // arriving. `lastRole` alone cannot tell the two apart: the trailing

--- a/website/src/pages/chat/CollapsibleToolGroup.tsx
+++ b/website/src/pages/chat/CollapsibleToolGroup.tsx
@@ -5,6 +5,7 @@ import { ToolInputText } from '../../components/ToolInputText'
 import { useRowDisclosure } from './rowDisclosure'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 interface CollapsibleToolGroupProps {
   count: number
   autoExpand?: boolean
@@ -52,6 +53,7 @@ function extractPreview(meta?: Record<string, unknown>): string {
 
 /** Collapsible row that wraps tool/thinking/permission messages — always collapsed unless autoExpand. */
 const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExpand, disclosureKey, hasPermission, isRunning, children, permissionMeta, pendingPermCount, onApprove, onViewActivity, activityOpen }: CollapsibleToolGroupProps) {
+  useI18nRevision()
   const [expanded, setExpanded] = useRowDisclosure(disclosureKey, !!autoExpand)
   const userToggled = useRef(false)
   const [submitting, setSubmitting] = useState(false)

--- a/website/src/pages/chat/SubagentProgressBar.tsx
+++ b/website/src/pages/chat/SubagentProgressBar.tsx
@@ -7,6 +7,7 @@ import { sanitizeLlmOutput } from '../../utils/sanitize'
 import type { SubagentActivity } from '../../types'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 const EMPTY_SUBAGENTS: Record<string, SubagentActivity> = {}
 
 /** Max agent rows rendered in the chip — exceptions (stalled/retrying) sort
@@ -26,6 +27,7 @@ interface SpawnListResponse {
 
 /** Active subagent summary above the chat input. */
 const SubagentProgressBar = memo(function SubagentProgressBar({ slot }: { slot: string | null }) {
+  useI18nRevision()
   // Use chatSlice.subagents — populated by subagent_spawn/tool/done WS events
   // (dashboardSlice.subagentRunning only updates on subagent_status which fires at completion)
   const dispatch = useAppDispatch()

--- a/website/src/pages/chat/SubagentRunCard.tsx
+++ b/website/src/pages/chat/SubagentRunCard.tsx
@@ -22,6 +22,7 @@ import type { ChatMessage, SubagentActivity } from '../../types'
 import { SPAWN_LAUNCH_MARKER } from './types'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 /** The `spawn_run` tool result opens with "Spawned N subagent(s)." followed by
  *  one indented "  <id> (<agent>): <task>" line per accepted agent (see the
  *  spawn_run handler in mcp_core.py). Matching the header identifies the call
@@ -149,6 +150,7 @@ const SubagentRunCard = memo(function SubagentRunCard({
   launch: SpawnRunLaunch
   slot: string
 }) {
+  useI18nRevision()
   const dispatch = useAppDispatch()
   const subagents = useAppSelector(s =>
     slot === s.chat.activeSlot ? s.chat.subagents : s.chat.slotActivity[slot]?.subagents ?? EMPTY_SUBAGENTS,

--- a/website/src/pages/chat/TaskProgressBar.tsx
+++ b/website/src/pages/chat/TaskProgressBar.tsx
@@ -6,6 +6,7 @@ import type { TodoList } from '../../types'
 import { useRowDisclosure } from './rowDisclosure'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 /** Rows rendered before the list scrolls internally — bounds DOM on long plans. */
 const MAX_VISIBLE_ROWS = 12
 
@@ -21,6 +22,7 @@ const MAX_VISIBLE_ROWS = 12
  * absent at the data layer.
  */
 const TaskProgressBar = memo(function TaskProgressBar({ slot, disclosureKey }: { slot: string | null; disclosureKey?: string }) {
+  useI18nRevision()
   const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   // Select the primitive-bearing todo object for this slot only, so unrelated
   // slot churn in the slots array doesn't re-render the pill.

--- a/website/src/pages/chat/UserMessage.tsx
+++ b/website/src/pages/chat/UserMessage.tsx
@@ -9,6 +9,7 @@ import { scrollCurrentMatchIntoView } from '../../utils/searchScroll'
 import { type PasteBlock, expandAll as expandPasteTokens } from '../../utils/pasteTokens'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 // Steer bubbles play a one-shot entrance (slide-in + ring pulse) when they land.
 // The chat transcript is virtualized, so a row can remount when scrolled away and
 // back; without this guard the entrance would replay every time. Module-level set
@@ -30,6 +31,7 @@ interface UserMessageProps {
 }
 
 const UserMessage = memo(function UserMessage({ content, meta, timestamp, renderContent, canEdit, messageIndex, messageTs, onEditResend, slotKey, slotTitle, mode }: UserMessageProps) {
+  useI18nRevision()
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(content)
   const [copied, setCopied] = useState(false)

--- a/website/src/pages/chat/WorkflowCompletionCard.tsx
+++ b/website/src/pages/chat/WorkflowCompletionCard.tsx
@@ -22,6 +22,7 @@ import MarkdownRenderer from '../../components/MarkdownRenderer'
 import type { ChatMessage } from '../../types'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 import { useRowDisclosure } from './rowDisclosure'
 const WF_COMPLETION_PREFIX = '[Workflow completion event]'
 // Name is backtick-delimited; allow any char except a backtick (including
@@ -73,6 +74,7 @@ const WorkflowCompletionCard = memo(function WorkflowCompletionCard({
   onFileOpen?: (path: string) => void
   disclosureKey?: string
 }) {
+  useI18nRevision()
   const dispatch = useAppDispatch()
   const [expanded, setExpanded] = useRowDisclosure(disclosureKey, false)
   const parsed = parseWorkflowCompletion(message.content || '')

--- a/website/src/pages/chat/WorkflowProgressBar.tsx
+++ b/website/src/pages/chat/WorkflowProgressBar.tsx
@@ -10,6 +10,7 @@ import { useRunSnapshot } from '../../apps/workflows/useRunSnapshot'
 import { runBelongsToSlot } from '../../apps/workflows/runModel'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 const EMPTY_RUNS: Record<string, WorkflowRunProgress> = {}
 // How long a finished/failed/cancelled run lingers before being dropped.
 const TERMINAL_LINGER_MS = 4000
@@ -24,6 +25,7 @@ const TERMINAL_LINGER_MS = 4000
  *  The full run snapshot (with events + source) is fetched on expand and
  *  refreshed every ~2s while the run is still running. */
 const WorkflowProgressBar = memo(function WorkflowProgressBar({ slot }: { slot: string | null }) {
+  useI18nRevision()
   const dispatch = useAppDispatch()
   const runs = useAppSelector(s => s.chat.workflowRuns ?? EMPTY_RUNS)
   // Only show runs launched FROM this chat session — a run sticks to the chat

--- a/website/src/pages/chat/WorkflowRunCard.tsx
+++ b/website/src/pages/chat/WorkflowRunCard.tsx
@@ -21,6 +21,7 @@ import { sanitizeLlmOutput } from '../../utils/sanitize'
 import type { ChatMessage } from '../../types'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 /** The `workflow_run` tool result reads "Started workflow run `wf_NNNNNN`…"
  *  (see the workflow_run handler in mcp_core.py). Matching that phrase both
  *  identifies the call as a launch and captures its run id — and works for
@@ -62,6 +63,7 @@ const WorkflowRunCard = memo(function WorkflowRunCard({
   runId: string
   message: ChatMessage
 }) {
+  useI18nRevision()
   const dispatch = useAppDispatch()
   const run = useAppSelector(s => s.chat.workflowRuns?.[runId])
   const status = run?.status

--- a/website/src/pages/chat/WorkflowSidebarRow.tsx
+++ b/website/src/pages/chat/WorkflowSidebarRow.tsx
@@ -16,6 +16,7 @@ import WorkflowSourcePanel from '../../apps/workflows/WorkflowSourcePanel'
 import { useRunSnapshot } from '../../apps/workflows/useRunSnapshot'
 
 import { i18nT } from '../../i18n/t'
+import { useI18nRevision } from '../../i18n/useI18nRevision'
 export interface WfRunRow {
   run_id: string
   name?: string
@@ -29,6 +30,7 @@ export interface WfRunRow {
 }
 
 const WorkflowSidebarRow = memo(function WorkflowSidebarRow({ row }: { row: WfRunRow }) {
+  useI18nRevision()
   const [expanded, setExpanded] = useState(false)
   const { snapshot, error: snapshotError } = useRunSnapshot(row.run_id, {
     enabled: expanded,


### PR DESCRIPTION

## Description

This is the deferred i18n follow-up to #692. Two accepted review findings, both in
`website/src/i18n/LanguageProvider.tsx`, are fixed here. Neither was a regression -
both degraded to English, the pre-#692 behaviour - so this is unfinished coverage.

Finding 1 is a cross-tab boot race. `LanguageProvider` guards boot adoption with a
`userChose` ref so an in-flight `/api/theme/boot` response cannot overwrite an
explicit pick. The cross-tab `onStorage` handler applied the new language via
`setLanguageState()` without setting that flag, so a boot response landing after a
cross-tab switch could revert the UI and localStorage while the server kept the newer
value. The root cause named in the issue is that the flag was set per entry path
rather than at the state transition. The fix sets `userChose.current = true` inside
`onStorage` before applying the storage value: a StorageEvent represents an explicit
user action in another tab, so it outranks the server value for the same reason a
local picker click does.

Finding 2 is that memoized descendants do not repaint on a language switch. The
provider repaints standalone `i18nT()` call sites by `cloneElement`-ing the root
child, which defeats React's referential-equality bailout for that element. But
`React.memo` compares props, and `i18nT()` output is not a prop, so a memoized
subtree with unchanged props keeps its stale strings. The fix exposes the runtime
`active` language on `LanguageContext` and adds a small `useI18nRevision()` hook
(new file `website/src/i18n/useI18nRevision.ts`) that reads it. A memoized component
calls the hook once at its top; when `active` changes the context value changes and
React re-renders through the memo boundary, so `i18nT()` re-evaluates against the new
catalog. This is issue approach (a) - subscribe centrally - and does not disable
memoization: a component still skips renders while its props and the language are
both unchanged. The hook was added to the 25 `memo()`-wrapped converted components
(the +2 lines each: an import and the call). `useLanguage()`'s no-provider fallback
also returns `active` so the context shape stays total.

## Related Issues

Fixes #727

## Testing

- [x] Existing tests pass (targeted vitest, see below - `make test` not run)
- [x] New tests added for new functionality
- [ ] Manual verification performed

Commands run in `website/` on commit `5857b189`, real observed output:

```
npx tsc --noEmit                  -> exit 0
npx eslint <29 changed .ts/.tsx>  -> exit 0; 0 errors, 10 warnings
npx vitest run src/i18n/LanguageProvider.test.tsx \
    src/i18n/memoBailout.test.tsx --coverage=false
                                  -> Test Files 2 passed (2); Tests 27 passed (27)
```

The 10 eslint warnings are all pre-existing (no-explicit-any, jsx-a11y, no-console,
exhaustive-deps) on lines untouched by this change - the diff adds only a 2-line
import+call to each affected component. `LanguageProvider.test.tsx` adds the cross-tab
probe (a delayed boot response no longer reverts a cross-tab switch, with a control
asserting a delayed boot IS adopted absent a cross-tab switch); `memoBailout.test.tsx`
flips the former `it.fails` D11 placeholder to a passing `it()` asserting the memo'd
leaf switches on language change. These numbers match what `LLM.log` recorded - no
discrepancy. Backend pytest and black/isort/flake8/mypy are not applicable: the diff
is frontend-only.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

Docs: `website/AGENTS.md` i18n section updated - corrected the stale "remounts the
tree" wording to "re-renders (via cloneElement, preserving state)" and added a bullet
documenting the `React.memo`/`useMemo` + `useI18nRevision()` pattern.

## Contribution License Agreement

The upstream template carries a placeholder: the CLA wording is supplied by OSPO and
must not be invented. Left as-is pending that text.

## Research

Investigation was code-reading against the two exact locations named in the issue,
both in `LanguageProvider.tsx`: the `onStorage` handler (finding 1) and the
`useMemo`/`cloneElement` repaint block (finding 2). Confirmed on `origin/main` that
`onStorage` did not set `userChose` and that `memoBailout.test.tsx` carried an
`it.fails` D11 placeholder marking finding 2 as a known live defect. The 25
`memo()`-wrapped `i18nT()` components were the set enumerated in the issue.

Both fixes were validated by neutralizing each mechanism and observing the pre-fix
failure (per `LLM.log`): removing `userChose` from `onStorage` made the cross-tab
probe fail (expected zh-CN, received en) while its control still passed; stubbing
`useI18nRevision()` to return empty made three memo tests fail on stale "View1". The
fixes were then restored.

Design choice: issue approach (a) central subscription was taken over (b) incremental
`useTranslation()` migration, because the strings live in hook-illegal positions
(render callbacks, non-component helpers) - the documented reason the codemod emits
standalone `i18nT()`. Approach (a) is mechanical and requires no call-site
restructuring; the completeness concern it raises is discharged by touching all 25
enumerated components.

Blast radius: `LanguageContextValue` gained one required field (`active`); every
consumer goes through `useLanguage()`, whose no-provider fallback was updated to
supply it, so the context shape stays total and tsc is clean. The 25 component edits
are additive (one import, one call) and cannot change existing behaviour when the
language is unchanged.

Scope note - this deliverable did not redo or extend the fix; it completes the
missing `PR.md`/`RESULT.json` from the already-committed `5857b189` and re-ran the
gates to report first-hand numbers. No follow-up gap was found: the commit addresses
both halves of the issue and both acceptance-criteria tests are present and green.

---

**Note on rebase:** this branch was rebased onto current `main` at PR time. One
conflict in `website/src/pages/chat/ChatFooter.tsx` was resolved by hand: `main`
had since added the `streamTick` prop and the `useStreamIdle` hook to
`ChatFooter`, while this change adds a `useI18nRevision()` call to the same
component. Both were kept. Re-verified after the rebase: `tsc -b` clean,
`eslint` clean, `src/test/ChatFooter.test.tsx` 41 passed,
`src/i18n/LanguageProvider.test.tsx` + `src/i18n/memoBailout.test.tsx` 27 passed.
