### PR TITLE
fix(skills): make app-provided skills visible to the skill scanner

### DIFF
--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -293,6 +293,41 @@ def _project_skills_dir() -> Path | None:
     return None
 
 
+def _trusted_skill_roots() -> tuple[str, ...]:
+    """Resolved roots a symlink inside the skills tree may legitimately point into.
+
+    An app ships its skills inside its OWN tree, and
+    ``apps.bridges._register_skills`` symlinks them into the skills dir "so the
+    skill scanner finds the skill" — so their resolved paths land OUTSIDE the
+    skills base by construction. Two roots are legitimate skill providers:
+
+    * the installed ``kiro_crew`` package — built-in apps keep their skills
+      under ``apps/builtins/<app>/skills/``;
+    * ``<data home>/apps`` — externally installed apps.
+
+    A symlink resolving anywhere else stays rejected: an arbitrary target would
+    admit unvetted ``SKILL.md`` prose into the agent's context.
+    """
+    roots: list[str] = [os.path.realpath(Path(__file__).parent)]
+    try:
+        roots.append(os.path.realpath(config_dir() / "apps"))
+    except Exception:  # noqa: BLE001 — an unresolvable data home must not stop scanning
+        pass
+    return tuple(roots)
+
+
+def _within_any(candidate: str, roots: tuple[str, ...]) -> bool:
+    """True when the already-resolved *candidate* equals one of *roots* or sits under it."""
+    cand = Path(candidate)
+    for root in roots:
+        try:
+            if cand == Path(root) or cand.is_relative_to(root):
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
 def _iter_skill_files(base: Path) -> list[tuple[str, Path]]:
     """Recursively find all SKILL.md files under *base*.
 
@@ -306,6 +341,9 @@ def _iter_skill_files(base: Path) -> list[tuple[str, Path]]:
     if not base.exists():
         return results
     real_base = os.path.realpath(base)
+    # A skills-tree symlink into an app's own tree resolves outside ``base`` by
+    # construction — allow those provider roots, and nothing else.
+    allowed_roots = (real_base,) + _trusted_skill_roots()
     seen_real: set[str] = set()
     for dirpath, _dirs, files in os.walk(base, followlinks=True):
         real = os.path.realpath(dirpath)
@@ -316,11 +354,16 @@ def _iter_skill_files(base: Path) -> list[tuple[str, Path]]:
         # Prune dot-directories (e.g. ``auto/.archive``, ``.pending``) so
         # archived / pending / hub-state skills are never enumerated as live,
         # trigger-matchable skills. Mutating ``_dirs`` in place prunes the walk.
-        _dirs[:] = [d for d in _dirs if not d.startswith(".")]
-        # Path containment: ensure we stay within the skill base directory
-        try:
-            Path(real).relative_to(real_base)
-        except ValueError:
+        # SORTED so enumeration is deterministic: ``bridges._register_skills``
+        # registers each app skill twice (``skills/<app>/<skill>`` and a flat
+        # ``skills/<skill>``), both resolving to one target, so the ``seen_real``
+        # guard keeps exactly one — and without a sort ``os.walk`` picks the
+        # winner in arbitrary ``scandir`` order, giving the same skill a
+        # different key on different machines.
+        _dirs[:] = sorted(d for d in _dirs if not d.startswith("."))
+        # Path containment: stay inside the skills base, or inside a trusted
+        # skill-provider root reached through an app's registered symlink.
+        if not _within_any(real, allowed_roots):
             _dirs.clear()
             continue
         if is_sensitive_path(real):

--- a/test/test_skill_index_app_symlinks.py
+++ b/test/test_skill_index_app_symlinks.py
@@ -1,0 +1,216 @@
+"""App-provided skills must be visible to the skill scanner.
+
+``apps.bridges._register_skills`` symlinks an app's skill directories into the
+skills tree "so the skill scanner finds the skill". Those symlinks resolve into
+the app's own tree, i.e. OUTSIDE the skills base, so a containment check written
+against the RESOLVED path silently pruned every one of them: an installed app's
+skills were absent from the pre-listed skills block AND from ``skill_search``,
+while still being reachable only by absolute path.
+
+These tests lock in both halves of the fix: a symlink into a trusted provider
+root is enumerated, and a symlink to an arbitrary target is still refused.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import kiro_crew.skills as skills_mod
+from kiro_crew.skills import _iter_skill_files, _within_any
+
+# Creating a symlink on Windows needs elevation or Developer Mode, which CI
+# runners do not have. The repo's established idiom is to skip such a test there
+# (see test/test_agent_home_isolation.py). Applied per-class rather than to the
+# whole module on purpose: the pure path-semantics tests below carry their weight
+# precisely ON Windows, where separators and case-folding differ.
+requires_symlinks = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink creation needs elevation on Windows",
+)
+
+
+def _write_skill(directory: Path, body: str = "# Skill\n") -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    skill_file = directory / "SKILL.md"
+    skill_file.write_text(body, encoding="utf-8")
+    return skill_file
+
+
+def _packaged_app_skill() -> Path:
+    """A skill dir that a built-in app ships INSIDE the installed package.
+
+    Resolved rather than hardcoded per-test so drift fails with this message
+    instead of a bare ``FileNotFoundError`` from ``os.symlink``.
+    """
+    skill = (
+        Path(skills_mod.__file__).parent
+        / "apps"
+        / "builtins"
+        / "dev_fleet"
+        / "skills"
+        / "pod-e2e"
+    )
+    assert skill.is_dir(), f"fixture drift: expected a built-in app skill at {skill}"
+    return skill
+
+
+@requires_symlinks
+class TestBuiltinAppSkillsAreVisible:
+    def test_symlink_into_the_package_tree_is_enumerated(self, tmp_path: Path) -> None:
+        """A built-in app's skill lives under the installed package, not the skills base."""
+        base = tmp_path / "skills"
+        base.mkdir()
+        os.symlink(str(_packaged_app_skill()), str(base / "pod-e2e"))
+
+        found = dict(_iter_skill_files(base))
+        assert "pod-e2e" in found, "app skill symlinked into the skills tree must be indexed"
+        assert found["pod-e2e"].is_file()
+
+    def test_double_registration_yields_one_key(self, tmp_path: Path) -> None:
+        """bridges registers BOTH ``skills/<app>/<skill>`` and a flat ``skills/<skill>``.
+
+        Both links resolve to one target, so the symlink-loop guard keeps exactly
+        one. Loading by either name still works — ``load_skill`` reads the path
+        directly and both symlinks are on disk regardless of which key is indexed.
+        """
+        packaged = _packaged_app_skill()
+        base = tmp_path / "skills"
+        (base / "dev-fleet").mkdir(parents=True)
+        os.symlink(str(packaged), str(base / "dev-fleet" / "pod-e2e"))
+        os.symlink(str(packaged), str(base / "pod-e2e"))
+
+        names = [name for name, _ in _iter_skill_files(base)]
+        assert names.count("dev-fleet/pod-e2e") + names.count("pod-e2e") == 1, (
+            f"one skill must yield one key, got {names}"
+        )
+
+    def test_surviving_key_is_a_function_of_the_names_not_the_filesystem(
+        self, tmp_path: Path
+    ) -> None:
+        """The sort buys DETERMINISM, not a namespacing preference.
+
+        Which of the two registered keys survives depends on how the app
+        directory name collates against the skill name — ``dev-fleet`` sorts
+        before ``pod-e2e`` so the namespaced key wins, while ``zzz-app`` sorts
+        after it so the flat key wins. Both are correct; the point is that the
+        outcome is a pure function of the names rather than of ``scandir`` order.
+        """
+        packaged = _packaged_app_skill()
+
+        early = tmp_path / "early"
+        (early / "dev-fleet").mkdir(parents=True)
+        os.symlink(str(packaged), str(early / "dev-fleet" / "pod-e2e"))
+        os.symlink(str(packaged), str(early / "pod-e2e"))
+        assert "dev-fleet/pod-e2e" in [n for n, _ in _iter_skill_files(early)]
+
+        late = tmp_path / "late"
+        (late / "zzz-app").mkdir(parents=True)
+        os.symlink(str(packaged), str(late / "zzz-app" / "pod-e2e"))
+        os.symlink(str(packaged), str(late / "pod-e2e"))
+        assert "pod-e2e" in [n for n, _ in _iter_skill_files(late)]
+
+        # Repeating a walk must give the identical key both times.
+        assert [n for n, _ in _iter_skill_files(early)] == [
+            n for n, _ in _iter_skill_files(early)
+        ]
+
+    def test_symlink_into_the_installed_apps_dir_is_enumerated(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """An externally installed app keeps its skills under ``<data home>/apps``."""
+        data_home = tmp_path / "home"
+        _write_skill(data_home / "apps" / "my-app" / "skills" / "thing")
+        monkeypatch.setattr(skills_mod, "config_dir", lambda: data_home)
+
+        base = tmp_path / "skills"
+        base.mkdir()
+        os.symlink(str(data_home / "apps" / "my-app" / "skills" / "thing"), str(base / "thing"))
+
+        names = {name for name, _ in _iter_skill_files(base)}
+        assert "thing" in names
+
+
+@requires_symlinks
+class TestUntrustedTargetsStillRefused:
+    def test_symlink_to_an_arbitrary_directory_is_refused(self, tmp_path: Path) -> None:
+        """An arbitrary target would admit unvetted SKILL.md prose into the context."""
+        outsider = tmp_path / "elsewhere" / "evil"
+        _write_skill(outsider, "# Injected\n")
+
+        base = tmp_path / "skills"
+        base.mkdir()
+        os.symlink(str(outsider), str(base / "evil"))
+
+        names = {name for name, _ in _iter_skill_files(base)}
+        assert "evil" not in names, "a symlink outside every trusted root must stay pruned"
+
+    def test_sensitive_target_is_refused_even_inside_a_trusted_root(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The credential-store guard runs AFTER the trusted-root check, not instead of it."""
+        data_home = tmp_path / "home"
+        secret_skill = data_home / "apps" / "my-app" / "skills" / "secretish"
+        _write_skill(secret_skill)
+        monkeypatch.setattr(skills_mod, "config_dir", lambda: data_home)
+
+        resolved = os.path.realpath(secret_skill)
+        monkeypatch.setattr(
+            skills_mod, "is_sensitive_path", lambda p: os.path.realpath(str(p)) == resolved
+        )
+
+        base = tmp_path / "skills"
+        base.mkdir()
+        os.symlink(str(secret_skill), str(base / "secretish"))
+
+        names = {name for name, _ in _iter_skill_files(base)}
+        assert "secretish" not in names
+
+
+class TestPreExistingBehaviourPreserved:
+    def test_plain_in_base_skill_still_found(self, tmp_path: Path) -> None:
+        base = tmp_path / "skills"
+        _write_skill(base / "nested" / "regular")
+        names = {name for name, _ in _iter_skill_files(base)}
+        assert "nested/regular" in names
+
+    def test_dot_directories_still_pruned(self, tmp_path: Path) -> None:
+        base = tmp_path / "skills"
+        _write_skill(base / "auto" / ".archive" / "old")
+        _write_skill(base / "auto" / "live")
+        names = {name for name, _ in _iter_skill_files(base)}
+        assert "auto/live" in names
+        assert not any(".archive" in n for n in names)
+
+    @requires_symlinks
+    def test_symlink_loop_is_pruned(self, tmp_path: Path) -> None:
+        """A self-referential link must not spin the walk forever."""
+        base = tmp_path / "skills"
+        _write_skill(base / "real")
+        os.symlink(str(base), str(base / "loop"))
+        names = {name for name, _ in _iter_skill_files(base)}
+        assert "real" in names
+
+    def test_missing_base_returns_empty(self, tmp_path: Path) -> None:
+        assert _iter_skill_files(tmp_path / "nope") == []
+
+
+class TestWithinAny:
+    def test_exact_root_matches(self, tmp_path: Path) -> None:
+        assert _within_any(str(tmp_path), (str(tmp_path),))
+
+    def test_descendant_matches(self, tmp_path: Path) -> None:
+        assert _within_any(str(tmp_path / "a" / "b"), (str(tmp_path),))
+
+    def test_sibling_does_not_match(self, tmp_path: Path) -> None:
+        assert not _within_any(str(tmp_path / "a"), (str(tmp_path / "b"),))
+
+    def test_no_roots_never_matches(self, tmp_path: Path) -> None:
+        assert not _within_any(str(tmp_path), ())
+
+    def test_prefix_lookalike_does_not_match(self, tmp_path: Path) -> None:
+        """``/x/skills-evil`` is not under ``/x/skills`` despite the string prefix."""
+        assert not _within_any(str(tmp_path / "skills-evil"), (str(tmp_path / "skills"),))


### PR DESCRIPTION
## Problem

Every skill an installed app provides is invisible to the agent. The built-in Dev Fleet app ships `pod-e2e` and `feature-demo-recording`; both are installed and symlinked into the skills directory, yet neither appears in the pre-listed skills block or in `skill_search` results. A literal `skill_search("pod-e2e")` returns eight other skills that merely *mention* it and not the skill itself. The usage ledger confirms neither has ever been loaded, once. The only way to reach one is to already know its absolute path.

## Why it matters

An app can ship a skill, the framework will dutifully register it, and the agent will never find it. That silently defeats the primary mechanism apps have for teaching the agent a capability — the skill exists, is enabled, and is unreachable. Dev Fleet's QA-verification skill is the concrete casualty: enabled app, skill on disk, never once used, because nothing that decides what the agent knows could see it.

## Fix (symptom → root cause → change)

**Symptom:** app-provided skills never enter the skill index.

**Root cause:** `_iter_skill_files` walks the skills tree with `os.walk(..., followlinks=True)`, then resolves each directory and prunes the branch when the **resolved** path falls outside the skills base. An app ships its skills inside its own tree, and `apps/bridges.py::_register_skills` symlinks them into the skills dir — its docstring states this is done "so the skill scanner finds the skill". Those links therefore *always* resolve outside the base, and were *always* pruned. The `followlinks=True` was defeated by the guard on the very next lines.

**Change:** containment now accepts two trusted provider roots in addition to the base — the installed `kiro_crew` package (built-in apps keep their skills under `apps/builtins/`) and `<data home>/apps` (externally installed apps). Any other out-of-base target stays pruned, so an arbitrary symlink still cannot admit unvetted `SKILL.md` text into the agent's context. The `is_sensitive_path` credential guard is untouched and still runs *after* the root check rather than instead of it.

Deriving the package root from the running module is deliberate: app registration and app loading always execute from the same install, so the tree that created the symlink is the tree that reads it.

The walk is also sorted now. `_register_skills` registers each app skill **twice** (a namespaced `skills/<app>/<skill>` link and a flat `skills/<skill>` one); both resolve to a single target, so the symlink-loop guard keeps exactly one — and without a sort `os.walk` picked the survivor in arbitrary `scandir` order, giving the same skill a different key on different machines. Sorting makes the surviving key a pure function of the directory names.

## Tests

New file `test/test_skill_index_app_symlinks.py`, 15 tests:

- a symlink into the package tree **and** one into `<data home>/apps` are both enumerated — the two halves of the fix
- a symlink to an arbitrary directory is still refused
- a sensitive target *inside* a trusted root is still refused — pins that the credential guard **adds to** the root check rather than being replaced by it
- double registration yields exactly one key; the survivor is a pure function of the names (namespaced wins for `dev-fleet`, flat wins for `zzz-app`), plus a repeat-walk equality assertion
- regression coverage retained: plain in-base skills, dot-directory pruning (`auto/.archive`), symlink-loop pruning, missing base
- `_within_any` unit coverage including the `/x/skills-evil` vs `/x/skills` prefix-lookalike that `startswith` would get wrong

The symlink-creating tests carry `@pytest.mark.skipif(sys.platform == "win32", ...)`, the repo's established idiom (used in 17 test files) since creating a symlink on Windows needs elevation. The marker is applied per-class rather than to the whole module on purpose: the pure path-semantics tests — `_within_any`, dot-directory pruning, plain in-base discovery — still run on Windows, which is exactly where separator and case-folding differences would bite.

## Manual verification

Ran the real loader against an identical skills tree under both code versions — one directory plus a symlink to the in-tree `dev_fleet` `pod-e2e` skill:

```
BEFORE (origin/main):     indexed: ['real']              pod-e2e visible: False
AFTER  (this branch):     indexed: ['pod-e2e', 'real']   pod-e2e visible: True
```

Local gates: `isort` clean, `flake8` clean, `mypy` clean on `src/kiro_crew/skills.py`. The 15 new tests pass, and 274 pre-existing tests covering the touched surface (`test_skills`, `test_skill_pending`, `test_skill_versioning`, `test_app_manager`, `test_skill_discover`) were independently re-run green.

## Screenshots

N/A — no UI surface is added or changed. The fix alters which entries a pre-existing list contains, and the probative evidence at the layer the bug lives is the loader before/after above.
