### PR TITLE
fix(chat): steer mid-stream strands the streaming marker above the bubble

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -523,6 +523,51 @@ A pending tool approval has **two** pieces of state that must stay in lockstep: 
 
 **Runner backstop totality**: `outcome` is pre-seeded to `"rejected"` before the approval `await`, because the `finally` runs on *every* exit including `CancelledError` (slot deletion and cleanup endpoints cancel `slot.task`). Assigning it only inside `try`/`except` would raise `UnboundLocalError` from the `finally`, replacing the cancellation with a spurious exception and skipping both the message marking and the Slack prompt cleanup.
 
+### Mid-Turn Steer (dashboard transcript contract)
+
+A steer (`POST /api/chat` with `steer: true` while the slot is running) injects
+the message into the in-flight turn via kiro-cli `_session/steer`. kiro-cli does
+NOT end the current text segment at the steer, so both sides of the boundary
+must be handled explicitly or the transcript disagrees with what the user
+watched stream (the "stuck streaming marker" bug: the live streaming message is
+stranded ABOVE the steer bubble, the rest of the segment streams into it there,
+and the finalized reply jumps BELOW the bubble when the `chat_done` refresh
+rebuilds from server history).
+
+**Backend — segment cut at the steer boundary.** `_run_chat` publishes a sync
+closure on the slot (`slot._steer_segment_cut`, same lifecycle as
+`slot._acp_client`: set at turn start, cleared in the turn's `finally`). The
+steer handler calls it right BEFORE `slot.append("user", …, meta={"steer": True})`,
+so the accumulated segment text is flushed as its own assistant message and the
+persisted order is `[assistant(pre-steer), user(steer), assistant(post-steer)]`
+— identical to the live view. The cut persists SILENTLY: `broadcast=False`
+(no `chat_segment`), `quiet_persist=True` (no per-message `chat_message` from
+the append), and the wire redactor's withheld tail is dropped via
+`_wsred.reset()` rather than emitted (no late `chat_chunk`). At the cut
+boundary every client has already finalized its streaming message — the
+initiating tab froze at optimistic-push time, other tabs freeze on the
+`steer_push` echo — so any of those events would materialize a duplicate copy
+of the pre-steer text (or a phantom streaming bubble) below the steer bubble.
+No text is lost: `assistant_text` accumulates independently of the wire
+buffer and is re-redacted at persist. The cut also sets
+`_produced_visible_output` (the flushed segment is visible output; without it
+a stream→steer→quiet-end turn would trip the empty-response requeue). The cut
+is best-effort (a failure logs and never loses the steer) and also prevents the
+chunk-entry leak: without it, `_flush_segment`'s trailing-run walk stops at the
+mid-run steer user message and the pre-steer `chunk` entries stay in
+`slot.messages` for the life of the process.
+
+**Frontend — finalize-on-steer.** Every path that INSERTS a steer bubble first
+finalizes the live `streaming` message in place via `finalizeTrailingStreaming`
+(streaming → assistant; placeholder-only content is dropped, same rule as the
+`_segment` handlers, which share the helper): the optimistic push
+(`appendMessage`, `meta.steer`), a pane-scoped optimistic push, and the
+`steer_push` echo when no optimistic bubble exists to reconcile (another tab /
+scene-interaction steered). The reconcile path deliberately does NOT freeze — by
+echo time a new post-steer streaming message may be live below the bubble and
+must keep streaming. Pinned by `test_chat_steer.py` (cut ordering, cut-failure
+resilience) and the `finalize-on-steer` describe in `chatSlice.test.ts`.
+
 ### Agent Questions (`ask_question`)
 
 `ask_question` is **non-blocking** as of issue #755: the tool renders a question card in the caller's own chat window and the agent ENDS its turn — it no longer holds the turn open on a server-side wait resolving to an answer map. User-facing documentation lives in `src/kiro_crew/docs/agent-questions.md`; this section is the contract.

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -266,6 +266,26 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
                         return web.json_response({"ok": True, "queued": True})
                 if steered:
                     _ts = datetime.now(timezone.utc).isoformat()
+                    # Cut the in-flight text segment at the steer boundary
+                    # BEFORE persisting the user message, so the transcript
+                    # reads [assistant(pre-steer), user(steer), …] — the same
+                    # order the client rendered live. Without this the whole
+                    # segment lands BELOW the steer bubble at end-of-turn and
+                    # the chat_done refresh visibly reorders the reply (and the
+                    # pre-steer chunk entries are stranded in slot.messages —
+                    # _flush_segment's trailing-run walk stops at this user
+                    # message). Best-effort: a cut failure must never lose the
+                    # steer itself.
+                    _cut = slot._steer_segment_cut
+                    if _cut is not None:
+                        try:
+                            _cut()
+                        except Exception:
+                            logger.warning(
+                                "steer segment cut failed for slot %s",
+                                slot.key,
+                                exc_info=True,
+                            )
                     # Sanitize: same chain as the queue path.
                     _sanitized, _ = redact_exfiltration_urls(message)
                     _sanitized, _ = redact_credentials(_sanitized)

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -1510,8 +1510,19 @@ def _flush_segment(
     assistant_text: str,
     *,
     broadcast: bool = True,
+    quiet_persist: bool = False,
 ) -> None:
-    """Finalize current text block as a segment and persist it."""
+    """Finalize current text block as a segment and persist it.
+
+    ``quiet_persist`` additionally suppresses the per-message ``chat_message``
+    broadcast that ``slot.append`` emits for the finalized assistant message.
+    Used ONLY by the mid-turn steer cut: at that boundary every client has
+    already finalized its streaming message (optimistic freeze on the
+    initiating tab, steer_push freeze on the others), so a broadcast here
+    would render a DUPLICATE copy of the pre-steer text below the steer
+    bubble. Normal end-of-segment flushes keep the broadcast — there the
+    clients still hold a live streaming message for it to reconcile into.
+    """
 
     # Remove trailing chunk messages (they belong to this segment).
     # Also pull aside any stop_event interleaved with this segment's chunks
@@ -1552,7 +1563,7 @@ def _flush_segment(
     # other tabs viewing the same slot receive the finalized text.
     # The active tab already has this content from streaming chunks;
     # the chat_segment event tells it to finalize streaming → assistant.
-    slot.append("assistant", redacted, "msg msg-a")
+    slot.append("assistant", redacted, "msg msg-a", broadcast=not quiet_persist)
     last_msg: dict = slot.messages[-1]
     # If a regenerate is pending, attach the stashed variants to this fresh assistant message.
     if slot._pending_variants:
@@ -2251,6 +2262,11 @@ async def _run_chat(
         return injected
 
     assistant_text = ""
+    # Initialized HERE (not with the other turn-state flags below) because
+    # _steer_segment_cut declares it nonlocal — mypy requires the binding to
+    # exist textually before the nested def. Semantics unchanged: nothing
+    # touches it between here and the flag block.
+    _produced_visible_output = False
     last_heartbeat = time.time()
     chunk_seq = 0
     in_tool_group = False
@@ -2284,6 +2300,50 @@ async def _run_chat(
         wire = _thinkred.flush()
         if wire:
             state.broadcast_ws("chat_thinking", {"slot": slot.key, "content": wire})
+
+    def _steer_segment_cut() -> None:
+        """Finalize the accumulated text as a segment at a mid-turn steer.
+
+        Published on the slot (next to ``_acp_client``) so the dashboard steer
+        handler can cut the segment right BEFORE it persists the steer user
+        message. Without the cut, kiro-cli keeps the segment open across the
+        steer, so ``_flush_segment`` at end-of-segment appends the WHOLE text
+        (pre-steer + post-steer) BELOW the steer bubble — the reply the user
+        watched stream above their steer jumps to the bottom when the chat_done
+        refresh rebuilds from server history — and the pre-steer ``chunk``
+        entries are stranded above the bubble forever (the trailing-run walk in
+        ``_flush_segment`` stops at the first non-chunk message).
+
+        ``broadcast=False``: the initiating tab already froze its streaming
+        message when it pushed the optimistic bubble, and other tabs freeze on
+        the ``steer_push`` echo (appendSlotMessage finalize-on-steer). A
+        chat_segment broadcast here could instead finalize a NEWER post-steer
+        streaming message that raced ahead on the initiating tab.
+
+        Sync on purpose — the handler and this turn share the event loop, so
+        the flush cannot interleave with chunk processing.
+        """
+        nonlocal assistant_text, _produced_visible_output
+        # Drop the wire redactor's withheld tail instead of emitting it: a
+        # chat_chunk broadcast here would arrive AFTER the clients froze their
+        # streaming message at the steer boundary, opening a phantom streaming
+        # bubble below the steer card. No text is lost — assistant_text
+        # accumulates the full segment independently of the wire buffer, and
+        # _flush_segment persists (and re-redacts) that full text.
+        _wsred.reset()
+        if assistant_text.strip():
+            # quiet_persist: the clients already hold this text in their
+            # frozen (pre-steer) message; the append's chat_message broadcast
+            # would render a duplicate copy below the steer bubble.
+            _flush_segment(state, slot, assistant_text, broadcast=False, quiet_persist=True)
+            # The flushed segment IS visible output. Every other mid-turn site
+            # that resets assistant_text (compaction, clear, agent switch,
+            # /compact) sets this flag too; without it, a turn that streamed
+            # text, got steered, and then ended with no further text would hit
+            # the empty-response branch and requeue the ORIGINAL prompt —
+            # re-running its side effects.
+            _produced_visible_output = True
+        assistant_text = ""
 
     # Partial-output guard for transient-5xx retry: flipped True once ANY
     # assistant token streams or a tool call fires this turn. A transient
@@ -2336,7 +2396,6 @@ async def _run_chat(
     needs_session_reset = False
     _auth_required = False
     saw_compaction = False
-    _produced_visible_output = False
     _turn_tool_calls = 0  # tool dispatches this turn (refusal diagnostic)
     _retrying_empty = False
     # Recoverable tool refusals (host-gate policy deny / read-only bash gate)
@@ -2554,6 +2613,10 @@ async def _run_chat(
         # (the dashboard steer handler) can reach the running session's client
         # to inject a mid-turn steer. Cleared in the finally below.
         slot._acp_client = getattr(client, "client", None)
+        # Companion steer handle: lets the steer handler cut the current text
+        # segment at the steer boundary (see _steer_segment_cut). Same
+        # lifecycle as _acp_client.
+        slot._steer_segment_cut = _steer_segment_cut
         # Backfill slot.model from provider if user didn't explicitly set one.
         # AcpProvider stores the resolved model on client._model. For claude_code
         # that is a provider id; map it back to the canonical registry key so it
@@ -5193,6 +5256,9 @@ async def _run_chat(
         # Steer handle: turn is over, drop the live client ref so a late steer
         # can't target a dead session (the route also re-checks running state).
         slot._acp_client = None
+        # Same lifecycle for the segment-cut handle: a late steer must not
+        # flush into a finished turn's (already-flushed) locals.
+        slot._steer_segment_cut = None
         # Ensure file changes always surface, even on cancel/error. Wrapped so
         # a raise here cannot skip the re-arm below and re-introduce the orphan
         # bug this fix prevents.

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -845,6 +845,7 @@ class _ChatSlot:
         "_browse_mode",
         "_side",
         "_acp_client",
+        "_steer_segment_cut",
         "_native_subagent_tracker",
         "_native_subagent_output",
         "_pending_steers",
@@ -1060,6 +1061,16 @@ class _ChatSlot:
         # dashboard steer handler) reach the running session's client to inject
         # a mid-turn steer. None when idle.
         self._acp_client = None
+        # Sync callable published by _run_chat alongside _acp_client (cleared in
+        # the same finally): flushes the turn's accumulated text as a finalized
+        # assistant segment NOW. The steer handler calls it right BEFORE
+        # persisting the steer user message, so the transcript order is
+        # [assistant(pre-steer), user(steer), assistant(post-steer)] — matching
+        # what the client rendered live — instead of the whole segment landing
+        # BELOW the steer bubble at end-of-turn (and stranding the pre-steer
+        # chunk entries above it, which _flush_segment's trailing-run walk could
+        # then never reclaim). None when idle.
+        self._steer_segment_cut: Callable[[], None] | None = None
         # Native kiro-cli subagents run inside the parent ACP turn. Keep their
         # live and terminal state on the slot so reconnects can hydrate cards.
         self._native_subagent_tracker: dict[str, dict[str, Any]] = {}

--- a/test/test_chat_steer.py
+++ b/test/test_chat_steer.py
@@ -105,3 +105,104 @@ class TestApiChatSteer:
             assert data.get("steered") is not True
 
         client_mock.steer.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_steer_cuts_segment_before_user_append(self, tmp_path, monkeypatch, _patch_sel):
+        """The segment cut runs BEFORE the steer user message is persisted, so
+        the flushed pre-steer assistant text lands ABOVE the steer bubble."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        roles_at_cut: list[str] = []
+
+        def _cut() -> None:
+            # Snapshot the transcript at cut time, then flush like the real
+            # closure does (persist the accumulated segment as assistant).
+            roles_at_cut.extend(m["role"] for m in slot.messages)
+            slot.append("assistant", "pre-steer text", "msg msg-a")
+
+        slot._steer_segment_cut = _cut
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat", json={"slot": "test", "message": "go left", "steer": True}
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("steered") is True
+
+        # Cut ran before the user append: no user message in the snapshot.
+        assert "user" not in roles_at_cut
+        # Persisted order: pre-steer assistant ABOVE the steer user bubble.
+        roles = [m["role"] for m in slot.messages]
+        assert roles.index("assistant") < roles.index("user")
+        steer_msg = next(m for m in slot.messages if m["role"] == "user")
+        assert steer_msg.get("meta", {}).get("steer") is True
+
+    @pytest.mark.asyncio
+    async def test_steer_cut_failure_does_not_lose_steer(self, tmp_path, monkeypatch, _patch_sel):
+        """A raising cut closure is best-effort: the steer user message is
+        still persisted and steer_push still broadcast."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+        slot._steer_segment_cut = MagicMock(side_effect=RuntimeError("boom"))
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat", json={"slot": "test", "message": "go left", "steer": True}
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("steered") is True
+
+        slot._steer_segment_cut.assert_called_once()
+        assert any(m["role"] == "user" and m.get("meta", {}).get("steer") for m in slot.messages)
+        events = [c.args[0] for c in state.broadcast_ws.call_args_list]
+        assert "steer_push" in events
+
+
+class TestFlushSegmentQuietPersist:
+    """Pin the steer-cut persistence contract: quiet_persist suppresses the
+    per-message chat_message broadcast slot.append emits for the finalized
+    assistant message. At the cut boundary every client has already frozen its
+    streaming message, so that broadcast would render a duplicate copy of the
+    pre-steer text below the steer bubble."""
+
+    def _slot_with_chunks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("test")
+        slot._on_message = MagicMock()
+        slot.append("chunk", "pre-steer", "chunk", broadcast=False)
+        return state, slot
+
+    def test_quiet_persist_suppresses_message_broadcast(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_runner import _flush_segment
+
+        state, slot = self._slot_with_chunks(tmp_path, monkeypatch)
+        _flush_segment(state, slot, "pre-steer text", broadcast=False, quiet_persist=True)
+        # Persisted (chunks collapsed into the assistant message)…
+        roles = [m["role"] for m in slot.messages]
+        assert "assistant" in roles and "chunk" not in roles
+        # …but with NO chat_message broadcast and NO chat_segment event.
+        slot._on_message.assert_not_called()
+        events = [c.args[0] for c in state.broadcast_ws.call_args_list]
+        assert "chat_segment" not in events
+
+    def test_default_flush_still_broadcasts_message(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_runner import _flush_segment
+
+        state, slot = self._slot_with_chunks(tmp_path, monkeypatch)
+        _flush_segment(state, slot, "normal segment", broadcast=False)
+        slot._on_message.assert_called_once()

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -29,6 +29,37 @@ const filterMessages = (msgs: ChatMessage[]) => msgs.filter(m => !SKIP_ROLES.has
 let bornKeySeq = 0
 const mintBornKey = (): string => `born-${Date.now()}-${bornKeySeq++}`
 
+/** Finalize the most recent live `streaming` message in place (streaming →
+ *  assistant), or drop it entirely when its content is a trivial placeholder
+ *  the model emits before tool calls ("...", "…", "---", ". . .", etc.).
+ *  Only patterns EXCLUSIVELY composed of 2+ repeated punctuation/whitespace
+ *  chars are dropped — never single characters, which could be the start of
+ *  legitimate content (list markers, etc.).
+ *
+ *  Shared by the two segment-finalize paths (active `sseChatMessage` and
+ *  background `applyMessageToArray`) AND the steer insertion paths: a mid-turn
+ *  steer bubble must never be pushed BELOW a live streaming message, or the
+ *  chunk reducer (which scans backwards for the last `streaming` role) keeps
+ *  streaming the rest of the segment into the stranded bubble ABOVE the steer
+ *  card — the "streaming marker stuck at the steer point" bug. Freezing first
+ *  means pre-steer text stays above the bubble and the next chunk opens a
+ *  fresh streaming message below it. */
+const finalizeTrailingStreaming = (msgs: ChatMessage[]) => {
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    if (msgs[i].role === 'streaming') {
+      const raw = msgs[i].content
+      const isPlaceholder = !raw || (/^[\s.\-…·•–—]{2,}$/.test(raw) && /[.\-…·•–—]/.test(raw)) || raw === '…'
+      if (isPlaceholder) {
+        msgs.splice(i, 1)
+      } else {
+        msgs[i].role = 'assistant'
+        msgs[i].rawText = msgs[i].content
+      }
+      break
+    }
+  }
+}
+
 /** The three keys that can pollute `Object.prototype` when used to index a
  *  plain-object map (`obj[key] = ...`). Slot ids, subagent ids, run ids, and
  *  session keys all flow in from WebSocket action payloads; a crafted payload
@@ -389,14 +420,7 @@ function applyNonActiveFrame(
     return
   }
   if (role === '_segment') {
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      if (msgs[i].role === 'streaming') {
-        const raw = msgs[i].content
-        const isPlaceholder = !raw || (/^[\s.\-…·•–—]{2,}$/.test(raw) && /[.\-…·•–—]/.test(raw)) || raw === '…'
-        if (isPlaceholder) { msgs.splice(i, 1) } else { msgs[i].role = 'assistant'; msgs[i].rawText = msgs[i].content }
-        break
-      }
-    }
+    finalizeTrailingStreaming(msgs)
     return
   }
   if (role === 'chunk') {
@@ -1066,7 +1090,18 @@ const chatSlice = createSlice({
         delete state.slotContextTokens[safeKey(slot)]
       }
     },
-    appendMessage(state, action: PayloadAction<ChatMessage>) { state.messages.push(action.payload) },
+    appendMessage(state, action: PayloadAction<ChatMessage>) {
+      // Finalize-on-steer: a mid-turn steer bubble (ChatPage steer(), meta.steer)
+      // must freeze the live streaming message BEFORE it is pushed, or the
+      // chunk reducer keeps appending the rest of the segment into the stranded
+      // streaming message ABOVE the bubble (stuck streaming marker at the steer
+      // point). The backend cuts the segment at the same boundary (see
+      // _run_chat's steer segment cut), so the frozen order matches the
+      // persisted transcript and the chat_done refresh doesn't reorder it.
+      const m = action.payload
+      if (m.role === 'user' && m.meta?.steer) finalizeTrailingStreaming(state.messages)
+      state.messages.push(m)
+    },
     /** Optimistically append a message to a specific slot's store — global
      *  `messages` when it's the active slot, else `slotMessages[slot]`. Lets a
      *  grid pane show a just-sent user message immediately in the right place. */
@@ -1115,6 +1150,19 @@ const chatSlice = createSlice({
           delete (bubble.meta as Record<string, unknown>).optimistic
           return
         }
+        // No optimistic bubble to reconcile — this tab did not initiate the
+        // steer (another tab / a scene-interaction steer). Finalize-on-steer
+        // before pushing, same as appendMessage: inserting the bubble below a
+        // live streaming message strands the streaming marker above it. Only
+        // done on the insert path — after a reconcile a NEW post-steer
+        // streaming message may already be live below the bubble, and freezing
+        // it here would wrongly finalize the in-flight stream.
+        finalizeTrailingStreaming(msgs)
+      }
+      // Optimistic steer bubble from a pane-scoped composer: same freeze as the
+      // appendMessage (active-slot) path.
+      if (message.role === 'user' && message.meta?.steer && message.meta?.optimistic) {
+        finalizeTrailingStreaming(msgs)
       }
       msgs.push(message)
     },
@@ -1784,24 +1832,7 @@ const chatSlice = createSlice({
       }
       // WS segment — finalize streaming into assistant without resetting sequence or slot state
       if (role === '_segment') {
-        for (let i = state.messages.length - 1; i >= 0; i--) {
-          if (state.messages[i].role === 'streaming') {
-            // Drop trivially meaningless placeholder content that the model
-            // emits before tool calls ("...", "…", "---", ". . .", etc.).
-            // Only drop patterns that are EXCLUSIVELY composed of 2+ repeated
-            // punctuation/whitespace chars — never single characters which could
-            // be the start of legitimate content (list markers, etc.).
-            const raw = state.messages[i].content
-            const isPlaceholder = !raw || (/^[\s.\-…·•–—]{2,}$/.test(raw) && /[.\-…·•–—]/.test(raw)) || raw === '…'
-            if (isPlaceholder) {
-              state.messages.splice(i, 1)
-            } else {
-              state.messages[i].role = 'assistant'
-              state.messages[i].rawText = state.messages[i].content
-            }
-            break
-          }
-        }
+        finalizeTrailingStreaming(state.messages)
         return
       }
       // WS chunk — accumulate into streaming message, preserve rawText

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -595,6 +595,73 @@ describe('appendSlotMessage steer reconcile', () => {
   })
 })
 
+describe('finalize-on-steer (stuck streaming marker fix)', () => {
+  const initial = reducer(undefined, { type: '@@INIT' })
+
+  it('optimistic steer bubble freezes the live streaming message; next chunk opens a NEW one below', () => {
+    // Repro of the bug: mid-text-stream steer. Without the freeze, the chunk
+    // reducer (backwards scan for role==='streaming') kept streaming the rest
+    // of the segment into the message ABOVE the bubble.
+    let state = { ...initial, activeSlot: 'A' }
+    state = reducer(state, sseChatMessage({ slot: 'A', role: 'chunk', content: 'pre-steer text' }))
+    state = reducer(state, appendMessage({ role: 'user', content: 'go left', cls: 'msg msg-u', ts: 't1', meta: { steer: true, optimistic: true } }))
+    // Pre-steer text is frozen as assistant ABOVE the bubble.
+    expect(state.messages.map(m => m.role)).toEqual(['assistant', 'user'])
+    expect(state.messages[0].content).toBe('pre-steer text')
+    expect(state.messages[0].rawText).toBe('pre-steer text')
+    // Post-steer chunks open a fresh streaming message BELOW the bubble.
+    state = reducer(state, sseChatMessage({ slot: 'A', role: 'chunk', content: 'post-steer text' }))
+    expect(state.messages.map(m => m.role)).toEqual(['assistant', 'user', 'streaming'])
+    expect(state.messages[2].content).toBe('post-steer text')
+  })
+
+  it('drops a placeholder-only streaming message instead of freezing it', () => {
+    let state = { ...initial, activeSlot: 'A' }
+    state = reducer(state, sseChatMessage({ slot: 'A', role: 'chunk', content: '…' }))
+    state = reducer(state, appendMessage({ role: 'user', content: 'go left', cls: 'msg msg-u', ts: 't1', meta: { steer: true, optimistic: true } }))
+    expect(state.messages.map(m => m.role)).toEqual(['user'])
+  })
+
+  it('steer echo with no optimistic bubble (other-tab view) freezes before inserting', () => {
+    // This tab did not initiate the steer — no optimistic bubble to reconcile,
+    // so appendSlotMessage inserts the echo. It must freeze first.
+    let state = { ...initial, activeSlot: 'A' }
+    state = reducer(state, sseChatMessage({ slot: 'A', role: 'chunk', content: 'pre-steer text' }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'go left', cls: 'msg msg-u', ts: 't2', meta: { steer: true } } }))
+    expect(state.messages.map(m => m.role)).toEqual(['assistant', 'user'])
+    state = reducer(state, sseChatMessage({ slot: 'A', role: 'chunk', content: 'post' }))
+    expect(state.messages.map(m => m.role)).toEqual(['assistant', 'user', 'streaming'])
+  })
+
+  it('steer echo freeze also applies to a backgrounded slot array', () => {
+    let state = { ...initial, activeSlot: 'A',
+      slotMessages: { 'B': [{ role: 'streaming' as const, content: 'bg partial', cls: 'msg msg-a' }] } }
+    state = reducer(state, appendSlotMessage({ slot: 'B', message: { role: 'user', content: 'go left', cls: 'msg msg-u', ts: 't2', meta: { steer: true } } }))
+    expect(state.slotMessages['B'].map(m => m.role)).toEqual(['assistant', 'user'])
+  })
+
+  it('echo reconcile does NOT freeze a live post-steer streaming message', () => {
+    // Freeze happened at optimistic-push time; by the time the echo arrives a
+    // NEW post-steer streaming message can be live below the bubble. The
+    // reconcile path must leave it streaming.
+    let state = { ...initial, activeSlot: 'A' }
+    state = reducer(state, sseChatMessage({ slot: 'A', role: 'chunk', content: 'pre' }))
+    state = reducer(state, appendMessage({ role: 'user', content: 'go left', cls: 'msg msg-u', ts: 't1', meta: { steer: true, optimistic: true } }))
+    state = reducer(state, sseChatMessage({ slot: 'A', role: 'chunk', content: 'post' }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'go left', cls: 'msg msg-u', ts: 't2', meta: { steer: true } } }))
+    expect(state.messages.map(m => m.role)).toEqual(['assistant', 'user', 'streaming'])
+    expect(state.messages[1].ts).toBe('t2')
+    expect(state.messages[2].content).toBe('post')
+  })
+
+  it('non-steer appendMessage does not touch a live streaming message', () => {
+    let state = { ...initial, activeSlot: 'A' }
+    state = reducer(state, sseChatMessage({ slot: 'A', role: 'chunk', content: 'streaming on' }))
+    state = reducer(state, appendMessage({ role: 'user', content: 'plain message', cls: 'msg msg-u', ts: 't1' }))
+    expect(state.messages.map(m => m.role)).toEqual(['streaming', 'user'])
+  })
+})
+
 describe('sseChatMessage', () => {
   const initial = reducer(undefined, { type: '@@INIT' })
   const withSlot = { ...initial, activeSlot: 'slot-1' }


### PR DESCRIPTION
## Problem

Sending a steer mid-text-stream sometimes leaves the streaming marker stuck at the point where the steer was sent: the rest of the reply streams into the message *above* the steer bubble, and when the turn completes the whole reply jumps to the bottom of the screen.

## Why it matters

Steering is the primary mid-turn interaction. The stuck marker makes the live transcript unreadable (new text appears mid-scrollback instead of at the bottom), and the end-of-turn reorder rewrites history the user just watched, breaking trust in the transcript. Mid-turn reloads also lose the pre-steer text entirely until the segment lands.

## Fix (symptoms -> root cause -> change)

**Symptom 1 - stuck marker:** the steer bubble is pushed *below* the live `streaming` message without finalizing it. The chunk reducer scans backwards for the last `role === 'streaming'` message, so every subsequent chunk lands in the stranded message above the bubble.
**Change (frontend):** new `finalizeTrailingStreaming` helper in `chatSlice.ts` freezes the live streaming message -> `assistant` (placeholder-only content like `…` is dropped, same rule as the `_segment` handlers, which now share the helper) at every steer insertion point: the optimistic push (`appendMessage`), the pane-scoped optimistic push, and the `steer_push` echo when no optimistic bubble exists (another tab steered). The echo *reconcile* path deliberately does not freeze - a new post-steer streaming message may already be live below the bubble.

**Symptom 2 - end-of-turn jump:** kiro-cli does not end the text segment at a steer. The steer handler persists the user message mid-chunk-run, and `_flush_segment`'s trailing-run walk stops at that user message - so the finalized assistant text (pre-steer + post-steer as one message) is appended *below* the steer bubble, and the `chat_done` refresh rebuilds the transcript in that order. The pre-steer `chunk` entries are also stranded in `slot.messages` forever.
**Change (backend):** `_run_chat` publishes a sync `slot._steer_segment_cut` closure (same lifecycle as `slot._acp_client`). The steer handler calls it right before persisting the steer user message, flushing the accumulated text as its own assistant segment - transcript order becomes `[assistant(pre-steer), user(steer), assistant(post-steer)]`, matching what the user watched live. The cut uses `broadcast=False` (the initiating tab froze at optimistic-push time; other tabs freeze on the `steer_push` echo) and is best-effort - a cut failure can never lose the steer.

System spec updated: `docs/system-specs/modules/learn-cron-dashboard.md` gains a "Mid-Turn Steer (dashboard transcript contract)" section.

## Tests

- `website/src/test/chatSlice.test.ts` - new `finalize-on-steer` describe (6 tests): optimistic-push freeze + fresh streaming bubble below, placeholder drop, echo-insert freeze (active + backgrounded slot), reconcile-does-not-freeze-live-stream, non-steer push untouched.
- `test/test_chat_steer.py` - `test_steer_cuts_segment_before_user_append` (cut runs before the user append; persisted order assistant < user) and `test_steer_cut_failure_does_not_lose_steer` (raising cut still persists + broadcasts the steer).

## Manual verification

Frontend suite green (601 files / 7538 tests), tsc clean; targeted backend files green (`test_chat_steer.py`, `test_dashboard_chat.py` + neighbors, 581+ tests). Full backend suite left to CI by request.

## Screenshots

N/A - the change is stream-timing/transcript-ordering behavior; stills cannot evidence it. Reducer-level tests pin the ordering; a pod video can be added on request.
