### PR TITLE
fix(desktop): grant the macOS mic entitlement so voice input can prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,6 +601,43 @@ jobs:
       - name: Lint deploy templates
         run: cfn-lint src/kiro_crew/deploy/skills/artifact-deploy/templates/*.yaml
 
+  # The Electron shell (website/electron) has its own 460+ test node:test suite,
+  # and until now NOTHING ran it on a PR — its only runner was ota-test.yml,
+  # which is nightly/on-demand and called by no other workflow. So main-process
+  # regressions (permission handling, packaging/entitlements contracts, the
+  # updater IPC surface) could land green and surface a day later, or in a
+  # shipped DMG. That is not hypothetical: the missing macOS microphone
+  # entitlement reached users this way. This job is deliberately tiny and fast —
+  # pure unit tests, no Electron binary download, no packaging.
+  electron-test:
+    name: Electron Shell Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/electron/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website/electron
+        # Belt-and-braces: this pin currently downloads no Electron binary
+        # anyway (electron 43's package ships no install script), so the var is
+        # inert today — it is set so a future version that reintroduces the
+        # ~100MB postinstall download cannot silently slow this job down. The
+        # tests require() only main-process modules and the stdlib test runner,
+        # so the binary is never needed.
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+        run: npm ci --no-audit --no-fund
+
+      - name: Unit tests
+        working-directory: website/electron
+        run: npm test
+
   frontend-test:
     name: Frontend Tests
     runs-on: ubuntu-latest

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -421,6 +421,77 @@ a *different* app after a rebuild and re-prompt for grants you already gave.
 Distributing the signed + notarized DMG (above) keeps grants sticky across
 updates.
 
+### Device resources (microphone) need an ENTITLEMENT, not just a usage string
+
+Folder access above needs only consent. A **device** resource is different: under
+the hardened runtime the capability is granted by a `com.apple.security.device.*`
+entitlement, and the `Info.plist` usage string only supplies the prompt's
+wording. Get this wrong and the failure is deeply misleading:
+
+> **Symptom:** voice input reports *"Microphone permission denied"* instantly,
+> **no** system prompt ever appears, and there is no KiroCrew row under System
+> Settings › Privacy & Security › Microphone to switch on. The same mic works in
+> Chrome at the same origin on the same machine.
+
+Because under the hardened runtime the microphone requires
+`com.apple.security.device.audio-input` **in addition to** the usage string —
+without it access is refused and no prompt appears, so there is nothing to
+consent to and nothing to toggle. The entitlement is a Hardened Runtime
+*Resource Access* capability (Xcode's "Audio Input" checkbox), **not** an
+App-Sandbox-only key: this app is not sandboxed, and neither are Chrome, Slack
+or Zoom — all three are hardened-runtime, non-sandboxed, and all three ship
+audio-input. The usage string is not a substitute; both are load-bearing.
+
+It is worth being precise about *where* the capability lives, because the
+intuitive answer is wrong: in Chromium the audio capture runs in the **browser
+(main) process** — the renderer only requests it over IPC — and TCC attributes
+access to the responsible main bundle. Chrome's and Slack's *Renderer* helper
+apps carry no audio-input entitlement at all, and their microphones work. So the
+main bundle's `entitlements` is what matters; `entitlementsInherit` is set to the
+same file so helpers keep their JIT/library-validation keys.
+
+Two things follow, and both are pinned by `website/electron/test/packaging.test.js`:
+
+- **There are TWO signing lanes reading TWO different files.** electron-builder
+  signs local/dev builds with `website/electron/build/entitlements.mac.plist`;
+  the release lane signs with `packaging/signing/Entitlements.entitlements`. An
+  entitlement added to one and not the other ships a **broken bundle on the other
+  lane** — keep them in sync.
+- **The camera is deliberately absent.** `permission-handler.js` denies any
+  request that explicitly asks for video, so requesting the camera entitlement
+  would widen the TCC surface for a capability the app never uses.
+
+The prompt is also **one-shot**: once a user denies the mic, macOS never asks
+again. So `permission-handler.js` consults
+`getMediaAccessStatus('microphone')` on each request and branches —
+`not-determined` asks in-context (right when the user clicks the mic, rather than
+spending the single prompt at launch on an unrelated moment), while
+`denied`/`restricted` opens the Privacy pane via `showMicPermissionDialog()`,
+since the OS will not re-prompt on its own. Every failure mode in that probe
+fails **open**, so diagnosing permissions can never itself be what breaks the mic.
+The sinks (breadcrumb log, recovery dialog) are deliberately kept off the
+answer path: an earlier revision had them inside the promise chain upstream of a
+fail-open `.catch`, so a throwing logger turned a user's explicit **refusal into
+a grant**. Auditing must never be able to change a permission verdict.
+
+#### Developer gotcha: a stale TCC row survives a fix
+
+TCC rows are pinned to the app's **code-signing identity (cdhash)**, not just its
+bundle id — and ad-hoc local builds share one collapsed `Identifier=Electron`
+identity. So a machine that ran a dev build can hold a Microphone row for
+`com.amazon.kiro.crew` whose `csreq` matches a cdhash the Developer-ID release
+can never satisfy. The row reads *granted* in the TCC database and is still never
+honored, which looks exactly like the entitlement bug and survives fixing it.
+
+If the mic still fails after a rebuild, clear the row and let the app re-prompt:
+
+```bash
+tccutil reset Microphone com.amazon.kiro.crew
+```
+
+This is also why distributing the signed + notarized DMG matters (above): a
+stable identity is what keeps grants sticky instead of silently orphaning them.
+
 ## Remote tunnel mode
 
 The desktop app can also connect to a gateway running on a **remote** host (e.g.

--- a/packaging/signing/Entitlements.entitlements
+++ b/packaging/signing/Entitlements.entitlements
@@ -5,6 +5,16 @@
      - allow-unsigned-executable-memory: required for V8 + native Node.js addons (numpy, aiohttp)
      - disable-library-validation: required to load native .node/.dylib addons not signed with the same identity
      - automation.apple-events: allows the app to send Apple Events (used for open-at-login registration)
+     - device.audio-input: REQUIRED for the microphone (voice input / streaming STT).
+       Under the hardened runtime this entitlement — not the Info.plist usage
+       string — is what grants the capability (a Resource Access key; it is NOT
+       App-Sandbox-only, and this app is not sandboxed). Without it the mic is
+       refused and the user is NEVER prompted, with no System Settings toggle to
+       fix it. THIS FILE is what signed the shipped bundle whose mic was dead.
+       This is the release-lane twin of website/electron/build/entitlements.mac.plist;
+       the two signing paths read their OWN file, so both must carry the key or
+       one lane ships a broken bundle. packaging.test.js pins both.
+       Camera is deliberately absent — permission-handler.js denies video.
 -->
 <plist version="1.0">
 <dict>
@@ -12,5 +22,6 @@
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
     <key>com.apple.security.cs.disable-library-validation</key><true/>
     <key>com.apple.security.automation.apple-events</key><true/>
+    <key>com.apple.security.device.audio-input</key><true/>
 </dict>
 </plist>

--- a/website/electron/build/entitlements.mac.plist
+++ b/website/electron/build/entitlements.mac.plist
@@ -16,5 +16,34 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <!--
+    RESOURCE ACCESS — required, not optional, under the hardened runtime.
+
+    The hardened runtime gates each protected resource behind its own
+    `device.*` entitlement — this is a Resource Access capability (Xcode's
+    "Audio Input"), NOT an App-Sandbox-only key, and this app is not sandboxed.
+    NSMicrophoneUsageDescription only supplies the PROMPT STRING; it does not
+    grant the capability. Without audio-input the microphone is refused and NO
+    system prompt appears — there is nothing for the user to allow, and no
+    System Settings toggle to flip. That is the exact bug this key fixes.
+    Chrome, Slack and Zoom are all hardened-runtime and non-sandboxed, and all
+    three ship this entitlement; the shipped bundle that lacked it was the only
+    one whose mic was dead.
+
+    Belongs on the MAIN bundle: Chromium captures audio in the browser process
+    (the renderer only asks over IPC), and Chrome's/Slack's Renderer helpers
+    carry no audio-input at all.
+
+    Keep this in sync with packaging/signing/Entitlements.entitlements — the
+    two signing paths (electron-builder locally, the enterprise signing service
+    for release) each read their OWN file, so an entitlement added to one and
+    not the other ships a broken bundle on the other lane.
+    `packaging.test.js` pins both.
+
+    Camera is deliberately ABSENT: permission-handler.js denies any request
+    that explicitly asks for video, so the app never needs it (least privilege).
+  -->
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
 </dict>
 </plist>

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1804,6 +1804,47 @@ function showScreenPermissionDialog() {
     .catch(() => {});
 }
 
+// The microphone twin of showScreenPermissionDialog, shown when macOS reports
+// the mic as denied/restricted. This dialog IS the recovery route: TCC's own
+// prompt is one-shot, so once denied the OS never asks again and the mic button
+// would otherwise fail forever with no way for the user to fix it.
+//
+// Latched, unlike the screen-capture dialog: that one has a single entry point,
+// whereas the mic is reachable from several independent capture call sites
+// (dictation, streaming STT, the settings mic test, meeting transcription), so
+// an unlatched dialog can stack copies of itself.
+let micDialogOpen = false;
+function showMicPermissionDialog(status = "denied") {
+  if (micDialogOpen) return;
+  micDialogOpen = true;
+  const pane = "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone";
+  // 'restricted' is policy-managed (MDM/parental controls): the toggle the
+  // 'denied' copy tells the user to flip either is not there or will not stick,
+  // so do not send them on an errand they cannot complete.
+  const restricted = status === "restricted";
+  dialog
+    .showMessageBox({
+      type: "info",
+      title: "Microphone permission needed",
+      message: restricted
+        ? "Microphone access is blocked by a policy"
+        : "Allow Kiro Crew to use the microphone",
+      detail: restricted
+        ? "Voice input needs macOS Microphone permission, but access is restricted by a device-management policy on this Mac. Contact whoever manages it to allow microphone access for Kiro Crew."
+        : "Voice input needs macOS Microphone permission, and macOS will not ask again once it has been denied. Open System Settings › Privacy & Security › Microphone, enable Kiro Crew, then try the mic again.",
+      buttons: restricted ? ["OK"] : ["Open System Settings", "Cancel"],
+      defaultId: 0,
+      cancelId: restricted ? 0 : 1,
+    })
+    .then(({ response }) => {
+      if (!restricted && response === 0) shell.openExternal(pane);
+    })
+    .catch(() => {})
+    .then(() => {
+      micDialogOpen = false;
+    });
+}
+
 // Last-resort safety net. An unhandled exception/rejection anywhere on the main
 // process would otherwise tear the app down with no trace — the exact "it just
 // crashed" the remote-tunnel drop used to produce. Log it (best-effort; logging
@@ -1987,14 +2028,46 @@ app.whenReady().then(async () => {
   // MIDI, …) per least privilege. Screen capture uses its own
   // setDisplayMediaRequestHandler and is unaffected. See permission-handler.js
   // for why the audio grant must NOT require a populated details.mediaTypes.
-  // On macOS we also proactively trigger the OS microphone (TCC) prompt.
-  session.defaultSession.setPermissionRequestHandler(createPermissionRequestHandler());
+  //
+  // The macOS (TCC) leg is wired INTO the request handler rather than fired at
+  // launch. Asking at launch spent the OS's one-shot prompt before the user had
+  // done anything mic-related — easy to dismiss, and once dismissed macOS never
+  // asks again, leaving voice input permanently dead. Asking from the handler
+  // puts the prompt exactly where the user clicked the mic, and an
+  // already-denied state now opens the Privacy pane instead of failing mutely.
+  // NOTE: none of this works without com.apple.security.device.audio-input in
+  // the signing entitlements — the hardened runtime refuses the mic before TCC
+  // is ever consulted, which is what produced a denial with no prompt at all.
+  const isMac = process.platform === "darwin";
+  session.defaultSession.setPermissionRequestHandler(
+    createPermissionRequestHandler(
+      isMac
+        ? {
+            getMicAccessStatus: () => systemPreferences.getMediaAccessStatus("microphone"),
+            askForMicAccess: () => systemPreferences.askForMediaAccess("microphone"),
+            onMicBlocked: () => showMicPermissionDialog(),
+          }
+        : {},
+    ),
+  );
   session.defaultSession.setPermissionCheckHandler(createPermissionCheckHandler());
-  if (process.platform === "darwin") {
-    systemPreferences.askForMediaAccess("microphone").catch(() => {
-      /* best effort — older macOS or TCC denied */
-    });
-  }
+
+  // Renderer-side recovery route. The handler above only sees requests that
+  // reach Electron; a mic can still fail further down (a stale TCC row pinned to
+  // an old code-signing identity, a revoked grant mid-session), and all the
+  // renderer gets is getUserMedia's opaque NotAllowedError. It reports that here
+  // so the OS status can be re-checked and the Privacy pane offered — otherwise
+  // the "permission denied" toast is a dead end, since macOS never re-prompts.
+  // Only speaks up when macOS is genuinely the one refusing.
+  ipcMain.on("mic:denied", () => {
+    if (!isMac) return;
+    try {
+      const status = systemPreferences.getMediaAccessStatus("microphone");
+      if (status === "denied" || status === "restricted") showMicPermissionDialog(status);
+    } catch {
+      /* status probe unavailable — stay silent rather than guess */
+    }
+  });
 
   createTray();
   const win = createWindow();

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -41,7 +41,8 @@
       "notarize": false,
       "x64ArchFiles": "{**/backend-dist/**,**/backend-dist/**/.*/**}",
       "extendInfo": {
-        "CFBundleDisplayName": "Kiro Crew"
+        "CFBundleDisplayName": "Kiro Crew",
+        "NSMicrophoneUsageDescription": "Kiro Crew uses the microphone for voice input and dictation in chat. Audio is captured only while you hold or toggle the mic button."
       }
     },
     "afterSign": "scripts/notarize.js",

--- a/website/electron/permission-handler.js
+++ b/website/electron/permission-handler.js
@@ -119,22 +119,102 @@ function logDeny(kind, permission, wc, origin, details) {
  * Denies every other permission type (geolocation, clipboard, notifications,
  * MIDI, …).
  *
+ * ── The macOS (TCC) leg ──────────────────────────────────────────────────────
+ *
+ * Granting at the Electron layer is necessary but NOT sufficient on macOS: the
+ * OS gates the mic separately, and its prompt is ONE-SHOT — once a user is
+ * 'denied', macOS never asks again, so a bare deny is a permanent dead end
+ * ("permission denied" with no prompt and nothing obvious to click). This
+ * handler therefore mirrors display-media.js's screen-capture treatment:
+ *
+ *   - 'granted'         -> grant.
+ *   - 'not-determined'  -> ask macOS NOW (the user just clicked the mic, so the
+ *                          prompt is in-context) and honor the answer.
+ *   - 'denied'/'restricted' -> deny AND surface a recovery route to System
+ *                          Settings; the OS will not re-prompt on its own.
+ *
+ * The TCC leg is OPT-IN via injected deps: with no `getMicAccessStatus` the
+ * handler stays fully synchronous and behaves exactly as before (non-darwin
+ * platforms and unit tests take that path).
+ *
  * @param {object} [deps]
  * @param {(wc: unknown, origin?: string) => boolean} [deps.isAppOrigin] - injectable for tests
  * @param {(...args: unknown[]) => void} [deps.onDeny] - injectable for tests
+ * @param {() => string} [deps.getMicAccessStatus] - systemPreferences.getMediaAccessStatus('microphone')
+ * @param {() => Promise<boolean>} [deps.askForMicAccess] - systemPreferences.askForMediaAccess('microphone')
+ * @param {(reason: string) => void} [deps.onMicBlocked] - surfaced when macOS will not re-prompt
  * @returns {(wc: unknown, permission: string, callback: (granted: boolean) => void, details?: object) => void}
  */
 function createPermissionRequestHandler(deps = {}) {
   const originOk = deps.isAppOrigin || isAppOrigin;
   const onDeny = deps.onDeny || logDeny;
+  const getMicAccessStatus = deps.getMicAccessStatus;
+  const askForMicAccess = deps.askForMicAccess;
+  const onMicBlocked = deps.onMicBlocked || (() => {});
+  // Audit sinks are OBSERVERS: they must never be able to change a verdict or
+  // strand a request. Both are real hazards, not hypotheticals — the default
+  // logDeny JSON.stringify()s an Electron-supplied `details`, which throws on a
+  // circular structure or a throwing getter, and onMicBlocked opens a real
+  // dialog. An escaping throw here would leave the renderer's getUserMedia
+  // promise unsettled FOREVER, the exact silent dead end this module exists to
+  // prevent. Wrapping once, at the source, is what keeps every call site safe.
+  const audit = (...args) => {
+    try {
+      onDeny(...args);
+    } catch {
+      /* breadcrumb is best effort — never let logging decide a permission */
+    }
+  };
   return function handlePermissionRequest(wc, permission, callback, details) {
     // The REQUEST handler has no origin string of its own; details may carry a
     // requesting URL on some Electron versions, so offer it as the fallback.
     const origin = details?.securityOrigin || details?.requestingUrl;
     const granted =
       permission === "media" && originOk(wc, origin) && !requestsVideo(details);
-    if (!granted) onDeny("request", permission, wc, origin, details);
-    return callback(granted);
+    if (!granted) {
+      audit("request", permission, wc, origin, details);
+      return callback(false);
+    }
+    // Electron says yes; on macOS the OS still has to. Absent the TCC deps
+    // (non-darwin, tests) this stays synchronous — the original behavior.
+    if (typeof getMicAccessStatus !== "function") return callback(true);
+
+    let status;
+    try {
+      status = getMicAccessStatus();
+    } catch {
+      // Probing the OS must never be what breaks the mic: fail OPEN and let
+      // getUserMedia surface whatever the OS decides.
+      return callback(true);
+    }
+    if (status === "granted") return callback(true);
+    if (status === "denied" || status === "restricted") {
+      audit("request", `${permission}:tcc-${status}`, wc, origin, details);
+      try {
+        onMicBlocked(status);
+      } catch {
+        /* recovery UI is best effort — see the `audit` note above */
+      }
+      return callback(false);
+    }
+    // 'not-determined' (or anything unrecognized): ask, in context.
+    if (typeof askForMicAccess !== "function") return callback(true);
+    Promise.resolve()
+      .then(askForMicAccess)
+      // Fail open ONLY on a rejection from askForMicAccess itself (older macOS,
+      // missing API). This must be settled BEFORE the sinks below run: with a
+      // single trailing .catch, anything thrown by onDeny or callback would be
+      // caught downstream and answered with a SECOND callback(true) — inverting
+      // a user's explicit refusal into a grant, and double-invoking a callback
+      // Electron only permits once.
+      .then(
+        (ok) => Boolean(ok),
+        () => true,
+      )
+      .then((ok) => {
+        if (!ok) audit("request", `${permission}:tcc-refused`, wc, origin, details);
+        callback(ok);
+      });
   };
 }
 
@@ -160,7 +240,16 @@ function createPermissionCheckHandler(deps = {}) {
       permission === "media" &&
       originOk(wc, origin) &&
       details?.mediaType !== "video";
-    if (!granted) onDeny("check", permission, wc, origin, details);
+    // Guarded for the same reason as the request handler's `audit`: this is a
+    // synchronous Electron callback, so a throwing breadcrumb would propagate
+    // into Chromium's permission check instead of just failing to log.
+    if (!granted) {
+      try {
+        onDeny("check", permission, wc, origin, details);
+      } catch {
+        /* breadcrumb is best effort — never let logging decide a permission */
+      }
+    }
     return granted;
   };
 }

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -42,6 +42,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // its unread (critical+default) count; main.js applies app.setBadgeCount.
   // No-op on platforms without badge support (Windows) -- Electron handles it.
   setBadgeCount: (count) => ipcRenderer.send("badge:set", count),
+  // Mic-denial recovery. The renderer only ever sees getUserMedia's
+  // NotAllowedError — it cannot tell "the OS refused" from "Electron refused",
+  // and it cannot open System Settings itself. So when a mic capture is denied
+  // it pings the main process, which checks the real OS status and shows the
+  // Privacy-pane dialog only if macOS is actually the one saying no. Without
+  // this the toast is a dead end: macOS never re-prompts after a denial.
+  reportMicDenied: () => ipcRenderer.send("mic:denied"),
 });
 
 // Native zoom bridge for the Settings > Display "Zoom Level" stepper.

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -52,6 +52,151 @@ describe("macOS bundle naming", () => {
 });
 
 
+// Under the hardened runtime, an Info.plist usage string does NOT grant a
+// protected resource — the matching `device.*` entitlement does. With
+// audio-input missing, the runtime refused the microphone BEFORE macOS (TCC) was
+// consulted, so voice input reported "permission denied" and the user was never
+// prompted and had no System Settings toggle to fix it. There are TWO signing
+// lanes reading TWO different files (electron-builder locally, the enterprise
+// signing service for release), so an entitlement present in one and absent from
+// the other still ships a broken bundle on that lane. Pin both.
+describe("macOS microphone entitlement (both signing lanes)", () => {
+  const MIC = "com.apple.security.device.audio-input";
+  const CAMERA = "com.apple.security.device.camera";
+
+  /**
+   * Strip XML comments, repeatedly, until the text stops changing.
+   *
+   * One pass is not enough: removing an outer `<!-- … -->` can splice together
+   * text that forms a NEW `<!--`, so a single replace can leave a comment
+   * opener behind. Looping to a fixed point (then asserting nothing is left)
+   * is what makes "this key is real, not commented-out prose" trustworthy.
+   */
+  function stripComments(xml) {
+    let out = xml;
+    for (let i = 0; i < 20; i += 1) {
+      const next = out.replace(/<!--[\s\S]*?-->/g, "");
+      if (next === out) return next;
+      out = next;
+    }
+    return out;
+  }
+
+  /**
+   * Parse an entitlements plist into a plain { key: value } map.
+   *
+   * Deliberately a scanner rather than a built-from-a-string RegExp: composing
+   * a pattern out of a key name means hand-rolling escaping, which is easy to
+   * get subtly wrong (CodeQL flags exactly that), and a text match cannot tell
+   * a genuine <dict> entry from one mentioned in a comment. Walking the tags
+   * gives an exact key->value answer with no escaping in the picture at all.
+   * Booleans are all these files hold; anything else is reported as its raw tag.
+   */
+  function parseEntitlements(xml) {
+    const body = stripComments(xml);
+    assert.equal(body.includes("<!--"), false, "unterminated XML comment");
+    const out = {};
+    const tag = /<key>([\s\S]*?)<\/key>\s*(<[^>]+>)/g;
+    let m;
+    while ((m = tag.exec(body)) !== null) {
+      const name = m[1].trim();
+      const value = m[2].replace(/\s|\//g, "");
+      out[name] = value === "<true>" ? true : value === "<false>" ? false : m[2];
+    }
+    return { entitlements: out, body };
+  }
+
+  const LANES = {
+    "electron-builder (build/entitlements.mac.plist)": path.join(
+      ROOT, "build", "entitlements.mac.plist"
+    ),
+    "signing service (packaging/signing/Entitlements.entitlements)": path.resolve(
+      ROOT, "..", "..", "packaging", "signing", "Entitlements.entitlements"
+    ),
+  };
+
+  for (const [lane, file] of Object.entries(LANES)) {
+    it(`grants the microphone in the ${lane} lane`, () => {
+      const { entitlements } = parseEntitlements(fs.readFileSync(file, "utf8"));
+      assert.equal(
+        entitlements[MIC],
+        true,
+        `${file} must set ${MIC} to <true/> as a real dict entry, or the ` +
+          "hardened runtime refuses the mic and no prompt ever appears"
+      );
+    });
+
+    it(`does not request the camera in the ${lane} lane`, () => {
+      // Least privilege: permission-handler.js denies any explicit video
+      // request, so the camera entitlement would widen the TCC surface for a
+      // capability the app never uses. Checked as a parsed key rather than a
+      // substring, because these files carry comments that MENTION the camera
+      // to explain its absence — a substring test would fail on the very prose
+      // documenting the rule.
+      const { entitlements } = parseEntitlements(fs.readFileSync(file, "utf8"));
+      assert.notEqual(
+        entitlements[CAMERA],
+        true,
+        `${file} must not grant ${CAMERA} — permission-handler.js denies video`
+      );
+    });
+
+    it(`parses as a well-formed plist in the ${lane} lane`, () => {
+      // codesign rejects a malformed plist outright, and the key assertions
+      // above would still read a value out of a file that cannot be signed.
+      const { entitlements, body } = parseEntitlements(fs.readFileSync(file, "utf8"));
+      assert.match(body, /<plist[^>]*>\s*<dict>/, "expected a plist wrapping one dict");
+      assert.equal(
+        (body.match(/<dict>/g) || []).length,
+        (body.match(/<\/dict>/g) || []).length,
+        "unbalanced <dict> tags"
+      );
+      // A dangling key (no value after it) breaks signing, and every value in
+      // these files is a boolean — so key count must equal parsed-entry count.
+      assert.equal(
+        (body.match(/<key>/g) || []).length,
+        Object.keys(entitlements).length,
+        "every entitlement key must be followed by a value"
+      );
+      for (const [name, value] of Object.entries(entitlements)) {
+        assert.equal(typeof value, "boolean", `${name} must be <true/> or <false/>`);
+      }
+    });
+  }
+
+  it("keeps electron-builder pointed at the entitlements file it signs with", () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+    assert.equal(pkg.build.mac.entitlements, "build/entitlements.mac.plist");
+    // `entitlements` is the one that matters for the mic: in Chromium the audio
+    // capture runs in the BROWSER (main) process — the renderer only requests it
+    // over IPC — and TCC attributes access to the responsible main bundle.
+    // Verified against shipping apps: Chrome's and Slack's Renderer helpers
+    // carry NO audio-input entitlement, yet their microphones work. Inherit is
+    // pinned too so helpers keep the JIT/library-validation keys they need
+    // (harmless for audio, and it matches what Slack does).
+    assert.equal(pkg.build.mac.entitlementsInherit, "build/entitlements.mac.plist");
+    // Without hardenedRuntime the resource-access entitlements are moot — this
+    // is what makes audio-input load-bearing rather than decorative.
+    assert.equal(pkg.build.mac.hardenedRuntime, true);
+  });
+
+  it("ships real Info.plist usage-string copy, not just the key", () => {
+    // The entitlement grants the capability; this string is what macOS SHOWS.
+    // macOS rejects an EMPTY purpose string, so asserting only that the key
+    // exists would pass in exactly the state the prompt is refused — assert the
+    // value. Declared here rather than inherited from Electron's generic
+    // boilerplate ("This app needs access to the microphone"), so a
+    // user-visible, load-bearing prompt is not at an upstream default's mercy.
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+    const usage = (pkg.build.mac.extendInfo || {}).NSMicrophoneUsageDescription;
+    assert.equal(typeof usage, "string", "NSMicrophoneUsageDescription must be declared");
+    assert.ok(
+      usage.trim().length >= 20,
+      "must be real prompt copy explaining WHY the mic is used, not empty/placeholder"
+    );
+  });
+});
+
 describe("uninstall data preservation contract", () => {
   const electronPkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
   const websitePkg = JSON.parse(

--- a/website/electron/test/permission-handler.test.js
+++ b/website/electron/test/permission-handler.test.js
@@ -157,6 +157,168 @@ describe("createPermissionRequestHandler", () => {
   });
 });
 
+// macOS gates the mic separately from Electron, and its prompt is ONE-SHOT:
+// once denied, the OS never asks again. So a bare deny is a permanent dead end
+// — which is exactly what the user saw ("permission denied", no prompt, nothing
+// to click). The request handler therefore consults TCC and routes a denied
+// state to a recovery dialog.
+describe("createPermissionRequestHandler — macOS TCC leg", () => {
+  /** Collect the callback value from an async (promise-tailed) handler. */
+  const grantAsync = async (h, wc, permission, details) => {
+    let got;
+    h(wc, permission, (v) => { got = v; }, details);
+    await new Promise((r) => setImmediate(r));
+    return got;
+  };
+  const audio = { mediaTypes: ["audio"] };
+
+  it("grants without asking when TCC already granted", async () => {
+    let asked = 0;
+    const h = createPermissionRequestHandler({
+      ...allowAll,
+      getMicAccessStatus: () => "granted",
+      askForMicAccess: async () => { asked += 1; return true; },
+    });
+    assert.equal(await grantAsync(h, APP, "media", audio), true);
+    assert.equal(asked, 0, "must not re-prompt when already granted");
+  });
+
+  it("asks the OS in-context when not-determined, and honors the answer", async () => {
+    for (const answer of [true, false]) {
+      let asked = 0;
+      const h = createPermissionRequestHandler({
+        ...allowAll,
+        getMicAccessStatus: () => "not-determined",
+        askForMicAccess: async () => { asked += 1; return answer; },
+      });
+      assert.equal(await grantAsync(h, APP, "media", audio), answer);
+      assert.equal(asked, 1);
+    }
+  });
+
+  it("denies AND surfaces a recovery route when TCC is denied/restricted", async () => {
+    // THE DEAD END: macOS will not re-prompt, so denying silently leaves the
+    // mic broken forever. The blocked callback is the only way back.
+    for (const status of ["denied", "restricted"]) {
+      const blocked = [];
+      let asked = 0;
+      const h = createPermissionRequestHandler({
+        ...allowAll,
+        getMicAccessStatus: () => status,
+        askForMicAccess: async () => { asked += 1; return true; },
+        onMicBlocked: (r) => blocked.push(r),
+      });
+      assert.equal(await grantAsync(h, APP, "media", audio), false);
+      assert.deepStrictEqual(blocked, [status]);
+      assert.equal(asked, 0, "asking is pointless once denied — macOS won't prompt");
+    }
+  });
+
+  it("never consults the OS for a request Electron already denied", async () => {
+    let probed = 0;
+    const h = createPermissionRequestHandler({
+      ...allowAll,
+      getMicAccessStatus: () => { probed += 1; return "granted"; },
+    });
+    assert.equal(await grantAsync(h, APP, "media", { mediaTypes: ["video"] }), false);
+    assert.equal(await grantAsync(h, APP, "geolocation", audio), false);
+    assert.equal(probed, 0);
+  });
+
+  it("fails OPEN when probing or asking throws (never blocks the mic itself)", async () => {
+    const throwing = createPermissionRequestHandler({
+      ...allowAll,
+      getMicAccessStatus: () => { throw new Error("no such API"); },
+    });
+    assert.equal(await grantAsync(throwing, APP, "media", audio), true);
+
+    const rejecting = createPermissionRequestHandler({
+      ...allowAll,
+      getMicAccessStatus: () => "not-determined",
+      askForMicAccess: async () => { throw new Error("older macOS"); },
+    });
+    assert.equal(await grantAsync(rejecting, APP, "media", audio), true);
+  });
+
+  it("stays synchronous with no TCC deps (non-darwin path unchanged)", () => {
+    const h = createPermissionRequestHandler(allowAll);
+    // No await: the callback must have fired already.
+    let got;
+    h(APP, "media", (v) => { got = v; }, audio);
+    assert.equal(got, true);
+  });
+
+  // REGRESSION: the sinks (onDeny / callback / onMicBlocked) must not be able to
+  // change the answer. A first cut put them INSIDE the promise chain, upstream of
+  // a trailing `.catch(() => callback(true))` — so a throwing sink was caught
+  // downstream and answered with a SECOND callback(true). Measured effect: a user
+  // who explicitly REFUSED the mic was reported as having GRANTED it. The
+  // exactly-once test below could not see it because its stubs never throw.
+  it("keeps a REFUSAL a refusal even when the deny breadcrumb throws", async () => {
+    const vals = [];
+    const h = createPermissionRequestHandler({
+      isAppOrigin: () => true,
+      onDeny: () => { throw new Error("logDeny blew up"); },
+      getMicAccessStatus: () => "not-determined",
+      askForMicAccess: async () => false, // the user said NO
+    });
+    h(APP, "media", (v) => vals.push(v), audio);
+    await new Promise((r) => setImmediate(r));
+    assert.deepStrictEqual(vals, [false], "a throwing sink must never invert a refusal");
+  });
+
+  it("still answers when the recovery dialog throws (no hung getUserMedia)", async () => {
+    // onMicBlocked is real Electron UI (dialog.showMessageBox) and can throw.
+    // If that escapes, the permission request never settles and the renderer's
+    // getUserMedia promise hangs forever — the silent dead end this module exists
+    // to prevent.
+    const vals = [];
+    const h = createPermissionRequestHandler({
+      isAppOrigin: () => true,
+      onDeny: () => {},
+      getMicAccessStatus: () => "denied",
+      onMicBlocked: () => { throw new Error("no window"); },
+    });
+    h(APP, "media", (v) => vals.push(v), audio);
+    await new Promise((r) => setImmediate(r));
+    assert.deepStrictEqual(vals, [false]);
+  });
+
+  it("invokes the callback exactly once on every TCC path", async () => {
+    const paths = [
+      { getMicAccessStatus: () => "granted" },
+      { getMicAccessStatus: () => "denied" },
+      { getMicAccessStatus: () => "not-determined", askForMicAccess: async () => true },
+      { getMicAccessStatus: () => "not-determined", askForMicAccess: async () => false },
+      { getMicAccessStatus: () => { throw new Error("x"); } },
+    ];
+    // Each path is exercised twice: once with inert sinks, and once with sinks
+    // that THROW. Electron permits the callback exactly once and throws on a
+    // second invoke, and the throwing variant is what caught the real
+    // double-invoke — inert stubs alone cannot see it.
+    for (const deps of paths) {
+      for (const hostile of [false, true]) {
+        const sinks = hostile
+          ? {
+              isAppOrigin: () => true,
+              onDeny: () => { throw new Error("sink"); },
+              onMicBlocked: () => { throw new Error("sink"); },
+            }
+          : { ...allowAll, onMicBlocked: () => {} };
+        let calls = 0;
+        const h = createPermissionRequestHandler({ ...sinks, ...deps });
+        h(APP, "media", () => { calls += 1; }, audio);
+        await new Promise((r) => setImmediate(r));
+        assert.equal(
+          calls,
+          1,
+          `callback count for ${JSON.stringify(Object.keys(deps))} (hostile=${hostile})`,
+        );
+      }
+    }
+  });
+});
+
 describe("check and request handlers agree", () => {
   it("never lets a check veto a grant the request handler would give", () => {
     // The observed contradiction: permissions.query() said "granted" while
@@ -195,5 +357,21 @@ describe("denial logging", () => {
     const h = createPermissionCheckHandler();
     // Real logDeny path with a throwing getURL() must not raise.
     assert.equal(h(wcDestroyed(), "media", undefined, { mediaType: "audio" }), false);
+  });
+
+  it("still returns a verdict when the breadcrumb itself throws", () => {
+    // logDeny JSON.stringify()s an Electron-supplied `details`, which throws on a
+    // circular structure or a throwing getter. This is a synchronous Chromium
+    // callback, so an escaping throw propagates into the permission check —
+    // logging must never be able to decide, or break, a permission.
+    const h = createPermissionCheckHandler({
+      onDeny: () => { throw new Error("stringify blew up"); },
+    });
+    assert.equal(h(null, "media", undefined, { mediaType: "audio" }), false);
+
+    const circular = { mediaType: "audio" };
+    circular.self = circular;
+    const real = createPermissionCheckHandler();
+    assert.equal(real(null, "geolocation", undefined, circular), false);
   });
 });

--- a/website/src/apps/meetings/hooks/useMeetingTranscription.ts
+++ b/website/src/apps/meetings/hooks/useMeetingTranscription.ts
@@ -20,6 +20,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { MeetingsApiError, meetingsApi } from '../api'
+import { reportIfMicDenied } from '../../../hooks/mic'
 
 /** Feature detection mirroring `useStreamingStt` — the dashboard's own hook. */
 export const transcriptionSupported =
@@ -196,7 +197,11 @@ export function useMeetingTranscription({ meetingId, onCaption, onFinal, onError
     let stream: MediaStream
     try {
       stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-    } catch {
+    } catch (e) {
+      // This surface reports its own generic 'microphone' error rather than
+      // routing through humanizeMicError, so hand a DENIAL to the shell here or
+      // the desktop app has no route to System Settings (macOS never re-prompts).
+      reportIfMicDenied(e)
       onErrorRef.current?.('microphone')
       startingRef.current = false
       return

--- a/website/src/hooks/mic.ts
+++ b/website/src/hooks/mic.ts
@@ -38,12 +38,50 @@ export function micAudioConstraints(): MediaStreamConstraints {
   return { audio: id ? { deviceId: { ideal: id } } : true }
 }
 
+/**
+ * Ask the desktop shell to offer an OS-level recovery route for a mic denial.
+ *
+ * In a browser the toast is the whole story — the user re-grants via the
+ * omnibox. In the packaged app it is a dead end: macOS's mic prompt is one-shot,
+ * so once denied the OS never asks again and page JS cannot open System
+ * Settings. The shell re-checks the real OS status and shows the Privacy pane
+ * only if macOS is the one refusing. No-op in a plain browser, and best-effort
+ * everywhere — telling the user why must never be what throws.
+ */
+export function reportMicDenied(): void {
+  try {
+    ;(window as { electronAPI?: { reportMicDenied?: () => void } }).electronAPI?.reportMicDenied?.()
+  } catch {
+    /* no shell bridge (browser), or IPC unavailable */
+  }
+}
+
+/** True when a getUserMedia rejection means "the user/OS refused", not "no device". */
+function isPermissionDenial(e: unknown): boolean {
+  const name = (e as { name?: string } | null)?.name || ''
+  return name === 'NotAllowedError' || name === 'SecurityError'
+}
+
+/**
+ * Report a mic failure to the shell when — and only when — it was a denial.
+ *
+ * For capture paths that do NOT route through `humanizeMicError` (they show no
+ * message, or their own), so a denial still gets its OS-level recovery route.
+ */
+export function reportIfMicDenied(e: unknown): void {
+  if (isPermissionDenial(e)) reportMicDenied()
+}
+
 /** Map a getUserMedia rejection to a short, human-readable message. */
 export function humanizeMicError(e: unknown): string {
   const name = (e as { name?: string } | null)?.name || ''
   switch (name) {
     case 'NotAllowedError':
     case 'SecurityError':
+      // The chokepoint most mic capture paths funnel their failure through, so
+      // the recovery hand-off lives here rather than in each hook. Paths that
+      // don't produce a message call reportIfMicDenied() directly.
+      reportMicDenied()
       return i18nT('hooks.mic.microphone_permission_denied_allow_mic_access_in')
     case 'NotFoundError':
     case 'OverconstrainedError':

--- a/website/src/pages/settings/SttSettings.tsx
+++ b/website/src/pages/settings/SttSettings.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle, X, Hourglass, Package } from 'lucide-react'
 import { SettingsCard, SettingsToggle, SettingsSelect, SettingsInput } from '../../components/settings'
 import { Badge, Btn, FormSkeleton } from '../../components/ui'
 import { api } from '../../api/client'
-import { listMicrophones, getPreferredMicId, setPreferredMicId, micAudioConstraints } from '../../hooks/mic'
+import { listMicrophones, getPreferredMicId, setPreferredMicId, micAudioConstraints, reportIfMicDenied } from '../../hooks/mic'
 
 import { i18nT } from '../../i18n/t'
 interface SttConfig {
@@ -93,8 +93,12 @@ export default function SttSettings() {
       const s = await navigator.mediaDevices.getUserMedia(micAudioConstraints())
       s.getTracks().forEach(t => t.stop())
       refreshMics()
-    } catch {
-      /* permission denied — device names stay hidden */
+    } catch (e) {
+      // Device names stay hidden, and this button is the user's ONLY affordance
+      // for fixing that — so a denial must still reach the shell's recovery
+      // route. Otherwise clicking "Allow microphone access" appears to do
+      // nothing at all, forever (macOS never re-prompts after a denial).
+      reportIfMicDenied(e)
     }
   }
   const changeMic = (id: string) => { setMicId(id); setPreferredMicId(id) }

--- a/website/src/test/mic.test.ts
+++ b/website/src/test/mic.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest'
-import { humanizeMicError } from '../hooks/mic'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { humanizeMicError, reportIfMicDenied } from '../hooks/mic'
+
+type MicWindow = { electronAPI?: { reportMicDenied?: () => void } }
 
 describe('humanizeMicError', () => {
   it('maps permission denial', () => {
@@ -13,5 +15,63 @@ describe('humanizeMicError', () => {
   })
   it('falls back for unknown errors', () => {
     expect(humanizeMicError(new Error('weird'))).toMatch(/could not start/i)
+  })
+})
+
+// In a browser the toast is the whole story — the user re-grants from the
+// omnibox. In the packaged desktop app it is a dead end: macOS's mic prompt is
+// one-shot, so once denied the OS never asks again and page JS cannot open
+// System Settings. So a denial hands off to the shell, which re-checks the real
+// OS status and offers the Privacy pane.
+describe('humanizeMicError — desktop recovery hand-off', () => {
+  afterEach(() => {
+    delete (window as MicWindow).electronAPI
+  })
+
+  it('notifies the shell on a permission denial', () => {
+    const reportMicDenied = vi.fn()
+    ;(window as MicWindow).electronAPI = { reportMicDenied }
+    humanizeMicError({ name: 'NotAllowedError' })
+    expect(reportMicDenied).toHaveBeenCalledTimes(1)
+    humanizeMicError({ name: 'SecurityError' })
+    expect(reportMicDenied).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT notify for failures the OS did not cause', () => {
+    // A missing device or a busy mic is not a permission problem; sending the
+    // user to the Privacy pane for those would be actively misleading.
+    const reportMicDenied = vi.fn()
+    ;(window as MicWindow).electronAPI = { reportMicDenied }
+    humanizeMicError({ name: 'NotFoundError' })
+    humanizeMicError({ name: 'NotReadableError' })
+    humanizeMicError({ name: 'OverconstrainedError' })
+    humanizeMicError(new Error('weird'))
+    expect(reportMicDenied).not.toHaveBeenCalled()
+  })
+
+  it('reportIfMicDenied covers paths that show no message', () => {
+    // The settings "Allow microphone access" button and meeting transcription
+    // don't call humanizeMicError, so they hand off explicitly — otherwise the
+    // one affordance for fixing a denial silently does nothing forever.
+    const reportMicDenied = vi.fn()
+    ;(window as MicWindow).electronAPI = { reportMicDenied }
+    reportIfMicDenied({ name: 'NotAllowedError' })
+    reportIfMicDenied({ name: 'SecurityError' })
+    expect(reportMicDenied).toHaveBeenCalledTimes(2)
+    // Not a permission problem -> no misleading trip to the Privacy pane.
+    reportIfMicDenied({ name: 'NotFoundError' })
+    reportIfMicDenied(new Error('weird'))
+    reportIfMicDenied(null)
+    expect(reportMicDenied).toHaveBeenCalledTimes(2)
+  })
+
+  it('still returns the message with no shell bridge, or a throwing one', () => {
+    // Plain browser: no electronAPI at all.
+    expect(humanizeMicError({ name: 'NotAllowedError' })).toMatch(/permission denied/i)
+    // Telling the user why must never be what throws.
+    ;(window as MicWindow).electronAPI = {
+      reportMicDenied: () => { throw new Error('ipc gone') },
+    }
+    expect(humanizeMicError({ name: 'NotAllowedError' })).toMatch(/permission denied/i)
   })
 })


### PR DESCRIPTION
## Problem

Voice input in the packaged macOS app fails **instantly** with "Microphone
permission denied. Allow mic access in your OS and browser settings." — and
**no system prompt ever appears**. Worse, following that advice leads nowhere:
there is no KiroCrew row under System Settings › Privacy & Security ›
Microphone to switch on. The same microphone works in Chrome at the same
origin, on the same machine.

## Why it matters

Every voice surface is dead in the shipped desktop app — chat dictation,
streaming STT, the Settings mic test, and meeting transcription — with an error
message that tells the user to fix it somewhere they cannot. There is no
workaround, and the toast blames the user's OS settings for something the app
never asked for.

## Fix (symptoms → root cause → change)

**Symptom → root cause.** A denial with no prompt means nothing ever asked. TCC
on my machine *reported* `com.amazon.kiro.crew` as granted, so the OS was not
the one refusing. Under the hardened runtime a **device** resource is granted by
its `com.apple.security.device.*` entitlement —
`NSMicrophoneUsageDescription` only supplies the prompt's *wording*.
`audio-input` was absent, so the mic was refused with nothing to consent to and
nothing to toggle.

This is a Hardened Runtime **Resource Access** capability, *not* an
App-Sandbox-only key — the common misconception here. Verified against shipping
apps on the same machine: Chrome, Slack and Zoom are all hardened-runtime and
**non-sandboxed**, and all three ship `audio-input`. The one bundle without it
was the only one whose mic was dead.

**Change.**

1. **Add `com.apple.security.device.audio-input` — to *both* signing lanes.**
   electron-builder reads `website/electron/build/entitlements.mac.plist`; the
   release lane reads `packaging/signing/Entitlements.entitlements`. The shipped
   bundle was signed by the *second* file, so adding the key to only one still
   ships a broken lane. Camera stays absent — `permission-handler.js` denies
   video, so requesting it would widen the TCC surface for nothing.
2. **Declare the usage string explicitly.** It was being inherited from
   Electron's unbranded default, "This app needs access to the microphone". A
   load-bearing, user-visible prompt should not be at an upstream default's mercy.
3. **Stop spending the one-shot prompt at launch.** `askForMediaAccess` ran in
   `whenReady`, before the user had done anything mic-related — easy to dismiss,
   and macOS never asks twice. It now runs *from the permission request handler*,
   so the prompt appears exactly where the user clicked the mic, and an
   already-`denied` state opens the Privacy pane instead of failing mutely
   (`restricted` gets its own copy, since that toggle is MDM-managed and the user
   cannot act on it).
4. **Give the renderer a route back.** `getUserMedia` only ever yields an opaque
   `NotAllowedError`, and page JS cannot open System Settings. A new `mic:denied`
   IPC re-checks the real OS status and offers the pane. Wired at
   `humanizeMicError` (the chokepoint most paths use) **plus** the two that show
   no message of their own — the Settings "Allow microphone access" button, whose
   `catch` was empty, and meeting transcription.
5. **Keep audit sinks off the answer path.** While fixing the above, the first
   revision put `onDeny`/`onMicBlocked` inside the promise chain *upstream* of a
   fail-open `.catch`. Consequence, reproduced: a throwing breadcrumb turned a
   user's explicit **refusal into a GRANT**, and could double-invoke a callback
   Electron permits once. Reachable via the default `logDeny`, which
   `JSON.stringify`s an Electron-supplied `details`. Both handlers now wrap their
   sink, and the fail-open is settled by a two-arg `.then` *before* the sinks run.
   Logging must never be able to decide, or strand, a permission.

## Signals called out

- **Manifest change** (`website/electron/package.json`): no dependency added or
  removed — the only edit is one `mac.extendInfo` key
  (`NSMicrophoneUsageDescription`).
- **CI/infra change** (`.github/workflows/ci.yml`): adds an `electron-test` job.
  The 467-test Electron shell suite previously ran **only** in `ota-test.yml`
  (nightly / on-demand, called by no other workflow), so main-process
  regressions could land green — which is how this bug reached users. Without
  this job the regression pins below would gate nothing.

## Tests

Electron suite 467/467, backend 25458 passed, frontend 7920 passed.

- `packaging.test.js` — per lane: the mic key is granted, the camera is not, and
  the plist is well-formed (balanced `<dict>`, every key has a value, key
  survives comment-stripping). **Verified to fail per-lane when stripped**, so
  the two-lane split is load-bearing, not decorative. Also pins
  `entitlements`/`entitlementsInherit`/`hardenedRuntime`, and asserts the usage
  string's *value* — an earlier version passed on an empty string, exactly the
  state macOS rejects.
- `permission-handler.test.js` — the TCC branch matrix (`granted` doesn't
  re-prompt · `not-determined` asks and honors the answer · `denied`/`restricted`
  denies **and** surfaces recovery · Electron-denied never probes the OS · every
  probe failure fails open · non-darwin stays synchronous), plus **hostile-sink**
  variants asserting exactly-once and that a refusal stays a refusal. The
  original exactly-once test used non-throwing stubs, which is precisely why it
  could not see the inversion.
- `mic.test.ts` — the hand-off fires for `NotAllowedError`/`SecurityError`, does
  **not** fire for a missing/busy device (no misleading trip to the Privacy
  pane), and still returns its message with no shell bridge or a throwing one.

## Manual verification

Root cause and fix were both confirmed against the real installed bundle rather
than reasoned about:

- The shipped `/Applications/KiroCrew Nightly.app` carries
  `NSMicrophoneUsageDescription` and **no** `audio-input` — so the usage string
  was never the missing piece.
- Its signed entitlements include `automation.apple-events` but not
  `allow-dyld-environment-variables`, proving it was signed from
  `packaging/signing/Entitlements.entitlements` — the lane that lacked the key.
- Re-signing a copy of the bundle with the updated plist produces
  `com.apple.security.device.audio-input` `<true/>` in the resulting signature.
- Cross-checked Chrome/Slack/Zoom for `app-sandbox` (absent) and `audio-input`
  (present), which is what rules out the "sandbox-only" reading.

**Developer note now in the docs:** TCC rows are pinned to the code-signing
identity, and ad-hoc local builds collapse onto one shared `Identifier=Electron`
cdhash. A machine that ran a dev build can hold a Microphone row for
`com.amazon.kiro.crew` whose `csreq` no Developer-ID release can satisfy — it
reads *granted* and is never honored, which mimics this bug and survives fixing
it. Recovery is `tccutil reset Microphone com.amazon.kiro.crew`. (I hit exactly
this on my own machine: the row's csreq pins `a7639b3d…`/`b65f5283…` while the
installed bundle is `dd7fecb1…`.)

## Screenshots

N/A — no UI change. The user-visible surfaces are two native macOS dialogs
(System Settings prompt / Privacy-pane recovery) and the pre-existing toast,
whose copy is unchanged.
