### PR TITLE
fix(telemetry): publish the bucket-generation disclosure for every histogram

### DIFF
--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -258,6 +258,18 @@ class _Hist:
         return max(0, len(self._groups) - 1)
 
     @property
+    def total_count(self) -> int:
+        """Samples across EVERY generation, not just the reported one.
+
+        ``count`` is deliberately scoped to one boundary generation, so on a
+        mixed window it under-reports. Pairing the two lets a caller say
+        "showing 141 of 1970" instead of publishing 141 as if it were the whole
+        population — which is what made a histogram card contradict a counter
+        for the same event with nothing explaining the gap.
+        """
+        return sum(int(g["count"]) for g in self._groups.values())
+
+    @property
     def outcomes(self) -> dict[str, int]:
         """Outcome tallies for the reported generation only.
 
@@ -269,11 +281,23 @@ class _Hist:
         return dict(g["outcomes"]) if g else {}
 
     def stats(self) -> dict[str, Any]:
+        """Reported-generation stats, WITH the mixed-window disclosure.
+
+        ``other_generations`` / ``total_count`` are part of this payload on
+        purpose rather than something each caller adds by hand: they were added
+        by the ``turn`` and ``startup`` blocks but forgotten by the generic
+        ``other`` surface, so every histogram there published a
+        one-generation subset as if it were the whole population (measured:
+        58-93% of samples dropped on three metrics, and a card contradicting the
+        counter for the same event). Emitting them here makes that omission
+        impossible for any future surface.
+        """
         g = self._dominant()
         if g is None:
             return {
                 "count": 0, "mean_ms": 0.0, "p50_ms": 0.0,
                 "p90_ms": 0.0, "min_ms": 0.0, "max_ms": 0.0,
+                "other_generations": 0, "total_count": 0,
             }
         cnt = int(g["count"])
         return {
@@ -283,6 +307,10 @@ class _Hist:
             "p90_ms": round(_pct_from_buckets(g["buckets"], g["bounds"], 0.90), 1),
             "min_ms": round(g["min"], 1) if g["min"] is not None else 0.0,
             "max_ms": round(g["max"], 1) if g["max"] is not None else 0.0,
+            # >0 means the window straddles a bucket-boundary change and only the
+            # dominant generation is reported; total_count is the full population.
+            "other_generations": self.other_generations,
+            "total_count": self.total_count,
         }
 
 
@@ -420,9 +448,6 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
         **turn.stats(),
         "outcome": turn_outcome,
         "fault_rate": round(turn_faults / turn_total, 4) if turn_total else 0.0,
-        # >0 means the window straddles a bucket-boundary change and only the
-        # dominant generation is reported (see _Hist).
-        "other_generations": turn.other_generations,
     }
 
     return {
@@ -431,7 +456,6 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
             "cold": cold.stats(),
             "warm": warm.stats(),
             "outcome": overall.outcomes,
-            "other_generations": overall.other_generations,
             "daily": daily_out,
             "distribution": {"buckets": overall.buckets, "bounds": overall.bounds},
             # Internal phase split (kiro backend): spawn_init, session_new,

--- a/test/metrics/test_generation_disclosure.py
+++ b/test/metrics/test_generation_disclosure.py
@@ -1,0 +1,162 @@
+"""Every histogram the telemetry API publishes must disclose a mixed window.
+
+``_Hist`` reports only the dominant bucket-boundary generation on purpose, so a
+boundary change cannot sum two unrelated distributions. The cost is that on a
+mixed window ``count`` is a subset. ``other_generations`` + ``total_count`` are
+what let a card say "showing 141 of 1970" instead of publishing the subset as if
+it were the whole population.
+
+The bug these tests lock out: the disclosure was added by hand in the ``turn``
+and ``startup`` blocks and forgotten in the generic ``other`` surface, so three
+real metrics under-reported by 58-93% with nothing on the page saying so, and a
+histogram card contradicted the counter for the same event.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.dashboard.handlers.telemetry import _aggregate, _Hist
+
+_BOUNDS_A = [10.0, 50.0, 100.0, 500.0, 1000.0]
+_BOUNDS_B = [25.0, 250.0, 2500.0, 25000.0, 250000.0]   # a boundary change
+
+# Anything kirocrew.* that is neither the startup metric nor turn.duration lands
+# in the generic `other` surface -- the one that forgot the disclosure.
+_OTHER_METRIC = "kirocrew.mcp.backend.acquire.duration"
+
+
+def _dp(bounds: list[float], bucket: int, count: int, ns: int) -> dict[str, Any]:
+    counts = [0] * (len(bounds) + 1)
+    counts[bucket] = count
+    return {
+        "attributes": {},
+        "count": count,
+        "sum": float(count * 15),
+        "min": 15.0,
+        "max": 15.0,
+        "bucket_counts": counts,
+        "explicit_bounds": bounds,
+        "time_unix_nano": ns,
+    }
+
+
+def _shard(tmp_path: Path, metrics: list) -> list[Path]:
+    line = {"resource_metrics": [{"scope_metrics": [{"metrics": metrics}]}]}
+    p = tmp_path / "metrics-2026-08-02-0001.jsonl"
+    p.write_text(json.dumps(line) + "\n", encoding="utf-8")
+    return [p]
+
+
+# ───────────────────────── _Hist semantics ─────────────────────────
+
+def test_clean_window_reports_total_equal_to_count():
+    """Single generation: the subset IS the population, so the two agree."""
+    h = _Hist()
+    h.add(_dp(_BOUNDS_A, 1, count=7, ns=1))
+    s = h.stats()
+    assert s["other_generations"] == 0
+    assert s["total_count"] == s["count"] == 7
+
+
+def test_mixed_window_total_exceeds_the_reported_count():
+    h = _Hist()
+    h.add(_dp(_BOUNDS_A, 1, count=5, ns=1))     # older generation
+    h.add(_dp(_BOUNDS_B, 2, count=2, ns=99))    # newer, wins on recency
+    s = h.stats()
+    assert s["other_generations"] == 1
+    assert s["count"] == 2, "recency should pick the newer generation"
+    assert s["total_count"] == 7, "total must span EVERY generation"
+
+
+def test_total_count_is_not_just_the_dominant_count():
+    """Negative control for the test above.
+
+    If ``total_count`` were wired to the dominant group it would still equal
+    ``count`` here and `test_mixed_window_...` would pass vacuously for the
+    wrong reason.
+    """
+    h = _Hist()
+    h.add(_dp(_BOUNDS_A, 1, count=5, ns=1))
+    h.add(_dp(_BOUNDS_B, 2, count=2, ns=99))
+    assert h.total_count != h.count
+
+
+def test_empty_histogram_still_carries_the_keys():
+    """Shape uniformity: a consumer spreading stats() always gets the fields."""
+    s = _Hist().stats()
+    assert s["other_generations"] == 0
+    assert s["total_count"] == 0
+
+
+# ─────────────────── the API surface that regressed ───────────────────
+
+def test_other_histograms_disclose_a_mixed_window(tmp_path):
+    """REGRESSION: this is what the `other` surface used to omit entirely.
+
+    Fails on the pre-fix code, where the `other` list was built from stats()
+    plus only name/kind.
+    """
+    shards = _shard(tmp_path, [{
+        "name": _OTHER_METRIC,
+        "data": {"data_points": [
+            _dp(_BOUNDS_A, 1, count=9, ns=1),
+            _dp(_BOUNDS_B, 2, count=3, ns=99),
+        ]},
+    }])
+    res = _aggregate(shards)
+    hists = [e for e in res["other"] if e.get("kind") == "histogram"]
+    assert hists, "the metric did not reach the `other` surface"
+    entry = next(e for e in hists if e["name"] == _OTHER_METRIC)
+    assert entry["other_generations"] == 1
+    assert entry["count"] == 3
+    assert entry["total_count"] == 12
+
+
+def _histogram_blocks(node: Any, path: str = "") -> list[tuple[str, dict]]:
+    """Every dict in the response that is shaped like histogram stats."""
+    found: list[tuple[str, dict]] = []
+    if isinstance(node, dict):
+        if "count" in node and "p50_ms" in node:
+            found.append((path or "<root>", node))
+        for k, v in node.items():
+            found.extend(_histogram_blocks(v, f"{path}.{k}" if path else k))
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            found.extend(_histogram_blocks(v, f"{path}[{i}]"))
+    return found
+
+
+def test_every_published_histogram_carries_the_disclosure(tmp_path):
+    """Structural invariant, so a FUTURE surface cannot omit it again.
+
+    Deliberately a walk over the whole response rather than a per-block
+    assertion: the failure mode being guarded is a new histogram surface added
+    later that forgets the field, which named-block assertions would not catch.
+    """
+    shards = _shard(tmp_path, [
+        {"name": _OTHER_METRIC,
+         "data": {"data_points": [_dp(_BOUNDS_A, 1, count=4, ns=1)]}},
+        {"name": "kirocrew.turn.duration",
+         "data": {"data_points": [_dp(_BOUNDS_A, 2, count=2, ns=2)]}},
+        {"name": "kirocrew.startup.duration",
+         "data": {"data_points": [_dp(_BOUNDS_A, 1, count=3, ns=3)]}},
+    ])
+    res = _aggregate(shards)
+    blocks = _histogram_blocks(res)
+    assert len(blocks) >= 4, (
+        f"walker found only {len(blocks)} histogram blocks -- too few for the "
+        "assertion below to mean anything"
+    )
+    for path, blk in blocks:
+        assert "other_generations" in blk, f"{path} omits other_generations"
+        assert "total_count" in blk, f"{path} omits total_count"
+
+
+def test_the_walker_can_actually_fail():
+    """Negative control for the invariant test's own walker."""
+    blocks = _histogram_blocks({"a": {"count": 1, "p50_ms": 2.0}})
+    assert len(blocks) == 1
+    assert "other_generations" not in blocks[0][1]


### PR DESCRIPTION
Fixes #1181

## Problem

A histogram card on the Telemetry page could report a sample count that
**contradicted a counter for the same event sitting beside it**, with nothing on
the page explaining the gap.

Measured on 47 real production shards (30-day window):

| metric | reported | true total | silently hidden |
|---|---|---|---|
| `kirocrew.gateway.request.duration` | 12177 | 38939 | **69%** |
| `kirocrew.mcp.backend.acquire.duration` | 1294 | 3066 | **58%** |
| `kirocrew.skill.lazy_load.duration` | 141 | 1970 | **93%** |
| `kirocrew.gateway.boot.duration` | 11 | 11 | 0 (clean) |

The decisive cross-check: the counter `kirocrew.mcp.warm_pool.acquire` reads
**3066** — exactly the histogram's true total — while the card beside it read
**1294**. Same event, two numbers, no explanation. 30363 samples dropped across
the window.

## Why it matters

Three PRs (#968, #1049, #1082) were spent getting this data correct in the store.
This bug meant the numbers were right in the store and wrong on the page — which
is where anyone actually looks. It is also strictly worse than #975: that issue is
about rendering a badge, whereas here the field never reached the API, so there
was nothing for any frontend to render.

## Fix (symptom → root cause → change)

`_Hist` reports only the **dominant bucket-boundary generation** on purpose, so a
boundary change (e.g. #968) cannot sum two unrelated distributions into one set of
buckets. That is correct, and it exposes `other_generations` precisely so a caller
can disclose a mixed window.

`stats()` did not include that field, and only **two of its three consumers**
added it back by hand:

```python
turn_block = {**turn.stats(), ..., "other_generations": turn.other_generations}   # had it
"startup":  {..., "other_generations": overall.other_generations}                 # had it

for name in sorted(other_hist):
    s = other_hist[name].stats()
    s.update({"name": name, "kind": "histogram"})    # ← forgot it
```

So every histogram in the generic `other` surface published a one-generation
subset as if it were the whole population.

The change moves the disclosure **into `stats()`**, so omitting it is no longer
possible, rather than adding a third hand-written copy. The two existing copies
become redundant and are removed.

`other_generations` alone says *"another generation exists"* but not *"you are
seeing 7% of the data"*. Since the concrete symptom is a **contradicted count**,
`stats()` also carries `total_count` (all generations), letting a card say
*showing 141 of 1970*. After the fix `total_count` equals the counter for the same
event **exactly** (3066 = 3066) — that equality is what resolves the
contradiction.

**No API break:** neither field is read anywhere under `website/src`, so moving
the startup block's sibling copy into each histogram's own payload is safe. It is
also more precise — `cold` and `warm` now disclose their own state instead of
inheriting one number describing `overall`. Frontend surfacing stays with #975.

## Tests

`test/metrics/test_generation_disclosure.py` (7 tests):

- **`_Hist` semantics** — a clean window has `total_count == count`; a mixed
  window reports the recency-selected generation while `total_count` spans both.
- **Negative control** proving `total_count` is not wired to the dominant group —
  without it the mixed-window assertion would pass for the wrong reason.
- **Empty-histogram shape**, so a consumer spreading `stats()` always gets the
  keys rather than a `KeyError` on an idle window.
- **Regression test** against the real `_aggregate` output for the `other`
  surface — the one that fails on pre-fix code.
- **Structural invariant** that walks the *whole* response and asserts every
  histogram-shaped block carries both fields. Deliberately a walk rather than
  per-block assertions: the failure mode worth guarding is a **future** surface
  that forgets the field, which named-block assertions would never catch. It
  carries its own negative control so it cannot pass vacuously.

**Test effectiveness verified, not assumed:** reverting only `telemetry.py` to
pre-fix makes **6 of the 7 fail**, and the one that still passes is the walker's
own negative control (which is meant to pass regardless).

## Manual verification

Ran the real `_aggregate` over the 47 production shards before and after.

- Before: all 4 `other` histograms missing both fields; `startup` reported 0 and
  `turn` reported 1, confirming the asymmetry was per-surface and not per-metric.
- After: none missing; the three mixed metrics report their true totals; the
  counter/histogram contradiction is gone.
- Also surfaced by the fix: the `turn` card was under-reporting too (94 of 119) —
  it could flag that a boundary change happened but not by how much.

Gates green: `isort --check-only`, `flake8 -j 1`, `mypy` (580 source files, no
issues), full pytest 22000+ passed. 20 failures are environment-only on this host
(cannot `unshare(CLONE_NEWUSER)`); triaged by comparing the **non-sandbox** set,
which is 9 and identical to the established clean-`main` baseline — all in files
this PR does not touch (beacon, deploy, dev_fleet, gateway_lock, issue_radar,
source_providers).

## Screenshots

N/A — API-only change, no user-visible UI in this PR. The page will show the new
information once #975 renders it; a screenshot now would look identical.
