### PR TITLE
fix(core): retry the atomic rename on Windows sharing violations

### DIFF
--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -7,15 +7,35 @@ writers target the same file.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 import tempfile
 import threading
+import time
 from pathlib import Path
 
 from kiro_crew import platform_compat
 
+logger = logging.getLogger(__name__)
+
 _umask_lock = threading.Lock()
 _default_mode: int | None = None
+
+# Bounded retry budget for the Windows rename window. ``os.replace`` on Windows
+# raises ``PermissionError`` when ANY other handle is open on either path, and a
+# just-created temp file is exactly what a Search-indexer or AV scanner reaches
+# for, so the rename can fail with WinError 5 / 32 / 33 while nothing is wrong.
+# POSIX imposes no such restriction, so the retry is Windows-only: a
+# PermissionError there is a genuine permission fault and must surface at once
+# rather than after a second of sleeping.
+#
+# Shape mirrors the create-race retry in ``dashboard/token_secret.py``. A
+# scanner hold is short but not instantaneous, so this trades ~0.45s of
+# worst-case added latency on a doomed write against surviving the common
+# transient. The numbers are a heuristic, not a measured hold-time distribution.
+_REPLACE_MAX_ATTEMPTS = 10
+_REPLACE_BACKOFF_SECONDS = 0.05
 
 
 def _get_default_mode() -> int:
@@ -28,6 +48,75 @@ def _get_default_mode() -> int:
                 os.umask(u)
                 _default_mode = 0o666 & ~u
     return _default_mode
+
+
+def _on_event_loop() -> bool:
+    """Whether this thread is currently running an asyncio event loop.
+
+    Mirrors the probe guarding ``CronService``'s store lock: a worker started by
+    ``asyncio.to_thread`` or ``run_in_executor`` has no running loop of its own,
+    so a caller that offloads its write keeps the retry while the loop thread
+    itself never sleeps.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+def replace_with_retry(src: Path | str, dst: Path | str) -> None:
+    """``os.replace(src, dst)``, retrying the Windows sharing-violation window.
+
+    Atomic replacement is the last step of every tmp-file-plus-rename writer. On
+    Windows that rename fails with ``PermissionError`` if any other handle is
+    open on either path. An indexer or an AV scanner touching the freshly
+    written temp file is enough, so a correct atomic write can still lose its
+    payload for reasons unrelated to the caller. Retry a bounded number of times
+    so the transient resolves instead of propagating.
+
+    On POSIX this is a plain ``os.replace``: the OS permits replacing an open
+    file, so a ``PermissionError`` means the caller genuinely cannot write there
+    and is re-raised immediately rather than slept over.
+
+    The retry sleeps, so it is gated on there being no running event loop in
+    this thread. A caller reached from the gateway loop gets the plain
+    ``os.replace`` semantics it had before this retry existed: the
+    ``PermissionError`` propagates on the first attempt rather than pausing the
+    single loop for the whole budget (``no-blocking-call-on-event-loop``). This
+    is a property of this function, so it holds no matter how many sync helpers
+    sit between a coroutine and this call. Callers wanting the retry on a
+    loop-driven path offload the write (``asyncio.to_thread`` /
+    ``run_in_executor``), as ``AutoNudgeService`` already does; the worker has no
+    loop of its own, so the retry applies there.
+
+    The final attempt sits OUTSIDE the retry loop on purpose. With it inside,
+    a budget of 0 would skip the body entirely and return having renamed
+    nothing, which every caller reads as success: a silently lost write. Out
+    here, any budget of 1 or less simply degrades to a plain ``os.replace``.
+    """
+    for attempt in range(_REPLACE_MAX_ATTEMPTS - 1):
+        try:
+            os.replace(str(src), str(dst))
+            return
+        except PermissionError:
+            if not platform_compat.IS_WINDOWS:
+                raise
+            if _on_event_loop():
+                logger.debug(
+                    "atomic rename contended at %s on the event loop; "
+                    "re-raising instead of sleeping (offload the write to retry)",
+                    dst,
+                )
+                raise
+            logger.debug(
+                "atomic rename contended at %s; retrying (attempt %d/%d)",
+                dst,
+                attempt + 1,
+                _REPLACE_MAX_ATTEMPTS,
+            )
+            time.sleep(_REPLACE_BACKOFF_SECONDS)
+    os.replace(str(src), str(dst))
 
 
 def atomic_write(
@@ -66,7 +155,7 @@ def atomic_write(
             if fsync:
                 f.flush()
                 os.fsync(f.fileno())
-        os.replace(tmp, str(path))
+        replace_with_retry(tmp, path)
     except Exception:
         if fd >= 0:
             os.close(fd)

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterator
 
 from kiro_crew import platform_compat, shutdown_event
+from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.loader import config_dir
 from kiro_crew.config.paths import legacy_home
 from kiro_crew.security import is_sensitive_path
@@ -363,9 +364,12 @@ class AutoNudgeService:
 
     def _write_state(self, payload: dict) -> None:
         # Atomic write: serialize to a temp file in the same dir, fsync, then
-        # os.replace() onto the target path. Eliminates the truncate-before-
+        # replace onto the target path. Eliminates the truncate-before-
         # flock race that plain open(path, "w") has — readers always see either
         # the old complete file or the new complete file, never a partial one.
+        # The rename goes through replace_with_retry because on Windows it can
+        # fail with PermissionError while another handle is transiently open on
+        # the fresh temp file (indexer / AV), which loses the write (issue #1105).
         # Blocking (fsync) — async callers offload this to an executor.
         self._path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp_path = tempfile.mkstemp(dir=self._path.parent, suffix=".tmp")
@@ -374,7 +378,7 @@ class AutoNudgeService:
                 json.dump(payload, fh, indent=2)
                 fh.flush()
                 os.fsync(fh.fileno())
-            os.replace(tmp_path, self._path)
+            replace_with_retry(tmp_path, self._path)
         except BaseException:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)

--- a/test/test_atomic_write_retry.py
+++ b/test/test_atomic_write_retry.py
@@ -1,0 +1,160 @@
+"""Tests for the Windows atomic-rename retry in ``atomic_write`` (issue #1105).
+
+``os.replace`` on Windows raises ``PermissionError`` while any other handle is
+open on either path, so an indexer or AV scanner touching the freshly written
+temp file can defeat an otherwise-correct atomic write. POSIX permits the
+replace, so the failure never reproduces on a dev machine and only surfaces on
+the ``Backend Tests (Windows)`` matrix.
+
+``windows_sim.replace_sharing_violation`` reproduces the fault deterministically
+on any OS, so these drive the exact code path a Windows host would take. They do
+NOT prove the real OS behaviour end-to-end, only that the retry is wired,
+bounded, gated to Windows, and gated off the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from windows_sim import replace_sharing_violation
+
+from kiro_crew import atomic_write as aw
+from kiro_crew import platform_compat
+from kiro_crew.autonudge import AutoNudgeService
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch):
+    """Keep the bounded retry loop instant; attempt COUNT is what these pin."""
+    monkeypatch.setattr(aw, "_REPLACE_BACKOFF_SECONDS", 0)
+
+
+def _tmp_leftovers(directory):
+    return sorted(p.name for p in directory.glob("*.tmp"))
+
+
+def test_windows_rename_contention_is_retried_until_it_succeeds(tmp_path, monkeypatch):
+    """Two faulted renames then a real one: the payload still lands."""
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    target = tmp_path / "state.json"
+
+    with replace_sharing_violation(match="state.json", times=2) as sim:
+        aw.atomic_write(target, "payload-v1")
+
+    assert target.read_text() == "payload-v1"
+    # 2 faults + the successful third call.
+    assert sim["n"] == 3
+    assert _tmp_leftovers(tmp_path) == []
+
+
+def test_windows_rename_gives_up_after_the_budget_and_removes_the_temp(tmp_path, monkeypatch):
+    """A permanent fault still raises, and does not litter a temp file."""
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    target = tmp_path / "state.json"
+
+    with replace_sharing_violation(match="state.json", times=10_000) as sim:
+        with pytest.raises(PermissionError):
+            aw.atomic_write(target, "payload-v1")
+
+    assert sim["n"] == aw._REPLACE_MAX_ATTEMPTS
+    assert not target.exists()
+    assert _tmp_leftovers(tmp_path) == []
+
+
+def test_posix_permission_error_surfaces_without_retrying(tmp_path, monkeypatch):
+    """On POSIX a PermissionError is a real fault, so it must not be slept over.
+
+    This is the non-vacuity proof for the platform gate: with the same simulator
+    settings the Windows case above recovers, and this one must not.
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+    target = tmp_path / "state.json"
+
+    with replace_sharing_violation(match="state.json", times=1) as sim:
+        with pytest.raises(PermissionError):
+            aw.atomic_write(target, "payload-v1")
+
+    # Exactly one attempt: no retry was made.
+    assert sim["n"] == 1
+    assert _tmp_leftovers(tmp_path) == []
+
+
+def test_a_zero_budget_still_renames_once_instead_of_doing_nothing(tmp_path, monkeypatch):
+    """A misconfigured budget must degrade to a plain rename, never a no-op.
+
+    The retry count is a module constant someone may tune. If the final attempt
+    lived inside ``range(_REPLACE_MAX_ATTEMPTS)``, a budget of 0 would skip the
+    body, return without renaming, and let ``atomic_write`` report success over
+    a target that was never written: a silent lost write plus a leaked temp
+    file. Pinning the degenerate value keeps the final attempt unconditional.
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(aw, "_REPLACE_MAX_ATTEMPTS", 0)
+    target = tmp_path / "state.json"
+
+    with replace_sharing_violation(match="state.json", times=0) as sim:
+        aw.atomic_write(target, "payload-v1")
+
+    assert target.read_text() == "payload-v1"
+    # Exactly one rename happened; the budget did not suppress it entirely.
+    assert sim["n"] == 1
+    assert _tmp_leftovers(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_a_caller_on_the_event_loop_reraises_instead_of_sleeping(tmp_path, monkeypatch):
+    """The retry sleeps, so it must never run on the single gateway loop.
+
+    Attempt count is the proof: one call means the loop thread went straight
+    back to the caller rather than pausing for the budget. Pinning the count
+    rather than elapsed time keeps this deterministic (the autouse fixture
+    zeroes the backoff, so a timing assertion could not discriminate).
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    target = tmp_path / "state.json"
+
+    with replace_sharing_violation(match="state.json", times=2) as sim:
+        with pytest.raises(PermissionError):
+            aw.atomic_write(target, "payload-v1")
+
+    assert sim["n"] == 1
+    assert not target.exists()
+    assert _tmp_leftovers(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_offloading_from_the_loop_restores_the_retry(tmp_path, monkeypatch):
+    """A worker thread has no loop of its own, so offloaded writes still retry.
+
+    This is the other half of the gate, and the reason it does not defeat
+    #1105: ``AutoNudgeService`` reaches ``_write_state`` through
+    ``run_in_executor``, so the case the issue reports keeps the retry even
+    though the service is driven from the loop.
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    target = tmp_path / "state.json"
+
+    with replace_sharing_violation(match="state.json", times=2) as sim:
+        await asyncio.to_thread(aw.atomic_write, target, "payload-v1")
+
+    assert target.read_text() == "payload-v1"
+    assert sim["n"] == 3
+    assert _tmp_leftovers(tmp_path) == []
+
+
+def test_autonudge_state_write_survives_the_rename_window(tmp_path, monkeypatch):
+    """The concrete failure #1105 reports: AutoNudgeService losing a state save.
+
+    ``_write_state`` keeps its own mkstemp/fsync dance but routes the rename
+    through the shared helper, so it inherits the retry.
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    svc = AutoNudgeService(base_dir=tmp_path)
+
+    with replace_sharing_violation(match="autonudge.json", times=2) as sim:
+        svc._save()
+
+    assert svc._path.exists()
+    assert sim["n"] == 3
+    assert _tmp_leftovers(svc._path.parent) == []

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import sys
 import threading
 from pathlib import Path
 
@@ -168,17 +167,6 @@ async def test_no_expired_event_on_manual_deactivate(svc, monkeypatch):
     svc.stop()
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Flaky on Windows CI: the state save does tempfile.mkstemp + os.replace, and "
-        "another handle transiently open on the fresh temp file (indexer / AV) makes "
-        "the rename raise PermissionError [WinError 5]. The repo already treats "
-        "Windows sharing violations as known transients elsewhere "
-        "(token_secret.py, taskrunner.py). Logic is platform-independent and stays "
-        "covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_unlimited_loop_never_expires(svc, monkeypatch):
     """max_cycles=0 means unlimited — the cap branch must not fire at all."""


### PR DESCRIPTION
## Description

Closes part 1 of #1105: the Windows atomic-rename gap. Part 2 (making the 11
`test_credwatch_*` tests deterministic) is **not** in this PR.

`os.replace` on Windows raises `PermissionError` whenever another handle is open
on either path. A just-written temp file is exactly what a Search indexer or AV
scanner reaches for, so a correct tmp+rename write can lose its payload for
reasons unrelated to the caller. As #1105 notes, this is a product-side
robustness gap, not only a test problem: a real gateway can lose an autonudge
state write.

Following the issue's suggestion the retry is centralized in
`atomic_write.replace_with_retry`, so every `atomic_write` caller inherits it
(including `config.json` via `write_config_atomically`).
`AutoNudgeService._write_state` keeps its own mkstemp/fsync dance but routes its
rename through the same helper, since that rename is the failure #1105 reports.

Budget is 10 attempts at 50 ms, mirroring the create-race retry in
`dashboard/token_secret.py`. The numbers are a heuristic, not a measured
hold-time distribution, so they are a fair thing to challenge.

### Three deliberate narrowings

- **`PermissionError`, not `OSError`.** CPython's `PC/errmap.h` maps
  `ERROR_ACCESS_DENIED` (5), `ERROR_SHARING_VIOLATION` (32) and
  `ERROR_LOCK_VIOLATION` (33) all to `EACCES`. The same table maps
  `ERROR_NOT_SAME_DEVICE` (17) to `EXDEV`, so a broader `except OSError` would
  retry cross-device renames, which fail permanently.
- **Windows-gated.** POSIX `rename(2)` replaces a destination another process
  holds open, so a `PermissionError` there is a genuine permission fault and must
  surface immediately rather than after ~0.45s of sleeping.
- **Off-loop-gated.** Described in the next section.

The final attempt sits outside the retry loop (`range(_MAX - 1)` plus one
unconditional `os.replace`) rather than inside it. With it inside, setting the
budget to 0 would skip the loop body and return having renamed nothing, which
every caller reads as success: a silently lost write plus a leaked temp file.
Outside, any budget of 1 or less degrades to a plain `os.replace`. Attempt
arithmetic is unchanged (10 calls, 9 sleeps, ~0.45s worst case) and the
degenerate value is pinned by its own test.

### The retry never runs on the event loop

The retry sleeps, and `no-blocking-call-on-event-loop` forbids that on the
gateway loop. `replace_with_retry` therefore probes for a running loop and
re-raises instead of sleeping when it finds one, using the same
`asyncio.get_running_loop()` / `except RuntimeError` probe that guards
`CronService`'s store lock. A caller reached from the loop gets exactly the
`os.replace` semantics it had before this PR, so the retry cannot pause the
single loop for any amount of time.

This is a property of the function rather than of its callers, which is why it is
the gate here instead of offloading callers one at a time. `atomic_write` is
reached from coroutines through intermediate sync helpers, for example
`api_slack_channels` to `channel_resolver._save_to_disk`, and `_write_cli_overlay`
in `providers/acp.py`. A caller-by-caller audit therefore has to be complete, and
stay complete as callers are added, to be worth anything. The gate holds however
many sync frames sit in between.

A caller that wants the retry on a loop-driven path offloads the write.
`AutoNudgeService` already does: `_write_state` is reached through
`run_in_executor` at three call sites, and a worker thread has no loop of its own,
so the failure #1105 reports keeps the retry. A test pins that.

An earlier revision of this PR instead offloaded the one lexically-inline caller,
`handle_registries` in `apps/routes.py`, with `asyncio.to_thread`. **That is
reverted.** GPT 5.6's review pointed out that it widens a read-modify-write
window: the handler loads the whole config, mutates `registries`, and writes the
whole document back, and before that change there was no `await` between the read
and the write. Adding one lets a concurrent config write land in between and then
be overwritten. The loop gate removes any reason to offload there.

### Not addressed here

- The 11 `test_credwatch_*` timing tests (part 2 of #1105) stay skipped.
- On-loop callers get no retry, by construction. That is the pre-PR behaviour for
  those paths rather than a regression, and the failure #1105 reports is not one
  of them. Giving them the retry means offloading each write, which is a
  per-caller change with its own concurrency question, as the reverted
  `handle_registries` hunk shows.
- Several modules define their own local atomic-write helper that does its own
  temp-file-plus-rename rather than calling the shared one, so they do not inherit
  the retry. `grep -rnE '^\s*def [_a-z]*atomic[_a-z]*\(' src/kiro_crew` lists the
  current set; an earlier revision of this description enumerated them with line
  numbers and the list went stale within days, so it is left as a query. Migrating
  them is mechanical but changes permission and newline behaviour per call site,
  so it belongs in its own PR.
- `cron.py:_save()` calls the shared helper while holding the cross-process store
  lock, from a worker thread, so the retry applies there and on Windows a
  contended rename extends the hold by up to 0.45s. Waiters spin against
  `_FILE_LOCK_TIMEOUT_SECS = 10.0`, so the retry consumes at most 4.5% of that
  budget and cannot by itself raise `CronStoreBusy`. Measured, not assumed; no
  change made.

## Related Issues

Refs #1105

## Testing

- [x] Existing tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

`test/test_atomic_write_retry.py` (new, 7 tests) drives the Windows path on POSIX
with the repo's own `test/windows_sim.py::replace_sharing_violation`, which
`windows_sim`'s docstring specifically asks atomic-replacement code to use. Each
behaviour was proven non-vacuous by mutation, targeting the construct by line and
printing the before/after:

| mutation | expected red | observed |
|---|---|---|
| `_REPLACE_MAX_ATTEMPTS = 10` to `1` | the two retry tests | 2 failed, 2 passed |
| drop the `IS_WINDOWS` gate | the POSIX test | 1 failed (`DID NOT RAISE PermissionError`) |
| move the final `os.replace` back inside the loop | zero-budget and budget-exhaustion | 2 failed (`FileNotFoundError`, target never created; `DID NOT RAISE`) |
| neuter `if _on_event_loop():` | the on-loop test | 1 failed (`DID NOT RAISE PermissionError`) |
| force `_on_event_loop()` to `True` | the offload test | 4 failed, including it |

The last two are the loop gate: without it an on-loop caller sleeps, and with it
wrongly always on, an offloaded caller loses the retry that #1105 depends on.

The repo's own `test_no_blocking_call_on_loop.py::test_no_blocking_call_on_event_loop`
scans every `kiro_crew/**/*.py` for on-loop blocking calls and passes on this
branch.

The `skipif(sys.platform == "win32")` on
`test_autonudge.py::test_unlimited_loop_never_expires` is removed, since the
marker names this exact `PermissionError [WinError 5]` rename. **The Windows
shards on this PR are the real verification** of that un-skip: the simulator
proves the retry is wired, not that a live Windows host behaves as modelled. All
four Windows shards passed on each of the four runs before this revision; this
revision is a rebase onto a newer base and needs its own run.

Gates, exactly as `ci.yml` runs them:

```
isort --check-only src/kiro_crew test  -> exit 0
flake8 src/kiro_crew test              -> exit 0
mypy src/kiro_crew/                    -> Success: no issues found in 723 source files
```

Test selection was made by grepping the changed symbols (`replace_with_retry`,
`_on_event_loop`, `_REPLACE_MAX_ATTEMPTS`, `atomic_write`) across `test/`, which
names 37 files: 19 failed, 3110 passed. Those 19 are identical to a pristine
worktree at the same base sha (set difference empty in both directions), so none
are introduced here. They are environmental in this sandbox: `link(2)` returns
`EPERM`, which fails the hardlink-rejection tests in `test_pptx_maker_library.py`;
the process-tree tests in `test_platform_compat.py` cannot see their own
descendants; and `py-spy` and `qrcode` are absent.

`black --check` is not run: it is deliberately disabled in `ci.yml`, and
`autonudge.py` / `test_autonudge.py` are already not black-clean on `main`, so
reformatting them would add churn unrelated to this fix. The new test file is
black-clean.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

