### PR TITLE
feat(perf): debug-only frontend bundle report and React commit timing

### DIFF
--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -221,4 +221,19 @@ export default [
       ],
     },
   },
+
+  // Debug-only developer diagnostics: text that goes to the browser console for
+  // whoever is profiling, never to a user through the UI. The module is inert
+  // unless explicitly armed with `?profile=commits`, and translating console
+  // output would mean shipping ten locales of strings no user can reach.
+  //
+  // Scoped to this one file rather than widened globally: a `words.exclude` shape
+  // rule cannot express "prose, but only in this module", and turning the rule off
+  // for `src/lib/**` would silence real copy in its neighbours.
+  {
+    files: ['src/lib/commitProfiler.tsx'],
+    rules: {
+      'i18next/no-literal-string': 'off',
+    },
+  },
 ]

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "analyze": "vite build --mode analyze && node scripts/bundle-report.mjs",
     "test": "npm run test:website && npm run test:electron",
     "test:website": "vitest run --coverage",
     "test:electron": "npm test --prefix electron",

--- a/website/scripts/bundle-report.mjs
+++ b/website/scripts/bundle-report.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Render the bundle report written by the `analyze` build mode.
+//
+// Usage:
+//   npm run analyze                 build in analyze mode, then print the report
+//   node scripts/bundle-report.mjs  print the report from the last analyze build
+//   node scripts/bundle-report.mjs --json
+//   node scripts/bundle-report.mjs --diff <baseline.json>
+//
+// Debug-only tooling: nothing here runs in a normal `npm run build`, and no part
+// of it ships in the bundle.
+import { readFileSync, existsSync } from 'fs'
+import path from 'path'
+import { renderReport, diffSummaries, formatBytes } from './lib/bundleReport.mjs'
+
+const REPORT_PATH = path.resolve('dist', 'bundle-report.json')
+
+function fail(message, code = 1) {
+  process.stderr.write(`${message}\n`)
+  process.exit(code)
+}
+
+function loadSummary(file) {
+  if (!existsSync(file)) {
+    fail(
+      `No bundle report at ${file}.\n` +
+        'Run `npm run analyze` first -- a plain `npm run build` deliberately does ' +
+        'not write one, so the normal build stays unaffected.',
+      2
+    )
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(file, 'utf-8'))
+  } catch (e) {
+    fail(`${file} is not valid JSON: ${e && e.message}`, 3)
+  }
+  if (!parsed || typeof parsed !== 'object') fail(`${file} does not contain a report object.`, 3)
+  if (parsed.version !== 1) {
+    // Refuse rather than misread a future shape as v1.
+    fail(`${file} has version ${JSON.stringify(parsed.version)}; this build understands 1.`, 3)
+  }
+  return parsed
+}
+
+const args = process.argv.slice(2)
+const summary = loadSummary(REPORT_PATH)
+
+const diffAt = args.indexOf('--diff')
+if (diffAt !== -1) {
+  const baselineFile = args[diffAt + 1]
+  if (!baselineFile) fail('--diff needs a path to a baseline bundle-report.json', 2)
+  const baseline = loadSummary(path.resolve(baselineFile))
+  const d = diffSummaries(baseline, summary)
+  const sign = (n) => (n > 0 ? `+${formatBytes(n)}` : n < 0 ? `-${formatBytes(-n)}` : '0 B')
+  process.stdout.write(`Bundle diff vs ${baselineFile}\n`)
+  process.stdout.write(`  JS chunks: ${sign(d.chunkBytesDelta)}\n`)
+  process.stdout.write(`  other assets: ${sign(d.assetBytesDelta)}\n`)
+  if (d.owners.length) {
+    process.stdout.write('\n  Changed contributors:\n')
+    for (const o of d.owners.slice(0, 20)) {
+      process.stdout.write(`    ${sign(o.delta).padStart(11)}  ${o.owner}\n`)
+    }
+  } else {
+    process.stdout.write('\n  No per-contributor change.\n')
+  }
+  process.exit(0)
+}
+
+if (args.includes('--json')) {
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`)
+  process.exit(0)
+}
+
+const topAt = args.indexOf('--top')
+const top = topAt !== -1 ? Number.parseInt(args[topAt + 1], 10) : undefined
+process.stdout.write(`${renderReport(summary, { top })}\n`)
+process.stdout.write(`\nFull data: ${REPORT_PATH}\n`)

--- a/website/scripts/lib/bundleReport.mjs
+++ b/website/scripts/lib/bundleReport.mjs
@@ -1,0 +1,191 @@
+// Pure helpers for the debug-only bundle weight report.
+//
+// Kept dependency-free and side-effect-free on purpose. Rollup already knows the
+// rendered size of every module it emitted, so a bundle report needs no analyzer
+// package -- adding one would put a build-time dependency (and its transitive
+// tree) into a repo that is already carrying a long dependabot backlog, to
+// compute numbers the bundler hands us for free.
+//
+// Split out from the Vite plugin so the arithmetic and formatting are testable
+// without running a build.
+
+/** Bytes-to-human, fixed-width friendly. */
+export function formatBytes(bytes) {
+  if (typeof bytes !== 'number' || !Number.isFinite(bytes) || bytes < 0) return '-'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+/**
+ * Attribute a module path to a coarse owner bucket.
+ *
+ * The question this report answers is "what is making the bundle big", and the
+ * useful granularity for that is the dependency or source area, not the
+ * individual file. node_modules entries collapse to their package name
+ * (including the scope, so `@scope/pkg` stays distinct from another `pkg`).
+ */
+export function ownerOf(modulePath) {
+  if (typeof modulePath !== 'string' || !modulePath) return '(unknown)'
+  const normalized = modulePath.replace(/\\/g, '/')
+  const nm = normalized.lastIndexOf('node_modules/')
+  if (nm !== -1) {
+    const rest = normalized.slice(nm + 'node_modules/'.length)
+    const parts = rest.split('/').filter(Boolean)
+    if (parts.length === 0) return '(unknown)'
+    // Scoped packages keep two segments; everything else takes one.
+    return parts[0].startsWith('@') && parts.length > 1 ? `${parts[0]}/${parts[1]}` : parts[0]
+  }
+  // First-party code: bucket by the directory under src/ so "pages" and
+  // "components" are separable without listing every file.
+  const src = normalized.lastIndexOf('/src/')
+  if (src !== -1) {
+    const parts = normalized.slice(src + '/src/'.length).split('/').filter(Boolean)
+    if (parts.length > 1) return `src/${parts[0]}`
+    return 'src'
+  }
+  return '(other)'
+}
+
+/**
+ * Reduce Rollup's `generateBundle` output to a serializable summary.
+ *
+ * `bundle` is the object Rollup passes to the hook: keys are output filenames,
+ * values carry `type`, `code`/`source` and, for chunks, a `modules` map whose
+ * entries have `renderedLength` (the bytes that module contributed AFTER
+ * tree-shaking and minification, which is the number that actually matters --
+ * a module's own file size overstates its cost when most of it is shaken out).
+ */
+export function summarizeBundle(bundle, options = {}) {
+  const entries = Object.entries(bundle || {})
+  const chunks = []
+  const assets = []
+  const owners = new Map()
+
+  for (const [fileName, output] of entries) {
+    if (!output || typeof output !== 'object') continue
+    if (output.type === 'asset') {
+      const source = output.source
+      const size =
+        typeof source === 'string'
+          ? Buffer.byteLength(source)
+          : source && typeof source.byteLength === 'number'
+            ? source.byteLength
+            : 0
+      assets.push({ fileName, size })
+      continue
+    }
+    const code = typeof output.code === 'string' ? output.code : ''
+    const size = Buffer.byteLength(code)
+    const modules = output.modules && typeof output.modules === 'object' ? output.modules : {}
+    let moduleCount = 0
+    for (const [modulePath, info] of Object.entries(modules)) {
+      const rendered =
+        info && typeof info.renderedLength === 'number' && Number.isFinite(info.renderedLength)
+          ? info.renderedLength
+          : 0
+      // renderedLength 0 means fully tree-shaken; counting it as an owner would
+      // pad the report with modules that cost nothing.
+      if (rendered <= 0) continue
+      moduleCount += 1
+      const owner = ownerOf(modulePath)
+      owners.set(owner, (owners.get(owner) || 0) + rendered)
+    }
+    chunks.push({
+      fileName,
+      size,
+      moduleCount,
+      isEntry: Boolean(output.isEntry),
+      isDynamicEntry: Boolean(output.isDynamicEntry),
+    })
+  }
+
+  // Byte comparison rather than localeCompare throughout: filenames, package
+  // names and source paths are machine values, and a locale-sensitive tiebreak
+  // would make the report order differ between machines running the same build.
+  const byName = (a, b) => (a < b ? -1 : a > b ? 1 : 0)
+  chunks.sort((a, b) => b.size - a.size || byName(a.fileName, b.fileName))
+  assets.sort((a, b) => b.size - a.size || byName(a.fileName, b.fileName))
+  const ownerList = [...owners.entries()]
+    .map(([owner, size]) => ({ owner, size }))
+    .sort((a, b) => b.size - a.size || byName(a.owner, b.owner))
+
+  return {
+    version: 1,
+    generatedAt: options.now ? options.now() : new Date().toISOString(),
+    totals: {
+      chunkBytes: chunks.reduce((a, c) => a + c.size, 0),
+      assetBytes: assets.reduce((a, c) => a + c.size, 0),
+      chunkCount: chunks.length,
+      assetCount: assets.length,
+    },
+    chunks,
+    assets,
+    owners: ownerList,
+  }
+}
+
+/** Render a summary as a fixed-width text report. */
+export function renderReport(summary, options = {}) {
+  const top = Number.isInteger(options.top) && options.top > 0 ? options.top : 15
+  if (!summary || typeof summary !== 'object') return 'No bundle summary available.'
+  const t = summary.totals || {}
+  const lines = []
+  lines.push(`Bundle report  (generated ${summary.generatedAt || 'unknown'})`)
+  lines.push(
+    `JS chunks: ${t.chunkCount ?? 0} totalling ${formatBytes(t.chunkBytes)}   ` +
+      `other assets: ${t.assetCount ?? 0} totalling ${formatBytes(t.assetBytes)}`
+  )
+
+  const chunks = Array.isArray(summary.chunks) ? summary.chunks : []
+  if (chunks.length) {
+    lines.push('')
+    lines.push(`Largest chunks (top ${Math.min(top, chunks.length)}):`)
+    lines.push(`  ${'SIZE'.padStart(10)}  ${'MODULES'.padStart(7)}  KIND     FILE`)
+    for (const c of chunks.slice(0, top)) {
+      const kind = c.isEntry ? 'entry' : c.isDynamicEntry ? 'dynamic' : 'shared'
+      lines.push(
+        `  ${formatBytes(c.size).padStart(10)}  ${String(c.moduleCount ?? 0).padStart(7)}  ` +
+          `${kind.padEnd(7)}  ${c.fileName}`
+      )
+    }
+  }
+
+  const owners = Array.isArray(summary.owners) ? summary.owners : []
+  if (owners.length) {
+    lines.push('')
+    lines.push(`Heaviest contributors after tree-shaking (top ${Math.min(top, owners.length)}):`)
+    lines.push(`  ${'SIZE'.padStart(10)}  OWNER`)
+    for (const o of owners.slice(0, top)) {
+      lines.push(`  ${formatBytes(o.size).padStart(10)}  ${o.owner}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Compare two summaries. Used to answer "did my change make it bigger", which is
+ * the question a report is usually opened to settle.
+ */
+export function diffSummaries(before, after) {
+  const b = (before && before.totals) || {}
+  const a = (after && after.totals) || {}
+  const byOwner = new Map()
+  for (const o of (before && before.owners) || []) byOwner.set(o.owner, -o.size)
+  for (const o of (after && after.owners) || []) {
+    byOwner.set(o.owner, (byOwner.get(o.owner) || 0) + o.size)
+  }
+  const changed = [...byOwner.entries()]
+    .filter(([, delta]) => delta !== 0)
+    .map(([owner, delta]) => ({ owner, delta }))
+    .sort(
+      (x, y) =>
+        Math.abs(y.delta) - Math.abs(x.delta) ||
+        (x.owner < y.owner ? -1 : x.owner > y.owner ? 1 : 0)
+    )
+  return {
+    chunkBytesDelta: (a.chunkBytes || 0) - (b.chunkBytes || 0),
+    assetBytesDelta: (a.assetBytes || 0) - (b.assetBytes || 0),
+    owners: changed,
+  }
+}

--- a/website/src/lib/commitProfiler.tsx
+++ b/website/src/lib/commitProfiler.tsx
@@ -1,0 +1,183 @@
+// Debug-only React commit timing.
+//
+// Answers "which part of the UI is re-rendering, how often, and how expensively"
+// using React's own <Profiler>, without a devtools session attached.
+//
+// OFF by default and off in every normal load. It arms only when explicitly
+// asked for, via `?profile=commits` in the URL or a `kirocrew.profileCommits`
+// localStorage key. When disarmed, `withCommitProfiler` returns its children
+// untouched, so React sees no extra element and there is no wrapper in the tree.
+//
+// IMPORTANT LIMITATION, stated up front because it changes how to read the
+// numbers: <Profiler> only reports real timings in a build of react-dom that
+// includes profiling instrumentation. In the production bundle the callback is
+// effectively inert, so this is a `npm run dev` tool. It is not a way to measure
+// shipped performance on a user's machine, and the report says so at runtime
+// rather than quietly showing zeros.
+import { Profiler, type ReactNode } from 'react'
+
+const URL_FLAG = 'profile'
+const URL_VALUE = 'commits'
+const STORAGE_KEY = 'kirocrew.profileCommits'
+
+// Bounded so a long session cannot grow this without limit; commits are frequent.
+const MAX_RECORDS = 2000
+
+export interface CommitRecord {
+  id: string
+  phase: 'mount' | 'update' | 'nested-update'
+  /** Time spent rendering the committed update, in ms. */
+  actualDuration: number
+  /** Estimated time to render the whole subtree without memoization, in ms. */
+  baseDuration: number
+  commitTime: number
+}
+
+export interface CommitSummaryRow {
+  id: string
+  commits: number
+  mounts: number
+  updates: number
+  totalMs: number
+  maxMs: number
+  meanMs: number
+  /** Sum of baseDuration - actualDuration: roughly what memoization saved. */
+  savedMs: number
+}
+
+const records: CommitRecord[] = []
+
+/** Whether commit profiling has been explicitly armed for this page load. */
+export function commitProfilingEnabled(
+  search: string = typeof window === 'undefined' ? '' : window.location.search,
+  storage: Pick<Storage, 'getItem'> | null = typeof window === 'undefined'
+    ? null
+    : safeLocalStorage()
+): boolean {
+  try {
+    const params = new URLSearchParams(search || '')
+    if (params.get(URL_FLAG) === URL_VALUE) return true
+  } catch {
+    // A malformed query string must not break app startup.
+  }
+  try {
+    return storage?.getItem(STORAGE_KEY) === '1'
+  } catch {
+    // Storage access throws in some privacy modes; treat as disabled.
+    return false
+  }
+}
+
+function safeLocalStorage(): Pick<Storage, 'getItem'> | null {
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function recordCommit(record: CommitRecord): void {
+  records.push(record)
+  // Drop oldest first: the recent window is what an operator is looking at.
+  if (records.length > MAX_RECORDS) records.splice(0, records.length - MAX_RECORDS)
+}
+
+export function clearCommits(): void {
+  records.length = 0
+}
+
+export function getCommits(): readonly CommitRecord[] {
+  return records
+}
+
+/** Aggregate the raw records per Profiler id, heaviest total first. */
+export function summarizeCommits(source: readonly CommitRecord[] = records): CommitSummaryRow[] {
+  const byId = new Map<string, CommitSummaryRow>()
+  for (const r of source) {
+    if (!r || typeof r.id !== 'string') continue
+    const actual = Number.isFinite(r.actualDuration) ? r.actualDuration : 0
+    const base = Number.isFinite(r.baseDuration) ? r.baseDuration : 0
+    const row =
+      byId.get(r.id) ??
+      { id: r.id, commits: 0, mounts: 0, updates: 0, totalMs: 0, maxMs: 0, meanMs: 0, savedMs: 0 }
+    row.commits += 1
+    if (r.phase === 'mount') row.mounts += 1
+    else row.updates += 1
+    row.totalMs += actual
+    row.maxMs = Math.max(row.maxMs, actual)
+    row.savedMs += Math.max(0, base - actual)
+    byId.set(r.id, row)
+  }
+  const rows = [...byId.values()]
+  for (const row of rows) row.meanMs = row.commits ? row.totalMs / row.commits : 0
+  // Byte comparison, not localeCompare: these ids are machine identifiers passed
+  // to <Profiler id=...>, and a locale-sensitive tiebreak would make a diagnostic
+  // table order differently on different machines for no benefit.
+  rows.sort((a, b) => b.totalMs - a.totalMs || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+  return rows
+}
+
+/** Render the summary as fixed-width text for the console. */
+export function renderCommitSummary(rows: CommitSummaryRow[] = summarizeCommits()): string {
+  if (!rows.length) return 'No commits recorded. Arm with ?profile=commits and interact with the UI.'
+  const lines: string[] = []
+  lines.push(`${'TOTAL'.padStart(9)} ${'MAX'.padStart(8)} ${'MEAN'.padStart(8)} ${'N'.padStart(5)} ${'SAVED'.padStart(9)}  ID`)
+  for (const r of rows) {
+    lines.push(
+      `${r.totalMs.toFixed(1).padStart(9)} ${r.maxMs.toFixed(1).padStart(8)} ` +
+        `${r.meanMs.toFixed(2).padStart(8)} ${String(r.commits).padStart(5)} ` +
+        `${r.savedMs.toFixed(1).padStart(9)}  ${r.id}`
+    )
+  }
+  lines.push('')
+  lines.push('TOTAL/MAX/MEAN/SAVED are milliseconds. SAVED is baseDuration minus')
+  lines.push('actualDuration summed -- roughly what memoization avoided.')
+  return lines.join('\n')
+}
+
+/**
+ * Wrap `children` in a <Profiler> when armed, otherwise return them unchanged.
+ *
+ * Returning children untouched (rather than always mounting a Profiler with a
+ * no-op callback) means the disarmed path adds nothing to the element tree.
+ */
+export function withCommitProfiler(id: string, children: ReactNode): ReactNode {
+  if (!commitProfilingEnabled()) return children
+  return (
+    <Profiler
+      id={id}
+      onRender={(profilerId, phase, actualDuration, baseDuration, _startTime, commitTime) => {
+        recordCommit({
+          id: profilerId,
+          phase: phase as CommitRecord['phase'],
+          actualDuration,
+          baseDuration,
+          commitTime,
+        })
+      }}
+    >
+      {children}
+    </Profiler>
+  )
+}
+
+/**
+ * Expose the read helpers on `window` so they can be called from the console
+ * without a devtools extension. Only runs when armed.
+ */
+export function installCommitProfilerConsoleApi(): void {
+  if (typeof window === 'undefined' || !commitProfilingEnabled()) return
+  const api = {
+    summary: () => renderCommitSummary(),
+    rows: () => summarizeCommits(),
+    raw: () => getCommits(),
+    clear: () => clearCommits(),
+  }
+  ;(window as unknown as Record<string, unknown>).kirocrewCommits = api
+  // eslint-disable-next-line no-console
+  console.info(
+    'Commit profiling armed. Call kirocrewCommits.summary() for a table.\n' +
+      'Note: React only reports real timings in a profiling-enabled build of ' +
+      'react-dom, so use this with `npm run dev`; production numbers are inert.'
+  )
+}

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -4,6 +4,7 @@
 import './extensions'
 import React, { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom/client'
+import { withCommitProfiler, installCommitProfilerConsoleApi } from './lib/commitProfiler'
 import { Provider } from 'react-redux'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
@@ -83,6 +84,11 @@ if (import.meta.env.DEV) {
 
 const WorldsPopout = lazy(() => import('./pages/WorldsPopout'))
 
+// Debug-only, and inert unless explicitly armed with ?profile=commits. When
+// disarmed withCommitProfiler returns the children untouched, so no Profiler
+// element enters the tree on a normal load.
+installCommitProfilerConsoleApi()
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary root scope="app-shell">
@@ -100,7 +106,7 @@ createRoot(document.getElementById('root')!).render(
                       element={(
                         <BrandingProvider>
                           <ProviderProvider>
-                            <DashboardBootstrap><App /></DashboardBootstrap>
+                            <DashboardBootstrap>{withCommitProfiler('app', <App />)}</DashboardBootstrap>
                           </ProviderProvider>
                         </BrandingProvider>
                       )}

--- a/website/src/test/bundleReport.test.ts
+++ b/website/src/test/bundleReport.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatBytes,
+  ownerOf,
+  summarizeBundle,
+  renderReport,
+  diffSummaries,
+} from '../../scripts/lib/bundleReport.mjs'
+
+describe('formatBytes', () => {
+  it('scales units', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(2048)).toBe('2.0 KB')
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.00 MB')
+  })
+
+  it('rejects junk rather than printing NaN', () => {
+    expect(formatBytes(undefined)).toBe('-')
+    expect(formatBytes(-1)).toBe('-')
+    expect(formatBytes(Number.NaN)).toBe('-')
+    expect(formatBytes('100')).toBe('-')
+  })
+})
+
+describe('ownerOf', () => {
+  it('collapses a node_modules path to its package', () => {
+    expect(ownerOf('/repo/node_modules/lodash/index.js')).toBe('lodash')
+  })
+
+  it('keeps the scope so two same-named packages stay distinct', () => {
+    expect(ownerOf('/repo/node_modules/@tanstack/react-query/dist/x.js')).toBe(
+      '@tanstack/react-query'
+    )
+  })
+
+  it('uses the LAST node_modules segment for nested dependencies', () => {
+    // A nested dep must be attributed to itself, not to its parent.
+    expect(ownerOf('/repo/node_modules/a/node_modules/b/index.js')).toBe('b')
+  })
+
+  it('buckets first-party code by its directory under src', () => {
+    expect(ownerOf('/repo/website/src/pages/ChatPage.tsx')).toBe('src/pages')
+    expect(ownerOf('/repo/website/src/main.tsx')).toBe('src')
+  })
+
+  it('normalizes Windows separators', () => {
+    expect(ownerOf('C:\\repo\\node_modules\\lodash\\index.js')).toBe('lodash')
+    expect(ownerOf('C:\\repo\\website\\src\\pages\\X.tsx')).toBe('src/pages')
+  })
+
+  it('handles junk input', () => {
+    expect(ownerOf(null)).toBe('(unknown)')
+    expect(ownerOf('')).toBe('(unknown)')
+    expect(ownerOf('/somewhere/else/file.js')).toBe('(other)')
+  })
+})
+
+function bundleFixture() {
+  return {
+    'assets/index-abc.js': {
+      type: 'chunk',
+      isEntry: true,
+      code: 'x'.repeat(1000),
+      modules: {
+        '/repo/node_modules/lodash/index.js': { renderedLength: 600 },
+        '/repo/website/src/pages/ChatPage.tsx': { renderedLength: 300 },
+        '/repo/website/src/pages/Other.tsx': { renderedLength: 100 },
+        '/repo/node_modules/shaken/index.js': { renderedLength: 0 },
+      },
+    },
+    'assets/lazy-def.js': {
+      type: 'chunk',
+      isDynamicEntry: true,
+      code: 'y'.repeat(200),
+      modules: { '/repo/node_modules/@scope/pkg/x.js': { renderedLength: 200 } },
+    },
+    'assets/style.css': { type: 'asset', source: 'z'.repeat(50) },
+  }
+}
+
+describe('summarizeBundle', () => {
+  it('totals chunks and assets separately', () => {
+    const s = summarizeBundle(bundleFixture(), { now: () => 'T' })
+    expect(s.version).toBe(1)
+    expect(s.generatedAt).toBe('T')
+    expect(s.totals.chunkBytes).toBe(1200)
+    expect(s.totals.assetBytes).toBe(50)
+    expect(s.totals.chunkCount).toBe(2)
+    expect(s.totals.assetCount).toBe(1)
+  })
+
+  it('sorts chunks largest first and labels their kind', () => {
+    const s = summarizeBundle(bundleFixture())
+    expect(s.chunks[0].fileName).toBe('assets/index-abc.js')
+    expect(s.chunks[0].isEntry).toBe(true)
+    expect(s.chunks[1].isDynamicEntry).toBe(true)
+  })
+
+  it('excludes fully tree-shaken modules from owners and the module count', () => {
+    const s = summarizeBundle(bundleFixture())
+    expect(s.owners.map((o) => o.owner)).not.toContain('shaken')
+    // 3 of the 4 modules in the entry chunk contributed bytes.
+    expect(s.chunks[0].moduleCount).toBe(3)
+  })
+
+  it('aggregates owners across chunks and sorts by weight', () => {
+    const s = summarizeBundle(bundleFixture())
+    expect(s.owners[0]).toEqual({ owner: 'lodash', size: 600 })
+    // Both pages collapse into one src/pages bucket: 300 + 100.
+    expect(s.owners.find((o) => o.owner === 'src/pages')?.size).toBe(400)
+    expect(s.owners.find((o) => o.owner === '@scope/pkg')?.size).toBe(200)
+  })
+
+  it('survives an empty or malformed bundle', () => {
+    expect(summarizeBundle({}).totals.chunkBytes).toBe(0)
+    expect(summarizeBundle(null).chunks).toEqual([])
+    const s = summarizeBundle({ a: null, b: 'nope', c: { type: 'chunk' } })
+    expect(s.chunks).toHaveLength(1)
+    expect(s.chunks[0].size).toBe(0)
+  })
+
+  it('handles a binary asset source with byteLength', () => {
+    const s = summarizeBundle({
+      'img.png': { type: 'asset', source: new Uint8Array(12) },
+    })
+    expect(s.totals.assetBytes).toBe(12)
+  })
+
+  it('ignores a non-numeric renderedLength instead of producing NaN totals', () => {
+    const s = summarizeBundle({
+      'a.js': {
+        type: 'chunk',
+        code: '',
+        modules: { '/repo/node_modules/x/i.js': { renderedLength: 'big' } },
+      },
+    })
+    expect(s.owners).toEqual([])
+  })
+})
+
+describe('renderReport', () => {
+  it('includes totals, chunks and contributors', () => {
+    const out = renderReport(summarizeBundle(bundleFixture(), { now: () => 'T' }))
+    expect(out).toContain('Bundle report')
+    expect(out).toContain('assets/index-abc.js')
+    expect(out).toContain('lodash')
+    expect(out).toContain('entry')
+    expect(out).toContain('dynamic')
+  })
+
+  it('honours the top cap', () => {
+    const out = renderReport(summarizeBundle(bundleFixture()), { top: 1 })
+    expect(out).toContain('assets/index-abc.js')
+    expect(out).not.toContain('assets/lazy-def.js')
+  })
+
+  it('does not throw on a missing summary', () => {
+    expect(renderReport(null)).toBe('No bundle summary available.')
+  })
+})
+
+describe('diffSummaries', () => {
+  it('reports growth and shrinkage per contributor', () => {
+    const before = summarizeBundle(bundleFixture())
+    const after = summarizeBundle({
+      'assets/index-abc.js': {
+        type: 'chunk',
+        isEntry: true,
+        code: 'x'.repeat(1500),
+        modules: {
+          '/repo/node_modules/lodash/index.js': { renderedLength: 900 },
+          '/repo/website/src/pages/ChatPage.tsx': { renderedLength: 300 },
+        },
+      },
+    })
+    const d = diffSummaries(before, after)
+    expect(d.chunkBytesDelta).toBe(300)
+    const lodash = d.owners.find((o) => o.owner === 'lodash')
+    expect(lodash?.delta).toBe(300)
+    // Dropped entirely: shows as a negative rather than vanishing from the diff.
+    expect(d.owners.find((o) => o.owner === '@scope/pkg')?.delta).toBe(-200)
+  })
+
+  it('reports no per-contributor change for identical builds', () => {
+    const s = summarizeBundle(bundleFixture())
+    expect(diffSummaries(s, s).owners).toEqual([])
+    expect(diffSummaries(s, s).chunkBytesDelta).toBe(0)
+  })
+})

--- a/website/src/test/commitProfiler.test.tsx
+++ b/website/src/test/commitProfiler.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  commitProfilingEnabled,
+  recordCommit,
+  clearCommits,
+  getCommits,
+  summarizeCommits,
+  renderCommitSummary,
+  withCommitProfiler,
+  type CommitRecord,
+} from '../lib/commitProfiler'
+
+function rec(over: Partial<CommitRecord> = {}): CommitRecord {
+  return {
+    id: 'app',
+    phase: 'update',
+    actualDuration: 5,
+    baseDuration: 8,
+    commitTime: 100,
+    ...over,
+  }
+}
+
+describe('commitProfilingEnabled', () => {
+  it('is off with no flag anywhere', () => {
+    expect(commitProfilingEnabled('', { getItem: () => null })).toBe(false)
+  })
+
+  it('arms from the URL flag', () => {
+    expect(commitProfilingEnabled('?profile=commits', { getItem: () => null })).toBe(true)
+  })
+
+  it('ignores a different profile value', () => {
+    expect(commitProfilingEnabled('?profile=other', { getItem: () => null })).toBe(false)
+  })
+
+  it('arms from localStorage', () => {
+    expect(commitProfilingEnabled('', { getItem: () => '1' })).toBe(true)
+  })
+
+  it('treats any other stored value as off', () => {
+    expect(commitProfilingEnabled('', { getItem: () => '0' })).toBe(false)
+    expect(commitProfilingEnabled('', { getItem: () => 'true' })).toBe(false)
+  })
+
+  it('survives storage access throwing, as it does in some privacy modes', () => {
+    expect(
+      commitProfilingEnabled('', {
+        getItem: () => {
+          throw new Error('blocked')
+        },
+      })
+    ).toBe(false)
+  })
+
+  it('survives a malformed query string rather than breaking startup', () => {
+    expect(commitProfilingEnabled('%%%', { getItem: () => null })).toBe(false)
+  })
+})
+
+describe('summarizeCommits', () => {
+  beforeEach(() => clearCommits())
+
+  it('aggregates per id with mounts and updates split out', () => {
+    const rows = summarizeCommits([
+      rec({ id: 'a', phase: 'mount', actualDuration: 10, baseDuration: 10 }),
+      rec({ id: 'a', actualDuration: 4, baseDuration: 9 }),
+      rec({ id: 'b', actualDuration: 1, baseDuration: 1 }),
+    ])
+    const a = rows.find((r) => r.id === 'a')!
+    expect(a.commits).toBe(2)
+    expect(a.mounts).toBe(1)
+    expect(a.updates).toBe(1)
+    expect(a.totalMs).toBe(14)
+    expect(a.maxMs).toBe(10)
+    expect(a.meanMs).toBe(7)
+    // baseDuration - actualDuration, floored at 0 per record: (0) + (5).
+    expect(a.savedMs).toBe(5)
+  })
+
+  it('sorts heaviest total first', () => {
+    const rows = summarizeCommits([
+      rec({ id: 'light', actualDuration: 1 }),
+      rec({ id: 'heavy', actualDuration: 50 }),
+    ])
+    expect(rows[0].id).toBe('heavy')
+  })
+
+  it('never reports negative savings when actual exceeds base', () => {
+    const rows = summarizeCommits([rec({ actualDuration: 10, baseDuration: 2 })])
+    expect(rows[0].savedMs).toBe(0)
+  })
+
+  it('ignores malformed records instead of producing NaN', () => {
+    const rows = summarizeCommits([
+      rec({ actualDuration: Number.NaN, baseDuration: Number.NaN }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      null as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 42 } as any,
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].totalMs).toBe(0)
+    expect(Number.isNaN(rows[0].meanMs)).toBe(false)
+  })
+
+  it('returns nothing for no input', () => {
+    expect(summarizeCommits([])).toEqual([])
+  })
+})
+
+describe('the record buffer', () => {
+  beforeEach(() => clearCommits())
+
+  it('is bounded so a long session cannot grow it without limit', () => {
+    for (let i = 0; i < 2100; i++) recordCommit(rec({ commitTime: i }))
+    const all = getCommits()
+    expect(all.length).toBe(2000)
+    // Oldest dropped first: the retained window is the most recent.
+    expect(all[all.length - 1].commitTime).toBe(2099)
+    expect(all[0].commitTime).toBe(100)
+  })
+
+  it('clears', () => {
+    recordCommit(rec())
+    clearCommits()
+    expect(getCommits()).toHaveLength(0)
+  })
+})
+
+describe('renderCommitSummary', () => {
+  it('explains itself when empty rather than printing an empty table', () => {
+    expect(renderCommitSummary([])).toContain('No commits recorded')
+  })
+
+  it('renders a row per id', () => {
+    const out = renderCommitSummary(summarizeCommits([rec({ id: 'chat' })]))
+    expect(out).toContain('chat')
+    expect(out).toContain('TOTAL')
+  })
+})
+
+describe('withCommitProfiler', () => {
+  it('returns children untouched when disarmed, adding nothing to the tree', () => {
+    const children = 'child-node'
+    // No URL flag and no storage key in the happy-dom default environment.
+    expect(withCommitProfiler('app', children)).toBe(children)
+  })
+})

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -270,8 +270,47 @@ function editionExtensionPlugin(): Plugin {
   }
 }
 
+/**
+ * Debug-only plugin: writes `dist/bundle-report.json` describing what the build
+ * emitted and which packages contribute the weight.
+ *
+ * Inert unless the build runs in `analyze` mode (`vite build --mode analyze`,
+ * wired up as `npm run analyze`), so a normal `npm run build` is byte-for-byte
+ * unaffected and never pays the walk. Mode is read here rather than by turning
+ * the whole config into a function, to keep this to one entry in `plugins`.
+ *
+ * Note there is no analyzer dependency: Rollup already reports the rendered size
+ * of every module it emitted, so the numbers are computed from data the bundler
+ * hands us. That keeps a build-time package (and its transitive tree) out of the
+ * repo for something it can already answer.
+ */
+function bundleReportPlugin(): Plugin {
+  const REPORT_MODE = 'analyze'
+  let active = false
+  return {
+    name: 'kirocrew-bundle-report',
+    apply: 'build',
+    configResolved(resolved) {
+      active = resolved.mode === REPORT_MODE
+    },
+    async generateBundle(_options, bundle) {
+      if (!active) return
+      // Imported lazily so a normal build never loads the helper at all.
+      const { summarizeBundle } = await import('./scripts/lib/bundleReport.mjs')
+      const summary = summarizeBundle(bundle)
+      // Emitted through Rollup rather than written directly so it lands in the
+      // configured outDir wherever that points.
+      this.emitFile({
+        type: 'asset',
+        fileName: 'bundle-report.json',
+        source: JSON.stringify(summary, null, 2),
+      })
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), tokenProxyPlugin(), appImportMapPlugin(), tailwindRuntimePlugin(), swVersionPlugin(), editionExtensionPlugin()],
+  plugins: [react(), tokenProxyPlugin(), appImportMapPlugin(), tailwindRuntimePlugin(), swVersionPlugin(), editionExtensionPlugin(), bundleReportPlugin()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Problem

Layer 3 of the profiling work, and the last gap. `kirocrew perf sample` (#1063)
profiles Python; `kirocrew desktop metrics` (#1199) covers the Electron shell. Neither
says anything about the **web app itself** — what is making the bundle heavy, or which
part of the React tree re-renders expensively.

Both questions were unanswerable without ad-hoc work: there was no bundle analysis of
any kind, and commit timing needed a devtools session attached by hand.

## Why it matters

"The dashboard feels slow to load" and "typing is janky" are different problems with
different fixes, and neither is diagnosable from the existing profilers. Bundle weight
in particular regresses silently — nothing today notices a dependency doubling a chunk.

## Fix (symptom -> root cause -> change)

Two independent, debug-only tools.

### 1. Bundle weight report — `npm run analyze`

A Vite plugin (`bundleReportPlugin` in `website/vite.config.ts`) writes
`dist/bundle-report.json` from Rollup's `generateBundle` metadata, and
`website/scripts/bundle-report.mjs` renders it.

**No analyzer dependency.** Rollup already knows the `renderedLength` of every module it
emitted — the size *after* tree-shaking and minification, which is the number that
actually matters, since a module's file size overstates its cost when most of it is
shaken out. Computing the report from that data avoids putting a build-time package and
its transitive tree into a repo already carrying a long dependabot backlog.

**Inert by default.** The plugin activates only in `analyze` mode
(`vite build --mode analyze`), read via `configResolved`. A plain `npm run build` writes
no report and does no extra walk — verified below. Mode is read inside the plugin rather
than by converting the whole config to a function form, to keep the config diff to one
entry in `plugins`.

Output on the current tree, which is immediately actionable:

```
Heaviest contributors after tree-shaking (top 15):
        SIZE  OWNER
     9.53 MB  monaco-editor
     2.99 MB  src/i18n
     2.14 MB  src/pages
     1.92 MB  mermaid
     1.44 MB  src/components
     1.05 MB  cytoscape
   936.7 KB  lucide-react
```

`--json` emits the raw document, `--top N` changes the cut, and `--diff <baseline.json>`
compares two reports per contributor — the "did my change make it bigger" question a
report is usually opened to settle.

### 2. React commit timing — `?profile=commits`

`website/src/lib/commitProfiler.tsx` wraps the app in React's own `<Profiler>` and
aggregates commits per id: count, total/max/mean duration, and how much `baseDuration`
exceeded `actualDuration` (roughly what memoization saved). `kirocrewCommits.summary()`
prints a table from the console — no devtools extension needed.

Armed only by `?profile=commits` or a `kirocrew.profileCommits` localStorage key. When
disarmed, `withCommitProfiler` returns its children **unchanged**, so no Profiler element
enters the tree on a normal load — rather than always mounting one with a no-op callback.
Records are capped at 2000, newest retained.

**Stated limitation, because it changes how to read the numbers:** `<Profiler>` only
reports real timings in a build of `react-dom` with profiling instrumentation. In the
production bundle the callback is effectively inert, so this is a `npm run dev` tool and
not a way to measure shipped performance on a user's machine. The console message says so
at arm time rather than quietly showing zeros.

### i18n exemption

Three strings in `commitProfiler.tsx` are developer console diagnostics that never reach
a user through the UI. Added a file-scoped `i18next/no-literal-string: off` block in
`eslint.i18n.config.js`, which is the gate's own documented remedy and follows the
existing `src/surfaces/builtins.tsx` precedent. Scoped to the one file — a `words.exclude`
shape rule cannot express "prose, but only in this module", and disabling for `src/lib/**`
would silence real copy in its neighbours.

## Tests

- `website/src/test/bundleReport.test.ts` (20): unit scaling and junk rejection in
  `formatBytes`; `ownerOf` collapsing `node_modules` paths to packages, keeping scopes
  distinct, attributing **nested** dependencies to themselves rather than their parent,
  bucketing first-party code under `src/<dir>`, and normalizing Windows separators;
  chunk/asset totals kept separate; entry vs dynamic vs shared labelling; fully
  tree-shaken modules excluded from both owners and the module count; owners aggregated
  across chunks; binary asset sources measured via `byteLength`; a non-numeric
  `renderedLength` ignored rather than producing NaN totals; empty and malformed bundles
  survived; `--diff` reporting growth, shrinkage, and a dropped contributor as a negative.
- `website/src/test/commitProfiler.test.tsx` (17): the gate off by default, armed from URL
  or storage, unaffected by a different `profile` value, surviving storage access throwing
  (as it does in some privacy modes) and a malformed query string; per-id aggregation with
  mounts and updates split; savings never negative when actual exceeds base; malformed
  records ignored rather than yielding NaN; the record buffer bounded at 2000 keeping the
  newest; and `withCommitProfiler` returning children identically when disarmed.

37 new tests. Full suite 7115 passed / 1 failed, where the one failure is
`src/i18n/format.test.ts` asserting the fallback path used when `Intl.DurationFormat` is
**absent** — it is present in the local Node 24, the file is not in this diff, and CI runs
the pinned Node where it passes.

One test failure during development **was** mine and is worth recording: the
`localeFormatting` ratchet went 62 -> 63 because `summarizeCommits` used a bare
`localeCompare` for its tiebreak. Fixed by comparing bytes, per the gate's own guidance
for machine values, and applied to all five sites (including the four in
`scripts/lib/bundleReport.mjs` that the gate does not scan) — sorting package names by
locale would make the report order differ between machines running the same build.

## Manual verification

- `npm run analyze` on this tree produces the report above, end to end through the real
  npm script.
- `npm run build` afterwards writes **no** `dist/bundle-report.json`, confirming the
  default build path is untouched.
- `node scripts/bundle-report.mjs` with no report present exits 2 and explains that
  `npm run analyze` must run first, rather than failing obscurely.

Gates: `tsc -b` clean, `i18n:check` clean with `I18N_BASE_REF=origin/main`, eslint
311 problems / **1 error** where that error (`src/vite-env.d.ts:3:9 Parsing error`) is
reproduced identically on clean `origin/main` and is not in this diff.

## Screenshots

N/A — no user-visible UI surface. Both tools output developer text (CLI report and console
table), shown above.
