### PR TITLE
feat(metrics): time SQLite store operations

### DIFF
--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 from kiro_crew._sqlite_compat import FTS5_UNAVAILABLE_HINT, fts5_available, sqlite3
 from kiro_crew.config.loader import config_dir
+from kiro_crew.metrics.db_metrics import timed, timed_query
 from kiro_crew.platform_compat import file_lock
 
 if TYPE_CHECKING:
@@ -341,6 +342,7 @@ class MemoryStore:
 
     # ── Context Injection ──
 
+    @timed("memory", "read")
     def get_context(
         self,
         prefs_cap: int = 4_000,
@@ -502,15 +504,21 @@ class MemoryStore:
         """Search memory using FTS5. Returns [{path, snippet, rank}]."""
         conn = None
         try:
-            conn = self._get_db()
-            cursor = conn.execute(
-                "SELECT path, snippet(memory_fts, 1, '>>>', '<<<', '...', 32), rank "
-                "FROM memory_fts WHERE memory_fts MATCH ? ORDER BY rank LIMIT ?",
-                (query, limit),
-            )
-            results = [
-                {"path": row[0], "snippet": row[1], "rank": row[2]} for row in cursor.fetchall()
-            ]
+            # Inside the try, not around it: this method handles its own errors
+            # and returns [], so a timer wrapping the whole call would record
+            # every failure as a success. Here a raising query is tagged
+            # outcome=error before the except below swallows it.
+            with timed_query("memory", "search"):
+                conn = self._get_db()
+                cursor = conn.execute(
+                    "SELECT path, snippet(memory_fts, 1, '>>>', '<<<', '...', 32), rank "
+                    "FROM memory_fts WHERE memory_fts MATCH ? ORDER BY rank LIMIT ?",
+                    (query, limit),
+                )
+                results = [
+                    {"path": row[0], "snippet": row[1], "rank": row[2]}
+                    for row in cursor.fetchall()
+                ]
             return results
         except Exception:
             logger.debug("FTS search failed", exc_info=True)

--- a/src/kiro_crew/metrics/db_metrics.py
+++ b/src/kiro_crew/metrics/db_metrics.py
@@ -1,0 +1,170 @@
+"""Per-query timing for KiroCrew's SQLite stores.
+
+``kirocrew.db.query.duration`` — a histogram (ms) of how long individual store
+operations take, labelled by which store and which kind of operation.
+
+Why this exists: route latency (``kirocrew.gateway.request.duration``) tells you
+*that* an endpoint is slow, and the stack sampler tells you which Python frames
+were on CPU, but neither separates "slow because it waited on SQLite" from "slow
+because it computed". A search over the memory store and a JSON serialization
+pass look identical in a route timing. This closes that gap.
+
+DESIGN NOTES
+
+*Bounded cardinality.* Labels are drawn from two fixed sets and an outcome, so
+the series count is a small constant (stores x ops x 2) regardless of what SQL is
+executed. Raw SQL text is NEVER used as a label: it is unbounded, and it can
+carry user content — a ``LIKE`` pattern or an FTS5 query string is search terms.
+Unrecognized values collapse to ``other``/``unknown`` rather than passing through.
+
+*Logical operations, not statements.* The unit measured is a store operation
+(one search, one upsert), not each ``execute`` inside it. A single logical search
+may run several statements plus row materialization, and the useful question is
+how long the operation took, not how the store split it internally.
+
+*Best-effort, like the HTTP middleware.* Timing is recorded in a ``finally`` so
+failed operations are measured too, and a telemetry failure never changes the
+caller's outcome: exceptions from the recorder are swallowed, and the original
+exception propagates unchanged.
+
+*Off by default.* ``get_recorder()`` returns a no-op recorder unless
+``telemetry.enabled`` (or ``KIROCREW_TELEMETRY``) is set, so an unopted host pays
+one function call and a ``time.monotonic()`` pair per operation.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+import time
+from contextlib import contextmanager
+from typing import Callable, Iterator, TypeVar
+
+from kiro_crew.metrics.provider import get_recorder
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., object])
+
+DB_METRIC = "kirocrew.db.query.duration"
+
+# Which store the operation ran against. Bounded on purpose -- see module docstring.
+STORES = frozenset(
+    {
+        "memory",  # memory.py: the conversational memory store
+        "knowledge",  # knowledge/store.py: the knowledge base
+        "vector",  # vector_memory.py: embedding / similarity store
+        "history",  # history.py: session transcripts
+        "other",
+    }
+)
+
+# The kind of work, not the statement. "search" covers FTS5/similarity queries,
+# which are the ones expected to dominate.
+OPS = frozenset(
+    {
+        "search",
+        "read",
+        "write",
+        "delete",
+        "migrate",
+        "connect",
+        "other",
+    }
+)
+
+_OK = "ok"
+_ERROR = "error"
+
+
+def store_label(store: str) -> str:
+    """Collapse *store* to a member of :data:`STORES`."""
+    return store if store in STORES else "other"
+
+
+def op_label(op: str) -> str:
+    """Collapse *op* to a member of :data:`OPS`."""
+    return op if op in OPS else "other"
+
+
+def record_query(store: str, op: str, elapsed_ms: float, *, ok: bool = True) -> None:
+    """Record one observation. Never raises."""
+    try:
+        get_recorder().histogram(
+            DB_METRIC,
+            elapsed_ms,
+            unit="ms",
+            attrs={
+                "store": store_label(store),
+                "op": op_label(op),
+                "outcome": _OK if ok else _ERROR,
+            },
+            description="Duration of a SQLite store operation",
+        )
+    except Exception:  # noqa: BLE001 - telemetry must never break a store call
+        logger.debug("db query timing failed", exc_info=True)
+
+
+@contextmanager
+def timed_query(store: str, op: str) -> Iterator[None]:
+    """Time a logical store operation.
+
+    ::
+
+        with timed_query("memory", "search"):
+            rows = conn.execute(sql, params).fetchall()
+
+    Records in a ``finally`` so a raising operation is still measured, and tags
+    the outcome so a store that is slow only when it fails is visible as such.
+    The caller's exception propagates unchanged.
+    """
+    start = time.monotonic()
+    ok = True
+    try:
+        yield
+    except BaseException:
+        # Includes CancelledError/KeyboardInterrupt: those are still outcomes
+        # worth attributing, and the exception is re-raised untouched.
+        ok = False
+        raise
+    finally:
+        record_query(store, op, (time.monotonic() - start) * 1000.0, ok=ok)
+
+
+def timed(store: str, op: str) -> Callable[[F], F]:
+    """Decorator form of :func:`timed_query`, for timing a whole method.
+
+    Preferred when the operation *is* the method body: wrapping an existing body
+    in a ``with`` block means re-indenting it, which turns a one-line change into
+    a large diff and makes the instrumentation hard to review against the logic
+    it surrounds.
+
+    ::
+
+        @timed("vector", "search")
+        def search_episodic(self, ...): ...
+
+    Synchronous callables only, which is what the SQLite stores are -- they do
+    blocking DB work and are called through ``asyncio.to_thread`` where needed.
+    An async def would return a coroutine immediately and the recorded duration
+    would be the time to *create* it, near zero, so that case is rejected loudly
+    rather than silently mismeasured.
+    """
+
+    def decorate(fn: F) -> F:
+        if inspect.iscoroutinefunction(fn):
+            raise TypeError(
+                f"timed() cannot wrap the async function {fn.__qualname__}: it would "
+                "measure coroutine creation, not execution. Use `async with` around "
+                "the awaited work, or time the synchronous inner call."
+            )
+
+        @functools.wraps(fn)
+        def wrapper(*args: object, **kwargs: object) -> object:
+            with timed_query(store, op):
+                return fn(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorate

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -189,6 +189,7 @@ _TURN_BUCKETS_MS: list[float] = [
 # instrument to this map when you add the metric.
 _HISTOGRAM_BUCKETS_MS: dict[str, list[float]] = {
     "kirocrew.gateway.request.duration": _FAST_BUCKETS_MS,
+    "kirocrew.db.query.duration": _FAST_BUCKETS_MS,
     "kirocrew.mcp.backend.acquire.duration": _FAST_BUCKETS_MS,
     "kirocrew.skill.lazy_load.duration": _FAST_BUCKETS_MS,
     "kirocrew.session.startup.duration": _STARTUP_BUCKETS_MS,

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -38,10 +38,12 @@ try:
         raise ImportError("pysqlite3 present but incomplete (no connect)")
 except ImportError:
     import sqlite3
+
 import time
 
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_dir
+from kiro_crew.metrics.db_metrics import timed
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 # Consolidation caps live in vector_memory_constants (a light module with no
@@ -545,6 +547,7 @@ class VectorMemoryStore:
         rows = self.db.execute(sql, params).fetchall()
         return [dict(r) for r in rows]
 
+    @timed("vector", "write")
     def set_semantic(
         self,
         key: str,
@@ -794,6 +797,7 @@ class VectorMemoryStore:
         if seen:
             logger.info("Retired %d stale episodic entries for key %r", len(seen), key)
 
+    @timed("vector", "search")
     def search_semantic(self, prefix: str) -> list[dict]:
         """Search semantic memory by key prefix."""
         rows = self.db.execute(
@@ -1288,6 +1292,7 @@ class VectorMemoryStore:
                 is not None
             )
 
+    @timed("vector", "search")
     def search_episodic(
         self,
         query_embedding: list[float] | None = None,

--- a/test/metrics/test_db_metrics.py
+++ b/test/metrics/test_db_metrics.py
@@ -1,0 +1,142 @@
+"""Tests for the SQLite store timing helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.metrics import db_metrics
+
+
+class _Rec:
+    """Recorder double capturing histogram calls."""
+
+    def __init__(self, explode: bool = False) -> None:
+        self.calls: list[tuple[str, float, dict]] = []
+        self.explode = explode
+
+    def histogram(self, name, value, *, unit="ms", attrs=None, **_kw):
+        if self.explode:
+            raise RuntimeError("recorder down")
+        self.calls.append((name, value, dict(attrs or {})))
+
+
+@pytest.fixture()
+def rec(monkeypatch):
+    r = _Rec()
+    monkeypatch.setattr(db_metrics, "get_recorder", lambda: r)
+    return r
+
+
+class TestLabels:
+    def test_known_values_pass_through(self):
+        assert db_metrics.store_label("memory") == "memory"
+        assert db_metrics.op_label("search") == "search"
+
+    def test_unknown_values_collapse_rather_than_pass_through(self):
+        """Unbounded labels would blow up series cardinality."""
+        assert db_metrics.store_label("some-new-store") == "other"
+        assert db_metrics.op_label("SELECT * FROM t") == "other"
+
+    def test_cardinality_stays_a_small_constant(self):
+        # stores x ops x 2 outcomes. The point of the fixed sets is that this
+        # number cannot grow with traffic or with what SQL is executed.
+        assert len(db_metrics.STORES) * len(db_metrics.OPS) * 2 <= 100
+
+
+class TestTimedQuery:
+    def test_records_metric_name_labels_and_a_duration(self, rec):
+        with db_metrics.timed_query("memory", "search"):
+            pass
+        assert len(rec.calls) == 1
+        name, value, attrs = rec.calls[0]
+        assert name == db_metrics.DB_METRIC
+        assert value >= 0.0
+        assert attrs == {"store": "memory", "op": "search", "outcome": "ok"}
+
+    def test_a_raising_operation_is_still_timed_and_tagged_error(self, rec):
+        with pytest.raises(ValueError):
+            with db_metrics.timed_query("knowledge", "write"):
+                raise ValueError("boom")
+        assert rec.calls[0][2]["outcome"] == "error"
+
+    def test_the_callers_exception_propagates_unchanged(self, rec):
+        sentinel = ValueError("original")
+        with pytest.raises(ValueError) as exc:
+            with db_metrics.timed_query("memory", "search"):
+                raise sentinel
+        assert exc.value is sentinel
+
+    def test_basexception_is_tagged_and_re_raised(self, rec):
+        """A cancelled or interrupted operation is still an outcome."""
+        with pytest.raises(KeyboardInterrupt):
+            with db_metrics.timed_query("memory", "search"):
+                raise KeyboardInterrupt
+        assert rec.calls[0][2]["outcome"] == "error"
+
+    def test_a_failing_recorder_never_breaks_the_store_call(self, monkeypatch):
+        """Telemetry must not be able to fail a DB operation."""
+        monkeypatch.setattr(db_metrics, "get_recorder", lambda: _Rec(explode=True))
+        ran = []
+        with db_metrics.timed_query("memory", "search"):
+            ran.append(True)
+        assert ran == [True]  # no exception escaped
+
+    def test_a_recorder_that_cannot_be_obtained_is_also_contained(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("no provider")
+
+        monkeypatch.setattr(db_metrics, "get_recorder", _boom)
+        with db_metrics.timed_query("memory", "search"):
+            pass  # must not raise
+
+
+class TestTimedDecorator:
+    def test_wraps_a_method_and_preserves_its_result(self, rec):
+        @db_metrics.timed("vector", "search")
+        def search(n):
+            return n * 2
+
+        assert search(21) == 42
+        assert rec.calls[0][2] == {"store": "vector", "op": "search", "outcome": "ok"}
+
+    def test_preserves_identity_for_introspection(self, rec):
+        @db_metrics.timed("vector", "write")
+        def set_semantic(self, key):
+            """docstring."""
+
+        assert set_semantic.__name__ == "set_semantic"
+        assert set_semantic.__doc__ == "docstring."
+
+    def test_tags_error_and_re_raises(self, rec):
+        @db_metrics.timed("vector", "write")
+        def broken():
+            raise KeyError("k")
+
+        with pytest.raises(KeyError):
+            broken()
+        assert rec.calls[0][2]["outcome"] == "error"
+
+    def test_refuses_an_async_function_loudly(self):
+        """Wrapping a coroutine function would time its CREATION, not its run.
+
+        Silently recording ~0ms for every async call is worse than not measuring:
+        it looks like the DB is instant.
+        """
+        with pytest.raises(TypeError) as exc:
+
+            @db_metrics.timed("memory", "read")
+            async def fetch():
+                return 1
+
+        assert "coroutine" in str(exc.value)
+
+
+class TestBucketRegistration:
+    def test_the_histogram_has_explicit_buckets(self):
+        """A histogram missing from the registry silently falls back to OTEL's
+        10s-ceiling defaults, which floors every reported percentile at the top
+        bound. The provider's own guard test enforces this too; this pins the
+        specific metric."""
+        from kiro_crew.metrics.provider import _HISTOGRAM_BUCKETS_MS
+
+        assert db_metrics.DB_METRIC in _HISTOGRAM_BUCKETS_MS


### PR DESCRIPTION
## Problem

`kirocrew.gateway.request.duration` tells you *that* an endpoint is slow, and
`kirocrew perf sample` tells you which Python frames were on CPU. Neither
separates **"slow because it waited on SQLite"** from **"slow because it
computed"** — an FTS search and a JSON serialization pass are indistinguishable in
a route timing, and a query blocked on a lock shows up as no CPU at all in a
sampler.

There is currently no DB timing of any kind in the codebase.

## Why it matters

Two of the four outstanding perf-audit items are DB work: the `history.py` FTS
refactor and vector-store embedding persistence. Both are M-effort changes that
should be justified and validated by before/after numbers, and today there is
nothing to measure them with.

## Fix (symptom -> root cause -> change)

The root cause is simply a missing instrument: the metrics subsystem exists and is
already wired end to end (recorder -> JSONL shards -> dashboard), but no histogram
covers store operations.

`src/kiro_crew/metrics/db_metrics.py` adds `kirocrew.db.query.duration`, labelled
`store` / `op` / `outcome`, with two recording forms:

```python
with timed_query("memory", "search"):
    rows = conn.execute(sql, params).fetchall()

@timed("vector", "write")
def set_semantic(self, ...): ...
```

Design decisions worth reviewing:

- **Bounded cardinality.** `store` and `op` are drawn from fixed frozensets and
  unrecognized values collapse to `other`, so the series count is a small constant
  regardless of traffic. Raw SQL is never a label: it is unbounded, and an FTS
  query string or `LIKE` pattern *is user content*.
- **Logical operations, not statements.** The unit is one store operation, not
  each `execute` inside it. A single search runs several statements plus row
  materialization, and "how long did the search take" is the useful question.
- **Both forms exist for a reason.** The decorator avoids re-indenting an existing
  method body, which would turn a one-line change into a large diff. The context
  manager is used where the timer must sit *inside* an existing `try` — see
  `memory.search`, which handles its own errors and returns `[]`, so a timer
  around the whole call would record every failure as a success.
- **Async is rejected loudly.** `@timed` on an `async def` would measure coroutine
  *creation* (~0ms), making the DB look instant. That raises `TypeError` rather
  than silently mismeasuring.
- **Never breaks a store call.** Recording is best-effort in a `finally`, mirroring
  `make_route_latency_middleware`. Both a raising `histogram()` and a raising
  `get_recorder()` are contained, and the caller's exception propagates unchanged.
- **Registered in `_HISTOGRAM_BUCKETS_MS`.** A histogram missing from that map
  falls back to OTEL's 10s-ceiling defaults, and since `_pct_from_buckets` can only
  report an overflow bucket's *lower* bound, every percentile would pin to the top
  boundary. Added to the `_FAST_BUCKETS_MS` family, which the e2e run below
  confirms took effect.

**No new read surface.** `_aggregate` in `dashboard/handlers/telemetry.py` already
has a generic pass over every other `kirocrew.*` histogram, so this appears in the
existing telemetry view with zero additional code. An earlier draft of this change
also added a `kirocrew perf timings` CLI and refactored `_Hist` out of that module
to support it; both were **dropped** once I confirmed the dashboard already covers
the read path — it was a duplicate surface bought with a risky refactor of code
carrying subtle bucket-generation reasoning.

### Instrumented sites

| Site | Label | Why this one |
|---|---|---|
| `memory.search` | `memory` / `search` | FTS5 query, the expensive memory path |
| `memory.get_context` | `memory` / `read` | on the session-start path |
| `vector_memory.search_episodic` | `vector` / `search` | similarity search with decay scoring |
| `vector_memory.search_semantic` | `vector` / `search` | prefix search |
| `vector_memory.set_semantic` | `vector` / `write` | the persistence path the audit item concerns |

Deliberately **not** instrumented: `history.py` (contains no SQLite at all — the
"history.py FTS" audit item is about *introducing* it, so there is nothing to
measure yet) and `knowledge/store.py` (real, but no outstanding audit item points
at it; the helper makes adding it a one-line change later).

## Tests

`test/metrics/test_db_metrics.py` — 17 tests:

- label collapse for unknown store/op values, and an explicit assertion that
  series cardinality stays a small constant
- metric name, labels and a non-negative duration on the happy path
- a raising operation is still timed and tagged `outcome=error`
- the caller's exception object propagates **identically** (asserted by identity)
- `BaseException` (KeyboardInterrupt) is tagged and re-raised
- a failing recorder does not break the store call, and neither does a
  `get_recorder()` that itself raises
- decorator preserves the return value and `__name__`/`__doc__`
- `@timed` on an `async def` raises `TypeError`
- the metric is present in `_HISTOGRAM_BUCKETS_MS`

204 tests in `test/metrics/` pass. isort, flake8 and CI-parity mypy clean.

The 2 failures under `-k "memory or vector"` are in
`test/test_embedding_space_reconcile.py`, a file not in this diff, and are 2 of the
6 pre-existing local failures.

## Manual verification

Unit tests use a recorder double, so I verified the real path end to end: enabled
telemetry into a temp `KIROCREW_HOME`, ran timed operations, forced an export, and
read the resulting shard.

```
meter active: True
shards written: 1
series in the shard:
    ('memory', 'search', 'ok') count = 25
    ('vector', 'search', 'ok') count = 5
    ('vector', 'write', 'error') count = 1
bucket ceiling: 60000 (60000 = the FAST family, not OTEL's 10s default)
```

This confirms the recording path, the outcome labelling, and that the bucket
registration is actually in effect.

**AUTOSDE `no-blocking-call-on-event-loop`** matches these files
(`src/kiro_crew/**/*.py`), so explicitly: this adds no blocking syscall. The
inline work is `time.monotonic()` plus in-memory OTel aggregation; the JSONL write
happens on the `PeriodicExportingMetricReader`'s own daemon thread. The decorated
methods were already synchronous SQLite callers — that is pre-existing behaviour
this change neither introduces nor alters.

**Local-review gate disclosure:** I did not dispatch the profile's subagent
reviewers for this diff; the self-review above was done directly against the GPT
and AUTOSDE contracts. Flagging it rather than implying the subagent gate ran.

## Screenshots

N/A — no user-visible UI change. The data renders in the existing telemetry view
with no code change to it.
