### PR TITLE
chore(rules): make the page StatCard row optional, not required

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -577,12 +577,16 @@ All dashboard pages MUST follow this consistent layout pattern. Do NOT invent cu
 <>
   <PageHeader title="PageName" subtitle="Short description" />
   <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
-    {/* StatCard row → Cards with tables/forms */}
+    {/* optional StatCard row → Cards with tables/forms */}
   </div>
 </>
 ```
 
-**Stat cards** — summary metrics at the top of every page:
+**Stat cards** — OPTIONAL summary metrics above the content. Add a row only when
+a number is not already visible in the content below it (a rolled-up total, a
+rate, an error count). Do NOT add one that restates `items.length` for a list
+rendered on the same screen: it costs ~90px above the fold and carries no action.
+A page with no stat card row is conformant.
 ```tsx
 <div className="grid gap-3.5 grid-cols-[repeat(auto-fit,minmax(150px,1fr))] mb-6">
   <StatCard label="Total" value={count} accent />

--- a/website/AUTOSDE.yaml
+++ b/website/AUTOSDE.yaml
@@ -89,12 +89,18 @@ custom-rules:
       Required structure:
       1. `<PageHeader title="..." subtitle="..." />` at top
       2. `<div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">` as content container
-      3. `StatCard` row for summary metrics
-      4. `Card` + `CardTitle` + `InfoTip` for data sections
-      5. `table-striped` tables with standard header style
-      6. `Input`, `Btn`, `SendBtn`, `SearchInput` — never raw HTML elements
-      7. `Badge` for status indicators — never raw colored text
-      8. `EmptyState` when lists are empty
+      3. `Card` + `CardTitle` + `InfoTip` for data sections
+      4. `table-striped` tables with standard header style
+      5. `Input`, `Btn`, `SendBtn`, `SearchInput` — never raw HTML elements
+      6. `Badge` for status indicators — never raw colored text
+      7. `EmptyState` when lists are empty
+
+      Optional: a `StatCard` row for summary metrics, directly below the content
+      container. Use it when a number is NOT already visible in the content
+      below it (a rolled-up total, a rate, an error count) — not to restate
+      `items.length` for a list rendered on the same screen. A row of derived
+      counts above the list costs ~90px above the fold and carries no action, so
+      a page omitting the row is CONFORMANT: do not flag its absence.
 
       Do NOT use `<div className="p-6 max-w-[960px] mx-auto">` — this is the old pattern.
 


### PR DESCRIPTION
## Problem

`page-layout-pattern` in `website/AUTOSDE.yaml` is `blocking: true`, and its
**Required structure** list named `StatCard` row for summary metrics as item 3.
Read literally — which is how the AI review gate reads it — every dashboard page
under `src/pages/*.tsx` MUST carry a stat card row, and removing one is a
blocking rule violation.

That fired on #1235 (removing the four derived cards from the Artifacts page):

```
BLOCKING -- website/src/pages/ArtifactsPage.tsx:1697 -- Required StatCard row removed
Opening /artifacts -> ArtifactsPage renders without summary metrics -> violates blocking page-layout-pattern.
```

The finding is a correct reading of the rule. The rule is what is wrong.

## Why it matters

The mandate applies even when every number in the row is already visible in the
list directly beneath it, which is the common case: `artifacts.length`,
`filter(pinned).length`, `folders.length`, `new Set(kind).size`. Such a row costs
roughly 90px at the top of the page — pushing real content toward or below the
fold on a laptop viewport — offers no click target and no filter, and adds four
translated strings across 11 locale catalogs. As written, the rule blocks any PR
that removes one, on every page, one PR at a time.

## Fix (symptoms → root cause → change)

Symptom: a legitimate UI simplification is blocked by a `blocking: true` rule.
Root cause: the rule conflates *layout* (the `PageHeader` +
`px-6 pb-8 overflow-y-auto flex-1 min-h-0` contract it exists to enforce, and the
old `max-w-[960px]` wrapper it exists to forbid) with *content composition* — the
presence of one optional widget.
Change: move the `StatCard` row out of **Required structure** into an explicit
**Optional** clause that states when it earns its space (a rolled-up total, a
rate, an error count — a number **not** already on screen), says plainly that a
page omitting the row is CONFORMANT, and tells reviewers not to flag its absence.
`website/AGENTS.md` → Page Layout Guide carries the same guidance and is the doc
the rule points at, so it is updated in lockstep.

Deliberately unchanged: the `blocking: true` flag, the `src/pages/*.tsx`
file-patterns, the `max-w-\[(?:9[0-9]{2}|[1-9][0-9]{3,})px\]` regex
(`check-added`), the wrapper prohibition, the `SidePanelLayout` exception, and
every other item in the required list. The deterministic mirror of this rule in
`.github/workflows/code-review.yml` only greps for the `max-w` wrapper, so it
needs no edit and its behavior is unaffected.

## Tests

No automated test asserts this rule's prose — `test/test_prepare_pr_profiles.py`
is the only test that touches an `AUTOSDE.yaml` and it writes its own `rules: []`
fixture. Verified locally instead:

- `website/AUTOSDE.yaml` still parses as YAML and `page-layout-pattern` still
  resolves with `blocking: true`, `file-patterns: ['src/pages/*.tsx']` and its
  regex block intact (all 10 rule ids unchanged).
- No source file references the removed list item; `grep -rn page-layout-pattern`
  finds only two explanatory code comments (`website/src/components/ui.tsx`,
  `website/src/pages/AppsPage.tsx`) and the deterministic check in
  `code-review.yml`, none of which mentions the stat row.

## Manual verification

N/A — rules and documentation only, no runtime code path and no user-visible
surface in this PR. The behavior this unblocks is verified with screenshots on
#1235.

## Note for the reviewer

Both AI review contracts state: *"Weakening or removing a `blocking: true` rule
is itself a violation of that rule."* This PR narrows one, so the AI gate is
**expected to block it by design** — that clause exists precisely so a rule
relaxation cannot land without a human decision. Clearing it needs a repository
writer's SHA-scoped override comment on this PR:

```
/ai-review override gpt 2e1825db30c7c404fa25a0e7469aa2b2c5a0915d: <reason>
```

That human step is the point of the gate, not a workaround of it.
