### PR TITLE
fix: nav rail flashes below chat input when crossing mobile breakpoint

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1833,18 +1833,18 @@ export default function App() {
       </AnimatePresence>
 
       {/* Nav */}
-      <AnimatePresence>
-      {(!isMobile || mobileNavOpen) && (
-      <motion.nav
-        initial={isMobile ? { x: -240 } : false}
-        animate={isMobile ? { width: 220, x: 0 } : { x: 0 }}
-        exit={{ x: -240 }}
-        transition={isMobile ? { duration: 0.25, ease: [0.32, 0.72, 0, 1] } : undefined}
-        className={`bg-bg-elevated border border-border rounded-xl flex flex-col mx-2 mt-0 mb-2 shadow-sm z-50 overflow-hidden ${isMobile ? 'fixed top-0 left-0 bottom-0' : ''}`}
-        style={isMobile ? undefined : { gridArea: 'nav', width: 'auto' }}
-        role="navigation"
-        aria-label={i18nT('app.main_navigation')}
-      >
+      {/* Desktop rail and mobile drawer share one body but get DIFFERENT
+          wrappers, and only the mobile drawer sits inside AnimatePresence.
+          An exit animation on the desktop rail is actively wrong: when the
+          viewport crosses the mobile threshold, the shell grid drops its
+          `nav` area in the same render — AnimatePresence would keep the
+          exiting rail mounted with its frozen `gridArea: 'nav'` style, and
+          CSS auto-places that orphaned item into an implicit row BELOW the
+          content (the rail visibly jumped under the chat input before
+          sliding away). The desktop rail therefore unmounts instantly at
+          the threshold; only the fixed-position drawer animates in/out. */}
+      {(() => {
+        const navBody = (<>
         {/* Top-fixed: menu row + primary destinations + Apps section header.
             The sidebar toggle lives HERE (menu row), not in the topbar. */}
         <div className="shrink-0 flex flex-col gap-0.5 px-2 pt-2">
@@ -2132,9 +2132,35 @@ export default function App() {
             </div>
           )
         })()}
-      </motion.nav>
-      )}
-      </AnimatePresence>
+        </>)
+        return isMobile ? (
+          <AnimatePresence>
+            {mobileNavOpen && (
+              <motion.nav
+                key="mobile-nav-drawer"
+                initial={{ x: -240 }}
+                animate={{ width: 220, x: 0 }}
+                exit={{ x: -240 }}
+                transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
+                className="bg-bg-elevated border border-border rounded-xl flex flex-col mx-2 mt-0 mb-2 shadow-sm z-50 overflow-hidden fixed top-0 left-0 bottom-0"
+                role="navigation"
+                aria-label={i18nT('app.main_navigation')}
+              >
+                {navBody}
+              </motion.nav>
+            )}
+          </AnimatePresence>
+        ) : (
+          <nav
+            className="bg-bg-elevated border border-border rounded-xl flex flex-col mx-2 mt-0 mb-2 shadow-sm z-50 overflow-hidden"
+            style={{ gridArea: 'nav', width: 'auto' }}
+            role="navigation"
+            aria-label={i18nT('app.main_navigation')}
+          >
+            {navBody}
+          </nav>
+        )
+      })()}
 
       {/* Content */}
       <div className="flex flex-col min-h-0 min-w-0" style={{ gridArea: 'content' }}>


### PR DESCRIPTION
## Problem

When the dashboard window is shrunk past the mobile-view threshold, the nav rail is supposed to simply disappear (it becomes the hamburger-triggered drawer). Instead, for ~250ms it visibly **jumps below the chat input box** and then slides away — a jarring flash of the whole rail in the wrong place on every crossing of the breakpoint.

## Why it matters

Resizing across the breakpoint is a common action (snapping windows, side-by-side layouts, narrow laptop screens). A full navigation rail teleporting under the composer looks broken and undermines the polish of the shell layout.

## Fix (symptom → root cause → change)

- **Symptom:** rail flashes below the content area while shrinking past the mobile threshold.
- **Root cause:** the desktop rail and the mobile drawer were a single `motion.nav` inside one `AnimatePresence`. When `isMobile` flips true, the nav's render condition goes false and `AnimatePresence` keeps the element mounted for its `exit={{ x: -240 }}` slide — with props **frozen from the last desktop render**, i.e. `style={{ gridArea: 'nav' }}` and no `fixed` positioning. In that *same* render the shell grid switches to the mobile template (`"topbar" "content"`), which no longer defines a `nav` area. Per CSS grid placement rules, the orphaned exiting item is auto-placed into an **implicit row below the content** — that is the rail appearing under the chat input before animating off.
- **Change:** split the two modes. The desktop rail is now a plain `<nav>` grid child that unmounts instantly at the threshold (it never animated on desktop anyway — its `initial={false} animate={{x:0}}` was a no-op). `AnimatePresence` now wraps only the fixed-position mobile drawer, whose open/close slide is unchanged. Both wrappers share one `navBody` so no inner content is duplicated.

## Tests

Existing coverage: `src/test/App.test.tsx` (66 tests) passes — it queries the nav by `role="navigation"` / accessible name, which both wrappers preserve. No new test added: the regression is an exit-animation × grid-template interaction that jsdom cannot observe (AnimatePresence exit retention + CSS implicit-row auto-placement are browser-layout behaviors).

## Manual verification

Verified structurally: the desktop branch no longer participates in `AnimatePresence`, so no exiting element can outlive the `nav` grid area. The glitch is a transient mid-resize animation frame, so a still screenshot cannot demonstrate it; the reporting user's screen capture in the issue thread shows the pre-fix behavior.

## Screenshots

### Before

https://github.com/user-attachments/assets/b752fcec-2f9c-416b-8ced-34acd83c491b

### After

https://github.com/user-attachments/assets/31dcbf1d-79b3-4139-b812-bd2fd90edb97


