### PR TITLE
fix(test): drop removed channel_id field from PoolKey test helper

### DIFF
--- a/test/test_mcp_gateway_shutdown_and_env.py
+++ b/test/test_mcp_gateway_shutdown_and_env.py
@@ -59,7 +59,6 @@ def _pool_key(
         approval_mode="reads",
         trust_all_tools=False,
         user_identity="testuser",
-        channel_id=None,
         config_snapshot_hash="jkl012",
     )
 


### PR DESCRIPTION
# Drop the removed `channel_id` field from the last `PoolKey` test call site

## Problem

`Backend Tests` shard 3 fails on **every** platform — `(3.10, 3)`, `(3.12, 3)` and
`(Windows) (3)` — with 20 failures in one file:

```
TypeError: PoolKey.__init__() got an unexpected keyword argument 'channel_id'
test/test_mcp_gateway_shutdown_and_env.py:62
```

`_pool_key()` in that file builds a `PoolKey` passing `channel_id=None`, but
`PoolKey` has no such field.

## Why it matters

This is red on `main` itself, so it fails for **every open PR based on current
main**, regardless of what that PR changes. It also makes shard 3 useless as a
signal: a genuine regression landing in those 20 tests would be invisible behind
the collection error.

## Fix (symptom → root cause → change)

Two PRs raced.

`#1191` (`refactor(mcp-gateway): drop channel_id from PoolKey`) removed the field
from the dataclass and cleaned up its call sites — including `channel_id=None` in
four test files (`test_mcp_apps_call_endpoint.py`, `test_mcp_apps_e2e.py`,
`test_mcp_gateway_apps_spool.py`, `test_mcp_gateway_bluegreen.py`).

`#1081` (`fix(mcp-gateway): stop SIGKILLing gatewayd on restart, ...`) added a
*new* `PoolKey` call site in `test_mcp_gateway_shutdown_and_env.py` while `#1191`
was in flight. `#1191` was written against a tree that did not contain it, so the
cleanup missed it and merging both left the one stale caller.

The field was dropped deliberately, so the correct side to change is the caller:
this removes the `channel_id=None` argument. It does not re-add the field.

I checked for other survivors — six test files construct `PoolKey`, and this was
the only one still passing `channel_id`; no call site under `src/` passes it. Note
that `PoolKey.from_register` still *accepts* `channel_id` in its payload and
ignores it, so payload-shaped callers were never affected; only the direct
constructor was.

## Tests

No new test. The 44 existing tests in the file are the coverage — they simply
could not run, because the `TypeError` fires in the module-level helper every test
calls. Verified by reverting: 20 failed / 24 passed before, 44 passed after.

`#1191` already added `test/test_mcp_gateway_poolkey.py` covering the field's
absence directly (including `test_payload_without_channel_id_is_accepted`), so the
behaviour is guarded; what slipped through was a mechanical call-site update, which
no assertion would have caught. Type-checking `test/` would have — CI's mypy scope
is `src/kiro_crew/` only. That is a broader change than this fix should carry, but
it is the durable answer to this class of break.

## Manual verification

N/A — this is a test-only change with no runtime surface. `PoolKey` and everything
under `src/` are untouched.

Gates run locally against `origin/main` (79c351bfd):

- `pytest test/test_mcp_gateway_shutdown_and_env.py` — 44 passed
- `pytest -k "pool or mcp_gateway or mcp_apps"` — 625 passed, 10 skipped
- `isort --check-only src/kiro_crew test` — clean
- `flake8 src/kiro_crew test` — clean
- `mypy src/kiro_crew/` — unchanged by this diff, which touches zero files under
  `src/`

## Screenshots

None — no user-visible surface.
