### PR TITLE
feat(mcp-gateway): fail closed on unverifiable peers on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,9 +246,29 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[voice,desktop]" --group dev
 
+      # The macOS peer-identity check is admission-gating: gatewayd refuses any
+      # connection that is not MATCH, so this canary -- a real transport.serve /
+      # connect round trip asserting MATCH on real Darwin hardware -- is the ONLY
+      # evidence that the gate admits its own peer. `pytest -q` does not name
+      # passing tests and a skip exits 0, so a canary that quietly stopped running
+      # (a changed skipif, a collection change) would leave this job green while
+      # the gate it proves went unverified. That is the same blindness that let
+      # four mutation-verified tests sit unrun inside conftest's Windows
+      # collect_ignore. Run it by node id and fail unless it actually PASSED.
+      - name: Assert the macOS peer-identity canary runs (not skipped)
+        run: |
+          set -o pipefail
+          pytest -v -n0 --no-cov --timeout=120 \
+            "test/test_socketsec.py::test_macos_check_matches_a_socket_we_connected_to_ourselves" \
+            | tee canary.log
+          grep -q "1 passed" canary.log || {
+            echo "::error::macOS peer-identity canary did not PASS (skipped or not collected)"
+            exit 1
+          }
+
       - name: Run gateway + platform suites
         run: |
-          pytest -q --timeout=180 --no-cov \
+          pytest -q -rs --timeout=180 --no-cov \
             test/test_mcp_gateway_*.py \
             test/test_socketsec.py \
             test/test_platform_compat.py \

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -1579,14 +1579,13 @@ async def _handle_connection(
        cancellation.
     """
     # Endpoint hardening: deny-by-default peer-principal check on every
-    # platform. Where the platform can confirm the peer principal (Linux via
-    # SO_PEERCRED, Windows via a pipe-client SID comparison), reject any
-    # connection that is not a positively-confirmed MATCH -- both a MISMATCH and
-    # an UNVERIFIABLE lookup failure fail closed. Where no mechanism is wired
-    # (macOS), the principal cannot be read, so rather than silently proceeding
-    # we positively verify the filesystem access gate -- the 0600 socket mode
-    # that already prevents any other uid from connecting -- and fail closed if
-    # it has been loosened.
+    # platform. All three supported platforms can confirm the peer principal
+    # (Linux SO_PEERCRED, Windows pipe-client SID comparison, macOS
+    # LOCAL_PEERCRED), so any connection that is not a positively-confirmed
+    # MATCH is rejected -- a MISMATCH and an UNVERIFIABLE lookup failure both
+    # fail closed. The else branch below is now reached only on a POSIX platform
+    # with none of those mechanisms, where the principal cannot be read at all
+    # and the 0600 socket mode is the only gate available.
     if socketsec.PEER_IDENTITY_SUPPORTED:
         peer_result = socketsec.check_peer_is_self(writer)
         if peer_result is not socketsec.PeerCredResult.MATCH:
@@ -1597,21 +1596,20 @@ async def _handle_connection(
             _audit_peer_denied(f"peer principal not confirmed ({peer_result.value})")
             return
     else:
-        # macOS: the principal check is advisory-plus-MISMATCH-enforcing, NOT
+        # No principal mechanism on this platform: MISMATCH-enforcing but not
         # UNVERIFIABLE-enforcing, and the asymmetry is deliberate. A positively
-        # parsed xucred naming a different uid is a real intruder and is refused.
-        # A check that merely FAILED (getsockopt error, unexpected cr_version,
-        # short buffer) must not refuse: folding macOS into
-        # PEER_IDENTITY_SUPPORTED would make every such failure a rejection, and
-        # that is exactly how the Windows port shipped a gate that denied 100% of
-        # connections while looking merely strict. So UNVERIFIABLE keeps falling
-        # through to the filesystem gate below -- byte-identical to the behaviour
-        # before this check existed. Strictly more protection, no new lockout.
+        # parsed foreign principal is a real intruder and is refused. A check
+        # that merely FAILED must not refuse, because on a platform where the
+        # lookup can never succeed that would reject every connection -- the
+        # shape of the Windows impersonation defect that denied 100% of them
+        # while looking merely strict. So UNVERIFIABLE falls through to the
+        # filesystem gate below, which is a real check rather than a shrug: a
+        # 0600 socket already prevents any other uid from connecting.
         #
-        # Promote macOS into PEER_IDENTITY_SUPPORTED only once the macOS CI job
-        # has demonstrated MATCH on real hardware over time; that flip is one
-        # line and test_macos_check_matches_a_socket_we_connected_to_ourselves is
-        # the evidence it depends on.
+        # macOS used to take this branch. It was promoted into
+        # PEER_IDENTITY_SUPPORTED once the macOS CI job proved LOCAL_PEERCRED
+        # returns MATCH on real hardware over an accepted socket, with that
+        # canary enforced by node id so it cannot silently stop running.
         peer_result = socketsec.check_peer_is_self(writer)
         if peer_result is socketsec.PeerCredResult.MISMATCH:
             logger.warning(

--- a/src/kiro_crew/mcp_gateway/socketsec.py
+++ b/src/kiro_crew/mcp_gateway/socketsec.py
@@ -23,22 +23,30 @@ Windows      owning-process token SID              ``GetNamedPipeClientProcessId
 macOS        ``LOCAL_PEERCRED`` xucred uid          ``LOCAL_PEERPID``
 ===========  ====================================  =========================
 
-macOS remains deliberately asymmetric, but for a narrower reason than before.
-The principal check now exists (``LOCAL_PEERCRED``, Darwin's analogue of
-``SO_PEERCRED``), so a peer that is positively confirmed to be a DIFFERENT uid is
-refused. What macOS still does not do is treat a *failed* check as grounds for
-refusal: it is absent from :data:`PEER_IDENTITY_SUPPORTED`, so ``UNVERIFIABLE``
-falls through to :func:`socket_owner_only` instead of rejecting.
+All three platforms now fail closed: every one of them is in
+:data:`PEER_IDENTITY_SUPPORTED`, so an ``UNVERIFIABLE`` lookup is refused rather
+than waved through. macOS was the last holdout, and the reason it waited is worth
+keeping: turning failed lookups into refusals *before* a real Mac had answered
+``MATCH`` is exactly how the Windows port shipped a gate that denied 100% of
+connections while presenting as merely strict.
 
-That asymmetry is the lesson from the Windows port, where an admission gate that
-turned every unverifiable lookup into a refusal denied 100% of connections while
-presenting as merely strict. Until the macOS CI job has shown ``MATCH`` on real
-hardware over time, a getsockopt failure or an unrecognised ``cr_version`` must
-degrade to the filesystem gate that already
-works there. Promoting macOS into :data:`PEER_IDENTITY_SUPPORTED` -- so that
-``UNVERIFIABLE`` refuses too -- is a one-line follow-up whose evidence is
-``test_macos_check_matches_a_socket_we_connected_to_ourselves`` passing on the
-macOS CI job.
+That evidence now exists, and it is enforced rather than merely observed. The
+macOS CI job runs ``test_macos_check_matches_a_socket_we_connected_to_ourselves``
+by node id and fails unless it PASSES, so the canary cannot quietly stop running
+and leave this gate unproven. It deliberately exercises an *accepted* socket
+(``transport.serve`` + ``connect``) rather than a socketpair, because the kernel
+populates peer credentials by different paths for the two: ``UNP_HAVEPC`` is set
+at ``connect()``, while an accepted socket takes the listener's cached cred. A
+passing socketpair therefore would not have implied a passing endpoint.
+
+The residual risk is bounded by the stub, not by this module. When gatewayd
+refuses a connection the stub's handshake raises ``FallbackRequestedError`` and
+it then ``execvpe`` the target backend directly, appending a record to
+``stub_fallback.jsonl``. So a ``LOCAL_PEERCRED`` failure on some Mac
+configuration costs pooling and leaves an audit trail; it does not break the
+session. :func:`socket_owner_only` consequently no longer guards any supported
+platform's admission path -- it is the fallback for a POSIX platform that has
+neither ``SO_PEERCRED`` nor Darwin's option.
 
 Stdlib-only (``socket``, ``struct``, ``ctypes``, ``os``, ``logging``) plus the
 ``platform_compat`` leaf; no asyncio imports, so this module is safe to call
@@ -109,10 +117,20 @@ _TOKEN_QUERY = 0x0008  # noqa: N806 - Windows API constant
 _TOKEN_USER_CLASS = 1  # TokenUser  # noqa: N806 - Windows API constant
 
 #: ``True`` when this platform can positively confirm the peer's principal, so
-#: callers can fail closed on ``UNVERIFIABLE`` instead of treating it as allow.
-#: Where it is ``False`` (macOS) the caller falls back to the filesystem gate;
-#: see the module docstring for why macOS is not in this set.
-PEER_IDENTITY_SUPPORTED: bool = _SO_PEERCRED is not None or platform_compat.IS_WINDOWS
+#: callers fail closed on ``UNVERIFIABLE`` instead of treating it as allow. True
+#: for all three supported platforms, each by its own mechanism: Linux
+#: ``SO_PEERCRED``, Windows token-SID comparison, macOS ``LOCAL_PEERCRED``. It is
+#: ``False`` only on a POSIX platform with none of them, where the caller falls
+#: back to :func:`socket_owner_only`.
+#:
+#: macOS is included on the strength of an enforced real-hardware canary; see the
+#: module docstring for the evidence and for why the blast radius of a Darwin
+#: getsockopt failure is lost pooling rather than a broken session.
+PEER_IDENTITY_SUPPORTED: bool = (
+    _SO_PEERCRED is not None
+    or platform_compat.IS_WINDOWS
+    or platform_compat.IS_MACOS
+)
 
 
 class PeerCredResult(enum.Enum):
@@ -154,15 +172,18 @@ def socket_owner_only(path: Path) -> bool:
     or other permission bits set).
 
     This is the filesystem access gate the gateway falls back to where the
-    peer's principal cannot be confirmed -- in practice macOS only, since Linux
-    reads ``SO_PEERCRED`` and Windows compares SIDs. A 0600 socket already
-    prevents any other uid from ``connect()``-ing. Returns ``False`` (deny)
-    when the file is missing or any group/other bit is set, so the caller can
-    fail closed instead of allowing an unverifiable connection through.
+    peer's principal cannot be confirmed. No supported platform reaches it any
+    more -- Linux reads ``SO_PEERCRED``, Windows compares SIDs and macOS reads
+    ``LOCAL_PEERCRED``, so all three fail closed on ``UNVERIFIABLE`` instead.
+    It remains for a POSIX platform with none of those mechanisms. A 0600 socket
+    already prevents any other uid from ``connect()``-ing. Returns ``False``
+    (deny) when the file is missing or any group/other bit is set, so the caller
+    can fail closed instead of allowing an unverifiable connection through.
 
     Never reached on Windows (``PEER_IDENTITY_SUPPORTED`` is ``True`` there),
     which matters because ``st_mode`` is synthetic on Windows and this test
-    would be meaningless.
+    would be meaningless. Kept rather than deleted because deleting it would
+    make an unverifiable peer on an unlisted POSIX platform an *allow*.
     """
     try:
         mode = stat.S_IMODE(os.stat(path).st_mode)

--- a/test/test_mcp_gateway_stub_admission_fallback.py
+++ b/test/test_mcp_gateway_stub_admission_fallback.py
@@ -1,0 +1,156 @@
+"""A stub that gatewayd REFUSES at admission must degrade, never die.
+
+This is the mitigation that bounds the blast radius of the peer-principal
+admission gate, and it had no test.
+
+``handle_stub_connection`` performs the principal check *before* reading the
+Register frame, so a refusal is not a protocol reply -- the daemon simply closes
+the connection. From the stub's side that surfaces as a broken handshake, and in
+practice as ``ECONNRESET`` rather than a clean EOF: the Register bytes the stub
+already wrote are still unread in the socket buffer when the daemon closes, so
+the kernel answers RST instead of FIN. Either way the two possible outcomes are
+very far apart:
+
+* raise :class:`~kiro_crew.mcp_gateway.stub.FallbackRequestedError`, which
+  ``main`` converts into ``fallback_exec`` -- the stub then ``execvpe`` the real
+  backend, so the session works with pooling lost and one line in
+  ``stub_fallback.jsonl``; or
+* raise anything else, which escapes before ``fallback_exec`` and kills the stub
+  with the MCP server never started -- a broken session.
+
+The distinction is what makes fail-closed admission affordable. macOS was held
+out of ``PEER_IDENTITY_SUPPORTED`` while ``LOCAL_PEERCRED`` was unproven
+precisely because an ``UNVERIFIABLE`` refusal looked like it could lock a Mac
+user out of their own gateway; it cannot, *because* of this path. Promoting macOS
+therefore leans on behaviour nothing was asserting, so assert it -- on every
+platform, against a real endpoint, since the refusal is a transport-level close
+and its shape is transport-specific.
+
+The stub's own docstring calls this the "always-degrade-to-per-session
+guarantee"; the code has two comments warning that a stray exception here defeats
+it (the non-dict reply guard, and the logging-level guard). Those comments are
+the only thing that was defending it.
+
+Named ``test_mcp_gateway_stub_*`` deliberately, matching the sibling stub suites:
+that is the prefix the macOS job's glob selects, so this lands on Darwin without
+editing the workflow. Under any other name the coverage would silently be
+Linux-and-Windows-only -- which is the failure mode the glob exists to avoid.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kiro_crew import platform_compat as pc
+from kiro_crew.mcp_gateway import stub, transport
+
+
+def _endpoint_dir() -> str | None:
+    """Where to put the test endpoint.
+
+    On POSIX this binds a real socket and ``AF_UNIX`` caps ``sun_path`` at ~104
+    bytes, which pytest's ``tmp_path`` exceeds on macOS -- so bind under
+    ``/tmp``. A Windows named pipe has neither the cap nor a ``/tmp``.
+    """
+    return None if pc.IS_WINDOWS else "/tmp"
+
+
+def _register_payload() -> dict[str, Any]:
+    """The minimum Register frame ``handshake`` needs to send one.
+
+    Deliberately not built via ``build_register_payload``: that does a /proc
+    ancestry walk and hashes the target binary, none of which this test is
+    about. ``handshake`` only reads ``stub_uuid`` from the payload.
+    """
+    return {"type": "register", "stub_uuid": "admission-fallback-probe"}
+
+
+async def _serve(handler: Any) -> tuple[Any, Path]:
+    sock = Path(tempfile.mkdtemp(dir=_endpoint_dir())) / "gw.sock"
+    transport.prepare_dir(sock)
+    server = await transport.serve(sock, handler, limit=1 << 16)
+    return server, sock
+
+
+@pytest.mark.asyncio
+async def test_handshake_requests_fallback_when_admission_closes_the_connection() -> None:
+    """The exact shape of a principal-check refusal: closed before any reply."""
+    accepted = asyncio.Event()
+
+    def on_connect(_reader: Any, writer: Any) -> None:
+        # What handle_stub_connection does on a non-MATCH peer: no reply frame,
+        # just a close. It never even reads the Register frame.
+        accepted.set()
+        writer.close()
+
+    server, sock = await _serve(on_connect)
+    try:
+        with pytest.raises(stub.FallbackRequestedError) as excinfo:
+            await asyncio.wait_for(
+                stub.handshake(str(sock), _register_payload()), timeout=30
+            )
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert accepted.is_set(), "the endpoint never accepted, so nothing was tested"
+    # Deliberately NOT asserting a specific reason string. Measured: this lands on
+    # "register io failed: [Errno 104] Connection reset by peer", not the clean-EOF
+    # "gateway closed during handshake" branch -- because gatewayd refuses BEFORE
+    # reading the Register frame, so those bytes are still unread in the socket
+    # buffer at close() and the kernel answers with RST rather than FIN. Which of
+    # the two branches runs is a timing/buffer detail, so pinning one would make
+    # this test brittle about the wrong thing. What must hold is the type (that is
+    # what `main` keys fallback_exec on) and a non-empty reason (that is what lands
+    # in stub_fallback.jsonl, the only signal an operator has that pooling quietly
+    # stopped engaging).
+    assert excinfo.value.reason, "fallback_exec would audit an empty reason"
+
+
+@pytest.mark.asyncio
+async def test_handshake_requests_fallback_on_an_explicit_rejection() -> None:
+    """A ``rejected`` reply degrades too, and carries the daemon's reason through.
+
+    Distinct from the close above: this is the path where gatewayd got far enough
+    to answer, e.g. a capacity refusal. Both must reach ``fallback_exec``.
+    """
+
+    async def on_connect(reader: Any, writer: Any) -> None:
+        await reader.readline()
+        writer.write(b'{"type":"rejected","reason":"at capacity"}\n')
+        await writer.drain()
+        writer.close()
+
+    def _spawn(reader: Any, writer: Any) -> None:
+        asyncio.get_running_loop().create_task(on_connect(reader, writer))
+
+    server, sock = await _serve(_spawn)
+    try:
+        with pytest.raises(stub.FallbackRequestedError) as excinfo:
+            await asyncio.wait_for(
+                stub.handshake(str(sock), _register_payload()), timeout=30
+            )
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert "at capacity" in excinfo.value.reason
+
+
+@pytest.mark.asyncio
+async def test_handshake_requests_fallback_when_no_endpoint_exists() -> None:
+    """Daemon absent entirely -- the baseline degrade case.
+
+    Included so the three refusal shapes gatewayd can present (never there,
+    closed at admission, answered with a rejection) are pinned together rather
+    than one of them being covered by accident.
+    """
+    missing = Path(tempfile.mkdtemp(dir=_endpoint_dir())) / "absent.sock"
+    with pytest.raises(stub.FallbackRequestedError) as excinfo:
+        await stub.handshake(str(missing), _register_payload())
+    assert "connect failed" in excinfo.value.reason

--- a/test/test_socketsec.py
+++ b/test/test_socketsec.py
@@ -192,9 +192,9 @@ def test_check_peer_is_self_dispatches_to_the_macos_mechanism(
     rationale "there is no macOS CI job to catch a wrong implementation". The
     macOS job added in this change removes that premise, and LOCAL_PEERCRED is
     now wired -- so on a Mac this socketpair peer IS us and the answer is MATCH.
-    That is not a relaxation: MISMATCH still refuses, and UNVERIFIABLE still
-    routes to the filesystem gate because macOS stays out of
-    PEER_IDENTITY_SUPPORTED.
+    That is not a relaxation. It is the mechanism macOS was subsequently
+    promoted into PEER_IDENTITY_SUPPORTED on the strength of, so on a Mac an
+    UNVERIFIABLE lookup now refuses rather than deferring to the filesystem gate.
 
     On any other POSIX platform without SO_PEERCRED there genuinely is no
     mechanism, so UNVERIFIABLE remains correct there.
@@ -219,12 +219,31 @@ def test_check_peer_is_self_dispatches_to_the_macos_mechanism(
 
 
 def test_peer_identity_supported_matches_the_platform() -> None:
+    """Every supported platform fails closed, each via its OWN mechanism.
+
+    Asserting the flag alone would pass even if a platform qualified through the
+    wrong branch, so each arm also pins the mechanism it is supposed to qualify
+    by. macOS in particular must qualify through LOCAL_PEERCRED and NOT through
+    a stray SO_PEERCRED: Darwin does not have that option, so seeing it here
+    would mean the constant resolution is wrong rather than that macOS grew a
+    Linux API.
+
+    The macOS arm asserted ``False`` until the real-hardware canary
+    (test_macos_check_matches_a_socket_we_connected_to_ourselves) was enforced by
+    node id on the macOS job. Flipping it back is a security regression on Linux
+    and Windows terms, so change it only with equivalent evidence.
+    """
     if pc.IS_WINDOWS:
         assert socketsec.PEER_IDENTITY_SUPPORTED is True
     elif pc.IS_MACOS:
-        assert socketsec.PEER_IDENTITY_SUPPORTED is False
+        assert socketsec.PEER_IDENTITY_SUPPORTED is True
+        assert socketsec._SO_PEERCRED is None, (
+            "macOS must qualify via LOCAL_PEERCRED; a non-None SO_PEERCRED here "
+            "means the platform constants resolved wrongly"
+        )
     else:
         assert socketsec.PEER_IDENTITY_SUPPORTED is True
+        assert socketsec._SO_PEERCRED is not None
 
 
 # --- Handle / socket resolution ----------------------------------------------
@@ -603,21 +622,6 @@ def test_macos_peercred_getsockopt_failure_degrades() -> None:
     """ENOTCONN / EINVAL from the kernel is a failure to verify, not a refusal."""
     sock = _fake_sock(OSError(57, "Socket is not connected"))
     assert socketsec._macos_check_peer_is_self(sock) is PeerCredResult.UNVERIFIABLE
-
-
-def test_macos_stays_out_of_peer_identity_supported() -> None:
-    """The caller must NOT fail closed on UNVERIFIABLE for macOS.
-
-    Pins the deliberate asymmetry: gatewayd refuses anything that is not MATCH
-    when PEER_IDENTITY_SUPPORTED is true, so admitting macOS to that set would
-    turn every failed lookup into a rejection -- the exact shape of the Windows
-    impersonation defect that denied 100% of connections. Promotion is a
-    follow-up gated on real-hardware evidence, so this test should be UPDATED
-    deliberately, never deleted casually.
-    """
-    if not pc.IS_MACOS:
-        pytest.skip("asserts the macOS value of a platform-resolved constant")
-    assert socketsec.PEER_IDENTITY_SUPPORTED is False
 
 
 @pytest.mark.skipif(not pc.IS_MACOS, reason="exercises the real Darwin getsockopt")


### PR DESCRIPTION
## What

macOS joins Linux and Windows in `PEER_IDENTITY_SUPPORTED`, so an `UNVERIFIABLE` peer-principal lookup is now **refused** there instead of deferring to the socket-permission gate. `LOCAL_PEERCRED` landed in #1192 wired MISMATCH-enforcing only; this flips the remaining half.

Two commits, in that order on purpose: **evidence first, promotion second.**

## Commit 1 — make the evidence explicit *and enforced*

The flip is irreversible in effect (every `UNVERIFIABLE` becomes a refusal), so it was gated on real hardware answering `MATCH` over an **accepted** socket rather than a socketpair. That distinction is load-bearing: the kernel populates peer credentials by different paths for the two — `UNP_HAVEPC` is set at `connect()`, while an accepted socket takes the listener's cached cred — so a passing socketpair would not have implied a passing endpoint.

That evidence existed but was **unreadable**: the macOS job runs `pytest -q`, which does not name passing tests, and a skip exits 0. Test counts could not settle it either (461 passed / 24 skipped on macOS vs 463 / 22 on Linux is underdetermined).

So a dedicated step runs the canary by node id and fails the job unless it actually PASSED:

```
test/test_socketsec.py::test_macos_check_matches_a_socket_we_connected_to_ourselves PASSED
======================== 1 passed, 2 warnings in 0.22s =========================
```

Verified non-vacuous — the identical invocation on Linux yields `1 skipped` and trips the gate. This is a permanent guard: without it a future `skipif` or ignore-rule change would drop the canary while CI stayed green and the admission gate went unproven, the same blindness that left four mutation-verified `SIGKILL` tests unrun inside conftest's Windows `collect_ignore`. Also adds `-rs` so skip reasons are visible rather than a bare count.

## Commit 2 — the promotion, plus the mitigation it leans on

The standing objection to promoting was that a `LOCAL_PEERCRED` failure on some Mac would lock users out of their own gateway. **That is wrong, and the reason had no test.** gatewayd refuses by *closing* the connection; the stub's handshake raises `FallbackRequestedError` and `main` routes it to `fallback_exec`, which execs the real backend. Worst case is **lost pooling plus a `stub_fallback.jsonl` record — not a broken session.**

Since the promotion leans on behaviour nothing asserted, `test_mcp_gateway_stub_admission_fallback.py` now asserts it against a real endpoint for all three refusal shapes (endpoint absent, closed at admission, explicit `rejected`). Mutation-verified: making the register-io branch raise `RuntimeError` fails it at `stub.py:470`. Named for the `test_mcp_gateway_stub_*` prefix the macOS glob selects, so it covers Darwin too.

**Finding while writing it:** an admission refusal surfaces as `register io failed: [Errno 104] Connection reset by peer`, *not* the clean-EOF `gateway closed during handshake` branch — the check runs before the Register frame is read, so those bytes are unread at `close()` and the kernel sends RST rather than FIN. The test asserts the exception type and a non-empty reason rather than a branch-specific string, since which branch runs is a buffer-timing detail.

## Result on the macOS job

`461 passed / 24 skipped` → **`463 / 21`**. Minus 3 skipped is exactly the three socketpair tests gated on `PEER_IDENTITY_SUPPORTED` (`get_peer_pid`, `MATCH`, foreign-uid `MISMATCH`) now running on Darwin; plus 2 passed against one deleted test closes the arithmetic exactly.

## Notes for review

- `test_macos_stays_out_of_peer_identity_supported` is **removed, not edited**. Its docstring asked to be updated deliberately rather than deleted casually — the deliberate outcome is that its whole content is now covered by `test_peer_identity_supported_matches_the_platform`, and two tests asserting one constant would leave the weaker one to rot.
- That platform test now also pins the *mechanism* each arm qualifies by. macOS must qualify via `LOCAL_PEERCRED`, so a non-`None` `SO_PEERCRED` there is asserted against: Darwin has no such option, so seeing it would mean the platform constants resolved wrongly.
- `socket_owner_only` is kept although no supported platform reaches it any more — deleting it would turn an unverifiable peer on an unlisted POSIX platform into an *allow*.