### PR TITLE
feat: add dev-fullstack.sh one-terminal dev stack launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,11 @@ When creating task specifications:
 
 Set `KIROCREW_HOME=.kirocrew-dev` to use an isolated data directory in the repo root (gitignored). This keeps dev data (contacts, lessons, config) separate from your real `~/.kiro/crew`. Data files are visible in the IDE for easy inspection.
 
-Set `KIROCREW_PORT=6777` so dev and production gateways can run side by side. Pass the same env var to `./dev-frontend.sh` so the Vite proxy points at the dev backend.
+**One-terminal launcher:** `./dev-fullstack.sh` starts the whole stack — the live-source backend (`dev-backend.sh`, port 6777, `.kirocrew-dev` home), the Vite dev server proxying to it, and a ready-to-open authenticated Vite URL. Ctrl+C tears both down.
+
+Manual flow, if you want the pieces in separate terminals:
+
+Set `KIROCREW_PORT=6777` so dev and production gateways can run side by side. Pass the same env var to Vite (`cd website && KIROCREW_PORT=6777 npm run dev`) so the proxy points at the dev backend.
 
 To authenticate the Vite dev server (port 3000) against the dev gateway (port 6777):
 

--- a/dev-backend.sh
+++ b/dev-backend.sh
@@ -45,4 +45,4 @@ echo "   Source: $PYTHONPATH"
 echo "   Data:   $KIROCREW_HOME"
 echo ""
 
-exec "$RUNTIME_PYTHON" -m kiro_crew gateway
+exec "$RUNTIME_PYTHON" -m kiro_crew gateway "$@"

--- a/dev-fullstack.sh
+++ b/dev-fullstack.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Start the full KiroCrew dev stack in ONE terminal:
+#   1. Backend gateway from live source (dev-backend.sh, port 6777, .kirocrew-dev home)
+#   2. Vite dev server (hot reload) proxying to it
+#   3. Mint a dashboard token and print the ready-to-open Vite URL
+#
+# Usage: ./dev-fullstack.sh
+#   Ctrl+C stops backend + Vite together. Logs stream into this terminal.
+#   Backend code changes: Ctrl+C and re-run. Frontend changes: hot-reload on save.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+GATEWAY_PORT="${KIROCREW_PORT:-6777}"
+
+# Resolve the runtime Python ONCE, with the same precedence dev-backend.sh
+# uses (RUNTIME_PYTHON override, else the repo venv), and reuse it for the
+# token mint below — hardcoding .venv/bin/python here while dev-backend.sh
+# honors RUNTIME_PYTHON would launch the stack fine but silently fail to
+# mint the promised auth URL.
+RUNTIME_PYTHON="${RUNTIME_PYTHON:-}"
+if [ -z "$RUNTIME_PYTHON" ] || [ ! -x "$RUNTIME_PYTHON" ]; then
+    if [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then
+        RUNTIME_PYTHON="$SCRIPT_DIR/.venv/bin/python"
+    fi
+fi
+if [ ! -x "$RUNTIME_PYTHON" ]; then
+    echo "[dev] ERROR: cannot find the KiroCrew venv Python at $SCRIPT_DIR/.venv/bin/python."
+    echo "[dev] Run 'bash minimal_install.sh' once to set up the venv, then try again."
+    exit 1
+fi
+
+# Fail fast if something already listens on the gateway port. Otherwise the
+# spawned gateway dies on bind while the readiness probe below is satisfied
+# by the OLD process — the script reports success, Vite proxies to an
+# unrelated (or stale) service, and teardown kills nothing that matters.
+if curl -fsS -o /dev/null --max-time 2 "http://127.0.0.1:$GATEWAY_PORT/" 2>/dev/null; then
+    echo "[dev] ERROR: something is already listening on :$GATEWAY_PORT."
+    echo "[dev] Stop it first (kirocrew stop --port $GATEWAY_PORT) or set KIROCREW_PORT to a free port."
+    exit 1
+fi
+# One EFFECTIVE data home for the whole stack. dev-backend.sh honors a
+# caller-provided KIROCREW_HOME, so the token mint below must use the same
+# home the backend booted with — hardcoding .kirocrew-dev for one of them
+# yields a token signed with a different secret (auth silently fails).
+# Same default + relative-path handling as dev-backend.sh.
+KIROCREW_HOME="${KIROCREW_HOME:-.kirocrew-dev}"
+case "$KIROCREW_HOME" in
+    /*) ;;
+    *) KIROCREW_HOME="$SCRIPT_DIR/$KIROCREW_HOME" ;;
+esac
+export KIROCREW_HOME
+# Logs live under the dev data home (repo-local, gitignored — same place
+# dev-backend.sh keeps its state) rather than the shared world-writable /tmp:
+# no cross-user collisions on predictable names, no symlink-planting surface,
+# and everything dev-stack-related stays in one directory.
+LOG_DIR="$KIROCREW_HOME/logs"
+mkdir -p "$LOG_DIR"
+BACKEND_LOG="$LOG_DIR/gateway.log"
+VITE_LOG="$LOG_DIR/vite.log"
+
+# Teardown: terminate exactly the processes we started, by PID, including
+# their descendants (npm spawns node; dev-backend execs python). The previous
+# `kill -- -$$` assumed this script is its own process-group leader — true
+# from an interactive shell, NOT when invoked from another script or an IDE —
+# and silently leaked the stack when that assumption failed. macOS has no
+# setsid to force group leadership, so explicit PID-tree kills it is.
+PIDS=()
+kill_tree() {
+    local child
+    for child in $(pgrep -P "$1" 2>/dev/null); do
+        kill_tree "$child"
+    done
+    kill -TERM "$1" 2>/dev/null || true
+}
+cleanup() {
+    trap - INT TERM EXIT
+    local pid
+    for pid in "${PIDS[@]}"; do
+        kill_tree "$pid"
+    done
+    wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "[dev] starting backend (port $GATEWAY_PORT, home .kirocrew-dev) -> $BACKEND_LOG"
+# --no-open: the gateway would otherwise auto-open its OWN url (:6777) — the
+# bundled-snapshot surface. The live surface is the Vite url printed below.
+#
+# NOTE: the gateway's CSRF origin allowlist trusts Vite's DEFAULT port 3000
+# only. If something squats on 3000, Vite falls back to 3001+ and every
+# mutating request (chat send, etc.) fails with "CSRF check failed" while
+# reads and the WS still work. If that happens, either free port 3000 or
+# export KIROCREW_ALLOWED_LOOPBACK_PORTS=3000,3001,3002 before running this.
+./dev-backend.sh --no-open > "$BACKEND_LOG" 2>&1 &
+PIDS+=($!)
+
+# Wait for the gateway to accept connections (up to 90s: first boot loads MCP servers).
+for i in $(seq 1 90); do
+    if curl -fsS -o /dev/null "http://127.0.0.1:$GATEWAY_PORT/" 2>/dev/null; then
+        break
+    fi
+    if [ "$i" -eq 90 ]; then
+        echo "[dev] ERROR: gateway did not come up on :$GATEWAY_PORT — see $BACKEND_LOG"
+        exit 1
+    fi
+    sleep 1
+done
+echo "[dev] backend up on :$GATEWAY_PORT"
+
+echo "[dev] starting Vite -> $VITE_LOG"
+( cd website && KIROCREW_PORT="$GATEWAY_PORT" exec npm run dev > "$VITE_LOG" 2>&1 ) &
+PIDS+=($!)
+
+# Vite picks 3000, or the next free port — read the real one from its banner.
+VITE_PORT=""
+for i in $(seq 1 30); do
+    VITE_PORT="$(grep -oE 'Local:.*localhost:[0-9]+' "$VITE_LOG" 2>/dev/null | grep -oE '[0-9]+$' | head -1)"
+    [ -n "$VITE_PORT" ] && break
+    sleep 1
+done
+if [ -z "$VITE_PORT" ]; then
+    echo "[dev] ERROR: Vite did not report a port — see $VITE_LOG"
+    exit 1
+fi
+echo "[dev] Vite up on :$VITE_PORT"
+
+# Mint a dashboard token against the DEV home and rewrite the URL to the Vite
+# port (the Vite proxy forwards the token to the backend and sets the cookie).
+# `kirocrew token` can print a SECOND, externally-advertised URL when
+# dashboard.url is configured — always take the localhost one.
+TOKEN_URL="$(PYTHONPATH="$SCRIPT_DIR/src" \
+    "$RUNTIME_PYTHON" -m kiro_crew token --port "$GATEWAY_PORT" 2>/dev/null \
+    | grep -oE 'http://localhost:[0-9]+[^ ]*' | head -1)"
+if [ -n "$TOKEN_URL" ]; then
+    OPEN_URL="$(printf '%s' "$TOKEN_URL" | sed "s/:$GATEWAY_PORT/:$VITE_PORT/")"
+    echo ""
+    echo "[dev] ============================================================"
+    echo "[dev] open:  $OPEN_URL"
+    echo "[dev] ============================================================"
+    echo ""
+    # Open the LIVE (Vite) surface in the browser — macOS `open`, Linux xdg-open.
+    # Best-effort: on a headless box the launcher exits nonzero, and under
+    # set -e that would tear down the whole stack we just brought up.
+    if command -v open >/dev/null 2>&1; then open "$OPEN_URL" || true
+    elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$OPEN_URL" || true
+    fi
+else
+    echo "[dev] WARNING: could not mint a token automatically. Run:"
+    echo "[dev]   KIROCREW_HOME=$KIROCREW_HOME PYTHONPATH=src .venv/bin/python -m kiro_crew token --port $GATEWAY_PORT"
+    echo "[dev] then open the URL with :$GATEWAY_PORT swapped to :$VITE_PORT"
+fi
+
+echo "[dev] streaming logs (Ctrl+C stops everything)"
+tail -f "$BACKEND_LOG" "$VITE_LOG"


### PR DESCRIPTION
## Problem

Running the KiroCrew dev stack from source takes three manual steps in separate terminals: start `./dev-backend.sh`, start Vite in `website/`, then mint a dashboard auth URL and hand-rewrite its port to the Vite port. Getting any step wrong (mismatched `KIROCREW_HOME`, stale port) yields silent auth failures or the wrong (bundled-snapshot) UI.

## Why it matters

Every contributor pays this setup tax on every backend restart, and the failure modes (auth link signed against a different data home, opening the `:6777` bundled surface instead of the live Vite one) are silent and confusing.

## Fix

One script, `./dev-fullstack.sh`, composes the existing pieces:

- Boots `dev-backend.sh --no-open` (port `6777` / `KIROCREW_PORT`, repo-local `.kirocrew-dev` home) and waits up to 90s for it to accept connections.
- Starts `npm run dev` in `website/` proxying to that port, and reads Vite's **actual** port from its banner (Vite falls back to 3001+ when 3000 is taken).
- Mints a dashboard auth URL against the **same effective data home** the backend booted with (a hardcoded home would sign with a different secret and auth would silently fail), rewrites it to the Vite port, prints it, and opens it (`open`/`xdg-open`).
- Teardown kills the exact PID trees it started rather than assuming process-group leadership (`kill -- -$$` leaked the stack when invoked from a script/IDE; macOS lacks `setsid`).
- Logs go under the dev data home (repo-local, gitignored) instead of world-writable `/tmp` — no predictable-name collisions or symlink-planting surface.
- Documents the CSRF caveat: the gateway's origin allowlist trusts Vite's default port 3000 only; the header comment names the `KIROCREW_ALLOWED_LOOPBACK_PORTS` escape hatch.


### Review-round fixes (amended into the single commit)

- Browser launch is best-effort (`|| true`) — a headless box no longer tears down the stack via `set -e`.
- Fail-fast pre-flight check when the gateway port is already occupied, instead of a false-positive readiness probe against a stale listener.
- `RUNTIME_PYTHON` resolved once (same precedence as `dev-backend.sh`) and reused for the auth-URL mint.
- `dev-backend.sh` now forwards `"$@"`, so the launcher's `--no-open` actually reaches the gateway (previously silently dropped).
- AGENTS.md § Dev Mode documents the launcher and drops the stale `dev-frontend.sh` reference.

## Tests

N/A — developer convenience shell script, no packaged code paths touched. `bash -n` syntax check passes.

## Manual verification

Used daily on the dev desktop: backend boots, Vite hot-reload works, printed URL authenticates through the Vite proxy, Ctrl+C tears down both processes with no leaked children.

## Screenshots

N/A — no UI change.
