### PR TITLE
ci: authenticate fork-review diff fetch with basic auth, not bearer

### DIFF
--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -146,7 +146,15 @@ jobs:
           # past the cap and still pass. Fetch the PR head history as OBJECTS only
           # (never checked out — the working tree stays the trusted base, so no
           # fork file/symlink is materialized) and diff locally, which has no cap.
-          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" \
+          # GitHub's git smart-HTTP transport authenticates with BASIC auth
+          # (base64 of "x-access-token:$GITHUB_TOKEN"); the `bearer` scheme is
+          # rejected, so git falls back to an interactive username prompt and
+          # dies with "could not read Username" in CI. This mirrors how
+          # actions/checkout injects its credential. The header value is never
+          # logged and the raw token stays masked.
+          auth_b64="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          echo "::add-mask::$auth_b64"  # mask the derived header so it can never surface in logs
+          git -c http.extraheader="AUTHORIZATION: basic $auth_b64" \
             fetch --no-tags --quiet origin "refs/pull/$PR/head" \
             || { echo "::error::could not fetch PR head history for #$PR"; exit 1; }
           # Pin to the exact CI-reviewed head SHA; fail closed if it is missing

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -151,7 +151,15 @@ jobs:
           # past the cap and still pass. Fetch the PR head history as OBJECTS only
           # (never checked out — the working tree stays the trusted base, so no
           # fork file/symlink is materialized) and diff locally, which has no cap.
-          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" \
+          # GitHub's git smart-HTTP transport authenticates with BASIC auth
+          # (base64 of "x-access-token:$GITHUB_TOKEN"); the `bearer` scheme is
+          # rejected, so git falls back to an interactive username prompt and
+          # dies with "could not read Username" in CI. This mirrors how
+          # actions/checkout injects its credential. The header value is never
+          # logged and the raw token stays masked.
+          auth_b64="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          echo "::add-mask::$auth_b64"  # mask the derived header so it can never surface in logs
+          git -c http.extraheader="AUTHORIZATION: basic $auth_b64" \
             fetch --no-tags --quiet origin "refs/pull/$PR/head" \
             || { echo "::error::could not fetch PR head history for #$PR"; exit 1; }
           # Pin to the exact CI-reviewed head SHA; fail closed if it is missing

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -151,7 +151,15 @@ jobs:
           # past the cap and still pass. Fetch the PR head history as OBJECTS only
           # (never checked out — the working tree stays the trusted base, so no
           # fork file/symlink is materialized) and diff locally, which has no cap.
-          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" \
+          # GitHub's git smart-HTTP transport authenticates with BASIC auth
+          # (base64 of "x-access-token:$GITHUB_TOKEN"); the `bearer` scheme is
+          # rejected, so git falls back to an interactive username prompt and
+          # dies with "could not read Username" in CI. This mirrors how
+          # actions/checkout injects its credential. The header value is never
+          # logged and the raw token stays masked.
+          auth_b64="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          echo "::add-mask::$auth_b64"  # mask the derived header so it can never surface in logs
+          git -c http.extraheader="AUTHORIZATION: basic $auth_b64" \
             fetch --no-tags --quiet origin "refs/pull/$PR/head" \
             || { echo "::error::could not fetch PR head history for #$PR"; exit 1; }
           # Pin to the exact CI-reviewed head SHA; fail closed if it is missing

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -147,7 +147,15 @@ jobs:
           # past the cap and still pass. Fetch the PR head history as OBJECTS only
           # (never checked out — the working tree stays the trusted base, so no
           # fork file/symlink is materialized) and diff locally, which has no cap.
-          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" \
+          # GitHub's git smart-HTTP transport authenticates with BASIC auth
+          # (base64 of "x-access-token:$GITHUB_TOKEN"); the `bearer` scheme is
+          # rejected, so git falls back to an interactive username prompt and
+          # dies with "could not read Username" in CI. This mirrors how
+          # actions/checkout injects its credential. The header value is never
+          # logged and the raw token stays masked.
+          auth_b64="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          echo "::add-mask::$auth_b64"  # mask the derived header so it can never surface in logs
+          git -c http.extraheader="AUTHORIZATION: basic $auth_b64" \
             fetch --no-tags --quiet origin "refs/pull/$PR/head" \
             || { echo "::error::could not fetch PR head history for #$PR"; exit 1; }
           # Pin to the exact CI-reviewed head SHA; fail closed if it is missing


### PR DESCRIPTION
## Problem

The Stage‑2 fork AI reviewers (`GPT 5.6 Review`, `Opus 5 Review`, `Design Review`, `UX Review`) fail before producing a verdict on every fork PR that reaches them. On PR #1259 — the first fork PR to pass CI and actually trigger the reviewers — GPT, Opus and Design all posted "⚠️ review incomplete", and the `GPT 5.6 Review` / `Opus 5 Review` blocking checks went red, leaving the PR `BLOCKED`.

The failing step is "Fetch authentic diff", with:

```
fatal: could not read Username for 'https://github.com': No such device or address
##[error]could not fetch PR head history for #1259
```

## Why it matters

The fork AI-review pipeline (shipped in #1145) is the only path that gives external contributors the same GPT/Opus/Design/UX review coverage as same‑repo PRs. With this bug, the pipeline dispatches and posts comments correctly but can never yield a real verdict — three of four reviewers hard‑fail (two of them blocking), so no fork PR can go green. The feature is effectively inert on the exact PRs it exists for.

## Fix (symptoms → root cause → change)

- **Symptom:** git prompts for a username and dies (`could not read Username`), i.e. the request went out unauthenticated / was rejected 401.
- **Root cause:** the fetch authenticated with `http.extraheader="AUTHORIZATION: bearer $GH_TOKEN"`. GitHub's git **smart‑HTTP transport rejects the `bearer` scheme** (it expects Basic auth); on a 401 git falls back to interactive credential entry, which has no TTY in CI and aborts. The preceding `actions/checkout` uses `persist-credentials: false`, so there is no working credential left on the `origin` remote to fall back to. This step had never executed before because no prior fork PR passed CI far enough to trigger Stage 2, so the untested scheme shipped.
- **Change:** authenticate with **Basic auth**, exactly as `actions/checkout` does — `AUTHORIZATION: basic base64("x-access-token:$GITHUB_TOKEN")` — and `::add-mask::` the derived header value as defense in depth. Applied identically to all four fork reviewers.

No change to the trust model: Stage 2 still runs from the default branch, checks out only the trusted base, fetches the fork head as **objects only (never checked out / executed)**, and remains egress‑locked by harden‑runner. Only the ephemeral job `GITHUB_TOKEN` is used, and only against GitHub endpoints. The edit changes the auth *scheme* of an already‑authenticated fetch; it does not widen credential exposure (the token was already on git's command line under the old `bearer` form).

## Tests

N/A — CI workflow definitions; there is no unit-test harness for `workflow_run` YAML. Validated by (a) YAML parse of all four files, (b) confirming the Basic-auth scheme matches `actions/checkout`'s own proven credential injection, and (c) grep-confirming no other workflow carried the `bearer` fetch pattern.

## Manual verification

- `ruby -ryaml -e 'YAML.load_file(...)'` passes for all four edited workflows.
- Because `workflow_run` always executes the **default-branch** copy of the workflow, this fix can only take effect once merged to `main`; it cannot be exercised on a fork PR pre-merge (this is the same property that prevents a fork from altering what runs). Post-merge validation: re-run the reviewers on fork PR #1259 (or push a trivial commit) and confirm the "Fetch authentic diff" step succeeds and GPT/Opus/Design produce real verdicts.
