### PR TITLE
fix(apps): a git-installed app could report success and install nothing

### DIFF
--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -2677,7 +2677,21 @@ async def _clone_build_app_locked(
             "error": f"blocked by admission policy: {denied}",
         }
 
-    result = await _run_app_build(pkg_dir, app_name, log_lines)
+    # Build in the directory that actually HOLDS the package, not the clone root.
+    #
+    # A monorepo registry entry declares `subdirectory`, and historically it was
+    # joined only AFTER this build ran — so `_run_app_build` looked for
+    # pyproject.toml/package.json at the clone root, found none, logged "No build
+    # step detected — using source as-is", and returned ok=True having installed
+    # nothing. The app's own pyproject.toml was never seen. A silent success is
+    # the worst shape for this: `setup.onInstall` does get `cwd=app_source`, so
+    # an app could paper over it with a script, which is exactly how a bug like
+    # this stays hidden.
+    #
+    # `app_source` is already the containment-checked join of `subdirectory`
+    # under the clone root (the identity gate above fails closed on an escaping
+    # value), so it is safe to run the build command there.
+    result = await _run_app_build(app_source, app_name, log_lines)
     if result["ok"]:
         result["pkg_dir"] = pkg_dir
         # Surface the pre-clone checkout state so the caller's LATER gates
@@ -2759,16 +2773,53 @@ async def _run_app_build(
         or (build_dir / "setup.py").is_file()
         or (build_dir / "requirements.txt").is_file()
     ):
-        pip = shutil.which("pip") or shutil.which("pip3")
-        if pip:
-            if (build_dir / "requirements.txt").is_file() and not (
-                (build_dir / "pyproject.toml").is_file() or (build_dir / "setup.py").is_file()
-            ):
-                build_cmds.append([pip, "install", "-r", "requirements.txt"])
-            else:
-                build_cmds.append([pip, "install", "."])
+        # `sys.executable -m pip`, NOT `shutil.which("pip")`.
+        #
+        # A Python app has to land in the interpreter that will IMPORT it — the one
+        # running this gateway. `which("pip")` resolves to whatever pip is first on
+        # PATH, which is routinely a different interpreter: `bin/kirocrew` execs
+        # `.venv/bin/kirocrew` WITHOUT putting the venv's `bin/` on PATH, and
+        # `service/common.py::service_path()` prepends `~/.local/bin` ahead of it. So the
+        # build pip was whatever the user happened to have.
+        #
+        # The failure is SILENT, which is why it survived. Measured on a host whose first
+        # pip was 3.7 and whose gateway venv was 3.12: with a version-incompatible pip the
+        # install failed loudly, but with a *compatible-but-different* pip (3.10) it
+        # reported "Successfully installed", the build step reported success, and the
+        # package landed in `~/.local/lib/python3.10/site-packages` — invisible to the
+        # gateway, with `ENABLE_USER_SITE = False` in a venv so there is no fallback. The
+        # app installs, the entry point never appears, and nothing anywhere says why.
+        #
+        # Our own packages only fail loudly because they declare `requires-python`; a
+        # third-party app without that constraint fails silently on EVERY mismatch.
+        #
+        # EXCEPTION: never run pip against the desktop app's bundled interpreter.
+        # The desktop build ships a python-build-standalone runtime inside the
+        # application bundle (`Resources/backend-dist/...`); on macOS that bundle is
+        # code-signed, so a pip install writing into its site-packages invalidates
+        # the signature and breaks subsequent launches/updates — and the write is
+        # discarded on every app update anyway. This is a LOUD failure, not a
+        # soft-skip: a Python app that declares a build step needs its packages
+        # importable by the gateway, and skipping the install while reporting
+        # success would recreate exactly the silent-broken-install shape this
+        # function is written to prevent.
+        if "backend-dist" in Path(sys.executable).resolve().parts:
+            return {
+                "ok": False,
+                "name": app_name,
+                "error": (
+                    "Python apps that require a build step are not supported in "
+                    "the desktop app: its bundled interpreter is inside the "
+                    "signed application bundle and cannot install packages"
+                ),
+            }
+        pip_cmd = [sys.executable, "-m", "pip"]
+        if (build_dir / "requirements.txt").is_file() and not (
+            (build_dir / "pyproject.toml").is_file() or (build_dir / "setup.py").is_file()
+        ):
+            build_cmds.append([*pip_cmd, "install", "-r", "requirements.txt"])
         else:
-            log_lines.append("pip not found on PATH — skipping Python build step")
+            build_cmds.append([*pip_cmd, "install", "."])
 
     if not build_cmds:
         log_lines.append("No build step detected — using source as-is")
@@ -3050,6 +3101,8 @@ async def install_from_registry(
             log_lines,
             branch=branch,
             index_originated=index_originated,
+            # Passed so the BUILD runs where the package is. The containment check
+            # below is still authoritative for choosing app.json's directory.
             subdirectory=subdirectory,
             entry_repo=repo,
         )

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -36,9 +36,7 @@ from kiro_crew.apps import registry
 @pytest.fixture(autouse=True)
 def _explicit_registry_execution_admission(monkeypatch):
     """These tests must reach admitted registry subprocess paths."""
-    monkeypatch.setattr(
-        "kiro_crew.apps.execution.third_party_execution_allowed", lambda: True
-    )
+    monkeypatch.setattr("kiro_crew.apps.execution.third_party_execution_allowed", lambda: True)
 
 
 # A portable long-lived child: sleeps well past any test timeout without
@@ -94,9 +92,7 @@ def _record_tree_kill(monkeypatch) -> list[int]:
         killed.append(pid)
         return True
 
-    monkeypatch.setattr(
-        registry.platform_compat, "kill_process_tree_async", _fake_tree_kill
-    )
+    monkeypatch.setattr(registry.platform_compat, "kill_process_tree_async", _fake_tree_kill)
     return killed
 
 
@@ -136,9 +132,7 @@ async def test_communicate_with_timeout_kills_whole_process_tree(monkeypatch):
         killed.append((pid, sig))
         return True
 
-    monkeypatch.setattr(
-        registry.platform_compat, "kill_process_tree_async", _fake_tree_kill
-    )
+    monkeypatch.setattr(registry.platform_compat, "kill_process_tree_async", _fake_tree_kill)
     with pytest.raises(asyncio.TimeoutError):
         await registry._communicate_with_timeout(proc, timeout=0.01)
 
@@ -158,9 +152,7 @@ async def test_communicate_with_timeout_falls_back_when_group_kill_fails(monkeyp
     async def _boom(pid, sig):
         raise ProcessLookupError  # subclass of OSError
 
-    monkeypatch.setattr(
-        registry.platform_compat, "kill_process_tree_async", _boom
-    )
+    monkeypatch.setattr(registry.platform_compat, "kill_process_tree_async", _boom)
     with pytest.raises(asyncio.TimeoutError):
         await registry._communicate_with_timeout(proc, timeout=0.01)
 
@@ -1337,3 +1329,155 @@ class TestApplyTrustFields:
         assert "featured" not in rows["ext-app"]
         # The internal snapshot key never leaks into the API payload.
         assert all("_index_author" not in r for r in rows.values())
+# ---------------------------------------------------------------------------
+# Git-install build step: the interpreter, and where the build runs.
+#
+# Both properties below were broken and NEITHER had a test, which is why they
+# survived — and both fail SILENTLY, reporting a successful install that installed
+# nothing the gateway can import.
+# ---------------------------------------------------------------------------
+
+
+def _build_cmds_for(tmp_path, monkeypatch, files: dict[str, str]) -> list[list[str]]:
+    """Run ``_run_app_build``'s command planning without executing anything.
+
+    Captures the argv list rather than asserting on side effects: the point of both
+    tests is WHICH command would run, and executing a real pip install in a unit test
+    would be both slow and environment-dependent.
+    """
+    for rel, body in files.items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+
+    captured: list[list[str]] = []
+
+    class _EmptyStdout:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class _Ok:
+        returncode = 0
+        stdout = _EmptyStdout()
+
+        async def wait(self):
+            return 0
+
+        async def communicate(self):
+            return (b"", b"")
+
+    async def _fake_exec(*argv, **_kwargs):
+        captured.append(list(argv))
+        return _Ok()
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_exec)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="standard": (list(cmd), None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: list(cmd))
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_python_build_uses_the_running_interpreter_not_path_pip(tmp_path, monkeypatch):
+    """A Python app must install into the interpreter that will IMPORT it.
+
+    ``shutil.which("pip")`` resolves to whatever pip is first on PATH, which is
+    routinely NOT the gateway's: ``bin/kirocrew`` execs ``.venv/bin/kirocrew`` without
+    putting the venv's ``bin/`` on PATH, and ``service_path()`` prepends
+    ``~/.local/bin`` ahead of it.
+
+    The failure mode is silent, which is what made it survive. Measured on a host whose
+    first pip was 3.7 and whose gateway venv was 3.12: a *compatible-but-different* pip
+    (3.10) reported "Successfully installed", the build reported success, and the package
+    landed in ``~/.local/lib/python3.10/site-packages`` — invisible to the gateway, and
+    a venv sets ``ENABLE_USER_SITE = False`` so there is no fallback.
+
+    Asserting ``sys.executable`` rather than "not the string 'pip'" so the test states
+    the property (install into THIS interpreter) instead of banning one spelling.
+    """
+    captured = _build_cmds_for(
+        tmp_path, monkeypatch, {"pyproject.toml": "[project]\nname='x'\nversion='0'\n"}
+    )
+    # A PATH pip that is emphatically not us — the old code would have used it.
+    monkeypatch.setattr(registry.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    await registry._run_app_build(tmp_path, "x", [])
+
+    assert captured, "a pyproject.toml must produce a build command"
+    argv = captured[0]
+    assert argv[0] == sys.executable, f"build must use the running interpreter, got {argv[0]!r}"
+    assert argv[1:3] == ["-m", "pip"], f"expected `-m pip`, got {argv[1:3]!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_monorepo_subdirectory_is_built_not_the_clone_root(tmp_path, monkeypatch):
+    """The build must run where the package IS, not at the clone root.
+
+    A monorepo registry entry declares ``subdirectory``, and that used to be joined
+    only AFTER the build — so the build looked for pyproject.toml at the clone root,
+    found none, logged "No build step detected — using source as-is" and returned
+    ok=True having installed nothing.
+    """
+    captured: list = []
+
+    async def _fake_build(build_dir, app_name, log_lines):
+        captured.append(build_dir)
+        return {"ok": True}
+
+    async def _fake_clone(git_url, branch, pkg_dir, log_lines, **kwargs):
+        sub = pkg_dir / "apps" / "my-tool"
+        sub.mkdir(parents=True, exist_ok=True)
+        (sub / "pyproject.toml").write_text("[project]\n", "utf-8")
+        # The identity gate reads app.json from the declared subdirectory and
+        # fails closed on a mismatch — the cloned repo must declare the name.
+        (sub / "app.json").write_text(json.dumps({"name": "my-tool"}), "utf-8")
+        return None
+
+    monkeypatch.setattr(registry, "_run_app_build", _fake_build)
+    monkeypatch.setattr(registry, "_git_clone_or_pull", _fake_clone)
+    monkeypatch.setattr(registry, "app_source_dir", lambda name: tmp_path / name)
+    monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+
+    await registry._clone_build_app_locked(
+        "https://example.invalid/r.git", "my-tool", [], subdirectory="apps/my-tool"
+    )
+
+    assert captured, "the build must be attempted"
+    assert (
+        captured[0].name == "my-tool" and captured[0].parent.name == "apps"
+    ), f"build ran in {captured[0]} — expected the declared subdirectory"
+
+
+@pytest.mark.asyncio
+async def test_a_traversing_subdirectory_does_not_choose_the_build_dir(tmp_path, monkeypatch):
+    """``subdirectory`` is untrusted index content, so it must not escape the clone.
+
+    The identity gate joins ``subdirectory`` under the clone root with a
+    containment check and FAILS CLOSED on an escaping value — no build command
+    may run in a directory chosen by a traversing path.
+    """
+    captured: list = []
+
+    async def _fake_build(build_dir, app_name, log_lines):
+        captured.append(build_dir)
+        return {"ok": True}
+
+    async def _fake_clone(git_url, branch, pkg_dir, log_lines, **kwargs):
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        return None
+
+    monkeypatch.setattr(registry, "_run_app_build", _fake_build)
+    monkeypatch.setattr(registry, "_git_clone_or_pull", _fake_clone)
+    monkeypatch.setattr(registry, "app_source_dir", lambda name: tmp_path / name)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+
+    result = await registry._clone_build_app_locked(
+        "https://example.invalid/r.git", "evil", [], subdirectory="../../etc"
+    )
+
+    assert result["ok"] is False
+    assert "unsafe subdirectory" in result["error"]
+    assert captured == [], f"build ran despite a traversing subdirectory: {captured}"

--- a/test/test_apps_registry_coverage.py
+++ b/test/test_apps_registry_coverage.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -1604,35 +1605,58 @@ class TestRunAppBuild:
     @pytest.mark.asyncio
     async def test_requirements_only_uses_the_requirements_file(self, tmp_path, monkeypatch):
         (tmp_path / "requirements.txt").write_text("pytest\n", encoding="utf-8")
-        monkeypatch.setattr(registry.shutil, "which", lambda name: "/usr/bin/pip")
         spawned = _fake_sandbox(monkeypatch, [_FakeProc(returncode=0)])
         assert await registry._run_app_build(tmp_path, "demo", []) == {"ok": True}
-        assert spawned == [["/usr/bin/pip", "install", "-r", "requirements.txt"]]
+        assert spawned == [[sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]]
 
     @pytest.mark.asyncio
     async def test_pyproject_installs_the_project(self, tmp_path, monkeypatch):
         (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
         (tmp_path / "requirements.txt").write_text("pytest\n", encoding="utf-8")
-        monkeypatch.setattr(registry.shutil, "which", lambda name: "/usr/bin/pip")
         spawned = _fake_sandbox(monkeypatch, [_FakeProc(returncode=0)])
         assert await registry._run_app_build(tmp_path, "demo", []) == {"ok": True}
-        assert spawned == [["/usr/bin/pip", "install", "."]]
+        assert spawned == [[sys.executable, "-m", "pip", "install", "."]]
 
     @pytest.mark.asyncio
     async def test_setup_py_installs_the_project(self, tmp_path, monkeypatch):
         (tmp_path / "setup.py").write_text("from setuptools import setup\n", encoding="utf-8")
-        monkeypatch.setattr(registry.shutil, "which", lambda name: "/usr/bin/pip3")
         spawned = _fake_sandbox(monkeypatch, [_FakeProc(returncode=0)])
         assert await registry._run_app_build(tmp_path, "demo", []) == {"ok": True}
-        assert spawned == [["/usr/bin/pip3", "install", "."]]
+        assert spawned == [[sys.executable, "-m", "pip", "install", "."]]
 
     @pytest.mark.asyncio
-    async def test_missing_pip_is_a_soft_skip(self, tmp_path, monkeypatch):
+    async def test_missing_path_pip_does_not_skip_the_python_build(self, tmp_path, monkeypatch):
+        """The Python build runs via ``sys.executable -m pip`` — the gateway's own
+        interpreter — so a host with no pip anywhere on PATH must still build."""
         (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
         monkeypatch.setattr(registry.shutil, "which", lambda name: None)
-        log: list[str] = []
-        assert await registry._run_app_build(tmp_path, "demo", log) == {"ok": True}
-        assert any("pip not found on PATH" in line for line in log)
+        spawned = _fake_sandbox(monkeypatch, [_FakeProc(returncode=0)])
+        assert await registry._run_app_build(tmp_path, "demo", []) == {"ok": True}
+        assert spawned == [[sys.executable, "-m", "pip", "install", "."]]
+
+    @pytest.mark.asyncio
+    async def test_desktop_bundled_interpreter_never_runs_pip(self, tmp_path, monkeypatch):
+        """pip must never write into the desktop app's signed bundle — and the
+        refusal must be LOUD.
+
+        The desktop build ships a python-build-standalone runtime under
+        ``Resources/backend-dist/``; on macOS the bundle is code-signed, so a pip
+        install into its site-packages invalidates the signature and breaks the
+        next launch/update. Reporting a skipped build as ok would recreate the
+        silent-broken-install failure this function exists to prevent, so the
+        build fails with an explicit error instead.
+        """
+        (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+        bundled = tmp_path / "App.app" / "Contents" / "Resources" / "backend-dist"
+        bundled = bundled / "kirocrew-backend-arm64" / "bin" / "python3.12"
+        bundled.parent.mkdir(parents=True, exist_ok=True)
+        bundled.write_text("", encoding="utf-8")
+        monkeypatch.setattr(registry.sys, "executable", str(bundled))
+        spawned = _fake_sandbox(monkeypatch, [_FakeProc(returncode=0)])
+        result = await registry._run_app_build(tmp_path, "demo", [])
+        assert result["ok"] is False
+        assert "bundled interpreter" in result["error"]
+        assert spawned == []
 
     @pytest.mark.asyncio
     async def test_build_output_is_streamed_into_the_log(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem
A git-installed Python app can report a successful install while installing nothing the gateway can import. Two silent failure modes:

1. **The build used `shutil.which("pip")`, not the gateway's interpreter.** `which("pip")` resolves to whatever pip is first on PATH — routinely a *different* interpreter (`bin/kirocrew` execs `.venv/bin/kirocrew` without putting the venv's `bin/` on PATH; `service_path()` prepends `~/.local/bin`). With a compatible-but-different pip (measured: PATH pip 3.10, gateway venv 3.12) the install reports "Successfully installed", the build reports ok, and the package lands in `~/.local/lib/python3.10/site-packages` — invisible to the gateway (`ENABLE_USER_SITE = False` in a venv, no fallback). No error anywhere.
2. **A monorepo entry's build ran at the clone root**, not in its declared `subdirectory` — so the build found no pyproject.toml, logged "No build step detected — using source as-is", and returned ok=True having installed nothing.

## Why it matters
Both bugs produce the worst failure shape: HTTP 201 / "install succeeded" with a backend that later dies with `ModuleNotFoundError`, and nothing anywhere says why. Third-party apps without `requires-python` hit this on **every** interpreter mismatch.

## Fix (symptoms → root cause → change)
- **Interpreter**: the build now plans `[sys.executable, "-m", "pip"]` — the interpreter that will import the app — instead of PATH pip, making the mismatch unrepresentable.
- **Build directory**: the build now runs in `app_source`, the containment-checked join of `subdirectory` under the clone root. (Since this branch was written, main independently landed the `subdirectory` threading and a fail-closed pre-build identity gate; the surviving delta is exactly "build where the package is". A traversing `subdirectory` is refused by the identity gate *before* any build — strictly stronger than the originally proposed fallback-to-root.)
- **⚠️ Desktop behavior change (deliberate)**: the desktop app ships a python-build-standalone interpreter inside the signed application bundle (`Resources/backend-dist/…`). Running pip there would write into signed contents, invalidating the macOS code signature and breaking the next launch/update — so on the bundled interpreter, a Python app **with a build step now fails loudly at install time** ("Python apps that require a build step are not supported in the desktop app…") instead of the previous silent no-op (the old PATH-pip lookup found no pip in the bundle and skipped, reporting success). Desktop users go from *silently broken installs* to an *explicit unsupported error*; Python apps without a build step, and JS apps, are unaffected.

## Tests
- `test_python_build_uses_the_running_interpreter_not_path_pip` — asserts the planned argv starts with `sys.executable -m pip` even when a decoy PATH pip exists.
- `test_a_monorepo_subdirectory_is_built_not_the_clone_root` — mutation-verified: reverting the build-dir change fails it.
- `test_a_traversing_subdirectory_does_not_choose_the_build_dir` — asserts refusal-before-build on `../../etc`.
- `test_desktop_bundled_interpreter_never_runs_pip` — asserts the loud `ok: False` and that no pip command is planned on a bundled interpreter.
- 4 existing tests in `test_apps_registry_coverage.py` updated from the PATH-pip contract to the `sys.executable -m pip` contract; the pip-missing soft-skip test became `test_missing_path_pip_does_not_skip_the_python_build`.

## Manual verification
N/A — unit coverage exercises the command-planning and refusal paths directly; no UI change.

---
*Rebased onto latest main (was 973 commits behind) by Kiro Crew drive-to-green; description updated to match the shipped diff (the original text described pre-rebase mechanics — clone-root fallback and `test_external_registry.py` stub loosening — which main's evolution made unnecessary).*
