### PR TITLE
fix(i18n): repair the lint exemptions that reported machine values as copy

### DIFF
--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -191,9 +191,46 @@ export default [
               // copy takes.
               '^[a-z][a-zA-Z0-9]*(?:\\.[a-z][a-zA-Z0-9_]*)+$',
               '^[A-Z][A-Z0-9_]*$',
+              // lowercase_snake, the third member of the identifier family above and
+              // the one this codebase generates most: the backend is Python, so every
+              // wire field, enum value and decision token arrives snake_case
+              // (`trust_command`, `design_doc`, `pool_agent`). Without it those literals
+              // are exempt only when something else happens to cover them — for a while
+              // that was the broad comparison-callee exemption, which meant
+              // `['trust_command', 'trust_base'].includes(decision)` went quiet for the
+              // wrong reason and got noisy again the moment that exemption was narrowed.
+              // Naming the shape puts the exemption where the argument actually lives.
+              //
+              // Known false negative, stated: snake_case copy would be missed. It is not
+              // a shape UI copy takes — copy has spaces and capitals, which is what keeps
+              // `['Save changes', 'Delete item']` reported.
+              '^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$',
               '^[\\w.-]+/[\\w./-]*$',
-              '^https?://',
-              '^[.~]?/',
+              // EVERY PATTERN IN THIS FILE IS MATCHED FULL-STRING, so a prefix
+              // pattern MUST spell out its own tail. `eslint-plugin-i18next` compiles
+              // each entry with `generateFullMatchRegExp`, which appends `$` unless the
+              // source already ends in one:
+              //
+              //   `^https?://`  ->  /^^https?:\/\/$/    matched ONLY the bare scheme
+              //   `^[.~]?/`     ->  /^^[.~]?\/$/        matched ONLY `/`, `./`, `~/`
+              //
+              // Both were written as prefixes and so exempted nothing. The URL/path
+              // class was silently carried by the lowercase-token pattern above
+              // instead, whose character class holds no `*`, `?`, `_`, `=`, `&` or
+              // capital — so `/api/chat/*`, `/api/file_read`, `/api/chat?slot=1` and
+              // `https://kiro.dev/Docs` were all reported as untranslated copy. That is
+              // invisible on existing code (frozen in the ledgers, and both whole-repo
+              // ledger checks are report-only) and fails only NEW code, at
+              // `[added-lines]`/`[vs-base]` zero tolerance — a hole that bites none of
+              // the authors who caused it and every author who arrives later. Repairing
+              // the two patterns drops 53 findings tree-wide and adds none.
+              //
+              // `\S*` rather than a character class: a leading `/` or a scheme plus no
+              // whitespace is not a shape UI copy takes, and enumerating URL characters
+              // is what produced the hole. Known false negative, stated: a one-word
+              // slash-prefixed string (`'/Delete'`) is exempt.
+              '^https?://\\S*$',
+              '^[.~]?/\\S*$',
               // Tokens with no letters at all: separators, punctuation, symbols, numbers.
               // Written as an ASCII class on purpose. `[^\p{L}]` looks equivalent but a
               // JS regex without the `u` flag reads `\p{L}` as the character class
@@ -251,9 +288,60 @@ export default [
               // exclusion cannot mask a `call(...)`/`vq(...)` callee elsewhere.
               '^mdnbCall$', '^mdnbVaultQuery$',
               'setAttribute', 'getAttribute', 'removeAttribute', 'classList\\.\\w+',
-              // The translate functions themselves. Anchored: these are matched as
-              // regexes, so a bare 't' would exclude every callee whose name contains
-              // the letter t.
+              // STRING COMPARISON. The argument is the value being compared AGAINST,
+              // so that call cannot render it — the same reason the plugin already
+              // exempts `x === 'lit'` and `switch (x) { case 'lit': }` by position.
+              // Without this, `err.startsWith('backing off')` is reported while the
+              // byte-identical `err === 'backing off'` two lines away is not, purely
+              // because one is a CallExpression.
+              //
+              // This is a POSITION exemption, not a shape one, and that is the whole
+              // point: `'backing off'` as a wire-protocol token and `'backing off'` as
+              // a label are the same string, so no content regex can separate them.
+              // Position can — and the argument of `.startsWith()` is decidable.
+              //
+              // Scope note: a literal assigned to a named constant first and compared
+              // later is still reported, correctly — nothing at the declaration says it
+              // is a token rather than copy. Declaring the type
+              // (`const X: Wire = 'backing off'`) is how an author says that, and the
+              // plugin honours it via `getContextualType` — but only under a type-aware
+              // parser, which this config deliberately does not pay for.
+              //
+              // ANCHORED, and not the bare method names, because a callee exemption
+              // suppresses the WHOLE call subtree, receiver included. The plugin pushes
+              // the callee verdict on `CallExpression` enter and tests the stack with
+              // `.some()`, and `withDottedPrefix` compiles a bare `includes` to
+              // `/^(?:.*\.)?includes$/` whose `.*` absorbs anything before the dot. With
+              // the bare names, an inline table of UI copy tested for membership passed
+              // at zero tolerance:
+              //
+              //   ['Save changes', 'Delete item'].includes(x)      // 0 findings
+              //   (c ? 'Save changes' : 'Delete item').startsWith(s)
+              //   g('Save changes').includes(x)
+              //
+              // Requiring the receiver to be an identifier/property chain reports all
+              // three again. `(?:\(\))?` admits a zero-argument link
+              // (`text.trim().startsWith(…)`) because empty parens cannot hold a
+              // literal, while `g('Save changes')` still cannot match. `\s*` is there
+              // because the plugin matches the callee's SOURCE TEXT, so a chain the
+              // formatter broke across lines carries newlines — without it the gate
+              // would depend on line width.
+              //
+              // Known false positives, stated: a receiver that is not a plain chain is
+              // reported even when the call is a genuine comparison — `(a || b)`,
+              // `(await p)`, `(x as string)`, `arr[0]`, `o['k']`, `s.slice(0, 3)`,
+              // `a.filter(Boolean)`, or a comment spliced mid-chain. None occurs in
+              // `src/` today with a reportable literal. Widening to admit them means
+              // admitting `(…)` and `[…]`, which is the hole itself, so the cost is
+              // deliberately left on the false-positive side — the same trade the
+              // lowercase-token pattern above documents.
+              '^[\\w$]+!?(?:\\s*\\??\\.\\s*[\\w$]+!?(?:\\(\\))?)*\\s*\\??\\.\\s*'
+                + '(?:startsWith|endsWith|includes|indexOf|lastIndexOf|localeCompare)$',
+              // The translate functions themselves. Anchored to the bare name: the
+              // plugin wraps every callee pattern as `^(?:.*\.)?<pattern>$`, so an
+              // UNANCHORED entry already matches the whole callee text (`fetch` and
+              // `api.fetch`, never `prefetch`). A leading `^` opts out of the dotted
+              // prefix, which is what is wanted here — `i18nT`, not `obj.i18nT`.
               '^i18nT$', '^t$',
             ],
           },

--- a/website/src/test/i18nLintExemptions.test.ts
+++ b/website/src/test/i18nLintExemptions.test.ts
@@ -1,0 +1,271 @@
+/**
+ * The exemptions in `eslint.i18n.config.js`, asserted through the real lint.
+ *
+ * ## Why this file exists
+ *
+ * `eslint-plugin-i18next` compiles every `words.exclude` entry with
+ * `generateFullMatchRegExp`, which appends `$` unless the source already ends in
+ * one. A pattern written as a PREFIX therefore matches only itself:
+ *
+ *   `^https?://`  ->  /^^https?:\/\/$/    matched only the bare scheme
+ *   `^[.~]?/`     ->  /^^[.~]?\/$/        matched only `/`, `./`, `~/`
+ *
+ * Both shipped like that and exempted nothing. Nothing failed, because the URL /
+ * path class was silently carried by the lowercase-token pattern instead — whose
+ * character class holds no `*`, `?`, `_`, `=`, `&` or capital. So `/api/chat/*`
+ * was reported as untranslated user copy while `/api/chat` on the line above was
+ * not, and the difference was one character nobody could see in the config.
+ *
+ * That failure mode is invisible in two directions at once: existing code is
+ * frozen in the ledgers (and both whole-repo ledger checks are report-only), and
+ * the diff-scoped gates fail only lines a branch WROTE. So the authors who could
+ * have noticed never saw it, and the authors who hit it had no way to tell a
+ * config bug from a real finding.
+ *
+ * These tests lint real source text with the real config, so they fail if a
+ * pattern stops matching what it claims to — including after a dependency bump
+ * that changes how patterns are compiled.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ESLint } from 'eslint'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import baseConfig from '../../eslint.i18n.config.js'
+
+const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+/** Lint one snippet exactly as the diff-scoped gates do. */
+async function lint(code: string): Promise<string[]> {
+  const engine = new ESLint({
+    cwd: WEBSITE_ROOT,
+    overrideConfigFile: 'eslint.i18n.strict.config.js',
+    allowInlineConfig: false,
+  })
+  const [result] = await engine.lintText(code, {
+    filePath: path.join(WEBSITE_ROOT, 'src/probe.tsx'),
+  })
+  return result.messages.map(m => m.message)
+}
+
+/** The `words.exclude` list actually in force. */
+function wordsExclude(): Array<string | RegExp> {
+  for (const block of baseConfig as Array<Record<string, unknown>>) {
+    const rules = block.rules as Record<string, unknown> | undefined
+    const options = rules?.['i18next/no-literal-string']
+    if (Array.isArray(options) && options[1] && typeof options[1] === 'object') {
+      const words = (options[1] as { words?: { exclude?: Array<string | RegExp> } }).words
+      if (words?.exclude) return words.exclude
+    }
+  }
+  throw new Error('no words.exclude found in eslint.i18n.config.js')
+}
+
+/**
+ * Whether `pattern` is genuinely end-anchored once the plugin compiles it.
+ *
+ * A raw `endsWith('$')` is not enough, and the gap is exactly the class this
+ * guard exists to catch: `'^Price: \\$'` ends in `$` as source text, but that `$`
+ * is ESCAPED, so `generateFullMatchRegExp` sees a terminal `$` and appends
+ * nothing — leaving `/^^Price: \$/`, which matches `'Price: $5 Save changes'`.
+ * That is a bare-prefix pattern smuggled past the check.
+ *
+ * Three ways a pattern can be end-unanchored, all of them checked:
+ *
+ *   1. no trailing `$` at all — the original bug;
+ *   2. a trailing `$` that is escaped — count the backslashes before it, an even
+ *      number (including none) leaves it an anchor, an odd number escapes it;
+ *   3. a TOP-LEVEL alternation — `'^X|.*$'` ends in an unescaped `$`, yet only
+ *      its second branch is anchored and that branch matches every string. A `|`
+ *      inside a group or a character class is fine (`^(Ctrl|Alt)$`), so depth has
+ *      to be tracked rather than the character merely searched for.
+ *
+ * A `RegExp` entry is checked the same way via its `source`: the plugin returns a
+ * `RegExp` untouched, so one written as a bare prefix is unanchored exactly as
+ * written.
+ */
+function endAnchored(pattern: string | RegExp): boolean {
+  const source = pattern instanceof RegExp ? pattern.source : pattern
+  if (!source.endsWith('$')) return false
+  const escapes = /(\\*)\$$/.exec(source)?.[1].length ?? 0
+  if (escapes % 2 !== 0) return false
+  return !hasTopLevelAlternation(source)
+}
+
+/** A `|` outside every group and character class, which splits the whole pattern. */
+function hasTopLevelAlternation(source: string): boolean {
+  let group = 0
+  let inClass = false
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i]
+    if (ch === '\\') { i += 1; continue }
+    if (inClass) { if (ch === ']') inClass = false; continue }
+    if (ch === '[') inClass = true
+    else if (ch === '(') group += 1
+    else if (ch === ')') group -= 1
+    else if (ch === '|' && group === 0) return true
+  }
+  return false
+}
+
+describe('words.exclude is compiled full-string', () => {
+  it('has no bare-prefix pattern, because the plugin anchors both ends', () => {
+    // The invariant that makes the trap unrepeatable. `generateFullMatchRegExp`
+    // appends `$` to any pattern that lacks one, so a pattern not ending in an
+    // unescaped `$` is silently end-anchored and almost never means what its
+    // author wrote. Spell the tail out (`\S*$`, `.*$`, an explicit class) instead.
+    expect(wordsExclude().filter(p => !endAnchored(p))).toEqual([])
+  })
+
+  it('the guard catches an ESCAPED trailing dollar, not just a missing one', () => {
+    // Without this, the check above passes on a pattern that is still a prefix.
+    expect(endAnchored('^Price: \\$')).toBe(false)
+    expect(endAnchored('^[.~]?/')).toBe(false)
+    expect(endAnchored('^[.~]?/\\S*$')).toBe(true)
+    // An even run of backslashes escapes the backslash, not the dollar.
+    expect(endAnchored('^a\\\\$')).toBe(true)
+    expect(endAnchored('^a\\\\\\$')).toBe(false)
+  })
+
+  it('the guard catches a top-level alternation whose other branch is open', () => {
+    expect(endAnchored('^X|.*$')).toBe(false)
+    // A `|` inside a group or a class is not an escape hatch — this is a real
+    // pattern in the list and must stay valid.
+    expect(endAnchored('^(Ctrl|Alt|Shift|Cmd|Win)$')).toBe(true)
+    expect(endAnchored('^[a|b]+$')).toBe(true)
+  })
+
+  it('the guard reads a RegExp entry rather than waving it through', () => {
+    // `generateFullMatchRegExp` returns a RegExp untouched, so one written as a
+    // bare prefix is unanchored exactly as written.
+    expect(endAnchored(/^https?:\/\/\S*$/)).toBe(true)
+    expect(endAnchored(/^https?:\/\//)).toBe(false)
+  })
+})
+
+describe('paths, routes and URLs are exempt', () => {
+  // Every string here is a real shape from this codebase. Each was REPORTED as
+  // untranslated user copy before the two prefix patterns were repaired.
+  const machine = [
+    "'/api/chat/*'", // permission-scope wildcard (PR #1276)
+    "'/api/apps/ops-mission-control/*'",
+    "'/api/file_read'", // underscore
+    "'/api/chat?slot=1'", // query string
+    "'/api/v1/Sessions'", // capital
+    "'/settings?tab=chat'",
+    "'/run?id=' + rid",
+    "'/-/merge_requests/'",
+    "'https://github.com/kirodotdev/KiroCrew/blob/main/README.md'",
+    "'~/.kiro/steering'",
+    "'./node_modules/@tailwindcss/browser/dist/index.global.js'",
+  ]
+
+  for (const literal of machine) {
+    it(`stays quiet on ${literal}`, async () => {
+      expect(await lint(`export const PROBE = [${literal}]`)).toEqual([])
+    })
+  }
+
+  it('still reports copy that merely starts with a slash-free word', async () => {
+    // The widened patterns must not swallow prose. `\S*` cannot match a space,
+    // which is what keeps a sentence out.
+    const messages = await lint(`export const PROBE = ['/ Delete this item', 'Save changes']`)
+    expect(messages).toHaveLength(2)
+  })
+})
+
+describe('string comparison is a position exemption', () => {
+  it('stays quiet on a literal compared with startsWith', async () => {
+    // The argument is the value being compared AGAINST, so the call cannot
+    // render it — the same reason the plugin already exempts `x === 'lit'`.
+    expect(await lint(`export const f = (e: string) => e.startsWith('backing off')`)).toEqual([])
+  })
+
+  it('stays quiet on includes, endsWith and indexOf', async () => {
+    expect(await lint(`
+      export const f = (e: string) => e.includes('building dist')
+        || e.endsWith('.tar.gz') || e.indexOf('Running: ') === 0
+    `)).toEqual([])
+  })
+
+  it('still reports the same string rendered as copy', async () => {
+    // The exemption is scoped to the comparison position, not to the value. If
+    // it leaked to the value, this would be the regression that hides real copy.
+    const messages = await lint(`export const LABEL = 'backing off'`)
+    expect(messages).toHaveLength(1)
+  })
+
+  it('still reports a literal passed to an unrelated single-word callee', async () => {
+    expect(await lint(`export const f = (s: string) => s.padStart(4, 'Waiting for input')`))
+      .toHaveLength(1)
+  })
+
+  // A callee exemption suppresses the WHOLE call subtree, receiver included — the
+  // plugin pushes the verdict on `CallExpression` enter and tests it with `.some()`.
+  // With bare method names these three passed at zero tolerance, because
+  // `withDottedPrefix`'s `(?:.*\.)?` absorbs any receiver. The anchored pattern
+  // requires an identifier/property-chain receiver, which reports them again.
+  it('still reports an inline table of copy tested for membership', async () => {
+    const messages = await lint(
+      `export const f = (x: string) => ['Save changes', 'Delete item'].includes(x)`,
+    )
+    expect(messages).toHaveLength(2)
+  })
+
+  it('still reports copy in a parenthesised receiver', async () => {
+    const messages = await lint(
+      `export const f = (c: boolean) => (c ? 'Save changes' : 'Delete item').startsWith('S')`,
+    )
+    expect(messages).toHaveLength(2)
+  })
+
+  it('still reports copy passed to a call that becomes the receiver', async () => {
+    const messages = await lint(
+      `export const f = (g: (s: string) => string) => g('Save changes').includes('x')`,
+    )
+    expect(messages).toHaveLength(1)
+  })
+
+  it('keeps a zero-argument link in the receiver chain exempt', async () => {
+    // `text.trim().startsWith('<svg')` is a real site in this codebase. Empty
+    // parens cannot hold a literal, so admitting them costs no coverage.
+    expect(await lint(`export const f = (t: string) => t.trim().startsWith('<svg')`)).toEqual([])
+  })
+
+  it('keeps an optional-chained property receiver exempt', async () => {
+    expect(await lint(
+      `export const f = (e: { types?: string[] }) => e.types?.includes('Files')`,
+    )).toEqual([])
+  })
+
+  it('keeps a receiver chain the formatter broke across lines exempt', async () => {
+    // The plugin matches the callee's SOURCE TEXT, so a wrapped chain carries
+    // newlines. Without `\s*` in the pattern the gate would depend on line width.
+    expect(await lint(`
+      export const f = (o: { p: { q: string } }) => o
+        .p
+        .q
+        .startsWith('backing off')
+    `)).toEqual([])
+  })
+
+  it('keeps an inline array of snake_case wire tokens exempt', async () => {
+    // Real sites: ChatInput.tsx:579 and pages/knowledge/helpers.ts:5. These are
+    // an inline-array receiver, so the anchored callee pattern reports them —
+    // the lowercase_snake shape is what exempts them, which is where the
+    // exemption belongs: the argument is a machine token by its own shape, not
+    // by where it sits.
+    expect(await lint(
+      `export const f = (d: string) =>`
+      + ` ['trust_command', 'trust_base', 'trust', 'trust_reads'].includes(d)`,
+    )).toEqual([])
+    expect(await lint(`export const f = (t: string) => ['design_doc', 'code_doc'].includes(t)`))
+      .toEqual([])
+  })
+
+  it('still reports snake_case-shaped copy that is really a sentence', async () => {
+    // The snake exemption is narrow: one lowercase run per underscore, no spaces.
+    expect(await lint(`export const LABEL = 'save changes_now'`)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Three exemptions in the i18n lint config did not cover what they claimed. Each failure is **invisible on existing code and fails only new code**, at `[added-lines]`/`[vs-base]` zero tolerance — so it never bites the author who caused it and always bites the next arrival, who has no way to tell a config bug from a real finding.

PR #1276 (since closed) hit all three at once, on an API-path allowlist, with the gate advising it wrap `'/api/chat/*'` in `i18nT()`.

## 1. Two patterns compiled into something that matched only themselves

`eslint-plugin-i18next` compiles every `words.exclude` entry with `generateFullMatchRegExp`, which appends `$` unless the source already ends in one. Two entries were written as prefixes:

| written | compiled | actually matched |
|---|---|---|
| `^https?://` | `/^^https?:\/\/$/` | only the bare scheme |
| `^[.~]?/` | `/^^[.~]?\/$/` | only `/`, `./`, `~/` |

Both were introduced already broken in `bf307136` (#1103), so nothing regressed — they never worked. The URL/path class was silently carried by the lowercase-token pattern above them instead, whose character class holds no `*`, `?`, `_`, `=`, `&` or capital. Hence `/api/chat/*` reported as untranslated user copy while `/api/chat` on the previous line was not.

## 2. String comparison had no exemption at all

The argument of `.startsWith()` is the value being compared *against*, so that call cannot render it — the same reason the plugin already exempts `x === 'lit'` and `switch (x) { case 'lit': }` by position. Without it, `err.startsWith('backing off')` was reported while the byte-identical `err === 'backing off'` two lines away was not, purely because one is a `CallExpression`.

This is a **position** exemption, not a shape one, and that is the point: the same string can be a wire token or a label, so no content regex can separate them, while the argument position is decidable.

The entry is **anchored on the receiver** rather than being the six bare method names. A callee exemption suppresses the whole call subtree — the plugin pushes the verdict on `CallExpression` enter and tests the stack with `.some()`, and `withDottedPrefix` compiles a bare `includes` to `/^(?:.*\.)?includes$/` whose `.*` absorbs any receiver. With bare names these passed at zero tolerance:

```js
['Save changes', 'Delete item'].includes(x)
(c ? 'Save changes' : 'Delete item').startsWith(s)
g('Save changes').includes(x)
```

## 3. `lowercase_snake` was missing from the identifier family

Narrowing the callee exemption exposed what it had been covering by accident. This backend is Python, so wire fields, enum values and decision tokens arrive snake_case — and the config exempts camelCase and `SCREAMING_SNAKE` on the machine-identifier argument but had no `lowercase_snake` rule. So `['trust_command', 'trust_base'].includes(decision)` was quiet only because a broad callee rule swallowed its receiver, and went noisy the moment that rule was tightened.

Naming the shape puts the exemption where the argument lives, and the pattern provably cannot hide copy: `^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$` admits no space and no capital, which is what keeps `['Save changes', 'Delete item']` reported. Known false negative, stated in the config: snake_case that really is copy.

## Measured

CI's own invocation (`eslint src/`, strict config), base `be79b1d6` vs head:

```
2415 -> 2279     136 newly exempt, 0 newly reported
```

Isolated per mechanism: **53** from the two patterns, **27** from the comparison entry, **57** from `lowercase_snake` — 137, with one site counted twice (a snake token inside a comparison).

All inspected. Paths, routes and query strings (`/api/file-raw?path=`, `~/.kiro/steering`); 10 documentation URLs (seven channel-panel `SETUP_GUIDE` links); format sniffs (`'<svg'`, `'B;'`, `'Running: '`, `'[Subagent completion event]'`); snake_case wire tokens (`'request_changes'`, `'tool_running'`, `'file_path'`). **No user-visible copy in the set.** The ledger figures agree independently: 1203 across 222 files + 1076 in ALL-CAPS constants across 115 files = 2279.

Ceilings deliberately left at 1833/1118 — `website/AGENTS.md` is explicit that a report-only ceiling is not re-snapshotted just because a change improved it.

## Test

`src/test/i18nLintExemptions.test.ts` lints real source with the real config, so a pattern that stops matching what it claims to now fails a test. **18 of its 28 assertions fail against main's config**; the 10 that pass are the negative controls proving the widening did not swallow prose, the receiver cases, and the snake pattern's own boundary.

It also pins the general invariant — no entry in `words.exclude` may be a bare prefix — against the **compiled** anchor rather than the source text. A raw `endsWith('$')` would wave through exactly the shape it exists to catch:

- `'^Price: \$'` ends in `$` yet compiles end-unanchored (the `$` is escaped)
- `'^X|.*$'` is anchored only on one branch of a top-level alternation
- a `RegExp` entry is returned by the plugin untouched, so an unanchored one stays unanchored

Known false positives are stated in the config, per the file's convention: a comparison receiver that is not a plain identifier/property chain — `(a || b)`, `(await p)`, `arr[0]`, `s.slice(0, 3)` — is reported even though the call is a genuine comparison. None occurs in `src/` today. Admitting them means admitting `(…)` and `[…]`, which is the hole itself.

## i18n remediation progress

This is gate-layer work, not translation work. Where it sits:

- **Phase 0–3** (seam, extraction, catalogues, label tables) — done, merged.
- **Phase 4** (date/time/number formatting) — done, merged.
- **Phase 5** (render-time gate under `en-XA`) — merged; log/verdict rework merged in #1257.
- **Gate correctness** — *this PR*. Repairs three exemptions in the static layer.
- **Not started**: widening the render gate's surface registry (20 of 54 URL-reachable surfaces are covered today); type-aware linting so an author can declare a protocol token via its type rather than relying on shape.

## Verification

| Gate | Result |
|---|---|
| `npx tsc -b` | 0 |
| `npx eslint src/ --max-warnings 1116` | 0 errors |
| `npx jscpd .` | 0 clones |
| `npx vitest run` | 618 files, 7920 passed / 3 skipped |
| `I18N_BASE_REF=be79b1d6 npm run i18n:check` | 11 checks PASS |

Reviewed locally by a `gpt-5.6-sol` mirror of `codex-review.yml` (no findings) and a `claude-opus-5` mirror of `claude-review.yml` (three findings, all fixed), then a focused verifier which found the anchored-receiver form had cost 5 existing exemptions — that is what produced fix 3.

Tracks #1004
