### PR TITLE
fix(discord): show typing before the session cold start

### DIFF
--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -338,6 +338,17 @@ class DiscordDispatcher:
         # Mirrors telegram/transport_dispatch.py.
         _acquired = False
         try:
+            # Typing indicator BEFORE the cold start. get_or_create can spend
+            # seconds spawning/handshaking an ACP session, and until this runs
+            # Discord shows nothing at all, so the user sees dead air and assumes
+            # the bot missed the message. This is the ordering the shared
+            # skeleton documents ("typing indicator before cold start" in
+            # messaging/dispatch.py) and the one telegram/transport_dispatch.py
+            # still uses. Safe here: on_turn_start only spawns a background
+            # refresh task, is idempotent (the driver calls it again later), and
+            # the enclosing finally always finalizes the renderer, so an early
+            # return below cannot leak a typing loop.
+            await renderer.on_turn_start()
             # Acquire before attachment I/O. A large download yields repeatedly;
             # leaving the session idle in that window lets a later message run
             # first and persist the conversation in reverse order.
@@ -353,7 +364,6 @@ class DiscordDispatcher:
                 text = append_attachment_context(text, attachment_result)
             if not text:
                 return
-            await renderer.on_turn_start()
             # New-session bookkeeping belongs to THIS conversation's own session
             # only. A resumed dashboard session is pre-existing by definition, and
             # `get_or_create` returns is_new whenever its ACP session is merely

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -1159,6 +1159,52 @@ class TestDispatcher:
         assert "!sessions [query]" in cli.sent[-1][0]
 
     @pytest.mark.asyncio
+    async def test_typing_indicator_starts_before_the_session_cold_start(
+        self, monkeypatch
+    ) -> None:
+        """TTFT guard: the typing loop must be STARTED before the ACP cold start.
+
+        ``sessions.get_or_create`` can spend seconds spawning and handshaking an
+        ACP session. ``on_turn_start`` does not send the indicator inline -- it
+        spawns a refresh task -- so it must be called BEFORE the cold start, or
+        the task is not even created until the cold start has finished and the
+        user sees several seconds of dead air. That regressed when attachment
+        ingestion was inserted ahead of ``on_turn_start`` (#1053). The shared
+        skeleton in messaging/dispatch.py documents this order as "typing
+        indicator before cold start"; telegram/transport_dispatch.py follows it.
+
+        Asserting the ORDER of the two calls, not merely that both happened:
+        both happen either way, so order is the entire bug. Deliberately spying
+        on ``on_turn_start`` rather than ``send_typing`` -- the latter runs on a
+        spawned task and cannot fire until the loop next yields, which makes it
+        useless for pinning this ordering.
+        """
+        d, cli, sess = _dispatcher({"u1"})
+        order: list[str] = []
+
+        real_get_or_create = sess.get_or_create
+        real_on_turn_start = DiscordRenderer.on_turn_start
+
+        async def _spy_get_or_create(*args: Any, **kwargs: Any) -> Any:
+            order.append("cold_start")
+            return await real_get_or_create(*args, **kwargs)
+
+        async def _spy_on_turn_start(self_: Any) -> None:
+            order.append("typing_started")
+            await real_on_turn_start(self_)
+
+        monkeypatch.setattr(sess, "get_or_create", _spy_get_or_create)
+        monkeypatch.setattr(DiscordRenderer, "on_turn_start", _spy_on_turn_start)
+
+        await d.handle_message(self._msg("hello world"))
+
+        assert "typing_started" in order, "typing was never started"
+        assert "cold_start" in order, "session was never acquired"
+        assert order.index("typing_started") < order.index("cold_start"), (
+            f"typing must start before the cold start, got {order}"
+        )
+
+    @pytest.mark.asyncio
     async def test_normal_turn_streams_and_releases(self) -> None:
         d, cli, sess = _dispatcher({"u1"})
         await d.handle_message(self._msg("hello world"))


### PR DESCRIPTION
## Problem

Discord's "typing…" indicator stopped appearing promptly. It used to show immediately after sending a message; now there is a multi-second gap where nothing happens, so the bot looks like it missed the message. Reported from live use after #1051–#1054 merged.

## Why it matters

The typing indicator is the only feedback Discord gives that a turn started. Without it the user has no signal for the entire ACP cold start and re-sends or assumes a failure. It is also the one channel affordance that costs nothing to show early.

## Fix (symptom → root cause → change)

**Symptom:** several seconds of dead air before the typing banner.

**Root cause:** `feat(discord): ingest inbound attachments` (#1053) correctly moved `sessions.get_or_create()` ahead of attachment I/O — a long download must not leave the session idle, or a later message can persist the conversation out of order. But it also pushed `renderer.on_turn_start()` down *past* the acquire, when only `process_discord_attachments()` needed to move.

`get_or_create` spawns and handshakes an ACP session and can take seconds cold. And `on_turn_start` does not send the indicator inline — it **spawns a refresh task** — so placing it after the cold start means the task is not created until the cold start has already finished.

This inverted the order the shared skeleton documents in `messaging/dispatch.py` (*"typing indicator before cold start"*), which `telegram/transport_dispatch.py` still follows, and it contradicted Discord's own module docstring, which was never updated. Telegram is unaffected.

**Change:** hoist `on_turn_start()` back to the top of the `try`, keeping `get_or_create` ahead of attachment I/O, so both invariants hold simultaneously. Safe there: it only spawns a background task, it is idempotent (the driver calls it again), and the enclosing `finally` always finalizes the renderer, so the early `if not text: return` cannot leak a typing loop.

## Tests

`test_typing_indicator_starts_before_the_session_cold_start` asserts the **order** of the two calls, because both happen either way — order is the entire bug. Verified to fail against the merged ordering (`['cold_start', 'typing_started']`) and pass after the fix.

It spies on `on_turn_start`, not `send_typing`, on purpose: the indicator is sent from a spawned task and cannot fire until the loop next yields, so a `send_typing` assertion fails in **both** orderings and pins nothing. That false signal was actually hit while writing this test, which is why the distinction is documented in the docstring.

Full backend suite: **22,768 passed**. isort / flake8 clean; mypy clean across 580 files.

## Manual verification

N/A — a backend ordering change with no user-visible surface beyond the timing the test now pins. The latency was reported from live Discord use; the ordering is what the test locks.
