### PR TITLE
docs(autopilot): bind the "Autopilot" name in the orchestrator prompt + design doc

### DIFF
--- a/docs/autopilot-design-and-lifecycle.md
+++ b/docs/autopilot-design-and-lifecycle.md
@@ -29,6 +29,8 @@ Orchestrated Chat (Autopilot) consolidates Chat mode and Task Runner into a sing
 
 Autopilot is **not** a separate app or page — it is a per-slot mode of the unified Chat surface, enabled when `_ChatSlot.mode == "orchestrator"` and toggled via `PATCH /api/chat/slots/{slot}/mode` (`chat_folders.py`; `_VALID_MODES = ("", "orchestrator")`, registered in `server.py`). Switching mode returns `409` while the slot is running. The standalone `orchestrated` builtin app was removed — it is deleted on startup via `manager.py`'s `_escalated` list — and there is no `/orchestrated` page or backend route.
 
+> **Terminology.** "Autopilot" is the user-facing name (badge, WelcomeView, nav). The slot `mode` value, the config section, and the system-prompt file (`prompt-orchestrator.md`) keep the internal name `orchestrator` for back-compat — renaming those would break persisted sessions and configs. The Autopilot system prompt recognizes user references to *autopilot* / *autopilot plan* / *autopilot this* as this mode.
+
 - **Simple tasks** (majority): behaves like chat — direct response, no planning overhead.
 - **Complex tasks**: structured plan, stage-by-stage execution, specialist agents — with user interaction between stages.
 - **Over time**: learns from user guidance and past plans, needs less human support for longer autonomous runs.

--- a/src/kiro_crew/config/prompt-orchestrator.md
+++ b/src/kiro_crew/config/prompt-orchestrator.md
@@ -29,6 +29,8 @@ Skills loaded into your context describe exact syntax. Read them before using a 
 
 ## Task Decomposition
 
+**This is Autopilot.** "Autopilot" is the user-facing name for this mode (internally the `orchestrator` slot mode). Treat any user reference to *autopilot* — e.g. "autopilot", "autopilot mode", "autopilot plan", "turn on autopilot", "autopilot this" — as referring to this plan→approve→execute workflow, in any language.
+
 When given a complex task, first create a high-level plan, get user approval, then execute:
 
 ### Step 1: Plan (one-time, before execution starts)
@@ -142,7 +144,7 @@ Assistant: Let me read the auth module... [starts editing files]
 ```
 **Instead:** present a plan with focused stages and wait for approval.
 
-The point of orchestrator mode is the plan→approve→execute flow **for work that warrants it** — not to add overhead to simple tasks, and not to skip alignment on genuinely complex ones.
+The point of Autopilot mode (the `orchestrator` slot mode) is the plan→approve→execute flow **for work that warrants it** — not to add overhead to simple tasks, and not to skip alignment on genuinely complex ones.
 
 ## Asking for Help
 

--- a/test/test_prompt_autopilot_binding_rule.py
+++ b/test/test_prompt_autopilot_binding_rule.py
@@ -1,0 +1,25 @@
+"""The orchestrator system prompt must bind the user-facing name "Autopilot".
+
+The mode is presented to users as **Autopilot** (badge, WelcomeView, nav), but
+the system prompt otherwise speaks in terms of "orchestrator"/"plan"/"stages"
+and the internal slot-mode value stays ``"orchestrator"`` for back-compat. If
+the prompt never states that "Autopilot" *is* this mode, the model has no
+binding for user references like "autopilot plan" / "autopilot this" and can
+fail to recognize them even while genuinely running in orchestrator mode.
+
+That name-binding line reads like ordinary prose and is exactly the kind of line
+a prompt rewrite drops -- silently reintroducing the misunderstanding -- so it is
+pinned by a test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "config"
+
+
+def test_orchestrator_prompt_binds_autopilot_name() -> None:
+    text = (CONFIG_DIR / "prompt-orchestrator.md").read_text(encoding="utf-8")
+    assert "This is Autopilot" in text
+    assert "autopilot plan" in text.lower()


### PR DESCRIPTION
## Problem
In Autopilot mode, the assistant sometimes doesn't understand references like "autopilot plan" — it ignores or misreads the instruction even though the session is genuinely running the orchestrator prompt.

## Why it matters
Users see the mode (badge, nav, WelcomeView all say **Autopilot**) fail to act on plain "autopilot"/"autopilot plan" phrasing, which reads as the feature being broken and erodes trust in Autopilot.

## Fix (symptom → root cause → change)
- **Symptom:** "autopilot plan" not recognized as a request to run the staged plan flow.
- **Root cause:** the orchestrator system prompt (`prompt-orchestrator.md`) never bound the user-facing name. It used the word "autopilot" only inside #883's explicit-plan-request trigger list and otherwise referred to itself as "orchestrator mode" — so the model had no general binding from the user-facing name "Autopilot" to this mode.
- **Change:** add a one-line definition at the top of Task Decomposition stating **this is Autopilot** and that user references to *autopilot* / *autopilot mode* / *autopilot plan* / *autopilot this* mean this plan→approve→execute workflow; reword the one self-referential "orchestrator mode" prose line to "Autopilot mode (the `orchestrator` slot mode)". The internal `orchestrator` slot-mode value, config section, and prompt filename are intentionally left unchanged for back-compat (renaming them would break persisted sessions and configs — deferred). A Terminology note is added to `docs/autopilot-design-and-lifecycle.md` recording the user-facing-name vs internal-value split.

## Tests
- New `test/test_prompt_autopilot_binding_rule.py` pins the binding: asserts `prompt-orchestrator.md` contains `This is Autopilot` and `autopilot plan`, mirroring the existing prompt-invariant tests (`test_prompt_trailing_space_rule.py`, `test_prompt_pr_link_rule.py`) so a future prompt rewrite can't silently drop the line and reintroduce the misunderstanding. Local run: 5 passed; isort/flake8 clean on the new file.

## Manual verification
N/A — the change is prompt/doc text plus a static-assertion test. Note: the live symptom was traced to an installed app predating #883; this PR adds the general name binding that #883's trigger-list change did not.

## Screenshots
N/A — no user-visible UI change.

## Out of scope (flagged, not addressed)
A user/project-level `prompt-orchestrator.md` override **replaces** the bundled prompt wholesale (`agent.py` `_prompt_path()`), so overriders won't inherit this binding. That is pre-existing prompt-override precedence behavior, unrelated to this terminology change.
