### PR TITLE
feat: advisory host-resource guard for heavy work

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -863,6 +863,27 @@ class AgentConfig:
             "Minimum available memory (GB) required to spawn a subagent. 0 disables the check.",
         ),
     )
+    resource_pressure_gb: float = field(
+        default=4.0,
+        metadata=_meta(
+            "Resource Pressure Threshold (GB)",
+            "Available memory (GB) at or below which the agent is told host memory "
+            "is 'tight' via a compact [RESOURCES] context line, so it can prefer "
+            "the lighter path for heavy work (targeted tests, smaller sub-agent "
+            "waves). Advisory only — not enforced. 0 disables the context line. "
+            "Lower this on small-memory hosts / memory-limited containers (e.g. a "
+            "2-4 GB pod) so the advisory only fires under genuine pressure.",
+        ),
+    )
+    resource_critical_gb: float = field(
+        default=2.0,
+        metadata=_meta(
+            "Resource Critical Threshold (GB)",
+            "Available memory (GB) at or below which the [RESOURCES] context line "
+            "escalates to 'critically low' and advises against starting heavy work "
+            "at all. Should be <= resource_pressure_gb. 0 disables the critical tier.",
+        ),
+    )
     workflow_run_timeout_secs: int = field(
         default=3600,
         metadata=_meta(
@@ -4126,6 +4147,12 @@ class KiroCrewConfig:
                 subagent_auto_max=_safe_int(agent_data.get("subagent_auto_max", 32), 32),
                 subagent_spawn_stagger_secs=_safe_float(
                     agent_data.get("subagent_spawn_stagger_secs", 2.0), 2.0
+                ),
+                resource_pressure_gb=_safe_float(
+                    agent_data.get("resource_pressure_gb", 4.0), 4.0
+                ),
+                resource_critical_gb=_safe_float(
+                    agent_data.get("resource_critical_gb", 2.0), 2.0
                 ),
                 subagent_max_turns=agent_data.get("subagent_max_turns", 100),
                 subagent_timeout_secs=agent_data.get("subagent_timeout_secs", 1800),

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -2107,6 +2107,29 @@ class ContextBuilder:
                 "when answering questions.\n\n"
             )
 
+        # Resource pressure — inject a compact advisory ONLY when host memory is
+        # tight/critical, so the model can choose the lighter path for heavy work
+        # (targeted tests, smaller sub-agent waves, deferred builds). Silent (zero
+        # token cost) when memory is ample or unreadable. Agent-agnostic: rides
+        # the gateway context rail, so it survives agent switches (a tool grant
+        # cannot). Skipped for minimal contexts. Best-effort — never let a probe
+        # failure break message assembly.
+        if not minimal_context:
+            try:
+                from kiro_crew.resource_status import probe as _probe_resources
+
+                _rstatus = _probe_resources()
+                _rline = _rstatus.context_line()
+                if _rline:
+                    parts.append(_rline + "\n\n")
+                    logger.info(
+                        "🔍 Injected resource pressure line (posture=%s, avail=%.1fGB)",
+                        _rstatus.posture,
+                        _rstatus.available_gb,
+                    )
+            except Exception:
+                logger.debug("resource pressure probe failed", exc_info=True)
+
         # Folder breadcrumb — the session's sidebar folder ancestry (root→leaf).
         # Injected when the caller supplies folder_path (once per session, and
         # again after a folder move). Kept lightweight — not re-sent every turn.

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -7,6 +7,7 @@ Tools:
     spawn_run       — spawn a background subagent
     spawn_list      — list running/completed subagents
     spawn_status    — retrieve full subagent output
+    resource_status — check host resource headroom before heavy work
     learn_add       — save a learned correction
     learn_list      — list all lessons
     learn_remove    — remove lessons by substring
@@ -385,6 +386,22 @@ def _list_tools() -> list[dict[str, Any]]:
         {
             "name": "spawn_list",
             "description": "List all running and completed subagents (read-only, no commands executed)",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "resource_status",
+            "description": (
+                "Check current host resource headroom BEFORE starting a heavy "
+                "step — a full test suite, a large build, or a big parallel "
+                "sub-agent wave. Returns available memory, CPU load, and an "
+                "advisory posture (ample / tight / critical) plus the current "
+                "concurrent sub-agent cap, so you can decide whether to run the "
+                "heavy path now, switch to a lighter path (targeted tests, fewer "
+                "sub-agents, deferred build), or wait for memory to free. "
+                "Read-only and advisory — it does NOT reserve or enforce "
+                "anything, and headroom can change between the check and your "
+                "action, so treat it as guidance, not a guarantee."
+            ),
             "inputSchema": {"type": "object", "properties": {}},
         },
         {
@@ -3628,6 +3645,37 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         except Exception:
             pass  # list_agents failure is non-critical
         return "\n".join(lines)
+
+    if name == "resource_status":
+        from kiro_crew.resource_status import probe as _probe_resources
+
+        rstatus = _probe_resources()
+        out = rstatus.summary_lines()
+        try:
+            cap = resolve_max_subagents(KiroCrewConfig.load())
+        except Exception:
+            cap = 0
+        if cap > 0:
+            out.append(f"  Concurrent sub-agent cap: {cap}")
+        if rstatus.posture == "critical":
+            out.append(
+                "\nGuidance: memory is critically low — do NOT start heavy work "
+                "(full suites, large builds, big sub-agent waves) now; run only "
+                "light steps or wait for memory to free."
+            )
+        elif rstatus.posture == "tight":
+            out.append(
+                "\nGuidance: memory is tight — prefer the lighter path (targeted "
+                "tests, fewer sub-agents, deferred builds) for heavy work."
+            )
+        elif rstatus.posture == "ample":
+            out.append("\nGuidance: ample headroom — heavy work is fine.")
+        else:
+            out.append(
+                "\nGuidance: headroom could not be measured on this host — "
+                "proceed with normal caution."
+            )
+        return "\n".join(out)
 
     if name == "spawn_status":
         agent_id = args.get("agent_id", "")

--- a/src/kiro_crew/resource_status.py
+++ b/src/kiro_crew/resource_status.py
@@ -1,0 +1,208 @@
+"""Lightweight, read-only host-resource probe.
+
+Shared by two advisory surfaces:
+
+* the **pressure-gated context line** injected in
+  :meth:`kiro_crew.context.ContextManager.build_message` — a compact
+  ``[RESOURCES]`` note the gateway adds to a turn ONLY when host memory is
+  tight/critical, so the model can pick the lighter path for heavy work. It
+  rides the gateway context rail (not an agent tool grant), so it survives
+  agent switches, including custom agents.
+* the **``resource_status`` pull tool** in ``mcp_core`` — an on-demand probe
+  the model can call before a heavy step ("am I clear to run the full suite?").
+
+This is **advisory only**: no enforcement, no lease, no cross-session
+coordination. Two sessions can both read "ample" and both launch heavy work —
+the tradeoff of a cheap, zero-tuning guard. It makes the agent *smarter* about
+when to go light, not *bounded*. (A hard, cross-session admission lease is a
+separate, heavier design.)
+
+The memory figure reuses :func:`kiro_crew.subagent._available_memory_gb`, the
+same cgroup-clamped, container-aware probe that auto-sizes the sub-agent cap, so
+the two never disagree. It is imported lazily to keep this module import-cheap
+and free of any import cycle (``context`` imports this; ``subagent`` is heavy).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Posture labels — coarse buckets, not a continuous score.
+POSTURE_AMPLE = "ample"
+POSTURE_TIGHT = "tight"
+POSTURE_CRITICAL = "critical"
+POSTURE_UNKNOWN = "unknown"
+
+# Fallback thresholds (GB) when config is unavailable. Mirror the AgentConfig
+# defaults (``resource_pressure_gb`` / ``resource_critical_gb``).
+_DEFAULT_PRESSURE_GB = 4.0
+_DEFAULT_CRITICAL_GB = 2.0
+
+
+def _read_available_gb() -> float:
+    """Cgroup-clamped available memory (GB), or ``-1.0`` when unreadable.
+
+    Lazily reuses :func:`kiro_crew.subagent._available_memory_gb` (the same
+    probe the dynamic sub-agent cap uses) so the container-aware clamping logic
+    lives in exactly one place. Any failure degrades to ``-1.0`` → posture
+    ``unknown`` → the caller stays silent (fail-open, never a false alarm).
+    """
+    try:
+        from kiro_crew.subagent import _available_memory_gb
+
+        return _available_memory_gb()
+    except Exception:  # pragma: no cover - defensive; probe must never raise
+        logger.debug("available-memory probe failed", exc_info=True)
+        return -1.0
+
+
+def _read_load_per_cpu(cpu_count: int) -> float | None:
+    """1-minute load average normalized per CPU, or ``None`` if unavailable.
+
+    ``os.getloadavg`` is Unix-only and raises ``OSError`` if the load cannot be
+    obtained; Windows lacks it entirely (``AttributeError``). Either way the
+    caller treats ``None`` as "no load signal" and omits it.
+    """
+    if cpu_count <= 0:
+        return None
+    try:
+        one_min = os.getloadavg()[0]
+    except (OSError, AttributeError, ValueError, IndexError):
+        return None
+    return round(one_min / cpu_count, 2)
+
+
+@dataclass(frozen=True)
+class ResourceStatus:
+    """A single advisory snapshot of host resource headroom."""
+
+    available_gb: float          # -1.0 when the memory probe is unavailable
+    cpu_count: int
+    load_per_cpu: float | None   # 1-min loadavg / cpu_count, None if unavailable
+    posture: str                 # one of the POSTURE_* constants
+    pressure_gb: float           # tight threshold in effect
+    critical_gb: float           # critical threshold in effect
+
+    @property
+    def under_pressure(self) -> bool:
+        """True only for tight/critical — the gate for injecting the context line."""
+        return self.posture in (POSTURE_TIGHT, POSTURE_CRITICAL)
+
+    def _load_suffix(self) -> str:
+        return f", load {self.load_per_cpu}/core" if self.load_per_cpu is not None else ""
+
+    def context_line(self) -> str:
+        """The compact ``[RESOURCES]`` advisory injected on a pressured turn.
+
+        Returns ``""`` when the line is disabled (``pressure_gb <= 0`` — the
+        documented off switch) or when not under pressure, so callers can append
+        unconditionally. Note this is the OFF switch for the injected line only;
+        ``posture`` / ``summary_lines`` still report the true state for the pull
+        tool. Kept short on purpose — it costs tokens every pressured turn.
+        """
+        if self.pressure_gb <= 0:
+            return ""  # off switch: disables the line regardless of critical tier
+        if not self.under_pressure:
+            return ""
+        gb = f"{self.available_gb:.1f}"
+        load = self._load_suffix()
+        if self.posture == POSTURE_CRITICAL:
+            return (
+                f"[RESOURCES] Host memory is CRITICALLY low (~{gb} GB free{load}). "
+                "Do NOT start heavy work now (full test suites, large builds, big "
+                "parallel sub-agent waves) — it may fail or destabilize other "
+                "sessions on this host. Run only the lightest necessary steps, or "
+                "wait for memory to free. Call the resource_status tool to re-check."
+            )
+        return (
+            f"[RESOURCES] Host memory is tight (~{gb} GB free{load}). Before heavy "
+            "work, prefer the lighter path: run targeted tests instead of the full "
+            "suite, avoid large parallel sub-agent waves, and serialize or defer "
+            "memory-heavy builds/test runs. Call the resource_status tool to "
+            "re-check before a heavy step."
+        )
+
+    def summary_lines(self) -> list[str]:
+        """Human/agent-readable multi-line report for the pull tool."""
+        lines = ["Host resources (advisory — not an enforced limit):"]
+        if self.available_gb < 0:
+            lines.append("  Available memory: unknown (probe unavailable on this host)")
+        else:
+            lines.append(
+                f"  Available memory: {self.available_gb:.1f} GB "
+                f"(tight \u2264 {self.pressure_gb:g} GB, critical \u2264 {self.critical_gb:g} GB)"
+            )
+        load = f"{self.load_per_cpu}/core" if self.load_per_cpu is not None else "unknown"
+        lines.append(f"  CPU cores: {self.cpu_count}   1-min load: {load}")
+        lines.append(f"  Posture: {self.posture.upper()}")
+        return lines
+
+
+def _resolve_thresholds(cfg: object | None) -> tuple[float, float]:
+    """Return (pressure_gb, critical_gb) from config, falling back to defaults."""
+    agent = getattr(cfg, "agent", None)
+    pressure = getattr(agent, "resource_pressure_gb", _DEFAULT_PRESSURE_GB)
+    critical = getattr(agent, "resource_critical_gb", _DEFAULT_CRITICAL_GB)
+    try:
+        pressure = float(pressure)
+        critical = float(critical)
+    except (TypeError, ValueError):
+        pressure, critical = _DEFAULT_PRESSURE_GB, _DEFAULT_CRITICAL_GB
+    # Invariant: critical must not exceed pressure. `_classify` tests critical
+    # first, so an inverted config (e.g. critical=8, pressure=4) would make the
+    # `tight` tier unreachable and report CRITICAL at high free memory. Clamp
+    # rather than reject so a misconfig degrades sensibly. Only meaningful when
+    # pressure is enabled (pressure<=0 disables the line anyway).
+    if pressure > 0 and critical > pressure:
+        critical = pressure
+    return pressure, critical
+
+
+def _classify(available_gb: float, pressure_gb: float, critical_gb: float) -> str:
+    """Map available memory + thresholds to a posture bucket.
+
+    A threshold of ``0`` disables its bucket: with ``pressure_gb == 0`` no
+    positive memory reading can ever be ``<=`` it, so the posture is always
+    ``ample`` and the context line never injects (the documented off switch).
+    An unreadable probe (``available_gb < 0``) is ``unknown`` → fail-open.
+    """
+    if available_gb < 0:
+        return POSTURE_UNKNOWN
+    if critical_gb > 0 and available_gb <= critical_gb:
+        return POSTURE_CRITICAL
+    if pressure_gb > 0 and available_gb <= pressure_gb:
+        return POSTURE_TIGHT
+    return POSTURE_AMPLE
+
+
+def probe(cfg: object | None = None) -> ResourceStatus:
+    """Take an advisory resource snapshot.
+
+    *cfg* is an optional pre-loaded ``KiroCrewConfig``; when omitted it is
+    loaded (the loader is fingerprint-cached, so this is cheap). Never raises —
+    on any failure it returns an ``unknown`` posture so callers stay silent.
+    """
+    if cfg is None:
+        try:
+            from kiro_crew.config.loader import KiroCrewConfig
+
+            cfg = KiroCrewConfig.load()
+        except Exception:  # pragma: no cover - defensive
+            cfg = None
+    pressure_gb, critical_gb = _resolve_thresholds(cfg)
+    available_gb = _read_available_gb()
+    cpu_count = os.cpu_count() or 1
+    load_per_cpu = _read_load_per_cpu(cpu_count)
+    posture = _classify(available_gb, pressure_gb, critical_gb)
+    return ResourceStatus(
+        available_gb=available_gb,
+        cpu_count=cpu_count,
+        load_per_cpu=load_per_cpu,
+        posture=posture,
+        pressure_gb=pressure_gb,
+        critical_gb=critical_gb,
+    )

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -999,6 +999,7 @@ SPAWN_STATUS_SCHEMA = ToolSchema(
 )
 
 SPAWN_LIST_SCHEMA = ToolSchema(tool_name="spawn_list")
+RESOURCE_STATUS_SCHEMA = ToolSchema(tool_name="resource_status")
 
 TASK_RUN_SCHEMA = ToolSchema(
     tool_name="task_run",
@@ -2009,6 +2010,7 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
     "spawn_run": SPAWN_RUN_SCHEMA,
     "spawn_sub_agents": SPAWN_SUB_AGENTS_SCHEMA,
     "spawn_list": SPAWN_LIST_SCHEMA,
+    "resource_status": RESOURCE_STATUS_SCHEMA,
     "spawn_status": SPAWN_STATUS_SCHEMA,
     "learn_add": LEARN_ADD_SCHEMA,
     "learn_remove": LEARN_REMOVE_SCHEMA,

--- a/test/test_resource_status.py
+++ b/test/test_resource_status.py
@@ -1,0 +1,199 @@
+"""Tests for the advisory resource probe and its two surfaces.
+
+Covers :mod:`kiro_crew.resource_status` (posture classification, context line,
+disable switch, fail-open) and the ``resource_status`` pull tool wired into
+``mcp_core`` (advertised + dispatchable).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew import resource_status as rs
+
+
+def _cfg(pressure: float, critical: float) -> SimpleNamespace:
+    """Minimal stand-in for KiroCrewConfig exposing the two thresholds."""
+    return SimpleNamespace(
+        agent=SimpleNamespace(
+            resource_pressure_gb=pressure,
+            resource_critical_gb=critical,
+        )
+    )
+
+
+# ── _classify ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "avail,expected",
+    [
+        (16.0, rs.POSTURE_AMPLE),
+        (4.01, rs.POSTURE_AMPLE),
+        (4.0, rs.POSTURE_TIGHT),   # boundary: <= pressure
+        (2.5, rs.POSTURE_TIGHT),
+        (2.0, rs.POSTURE_CRITICAL),  # boundary: <= critical
+        (0.5, rs.POSTURE_CRITICAL),
+        (-1.0, rs.POSTURE_UNKNOWN),  # unreadable probe → fail open
+    ],
+)
+def test_classify_buckets(avail: float, expected: str) -> None:
+    assert rs._classify(avail, pressure_gb=4.0, critical_gb=2.0) == expected
+
+
+def test_zero_thresholds_disable_buckets() -> None:
+    # pressure=0 → never tight; critical=0 → never critical, for any positive avail.
+    assert rs._classify(0.1, pressure_gb=0.0, critical_gb=0.0) == rs.POSTURE_AMPLE
+    assert rs._classify(0.1, pressure_gb=4.0, critical_gb=0.0) == rs.POSTURE_TIGHT
+
+
+# ── probe ──────────────────────────────────────────────────────────────────────
+
+
+def test_probe_tight(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 3.0)
+    status = rs.probe(_cfg(4.0, 2.0))
+    assert status.posture == rs.POSTURE_TIGHT
+    assert status.under_pressure is True
+    assert status.available_gb == 3.0
+    assert status.cpu_count >= 1
+
+
+def test_probe_ample_is_silent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 32.0)
+    status = rs.probe(_cfg(4.0, 2.0))
+    assert status.posture == rs.POSTURE_AMPLE
+    assert status.under_pressure is False
+    assert status.context_line() == ""
+
+
+def test_probe_unknown_when_unreadable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: -1.0)
+    status = rs.probe(_cfg(4.0, 2.0))
+    assert status.posture == rs.POSTURE_UNKNOWN
+    assert status.under_pressure is False
+    assert status.context_line() == ""
+
+
+def test_probe_never_raises_on_bad_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 3.0)
+    # Garbage thresholds fall back to defaults rather than raising.
+    status = rs.probe(_cfg("nan", None))  # type: ignore[arg-type]
+    assert status.pressure_gb == rs._DEFAULT_PRESSURE_GB
+    assert status.critical_gb == rs._DEFAULT_CRITICAL_GB
+
+
+# ── context_line ────────────────────────────────────────────────────────────────
+
+
+def test_context_line_tight_wording(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 3.0)
+    line = rs.probe(_cfg(4.0, 2.0)).context_line()
+    assert line.startswith("[RESOURCES]")
+    assert "tight" in line
+    assert "resource_status" in line  # points the model at the pull tool
+
+
+def test_context_line_critical_wording(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 1.0)
+    line = rs.probe(_cfg(4.0, 2.0)).context_line()
+    assert line.startswith("[RESOURCES]")
+    assert "CRITICALLY" in line
+
+
+def test_load_suffix_omitted_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 3.0)
+    monkeypatch.setattr(rs, "_read_load_per_cpu", lambda cpu: None)
+    line = rs.probe(_cfg(4.0, 2.0)).context_line()
+    assert "load" not in line
+
+
+def test_read_load_per_cpu_handles_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom() -> tuple[float, float, float]:
+        raise OSError("no loadavg")
+
+    monkeypatch.setattr(rs.os, "getloadavg", _boom, raising=False)
+    assert rs._read_load_per_cpu(4) is None
+    assert rs._read_load_per_cpu(0) is None
+
+
+# ── summary_lines ────────────────────────────────────────────────────────────────
+
+
+def test_summary_lines_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 3.0)
+    lines = rs.probe(_cfg(4.0, 2.0)).summary_lines()
+    joined = "\n".join(lines)
+    assert "Available memory: 3.0 GB" in joined
+    assert "Posture: TIGHT" in joined
+
+
+def test_summary_lines_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: -1.0)
+    joined = "\n".join(rs.probe(_cfg(4.0, 2.0)).summary_lines())
+    assert "unknown" in joined.lower()
+
+
+# ── mcp_core pull tool ──────────────────────────────────────────────────────────
+
+
+def test_tool_is_advertised() -> None:
+    from kiro_crew import mcp_core
+
+    names = {t["name"] for t in mcp_core._list_tools()}
+    assert "resource_status" in names
+
+
+def test_tool_dispatch_returns_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    from kiro_crew import mcp_core
+
+    fake = rs.ResourceStatus(
+        available_gb=3.0,
+        cpu_count=8,
+        load_per_cpu=0.5,
+        posture=rs.POSTURE_TIGHT,
+        pressure_gb=4.0,
+        critical_gb=2.0,
+    )
+    monkeypatch.setattr(rs, "probe", lambda cfg=None: fake)
+    out = mcp_core._call_tool_inner("resource_status", {})
+    assert "Posture: TIGHT" in out
+    assert "Guidance:" in out
+
+
+# ── review-round fixes: off-switch, invariant clamp, schema registration ──────
+
+
+def test_off_switch_disables_line_not_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    # pressure_gb=0 disables the injected line even at critically low memory,
+    # but the true posture is still reported for the pull tool.
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 1.0)
+    status = rs.probe(_cfg(0.0, 2.0))
+    assert status.posture == rs.POSTURE_CRITICAL
+    assert status.context_line() == ""            # line suppressed
+    assert "CRITICAL" in "\n".join(status.summary_lines())  # tool still honest
+
+
+def test_thresholds_clamped_when_inverted(monkeypatch: pytest.MonkeyPatch) -> None:
+    # critical > pressure is clamped so the tight tier stays reachable.
+    monkeypatch.setattr(rs, "_read_available_gb", lambda: 6.0)
+    status = rs.probe(_cfg(4.0, 8.0))
+    assert status.critical_gb == 4.0
+    # 6 GB is above the (clamped) 4 GB pressure line → ample, not critical.
+    assert status.posture == rs.POSTURE_AMPLE
+
+
+def test_tool_registered_and_rejects_stray_args() -> None:
+    from kiro_crew.validation import (
+        MCP_CORE_SCHEMAS,
+        ValidationError,
+        validate_tool_args,
+    )
+
+    assert "resource_status" in MCP_CORE_SCHEMAS
+    schema = MCP_CORE_SCHEMAS["resource_status"]
+    assert validate_tool_args({}, schema) == {}          # zero-arg call is valid
+    with pytest.raises(ValidationError):
+        validate_tool_args({"bogus": 1}, schema)          # stray arg rejected


### PR DESCRIPTION
## Problem
When several sessions each run heavy work (full test suites, large builds) at the same time, host memory can be exhausted and the whole run destabilizes. Sub-agent spawning already has a memory gate, but (a) nothing tells the model — main **or** sub-agent — about live headroom so it can choose a lighter path, and (b) the gate only covers *spawning*, not heavy work inside a single session.

## Why it matters
An unguarded burst of concurrent heavy tasks is exactly the "memory usage too high, tests get killed" failure. Giving the agent a cheap, always-available read of host headroom lets it self-moderate (targeted tests, smaller sub-agent waves, deferred builds) instead of blindly piling on.

## Fix (symptom → root cause → change)
- **Root cause:** the resource signal lived only inside the sub-agent spawn path and was invisible to the model.
- **Change:** a lightweight, read-only, *advisory* signal delivered two ways:
  - **`resource_status.py`** — one `probe()` returning available memory (cgroup-aware, reusing `subagent._available_memory_gb`), CPU load, and a coarse posture (`ample` / `tight` / `critical` / `unknown`). Fail-open to `unknown`.
  - **Pressure-gated context line** in `context.build_message` — injects a compact `[RESOURCES]` advisory **only** when memory is tight/critical; silent otherwise. It rides the gateway context rail, so it survives agent switches (a per-agent tool grant cannot).
  - **Pull tool `resource_status`** in `mcp_core` — on-demand headroom + sub-agent cap + guidance. Auto-granted via the existing `@kirocrew-core` wildcard, so it reaches main and sub-agents with no self-heal.
  - Config knobs `resource_pressure_gb` (default 4.0) and `resource_critical_gb` (default 2.0); `pressure=0` disables the line.

Advisory only — no enforcement, no cross-session lease. Makes the agent smarter about going light, not hard-bounded (a hard admission lease is a separate, heavier design).

### Local-review fixes folded in (both reviewers: no blocking)
- `pressure_gb=0` now fully disables the line (previously a `critical`-tier line could still fire); `context_line()` returns empty and injection is gated on a non-empty line.
- `_resolve_thresholds` clamps `critical ≤ pressure` so an inverted config can't make the `tight` tier unreachable.
- `resource_status` registered in `MCP_CORE_SCHEMAS` (empty schema) so a stray argument is rejected, matching `spawn_list`.

**Rebutted (non-blocking, by design):**
- *Steady-state injection on small-limit containers (Medium):* advisory, not enforcement, and the thresholds are the operator knob for this — a 2–4 GB pod lowers them (now called out in the field docs). Adding cross-turn posture-change state is the defensive complexity this lightweight design intentionally avoids.
- *`[RESOURCES]` not in the structural-marker neutralizer (Low):* a forged line is de-escalation-only (makes the agent *more* cautious), the exact class `_STRUCTURAL_MARKER_RES` documents it deliberately omits; no breakout/priv-esc vector.

## Tests
`test/test_resource_status.py` (23 tests): posture classification incl. boundaries and the `0`-threshold disable, the `pressure=0` off-switch (line suppressed but tool still reports true posture), the `critical>pressure` clamp, fail-open on unreadable probe, context-line wording (tight vs critical), `summary_lines`, and the `mcp_core` tool being advertised, dispatchable, and rejecting stray args.

## Manual verification
N/A — unit coverage is sufficient; the probe is pure/read-only and the injection path is exercised by tests. No live gateway behavior change beyond the guarded, best-effort context line.

## Screenshots
N/A — no user-visible UI change (backend + config only; no Settings UI added, by design).
