### PR TITLE
fix(security): a read-only command could delete branches, repoint a remote, and write files

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -10,6 +10,7 @@ import logging
 import math
 import os
 import re
+import shlex
 import tempfile
 import threading
 import time
@@ -279,6 +280,185 @@ _UNSAFE_SHELL_RE = re.compile(r">|`|\$\(|<\(|(?<!&)&(?!&)")
 # a sink, smuggling a real-file write past the unsafe-shell check.
 _DEVNULL_REDIR_RE = re.compile(r"(?:\d*>>?|&>)\s*/dev/null(?![\w./-])|\d*>&\d+")
 
+# ── Side effects reached through an allowlisted read-only verb ──
+#
+# The allowlist above names a verb and is matched as a prefix, so it vouches
+# for every flag, subcommand and operand that verb accepts. Some of those
+# write a file, change a ref or launch another program — and none of it goes
+# through a shell redirect, so `_UNSAFE_SHELL_RE` never sees it.
+#
+# The tables are keyed by verb because the same spelling is harmless
+# elsewhere: `ls -o` is a long listing format and `grep -o` prints only the
+# match, while `sort -o FILE` truncates and writes FILE.
+
+# Flags that make the program write a file named on its own command line.
+_WRITE_FLAGS: dict[str, tuple[str, ...]] = {
+    "sort": ("-o", "--output"),
+    "tree": ("-o", "--output"),
+    "file": ("-C", "--compile"),
+    "uniq": ("-o",),
+    "git diff": ("--output",),
+    "git show": ("--output",),
+    "git log": ("--output",),
+}
+
+# Flags that hand control to a program the repository names, not the caller:
+# an external diff driver comes from the repo's config or .gitattributes.
+_EXEC_FLAGS: dict[str, tuple[str, ...]] = {
+    "git diff": ("--ext-diff",),
+    "git show": ("--ext-diff",),
+    "git log": ("--ext-diff",),
+}
+
+# `git branch` and `git tag` each carry a read mode and a write mode under one
+# subcommand, so the prefix match admits the destructive spellings. Some of
+# these also open `$EDITOR`, which runs a program of the environment's
+# choosing: `git branch --edit-description` always does, and `git tag <name>`
+# does whenever `tag.gpgSign` or `tag.forceSignAnnotated` is set.
+_GIT_REF_WRITE_FLAGS: dict[str, tuple[str, ...]] = {
+    "branch": (
+        "-d",
+        "-D",
+        "--delete",
+        "-m",
+        "-M",
+        "--move",
+        "-c",
+        "-C",
+        "--copy",
+        "-f",
+        "--force",
+        "-u",
+        "--set-upstream",
+        "--set-upstream-to",
+        "--unset-upstream",
+        "--edit-description",
+    ),
+    "tag": (
+        "-d",
+        "--delete",
+        "-a",
+        "--annotate",
+        "-s",
+        "--sign",
+        "-m",
+        "--message",
+        "-F",
+        "--file",
+        "-f",
+        "--force",
+        "--cleanup",
+    ),
+}
+
+# Read-only `git branch`/`git tag` flags that consume the following token, so
+# a bare operand after one of them is that flag's value rather than the name
+# of a ref to create.
+_GIT_REF_VALUE_FLAGS: frozenset[str] = frozenset(
+    (
+        "-l",
+        "--list",
+        "-n",
+        "--contains",
+        "--no-contains",
+        "--merged",
+        "--no-merged",
+        "--points-at",
+        "--format",
+        "--sort",
+        "--color",
+    )
+)
+
+# `git remote` subcommands that rewrite remote configuration. `set-url` is the
+# sharpest: it repoints the remote, so later fetches and pushes go elsewhere.
+_GIT_REMOTE_WRITE_SUBCOMMANDS: frozenset[str] = frozenset(
+    ("add", "remove", "rm", "rename", "set-url", "set-head", "set-branches", "prune", "update")
+)
+
+
+def _matched_flag(tokens: list[str], flags: tuple[str, ...]) -> str:
+    """Return the first token in *tokens* that supplies one of *flags*.
+
+    Matches the flag on its own (``-o``), joined to its value (``--output=x``)
+    and bundled into a short-option cluster (``-uo`` supplies ``-o``), so the
+    check cannot be stepped around by respelling the same flag.
+    """
+    shorts = {f[1] for f in flags if len(f) == 2 and f[0] == "-"}
+    for tok in tokens:
+        if tok in flags:
+            return tok
+        for flag in flags:
+            if tok.startswith(flag + "="):
+                return flag
+        if shorts and len(tok) > 1 and tok[0] == "-" and tok[1] != "-":
+            for ch in tok[1:]:
+                if ch in shorts:
+                    return "-" + ch
+    return ""
+
+
+def _side_effect_reason(segment: str) -> str:
+    """Reason *segment* has a side effect, despite naming a read-only verb.
+
+    Returns "" when the segment is genuinely read-only. Called after the verb
+    has cleared the allowlist, because the allowlist only decides *which
+    program* runs — not what the rest of the command line asks it to do.
+    """
+    try:
+        tokens = shlex.split(segment)
+    except ValueError:
+        # Cannot recover argv, so cannot vouch for the operands.
+        return "quoting cannot be resolved"
+    if not tokens:
+        return ""
+    # The verb is matched case-insensitively, like the allowlist does, so an
+    # unusual spelling cannot step past the table. Flags keep their case,
+    # because for these programs the case carries the meaning.
+    verb = tokens[0].rsplit("/", 1)[-1].lower()
+    args = tokens[1:]
+
+    # The allowlist names `git <subcommand>`, so that is the unit to key on.
+    key = verb
+    if verb == "git" and args:
+        subcommand = args[0].lower()
+        key = f"git {subcommand}"
+        args = args[1:]
+
+        if subcommand in _GIT_REF_WRITE_FLAGS:
+            hit = _matched_flag(args, _GIT_REF_WRITE_FLAGS[subcommand])
+            if hit:
+                return f"'git {subcommand} {hit}' changes a ref"
+            # A bare operand names a ref to create, unless it is the value of
+            # a read-only flag.
+            previous = ""
+            for tok in args:
+                if tok.startswith("-"):
+                    previous = tok
+                    continue
+                if previous in _GIT_REF_VALUE_FLAGS:
+                    previous = ""
+                    continue
+                return f"'git {subcommand} {tok}' creates a ref"
+
+        if subcommand == "remote" and args and args[0] in _GIT_REMOTE_WRITE_SUBCOMMANDS:
+            return f"'git remote {args[0]}' rewrites remote configuration"
+
+    hit = _matched_flag(args, _WRITE_FLAGS.get(key, ()))
+    if hit:
+        return f"'{key} {hit}' writes a file"
+    hit = _matched_flag(args, _EXEC_FLAGS.get(key, ()))
+    if hit:
+        return f"'{key} {hit}' runs a program named by the repository"
+
+    # `uniq INPUT OUTPUT` writes its second operand.
+    if verb == "uniq":
+        operands = [tok for tok in args if not tok.startswith("-")]
+        if len(operands) > 1:
+            return "'uniq INPUT OUTPUT' writes its second operand"
+
+    return ""
+
 
 def _classify_bash(cmd: str) -> str:
     """Single source of truth for read-only bash classification.
@@ -303,7 +483,12 @@ def _classify_bash(cmd: str) -> str:
         pipe_parts = [p.strip() for p in part.split("|") if p.strip()]
         if not pipe_parts:
             return "unsafe shell pattern"
-        first = pipe_parts[0].strip().lower()
+        # The verb is compared case-insensitively, but the side-effect check
+        # below needs the original spelling: flags are case-sensitive, and the
+        # two cases can mean opposite things (`file -C` compiles a magic file,
+        # `file -c` only prints one).
+        head = pipe_parts[0].strip()
+        first = head.lower()
         if not (
             first.endswith("--help")
             or first.endswith("--version")
@@ -311,10 +496,21 @@ def _classify_bash(cmd: str) -> str:
         ):
             base = first.split()[0] if first.split() else first
             return f"command '{base}' is not on the read-only allowlist"
+        # Clearing the allowlist only settles which program runs. The rest of
+        # the command line can still write a file, change a ref or start
+        # another program.
+        side_effect = _side_effect_reason(head)
+        if side_effect:
+            return f"not read-only: {side_effect}"
         for target in pipe_parts[1:]:
             if not _READ_ONLY_PIPE_RE.match(target):
                 tgt = target.split()[0] if target.split() else target
                 return f"pipe target '{tgt}' is not a read-only filter"
+            # The pipe allowlist matches only the leading verb, so a filter's
+            # own output flag (`sort -o FILE`) needs the same check.
+            side_effect = _side_effect_reason(target)
+            if side_effect:
+                return f"pipe target is not read-only: {side_effect}"
     return ""
 
 

--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -90,6 +90,91 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("java -version") is True
         assert is_read_only_bash("some-tool --help") is True
 
+    def test_allowlisted_verb_may_not_write_via_its_own_output_flag(self):
+        """A write does not need a shell redirect to be a write.
+
+        `_UNSAFE_SHELL_RE` only sees `>`, so a program's own output flag
+        reached the filesystem while the command still classified read-only.
+        """
+        assert is_read_only_bash("tree -o /tmp/pwned") is False
+        assert is_read_only_bash("git diff --output=/tmp/pwned") is False
+        assert is_read_only_bash("git show --output=/tmp/pwned") is False
+        assert is_read_only_bash("git log --output=/tmp/pwned") is False
+        # `file -C` compiles a magic file; `file -c` only prints one.
+        assert is_read_only_bash("file -C -m /tmp/magic.src") is False
+        assert is_read_only_bash("file -c") is True
+
+    def test_pipe_target_may_not_write_via_its_own_output_flag(self):
+        """The pipe allowlist matched only the filter's leading verb."""
+        assert is_read_only_bash("cat f | sort -o /tmp/pwned") is False
+        assert is_read_only_bash("cat f | sort --output=/tmp/pwned") is False
+        # Bundled short cluster supplies the same flag.
+        assert is_read_only_bash("cat f | sort -uo /tmp/pwned") is False
+        # `uniq INPUT OUTPUT` writes its second operand.
+        assert is_read_only_bash("cat f | uniq /tmp/in /tmp/pwned") is False
+        # The read-only spellings of the same filters still pass.
+        assert is_read_only_bash("cat f | sort") is True
+        assert is_read_only_bash("cat f | sort -u") is True
+        assert is_read_only_bash("cat f | uniq -c") is True
+
+    def test_allowlisted_git_verb_may_not_change_a_ref_or_remote(self):
+        """`git branch`/`git tag`/`git remote` have read and write modes.
+
+        The allowlist entries are the listing forms, but a prefix match
+        admitted the destructive spellings under the same verb.
+        """
+        # Ref deletion, rename and copy.
+        assert is_read_only_bash("git branch -D release") is False
+        assert is_read_only_bash("git branch -d release") is False
+        assert is_read_only_bash("git branch -m main hijacked") is False
+        # A bare operand names a ref to create.
+        assert is_read_only_bash("git branch newbranch") is False
+        assert is_read_only_bash("git tag sometag") is False
+        assert is_read_only_bash("git tag -d v1.0.0") is False
+        assert is_read_only_bash("git tag -m msg v1.0.0") is False
+        # Remote configuration: `set-url` repoints where pushes go.
+        assert is_read_only_bash("git remote set-url origin https://evil.example/x.git") is False
+        assert is_read_only_bash("git remote add evil https://evil.example/x.git") is False
+        assert is_read_only_bash("git remote remove origin") is False
+        assert is_read_only_bash("git remote rename origin upstream") is False
+
+    def test_allowlisted_git_verb_may_not_launch_an_editor_or_diff_driver(self):
+        """Both spellings hand control to a program the caller did not name."""
+        # `--edit-description` always opens $EDITOR.
+        assert is_read_only_bash("git branch --edit-description") is False
+        # An external diff driver comes from repo config / .gitattributes.
+        assert is_read_only_bash("git diff --ext-diff") is False
+        assert is_read_only_bash("git log --ext-diff") is False
+
+    def test_read_only_git_inspection_still_auto_approves(self):
+        """The listing and inspection forms must not regress into a prompt."""
+        assert is_read_only_bash("git branch") is True
+        assert is_read_only_bash("git branch -a") is True
+        assert is_read_only_bash("git branch -vv") is True
+        assert is_read_only_bash("git branch --list") is True
+        assert is_read_only_bash("git branch --show-current") is True
+        assert is_read_only_bash("git branch --merged") is True
+        # A bare operand that is the value of a read-only flag is not a new ref.
+        assert is_read_only_bash("git branch --contains HEAD") is True
+        assert is_read_only_bash("git tag") is True
+        assert is_read_only_bash("git tag -l") is True
+        assert is_read_only_bash("git tag -l v1.*") is True
+        assert is_read_only_bash("git remote") is True
+        assert is_read_only_bash("git remote -v") is True
+        assert is_read_only_bash("git remote get-url origin") is True
+
+    def test_side_effect_check_is_case_insensitive_on_the_verb_only(self):
+        """The verb is matched like the allowlist does; flags keep their case.
+
+        The allowlist lowercases before comparing, so an odd verb spelling
+        clears it — the side-effect table has to fold the verb the same way,
+        while `-C` and `-c` must stay distinct.
+        """
+        assert is_read_only_bash("FILE -C -m /tmp/magic.src") is False
+        assert is_read_only_bash("GIT BRANCH -D release") is False
+        assert is_read_only_bash("ls -o") is True
+        assert is_read_only_bash("grep -o pattern file") is True
+
     def test_compound_read_commands(self):
         assert is_read_only_bash("git status && git log --oneline -3") is True
         assert is_read_only_bash("ls -la; echo done") is True
@@ -112,9 +197,7 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("ls -la 2>&1") is True
         # Compound + pipe chains with a /dev/null sink stay read-only.
         assert is_read_only_bash("grep -r foo . 2>/dev/null | head -20") is True
-        assert (
-            is_read_only_bash("ls /a 2>/dev/null; grep -r foo /b 2>/dev/null") is True
-        )
+        assert is_read_only_bash("ls /a 2>/dev/null; grep -r foo /b 2>/dev/null") is True
 
     def test_devnull_does_not_unlock_write_commands(self):
         """The /dev/null exemption must not allowlist a write/exec command."""


### PR DESCRIPTION
## Description

`_READ_ONLY_BASH_PREFIXES` names a verb, and `_classify_bash` matches it as a **prefix**:

```python
any(first == p or first.startswith(p + " ") for p in _READ_ONLY_BASH_PREFIXES)
```

So clearing the allowlist vouched for every flag, subcommand and operand that verb accepts. Several of them accept operands that write a file, change a ref or start another program — and none of that goes through a shell redirect, so `_UNSAFE_SHELL_RE`, which only looks for `>`, never saw it.

Every line below classified read-only, so it auto-approved and `hooks.on_tool_call` — the PreToolUse gate carrying the deny floor and the sensitive-path check — was never reached for it. I ran each one and confirmed the side effect:

| command | verified effect |
|---|---|
| `git remote set-url origin <attacker-url>` | remote repointed; later fetches and pushes go there |
| `git branch -D release` | branch deleted |
| `git branch --edit-description` | `$EDITOR` executed |
| `git tag <name>` | `$EDITOR` executed when `tag.gpgSign` is set |
| `git tag -d v1.0.0` | tag deleted |
| `git branch <name>` | branch created |
| `git diff --output=FILE` | FILE written |
| `sort -o FILE` (as a pipe target) | FILE written |
| `uniq IN OUT` | OUT written |
| `file -C -m FILE` | `FILE.mgc` written |

None of these were caught by `is_sensitive_bash_command` or the deny floor either — I checked both.

The two editor cases are the sharpest: an auto-approved command starts a program the caller never named. `--edit-description` opens `$EDITOR` unconditionally; `git tag <name>` does so whenever `tag.gpgSign` or `tag.forceSignAnnotated` is set, which is how I hit it — this host has `tag.gpgSign=true` globally.

### What changed

`_side_effect_reason` runs after the verb clears the allowlist, because the allowlist only settles **which program runs**, not what the rest of the command line asks it to do.

The tables are keyed by verb, because the same spelling is harmless elsewhere: `ls -o` is a long listing format and `grep -o` prints only the match, while `sort -o FILE` truncates and writes FILE. A blanket ban on `-o` would have broken both.

| table | covers |
|---|---|
| `_WRITE_FLAGS` | `sort -o`, `tree -o`, `file -C`, `uniq -o`, `git diff/show/log --output` |
| `_EXEC_FLAGS` | `git diff/show/log --ext-diff` — the driver comes from repo config or `.gitattributes` |
| `_GIT_REF_WRITE_FLAGS` | the write-mode flags of `git branch` and `git tag`, including `--edit-description` |
| `_GIT_REMOTE_WRITE_SUBCOMMANDS` | `add`, `remove`, `rm`, `rename`, `set-url`, `set-head`, `set-branches`, `prune`, `update` |

Three details that decide whether the check actually holds:

- **Flag respelling.** `_matched_flag` accepts the flag alone (`-o`), joined to its value (`--output=x`) and bundled into a short cluster (`-uo` supplies `-o`), so the same flag cannot be smuggled past in a different spelling.
- **Bare operands create refs.** `git branch <name>` and `git tag <name>` mutate with no flag at all, so a bare operand is rejected — unless it is the value of a read-only flag, which is what keeps `git branch --contains HEAD` and `git tag -l 'v1.*'` working.
- **Case.** `_classify_bash` lowercases before comparing against the allowlist, so an odd verb spelling clears it; the side-effect lookup folds the verb the same way. Flags keep their case, because here the case carries the meaning — `file -C` compiles a magic file, `file -c` only prints one.

The pipe allowlist (`_READ_ONLY_PIPE_RE`) matched only a filter's leading verb, so the same check now runs on each pipe target. That is what `cat f | sort -o /tmp/x` needed.

Nothing is newly blocked. A rejected segment falls through to the human approval prompt, which is where a write or a ref change belonged.

## Related Issues

None filed — reporting and fixing together.

Same function as #1259, different root cause: that one is a suffix rule vouching for arbitrary command text, this one is an allowlist keyed on the verb without constraining its flags. They are independent and can be reviewed or merged in either order. They do conflict textually, because both insert a helper after `_DEVNULL_REDIR_RE` and both add tests at the same place in `test_trust_reads.py` — I tried the merge locally to confirm it is only that, adjacent insertions with no semantic overlap. I will rebase whichever lands second, promptly.

## Testing

- [x] Existing tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

Six new cases in `test/test_trust_reads.py`, one per bypass shape: writes through an output flag; the same on a pipe target, including the bundled `-uo` spelling and `uniq`'s second operand; ref and remote mutation under `git branch`/`git tag`/`git remote`; hand-off to `$EDITOR` and to an external diff driver.

Two of them guard against the fix going wrong in the other direction — the listing and inspection forms must keep auto-approving, and the verb-only case folding must not collapse `-C` into `-c`.

```
pytest (full suite)                                                                ->  24556 passed, 124 skipped, 5 xfailed, 1 failed
pytest test/test_trust_reads.py test/test_dashboard_approval.py test/test_hooks.py  ->  175 passed
flake8 / isort / black / mypy on the changed module                                 ->  clean
```

The single failure is pre-existing and unrelated: `test_browser_recording_skill.py::TestRunnerValidation::test_missing_playwright_fails_loud_without_install` asserts on an "install playwright" hint, but this host has no `node` on PATH so the runner fails earlier with `node not found on PATH`. It reproduces identically on clean `main`.

Both call sites of the classifier are exercised by those files: the approval flow in `dashboard/chat_runner.py` and the PreToolUse gate in `hooks.py`.

Manual verification, run against the classifier on each branch. `AUTO-APPROVE` means `_classify_bash` returned `""`, i.e. no permission request is emitted. 26 side-effect commands and 38 read-only commands, no misclassification either way:

| command | `main` | this branch |
|---|---|---|
| `git remote set-url origin https://evil.example/x.git` | AUTO-APPROVE | prompts |
| `git remote add evil https://evil.example/x.git` | AUTO-APPROVE | prompts |
| `git remote remove origin`, `git remote rename origin upstream` | AUTO-APPROVE | prompts |
| `git branch -D release`, `git branch -d release` | AUTO-APPROVE | prompts |
| `git branch -m main hijacked`, `git branch newbranch` | AUTO-APPROVE | prompts |
| `git branch --edit-description` | AUTO-APPROVE | prompts |
| `git tag sometag`, `git tag -d v1.0.0`, `git tag -m msg v1.0.0` | AUTO-APPROVE | prompts |
| `git diff --output=/tmp/pwned`, `git show --output=…`, `git log --output=…` | AUTO-APPROVE | prompts |
| `git diff --ext-diff`, `git log --ext-diff` | AUTO-APPROVE | prompts |
| `tree -o /tmp/pwned` | AUTO-APPROVE | prompts |
| `file -C -m /tmp/magic.src`, `file -bC -m /tmp/magic.src` | AUTO-APPROVE | prompts |
| `cat f \| sort -o /tmp/pwned`, `sort -uo …`, `sort --output=…` | AUTO-APPROVE | prompts |
| `cat f \| uniq /tmp/in /tmp/pwned` | AUTO-APPROVE | prompts |
| `FILE -C -m …`, `GIT BRANCH -D release` | AUTO-APPROVE | prompts |
| `git branch`, `-a`, `-vv`, `--list`, `--show-current`, `--merged`, `--contains HEAD` | AUTO-APPROVE | AUTO-APPROVE |
| `git tag`, `git tag -l`, `git tag -l 'v1.*'` | AUTO-APPROVE | AUTO-APPROVE |
| `git remote`, `git remote -v`, `git remote get-url origin` | AUTO-APPROVE | AUTO-APPROVE |
| `ls -o`, `grep -o pattern file`, `file -c`, `tree -L 2` | AUTO-APPROVE | AUTO-APPROVE |
| `cat f \| sort`, `sort -u`, `uniq`, `uniq -c` | AUTO-APPROVE | AUTO-APPROVE |
| `git status`, `git log --oneline -5`, `git diff HEAD`, `git blame f.py` | AUTO-APPROVE | AUTO-APPROVE |

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

On documentation: the rationale lives in comments above each table, since that is where a future edit would need it. Happy to add a note to the security module spec if you would prefer it recorded there too.

### Not in scope

The tables are a denylist, and a denylist over third-party CLI surface is never provably complete — this closes the shapes I could verify, it does not prove no other allowlisted verb has a side effect. The durable fix is the other direction: an allowlist of permitted flags per verb, or running these commands under a filesystem sandbox so a write cannot land regardless of how it was spelled. Both are larger changes than this, and worth their own discussion.

Two things I did **not** claim, because I could not verify them: `less`/`more` as pipe targets have a `!command` shell escape, but it needs an interactive TTY, which a tool call does not have; and `git diff --ext-diff` is included on the strength of the documented behaviour, since reaching the driver needs repo config or `.gitattributes` I did not stage.

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

