### PR TITLE
fix(security): credential paths were readable by respelling them with a variable or cd

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3048,6 +3048,51 @@ def is_sensitive_bash_command(command: str) -> str | None:
     return None
 
 
+# Command separators that end one simple command and begin the next. A `cd` in
+# one segment sets the working directory the following segments resolve against,
+# which is why the second pass has to walk segments rather than one flat token
+# list. Pipes are deliberately absent: they do not change the directory.
+_SHELL_SEGMENT_RE = re.compile(r"\s*(?:&&|\|\||;|\n)\s*")
+
+# `NAME=value` prefix. `normalize_shell_command` keeps it as a single token, and
+# the value is already $HOME-expanded by the time we see it.
+_SHELL_ASSIGN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", re.DOTALL)
+
+# A variable reference that survived `$HOME` expansion, e.g. `$V` or `${V}`.
+_SHELL_VAR_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _expand_known_vars(token: str, assignments: dict[str, str]) -> str:
+    """Substitute variables this command assigned earlier in its own text."""
+
+    def repl(match: re.Match[str]) -> str:
+        name = match.group(1) or match.group(2)
+        return assignments.get(name, match.group(0))
+
+    return _SHELL_VAR_REF_RE.sub(repl, token)
+
+
+def _sensitive_under_unresolved_var(token: str) -> bool:
+    """Would *token* be sensitive if its unresolved variables named a home?
+
+    `normalize_shell_command` expands `$HOME`, so a path that still carries a
+    variable cannot be resolved — the value lives in the shell, not the command
+    text. Rather than let the token through unchecked, test the hypothesis that
+    the variable holds a home directory: `$V/.aws/credentials` becomes
+    `~/.aws/credentials` and is caught, while `$BUILD/out.txt` stays clean
+    because its remainder is not sensitive either way. Fails closed only when
+    the literal part of the path is itself sensitive.
+    """
+    if not _SHELL_VAR_REF_RE.search(token):
+        return False
+    hypothesis = _SHELL_VAR_REF_RE.sub("~", token, count=1)
+    # `~` only expands at the start, so collapse `~/a/~/b` shapes to the tail.
+    hypothesis = _SHELL_VAR_REF_RE.sub("", hypothesis)
+    if not hypothesis.startswith("~"):
+        return False
+    return bool(is_sensitive_path(hypothesis))
+
+
 def _check_sensitive_via_normalizer(command: str) -> str | None:
     """Normalizer second-pass: tokenize command and route paths through is_sensitive_path.
 
@@ -3056,55 +3101,97 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
     - Variable expansion: ``$HOME/.ssh/id_rsa``
     - Relative traversal: ``awk '{print}' ~/../../.aws/credentials``
     - Mixed evasion: ``"cat" ~/.aws/credentials``
+    - Indirection through a variable the command itself assigned:
+      ``V=$HOME; awk 1 $V/.aws/credentials``
+    - A bare filename read after a ``cd``:
+      ``cd ~/.kiro/crew && cat token_signing.key``
 
-    Only triggers when a recognized read verb is present in the resolved tokens
-    (avoids false positives on write/create commands).
+    The command is walked segment by segment so a ``cd`` target becomes the base
+    directory for the segments after it. Without that base, a bare filename is
+    not even path-like, so it was never checked at all, and `is_sensitive_path`
+    would have resolved it against the gateway's own working directory rather
+    than the directory the command moved to.
+
+    Only triggers when a recognized read verb is present in the segment (avoids
+    false positives on write/create commands).
 
     Returns denial reason string, or None if clean.
     """
-    try:
-        tokens = normalize_shell_command(command)
-    except Exception:
-        return None
+    assignments: dict[str, str] = {}
+    base_dir: str | None = None
 
-    if not tokens:
-        return None
+    for segment in _SHELL_SEGMENT_RE.split(command):
+        if not segment.strip():
+            continue
+        try:
+            tokens = normalize_shell_command(segment)
+        except Exception:
+            continue
+        if not tokens:
+            continue
 
-    # Check if any token resolves to a known read verb (by basename, so
-    # /usr/bin/cat is recognized as "cat").
-    has_read_verb = False
-    for token in tokens:
-        if not token:
-            continue
-        basename = os.path.basename(token).lower()
-        if basename in _NORMALIZER_READ_VERBS:
-            has_read_verb = True
-            break
+        # Peel off `NAME=value` prefixes, recording them for later segments, and
+        # resolve references to names this command already assigned.
+        operands: list[str] = []
+        for token in tokens:
+            if not token:
+                continue
+            assign = _SHELL_ASSIGN_RE.match(token)
+            if assign and not token.startswith("/"):
+                assignments[assign.group(1)] = _expand_known_vars(assign.group(2), assignments)
+                continue
+            operands.append(_expand_known_vars(token, assignments))
 
-    if not has_read_verb:
-        return None
+        if not operands:
+            continue
 
-    # Route each path-like token through is_sensitive_path()
-    for token in tokens:
-        if not token:
+        # `cd <target>` moves the base directory for everything after it.
+        if os.path.basename(operands[0]).lower() == "cd":
+            target = next((t for t in operands[1:] if not t.startswith("-")), None)
+            if target:
+                base_dir = os.path.expanduser(target) if target.startswith("~") else target
             continue
-        # Skip flags
-        if token.startswith("-"):
+
+        has_read_verb = any(
+            os.path.basename(token).lower() in _NORMALIZER_READ_VERBS for token in operands
+        )
+        if not has_read_verb:
             continue
-        # Skip tokens that ARE the read verb itself
-        basename = os.path.basename(token).lower()
-        if basename in _NORMALIZER_READ_VERBS:
-            continue
-        # Only check tokens that look like filesystem paths
-        if not _is_path_like(token):
-            continue
-        # is_sensitive_path handles symlink resolution, traversal, ~ expansion,
-        # $HOME expansion, and all sensitive directory checks
-        if is_sensitive_path(token):
-            return (
-                "Blocked: command accesses sensitive credential path "
-                f"(resolved via normalizer: {token[:80]})"
-            )
+
+        for token in operands:
+            # Skip flags
+            if token.startswith("-"):
+                continue
+            # Skip tokens that ARE the read verb itself
+            if os.path.basename(token).lower() in _NORMALIZER_READ_VERBS:
+                continue
+
+            # is_sensitive_path handles symlink resolution, traversal, ~ expansion,
+            # $HOME expansion, and all sensitive directory checks
+            if _is_path_like(token) and is_sensitive_path(token):
+                return (
+                    "Blocked: command accesses sensitive credential path "
+                    f"(resolved via normalizer: {token[:80]})"
+                )
+
+            # A relative operand — including a bare filename, which is not
+            # path-like on its own — resolves against the directory a preceding
+            # `cd` moved to.
+            if base_dir and not token.startswith("/") and not token.startswith("~"):
+                candidate = os.path.join(base_dir, token)
+                if is_sensitive_path(candidate):
+                    return (
+                        "Blocked: command accesses sensitive credential path "
+                        f"(resolved against 'cd' target: {candidate[:80]})"
+                    )
+
+            # A path whose variable this command never assigned cannot be
+            # resolved from the command text alone.
+            if _sensitive_under_unresolved_var(token):
+                return (
+                    "Blocked: command accesses sensitive credential path through an "
+                    f"unresolved variable: {token[:80]}"
+                )
     return None
 
 

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -643,9 +643,7 @@ class TestRedactCredentials:
         from kiro_crew.dashboard.token_auth import generate_token
         from kiro_crew.security import _CREDENTIAL_PATTERNS
 
-        floors = re.findall(
-            r"eyJ\[A-Za-z0-9_-\]\{(\d+),\}", _CREDENTIAL_PATTERNS.pattern
-        )
+        floors = re.findall(r"eyJ\[A-Za-z0-9_-\]\{(\d+),\}", _CREDENTIAL_PATTERNS.pattern)
         assert len(floors) == 1, f"expected one bounded eyJ floor, got {floors}"
         floor = int(floors[0])
 
@@ -655,9 +653,7 @@ class TestRedactCredentials:
 
         # Derived worst case: the narrowest `sub` a caller could pass, with every
         # float claim at its shortest repr (an exactly-integral `time.time()`).
-        claims = json.loads(
-            base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
-        )
+        claims = json.loads(base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)))
         # `gen` is normalised alongside `sub` because it mirrors the process-global
         # `_REVOCATION_GEN`, which is LOADED FROM DISK at import. Left ambient, the
         # derived floor would depend on how many times this machine has revoked:
@@ -2272,6 +2268,60 @@ class TestIsSensitiveBashCommand:
 
     def test_safe_command(self) -> None:
         assert is_sensitive_bash_command("cat ~/readme.md") is None
+
+    # ── Shell normalization: variable indirection and `cd` targets ──
+
+    def test_variable_assigned_in_the_command_is_resolved(self) -> None:
+        """A path reached through a variable the command itself assigned.
+
+        The normalizer expands `$HOME`, so `V=$HOME` resolves, but `$V` used as
+        a path prefix stayed literal and the path never matched. The assignment
+        is in the command text, so it can be substituted.
+        """
+        assert is_sensitive_bash_command("V=$HOME; awk 1 $V/.aws/credentials") is not None
+        assert is_sensitive_bash_command("V=$HOME; cat $V/.ssh/id_rsa") is not None
+        assert is_sensitive_bash_command("V=${HOME}; xxd $V/.ssh/id_rsa") is not None
+        # The variable can carry part of the sensitive path itself.
+        assert is_sensitive_bash_command("D=$HOME/.aws; cat $D/credentials") is not None
+
+    def test_unresolvable_variable_over_a_sensitive_tail_is_blocked(self) -> None:
+        """A variable assigned outside the command still cannot hide the tail.
+
+        The value lives in the shell, not the command text, so it cannot be
+        resolved. Fail closed only when the literal remainder is itself
+        sensitive — see the benign counterparts below.
+        """
+        assert is_sensitive_bash_command("awk 1 $V/.aws/credentials") is not None
+        assert is_sensitive_bash_command("cat $SOMEVAR/.ssh/id_rsa") is not None
+
+    def test_variable_over_a_benign_tail_is_allowed(self) -> None:
+        """An unresolved variable is not itself a reason to block."""
+        assert is_sensitive_bash_command("B=$HOME/build; cat $B/out.txt") is None
+        assert is_sensitive_bash_command("cat $PWD/out.txt") is None
+        assert is_sensitive_bash_command("cat $BUILD_DIR/report.log") is None
+
+    def test_bare_filename_after_cd_is_resolved_against_the_cd_target(self) -> None:
+        """`cd` + a bare filename read the same file as the absolute form.
+
+        A bare filename has no path separator, so it is not path-like and was
+        never checked; had it been, it would have resolved against the
+        gateway's working directory rather than the directory the command
+        moved to.
+        """
+        assert is_sensitive_bash_command("cd ~/.kiro/crew && cat token_signing.key") is not None
+        assert is_sensitive_bash_command("cd ~/.kiro/crew; cat token_signing.key") is not None
+        assert is_sensitive_bash_command("cd ~/.aws && cat credentials") is not None
+        assert is_sensitive_bash_command("cd ~/.ssh && cat id_rsa") is not None
+        # The `cd` target may itself arrive through $HOME.
+        assert (
+            is_sensitive_bash_command("cd $HOME/.kiro/crew && awk 1 token_signing.key") is not None
+        )
+
+    def test_cd_into_a_benign_directory_is_allowed(self) -> None:
+        """Tracking the `cd` target must not block ordinary relative reads."""
+        assert is_sensitive_bash_command("cd /tmp && cat notes.txt") is None
+        assert is_sensitive_bash_command("cd ~/project && cat config.json") is None
+        assert is_sensitive_bash_command("cd src && grep -rn pattern .") is None
 
     # ── Symlink-staging (pentest recommendation item 3) ──
 


### PR DESCRIPTION
## Description

`is_sensitive_bash_command` denies reads of credential paths. Two respellings of the same path walked past it, and both read the real file:

```
V=$HOME; awk 1 $V/.aws/credentials
cd ~/.kiro/crew && cat token_signing.key
```

Both return `None` on `main` — no denial. The absolute forms are correctly blocked, so the gate covers the file; only these spellings escape it.

**Variable indirection.** `normalize_shell_command` expands `$HOME` and `~`, nothing else. So `V=$HOME` resolves, but the reference does not:

```
tokens: ['V=/home/user;', 'awk', '1', '$V/.aws/credentials']
                                     ^ path-like, but resolves to a directory
                                       literally named "$V" — not sensitive
```

The assignment is in the command text, so it can be substituted.

**Bare filename after `cd`.** A bare filename has no path separator, so `_is_path_like` rejects it and it is never checked at all:

```
tokens: ['cd', '/home/user/.kiro/crew', '&&', 'cat', 'token_signing.key']
                                                     ^ path_like=False — skipped
```

Had it been checked, `is_sensitive_path` takes no base directory and would have resolved it against the gateway's own working directory rather than the directory the command moved to. Either way `token_signing.key` — the token signing key — was readable, and `denied_commands.json` writable by the same shape.

### What changed

The second pass now walks the command segment by segment, splitting on `&&`, `||`, `;` and newline. Pipes are deliberately not separators: they do not change the working directory.

Per segment:

- **`NAME=value` prefixes are recorded**, and later `$NAME` / `${NAME}` references are substituted from them. The value is already `$HOME`-expanded by the time the token arrives, so `V=$HOME` yields a real path.
- **A `cd <target>` segment sets the base directory** that following segments resolve their relative operands against — including bare filenames, which is the case that was skipped entirely.
- **The read-verb requirement is evaluated per segment**, so the verb and the operand have to appear together rather than anywhere on the line.

For a variable the command never assigned, the value lives in the shell and cannot be recovered from the text. Rather than pass the token through unchecked, `_sensitive_under_unresolved_var` tests the hypothesis that the variable holds a home directory:

| token | hypothesis | verdict |
|---|---|---|
| `$V/.aws/credentials` | `~/.aws/credentials` | blocked |
| `$SOMEVAR/.ssh/id_rsa` | `~/.ssh/id_rsa` | blocked |
| `$BUILD/out.txt` | `~/out.txt` | allowed |
| `$PWD/out.txt` | `~/out.txt` | allowed |

It fails closed only when the literal part of the path is sensitive on its own, so an unresolved variable is not by itself a reason to deny.

The existing path-like check is unchanged and still runs first, so nothing that was detected before stops being detected.

## Related Issues

None filed — reporting and fixing together.

Same family as the earlier shared-normalizer work: that landed `$HOME`, `${IFS}`, brace and tilde expansion and routed resolved tokens through `is_sensitive_path`. An assignment-and-reference pair inside one command line, and a `cd` target carried across `&&`, were left open. This closes those two.

Independent of #1259 and #1263, which touch `dashboard/state.py`; this one touches `security.py` only, so there is no overlap and no conflict.

## Testing

- [x] Existing tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

Five new cases in `test/test_security.py::TestIsSensitiveBashCommand`: variables the command assigns itself; a variable assigned outside it over a sensitive tail; the benign counterpart, so an unresolved variable alone does not deny; bare filenames after `cd`; and `cd` into an ordinary directory, so tracking the target does not start blocking normal relative reads.

```
pytest (full suite)                                          ->  24626 passed, 129 skipped, 5 xfailed, 1 failed
pytest test/test_security.py + the 5 files that import the gate ->  786 passed, 5 skipped
flake8 / isort / black / mypy on the changed module           ->  clean
```

The single failure is pre-existing and unrelated: `test_browser_recording_skill.py::TestRunnerValidation::test_missing_playwright_fails_loud_without_install` asserts on an "install playwright" hint, but this host has no `node` on PATH so the runner fails earlier with `node not found on PATH`. It reproduces identically on clean `main`.

Manual verification, run against the gate on each branch:

| command | `main` | this branch |
|---|---|---|
| `V=$HOME; awk 1 $V/.aws/credentials` | passes | blocked |
| `V=$HOME; cat $V/.ssh/id_rsa` | passes | blocked |
| `V=${HOME}; xxd $V/.ssh/id_rsa` | passes | blocked |
| `D=$HOME/.aws; cat $D/credentials` | passes | blocked |
| `awk 1 $V/.aws/credentials` | passes | blocked |
| `cat $SOMEVAR/.ssh/id_rsa` | passes | blocked |
| `cd ~/.kiro/crew && cat token_signing.key` | passes | blocked |
| `cd ~/.kiro/crew; cat token_signing.key` | passes | blocked |
| `cd ~/.aws && cat credentials` | passes | blocked |
| `cd ~/.ssh && cat id_rsa` | passes | blocked |
| `cd $HOME/.kiro/crew && awk 1 token_signing.key` | passes | blocked |
| `cat ~/.aws/credentials` | blocked | blocked |
| `cat ~/.kiro/crew/token_signing.key` | blocked | blocked |
| `cat $HOME/.ssh/id_rsa` | blocked | blocked |
| `cd /tmp && cat notes.txt` | passes | passes |
| `cd ~/project && cat config.json` | passes | passes |
| `cd src && grep -rn pattern .` | passes | passes |
| `B=$HOME/build; cat $B/out.txt` | passes | passes |
| `cat $PWD/out.txt` | passes | passes |
| `cat README.md`, `ls -la /tmp`, `grep -r foo src/`, `git status` | passes | passes |

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

On documentation: the reasoning lives in the docstrings of the two new helpers and the rewritten one, which is where an edit to this logic would need it. Happy to add a note to the security module spec if you would prefer it recorded there.

### Not in scope

`cd` tracking follows the most recent target and joins relative operands onto it. It does not model a shell's full directory state, so these still resolve loosely and are worth a follow-up if you want them tight:

- accumulated moves (`cd a && cd b`) and upward moves (`cd /x && cd ../y`) are joined, not normalized
- `pushd` / `popd`
- a subshell that scopes the move: `( cd ~/.aws && cat credentials )`

Also unchanged: the read-verb list gates whether a segment is examined at all, so a verb outside `_NORMALIZER_READ_VERBS` still bypasses this pass. Widening that list is a separate decision from the two respellings fixed here.

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

