### PR TITLE
ci: cap every workflow job with timeout-minutes

### DIFF
--- a/.github/workflows/ai-review-human-override.yml
+++ b/.github/workflows/ai-review-human-override.yml
@@ -34,6 +34,7 @@ jobs:
       github.event.issue.pull_request != null
       && startsWith(github.event.comment.body, '/ai-review override ')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Validate and record the decision
         id: context

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -53,6 +53,7 @@ jobs:
   build-desktop:
     name: Build Desktop (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -23,6 +23,7 @@ jobs:
   build-wheel:
     name: Build Wheel (CLI)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -126,6 +126,7 @@ jobs:
     # startup. Comparing to true always produces a boolean.
     continue-on-error: ${{ inputs.soft_fail == true }}
     runs-on: windows-latest
+    timeout-minutes: 60
     # Publishing callers pass use_prod_environment: true -- REQUIRED, because
     # the signing role's OIDC trust accepts exactly two subjects
     # (ref:refs/heads/main and environment:prod) and tag-triggered release runs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
   build-wheel:
     name: Build Wheel
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -68,6 +69,8 @@ jobs:
   build-desktop:
     name: Build Desktop (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # macOS bills at 10x, so an unbounded hang here is the costliest in the repo.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   scrub-lint:
     name: De-Amazon Scrub Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         # Full history is fetched lazily by the script only for the (skipped)
@@ -37,6 +38,7 @@ jobs:
   backend-lint:
     name: Backend Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.10", "3.12"]
@@ -83,6 +85,7 @@ jobs:
   backend-test:
     name: Backend Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       # Don't cancel sibling shards when one fails -- we want the full failure
       # picture across the suite, not just the first shard to break.
@@ -170,6 +173,8 @@ jobs:
   backend-test-windows:
     name: Backend Tests (Windows)
     runs-on: windows-latest
+    # windows-latest runs the same shards measurably slower than POSIX.
+    timeout-minutes: 40
     strategy:
       # Full failure picture across shards, same as backend-test.
       fail-fast: false
@@ -254,6 +259,7 @@ jobs:
     name: Coverage Combine
     needs: backend-test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -313,6 +319,7 @@ jobs:
   coverage-gate:
     name: Coverage Gate
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [coverage-combine, frontend-test]
     # Always run so the required check emits a real verdict. Without
     # `if: always()`, a failing OR skipped dependency would SKIP this job, and
@@ -395,6 +402,7 @@ jobs:
   frontend-lint:
     name: Frontend Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -530,6 +538,7 @@ jobs:
   cfn-lint:
     name: CloudFormation Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -548,6 +557,8 @@ jobs:
   frontend-test:
     name: Frontend Tests
     runs-on: ubuntu-latest
+    # vitest + coverage is the longest ubuntu job (~23 min observed max).
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/cleanup-temp-screenshots.yml
+++ b/.github/workflows/cleanup-temp-screenshots.yml
@@ -33,6 +33,7 @@ jobs:
   prune:
     name: Prune stale temp-screenshots
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -12,6 +12,7 @@ jobs:
   autosde-rules:
     name: Automated Rule Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -162,6 +163,7 @@ jobs:
   inclusive-language:
     name: Inclusive Language
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -231,6 +233,7 @@ jobs:
   sast:
     name: SAST (Semgrep)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: semgrep/semgrep:1.78
     steps:
@@ -256,6 +259,7 @@ jobs:
   pr-hygiene:
     name: PR Hygiene
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -35,6 +35,7 @@ jobs:
   license-gate:
     name: Dependency License Gate
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -28,6 +28,7 @@ jobs:
   design-review:
     name: Design Review
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Same-repo PRs only (not forks): fork PRs have no OIDC/secrets access, and
     # this keeps budget abuse / prompt-injection / secret-exfil out — mirrors
     # the fork guard in codex-review.yml.

--- a/.github/workflows/fork-workflow-guard.yml
+++ b/.github/workflows/fork-workflow-guard.yml
@@ -46,6 +46,7 @@ jobs:
   guard:
     name: Fork workflow-change guard
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # FORK ONLY, both event shapes. Same-repo PRs are unaffected.
     if: >-
       ( github.event_name == 'workflow_run'
@@ -130,6 +131,7 @@ jobs:
   strip-stale-override:
     name: Strip stale workflow-change override
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       github.event_name == 'pull_request_target'
       && github.event.action == 'synchronize'

--- a/.github/workflows/longterm-arbiter.yml
+++ b/.github/workflows/longterm-arbiter.yml
@@ -80,6 +80,7 @@ jobs:
   arbiter:
     name: Arbiter
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -587,6 +588,7 @@ jobs:
     needs: arbiter
     if: always() && needs.arbiter.outputs.published == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,7 @@ jobs:
   version:
     name: Compute Nightly Version
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       nightly_version: ${{ steps.stamp.outputs.version }}
       wheel_version: ${{ steps.stamp.outputs.wheel_version }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: site
@@ -43,6 +44,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/pr-merge-conflict-label.yml
+++ b/.github/workflows/pr-merge-conflict-label.yml
@@ -39,6 +39,7 @@ jobs:
   label:
     name: Sync merge-conflict label
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Sync "merge conflict" label across open pull requests
         env:

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -97,6 +97,7 @@ jobs:
           && github.event.workflow_run.pull_requests[0].number != null)
       || github.event.workflow_run.event == 'dynamic'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Resolve current pull request revision
         id: context

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -39,6 +39,7 @@ jobs:
   publish-cli:
     name: Publish CLI wheel (${{ inputs.channel }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # REQUIRED for tag-triggered (release) runs: the signing role's OIDC trust
     # accepts exactly two subjects -- ref:refs/heads/main and environment:prod.
     # Nightly runs on main's ref and passes bare, which masked this gap until the

--- a/.github/workflows/publish-installer.yml
+++ b/.github/workflows/publish-installer.yml
@@ -51,6 +51,7 @@ jobs:
   publish-installer:
     name: Publish cli.sh
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Upstream only. Forks pushing to their own main have no publish role and
     # nothing to publish to; skipping at the JOB level (rather than gating each
     # step on a secret) is what keeps the fail-closed behaviour below honest.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
   version:
     name: Derive Version + Channel
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.channel.outputs.version }}
       channel: ${{ steps.channel.outputs.channel }}
@@ -196,6 +197,7 @@ jobs:
     name: Create GitHub Release
     needs: [version, sign-and-notarize]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -84,6 +84,7 @@ jobs:
   sign:
     name: Sign with signing service (${{ inputs.channel }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # OIDC subject alignment: tag-triggered callers (release.yml) present
     # ref:refs/tags/<tag>, which the signing role does not trust. The prod
     # environment switches the subject to environment:prod, which it does.

--- a/.github/workflows/test-durations.yml
+++ b/.github/workflows/test-durations.yml
@@ -26,6 +26,8 @@ jobs:
   refresh:
     name: Refresh .test_durations
     runs-on: ubuntu-latest
+    # runs the WHOLE suite unsharded to record per-test durations.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -37,6 +37,9 @@ jobs:
   ux-review:
     name: UX Review
     runs-on: ubuntu-latest
+    # Model-call latency has a fat tail: ~18 min observed max, and a killed
+    # review surfaces as a RED required check, so keep generous headroom.
+    timeout-minutes: 60
     # Same-repo PRs only (not forks): fork PRs have no OIDC/secrets access, and
     # this keeps budget abuse / prompt-injection / secret-exfil out — mirrors
     # the fork guard in design-review.yml / codex-review.yml.


### PR DESCRIPTION
## Problem

38 of the repository's 74 workflow jobs had no `timeout-minutes`. GitHub's default
for an unbounded job is **6 hours**, so any job that wedges — a hung `npm ci`, a
network stall, a deadlocked test, a runner that stops responding — keeps a billed
runner for up to 360 minutes before it is reclaimed.

## Why it matters

This repository is private, so runner minutes are billed, and the non-Linux
multipliers make an unbounded hang expensive:

| Job | Typical runtime | Cost of one 6-hour hang |
|---|---|---|
| `Build Desktop (macos-15)` | ~7 min | 360 min x 10 = **~$28.80** |
| `Backend Tests (Windows)` (x4 shards) | ~14 min | 360 min x 2 = ~$11.52 **each** |
| any `ubuntu-latest` job | 0.2–23 min | 360 min x 1 = ~$2.88 |

A single wedged macOS build cost more than nine complete PR validations
(~$3.19 per push across all workflows). Nothing capped that.

## Fix (symptom -> root cause -> change)

- **Symptom:** an unbounded job can bill up to 6 hours of runner time.
- **Root cause:** `timeout-minutes` is opt-in per job, and 38 jobs never set it.
  There is no repository-level default to inherit.
- **Change:** add `timeout-minutes` to every job that provisions a runner.

Caps are sized at roughly **2–3x the maximum runtime observed across recent runs**
(measured via the Actions API, 20 runs per workflow where available), ranging
10–90 minutes. Two caps were raised during review after measurement showed the
first value was too tight:

- `ux-review` -> **60** (18.2 min observed max; 30 was only 1.6x, and model-call
  latency has a fat tail — a killed review surfaces as a RED required check)
- `frontend-test` -> **50** (22.8 min observed max; 40 was 1.8x)

Four caps carry a one-line comment naming the basis, because their value is not
self-evident: the Windows shards (slower than POSIX), Frontend Tests (longest
ubuntu job), the macOS desktop build (the 10x biller), and `test-durations`
(runs the whole suite unsharded).

### Reusable-workflow call sites

The 17 `uses:` jobs in `nightly.yml`, `release.yml` and `code-review.yml` are
deliberately untouched: `timeout-minutes` is not valid on a reusable-workflow
call site, so the cap has to live in the called workflow. All of those callees
(`build-desktop.yml`, `build-wheel.yml`, `build-windows.yml`, `publish-cli.yml`,
`publish-linux.yml`, `publish-docker.yml`, `sign-and-notarize.yml`,
`dependency-vulnerability.yml`) are covered here or already had a cap — so every
job that actually starts a runner is now bounded.

### Scope note

This is a **cost ceiling, not a cost reduction**. It bounds runaway spend without
changing steady-state minutes. It came out of a spend review; the reductions
identified there (path-gating the macOS desktop build, trimming the Windows
matrix on PRs, moving the Python 3.10 test lane to nightly) are separate changes.

## Tests

No new automated tests. The invariant this change establishes — "every job has a
timeout" — is a property of the workflow YAML rather than of shipped code, and a
test asserting it would need a new test module, which the reviewers' fix bar puts
out of scope for this PR. It is a reasonable follow-up.

Existing coverage was run and is unaffected: **1552 tests pass** across all 53
test files that read `.github/` (including `test_github_workflow_security.py`,
`test_workflow_permissions.py`, `test_ai_review_workflows.py`,
`test_nightly_version_contract.py`, `test_release_macos_fail_closed.py`,
`test_windows_signing_contract.py`, `test_publish_feed_contract.py`).
`isort`, `flake8` and `mypy` are clean (no Python changed).

## Manual verification

- Every workflow still parses as YAML (`yaml.safe_load` over all 30 files).
- A **structural diff** against `origin/main` — comparing both trees with the
  `timeout-minutes` keys stripped — confirms `timeout-minutes` is the *only* key
  added anywhere: no reindentation, no accidental edits, no reordering.
- Placement verified per job: `timeout-minutes` is a 4-space sibling of
  `runs-on`, never nested under `strategy:`, `container:`, `permissions:`,
  `outputs:`, `defaults:` or a step, including the hunks that insert directly
  before those keys.
- Post-change parse re-confirms 57 timed jobs / 17 reusable / 0 missing.
- Every cap checked against its job's historical max from the Actions API. The
  tightest remaining ratio is 2.2x (`Backend Tests`, 13.5 min max, cap 30).
  Release-path jobs, where an abort could leave a half-published artifact, have
  the largest margins: `notarize` 14.1 min max vs 90 (pre-existing), `sign`
  6.8 vs 30, `publish-cli` 1.9 vs 30, `publish-installer` 0.2 vs 30.

Frontend gates (`npm run build`, `npm test`) were not run: zero frontend files
are in this diff.

## Screenshots

N/A — no user-visible UI change. This diff touches only `.github/workflows/*.yml`.
