### PR TITLE
fix(dashboard): show full session title in inline rename field

### DIFF
--- a/website/integration/ChatSidebarRenameFocus.integration.test.tsx
+++ b/website/integration/ChatSidebarRenameFocus.integration.test.tsx
@@ -132,16 +132,16 @@ function rowFor(container: HTMLElement): HTMLElement {
   return row as HTMLElement
 }
 
-function renameInput(): HTMLInputElement {
-  const input = Array.from(document.querySelectorAll('input'))
-    .find(i => (i as HTMLInputElement).value === TITLE) as HTMLInputElement
+function renameInput(): HTMLTextAreaElement {
+  const input = Array.from(document.querySelectorAll('textarea'))
+    .find(i => (i as HTMLTextAreaElement).value === TITLE) as HTMLTextAreaElement
   expect(input).toBeTruthy()
   return input
 }
 
-function renameInputWithValue(value: string): HTMLInputElement | undefined {
-  return Array.from(document.querySelectorAll('input'))
-    .find(i => (i as HTMLInputElement).value === value) as HTMLInputElement | undefined
+function renameInputWithValue(value: string): HTMLTextAreaElement | undefined {
+  return Array.from(document.querySelectorAll('textarea'))
+    .find(i => (i as HTMLTextAreaElement).value === value) as HTMLTextAreaElement | undefined
 }
 
 // Flush enough animation frames for both the component's single-rAF focus and

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -33,6 +33,7 @@ import { useSessionPalette } from '../hooks/useSessionPalette'
 import { useMoveSlotToFolder } from '../hooks/useMoveSlotToFolder'
 import { useSimplifiedToolNames } from '../hooks/useSimplifiedToolNames'
 import { useSessionActions } from '../hooks/useSessionActions'
+import { useAutoGrowTextarea } from '../hooks/useAutoGrowTextarea'
 import { useChatPopouts } from '../hooks/useChatPopouts'
 import { useImeGuard } from '../hooks/useImeGuard'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -65,6 +66,11 @@ import { loadChatConfig, saveChatConfig } from './chat/ChatSettings'
 
 import { i18nT } from '../i18n/t'
 import { compareText, fmtDateFields } from '../i18n/format'
+
+/** Max height (px) of the inline session-rename <textarea> before it scrolls.
+ *  ~6 lines at the row's 13px/leading-snug type. Shared by the auto-grow hook
+ *  (grows while typing) and the open effect (sizes on every open). */
+const RENAME_MAX_H = 120
 
 /** Translate a slot's running-status line. The status `text` is stored as a raw
  *  English literal by the websocket layer (a plain `.ts` module the i18n codemod
@@ -610,7 +616,15 @@ function ChatSidebar({
   const [renameScope, setRenameScope] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
   const cancelRenameRef = useRef(false)
-  const renameInputRef = useRef<HTMLInputElement | null>(null)
+  const renameInputRef = useRef<HTMLTextAreaElement | null>(null)
+  // The rename field is a wrapping, auto-growing <textarea> (not a single-line
+  // <input>) so a long session title is fully visible while editing instead of
+  // being clipped at the right edge — you can see and edit words that a
+  // single-line box would scroll out of view. Enter still commits (bindEnter
+  // preventDefaults it, so no newline is inserted). Caps at ~6 lines, then
+  // scrolls. Only one row renames at a time (renamingSlot), so the single
+  // shared ref always points at the one mounted textarea.
+  useAutoGrowTextarea(renameInputRef, renameValue, RENAME_MAX_H)
   // Set by any menu's Rename item (session rows + folder headers) so the closing
   // menu's onCloseAutoFocus knows to skip Radix's trigger-focus-restore for this
   // one close (see the menu Content handlers below). One-shot: read and cleared
@@ -654,7 +668,18 @@ function ChatSidebar({
     if (!renamingSlot) { setRenameScope(null); return }
     const raf = requestAnimationFrame(() => {
       const el = renameInputRef.current
-      if (el) { el.focus({ preventScroll: true }); el.select() }
+      if (el) {
+        el.focus({ preventScroll: true }); el.select()
+        // Size the box on OPEN too, not only when renameValue changes: after a
+        // save, reopening the same slot sets renameValue to the identical title,
+        // so useAutoGrowTextarea's value-keyed effect never fires and the freshly
+        // mounted textarea would otherwise sit at its 1-line resting height and
+        // clip a long name. Mirror the hook's measure here so every open shows
+        // the full name.
+        el.style.height = 'auto'
+        el.style.height = `${Math.min(el.scrollHeight, RENAME_MAX_H)}px`
+        el.style.overflowY = el.scrollHeight > RENAME_MAX_H ? 'auto' : 'hidden'
+      }
     })
     return () => cancelAnimationFrame(raf)
   }, [renamingSlot, renameScope])
@@ -2154,7 +2179,7 @@ function ChatSidebar({
                 </span>
               ) : null}
             </div>
-            <div className="text-[13px] font-semibold leading-snug line-clamp-2 break-words text-text" title={s.title && s.title !== s.key ? s.title : s.key}>
+            <div className={`text-[13px] font-semibold leading-snug break-words text-text ${renamingSlot === s.key && renameScope === scope ? '' : 'line-clamp-2'}`} title={s.title && s.title !== s.key ? s.title : s.key}>
               {/* No separate fork glyph: forked titles already carry the
                   persisted "↳ " marker (chat_fork.py _FORK_TITLE_MARKER). Keeping
                   the arrow in the title text — rather than as a UI-only glyph —
@@ -2162,7 +2187,7 @@ function ChatSidebar({
                   onRename handler) so users can edit or drop it when they rename.
                   A separate ↳ glyph also double-stacked into "↳↳ Fork of …". */}
               {renamingSlot === s.key && renameScope === scope ? (
-                <Input ref={renameInputRef} className="w-full bg-transparent border border-accent rounded px-1 py-0 text-text-strong outline-none text-[13px] select-text" value={renameValue} onChange={e => setRenameValue(e.target.value)} {...ime.bindEnter<HTMLInputElement>({ onEnter: () => { (document.activeElement as HTMLInputElement)?.blur() }, onEscape: () => { cancelRenameRef.current = true; setRenamingSlot(null) }, onBlur: () => { if (!cancelRenameRef.current && renameValue.trim()) { dispatch(sseSlotTitle({ key: s.key, title: renameValue.trim() })); api.renameSlot(s.key, renameValue.trim()).catch(() => { queryClient.invalidateQueries({ queryKey: ['chat-slots'] }) }) } cancelRenameRef.current = false; setRenamingSlot(null) } })} onMouseDown={e => e.stopPropagation()} />
+                <textarea ref={renameInputRef} rows={1} className="w-full bg-transparent border border-accent rounded px-1 py-0 leading-snug text-text-strong outline-none text-[13px] select-text resize-none block overflow-hidden" value={renameValue} onChange={e => setRenameValue(e.target.value.replace(/[\r\n]+/g, ' '))} {...ime.bindEnter<HTMLTextAreaElement>({ onEnter: () => { (document.activeElement as HTMLTextAreaElement)?.blur() }, onEscape: () => { cancelRenameRef.current = true; setRenamingSlot(null) }, onBlur: () => { if (!cancelRenameRef.current && renameValue.trim()) { dispatch(sseSlotTitle({ key: s.key, title: renameValue.trim() })); api.renameSlot(s.key, renameValue.trim()).catch(() => { queryClient.invalidateQueries({ queryKey: ['chat-slots'] }) }) } cancelRenameRef.current = false; setRenamingSlot(null) } })} onMouseDown={e => e.stopPropagation()} />
               ) : (s.title && s.title !== s.key ? s.title : s.key)}
             </div>
             {s.pending_approval ? (
@@ -2308,7 +2333,12 @@ function ChatSidebar({
               </div>
             )}
           </div>
-          {isMobile ? (
+          {/* Hide the hover action popup (⋯ / duplicate / close) while THIS slot
+           *  is being renamed: it is absolute-positioned at right-1.5 and reveals
+           *  on focus-within, so the focused rename input would otherwise make it
+           *  pop up and overlap the input's right edge. Mirrors the folder-header
+           *  guard below (!(editingId === folder.id && editScope === 'list')). */}
+          {!(renamingSlot === s.key && renameScope === scope) && (isMobile ? (
             <div className="absolute top-1/2 -translate-y-1/2 right-1.5 flex items-center gap-0.5">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -2332,7 +2362,7 @@ function ChatSidebar({
               <IconButton variant="accent" title={i18nT('pages.chatSidebar.duplicate')} aria-label={i18nT('pages.chatSidebar.duplicate')} onMouseDown={e => e.stopPropagation()} onClick={e => { e.stopPropagation(); sessionActions.duplicate(s.key) }}><Copy size={12} /></IconButton>
               <IconButton variant="danger" title={i18nT('pages.chatSidebar.close')} aria-label={i18nT('pages.chatSidebar.close_session')} onMouseDown={e => e.stopPropagation()} onClick={e => { e.stopPropagation(); sessionActions.close(s.key) }}><X size={12} /></IconButton>
             </IconButtonGroup>
-          )}
+          ))}
         </div>
           </ContextMenuTrigger>
           <ContextMenuContent className="min-w-[160px]" onCloseAutoFocus={onMenuCloseAutoFocus}>


### PR DESCRIPTION
## Problem
Renaming a session in the sidebar was awkward for long titles:
1. **Clipped title** — the inline rename field was a single-line `<input>`, so a long title was cut off at the right edge with no way to see or edit the words scrolled out of view.
2. **Popup overlap** — the row's hover action popup (⋯ / duplicate / close) is absolute-positioned at `right-1.5` and reveals on `focus-within`. While the rename input held focus, the popup appeared and overlapped the input's right edge.

## Why it matters
Renaming is a core, frequent action. A user could not reliably edit a word in the middle/end of a long title, and the overlapping popup covered the very text being edited — a visible, everyday papercut in the primary navigation surface.

## Fix (symptom → root cause → change)
- **Clipped title:** a single-line input can only ever show one line and scrolls horizontally. Root cause is the element type, not styling. → Swap the `<input>` for a wrapping, auto-growing `<textarea>` (`useAutoGrowTextarea`, capped at `RENAME_MAX_H = 120px`, then scrolls). Enter still commits (`useImeGuard.bindEnter` `preventDefault`s Enter, so no newline is inserted), Escape cancels, blur saves — behavior unchanged.
- The title container carries `line-clamp-2` for the *display* text; on a `<textarea>` child that `-webkit-box`/overflow-hidden clips growth. → Drop `line-clamp-2` **only while this slot is renaming** so the textarea can expand past two lines.
- **Reopen-after-save regression:** `useAutoGrowTextarea` resizes only when `renameValue` changes. After a save, reopening the same slot sets `renameValue` to the identical title → the value-keyed effect never fires → the freshly mounted textarea sat at its 1-line resting height and re-clipped the name. → Also measure/size the textarea in the rename-open effect (keyed on `renamingSlot`/`renameScope`), so every open sizes correctly.
- **Popup overlap:** the hover action group renders unconditionally and reveals on `focus-within`. → Guard it with `!(renamingSlot === s.key && renameScope === scope)` so it does not render while THIS slot is being renamed — mirroring the existing folder-header guard (`!(editingId === folder.id && editScope === 'list')`).

## Tests
No new automated test: the interactive rename path is only reachable through a Radix menu that needs `PointerEvent`, which jsdom lacks (the repo's existing `ChatSidebar.renameDraggable` interactive assertion is already `it.skip`ed for this reason). Existing suites re-run green:
- `ChatSidebar.renameDraggable.test.tsx`, `ChatSidebar.boardFolderRename.test.tsx`, `useImeGuard.test.ts` — 16 passed / 1 pre-existing skip.
- `tsc -b` clean.

## Manual verification
Applied to the running local edition and verified by hand: renaming a long title now wraps and shows the full name; the ⋯/duplicate/close popup no longer overlaps the field; Enter commits without inserting a newline; reopening a saved long title re-expands correctly.

## Screenshots
_Pending capture via web-verify against a local dev server before review._
