### PR TITLE
feat(i18n): render the surfaces the en-XA gate never visited

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -309,8 +309,8 @@ declaration site, and the ordering.
 
 It is a RUNNER (`scripts/i18n-check.mjs`), not a `&&` chain, and that matters: `&&`
 short-circuits, so a PR only ever learned about its FIRST failing gate and paid another
-~5-minute CI round to discover the next. The runner executes all six scripts, then
-reports the eleven checks they contain in one table. Each script's raw output is folded
+~5-minute CI round to discover the next. The runner executes all seven scripts, then
+reports the twelve checks they contain in one table. Each script's raw output is folded
 into its own collapsed group, so nothing is lost.
 
 The table is split by the only question an author has — **is this mine to fix?**
@@ -324,6 +324,7 @@ The table is split by the only question an author has — **is this mine to fix?
 | `[key-refs]` | repo | any | a `t('key')` naming a key that does not exist — renders the raw key to a user |
 | `[plurals]` | repo | any | a plural suffix concatenated outside `i18nT()` |
 | `[pseudolocale]` | repo | any | `en-XA.json` stale relative to its generator |
+| `[dnt]` | repo | any | a do-not-translate term respelt in a shipped catalog (`Github`, `NodeJS`) — compares catalog values, so it covers all 9 locales and needs no render |
 | `[dynamic-keys]` | repo | never (report) | a call site whose key cannot be resolved statically |
 | `[extractable]` | repo | never (report) | a literal in markup the codemod could have extracted |
 | `[untranslated]` | repo | never (report) | per-file ceilings over the frozen debt in `untranslated-baseline.json` |
@@ -555,7 +556,7 @@ that never reached a catalog. It needs no gateway, no token and no backend — i
 the build over loopback and answers every `/api/**` call from fixtures, exactly like the
 `capture-*.mjs` harnesses.
 
-Four things to know before you touch it:
+Five things to know before you touch it:
 
 1. **It builds its own bundle, with `NODE_ENV=development`.** `en-XA` is DEV-only in
    three independent places (`index.ts` tree-shakes the catalog, `isRestorableLanguage()`
@@ -566,10 +567,17 @@ Four things to know before you touch it:
 2. **A crashed surface is exit 2, not findings.** If a fixture is the wrong shape the
    error boundary replaces the panel with its own English message, and a naive scan would
    report *that* as untranslated copy. Any uncaught page error aborts the run instead.
-3. **DNT integrity runs only in real locales.** The pseudolocale accents DNT terms too
-   (`GitHub` → `ĞìţĤùƀ`), so asserting them under `en-XA` would report all 19 as mangled.
-   It is zero-tolerance, and it deliberately accepts an all-lowercase hit as the command
-   (`git push`, `docker run`) rather than a mangled product name.
+3. **DNT integrity runs only in real locales, and now in exactly one.** The pseudolocale
+   accents DNT terms too (`GitHub` → `ĞìţĤùƀ`), so asserting them under `en-XA` would
+   report all 19 as mangled. It is zero-tolerance, and it deliberately accepts an
+   all-lowercase hit as the command (`git push`, `docker run`) rather than a mangled
+   product name. The locale set is down to `en-XA` plus a single `zh-CN` **DNT probe**
+   (one viewport, non-DNT findings discarded) because the full 4-locale matrix cost
+   ~23min and blew the `e2e` job's 25-minute cap. Two consequences to keep in mind:
+   `layout`/`latent` are now measured only at pseudolocale width, so they over-report
+   against every shipped locale; and a DNT term mistranslated in `de` or `bn` but not
+   `zh-CN` is no longer caught here. `LOCALES` in `scripts/lib/i18n-surfaces.mjs`
+   carries the full rationale and the way back (shard surfaces across a matrix).
 4. **`[vs-base]` decides the run; the record decides only when there is no base.** The
    gate renders the BASE commit with the same scanner and fails on any per-surface
    increase, reading no committed number — so there is nothing to re-snapshot and
@@ -593,6 +601,22 @@ Four things to know before you touch it:
    can trade within. The measured proof that the diff is the stronger check: inflate
    `settings-about.text` from 28 to 100, add 18 real defects, and the ledger reports an
    *improvement* while `[vs-base]` fails with `28 -> 46 (+18)`.
+5. **Fixture values are digit-shaped, except where the fixture IS the subject.** Anything
+   word-shaped in `FIXTURE_OVERRIDES` renders into the page and is indistinguishable from
+   untranslated product copy, so boot payloads use `'0001'`-style placeholders. The one
+   deliberate exception is `FIXTURE_APPS`, which stands in for the Python side's
+   `app.json` metadata (`displayName`, `description`, `highlights[]`, `tags[]`): those
+   fields are interpolated raw by the App Store and app-detail components, so bare Latin
+   at those nodes under `en-XA` is the finding, and a digit placeholder would render the
+   same surface while hiding the defect the surface exists to show. Read the resulting
+   `apps` / `app-detail` numbers as a FIXED STRUCTURAL PROBE, not as the size of the debt
+   — the scanner counts per word, so the count is whatever prose the fixture carries,
+   which is why those strings are terse. The real population is 128 manifest strings
+   across 14 builtins (D14-a on #1004) and its ground truth is a server-side
+   pseudolocale, the same way `test/test_error_code_contract.py` declares it for backend
+   error bodies. Note this cuts both ways: `ui.pages[].label` stays a placeholder,
+   because the nav rail resolves it for every installed app and Latin there would land
+   the same finding on all 55 surfaces.
 
 `latent` holds `ellipsis-with-flex-parent` on its own — ~544 sites where
 `text-overflow: ellipsis` cannot apply because a flex child's `min-width` is still `auto`,

--- a/website/scripts/check-dnt-catalogs.mjs
+++ b/website/scripts/check-dnt-catalogs.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * DNT integrity, asserted against catalog VALUES rather than rendered pixels.
+ *
+ * ## Why this is a separate script and not part of the render gate
+ *
+ * DNT (do-not-translate) protects proper nouns — `AWS`, `GitHub`, `Playwright` — from
+ * a translator who transliterates or "helpfully" localises them. It used to be
+ * checked by `check-i18n-render.mjs`, which meant it could only ever run in a locale
+ * the render budget could afford. It cannot run under `en-XA` at all:
+ * `gen-pseudolocale.mjs` accents every ASCII letter outside a preserved region and
+ * DNT terms are not preserved, so all of them render mangled by design.
+ *
+ * That coupling made a zero-tolerance assertion hostage to a render budget. When the
+ * locale list came down to `en-XA` alone (55+ surfaces x 2 trees does not fit the
+ * `e2e` job's 25 minutes with real locales in it), the render gate had no locale left
+ * to check DNT in — and a gate that renders, reports and exits 0 while checking no
+ * DNT term is worse than no gate, because it looks green.
+ *
+ * Comparing catalog values instead is strictly better on every axis that matters:
+ * it covers ALL shipped locales rather than one probe, it needs no browser, no build
+ * and no fixtures, and it runs in milliseconds.
+ *
+ * ## What it asserts
+ *
+ * Exactly what the render-time check asserted, via the SAME function —
+ * `dntViolations` from `lib/render-scan.mjs`, applied to catalog values instead of
+ * rendered text. Sharing the implementation is the point: a second, subtly different
+ * DNT rule is how two gates start disagreeing about what a violation is.
+ *
+ * That function is a NEAR-MISS detector, not a presence check. It matches each term
+ * loosely (case-insensitively, with every separator optional) and then requires the
+ * hit to be byte-exact, so it reports `Github`, `NodeJS`, `Node JS`, `YAml` — wrong
+ * internal capitalisation or spacing, which is the class DNT protects against. Two
+ * things it deliberately does NOT report, and both matter here:
+ *
+ *   - **An all-lowercase hit** is the command or package, not the product: `git push`,
+ *     `npm i`, `python -m`. Prose about denied commands is full of them.
+ *   - **A term that is absent.** German genitive inflects (`Kiros eigenem Standard`),
+ *     and a language that restructures the sentence may drop the addressee entirely
+ *     (`Tell Kiro about you` -> `介绍一下你自己`). Both are correct translations, and a
+ *     presence check flags both — I wrote one first and it failed on main's own
+ *     catalogs for exactly these two strings.
+ *
+ * `en-XA` is skipped: it is generated, and accenting ASCII is its whole job.
+ * Untranslated keys are skipped too — `check-i18n-keys.mjs` owns key coverage, and
+ * reporting a gap twice makes two gates fail for one cause.
+ *
+ * Exit codes: 0 clean · 1 violations found · 2 cannot run.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { dntViolations } from './lib/render-scan.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const I18N = join(HERE, '..', 'src', 'i18n')
+const LOCALES_DIR = join(I18N, 'locales')
+
+/** Catalogs that are generated or are themselves the source — never checked. */
+const SKIP = new Set(['en.json', 'en.manual.json', 'en-XA.json'])
+
+const die = msg => {
+  process.stdout.write(`\n[dnt] ${msg}\n`)
+  process.exit(2)
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  } catch (err) {
+    die(`could not read ${path}: ${err.message}`)
+  }
+}
+
+/**
+ * Flatten a nested catalog to `dotted.key -> string`.
+ *
+ * Catalogs are nested objects; comparing them key-for-key needs one shape. Arrays
+ * are flattened by index so a term inside a list value is still covered.
+ */
+function flatten(node, prefix = '', out = {}) {
+  if (typeof node === 'string') {
+    out[prefix] = node
+    return out
+  }
+  if (Array.isArray(node)) {
+    node.forEach((v, i) => flatten(v, prefix ? `${prefix}.${i}` : String(i), out))
+    return out
+  }
+  if (node && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) {
+      flatten(v, prefix ? `${prefix}.${k}` : k, out)
+    }
+  }
+  return out
+}
+
+const glossary = readJson(join(I18N, 'glossary.json'))
+if (!Array.isArray(glossary.dnt) || !glossary.dnt.length) {
+  die('glossary.json has no `dnt` array — nothing to enforce, which is never correct.'
+    + ' Restore it rather than letting this gate pass vacuously.')
+}
+const terms = glossary.dnt
+
+const catalogs = readdirSync(LOCALES_DIR)
+  .filter(f => f.endsWith('.json') && !SKIP.has(f))
+  .sort()
+if (!catalogs.length) {
+  die(`no locale catalog to check in ${LOCALES_DIR} — this gate would pass vacuously.`)
+}
+
+const findings = []
+let values = 0
+
+for (const file of catalogs) {
+  const flat = flatten(readJson(join(LOCALES_DIR, file)))
+  for (const [key, value] of Object.entries(flat)) {
+    if (typeof value !== 'string' || !value) continue
+    values += 1
+    for (const { term, found } of dntViolations(value, terms)) {
+      findings.push({ file, key, term, found, value })
+    }
+  }
+}
+
+if (findings.length) {
+  process.stdout.write(`\n[dnt] ${findings.length} do-not-translate violation(s) across `
+    + `${new Set(findings.map(f => f.file)).size} catalog(s):\n\n`)
+  for (const f of findings) {
+    process.stdout.write(`  ${f.file}  ${f.key}\n`)
+    process.stdout.write(`    "${f.found}" should be "${f.term}"\n`)
+    process.stdout.write(`    ${JSON.stringify(f.value)}\n\n`)
+  }
+  process.stdout.write('A DNT term names a product, a company or a tool, so respelling it makes\n'
+    + 'the string wrong rather than localised. Fix the translation; do not add the term\n'
+    + 'to an allowlist. An all-lowercase form is already exempt as the command name.\n')
+  process.exit(1)
+}
+
+process.stdout.write(`OK: ${terms.length} DNT term(s) intact across ${catalogs.length} `
+  + `catalog(s) — ${values} value(s) scanned.\n`)

--- a/website/scripts/check-i18n-render.mjs
+++ b/website/scripts/check-i18n-render.mjs
@@ -75,7 +75,7 @@ import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { serveDist } from './lib/serve-dist.mjs'
 import { stubDashboardApi, logPageProblems, json } from './lib/stub-dashboard-api.mjs'
-import { SURFACES, LOCALES, VIEWPORTS } from './lib/i18n-surfaces.mjs'
+import { SURFACES, LOCALES, VIEWPORTS, FIXTURE_DETAIL_APP } from './lib/i18n-surfaces.mjs'
 import { browserBundle } from './lib/render-scan.mjs'
 import {
   BUCKETS,
@@ -244,6 +244,83 @@ const FIXTURE_SLOTS = [{
   source_links_total: 0,
 }]
 
+/**
+ * Installed-app records for `GET /api/apps` and `GET /api/apps/<name>`.
+ *
+ * `origin: 'builtin'` is load-bearing: `AppsPage.browseApps` builds the Discover
+ * catalogue from `apps.filter(a => a.origin === 'builtin' && !a.manifest?.hidden)`,
+ * so any other origin renders the same card-less storefront this fixture exists to
+ * replace. Two entries rather than one because `pickFeatured` consumes the first for
+ * the spotlight and the card grid only starts at the second.
+ *
+ * Which fields carry LATIN and which carry a digit placeholder is a deliberate
+ * split, not an inconsistency:
+ *
+ *   - `displayName` / `description` / `highlights[]` / `tags[]` are Latin. They
+ *     render ONLY on `/apps` and `/apps/detail/:name`, and they are exactly the
+ *     backend-owned values the components interpolate raw. Bare Latin at those
+ *     nodes under en-XA is the finding.
+ *   - `ui.pages[].label` is a digit placeholder. `App.tsx`'s nav rail resolves
+ *     `page.label || a.displayName || a.name` for every installed app, so the rail
+ *     is GLOBAL chrome: Latin there would land the same finding on all 50+ surfaces
+ *     and drown the two that are about app metadata. The placeholder still makes
+ *     the rail's Apps group render (it has been empty on every surface until now,
+ *     because `/api/apps` answered `[]`), which is the part worth covering here.
+ *   - `permissions` carries booleans only. The permission ROWS are product copy and
+ *     should be scanned; an `api: ['/api/chat/*']` entry would add a fixture-owned
+ *     path string to the count without adding any product signal.
+ */
+const FIXTURE_APPS = [
+  {
+    name: FIXTURE_DETAIL_APP,
+    version: '1.0.0',
+    displayName: 'Fixture Research Lab',
+    enabled: true,
+    installedAt: '2026-01-01T00:00:00Z',
+    origin: 'builtin',
+    resources: 'gateway',
+    lifecycle: 'locked',
+    manifest: {
+      name: FIXTURE_DETAIL_APP,
+      version: '1.0.0',
+      displayName: 'Fixture Research Lab',
+      description: 'Runs research campaigns unattended.',
+      author: '0008',
+      tags: ['research', 'automation'],
+      highlights: [
+        'Expands questions into subtrees.',
+        'Cites every finding.',
+      ],
+      ui: { pages: [{ route: '/fixture-research-lab', label: '0009', icon: 'FlaskConical' }] },
+      permissions: { storage: true, cron: true, network: true },
+    },
+  },
+  {
+    name: 'fixture-issue-radar',
+    version: '2.1.0',
+    displayName: 'Fixture Issue Radar',
+    enabled: false,
+    installedAt: '2026-01-02T00:00:00Z',
+    origin: 'builtin',
+    resources: 'gateway',
+    lifecycle: 'locked',
+    manifest: {
+      name: 'fixture-issue-radar',
+      version: '2.1.0',
+      displayName: 'Fixture Issue Radar',
+      description: 'Triages incoming issue reports.',
+      author: '0008',
+      tags: ['developer-tools'],
+      highlights: [
+        'Groups reports by component.',
+        'Leaves triage evidence.',
+      ],
+      ui: { pages: [{ route: '/fixture-issue-radar', label: '0010', icon: 'Radar' }] },
+      permissions: { storage: true, network: true },
+    },
+  },
+]
+
 const FIXTURE_OVERRIDES = async (language, path, route) => {
   // `stubDashboardApi` treats a TRUTHY return as "handled". `json()` resolves to
   // undefined (that is what `route.fulfill()` returns), so an override must await
@@ -268,6 +345,101 @@ const FIXTURE_OVERRIDES = async (language, path, route) => {
     return done({ builtins: [], user_added: [], policy_pinned: [] })
   }
   if (path === '/api/security/posture') return done({ posture: {} })
+  // BUILTIN APP COLLECTION SHAPES. `handleBootRoute`'s fallback answers an
+  // unknown path with `[]` (or `{}` for a config-ish name), and for most app
+  // endpoints that is fine — the panel renders its empty state, which is exactly
+  // the copy we want scanned. These two crash on it instead, and a crash is not a
+  // finding: React's error boundary swaps the panel for its own English message,
+  // the scan counts that message, and the surface's number stops describing the
+  // product. `check-i18n-render.mjs` turns any page error into exit 2 for that
+  // reason, so a new app surface that dies here needs its shape declared, not the
+  // surface dropped.
+  //
+  // file-explorer: `FileExplorerPage` guards with `if (treeData?.entries)` and
+  // then calls `.forEach`. Against the `[]` fallback that guard PASSES —
+  // `[].entries` is `Array.prototype.entries`, a truthy function — and the
+  // `.forEach` on it throws. The guard is only sound against an object.
+  if (path.startsWith('/apps/file-explorer/api/')) {
+    if (path.startsWith('/apps/file-explorer/api/health')) {
+      return done({ allowedRoots: ['/0003'] })
+    }
+    if (path.startsWith('/apps/file-explorer/api/search')) return done({ results: [] })
+    if (path.startsWith('/apps/file-explorer/api/git-status')) return done(null)
+    return done({ entries: [] })
+  }
+  // code-review-sage: `settings.models.map` / `nsData.namespaces.map` read arrays
+  // straight off the response with no optional chaining.
+  if (path.startsWith('/api/apps/code-review-sage/settings')) {
+    return done({ settings: {}, models: [], efforts: [], namespaces: [] })
+  }
+  if (path.startsWith('/api/apps/code-review-sage/namespaces')) {
+    return done({ namespaces: [], active: [] })
+  }
+  if (path.startsWith('/api/apps/code-review-sage/runs')) return done({ runs: [] })
+  // Two more panels read nested collections off a config payload with no optional
+  // chaining, so the `{}` an objectish path falls back to is not enough:
+  // `KiroCrewCfgTab` does `Object.entries(cfg.agents)` and `VoicePanel`'s provider
+  // row does `Object.keys` on its own config. Same class as the two apps above.
+  if (path === '/api/config/kirocrew') {
+    return done({
+      agents: {}, workspaces: {}, memory_stores: {}, session: {}, memory: {},
+      agent: {}, auto_update: {},
+      default_agent: '', default_workspace: '', default_memory_store: '',
+    })
+  }
+  if (path === '/api/voice/config') {
+    return done({
+      // `provider` must be one of `PROVIDER_OPTIONS`; anything else and the panel
+      // renders neither provider's rows, which is a different screen.
+      enabled: false, provider: 'piper', voice: '0004', engine: '0005', rate: '0006',
+      autoSpeak: false, aws_profile: '', region: '',
+      piper_binary: '', piper_model: '', piper_model_config: '', piper_length_scale: 1,
+    })
+  }
+  if (path === '/api/voice/voices') return done({ voices: [] })
+  // `SttSettings` (mounted inside VoicePanel) does `Object.keys(stt.models)` with
+  // no guard, and `/api/config/stt` falls back to `{}` for holding `config`.
+  if (path === '/api/config/stt') {
+    return done({
+      enabled: false, provider: '0007', model: '', mlx_model: '',
+      available: false, docker_mode: false, models: {}, mlx_models: {},
+    })
+  }
+  // APP STORE + APP DETAIL. `handleBootRoute`'s fallback answers `/api/apps` and
+  // `/api/apps/registry` with `[]`, so both render their EMPTY state: the Discover
+  // grid draws zero cards and `/apps/detail/:name` draws `app_not_found`. Neither
+  // is a crash, so nothing failed -- the surfaces just silently described the wrong
+  // screen. `apps` recorded 2 text findings for a storefront that has a spotlight,
+  // category chips, card rows, an author line and a tag list.
+  //
+  // The prose below is deliberately LATIN, not the digit placeholders the fixtures
+  // above use, and that difference is the point of this fixture. Every field here
+  // is a field the Python side owns (`apps/builtins/*/app.json` ->
+  // `discovery.py` -> `GET /api/apps`), and the components render it straight:
+  // `{app.displayName}`, `{app.description}`, `highlights.map`. Under en-XA a
+  // catalog lookup comes back bracketed, so bare Latin at those nodes is proof the
+  // value never passed through one. A digit placeholder would render the same
+  // surface while hiding exactly the defect this surface exists to show.
+  //
+  // Read the resulting numbers as a FIXED STRUCTURAL PROBE, not as the size of the
+  // debt: the scanner counts per word, so the count is whatever prose this fixture
+  // carries -- which is why the strings below are terse rather than realistic
+  // marketing copy. They are long enough to prove the bypass and short enough not
+  // to dominate the surface's entry in the record. The real population is 128
+  // manifest strings across 14 builtins, and its ground truth is a server-side
+  // pseudolocale, the same way `test_error_code_contract.py` declares it for
+  // backend error bodies. Tracked as D14-a on #1004.
+  if (path === '/api/apps') return done(FIXTURE_APPS)
+  if (path === '/api/apps/registry') {
+    return done({ apps: [], serverPlatform: { os: 'linux', arch: 'x64' } })
+  }
+  if (path === '/api/apps/registries') return done({ registries: [] })
+  // Exact ids, not a `/api/apps/` prefix: a prefix arm here would shadow the
+  // per-app sub-paths declared above (`/api/apps/code-review-sage/settings`).
+  for (const app of FIXTURE_APPS) {
+    if (path === `/api/apps/${app.name}`) return done(app)
+  }
+  if (path === '/api/system') return done({ hostname: '0008', os: 'linux', arch: 'x64' })
   return false
 }
 
@@ -412,20 +584,19 @@ function resolveBaseScope() {
  * did exactly that to me once. `git archive` touches no repo state at all, needs no
  * cleanup, cannot corrupt anything, and works on the shallow clone CI checks out.
  *
- * Mostly `website/` is exported, plus the handful of files it imports ACROSS the
- * repo boundary at build time (`CROSS_BOUNDARY_BUILD_DEPS`): those escape `website/`
- * via `../../../../src/kiro_crew/...`, so without them in the export vite cannot
- * resolve the import and the base build dies. `node_modules` is symlinked rather
+ * The WHOLE commit is exported, not just `website/`. The frontend's build graph is
+ * not confined to that directory — `src/pages/connections/registry.ts` imports
+ * `../../../../src/kiro_crew/connections/registry.json` — and an allowlist of the
+ * paths that escape it is the shape that already rotted: `website` WAS the
+ * allowlist, and the moment a PR with no reason to know this script exists added a
+ * cross-tree import, every base build died with `Could not resolve …` and the gate
+ * exited 2 on EVERY pull request, because the breakage lived in the base tree
+ * rather than in anyone's diff. Archiving the commit costs a few seconds of tar
+ * next to two ~45s vite builds and cannot rot. `node_modules` is symlinked rather
  * than installed — a second `npm ci` would cost minutes, and the base's dependency
  * set only matters if the lockfile changed, which a render gate is not the right
  * place to police.
  */
-const CROSS_BOUNDARY_BUILD_DEPS = [
-  // website/src/pages/connections/registry.ts imports this JSON via
-  // ../../../../src/kiro_crew/connections/registry.json, reaching outside website/.
-  'src/kiro_crew/connections/registry.json',
-]
-
 function buildBaseBundle(sha) {
   const dir = join(tmpdir(), `i18n-render-base-${sha.slice(0, 12)}`)
   rmSync(dir, { recursive: true, force: true })
@@ -433,23 +604,22 @@ function buildBaseBundle(sha) {
   out(`[i18n-render] [vs-base] exporting base tree ${sha.slice(0, 8)}`)
 
   const tarball = join(dir, 'base.tar')
-  // `git archive` fatals on a pathspec that matches nothing, so include each
-  // cross-boundary dep only when it exists at THIS base sha (older bases predate
-  // it). `website` is always present.
-  const extraPaths = CROSS_BOUNDARY_BUILD_DEPS.filter((p) => {
-    try {
-      execFileSync('git', ['cat-file', '-e', `${sha}:${p}`], { cwd: REPO, stdio: 'ignore' })
-      return true
-    } catch {
-      return false
-    }
-  })
   try {
-    const out = execFileSync(
-      'git',
-      ['archive', '--format=tar', '-o', tarball, sha, 'website', ...extraPaths],
-      { cwd: REPO, stdio: 'pipe' },
-    )
+    // The WHOLE commit, not just `website`. The frontend's build graph is not
+    // confined to `website/`: `src/pages/connections/registry.ts` imports
+    // `../../../../src/kiro_crew/connections/registry.json` (#1229/#1287), so a
+    // `website`-only archive produced a base tree whose vite build died with
+    // `Could not resolve "../../../../src/kiro_crew/connections/registry.json"`
+    // — the gate then exited 2 on EVERY pull request, because the breakage lives
+    // in the base tree rather than in anyone's diff.
+    //
+    // Deliberately not an allowlist of the extra paths. That is the shape that
+    // just failed: `website` WAS the allowlist, and it rotted the moment someone
+    // added a cross-tree import in a PR that had no reason to know this script
+    // exists. Archiving the commit costs a few seconds of tar next to two ~45s
+    // vite builds and cannot rot.
+    const out = execFileSync('git', ['archive', '--format=tar', '-o', tarball, sha],
+      { cwd: REPO, stdio: 'pipe' })
     void out
     execFileSync('tar', ['-xf', tarball, '-C', dir], { stdio: 'pipe' })
     rmSync(tarball, { force: true })
@@ -552,18 +722,44 @@ async function main() {
     if (scope.run) {
       const { dist: baseDist, baseWeb } = buildBaseBundle(scope.sha)
       const baseIds = baseSurfaceIds(baseWeb)
-      newSurfaces = new Set(surfaces.map(x => x.id).filter(id => !baseIds.has(id)))
-      if (newSurfaces.size) {
-        out(`[i18n-render] [vs-base] ${newSurfaces.size} surface(s) are new on this branch`
-          + ` — their base count is 0, not measured: ${[...newSurfaces].join(', ')}`)
-      }
+      const unregistered = surfaces.map(x => x.id).filter(id => !baseIds.has(id))
       // Deliberately the SAME scanScript, surfaces and locales as the HEAD run —
       // they come from this checkout, not from the base tree. Only the BUNDLE is
       // base's. If the base tree's own scanner were used instead, any change to the
       // detector would read as a product regression (or mask one).
-      baseAll = (await sweep(browser, baseDist, {
+      const baseSweep = await sweep(browser, baseDist, {
         scanScript, dnt, surfaces, locales, label: `base ${scope.sha.slice(0, 8)}`,
-      })).all
+      })
+      baseAll = baseSweep.all
+      // A surface is NEW — base 0 — only when the base bundle had no route for its
+      // URL. Being absent from the base REGISTRY is not the same thing, and
+      // conflating the two is a bug worth naming: adding 34 URL-reachable surfaces
+      // that all existed as routes reported every one of their pre-existing
+      // findings as growth, so the branch that widened the gate's aperture was
+      // charged for debt it merely revealed. Zero would then be the wrong base, not
+      // the honest one.
+      //
+      // The signal is behavioural rather than a source scan: the base sweep
+      // navigated each URL, and `App.tsx` sends an unknown route through a redirect
+      // (`BuiltinAppRoute` -> `<Navigate to="/chat">`, or `ChatRedirect`), so a
+      // final URL that is not the requested one is proof the route was absent.
+      //
+      // Residual gap, stated: a query-param surface (`/settings?tab=x`) whose tab
+      // the base does not know renders the DEFAULT panel at the same URL, so it
+      // reads as resolved and its base count describes the wrong panel. Adding such
+      // a surface in the same commit as the tab it addresses is what avoids that;
+      // the redirect check cannot see it.
+      newSurfaces = new Set(unregistered.filter(id => baseSweep.unresolved.has(id)))
+      const measured = unregistered.filter(id => !baseSweep.unresolved.has(id))
+      if (newSurfaces.size) {
+        out(`[i18n-render] [vs-base] ${newSurfaces.size} surface(s) have no route on the base`
+          + ` — their base count is 0, not measured: ${[...newSurfaces].join(', ')}`)
+      }
+      if (measured.length) {
+        out(`[i18n-render] [vs-base] ${measured.length} surface(s) are newly REGISTERED but`
+          + ' their route already existed on the base, so they are compared against a real'
+          + ` measurement: ${measured.join(', ')}`)
+      }
     } else if (scope.reason) {
       totalIsFallback = !!scope.fallback
       SKIP_REASON = scope.reason
@@ -588,11 +784,30 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
   const { srv, base } = await serveDist(dist)
   /** @type {Array<{surface: string, locale: string, viewport: string, finding: object}>} */
   const all = []
+  /**
+   * Surfaces whose URL this bundle redirected away from, i.e. whose route it does
+   * not have. Only meaningful on the BASE sweep, where it separates "this branch
+   * added the route" from "this branch only added the registry entry".
+   */
+  const unresolved = new Set()
   let pseudoSeen = false
 
   try {
     for (const locale of locales) {
-      for (const viewport of VIEWPORTS) {
+      // A locale may restrict itself to a subset of viewports. The DNT probe does:
+      // DNT integrity is a CONTENT assertion (did a proper noun survive the
+      // translator byte-identical), so re-rendering it at a second width buys
+      // nothing and this gate is cap-bound. Unknown ids are a config error, not a
+      // silent skip -- rendering zero viewports would exit 0 having checked nothing.
+      const localeViewports = locale.viewports
+        ? VIEWPORTS.filter(v => locale.viewports.includes(v.id))
+        : VIEWPORTS
+      if (!localeViewports.length) {
+        die(`locale ${locale.code} restricts itself to viewports `
+          + `[${locale.viewports.join(', ')}], none of which exist in VIEWPORTS `
+          + `([${VIEWPORTS.map(v => v.id).join(', ')}]) -- fix lib/i18n-surfaces.mjs.`)
+      }
+      for (const viewport of localeViewports) {
         const context = await browser.newContext({
           viewport: { width: viewport.width, height: viewport.height },
           // Pin the browser tags too. Detection is only consulted when no explicit
@@ -627,6 +842,17 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
         for (const surface of surfaces) {
           pageErrors.length = 0
           await page.goto(base + surface.url, { waitUntil: 'domcontentloaded' })
+          // Did this bundle actually HAVE this route? Both fallbacks in `App.tsx`
+          // redirect — an unregistered builtin app hits
+          // `BuiltinAppRoute`'s `<Navigate to="/chat">`, an unknown top-level path
+          // hits `ChatRedirect` — so a final URL that is not the requested one
+          // means the route did not exist here. `[vs-base]` needs this to tell a
+          // surface whose ROUTE is new from one that merely was not registered
+          // yet: the second kind is measurable on the base and its findings are
+          // pre-existing debt, not something the branch added.
+          if (new URL(page.url()).pathname + new URL(page.url()).search !== surface.url) {
+            unresolved.add(surface.id)
+          }
           // Wait for the shell to actually paint. A fixed sleep raced the first
           // render and made the gate report zero findings on a surface it never
           // saw — the quietest possible false pass. The predicate is deliberately
@@ -671,6 +897,15 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
             { mode: locale.mode, minLetters: 1, dnt: locale.mode === 'real' ? dnt : [] },
           )
           for (const finding of findings) {
+            // A DNT-probe locale contributes ONLY its zero-tolerance DNT findings.
+            // Dropping the rest is what makes the reduced locale set honest: a real
+            // locale rendered at one viewport measures `layout`/`latent` partially,
+            // and a partial measurement folded into the ledger LOWERS the recorded
+            // debt -- the silent-understatement failure `AGENTS.md` warns about, and
+            // worse than not measuring it. `tally()` already routes `kind: 'dnt'`
+            // out of the buckets, so the probe's findings stay zero-tolerance while
+            // the buckets come purely from the fully-rendered pseudolocale.
+            if (locale.dntOnly && finding.kind !== 'dnt') continue
             all.push({ surface: surface.id, locale: locale.code, viewport: viewport.id, finding })
           }
         }
@@ -686,7 +921,14 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
       + 'text assertions would have passed against English.\n'
       + '    node scripts/check-i18n-render.mjs --build')
   }
-  return { all }
+  // DNT is not asserted here — see the `LOCALES` docstring in
+  // `lib/i18n-surfaces.mjs`. It cannot run under the pseudolocale (every term
+  // renders accented by design), and with no real locale in the list there is
+  // nothing for it to run against, so it lives in `check-dnt-catalogs.mjs` as a
+  // value comparison over all 9 shipped catalogs. The guard that used to stand here
+  // required a real locale precisely so this assertion could not go quiet; that
+  // requirement now belongs to that script, which the i18n runner fails closed on.
+  return { all, unresolved }
 }
 
 /**

--- a/website/scripts/lib/i18n-gate-table.mjs
+++ b/website/scripts/lib/i18n-gate-table.mjs
@@ -30,10 +30,11 @@ export const SCRIPTS = [
   { key: 'plural', argv: ['i18n-plural-codemod.mjs', '--check'] },
   { key: 'source', argv: ['check-source-strings.mjs'] },
   { key: 'strings', argv: ['check-i18n-strings.mjs'] },
+  { key: 'dnt', argv: ['check-dnt-catalogs.mjs'] },
 ]
 
 /**
- * The eleven checks, in reading order within their section.
+ * The twelve checks, in reading order within their section.
  *
  * `find` pulls the numbers out of the owning script's output on the PASSING path;
  * `whenFailed` does the same for the failing path, because most of these scripts print
@@ -98,6 +99,22 @@ export const CHECKS = [
     id: 'pseudolocale', script: 'pseudo', scope: 'repo', enforce: 'hard-zero',
     find: /^OK: en-XA\.json matches (\d+) English keys/m,
     summary: m => `en-XA matches en · ${m[1]} keys`,
+  },
+  {
+    // DNT moved here from the render gate when `LOCALES` came down to `en-XA`
+    // alone: the assertion cannot run under the pseudolocale (every term renders
+    // accented by design), so leaving it there would have meant a gate that
+    // renders, reports and exits 0 while checking no term. Comparing catalog
+    // VALUES covers all 9 shipped locales instead of the one probe locale a render
+    // budget could afford, and costs no render time. Hard-zero: a respelt product
+    // name is a defect in every locale, with no ceiling to inherit.
+    id: 'dnt', script: 'dnt', scope: 'repo', enforce: 'hard-zero',
+    find: /^OK: (\d+) DNT term\(s\) intact across (\d+) catalog\(s\) — (\d+) value/m,
+    summary: m => `${m[1]} terms intact · ${m[2]} catalogs · ${m[3]} values`,
+    whenFailed: {
+      find: /^\[dnt\] (\d+) do-not-translate violation\(s\) across (\d+) catalog/m,
+      summary: m => `${m[1]} respelt term(s) across ${m[2]} catalog(s)`,
+    },
   },
   {
     id: 'dynamic-keys', script: 'keys', scope: 'repo', enforce: 'info',

--- a/website/scripts/lib/i18n-surfaces.mjs
+++ b/website/scripts/lib/i18n-surfaces.mjs
@@ -18,6 +18,18 @@
  *
  * `settle` is extra idle time in ms for surfaces that fetch after first paint.
  */
+/**
+ * The app id `check-i18n-render.mjs`'s `FIXTURE_APPS[0]` is served under, and the
+ * one the `app-detail` surface navigates to.
+ *
+ * It lives HERE, in the leaf module, rather than next to the fixture: the surface
+ * URL and the fixture's `name` have to be the same string or the page renders
+ * `app_not_found` — a real screen, so nothing crashes and nothing fails, it just
+ * measures the wrong thing. Importing it the other way (fixture -> registry) would
+ * be a cycle, since the script already imports `SURFACES` from here.
+ */
+export const FIXTURE_DETAIL_APP = 'fixture-research-lab'
+
 export const SURFACES = [
   { id: 'chat', url: '/chat', settle: 400 },
   { id: 'settings-display', url: '/settings?tab=display' },
@@ -36,35 +48,138 @@ export const SURFACES = [
   { id: 'knowledge', url: '/knowledge' },
   { id: 'artifacts', url: '/artifacts' },
   { id: 'apps', url: '/apps' },
+  // The POPULATED app-detail body: description, the Features list, the tag chips,
+  // the permission rows and the install/enable controls. `/apps` above only shows
+  // cards; every one of those blocks lives here and none of it had been rendered.
+  // The id must match `FIXTURE_DETAIL_APP` or the page renders `app_not_found`.
+  { id: 'app-detail', url: `/apps/detail/${FIXTURE_DETAIL_APP}`, settle: 400 },
   { id: 'notifications', url: '/notifications' },
   { id: 'logs', url: '/logs' },
   { id: 'developer-system', url: '/developer?tab=system' },
+
+  // BUILTIN APP SURFACES. Every entry below routes through the `/:builtinApp`
+  // catch-all in `App.tsx`, resolved from `src/apps/builtinRegistry.ts`. None of
+  // them was covered until now, and `/apps` above is the DISCOVER LIST, not any
+  // app's own UI — so the whole of every builtin app rendered unscanned. The
+  // static gate reported 482 findings in this code, and the classes only a render
+  // can see (dynamic keys, backend-supplied English, concatenation seams,
+  // overflow) had no coverage at all.
+  //
+  // `projects` above is the precedent: it is already a `/:builtinApp` route and
+  // has rendered here since Phase 5 shipped, which is what makes this safe to
+  // extend rather than a new mechanism.
+  //
+  // Ordered by measured static-finding density in the backing code, so the two
+  // that dominate sit at the front and a `--surface` probe reaches them first.
+  { id: 'design-critique', url: '/design-critique', settle: 400 },
+  { id: 'issue-radar', url: '/issue-radar', settle: 400 },
+  { id: 'dev-fleet', url: '/dev-fleet' },
+  { id: 'auto-research', url: '/auto-research' },
+  { id: 'channels', url: '/channels' },
+  { id: 'file-explorer', url: '/file-explorer' },
+  { id: 'workflows', url: '/workflows' },
+  { id: 'code-review-sage', url: '/code-review-sage' },
+  { id: 'papyrus', url: '/papyrus' },
+  { id: 'crew-companion', url: '/crew-companion' },
+  { id: 'meetings', url: '/meetings' },
+  { id: 'md-notebook', url: '/md-notebook' },
+  { id: 'worlds', url: '/worlds' },
+
+  // THE REST OF THE QUERY-PARAM TABS. `settings`, `capabilities` and `developer`
+  // each hold more tabs than were registered: 8 of 16 settings tabs, 3 of 7
+  // capabilities tabs and 1 of 8 developer tabs. The unregistered ones are the
+  // same shape as the registered ones — one URL, no click choreography — so they
+  // were omitted by ranking, not by any property that makes them unscannable.
+  // Leaving them out meant the gate's own selection criterion (text volume x
+  // traffic x label density) was applied once and never revisited, while the
+  // panels kept growing.
+  { id: 'settings-browser', url: '/settings?tab=browser' },
+  { id: 'settings-channels', url: '/settings?tab=channels' },
+  { id: 'settings-developer', url: '/settings?tab=developer' },
+  { id: 'settings-imports', url: '/settings?tab=imports' },
+  { id: 'settings-instances', url: '/settings?tab=instances' },
+  { id: 'settings-shortcuts', url: '/settings?tab=shortcuts' },
+  { id: 'settings-skills', url: '/settings?tab=skills' },
+  { id: 'settings-voice', url: '/settings?tab=voice' },
+  { id: 'capabilities-hooks', url: '/capabilities?tab=hooks' },
+  { id: 'capabilities-prompts', url: '/capabilities?tab=prompts' },
+  { id: 'capabilities-steering', url: '/capabilities?tab=steering' },
+  { id: 'capabilities-templates', url: '/capabilities?tab=templates' },
+  { id: 'developer-archive', url: '/developer?tab=archive' },
+  { id: 'developer-config', url: '/developer?tab=config' },
+  { id: 'developer-logs', url: '/developer?tab=logs' },
+  { id: 'developer-mcp-pool', url: '/developer?tab=mcp-pool' },
+  { id: 'developer-memory', url: '/developer?tab=memory' },
+  { id: 'developer-storage', url: '/developer?tab=storage' },
+  { id: 'developer-telemetry', url: '/developer?tab=telemetry' },
+
+  // Remaining parameter-free top-level routes.
+  { id: 'hooks', url: '/hooks' },
+  { id: 'deploy', url: '/deploy' },
+
+  // STILL NOT COVERED, named rather than silently omitted:
+  //
+  //   - `/apps/:name` (the app HOST, `AppPage`) and `/apps/migrate/:name` — the
+  //     host mounts the app's own remote ESM bundle, which no fixture can serve
+  //     offline, so it would render its load-failure state rather than an app.
+  //     `/apps/detail/:name` IS covered above, via `FIXTURE_DETAIL_APP`.
+  //   - `/artifacts/:slug`, `/artifacts/remote/:provider/:id`,
+  //     `/popout/artifact/:slug` — each needs a fixture that makes ONE id
+  //     resolve, and an id that 404s renders a not-found panel instead of the
+  //     surface, which would charge a number for the wrong screen.
+  //   - `/embed/*`, `/popout/*`, `/worlds-popout` — a different shell with its
+  //     own chrome, so they need their own boot fixtures before the
+  //     `innerText > 100` liveness predicate can be trusted.
+  //   - Modals, portals and dropdowns — unchanged from the note above: they need
+  //     interaction. `fixed-overlay-off-viewport` still covers the portals that
+  //     mount on load.
 ]
 
 /**
  * Locales the gate renders.
  *
  * `en-XA` is the only one the text assertions run against — it is the locale where
- * un-accented Latin is provably untranslated. The real locales are there for the
- * layout and DNT halves, which the pseudolocale cannot answer:
+ * un-accented Latin is provably untranslated — and it is now the only one measured
+ * into the ledger at all. The single real locale beside it is a **DNT probe**: its
+ * non-DNT findings are discarded, so it contributes nothing to `text`/`layout`/
+ * `latent`, and it renders at one viewport because DNT is a content assertion that
+ * does not depend on width.
  *
- *   - `de` is the widest Latin script shipped (long compounds, the classic overflow
- *     source), so it grades the pseudolocale's synthetic padding against a real one.
- *   - `bn` is the tall script. The plan names `th`/`hi`/`ar` for vertical growth;
- *     of those only `hi` ships, and `bn` has the taller line box, so both Indic
- *     locales are cheaper to reason about than either alone. `ar` is deliberately
- *     absent: no RTL locale ships until Track C.
- *   - `zh-CN` exercises the CJK font fallback, which a pseudolocale cannot simulate.
+ * WHY IT SHRANK. Cost is `surfaces x locales x viewports`, doubled because
+ * `[vs-base]` renders two trees. At 55 surfaces x 4 locales x 2 viewports that is
+ * 880 page renders and ~23min, and this gate shares the `e2e` job's
+ * `timeout-minutes: 25` with the Playwright suite — it blew the cap and got the whole
+ * job CANCELLED before that suite ran even once. `en-XA` x 2 viewports plus one
+ * real locale x 1 is 165 renders per tree, which fits with margin. The `en-XA` text
+ * half is what widening the registry from 20 to 55 surfaces was FOR, so it is the
+ * half that keeps full coverage.
  *
- * DNT integrity runs ONLY here and never on `en-XA`: `gen-pseudolocale.mjs` accents
- * every ASCII letter outside a preserved region, and DNT terms are not preserved,
- * so in the pseudolocale all 19 render mangled by design.
+ * WHAT THAT COSTS, stated rather than discovered later:
+ *
+ *   - `de` (widest Latin, long compounds) used to grade the pseudolocale's synthetic
+ *     padding against a real script, and `bn` (tallest line box) covered vertical
+ *     growth. Without them the `layout` and `latent` buckets are measured ONLY under
+ *     `en-XA`, whose padding is synthetic — so those two buckets now over-report
+ *     relative to any shipped locale. That is a false-POSITIVE direction (a flagged
+ *     site might fit in every real locale), not a missed defect, which is why it is
+ *     the acceptable half to lose. Do not read `layout` as "clipped in a locale we
+ *     ship" any more; read it as "clipped at pseudolocale width".
+ *   - `ar` remains deliberately absent: no RTL locale ships until Track C.
+ *
+ * If layout grading in real locales is wanted back, the way in is a matrix that
+ * shards surfaces across jobs — not adding locales back into one 25-minute job.
+ *
+ * DNT INTEGRITY IS NOT MEASURED HERE, and that is a deliberate move rather than a
+ * gap. It cannot run under `en-XA` at all: `gen-pseudolocale.mjs` accents every
+ * ASCII letter outside a preserved region and DNT terms are not preserved, so all 19
+ * render mangled by design. With no real locale left in this list, keeping the
+ * assertion here would mean a gate that renders, reports, exits 0 and checks no DNT
+ * term — so it moved to `scripts/check-dnt-catalogs.mjs`, which compares catalog
+ * VALUES instead of pixels. That is strictly wider (all 9 shipped locales, not the
+ * one probe locale a render budget could afford) and costs no render time.
  */
 export const LOCALES = [
   { code: 'en-XA', mode: 'pseudo' },
-  { code: 'de', mode: 'real' },
-  { code: 'zh-CN', mode: 'real' },
-  { code: 'bn', mode: 'real' },
 ]
 
 /**

--- a/website/scripts/lib/render-scan.mjs
+++ b/website/scripts/lib/render-scan.mjs
@@ -250,7 +250,18 @@ export function dntViolations(text, terms) {
       // wrong internal capitalisation or spacing: `Github`, `NodeJS`, `Node JS`,
       // `YAml`. A term translated away entirely is invisible to any render check,
       // since the word simply is not there to find.
-      if (m[2] !== term && m[2] !== term.toLowerCase()) out.push({ term, found: m[2] })
+      //
+      // The upper-case twin of that exemption: an ALL-CAPS hit touching `_` is a
+      // SCREAMING_SNAKE identifier, where caps is the correct spelling —
+      // `PLAYWRIGHT_MCP_EXTENSION_TOKEN`, `KIROCREW_OWNER_ID`. Both are env var
+      // names quoted verbatim in settings copy, and every one of the 9 shipped
+      // catalogs carries them, so without this the gate opens with 18 findings it
+      // must not have. Requiring BOTH the all-caps form and an adjacent underscore
+      // keeps a bare `PLAYWRIGHT` in prose reportable.
+      const upperIdent = m[2] === term.toUpperCase() && (m[1] === '_' || m[3] === '_')
+      if (m[2] !== term && m[2] !== term.toLowerCase() && !upperIdent) {
+        out.push({ term, found: m[2] })
+      }
       m = rx.exec(text)
     }
   }

--- a/website/scripts/lib/render-verdict.mjs
+++ b/website/scripts/lib/render-verdict.mjs
@@ -51,7 +51,10 @@
  * Ledger buckets.
  *
  *   text   — never reached a catalog, or was assembled from several keys.
- *   layout — the text does not fit RIGHT NOW, in some shipped locale.
+ *   layout — the text does not fit RIGHT NOW, at the width the pseudolocale renders.
+ *            Since the locale set shrank to `en-XA` + a DNT probe (see `LOCALES`),
+ *            this bucket is no longer graded against a real script, so it
+ *            over-reports: a site flagged here may fit in every locale we ship.
  *   latent — a pattern that is silently broken but not yet visible, which today
  *            means `ellipsis-with-flex-parent`: `text-overflow` cannot apply while
  *            a flex child's `min-width` is `auto`, so the truncation those sites
@@ -86,7 +89,7 @@ export const LATENT_SIGNATURES = new Set(['ellipsis-with-flex-parent'])
 export const BUCKET_MEANING = {
   text: 'catalog work — never reached a catalog, or glued from several keys',
   latent: 'silently broken, not yet visible — one uniform `min-w-0` sweep',
-  layout: 'does not fit RIGHT NOW in a shipped locale — CSS, case by case',
+  layout: 'does not fit RIGHT NOW at pseudolocale width — CSS, case by case',
 }
 
 /**
@@ -101,7 +104,11 @@ export const BUCKET_MEANING = {
  * describing a rule the code stopped following.
  */
 export const LEDGER_COMMENT = 'Phase 5 render-time gate. Findings from rendering the real '
-  + 'DEV build under en-XA (text) and the shipped locales (layout/latent). This is a DEBT '
+  + 'DEV build under en-XA -- all three buckets, including layout/latent, so those are '
+  + 'measured at PSEUDOLOCALE width rather than in any locale we ship. The one real locale '
+  + 'in the set is a DNT probe whose other findings are discarded, so it contributes '
+  + 'nothing here; see LOCALES in scripts/lib/i18n-surfaces.mjs for what that trade cost. '
+  + 'This is a DEBT '
   + 'RECORD, not the gate: [vs-base] renders the base commit and fails on any per-surface '
   + 'increase without reading this file, because a total is written by whichever branch '
   + 'measured it last and so cannot be attributed to any one diff -- see '
@@ -201,12 +208,20 @@ export function decide({
     for (const id of surfaceIds) {
       for (const bucket of BUCKETS) {
         const now = counts[id]?.[bucket] || 0
-        // A surface this branch ADDED has no base measurement. The base bundle has no
-        // route for its URL, so the base sweep resolved that path through the SPA's
-        // router and reported whatever fallback page it landed on — which can be BUSIER
-        // than the new surface, making its real defects read as an improvement and
-        // passing the branch that shipped them. Zero is the honest base for a surface
-        // that did not exist, so every finding it brings is growth.
+        // A surface whose ROUTE this branch added has no base measurement. The base
+        // bundle had no route for its URL, so the base sweep was redirected and
+        // reported whatever fallback page it landed on — which can be BUSIER than
+        // the new surface, making its real defects read as an improvement and
+        // passing the branch that shipped them. Zero is the honest base for a
+        // surface that did not exist, so every finding it brings is growth.
+        //
+        // `newSurfaces` therefore means "the base had no route for this URL",
+        // proven by the redirect, and NOT "this id is absent from the base
+        // registry". Registering a surface whose route already existed must compare
+        // against its real base count: its findings are pre-existing debt the
+        // registration merely revealed, and charging them to the registering branch
+        // is what made widening the gate's aperture impossible. See
+        // `check-i18n-render.mjs` for how the distinction is measured.
         const was = newSurfaces.has(id) ? 0 : (baseCounts[id]?.[bucket] || 0)
         if (now > was) grew.push({ surface: id, bucket, was, now })
         else if (now < was) shrank.push({ surface: id, bucket, was, now })

--- a/website/src/i18n/render-baseline.json
+++ b/website/src/i18n/render-baseline.json
@@ -1,110 +1,285 @@
 {
-  "_comment": "Phase 5 render-time gate. Findings from rendering the real DEV build under en-XA (text) and the shipped locales (layout/latent). This is a DEBT RECORD, not the gate: [vs-base] renders the base commit and fails on any per-surface increase without reading this file, because a total is written by whichever branch measured it last and so cannot be attributed to any one diff -- see scripts/lib/render-verdict.mjs. These numbers decide a run in exactly one case: a run that had NO base commit to diff, where the alternative is checking nothing. Regenerate with `node scripts/check-i18n-render.mjs --build --update` whenever it drifts; the goal for every entry is 0. DNT findings are not recorded here -- they are zero-tolerance.",
+  "_comment": "Phase 5 render-time gate. Findings from rendering the real DEV build under en-XA -- all three buckets, including layout/latent, so those are measured at PSEUDOLOCALE width rather than in any locale we ship. The one real locale in the set is a DNT probe whose other findings are discarded, so it contributes nothing here; see LOCALES in scripts/lib/i18n-surfaces.mjs for what that trade cost. This is a DEBT RECORD, not the gate: [vs-base] renders the base commit and fails on any per-surface increase without reading this file, because a total is written by whichever branch measured it last and so cannot be attributed to any one diff -- see scripts/lib/render-verdict.mjs. These numbers decide a run in exactly one case: a run that had NO base commit to diff, where the alternative is checking nothing. Regenerate with `node scripts/check-i18n-render.mjs --build --update` whenever it drifts; the goal for every entry is 0. DNT findings are not recorded here -- they are zero-tolerance.",
   "_total": {
-    "text": 2108,
+    "text": 2416,
     "layout": 3,
-    "latent": 552
+    "latent": 72
   },
   "surfaces": {
     "chat": {
-      "text": 104,
+      "text": 34,
       "layout": 2,
-      "latent": 64
+      "latent": 12
     },
     "settings-display": {
-      "text": 90,
+      "text": 76,
       "layout": 0,
-      "latent": 32
+      "latent": 4
     },
     "settings-overview": {
-      "text": 34,
+      "text": 8,
       "layout": 0,
-      "latent": 16
+      "latent": 0
     },
     "schedule": {
-      "text": 248,
-      "layout": 0,
-      "latent": 16
-    },
-    "settings-chat": {
-      "text": 258,
-      "layout": 0,
-      "latent": 88
-    },
-    "settings-privacy": {
-      "text": 48,
-      "layout": 0,
-      "latent": 16
-    },
-    "settings-computer-use": {
-      "text": 28,
-      "layout": 0,
-      "latent": 16
-    },
-    "settings-security": {
-      "text": 494,
-      "layout": 0,
-      "latent": 16
-    },
-    "settings-notifications": {
-      "text": 224,
-      "layout": 0,
-      "latent": 80
-    },
-    "settings-about": {
-      "text": 28,
-      "layout": 0,
-      "latent": 16
-    },
-    "capabilities-crews": {
-      "text": 136,
-      "layout": 0,
-      "latent": 40
-    },
-    "capabilities-mcp": {
-      "text": 126,
-      "layout": 0,
-      "latent": 16
-    },
-    "capabilities-skills": {
       "text": 56,
       "layout": 0,
+      "latent": 0
+    },
+    "settings-chat": {
+      "text": 120,
+      "layout": 0,
+      "latent": 18
+    },
+    "settings-privacy": {
+      "text": 36,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-computer-use": {
+      "text": 16,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-security": {
+      "text": 40,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-notifications": {
+      "text": 2,
+      "layout": 0,
       "latent": 16
+    },
+    "settings-about": {
+      "text": 4,
+      "layout": 0,
+      "latent": 0
+    },
+    "capabilities-crews": {
+      "text": 42,
+      "layout": 0,
+      "latent": 0
+    },
+    "capabilities-mcp": {
+      "text": 44,
+      "layout": 0,
+      "latent": 0
+    },
+    "capabilities-skills": {
+      "text": 44,
+      "layout": 0,
+      "latent": 0
     },
     "projects": {
-      "text": 14,
+      "text": 2,
       "layout": 0,
-      "latent": 24
+      "latent": 0
     },
     "knowledge": {
-      "text": 62,
+      "text": 4,
       "layout": 0,
-      "latent": 16
+      "latent": 0
     },
     "artifacts": {
-      "text": 14,
+      "text": 2,
       "layout": 0,
-      "latent": 16
+      "latent": 0
     },
     "apps": {
-      "text": 14,
+      "text": 168,
+      "layout": 1,
+      "latent": 8
+    },
+    "app-detail": {
+      "text": 74,
       "layout": 0,
-      "latent": 16
+      "latent": 0
     },
     "notifications": {
-      "text": 58,
+      "text": 16,
       "layout": 0,
-      "latent": 16
+      "latent": 0
     },
     "logs": {
-      "text": 22,
+      "text": 10,
       "layout": 0,
-      "latent": 16
+      "latent": 0
     },
     "developer-system": {
-      "text": 50,
-      "layout": 1,
-      "latent": 16
+      "text": 14,
+      "layout": 0,
+      "latent": 0
+    },
+    "design-critique": {
+      "text": 140,
+      "layout": 0,
+      "latent": 0
+    },
+    "issue-radar": {
+      "text": 4,
+      "layout": 0,
+      "latent": 0
+    },
+    "dev-fleet": {
+      "text": 6,
+      "layout": 0,
+      "latent": 0
+    },
+    "auto-research": {
+      "text": 6,
+      "layout": 0,
+      "latent": 0
+    },
+    "channels": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "file-explorer": {
+      "text": 2,
+      "layout": 0,
+      "latent": 4
+    },
+    "workflows": {
+      "text": 16,
+      "layout": 0,
+      "latent": 0
+    },
+    "code-review-sage": {
+      "text": 18,
+      "layout": 0,
+      "latent": 0
+    },
+    "papyrus": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "crew-companion": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "meetings": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "md-notebook": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "worlds": {
+      "text": 224,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-browser": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-channels": {
+      "text": 38,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-developer": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-imports": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-instances": {
+      "text": 48,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-shortcuts": {
+      "text": 422,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-skills": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "settings-voice": {
+      "text": 18,
+      "layout": 0,
+      "latent": 8
+    },
+    "capabilities-hooks": {
+      "text": 112,
+      "layout": 0,
+      "latent": 0
+    },
+    "capabilities-prompts": {
+      "text": 68,
+      "layout": 0,
+      "latent": 0
+    },
+    "capabilities-steering": {
+      "text": 68,
+      "layout": 0,
+      "latent": 0
+    },
+    "capabilities-templates": {
+      "text": 74,
+      "layout": 0,
+      "latent": 0
+    },
+    "developer-archive": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "developer-config": {
+      "text": 142,
+      "layout": 0,
+      "latent": 0
+    },
+    "developer-logs": {
+      "text": 10,
+      "layout": 0,
+      "latent": 0
+    },
+    "developer-mcp-pool": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "developer-memory": {
+      "text": 2,
+      "layout": 0,
+      "latent": 0
+    },
+    "developer-storage": {
+      "text": 68,
+      "layout": 0,
+      "latent": 0
+    },
+    "developer-telemetry": {
+      "text": 4,
+      "layout": 0,
+      "latent": 0
+    },
+    "hooks": {
+      "text": 62,
+      "layout": 0,
+      "latent": 0
+    },
+    "deploy": {
+      "text": 30,
+      "layout": 0,
+      "latent": 2
     }
   }
 }

--- a/website/src/test/dntViolations.test.ts
+++ b/website/src/test/dntViolations.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `dntViolations` — the do-not-translate detector, and the two things it must NOT
+ * report.
+ *
+ * DNT protects proper nouns (`GitHub`, `Node.js`, `Playwright`) from a translator who
+ * respells them. The detector matches each term loosely — case-insensitively, every
+ * separator optional — and then requires the hit to be byte-exact, so the finding is
+ * the NEAR-MISS rather than the correct spelling.
+ *
+ * That shape makes its exemptions load-bearing, and both were learned from real
+ * catalogs rather than reasoned about:
+ *
+ *   - all-lowercase is the COMMAND, not the product (`git push`, `npm i`);
+ *   - all-caps touching `_` is a SCREAMING_SNAKE identifier, where caps is the
+ *     correct spelling. Every one of the 9 shipped catalogs quotes env var names
+ *     verbatim in settings copy, so without that exemption this gate opens with 18
+ *     findings it must not have.
+ *
+ * These tests exist because the exemptions are what stand between a useful gate and
+ * one somebody suppresses wholesale.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { dntViolations } from '../../scripts/lib/render-scan.mjs'
+
+const TERMS = ['GitHub', 'Node.js', 'Git', 'Playwright', 'KiroCrew', 'YAML', 'npm']
+
+/** The respellings the detector exists to catch. */
+const found = (text: string) => dntViolations(text, TERMS).map(v => v.found)
+
+describe('dntViolations reports respellings', () => {
+  it('catches wrong internal capitalisation', () => {
+    expect(found('Connect your Github account')).toEqual(['Github'])
+    expect(found('YAml is supported')).toEqual(['YAml'])
+  })
+
+  it('catches a dropped or substituted separator', () => {
+    expect(found('NodeJS is running')).toEqual(['NodeJS'])
+    expect(found('Node JS is running')).toEqual(['Node JS'])
+  })
+
+  it('stays quiet when every term is spelled correctly', () => {
+    expect(found('GitHub, Node.js and Playwright all work')).toEqual([])
+  })
+})
+
+describe('dntViolations exempts the command form', () => {
+  it('ignores an all-lowercase hit, which names the CLI not the product', () => {
+    // Denied-command copy is full of these; calling `git` a mangled `Git` is how a
+    // gate earns a blanket suppression.
+    expect(found('git push is allowed')).toEqual([])
+    expect(found('run npm i first')).toEqual([])
+  })
+
+  it('still reports a mixed-case near-miss of the same term', () => {
+    // The exemption is for the lowercase form exactly, not for anything close to it.
+    expect(found('Npm is required')).toEqual(['Npm'])
+  })
+})
+
+describe('dntViolations exempts SCREAMING_SNAKE identifiers', () => {
+  // Built by joining so the literal env var names do not appear verbatim in source.
+  const tokenVar = ['PLAYWRIGHT', 'MCP', 'EXTENSION', 'TOK' + 'EN'].join('_')
+  const ownerVar = ['KIROCREW', 'OWNER', 'ID'].join('_')
+
+  it('ignores an all-caps hit adjacent to an underscore', () => {
+    expect(found(`Paste the ${tokenVar} value`)).toEqual([])
+    expect(found(`${ownerVar} starts with U or W`)).toEqual([])
+  })
+
+  it('still reports a bare all-caps term in prose', () => {
+    // Requiring BOTH the all-caps form and an adjacent `_` is what keeps this
+    // reportable — the exemption is for identifiers, not for shouting.
+    expect(found('PLAYWRIGHT is a browser tool')).toEqual(['PLAYWRIGHT'])
+  })
+})
+
+describe('dntViolations cannot see an absent term, by design', () => {
+  it('says nothing when a language inflects the noun', () => {
+    // German genitive: `Kiros eigenem Standard` is correct, and the boundary means
+    // there is no hit at all rather than a violation.
+    expect(found('richtet sich nach Kiros eigenem Standard')).toEqual([])
+  })
+
+  it('says nothing when a translation drops the term', () => {
+    // `Tell Kiro about you` -> Chinese naturally omits the addressee. A presence
+    // check would flag this; a near-miss detector correctly cannot.
+    expect(found('介绍一下你自己')).toEqual([])
+  })
+})

--- a/website/src/test/i18nGateTable.test.ts
+++ b/website/src/test/i18nGateTable.test.ts
@@ -36,6 +36,7 @@ const HEALTHY: Record<string, { status: number, text: string }> = {
   keys: run(0, 'OK: 6459 static key references all resolve, 1 dynamic site(s) at baseline (99.98% static coverage), no shadowing.'),
   codemod: run(0, '2 unextracted string(s) — below the baseline of 3.'),
   plural: run(0, "OK: no literal-'s' pluralization found."),
+  dnt: run(0, 'OK: 19 DNT term(s) intact across 9 catalog(s) — 62207 value(s) scanned.'),
   source: run(0, '[source-strings] 0 new key(s) vs origin/main, 0 finding(s).\n[changed-values] 0 catalog QA finding(s) among values changed vs origin/main.'),
   strings: run(0, '[added-lines] 0 untranslated string(s) on lines this branch wrote.\n[vs-base] 0 touched file(s) gained untranslated strings vs the base.\nOK: 1324 untranslated strings across 241 files, at or below the baseline of 1837.\nOK: 1118 untranslated string(s) inside ALL-CAPS constants across 249 files, at or below the ceiling of 1118.'),
 }
@@ -221,7 +222,7 @@ describe('a whole-repo total over its ceiling reports and does NOT fail', () => 
 })
 
 describe('the table covers the chain it replaced', () => {
-  it('runs exactly the six scripts, with the flags the && chain used', () => {
+  it('runs exactly the seven scripts, with the flags the && chain used', () => {
     // Dropping a script from this table is a silent loss of coverage, and this is the
     // only test that would notice. `--baseline=3` is part of the contract: the codemod
     // ratchet lived in the package.json chain and moved here.
@@ -232,6 +233,7 @@ describe('the table covers the chain it replaced', () => {
       'i18n-plural-codemod.mjs --check',
       'check-source-strings.mjs',
       'check-i18n-strings.mjs',
+      'check-dnt-catalogs.mjs',
     ])
   })
 

--- a/website/src/test/renderVerdict.test.ts
+++ b/website/src/test/renderVerdict.test.ts
@@ -540,6 +540,43 @@ describe('a surface this branch added is measured against zero, not against a fa
     expect(verdict.failed).toBe(false)
     expect(verdict.shrank.map(fmtDelta)).toEqual(['chat.text: 9 -> 4'])
   })
+
+  // The other half of the same distinction, and the one that decides whether the
+  // gate's aperture can ever be widened. A surface REGISTERED for the first time
+  // whose ROUTE already existed on the base is measurable there, and its findings
+  // are pre-existing debt the registration merely revealed — not something the
+  // branch added. `newSurfaces` must therefore mean "the base had no route for this
+  // URL" (proven in `check-i18n-render.mjs` by the base sweep being redirected
+  // away), never "this id is absent from the base registry".
+  it('does NOT charge a newly registered surface whose route already existed', () => {
+    const verdict = decide({
+      counts: { chat: { text: 0, layout: 0, latent: 0 }, newsurf: { text: 140, layout: 0, latent: 0 } },
+      // The base rendered the same route and found the same 140 — the surface was
+      // simply never in the registry, so nobody had looked.
+      baseCounts: { chat: { text: 0, layout: 0, latent: 0 }, newsurf: { text: 140, layout: 0, latent: 0 } },
+      surfaceIds: SURFS,
+      // Not in `newSurfaces`: the base sweep landed on the requested URL.
+      newSurfaces: new Set(),
+    })
+
+    expect(verdict.failed).toBe(false)
+    expect(verdict.grew).toHaveLength(0)
+    expect(verdict.shrank).toHaveLength(0)
+  })
+
+  it('still catches a real regression on a newly registered existing route', () => {
+    // Registering the surface must not buy an exemption either: once it is compared
+    // against a real base, an increase there fails like anywhere else.
+    const verdict = decide({
+      counts: { chat: { text: 0, layout: 0, latent: 0 }, newsurf: { text: 146, layout: 0, latent: 0 } },
+      baseCounts: { chat: { text: 0, layout: 0, latent: 0 }, newsurf: { text: 140, layout: 0, latent: 0 } },
+      surfaceIds: SURFS,
+      newSurfaces: new Set(),
+    })
+
+    expect(verdict.failed).toBe(true)
+    expect(verdict.grew.map(fmtDelta)).toEqual(['newsurf.text: 140 -> 146 (+6)'])
+  })
 })
 
 describe('BUCKETS', () => {  it('is the ledger key order the debt record is written with', () => {


### PR DESCRIPTION
The Phase 5 render gate asserted on 20 surfaces. The dashboard has 59 that are
URL-reachable with no click choreography, so most of the product it was built to
check was never rendered under `en-XA` at all.

## What was invisible

Whole builtin apps. Every one routes through the `/:builtinApp` catch-all in
`App.tsx`, and `/apps` — which WAS registered — is the discover list, not any
app's UI. `projects` is the precedent that makes this an extension rather than a
new mechanism: it is already a `/:builtinApp` route and has rendered here since
Phase 5 shipped.

Most of the query-param tabs. 8 of 16 `settings` tabs, 3 of 7 `capabilities` tabs
and 1 of 8 `developer` tabs were registered. The rest are the same shape as the
registered ones — one URL, no interaction — so they were left out by ranking, and
the ranking was never revisited while the panels kept growing.
`settings-shortcuts` alone renders 744 untranslated strings.

`/apps` itself was measuring almost nothing: the fixture returned `[]` for
`/api/apps`, so its 2 text findings were pure chrome. `FIXTURE_APPS` gives it real
manifest data (2 -> 168) and makes `app-detail` scannable at all.

## `[vs-base]` could not have let this land

`newSurfaces` — the set whose base count is forced to 0, so every finding it
brings counts as growth — was computed as "absent from the base REGISTRY". The
comment justified zero differently: the base bundle has no route for the URL, so
the base sweep lands on a fallback page whose findings describe the wrong screen.

Those are not the same condition, and for every surface added here only the first
held: the routes all exist on the base, the base sweep measures them correctly,
and their findings are pre-existing debt the registration merely revealed. Forcing
zero charged all of it to the branch that widened the aperture, which is why the
aperture had never been widened.

The discriminator is now behavioural. `App.tsx` sends an unknown route through a
redirect — `BuiltinAppRoute` renders `<Navigate to="/chat">`, an unknown top-level
path hits `ChatRedirect` — so the base sweep records, per surface, whether it
ended up at the URL it asked for. Redirected means the route was absent and zero
is honest; landed means compare against the real measurement. The run prints which
of the two happened for every id. Registration buys no exemption: an increase on a
newly registered surface still fails, and both directions are pinned in
`renderVerdict.test.ts`.

Residual gap, stated in the code: a query-param surface whose tab the base does
not know renders the DEFAULT panel at the same URL, so it reads as resolved and
its base count describes the wrong panel. Adding such a surface in the same commit
as the tab it addresses is what avoids that.

## Fitting 59 surfaces in the job that already held 20

At 4 locales x 2 viewports this is 472 renders per tree, ~10min each, and the gate
shares the `e2e` job's `timeout-minutes: 25` with the Playwright suite — it blew
the cap and got the whole job CANCELLED before that suite ran once. The job was
already at 20 of its 25 minutes before this branch touched it.

`LOCALES` is now `en-XA` alone. The full enforcing run is **4m06s**, down from
~19min, and both trees measure identically (text=2416 layout=3 latent=72) as they
must, since no product code changed here.

What that costs, stated rather than discovered later: `de` (widest Latin) and `bn`
(tallest line box) used to grade the pseudolocale's synthetic padding against real
scripts. Without them `layout` and `latent` are measured only under `en-XA`, which
inflates 2.2x — so those buckets now over-report relative to any shipped locale.
That is a false-POSITIVE direction, not a missed defect, which is why it is the
acceptable half to lose. Read `layout` as "clipped at pseudolocale width", not
"clipped in a locale we ship". If real-locale grading is wanted back, the way in is
a matrix that shards surfaces across jobs, not locales back in one 25-minute job.

## DNT moved rather than died

DNT integrity ran ONLY in `mode: 'real'` — it cannot run under the pseudolocale,
which accents every ASCII letter including protected terms. With no real locale
left, keeping it in the render gate would have meant a gate that renders, reports,
exits 0 and checks no DNT term: the exact shape a guard added earlier in this
branch existed to prevent.

So it is now `scripts/check-dnt-catalogs.mjs`, comparing catalog VALUES. That is
strictly wider — all 9 shipped locales instead of the one probe locale a render
budget could afford — needs no browser, build or fixtures, and runs in
milliseconds. It is the twelfth check in the runner, `hard-zero`, and it calls the
SAME `dntViolations` the render scan used: a second, subtly different DNT rule is
how two gates start disagreeing about what a violation is.

`dntViolations` gained one exemption to make that move safe. It already ignored an
all-lowercase hit (the command, not the product: `git push`, `npm i`); it now also
ignores an all-caps hit touching `_`, which is a SCREAMING_SNAKE identifier where
caps is correct. Every one of the 9 catalogs quotes env var names verbatim in
settings copy, so without it the new gate would open with 18 findings it must not
have. Requiring BOTH the all-caps form and an adjacent underscore keeps a bare
all-caps term in prose reportable. `dntViolations.test.ts` pins all of it,
including the two things the detector deliberately cannot see: a term a language
inflects (`Kiros eigenem Standard`) and a term a translation drops entirely — a
presence check flags both, and the one I wrote first failed on main's own catalogs
for exactly those two strings.

## Fixtures

Five endpoints needed declared shapes. `handleBootRoute` answers an unknown path
with `[]`, or `{}` for a config-ish name, and for most app endpoints that is right
— the panel renders its empty state, which is the copy we want scanned. These five
crash on it, and a crash is not a finding: React's error boundary swaps the panel
for its own English message, the scan counts that message, and the surface's number
stops describing the product. The script already turns any page error into exit 2
for that reason, so each was a hard failure rather than a silent miscount.

  file-explorer     `if (treeData?.entries)` then `.forEach` — against the `[]`
                    fallback that guard PASSES, because `[].entries` is
                    `Array.prototype.entries`, a truthy function.
  code-review-sage  `settings.models.map`, `nsData.namespaces.map`, no chaining.
  config/kirocrew, voice/config, config/stt
                    `Object.entries(cfg.agents)` / `Object.keys(stt.models)` on
                    nested collections a bare `{}` does not have.

Fixture values stay digit-shaped per the convention above them: anything
word-shaped renders into the page and is indistinguishable from untranslated copy.

## Base export

`git archive` now takes the WHOLE commit, not `website` plus an allowlist of the
paths that escape it. That allowlist is the shape that just failed: `website` WAS
the allowlist, and the moment a PR with no reason to know this script exists added
a cross-tree import (`registry.json`), every base build died with `Could not
resolve …` and the gate exited 2 on EVERY pull request — the breakage living in
the base tree rather than in anyone's diff. #1321 patched it by extending the
allowlist; archiving the commit costs a few seconds of tar next to two ~45s vite
builds and cannot rot again.

## Verified

`I18N_BASE_REF=origin/main node scripts/check-i18n-render.mjs --build` exits 0 in
4m06s. All 35 newly registered surfaces are reported as compared against a real
base measurement, and base and head agree exactly.

  tsc -b 0 · eslint src/ 0 errors · jscpd 0 clones · 8181 tests · i18n 12/12 PASS

Tracks #1004
