### PR TITLE
fix: self-heal a stray auth-staging path so gateway boot doesn't crash (#561)

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -747,6 +747,27 @@ def _ensure_auth_staging_parent(home: Path) -> Path:
     """Create the fixed sandbox-hidden parent before agent sessions can start."""
 
     staging_parent = home / _AUTH_STAGING_RELATIVE
+    # A stray file or dangling/loop symlink at this path makes a plain
+    # mkdir(exist_ok=True) raise FileExistsError and crash gateway boot. Remove
+    # it before mkdir so boot self-heals. UNLINK rather than rename-aside: the
+    # staging root holds credential material, and moving an unexpected file to a
+    # sibling name would leave its (possibly sensitive) contents readable outside
+    # the sandbox-hidden staging prefix. unlink() acts on the symlink itself,
+    # never its target. (#561)
+    if staging_parent.is_symlink() or (staging_parent.exists() and not staging_parent.is_dir()):
+        try:
+            staging_parent.unlink()
+        except OSError as exc:
+            # A concurrent gateway boot may have won the race and already cleared
+            # the stray path (FileNotFoundError) or replaced it with the real
+            # private directory. Only abort if a non-directory we cannot clear is
+            # STILL sitting here; otherwise fall through to the idempotent mkdir.
+            # (#561, concurrent-boot race)
+            if staging_parent.is_symlink() or (staging_parent.exists() and not staging_parent.is_dir()):
+                raise OSError(
+                    f"Kiro auth staging root {staging_parent} is not a private "
+                    "directory and could not be reset"
+                ) from exc
     staging_parent.mkdir(parents=True, exist_ok=True)
     if staging_parent.is_symlink() or not staging_parent.is_dir():
         raise OSError("Kiro auth staging root is not a private directory")

--- a/test/test_auth_staging_561.py
+++ b/test/test_auth_staging_561.py
@@ -1,0 +1,71 @@
+"""Regression: gateway boot self-heals a stray auth-staging path (#561).
+
+A stray file or dangling symlink at ``<home>/.kiro/crew-auth-staging`` used to
+make ``mkdir(exist_ok=True)`` raise ``FileExistsError`` and crash boot. It must
+now be removed (unlinked, so no sensitive contents survive to a readable
+sibling) and a fresh private directory created.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kiro_crew.kiro_prerequisite import _AUTH_STAGING_RELATIVE, _ensure_auth_staging_parent
+
+
+def test_stray_file_is_removed(tmp_path: Path) -> None:
+    staging = tmp_path / _AUTH_STAGING_RELATIVE
+    staging.parent.mkdir(parents=True, exist_ok=True)
+    staging.write_text("stray")  # a FILE where a directory must be
+
+    result = _ensure_auth_staging_parent(tmp_path)
+
+    assert result.is_dir() and not result.is_symlink()
+    # The stray file's (possibly sensitive) contents are gone — not renamed to a
+    # readable sibling.
+    assert list(result.iterdir()) == []
+    assert not any(".broken-" in p.name for p in staging.parent.iterdir())
+
+
+def test_dangling_symlink_is_removed(tmp_path: Path) -> None:
+    staging = tmp_path / _AUTH_STAGING_RELATIVE
+    staging.parent.mkdir(parents=True, exist_ok=True)
+    staging.symlink_to(tmp_path / "nonexistent-target")  # dangling symlink
+
+    result = _ensure_auth_staging_parent(tmp_path)
+
+    assert result.is_dir() and not result.is_symlink()
+
+
+def test_existing_directory_is_left_intact(tmp_path: Path) -> None:
+    first = _ensure_auth_staging_parent(tmp_path)
+    (first / "keep").write_text("x")
+
+    second = _ensure_auth_staging_parent(tmp_path)
+
+    assert (second / "keep").exists()  # not quarantined or recreated
+
+
+def test_concurrent_boot_race_is_tolerated(tmp_path: Path, monkeypatch) -> None:
+    # A second gateway boot may win the race and remove the stray path first, so
+    # our unlink() loses with FileNotFoundError. Boot must still self-heal (mkdir
+    # the private dir) rather than abort. (#561, concurrent-boot race)
+    import os as _os
+    from pathlib import Path as _P
+
+    staging = tmp_path / _AUTH_STAGING_RELATIVE
+    staging.parent.mkdir(parents=True, exist_ok=True)
+    staging.write_text("stray")
+
+    real_unlink = _P.unlink
+
+    def racing_unlink(self, *a, **k):
+        # The "winner" already removed it; our unlink then loses the race.
+        if _os.path.lexists(self):
+            real_unlink(self)
+        raise FileNotFoundError(2, "No such file or directory", str(self))
+
+    monkeypatch.setattr(_P, "unlink", racing_unlink)
+
+    result = _ensure_auth_staging_parent(tmp_path)
+    assert result.is_dir() and not result.is_symlink()


### PR DESCRIPTION
## Problem
If `<home>/.kiro/crew-auth-staging` is a stray **file** or a **dangling symlink**, `_ensure_auth_staging_parent`'s `mkdir(parents=True, exist_ok=True)` raises `FileExistsError` and the gateway **crashes on boot**. The existing private-dir guard runs *after* the mkdir, so it never gets the chance. (#561)

## Why it matters
A hard boot failure with no self-recovery — a leftover file or symlink at that path (e.g. a botched restore) bricks startup.

## Fix (symptom → root cause → change)
Crash on boot → mkdir runs before the non-directory check → **unlink** a stray file / dangling symlink at the staging root *before* `mkdir`, then create a fresh `0700` dir. Unlink (not rename-aside) so no credential-adjacent contents survive to a readable sibling; `unlink()` acts on the symlink itself, never its target. The post-mkdir private-dir guard + chmod are unchanged.

## Tests
`test_auth_staging_561.py` — stray file removed + fresh empty dir created (no readable sibling); dangling symlink removed (result is a real dir, not a symlink); an existing dir is left intact.

## Manual verification
N/A — unit coverage sufficient. Local gates green: 138 backend tests (targeted + `test_kiro_prerequisite`), isort, flake8, mypy. Backend-only; no frontend surface.

## Screenshots
N/A — no user-visible UI change.

## Scope note
This branch originally also carried the #1113 `spawn_steer` `session_starting` hint. A more complete bounded-startup-wait implementation of #1113 has since merged to `main`, so that half was dropped on rebase and only the #561 fix remains here.
