### PR TITLE
fix(subagent): continuable-conversation hardening follow-ups (#1113 #1114 #1115)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -257,6 +257,15 @@ async def api_spawn_steer(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": detail, "code": "not_running"}, status=409
             )
+        if detail.startswith("session_starting"):
+            # Transient: the run is alive but its session has not registered
+            # yet (#1113). 503 + Retry-After tells clients to retry, unlike
+            # the terminal 502 steer_failed.
+            return web.json_response(
+                {"error": detail, "code": "session_starting"},
+                status=503,
+                headers={"Retry-After": "5"},
+            )
         return web.json_response(
             {"error": detail, "code": "steer_failed"}, status=502
         )

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -341,8 +341,12 @@ def _list_tools() -> list[dict[str, Any]]:
             "description": (
                 "Inject a message into a RUNNING subagent's in-flight turn "
                 "(course-correct without restarting it) — like steering a chat "
-                "session. Only works while the run is executing; for a finished "
-                "continuable run use spawn_continue instead."
+                "session. A steer arriving while a just-started run's session "
+                "is still registering waits briefly for it (typed "
+                "session_starting error if it still isn't up — retry then); "
+                "runs still WAITING in the spawn queue return not_found until "
+                "they start. Only works while the run is executing; for a "
+                "finished continuable run use spawn_continue instead."
             ),
             "inputSchema": {
                 "type": "object",

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -673,6 +673,14 @@ class SessionManager:
         # SubagentManager for ``keep=True`` spawns; unregistered on explicit
         # conversation release.
         self._continuable_keys: set[str] = set()
+        # Disk-truth fallback for continuable checks (#1115): SubagentManager
+        # injects a callable that reads ``keep`` from the run's state.json.
+        # The in-memory set above is a CACHE for the common case; state.json
+        # is the source of truth, so a cache miss (e.g. after a gateway
+        # restart, before the reaper rebuilds the registry) falls through to
+        # disk instead of silently treating a promoted conversation as
+        # stateless.
+        self._continuable_fallback: Callable[[str], bool] | None = None
         self._active_dashboard_slots: set[str] | None = (
             None  # None = uninitialized; empty set = all tabs closed
         )
@@ -2124,7 +2132,7 @@ class SessionManager:
         is_stateless = (
             key in (BACKGROUND_KEY, HEARTBEAT_KEY)
             or any(key.startswith(p) for p in _STATELESS_PREFIXES)
-        ) and key not in self._continuable_keys
+        ) and not self._is_continuable_key(key)
         if not is_stateless:
             resume_sid = self._session_map.get(key)
 
@@ -3064,7 +3072,7 @@ class SessionManager:
                         and key != BACKGROUND_KEY
                         and (
                             not any(key.startswith(p) for p in _STATELESS_PREFIXES)
-                            or key in self._continuable_keys
+                            or self._is_continuable_key(key)
                         )
                     ):
                         # Persist the provider label so detect_provider_switch
@@ -3082,7 +3090,7 @@ class SessionManager:
                         and key != BACKGROUND_KEY
                         and (
                             not any(key.startswith(p) for p in _STATELESS_PREFIXES)
-                            or key in self._continuable_keys
+                            or self._is_continuable_key(key)
                         )
                     ):
                         self._session_map.set(key, sid, provider="claude_code", cwd=_cwd_str)
@@ -3205,9 +3213,41 @@ class SessionManager:
         """Remove *key* from the continuable set (conversation released)."""
         self._continuable_keys.discard(self._fold_key(key))
 
+    def set_continuable_fallback(self, fn: Callable[[str], bool] | None) -> None:
+        """Install the disk-truth fallback for continuable checks (#1115).
+
+        *fn* receives the (folded) session key and returns True when the
+        underlying run's ``state.json`` records ``keep``. Injected by
+        SubagentManager so this module stays free of subagent-persistence
+        imports.
+        """
+        self._continuable_fallback = fn
+
+    def _is_continuable_key(self, folded: str) -> bool:
+        """Cache-then-disk continuable check for an already-folded key.
+
+        The in-memory set answers the common case; a miss consults the
+        injected state.json fallback so a gateway restart cannot demote a
+        promoted conversation to stateless treatment. A disk hit re-warms
+        the cache.
+        """
+        if folded in self._continuable_keys:
+            return True
+        # getattr: tests construct SessionManager bypassing __init__.
+        fb = getattr(self, "_continuable_fallback", None)
+        if fb is None:
+            return False
+        try:
+            if fb(folded):
+                self._continuable_keys.add(folded)
+                return True
+        except Exception:
+            logger.debug("continuable fallback failed for %s", folded, exc_info=True)
+        return False
+
     def is_continuable(self, key: str) -> bool:
         """True iff *key* is registered as a continuable conversation."""
-        return self._fold_key(key) in self._continuable_keys
+        return self._is_continuable_key(self._fold_key(key))
 
     def resumable_sid(self, key: str) -> str | None:
         """Return the persisted sid for *key*, or None.
@@ -3263,7 +3303,7 @@ class SessionManager:
             if (
                 cleanup
                 and key.startswith(_SUBAGENT_PREFIX)
-                and key not in self._continuable_keys
+                and not self._is_continuable_key(key)
             ):
                 try:
                     session_id = session.provider.session_id

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -72,6 +72,7 @@ from kiro_crew.subagent_cost import (
 from kiro_crew.subagent_persistence import (
     _agent_dir,
     _cleanup_session_files_sync,
+    _subagents_dir,
     clear_tombstone,
     create_agent_folder,
     list_orphans,
@@ -213,6 +214,11 @@ _REAPER_INTERVAL = 60  # seconds between reaper sweeps
 # run for this long has its session files + map entry deleted by the reaper.
 # Hibernated conversations cost a JSON file, not RSS, so this is generous.
 _CONVERSATION_TTL_SECS = 6 * 3600
+# Startup grace for spawn_steer (#1113): how long a steer on a live run
+# waits for its session to register before returning the typed
+# ``session_starting`` refusal, and the poll cadence within that window.
+_STEER_STARTUP_WAIT_SECS = 15.0
+_STEER_STARTUP_POLL_SECS = 0.5
 # Wave liveness backstop: a wave with lost submissions (submitted < expected,
 # all registered members terminal, nothing queued) is force-reconciled after
 # this many seconds without submission progress, so held digest results can
@@ -1022,10 +1028,20 @@ class SubagentManager:
         self.hook_store: Any = None  # Optional ScriptHookStore, set by server.py
         self._agents: dict[str, SubagentInfo] = {}
         # Continuable conversations: session_key ("subagent:<conv-id>") →
-        # last-used unix ts. Drives the reaper's idle-TTL sweep. Rebuilt
-        # lazily after a gateway restart: a spawn_continue on an unknown key
-        # re-registers it when SessionManager still holds a resumable sid.
+        # last-used unix ts. Drives the reaper's idle-TTL sweep. Rebuilt from
+        # state.json (keep=True runs) on the reaper's first pass after a
+        # gateway restart (#1114), so promoted conversations stay owned by
+        # the TTL sweep across restarts; a spawn_continue on an unknown key
+        # also re-registers it on demand.
         self._conversations: dict[str, float] = {}
+        self._conv_registry_rebuilt = False
+        # state.json is the source of truth for retention (#1115): give the
+        # SessionManager's in-memory continuable cache a disk fallback so a
+        # cache miss (restart window) cannot demote a promoted conversation.
+        try:
+            self._sessions.set_continuable_fallback(self._keep_recorded_on_disk)
+        except AttributeError:
+            pass  # test doubles without the setter
         self._tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
         # Queued spawns store the FULL spawn() kwarg set (not just a 5-tuple), so a
         # drained spawn preserves approval_mode / silent / model / allowed_tools / bare —
@@ -1477,6 +1493,21 @@ class SubagentManager:
         while True:
             await asyncio.sleep(_REAPER_INTERVAL)
             now = time.time()
+            if not self._conv_registry_rebuilt:
+                # First pass after (re)start: re-seed the conversation TTL
+                # registry from state.json so promoted conversations survive
+                # a gateway restart under sweep ownership (#1114). The flag
+                # is set only on SUCCESS — a failed rebuild retries on the
+                # next sweep instead of silently restoring the pre-#1114
+                # orphaning until the next restart (Arbiter, PR #1246).
+                try:
+                    await self._rebuild_conversation_registry()
+                    self._conv_registry_rebuilt = True
+                except Exception:
+                    logger.warning(
+                        "Reaper: conversation registry rebuild failed — retrying next sweep",
+                        exc_info=True,
+                    )
             self._sample_live_costs()
             # Wave liveness backstop: reconcile waves wedged by submissions
             # lost before the process boundary (see _sweep_stuck_waves).
@@ -2758,6 +2789,127 @@ class SubagentManager:
                 )
         return None
 
+    def _keep_recorded_on_disk(self, key: str) -> bool:
+        """Disk-truth continuable check for SessionManager's cache (#1115).
+
+        True iff *key* is a subagent conversation whose run's ``state.json``
+        records ``keep`` — the single persisted source of retention intent.
+        Non-subagent keys short-circuit without touching disk.
+        """
+        if not key.startswith("subagent:"):
+            return False
+        conv_id = key[len("subagent:"):]
+        try:
+            state = read_state(conv_id) or {}
+        except Exception:
+            return False
+        return bool(state.get("keep"))
+
+    def _promote_conversation(self, conv_id: str, conv_key: str, last_used: float | None = None) -> None:
+        """Single choke point for promoting a conversation's retention (#1115).
+
+        Writes all three retention surfaces together so they cannot drift:
+        ``keep=True`` in state.json (the persisted source of truth), the
+        SessionManager continuable cache (file-deletion exemption), and the
+        TTL registry entry (sweep ownership).
+        """
+        try:
+            update_state(conv_id, keep=True)
+        except Exception:
+            logger.debug("promote: failed to persist keep for %s", conv_id, exc_info=True)
+        self._sessions.mark_continuable(conv_key)
+        self._conversations[conv_key] = last_used if last_used is not None else time.time()
+
+    def _scan_keep_states(self) -> list[tuple[str, str, str, str, str, float]]:
+        """Blocking scan for keep runs (#1114): read every ``state.json``
+        under the subagents dir and collect the promoted conversations.
+
+        Returns ``(conv_id, conv_key, sid, provider, cwd, last_used)`` tuples.
+        Runs in an executor — no event-loop work here.
+        """
+        out: list[tuple[str, str, str, str, str, float]] = []
+        try:
+            base = _subagents_dir()
+            entries = list(base.iterdir()) if base.is_dir() else []
+        except Exception:
+            return out
+        for d in entries:
+            try:
+                if not d.is_dir():
+                    continue
+                state = read_state(d.name) or {}
+                if not state.get("keep"):
+                    continue
+                conv_key = str(state.get("conversation_key") or "") or f"subagent:{d.name}"
+                conv_id = conv_key[len("subagent:"):]
+                sid = str(state.get("session_id") or "")
+                last_used = float(state.get("updated_at") or state.get("started") or 0.0)
+                out.append((
+                    conv_id, conv_key, sid,
+                    str(state.get("provider") or "acp"),
+                    str(state.get("cwd") or ""),
+                    last_used,
+                ))
+            except Exception:
+                logger.debug("registry rebuild: skipping %s", d, exc_info=True)
+        return out
+
+    async def _rebuild_conversation_registry(self) -> None:
+        """Re-seed the conversation TTL registry from disk after a restart (#1114).
+
+        The registry (``_conversations`` + the SessionManager continuable
+        cache + session map) is in-memory; without this, a gateway restart
+        orphans promoted conversations — the TTL sweep no longer knows them,
+        and nothing else deletes their session files (the tombstone pruner
+        skips keep runs by design). Runs on the reaper's first pass (retried
+        until it succeeds); entries already past TTL are released by the
+        very next sweep.
+
+        Threading contract (Arbiter, PR #1246): ONLY the pure-read
+        ``_scan_keep_states`` runs in the executor. All ``SessionMap``
+        access (``resumable_sid`` self-prune, ``seed_conversation`` writes)
+        stays on the event loop — the map is an unlocked dict with
+        whole-file saves, concurrently mutated by ``get_or_create`` /
+        ``close_all``, so touching it from a worker thread races restart
+        cold-starts (lost mappings / dict-changed-size errors). Per-entry
+        work is small and bounded by the keep-run count, and the loop
+        yields between entries so a large batch cannot stall chat turns
+        (the round-2 event-loop concern).
+        """
+        loop = asyncio.get_running_loop()
+        found = await loop.run_in_executor(None, self._scan_keep_states)
+        # Newest record wins: a conversation appears once per run that
+        # touched it (original + each continuation). The first record kept
+        # for a conv_key wins the `in self._conversations` guard below, so
+        # iterate newest-first — an oldest-first order would seed a stale
+        # last_used and let the SAME pass's sweep expire (and delete) a
+        # conversation whose real last-use is recent.
+        found.sort(key=lambda t: t[5], reverse=True)
+        seeded = 0
+        for conv_id, conv_key, sid, provider, cwd, last_used in found:
+            if conv_key in self._conversations:
+                continue  # live registration wins over the disk snapshot
+            # Same on-demand seeding as continue_conversation (also on-loop):
+            # the map entry is what makes release_conversation able to find
+            # and delete files.
+            if sid and not self._sessions.resumable_sid(conv_key):
+                self._sessions.seed_conversation(conv_key, sid, provider=provider, cwd=cwd)
+            # Resumability gate: SessionMap.get self-prunes entries whose
+            # session files are missing, so this also rejects RELEASED
+            # conversations whose continuation runs still carry a stale
+            # keep=True in their own state.json — their files are gone, and
+            # re-owning them would resurrect a released conversation.
+            if not self._sessions.resumable_sid(conv_key):
+                continue
+            self._sessions.mark_continuable(conv_key)
+            self._conversations[conv_key] = last_used or time.time()
+            seeded += 1
+            # Cooperative yield: keep restart cold-start turns responsive
+            # while a large keep batch seeds (one small file write each).
+            await asyncio.sleep(0)
+        if seeded:
+            logger.info("Rebuilt conversation TTL registry from disk: %d conversation(s)", seeded)
+
     def continue_conversation(
         self,
         conv_id: str,
@@ -2834,15 +2986,11 @@ class SubagentManager:
                 ),
             )
             return info
-        self._sessions.mark_continuable(conv_key)
-        self._conversations[conv_key] = time.time()
-        # Promote the ORIGINAL run's retention: the tombstone pruner reads
-        # keep from state.json and skips session-file deletion for it. The
-        # conversation TTL sweep / spawn_release owns deletion from here.
-        try:
-            update_state(conv_id, keep=True)
-        except Exception:
-            logger.debug("continue: failed to promote state for %s", conv_id, exc_info=True)
+        # Promote the run's retention through the single choke point
+        # (#1115): state.json keep=True (tombstone pruner skips deletion),
+        # the SessionManager continuable cache, and the TTL registry entry.
+        # The conversation TTL sweep / spawn_release owns deletion from here.
+        self._promote_conversation(conv_id, conv_key)
         return self.spawn(
             task,
             parent_session_key=parent_session_key,
@@ -2858,22 +3006,47 @@ class SubagentManager:
 
         Returns ``(ok, detail)``. Typed detail values on refusal:
         ``not_found`` (unknown id), ``not_running`` (run finished — use
-        spawn_continue), ``no_session`` (session not reachable), or the
-        provider's failure reason.
+        spawn_continue), ``session_starting`` (run alive but its session has
+        not registered yet — retry shortly), ``no_session`` (session not
+        reachable), or the provider's failure reason.
+
+        Startup grace (#1113): the window between spawn-return and session
+        registration is precisely when a parent most wants to steer (it just
+        realized the task text was wrong), so a missing provider on a live
+        run polls for up to ``_STEER_STARTUP_WAIT_SECS`` instead of failing
+        immediately with a bare ``no_session``.
         """
         info = self._agents.get(agent_id)
         if info is None:
             return False, "not_found"
         if info.done:
             return False, "not_running: run finished — use spawn_continue"
-        provider: Any = None
-        if info._session_sharing and info._shared_provider is not None:
-            provider = info._shared_provider
-        else:
+
+        def _resolve_provider() -> Any:
+            if info._session_sharing and info._shared_provider is not None:
+                return info._shared_provider
             session_key = info.conversation_key or f"subagent:{info.id}"
-            provider = self._sessions.get_provider(session_key)
+            return self._sessions.get_provider(session_key)
+
+        provider: Any = _resolve_provider()
         if provider is None or not hasattr(provider, "steer"):
-            return False, "no_session"
+            # Bounded wait for session registration on a run that is still
+            # alive. Re-checks done-ness each tick: a run finishing while we
+            # wait flips the answer to not_running, never a stale inject.
+            deadline = time.monotonic() + _STEER_STARTUP_WAIT_SECS
+            while time.monotonic() < deadline:
+                await asyncio.sleep(_STEER_STARTUP_POLL_SECS)
+                if info.done:
+                    return False, "not_running: run finished — use spawn_continue"
+                provider = _resolve_provider()
+                if provider is not None and hasattr(provider, "steer"):
+                    break
+            else:
+                return False, (
+                    "session_starting: the run is alive but its session has "
+                    f"not registered within {_STEER_STARTUP_WAIT_SECS}s — "
+                    "retry in a few seconds"
+                )
         try:
             ok = await provider.steer(message)
         except Exception as exc:  # pragma: no cover - provider-specific
@@ -2905,6 +3078,14 @@ class SubagentManager:
         provider_label = self._sessions.conversation_provider(conv_key) or "acp"
         sid = self._sessions.forget_conversation(conv_key)
         self._conversations.pop(conv_key, None)
+        # Demote the persisted source of truth too (#1115): with the disk
+        # fallback in place, a stale keep=True would re-warm the continuable
+        # cache after release and resurrect the conversation on the next
+        # restart's registry rebuild.
+        try:
+            update_state(conv_id, keep=False)
+        except Exception:
+            logger.debug("release: failed to demote state for %s", conv_id, exc_info=True)
         if not sid:
             return False, "conversation_gone: nothing to release"
         try:

--- a/test/test_continuable_followups.py
+++ b/test/test_continuable_followups.py
@@ -1,0 +1,335 @@
+"""Tests for the continuable-conversation follow-up fixes (#1113/#1114/#1115).
+
+- #1113: spawn_steer startup grace — a steer landing before the run's
+  session registers waits (bounded) instead of failing with a bare
+  ``no_session``; typed ``session_starting`` on timeout; ``not_running``
+  when the run finishes mid-wait.
+- #1114: conversation TTL registry rebuild from state.json on the reaper's
+  first pass after a gateway restart, gated on session files still being
+  resumable (released conversations stay dead).
+- #1115: state.json as the single source of retention truth — the
+  SessionManager continuable cache falls back to disk on a miss, promotion
+  goes through one choke point, and release demotes the disk flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import kiro_crew.subagent as subagent_mod
+from kiro_crew.subagent import SubagentInfo, SubagentManager
+from kiro_crew.subagent_persistence import create_agent_folder, read_state, update_state
+
+# Subagent-registry isolation is provided globally by the autouse
+# ``_isolate_subagents_dir`` fixture in ``conftest.py``.
+
+
+def _mock_sessions() -> MagicMock:
+    sessions = MagicMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.mark_continuable = MagicMock()
+    sessions.unmark_continuable = MagicMock()
+    sessions.resumable_sid = MagicMock(return_value="sid-123")
+    sessions.seed_conversation = MagicMock()
+    sessions.forget_conversation = MagicMock(return_value="sid-123")
+    sessions.conversation_provider = MagicMock(return_value="acp")
+    sessions.get_provider = MagicMock(return_value=None)
+    sessions.set_continuable_fallback = MagicMock()
+    return sessions
+
+
+def _mock_ctx_builder() -> MagicMock:
+    ctx = MagicMock()
+    ctx.build_message = MagicMock(return_value=("built_message", None))
+    ctx.hooks.on_tool_call = MagicMock()
+    ctx.hooks.auto_approve_subagent_spawn = True
+    return ctx
+
+
+def _manager(sessions: MagicMock | None = None) -> SubagentManager:
+    return SubagentManager(
+        sessions=sessions or _mock_sessions(),
+        ctx_builder=_mock_ctx_builder(),
+    )
+
+
+def _steer_provider(ok: bool = True) -> MagicMock:
+    provider = MagicMock()
+    provider.steer = AsyncMock(return_value=ok)
+    return provider
+
+
+# ── #1113: steer startup grace ──
+
+
+class TestSteerStartupGrace:
+    @pytest.mark.asyncio
+    async def test_steer_waits_for_session_registration(self) -> None:
+        """A steer arriving before the session registers succeeds once the
+        provider shows up within the grace window."""
+        sessions = _mock_sessions()
+        provider = _steer_provider()
+        # None on the first two polls, then the provider registers.
+        sessions.get_provider = MagicMock(side_effect=[None, None, provider, provider])
+        mgr = _manager(sessions)
+        info = SubagentInfo(id="run1", task="t")
+        mgr._agents["run1"] = info
+        with (
+            patch.object(subagent_mod, "_STEER_STARTUP_WAIT_SECS", 1.0),
+            patch.object(subagent_mod, "_STEER_STARTUP_POLL_SECS", 0.01),
+        ):
+            ok, detail = await mgr.steer_run("run1", "adjust course")
+        assert ok is True
+        assert detail == "ok"
+        provider.steer.assert_awaited_once_with("adjust course")
+
+    @pytest.mark.asyncio
+    async def test_steer_session_starting_after_timeout(self) -> None:
+        """Provider never registers within the window → typed session_starting."""
+        sessions = _mock_sessions()
+        sessions.get_provider = MagicMock(return_value=None)
+        mgr = _manager(sessions)
+        mgr._agents["run1"] = SubagentInfo(id="run1", task="t")
+        with (
+            patch.object(subagent_mod, "_STEER_STARTUP_WAIT_SECS", 0.05),
+            patch.object(subagent_mod, "_STEER_STARTUP_POLL_SECS", 0.01),
+        ):
+            ok, detail = await mgr.steer_run("run1", "msg")
+        assert ok is False
+        assert detail.startswith("session_starting")
+
+    @pytest.mark.asyncio
+    async def test_steer_not_running_when_run_finishes_mid_wait(self) -> None:
+        """A run completing during the grace window flips the answer to
+        not_running — the message is never injected into a dead turn."""
+        sessions = _mock_sessions()
+        sessions.get_provider = MagicMock(return_value=None)
+        mgr = _manager(sessions)
+        info = SubagentInfo(id="run1", task="t")
+        mgr._agents["run1"] = info
+
+        async def _finish_soon() -> None:
+            await asyncio.sleep(0.02)
+            info.done = True
+
+        with (
+            patch.object(subagent_mod, "_STEER_STARTUP_WAIT_SECS", 5.0),
+            patch.object(subagent_mod, "_STEER_STARTUP_POLL_SECS", 0.01),
+        ):
+            finisher = asyncio.ensure_future(_finish_soon())
+            ok, detail = await mgr.steer_run("run1", "msg")
+            await finisher
+        assert ok is False
+        assert detail.startswith("not_running")
+
+    @pytest.mark.asyncio
+    async def test_steer_immediate_when_provider_present(self) -> None:
+        """No grace-window delay when the session is already reachable."""
+        sessions = _mock_sessions()
+        provider = _steer_provider()
+        sessions.get_provider = MagicMock(return_value=provider)
+        mgr = _manager(sessions)
+        mgr._agents["run1"] = SubagentInfo(id="run1", task="t")
+        t0 = time.monotonic()
+        ok, _ = await mgr.steer_run("run1", "msg")
+        assert ok is True
+        assert time.monotonic() - t0 < 1.0  # no full-window wait
+
+
+# ── #1114: TTL registry rebuild from disk ──
+
+
+class TestConversationRegistryRebuild:
+    def _keep_run(self, run_id: str, *, sid: str = "sid-x", conv_key: str = "") -> None:
+        create_agent_folder(run_id, task="t")
+        update_state(
+            run_id,
+            keep=True,
+            session_id=sid,
+            provider="acp",
+            cwd="",
+            conversation_key=conv_key,
+        )
+
+    def test_scan_keep_states_finds_only_keep_runs(self) -> None:
+        mgr = _manager()
+        self._keep_run("keeprun1")
+        create_agent_folder("plainrun", task="t")  # keep absent
+        found = mgr._scan_keep_states()
+        ids = {t[0] for t in found}
+        assert ids == {"keeprun1"}
+        conv_id, conv_key, sid, provider, _cwd, last_used = found[0]
+        assert conv_key == "subagent:keeprun1"
+        assert sid == "sid-x"
+        assert provider == "acp"
+        assert last_used > 0
+
+    def test_scan_uses_recorded_conversation_key(self) -> None:
+        """A continuation run's state points at the ORIGINAL conversation."""
+        mgr = _manager()
+        self._keep_run("contrun", conv_key="subagent:origrun")
+        found = mgr._scan_keep_states()
+        assert found[0][1] == "subagent:origrun"
+
+    @pytest.mark.asyncio
+    async def test_rebuild_seeds_map_registry_and_cache(self) -> None:
+        sessions = _mock_sessions()
+        # Not resumable before the seed, resumable after it.
+        sessions.resumable_sid = MagicMock(side_effect=[None, "sid-x"])
+        mgr = _manager(sessions)
+        self._keep_run("keeprun1")
+        await mgr._rebuild_conversation_registry()
+        sessions.seed_conversation.assert_called_once_with(
+            "subagent:keeprun1", "sid-x", provider="acp", cwd=""
+        )
+        sessions.mark_continuable.assert_called_with("subagent:keeprun1")
+        assert "subagent:keeprun1" in mgr._conversations
+
+    @pytest.mark.asyncio
+    async def test_rebuild_skips_released_conversations(self) -> None:
+        """Stale keep=True with no resumable files (released) stays dead."""
+        sessions = _mock_sessions()
+        sessions.resumable_sid = MagicMock(return_value=None)  # files gone
+        mgr = _manager(sessions)
+        self._keep_run("released1")
+        await mgr._rebuild_conversation_registry()
+        assert "subagent:released1" not in mgr._conversations
+        sessions.mark_continuable.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rebuild_newest_record_wins_for_duplicate_conversation(self) -> None:
+        """A conversation appears once per run that touched it (original +
+        continuations). The rebuild must register the NEWEST last_used —
+        seeding a stale one would let the same pass's sweep expire a
+        conversation whose real last-use is recent (GPT finding, PR #1246)."""
+        sessions = _mock_sessions()
+        mgr = _manager(sessions)
+        # Original run: old timestamp. Continuation run: recent, points at
+        # the same conversation via conversation_key. update_state() always
+        # stamps updated_at=now, so write the timestamps directly.
+        import json as _json
+
+        from kiro_crew.subagent_persistence import _agent_dir
+
+        def _write_keep_state(run_id: str, conv_key: str, ts: float) -> None:
+            create_agent_folder(run_id, task="t")
+            p = _agent_dir(run_id) / "state.json"
+            state = _json.loads(p.read_text(encoding="utf-8"))
+            state.update(
+                keep=True, session_id="sid-x", provider="acp", cwd="",
+                conversation_key=conv_key, updated_at=ts,
+            )
+            p.write_text(_json.dumps(state), encoding="utf-8")
+
+        _write_keep_state("origrun", "", 1000.0)
+        _write_keep_state("contrun", "subagent:origrun", 2000.0)
+        await mgr._rebuild_conversation_registry()
+        assert mgr._conversations["subagent:origrun"] == 2000.0
+
+    @pytest.mark.asyncio
+    async def test_rebuild_flag_not_set_on_failure(self) -> None:
+        """A failed rebuild must retry on the next sweep (flag only set on
+        success — Arbiter suggestion, PR #1246). Covered here by verifying
+        the rebuild raises through (the reaper catches and leaves the flag
+        unset)."""
+        sessions = _mock_sessions()
+        sessions.resumable_sid = MagicMock(side_effect=RuntimeError("boom"))
+        mgr = _manager(sessions)
+        self._keep_run("keeprun1")
+        # Per-entry code is wrapped, but a raising sessions API inside the
+        # loop is caught per-entry; simulate a scan-level failure instead.
+        with patch.object(mgr, "_scan_keep_states", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                await mgr._rebuild_conversation_registry()
+
+    @pytest.mark.asyncio
+    async def test_rebuild_never_overwrites_live_registration(self) -> None:
+        sessions = _mock_sessions()
+        mgr = _manager(sessions)
+        self._keep_run("keeprun1")
+        live_ts = time.time() + 999
+        mgr._conversations["subagent:keeprun1"] = live_ts
+        await mgr._rebuild_conversation_registry()
+        assert mgr._conversations["subagent:keeprun1"] == live_ts
+        sessions.seed_conversation.assert_not_called()
+
+
+# ── #1115: state.json as retention source of truth ──
+
+
+class TestRetentionSourceOfTruth:
+    def test_keep_recorded_on_disk(self) -> None:
+        mgr = _manager()
+        create_agent_folder("keeprun1", task="t")
+        update_state("keeprun1", keep=True)
+        create_agent_folder("plainrun", task="t")
+        assert mgr._keep_recorded_on_disk("subagent:keeprun1") is True
+        assert mgr._keep_recorded_on_disk("subagent:plainrun") is False
+        assert mgr._keep_recorded_on_disk("subagent:missing") is False
+        assert mgr._keep_recorded_on_disk("dashboard:tab1") is False
+
+    def test_manager_installs_fallback_on_sessions(self) -> None:
+        sessions = _mock_sessions()
+        mgr = _manager(sessions)
+        sessions.set_continuable_fallback.assert_called_once_with(
+            mgr._keep_recorded_on_disk
+        )
+
+    def test_promote_conversation_writes_all_three_surfaces(self) -> None:
+        sessions = _mock_sessions()
+        mgr = _manager(sessions)
+        create_agent_folder("conv1", task="t")
+        mgr._promote_conversation("conv1", "subagent:conv1")
+        assert bool((read_state("conv1") or {}).get("keep")) is True
+        sessions.mark_continuable.assert_called_with("subagent:conv1")
+        assert "subagent:conv1" in mgr._conversations
+
+    def test_release_demotes_disk_keep(self) -> None:
+        """release_conversation must flip keep=False on disk, or the disk
+        fallback would resurrect the released conversation."""
+        sessions = _mock_sessions()
+        mgr = _manager(sessions)
+        create_agent_folder("conv1", task="t")
+        update_state("conv1", keep=True)
+        with patch.object(subagent_mod, "_cleanup_session_files_sync"):
+            ok, detail = mgr.release_conversation("conv1")
+        assert ok is True
+        assert bool((read_state("conv1") or {}).get("keep")) is False
+
+    def _session_manager(self):  # type: ignore[no-untyped-def]
+        from kiro_crew.session import SessionManager
+
+        with patch.object(SessionManager, "__init__", lambda self: None):
+            smgr = SessionManager()  # type: ignore[call-arg]
+        smgr._continuable_keys = set()
+        smgr._fold_key = lambda k: k  # type: ignore[assignment]
+        return smgr
+
+    def test_session_fallback_warms_cache_on_disk_hit(self) -> None:
+        smgr = self._session_manager()
+        smgr.set_continuable_fallback(lambda key: key == "subagent:kept")
+        assert smgr.is_continuable("subagent:kept") is True
+        # Cache warmed: a second check answers without the fallback.
+        smgr.set_continuable_fallback(None)
+        assert smgr.is_continuable("subagent:kept") is True
+        assert smgr.is_continuable("subagent:other") is False
+
+    def test_session_fallback_exception_is_safe(self) -> None:
+        smgr = self._session_manager()
+
+        def _boom(_key: str) -> bool:
+            raise RuntimeError("disk unhappy")
+
+        smgr.set_continuable_fallback(_boom)
+        assert smgr.is_continuable("subagent:kept") is False
+
+    def test_session_fallback_absent_attribute_is_safe(self) -> None:
+        """Fixtures that bypass __init__ (no _continuable_fallback attr)
+        must not crash the helper."""
+        smgr = self._session_manager()
+        # No set_continuable_fallback call — attribute never created.
+        assert smgr.is_continuable("subagent:kept") is False

--- a/test/test_subagent_continuable.py
+++ b/test/test_subagent_continuable.py
@@ -306,12 +306,21 @@ class TestSteerRun:
 
     @pytest.mark.asyncio
     async def test_no_session_reachable(self) -> None:
+        """A live run with no reachable session now gets the #1113 startup
+        grace, then the typed ``session_starting`` refusal (retryable) —
+        not the old terminal bare ``no_session``."""
+        import kiro_crew.subagent as subagent_mod
+
         sessions = _mock_sessions()
         sessions.get_provider = MagicMock(return_value=None)
         manager = _manager(sessions)
         manager._agents["a1"] = SubagentInfo(id="a1", task="t")
-        ok, detail = await manager.steer_run("a1", "hi")
-        assert not ok and detail == "no_session"
+        with (
+            patch.object(subagent_mod, "_STEER_STARTUP_WAIT_SECS", 0.05),
+            patch.object(subagent_mod, "_STEER_STARTUP_POLL_SECS", 0.01),
+        ):
+            ok, detail = await manager.steer_run("a1", "hi")
+        assert not ok and detail.startswith("session_starting")
 
 
 # ── release_conversation + TTL sweep ──


### PR DESCRIPTION
## Summary

Hardening follow-ups for continuable subagent conversations (#1023), found during the live end-to-end verification on `0.1.2-nightly.20260802t021631` and the Arbiter review. Closes #1113, closes #1114, closes #1115.

### #1113 — steer startup grace

Observed live: `spawn_steer` fired immediately after `spawn_run` returned a bare `no_session` because the run's ACP session had not registered yet; an identical retry ~15s later succeeded. The window between spawn-return and session registration is precisely when a parent most wants to steer.

- `steer_run` now polls for the provider for up to `_STEER_STARTUP_WAIT_SECS` (15s, 0.5s cadence), re-checking done-ness each tick — a run finishing mid-wait returns `not_running`, never a stale inject.
- On timeout it returns a typed `session_starting` refusal (retryable) instead of the terminal `no_session`.
- HTTP: `session_starting` → 503 + `Retry-After: 5` (vs 502 `steer_failed`). MCP tool description updated.
- The in-handler wait (15s) is well inside the MCP `_post` timeout (30s).

### #1114 — conversation TTL registry rebuild on restart

The TTL registry (`_conversations` + SessionManager continuable cache) was in-memory only: a gateway restart orphaned promoted conversations — the sweep no longer knew them, and nothing else deletes keep-run session files (the tombstone pruner skips them by design).

- The reaper's first pass now re-seeds the registry from disk: scan `state.json` files with `keep=True` (executor, off the event loop), seed the session map on demand (same seam as `spawn_continue`), and register with the recorded `updated_at` as last-used — entries already past TTL are released by the next sweep.
- Gated on resumability: `SessionMap.get` self-prunes entries whose session files are gone, so released conversations (whose continuation runs still carry a stale `keep=True`) are NOT resurrected.
- Live registrations always win over the disk snapshot.

### #1115 — retention source of truth

Retention intent lived in three independently-written places (state.json `keep`, `_continuable_keys`, per-handle `keep_transcript`); drift produced silent misbehavior. state.json is now authoritative:

- `SessionManager._continuable_keys` is a cache: all four consumption sites (`is_stateless` gate, both `close_all` persist branches, `release()` cleanup exemption) go through `_is_continuable_key`, which falls back to an injected disk check (`state.json` keep) on a miss and re-warms the cache on a hit. SubagentManager injects the fallback at construction, keeping session.py free of subagent-persistence imports.
- Promotion goes through one choke point (`_promote_conversation`) writing all three surfaces together.
- `release_conversation` now also demotes `keep=False` on disk — required so the fallback and the #1114 rebuild cannot resurrect a released conversation.
- `keep_transcript` remains the per-handle delivery mechanism (set at the consumption point, derived from run state), not an independent store.

## Testing

- 16 new tests in `test/test_continuable_followups.py` covering: grace-window success/timeout/mid-wait-finish/no-delay-when-present; disk scan (keep-only, recorded conversation_key), rebuild seeding, released-conversation gate, live-registration precedence; disk-truth checks, fallback installation, choke-point promotion, release demotion, cache re-warm, fallback exception/absent-attribute safety.
- 1 existing test updated to the new typed steer contract (`test_no_session_reachable`).
- 389 tests green across the affected suites (`test_subagent_continuable`, `test_session_cleanup`, `test_subagent`, `test_session`, new file); isort/flake8/mypy clean.

## Not in scope

#1116 (nightly CLI wheel signing key) is an ops/secrets action, not a code change.
