### PR TITLE
fix(heartbeat): make sessions stateless, matching the documented contract

### DIFF
--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -62,7 +62,7 @@ Four mechanisms clean up processes. They are complementary — not redundant.
 3. ``_expire_idle()`` — **periodic** (every ~5 min).
    Kills sessions idle for >``timeout_secs`` (default 30 min) via
    ``reset()`` → ``provider.shutdown()`` → SIGKILL process tree.
-   Protected keys: ``_PERSISTENT_KEYS`` (``_bg`` only).
+   Protected keys: ``_PERSISTENT_KEYS`` (``_bg`` and ``_hb``).
    **Known limitation**: ``last_used`` is only bumped on ``get_or_create()``,
    not on every LLM round-trip. A task runner step doing continuous work for
    >30 min without a new ``get_or_create()`` call could be swept. This is
@@ -1892,16 +1892,23 @@ class SessionManager:
         await self._ensure_background()
 
     async def recycle_heartbeat(self) -> None:
-        """Check heartbeat session context and recycle if too full.
+        """Tear down the heartbeat session at the end of a cycle.
 
         Mirrors :meth:`recycle_background` but for ``HEARTBEAT_KEY``.  Called
         once per heartbeat cycle (after all tasks finish), NOT per task —
         per-task recycle would tear down the session under concurrent
         ``asyncio.gather``'d siblings sharing the same key.
 
-        Same thresholds as background:
-        - At ≥ 70% context → recycle
-        - After 40 prompts with no metadata → recycle (blind fallback)
+        Unconditional, unlike :meth:`recycle_background`.  Heartbeat's
+        published contract is "fresh context each cycle"
+        (``config/prompt.md``), and every entry is re-read from
+        ``HEARTBEAT.md`` each cycle, so a retained transcript supplies
+        nothing the next cycle depends on while costing input tokens on
+        every tick.  It is also actively wrong to keep: for a watch task the
+        external system — not the prior transcript — is the source of truth,
+        and unrelated queued tasks would otherwise inherit each other's
+        reasoning.  Heartbeat runs in the background with nobody waiting on
+        a tick, so the per-cycle cold-start it costs is unobserved.
 
         No-op if the heartbeat session was never created (cycle had no
         tasks) or already torn down by a per-task timeout reset.
@@ -1911,15 +1918,7 @@ class SessionManager:
             return
 
         pct = session.provider.context_usage_pct()
-        needs_recycle = pct >= _BG_RECYCLE_PCT
-        if not needs_recycle and pct == 0.0:
-            needs_recycle = session.prompt_count >= _BG_BLIND_RECYCLE_PROMPTS
-
-        if not needs_recycle:
-            return
-
-        reason = f"context at {pct:.0f}%" if pct > 0 else f"blind ({session.prompt_count} prompts)"
-        logger.info("Recycling heartbeat session — %s", reason)
+        logger.info("Recycling heartbeat session — cycle end (context at %.0f%%)", pct)
 
         # Kill old session — next get_or_create(HEARTBEAT_KEY) will create
         # a fresh one (no eager _ensure_heartbeat — heartbeat sessions are
@@ -2116,10 +2115,15 @@ class SessionManager:
                 None, _session_model, self._cfg, agent
             )
 
-        # Check session map for resume — only for long-lived sessions
+        # Check session map for resume — only for long-lived sessions.
+        # ``_hb`` is stateless alongside ``_bg``: heartbeat's published
+        # contract is "fresh context each cycle" (config/prompt.md), and each
+        # entry is re-read from HEARTBEAT.md every cycle, so resuming a prior
+        # transcript supplies nothing while costing input tokens every tick.
         resume_sid: str | None = None
         is_stateless = (
-            key == BACKGROUND_KEY or any(key.startswith(p) for p in _STATELESS_PREFIXES)
+            key in (BACKGROUND_KEY, HEARTBEAT_KEY)
+            or any(key.startswith(p) for p in _STATELESS_PREFIXES)
         ) and key not in self._continuable_keys
         if not is_stateless:
             resume_sid = self._session_map.get(key)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2722,9 +2722,11 @@ class GatewayOrchestrator:
             ``asyncio.gather`` and share ``HEARTBEAT_KEY``.  A per-task
             ``reset()`` would tear down the session under sibling tasks
             still in flight (per code review).
-            ``recycle_heartbeat`` is conditional (only kills when context
-            crosses the 70% threshold) so warm cycles reuse the same MCP
-            toolbelt and avoid per-cycle cold-start cost.
+            ``recycle_heartbeat`` is unconditional: heartbeat promises
+            "fresh context each cycle", and each entry is re-read from
+            HEARTBEAT.md every cycle, so carrying a transcript forward only
+            costs input tokens. Nobody waits on a heartbeat tick, so the
+            per-cycle MCP cold-start is unobserved.
             """
             assert self.sessions is not None
             try:

--- a/test/test_heartbeat_cycle_recycle.py
+++ b/test/test_heartbeat_cycle_recycle.py
@@ -5,13 +5,18 @@ Per code review:
   tears down the session under concurrent ``asyncio.gather``'d sibling tasks
   sharing the same key — the next sibling streams against a torn-down provider.
 - Per-cycle reset (always-recycle) cold-starts the entire MCP toolbelt every
-  minute even on healthy idle sessions.
+  minute even on healthy idle sessions. This cost is now accepted deliberately:
+  it is unobserved (nothing waits on a tick) and strictly cheaper than re-sending
+  an accumulated transcript as input tokens every tick.
 
 Resolution: per-task ``finally`` only releases the per-key semaphore; cycle-end
 recycle is handled once by ``SessionManager.recycle_heartbeat`` (called from
-``HeartbeatService._process_heartbeat_file`` after ``asyncio.gather`` completes,
-matching ``recycle_background``'s ≥70% / 40-prompt-blind thresholds).  Multi-task
-cycles share one warm session; only between cycles do we conditionally recycle.
+``HeartbeatService._process_heartbeat_file`` after ``asyncio.gather`` completes).
+Multi-task cycles share one warm session; between cycles the session is always
+torn down, so each cycle starts fresh — matching the "fresh context each cycle"
+contract in ``config/prompt.md``.  Nobody waits on a heartbeat tick, so the
+per-cycle cold-start is unobserved, whereas a retained transcript would be
+re-sent as input tokens on every tick.
 """
 
 from __future__ import annotations
@@ -152,8 +157,11 @@ class TestOnCycleEndCallback:
 
 
 class TestRecycleHeartbeat:
-    """``SessionManager.recycle_heartbeat`` mirrors ``recycle_background`` —
-    threshold-driven, no eager replacement (heartbeat is on-demand)."""
+    """``SessionManager.recycle_heartbeat`` tears the session down at the end
+    of EVERY cycle, regardless of context% or prompt count — heartbeat
+    promises "fresh context each cycle" and nobody waits on a tick, so the
+    per-cycle cold-start is unobserved while a retained transcript costs input
+    tokens on every tick."""
 
     @pytest.mark.asyncio
     async def test_no_op_when_session_absent(self):
@@ -166,9 +174,11 @@ class TestRecycleHeartbeat:
         await mgr.recycle_heartbeat()
 
     @pytest.mark.asyncio
-    async def test_no_op_below_threshold(self):
-        """Healthy session (under 70% context, under 40 prompts) is preserved
-        — cycle-end recycle must NOT churn warm sessions."""
+    async def test_recycles_healthy_session(self):
+        """A nearly-empty session is STILL recycled. This is the behavioural
+        change: previously a session under 70% context and under 40 prompts
+        was preserved, which is what let the heartbeat transcript accumulate
+        across cycles while the docs promised fresh context."""
         from kiro_crew.session import SessionManager, _Session
 
         mgr = SessionManager(cfg=_make_cfg(), provider_factory=MagicMock())
@@ -181,14 +191,13 @@ class TestRecycleHeartbeat:
 
         await mgr.recycle_heartbeat()
 
-        # Session preserved; no shutdown.
-        assert HEARTBEAT_KEY in mgr._sessions
-        provider.shutdown.assert_not_awaited()
+        assert HEARTBEAT_KEY not in mgr._sessions
+        provider.shutdown.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_recycles_at_pct_threshold(self):
-        """At ≥70% context, recycle drops the session so the next
-        ``get_or_create`` creates a fresh one on demand."""
+        """A full session is recycled too — the next ``get_or_create``
+        creates a fresh one on demand."""
         from kiro_crew.session import SessionManager, _Session
 
         mgr = SessionManager(cfg=_make_cfg(), provider_factory=MagicMock())
@@ -208,8 +217,9 @@ class TestRecycleHeartbeat:
         provider.shutdown.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_recycles_blind_at_40_prompts(self):
-        """When provider can't report context%, fall back to prompt count."""
+    async def test_recycles_when_context_pct_unavailable(self):
+        """A provider that can't report context% is recycled all the same —
+        there is no threshold left to fall back on."""
         from kiro_crew.session import SessionManager, _Session
 
         mgr = SessionManager(cfg=_make_cfg(), provider_factory=MagicMock())
@@ -217,7 +227,7 @@ class TestRecycleHeartbeat:
         provider.context_usage_pct = MagicMock(return_value=0.0)
         provider.shutdown = AsyncMock()
         sess = _Session(provider=provider, is_new=False)
-        sess.prompt_count = 40
+        sess.prompt_count = 1
         mgr._sessions[HEARTBEAT_KEY] = sess
 
         await mgr.recycle_heartbeat()

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -381,6 +381,38 @@ class TestWorkflowPoolStateless:
         await mgr.close_all()
 
 
+class TestHeartbeatStateless:
+    """``_hb`` must be treated as stateless alongside ``_bg``.
+
+    Heartbeat's published contract (``config/prompt.md``) is "fresh context
+    each cycle", and every entry is re-read from ``HEARTBEAT.md`` each cycle,
+    so a resumed transcript supplies nothing the next cycle depends on while
+    costing input tokens on every tick. Resuming is also actively wrong: for a
+    watch task the external system is the source of truth, and unrelated
+    queued tasks would inherit each other's reasoning.
+    """
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_key_skips_resume_lookup(self, cfg):
+        """``_hb`` must NOT consult the session_map for a resume sid."""
+        from kiro_crew.session import HEARTBEAT_KEY
+
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        mgr._session_map.get = MagicMock(return_value="stale-sid")  # type: ignore[method-assign]
+        await mgr.get_or_create(HEARTBEAT_KEY)
+        mgr._session_map.get.assert_not_called()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_background_key_also_stateless(self, cfg):
+        """Control: ``_bg`` was already stateless — ``_hb`` now matches it."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        mgr._session_map.get = MagicMock(return_value="stale-sid")  # type: ignore[method-assign]
+        await mgr.get_or_create(BACKGROUND_KEY)
+        mgr._session_map.get.assert_not_called()
+        await mgr.close_all()
+
+
 class TestRecycleBackground:
     """Tests for background session context overflow recycling."""
 


### PR DESCRIPTION
## Summary

`config/prompt.md` tells the agent that heartbeat runs work **"OUTSIDE this session (fresh context each cycle)"**. The implementation does the opposite: `_hb` resumes its prior conversation via `session/load`, and is only torn down once context crosses 70% — so a heartbeat transcript accumulates across cycles *and* across gateway restarts.

Most heartbeat tasks are watches ("check X until it's true"), and most ticks answer *"not yet."* Each of those answers was a full model turn that re-sent the whole accumulated transcript as input. A watch polling 200 times to catch one event cost ~200 model turns to produce ~1 decision.

## This looks accidental, not designed

`_bg` is already stateless — an explicit exact-match case in `get_or_create`:

```python
is_stateless = (
    key == BACKGROUND_KEY or any(key.startswith(p) for p in _STATELESS_PREFIXES)
) and key not in self._continuable_keys
```

`_hb` is not in that branch and matches no `_STATELESS_PREFIXES` entry, which made **heartbeat the only background key that reloads its prior transcript.**

And per the comment above `HEARTBEAT_KEY`, `_hb` was split off from `_bg` for exactly one stated reason: so heartbeat could run a **tooled agent** without forcing chat-title / consolidator / taskkeeper to load the same MCP servers. Statefulness was never the goal — it fell out of the stateless branch when the key was split.

So this PR restores a property `_bg` already has, rather than proposing a new design.

## Why the existing tradeoff optimized the wrong variable

The shared warm session avoids MCP server cold-start. But **heartbeat is background work — nothing is waiting on a tick**, so that latency is unobserved. We were spending input tokens every cycle (recurring, and scaling with accumulated history) to save process spawn time (one-off, seconds, unobserved).

Prompt caching does not offset it: caching only makes *re-sending* a prefix cheaper. A fresh session has no prefix to re-send at all.

## Changes

| file | change |
|---|---|
| `session.py` `get_or_create` | treat `HEARTBEAT_KEY` as stateless alongside `BACKGROUND_KEY`, so a restart no longer resumes the prior heartbeat conversation |
| `session.py` `recycle_heartbeat` | tear the session down at **every** cycle end instead of only above `_BG_RECYCLE_PCT`. This is what actually delivers "fresh context each cycle" |
| `session.py` module docstring | corrected — it claimed `_PERSISTENT_KEYS` holds `_bg` only |
| `slack/gateway.py` `_on_cycle_end` docstring | corrected — it described the recycle as conditional |

## Correctness, not only cost

- For a watch, **the external system is the source of truth.** Carrying prior reasoning forward risks compounding a stale belief instead of re-deriving from the world.
- Concurrent tasks are `gather`-ed onto one key, so unrelated queued tasks inherited each other's reasoning.
- `HEARTBEAT_KEEP` already forces each entry to be self-contained (it is re-read from `HEARTBEAT.md` every cycle), so the retained transcript supplied nothing tasks depended on.

## Deliberately NOT done

**`HEARTBEAT_KEY` stays in `_PERSISTENT_KEYS`.** Removing it looks tempting (and the design doc originally proposed it), but `_expire_idle` has **no in-flight guard** — unlike the RSS sweep, which checks `sess.semaphore.locked()`. Heartbeat tasks may run up to `HEARTBEAT_TASK_TIMEOUT_SECS` (1800s), so exposing them to idle expiry could reap a session mid-task. Cycle-end recycle already bounds growth, so this buys nothing and adds risk. The docstring is corrected to say `_bg` **and** `_hb` instead.

`_bg` behaviour is untouched — it was already stateless, and it still uses the `_BG_RECYCLE_PCT` / `_BG_BLIND_RECYCLE_PROMPTS` thresholds via `recycle_background`.

## Testing

- `test/test_session.py` — new `TestHeartbeatStateless`: asserts `_hb` never consults `_session_map.get()` for a resume sid, with `_bg` as the control. Mirrors the existing `TestWorkflowPoolStateless` pattern.
- `test/test_heartbeat_cycle_recycle.py` — replaced `test_no_op_below_threshold` (which asserted a healthy session is *preserved*) with `test_recycles_healthy_session`, plus `test_recycles_when_context_pct_unavailable`. Updated the module/class docstrings that documented the old conditional design.

**321 tests pass** locally: `test_heartbeat_cycle_recycle.py` (15), `test_session.py` (223), `test_session_pool.py` + `test_cron_ephemeral_session.py` (83 — these exercise the same `is_stateless` classification). `flake8`, `isort --check-only`, and `mypy` all clean on the touched files.

## Follow-ups (not in this PR)

- **The bigger token win**: let a heartbeat entry carry an optional deterministic guard, so a "not yet" tick costs **zero tokens** and the model is only invoked when something actually changed. `cron_script.py` already has the whole until-done contract (`Skip` / `Report` / `Done`) at zero tokens — `HEARTBEAT_KEEP` is effectively `Skip`, except it costs a model turn.
- Per-task heartbeat agent — a fresh session per cycle is the enabling change, but tool-permission work is owned elsewhere.
- Event triggers instead of polling (a PR merge is an event, not something to poll for).
