### PR TITLE
refactor(mcp-gateway): drop channel_id from PoolKey

### DIFF
--- a/src/kiro_crew/mcp_gateway/breaker.py
+++ b/src/kiro_crew/mcp_gateway/breaker.py
@@ -41,9 +41,9 @@ FAST_DEATH_LIMIT = 5
 WINDOW_SECS = 60.0
 
 # Upper bound on distinct keys tracked in ``_states``. The gateway keys the
-# breaker by ``PoolKey.stable_hash()`` (agent x server x channel x config), an
-# open-ended space, so a long-lived daemon must prune fully-inactive keys to
-# avoid unbounded growth (mirrors HotKeyStore's cap).
+# breaker by ``PoolKey.stable_hash()`` (agent x server x execution x security x
+# config), an open-ended space, so a long-lived daemon must prune fully-inactive
+# keys to avoid unbounded growth (mirrors HotKeyStore's cap).
 MAX_TRACKED_KEYS = 512
 
 # Time the breaker stays OPEN once tripped. ``allow()`` returns False

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -912,8 +912,13 @@ def env_target_resolver(pool_key: PoolKey) -> Optional[tuple[str, list[str], dic
     # environment doesn't leak into Python-based MCP backends (import conflicts).
     env.pop("PYTHONPATH", None)
     env.pop("PYTHONHOME", None)
-    if pool_key.channel_id:
-        env["KIROCREW_CHANNEL_ID"] = pool_key.channel_id
+    # No KIROCREW_CHANNEL_ID is exported into the backend env. It used to be
+    # copied from PoolKey.channel_id, which only made sense while a backend was
+    # owned by one channel. A pooled backend serves several channels, so a
+    # single channel baked into its environment at spawn would be actively
+    # wrong — it would tell the server it belongs to whichever channel happened
+    # to spawn it first. The channel is delivered PER CALL instead, in
+    # _meta.kirocrew.caller (see _inject_caller_meta).
     return command, args, env, pool_key.work_dir
 
 

--- a/src/kiro_crew/mcp_gateway/pool.py
+++ b/src/kiro_crew/mcp_gateway/pool.py
@@ -4,13 +4,34 @@ Two sessions sharing a single backend MUST produce the same answers as if
 each had its own backend. Every attribute that changes backend behavior
 MUST be in :class:`PoolKey`, or two sessions can see cross-tenant state.
 
-The 14 dimensions captured below are the union of every spawn-time input
+The 13 dimensions captured below are the union of every spawn-time input
 that influences a Kiro MCP subprocess: identity (``server_name``,
 ``agent_name``), execution (``command_args_hash``, ``effective_env_hash``,
 ``work_dir``, ``binary_version``), security (``os_uid``, ``sandbox_mode``,
 ``autoapprove_set_hash``, ``approval_mode``, ``trust_all_tools``,
-``user_identity``), tenancy (``channel_id``), and config drift
-(``config_snapshot_hash``).
+``user_identity``), and config drift (``config_snapshot_hash``).
+
+There is deliberately NO channel dimension. A channel is not a trust
+boundary and never was a usable proxy for one:
+
+* It is not a consistent unit. On Slack a channel is a ROOM shared by many
+  people, so two different humans in one channel landed on the same backend
+  anyway — the isolation it advertised was never delivered. On Telegram the
+  same field held a per-user id. A dimension whose meaning changes per
+  transport cannot carry a security invariant.
+* It over-partitions the common case. One person reaching the same agent
+  from the dashboard and from a chat transport would burn a separate backend
+  per surface, which is exactly the memory pooling exists to reclaim.
+* It is redundant with a mechanism that already works. ``gatewayd`` stamps
+  ``_meta.kirocrew.caller`` (session key, session type, principal, channel)
+  onto every forwarded ``tools/call``, so a channel-aware backend learns the
+  channel PER CALL and does not need a process to itself.
+
+The axis that genuinely expresses "a different person must not share a
+backend" is ``user_identity``. It is present above, and today it degrades to
+the OS user because nothing populates ``KIROCREW_PRINCIPAL`` — making that
+real is the prerequisite for a shared multi-principal gateway, and is
+tracked separately. Re-adding a channel dimension is not that fix.
 
 Stable hashing uses SHA-256 over a JSON-serialized tuple with sorted keys.
 Python's built-in ``hash()`` is intentionally non-deterministic across
@@ -220,8 +241,7 @@ class PoolKey:
     trust_all_tools: bool
     user_identity: str
 
-    # Tenancy + config drift
-    channel_id: Optional[str]
+    # Config drift
     config_snapshot_hash: str
 
     # --- Constructors ------------------------------------------------------
@@ -241,21 +261,20 @@ class PoolKey:
         missing = [
             f.name
             for f in cls.__dataclass_fields__.values()  # type: ignore[attr-defined]
-            if f.name != "channel_id" and f.name not in register
+            if f.name not in register
         ]
         if missing:
             raise ValueError(f"Register payload missing required fields: {missing}")
 
-        channel_id = register.get("channel_id")
-        if channel_id is not None and not isinstance(channel_id, str):
-            raise ValueError(f"channel_id must be str or None, got {type(channel_id).__name__}")
-        if isinstance(channel_id, str) and not channel_id:
-            channel_id = None  # empty string ⇒ no channel
-
+        # A ``channel_id`` on the payload is IGNORED here, not rejected: the
+        # stub still reports it because gatewayd threads it into the per-call
+        # caller identity (see ``_build_caller_block``), and an older stub
+        # against a newer daemon must keep registering cleanly. It is simply
+        # not a pool dimension — see the module docstring.
         # Security-boundary dims: type-check rather than coerce. bool("false")
         # is True and int() on a bool silently passes, so a stub sending a JSON
         # string/number for these could land in the wrong trust/uid partition.
-        # Reject a non-matching type (mirrors the channel_id check above).
+        # Reject a non-matching type rather than coercing it.
         os_uid = register["os_uid"]
         if isinstance(os_uid, bool) or not isinstance(os_uid, int):
             raise ValueError(f"os_uid must be int, got {type(os_uid).__name__}")
@@ -277,7 +296,6 @@ class PoolKey:
                 approval_mode=str(register["approval_mode"]),
                 trust_all_tools=trust_all_tools,
                 user_identity=str(register["user_identity"]),
-                channel_id=channel_id,
                 config_snapshot_hash=str(register["config_snapshot_hash"]),
             )
         except (TypeError, ValueError) as exc:
@@ -310,11 +328,10 @@ class PoolKey:
             if len(self.effective_env_hash) > 8
             else self.effective_env_hash
         )
-        chan = f" chan={self.channel_id}" if self.channel_id else ""
         return (
             f"{self.agent_name}:{self.server_name} "
             f"uid={self.os_uid} sbx={self.sandbox_mode} "
-            f"cmd={cmd_short} env={env_short} ws={self.work_dir}{chan}"
+            f"cmd={cmd_short} env={env_short} ws={self.work_dir}"
         )
 
 

--- a/src/kiro_crew/mcp_gateway/prewarm.py
+++ b/src/kiro_crew/mcp_gateway/prewarm.py
@@ -24,10 +24,12 @@ Two halves, both deliberately cheap on the event loop:
   ``acquire`` callable the live path uses, so a prewarmed backend is
   byte-identical to a lazily-spawned one.
 
-The PoolKey's ``channel_id`` dimension is the stable Slack channel/DM id
-(not a per-session uuid), so a backend prewarmed for a channel is hit by
-every later new-chat in that channel — prewarming by observed hot key is
-sound without any shared-fallback path.
+A PoolKey carries no channel dimension (see :mod:`kiro_crew.mcp_gateway.pool`),
+so a hot key is not tied to one conversation surface: a backend prewarmed from
+an observed key is hit by every later session that matches on agent, server and
+the execution/security dimensions, whichever channel it arrives from.
+Prewarming by observed hot key is therefore sound without any shared-fallback
+path.
 """
 
 from __future__ import annotations

--- a/src/kiro_crew/mcp_gateway/session_servers.py
+++ b/src/kiro_crew/mcp_gateway/session_servers.py
@@ -105,12 +105,14 @@ def pooled_session_servers(
     gateway is disabled, which is the natural off switch — this returns ``[]``
     and the session runs entirely on the agent's own servers.
 
-    ``channel_id`` scopes the pool key so sessions in different channels do not
-    share a backend. It is passed here rather than baked into the overlay
-    because the overlay is written once at gateway startup and is
-    session-agnostic, while this function runs per session. ``None`` (the
-    default, and what a runtime with no channel concept supplies) leaves the
-    flag off and the stub collapses to the channel-less pool key.
+    ``channel_id`` reaches the stub so it can report the channel in its caller
+    identity, which ``gatewayd`` stamps onto every forwarded ``tools/call`` as
+    ``_meta.kirocrew.caller``. It is deliberately NOT a pool dimension (see
+    :mod:`kiro_crew.mcp_gateway.pool`), so passing it does not split backends —
+    two channels reaching the same agent still share one. It is passed here
+    rather than baked into the overlay because the overlay is written once at
+    gateway startup and is session-agnostic, while this function runs per
+    session. ``None`` simply leaves the flag off and the channel unreported.
 
     Fail-soft by design: any unreadable or malformed overlay yields ``[]``, so a
     bad rewrite degrades to unpooled operation rather than breaking the spawn.

--- a/test/test_mcp_apps_call_endpoint.py
+++ b/test/test_mcp_apps_call_endpoint.py
@@ -65,7 +65,6 @@ def _pool_key(server: str = "fake-mcp-app") -> PoolKey:
         approval_mode="reads",
         trust_all_tools=False,
         user_identity="testuser",
-        channel_id=None,
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_apps_e2e.py
+++ b/test/test_mcp_apps_e2e.py
@@ -69,7 +69,6 @@ def _pool_key() -> PoolKey:
         approval_mode="reads",
         trust_all_tools=False,
         user_identity="testuser",
-        channel_id=None,
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_gateway_apps_spool.py
+++ b/test/test_mcp_gateway_apps_spool.py
@@ -342,7 +342,6 @@ def _pool_key(server: str = "excalidraw-mcp") -> PoolKey:
         approval_mode="reads",
         trust_all_tools=False,
         user_identity="testuser",
-        channel_id=None,
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_gateway_bluegreen.py
+++ b/test/test_mcp_gateway_bluegreen.py
@@ -48,7 +48,6 @@ def _make_pool_key(server: str = "test-server", agent: str = "test-agent") -> Po
         approval_mode="reads",
         trust_all_tools=False,
         user_identity="testuser",
-        channel_id=None,
         config_snapshot_hash="jkl012",
     )
 

--- a/test/test_mcp_gateway_poolkey.py
+++ b/test/test_mcp_gateway_poolkey.py
@@ -52,3 +52,57 @@ def test_bool_os_uid_is_rejected() -> None:
 def test_string_os_uid_is_rejected_not_coerced() -> None:
     with pytest.raises(ValueError, match="os_uid must be int"):
         PoolKey.from_register({**_VALID, "os_uid": "1000"})
+
+
+class TestChannelIsNotAPoolDimension:
+    """A channel does not partition the pool.
+
+    It was never a usable trust boundary: on Slack a channel is a room shared
+    by several people (so two humans in one channel shared a backend anyway),
+    while on Telegram the same field carried a per-user id. The channel is
+    delivered to backends PER CALL via ``_meta.kirocrew.caller`` instead, so a
+    channel-aware server does not need a process to itself.
+    """
+
+    def test_two_channels_share_one_backend(self) -> None:
+        a = PoolKey.from_register({**_VALID, "channel_id": "C_AAA"})
+        b = PoolKey.from_register({**_VALID, "channel_id": "C_BBB"})
+        assert a.stable_hash() == b.stable_hash()
+        assert a == b
+
+    def test_channel_and_no_channel_share_one_backend(self) -> None:
+        with_chan = PoolKey.from_register({**_VALID, "channel_id": "C_AAA"})
+        without = PoolKey.from_register({**_VALID, "channel_id": None})
+        assert with_chan.stable_hash() == without.stable_hash()
+
+    def test_payload_without_channel_id_is_accepted(self) -> None:
+        """It is no longer a special-cased optional field — it is simply not a
+        field, so a payload omitting it is complete rather than tolerated."""
+        payload = {k: v for k, v in _VALID.items() if k != "channel_id"}
+        key = PoolKey.from_register(payload)
+        assert key.stable_hash() == PoolKey.from_register(dict(_VALID)).stable_hash()
+
+    def test_unknown_channel_id_shape_does_not_break_register(self) -> None:
+        """Forward/backward compat: an older stub still reports ``channel_id``
+        (gatewayd threads it into caller identity), and a malformed value must
+        not fail a register that no longer depends on it."""
+        for bogus in (123, {"a": 1}, ["x"], ""):
+            key = PoolKey.from_register({**_VALID, "channel_id": bogus})
+            assert key.stable_hash() == PoolKey.from_register(dict(_VALID)).stable_hash()
+
+    def test_channel_absent_from_repr(self) -> None:
+        assert "chan=" not in str(PoolKey.from_register({**_VALID, "channel_id": "C_X"}))
+
+    def test_security_dimensions_still_partition(self) -> None:
+        """Negative control: dropping the channel dimension must not have made
+        the key permissive — the real boundaries still split."""
+        base = PoolKey.from_register(dict(_VALID))
+        for field, other in (
+            ("user_identity", "someone-else"),
+            ("os_uid", 1001),
+            ("sandbox_mode", "none"),
+            ("effective_env_hash", "different"),
+            ("work_dir", "/tmp/other"),
+        ):
+            variant = PoolKey.from_register({**_VALID, field: other})
+            assert variant.stable_hash() != base.stable_hash(), field


### PR DESCRIPTION
Fixes #1189. Supersedes #1056.

## What

`PoolKey` no longer has a `channel_id` dimension — 14 dimensions become 13. A channel
no longer partitions the pooled MCP backends.

## Why

A channel is not a trust boundary, and it was never a usable proxy for one.

**It is not a consistent unit.** On Slack `channel_id` is the channel — a *room*
shared by many people (`slack/transport_dispatch.py:273`). Two different humans in one
channel therefore landed on the same backend anyway, so the isolation the dimension
advertised was never delivered where it would matter most. On Telegram the same field
held a per-*user* id (`telegram/transport_dispatch.py:281`). A dimension whose meaning
changes per transport cannot carry a security invariant.

**It over-partitions the common case.** One person reaching the same agent from the
dashboard and from a chat transport burned a separate backend per surface — exactly
the memory pooling exists to reclaim.

**It is redundant with a mechanism that already works.** `gatewayd` stamps
`_meta.kirocrew.caller` (session key, session type, principal, channel) onto every
forwarded `tools/call`, so a channel-aware backend learns the channel *per call* and
does not need a process to itself.

The axis that genuinely expresses "a different person must not share a backend" is
`user_identity`, which stays. It currently degrades to the OS user because nothing in
the tree populates `KIROCREW_PRINCIPAL` — filed as #1190, which is the real
prerequisite for a shared multi-principal gateway. Re-adding a channel dimension is
not that fix.

## What is deliberately NOT changed

Caller identity. The stub still accepts `--channel-id`, still reports `channel_id` on
the Register payload, and `_build_caller_block` plus the recaller/claim path are
untouched — so the channel keeps reaching backends per call. The existing
`test_mcp_gateway_recaller.py` / `test_mcp_gateway_claim.py` coverage of that path is
unmodified and still passing, which is the evidence that this PR removed the
partitioning without touching identity delivery.

## One connected removal

`gatewayd` copied `PoolKey.channel_id` into the backend's spawn env as
`KIROCREW_CHANNEL_ID`. That only made sense while a backend was owned by one channel:
for a shared backend, a single channel baked into its environment is actively wrong —
it tells the server it belongs to whichever channel happened to spawn it first. The
per-call caller meta is the correct carrier, so the export goes with the dimension.

Note this is a no-op in practice today: the guard was `if pool_key.channel_id:`, and
the channel is absent on the default backend path (see #1056 / the compatibility note
below), so the variable was not actually being set.

## Compatibility

- `from_register` now **ignores** a `channel_id` on the payload rather than rejecting
  it, and no longer special-cases it in the required-field check. An older stub
  against a newer daemon keeps registering cleanly, and a malformed value cannot fail
  a register that no longer depends on it.
- The digest changes shape, so pooled backends re-partition once on the first restart
  after deploy. There is no golden digest pinned anywhere, and `stable_hash()` is
  recomputed on both sides at runtime, so nothing needs regenerating.
- Backend count should go **down**, not up: this removes a splitting dimension.

## Relationship to #1056

#1056 reports that `AcpRuntime` sessions register with no `channel_id` and proposes
threading it through. The report is accurate and, if anything, understated:
`AcpRuntime` is the **default** kiro backend path (`providers/acp.py:329` →
`_start_kiro_runtime_impl` → `runtime.create_session` →
`pooled_session_servers(overlay, agent)` with the channel defaulted away), so channel
partitioning was inert for essentially every session, not only for subagents. On a
live gateway all 201 stub processes were channel-less.

Threading the value through would have made a wrong axis functional: more backends,
more memory, and still no real tenancy isolation. Hence removal instead.

## Tests

The dimension had **no test asserting that it partitioned anything** — its only
appearance in the gateway tests was as a register-payload field, which is consistent
with it being inert.

Added `TestChannelIsNotAPoolDimension`:

- two different channels produce the same `stable_hash()`
- channel vs no-channel produce the same `stable_hash()`
- a payload omitting `channel_id` is complete rather than tolerated
- a malformed `channel_id` (int / dict / list / empty) does not break register
- `chan=` no longer appears in the repr
- **negative control**: `user_identity`, `os_uid`, `sandbox_mode`,
  `effective_env_hash` and `work_dir` still partition — so removing the dimension
  cannot be read as having made the key permissive

Also corrected the stale docstrings that justified the dimension: `session_servers`
(the flag now scopes caller identity, not the pool key), `prewarm` (hot-key
prewarming no longer rests on a channel-stable key), and the `breaker` key-space
comment.

## Verification

- `isort --check-only`, `flake8 -j 1`, `mypy src/kiro_crew/` (580 files) clean
- 635 targeted tests pass: poolkey, bluegreen, claim, recaller, stub_recaller,
  prewarm, breaker, mcp_apps (call_endpoint / e2e / spool), stop_kill_cancel,
  acp_client

No spec module documents the PoolKey dimension list (there is no `mcp-gateway.md`;
the only `PoolKey` reference in the specs is `pool_digest` in `mcp-apps.md`, which is
unaffected), so the module docstring — rewritten here to record why there is no
channel dimension — is the canonical documentation.
