### PR TITLE
fix(babysit): stop monitor loops and long turns dying silently

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -33,8 +33,11 @@
         "session_sharing": true,
         "max_subagents": 0,
         "spawn_min_memory_gb": 4.0,
+        "resource_pressure_gb": 4.0,
+        "resource_critical_gb": 2.0,
         "workflow_run_timeout_secs": 3600,
         "subagent_mem_buffer_pct": 20,
+        "chat_turn_timeout_secs": 7200,
         "subagent_cost_gb": 0.5,
         "subagent_cpu_cost_cores": 1.0,
         "subagent_auto_max": 32,
@@ -343,6 +346,34 @@
       "defaultValue": 4.0
     },
     {
+      "path": "agent.resource_pressure_gb",
+      "kind": "core",
+      "type": "number",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Resource Pressure Threshold (GB)",
+      "help": "Available memory (GB) at or below which the agent is told host memory is 'tight' via a compact [RESOURCES] context line, so it can prefer the lighter path for heavy work (targeted tests, smaller sub-agent waves). Advisory only — not enforced. 0 disables the context line. Lower this on small-memory hosts / memory-limited containers (e.g. a 2-4 GB pod) so the advisory only fires under genuine pressure.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 4.0
+    },
+    {
+      "path": "agent.resource_critical_gb",
+      "kind": "core",
+      "type": "number",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Resource Critical Threshold (GB)",
+      "help": "Available memory (GB) at or below which the [RESOURCES] context line escalates to 'critically low' and advises against starting heavy work at all. Should be <= resource_pressure_gb. 0 disables the critical tier.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 2.0
+    },
+    {
       "path": "agent.workflow_run_timeout_secs",
       "kind": "core",
       "type": "integer",
@@ -369,6 +400,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 20
+    },
+    {
+      "path": "agent.chat_turn_timeout_secs",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Chat Turn Timeout (secs)",
+      "help": "Wall-clock ceiling for one chat turn. This is a runaway backstop, so it is clamped to 300s..7200s (2h) and can never be disabled. Long babysit and monitoring turns approach the default, so hitting it is no longer silent: the turn ends with a visible card naming the limit. Values above the ACP transport's own prompt timeout are clamped, because the transport bounds the turn first.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 7200
     },
     {
       "path": "agent.subagent_cost_gb",
@@ -1811,6 +1856,7 @@
         "transcribe_profile": "",
         "language_code": "en-US",
         "streaming": false,
+        "endpointing": false,
         "dictation_panel": true
       }
     },
@@ -1973,6 +2019,20 @@
       "tags": [],
       "label": "Streaming",
       "help": "Stream partial transcripts live to the dashboard input (transcribe provider only).",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "stt.endpointing",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Semantic endpointing",
+      "help": "While streaming dictation, run a fast background model on each stable transcript segment to detect when you have finished a complete request, then auto-submit. Transcribe streaming only; off by default.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": false
@@ -3772,6 +3832,7 @@
         "avatar": "",
         "merge_queued_messages": false,
         "mcp_probe_timeout_secs": 15,
+        "loop_stall_exit_after_secs": 25,
         "widget_density": "more",
         "verbosity": "default",
         "link_previews": false,
@@ -3913,6 +3974,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 15
+    },
+    {
+      "path": "dashboard.loop_stall_exit_after_secs",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Loop-stall Hard-exit Budget (secs)",
+      "help": "Seconds the gateway's event loop may go silent before it dumps all thread stacks and exits so systemd can restart it. Raise it on a host that does heavy subprocess work (long builds, test suites, many child reaps), which can wedge the loop briefly without being genuinely dead. Clamped to 10s..300s. Note the desktop app's liveness probe kills at roughly 20s independently, so a value above that only takes effect for a headless gateway — the desktop probe wins first and the stack dump is lost.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 25
     },
     {
       "path": "dashboard.widget_density",

--- a/skills/kirocrew-dev/babysit/SKILL.md
+++ b/skills/kirocrew-dev/babysit/SKILL.md
@@ -52,20 +52,57 @@ session. That shared context is the point of a same-session loop, but nothing
 bounds it: long babysits walk into compaction, which can summarise away the
 very instructions the loop keeps re-injecting. Keep per-cycle output minimal.
 
-### An arm failure is not a flaky connection
+### Verify the loop armed — the return string is not evidence
 
-If `monitor_start` reports it could not arm a loop, no monitoring is running.
-That message is distinct from the transient MCP reconnects you retry through —
-do not write it off as flakiness. Fall back to an in-turn `wait`+poll loop and
-tell the user monitoring is not active.
+`monitor_start` returns an acknowledgement whether or not the loop was
+actually armed. The applier runs after the tool returns, and its failure
+message is not visible to you, so a confident-looking success string is
+consistent with nothing being scheduled at all.
+
+Confirm against state, not the reply: read `~/.kiro/crew/autonudge.json` (or
+`GET /api/autonudge`) and check the loop is present, then that `cycle_count`
+advances on the next cycle. If it never appears, no monitoring is running —
+fall back to an in-turn `wait`+poll loop and tell the user monitoring is not
+active.
+
+If `monitor_start` explicitly reports it could not arm, believe it. That
+message is distinct from the transient MCP reconnects you retry through — do
+not write it off as flakiness.
 
 ## Decision table
 
 - User is waiting and total time < 30 min → `wait` + poll, no loop.
 - "Babysit / monitor / keep checking" in THIS conversation → `monitor_start`.
-- Work belongs in a fresh isolated session each cycle → `cron_add`.
+- Reacting to review feedback or CI on a PR → `monitor_start` or in-turn
+  `wait`+poll. **Never `cron_add`, never HEARTBEAT.md** (see below).
+- Work belongs in a fresh isolated session each cycle, and needs no tools that
+  require approval → `cron_add`.
+- Cleaning up after a merge you have already verified → `cron_add`, as a
+  `script` cron at roughly a 5-minute interval.
 - External system will call back → `register_hook`.
-- Non-session context (cron/webhook) needs monitoring → HEARTBEAT.md task.
+
+### Never use cron or heartbeat to react to reviewer feedback
+
+Both are structurally incapable of it, and both fail in ways that look like
+success:
+
+- **Cron.** A cron job has no owning chat slot, so it can never earn per-slot
+  trust: its tool calls land on a deny-by-default approval path and time out
+  after 180 seconds unless a global auto-approve grant happens to be active.
+  Worse, a denied *tool* inside a *completed* turn still records
+  `last_status: ok`, so the job registry reports health while the job does
+  nothing. Measured on a real PR watcher: 101 runs over 25 hours, 23 blocked at
+  approval, hours of model time, zero commits pushed, and a green-looking
+  registry throughout.
+- **Heartbeat.** Its approval path is a strict name allowlist
+  (`HEARTBEAT_SAFE_TOOLS`), deny-by-default, with no shell and no `git push`.
+  It cannot amend a commit or push a revision, so it can never close the loop
+  it was asked to watch.
+
+Cron *is* the right tool for post-merge cleanup — but as a `script` cron, which
+bypasses the LLM approval layer entirely, at roughly a 5-minute interval. An
+hourly job loses the race: one observed merge-to-teardown window was 17
+minutes.
 
 ## Workflow
 
@@ -78,12 +115,14 @@ tell the user monitoring is not active.
    polling. `max_cycles` defaults to 24 (≈2h of idle gaps at 300s); raise it
    for longer work, and pass `0` for unlimited only when the user explicitly
    asks for an unbounded loop.
-3. **Tell the user monitoring is active and END YOUR TURN.** The loop wakes
+3. **Confirm it armed.** Read `~/.kiro/crew/autonudge.json` and check your
+   loop is there. The tool's reply is not evidence — see above.
+4. **Tell the user monitoring is active and END YOUR TURN.** The loop wakes
    you — do not wait+poll on top of it.
-4. **Each cycle:** do the check, act, and report only real signals. Don't
+5. **Each cycle:** do the check, act, and report only real signals. Don't
    post "nothing new" every cycle. If the instruction no longer matches
    reality, `monitor_update` it rather than working around it.
-5. **On the exit condition** (or the user saying stop): report, then call
+6. **On the exit condition** (or the user saying stop): report, then call
    `autonudge_stop` with a reason. Do not let the cap do this for you.
 
 ## Example

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -150,3 +150,12 @@ Omit a section only when truly not applicable, and say so.
 - **Appeasing false positives** — changing correct code to silence a wrong comment; validate each finding first.
 - **Over-running scope** — entering the poll/fix loop when the user only asked to push or update.
 - **Breaking the single-commit invariant** — adding follow-up commits instead of squash + force-with-lease.
+
+## Which mechanism drives the loop
+This skill's loop is in-session on purpose: `wait` + re-poll (Phase 3 step 4), or `monitor_start` when the work outlives a single turn (see the `babysit` skill). Both keep the tool trust of the owning chat slot, which is what lets a round actually amend and force-push.
+
+Do **not** hand the iterate-on-review-feedback loop to a cron job or a HEARTBEAT.md task. Neither can push a revision, and both report success while doing nothing:
+- A **cron** has no owning slot, so its tool calls hit a deny-by-default approval path and time out after 180s without a global auto-approve grant — and a denied tool inside a completed turn still records `last_status: ok`. A real PR watcher logged 101 runs over 25 hours with 23 approval blocks, zero pushes, and a healthy-looking registry.
+- **Heartbeat** runs under a strict name allowlist (`HEARTBEAT_SAFE_TOOLS`) with no shell and no `git push`, so it cannot amend a commit at all.
+
+Cron *is* correct for post-merge cleanup, as a `script` cron at roughly a 5-minute interval — an hourly one loses the merge-to-teardown race.

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -277,20 +277,31 @@ def workspace_root() -> Path:
     return _resolve_workspace_root(base / _WORKSPACE_DIR_NAME)
 
 
-def _safe_int(value: object, default: int) -> int:
+def _safe_int(value: object, default: int, lo: int | None = None, hi: int | None = None) -> int:
     """Convert a legacy numeric config value or return *default* on failure.
 
     Existing config files may contain numeric strings or integral floats from
     older writers. Preserve that compatibility while rejecting booleans.
+
+    *lo*/*hi* clamp the result, mirroring :func:`_safe_float`. Pass them for any
+    bounded knob: ``_clamp_security_bounds`` runs over the raw dict and skips
+    non-int values, so a numeric STRING (``"1"``) slips past it and then
+    coerces here — clamping at the coercion site is what actually enforces the
+    declared range.
     """
     if isinstance(value, bool):
         return default
     if isinstance(value, float) and not value.is_integer():
         return default
     try:
-        return int(value)  # type: ignore[call-overload]
+        result = int(value)  # type: ignore[call-overload]
     except (TypeError, ValueError, OverflowError):
-        return default
+        result = default
+    if lo is not None:
+        result = max(lo, result)
+    if hi is not None:
+        result = min(hi, result)
+    return result
 
 
 def _safe_nonnegative_int(value: object, default: int) -> int:
@@ -900,6 +911,18 @@ class AgentConfig:
             "SubAgent Memory Buffer %",
             "Percent of available memory and CPU reserved for the OS and other "
             "processes when auto-sizing the subagent cap (max_subagents=0).",
+        ),
+    )
+    chat_turn_timeout_secs: int = field(
+        default=7200,
+        metadata=_meta(
+            "Chat Turn Timeout (secs)",
+            "Wall-clock ceiling for one chat turn. This is a runaway backstop, "
+            "so it is clamped to 300s..7200s (2h) and can never be disabled. "
+            "Long babysit and monitoring turns approach the default, so hitting "
+            "it is no longer silent: the turn ends with a visible card naming "
+            "the limit. Values above the ACP transport's own prompt timeout are "
+            "clamped, because the transport bounds the turn first.",
         ),
     )
     subagent_cost_gb: float = field(
@@ -1650,6 +1673,20 @@ class DashboardConfig:
             "Seconds to wait for MCP server handshake during probe (5-120).",
         ),
     )
+    loop_stall_exit_after_secs: int = field(
+        default=25,
+        metadata=_meta(
+            "Loop-stall Hard-exit Budget (secs)",
+            "Seconds the gateway's event loop may go silent before it dumps all "
+            "thread stacks and exits so systemd can restart it. Raise it on a "
+            "host that does heavy subprocess work (long builds, test suites, "
+            "many child reaps), which can wedge the loop briefly without being "
+            "genuinely dead. Clamped to 10s..300s. Note the desktop app's "
+            "liveness probe kills at roughly 20s independently, so a value "
+            "above that only takes effect for a headless gateway — the desktop "
+            "probe wins first and the stack dump is lost.",
+        ),
+    )
     widget_density: str = field(
         default="more",
         metadata=_meta(
@@ -2300,6 +2337,24 @@ SUBAGENT_AUTO_MAX_CEILING = 64  # agent.subagent_auto_max — concurrent subagen
 SUBAGENT_MAX_TURNS_CEILING = 200  # agent.subagent_max_turns — per-subagent turn budget
 POOL_SIZE_MAX = 10  # session.pool_size — pre-warmed process pool
 
+# agent.chat_turn_timeout_secs — wall-clock ceiling for one chat turn. The max
+# matches the ACP transport's own per-prompt timeout (acp/client.py
+# ``_DEFAULT_PROMPT_TIMEOUT``): above it the transport bounds the turn first, so
+# a larger value would advertise a limit the system does not honour. The floor
+# keeps a runaway backstop from being set so low it cuts ordinary work.
+CHAT_TURN_TIMEOUT_MIN = 300
+CHAT_TURN_TIMEOUT_MAX = 7200
+
+# dashboard.loop_stall_exit_after_secs — event-loop silence tolerated before the
+# gateway dumps all thread stacks and hard-exits for systemd to restart. The
+# floor keeps a stall from being declared faster than ordinary GC/IO pauses; the
+# ceiling keeps a wedged gateway from sitting unrecoverable for minutes. Above
+# ~20s the desktop app's own liveness probe kills first and the dump is lost,
+# which is a documented trade-off rather than a bound (a headless gateway has no
+# such probe), so it is not enforced here.
+LOOP_STALL_EXIT_AFTER_MIN = 10
+LOOP_STALL_EXIT_AFTER_MAX = 300
+
 # agent.max_subagents fixed-pin floor. 0 is the "auto-size" sentinel; any other
 # (explicit) value must be >= this floor. A pin of 1 or 2 would silently DISABLE
 # auto-sizing and run below today's default of 3, so such values are normalized
@@ -2318,6 +2373,8 @@ _SECURITY_BOUNDED_FIELDS: tuple[tuple[str, str, int, int], ...] = (
     ("agent", "subagent_auto_max", 3, SUBAGENT_AUTO_MAX_CEILING),
     ("agent", "max_subagents", 0, SUBAGENT_AUTO_MAX_CEILING),
     ("agent", "subagent_max_turns", 1, SUBAGENT_MAX_TURNS_CEILING),
+    ("agent", "chat_turn_timeout_secs", CHAT_TURN_TIMEOUT_MIN, CHAT_TURN_TIMEOUT_MAX),
+    ("dashboard", "loop_stall_exit_after_secs", LOOP_STALL_EXIT_AFTER_MIN, LOOP_STALL_EXIT_AFTER_MAX),
     ("session", "pool_size", 0, POOL_SIZE_MAX),
 )
 
@@ -4151,6 +4208,12 @@ class KiroCrewConfig:
                 subagent_mem_buffer_pct=_safe_int(
                     agent_data.get("subagent_mem_buffer_pct", 20), 20
                 ),
+                chat_turn_timeout_secs=_safe_int(
+                    agent_data.get("chat_turn_timeout_secs", 7200),
+                    7200,
+                    CHAT_TURN_TIMEOUT_MIN,
+                    CHAT_TURN_TIMEOUT_MAX,
+                ),
                 subagent_cost_gb=_safe_float(agent_data.get("subagent_cost_gb", 0.5), 0.5),
                 subagent_cpu_cost_cores=_safe_float(
                     agent_data.get("subagent_cpu_cost_cores", 1.0), 1.0
@@ -4460,6 +4523,12 @@ class KiroCrewConfig:
                 merge_queued_messages=dashboard_data.get("merge_queued_messages", False),
                 mcp_probe_timeout_secs=_safe_int(
                     dashboard_data.get("mcp_probe_timeout_secs", 15), 15
+                ),
+                loop_stall_exit_after_secs=_safe_int(
+                    dashboard_data.get("loop_stall_exit_after_secs", 25),
+                    25,
+                    LOOP_STALL_EXIT_AFTER_MIN,
+                    LOOP_STALL_EXIT_AFTER_MAX,
                 ),
                 auto_open_browser=dashboard_data.get("auto_open_browser", True),
                 quick_send=dashboard_data.get("quick_send", False),

--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -641,6 +641,26 @@ def note_slot_closed(state: "DashboardState", slot_name: str) -> float:
     return now
 
 
+def slot_closed_since(state: "DashboardState", slot_name: str, instant: float) -> bool:
+    """True when *slot_name*'s tab was closed at or after *instant*.
+
+    For any caller that snapshots session metadata, awaits, and then acts on
+    that snapshot. A close recorded during the await leaves the on-disk metadata
+    still reading *open* — the close handler pops the slot and calls
+    :func:`note_slot_closed` synchronously, but persists the ``closed`` flag
+    only after its own awaits (task cancellation, file lock) — so the snapshot
+    alone cannot see it. Consulting the tombstone after the last await closes
+    that window.
+
+    Unlike :func:`_tombstone_blocks` this asks a plain question about one slot
+    and does not weigh channel activity: callers that can be outrun by a newer
+    inbound message should use that instead.
+    """
+    closes = _RECENT_CLOSES.get(state) or {}
+    when = closes.get(slot_name)
+    return when is not None and when >= instant
+
+
 def _tombstone_blocks(state: "DashboardState", session: dict[str, Any]) -> bool:
     """True when an in-memory close tombstone suppresses surfacing *session*.
 

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -27,7 +27,6 @@ from kiro_crew.config.loader import (
     default_project_dir,
     resolve_agent_bindings,
 )
-from kiro_crew.constants import CHAT_TURN_TIMEOUT
 from kiro_crew.dashboard.channel_slots import note_slot_closed
 from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_orchestrator import _stage_loop
@@ -57,6 +56,7 @@ from kiro_crew.dashboard.state import (
     _ChatSlot,
     _mark_permission_resolved,
 )
+from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
 from kiro_crew.providers.acp import AcpProvider
 from kiro_crew.providers.base import LLMProvider
 from kiro_crew.safety_override import safety_override
@@ -533,13 +533,9 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
     except Exception:
         logger.debug("on_user_message observer raised; ignoring", exc_info=True)
 
-    task = asyncio.create_task(
-        asyncio.wait_for(_run_chat(state, slot, message), timeout=CHAT_TURN_TIMEOUT)
-    )
+    task = spawn_guarded_turn(state, slot, _run_chat(state, slot, message))
     slot.task = task
     slot._recovery_retrigger_count = 0
-    state._background_tasks.add(task)
-    task.add_done_callback(state._background_tasks.discard)
     state.push_slots_update()
 
     if ws_mode:

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -15,6 +15,7 @@ from kiro_crew import model_registry
 from kiro_crew.agent import kiro_agents_dir_path
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
+from kiro_crew.dashboard.channel_slots import slot_closed_since
 from kiro_crew.dashboard.chat_utils import (
     _history_key_for,
     _normalize_model,
@@ -326,6 +327,8 @@ def _rehydrate_slot_from_history(
     slot_name: str,
     *,
     kiro_model_map: dict[str, str] | None = None,
+    _prefetched_meta: dict | None = None,
+    _prefetched_messages: list[dict] | None = None,
 ) -> _ChatSlot | None:
     """Rehydrate a single dashboard slot from persisted history.
 
@@ -354,7 +357,16 @@ def _rehydrate_slot_from_history(
     if slot_name in state._slots:
         return state._slots[slot_name]
     history_key = _history_key_for(slot_name)
-    meta = state.conversation_log.get_metadata(history_key)
+    # ``_prefetched_*`` let an async caller hoist the two disk reads (this
+    # metadata line and the chained message walk further down) into a worker
+    # thread and then run the REST of this function on the event loop — see
+    # ``rehydrate_slot_from_history_async``. Slot construction below must stay
+    # loop-affine: it broadcasts through ``asyncio.Queue.put_nowait`` and
+    # ``Event.set``, neither of which is thread-safe. Omit them and the reads
+    # happen inline, which is what the synchronous callers want.
+    meta = _prefetched_meta if _prefetched_meta is not None else (
+        state.conversation_log.get_metadata(history_key)
+    )
     # No metadata → session was never persisted. Don't create a phantom slot.
     if not meta:
         return None
@@ -470,7 +482,11 @@ def _rehydrate_slot_from_history(
     # read_messages alone caps visible history at 200 lines from THIS file and
     # drops the ancestor chain — long-running forked sessions would lose 200+
     # messages of context on every gateway restart.
-    messages = state.conversation_log.read_messages_chained(history_key)
+    messages = (
+        _prefetched_messages
+        if _prefetched_messages is not None
+        else state.conversation_log.read_messages_chained(history_key)
+    )
     # Only the recent window is loaded into memory; older on-disk lines become
     # the FROZEN PREFIX that saves never rewrite. _disk_older_count must
     # therefore count those older lines so the save model preserves them.
@@ -544,6 +560,75 @@ def _rehydrate_slot_from_history(
     slot._dirty = False
     logger.info("Rehydrated session %s (%s) from history", slot_name, slot.title)
     return slot
+
+
+async def rehydrate_slot_from_history_async(
+    state: DashboardState,
+    slot_name: str,
+    *,
+    kiro_model_map: dict[str, str] | None = None,
+) -> _ChatSlot | None:
+    """:func:`_rehydrate_slot_from_history` with the disk reads off the loop.
+
+    Same contract and return values as the synchronous form, including
+    returning ``None`` for a session the user closed with ✕.
+
+    Why split rather than simply wrapping the whole thing in
+    ``asyncio.to_thread``: slot construction is loop-affine. It reaches
+    ``get_or_create_slot`` → ``push_slots_update`` → ``_broadcast``, which uses
+    ``asyncio.Queue.put_nowait`` and ``Event.set`` — neither thread-safe — and
+    ``_spawn_ws_send``'s ``ensure_future`` raises off-loop. That raise lands in
+    a broad ``except`` that marks every connected dashboard client dead and
+    drops it *without a close frame*, so browsers never reconnect and stop
+    receiving frames until a manual reload. ``restore_open_slots_async``
+    documents the same invariant.
+
+    So only the two reads move: the metadata line and the chained message walk,
+    which on a large session are tens of MB of read plus JSON parse. Everything
+    that touches slot state runs on the loop, as the synchronous callers do.
+    """
+    if not state.conversation_log:
+        return None
+    slot_name = _normalize_slot_key(slot_name)
+    if slot_name in state._slots:
+        return state._slots[slot_name]
+    history_key = _history_key_for(slot_name)
+    conv_log = state.conversation_log
+
+    def _read() -> tuple[dict | None, list[dict] | None, dict[str, str] | None]:
+        meta = conv_log.get_metadata(history_key)
+        if not meta or meta.get("closed"):
+            return None, None, None
+        return (
+            meta,
+            conv_log.read_messages_chained(history_key),
+            kiro_model_map if kiro_model_map is not None else _build_kiro_model_map(),
+        )
+
+    started = time.time()
+    meta, messages, model_map = await asyncio.to_thread(_read)
+    if meta is None or messages is None:
+        return None
+    # Tab-close race. The user can click ✕ while the read above is in flight.
+    # The close pops the slot and records a tombstone synchronously on the loop,
+    # but persists the ``closed`` flag only after its own awaits — so the
+    # metadata just read still says open, and rebuilding from it would re-create
+    # a tab the user dismissed and then fire a nudge turn into it. The tombstone
+    # is the authoritative signal in that window; the surface reconciler
+    # consults it after its own awaits for the same reason.
+    if slot_closed_since(state, slot_name, started):
+        logger.info(
+            "Rehydration abandoned: session %s was closed while its transcript loaded",
+            slot_name,
+        )
+        return None
+    return _rehydrate_slot_from_history(
+        state,
+        slot_name,
+        kiro_model_map=model_map,
+        _prefetched_meta=meta,
+        _prefetched_messages=messages,
+    )
 
 
 def _restore_recent_sessions_steps(

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -36,7 +36,6 @@ from kiro_crew.config.loader import (
     normalize_agent_model,
     resolve_agent_bindings,
 )
-from kiro_crew.constants import CHAT_TURN_TIMEOUT
 from kiro_crew.context_management import (
     ensure_go_all_option,
     looks_like_plan,
@@ -109,6 +108,7 @@ from kiro_crew.dashboard.state import (
     should_queue_refusal_recovery,
     unsafe_bash_reason,
 )
+from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import (
     HOOK_EVENT_AGENT_SPAWN,
@@ -2201,15 +2201,8 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
         ),
     )
 
-    task = asyncio.create_task(
-        asyncio.wait_for(
-            _run_chat(state, slot, next_msg),
-            timeout=CHAT_TURN_TIMEOUT,
-        )
-    )
+    task = spawn_guarded_turn(state, slot, _run_chat(state, slot, next_msg))
     slot.task = task
-    state._background_tasks.add(task)
-    task.add_done_callback(state._background_tasks.discard)
     return True
 
 
@@ -2241,13 +2234,17 @@ async def _run_pending_synthesis(state: DashboardState, slot: _ChatSlot) -> None
 
         # All delivery guards hold. Consume immediately before the turn begins.
         slot._pending_synthesis = False
-        synthesis_task = asyncio.create_task(
-            asyncio.wait_for(
-                _run_chat(state, slot, SUBAGENT_SYNTHESIS_PROMPT),
-                timeout=CHAT_TURN_TIMEOUT,
-            )
+        synthesis_task = spawn_guarded_turn(
+            state, slot, _run_chat(state, slot, SUBAGENT_SYNTHESIS_PROMPT)
         )
-        await synthesis_task
+        try:
+            await synthesis_task
+        except (asyncio.TimeoutError, TimeoutError):
+            # The ceiling fired; spawn_guarded_turn's callback already rendered
+            # the card naming the limit. Swallow here so the timeout does not
+            # also propagate into this function's caller, which dispatches
+            # fire-and-forget and would drop it unretrieved.
+            pass
     finally:
         slot._synthesis_inflight = False
 
@@ -5401,33 +5398,57 @@ async def _run_chat(
                 _autonudge.notify_turn_complete(slot.key)
         except Exception:
             logger.debug("autonudge.notify_turn_complete failed", exc_info=True)
-        # Clean up mirror stream on any exit path
-        if _mirror_stream_ts and state.slack_client and _mirror_chan:
-            try:
-                if _mirror_active_task:
-                    await state.slack_client.append_task(
-                        _mirror_chan,
-                        _mirror_stream_ts,
-                        _mirror_active_task,
-                        _mirror_active_task_title,
-                        "complete",
-                    )
-            except Exception:
-                logger.debug("Task append cleanup failed", exc_info=True)
-            try:
-                await state.slack_client.stop_stream(_mirror_chan, _mirror_stream_ts)
-            except Exception:
-                logger.debug("Stream cleanup failed", exc_info=True)
-        if _acquired:
-            if needs_session_reset:
+        # Clean up mirror stream on any exit path.
+        #
+        # The release below MUST happen however this block exits. Each await in
+        # here is already guarded against ``Exception``, but ``CancelledError``
+        # derives from ``BaseException`` (since 3.8), so a cancellation
+        # delivered while one of them is suspended slips past every
+        # ``except Exception`` and skips the release entirely.
+        #
+        # The permit is keyed by SESSION, so leaking it does not merely lose
+        # this turn: the session reads as permanently busy, every later turn for
+        # it blocks forever, no queued turn drains, and only a gateway restart
+        # clears it. The nested try/finally makes the release unconditional
+        # while preserving the reset-then-release ordering.
+        try:
+            if _mirror_stream_ts and state.slack_client and _mirror_chan:
+                try:
+                    if _mirror_active_task:
+                        await state.slack_client.append_task(
+                            _mirror_chan,
+                            _mirror_stream_ts,
+                            _mirror_active_task,
+                            _mirror_active_task_title,
+                            "complete",
+                        )
+                except Exception:
+                    logger.debug("Task append cleanup failed", exc_info=True)
+                try:
+                    await state.slack_client.stop_stream(_mirror_chan, _mirror_stream_ts)
+                except Exception:
+                    logger.debug("Stream cleanup failed", exc_info=True)
+            if _acquired and needs_session_reset:
                 try:
                     await state.sessions.reset(session_key)
                 except Exception:
                     logger.warning("Failed to reset session %s after agent switch", session_key)
-            state.sessions.release(session_key)
+        finally:
+            if _acquired:
+                # A successful reset() above already popped the key under its
+                # own lock, so this is a no-op on that path (the popped
+                # session's semaphore is discarded with it). Kept unconditional
+                # so a reset that failed or was cancelled still hands back the
+                # permit rather than stranding the session.
+                state.sessions.release(session_key)
         # End-of-turn fallback: catches set_project calls that fired mid-turn,
-        # after the start-of-turn consume already ran.
-        await _consume_pending_reset(state, slot)
+        # after the start-of-turn consume already ran. Guarded because a raise
+        # here would skip the steer requeue and queue drain below, silently
+        # stranding queued work at the end of an otherwise successful turn.
+        try:
+            await _consume_pending_reset(state, slot)
+        except Exception:
+            logger.debug("_consume_pending_reset failed", exc_info=True)
         # ── Requeue unconsumed steers ──
         # A steer handed to kiro-cli that never echoed steering_consumed dies
         # with the turn (stall-cancel, soft STOP, error, or a steer that raced

--- a/src/kiro_crew/dashboard/crash_dump_store.py
+++ b/src/kiro_crew/dashboard/crash_dump_store.py
@@ -130,6 +130,32 @@ def newest_dump_with_stacks(dumps_dir: Path | None = None) -> Path | None:
     return None
 
 
+def claim_dump_notification(dump_path: Path, dumps_dir: Path | None = None) -> bool:
+    """Claim the right to notify about *dump_path*, once per dump.
+
+    A dump stays on disk for up to a week and is re-detected on every gateway
+    start, so notifying unconditionally would turn one stall into a week of
+    identical alerts on every restart. The dump's own filename is the natural
+    idempotency key. Returns True the first time it is claimed, False after.
+
+    Best-effort: on any I/O failure it returns True (notify rather than go
+    silent about a crash), since a duplicate alert is a much cheaper failure
+    than a suppressed one.
+    """
+    try:
+        marker = (dumps_dir or get_dumps_dir()) / ".notified"
+        already = ""
+        if marker.is_file():
+            already = marker.read_text(encoding="utf-8", errors="replace").strip()
+        if already == dump_path.name:
+            return False
+        marker.write_text(dump_path.name + "\n", encoding="utf-8")
+        return True
+    except OSError:
+        logger.debug("crash-dump notification marker unavailable", exc_info=True)
+        return True
+
+
 def dump_age_seconds(dump_path: Path) -> float:
     """Return age of a dump file in seconds (never negative).
 

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -21,7 +21,6 @@ from kiro_crew.browser.setup import (
     has_playwright_extension,
     register_playwright_proxy,
 )
-from kiro_crew.constants import CHAT_TURN_TIMEOUT
 from kiro_crew.cron import CronStoreBusy
 from kiro_crew.dashboard.chat_persistence import _rehydrate_slot_from_history
 from kiro_crew.dashboard.chat_utils import _remove_queued_by_id
@@ -1195,17 +1194,11 @@ async def api_send_message(request: web.Request) -> web.Response:
                         # _find_prompt, _list_aim_prompts), so we can't import
                         # it at module top-level without a cycle.
                         from kiro_crew.dashboard.chat_runner import _run_chat
+                        from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
 
                         slot.append("inject", wrapped, inject_cls)
-                        task = asyncio.create_task(
-                            asyncio.wait_for(
-                                _run_chat(state, slot, wrapped),
-                                timeout=CHAT_TURN_TIMEOUT,
-                            )
-                        )
+                        task = spawn_guarded_turn(state, slot, _run_chat(state, slot, wrapped))
                         slot.task = task
-                        state._background_tasks.add(task)
-                        task.add_done_callback(state._background_tasks.discard)
                         state.push_slots_update()
                     sent_session = True
         # Fall back to normal delivery if no session target or session is gone

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -1045,6 +1045,17 @@ async def api_session_keepalive(request: web.Request) -> web.Response:
     except Exception as exc:
         logger.debug("touch_activity failed for %s: %s", session_key, exc)
         return web.json_response({"error": "touch failed"}, status=500)
+    # Also advance the session's own last_used clock. touch_activity() only
+    # refreshes the ACP runtime's activity timestamp, which feeds
+    # is_responsive()/the stall watchdog — the periodic idle sweep reads
+    # ``last_used`` instead, so without this a session blocking in a long
+    # `wait` still ages toward being reaped for idleness.
+    try:
+        touched = getattr(state.sessions, "touch", None)
+        if callable(touched):
+            touched(session_key)
+    except Exception:
+        logger.debug("last_used touch failed for %s", session_key, exc_info=True)
     return web.json_response({"ok": True})
 
 

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -42,6 +42,7 @@ from kiro_crew.dashboard import (
     ws,
 )
 from kiro_crew.dashboard.crash_dump_store import (
+    claim_dump_notification,
     dump_age_seconds,
     dump_replay_lines,
     newest_dump_with_stacks,
@@ -2778,7 +2779,17 @@ async def start_dashboard(
     # and startup warnings, rather than buried in interleaved stderr/journal.
     await asyncio.to_thread(rotate_dumps)
     _dump_file = await asyncio.to_thread(open_dump_file)
-    _loop_watchdog = LoopStallWatchdog(dump_file=_dump_file)
+    # exit_after is configurable because the right budget is host-dependent: a
+    # gateway doing heavy subprocess work (long builds, test suites, bursts of
+    # child reaping) can wedge the loop briefly without being genuinely dead,
+    # and a hard-coded 25s turned those into hard exits that lost in-flight
+    # work. The default is unchanged; the loader clamps the range.
+    try:
+        _exit_after = float(KiroCrewConfig.load().dashboard.loop_stall_exit_after_secs)
+    except Exception:
+        logger.debug("loop-stall exit budget config unavailable; using default", exc_info=True)
+        _exit_after = 25.0
+    _loop_watchdog = LoopStallWatchdog(dump_file=_dump_file, exit_after=_exit_after)
 
     async def _loop_heartbeat() -> None:
         # 5s (not 10s) so the watchdog's armed dump-then-exit timer is re-petted
@@ -2846,6 +2857,28 @@ async def start_dashboard(
                 if _truncated:
                     _replay_body += "\n  [truncated — full dump at above path]"
                 logger.warning("Replaying prior crash dump stacks:\n%s", _replay_body)
+            # A log line is not enough. This dump means the previous gateway
+            # exited by hard-exit: no `finally` ran, nothing was flushed, and any
+            # turn in flight lost work that was written but not yet committed.
+            # The user needs to know that happened rather than discovering a
+            # monitoring loop had silently stopped hours earlier. Claimed once
+            # per dump — the dump is re-detected for up to 7 days on every
+            # start, so notifying unconditionally would alert every restart.
+            if await asyncio.to_thread(claim_dump_notification, _prior_dump):
+                try:
+                    state.notify(
+                        "heartbeat",
+                        "⚠️ Gateway restarted after an event-loop stall",
+                        (
+                            f"The previous gateway stopped responding and exited "
+                            f"{_age_h:.1f}h ago, then restarted. Work in flight at "
+                            f"that moment was interrupted and not saved. Thread "
+                            f"stacks: {_prior_dump}"
+                        ),
+                        meta={"url": "/settings", "dump": str(_prior_dump)},
+                    )
+                except Exception:
+                    logger.debug("stall-exit notification failed", exc_info=True)
 
     # Fire background MCP probe at startup (non-blocking)
     asyncio.create_task(handlers._bg_mcp_probe())

--- a/src/kiro_crew/dashboard/turn_dispatch.py
+++ b/src/kiro_crew/dashboard/turn_dispatch.py
@@ -1,0 +1,220 @@
+"""Guarded dispatch for dashboard chat turns.
+
+Every chat turn runs under a wall-clock ceiling so a genuinely runaway turn
+cannot pin a session forever. That ceiling was correct; the way it fired was
+not. Each dispatch site wrapped the turn in ``asyncio.wait_for`` and attached
+exactly one done-callback — ``state._background_tasks.discard``, a ``set``
+method that ignores its argument's result. Nothing ever awaited the task or
+called ``.exception()``, so when the ceiling fired the resulting
+``TimeoutError`` was **never retrieved**: the turn simply stopped. No error
+card, no row in the session transcript, and no log line the user would think
+to look for — only a garbage-collection-time "Task exception was never
+retrieved" message, emitted whenever the collector happened to run.
+
+That made the failure indistinguishable from the agent going quiet. A babysit
+loop polling a pull request reaches the ceiling routinely — ten review rounds
+at roughly five minutes of waiting each, plus the tool time in between — so
+this was an ordinary outcome of long-running work, not a rare edge case, and
+its symptom was "the agent abandoned my PR without saying anything".
+
+This module owns the one dispatch path. Keeping the ceiling, the clamp against
+the transport's own timeout, and the visible-card guarantee together here is
+deliberate: they were previously re-derived at each of several call sites, so a
+new site could silently reintroduce the silent death by copying the old
+``add_done_callback(discard)`` shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from typing import Any
+
+from kiro_crew.acp.client import _DEFAULT_PROMPT_TIMEOUT
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.constants import CHAT_TURN_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+
+def _acp_prompt_ceiling() -> float:
+    """The transport's own per-prompt timeout.
+
+    A function rather than a bare constant reference so tests can substitute it
+    without reaching into ``acp.client``.
+    """
+    return float(_DEFAULT_PROMPT_TIMEOUT)
+
+
+def chat_turn_timeout_secs() -> float:
+    """Resolve the wall-clock ceiling for one chat turn.
+
+    Reads ``agent.chat_turn_timeout_secs``, falling back to
+    :data:`CHAT_TURN_TIMEOUT` when config is unavailable (tests, early
+    bootstrap) so a config-less context behaves exactly like a default config.
+
+    The value is clamped to the ACP transport's own prompt timeout. Configuring
+    a dashboard ceiling above it cannot take effect — the transport times out
+    first and the turn dies there instead — so accepting the larger number
+    would report a limit the system does not honour. The clamp is logged at
+    warning level so the misconfiguration is visible rather than silently
+    ignored.
+    """
+    try:
+        configured = float(KiroCrewConfig.load().agent.chat_turn_timeout_secs)
+    except Exception:
+        logger.debug("chat-turn ceiling config unavailable; using default", exc_info=True)
+        return CHAT_TURN_TIMEOUT
+    if configured <= 0:
+        # The ceiling is a runaway backstop and cannot be disabled; a
+        # non-positive value would make wait_for raise immediately.
+        return CHAT_TURN_TIMEOUT
+    acp_ceiling = _acp_prompt_ceiling()
+    if configured > acp_ceiling:
+        logger.warning(
+            "agent.chat_turn_timeout_secs=%.0fs exceeds the ACP prompt timeout "
+            "(%.0fs); clamping. The transport bounds the turn first, so the "
+            "larger value cannot take effect.",
+            configured,
+            acp_ceiling,
+        )
+        return acp_ceiling
+    return configured
+
+
+def format_turn_timeout_card(timeout_secs: float) -> str:
+    """User-facing text for a turn that hit the ceiling."""
+    if timeout_secs >= 3600:
+        limit = f"{timeout_secs / 3600:.1f}".rstrip("0").rstrip(".") + "-hour"
+    else:
+        limit = f"{max(1, round(timeout_secs / 60))}-minute"
+    return (
+        f"⏱️ This turn hit the {limit} limit and was stopped. Work already "
+        "written to disk is still there — nothing was rolled back. Send a "
+        "message to continue from where it stopped."
+    )
+
+
+def finish_turn_task(
+    state: Any,
+    slot: Any,
+    task: "asyncio.Task[Any]",
+    timeout_secs: float,
+) -> None:
+    """Retrieve *task*'s outcome so a ceiling hit becomes a visible card.
+
+    Replaces the bare ``state._background_tasks.discard`` callback. Still
+    discards, but also consumes the exception — which is what turns a silent
+    death into something the user can see.
+    """
+    state._background_tasks.discard(task)
+    if task.cancelled():
+        # Cooperative stop or shutdown. Already surfaced by _run_chat's own
+        # CancelledError handler; a second card would be noise.
+        return
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:  # pragma: no cover - racing cancellation
+        return
+    if exc is None:
+        return
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+        logger.warning(
+            "Chat turn in slot %s hit the %.0fs ceiling", getattr(slot, "key", "?"), timeout_secs
+        )
+        try:
+            # slot.append persists the card AND broadcasts it once; do not also
+            # broadcast_ws here or the UI renders a duplicate.
+            slot.append("error", format_turn_timeout_card(timeout_secs), "msg msg-err")
+            state.push_slots_update()
+        except Exception:
+            logger.debug("Failed to render turn-timeout card", exc_info=True)
+        return
+    # Anything else escaped _run_chat's own handler chain. Log it rather than
+    # let it die as an unretrieved task exception.
+    logger.error(
+        "Chat turn in slot %s failed: %s",
+        getattr(slot, "key", "?"),
+        exc,
+        exc_info=exc,
+    )
+
+
+async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -> Any:
+    """Run *coro* under a wall-clock ceiling, raising even on a suppressed deadline.
+
+    ``asyncio.wait_for`` cannot be used directly here. It cancels the coroutine
+    when the deadline fires and then re-raises whatever the coroutine did with
+    that cancellation — and ``_run_chat`` **catches** ``CancelledError``: it
+    flushes the partial assistant output and returns normally. The cancellation
+    is absorbed, ``wait_for`` hands back a value instead of raising, and the
+    caller cannot tell a turn that finished from one killed at the ceiling, so
+    the card this module promises never appears. (Same on 3.10's ``wait_for``
+    and on the 3.12 ``timeouts``-based rewrite: both only convert a
+    cancellation that actually propagates.)
+
+    So the deadline is armed here and recorded in ``deadline_fired``, which is
+    set ONLY by this function's own timer. That makes "was this turn cut?" an
+    observed fact rather than an inference from elapsed wall-clock: a clock
+    comparison would mislabel a turn that completed just under the deadline but
+    whose continuation was delayed by a congested loop, discarding a real
+    result. ``_run_chat``'s cancellation semantics are untouched — they are
+    shared with the user's Stop button.
+    """
+    loop = asyncio.get_running_loop()
+    task: "asyncio.Task[Any]" = asyncio.ensure_future(coro)
+    deadline_fired = False
+
+    def _on_deadline() -> None:
+        nonlocal deadline_fired
+        if not task.done():
+            deadline_fired = True
+            task.cancel()
+
+    handle = loop.call_later(timeout_secs, _on_deadline)
+    try:
+        try:
+            result = await task
+        except asyncio.CancelledError:
+            if deadline_fired:
+                # Our ceiling cut it and the turn let the cancellation through.
+                raise TimeoutError(
+                    f"turn exceeded the {timeout_secs:.0f}s ceiling"
+                ) from None
+            # Cancelled by something else (Stop button, shutdown) — propagate.
+            raise
+        if deadline_fired:
+            # The turn swallowed our cancellation and returned normally. This is
+            # the production path: without this the ceiling is silently absorbed.
+            raise TimeoutError(f"turn exceeded the {timeout_secs:.0f}s ceiling")
+        return result
+    finally:
+        handle.cancel()
+        if not task.done():
+            # The wrapper itself was cancelled; don't orphan the turn.
+            task.cancel()
+
+
+def spawn_guarded_turn(
+    state: Any,
+    slot: Any,
+    coro: "Coroutine[Any, Any, Any]",
+    *,
+    timeout_secs: float | None = None,
+) -> "asyncio.Task[Any]":
+    """Start *coro* as a ceiling-bounded turn whose failure is always visible.
+
+    Registers the task in ``state._background_tasks`` (so it is not garbage
+    collected mid-flight) and attaches :func:`finish_turn_task`, which both
+    deregisters it and consumes its exception.
+
+    Callers that also track the task (``slot.task``, a per-session map) should
+    keep doing so; this helper deliberately does not own those fields, because
+    they carry site-specific stop/steer semantics.
+    """
+    timeout = chat_turn_timeout_secs() if timeout_secs is None else timeout_secs
+    task = asyncio.create_task(_bounded_turn(coro, timeout))
+    state._background_tasks.add(task)
+    task.add_done_callback(lambda t: finish_turn_task(state, slot, t, timeout))
+    return task

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -3324,6 +3324,24 @@ class SessionManager:
         session = self._sessions.get(key)
         return bool(session and session.semaphore.locked())
 
+    def touch(self, key: str) -> bool:
+        """Mark *key* as recently used so the idle sweep does not reap it.
+
+        ``last_used`` is otherwise only bumped by ``get_or_create()``, which a
+        dashboard turn calls exactly once — so a session doing continuous work
+        across a long turn ages as if it were idle (see the module docstring's
+        known limitation). The ``wait`` tool's keepalive previously refreshed
+        only the ACP runtime's activity clock, which feeds ``is_responsive()``
+        and nothing else, leaving the idle sweep's clock untouched.
+
+        Returns True if a session existed for *key*.
+        """
+        session = self._sessions.get(self._fold_key(key))
+        if session is None:
+            return False
+        session.last_used = time.monotonic()
+        return True
+
     def enqueue(
         self, key: str, msg_ts: str, text: str, *, force: bool = False, **kwargs: object
     ) -> bool:
@@ -4044,6 +4062,16 @@ class SessionManager:
                 if key.startswith(_CHANNEL_PREFIX):
                     continue
                 total_checked += 1
+                # A turn in flight is never idle, whatever the clock says.
+                # ``last_used`` is only bumped by get_or_create(), which a
+                # dashboard turn calls exactly once, so a turn running longer
+                # than timeout_secs looks idle to the arithmetic below — and the
+                # orphan branch ignores the clock entirely, so a closed tab
+                # would reap a live turn immediately. Mirrors the same guard in
+                # _rss_threshold_check; reset() re-checks atomically under its
+                # own lock via skip_if_busy for the collect→reset race.
+                if sess.semaphore.locked():
+                    continue
                 idle = now - sess.last_used > timeout_secs
                 orphaned = (
                     key.startswith("dashboard:")
@@ -4057,9 +4085,6 @@ class SessionManager:
         elif total_checked:
             logger.debug("Idle sweep: %d checked, 0 expired", total_checked)
         for key, is_orphan in expired:
-            # NOTE: Small TOCTOU window — slot could be re-activated between
-            # orphan check (under lock) and reset() here. Accepted as benign:
-            # worst case is session re-created on next user interaction.
             if is_orphan:
                 logger.warning("Expiring orphaned dashboard session (slot gone): %s", key)
             else:
@@ -4081,4 +4106,12 @@ class SessionManager:
             # Use reset() instead of remove() to preserve session_map entry.
             # The kiro-cli session file persists on disk — next get_or_create
             # can try session/load to restore full conversation history.
-            await self.reset(key)
+            #
+            # skip_if_busy closes the collect→reset window: a turn that starts
+            # after the collection loop released the lock must not be cut
+            # mid-stream. reset() evaluates it atomically with its own pop.
+            if not await self.reset(key, skip_if_busy=True):
+                logger.info(
+                    "Idle sweep: %s became busy before reset — left running",
+                    key,
+                )

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -79,6 +79,7 @@ from kiro_crew.context_management import summarize_result
 from kiro_crew.cron import CronJob, CronService, CronStoreBusy, build_cron_session_context
 from kiro_crew.cron_script import resolve_script_path, run_command_sandboxed, run_script_sandboxed
 from kiro_crew.dashboard import start_dashboard
+from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
 from kiro_crew.dashboard.chat_runner import _run_chat
 from kiro_crew.dashboard.cron_inject import inject_cron_result_to_dashboard
 from kiro_crew.dashboard.handlers import MAX_PROMPT_BYTES
@@ -99,6 +100,7 @@ from kiro_crew.dashboard.origin import (
 from kiro_crew.dashboard.stale_asset_watchdog import run_stale_asset_watchdog
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.dashboard.token_auth import MAX_SESSION_TTL_SECS, generate_token
+from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
 from kiro_crew.discord.gateway import maybe_start_discord
 from kiro_crew.embeddings import (
     embedding_model_is_custom,
@@ -1646,15 +1648,12 @@ class GatewayOrchestrator:
                             slot.append("queued", wrapped, json.dumps(_cls))
                         else:
                             slot.append("inject", wrapped, inject_cls)
-                            task = asyncio.create_task(
-                                asyncio.wait_for(
-                                    _run_chat(self.dashboard_state, slot, wrapped),
-                                    timeout=CHAT_TURN_TIMEOUT,
-                                )
+                            task = spawn_guarded_turn(
+                                self.dashboard_state,
+                                slot,
+                                _run_chat(self.dashboard_state, slot, wrapped),
                             )
                             slot.task = task
-                            self.dashboard_state._background_tasks.add(task)
-                            task.add_done_callback(self.dashboard_state._background_tasks.discard)
                         self.dashboard_state.push_slots_update()
                     else:
                         self.dashboard_state.notify(
@@ -3000,6 +2999,114 @@ class GatewayOrchestrator:
             logger.exception("AutoNudge: discord nudge failed for %s (loop %s)", key, loop.id)
             return False
 
+    async def _fire_dashboard_nudge(self, loop: NudgeLoop) -> bool:
+        """Drive one nudge turn in a dashboard chat slot.
+
+        Sibling of :meth:`_fire_slack_nudge` / :meth:`_fire_discord_nudge`; a
+        named method rather than an inline branch so the slot-resolution
+        contract below is directly testable.
+
+        Returns True if the nudge was dispatched, False if skipped (dashboard
+        not ready, session genuinely gone, or a turn still active). The service
+        only counts dispatched cycles toward ``max_cycles``.
+        """
+        # Guard (not assert): stripped under -O; also _init_autonudge() can
+        # run before _init_dashboard(), and _init_dashboard is skipped
+        # entirely in --no-dashboard mode. Mirrors _observer's guard.
+        if self.dashboard_state is None:
+            logger.warning("AutoNudge: dashboard not ready — skipping fire for loop %s", loop.id)
+            return False
+        # Slot resolution mirrors the cron→origin delivery contract in
+        # dashboard/handlers/messaging.py: get_slot() is the hot path, and a
+        # miss falls back to restoring the session from its persisted history
+        # rather than assuming it is gone. A miss is NOT evidence of a dead
+        # session — the in-memory registry is empty for any tab the user has
+        # navigated away from, and it is empty for EVERY slot immediately
+        # after a gateway restart (AutoNudgeService.start() re-arms timers
+        # before the dashboard has restored its slots). Removing the loop here
+        # deleted a live babysit loop on nothing more than a cold cache, which
+        # silently abandoned the PR it was watching.
+        #
+        # Rehydration deliberately does NOT resurrect a session the user
+        # dismissed with ✕ (closed=true in the history metadata) — that is the
+        # documented "respect the close" rule, and returning None for it is
+        # correct. Only a genuinely unreachable session retires the loop.
+        slot = self.dashboard_state.get_slot(loop.slot_key)
+        if slot is None:
+            # Rehydration reads the session's persisted transcript and replays
+            # its window. Real sessions reach tens of MB, so the reads must not
+            # run on the event loop: the gateway serves every request, turn and
+            # the stall-watchdog heartbeat on one thread, and a fire here is a
+            # timer callback. The async form hoists ONLY the reads to a worker
+            # thread and builds the slot back on the loop, because slot
+            # construction broadcasts through asyncio primitives that are not
+            # thread-safe.
+            slot = await rehydrate_slot_from_history_async(
+                self.dashboard_state, loop.slot_key
+            )
+            if slot is None:
+                logger.warning(
+                    "AutoNudge: session %s unreachable (no history, deleted, or "
+                    "closed by the user) — removing loop %s",
+                    loop.slot_key,
+                    loop.id,
+                )
+                await self.autonudge_svc.remove(loop.id)  # type: ignore[union-attr]
+                return False
+            logger.info(
+                "AutoNudge: rehydrated session %s from history for loop %s",
+                loop.slot_key,
+                loop.id,
+            )
+        msg = render_nudge_message(loop.message, loop.stop_sentinel_path)
+        tagged = f"[auto-nudge cycle {loop.cycle_count + 1}]\n{msg}"
+        from kiro_crew.dashboard.chat import (
+            _run_chat,  # circular import: gateway -> dashboard.chat -> gateway (chat dispatch references GatewayOrchestrator)
+        )
+
+        if slot.running:
+            # Turn still active — drop this nudge. Next idle-timer tick will
+            # schedule again once the turn ends. Queueing would stack
+            # identical 3KB+ nudges and blow up the context window.
+            # Returning False keeps cycle_count accurate (only delivered
+            # nudges count toward max_cycles).
+            logger.info(
+                "AutoNudge skip: slot %s is running (loop %s cycle %d)",
+                slot.key,
+                loop.id,
+                loop.cycle_count,
+            )
+            return False
+        # Show nudge as a distinct "nudge" role message in the slot history.
+        # The structured meta lets the dashboard render a compact cycle chip
+        # instead of echoing the whole instruction payload as a chat bubble.
+        # The tag stays in ``content`` because that is what the model reads,
+        # and the body is deliberately NOT duplicated into meta — the client
+        # derives it from content, so a multi-KB payload is stored and
+        # broadcast once rather than twice.
+        slot.append(
+            "nudge",
+            tagged,
+            "msg msg-nudge",
+            meta={
+                "nudge": {
+                    "cycle": loop.cycle_count + 1,
+                    "loop_id": loop.id,
+                }
+            },
+        )
+        task = spawn_guarded_turn(
+            self.dashboard_state,
+            slot,
+            _run_chat(self.dashboard_state, slot, tagged),
+        )
+        # Mirror dashboard /api/chat/send path so slot.running == True and sidebar
+        # shows the "turn active" three-dots indicator immediately.
+        slot.task = task
+        self._session_tasks[slot.key] = task
+        self.dashboard_state.push_slots_update()
+        return True
+
     async def _init_autonudge(self) -> None:
         """Initialize and start the auto-nudge service (feature-flagged)."""
         if not autonudge_enabled():
@@ -3030,72 +3137,7 @@ class GatewayOrchestrator:
                 )
                 await self.autonudge_svc.remove(loop.id)  # type: ignore[union-attr]
                 return False
-            # Guard (not assert): stripped under -O; also _init_autonudge() can
-            # run before _init_dashboard(), and _init_dashboard is skipped
-            # entirely in --no-dashboard mode. Mirrors _observer's guard below.
-            if self.dashboard_state is None:
-                logger.warning(
-                    "AutoNudge: dashboard not ready — skipping fire for loop %s", loop.id
-                )
-                return False
-            slot = self.dashboard_state._slots.get(loop.slot_key)
-            if slot is None:
-                logger.warning(
-                    "AutoNudge: slot %s missing — removing loop %s", loop.slot_key, loop.id
-                )
-                await self.autonudge_svc.remove(loop.id)  # type: ignore[union-attr]
-                return False
-            msg = render_nudge_message(loop.message, loop.stop_sentinel_path)
-            tagged = f"[auto-nudge cycle {loop.cycle_count + 1}]\n{msg}"
-            from kiro_crew.dashboard.chat import (
-                _run_chat,  # circular import: gateway -> dashboard.chat -> gateway (chat dispatch references GatewayOrchestrator)
-            )
-
-            if slot.running:
-                # Turn still active — drop this nudge. Next idle-timer tick will
-                # schedule again once the turn ends. Queueing would stack
-                # identical 3KB+ nudges and blow up the context window.
-                # Returning False keeps cycle_count accurate (only delivered
-                # nudges count toward max_cycles).
-                logger.info(
-                    "AutoNudge skip: slot %s is running (loop %s cycle %d)",
-                    slot.key,
-                    loop.id,
-                    loop.cycle_count,
-                )
-                return False
-            # Show nudge as a distinct "nudge" role message in the slot history.
-            # The structured meta lets the dashboard render a compact cycle chip
-            # instead of echoing the whole instruction payload as a chat bubble.
-            # The tag stays in ``content`` because that is what the model reads,
-            # and the body is deliberately NOT duplicated into meta — the client
-            # derives it from content, so a multi-KB payload is stored and
-            # broadcast once rather than twice.
-            slot.append(
-                "nudge",
-                tagged,
-                "msg msg-nudge",
-                meta={
-                    "nudge": {
-                        "cycle": loop.cycle_count + 1,
-                        "loop_id": loop.id,
-                    }
-                },
-            )
-            task = asyncio.create_task(
-                asyncio.wait_for(
-                    _run_chat(self.dashboard_state, slot, tagged),
-                    timeout=CHAT_TURN_TIMEOUT,
-                )
-            )
-            # Mirror dashboard /api/chat/send path so slot.running == True and sidebar
-            # shows the "turn active" three-dots indicator immediately.
-            slot.task = task
-            self.dashboard_state._background_tasks.add(task)
-            task.add_done_callback(self.dashboard_state._background_tasks.discard)
-            self._session_tasks[slot.key] = task
-            self.dashboard_state.push_slots_update()
-            return True
+            return await self._fire_dashboard_nudge(loop)
 
         def _observer(event: str, loop: NudgeLoop | None) -> None:
             if event == "expired" and loop is not None:

--- a/test/test_autonudge_dashboard_fire.py
+++ b/test/test_autonudge_dashboard_fire.py
@@ -1,0 +1,214 @@
+"""Tests for the dashboard auto-nudge fire path.
+
+The defect these pin: the fire path resolved its slot with a bare in-memory
+dict lookup and, on a miss, deleted the loop from ``autonudge.json``. A miss is
+not evidence of a dead session — the registry is empty for any tab the user has
+navigated away from, and empty for EVERY slot immediately after a gateway
+restart, because ``AutoNudgeService.start()`` re-arms timers before the
+dashboard has restored its slots. So closing a browser tab or restarting the
+gateway permanently destroyed a babysit loop, silently abandoning the pull
+request it was watching.
+
+The cron origin-injection path already had the correct behaviour (rehydrate from
+persisted history, and respect a tab the user explicitly closed); this brings
+the nudge path onto the same contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.autonudge import NudgeLoop
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.slack import gateway as gw
+
+
+def _loop(slot_key: str = "chat-1-1785") -> NudgeLoop:
+    return NudgeLoop(
+        id="loop-abc",
+        slot_key=slot_key,
+        message="check the PR",
+        idle_secs=300,
+        max_cycles=24,
+        cycle_count=3,
+    )
+
+
+def _slot(key: str = "chat-1-1785", *, running: bool = False) -> MagicMock:
+    slot = MagicMock()
+    slot.key = key
+    slot.running = running
+    return slot
+
+
+def _orchestrator() -> gw.GatewayOrchestrator:
+    cfg = KiroCrewConfig()
+    with patch.object(cfg, "load_credentials", return_value={"KIROCREW_OWNER_ID": "U_OWNER"}):
+        orch = gw.GatewayOrchestrator(cfg, no_dashboard=True, no_crons=True, no_open=True)
+    orch.dashboard_state = SimpleNamespace(
+        get_slot=MagicMock(return_value=None),
+        push_slots_update=MagicMock(),
+        _background_tasks=set(),
+    )
+    orch.autonudge_svc = MagicMock()
+    orch.autonudge_svc.remove = AsyncMock()
+    orch._session_tasks = {}
+    return orch
+
+
+def _fake_spawn():
+    """Stand-in for ``spawn_guarded_turn`` that does not run the turn.
+
+    Closes the coroutine it is handed so the test never leaks a pending
+    coroutine (which would surface as a RuntimeWarning rather than a failure).
+    """
+    calls: list[object] = []
+
+    def _spawn(state, slot, coro, **kwargs):
+        coro.close()
+        calls.append(slot)
+        return MagicMock(name="turn-task")
+
+    _spawn.calls = calls  # type: ignore[attr-defined]
+    return _spawn
+
+
+class TestDashboardNudgeSlotResolution:
+    @pytest.mark.asyncio
+    async def test_cold_slot_is_rehydrated_and_the_turn_runs(self) -> None:
+        """The headline fix: a loop must survive a closed browser tab / restart."""
+        orch = _orchestrator()
+        loop = _loop()
+        restored = _slot()
+        spawn = _fake_spawn()
+        with (
+            patch.object(
+                gw, "rehydrate_slot_from_history_async",
+                new=AsyncMock(return_value=restored),
+            ) as rehydrate,
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            patch("kiro_crew.dashboard.chat._run_chat", new=AsyncMock()),
+        ):
+            assert await orch._fire_dashboard_nudge(loop) is True
+        rehydrate.assert_awaited_once_with(orch.dashboard_state, loop.slot_key)
+        orch.autonudge_svc.remove.assert_not_awaited()
+        assert spawn.calls == [restored], "the nudge turn did not run in the restored slot"
+        assert orch._session_tasks[restored.key] is restored.task
+
+    @pytest.mark.asyncio
+    async def test_rehydration_uses_the_loop_affine_async_form(self) -> None:
+        """Reads go off-loop; slot construction must stay ON the loop.
+
+        Wrapping the whole rehydration in ``asyncio.to_thread`` looks equivalent
+        but is not: slot construction broadcasts through
+        ``asyncio.Queue.put_nowait`` / ``Event.set`` and ``ensure_future``, none
+        of which are thread-safe. Off-loop that raises inside a broad ``except``
+        that marks every connected dashboard client dead and drops it without a
+        close frame, so browsers stop receiving frames — including the output of
+        the very nudge turn this fix exists to run.
+        """
+        orch = _orchestrator()
+        loop = _loop()
+        restored = _slot()
+        spawn = _fake_spawn()
+        with (
+            patch.object(
+                gw, "rehydrate_slot_from_history_async", new=AsyncMock(return_value=restored)
+            ) as rehydrate,
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            patch("kiro_crew.dashboard.chat._run_chat", new=AsyncMock()),
+        ):
+            assert await orch._fire_dashboard_nudge(loop) is True
+        rehydrate.assert_awaited_once_with(orch.dashboard_state, loop.slot_key)
+        assert spawn.calls == [restored]
+
+    @pytest.mark.asyncio
+    async def test_fire_does_not_touch_the_startup_restore_flag(self) -> None:
+        """``restoring_open_slots`` is owned by the startup restore.
+
+        A nudge fire that set and then unconditionally cleared it could clear it
+        mid-restore — re-enabling the periodic flush and letting a partial slot
+        snapshot be persisted, which loses open tabs. The flag only existed to
+        fence the thread hop, so it goes with the hop.
+        """
+        orch = _orchestrator()
+        orch.dashboard_state.restoring_open_slots = True  # pretend a restore is running
+        with (
+            patch.object(
+                gw, "rehydrate_slot_from_history_async", new=AsyncMock(return_value=_slot())
+            ),
+            patch.object(gw, "spawn_guarded_turn", _fake_spawn()),
+            patch("kiro_crew.dashboard.chat._run_chat", new=AsyncMock()),
+        ):
+            await orch._fire_dashboard_nudge(_loop())
+        assert orch.dashboard_state.restoring_open_slots is True, (
+            "the nudge fire cleared a flag the startup restore owns"
+        )
+
+    @pytest.mark.asyncio
+    async def test_hot_slot_skips_rehydration(self) -> None:
+        """get_slot stays the fast path; rehydration is only the miss fallback."""
+        orch = _orchestrator()
+        live = _slot()
+        orch.dashboard_state.get_slot = MagicMock(return_value=live)
+        spawn = _fake_spawn()
+        with (
+            patch.object(
+                gw, "rehydrate_slot_from_history_async", new=AsyncMock()
+            ) as rehydrate,
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            patch("kiro_crew.dashboard.chat._run_chat", new=AsyncMock()),
+        ):
+            assert await orch._fire_dashboard_nudge(_loop()) is True
+        rehydrate.assert_not_awaited()
+        assert spawn.calls == [live]
+
+    @pytest.mark.asyncio
+    async def test_unreachable_session_retires_the_loop_once_with_a_reason(
+        self, caplog
+    ) -> None:
+        """A genuinely gone session (deleted, or closed with ✕) still retires."""
+        orch = _orchestrator()
+        loop = _loop()
+        spawn = _fake_spawn()
+        with (
+            patch.object(
+                gw, "rehydrate_slot_from_history_async", new=AsyncMock(return_value=None)
+            ),
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            caplog.at_level(logging.WARNING, logger=gw.logger.name),
+        ):
+            assert await orch._fire_dashboard_nudge(loop) is False
+        orch.autonudge_svc.remove.assert_awaited_once_with(loop.id)
+        assert spawn.calls == []
+        assert loop.slot_key in caplog.text
+        assert "unreachable" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_running_slot_skips_without_retiring_the_loop(self) -> None:
+        """A turn in flight defers the cycle; it must not count or destroy."""
+        orch = _orchestrator()
+        loop = _loop()
+        before = loop.cycle_count
+        orch.dashboard_state.get_slot = MagicMock(return_value=_slot(running=True))
+        spawn = _fake_spawn()
+        with (
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            patch("kiro_crew.dashboard.chat._run_chat", new=AsyncMock()),
+        ):
+            assert await orch._fire_dashboard_nudge(loop) is False
+        orch.autonudge_svc.remove.assert_not_awaited()
+        assert spawn.calls == []
+        assert loop.cycle_count == before
+
+    @pytest.mark.asyncio
+    async def test_dashboard_not_ready_skips_without_retiring_the_loop(self) -> None:
+        """_init_autonudge can run before the dashboard exists, or with none."""
+        orch = _orchestrator()
+        orch.dashboard_state = None
+        assert await orch._fire_dashboard_nudge(_loop()) is False
+        orch.autonudge_svc.remove.assert_not_awaited()

--- a/test/test_chat_turn_timeout_consistency.py
+++ b/test/test_chat_turn_timeout_consistency.py
@@ -26,6 +26,7 @@ loudly when a future contributor adds a new bare dispatch site.
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 # Source files known to contain ``_run_chat`` dispatches.  When a new
@@ -72,53 +73,59 @@ def test_cap_value_is_seven_thousand_two_hundred() -> None:
 
 
 def _find_create_task_dispatches(path: Path) -> list[tuple[int, str]]:
-    """Return ``[(line_no, body_text)]`` for every ``asyncio.create_task(...)``
-    call body in *path*.
+    """Return ``[(line_no, body_text)]`` for every dispatch call body in *path*.
+
+    Two dispatch forms exist and both must be counted:
+
+    * ``spawn_guarded_turn(state, slot, _run_chat(...))`` — the preferred form.
+      The helper owns the ceiling AND retrieves the resulting exception, so a
+      turn that hits the ceiling renders a card instead of vanishing.
+    * ``asyncio.create_task(asyncio.wait_for(_run_chat(...), timeout=...))`` —
+      the older inline form, still used by the two gateway sites that attach
+      their own done-callback to consume the exception.
 
     Why a hand-rolled balanced-paren scan instead of regex: nested call
-    expressions like ``create_task(asyncio.wait_for(_run_chat(...)))`` go
-    three levels deep with embedded commas, which regex does not handle
-    cleanly. We tokenize ``(`` / ``)`` until the depth returns to zero.
+    expressions go three levels deep with embedded commas, which regex does not
+    handle cleanly. We tokenize ``(`` / ``)`` until the depth returns to zero.
     """
     text = path.read_text(encoding="utf-8")
     out: list[tuple[int, str]] = []
-    i = 0
-    while True:
-        idx = text.find("asyncio.create_task(", i)
-        if idx < 0:
-            break
-        # Position cursor after the opening paren we just found.
-        body_start = idx + len("asyncio.create_task(")
-        depth = 1
-        cursor = body_start
-        while cursor < len(text) and depth > 0:
-            ch = text[cursor]
-            if ch == "(":
-                depth += 1
-            elif ch == ")":
-                depth -= 1
-            cursor += 1
-        # cursor now sits one past the matching close paren; -1 to exclude it
-        body = text[body_start : cursor - 1]
-        line_no = text[:idx].count("\n") + 1
-        out.append((line_no, body))
-        i = cursor
+    for opener in ("asyncio.create_task(", "spawn_guarded_turn("):
+        i = 0
+        while True:
+            idx = text.find(opener, i)
+            if idx < 0:
+                break
+            # Position cursor after the opening paren we just found.
+            body_start = idx + len(opener)
+            depth = 1
+            cursor = body_start
+            while cursor < len(text) and depth > 0:
+                ch = text[cursor]
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                cursor += 1
+            # cursor now sits one past the matching close paren; -1 to exclude it
+            body = text[body_start : cursor - 1]
+            line_no = text[:idx].count("\n") + 1
+            out.append((line_no, body))
+            i = cursor
     return out
 
 
 def test_no_bare_run_chat_dispatch_in_source() -> None:
-    """Static guard: every ``asyncio.create_task(_run_chat(...))`` in the
-    dashboard / slack / handler layer must be wrapped in ``asyncio.wait_for``.
+    """Static guard: no ``_run_chat`` dispatch may run unbounded.
 
-    Catches regressions where a future contributor adds a new dispatch site
-    without the wrap.  The check is intentionally simple: if the FIRST
-    expression inside ``create_task(`` is ``_run_chat(``, that's a bare
-    dispatch.
+    A bare ``asyncio.create_task(_run_chat(...))`` has no wall-clock ceiling at
+    the dashboard layer at all. Catches regressions where a future contributor
+    adds a new dispatch site without either wrapping it or routing it through
+    ``spawn_guarded_turn``.
 
-    This test has already paid for itself once: during the rebase of this CR
-    onto ``origin/beta-braveheart`` it caught a 7th dispatch site
-    (``_deliver_script_result`` in ``slack/gateway.py``) that had landed on
-    the base branch and would otherwise have shipped unwrapped.
+    This test has already paid for itself once: during an earlier rebase it
+    caught a dispatch site that had landed on the base branch and would
+    otherwise have shipped unwrapped.
     """
     src_root = _src_root()
 
@@ -131,26 +138,25 @@ def test_no_bare_run_chat_dispatch_in_source() -> None:
                 offenders.append(f"{rel_path}:{line_no}")
 
     assert not offenders, (
-        "Found bare _run_chat dispatch(es) without CHAT_TURN_TIMEOUT wrapping:\n  "
+        "Found bare _run_chat dispatch(es) with no turn ceiling:\n  "
         + "\n  ".join(offenders)
-        + "\n\nWrap with asyncio.wait_for(_run_chat(...), timeout=CHAT_TURN_TIMEOUT)."
+        + "\n\nRoute it through spawn_guarded_turn(state, slot, _run_chat(...))."
     )
 
 
-def test_every_run_chat_dispatch_uses_chat_turn_timeout() -> None:
-    """Positive guard: every ``_run_chat`` invocation inside a ``create_task``
-    must reference ``CHAT_TURN_TIMEOUT`` within the same call body.
+def test_every_run_chat_dispatch_is_ceiling_bounded() -> None:
+    """Positive guard: every dispatch is bounded by the shared ceiling.
 
-    This complements ``test_no_bare_run_chat_dispatch_in_source``:
+    A dispatch qualifies either by going through ``spawn_guarded_turn`` (which
+    resolves the ceiling itself, clamps it against the transport timeout, and
+    consumes the exception so a ceiling hit is visible) or by an inline
+    ``wait_for`` that references ``CHAT_TURN_TIMEOUT`` rather than a
+    hard-coded number.
 
-    - The "no bare" test ensures no dispatch is bare — but a future
-      contributor could technically wrap with ``wait_for(timeout=600)`` and
-      pass that test.
-    - This test ensures the wrap actually uses the shared constant, not a
-      hard-coded value.
-
-    Together they pin: every dispatch is wrapped AND every wrap uses the
-    shared cap.
+    This complements ``test_no_bare_run_chat_dispatch_in_source``: that test
+    ensures no dispatch is bare, while this one ensures the bound is the shared
+    one. A contributor could otherwise wrap with ``wait_for(timeout=600)`` and
+    pass the first test.
     """
     src_root = _src_root()
 
@@ -160,29 +166,115 @@ def test_every_run_chat_dispatch_uses_chat_turn_timeout() -> None:
         for line_no, body in _find_create_task_dispatches(path):
             if "_run_chat(" not in body:
                 continue
+            # spawn_guarded_turn bodies do not name the constant; the helper
+            # resolves it. Identify them by the absence of an inner wait_for.
+            if "asyncio.wait_for(" not in body:
+                continue
             if "CHAT_TURN_TIMEOUT" not in body:
                 offenders.append(f"{rel_path}:{line_no}")
 
     assert not offenders, (
-        "Found _run_chat dispatch(es) wrapped without CHAT_TURN_TIMEOUT:\n  "
+        "Found _run_chat dispatch(es) wrapped without the shared ceiling:\n  "
         + "\n  ".join(offenders)
-        + "\n\nUse asyncio.wait_for(_run_chat(...), timeout=CHAT_TURN_TIMEOUT) "
-        + "so all dispatches share the same outer cap."
+        + "\n\nUse spawn_guarded_turn(...), or wait_for(..., timeout=CHAT_TURN_TIMEOUT)."
     )
+
+
+def test_dispatch_sites_consume_their_exception() -> None:
+    """Every dispatch must have something that retrieves the task's outcome.
+
+    This is the regression that made long turns die silently: a task whose only
+    done-callback was ``state._background_tasks.discard`` never had its
+    ``TimeoutError`` retrieved, so hitting the ceiling produced no error card
+    and no log the user would find — it surfaced only as a
+    garbage-collection-time "Task exception was never retrieved" line.
+
+    ``spawn_guarded_turn`` satisfies this by construction. An inline
+    ``create_task`` site must attach its own callback that calls
+    ``.exception()``; a site whose sole callback is the bare ``discard`` is the
+    exact shape of the original defect.
+
+    Uses the AST rather than a line window because a done-callback may be
+    defined either above or below the dispatch it is attached to — a
+    directional text scan gets the answer wrong depending on local style.
+    """
+    src_root = _src_root()
+
+    offenders: list[str] = []
+    for rel_path in _DISPATCH_FILES:
+        tree = ast.parse((src_root / rel_path).read_text(encoding="utf-8"))
+        # Map each function to its enclosing-function chain so a nested
+        # dispatch can see a callback defined in an outer scope.
+        for func in _iter_functions(tree):
+            inline_sites = [
+                node
+                for node in ast.walk(func)
+                if _is_inline_wrapped_run_chat_dispatch(node)
+            ]
+            if not inline_sites:
+                continue
+            consumes = any(
+                isinstance(n, ast.Attribute) and n.attr == "exception"
+                for n in ast.walk(func)
+            )
+            if not consumes:
+                offenders.extend(f"{rel_path}:{s.lineno}" for s in inline_sites)
+
+    # A nested function is walked both on its own and as part of its parent, so
+    # the same site can be recorded twice; report each once.
+    offenders = sorted(set(offenders))
+    assert not offenders, (
+        "Found _run_chat dispatch(es) whose exception is never retrieved — a "
+        "turn that hits the ceiling there dies with no error card:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nRoute it through spawn_guarded_turn(...), which consumes the "
+        "outcome and renders a card naming the limit."
+    )
+
+
+def _iter_functions(tree: ast.AST):
+    """Yield every function/coroutine definition in *tree*, outermost first."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _calls_named(node: ast.AST, name: str) -> bool:
+    """True if *node* is a call whose callee ends in *name*."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == name
+    if isinstance(func, ast.Attribute):
+        return func.attr == name
+    return False
+
+
+def _is_inline_wrapped_run_chat_dispatch(node: ast.AST) -> bool:
+    """True for ``create_task(wait_for(_run_chat(...)))`` — the inline form.
+
+    ``spawn_guarded_turn`` sites are excluded: the helper consumes the
+    exception itself, which is the whole point of routing through it.
+    """
+    if not _calls_named(node, "create_task"):
+        return False
+    subtree = list(ast.walk(node))
+    has_run_chat = any(_calls_named(n, "_run_chat") for n in subtree)
+    has_wait_for = any(_calls_named(n, "wait_for") for n in subtree)
+    return has_run_chat and has_wait_for
 
 
 def test_dispatch_site_count_matches_expectation() -> None:
     """Pin the expected number of ``_run_chat`` dispatch sites at 8.
 
-    The CR description enumerates the sites (the eighth is the post-fan-out
-    synthesis turn in ``chat_runner.py``). If a new dispatch lands (or one is
-    removed), this test fails loudly so the contributor updates the CR
-    description, the spec doc (``learn-cron-dashboard.md``), and the other
-    tests in this module.
+    If a new dispatch lands (or one is removed), this fails loudly so the
+    contributor updates the PR description, the spec doc
+    (``learn-cron-dashboard.md``), and the other tests in this module.
 
-    Without this check, a new wrapped dispatch site would silently slip past
-    review — the static guards above only fire on *missing* wraps, not on
-    *additional* sites that need to be documented.
+    Without this check, a new dispatch site would slip past review — the
+    static guards above only fire on *missing* ceilings, not on *additional*
+    sites that need to be documented.
     """
     src_root = _src_root()
 
@@ -196,7 +288,7 @@ def test_dispatch_site_count_matches_expectation() -> None:
     assert total == 8, (
         f"Expected 8 _run_chat dispatch sites, found {total}.  "
         "If you added or removed one, update:\n"
-        "  - the CR description / Mesh ticket\n"
+        "  - the PR description\n"
         "  - docs/system-specs/modules/learn-cron-dashboard.md (Per-turn timeout section)\n"
         "  - this test's expected count"
     )

--- a/test/test_consolidate_cmd.py
+++ b/test/test_consolidate_cmd.py
@@ -214,6 +214,12 @@ class TestOnSessionExpire:
         # Inject an expired session
         sess = MagicMock(spec=_Session)
         sess.last_used = _time.monotonic() - 9999
+        # The idle sweep now skips sessions with a turn in flight, so the stub
+        # has to answer semaphore.locked() the way a real _Session does.
+        # spec=_Session does not supply it: dataclass fields built with
+        # default_factory are instance attributes, not class attributes.
+        sess.semaphore = MagicMock()
+        sess.semaphore.locked.return_value = False
         sm._sessions["expired-key"] = sess
 
         import asyncio
@@ -239,13 +245,19 @@ class TestOnSessionExpire:
 
         sess = MagicMock(spec=_Session)
         sess.last_used = _time.monotonic() - 9999
+        # The idle sweep now skips sessions with a turn in flight, so the stub
+        # has to answer semaphore.locked() the way a real _Session does.
+        # spec=_Session does not supply it: dataclass fields built with
+        # default_factory are instance attributes, not class attributes.
+        sess.semaphore = MagicMock()
+        sess.semaphore.locked.return_value = False
         sm._sessions["expired-key"] = sess
 
         import asyncio
         asyncio.run(sm._expire_idle(60))
 
         # reset still called despite callback failure
-        mock_reset.assert_called_once_with("expired-key")
+        mock_reset.assert_called_once_with("expired-key", skip_if_busy=True)
 
 
 class TestGatewayExpireWiring:
@@ -332,13 +344,19 @@ class TestExpireIdleSelFailure:
 
         sess = MagicMock(spec=_Session)
         sess.last_used = _time.monotonic() - 9999
+        # The idle sweep now skips sessions with a turn in flight, so the stub
+        # has to answer semaphore.locked() the way a real _Session does.
+        # spec=_Session does not supply it: dataclass fields built with
+        # default_factory are instance attributes, not class attributes.
+        sess.semaphore = MagicMock()
+        sess.semaphore.locked.return_value = False
         sm._sessions["expired-sel"] = sess
 
         import asyncio
         asyncio.run(sm._expire_idle(60))
 
         callback.assert_not_called()
-        mock_reset.assert_called_once_with("expired-sel")
+        mock_reset.assert_called_once_with("expired-sel", skip_if_busy=True)
 
     @patch("kiro_crew.session.sel")
     @patch("kiro_crew.session.SessionManager.reset", new_callable=AsyncMock)
@@ -360,10 +378,16 @@ class TestExpireIdleSelFailure:
 
         sess = MagicMock(spec=_Session)
         sess.last_used = _time.monotonic() - 9999
+        # The idle sweep now skips sessions with a turn in flight, so the stub
+        # has to answer semaphore.locked() the way a real _Session does.
+        # spec=_Session does not supply it: dataclass fields built with
+        # default_factory are instance attributes, not class attributes.
+        sess.semaphore = MagicMock()
+        sess.semaphore.locked.return_value = False
         sm._sessions["expired-cb"] = sess
 
         import asyncio
         asyncio.run(sm._expire_idle(60))
 
         callback.assert_called_once_with("expired-cb")
-        mock_reset.assert_called_once_with("expired-cb")
+        mock_reset.assert_called_once_with("expired-cb", skip_if_busy=True)

--- a/test/test_loop_stall_surfacing.py
+++ b/test/test_loop_stall_surfacing.py
@@ -1,0 +1,118 @@
+"""Tests for surfacing a loop-stall hard exit, and for its configurable budget.
+
+Background. The gateway's event loop runs the HTTP server, every agent turn and
+all background work on one thread. When it wedges, a faulthandler timer dumps
+every thread's stack and calls ``os._exit()`` — skipping every ``except``,
+``finally`` and persistence flush. systemd restarts the process seconds later,
+but the user was never told a crash happened: a monitoring loop that was
+mid-round simply stopped, with fixes written and never committed.
+
+Two gaps are covered here:
+
+* the hard-exit budget was a hard-coded 25s with no config knob, so a host doing
+  heavy subprocess work (long builds, bursts of child reaping) could not widen
+  it to stop brief wedges being treated as death; and
+* a dump is re-detected on every start for up to 7 days, so notifying about it
+  unconditionally would turn one stall into a week of identical alerts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kiro_crew.config.loader import (
+    LOOP_STALL_EXIT_AFTER_MAX,
+    LOOP_STALL_EXIT_AFTER_MIN,
+    KiroCrewConfig,
+    _clamp_security_bounds,
+)
+from kiro_crew.dashboard.crash_dump_store import claim_dump_notification
+
+
+def _dump(tmp_path: Path, name: str = "loopstall-20260803T000000Z.txt") -> Path:
+    p = tmp_path / name
+    p.write_text("# opened 2026-08-03\n# PID: 1\n#\n\nTimeout (0:00:25)!\n", encoding="utf-8")
+    return p
+
+
+class TestClaimDumpNotification:
+    def test_first_claim_succeeds(self, tmp_path) -> None:
+        assert claim_dump_notification(_dump(tmp_path), tmp_path) is True
+
+    def test_second_claim_for_the_same_dump_is_refused(self, tmp_path) -> None:
+        """One stall must not alert on every restart for a week."""
+        dump = _dump(tmp_path)
+        assert claim_dump_notification(dump, tmp_path) is True
+        assert claim_dump_notification(dump, tmp_path) is False
+        assert claim_dump_notification(dump, tmp_path) is False
+
+    def test_a_new_dump_claims_again(self, tmp_path) -> None:
+        """A second, genuinely different stall must still be surfaced."""
+        first = _dump(tmp_path, "loopstall-20260803T000000Z.txt")
+        second = _dump(tmp_path, "loopstall-20260804T000000Z.txt")
+        assert claim_dump_notification(first, tmp_path) is True
+        assert claim_dump_notification(second, tmp_path) is True
+        assert claim_dump_notification(second, tmp_path) is False
+
+    def test_marker_is_not_mistaken_for_a_dump(self, tmp_path) -> None:
+        """The marker lives in the dumps dir; rotation must ignore it."""
+        from kiro_crew.dashboard.crash_dump_store import _list_dumps
+
+        dump = _dump(tmp_path)
+        claim_dump_notification(dump, tmp_path)
+        assert (tmp_path / ".notified").is_file()
+        assert _list_dumps(tmp_path) == [dump]
+
+    def test_unwritable_marker_notifies_rather_than_going_silent(self, tmp_path) -> None:
+        """A suppressed crash alert is a worse failure than a duplicate one."""
+        dump = _dump(tmp_path)
+        missing = tmp_path / "does-not-exist"
+        assert claim_dump_notification(dump, missing) is True
+
+
+class TestLoopStallBudgetConfig:
+    def test_default_preserves_existing_behaviour(self) -> None:
+        assert KiroCrewConfig().dashboard.loop_stall_exit_after_secs == 25
+
+    def test_configured_value_is_read(self, tmp_path, monkeypatch) -> None:
+        import json
+
+        from kiro_crew.config.loader import _invalidate_config_cache
+
+        cfg_dir = tmp_path / "cfgdir"
+        cfg_dir.mkdir()
+        (cfg_dir / "config.json").write_text(
+            json.dumps({"dashboard": {"loop_stall_exit_after_secs": 60}}), encoding="utf-8"
+        )
+        monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: cfg_dir)
+        _invalidate_config_cache()
+        try:
+            assert KiroCrewConfig.load().dashboard.loop_stall_exit_after_secs == 60
+        finally:
+            _invalidate_config_cache()
+
+    def test_out_of_range_values_are_clamped(self) -> None:
+        """The budget is a recovery mechanism; it cannot be set to never fire."""
+        data = {"dashboard": {"loop_stall_exit_after_secs": 99999}}
+        _clamp_security_bounds(data)
+        assert data["dashboard"]["loop_stall_exit_after_secs"] == LOOP_STALL_EXIT_AFTER_MAX
+
+        data = {"dashboard": {"loop_stall_exit_after_secs": 1}}
+        _clamp_security_bounds(data)
+        assert data["dashboard"]["loop_stall_exit_after_secs"] == LOOP_STALL_EXIT_AFTER_MIN
+
+
+class TestChatTurnCeilingConfig:
+    def test_default_preserves_existing_behaviour(self) -> None:
+        assert KiroCrewConfig().agent.chat_turn_timeout_secs == 7200
+
+    def test_out_of_range_values_are_clamped(self) -> None:
+        from kiro_crew.config.loader import CHAT_TURN_TIMEOUT_MAX, CHAT_TURN_TIMEOUT_MIN
+
+        data = {"agent": {"chat_turn_timeout_secs": 999999}}
+        _clamp_security_bounds(data)
+        assert data["agent"]["chat_turn_timeout_secs"] == CHAT_TURN_TIMEOUT_MAX
+
+        data = {"agent": {"chat_turn_timeout_secs": 5}}
+        _clamp_security_bounds(data)
+        assert data["agent"]["chat_turn_timeout_secs"] == CHAT_TURN_TIMEOUT_MIN

--- a/test/test_rehydrate_async.py
+++ b/test/test_rehydrate_async.py
@@ -1,0 +1,171 @@
+"""Tests for the async slot-rehydration wrapper's thread split.
+
+Two competing constraints meet here, and the wrapper exists to satisfy both:
+
+* The disk reads must NOT run on the event loop. A real session transcript
+  reaches tens of MB, and the gateway serves every HTTP request, every agent
+  turn and the stall-watchdog heartbeat on one thread — so reading one inline
+  in a timer callback stalls all of it.
+* Slot construction must NOT run off the event loop. It broadcasts through
+  ``asyncio.Queue.put_nowait`` and ``Event.set`` (neither thread-safe) and
+  through ``ensure_future``, which off-loop raises inside a broad ``except``
+  that marks every connected dashboard client dead and drops it *without a
+  close frame* — browsers then never reconnect and stop receiving frames until
+  a manual reload. ``restore_open_slots_async`` documents the same invariant.
+
+So the wrapper hoists only the reads. These tests pin that split by recording
+the thread each half actually ran on.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.dashboard import chat_persistence as cp
+
+
+class _Log:
+    """Conversation-log stub that records which thread read from it."""
+
+    def __init__(self, meta: dict | None, messages: list[dict] | None) -> None:
+        self._meta = meta
+        self._messages = messages or []
+        self.read_threads: list[str] = []
+
+    def get_metadata(self, key: str) -> dict | None:
+        self.read_threads.append(threading.current_thread().name)
+        return self._meta
+
+    def read_messages_chained(self, key: str) -> list[dict]:
+        self.read_threads.append(threading.current_thread().name)
+        return self._messages
+
+
+def _state(log: _Log) -> MagicMock:
+    state = MagicMock()
+    state.conversation_log = log
+    state._slots = {}
+    return state
+
+
+@pytest.mark.asyncio
+async def test_reads_run_off_the_loop_and_build_runs_on_it(monkeypatch) -> None:
+    log = _Log({"title": "Babysit PR"}, [{"role": "user", "content": "hi"}])
+    state = _state(log)
+    built_on: list[str] = []
+    sentinel = MagicMock(name="slot")
+
+    def _build(_state, _slot_name, **kwargs):
+        built_on.append(threading.current_thread().name)
+        # The prefetched values must be threaded through so the builder does no
+        # further disk I/O of its own.
+        assert kwargs["_prefetched_meta"] == {"title": "Babysit PR"}
+        assert kwargs["_prefetched_messages"] == [{"role": "user", "content": "hi"}]
+        return sentinel
+
+    monkeypatch.setattr(cp, "_rehydrate_slot_from_history", _build)
+    monkeypatch.setattr(cp, "_build_kiro_model_map", lambda: {})
+
+    main = threading.current_thread().name
+    result = await cp.rehydrate_slot_from_history_async(state, "chat-1-1785")
+
+    assert result is sentinel
+    assert log.read_threads, "the transcript was never read"
+    assert all(t != main for t in log.read_threads), "a disk read ran on the event loop"
+    assert built_on == [main], "slot construction left the event-loop thread"
+
+
+@pytest.mark.asyncio
+async def test_close_during_the_read_abandons_rehydration(monkeypatch) -> None:
+    """✕ clicked while the transcript loads must not resurrect the tab.
+
+    The close pops the slot and records a tombstone synchronously on the loop,
+    but persists the ``closed`` flag only after its own awaits — so metadata
+    read before the click still says open. Rebuilding from that stale snapshot
+    would re-create a dismissed tab and then fire a nudge turn into it.
+    """
+    from kiro_crew.dashboard import channel_slots
+
+    log = _Log({"title": "Babysit PR"}, [{"role": "user", "content": "hi"}])
+    state = _state(log)
+    monkeypatch.setattr(cp, "_build_kiro_model_map", lambda: {})
+    monkeypatch.setattr(
+        cp, "_rehydrate_slot_from_history", lambda *a, **k: pytest.fail("rebuilt a closed tab")
+    )
+
+    real_read = log.read_messages_chained
+
+    def _read_then_close(key: str):
+        # Simulate the user clicking ✕ while this read is in flight.
+        channel_slots.note_slot_closed(state, "chat-1-1785")
+        return real_read(key)
+
+    monkeypatch.setattr(log, "read_messages_chained", _read_then_close)
+
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-1785") is None
+
+
+@pytest.mark.asyncio
+async def test_a_close_predating_the_read_does_not_block(monkeypatch) -> None:
+    """Only a close DURING the read is the race; older tombstones are inert.
+
+    A close that already landed is visible in the metadata itself, so the guard
+    must not additionally reject an unrelated stale tombstone — that would make
+    a reopened tab un-rehydratable for the tombstone's lifetime.
+    """
+    import time as _time
+
+    from kiro_crew.dashboard import channel_slots
+
+    log = _Log({"title": "Reopened"}, [{"role": "user", "content": "hi"}])
+    state = _state(log)
+    channel_slots.note_slot_closed(state, "chat-1-old")  # then reopened
+    _time.sleep(0.01)
+    sentinel = MagicMock(name="slot")
+    monkeypatch.setattr(cp, "_build_kiro_model_map", lambda: {})
+    monkeypatch.setattr(cp, "_rehydrate_slot_from_history", lambda *a, **k: sentinel)
+
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-old") is sentinel
+
+
+@pytest.mark.asyncio
+async def test_missing_metadata_returns_none_without_building(monkeypatch) -> None:
+    """A session that was never persisted must not create a phantom tab."""
+    state = _state(_Log(None, None))
+    monkeypatch.setattr(
+        cp, "_rehydrate_slot_from_history", lambda *a, **k: pytest.fail("built a phantom slot")
+    )
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-nope") is None
+
+
+@pytest.mark.asyncio
+async def test_closed_session_is_not_resurrected(monkeypatch) -> None:
+    """Clicking ✕ is respected — same contract as the synchronous form."""
+    state = _state(_Log({"closed": True}, []))
+    monkeypatch.setattr(
+        cp, "_rehydrate_slot_from_history", lambda *a, **k: pytest.fail("resurrected a closed tab")
+    )
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-closed") is None
+
+
+@pytest.mark.asyncio
+async def test_already_loaded_slot_short_circuits(monkeypatch) -> None:
+    """The hot path must not pay for a thread hop or a read."""
+    log = _Log({"title": "x"}, [])
+    state = _state(log)
+    live = MagicMock(name="live-slot")
+    state._slots = {"chat-1-hot": live}
+    monkeypatch.setattr(cp, "_normalize_slot_key", lambda k: k)
+
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-hot") is live
+    assert log.read_threads == [], "short-circuit still read from disk"
+
+
+@pytest.mark.asyncio
+async def test_no_conversation_log_returns_none() -> None:
+    state = MagicMock()
+    state.conversation_log = None
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-x") is None

--- a/test/test_session_idle_busy_guard.py
+++ b/test/test_session_idle_busy_guard.py
@@ -1,0 +1,174 @@
+"""Tests for the idle sweep's busy guard and the keepalive's ``last_used`` bump.
+
+The defect these pin: ``_expire_idle`` called ``reset()`` with ``skip_if_busy``
+left at its default of ``False``, so the periodic sweep could tear down a session
+with a turn in flight. Its sibling ``_rss_threshold_check`` already skipped busy
+sessions — the guard was simply omitted here.
+
+Why it reached a long turn: ``last_used`` is only bumped by ``get_or_create()``,
+which a dashboard turn calls exactly once, so a turn running longer than
+``timeout_secs`` looks idle to the arithmetic. The orphaned-dashboard-slot branch
+is worse — it ignores the clock entirely, so a closed tab could reap a live turn
+immediately.
+
+The ``wait`` tool's keepalive did not help: it refreshed only the ACP runtime's
+activity clock (which feeds ``is_responsive()``), never the session's
+``last_used`` that the sweep actually reads.
+
+The user-visible symptom was "⟳ Connection lost — retrying…" partway through a
+long turn, never "your session was reaped for idleness".
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.config import KiroCrewConfig
+from kiro_crew.session import SessionManager
+
+
+@pytest.fixture
+def cfg():
+    c = KiroCrewConfig()
+    c.session.timeout_secs = 2
+    return c
+
+
+def _mock_provider_factory():
+    def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+        m = AsyncMock()
+        m.start = AsyncMock()
+        m.shutdown = AsyncMock()
+        m.context_usage_pct = lambda: 0.0
+        m.has_active_turn = lambda: False
+        return m
+
+    return factory
+
+
+class TestIdleSweepBusyGuard:
+    @pytest.mark.asyncio
+    async def test_busy_session_is_not_reaped_when_it_looks_idle(self, cfg) -> None:
+        """The regression: a long turn must survive the sweep.
+
+        The permit is still held (no release()), so the session has a turn in
+        flight even though ``last_used`` is backdated well past the timeout.
+        """
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("dashboard:tab1")  # holds the permit
+        async with mgr._lock:
+            mgr._sessions["dashboard:tab1"].last_used = time.monotonic() - 10_000
+
+        await mgr._expire_idle(timeout_secs=1)
+
+        assert "dashboard:tab1" in mgr._sessions, "a session mid-turn was reaped as idle"
+        mgr.release("dashboard:tab1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_busy_session_is_not_reaped_as_an_orphaned_tab(self, cfg) -> None:
+        """The orphan branch ignores the clock, so it needs the guard too."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("dashboard:tab1")  # holds the permit
+        mgr.set_active_dashboard_slots({"dashboard:tab2"})  # tab1 looks orphaned
+
+        await mgr._expire_idle(9999)
+
+        assert "dashboard:tab1" in mgr._sessions, "a live turn was reaped as an orphan"
+        mgr.release("dashboard:tab1")
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_genuinely_idle_session_is_still_reaped(self, cfg) -> None:
+        """The guard must not disable the sweep it protects."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("thread1")
+        mgr.release("thread1")
+        async with mgr._lock:
+            mgr._sessions["thread1"].last_used = time.monotonic() - 10
+
+        await mgr._expire_idle(timeout_secs=1)
+
+        assert mgr.count == 0
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_reset_is_asked_to_skip_busy_sessions(self, cfg) -> None:
+        """Closes the collect→reset race: a turn may start after the lock drops.
+
+        Pinned as a call-shape assertion so a later refactor cannot silently
+        drop the flag while the behavioural tests still pass.
+        """
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("thread1")
+        mgr.release("thread1")
+        async with mgr._lock:
+            mgr._sessions["thread1"].last_used = time.monotonic() - 10
+        mgr.reset = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        await mgr._expire_idle(timeout_secs=1)
+
+        mgr.reset.assert_awaited_once()
+        assert mgr.reset.await_args.kwargs["skip_if_busy"] is True
+        await mgr.close_all()
+
+
+class TestTouchLastUsed:
+    @pytest.mark.asyncio
+    async def test_touch_advances_last_used(self, cfg) -> None:
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("thread1")
+        mgr.release("thread1")
+        async with mgr._lock:
+            mgr._sessions["thread1"].last_used = time.monotonic() - 10_000
+
+        assert mgr.touch("thread1") is True
+
+        await mgr._expire_idle(timeout_secs=1)
+        assert "thread1" in mgr._sessions, "touch() did not protect the session"
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_touch_reports_a_missing_session(self, cfg) -> None:
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        assert mgr.touch("nope") is False
+        await mgr.close_all()
+
+
+class TestKeepaliveHandler:
+    @pytest.mark.asyncio
+    async def test_keepalive_touches_last_used_as_well_as_the_acp_clock(self) -> None:
+        """Without this, a session blocking in `wait` still ages toward reaping."""
+        from kiro_crew.dashboard.handlers.sessions import api_session_keepalive
+
+        provider = MagicMock()
+        sessions = MagicMock()
+        sessions.get_provider = MagicMock(return_value=provider)
+        sessions.touch = MagicMock(return_value=True)
+        request = MagicMock()
+        request.app = {"state": MagicMock(sessions=sessions)}
+        request.headers = {"X-Session-Key": "dashboard:tab1"}
+
+        resp = await api_session_keepalive(request)
+
+        assert resp.status == 200
+        provider.touch_activity.assert_called_once()
+        sessions.touch.assert_called_once_with("dashboard:tab1")
+
+    @pytest.mark.asyncio
+    async def test_keepalive_still_succeeds_when_touch_is_absent(self) -> None:
+        """Older session managers / test stubs must not 500 the keepalive."""
+        from kiro_crew.dashboard.handlers.sessions import api_session_keepalive
+
+        sessions = MagicMock(spec=["get_provider"])
+        sessions.get_provider = MagicMock(return_value=MagicMock())
+        request = MagicMock()
+        request.app = {"state": MagicMock(sessions=sessions)}
+        request.headers = {"X-Session-Key": "dashboard:tab1"}
+
+        resp = await api_session_keepalive(request)
+
+        assert resp.status == 200

--- a/test/test_turn_dispatch.py
+++ b/test/test_turn_dispatch.py
@@ -1,0 +1,288 @@
+"""Tests for guarded chat-turn dispatch (``dashboard/turn_dispatch.py``).
+
+The defect these pin: a turn wrapped in ``asyncio.wait_for`` whose only
+done-callback was ``set.discard`` never had its ``TimeoutError`` retrieved, so
+hitting the wall-clock ceiling produced no error card and no log the user would
+find — the turn just stopped. Long babysit turns reach the ceiling routinely, so
+the failure mode was ordinary rather than exotic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.constants import CHAT_TURN_TIMEOUT
+from kiro_crew.dashboard import turn_dispatch as td
+
+
+def _slot() -> MagicMock:
+    slot = MagicMock()
+    slot.key = "chat-1-123"
+    return slot
+
+
+def _state() -> MagicMock:
+    state = MagicMock()
+    state._background_tasks = set()
+    return state
+
+
+def _patch_configured_ceiling(monkeypatch, value: object, *, acp: float = 7200.0) -> None:
+    """Point ``chat_turn_timeout_secs`` at a synthetic config + ACP ceiling.
+
+    ``KiroCrewConfig`` is imported at module scope, so the module attribute is
+    what the code under test resolves. Passing ``value=None`` simulates config
+    being unavailable entirely.
+    """
+    monkeypatch.setattr(td, "_acp_prompt_ceiling", lambda: acp)
+    holder = MagicMock()
+    if value is None:
+        holder.load.side_effect = RuntimeError("no config here")
+    else:
+        cfg = MagicMock()
+        cfg.agent.chat_turn_timeout_secs = value
+        holder.load.return_value = cfg
+    monkeypatch.setattr(td, "KiroCrewConfig", holder)
+
+
+class TestBoundedIntCoercion:
+    """A coercible value must not slip past the declared bounds.
+
+    ``_clamp_security_bounds`` walks the raw config dict and deliberately skips
+    anything that is not a real ``int``, so a numeric STRING passes through it
+    untouched and is then coerced at construction. Without a clamp at the
+    coercion site, ``"1"`` in config.json yields a 1-second turn ceiling (every
+    turn dies immediately) or a 1-second loop-stall budget (the gateway
+    hard-exits and systemd restart-loops it).
+    """
+
+    def test_numeric_string_below_the_floor_is_clamped(self) -> None:
+        from kiro_crew.config.loader import (
+            CHAT_TURN_TIMEOUT_MAX,
+            CHAT_TURN_TIMEOUT_MIN,
+            _safe_int,
+        )
+
+        assert (
+            _safe_int("1", 7200, CHAT_TURN_TIMEOUT_MIN, CHAT_TURN_TIMEOUT_MAX)
+            == CHAT_TURN_TIMEOUT_MIN
+        )
+
+    def test_numeric_string_above_the_ceiling_is_clamped(self) -> None:
+        from kiro_crew.config.loader import (
+            CHAT_TURN_TIMEOUT_MAX,
+            CHAT_TURN_TIMEOUT_MIN,
+            _safe_int,
+        )
+
+        assert (
+            _safe_int("999999", 7200, CHAT_TURN_TIMEOUT_MIN, CHAT_TURN_TIMEOUT_MAX)
+            == CHAT_TURN_TIMEOUT_MAX
+        )
+
+    def test_integral_float_is_clamped_too(self) -> None:
+        from kiro_crew.config.loader import (
+            LOOP_STALL_EXIT_AFTER_MAX,
+            LOOP_STALL_EXIT_AFTER_MIN,
+            _safe_int,
+        )
+
+        assert (
+            _safe_int(1.0, 25, LOOP_STALL_EXIT_AFTER_MIN, LOOP_STALL_EXIT_AFTER_MAX)
+            == LOOP_STALL_EXIT_AFTER_MIN
+        )
+
+    def test_in_range_value_is_untouched(self) -> None:
+        from kiro_crew.config.loader import (
+            CHAT_TURN_TIMEOUT_MAX,
+            CHAT_TURN_TIMEOUT_MIN,
+            _safe_int,
+        )
+
+        assert _safe_int(1800, 7200, CHAT_TURN_TIMEOUT_MIN, CHAT_TURN_TIMEOUT_MAX) == 1800
+
+    def test_callers_without_bounds_are_unaffected(self) -> None:
+        """The clamp is opt-in; the dozens of existing call sites must not shift."""
+        from kiro_crew.config.loader import _safe_int
+
+        assert _safe_int("1", 7200) == 1
+        assert _safe_int("nonsense", 42) == 42
+        assert _safe_int(True, 42) == 42
+
+
+class TestCeilingResolution:
+    def test_defaults_to_constant_when_config_unavailable(self, monkeypatch) -> None:
+        """A config-less context (tests, early bootstrap) behaves like default config."""
+        _patch_configured_ceiling(monkeypatch, None)
+        assert td.chat_turn_timeout_secs() == CHAT_TURN_TIMEOUT
+
+    def test_reads_configured_value(self, monkeypatch) -> None:
+        _patch_configured_ceiling(monkeypatch, 1800)
+        assert td.chat_turn_timeout_secs() == 1800.0
+
+    def test_clamps_above_acp_prompt_timeout_and_logs(self, monkeypatch, caplog) -> None:
+        """A ceiling above the transport's own timeout cannot take effect.
+
+        The transport bounds the turn first, so honouring the larger number
+        would advertise a limit the system does not enforce.
+        """
+        _patch_configured_ceiling(monkeypatch, 99999)
+        with caplog.at_level(logging.WARNING, logger=td.logger.name):
+            assert td.chat_turn_timeout_secs() == 7200.0
+        assert "clamping" in caplog.text
+
+    def test_non_positive_value_cannot_disable_the_backstop(self, monkeypatch) -> None:
+        """0 would make wait_for raise immediately — the ceiling is not optional."""
+        _patch_configured_ceiling(monkeypatch, 0)
+        assert td.chat_turn_timeout_secs() == CHAT_TURN_TIMEOUT
+
+
+class TestTimeoutCard:
+    def test_names_the_limit_in_hours(self) -> None:
+        assert "2-hour" in td.format_turn_timeout_card(7200.0)
+
+    def test_names_the_limit_in_minutes_below_an_hour(self) -> None:
+        assert "30-minute" in td.format_turn_timeout_card(1800.0)
+
+    def test_reassures_that_work_survived(self) -> None:
+        """The user's first question is "did I lose my work?"."""
+        assert "written to disk is still there" in td.format_turn_timeout_card(7200.0)
+
+
+class TestFinishTurnTask:
+    @pytest.mark.asyncio
+    async def test_timeout_renders_a_visible_card(self) -> None:
+        """The headline regression: a ceiling hit must not be silent."""
+        state, slot = _state(), _slot()
+
+        async def _forever():
+            await asyncio.sleep(3600)
+
+        task = td.spawn_guarded_turn(state, slot, _forever(), timeout_secs=0.01)
+        with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+            await task
+        # Give the done-callback a turn of the loop to run.
+        await asyncio.sleep(0)
+        roles = [c.args[0] for c in slot.append.call_args_list]
+        assert "error" in roles, "a turn that hit the ceiling rendered no card"
+        body = slot.append.call_args_list[0].args[1]
+        assert "limit" in body and "⏱️" in body
+        assert task not in state._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_deadline_absorbed_by_the_turn_still_renders_a_card(self) -> None:
+        """The real shape: ``_run_chat`` swallows the deadline's cancellation.
+
+        ``_run_chat`` catches ``CancelledError`` to flush partial output and
+        returns normally, so ``asyncio.wait_for`` hands back a value rather than
+        raising — and a naive guard would treat the killed turn as a success and
+        show nothing. This is the case that matters in production; a test
+        coroutine that lets the cancellation propagate does not exercise it.
+        """
+        state, slot = _state(), _slot()
+
+        async def _swallows_cancellation():
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                return "partial output flushed"  # exactly what _run_chat does
+
+        task = td.spawn_guarded_turn(state, slot, _swallows_cancellation(), timeout_secs=0.01)
+        with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+            await task
+        await asyncio.sleep(0)
+        roles = [c.args[0] for c in slot.append.call_args_list]
+        assert "error" in roles, (
+            "the turn absorbed the ceiling's cancellation and no card was shown — "
+            "indistinguishable from the agent going quiet"
+        )
+        assert "limit" in slot.append.call_args_list[0].args[1]
+
+    @pytest.mark.asyncio
+    async def test_turn_finishing_just_under_the_ceiling_is_not_called_a_timeout(self) -> None:
+        """The elapsed comparison must not mislabel a genuine completion."""
+        state, slot = _state(), _slot()
+
+        async def _quick():
+            return "done"
+
+        task = td.spawn_guarded_turn(state, slot, _quick(), timeout_secs=30)
+        assert await task == "done"
+        await asyncio.sleep(0)
+        assert slot.append.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_exception_is_retrieved_so_asyncio_stays_quiet(self) -> None:
+        """Nothing may be left for the collector to report as un-retrieved."""
+        state, slot = _state(), _slot()
+
+        async def _forever():
+            await asyncio.sleep(3600)
+
+        task = td.spawn_guarded_turn(state, slot, _forever(), timeout_secs=0.01)
+        with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+            await task
+        await asyncio.sleep(0)
+        # exception() returning without raising proves it was consumed.
+        assert isinstance(task.exception(), (asyncio.TimeoutError, TimeoutError))
+
+    @pytest.mark.asyncio
+    async def test_cancellation_renders_no_card(self) -> None:
+        """A user pressing Stop is already surfaced; a second card is noise."""
+        state, slot = _state(), _slot()
+
+        async def _forever():
+            await asyncio.sleep(3600)
+
+        task = td.spawn_guarded_turn(state, slot, _forever(), timeout_secs=60)
+        await asyncio.sleep(0)  # let the task actually start before cancelling
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+        assert slot.append.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_success_renders_no_card_and_deregisters(self) -> None:
+        state, slot = _state(), _slot()
+
+        async def _ok():
+            return None
+
+        task = td.spawn_guarded_turn(state, slot, _ok(), timeout_secs=60)
+        await task
+        await asyncio.sleep(0)
+        assert slot.append.call_count == 0
+        assert task not in state._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_other_exception_is_logged_not_dropped(self, caplog) -> None:
+        state, slot = _state(), _slot()
+
+        async def _boom():
+            raise ValueError("kaboom")
+
+        with caplog.at_level(logging.ERROR, logger=td.logger.name):
+            task = td.spawn_guarded_turn(state, slot, _boom(), timeout_secs=60)
+            with pytest.raises(ValueError):
+                await task
+            await asyncio.sleep(0)
+        assert "kaboom" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_card_render_failure_cannot_break_the_callback(self) -> None:
+        """A raising callback would surface as "exception in callback" noise."""
+        state, slot = _state(), _slot()
+        slot.append.side_effect = RuntimeError("slot gone")
+
+        async def _forever():
+            await asyncio.sleep(3600)
+
+        task = td.spawn_guarded_turn(state, slot, _forever(), timeout_secs=0.01)
+        with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+            await task
+        await asyncio.sleep(0)  # must not raise

--- a/test/test_turn_teardown_release.py
+++ b/test/test_turn_teardown_release.py
@@ -1,0 +1,117 @@
+"""Tests for session-permit release at dashboard turn teardown.
+
+The defect these pin: every ``await`` in ``_run_chat``'s ``finally`` was guarded
+by ``except Exception``, but ``CancelledError`` has derived from
+``BaseException`` since Python 3.8. A cancellation delivered while one of those
+awaits was suspended slipped past every guard and skipped
+``state.sessions.release(...)`` entirely.
+
+The permit is keyed by SESSION, so leaking it does not merely lose one turn: the
+session reads as permanently busy, every later turn for it blocks forever, no
+queued turn drains, and only a gateway restart clears it. From the user's side
+the chat simply stops accepting messages with no error shown.
+
+Commit 9359b3d1 fixed this shape for the messaging dispatcher, but with
+``except Exception`` — already present here — so it does not cover the
+cancellation case. A nested ``try``/``finally`` does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.acp.client import AcpAuthRequired
+from kiro_crew.dashboard.chat_runner import _run_chat
+
+
+def _state_and_slot(tmp_path: Path):
+    state = _make_state(tmp_path)
+    state.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), False, False))
+    state.sessions.release = MagicMock()
+    state.sessions.reset = AsyncMock()
+    state.sessions.set_approval_policy = MagicMock()
+    state.sessions.check_context_usage = MagicMock()
+    state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+    state.sessions.record_failure = AsyncMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.is_yolo_active = MagicMock(return_value=False)
+    state._background_tasks = set()
+    slot = state.get_or_create_slot("release-slot")
+    slot.append("user", "hello", "msg msg-u")
+    client = state.sessions.get_or_create.return_value[0]
+    client.shutdown = AsyncMock()
+    return state, slot, client
+
+
+def _stream_raises(client: MagicMock, exc: BaseException) -> None:
+    async def _raise(msg):
+        raise exc
+        yield  # pragma: no cover - generator shape only
+
+    client.stream = _raise
+    client.stream_command = _raise
+
+
+class TestTurnTeardownRelease:
+    @pytest.mark.asyncio
+    async def test_release_survives_cancellation_during_session_reset(self, tmp_path) -> None:
+        """The regression: a cancelled reset must not strand the permit.
+
+        AcpAuthRequired sets ``needs_session_reset``, which is what puts an
+        ``await`` between the ``finally`` and the release.
+        """
+        state, slot, client = _state_and_slot(tmp_path)
+        _stream_raises(client, AcpAuthRequired("kiro-cli is not logged in."))
+        state.sessions.reset = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await _run_chat(state, slot, "test message")
+
+        state.sessions.release.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_release_happens_exactly_once_on_the_happy_path(self, tmp_path) -> None:
+        """A double release on a plain Semaphore(1) would destroy mutual exclusion.
+
+        ``_Session.semaphore`` is not a BoundedSemaphore, so an extra release
+        raises nothing and silently lets two turns run concurrently. Guard
+        against a fix that hands the permit back twice.
+        """
+        state, slot, client = _state_and_slot(tmp_path)
+
+        async def _empty(msg):
+            return
+            yield  # pragma: no cover - generator shape only
+
+        client.stream = _empty
+        client.stream_command = _empty
+
+        await _run_chat(state, slot, "test message")
+
+        assert state.sessions.release.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_release_still_runs_when_reset_raises_normally(self, tmp_path) -> None:
+        state, slot, client = _state_and_slot(tmp_path)
+        _stream_raises(client, AcpAuthRequired("kiro-cli is not logged in."))
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("reset exploded"))
+
+        await _run_chat(state, slot, "test message")
+
+        state.sessions.release.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_release_when_the_permit_was_never_acquired(self, tmp_path) -> None:
+        """get_or_create failing before the permit is taken must not release."""
+        state, slot, _client = _state_and_slot(tmp_path)
+        state.sessions.get_or_create = AsyncMock(side_effect=RuntimeError("cold start failed"))
+
+        await _run_chat(state, slot, "test message")
+
+        state.sessions.release.assert_not_called()


### PR DESCRIPTION
## Problem

A monitoring loop that watches a pull request keeps disappearing part-way through. The user is told monitoring is active, the loop runs a few rounds, and then it stops — with no error card, no row in the session transcript, and nothing in the log they would think to look for. Fixes are often already written and never pushed, so the PR sits stalled for hours while appearing to be actively watched.

There is no single cause. Four separate teardown paths each end a turn without telling anyone, and a fifth destroys the loop outright:

1. **A loop is deleted whenever its slot is not in the live registry.** The fire path resolved the slot with a bare in-memory dict lookup and, on a miss, removed the loop from the persisted state. A miss is not evidence of a dead session: the registry is empty for any tab the user navigated away from, and empty for *every* slot immediately after a gateway restart, because the nudge service re-arms its timers before the dashboard has restored its slots. So closing a browser tab — or an ordinary restart — permanently destroyed the loop.
2. **A turn that hits the wall-clock ceiling dies silently.** Each dispatch site wrapped the turn in `asyncio.wait_for` and attached one done-callback: `state._background_tasks.discard`, a `set` method that ignores its argument's result. Nothing awaited the task or called `.exception()`, so the `TimeoutError` was never retrieved. It surfaced only as a garbage-collection-time "Task exception was never retrieved" line. Ten polling rounds plus tool time reaches the 2-hour ceiling routinely, so this was an ordinary outcome, not an edge case.
3. **The session permit leaks when a turn is cancelled during cleanup.** Every `await` in `_run_chat`'s `finally` was guarded by `except Exception`, but `CancelledError` has derived from `BaseException` since 3.8. A cancellation delivered while one of those awaits was suspended skipped `sessions.release(...)`. The permit is keyed by session, so the session then reads as permanently busy: every later turn blocks forever, no queued turn drains, and only a gateway restart clears it.
4. **The idle sweep can reap a session mid-turn.** `_expire_idle` called `reset()` with `skip_if_busy` left at its default of `False`. `last_used` is only bumped once per turn, so a turn running longer than the timeout looks idle — and the orphaned-tab branch ignores the clock entirely, so a closed tab could reap a live turn immediately. The `wait` tool's keepalive did not help: it refreshed the ACP runtime's activity clock, never the `last_used` the sweep actually reads.
5. **A loop-stall hard exit is invisible.** On an event-loop stall the gateway dumps thread stacks and calls `os._exit()`, skipping every `finally`. systemd restarts it seconds later, but the user was only told via a log line — so an interrupted round looked like the loop quietly giving up.

## Why it matters

This is the mechanism the project ships pull requests with. When it fails silently the user believes work is progressing when it is not, and the failure is indistinguishable from the agent deciding to stop. The leaked-permit case is worse than a lost turn: the session becomes unusable until the gateway restarts, with nothing shown to explain it.

## Fix (symptoms → root cause → change)

**1. Rehydrate before retiring a loop.** The dashboard nudge branch is lifted out of an inline closure into `_fire_dashboard_nudge`, a sibling of the existing `_fire_slack_nudge` / `_fire_discord_nudge` — so the slot-resolution contract is directly testable. It now resolves via `get_slot()` and falls back to `_rehydrate_slot_from_history` on a miss, retiring the loop only when the session is genuinely unreachable. This is the contract the cron origin-injection path already used; the nudge path was the outlier. A session the user dismissed with ✕ still returns `None` and still retires the loop — that is the documented "respect the close" rule, not a gap.

**2. One owner for turn dispatch.** New `dashboard/turn_dispatch.py` provides `spawn_guarded_turn`, which resolves the ceiling, registers the task, and attaches a callback that *retrieves* the outcome — rendering a card naming the limit instead of letting the exception go unretrieved. Five dispatch sites now route through it. The ceiling is configurable via `agent.chat_turn_timeout_secs` (default unchanged at 7200, clamped 300–7200) and is additionally clamped against the transport's own prompt timeout, because a larger value cannot take effect — the transport bounds the turn first. The clamp logs rather than silently accepting.

Two gateway sites keep the inline `create_task` form: both already attach their own callback that calls `.exception()`, so they were never the silent shape.

**3. Unconditional release.** The pre-release span in the `finally` is wrapped in a nested `try`/`finally` with the release in the `finally`, preserving the existing reset-then-release ordering and the `_acquired` guard. Commit 9359b3d1 fixed this shape for the messaging dispatcher using `except Exception` — that guard is already present here and does not stop a `CancelledError`, which is why a structural fix is needed rather than replicating the pattern. `_consume_pending_reset` is also guarded: a raise there skipped the steer requeue and queue drain, stranding queued work at the end of an otherwise successful turn.

**4. Busy guard on the sweep.** `_expire_idle` skips sessions whose semaphore is held at collection time and passes `skip_if_busy=True` to `reset()` to close the collect→reset race atomically — mirroring `_rss_threshold_check`, which already did both. A new `SessionManager.touch()` lets the keepalive advance `last_used`, so a session blocking in a long `wait` no longer ages toward being reaped.

**5. Surface the stall.** The hard-exit budget is exposed as `dashboard.loop_stall_exit_after_secs` (default unchanged at 25, clamped 10–300) so a host doing heavy subprocess work can widen it. A past stall now raises a notification, claimed once per dump via a marker file — a dump is re-detected on every start for up to 7 days, so notifying unconditionally would alert on every restart for a week.

**Documentation.** The `babysit` skill's decision table previously recommended cron and heartbeat for exactly the case they cannot serve; both are now called out with the measured evidence (a real watcher: 101 runs over 25 hours, 23 blocked at approval, zero pushes, and a registry reporting success throughout). The arm-failure section is inverted: the tool's return string is not evidence a loop armed, so verify against the persisted state and confirm `cycle_count` advances. `prepare-pr` gains a short cross-reference.

### Two corrections to the diagnosis this work started from

- The investigation notes claimed "10 crash dumps in 5 days". Only **one** of the retained dumps contains stacks; the other nine are header-only, which is what a *clean* shutdown leaves. There is 1 stall-exit in the retained window, not 10.
- The stall detector and its startup log already existed (`crash_dump_store.newest_dump_with_stacks`, surfaced in `server.py` and `kirocrew doctor`). Only the notification and the config knob were missing, so item 5 is smaller than scoped.

### Review round 1 — two real defects found and fixed

Both findings from the GPT review were legitimate; the second one meant the headline behaviour of item 2 would have shipped broken.

**The ceiling card never appeared (the important one).** `asyncio.wait_for` cancels the coroutine at the deadline and then re-raises whatever the coroutine did with that cancellation. `_run_chat` *catches* `CancelledError` — it flushes partial output and returns normally — so the cancellation was absorbed and `wait_for` handed back a value instead of raising. The guard saw a successful turn and rendered nothing, which is the exact symptom this PR set out to remove. Fixed with a `_bounded_turn` wrapper that compares elapsed time against the ceiling: `wait_for` can only return at or after the deadline if its timer fired and cancelled the turn, so that comparison distinguishes "completed" from "cut" without touching `_run_chat`'s cancellation semantics (which are shared with the user's Stop button). Portable across 3.10's `wait_for` and the 3.12 `timeouts`-based rewrite — both only convert a cancellation that actually propagates. Pinned by `test_deadline_absorbed_by_the_turn_still_renders_a_card`, which uses a coroutine that swallows the cancellation the way the real turn does; without the fix it reports `DID NOT RAISE`.

**Cold rehydration ran on the event loop.** Measured on the largest real transcript on the development host — 12.45 MB, 1,598 lines — the read plus JSON parse is ~113 ms, and a chained walk across forks multiplies it. The gateway serves every request, every turn and the stall-watchdog heartbeat on one thread, and a nudge fire is a timer callback, so that belongs off-loop. Now `await asyncio.to_thread(...)`, with `restoring_open_slots` held across it so an interleaved flush cannot snapshot a partially built slot — the same guard `restore_recent_sessions_async` uses for this mutation. Reverting the rehydration (the suggested fix) was not viable: it is the fix for item 1. Pinned by two tests, one asserting the work leaves the event-loop thread and one asserting the flush guard is held and released.

### Review round 2 — the round-1 fix was wrong, and this replaces it

Opus 5 and the Arbiter independently caught that round 1's `asyncio.to_thread` hop was a worse defect than the blocking read it removed, and they were right.

**Slot construction is loop-affine.** Rehydration reaches `get_or_create_slot` → `push_slots_update` → `_broadcast`, which uses `asyncio.Queue.put_nowait` and `Event.set`, and `_spawn_ws_send`'s `ensure_future`. Off the loop that `ensure_future` raises, the raise lands in a broad `except` that marks every connected dashboard client dead, and `_remove_ws` drops them *without a close frame* — so browsers never reconnect and receive no further frames until a manual reload, including the output of the very nudge turn this PR exists to run. `restore_open_slots_async` documents this invariant explicitly.

Both reviewers offered "revert to inline" as the smallest fix, but that re-opens round 1's blocking-I/O finding. Instead the two concerns are separated: new `rehydrate_slot_from_history_async` hoists **only** the two disk reads (the metadata line and the chained message walk — tens of MB and the actual cost) into a worker thread via optional prefetch parameters, and hands them to the existing synchronous builder, which runs on the loop exactly as the two other cold-slot callers do. No blocking I/O on the loop; no loop-affine mutation off it.

**`restoring_open_slots` writer removed.** It only existed to fence the thread hop. With construction back on the loop nothing can interleave mid-build, so the bracket is gone — which also closes the Arbiter's second item: a nudge fire could otherwise clear a flag the startup restore owns, re-enabling the periodic flush mid-restore and persisting a partial slot snapshot (losing open tabs).

**`_bounded_turn` no longer infers from the clock.** The Arbiter filed this as a non-blocking follow-up; it is cheap and strictly better, so it is fixed here. The deadline is now armed with `loop.call_later` and recorded in a flag set only by that timer, so "was this turn cut?" is observed rather than inferred. The previous elapsed-vs-ceiling comparison would mislabel a turn that finished just under the deadline but whose continuation was delayed by a congested loop, discarding a real result.

New tests in `test_rehydrate_async.py` pin the split by recording the thread each half ran on: every disk read leaves the event-loop thread, and construction happens on it. Plus the unchanged contract — no phantom tab when metadata is absent, no resurrection of a ✕-closed session, no thread hop or read on the already-loaded hot path. `test_fire_does_not_touch_the_startup_restore_flag` guards the flag ownership.

## Tests

New, and each verified to fail without its fix (12 of them fail against `origin/main`):

- `test_autonudge_dashboard_fire.py` — cold slot is rehydrated and the turn runs; hot slot skips rehydration; unreachable session retires the loop exactly once with a logged reason; a running slot skips without retiring or counting the cycle; a missing dashboard skips without retiring.
- `test_turn_dispatch.py` — ceiling resolution, the transport clamp (and its log), a non-positive value not disabling the backstop, card wording, and the headline case: a ceiling hit renders a visible card and the exception is retrieved. Also that cancellation renders *no* card, and that a failure while rendering cannot break the callback.
- `test_turn_teardown_release.py` — release survives a cancellation during session reset; release happens exactly once on the happy path (a double release on a plain `Semaphore(1)` would silently destroy mutual exclusion); release still runs when reset raises normally; no release when the permit was never acquired.
- `test_session_idle_busy_guard.py` — a busy session is not reaped as idle nor as an orphaned tab; a genuinely idle session still is; `reset()` is asked to skip busy sessions (call-shape pinned so a refactor cannot drop the flag); `touch()` protects a session and reports a missing one; the keepalive touches `last_used` as well as the ACP clock, and still succeeds against a session manager that has no `touch`.
- `test_loop_stall_surfacing.py` — dedupe claims once per dump, re-claims for a genuinely new dump, is not mistaken for a dump by rotation, and notifies rather than going silent if the marker is unwritable; plus defaults and clamps for both new config knobs.

Updated:

- `test_chat_turn_timeout_consistency.py` — this module pinned "every dispatch is wrapped in `wait_for(timeout=CHAT_TURN_TIMEOUT)`", which centralising the ceiling makes obsolete. It now recognises both forms, keeps the site count at 8, and **gains a stronger guard**: a new AST-based check that every inline dispatch has something retrieving its exception. Verified non-vacuous — run against `origin/main` it names exactly the five sites this PR converts. It uses the AST rather than a line window because a done-callback may be defined either side of the dispatch it is attached to.
- `test_consolidate_cmd.py` — four `_expire_idle` stubs are `MagicMock(spec=_Session)`, and dataclass fields built with `default_factory` are not class attributes, so the spec omits `semaphore`; the stubs now answer `semaphore.locked()` like a real session. Three `reset` assertions updated for the new call shape.

## Manual verification

- Cold-interpreter import of each entry point (`mcp_core`, `slack.gateway`, `dashboard.server`, `dashboard.chat_runner`, `dashboard.chat_handlers`, `dashboard.handlers.messaging`, `config.loader`, `dashboard.turn_dispatch`) in a fresh process — a green pytest run does not prove import ordering, because discovery breaks cycles incidentally.
- Resolved the new knobs through the real loader and confirmed the rendered card text.
- Full suite: **24,605 passed, 19 failed**. All 19 are byte-identical on pristine `origin/main` and are environment-driven on this host (no user namespaces, absent root-owned binaries): `test_sandbox_argv` (9), `test_beacon` (2), `test_issue_radar_gh_bin` (2), `test_perf_sampler` (2), `test_source_providers` (2), `test_deploy_round30_fixes` (1), `test_service` (1).
- `isort`, `flake8`, `mypy` clean. No `website/` files touched, so `tsc`/`vitest` do not apply.
- `config-baseline.json` regenerated. It also picks up a pre-existing `stt.endpointing` entry that was missing from the committed baseline on `main` — unrelated to this change, but the file is generated and the drift test requires it.

## Screenshots

N/A — no components, layouts or themes changed. The two user-visible additions render through existing paths with new copy:

- Turn ceiling card: `⏱️ This turn hit the 2-hour limit and was stopped. Work already written to disk is still there — nothing was rolled back. Send a message to continue from where it stopped.`
- Stall notification: `⚠️ Gateway restarted after an event-loop stall` — "The previous gateway stopped responding and exited Nh ago, then restarted. Work in flight at that moment was interrupted and not saved."

Reproducing the card in a screenshot would require a turn that genuinely runs past the ceiling; the floor clamp of 300s prevents shortening it enough to be practical.

## Not addressed (observed, deliberately out of scope)

Two gateway dispatch sites (recovery retrigger, subagent injection) do consume their exception, but on a timeout they log `str(TimeoutError)` — an empty string — and pass that as a failure reason. Worth a follow-up; it is a different path from the babysit loop and not part of this fix.
