### PR TITLE
fix(messaging): release the session when renderer finalization fails

### DIFF
--- a/src/kiro_crew/messaging/dispatch.py
+++ b/src/kiro_crew/messaging/dispatch.py
@@ -267,6 +267,27 @@ async def drive_turn(turn: ChannelTurn, *, sessions: Any, ctx_builder: Any) -> N
     finally:
         # Always finalize the turn, even if get_or_create raised before the
         # semaphore was held. Only release if we actually acquired it.
-        await renderer.close()
+        #
+        # ``renderer.close()`` is best-effort and must NEVER prevent the release
+        # below. A renderer that fails to finalize -- a malformed vendor
+        # response, a dropped socket mid-flush -- would otherwise leave the
+        # semaphore held with no path to give it back. Because the semaphore is
+        # keyed by SESSION, that does not just lose this turn: every later
+        # message for that conversation blocks forever, and any queued turn
+        # never drains. The channel looks permanently busy until the gateway
+        # restarts.
+        #
+        # Discord already guards this in its own dispatcher, which is how the
+        # hazard was found; the guard belongs here so every channel on the
+        # shared pipeline inherits it instead of re-deriving it.
+        try:
+            await renderer.close()
+        except Exception:
+            logger.warning(
+                "%s: renderer.close failed session=%s",
+                turn.channel_type,
+                session_key,
+                exc_info=True,
+            )
         if _acquired:
             sessions.release(session_key)

--- a/test/test_messaging_dispatch.py
+++ b/test/test_messaging_dispatch.py
@@ -1,0 +1,189 @@
+"""Finalization contract of the shared channel turn pipeline.
+
+``drive_turn`` owns the semaphore lifetime for every adopted channel, so a bug
+in its ``finally`` is a bug in all of them at once. These tests pin the part
+that is invisible on the happy path: what happens to ``release()`` when
+finalization itself fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from kiro_crew.messaging import dispatch as D
+from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn
+
+
+class _Sessions:
+    """Minimal stand-in that counts the calls this contract is about."""
+
+    def __init__(self, raise_on_acquire: bool = False):
+        self.released = 0
+        self.successes = 0
+        self.failures = 0
+        self._raise_on_acquire = raise_on_acquire
+
+    async def get_or_create(self, key, agent=None, channel_id=None):
+        if self._raise_on_acquire:
+            raise RuntimeError("cold start failed")
+        return object(), False, False
+
+    async def set_channel(self, key, channel_id):
+        pass
+
+    def record_success(self, key):
+        self.successes += 1
+
+    async def record_failure(self, key):
+        self.failures += 1
+
+    def release(self, key):
+        self.released += 1
+
+    def get_provider(self, key):
+        return object()
+
+
+class _Renderer:
+    """Renderer whose ``close`` can fail the way a real one can mid-flush."""
+
+    def __init__(self, close_raises: bool = False):
+        self.close_raises = close_raises
+        self.closed = 0
+
+    async def on_turn_start(self):
+        pass
+
+    async def close(self):
+        self.closed += 1
+        if self.close_raises:
+            raise RuntimeError("renderer finalization failed")
+
+
+class _CtxBuilder:
+    def build_message(self, text, is_new, session_key, **kw):
+        return text, None
+
+
+class _Driver:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def run(self, message):
+        return "the reply"
+
+
+def _turn(renderer: Any) -> ChannelTurn:
+    return ChannelTurn(
+        channel_type="weixin",
+        session_key="weixin:agentA:direct:userA",
+        conversation_id="weixin:userA",
+        agent="agentA",
+        user_text="hi",
+        renderer=renderer,
+        approval_mode="auto",
+    )
+
+
+def _patch_pipeline(monkeypatch, *, permitted: bool = True):
+    """Stub everything drive_turn touches except the finalization under test."""
+
+    async def _permitted(_channel_type):
+        return permitted
+
+    async def _publish(_sessions, _key):
+        pass
+
+    async def _embed(fn, *args, **kw):
+        return fn(*args, **kw)
+
+    monkeypatch.setattr(D, "inbound_permitted", _permitted)
+    monkeypatch.setattr(D, "publish_turn_identity", _publish)
+    monkeypatch.setattr(D, "run_in_embed_pool", _embed)
+    monkeypatch.setattr(D, "TurnDriver", _Driver)
+
+
+def test_release_still_runs_when_renderer_close_fails(monkeypatch) -> None:
+    """A failed renderer.close must NOT strand the session semaphore.
+
+    The semaphore is keyed by SESSION, so leaking it does not merely lose this
+    turn -- every later message for that conversation blocks forever and any
+    queued turn never drains, until the gateway restarts.
+    """
+    _patch_pipeline(monkeypatch)
+    sessions = _Sessions()
+    renderer = _Renderer(close_raises=True)
+
+    asyncio.run(drive_turn(_turn(renderer), sessions=sessions, ctx_builder=_CtxBuilder()))
+
+    assert renderer.closed == 1, "close should still be attempted"
+    assert sessions.released == 1, (
+        "renderer.close raised and the session was never released -- the "
+        "conversation is now permanently busy"
+    )
+
+
+def test_a_failing_close_does_not_escape_drive_turn(monkeypatch) -> None:
+    """The failure is logged and swallowed, not raised at the caller.
+
+    Adopters call drive_turn from a per-message task; letting finalization
+    raise would surface as an unhandled task exception for a turn that already
+    delivered its reply.
+    """
+    _patch_pipeline(monkeypatch)
+    sessions = _Sessions()
+
+    # asyncio.run re-raises anything drive_turn lets escape.
+    asyncio.run(
+        drive_turn(
+            _turn(_Renderer(close_raises=True)),
+            sessions=sessions,
+            ctx_builder=_CtxBuilder(),
+        )
+    )
+
+    assert sessions.successes == 1, "the turn itself succeeded"
+
+
+def test_release_is_not_called_when_the_semaphore_was_never_acquired(monkeypatch) -> None:
+    """The _acquired gate must survive the new guard.
+
+    A cold-start failure raises before get_or_create returns, so nothing was
+    ever held -- releasing here would hand back a permit that does not exist.
+    """
+    _patch_pipeline(monkeypatch)
+    sessions = _Sessions(raise_on_acquire=True)
+    renderer = _Renderer(close_raises=True)
+
+    asyncio.run(drive_turn(_turn(renderer), sessions=sessions, ctx_builder=_CtxBuilder()))
+
+    assert renderer.closed == 1, "finalization still runs on the failure path"
+    assert sessions.released == 0, "nothing was acquired, so nothing may be released"
+    assert sessions.failures == 0, "record_failure is also gated on _acquired"
+
+
+def test_the_happy_path_releases_exactly_once(monkeypatch) -> None:
+    """Guard rail: the new try/except must not double-release."""
+    _patch_pipeline(monkeypatch)
+    sessions = _Sessions()
+    renderer = _Renderer()
+
+    asyncio.run(drive_turn(_turn(renderer), sessions=sessions, ctx_builder=_CtxBuilder()))
+
+    assert renderer.closed == 1
+    assert sessions.released == 1
+    assert sessions.successes == 1
+
+
+def test_a_denied_turn_neither_renders_nor_releases(monkeypatch) -> None:
+    """Governance backstop returns before any side effect."""
+    _patch_pipeline(monkeypatch, permitted=False)
+    sessions = _Sessions()
+    renderer = _Renderer()
+
+    asyncio.run(drive_turn(_turn(renderer), sessions=sessions, ctx_builder=_CtxBuilder()))
+
+    assert renderer.closed == 0
+    assert sessions.released == 0
+    assert sessions.successes == 0


### PR DESCRIPTION
## The bug

`drive_turn`'s `finally` awaited `renderer.close()` **unguarded**, ahead of `sessions.release(session_key)`:

```python
finally:
    await renderer.close()      # ← raises
    if _acquired:
        sessions.release(session_key)   # ← never runs
```

Two consequences, and the second is the serious one:

1. The exception escapes `drive_turn` into the caller's per-message task — an unhandled task exception on a turn that already delivered its reply.
2. **The session semaphore is never released.** It is keyed by *session*, not by turn, so the leak is not confined to the failed turn: every later message for that conversation waits on a permit nobody will hand back, and any queued turn never drains. The channel presents as **permanently busy until the gateway restarts**.

The trigger is realistic, not theoretical — finalizing a renderer means a final flush to the vendor, so a malformed response body or a socket dropped mid-flush is sufficient.

## Blast radius

Every channel on the shared pipeline: **weixin, wecom, webex, teams**.

Discord already guards the same call in its own dispatcher, with a comment naming this exact hazard:

> *Renderer finalization is best-effort and must NEVER prevent the session release below — a rendering failure … that also failed finalization would otherwise leave the session permanently busy, blocking every subsequent Discord message and the queue drain.*

That is how this was found: while measuring discord for pipeline adoption, adopting `drive_turn` as-written would have **regressed** discord by replacing its guard with the unguarded version. Fixing it here means the four current adopters inherit the guard rather than each re-deriving it, and discord loses nothing when it adopts.

## The fix

`close()` is still attempted; failure is logged at warning with the session key; the `_acquired` gate is untouched, so a semaphore that was never held is still never released. This matches the guarded-step pattern the pipeline already uses for `record_success` and `persist` immediately above.

## Tests

Adds `test/test_messaging_dispatch.py`.

The shared pipeline had **no test file of its own** — it was covered only indirectly via `test_weixin_dispatch.py`. That is the structural reason a defect in code shared by four channels went unnoticed, so the new file is scoped to pipeline-level contracts and gives later pipeline work somewhere to land.

Five tests, pinning the finalization contract rather than the happy path:

| test | pins |
|---|---|
| `test_release_still_runs_when_renderer_close_fails` | the regression itself |
| `test_a_failing_close_does_not_escape_drive_turn` | the exception is swallowed, not raised at the caller |
| `test_release_is_not_called_when_the_semaphore_was_never_acquired` | the `_acquired` gate survives the new guard |
| `test_the_happy_path_releases_exactly_once` | no double-release introduced by the new `try` |
| `test_a_denied_turn_neither_renders_nor_releases` | governance backstop stays inert |

**3 of the 5 fail on the unfixed code** (verified by reverting `dispatch.py` alone and re-running).

## Verification

- 855 passed, 1 skipped across every channel-dispatch, governance and channel suite
- flake8, isort clean; mypy clean on 592 source files
- Full backend suite deferred to CI

## Follow-up context

This is the first of a re-sequenced PR ④. Measurement of the two unmigrated dispatchers (telegram 1050 lines, discord 1158) showed pipeline adoption removes only ~9% of each, while a **queue + collapsing-receipt subsystem duplicated across exactly those two channels (~558 lines)** is the larger win. This PR is the prerequisite both of those steps needed.
