### PR TITLE
ci: label fork PRs for reviewer visibility in the pulls list

### DIFF
--- a/.github/workflows/fork-pr-label.yml
+++ b/.github/workflows/fork-pr-label.yml
@@ -1,0 +1,89 @@
+name: Fork PR Label
+
+# Adds a single "fork" label to every pull request opened from a fork, so a
+# reviewer scanning the /pulls list can identify external-contributor PRs at a
+# glance. GitHub does not surface fork status in that list, so the label closes
+# the gap (same idea as pr-merge-conflict-label.yml).
+#
+# Visibility only: this workflow never blocks merge, and never checks out or
+# executes PR code -- it only reads the PR's fork flag and adds a label. Fork
+# status is immutable for a given PR, so the label is only ever ADDED, never
+# removed.
+on:
+  pull_request_target:
+    # Runs in the trusted base context (write token) even for fork PRs, which a
+    # fork `pull_request` run could not do. No fork code is checked out.
+    types: [opened, reopened]
+  schedule:
+    # Backstop sweep: labels any pre-existing open fork PR and catches a PR the
+    # event path missed (e.g. opened while this workflow was briefly failing).
+    - cron: "23 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  # Per-PR for the event path; a single shared group for the sweep. The work is
+  # idempotent, so cancelling an in-flight run is safe.
+  group: fork-pr-label-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Label fork pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add "fork" label to fork pull requests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          LABEL: "fork"
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the label exists (idempotent).
+          existing="$(gh label list --repo "$REPO" --limit 300 --json name --jq '.[].name')"
+          if ! grep -Fxq "$LABEL" <<<"$existing"; then
+            gh label create "$LABEL" --repo "$REPO" \
+              --color "5319E7" \
+              --description "Pull request from a fork (external contributor)"
+          fi
+
+          # Adding a label that is already present is a no-op, so this is safe to
+          # re-run on every event and every sweep.
+          add_label() {
+            jq -n --arg label "$LABEL" '{labels: [$label]}' \
+              | gh api --method POST "repos/$REPO/issues/$1/labels" --input - >/dev/null
+          }
+
+          if [ "$EVENT" = "pull_request_target" ]; then
+            # Single PR: label only when it originates from a fork.
+            if [ "$PR_IS_FORK" = "true" ]; then
+              add_label "$PR_NUMBER"
+              echo "PR #$PR_NUMBER is a fork -> ensured '$LABEL'"
+            else
+              echo "PR #$PR_NUMBER is same-repo -> no label"
+            fi
+            exit 0
+          fi
+
+          # Sweep (schedule / manual dispatch): label every open fork PR that is
+          # missing the label. `isCrossRepository` is GitHub's own fork flag.
+          prs="$(gh pr list --repo "$REPO" --state open --limit 300 \
+            --json number,isCrossRepository,labels)"
+          echo "$prs" | jq -c '.[] | select(.isCrossRepository == true)' | while read -r pr; do
+            number="$(jq -r '.number' <<<"$pr")"
+            has_label="$(jq -r --arg l "$LABEL" 'any(.labels[]?; .name == $l)' <<<"$pr")"
+            if [ "$has_label" != "true" ]; then
+              add_label "$number"
+              echo "PR #$number: fork -> added '$LABEL'"
+            else
+              echo "PR #$number: fork -> already labeled"
+            fi
+          done


### PR DESCRIPTION
## Problem
Reviewers scanning the open-PR list (`/pulls`) cannot tell which PRs come from forks (external contributors). GitHub shows fork status on each PR's detail page but does **not** surface it in the list view, and there is no `is:fork` search qualifier — so external PRs blend in with same-repo ones.

## Why it matters
Fork PRs are exactly the ones a maintainer wants to spot at a glance: they run the CI-gated two-stage fork AI-review path, they never receive repo secrets, and they warrant a human eye. Today the only ways to identify them are opening each PR (header reads `from <otherOwner>:branch`) or running a `gh` query — neither works while triaging the list.

## Fix
Symptom: no fork indicator in the `/pulls` list. Root cause: GitHub emits no list-level fork signal and there was no automation to add one. Change: a standalone `.github/workflows/fork-pr-label.yml` that adds a single **`fork`** label to any PR from a fork — mirroring the existing `pr-merge-conflict-label.yml` visibility pattern.

- `pull_request_target: [opened, reopened]` labels a new fork PR immediately. It runs in the trusted base context (so it has the write token a fork `pull_request` run lacks) and **never checks out or executes PR code** — it only reads the fork flag and calls `gh`.
- `schedule` (hourly) + `workflow_dispatch` sweep labels any open fork PR still missing the label (backfill + backstop for a missed event).
- Additive only: fork status is immutable for a given PR, so the label is only ever added, never removed. Visibility only — it never blocks merge.

## Tests
- YAML parses; the `run:` block passes `bash -n`.
- Label add is idempotent (`POST issues/{n}/labels` with an already-present label is a no-op), safe to re-run on every event and every sweep.
- The 25 currently-open fork PRs were labeled out-of-band to give immediate visibility; the scheduled sweep keeps that state and covers future PRs.

## Manual verification
Filter the list with `is:pr is:open label:fork` — the fork PRs (e.g. #1168, #896, #773) show the label. New fork PRs get it on open; same-repo PRs are untouched.

## Screenshots
N/A — CI-workflow-only change, no user-visible UI surface.
