### PR TITLE
fix(ci): raise AI review timeout to 90m as a runaway backstop

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -53,11 +53,14 @@ jobs:
     # (branch lives in this repo) so they still enter the job and are handled by
     # the step-level dependabot skip + gate pass below.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    # Hard runtime ceiling: if the agentic review ever runs away, the job is
-    # cancelled at 30 min and the gate fails closed (a no-output review can't
-    # look clean). Lowered from 40 alongside --max-turns: the review is now a
-    # single narrow pass, not a whole-repo audit.
-    timeout-minutes: 30
+    # Runaway/hang backstop only, NOT a per-review budget: a healthy review
+    # self-terminates at --max-turns 120 (see below) long before this, so this
+    # ceiling exists solely to fail the gate closed (a no-output review can't
+    # look clean) if the agentic review ever HANGS -- a Bedrock stall or retry
+    # loop. Set generously at 90 min so it never cuts a completing 120-turn
+    # review the way the old 30-min wall did, while still killing a true hang
+    # well under GitHub's 360-min job default. Keep in sync with codex-review.yml.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -35,7 +35,12 @@ jobs:
   codex-review:
     name: GPT 5.6 Review
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Runaway/hang backstop only, NOT a per-review budget: the two-pass review
+    # self-terminates on its own long before this. Set generously at 90 min so
+    # it never cuts a completing review the way the old 30-min wall did, while
+    # still failing the gate closed on a true hang well under GitHub's 360-min
+    # job default. Keep in sync with claude-review.yml.
+    timeout-minutes: 90
     # Only run on PRs from the same repo (not forks) to prevent budget abuse,
     # prompt injection via malicious diffs, and secret exfiltration attempts.
     if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## What

Raise `timeout-minutes` from **30 → 90** on both AI code-review jobs:
- `.github/workflows/claude-review.yml` (Opus 5 Review)
- `.github/workflows/codex-review.yml` (GPT 5.6 Review)

## Why

The 30-min job wall frequently cancelled **healthy** reviews before they finished. On `claude-review.yml` the review carries a `--max-turns 120` budget on the slow Opus 5 model; 120 agentic turns (each a full model round-trip + Read/Grep/Glob) can't reliably complete in 30 min, especially with any Bedrock throttling/backoff. When the wall hits, GitHub cancels the job, `steps.review.outcome != success`, the gate fails **closed**, and the required check turns red — blocking the PR on a timeout rather than a real finding.

`timeout-minutes` and `--max-turns` are independent ceilings: a healthy review self-terminates at the turn budget on its own. The wall's only real job is to kill a genuine **hang** (Bedrock stall, retry loop). Reframing it as a generous 90-min runaway/hang backstop means it no longer cuts a completing review, while still failing the gate closed on a true hang — and well under GitHub's 360-min job default (so removing the key entirely, which would fall back to that 6h default, is avoided).

`--max-turns 120` is intentionally kept unchanged.

## Testing

- `test/test_ai_review_workflows.py` — 38 passed (no assertions on `timeout-minutes`; structural review-gate invariants intact).
- Both workflow files reviewed for YAML shape; only the two `timeout-minutes` values + their explanatory comments changed.