### PR TITLE
feat(perf): desktop app metrics via `kirocrew desktop metrics`

### DIFF
--- a/skills/kirocrew-commands/SKILL.md
+++ b/skills/kirocrew-commands/SKILL.md
@@ -268,9 +268,15 @@ stacks (open in speedscope / flamegraph.pl). See `docs/profiling.md`.
 | `KIROCREW_DEBUG=1 kirocrew perf sample --pid 1234 --seconds 30` | Attach to a specific PID for N seconds (1-300) |
 | `... --interval 0.002` | Seconds between samples (0.001-1.0, default 0.005) |
 | `... --output /tmp/p.folded` | Where to write the profile (default `./kirocrew-profile.folded`) |
+| `KIROCREW_DEBUG=1 kirocrew desktop metrics` | Per-process CPU/memory of the **Electron** app (`--json`, `--top N`, `--path`) |
 
 On macOS the attach path additionally needs elevated privileges (the OS denies
 `task_for_pid`), so it may require sudo; `--call` needs neither py-spy nor sudo.
+
+`desktop metrics` reads a recording rather than querying the app: `getAppMetrics()`
+is Electron-main-only, so the app samples itself into an artifact when **started**
+with `KIROCREW_DEBUG` set. Setting the variable only for the CLI does not make an
+already-running app record -- restart it.
 
 ## Security & Eval
 

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1170,6 +1170,7 @@ Examples:
     profile_show.add_argument("name", help="Profile file stem (without .json)")
 
     register_perf_parser(sub)
+    register_desktop_parser(sub)
 
     kn_parser = sub.add_parser("knowledge", help="Knowledge Base maintenance")
     kn_sub = kn_parser.add_subparsers(dest="knowledge_action")
@@ -2063,6 +2064,10 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         rc = perf_cmd(args)
         if rc:
             raise SystemExit(rc)
+    elif args.command == "desktop":
+        rc = desktop_cmd(args)
+        if rc:
+            raise SystemExit(rc)
     elif args.command == "snapshot":
         from kiro_crew.snapshot import snapshot_main
 
@@ -2107,6 +2112,7 @@ from kiro_crew.cli_commands import (  # noqa: E402
     _telemetry,
 )
 from kiro_crew.cli_config import _config_cmd  # noqa: E402
+from kiro_crew.cli_desktop import desktop_cmd, register_desktop_parser  # noqa: E402
 from kiro_crew.cli_doctor import _doctor  # noqa: E402
 from kiro_crew.cli_perf import perf_cmd, register_perf_parser  # noqa: E402
 from kiro_crew.cli_server import (  # noqa: E402

--- a/src/kiro_crew/cli_desktop.py
+++ b/src/kiro_crew/cli_desktop.py
@@ -1,0 +1,336 @@
+"""``kirocrew desktop`` -- read the Electron app's debug metrics artifact.
+
+Why this is a reader and not a query: ``app.getAppMetrics()`` is an Electron-main
+API, readable only from inside that process. This CLI is a separate Python
+process, and a second Electron instance cannot see the first one's metrics, so
+there is no way to ask the running app for a live sample without adding a
+listener to it. Rather than open one, ``website/electron/perf-metrics.js`` records
+a bounded rolling artifact and this command reads it.
+
+The consequence worth stating plainly: the numbers here are the most recent
+samples the app wrote, not an instant captured on demand. If the app is not
+running with ``KIROCREW_DEBUG`` set, there is no artifact at all.
+
+Debug-only, and gated by the same ``KIROCREW_DEBUG`` check as ``kirocrew perf``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from kiro_crew import platform_compat
+from kiro_crew.hooks import safe_read_file
+from kiro_crew.perf_sampler import gate_refusal_message, profiling_enabled
+
+# Kept in sync with ARTIFACT_NAME in website/electron/perf-metrics.js. A rename on
+# either side makes this command report "not found" against an app that is
+# recording perfectly well, so the two names must move together.
+ARTIFACT_NAME = "desktop-metrics.json"
+
+# Electron productName values, which determine app.getPath("logs"). Kept in sync
+# with website/electron/package.json (the release default) and
+# packaging/build-desktop.sh, which overrides it with
+# `-c.productName=KiroCrew Nightly` for nightly stamps. Nightly is not a cosmetic
+# variant: it installs as a separate app with its own log directory, and its users
+# are the ones most likely to be profiling, so omitting it made the command report
+# "not found" against an app that was recording correctly.
+PRODUCT_NAMES = ("KiroCrew", "KiroCrew Nightly")
+
+SUPPORTED_VERSION = 1
+
+
+def _home_dir() -> Path:
+    """Return the user's home directory.
+
+    Indirection so tests can simulate an unresolvable home without patching
+    ``pathlib.Path.home``, which mutates pathlib process-wide and corrupts
+    ``WindowsPath`` internals on the Windows CI shard.
+    """
+    return Path.home()
+
+
+def desktop_log_dirs(env: dict[str, str] | None = None) -> tuple[Path, ...]:
+    """Candidate directories for Electron's ``app.getPath("logs")``.
+
+    Mirrors Electron's own per-platform resolution, for **every** product name:
+
+    * macOS   ``~/Library/Logs/<productName>``
+    * Windows ``%APPDATA%/<productName>/logs``
+    * Linux   ``$XDG_CONFIG_HOME/<productName>/logs`` (``~/.config`` default)
+
+    Both release and nightly are probed, because they install side by side with
+    separate log directories. Returns an empty tuple when the home directory
+    cannot be resolved, which is the correct answer rather than an error.
+    """
+    environ = os.environ if env is None else env
+    try:
+        home = _home_dir()
+    except (RuntimeError, OSError):
+        # No HOME and no passwd entry. Nothing to probe; the caller falls back to
+        # requiring an explicit --path rather than raising out of a helper.
+        return ()
+
+    if platform_compat.IS_MACOS:
+        return tuple(home / "Library" / "Logs" / name for name in PRODUCT_NAMES)
+    if platform_compat.IS_WINDOWS:
+        appdata = environ.get("APPDATA")
+        base = Path(appdata) if appdata else home / "AppData" / "Roaming"
+        return tuple(base / name / "logs" for name in PRODUCT_NAMES)
+    xdg = environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else home / ".config"
+    return tuple(base / name / "logs" for name in PRODUCT_NAMES)
+
+
+def find_metrics_artifact(
+    explicit: Path | None = None, env: dict[str, str] | None = None
+) -> Path | None:
+    """Locate the metrics artifact, honouring an explicit path first.
+
+    When both release and nightly have recorded, the **newest** artifact wins:
+    with both installed, the one the operator just reproduced against is the one
+    that was written last, and silently preferring release would report stale
+    numbers rather than the run being investigated.
+    """
+    if explicit is not None:
+        try:
+            return explicit if explicit.is_file() else None
+        except OSError:
+            # An unreadable or malformed path is "not found" for our purposes.
+            return None
+    found: list[tuple[float, Path]] = []
+    for directory in desktop_log_dirs(env):
+        candidate = directory / ARTIFACT_NAME
+        try:
+            if candidate.is_file():
+                found.append((candidate.stat().st_mtime, candidate))
+        except OSError:
+            continue
+    if not found:
+        return None
+    # Sort by mtime, then by path so ties are deterministic rather than
+    # filesystem-order dependent.
+    found.sort(key=lambda pair: (pair[0], str(pair[1])))
+    return found[-1][1]
+
+
+def artifact_missing_message() -> str:
+    """Explain the two distinct reasons the artifact can be absent."""
+    searched = ", ".join(str(d) for d in desktop_log_dirs()) or "(no home directory)"
+    return (
+        f"No {ARTIFACT_NAME} found (searched: {searched}).\n"
+        "The desktop app only records metrics when it is started with "
+        f"KIROCREW_DEBUG set, so the usual cause is that the running app was "
+        "launched without it -- restart the app with KIROCREW_DEBUG=1 and let it "
+        "run for a few seconds. Pass --path to read an artifact from elsewhere."
+    )
+
+
+def summarize(doc: dict, top: int = 5) -> str:
+    """Render the artifact as a short human-readable report.
+
+    Reports the latest sample plus the peak across the retained window, because
+    the reason to reach for this is usually a spike that has already passed.
+    Entries that are not objects are discarded before anything indexes into them.
+    A ``samples`` list is attacker-influencable only in the sense that any JSON
+    file can be pointed at with ``--path``, but the artifact is also a file on
+    disk that could be truncated or hand-edited, and ``[null]`` previously reached
+    ``first.get(...)`` and raised an uncaught AttributeError. Three separate
+    call sites here assume dict entries (first/last, the peak scan, and the
+    process table), so the filter is applied once, up front, rather than guarding
+    each.
+    """
+    raw_samples = doc.get("samples") or []
+    samples = [s for s in raw_samples if isinstance(s, dict)]
+    if not samples:
+        if raw_samples:
+            return "The artifact contains no usable samples (entries are malformed)."
+        return "The artifact contains no samples yet."
+
+    lines: list[str] = []
+    window = f"{len(samples)} sample(s)"
+    interval = doc.get("intervalMs")
+    if isinstance(interval, (int, float)) and interval > 0:
+        window += f" at {interval / 1000:g}s"
+    lines.append(
+        f"platform={doc.get('platform') or 'unknown'} "
+        f"electron={doc.get('electron') or 'unknown'}  {window}"
+    )
+    first, last = samples[0], samples[-1]
+    lines.append(f"window: {first.get('at')} -> {last.get('at')}")
+
+    peak = max(samples, key=lambda s: _num(s.get("totalCpuPercent")))
+    lines.append(
+        f"latest total: cpu={_fmt_pct(last.get('totalCpuPercent'))} "
+        f"rss={_fmt_kb(last.get('totalWorkingSetKb'))}"
+    )
+    lines.append(
+        f"peak total:   cpu={_fmt_pct(peak.get('totalCpuPercent'))} "
+        f"rss={_fmt_kb(peak.get('totalWorkingSetKb'))}  at {peak.get('at')}"
+    )
+
+    raw_procs = last.get("processes")
+    # A non-list "processes" (a dict, a string, null) must not be iterated as one.
+    procs = [p for p in raw_procs if isinstance(p, dict)] if isinstance(raw_procs, list) else []
+    procs.sort(key=lambda p: _num(p.get("cpuPercent")), reverse=True)
+    if procs:
+        lines.append("")
+        lines.append(f"latest sample, top {min(top, len(procs))} process(es) by CPU:")
+        lines.append(f"  {'PID':>7}  {'TYPE':<12} {'CPU':>7}  {'RSS':>10}  NAME")
+        for proc in procs[:top]:
+            label = proc.get("serviceName") or proc.get("name") or ""
+            lines.append(
+                f"  {_fmt_int(proc.get('pid')):>7}  {str(proc.get('type') or '-'):<12} "
+                f"{_fmt_pct(proc.get('cpuPercent')):>7}  {_fmt_kb(proc.get('workingSetKb')):>10}  {label}"
+            )
+    return "\n".join(lines)
+
+
+def _num(value: object) -> float:
+    """Coerce a metric value to a number for ordering, treating junk as 0.
+
+    ``max()`` and ``list.sort()`` compare the key values against each other, so a
+    single string among numeric entries raises ``TypeError`` mid-sort -- the
+    ``or 0`` idiom does not help, because a non-empty string is truthy and is
+    returned as-is. bool is excluded deliberately: it is an int subclass, and a
+    ``true`` in a CPU field is corruption rather than the number 1.
+    """
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value) if value == value and value not in (float("inf"), float("-inf")) else 0.0
+    return 0.0
+
+
+def _fmt_pct(value: object) -> str:
+    return f"{value:.1f}%" if _is_num(value) else "-"
+
+
+def _fmt_kb(value: object) -> str:
+    if not _is_num(value):
+        return "-"
+    kb = float(value)  # type: ignore[arg-type]
+    return f"{kb / 1024:.1f} MB" if kb >= 1024 else f"{kb:.0f} KB"
+
+
+def _is_num(value: object) -> bool:
+    """Whether a value is a finite real number (and not a bool)."""
+    if isinstance(value, bool):
+        return False
+    if not isinstance(value, (int, float)):
+        return False
+    return value == value and value not in (float("inf"), float("-inf"))
+
+
+def _fmt_int(value: object) -> str:
+    return str(value) if isinstance(value, int) and not isinstance(value, bool) else "-"
+
+
+def _load(path: Path) -> tuple[dict | None, str | None]:
+    """Read and parse the artifact. Returns ``(doc, error)``.
+
+    Reads through :func:`hooks.safe_read_file` rather than ``Path.read_text``.
+    ``--path`` is caller-supplied, and printing a file's contents is exactly the
+    capability the centralized ``is_sensitive_path`` gate exists to bound, so this
+    goes through the same helper every other caller-path JSON read in the CLI uses
+    (see ``cli_config``/``cli_commands``). It also canonicalizes and opens with
+    O_NOFOLLOW, which closes a symlink swap the plain ``is_file()`` probe would
+    have followed.
+
+    The auto-discovered path is read the same way, deliberately: the app's log
+    directory is user-writable, so a symlink planted there would otherwise be
+    followed just as readily as one passed on the command line.
+    """
+    try:
+        raw = safe_read_file(str(path))
+    except PermissionError:
+        return None, (
+            f"Refusing to read {path}: the path is protected or resolves to a "
+            "sensitive location."
+        )
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, f"Could not read {path}: {exc}"
+    try:
+        doc = json.loads(raw)
+    except ValueError as exc:
+        # A torn read should be impossible (the writer renames into place), so a
+        # parse failure means the file is genuinely malformed.
+        return None, f"{path} is not valid JSON: {exc}"
+    if not isinstance(doc, dict):
+        return None, f"{path} does not contain a metrics object."
+    samples = doc.get("samples")
+    if samples is not None and not isinstance(samples, list):
+        return None, f"{path} has a malformed 'samples' field (expected a list)."
+    return doc, None
+
+
+def _desktop_metrics(args: argparse.Namespace) -> int:
+    if not profiling_enabled():
+        print(gate_refusal_message(), file=sys.stderr)
+        return 1
+
+    path = find_metrics_artifact(getattr(args, "path", None))
+    if path is None:
+        print(artifact_missing_message(), file=sys.stderr)
+        return 3
+
+    doc, error = _load(path)
+    if doc is None:
+        print(error, file=sys.stderr)
+        return 5
+
+    version = doc.get("version")
+    if version != SUPPORTED_VERSION:
+        # Fail loudly rather than misreading a future shape as v1.
+        print(
+            f"{path} has version {version!r}, but this build understands "
+            f"version {SUPPORTED_VERSION}. Update kirocrew to read it.",
+            file=sys.stderr,
+        )
+        return 5
+
+    if args.json:
+        print(json.dumps(doc, indent=2))
+        return 0
+
+    print(f"source: {path}")
+    print(summarize(doc, top=args.top))
+    return 0
+
+
+def desktop_cmd(args: argparse.Namespace) -> int:
+    """Dispatch a ``kirocrew desktop`` subcommand."""
+    if args.desktop_cmd == "metrics":
+        return _desktop_metrics(args)
+    print(f"Unknown desktop subcommand: {args.desktop_cmd}", file=sys.stderr)
+    return 2
+
+
+def register_desktop_parser(sub: argparse._SubParsersAction) -> None:
+    """Register ``kirocrew desktop`` and its subcommands."""
+    parser = sub.add_parser(
+        "desktop",
+        help="Debug-only desktop app diagnostics (requires KIROCREW_DEBUG)",
+    )
+    # dest must NOT be "command": that collides with the top-level subparsers'
+    # dest and silently overwrites the "desktop" value, so dispatch falls through
+    # to the argparse help instead of running the subcommand.
+    desktop_sub = parser.add_subparsers(dest="desktop_cmd", required=True)
+
+    metrics = desktop_sub.add_parser(
+        "metrics",
+        help="Show the desktop app's recorded per-process CPU and memory metrics",
+    )
+    metrics.add_argument(
+        "--path",
+        type=Path,
+        default=None,
+        help=f"Read a specific {ARTIFACT_NAME} instead of probing the app's log directory",
+    )
+    metrics.add_argument("--json", action="store_true", help="Emit the raw artifact as JSON")
+    metrics.add_argument(
+        "--top", type=int, default=5, help="How many processes to list (default: 5)"
+    )

--- a/src/kiro_crew/docs/index.md
+++ b/src/kiro_crew/docs/index.md
@@ -66,7 +66,7 @@ agent backend and Slack credentials.
 - [Getting Started](getting-started.md) — Installation, first-time setup, background running
 - [Configuration](configuration.md) — Config file reference, environment variables, sandbox modes
 - [Use Cases](use-cases.md) — Real-world workflows from the community
-- [Profiling](profiling.md) — Debug-only stack sampler (`kirocrew perf sample`) for attributing time to call paths
+- [Profiling](profiling.md) — Debug-only stack sampler (`kirocrew perf sample`) and desktop app metrics (`kirocrew desktop metrics`)
 - [Troubleshooting](troubleshooting.md) — Common issues and fixes
 
 ## Security

--- a/src/kiro_crew/docs/profiling.md
+++ b/src/kiro_crew/docs/profiling.md
@@ -77,6 +77,80 @@ tracer, or missing privileges) rather than assuming it is a permissions problem.
 macOS behaves differently — py-spy reads via `task_for_pid` there, where several
 readers can hold a task port — so a refusal on macOS points at privileges.
 
+## Profiling the desktop app (`kirocrew desktop metrics`)
+
+The two commands above sample **Python**. They cannot tell you anything about the
+Electron shell itself -- if the desktop app is burning CPU in its renderer or
+growing a window's working set, a py-spy attach on the gateway shows nothing
+unusual.
+
+`kirocrew desktop metrics` covers that half:
+
+```
+KIROCREW_DEBUG=1 kirocrew desktop metrics
+```
+
+### It reads a recording; it does not query the running app
+
+This is the one structural difference from `perf sample`, and it is worth
+understanding before you trust the numbers.
+
+`app.getAppMetrics()` is an Electron-main API, so it can only be called from
+inside that process. This CLI is a separate Python process, and starting a second
+Electron instance does not let it read the first one's metrics. Getting a live
+sample on demand would therefore require the desktop app to listen for a request
+-- a new local network surface whose only purpose is debugging.
+
+Rather than add one, the app **records**: when it starts with `KIROCREW_DEBUG`
+set, `website/electron/perf-metrics.js` samples its own per-process metrics every
+5 seconds into a bounded artifact next to the gateway log, and this command reads
+that file.
+
+Consequences to keep in mind:
+
+- The app must have been **started** with `KIROCREW_DEBUG` set. Setting the
+  variable in the shell you run the CLI from changes nothing about an app that is
+  already running without it -- restart the app.
+- You see the retained window (the last 120 samples, about ten minutes), not the
+  current instant.
+- Because it is a recording, it survives the app becoming unresponsive, and it
+  keeps the peak. That is usually what you want: the spike you are chasing has
+  normally passed by the time you go looking, so the report names both the latest
+  totals and the worst sample in the window.
+
+The artifact is bounded on purpose -- it is written on an interval into the user's
+log directory, so an unbounded file would be a slow disk leak in a debug aid. It
+is rewritten whole via a temp file and a rename, so a read never catches a
+half-written file.
+
+### Where it looks
+
+Electron's own log directory, per platform:
+
+| Platform | Path |
+|---|---|
+| macOS | `~/Library/Logs/KiroCrew/desktop-metrics.json` |
+| Linux | `${XDG_CONFIG_HOME:-~/.config}/KiroCrew/logs/desktop-metrics.json` |
+| Windows | `%APPDATA%\KiroCrew\logs\desktop-metrics.json` |
+
+Nightly builds install under their own product name (`KiroCrew Nightly`), so they
+log to a sibling directory -- `~/Library/Logs/KiroCrew Nightly/` and equivalents.
+Both are probed, and if both have recorded, the **newest** artifact wins: with
+release and nightly side by side, the build you just reproduced against is the one
+that wrote last.
+
+Pass `--path` to read an artifact from somewhere else (one attached to a bug
+report, for instance). `--json` emits the raw document; `--top N` changes how many
+processes are listed.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 1 | `KIROCREW_DEBUG` not set |
+| 3 | No artifact found (usually: the app was not started with the flag) |
+| 5 | Artifact unreadable, malformed, or a version this build does not understand |
+
 ## Reading the output
 
 Each line is `outermost;...;innermost <sample-count>`, hottest first:

--- a/test/test_cli_desktop.py
+++ b/test/test_cli_desktop.py
@@ -1,0 +1,445 @@
+"""Tests for ``kirocrew desktop metrics``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import cli_desktop, perf_sampler, platform_compat
+
+
+def _doc(**over) -> dict:
+    doc = {
+        "version": 1,
+        "platform": "darwin",
+        "electron": "31.0.0",
+        "intervalMs": 5000,
+        "samples": [
+            {
+                "at": "2026-08-02T12:00:00.000Z",
+                "processes": [
+                    {"pid": 1, "type": "Browser", "cpuPercent": 3.0, "workingSetKb": 4096},
+                    {"pid": 2, "type": "Tab", "cpuPercent": 9.0, "workingSetKb": 2048},
+                ],
+                "totalCpuPercent": 12.0,
+                "totalWorkingSetKb": 6144,
+            },
+            {
+                "at": "2026-08-02T12:00:05.000Z",
+                "processes": [
+                    {"pid": 1, "type": "Browser", "cpuPercent": 1.0, "workingSetKb": 4096},
+                ],
+                "totalCpuPercent": 1.0,
+                "totalWorkingSetKb": 4096,
+            },
+        ],
+    }
+    doc.update(over)
+    return doc
+
+
+def _args(path: Path | None = None, **over) -> argparse.Namespace:
+    ns = argparse.Namespace(desktop_cmd="metrics", path=path, json=False, top=5)
+    for k, v in over.items():
+        setattr(ns, k, v)
+    return ns
+
+
+class TestGate:
+    def test_refuses_without_the_debug_flag(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.delenv(perf_sampler.DEBUG_ENV_VAR, raising=False)
+        assert cli_desktop.desktop_cmd(_args(tmp_path / "x.json")) == 1
+        assert "KIROCREW_DEBUG" in capsys.readouterr().err
+
+    def test_an_explicit_falsey_value_is_off(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "0")
+        assert cli_desktop.desktop_cmd(_args(tmp_path / "x.json")) == 1
+
+
+class TestLogDirResolution:
+    def test_macos_uses_library_logs(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_MACOS", True)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        dirs = cli_desktop.desktop_log_dirs({})
+        assert any(d.as_posix().endswith("Library/Logs/KiroCrew") for d in dirs)
+
+    def test_windows_uses_appdata(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_MACOS", False)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        # Compared with as_posix so the assertion does not depend on the host
+        # separator: str() of a path is backslash-separated on Windows.
+        dirs = [d.as_posix() for d in cli_desktop.desktop_log_dirs({"APPDATA": "/roam"})]
+        assert "/roam/KiroCrew/logs" in dirs
+
+    def test_linux_honours_xdg_config_home(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_MACOS", False)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        dirs = [d.as_posix() for d in cli_desktop.desktop_log_dirs({"XDG_CONFIG_HOME": "/cfg"})]
+        assert "/cfg/KiroCrew/logs" in dirs
+
+    def test_unresolvable_home_degrades_instead_of_raising(self, monkeypatch):
+        """No HOME and no passwd entry must not raise out of a helper.
+
+        Patches the module seam, not ``pathlib.Path.home``: patching the class
+        attribute mutates pathlib process-wide and corrupts WindowsPath internals
+        on the Windows shard.
+        """
+        monkeypatch.setattr(platform_compat, "IS_MACOS", False)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+
+        def _no_home():
+            raise RuntimeError("no home")
+
+        monkeypatch.setattr(cli_desktop, "_home_dir", _no_home)
+        assert cli_desktop.desktop_log_dirs({}) == ()
+
+
+class TestReading:
+    def test_reports_latest_and_peak(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(_doc()), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+        out = capsys.readouterr().out
+        # The peak is the earlier sample, so a report that only showed "latest"
+        # would hide the spike this command exists to find.
+        assert "peak total" in out
+        assert "12.0%" in out
+        assert "1.0%" in out
+
+    def test_json_mode_emits_the_raw_document(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(_doc()), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art, json=True)) == 0
+        assert json.loads(capsys.readouterr().out)["version"] == 1
+
+    def test_missing_artifact_explains_the_debug_requirement(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        assert cli_desktop.desktop_cmd(_args(tmp_path / "absent.json")) == 3
+        err = capsys.readouterr().err
+        assert "KIROCREW_DEBUG" in err, "the usual cause must be named, not just 'not found'"
+
+    def test_malformed_json_is_reported_not_raised(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text("{not json", encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 5
+        assert "not valid JSON" in capsys.readouterr().err
+
+    def test_a_future_version_is_refused_rather_than_misread(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(_doc(version=2)), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 5
+        assert "version" in capsys.readouterr().err
+
+    def test_a_json_array_is_refused(self, monkeypatch, capsys, tmp_path):
+        """Valid JSON that is not an object must not crash the formatter."""
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text("[]", encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 5
+
+    def test_an_empty_sample_list_is_handled(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(_doc(samples=[])), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+        assert "no samples" in capsys.readouterr().out
+
+    def test_a_directory_passed_as_path_is_not_found_rather_than_a_crash(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        assert cli_desktop.desktop_cmd(_args(tmp_path)) == 3
+
+    def test_missing_numeric_fields_render_as_dashes(self, monkeypatch, capsys, tmp_path):
+        """A partial record must not raise a formatting error."""
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        doc = _doc(
+            samples=[{"at": "t", "processes": [{"pid": 1}], "totalCpuPercent": None}]
+        )
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(doc), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+
+    def test_unknown_subcommand_returns_two(self, monkeypatch, capsys):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        assert cli_desktop.desktop_cmd(_args(desktop_cmd="bogus")) == 2
+
+
+class TestMalformedSamples:
+    """The artifact is a file on disk; it can be truncated or hand-edited."""
+
+    def test_a_null_sample_entry_does_not_crash(self, monkeypatch, capsys, tmp_path):
+        """The exact payload that reached first.get() and raised AttributeError."""
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text('{"version": 1, "samples": [null]}', encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+        assert "no usable samples" in capsys.readouterr().out
+
+    def test_mixed_valid_and_junk_entries_keep_the_valid_ones(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        doc = _doc()
+        doc["samples"] = [None, doc["samples"][0], "junk", 42]
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(doc), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+        out = capsys.readouterr().out
+        assert "12.0%" in out, "the one real sample should still be reported"
+
+    def test_a_non_list_samples_field_is_refused(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text('{"version": 1, "samples": {"not": "a list"}}', encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 5
+        assert "malformed" in capsys.readouterr().err
+
+    def test_a_sample_with_junk_processes_does_not_crash(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        doc = _doc(
+            samples=[{"at": "t", "processes": [None, "x", 3], "totalCpuPercent": 1.0}]
+        )
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(doc), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+
+
+class TestNonNumericValues:
+    """max()/sort() compare key values, so one string among numbers raises TypeError.
+
+    The `or 0` idiom does not save it: a non-empty string is truthy and is
+    returned as the key.
+    """
+
+    def test_mixed_string_and_numeric_totals_do_not_crash(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        doc = _doc(
+            samples=[
+                {"at": "a", "processes": [], "totalCpuPercent": "high"},
+                {"at": "b", "processes": [], "totalCpuPercent": 4.0},
+            ]
+        )
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(doc), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+
+    def test_mixed_string_and_numeric_process_cpu_does_not_crash(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        doc = _doc(
+            samples=[
+                {
+                    "at": "a",
+                    "processes": [
+                        {"pid": 1, "type": "Browser", "cpuPercent": "lots"},
+                        {"pid": 2, "type": "Tab", "cpuPercent": 7.0},
+                    ],
+                    "totalCpuPercent": 7.0,
+                }
+            ]
+        )
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(doc), encoding="utf-8")
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+        out = capsys.readouterr().out
+        # The junk value sorts as 0 and renders as a dash, not as "lots".
+        assert "lots" not in out
+        assert "7.0%" in out
+
+    def test_a_non_list_processes_value_is_not_iterated(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        for junk in ({"a": 1}, "text", 5):
+            doc = _doc(samples=[{"at": "a", "processes": junk, "totalCpuPercent": 1.0}])
+            art = tmp_path / "desktop-metrics.json"
+            art.write_text(json.dumps(doc), encoding="utf-8")
+            assert cli_desktop.desktop_cmd(_args(art)) == 0, junk
+
+    def test_booleans_are_not_treated_as_numbers(self):
+        """bool is an int subclass; `true` in a CPU field is corruption, not 1."""
+        assert cli_desktop._num(True) == 0.0
+        assert cli_desktop._fmt_pct(True) == "-"
+        assert cli_desktop._fmt_int(True) == "-"
+
+    def test_non_finite_values_are_rejected(self):
+        assert cli_desktop._num(float("inf")) == 0.0
+        assert cli_desktop._num(float("nan")) == 0.0
+        assert cli_desktop._fmt_pct(float("nan")) == "-"
+
+
+class TestNightlyProductDirectory:
+    """Nightly installs under its own productName and so its own log directory.
+
+    packaging/build-desktop.sh passes `-c.productName=KiroCrew Nightly` for nightly
+    stamps, so probing only "KiroCrew" reported "not found" against a nightly app
+    that was recording correctly -- and nightly users are the likeliest profilers.
+    """
+
+    def test_both_product_directories_are_probed_on_macos(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_MACOS", True)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        dirs = [d.as_posix() for d in cli_desktop.desktop_log_dirs({})]
+        assert any(d.endswith("Library/Logs/KiroCrew") for d in dirs)
+        assert any(d.endswith("Library/Logs/KiroCrew Nightly") for d in dirs)
+
+    def test_both_product_directories_are_probed_on_linux(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_MACOS", False)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        dirs = [d.as_posix() for d in cli_desktop.desktop_log_dirs({"XDG_CONFIG_HOME": "/cfg"})]
+        assert "/cfg/KiroCrew/logs" in dirs
+        assert "/cfg/KiroCrew Nightly/logs" in dirs
+
+    def test_both_product_directories_are_probed_on_windows(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_MACOS", False)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        dirs = [d.as_posix() for d in cli_desktop.desktop_log_dirs({"APPDATA": "/roam"})]
+        assert "/roam/KiroCrew/logs" in dirs
+        assert "/roam/KiroCrew Nightly/logs" in dirs
+
+    def test_the_newest_artifact_wins_when_both_exist(self, monkeypatch, tmp_path):
+        """With both installed, the run just reproduced is the one written last."""
+        release = tmp_path / "KiroCrew"
+        nightly = tmp_path / "KiroCrew Nightly"
+        release.mkdir()
+        nightly.mkdir()
+        old = release / cli_desktop.ARTIFACT_NAME
+        new = nightly / cli_desktop.ARTIFACT_NAME
+        old.write_text("{}", encoding="utf-8")
+        new.write_text("{}", encoding="utf-8")
+        os.utime(old, (1000, 1000))
+        os.utime(new, (2000, 2000))
+        monkeypatch.setattr(
+            cli_desktop, "desktop_log_dirs", lambda env=None: (release, nightly)
+        )
+        assert cli_desktop.find_metrics_artifact() == new
+        # And the reverse ordering, so the result is mtime-driven not list-order.
+        os.utime(old, (3000, 3000))
+        assert cli_desktop.find_metrics_artifact() == old
+
+    def test_the_missing_message_names_every_searched_directory(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        monkeypatch.setattr(platform_compat, "IS_MACOS", True)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        assert cli_desktop.desktop_cmd(_args(tmp_path / "absent.json")) == 3
+        err = capsys.readouterr().err
+        assert "KiroCrew Nightly" in err, "the nightly path must be discoverable from the error"
+
+    def test_product_names_stay_in_sync_with_the_packaging_script(self):
+        """A rename in build-desktop.sh silently breaks discovery for that build."""
+        sh = Path(__file__).resolve().parents[1] / "packaging" / "build-desktop.sh"
+        if not sh.is_file():  # pragma: no cover - source checkout only
+            pytest.skip("packaging scripts not present in this build")
+        text = sh.read_text(encoding="utf-8")
+        for name in cli_desktop.PRODUCT_NAMES:
+            assert name in text, f"{name} not found in build-desktop.sh"
+
+
+class TestSensitivePathGate:
+    """--path is caller-supplied, and this command prints file contents."""
+
+    def test_the_read_goes_through_the_centralized_gate(self, monkeypatch, tmp_path):
+        """Not just "it works": the specific helper must be on the path.
+
+        Reading with Path.read_text would bypass is_sensitive_path entirely, and
+        that bypass is invisible in output-based assertions.
+        """
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text(json.dumps(_doc()), encoding="utf-8")
+        called: list[str] = []
+        real = cli_desktop.safe_read_file
+
+        def _spy(p: str) -> str:
+            called.append(p)
+            return real(p)
+
+        monkeypatch.setattr(cli_desktop, "safe_read_file", _spy)
+        assert cli_desktop.desktop_cmd(_args(art)) == 0
+        assert called == [str(art)]
+
+    def test_a_refused_sensitive_path_reports_instead_of_raising(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / "desktop-metrics.json"
+        art.write_text("{}", encoding="utf-8")
+
+        def _refuse(_p: str) -> str:
+            raise PermissionError("sensitive path")
+
+        monkeypatch.setattr(cli_desktop, "safe_read_file", _refuse)
+        assert cli_desktop.desktop_cmd(_args(art)) == 5
+        err = capsys.readouterr().err
+        assert "protected or resolves to a sensitive location" in err
+
+    def test_the_discovered_path_is_gated_too(self, monkeypatch, tmp_path):
+        """The app's log directory is user-writable, so a planted symlink there
+        must be refused exactly as one passed on the command line."""
+        monkeypatch.setenv(perf_sampler.DEBUG_ENV_VAR, "1")
+        art = tmp_path / cli_desktop.ARTIFACT_NAME
+        art.write_text(json.dumps(_doc()), encoding="utf-8")
+        monkeypatch.setattr(cli_desktop, "desktop_log_dirs", lambda env=None: (tmp_path,))
+        called: list[str] = []
+        real = cli_desktop.safe_read_file
+
+        def _spy(p: str) -> str:
+            called.append(p)
+            return real(p)
+
+        monkeypatch.setattr(cli_desktop, "safe_read_file", _spy)
+        # No --path: force the discovery route.
+        assert cli_desktop.desktop_cmd(_args(None)) == 0
+        assert called == [str(art)]
+
+
+class TestParserWiring:
+    def test_subcommand_dest_does_not_shadow_the_top_level_command(self):
+        """A nested dest of "command" silently overwrites the top-level value.
+
+        That exact collision made `kirocrew perf sample` fall through to the
+        argparse help during layer 1, so it is pinned here too.
+        """
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        cli_desktop.register_desktop_parser(sub)
+        args = parser.parse_args(["desktop", "metrics"])
+        assert args.command == "desktop"
+        assert args.desktop_cmd == "metrics"
+
+    def test_top_and_json_flags_parse(self):
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        cli_desktop.register_desktop_parser(sub)
+        args = parser.parse_args(["desktop", "metrics", "--json", "--top", "3"])
+        assert args.json is True and args.top == 3
+
+    def test_metrics_subcommand_is_required(self):
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        cli_desktop.register_desktop_parser(sub)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["desktop"])
+
+
+class TestArtifactNameStaysInSync:
+    def test_python_and_electron_agree_on_the_filename(self):
+        """A rename on either side makes this command report a false negative."""
+        js = (
+            Path(__file__).resolve().parents[1]
+            / "website"
+            / "electron"
+            / "perf-metrics.js"
+        )
+        if not js.is_file():  # pragma: no cover - source checkout only
+            pytest.skip("electron sources not present in this build")
+        text = js.read_text(encoding="utf-8")
+        assert f'ARTIFACT_NAME = "{cli_desktop.ARTIFACT_NAME}"' in text

--- a/test/test_mcp_gateway_shutdown_and_env.py
+++ b/test/test_mcp_gateway_shutdown_and_env.py
@@ -59,7 +59,6 @@ def _pool_key(
         approval_mode="reads",
         trust_all_tools=False,
         user_identity="testuser",
-        channel_id=None,
         config_snapshot_hash="jkl012",
     )
 

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -64,6 +64,7 @@ const { sanitizeWindowState, captureWindowState } = require("./window-state");
 const { createLivenessMonitor } = require("./gateway-liveness");
 const { chooseRecoveryStrategy } = require("./gateway-recovery");
 const { capturePySpyDump } = require("./pyspy-dump");
+const { createMetricsRecorder } = require("./perf-metrics");
 const { identityFamily, decideGatewayAction, FAMILY_META, HEALTH_IDENTITY_PATH } = require("./instance-guard");
 const { clampZoomFactor, stepZoomFactor } = require("./zoom");
 const { buildMenuTemplate } = require("./app-menu");
@@ -215,6 +216,8 @@ let livenessMonitor = null;
 // path). Consulted only during the primary boot wait (see showLoadingThenConnect).
 let gatewayStartFailure = null;
 let isQuitting = false;
+// Debug-only metrics recorder handle; null unless KIROCREW_DEBUG enabled it.
+let desktopMetricsRecorder = null;
 // True from the moment an update install is dispatched. The updater stops the
 // gateway ON PURPOSE before the bundle swap; without this flag the liveness
 // watchdog reads that intentional stop as a wedge and resurrects the gateway
@@ -1814,6 +1817,21 @@ process.on("unhandledRejection", (reason) => {
 });
 
 app.whenReady().then(async () => {
+  // Debug-only per-process metrics recorder. No-ops unless KIROCREW_DEBUG is set,
+  // so a normal install pays nothing; when on, it writes a bounded rolling
+  // artifact next to the gateway log for `kirocrew desktop metrics` to read.
+  try {
+    desktopMetricsRecorder = createMetricsRecorder({
+      dir: path.dirname(gatewayLogPath()),
+      getAppMetrics: () => app.getAppMetrics(),
+      log: (m) => glog(`perf: ${m}`),
+      meta: { electron: process.versions && process.versions.electron },
+    });
+    desktopMetricsRecorder.start();
+  } catch (e) {
+    // A diagnostic aid must never take the app down at boot.
+    try { glog(`perf: metrics recorder failed to start: ${e && e.message}`); } catch { /* ignore */ }
+  }
   // Running from a mounted DMG or a Gatekeeper App Translocation copy looks
   // fine at launch but can NEVER install an update (the macOS install path
   // replaces the running .app in place). Say so once, up front, and offer the
@@ -2117,6 +2135,8 @@ app.whenReady().then(async () => {
 
 app.on("before-quit", () => {
   isQuitting = true;
+  // Flush the final metrics window before the gateway teardown begins.
+  try { if (desktopMetricsRecorder) desktopMetricsRecorder.stop(); } catch { /* best effort */ }
   stopGateway();
 });
 

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -74,6 +74,7 @@
       "gateway-liveness.js",
       "gateway-recovery.js",
       "pyspy-dump.js",
+      "perf-metrics.js",
       "host-config.js",
       "remote-token.js",
       "token-retry.js",

--- a/website/electron/perf-metrics.js
+++ b/website/electron/perf-metrics.js
@@ -1,0 +1,235 @@
+"use strict";
+//
+// Debug-only recorder for Electron's own per-process metrics.
+//
+// Why a recorder and not a query endpoint: `app.getAppMetrics()` is an
+// Electron-main API, so it can only be read from inside this process. The
+// backend CLI (`kirocrew desktop metrics`) is a separate Python process and a
+// second Electron instance cannot read the first one's metrics, so there is no
+// way for the CLI to ask the running app for a live sample without introducing
+// a listener. Rather than open one, this module samples on an interval and
+// writes a bounded artifact next to the gateway log; the CLI reads that file.
+//
+// The tradeoff is deliberate: the CLI sees recent history rather than a live
+// instant. For the question this exists to answer -- which process is burning
+// CPU or growing its working set, and since when -- a short rolling history is
+// more useful than a single sample anyway, and it survives the app becoming
+// unresponsive.
+//
+// Same contract as pyspy-dump.js: strictly best-effort, never throws, and never
+// keeps the app alive. It is OFF unless KIROCREW_DEBUG is set, so a normal user
+// install writes nothing and pays no sampling cost.
+//
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const ARTIFACT_NAME = "desktop-metrics.json";
+const DEBUG_ENV_VAR = "KIROCREW_DEBUG";
+
+// Kept in sync with kiro_crew.perf_sampler.profiling_enabled: the desktop and
+// backend halves of the profiler must agree on what "debug" means, or the CLI
+// reads an artifact the app declined to write (or vice versa).
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+
+// 120 samples at the default 5s interval is ten minutes of history for a few
+// hundred KB. Bounded on purpose: this writes into the user's log directory on
+// an interval, so unbounded growth would be a disk leak in a debug tool.
+const DEFAULT_CAPACITY = 120;
+const DEFAULT_INTERVAL_MS = 5000;
+const MIN_INTERVAL_MS = 500;
+
+/**
+ * Whether debug profiling is enabled.
+ *
+ * Mirrors the backend gate exactly, including treating an explicit "0"/"false"
+ * as OFF rather than as "the variable is set, so on".
+ */
+function profilingEnabled(env = process.env) {
+  const raw = env && env[DEBUG_ENV_VAR];
+  if (raw === undefined || raw === null) return false;
+  return TRUTHY.has(String(raw).trim().toLowerCase());
+}
+
+/**
+ * Reduce one `app.getAppMetrics()` entry to the fields worth recording.
+ *
+ * An allowlist rather than a passthrough: the raw entries carry platform-specific
+ * extras, and this artifact is meant to be attachable to a bug report, so the
+ * shape it can contain should be known rather than whatever the runtime supplies.
+ */
+function normalizeMetric(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  const cpu = entry.cpu || {};
+  const memory = entry.memory || {};
+  const num = (v) => (typeof v === "number" && Number.isFinite(v) ? v : null);
+  const out = {
+    pid: num(entry.pid),
+    type: typeof entry.type === "string" ? entry.type : null,
+    cpuPercent: num(cpu.percentCPUUsage),
+    idleWakeupsPerSecond: num(cpu.idleWakeupsPerSecond),
+    workingSetKb: num(memory.workingSetSize),
+    peakWorkingSetKb: num(memory.peakWorkingSetSize),
+  };
+  // Only present for utility processes; omitted entirely when absent so the
+  // record does not carry a wall of nulls.
+  if (typeof entry.name === "string" && entry.name) out.name = entry.name;
+  if (typeof entry.serviceName === "string" && entry.serviceName) out.serviceName = entry.serviceName;
+  return out;
+}
+
+/**
+ * Build one timestamped sample from a metrics array.
+ */
+function buildSample(rawMetrics, now = () => new Date()) {
+  const list = Array.isArray(rawMetrics) ? rawMetrics : [];
+  const processes = list.map(normalizeMetric).filter((m) => m !== null);
+  return {
+    at: now().toISOString(),
+    processes,
+    totalCpuPercent: processes.reduce((a, p) => a + (p.cpuPercent || 0), 0),
+    totalWorkingSetKb: processes.reduce((a, p) => a + (p.workingSetKb || 0), 0),
+  };
+}
+
+/**
+ * Serialize the ring to the artifact shape the CLI reads.
+ */
+function renderArtifact(samples, meta = {}) {
+  return JSON.stringify(
+    {
+      version: 1,
+      // The reader keys off this, so a future shape change is detectable rather
+      // than being silently misparsed as v1.
+      platform: meta.platform || process.platform,
+      electron: meta.electron || null,
+      intervalMs: meta.intervalMs || null,
+      samples,
+    },
+    null,
+    2
+  );
+}
+
+/**
+ * Create the interval recorder.
+ *
+ * Returns `{start, stop, sampleOnce, artifactPath, enabled}`. When profiling is
+ * disabled, `start` is a no-op and nothing is ever written -- callers do not need
+ * to check the gate themselves.
+ *
+ * Every dependency is injectable because this runs inside Electron main, which is
+ * not exercised by the unit-test runner.
+ */
+function createMetricsRecorder({
+  dir,
+  getAppMetrics,
+  intervalMs = DEFAULT_INTERVAL_MS,
+  capacity = DEFAULT_CAPACITY,
+  env = process.env,
+  log = () => {},
+  now = () => new Date(),
+  writeFileSync = fs.writeFileSync,
+  renameSync = fs.renameSync,
+  mkdirSync = fs.mkdirSync,
+  unlinkSync = fs.unlinkSync,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  meta = {},
+} = {}) {
+  const enabled = profilingEnabled(env);
+  const artifactPath = dir ? path.join(dir, ARTIFACT_NAME) : null;
+  // Guard the interval floor so a bad value cannot turn a debug aid into a busy
+  // loop competing with the app it is measuring.
+  const effectiveInterval = Math.max(MIN_INTERVAL_MS, Number(intervalMs) || DEFAULT_INTERVAL_MS);
+  const cap = Math.max(1, Number(capacity) || DEFAULT_CAPACITY);
+  const samples = [];
+  let handle = null;
+
+  function flush() {
+    if (!artifactPath) return false;
+    // Write to a sibling temp file and rename: the CLI may read this at any
+    // moment, and a partially written JSON file would fail to parse. rename is
+    // atomic within a directory, so a reader sees either the old or the new file.
+    const tmp = `${artifactPath}.${process.pid}.tmp`;
+    try {
+      mkdirSync(path.dirname(artifactPath), { recursive: true });
+      writeFileSync(tmp, renderArtifact(samples, { ...meta, intervalMs: effectiveInterval }), {
+        mode: 0o600,
+      });
+      renameSync(tmp, artifactPath);
+      return true;
+    } catch (e) {
+      log(`desktop metrics write failed: ${e && e.message}`);
+      try {
+        unlinkSync(tmp);
+      } catch {
+        /* the temp file may not exist; nothing to clean up */
+      }
+      return false;
+    }
+  }
+
+  function sampleOnce() {
+    if (!enabled) return false;
+    let raw;
+    try {
+      raw = getAppMetrics ? getAppMetrics() : [];
+    } catch (e) {
+      // A debug recorder must never destabilize the app it measures.
+      log(`desktop metrics sample failed: ${e && e.message}`);
+      return false;
+    }
+    samples.push(buildSample(raw, now));
+    // Ring: drop oldest first so the artifact is the most recent window.
+    while (samples.length > cap) samples.shift();
+    return flush();
+  }
+
+  function start() {
+    if (!enabled) {
+      return false;
+    }
+    if (handle !== null) return true; // idempotent; a second start must not double-sample
+    sampleOnce(); // write immediately so the artifact exists before the first tick
+    handle = setIntervalFn(sampleOnce, effectiveInterval);
+    // unref so a debug sampler can never hold the app open at quit. Electron's
+    // timers are Node timers, so this is available; guarded for injected fakes.
+    if (handle && typeof handle.unref === "function") handle.unref();
+    log(`desktop metrics recording every ${effectiveInterval}ms to ${artifactPath}`);
+    return true;
+  }
+
+  function stop() {
+    if (handle !== null) {
+      clearIntervalFn(handle);
+      handle = null;
+    }
+    // Final flush so the last window survives a clean quit.
+    return enabled ? flush() : false;
+  }
+
+  return {
+    start,
+    stop,
+    sampleOnce,
+    artifactPath,
+    enabled,
+    get sampleCount() {
+      return samples.length;
+    },
+  };
+}
+
+module.exports = {
+  createMetricsRecorder,
+  profilingEnabled,
+  normalizeMetric,
+  buildSample,
+  renderArtifact,
+  ARTIFACT_NAME,
+  DEBUG_ENV_VAR,
+  DEFAULT_INTERVAL_MS,
+  DEFAULT_CAPACITY,
+  MIN_INTERVAL_MS,
+};

--- a/website/electron/test/perf-metrics.test.js
+++ b/website/electron/test/perf-metrics.test.js
@@ -1,0 +1,208 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const {
+  createMetricsRecorder,
+  profilingEnabled,
+  normalizeMetric,
+  buildSample,
+  MIN_INTERVAL_MS,
+} = require("../perf-metrics");
+
+// A recorder wired entirely to fakes: Electron main is not available here, and
+// the real timers/filesystem would make these tests slow and order-dependent.
+function harness(overrides = {}) {
+  const writes = [];
+  const renames = [];
+  let intervalFn = null;
+  const logs = [];
+  const rec = createMetricsRecorder({
+    dir: "/tmp/logs",
+    env: { KIROCREW_DEBUG: "1" },
+    getAppMetrics: () => [
+      { pid: 1, type: "Browser", cpu: { percentCPUUsage: 3.5 }, memory: { workingSetSize: 100 } },
+      { pid: 2, type: "Tab", cpu: { percentCPUUsage: 1.5 }, memory: { workingSetSize: 50 } },
+    ],
+    writeFileSync: (p, data, opts) => writes.push({ p, data, opts }),
+    renameSync: (from, to) => renames.push({ from, to }),
+    mkdirSync: () => {},
+    unlinkSync: () => {},
+    setIntervalFn: (fn) => {
+      intervalFn = fn;
+      return { unref() {} };
+    },
+    clearIntervalFn: () => {
+      intervalFn = null;
+    },
+    log: (m) => logs.push(m),
+    now: () => new Date("2026-08-02T12:00:00.000Z"),
+    ...overrides,
+  });
+  return { rec, writes, renames, logs, tick: () => intervalFn && intervalFn(), hasInterval: () => intervalFn !== null };
+}
+
+test("the gate is off by default and nothing is written", () => {
+  const h = harness({ env: {} });
+  assert.strictEqual(h.rec.enabled, false);
+  assert.strictEqual(h.rec.start(), false);
+  assert.strictEqual(h.rec.sampleOnce(), false);
+  assert.strictEqual(h.writes.length, 0, "a non-debug install must write no artifact at all");
+});
+
+test("an explicit falsey value reads as off, not as merely-set", () => {
+  for (const raw of ["0", "false", "no", "off", ""]) {
+    assert.strictEqual(profilingEnabled({ KIROCREW_DEBUG: raw }), false, `${raw} should be off`);
+  }
+  for (const raw of ["1", "true", "YES", " on "]) {
+    assert.strictEqual(profilingEnabled({ KIROCREW_DEBUG: raw }), true, `${raw} should be on`);
+  }
+});
+
+test("start writes an artifact immediately rather than waiting for the first tick", () => {
+  const h = harness();
+  assert.strictEqual(h.rec.start(), true);
+  assert.strictEqual(h.rec.sampleCount, 1);
+  assert.strictEqual(h.renames.length, 1, "the artifact should be published on start");
+});
+
+test("the artifact is written via a temp file and renamed into place", () => {
+  const h = harness();
+  h.rec.sampleOnce();
+  assert.match(h.writes[0].p, /\.tmp$/, "must write to a temp path, never the artifact directly");
+  assert.strictEqual(h.renames[0].to, h.rec.artifactPath);
+  assert.strictEqual(h.renames[0].from, h.writes[0].p);
+});
+
+test("the artifact is written 0600", () => {
+  const h = harness();
+  h.rec.sampleOnce();
+  assert.strictEqual(h.writes[0].opts && h.writes[0].opts.mode, 0o600);
+});
+
+test("the artifact parses and carries normalized totals", () => {
+  const h = harness();
+  h.rec.sampleOnce();
+  const parsed = JSON.parse(h.writes[0].data);
+  assert.strictEqual(parsed.version, 1);
+  assert.strictEqual(parsed.samples.length, 1);
+  const s = parsed.samples[0];
+  assert.strictEqual(s.at, "2026-08-02T12:00:00.000Z");
+  assert.strictEqual(s.processes.length, 2);
+  assert.strictEqual(s.totalCpuPercent, 5);
+  assert.strictEqual(s.totalWorkingSetKb, 150);
+});
+
+test("the sample ring is bounded so the log directory cannot grow without limit", () => {
+  const h = harness({ capacity: 3 });
+  for (let i = 0; i < 10; i++) h.rec.sampleOnce();
+  assert.strictEqual(h.rec.sampleCount, 3);
+  const parsed = JSON.parse(h.writes[h.writes.length - 1].data);
+  assert.strictEqual(parsed.samples.length, 3);
+});
+
+test("the ring keeps the NEWEST samples, not the oldest", () => {
+  let n = 0;
+  const h = harness({
+    capacity: 2,
+    now: () => new Date(Date.UTC(2026, 7, 2, 12, 0, n++)),
+  });
+  for (let i = 0; i < 4; i++) h.rec.sampleOnce();
+  const parsed = JSON.parse(h.writes[h.writes.length - 1].data);
+  assert.deepStrictEqual(
+    parsed.samples.map((s) => s.at),
+    ["2026-08-02T12:00:02.000Z", "2026-08-02T12:00:03.000Z"]
+  );
+});
+
+test("a throwing getAppMetrics is contained and does not propagate", () => {
+  const h = harness({
+    getAppMetrics: () => {
+      throw new Error("metrics unavailable");
+    },
+  });
+  assert.strictEqual(h.rec.sampleOnce(), false);
+  assert.match(h.logs.join("\n"), /sample failed/);
+});
+
+test("a failing write is contained, reported, and cleans up its temp file", () => {
+  const unlinked = [];
+  const h = harness({
+    writeFileSync: () => {
+      throw new Error("ENOSPC");
+    },
+    unlinkSync: (p) => unlinked.push(p),
+  });
+  assert.strictEqual(h.rec.sampleOnce(), false);
+  assert.match(h.logs.join("\n"), /write failed/);
+  assert.strictEqual(unlinked.length, 1, "the temp file must not be left behind");
+});
+
+test("the interval is floored so a bad value cannot busy-loop against the app", () => {
+  const h = harness({ intervalMs: 1 });
+  h.rec.sampleOnce();
+  const parsed = JSON.parse(h.writes[0].data);
+  assert.strictEqual(parsed.intervalMs, MIN_INTERVAL_MS);
+});
+
+test("start is idempotent so a second call does not double-sample", () => {
+  const h = harness();
+  h.rec.start();
+  h.rec.start();
+  assert.strictEqual(h.rec.sampleCount, 1);
+});
+
+test("stop clears the interval and flushes a final time", () => {
+  const h = harness();
+  h.rec.start();
+  const before = h.renames.length;
+  assert.strictEqual(h.rec.stop(), true);
+  assert.strictEqual(h.hasInterval(), false);
+  assert.strictEqual(h.renames.length, before + 1, "the last window should survive a clean quit");
+});
+
+test("the interval is unref'd so the recorder cannot hold the app open at quit", () => {
+  let unrefCalled = false;
+  const h = harness({
+    setIntervalFn: () => ({
+      unref() {
+        unrefCalled = true;
+      },
+    }),
+  });
+  h.rec.start();
+  assert.strictEqual(unrefCalled, true);
+});
+
+test("ticking the interval accumulates samples", () => {
+  const h = harness();
+  h.rec.start();
+  h.tick();
+  h.tick();
+  assert.strictEqual(h.rec.sampleCount, 3);
+});
+
+test("normalizeMetric allowlists fields and drops non-finite numbers", () => {
+  const m = normalizeMetric({
+    pid: 7,
+    type: "Tab",
+    cpu: { percentCPUUsage: NaN, idleWakeupsPerSecond: 4 },
+    memory: { workingSetSize: 10 },
+    integrityLevel: "medium",
+    creationTime: 123,
+  });
+  assert.strictEqual(m.cpuPercent, null, "NaN must not land in the artifact");
+  assert.strictEqual(m.idleWakeupsPerSecond, 4);
+  assert.ok(!("integrityLevel" in m), "unlisted platform extras must be dropped");
+  assert.ok(!("creationTime" in m), "unlisted platform extras must be dropped");
+  assert.ok(!("name" in m), "absent optional fields should be omitted, not null");
+});
+
+test("normalizeMetric rejects junk entries", () => {
+  assert.strictEqual(normalizeMetric(null), null);
+  assert.strictEqual(normalizeMetric("nope"), null);
+});
+
+test("buildSample tolerates a non-array from getAppMetrics", () => {
+  const s = buildSample(undefined, () => new Date("2026-08-02T12:00:00.000Z"));
+  assert.deepStrictEqual(s.processes, []);
+  assert.strictEqual(s.totalCpuPercent, 0);
+});


### PR DESCRIPTION
## Problem

`kirocrew perf sample` (layer 1, #1063) profiles **Python only**. If the Electron
shell is the thing burning CPU -- a renderer spinning, a window's working set
climbing -- a py-spy attach on the gateway shows nothing unusual, and there is no
way to see the desktop app's own per-process numbers at all.

## Why it matters

"The app feels heavy" is a common report, and today it is unactionable: the only
profiler covers the half of the process tree that may not be at fault. Worse, when
the app becomes unresponsive there is no record of what its processes were doing
in the run-up.

## Fix (symptom -> root cause -> change)

The reason no such command exists is structural, not an oversight.
`app.getAppMetrics()` is an Electron-**main** API: it can only be called from
inside that process. This CLI is a separate Python process, and starting a second
Electron instance does not let it read the first one's metrics. So an on-demand
`kirocrew desktop metrics` that queried the live app would have required the
desktop app to **listen** for requests -- a new local network surface whose only
purpose is debugging.

I did not add one. Instead the app **records**:

- `website/electron/perf-metrics.js` (new) samples `app.getAppMetrics()` on an
  interval into a bounded artifact next to the gateway log, and is wired into
  `main.js` at `whenReady` / `before-quit`.
- `src/kiro_crew/cli_desktop.py` (new) resolves Electron's per-platform log
  directory, reads that artifact, and reports the latest totals plus the **peak**
  across the retained window.

The tradeoff, stated plainly because it changes how you read the output: you get a
recent window, not a live instant, and the app must have been **started** with
`KIROCREW_DEBUG` set. Two properties fall out of that which a live query would not
have: the record survives the app becoming unresponsive, and it keeps the peak --
which is usually the point, since the spike has passed by the time anyone looks.

Both halves are debug-gated on `KIROCREW_DEBUG` using the same truthy set as layer
1 (an explicit `0`/`false` reads as OFF, not as "the variable is set"). A normal
install writes nothing and pays no sampling cost.

Deliberate design choices worth reviewing:

- **Bounded ring** (120 samples, ~10 min). It writes on an interval into the
  user's log directory, so an unbounded file would be a slow disk leak in a debug
  aid.
- **Temp file + rename**, not in-place write, because the CLI can read at any
  moment and a torn JSON file would fail to parse. 0600, matching layer 1.
- **Field allowlist** in `normalizeMetric` rather than dumping raw entries: the
  artifact is meant to be attachable to a bug report, so its shape should be known
  rather than whatever the runtime supplies.
- **Interval floor** (500ms) so a bad value cannot turn the recorder into a busy
  loop competing with the app it measures.
- **`unref()`** on the timer so a debug sampler can never hold the app open at
  quit; the recorder never throws, matching `pyspy-dump.js`'s contract.
- **Version field** checked on read, so a future shape is refused rather than
  silently misread as v1.

## Tests

- `website/electron/test/perf-metrics.test.js` (19 tests): the gate is off by
  default and writes nothing; explicit falsey values read as off; temp-file+rename;
  0600; the ring is bounded and keeps the **newest** samples; a throwing
  `getAppMetrics` is contained; a failing write cleans up its temp file; the
  interval floor; `start` is idempotent; `stop` flushes; the timer is `unref`'d;
  the field allowlist drops unlisted platform extras and non-finite numbers.
- `test/test_cli_desktop.py` (20 tests): the gate; per-platform log-dir resolution
  (macOS/Windows/Linux + `XDG_CONFIG_HOME`); unresolvable `HOME` degrades instead
  of raising; latest-and-peak reporting; `--json`; missing artifact names the
  debug requirement rather than just "not found"; malformed JSON, a JSON array, a
  future version, a directory passed as `--path`, and partial records are all
  handled by exit code, not a traceback; and the subcommand `dest` does not shadow
  the top-level `command` dest (the collision that broke layer 1).
- Four guards revert-verified (version check, non-dict guard, explicit-path
  `is_file` check, missing-artifact message): breaking each fails its own test.
- A sync test asserts the Python and Electron halves agree on the artifact
  filename, since a rename on either side would make the command report a false
  "not found" against an app that is recording fine.

`packaging.test.js` -- which asserts every local `require()` in `main.js` is in
electron-builder's `build.files` -- caught that `perf-metrics.js` was missing from
the packaged file list. Left unfixed, the module would have been absent from the
DMG and `main.js` would have thrown on require in a real install. Added.

## Manual verification

Exercised the CLI end to end through the real `main()` entry point against a
synthetic artifact (`cli.py` has no `__main__` guard, so `python -m` silently does
nothing -- `main()` must be called directly):

```
source: /tmp/.../desktop-metrics.json
platform=darwin electron=31.0.0  1 sample(s) at 5s
window: 2026-08-02T12:00:00.000Z -> 2026-08-02T12:00:00.000Z
latest total: cpu=23.1% rss=250.0 MB
peak total:   cpu=23.1% rss=250.0 MB  at 2026-08-02T12:00:00.000Z

latest sample, top 2 process(es) by CPU:
      PID  TYPE             CPU         RSS  NAME
       12  Tab            18.9%    200.0 MB  dashboard
       11  Browser         4.2%     50.0 MB
```

The recorder half is not exercised against a real Electron main process in this
environment (no desktop app running here); it is covered by unit tests with
injected dependencies, matching how `pyspy-dump.js` is tested.

Gates: 160 backend tests in scope, isort / flake8 / CI-parity mypy clean, Electron
suite at 28 pass / 2 fail where **both failures are pre-existing on clean main**
(`auto-update.test.js`, `auto-update-install-timing.test.js` -- verified by
stashing this diff out and re-running).

## Screenshots

N/A -- no user-visible UI surface. The only output is CLI text, shown above.
