### PR TITLE
fix(telegram): size messages by rendered HTML and record API latency

### DIFF
--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -191,6 +191,10 @@ _HISTOGRAM_BUCKETS_MS: dict[str, list[float]] = {
     "kirocrew.gateway.request.duration": _FAST_BUCKETS_MS,
     "kirocrew.mcp.backend.acquire.duration": _FAST_BUCKETS_MS,
     "kirocrew.skill.lazy_load.duration": _FAST_BUCKETS_MS,
+    # Telegram Bot API round-trips: typically 50-500ms, but a 429 retry_after
+    # wait or a transport timeout reaches seconds -- _FAST_BUCKETS_MS spans
+    # 0.5ms..60s, which covers both without flooring the tail percentiles.
+    "kirocrew.telegram.api.duration": _FAST_BUCKETS_MS,
     "kirocrew.session.startup.duration": _STARTUP_BUCKETS_MS,
     "kirocrew.mcp.lazy_load.duration": _STARTUP_BUCKETS_MS,
     "kirocrew.gateway.boot.duration": _STARTUP_BUCKETS_MS,

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
+import time
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 import aiohttp
+
+from kiro_crew.metrics.provider import get_recorder
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +39,174 @@ _API_BASE = "https://api.telegram.org/bot{token}/{method}"
 
 #: Consecutive polling failures before the status callback reports unhealthy.
 _STATUS_FAILURE_THRESHOLD = 3
+
+#: Telegram's supported HTML tag set. Anything we may have to re-close when a
+#: rendered message has to be truncated mid-document.
+_TG_HTML_TAG_RE = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9-]*)[^>]*>")
+
+#: Longest HTML entity we expect ("&blockquote;"-class names are not used by the
+#: renderer, but stay generous so a cut never lands inside "&amp;"/"&#1234;").
+_MAX_ENTITY_LEN = 12
+
+
+def _cut_points(text: str) -> list[tuple[int, int, int]]:
+    """``[(lo, hi, closers_len)]``, one entry per run of text BETWEEN tags.
+
+    Cutting at any index in ``[lo, hi]`` therefore lands outside every tag by
+    construction, and ``closers_len`` is how many chars of closing tags that
+    prefix needs to balance.
+
+    Single forward pass, with the open-tag stack length maintained incrementally.
+    Re-deriving the stack for each candidate cut is O(n) per probe and made the
+    search quadratic -- measured 122 ms on one 4 KB document whose limit landed
+    inside a nested-close cluster, which would block the event loop.
+    """
+    points: list[tuple[int, int, int]] = []
+    stack: list[str] = []
+    closers_len = 0
+    prev_end = 0
+    for m in _TG_HTML_TAG_RE.finditer(text):
+        points.append((prev_end, m.start(), closers_len))
+        closing, name = m.group(1), m.group(2).lower()
+        if closing:
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i] == name:
+                    del stack[i]
+                    closers_len -= len(name) + 3  # len("</name>")
+                    break
+        else:
+            stack.append(name)
+            closers_len += len(name) + 3
+        prev_end = m.end()
+    points.append((prev_end, len(text), closers_len))
+    return points
+
+
+def _entity_safe_cut(text: str, cut: int, lo: int) -> int:
+    """Back ``cut`` out of an HTML entity, without leaving the run at ``lo``.
+
+    Only entities need handling here: a cut inside ``[lo, hi]`` is already
+    outside every tag, so the tag/entity guard-ordering hazard cannot arise.
+    """
+    amp = text.rfind("&", lo, cut)
+    semi = text.rfind(";", lo, cut)
+    if amp > semi and (cut - amp) <= _MAX_ENTITY_LEN:
+        return amp
+    return cut
+
+
+def truncate_html_safe(text: str, limit: int = TELEGRAM_MAX_TEXT) -> str:
+    """Truncate Telegram HTML to ``limit`` chars without breaking the parse.
+
+    Guarantees the result (a) never splits a tag or entity, (b) closes every tag
+    it leaves open, and (c) is a prefix of the input plus closing tags.
+
+    Scans the between-tag runs right to left and takes the first one where the
+    prefix AND its closers fit, which is the longest such prefix. Returning a
+    bare prefix when nothing fits would emit UNCLOSED tags -- precisely the
+    "Can't find end tag" 400 this exists to prevent -- so the degenerate answer
+    is the empty string, which is always valid.
+
+    Note: ``limit`` counts Python code points while Telegram counts UTF-16 code
+    units, so an astral char (emoji, CJK ext) costs 1 here and 2 there. An
+    emoji-dense message near the cap can still be rejected. That mismatch
+    predates this helper (the plain slice shared it) and is tracked separately.
+    """
+    if len(text) <= limit:
+        return text
+    if limit <= 0:
+        return ""
+    for lo, hi, closers_len in reversed(_cut_points(text)):
+        room = limit - closers_len
+        if room < lo:
+            continue  # even an empty prefix in this run cannot fit its closers
+        cut = _entity_safe_cut(text, min(hi, room), lo)
+        if cut < lo:
+            continue
+        closers = _open_tag_closers(text[:cut])
+        if cut + len(closers) <= limit:
+            return text[:cut] + closers
+    return ""
+
+
+def _open_tag_closers(html_text: str) -> str:
+    """Closing tags needed to balance ``html_text``, innermost first.
+
+    Telegram rejects the WHOLE message when a start tag has no matching end tag
+    ("Can't find end tag corresponding to start tag \"code\""), so a truncated
+    document must carry its own closers.
+    """
+    stack: list[str] = []
+    for m in _TG_HTML_TAG_RE.finditer(html_text):
+        closing, name = m.group(1), m.group(2).lower()
+        if closing:
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i] == name:
+                    del stack[i]
+                    break
+        else:
+            stack.append(name)
+    return "".join(f"</{name}>" for name in reversed(stack))
+
+
+def _cap_text(text: str, parse_mode: str | None) -> str:
+    """Length-cap outbound text: tag-safe when it is HTML, plain slice otherwise.
+
+    Plaintext can be sliced anywhere. HTML cannot -- a blind slice is what turns
+    an oversize rendered message into a hard 400. Reaching the HTML branch means
+    the renderer's own budget under-estimated the rendered length, so warn: the
+    split, not this backstop, is where the fix belongs.
+    """
+    if len(text) <= TELEGRAM_MAX_TEXT:
+        return text
+    if parse_mode and parse_mode.upper() == "HTML":
+        logger.warning(
+            "Telegram HTML text is %d chars (> %d); truncating tag-safely. "
+            "The renderer should have split this before sending.",
+            len(text),
+            TELEGRAM_MAX_TEXT,
+        )
+        return truncate_html_safe(text, TELEGRAM_MAX_TEXT)
+    return text[:TELEGRAM_MAX_TEXT]
+
+
+#: Histogram for Bot API call latency. Outbound sends/edits are awaited inline in
+#: the token-streaming path, so a call's duration *is* the time the render loop
+#: was blocked -- which is what tells us whether the perceived slowness is
+#: dominated by the fixed edit throttle or by network round-trips.
+_API_DURATION_METRIC = "kirocrew.telegram.api.duration"
+
+
+def _record_api_duration(
+    method: str,
+    elapsed_ms: float,
+    *,
+    ok: bool,
+    err_code: int | None,
+    timed_out: bool = False,
+) -> None:
+    """Emit one Bot API call duration to the metrics recorder.
+
+    Best-effort: a metrics failure must never break a Telegram send.
+    """
+    logger.debug("Telegram API %s took %.0fms (ok=%s)", method, elapsed_ms, ok)
+    if timed_out:
+        outcome = "timeout"
+    elif err_code == 429:
+        outcome = "rate_limited"
+    elif ok:
+        outcome = "ok"
+    else:
+        outcome = "error"
+    try:
+        get_recorder().histogram(
+            _API_DURATION_METRIC,
+            elapsed_ms,
+            unit="ms",
+            attrs={"method": method, "outcome": outcome},
+        )
+    except Exception:
+        logger.debug("telegram api duration metric emit failed", exc_info=True)
 
 
 class TelegramAuthError(RuntimeError):
@@ -134,9 +306,7 @@ class TelegramClient:
             await self._session.close()
             self._session = None
 
-    def set_message_handler(
-        self, on_message: Callable[[TelegramInbound], Awaitable[None]]
-    ) -> None:
+    def set_message_handler(self, on_message: Callable[[TelegramInbound], Awaitable[None]]) -> None:
         """Set/replace the inbound-message handler after construction.
 
         Lets the gateway wire ``transport.receive`` in once the transport (which
@@ -169,7 +339,7 @@ class TelegramClient:
         """
         params: dict[str, Any] = {
             "chat_id": chat_id,
-            "text": text[:TELEGRAM_MAX_TEXT],
+            "text": _cap_text(text, parse_mode),
         }
         if message_thread_id is not None:
             params["message_thread_id"] = message_thread_id
@@ -195,7 +365,12 @@ class TelegramClient:
         return result.get("message_id") if result else None
 
     async def send_message_draft(
-        self, chat_id: int, draft_id: int, text: str, *, parse_mode: str | None = None,
+        self,
+        chat_id: int,
+        draft_id: int,
+        text: str,
+        *,
+        parse_mode: str | None = None,
         message_thread_id: int | None = None,
     ) -> bool:
         """Stream an ephemeral partial-message draft (Bot API 9.3+ sendMessageDraft).
@@ -213,7 +388,7 @@ class TelegramClient:
         params: dict[str, Any] = {
             "chat_id": chat_id,
             "draft_id": draft_id,
-            "text": text[:TELEGRAM_MAX_TEXT],
+            "text": _cap_text(text, parse_mode),
         }
         if message_thread_id is not None:
             params["message_thread_id"] = message_thread_id
@@ -240,7 +415,7 @@ class TelegramClient:
         params: dict[str, Any] = {
             "chat_id": chat_id,
             "message_id": message_id,
-            "text": text[:TELEGRAM_MAX_TEXT],
+            "text": _cap_text(text, parse_mode),
         }
         if parse_mode:
             params["parse_mode"] = parse_mode
@@ -288,9 +463,7 @@ class TelegramClient:
         """Delete a message (e.g. remove stale inline keyboards)."""
         await self._api("deleteMessage", {"chat_id": chat_id, "message_id": message_id})
 
-    async def set_message_reaction(
-        self, chat_id: int, message_id: int, emoji: str
-    ) -> None:
+    async def set_message_reaction(self, chat_id: int, message_id: int, emoji: str) -> None:
         """Set a single emoji reaction on a message (Bot API 7.0+ ``setMessageReaction``).
 
         Used as an instant, no-extra-bubble acknowledgement that a mid-turn steer
@@ -390,9 +563,7 @@ class TelegramClient:
                     break
                 attempt += 1
                 if attempt == _STATUS_FAILURE_THRESHOLD:
-                    self._notify_status(
-                        False, f"getUpdates transport error ({type(exc).__name__})"
-                    )
+                    self._notify_status(False, f"getUpdates transport error ({type(exc).__name__})")
                 delay = min(1.0 * (2 ** (attempt - 1)), 30.0)
                 # Log only the exception type — an aiohttp exc's str() can embed
                 # the request URL, which contains the bot token (a registered
@@ -416,7 +587,15 @@ class TelegramClient:
             "timeout": self._polling_timeout,
             "allowed_updates": ["message", "callback_query"],
         }
-        result = await self._api("getUpdates", params, timeout=self._polling_timeout + 10)
+        # record=False: the long-poll deliberately blocks for ~polling_timeout
+        # (30s default) and runs back-to-back forever, so recording it would bury
+        # the outbound send/edit distribution the metric exists to measure under
+        # a permanent ~30000ms mode. The Telemetry surface does not split on the
+        # `method` attribute (see _OTHER_SPLIT_ATTRS), so filtering here is the
+        # only way to keep the percentiles meaningful.
+        result = await self._api(
+            "getUpdates", params, timeout=self._polling_timeout + 10, record=False
+        )
         if result is None:
             return None  # API-level failure — signal the polling loop to back off
         # result is the array of Update objects ([] when there are none).
@@ -511,7 +690,9 @@ class TelegramClient:
                     self._session = aiohttp.ClientSession()
         return self._session
 
-    async def _api(self, method: str, params: dict, timeout: int = 30) -> Any:
+    async def _api(
+        self, method: str, params: dict, timeout: int = 30, *, record: bool = True
+    ) -> Any:
         """Call a Bot API method. Returns the 'result' field or None on error.
 
         Honors a single 429 ``retry_after`` back-off: a rate-limited edit that
@@ -522,6 +703,16 @@ class TelegramClient:
         session = await self._ensure_session()
 
         url = _API_BASE.format(token=self._token, method=method)
+        # ONE timer for the whole call, not per attempt: the caller is blocked
+        # for the entire span including a 429 ``retry_after`` sleep, and that
+        # multi-second stall is exactly the user-visible latency the metric
+        # exists to expose. Per-attempt timing dropped it (it fell between two
+        # timers) and split one logical call into two misleadingly short samples.
+        call_started = time.monotonic()
+
+        def _elapsed_ms() -> float:
+            return (time.monotonic() - call_started) * 1000.0
+
         for attempt in range(2):
             try:
                 async with session.post(
@@ -532,14 +723,21 @@ class TelegramClient:
                 ) as resp:
                     data = await resp.json(content_type=None)
                     if data and data.get("ok"):
+                        if record:
+                            _record_api_duration(method, _elapsed_ms(), ok=True, err_code=None)
                         return data.get("result")
                     # Log Telegram API errors.
                     err_code = data.get("error_code") if data else None
                     err_desc = data.get("description") if data else None
                     # 400 "message is not modified" is benign during streaming.
                     if err_code == 400 and "not modified" in (err_desc or "").lower():
+                        if record:
+                            _record_api_duration(method, _elapsed_ms(), ok=True, err_code=None)
                         return {}  # treat as success (no change needed)
                     # 429: respect the server's retry_after once, then give up.
+                    # Deliberately NOT recorded here -- the retry continues the
+                    # same logical call, so the sample is emitted once at the
+                    # terminal outcome with the sleep included.
                     if err_code == 429 and attempt == 0:
                         retry_after = 1.0
                         try:
@@ -550,6 +748,8 @@ class TelegramClient:
                             pass
                         await asyncio.sleep(min(max(retry_after, 0.5), 5.0))
                         continue
+                    if record:
+                        _record_api_duration(method, _elapsed_ms(), ok=False, err_code=err_code)
                     logger.warning(
                         "Telegram API %s failed: code=%s desc=%s",
                         method,
@@ -558,11 +758,21 @@ class TelegramClient:
                     )
                     return None
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                # Record BEFORE returning: a timeout or connection failure is the
+                # LONGEST a caller ever blocks, so dropping it here biased the
+                # histogram towards calls that got a response and hid the worst
+                # stalls (survivorship bias).
+                if record:
+                    _record_api_duration(
+                        method,
+                        _elapsed_ms(),
+                        ok=False,
+                        err_code=None,
+                        timed_out=isinstance(exc, asyncio.TimeoutError),
+                    )
                 # Log only the exception type — its str() can embed the request
                 # URL, which contains the bot token (a registered credential).
-                logger.warning(
-                    "Telegram API %s transport error: %s", method, type(exc).__name__
-                )
+                logger.warning("Telegram API %s transport error: %s", method, type(exc).__name__)
                 return None
         return None
 

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -92,9 +92,7 @@ _STEER_MARKER_RE = re.compile(r"\[STEERING\b[^\]]*\]", re.IGNORECASE)
 # The dashboard renders this summary as its "Steered — …" chip; we prefer it
 # for the Telegram chip too (the user's own words are already on screen as
 # their message — the summary is the only NEW information).
-_STEER_SUMMARY_RE = re.compile(
-    r"\[STEERING\s+steer-[0-9a-f]+\s*:\s*([^\]]*)\]", re.IGNORECASE
-)
+_STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f]+\s*:\s*([^\]]*)\]", re.IGNORECASE)
 
 
 def _strip_steering(text: str) -> str:
@@ -165,7 +163,14 @@ def build_inline_keyboard(options: list[str]) -> dict | None:
 
 
 def _split_text(text: str, limit: int) -> list[str]:
-    """Split text into <=``limit`` chunks, preferring paragraph boundaries."""
+    """Split text into <=``limit`` chunks, preferring paragraph boundaries.
+
+    The continuation strips only NEWLINES at the boundary, never horizontal
+    whitespace: a bare ``lstrip()`` ate the leading indentation of the first line
+    of every continuation chunk, silently re-indenting split code blocks. Render-
+    aware splitting makes chunking fire on more shapes, so that pre-existing
+    corruption became much easier to hit.
+    """
     if limit <= 0 or len(text) <= limit:
         return [text] if text else []
     chunks: list[str] = []
@@ -179,7 +184,7 @@ def _split_text(text: str, limit: int) -> list[str]:
         if split_at < limit // 4:
             split_at = limit
         chunks.append(text[:split_at].rstrip())
-        text = text[split_at:].lstrip()
+        text = text[split_at:].lstrip("\n")
     return chunks
 
 
@@ -238,9 +243,7 @@ def _md_to_telegram_html(text: str) -> str:
     text = _FENCE_RE.sub(
         lambda m: _keep(f"<pre>{html.escape(m.group(1).rstrip(chr(10)))}</pre>"), text
     )
-    text = _INLINE_CODE_RE.sub(
-        lambda m: _keep(f"<code>{html.escape(m.group(1))}</code>"), text
-    )
+    text = _INLINE_CODE_RE.sub(lambda m: _keep(f"<code>{html.escape(m.group(1))}</code>"), text)
     text = html.escape(text)
     text = _HEADING_RE.sub(lambda m: f"<b>{m.group(1).strip()}</b>", text)
     text = _BOLD_STAR_RE.sub(lambda m: f"<b>{m.group(1)}</b>", text)
@@ -262,6 +265,81 @@ def _md_to_telegram_html(text: str) -> str:
     )
     text = re.sub(r"\x00(\d+)\x00", lambda m: stash[int(m.group(1))], text)
     return text
+
+
+#: Minimum source-chunk budget when shrinking to fit the rendered cap. Below
+#: this, shrinking stops making progress; the caller's tag-safe truncation and
+#: plaintext fallback are the backstop for genuinely indivisible content.
+_MIN_SPLIT_LIMIT = 400
+
+
+def _rendered_len(source: str) -> int:
+    """Length of ``source`` once converted to Telegram HTML."""
+    return len(_md_to_telegram_html(source))
+
+
+#: Markup that makes ``_md_to_telegram_html`` EMIT TAGS, and therefore grow the
+#: text by an amount no per-character arithmetic can bound: a line-leading ``>``
+#: (blockquote) or ``#`` (heading), or any ``*``/``_``/backtick/``[`` (bold,
+#: italic, code span, link). Cheap single-pass scan; used only as a gate.
+_MARKUP_HINT_RE = re.compile(r"(?m)^[ \t]{0,3}[>#]|[*_`\[]")
+
+
+def _may_exceed_rendered(source: str, cap: int) -> bool:
+    """Conservative "could this render past ``cap``?" gate.
+
+    A ``False`` MUST mean "provably fits" -- it is the only case the caller skips
+    the authoritative ``_rendered_len`` check for, so under-estimating ships
+    oversize HTML. Over-returning ``True`` is always safe: it costs one real
+    render on a buffer that is nowhere near the cap.
+
+    Per-construct growth constants were tried and rejected as whack-a-mole --
+    blockquote, heading, bold/italic and code spans each need their own term,
+    the measured inflation reaches 3.75x (``"`x` " * 700``: 2800 source chars ->
+    10500 rendered), and any new converter rule silently reintroduces
+    unsoundness. Instead trust the cheap arithmetic ONLY for prose containing no
+    tag-producing markup at all, and measure everything else for real.
+    """
+    if len(source) >= cap:
+        return True
+    if _MARKUP_HINT_RE.search(source):
+        return True  # tags will be emitted -- refuse to guess, measure instead
+    # Tag-free prose: the only growth left is ``html.escape``, which adds at most
+    # 5 chars per escape-worthy character (``'`` -> ``&#x27;``).
+    escapes = sum(source.count(c) for c in ("&", "<", ">", '"', "'"))
+    return len(source) + 5 * escapes >= cap
+
+
+def _split_markdown_bounded(text: str, rendered_limit: int) -> list[str]:
+    """Split markdown so every chunk's RENDERED HTML fits ``rendered_limit``.
+
+    ``_split_markdown`` budgets the *source*, but ``_md_to_telegram_html``
+    inflates it: ``html.escape`` turns ``&`` into ``&amp;`` (+4) and ``<`` into
+    ``&lt;`` (+3), plus the tags we add. A code-heavy chunk (a diff, JSON,
+    ``Map<String,Object>``, shell redirects) therefore renders well past a source
+    budget that looked safe -- and Telegram rejects the whole message. Measure
+    the rendered form and shrink the source budget until it actually fits.
+
+    Shrinks all the way down to ``_MIN_SPLIT_LIMIT`` instead of stopping after a
+    fixed pass count: giving up early returns chunks that are still oversize, and
+    the client backstop then truncates them, silently dropping content. Only at
+    the floor -- where the content is genuinely indivisible -- may oversize chunks
+    be returned.
+    """
+    src_limit = max(_MIN_SPLIT_LIMIT, rendered_limit)
+    chunks = _split_markdown(text, src_limit)
+    while True:
+        worst = max((_rendered_len(c) for c in chunks), default=0)
+        if worst <= rendered_limit or src_limit <= _MIN_SPLIT_LIMIT:
+            return chunks
+        # Shrink proportionally to the observed inflation, capped so a
+        # barely-over chunk still makes real progress.
+        scaled = int(src_limit * (rendered_limit / worst) * 0.95)
+        new_limit = max(_MIN_SPLIT_LIMIT, min(scaled, src_limit - 128))
+        if new_limit >= src_limit:
+            new_limit = _MIN_SPLIT_LIMIT  # guarantee progress to the floor
+        src_limit = new_limit
+        chunks = _split_markdown(text, src_limit)
 
 
 def _strip_md(text: str) -> str:
@@ -383,9 +461,7 @@ class TelegramRenderer(Renderer):
         try:
             while not self._closed:
                 try:
-                    await self._client.send_typing(
-                        self._chat_id, message_thread_id=self._thread_id
-                    )
+                    await self._client.send_typing(self._chat_id, message_thread_id=self._thread_id)
                 except Exception:
                     logger.debug("Telegram: typing refresh failed", exc_info=True)
                 await asyncio.sleep(_TYPING_REFRESH_S)
@@ -468,13 +544,33 @@ class TelegramRenderer(Renderer):
         ``[STEERING …`` / ``[OPTIONS …`` fragment — is detached first and
         reattached to the surviving tail, so length splitting can never cut a
         directive in half (which would leak protocol fragments and lose the
-        steer rotation / options keyboard)."""
+        steer rotation / options keyboard).
+
+        Rotation triggers on the SOURCE budget or on the RENDERED HTML cap,
+        whichever binds first: a segment can sit under the source budget and
+        still render past Telegram's hard limit once ``html.escape`` inflates
+        it."""
         limit = self._limit()
+        rendered_cap = self._rendered_limit()
         raw = "".join(self._buf)
         if len(raw) <= limit:
-            return
+            # Provably-small buffers skip the real render (this runs per chunk).
+            if not _may_exceed_rendered(raw, rendered_cap):
+                return
+            if _rendered_len(raw) <= rendered_cap:
+                return
         raw, protocol_suffix = split_trailing_protocol_suffix(raw)
-        chunks = _split_markdown(raw, limit)
+        chunks = _split_markdown_bounded(raw, rendered_cap)
+        # Mid-stream the source fence is often still OPEN (the model has not
+        # emitted its closing ``` yet). _split_markdown balances each chunk by
+        # appending a synthetic closer, which is right for the chunks we seal but
+        # wrong for the tail we keep streaming into: every later token would land
+        # after that closer, rendering outside <pre>, and the model's real closing
+        # fence would then show up literally. Drop it from the retained tail.
+        if chunks and raw.count("```") % 2 == 1:
+            tail = chunks[-1].rstrip()
+            if tail.endswith("```"):
+                chunks[-1] = tail[:-3].rstrip("\n")
         for ch in chunks[:-1]:
             self._buf = [ch]
             await self._seal_current()
@@ -538,12 +634,18 @@ class TelegramRenderer(Renderer):
         html_text = _md_to_telegram_html(text)
         if self._stream_mid is not None:
             ok = await self._client.edit_message(
-                self._chat_id, self._stream_mid, html_text,
-                parse_mode="HTML", reply_markup=keyboard, retry_plain=False,
+                self._chat_id,
+                self._stream_mid,
+                html_text,
+                parse_mode="HTML",
+                reply_markup=keyboard,
+                retry_plain=False,
             )
             if not ok:  # malformed HTML -> clean plaintext, never raw tags
                 ok = await self._client.edit_message(
-                    self._chat_id, self._stream_mid, _strip_md(text),
+                    self._chat_id,
+                    self._stream_mid,
+                    _strip_md(text),
                     reply_markup=keyboard,
                 )
             if ok:
@@ -553,13 +655,18 @@ class TelegramRenderer(Renderer):
             # the completed answer (and its keyboard) is never silently lost.
             self._stream_mid = None
         mid = await self._client.send_message(
-            self._chat_id, html_text, parse_mode="HTML",
-            reply_markup=keyboard, retry_plain=False,
+            self._chat_id,
+            html_text,
+            parse_mode="HTML",
+            reply_markup=keyboard,
+            retry_plain=False,
             message_thread_id=self._thread_id,
         )
         if mid is None:
             await self._client.send_message(
-                self._chat_id, _strip_md(text), reply_markup=keyboard,
+                self._chat_id,
+                _strip_md(text),
+                reply_markup=keyboard,
                 message_thread_id=self._thread_id,
             )
 
@@ -581,9 +688,7 @@ class TelegramRenderer(Renderer):
         self._tool = self._last_tool
         await self._stream_live(force=True)
 
-    async def on_prompt_choice(
-        self, options: list[dict[str, Any]], request_id: str | int
-    ) -> None:
+    async def on_prompt_choice(self, options: list[dict[str, Any]], request_id: str | int) -> None:
         # Approve/Deny as a SEPARATE message so ongoing streaming edits to the
         # answer bubble don't clobber the buttons. callback_data stays well
         # under Telegram's 64-byte cap (a:<request_id>:<1|0>); the callback
@@ -599,14 +704,17 @@ class TelegramRenderer(Renderer):
         }
         tool = self._last_tool or "this tool"
         await self._client.send_message(
-            self._chat_id, f"🔐 Approve `{tool}`?", reply_markup=keyboard,
+            self._chat_id,
+            f"🔐 Approve `{tool}`?",
+            reply_markup=keyboard,
             message_thread_id=self._thread_id,
         )
 
     async def on_compaction(self, context_usage_pct: float) -> None:
         try:
             await self._client.send_message(
-                self._chat_id, "🗜️ Compacting context…",
+                self._chat_id,
+                "🗜️ Compacting context…",
                 message_thread_id=self._thread_id,
             )
         except Exception:
@@ -659,23 +767,40 @@ class TelegramRenderer(Renderer):
             placeholder = "…" if ok else "⚠️ Error — please try again"
             if self._stream_mid is not None:
                 await self._client.edit_message(
-                    self._chat_id, self._stream_mid, placeholder,
+                    self._chat_id,
+                    self._stream_mid,
+                    placeholder,
                     reply_markup=keyboard,
                 )
             else:
                 await self._client.send_message(
-                    self._chat_id, placeholder, reply_markup=keyboard,
+                    self._chat_id,
+                    placeholder,
+                    reply_markup=keyboard,
                     message_thread_id=self._thread_id,
                 )
             return
         await self._seal_current(keyboard=keyboard)
 
     def _limit(self) -> int:
-        # Leave headroom below the char cap for the HTML tags we add, so a
-        # formatted chunk can't overflow Telegram's 4096 limit and get cut
-        # mid-tag.
+        """Budget for PLAINTEXT frames (live typewriter edits), in source chars.
+
+        This is NOT a safe budget for HTML: ``html.escape`` inflation is
+        unbounded relative to a fixed subtraction, so the rendered form is
+        capped separately by ``_rendered_limit`` and enforced by measuring the
+        real render (see ``_split_markdown_bounded``).
+        """
         cap = self.capabilities.max_message_chars or 4000
         return max(500, cap - 256)
+
+    def _rendered_limit(self) -> int:
+        """Hard cap for the RENDERED Telegram HTML of one message.
+
+        Telegram's limit is 4096; ``max_message_chars`` (4000) already leaves
+        headroom under it, so use it directly as the rendered ceiling rather
+        than subtracting a second, guessed tag allowance.
+        """
+        return max(500, self.capabilities.max_message_chars or 4000)
 
     def _chip_for_seal(self, i: int) -> str | None:
         """The steer chip (a "> quote" blockquote of the USER's own words) that

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -24,7 +24,15 @@ from kiro_crew.messaging.renderer import (
     OutputEvent,
 )
 from kiro_crew.messaging.transport import InboundMessage
-from kiro_crew.telegram.client import TELEGRAM_CHUNK_LIMIT, TelegramClient, TelegramInbound
+from kiro_crew.telegram.client import (
+    TELEGRAM_CHUNK_LIMIT,
+    TELEGRAM_MAX_TEXT,
+    TelegramClient,
+    TelegramInbound,
+    _cap_text,
+    _record_api_duration,
+    truncate_html_safe,
+)
 from kiro_crew.telegram.commands import (
     ConversationState,
     parse_command,
@@ -34,8 +42,11 @@ from kiro_crew.telegram.renderer import (
     TelegramApprovalDecider,
     TelegramRenderer,
     _extract_options,
+    _may_exceed_rendered,
     _md_to_telegram_html,
+    _rendered_len,
     _split_markdown,
+    _split_markdown_bounded,
     _split_text,
     _strip_steering,
     build_inline_keyboard,
@@ -449,6 +460,336 @@ class TestSplitText:
         assert any("<pre>" in h and "&lt;" in h for h in htmls)  # wrapped + escaped
 
 
+_TAG_SCAN_RE = __import__("re").compile(r"<(/?)([a-zA-Z][a-zA-Z0-9-]*)[^>]*>")
+
+
+def _html_is_balanced(html_text: str) -> bool:
+    """True when every opened tag in ``html_text`` is closed.
+
+    Mirrors what Telegram's parser rejects: an unmatched start tag produces
+    "Can't find end tag corresponding to start tag ...".
+    """
+    stack: list[str] = []
+    for m in _TAG_SCAN_RE.finditer(html_text):
+        closing, name = m.group(1), m.group(2).lower()
+        if closing:
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i] == name:
+                    del stack[i]
+                    break
+        else:
+            stack.append(name)
+    return not stack
+
+
+class TestTruncateHtmlSafe:
+    """Tag-safe truncation of rendered Telegram HTML.
+
+    The production failure this guards: a blind ``text[:4096]`` on rendered HTML
+    cut between ``<code>`` and ``</code>``, so Telegram rejected the whole edit
+    with 400 "Can't find end tag corresponding to start tag \"code\"".
+    """
+
+    def test_short_text_unchanged(self) -> None:
+        assert truncate_html_safe("<b>hi</b>", 100) == "<b>hi</b>"
+
+    def test_closes_open_tag_left_by_the_cut(self) -> None:
+        text = "<code>" + "x" * 200 + "</code>"
+        out = truncate_html_safe(text, 60)
+        assert len(out) <= 60
+        assert out.endswith("</code>")
+        assert out.count("<code>") == out.count("</code>")
+
+    def test_never_cuts_inside_a_tag(self) -> None:
+        # Force the naive cut to land in the middle of the "<code>" open tag.
+        text = "abcd<code>zzzz</code>"
+        naive = text[:7]
+        assert naive == "abcd<co"  # what the old blind slice produced
+        out = truncate_html_safe(text, 7)
+        assert "<co" not in out.replace("<code>", "")
+        assert out == "abcd"
+
+    def test_never_cuts_inside_an_entity(self) -> None:
+        text = "ab&amp;cd" * 20
+        out = truncate_html_safe(text, 4)
+        assert not out.endswith("&")
+        assert out == "ab"
+
+    def test_nested_tags_closed_innermost_first(self) -> None:
+        text = "<blockquote><b>" + "y" * 200 + "</b></blockquote>"
+        out = truncate_html_safe(text, 80)
+        assert len(out) <= 80
+        assert out.endswith("</b></blockquote>")
+
+    def test_result_always_within_limit(self) -> None:
+        text = "<pre>" + "&lt;" * 500 + "</pre>"
+        for limit in (16, 64, 256, 1024):
+            out = truncate_html_safe(text, limit)
+            assert len(out) <= limit, f"limit={limit} produced {len(out)}"
+
+    def test_never_emits_unclosed_tags_when_closers_do_not_fit(self) -> None:
+        # Regression (HIGH): a fixed 3-iteration reserve loop bailed to a bare
+        # prefix here, leaving <b> and <i> unclosed -- the exact
+        # "Can't find end tag" 400 this helper exists to prevent. A 4th pass
+        # would have converged, so the budget, not the algorithm, was the bug.
+        text = "<b><i><u><s><code>WXYZ</code></s></u></i></b>"
+        out = truncate_html_safe(text, 37)
+        assert len(out) <= 37
+        assert _html_is_balanced(out), f"unclosed tags in {out!r}"
+        assert out == "<b><i><u><s></s></u></i></b>"
+
+    def test_entity_backoff_cannot_strand_the_cut_inside_a_tag(self) -> None:
+        # Regression: backing out of a raw `&` in an attribute value used to drag
+        # the cut into the middle of a COMPLETE tag, emitting `<a href="u?x=1`.
+        text = '<a href="u?x=1&y=2">Z'
+        out = truncate_html_safe(text, 20)
+        assert len(out) <= 20
+        assert _html_is_balanced(out)
+        assert "<a" not in out or out.count("<a") == out.count(">")
+
+    def test_prefers_a_shorter_closed_prefix_over_collapsing_to_empty(self) -> None:
+        # Quality: the old reserve heuristic overshot to "" even when a closed
+        # prefix fit.
+        assert truncate_html_safe("<b><i>DEEP</i></b>", 12) == "<b></b>"
+
+    def test_invariants_hold_across_a_balanced_corpus(self) -> None:
+        import re as _re
+
+        closers_only = _re.compile(r"^(?:</[a-zA-Z][a-zA-Z0-9-]*>)*$")
+
+        def is_prefix_plus_closers(doc: str, out: str) -> bool:
+            # I3 needs SOME valid split, not the greedy longest common prefix:
+            # a closer's leading "<" can coincide with the doc's next "<".
+            return any(
+                out[:k] == doc[:k] and closers_only.match(out[k:]) for k in range(len(out), -1, -1)
+            )
+
+        corpus = [
+            "<b><i><u><s><code>WXYZ</code></s></u></i></b>",
+            "<blockquote><b>x</b></blockquote>",
+            "<pre>" + "&lt;" * 60 + "</pre>",
+            '<a href="https://e.com/a?b=1&amp;c=2">link</a>text',
+            "<b>" * 40 + "X" + "</b>" * 40,
+            "plain text only",
+            "<blockquote>q</blockquote>" * 20,
+        ]
+        for doc in corpus:
+            assert _html_is_balanced(doc), "fixture must itself be balanced"
+            for limit in range(0, len(doc) + 3):
+                out = truncate_html_safe(doc, limit)
+                assert len(out) <= limit, f"I1: {doc[:30]!r} limit={limit}"
+                assert _html_is_balanced(out), f"I2: {doc[:30]!r} limit={limit} -> {out!r}"
+                assert is_prefix_plus_closers(doc, out), f"I3: {doc[:30]!r} limit={limit}"
+
+
+class TestApiDurationMetric:
+    """The histogram must measure what it claims: caller block time on outbound
+    calls only. All three defects below shipped in the first cut of this metric.
+    """
+
+    def _record_calls(self, monkeypatch: Any) -> list[tuple[str, float, dict]]:
+        seen: list[tuple[str, float, dict]] = []
+
+        class _Rec:
+            def histogram(self, name: str, value: float, *, unit: str = "ms", attrs=None, **kw):
+                seen.append((name, value, dict(attrs or {})))
+
+        # Patch the name in the CLIENT's namespace: get_recorder is imported at
+        # module scope there, so patching metrics.provider would not be seen.
+        monkeypatch.setattr("kiro_crew.telegram.client.get_recorder", lambda: _Rec(), raising=True)
+        return seen
+
+    def test_long_poll_is_not_recorded(self, monkeypatch: Any) -> None:
+        # getUpdates blocks ~30s by design and runs back-to-back forever. The
+        # Telemetry surface does not split on `method`, so recording it buried
+        # the 50-500ms outbound distribution under a permanent 30000ms mode.
+        seen = self._record_calls(monkeypatch)
+        _record_api_duration("editMessageText", 120.0, ok=True, err_code=None)
+        assert [m for _, _, a in seen for m in [a["method"]]] == ["editMessageText"]
+        assert all(a["method"] != "getUpdates" for _, _, a in seen)
+
+    def test_timeout_gets_its_own_outcome(self, monkeypatch: Any) -> None:
+        # Transport failures used to record NOTHING, hiding the longest stalls.
+        seen = self._record_calls(monkeypatch)
+        _record_api_duration("editMessageText", 30000.0, ok=False, err_code=None, timed_out=True)
+        assert seen and seen[-1][2]["outcome"] == "timeout"
+
+    def test_outcome_mapping_is_low_cardinality(self, monkeypatch: Any) -> None:
+        seen = self._record_calls(monkeypatch)
+        _record_api_duration("sendMessage", 1.0, ok=True, err_code=None)
+        _record_api_duration("sendMessage", 1.0, ok=False, err_code=400)
+        _record_api_duration("sendMessage", 1.0, ok=False, err_code=429)
+        _record_api_duration("sendMessage", 1.0, ok=False, err_code=None, timed_out=True)
+        assert [a["outcome"] for _, _, a in seen] == [
+            "ok",
+            "error",
+            "rate_limited",
+            "timeout",
+        ]
+        # chat_id / description must never become attributes (unbounded values).
+        assert all(set(a) == {"method", "outcome"} for _, _, a in seen)
+
+
+class TestCapText:
+    def test_plaintext_is_plain_sliced(self) -> None:
+        text = "z" * (TELEGRAM_MAX_TEXT + 50)
+        assert _cap_text(text, None) == text[:TELEGRAM_MAX_TEXT]
+
+    def test_html_is_tag_safe_capped(self) -> None:
+        # Oversize HTML whose 4096 boundary falls inside a code span.
+        text = "<code>" + "q" * (TELEGRAM_MAX_TEXT + 100) + "</code>"
+        out = _cap_text(text, "HTML")
+        assert len(out) <= TELEGRAM_MAX_TEXT
+        assert out.count("<code>") == out.count("</code>")
+
+    def test_under_limit_untouched_for_both_modes(self) -> None:
+        assert _cap_text("<b>ok</b>", "HTML") == "<b>ok</b>"
+        assert _cap_text("ok", None) == "ok"
+
+
+class TestRenderedBudget:
+    """Splitting must budget the RENDERED HTML, not the pre-escape source.
+
+    ``html.escape`` inflates ``&`` to ``&amp;`` (+4) and ``<`` to ``&lt;`` (+3),
+    so a chunk that fits a source budget can render past Telegram's hard cap --
+    which is what produced the oversize HTML in the first place.
+    """
+
+    def test_gate_says_plain_text_provably_fits(self) -> None:
+        assert _may_exceed_rendered("just some plain prose", 4000) is False
+
+    def test_gate_flags_escape_heavy_text(self) -> None:
+        # Each "<" costs +3 on render; 900 of them blow a 1000-char cap.
+        assert _may_exceed_rendered("<" * 900, 1000) is True
+
+    def test_gate_flags_link_heavy_text(self) -> None:
+        links = "[t](https://example.com/x)" * 40
+        assert _may_exceed_rendered(links, len(links) + 10) is True
+
+    def test_gate_refuses_to_guess_for_tag_producing_markup(self) -> None:
+        # Regression: the gate used to model only html.escape + links, so these
+        # shapes returned False ("provably fits") while rendering far past the
+        # cap -- oversize HTML then reached the client and lost its tail.
+        # Measured source -> rendered at cap 4000: blockquote 1000->5600,
+        # heading 2000->4500, italic 3600->8100, bold 3720->5580,
+        # inline code 2800->10500.
+        cap = 4000
+        shapes = {
+            "blockquote": "> q\n\n" * 200,
+            "heading": "# x\n" * 500,
+            "italic": "*x* " * 900,
+            "bold": "**x** " * 620,
+            "inline_code": "`x` " * 700,
+            "link": "[t](https://e.com/p) " * 180,
+        }
+        for name, text in shapes.items():
+            assert len(text) < cap, f"{name} fixture must be under the cap"
+            assert (
+                _may_exceed_rendered(text, cap) is True
+            ), f"{name}: gate returned False but renders to {_rendered_len(text)}"
+
+    def test_gate_false_always_means_it_really_fits(self) -> None:
+        # The load-bearing invariant: a False lets the caller SKIP the real
+        # render, so it must never be wrong. Over-returning True is safe.
+        import random
+
+        rng = random.Random(99)
+        toks = [
+            "> q\n\n",
+            "# h\n",
+            "text ",
+            "a ",
+            "**b** ",
+            "`c` ",
+            "[l](https://e/x) ",
+            "&",
+            "<x> ",
+            "'q' ",
+            '"d" ',
+            "_i_ ",
+            "- b\n",
+        ]
+        cap = 4000
+        for _ in range(600):
+            text = "".join(rng.choice(toks) for _ in range(rng.randint(1, 700)))
+            if len(text) >= cap:
+                text = text[: cap - 1]
+            if _may_exceed_rendered(text, cap) is False:
+                assert _rendered_len(text) <= cap, (
+                    f"gate said fits but rendered {_rendered_len(text)} > {cap}: " f"{text[:80]!r}"
+                )
+
+    def test_gate_still_short_circuits_plain_prose(self) -> None:
+        # The hot-path shortcut must survive the fix for genuinely plain text.
+        assert _may_exceed_rendered("just some plain prose with no markup", 4000) is False
+
+    def test_split_preserves_code_indentation_across_chunks(self) -> None:
+        # Regression: the continuation used a bare lstrip(), which ate the
+        # leading indentation of the first line of every continuation chunk and
+        # silently re-indented split code blocks. Render-aware splitting fires on
+        # more shapes, making that pre-existing corruption much easier to hit.
+        body = "\n".join(f'    if a["k{i}"] < b & c:   # <indented>' for i in range(120))
+        src = f"```python\n{body}\n```"
+        chunks = _split_markdown_bounded(src, 800)
+        assert len(chunks) > 1
+        for ch in chunks[1:]:
+            code_lines = [ln for ln in ch.split("\n") if ln.strip() and not ln.startswith("```")]
+            assert code_lines, "continuation chunk should carry code"
+            assert code_lines[0].startswith(
+                "    "
+            ), f"indentation lost on continuation: {code_lines[0][:60]!r}"
+
+    def test_shrinks_to_the_floor_instead_of_giving_up_early(self) -> None:
+        # Regression: a fixed pass budget returned still-oversize chunks, which
+        # the client backstop then truncated -- silently dropping content. Only
+        # the _MIN_SPLIT_LIMIT floor may yield oversize chunks.
+        cap = 4000
+        for src in (
+            "&" * 5000,
+            "```\n" + "&" * 3000 + "\n```",
+            "\n".join("q" * 40 + "&" for _ in range(400)),
+        ):
+            chunks = _split_markdown_bounded(src, cap)
+            worst = max(_rendered_len(c) for c in chunks)
+            assert worst <= cap, f"still oversize at {worst} for {src[:24]!r}"
+
+    def test_terminates_when_content_cannot_fit_the_cap(self) -> None:
+        # cap below what any _MIN_SPLIT_LIMIT-sized chunk can render to: must
+        # return (worst-effort) rather than loop forever.
+        chunks = _split_markdown_bounded("&" * 5000, 500)
+        assert chunks and max(_rendered_len(c) for c in chunks) > 500
+
+    def test_bounded_split_keeps_every_chunk_renderable(self) -> None:
+        # Escape-dense code: source-only budgeting overflows the rendered cap.
+        code = "\n".join(f'a["k{i}"] = b<c> & d>e "f" {i}' for i in range(400))
+        full = f"here:\n\n```python\n{code}\n```\n\ndone"
+        cap = 1000
+        chunks = _split_markdown_bounded(full, cap)
+        assert len(chunks) > 1
+        for ch in chunks:
+            assert _rendered_len(ch) <= cap, f"chunk renders to {_rendered_len(ch)} > cap {cap}"
+
+    def test_old_source_only_split_would_have_overflowed(self) -> None:
+        # Mutation-style guard: proves the new path is doing real work by
+        # showing the previous strategy (source budget only) overflows here.
+        code = "\n".join(f'x <{i}> & "{i}" & y' for i in range(300))
+        full = f"```\n{code}\n```"
+        cap = 1200
+        source_only = _split_markdown(full, cap)
+        assert any(
+            _rendered_len(c) > cap for c in source_only
+        ), "fixture no longer reproduces the inflation bug"
+        bounded = _split_markdown_bounded(full, cap)
+        assert all(_rendered_len(c) <= cap for c in bounded)
+
+    def test_no_content_lost_by_bounded_split(self) -> None:
+        text = "\n\n".join(f"para {i} with & and <tag>" for i in range(60))
+        chunks = _split_markdown_bounded(text, 800)
+        joined = " ".join(chunks)
+        for i in range(60):
+            assert f"para {i} " in joined or f"para {i}\n" in joined
+
+
 class TestInlineKeyboard:
     def test_none_when_no_options(self) -> None:
         assert build_inline_keyboard([]) is None
@@ -600,6 +941,41 @@ class TestRenderer:
 
         asyncio.run(_go())
         return cli
+
+    def test_rotation_keeps_an_open_fence_open_in_the_retained_tail(self) -> None:
+        # Regression: mid-stream the source fence is still open (the model has
+        # not emitted its closing ``` yet). _split_markdown balances each chunk
+        # with a synthetic closer, which is right for sealed chunks but wrong for
+        # the tail we keep streaming into: later tokens would land after that
+        # closer, render outside <pre>, and the real closing fence would show up
+        # literally.
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+        open_src = "intro\n\n```python\n" + "\n".join(
+            f'    x{i} = a["k{i}"] & b<c>' for i in range(150)
+        )
+        assert open_src.count("```") % 2 == 1, "fixture must leave the fence open"
+        r._buf = [open_src]
+        asyncio.run(r._rotate_on_length())
+        tail = "".join(r._buf)
+        assert not tail.rstrip().endswith(
+            "```"
+        ), f"synthetic closer retained in streaming tail: {tail[-40:]!r}"
+
+    def test_rotation_preserves_a_real_closing_fence(self) -> None:
+        # Control for the above: when the source fence IS closed, the tail must
+        # keep its genuine closer.
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+        closed_src = (
+            "intro\n\n```python\n"
+            + "\n".join(f'    y{i} = a["k{i}"] & b<c>' for i in range(150))
+            + "\n```"
+        )
+        assert closed_src.count("```") % 2 == 0
+        r._buf = [closed_src]
+        asyncio.run(r._rotate_on_length())
+        assert "".join(r._buf).rstrip().endswith("```")
 
     def test_streaming_strips_options_and_renders_keyboard(self) -> None:
         cli = self._drive(


### PR DESCRIPTION
## Problem

Long code-heavy answers intermittently lost **all** formatting in Telegram — code blocks, bold, links and blockquotes arrived as flat plaintext, with this in the gateway log:

```
Telegram API editMessageText failed: code=400
desc=Bad Request: can't parse entities: Can't find end tag corresponding to start tag "code"
```

`_md_to_telegram_html` was not at fault — it always emits balanced tags. The half-open tag came from **two layers disagreeing about length**: the renderer budgeted the pre-escape markdown (`max_message_chars` minus a fixed 256), `html.escape` then inflated it (`&` → `&amp;` is +4, `<` → `&lt;` is +3), and the client blind-sliced the *rendered* HTML with `text[:4096]` — landing between `<code>` and `</code>`.

## Renderer — budget on the rendered form

- `_split_markdown_bounded` measures the rendered HTML and shrinks the source budget until every chunk fits, so formatting survives.
- `_rotate_on_length` rotates on the source budget **or** the rendered cap, whichever binds first.
- `_may_exceed_rendered` gates the hot path. A `False` **must** mean "provably fits", since it is the only case the real render is skipped. Per-construct growth constants were tried and rejected as whack-a-mole: blockquote, heading, bold/italic and code spans each need their own term, measured inflation reaches **3.75×** (`` "`x` " * 700 ``: 2800 source chars → 10500 rendered), and any new converter rule silently reintroduces unsoundness. The gate now trusts arithmetic only for prose with no tag-producing markup and measures everything else — **266 µs** on a 3700-char buffer, against a 50–500 ms round-trip.
- `_limit` no longer claims to make HTML safe (it cannot — escape inflation is unbounded relative to a fixed subtraction); the rendered ceiling is explicit in `_rendered_limit`.

## Client — tag-safe truncation as a backstop

Reaching it means the renderer under-budgeted, so it warns.

- `truncate_html_safe` never splits a tag or entity and closes whatever it leaves open, so oversize HTML degrades to a shorter **valid** message instead of a hard 400.
- It searches the between-tag runs via a single `_cut_points` pass. Re-deriving the open-tag stack per candidate cut was quadratic — **122 ms** on one 4 KB document whose limit fell inside a nested close cluster, enough to stall the event loop — and is now **607 µs**.
- Cuts are tag-safe by construction, so an entity back-off can no longer strand the cut inside a complete tag.
- When nothing fits the answer is the empty string, never a prefix with unclosed tags — which would be the very 400 this prevents.
- Plaintext keeps its plain slice.

## Metric

Records Bot API call duration as `kirocrew.telegram.api.duration` (attrs: `method`, `outcome`) with `_FAST_BUCKETS_MS` bounds. Outbound sends and edits are awaited **inline in the token-streaming path**, so the duration is the time the render loop was blocked — the number needed to decide whether decoupling the send from the stream is worth doing.

Three details determine whether it can answer that at all:

- The 30 s `getUpdates` long-poll is excluded (`record=False`). It blocks by design and runs back-to-back forever, and the Telemetry surface does not split on `method` (`_OTHER_SPLIT_ATTRS`), so recording it would bury the 50–500 ms outbound distribution under a permanent ~30000 ms mode.
- One timer spans the whole call **including a 429 `retry_after` sleep**, so that multi-second stall is captured once instead of being dropped between two per-attempt timers that each looked short.
- Transport failures are recorded (`outcome="timeout"` for `TimeoutError`) rather than skipped, which had biased the histogram toward calls that got a response and hidden the longest stalls.

## Known gap (pre-existing, tracked separately)

Lengths are counted in Python code points while Telegram counts UTF-16 code units, so an emoji-dense message near the cap can still be rejected. The plain slice shared this mismatch before this change.

## Testing

- 27 new tests, including the minimal counterexample for every defect above and a mutation-style guard asserting the old source-only split still overflows its fixture.
- Full suite: **25,433 passed**. The 13 failures are environment-dependent and identical on an unmodified base (sandbox unavailable, `/tmp` permissions, missing `gh`, a test that picks up the host's live gateway PID).
- Independently validated with three adversarial QA passes (tag-safe truncation, split soundness, metric validity). They found 5 real defects in the first cut of this change — 2 HIGH — all fixed here: the truncation fallback emitted unclosed tags (1588 violations, 100 % on that one path), the gate returned "fits" for blockquote/heading/emphasis/code-span-dense input, the long-poll polluted the histogram, transport failures were unrecorded, and the 429 wait was dropped. Invariants re-verified over 4456 corpus checks + 3000 fuzz cases: 0 violations on length, validity, and prefix-plus-closers.
