### PR TITLE
fix(mcp-apps): pace the reveal per element so the draw-on is perceptible

### DIFF
--- a/website/src/components/mcpAppReveal.ts
+++ b/website/src/components/mcpAppReveal.ts
@@ -27,29 +27,68 @@
  *  the pre-existing behaviour.
  */
 
-/** Wall-clock budget for the whole reveal. Deliberately short: the reveal is
- *  gated on argument SHAPE, not on app capability, so an app that ignores
- *  `tool-input-partial` still waits this long for its complete input and result.
- *  A capability gate is not available — `ui/initialize` params do carry
- *  `appCapabilities`, but excalidraw (the reference partial-aware consumer)
- *  declares `capabilities: {}`, so gating on a declared capability would switch
- *  the animation off for the very app that implements it. Keeping the budget
- *  small is the honest trade instead. */
-export const REVEAL_BUDGET_MS = 700
-/** Upper bound on posted frames. A 4000-element diagram must not become 4000
- *  postMessage round-trips; past ~two dozen steps the motion reads identically. */
-export const REVEAL_MAX_FRAMES = 24
-/** Floor on the gap between frames, so a short list still animates visibly
- *  instead of flashing through in three frames' worth of milliseconds. */
-export const REVEAL_MIN_STEP_MS = 45
+/** Gap between frames. Matched deliberately to excalidraw's OWN reference
+ *  harness (`dev-mock.ts` `streamElements(elements, intervalMs = 120)`), which
+ *  posts one element per 120ms with no total budget — that cadence is what the
+ *  project's sample recordings show, and its tool description promises
+ *  "elements stream in one by one with draw-on animations".
+ *
+ *  A previous revision used a fixed ~700ms TOTAL budget instead. That squeezed
+ *  a whole diagram into under a second and batched several elements per frame,
+ *  which reads as a flicker rather than a draw-on: the animation was there but
+ *  not perceptible. Pace per element, not per payload.
+ *
+ *  PROVENANCE (this is a sibling checkout, NOT a dependency — nothing in CI can
+ *  notice if these upstream numbers change, so they are pinned here by hand):
+ *  github.com/excalidraw/excalidraw-mcp @ 157aa23 — `src/dev-mock.ts:105`
+ *  (intervalMs = 120), `src/server.ts:12` (MAX_INPUT_BYTES = 5MB),
+ *  `src/mcp-app.tsx:32` (excludeIncompleteLastItem).
+ *
+ *  ONE DELIBERATE DEVIATION from that reference: the harness increments before
+ *  posting, so it emits prefixes 1..n — the complete array included, as a
+ *  "partial". We never do: a partial equal to the whole payload would tell an
+ *  app that only listens to partials that it had final state. Combined with the
+ *  app dropping each frame's last element, the visible consequence is that our
+ *  final partial shows total-2 elements and the complete `tool-input` then
+ *  jumps to total — the tail lands two elements at once where the reference
+ *  lands one. That is the one place this cadence provably differs.
+ *
+ *  WHY THE REVEAL IS GATED ON ARGUMENT SHAPE AND NOT APP CAPABILITY (kept here
+ *  so the gap is not re-litigated): `ui/initialize` params DO carry
+ *  `appCapabilities`, so a real capability gate looks available. It is not —
+ *  excalidraw, the reference partial-aware consumer, declares `capabilities: {}`
+ *  while implementing `ontoolinputpartial`, so gating on a declared capability
+ *  would switch the animation off for the very app that implements it. The cost
+ *  of shape-gating is that an app which ignores partials still waits out the
+ *  reveal for its complete input; REVEAL_MAX_TOTAL_MS bounds that wait. */
+export const REVEAL_STEP_MS = 120
+/** Ceiling on the whole reveal, so a 400-element diagram does not hold the
+ *  app's complete input for the best part of a minute. Past this, frames carry
+ *  more than one element each (see prefixLengths). */
+export const REVEAL_MAX_TOTAL_MS = 7_200
+/** Frame ceiling implied by the interval and the total cap. */
+export const REVEAL_MAX_FRAMES = Math.floor(REVEAL_MAX_TOTAL_MS / REVEAL_STEP_MS)
 /** Cap on the encoded size of the WHOLE arguments object.
  *
  *  It must be the whole object, not just the revealed array: every frame is
  *  `{...toolInput, [key]: prefix}`, so each frame structured-clones every
  *  SIBLING argument too. Measuring only the array would let a small array
  *  beside a multi-megabyte sibling ship (frames x sibling) bytes through
- *  postMessage. At this cap the worst case is ~24 x 256KB. */
-export const REVEAL_MAX_SOURCE_BYTES = 256_000
+ *  postMessage.
+ *
+ *  1MB, not the 256KB a previous revision used: the excalidraw server itself
+ *  accepts up to 5MB of elements (`MAX_INPUT_BYTES`), so a much tighter host
+ *  cap meant large-but-legal diagrams silently got no animation at all. Total
+ *  cloned bytes stay bounded by REVEAL_MAX_CLONE_BYTES below rather than by
+ *  making the accepted payload small. */
+export const REVEAL_MAX_SOURCE_BYTES = 1_000_000
+/** Budget for total bytes handed to postMessage across the whole reveal.
+ *
+ *  Frame count and payload size multiply, so bounding either alone is not
+ *  enough. This trades frames against size: a typical 40KB diagram gets the
+ *  full per-element cadence, while a 1MB one animates in fewer, larger steps
+ *  instead of cloning 60MB. */
+export const REVEAL_MAX_CLONE_BYTES = 24_000_000
 
 /** How the revealed array was carried in the arguments object. Servers differ:
  *  excalidraw passes `elements` as a JSON *string*, others pass a real array. */
@@ -98,13 +137,26 @@ function encodeItems(items: unknown[], encoding: RevealEncoding): unknown {
   return encoding === 'json-string' ? JSON.stringify(items) : items
 }
 
-/** Evenly spaced prefix lengths over `1 .. total-1`, at most `REVEAL_MAX_FRAMES`
- *  of them, strictly increasing and never including `total`. */
-function prefixLengths(total: number): number[] {
-  const steps = Math.min(REVEAL_MAX_FRAMES, total - 1)
+/** Prefix lengths to reveal, strictly increasing and never including `total`.
+ *
+ *  Starts at TWO, not one, because the app drops the last element of every
+ *  partial frame on purpose (`excludeIncompleteLastItem` in excalidraw's
+ *  DiagramView — during real streaming that element is truncated mid-JSON). A
+ *  1-element frame therefore renders nothing, so it would waste the first step.
+ *
+ *  `maxFrames` collapses steps when the payload is large: one element per frame
+ *  is the ideal, but frames x payload bytes has to stay bounded. */
+function prefixLengths(total: number, maxFrames: number): number[] {
+  const last = total - 1
+  if (last < 2) return []
+  // Available lengths are 2..last inclusive; `span` is the largest increment
+  // above the starting length, so the final frame lands exactly on `last` and
+  // never on `total`.
+  const span = last - 2
+  const steps = Math.max(1, Math.min(maxFrames, last - 1))
   const out: number[] = []
-  for (let i = 1; i <= steps; i++) {
-    const len = Math.max(1, Math.round((i * (total - 1)) / steps))
+  for (let i = 0; i < steps; i++) {
+    const len = steps === 1 ? last : 2 + Math.round((i * span) / (steps - 1))
     if (out[out.length - 1] !== len) out.push(len)
   }
   return out
@@ -140,10 +192,14 @@ export function planReveal(toolInput: unknown): RevealPlan | null {
       best = { key, items: decoded.items, encoding: decoded.encoding }
     }
   }
-  // Fewer than two items yields no intermediate state worth showing.
-  if (!best || best.items.length < 2) return null
+  // Fewer than three items yields no useful intermediate state: the app drops
+  // the last element of each partial, so only a 3+ element array can show a
+  // frame with something in it that is also short of the whole diagram.
+  if (!best || best.items.length < 3) return null
 
-  const lengths = prefixLengths(best.items.length)
+  // Trade frames against payload size so total cloned bytes stay bounded.
+  const byteCappedFrames = Math.max(1, Math.floor(REVEAL_MAX_CLONE_BYTES / Math.max(1, encodedBytes)))
+  const lengths = prefixLengths(best.items.length, Math.min(REVEAL_MAX_FRAMES, byteCappedFrames))
   if (lengths.length === 0) return null
 
   const frames = lengths.map((len) => ({
@@ -154,7 +210,7 @@ export function planReveal(toolInput: unknown): RevealPlan | null {
   return {
     key: best.key,
     frames,
-    stepMs: Math.max(REVEAL_MIN_STEP_MS, Math.round(REVEAL_BUDGET_MS / frames.length)),
+    stepMs: REVEAL_STEP_MS,
   }
 }
 

--- a/website/src/test/McpAppFrame.test.tsx
+++ b/website/src/test/McpAppFrame.test.tsx
@@ -171,13 +171,14 @@ describe('McpAppFrame', () => {
         'ui/notifications/tool-result',
       ])
       expect(new Set(methods.slice(0, -2))).toEqual(new Set(['ui/notifications/tool-input-partial']))
-      expect(methods.filter((m) => m === 'ui/notifications/tool-input-partial').length).toBe(4)
+      expect(methods.filter((m) => m === 'ui/notifications/tool-input-partial').length).toBe(3)
 
       // Partials grow monotonically and stay short of the full array.
       const counts = win.postMessage.mock.calls
         .filter((c) => c[0].method === 'ui/notifications/tool-input-partial')
         .map((c) => (JSON.parse(c[0].params.arguments.elements as string) as unknown[]).length)
-      expect(counts).toEqual([1, 2, 3, 4])
+      // Prefixes start at 2 because the app drops each frame's last element.
+      expect(counts).toEqual([2, 3, 4])
 
       // The COMPLETE notification carries the whole payload, unmodified.
       const complete = win.postMessage.mock.calls.at(-2)![0]

--- a/website/src/test/mcpAppReveal.test.ts
+++ b/website/src/test/mcpAppReveal.test.ts
@@ -7,7 +7,7 @@ import {
   __resetRevealedForTests,
   REVEAL_MAX_FRAMES,
   REVEAL_MAX_SOURCE_BYTES,
-  REVEAL_MIN_STEP_MS,
+  REVEAL_STEP_MS,
 } from '../components/mcpAppReveal'
 
 /** N distinct element-ish objects, the shape a diagram tool actually sends. */
@@ -24,9 +24,13 @@ describe('planReveal', () => {
     expect(planReveal({ prose: 'not json at all' })).toBeNull()
   })
 
-  it('returns null for a single-element array — there is no intermediate state', () => {
-    expect(planReveal({ elements: elements(1) })).toBeNull()
-    expect(planReveal({ elements: JSON.stringify(elements(1)) })).toBeNull()
+  it('returns null below three elements — the app drops each frame\'s last element', () => {
+    // excalidraw's excludeIncompleteLastItem means a 1- or 2-element array has
+    // no frame that both shows something AND is short of the whole diagram.
+    for (const n of [1, 2]) {
+      expect(planReveal({ elements: elements(n) })).toBeNull()
+      expect(planReveal({ elements: JSON.stringify(elements(n)) })).toBeNull()
+    }
   })
 
   it('reveals a JSON-STRING encoded array as growing JSON strings', () => {
@@ -34,18 +38,18 @@ describe('planReveal', () => {
     // parsePartialElements tolerates truncation — so frames must stay strings.
     const plan = planReveal({ elements: JSON.stringify(elements(4)) })!
     expect(plan.key).toBe('elements')
-    expect(plan.frames.length).toBe(3)
+    expect(plan.frames.length).toBe(2)
     for (const frame of plan.frames) {
       expect(typeof frame.elements).toBe('string')
     }
     const lengths = plan.frames.map((f) => (JSON.parse(f.elements as string) as unknown[]).length)
-    expect(lengths).toEqual([1, 2, 3])
+    expect(lengths).toEqual([2, 3])
   })
 
   it('reveals a NATIVE array as growing arrays', () => {
     const plan = planReveal({ elements: elements(3) })!
     const lengths = plan.frames.map((f) => (f.elements as unknown[]).length)
-    expect(lengths).toEqual([1, 2])
+    expect(lengths).toEqual([2])
     expect(Array.isArray(plan.frames[0].elements)).toBe(true)
   })
 
@@ -108,9 +112,25 @@ describe('planReveal', () => {
     expect(planReveal(circular)).toBeNull()
   })
 
-  it('never schedules frames faster than the minimum step', () => {
-    const plan = planReveal({ elements: elements(400) })!
-    expect(plan.stepMs).toBeGreaterThanOrEqual(REVEAL_MIN_STEP_MS)
+  it('paces per element at excalidraw\'s reference interval, not a total budget', () => {
+    // The reference harness (dev-mock streamElements) uses 120ms per element.
+    const small = planReveal({ elements: elements(6) })!
+    const large = planReveal({ elements: elements(400) })!
+    expect(small.stepMs).toBe(REVEAL_STEP_MS)
+    expect(large.stepMs).toBe(REVEAL_STEP_MS)
+    // A small diagram gets one element per frame rather than batching.
+    expect(small.frames.map((f) => (f.elements as unknown[]).length)).toEqual([2, 3, 4, 5])
+  })
+
+  it('bounds total cloned bytes by trading frames against payload size', () => {
+    // A fat-but-legal payload animates in fewer, larger steps instead of
+    // cloning frames x payload without limit.
+    const fat = planReveal({
+      elements: elements(300),
+      backdrop: 'z'.repeat(400_000),
+    })!
+    expect(fat.frames.length).toBeLessThan(REVEAL_MAX_FRAMES)
+    expect(fat.frames.length).toBeGreaterThan(0)
   })
 })
 


### PR DESCRIPTION
# Problem

The progressive draw-on reveal shipped in #1143 is not visible in practice. A live test rendered an excalidraw diagram with no perceptible animation at all — the diagram simply appeared, which is the exact symptom #1143 set out to fix.

# Why it matters

The draw-on is the whole point of the feature: it is the difference between "a picture arrived" and "the assistant is drawing this for you". Shipped-but-imperceptible is worse than not shipped, because the code carries maintenance cost while delivering none of the value, and the missing animation looks like a broken integration rather than a tuning choice.

# Fix (symptom → root cause → change)

**Symptom:** no visible animation on a real `create_view` render, even though the host is provably sending `tool-input-partial` (verified: PR #1143 merged as `3d31fe16`, the served bundle contains the notification, and `create_view`'s schema puts `elements` at the top level where `planReveal` finds it).

**Root cause — the cadence was mine to choose and I chose wrong.** excalidraw's own reference harness sets the cadence this feature exists to reproduce: `dev-mock.ts:105` `streamElements(elements, intervalMs = 120)` posts **one element per 120 ms with no total budget**. That is what the project's sample recordings show and what its tool description promises ("elements stream in one by one with draw-on animations"). #1143 instead used a fixed **~700 ms total budget across ≤24 frames**, so a 20-element diagram finished in ~0.85 s and larger diagrams batched several elements per step — motion technically present, but reading as a flicker.

**Change:** pace per element, not per payload. 120 ms per frame, with a 7.2 s total ceiling above which frames batch, and a clone-byte budget that trades frame count against payload size (frames × payload is the real cost, so bounding either alone is insufficient).

Two further defects surfaced while fixing the cadence:

- **Prefixes started at 1, and a 1-element frame renders nothing.** The app calls `excludeIncompleteLastItem` on every partial — it deliberately drops the frame's last element, because during genuine streaming that element is truncated mid-JSON. So the first frame was always blank and every frame showed one fewer element than intended. Prefixes now start at 2. Consequently arrays under 3 elements no longer animate: with the last element dropped, no frame of theirs can both show something and stay short of the whole diagram. Verified as **not** a regression — `excludeIncompleteLastItem` returns `[]` for length ≤ 1, so the old 2-element plan already rendered zero elements. Visible output is identical; one wasted step is gone.

- **The 256 KB payload cap was 20× tighter than the producer's own limit.** The excalidraw server accepts up to `MAX_INPUT_BYTES = 5 * 1024 * 1024` (`src/server.ts:12`), so large-but-legal diagrams silently got no animation at all. Raised to 1 MB, with total cloned bytes now bounded by `REVEAL_MAX_CLONE_BYTES` (24 MB worst case) rather than by keeping the accepted payload small.

## A deliberate reversal, stated plainly

#1143 shortened this budget to 700 ms specifically to limit the delay absorbed by an app that *ignores* `tool-input-partial`. This PR reverses that: the delay is back and can reach 7.2 s. That earlier trade optimised a hypothetical non-participating app at the direct expense of the only app that implements the feature, which was the wrong call. The reveal is still gated on argument **shape** rather than app **capability**, and that gap is now documented in-code rather than left to be re-discovered: `ui/initialize` params do carry `appCapabilities`, but excalidraw declares `capabilities: {}` while implementing the handler, so a capability gate would disable the animation for its only consumer.

## One deliberate deviation from the reference

The reference harness increments before posting, so it emits prefixes `1..n` — including the complete array *as a partial*. This implementation never does, because a partial equal to the whole payload would tell a partial-only app that it had final state. Combined with the dropped last element, the visible consequence is that our final partial shows `total-2` elements and the complete `tool-input` then jumps to `total`: the tail lands two elements at once where the reference lands one. It is the one place the cadence provably differs, and it is commented as such.

# Tests

`website/src/test/mcpAppReveal.test.ts` (16) — re-derived, not relaxed. Locks: per-element pacing at the reference interval (not a total budget), one element per frame for a small diagram, prefixes starting at 2, **no partial ever equal to the complete array**, strictly increasing prefixes at 500 elements, sub-3-element arrays declining, the whole-object byte cap including the sibling-argument case, circular input declining rather than throwing, frames-vs-payload trading for a fat payload, and oldest-entry cache eviction.

`website/src/test/McpAppFrame.test.tsx` (51) — host wiring unchanged in behaviour: full partial → complete → result ordering, duplicate-`initialized` guard, reduced-motion skip, no replay on remount, cancellation on unmount.

The prefix arithmetic is where the risk sat, and the test suite earned its keep during this change: an intermediate version of `prefixLengths` emitted `total` itself, and the no-complete-array-in-a-partial assertion caught it immediately.

# Manual verification

The built dist is staged to the local gateway and the branch is ready to exercise, but **the perceptual claim is not yet independently confirmed** — that is the whole subject of this PR, so I am not asserting it from unit tests. Automated coverage proves the frame maths and the notification ordering; it cannot prove an eye sees a draw-on.

Gates: `tsc --noEmit` ✓, vitest **601 files / 7533 tests** ✓, production build ✓, and on the backend `isort` / `flake8` / `mypy` (594 files) ✓ — no Python is touched.

# Screenshots

**Outstanding, and load-bearing for this PR specifically.** This change is *about* perceptible motion, so a still frame cannot evidence it and a GIF is the only meaningful artifact — a ~2.3 s draw-on for a 20-element diagram versus the previous ~0.85 s flicker. Capturing it needs a live dashboard render of `excalidraw/create_view` against this build. Flagging it explicitly rather than omitting the section: treat the perceptual fix as unverified until the recording is attached.
