### PR TITLE
feat(apps): auto-approve a builtin app's calls to its own MCP server

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -609,11 +609,29 @@ read-your-writes should add it deliberately, with its own tests.
   as `denied_regexes` (see `security.md`). Gate order: **sensitive-path
   keystone → effective deny-floor (`is_denied`) → `gate_decision(ceiling,
   profile, title)` (governance, incl. the `commands` scope, and MCP titles
-  `mcp__server__tool` converted to `@server/tool`) → read-only auto-approve →
+  `mcp__server__tool` converted to `@server/tool`) → first-party app-own MCP
+  server auto-approve → read-only auto-approve →
   user `auto_approve_tools` loop**. A governance deny wins over a user
   auto-approve, and the read-only auto-approve fast-path runs strictly AFTER
   both the deny-floor and `gate_decision`, so a read-only classification can
-  never re-admit a denied/governed call. **Inside** that fast-path the semantic
+  never re-admit a denied/governed call. **First-party app-own MCP server
+  auto-approve** (`_app_owns_mcp_server` ∧ `_is_first_party_app`) sits
+  immediately after `gate_decision`, so a ceiling/profile still denies it: a
+  **builtin** app agent calling its OWN app-scoped server (registered
+  `<app>:<server>`) is intra-app — the app talking to its own gateway-shipped
+  code, not a host surface — and is auto-approved without re-widening any host
+  grant, independent of the Normal/Read/Trust tier (that tier governs the HOST
+  tools an app may reach, not the app talking to itself). It keys on the trusted,
+  non-model-authored `mcp_server_name` (the ACP `_meta.kiro.mcpServerName`), NEVER
+  the LLM-authored title: kiro-cli sets that field only for a genuine MCP-served
+  call, so a prompt-injected agent that titles a Bash call `mcp__<app>:srv__x`
+  carries an empty server name and never matches (fail-closed). Restricted to
+  builtins on purpose: only a builtin's server is provably first-party. A
+  THIRD-PARTY app's own server is arbitrary installed code whose internals the
+  gate cannot see, so its own-server calls are NOT auto-approved here — the OS
+  sandbox it runs under and the third-party admission gate bound its behavior,
+  not this prompt. **Inside**
+  the read-only fast-path the semantic
   `tool_kind` is authoritative and is tested first, as an ALLOW-list: only
   `read`/`fetch` auto-approve, and every other non-empty kind falls through to
   interactive approval before any title-keyed branch (including the computer-use one)

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -299,6 +299,8 @@ def build_permission_event(
     tool_input_cache: dict[str, str] | None = None,
     shell_cache: dict[str, bool] | None = None,
     raw_params_cache: dict[str, dict] | None = None,
+    mcp_server_name_cache: dict[str, str] | None = None,
+    tool_name_cache: dict[str, str] | None = None,
 ) -> tuple[AcpEvent, dict[str, str] | None]:
     """Build an ``EVENT_PERMISSION_REQUEST`` from a ``session/request_permission``.
 
@@ -448,6 +450,25 @@ def build_permission_event(
         tool_call_id=tool_call_id,
         raw_tool_params=_resolved_raw_params,
         is_shell=is_shell,
+        # Trusted MCP server identity recovered from the preceding tool_call
+        # (the permission payload carries no _meta). .get() (not .pop()) mirrors
+        # the is_shell cache: a later tool_call_update for the same id re-reads
+        # it; the per-turn dispatch .clear() handles cleanup. Empty on a miss
+        # (fail-closed for the app-own-server auto-approve).
+        mcp_server_name=(
+            mcp_server_name_cache.get(tool_call_id, "")
+            if (mcp_server_name_cache is not None and tool_call_id)
+            else ""
+        ),
+        # Trusted tool identity recovered from the preceding tool_call, mirroring
+        # mcp_server_name above. Lets the app-own-server auto-approve govern the
+        # canonical mcp__<server>__<tool> on the permission path (no _meta here).
+        # Empty on a miss (fail-closed: no trusted tool name → no auto-approve).
+        tool_name=(
+            tool_name_cache.get(tool_call_id, "")
+            if (tool_name_cache is not None and tool_call_id)
+            else ""
+        ),
     )
     return event, recorded
 
@@ -457,6 +478,8 @@ def _build_tool_call_event(
     tool_input_cache: dict[str, str] | None,
     shell_cache: dict[str, bool] | None = None,
     raw_params_cache: dict[str, dict] | None = None,
+    mcp_server_name_cache: dict[str, str] | None = None,
+    tool_name_cache: dict[str, str] | None = None,
 ) -> AcpEvent:
     """Build an ``EVENT_TOOL_CALL`` from a ``tool_call`` update (with redaction)."""
     title = update.get("title", "unknown")
@@ -475,6 +498,21 @@ def _build_tool_call_event(
     is_shell = is_shell_kind(kind)
     if tool_call_id and shell_cache is not None:
         shell_cache[tool_call_id] = is_shell
+    # Capture the TRUSTED MCP server identity (_meta.kiro.mcpServerName) so the
+    # later permission_request — the dashboard's gate path, which carries no
+    # _meta — can inherit it via mcp_server_name_cache. This is what lets the
+    # app-own-server auto-approve (hooks.on_tool_call) fire on the permission
+    # path: without the cache, the permission event's mcp_server_name is always
+    # "" and the branch never matches.
+    _mcp_server_name = _kiro_mcp_server_name(update)
+    if tool_call_id and mcp_server_name_cache is not None:
+        mcp_server_name_cache[tool_call_id] = _mcp_server_name
+    # Same lifecycle for the trusted tool name (_meta.kiro.toolName) so the
+    # permission event can reconstruct the canonical mcp__<server>__<tool> for
+    # per-tool governance in the app-own-server auto-approve.
+    _tool_name = _kiro_tool_name(update)
+    if tool_call_id and tool_name_cache is not None:
+        tool_name_cache[tool_call_id] = _tool_name
     # Initial tool input string from raw params.
     input_str = ""
     if tool_call_id and raw_input:
@@ -531,8 +569,8 @@ def _build_tool_call_event(
         raw_tool_params=raw_input if isinstance(raw_input, dict) else None,
         is_shell=is_shell,
         # Trusted identity from _meta.kiro (NOT the LLM-authored title).
-        tool_name=_kiro_tool_name(update),
-        mcp_server_name=_kiro_mcp_server_name(update),
+        tool_name=_tool_name,
+        mcp_server_name=_mcp_server_name,
         diff_old_text=_diff_old_text,
         diff_path=_diff_path,
     )
@@ -815,6 +853,8 @@ def parse_session_update(
     tool_input_cache: dict[str, str] | None = None,
     shell_cache: dict[str, bool] | None = None,
     raw_params_cache: dict[str, dict] | None = None,
+    mcp_server_name_cache: dict[str, str] | None = None,
+    tool_name_cache: dict[str, str] | None = None,
 ) -> list[AcpEvent]:
     """Parse one ``session/update`` inner ``update`` dict into ``AcpEvent``s.
 
@@ -843,7 +883,14 @@ def parse_session_update(
         return events
     if kind == UPDATE_TOOL_CALL:
         events.append(
-            _build_tool_call_event(update, tool_input_cache, shell_cache, raw_params_cache)
+            _build_tool_call_event(
+                update,
+                tool_input_cache,
+                shell_cache,
+                raw_params_cache,
+                mcp_server_name_cache,
+                tool_name_cache,
+            )
         )
         return events
     if kind == UPDATE_TOOL_CALL_UPDATE:

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1359,6 +1359,16 @@ class AcpClient:
         # the later permission_request event (which carries no kind) can inherit
         # the canonical shell signal. Mirrors _tool_call_inputs lifecycle.
         self._tool_call_is_shell: dict[str, bool] = {}
+        # Map toolCallId → trusted MCP server name (_meta.kiro.mcpServerName),
+        # cached from the tool_call notification so the later permission_request
+        # event (which carries no _meta) can inherit it — the signal the
+        # app-own-server auto-approve keys on. Mirrors _tool_call_is_shell.
+        self._tool_call_mcp_server: dict[str, str] = {}
+        # Map toolCallId → trusted tool name (_meta.kiro.toolName), cached like
+        # _tool_call_mcp_server so the permission_request event can rebuild the
+        # canonical mcp__<server>__<tool> for per-tool governance in the
+        # app-own-server auto-approve.
+        self._tool_call_tool_name: dict[str, str] = {}
         # Structured raw tool params (rawInput dict) keyed by toolCallId, cached
         # from the ToolCall notification so the later request_permission event —
         # which carries only a truncated title — can recover the real path/url
@@ -3110,6 +3120,8 @@ class AcpClient:
         )
         self._tool_call_inputs.clear()
         self._tool_call_is_shell.clear()
+        self._tool_call_mcp_server.clear()
+        self._tool_call_tool_name.clear()
         self._tool_call_params.clear()
         # Reset the per-turn observed-tool-call bookkeeping (see __init__).
         self._observed_tool_calls.clear()
@@ -4082,6 +4094,12 @@ class AcpClient:
             is_shell = _is_shell_kind(kind)
             if tool_call_id:
                 self._tool_call_is_shell[tool_call_id] = is_shell
+                # Same lifecycle as is_shell: cache the trusted MCP server
+                # identity so the later permission event can inherit it.
+                self._tool_call_mcp_server[tool_call_id] = _kiro_mcp_server_name(update)
+                # Cache the trusted tool name too, so the permission event can
+                # rebuild mcp__<server>__<tool> for per-tool governance.
+                self._tool_call_tool_name[tool_call_id] = _kiro_tool_name(update)
             title = _select_tool_title(title, raw_input) or ""
             if title:
                 title, _ = redact_exfiltration_urls(title)
@@ -4477,6 +4495,18 @@ class AcpClient:
             tool_call_id=tool_call_id,
             raw_tool_params=raw_params,
             is_shell=is_shell,
+            # Trusted MCP server identity recovered from the preceding tool_call
+            # (the permission payload has no _meta). .get() mirrors the is_shell
+            # cache-read; empty on a miss (fail-closed for app-own auto-approve).
+            mcp_server_name=(
+                self._tool_call_mcp_server.get(tool_call_id, "") if tool_call_id else ""
+            ),
+            # Trusted tool name recovered from the preceding tool_call, mirroring
+            # mcp_server_name — lets the app-own-server auto-approve govern the
+            # canonical mcp__<server>__<tool> on this permission path.
+            tool_name=(
+                self._tool_call_tool_name.get(tool_call_id, "") if tool_call_id else ""
+            ),
         )
 
     def _backfill_context_window(self, pct: float) -> None:

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -275,6 +275,16 @@ class AcpSessionHandle:
         # raw_tool_params for the governance keystone (sensitive-path /
         # write-protected-config) checks. Mirrors AcpClient's _tool_call_params.
         self._tool_call_raw_params: dict[str, dict] = {}
+        # toolCallId -> trusted MCP server name (_meta.kiro.mcpServerName) cached
+        # from the tool_call notification so the later permission_request event
+        # can carry mcp_server_name (empty on the permission payload). This is
+        # what lets hooks.on_tool_call's app-own-server auto-approve fire on the
+        # permission path. Mirrors _tool_call_is_shell.
+        self._tool_call_mcp_server: dict[str, str] = {}
+        # Trusted tool name (_meta.kiro.toolName) cached like _tool_call_mcp_server
+        # so the permission event can rebuild mcp__<server>__<tool> for per-tool
+        # governance in the app-own-server auto-approve.
+        self._tool_call_tool_name: dict[str, str] = {}
         # Server names for which a mid-session MCP OAuth banner was already
         # emitted, so we don't spam duplicates. Discarded on the matching
         # server_initialized / server_init_failure so a later token-expiry
@@ -379,6 +389,8 @@ class AcpSessionHandle:
         self._tool_call_inputs.clear()
         self._tool_call_is_shell.clear()
         self._tool_call_raw_params.clear()
+        self._tool_call_mcp_server.clear()
+        self._tool_call_tool_name.clear()
         self._permission_options.clear()
 
         # Drain frames left over from a prior abandoned turn. The cancel-unacked
@@ -1644,6 +1656,8 @@ class AcpSessionHandle:
             tool_input_cache=self._tool_call_inputs,
             shell_cache=self._tool_call_is_shell,
             raw_params_cache=self._tool_call_raw_params,
+            mcp_server_name_cache=self._tool_call_mcp_server,
+            tool_name_cache=self._tool_call_tool_name,
         )
         if recorded is not None and event.request_id != "":
             self._permission_options[event.request_id] = recorded
@@ -1694,6 +1708,8 @@ class AcpSessionHandle:
             tool_input_cache=self._tool_call_inputs,
             shell_cache=self._tool_call_is_shell,
             raw_params_cache=self._tool_call_raw_params,
+            mcp_server_name_cache=self._tool_call_mcp_server,
+            tool_name_cache=self._tool_call_tool_name,
         )
         for ev in events:
             if ev.kind == EVENT_TEXT_CHUNK:

--- a/src/kiro_crew/apps/execution.py
+++ b/src/kiro_crew/apps/execution.py
@@ -83,6 +83,123 @@ def shipped_builtin_app_root(app_name: str) -> Path | None:
     return None
 
 
+def builtin_app_names() -> frozenset[str]:
+    """First-party app names: shipped-manifest provenance AND a builtin-owned install.
+
+    A name qualifies only when BOTH hold:
+
+    1. A shipped ``app.json`` declares it — the SAME manifest sources as
+       :func:`shipped_builtin_app_root` (core ``builtins/`` plus any
+       edition/companion source via the platform ``apps_loader``). This says the
+       app *could* be first party.
+    2. Its active ``installed.json`` record is builtin-owned
+       (:func:`manager.builtin_owns_installed`). This proves the builtin
+       actually occupies the slot rather than a user-installed app that shares
+       the name and made the builtin registration *stand down*
+       (see :func:`manager.register_builtin_apps`). A shadowing third-party app,
+       or a missing/unreadable record, is excluded.
+
+    ``installed.json`` is consulted ONLY to REMOVE trust, never to widen it: a
+    name absent from every shipped manifest can never enter this set regardless
+    of installed metadata, so a mutable record cannot forge first-party
+    provenance. The gate's sole consumer therefore auto-approves an app's calls
+    to its own MCP server only when that app is genuinely the shipped builtin —
+    not a user app that merely shadows a builtin name.
+
+    Does filesystem I/O (dir scan + manifest reads + one installed-record read
+    per candidate); callers warm it ONCE off the event loop. A source that fails
+    to read is skipped, and an unreadable installed record drops just that name
+    (fail-closed) — neither ever widens provenance.
+    """
+    candidates: set[str] = set()
+    for source in _builtin_manifest_sources():
+        try:
+            entries = sorted(source.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                root = entry.resolve(strict=True)
+                if not root.is_dir() or not root.is_relative_to(source):
+                    continue
+                manifest_path = (root / "app.json").resolve(strict=True)
+                if not manifest_path.is_file() or not manifest_path.is_relative_to(root):
+                    continue
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                continue
+            if isinstance(manifest, dict):
+                name = manifest.get("name")
+                if isinstance(name, str) and name:
+                    candidates.add(name)
+
+    # Narrow shipped-manifest candidates to those whose ACTIVE install is
+    # builtin-owned, so a user app shadowing a builtin's name is NOT trusted as
+    # first party. Deferred import: manager imports this module at load time, so
+    # the reverse edge must resolve lazily (manager is fully imported by the
+    # time this runs, off the event loop, at gateway boot).
+    from kiro_crew.apps.manager import builtin_owns_installed
+
+    return frozenset(name for name in candidates if builtin_owns_installed(name))
+
+
+def builtin_app_mcp_servers() -> frozenset[str]:
+    """Canonical ``<app>:<server>`` names DECLARED in shipped builtin manifests.
+
+    For each first-party manifest (the SAME sources as :func:`builtin_app_names`)
+    whose active install is builtin-owned, emit ``f"{name}:{server}"`` for every
+    key in its ``mcpServers``. This is the IMMUTABLE set of app-own MCP servers:
+    the gate's app-own-server auto-approve requires membership here so it trusts
+    only a server the app's SHIPPED manifest declares — never an arbitrary
+    ``<app>:``-prefixed entry that landed in the mutable global MCP config (which
+    ``bridges._own_mcp_servers`` injects into the agent by prefix). Narrowed to
+    builtin-owned installs exactly like :func:`builtin_app_names`, so a shadowing
+    user app cannot contribute declared servers.
+
+    Enumerates its own manifest loop (mirroring :func:`builtin_app_names`) rather
+    than sharing state with it, to keep that security-sensitive function
+    untouched. Filesystem I/O; callers warm it ONCE off the event loop. A source
+    or manifest that fails to read is skipped (fail-closed), never widening the
+    trusted set.
+    """
+    # Deferred import: manager imports this module at load time (see
+    # builtin_app_names), so the reverse edge resolves lazily.
+    from kiro_crew.apps.manager import builtin_owns_installed
+
+    servers: set[str] = set()
+    owned: dict[str, bool] = {}
+    for source in _builtin_manifest_sources():
+        try:
+            entries = sorted(source.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                root = entry.resolve(strict=True)
+                if not root.is_dir() or not root.is_relative_to(source):
+                    continue
+                manifest_path = (root / "app.json").resolve(strict=True)
+                if not manifest_path.is_file() or not manifest_path.is_relative_to(root):
+                    continue
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                continue
+            if not isinstance(manifest, dict):
+                continue
+            name = manifest.get("name")
+            mcp_servers = manifest.get("mcpServers")
+            if not (isinstance(name, str) and name and isinstance(mcp_servers, dict)):
+                continue
+            if name not in owned:
+                owned[name] = builtin_owns_installed(name)
+            if not owned[name]:
+                continue
+            for server_name in mcp_servers:
+                if isinstance(server_name, str) and server_name:
+                    servers.add(f"{name}:{server_name}")
+    return frozenset(servers)
+
+
 def shipped_builtin_module_path(app_name: str, module_name: str) -> Path | None:
     """Resolve a ``python -m`` target only when it belongs to ``app_name``'s package."""
     root = shipped_builtin_app_root(app_name)

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1120,6 +1120,31 @@ def register_external_app(
     dest = app_dir(name)
     existing = _read_installed(name)
 
+    # Builtin provenance is assigned ONLY by register_builtin_apps(). A
+    # self-registration must never OVERWRITE an existing builtin-owned record
+    # (which the update branch below would do — downgrading origin/lifecycle to
+    # external/app). That would both hand a third-party app a shipped builtin's
+    # execution exemption AND leave the boot-warmed first-party name / MCP-server
+    # sets stale until the next gateway restart. Stand down, mirroring
+    # register_builtin_apps()'s refusal to take over a user-installed app — so a
+    # builtin's provenance is immutable at runtime and the warmed sets stay valid.
+    if existing and _builtin_owns_install(existing):
+        sel().log_api_access(
+            caller="app_register_external",
+            operation="provenance",
+            outcome="rejected",
+            resources=f"name={name!r}",
+            error="builtin-owned app cannot be replaced by self-registration",
+        )
+        return AppResult(
+            ok=False,
+            name=name,
+            error=(
+                f"{name!r} is a KiroCrew-shipped builtin and cannot be replaced "
+                "by self-registration"
+            ),
+        )
+
     if existing:
         # Update existing registration
         existing.version = version
@@ -1520,6 +1545,22 @@ def _builtin_owns_install(existing: InstalledApp) -> bool:
     by older gateway versions are still recognised as ours.
     """
     return existing.source == "builtin" or existing.origin == "builtin"
+
+
+def builtin_owns_installed(name: str) -> bool:
+    """Whether the ACTIVE installed record for ``name`` is builtin-owned.
+
+    ``True`` only when an ``installed.json`` exists for ``name`` AND it was
+    written by :func:`register_builtin_apps` (``source``/``origin`` == builtin,
+    per :func:`_builtin_owns_install`). A user-installed app that shadows a
+    builtin's name — which makes registration *stand down* and leaves the
+    user's record in place — or a missing/unreadable record both return
+    ``False`` (fail-closed). Callers use this to confirm a shipped-manifest name
+    is actually occupied by first-party code before granting it first-party
+    trust; it can only REMOVE trust, never manufacture it.
+    """
+    existing = _read_installed(name)
+    return existing is not None and _builtin_owns_install(existing)
 
 
 def _app_declares_backend(app_data: dict[str, Any]) -> bool:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3699,10 +3699,13 @@ async def _run_chat(
                         event.title,
                         session_key=session_key,
                         agent=slot.agent or "",
+                        app=slot._app or "",
                         tool_kind=event.tool_kind,
                         raw_params=event.raw_tool_params,
                         command=event.shell_command,
                         is_shell=event.is_shell,
+                        mcp_server_name=event.mcp_server_name,
+                        mcp_tool_name=event.tool_name,
                     )
                     if tool_result.action == TOOL_DENY:
                         await client.reject_tool(event.request_id)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2377,6 +2377,29 @@ async def start_dashboard(
     # dirs, which must not block the event loop during startup.
     await asyncio.get_running_loop().run_in_executor(subprocess_executor(), register_builtin_apps)
 
+    # Warm the PreToolUse gate's first-party (builtin) app-name set from the
+    # shipped manifests, ONCE, on the executor (the discovery walk touches the
+    # filesystem and must not run on the event loop). The gate's app-own-server
+    # auto-approve then does a pure in-memory membership test with zero I/O; an
+    # empty set (should this fail) simply fails closed (owns-server calls prompt).
+    async def _warm_builtin_app_names() -> None:
+        try:
+            from kiro_crew.apps.execution import builtin_app_mcp_servers, builtin_app_names
+            from kiro_crew.hooks import set_builtin_app_mcp_servers, set_builtin_app_names
+
+            names = await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), builtin_app_names
+            )
+            set_builtin_app_names(names)
+            servers = await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), builtin_app_mcp_servers
+            )
+            set_builtin_app_mcp_servers(servers)
+        except Exception:  # noqa: BLE001 — a warm failure only costs an extra prompt
+            logger.warning("Failed to warm builtin app-name set for the gate", exc_info=True)
+
+    await _warm_builtin_app_names()
+
     # Reconcile resources (agents / skills / crons / MCP) for every ENABLED app.
     # Registration otherwise happens only in the enable path, so an app that
     # gains agents or skills in a later version never registers them for a user

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -12,6 +12,7 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -404,6 +405,8 @@ class HookManager:
         raw_params: dict | None = None,
         command: str | None = None,
         is_shell: bool = False,
+        mcp_server_name: str = "",
+        mcp_tool_name: str = "",
     ) -> ToolHookResult:
         """Check if a tool should be auto-approved, denied, or handled normally.
 
@@ -442,6 +445,27 @@ class HookManager:
         that always pass a resolved command can leave ``is_shell`` at its
         default; those forwarding an event should pass both the command and the
         event's ``is_shell`` flag.
+
+        ``mcp_server_name`` is the NON-model-authored MCP server identity from
+        the ACP event's ``_meta.kiro.mcpServerName`` (``AcpEvent.mcp_server_name``),
+        set by kiro-cli ONLY for MCP-served tool calls and empty for shell /
+        built-in tools. It is the trusted discriminator "this call was genuinely
+        served by MCP server X" — as opposed to the LLM-authored ``tool_name``
+        title, which a prompt-injected agent can forge (e.g. titling a Bash call
+        ``mcp__<app>:srv__x``). The app-own-server auto-approve keys on THIS, never
+        on the title, so a forged title cannot win an auto-approval. Empty (the
+        default, or a backend that omits ``_meta.kiro``) fails closed: no match.
+
+        ``mcp_tool_name`` is the sibling NON-model-authored tool identity from
+        ``_meta.kiro.toolName`` (``AcpEvent.tool_name``), set by kiro-cli
+        alongside ``mcp_server_name`` for MCP-served calls. It is used to
+        reconstruct the canonical ``mcp__<server>__<tool>`` name and govern the
+        REAL tool before the app-own-server auto-approve — because the ``tool_name``
+        title above is LLM-authored prose (``select_tool_title`` prefers the
+        model's ``description``) and may not carry the canonical form a per-tool
+        MCP policy matches on. Empty (no ``_meta.kiro.toolName``) means the tool
+        cannot be identified for governance, so the own-server auto-approve does
+        NOT fire (fall through to interactive approval — fail-closed).
         """
         # Deny-by-default: a shell tool whose command could not be recovered
         # must not be evaluated on the untrusted title alone — that is the very
@@ -567,6 +591,86 @@ class HookManager:
         )
         if gov_reason:
             return ToolHookResult.deny(gov_reason)
+
+        # App-own MCP server auto-approve — a FIRST-PARTY (builtin) app agent
+        # calling its OWN app-scoped MCP server is intra-app, not a host surface.
+        # A builtin app's declared server is registered under the
+        # ``<app>:<server>`` key (see ``apps/bridges.py``) and IS the gateway's
+        # own shipped code, so it only touches the app's own data — never
+        # fs/network/exec/exfil on the host. Once a shipped app agent stopped
+        # pre-authorizing tools (no template ``allowedTools``, the "no template
+        # pre-authorizes tools" invariant), even those intra-app calls fell
+        # through to an interactive prompt the user could not meaningfully act on
+        # (the app was blocked from talking to itself). Auto-approving them here
+        # restores that UX without re-widening any host grant.
+        #
+        # Keyed on the NON-model-authored ``mcp_server_name`` (the ACP
+        # ``_meta.kiro.mcpServerName``), NEVER on the LLM-authored title: a
+        # prompt-injected agent can title a Bash call ``mcp__<app>:srv__x``, but
+        # kiro-cli only sets ``mcp_server_name`` for a genuine MCP-served call, so
+        # a forged shell/host title carries an empty server name and never
+        # matches (fail-closed). Restricted to builtins on purpose: only a
+        # builtin's server is provably first-party. A THIRD-PARTY app's server is
+        # arbitrary installed code whose internals the gate cannot see, so its
+        # own-server calls are NOT auto-approved here — the OS sandbox it runs
+        # under and the third-party admission gate bound its behavior instead.
+        #
+        # Placed AFTER the always-on deny floor and ``_governance_denial`` so a
+        # ceiling/profile can still deny even a builtin's own server and every
+        # sensitive-path / keystone / exfil deny above still wins; and BEFORE the
+        # interactive fall-through, independent of the Normal/Read/Trust tier
+        # (that tier governs the HOST tools an app agent may reach, not the app
+        # talking to its own server). Generic App Kit contract keyed only on the
+        # ``<app>:<server>`` convention + shipped-manifest provenance — no per-app
+        # special-casing.
+        #
+        # ``_app_owns_mcp_server`` only proves the NAME is ``<app>:``-prefixed;
+        # ``_own_mcp_servers`` (bridges.py) injects app servers into the agent by
+        # reading that prefix from the MUTABLE global MCP config, so a
+        # ``<app>:evil`` entry that landed there (not declared by the app) would
+        # otherwise be trusted. Require the server to be DECLARED in the app's
+        # SHIPPED manifest (``_is_declared_builtin_mcp_server``, an in-memory set
+        # warmed at boot from immutable manifests — same discipline as
+        # ``_BUILTIN_APP_NAMES``) so only a genuinely app-own server auto-approves.
+        if (
+            _app_owns_mcp_server(mcp_server_name, app)
+            and _is_first_party_app(app)
+            and _is_declared_builtin_mcp_server(mcp_server_name)
+        ):
+            # Govern the REAL tool by its TRUSTED _meta.kiro identity before
+            # granting the intra-app auto-approve. ``select_tool_title`` prefers
+            # the model's prose ``description``, so ``tool_name`` (and thus the
+            # ``_governance_denial`` above) may not carry the canonical
+            # ``mcp__server__tool`` a per-tool policy matches on — a ceiling /
+            # profile that denies ONE tool of this server would otherwise be
+            # skipped here and the tool auto-executed. Reconstruct the canonical
+            # title from the NON-model-authored server + tool names (mirroring
+            # the ``mcp__<server>__<tool>`` form ``mcp_title_to_ref`` parses) and
+            # re-check governance. A missing trusted tool name (a backend without
+            # ``_meta.kiro.toolName``, or an uncached permission event) means we
+            # cannot prove WHICH tool this is, so we do NOT auto-approve — fall
+            # through to interactive approval (fail-closed), never silent execute.
+            if mcp_tool_name:
+                canonical_mcp_name = f"mcp__{mcp_server_name}__{mcp_tool_name}"
+                # Re-apply the always-on deny floor to the canonical name too:
+                # the top-of-method ``authority.is_denied`` ran against the prose
+                # title / command, so a configured deny rule (``auto_deny_tools``
+                # or a denied regex) keyed on the canonical ``mcp__server__tool``
+                # would have MISSED — and this auto-approve must never re-admit a
+                # tool the deny floor forbids. Mirrors the governance re-check.
+                deny_reason = authority.is_denied(
+                    canonical_mcp_name,
+                    self._config.auto_deny_tools,
+                    denied_regexes=denied_regexes,
+                )
+                if deny_reason:
+                    return ToolHookResult.deny(deny_reason)
+                gov_reason = _governance_denial(
+                    ctx, canonical_mcp_name, session_key, agent, app, tool_kind, raw_params
+                )
+                if gov_reason:
+                    return ToolHookResult.deny(gov_reason)
+                return ToolHookResult.auto_approve()
 
         # Auto-approve — match against both the original title (preserves
         # "Running: "/"Reading " prefixes) and the normalized name (stripped)
@@ -834,6 +938,116 @@ def _governance_denial(
         except Exception:
             logger.debug("governance degrade audit unavailable", exc_info=True)
         return None
+
+
+def _app_owns_mcp_server(mcp_server_name: str, app: str) -> bool:
+    """True when *mcp_server_name* is *app*'s OWN app-scoped MCP server.
+
+    App-declared MCP servers are registered under the ``<app>:<server>`` key
+    (``apps/bridges.py`` ``_own_mcp_servers``), so the owning app is the segment
+    before the first ``:``.  ``mcp_server_name`` is the trusted, NON-model-authored
+    identity from ``_meta.kiro.mcpServerName`` (``AcpEvent.mcp_server_name``) —
+    NOT the LLM-authored display title — so a forged shell/host title cannot spoof
+    a match: kiro-cli leaves ``mcp_server_name`` empty for non-MCP tools, and an
+    empty value fails closed here.  Comparison is case-insensitive to mirror the
+    governance MCP matcher.  Returns ``False`` for a blank ``app`` (an ordinary
+    user/host turn carries no app identity) and for any server name that is not
+    ``<app>:``-prefixed (host/managed servers such as ``kirocrew-cron`` never
+    match).
+    """
+    if not app or not mcp_server_name:
+        return False
+    owning_app, sep, _rest = mcp_server_name.partition(":")
+    return bool(sep) and owning_app.casefold() == app.casefold()
+
+
+# Canonical ``<app>:<server>`` names DECLARED in shipped builtin manifests,
+# populated ONCE at gateway boot via ``set_builtin_app_mcp_servers`` (see the
+# dashboard startup). Parallel to ``_BUILTIN_APP_NAMES`` and kept as a plain
+# module global for the same reason — the PreToolUse gate does ZERO filesystem
+# I/O; the shipped-manifest scan happens once at boot, off the event loop. Names
+# are casefolded on ingest so the gate lookup is a pure set membership test.
+# Empty until warmed → fail-closed: an unrecognised server name never
+# auto-approves. This is what stops an undeclared ``<app>:evil`` entry that
+# landed in the MUTABLE global MCP config from being trusted just because its
+# prefix matches a first-party app.
+_BUILTIN_APP_MCP_SERVERS: frozenset[str] = frozenset()
+
+
+def set_builtin_app_mcp_servers(names: Iterable[str]) -> None:
+    """Install the set of shipped-manifest-declared ``<app>:<server>`` names.
+
+    Called once at gateway boot with the names from
+    ``apps.execution.builtin_app_mcp_servers`` (which enumerates the same
+    immutable manifest sources as ``builtin_app_names``). Dependency-inverted
+    like ``set_builtin_app_names`` so ``hooks`` never imports ``apps`` and the
+    gate never touches the filesystem. Idempotent; a later call replaces the set.
+    """
+    global _BUILTIN_APP_MCP_SERVERS
+    _BUILTIN_APP_MCP_SERVERS = frozenset(
+        n.casefold() for n in names if isinstance(n, str) and n
+    )
+
+
+def _is_declared_builtin_mcp_server(mcp_server_name: str) -> bool:
+    """True when *mcp_server_name* is a server a shipped builtin manifest declares.
+
+    Pure in-memory, case-insensitive membership test against
+    ``_BUILTIN_APP_MCP_SERVERS`` (warmed at boot from immutable manifests). The
+    app-own-server auto-approve requires this in addition to prefix ownership so
+    a ``<app>:``-prefixed entry the app never declared (e.g. one injected into
+    the mutable global MCP config) cannot win an auto-approval. Fail-closed
+    before the set is warmed.
+    """
+    return bool(mcp_server_name) and mcp_server_name.casefold() in _BUILTIN_APP_MCP_SERVERS
+
+
+# Builtin (first-party) app names, populated ONCE at gateway boot via
+# ``set_builtin_app_names`` (see the dashboard startup). Kept as a plain
+# module global — NOT derived on the per-tool-call path — so the PreToolUse gate
+# does ZERO filesystem I/O: scanning the shipped-manifest tree on the event loop
+# (even once, before an lru_cache warmed) would stall every gateway task. Names
+# are casefolded on ingest so the gate lookup is a pure set membership test.
+# Empty until warmed → fail-closed: an app whose provenance is not yet known is
+# treated as third-party and its own-server calls simply prompt (never wrongly
+# auto-approved). Boot runs on the startup thread, well before any tool call.
+_BUILTIN_APP_NAMES: frozenset[str] = frozenset()
+
+
+def set_builtin_app_names(names: Iterable[str]) -> None:
+    """Install the set of first-party (builtin) app names for the gate.
+
+    Called once at gateway boot with the names discovered from the shipped
+    manifests (``apps.execution.builtin_app_names``, which enumerates the same
+    sources as ``shipped_builtin_app_root`` — core + the active edition). The
+    dependency is
+    inverted on purpose — boot code (which already imports ``apps``) pushes the
+    names in, so ``hooks`` never imports ``apps`` and the gate never touches the
+    filesystem. Idempotent; a later call replaces the set.
+    """
+    global _BUILTIN_APP_NAMES
+    _BUILTIN_APP_NAMES = frozenset(n.casefold() for n in names if isinstance(n, str) and n)
+
+
+def _is_first_party_app(app: str) -> bool:
+    """True when *app* is a shipped builtin (first-party gateway code).
+
+    Only a BUILTIN app's MCP server is provably the gateway's own shipped code,
+    so only then does the app-own-server auto-approve's justification — "the
+    server is the app's own declared code and only touches the app's own data,
+    never a host surface" — actually hold.  A THIRD-PARTY installed app's server
+    is arbitrary operator-installed code whose internals the PreToolUse gate
+    cannot see (it reads files with plain OS syscalls in its own process, which
+    the gate never observes), so its own-server calls are NOT blanket
+    auto-approved here — they still surface for interactive approval / governance.
+    What bounds a server's internal behavior is the OS sandbox it runs under plus
+    the third-party install/admission gate, not this UX auto-approve.
+
+    Pure in-memory lookup against ``_BUILTIN_APP_NAMES`` (populated at boot from
+    immutable shipped-manifest provenance) — NO filesystem I/O on the event loop.
+    Fail-closed before the set is warmed.
+    """
+    return bool(app) and app.casefold() in _BUILTIN_APP_NAMES
 
 
 def _cu_read_only_auto_approve(tool_name: str) -> bool:

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -4286,6 +4286,8 @@ class SubagentManager:
                     raw_params=event.raw_tool_params,
                     command=event.shell_command,
                     is_shell=event.is_shell,
+                    mcp_server_name=event.mcp_server_name,
+                    mcp_tool_name=event.tool_name,
                 )
                 if tool_result.action == TOOL_DENY:
                     await self._reject_and_log(

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -8276,6 +8276,40 @@ class TestAcpClientIsShellSignal:
         perm = client._build_permission_event(self._permission_msg())
         assert perm.is_shell is False
 
+    def test_permission_event_inherits_trusted_tool_identity(self, tmp_path):
+        # The client caches the trusted _meta.kiro identity (mcpServerName +
+        # toolName) from the tool_call so the later permission event (which
+        # carries no _meta) can rebuild mcp__<server>__<tool> for the
+        # app-own-server auto-approve's per-tool governance. Without the
+        # tool_name cache the permission event's tool_name is always "" and the
+        # auto-approve fails closed (never fires).
+        from kiro_crew.acp.client import AcpClient
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        client = AcpClient(work_dir=tmp_path)
+        tc = JsonRpcMessage(
+            method="session/update",
+            params={
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "tc-1",
+                    "title": "Doing app work",  # prose, not the canonical mcp__ form
+                    "kind": "other",
+                    "rawInput": {},
+                    "_meta": {
+                        "kiro": {
+                            "toolName": "list_intakes",
+                            "mcpServerName": "beehive:beehive-mcp",
+                        }
+                    },
+                }
+            },
+        )
+        client._extract_tool_event(tc)
+        perm = client._build_permission_event(self._permission_msg())
+        assert perm.tool_name == "list_intakes"
+        assert perm.mcp_server_name == "beehive:beehive-mcp"
+
     def test_end_to_end_long_shell_title_passes_validation(self, tmp_path):
         """The full regression: a 400-char shell title validates only because
         is_shell propagated from tool_call → permission → _validate_tool_name."""

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -3890,6 +3890,92 @@ def test_build_permission_event_raw_params_none_without_cache():
     assert event.raw_tool_params is None
 
 
+def test_build_permission_event_recovers_mcp_server_name_from_cache():
+    """Regression: build_permission_event must carry mcp_server_name recovered
+    from the preceding tool_call (the permission payload has no _meta), so
+    hooks.on_tool_call's app-own-server auto-approve can fire on the dashboard
+    permission path. Without this the event's mcp_server_name is always "" and
+    the feature is inert."""
+    from kiro_crew.acp._dispatch import build_permission_event
+    from kiro_crew.acp.types import METHOD_REQUEST_PERMISSION
+
+    mcp_cache = {"tc-1": "mochi:mochi"}
+    msg = JsonRpcMessage.from_dict(
+        {
+            "id": 7,
+            "method": METHOD_REQUEST_PERMISSION,
+            "params": {
+                "toolCall": {"toolCallId": "tc-1", "title": "perform_pet_action"},
+                "options": [],
+            },
+        }
+    )
+    event, _ = build_permission_event(msg, mcp_server_name_cache=mcp_cache)
+    assert event.mcp_server_name == "mochi:mochi"
+    # .get() (not .pop()): a later tool_call_update for the same id re-reads it.
+    assert mcp_cache.get("tc-1") == "mochi:mochi"
+
+
+def test_build_permission_event_mcp_server_name_empty_without_cache():
+    """No cache / no entry → mcp_server_name stays "" (fail-closed: the app-own
+    auto-approve never matches on a forged title with no trusted server name)."""
+    from kiro_crew.acp._dispatch import build_permission_event
+    from kiro_crew.acp.types import METHOD_REQUEST_PERMISSION
+
+    msg = JsonRpcMessage.from_dict(
+        {
+            "id": 8,
+            "method": METHOD_REQUEST_PERMISSION,
+            "params": {"toolCall": {"toolCallId": "tc-y", "title": "x"}, "options": []},
+        }
+    )
+    event, _ = build_permission_event(msg, mcp_server_name_cache={})
+    assert event.mcp_server_name == ""
+
+
+def test_build_permission_event_recovers_tool_name_from_cache():
+    """Mirror of the mcp_server_name recovery: the permission payload carries no
+    _meta, so build_permission_event recovers the trusted tool name from the
+    preceding tool_call via tool_name_cache. This is what lets the
+    app-own-server auto-approve rebuild the canonical mcp__<server>__<tool> and
+    govern the real tool on the permission path."""
+    from kiro_crew.acp._dispatch import build_permission_event
+    from kiro_crew.acp.types import METHOD_REQUEST_PERMISSION
+
+    name_cache = {"tc-1": "perform_pet_action"}
+    msg = JsonRpcMessage.from_dict(
+        {
+            "id": 9,
+            "method": METHOD_REQUEST_PERMISSION,
+            "params": {
+                "toolCall": {"toolCallId": "tc-1", "title": "perform_pet_action"},
+                "options": [],
+            },
+        }
+    )
+    event, _ = build_permission_event(msg, tool_name_cache=name_cache)
+    assert event.tool_name == "perform_pet_action"
+    # .get() (not .pop()): a later tool_call_update for the same id re-reads it.
+    assert name_cache.get("tc-1") == "perform_pet_action"
+
+
+def test_build_permission_event_tool_name_empty_without_cache():
+    """No cache / no entry → tool_name stays "" (fail-closed: the app-own-server
+    auto-approve cannot identify the tool to govern it, so it never fires)."""
+    from kiro_crew.acp._dispatch import build_permission_event
+    from kiro_crew.acp.types import METHOD_REQUEST_PERMISSION
+
+    msg = JsonRpcMessage.from_dict(
+        {
+            "id": 10,
+            "method": METHOD_REQUEST_PERMISSION,
+            "params": {"toolCall": {"toolCallId": "tc-z", "title": "x"}, "options": []},
+        }
+    )
+    event, _ = build_permission_event(msg, tool_name_cache={})
+    assert event.tool_name == ""
+
+
 def test_build_permission_event_non_string_option_entries_skipped():
     """The shared parser feeds AcpSessionHandle's prompt event generator; a
     truthy non-string id (e.g. {"id": 42}) crashed opt_id.lower() in the

--- a/test/test_app_execution.py
+++ b/test/test_app_execution.py
@@ -183,6 +183,140 @@ class TestExecutionDecision:
             app_root=outside_root,
         )
 
+    def test_builtin_app_names_requires_builtin_owned_install(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # A shipped manifest makes a name a CANDIDATE; it enters the first-party
+        # set only when its active installed record is builtin-owned. Both a
+        # core builtin and an edition/companion-contributed builtin count, so
+        # long as the builtin actually occupies the slot.
+        import kiro_crew.platform as platform_mod
+        from kiro_crew.apps import execution
+        from kiro_crew.apps.manager import InstalledApp, _write_installed
+
+        home = tmp_path / "kirocrew-home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        source = tmp_path / "edition-builtins"
+        shipped_root = source / "edition-app"
+        shipped_root.mkdir(parents=True)
+        (shipped_root / "app.json").write_text(json.dumps({"name": "edition-app"}), encoding="utf-8")
+        context = SimpleNamespace(apps_loader=SimpleNamespace(manifest_sources=lambda: [source]))
+        monkeypatch.setattr(platform_mod, "current_context", lambda: context)
+
+        # Builtin registration won the slot for both the edition builtin and a
+        # real core builtin → builtin-owned installed records.
+        _write_installed(
+            "edition-app", InstalledApp(name="edition-app", source="builtin", origin="builtin")
+        )
+        _write_installed(
+            "file-explorer", InstalledApp(name="file-explorer", source="builtin", origin="builtin")
+        )
+
+        names = execution.builtin_app_names()
+        assert isinstance(names, frozenset)
+        assert "edition-app" in names  # edition/companion source, builtin-owned
+        assert "file-explorer" in names  # core builtin, builtin-owned
+
+    def test_builtin_app_names_excludes_shadowing_user_app(self, tmp_path, monkeypatch) -> None:
+        # A user-installed app that shares a builtin's name makes registration
+        # stand down and keeps its own (non-builtin) installed record. The
+        # shipped manifest still exists, but the name must NOT be trusted as
+        # first-party — otherwise the shadowing app's own-server MCP calls would
+        # be auto-approved without a prompt.
+        import kiro_crew.platform as platform_mod
+        from kiro_crew.apps import execution
+        from kiro_crew.apps.manager import InstalledApp, _write_installed
+
+        home = tmp_path / "kirocrew-home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        source = tmp_path / "edition-builtins"
+        shipped_root = source / "shadowed-app"
+        shipped_root.mkdir(parents=True)
+        (shipped_root / "app.json").write_text(
+            json.dumps({"name": "shadowed-app"}), encoding="utf-8"
+        )
+        context = SimpleNamespace(apps_loader=SimpleNamespace(manifest_sources=lambda: [source]))
+        monkeypatch.setattr(platform_mod, "current_context", lambda: context)
+
+        # Pre-existing third-party install occupies the name (source/origin are
+        # NOT builtin), exactly as register_builtin_apps() leaves it on stand-down.
+        _write_installed(
+            "shadowed-app",
+            InstalledApp(name="shadowed-app", source="registry:evil", origin="registry"),
+        )
+
+        assert "shadowed-app" not in execution.builtin_app_names()
+
+    def test_builtin_app_names_excludes_unregistered_manifest(self, tmp_path, monkeypatch) -> None:
+        # A shipped manifest with NO installed record at all (registration has
+        # not run, or the record is unreadable) fails closed: the name is not
+        # trusted until a builtin-owned install proves it occupies the slot.
+        import kiro_crew.platform as platform_mod
+        from kiro_crew.apps import execution
+
+        home = tmp_path / "kirocrew-home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        source = tmp_path / "edition-builtins"
+        shipped_root = source / "unregistered-app"
+        shipped_root.mkdir(parents=True)
+        (shipped_root / "app.json").write_text(
+            json.dumps({"name": "unregistered-app"}), encoding="utf-8"
+        )
+        context = SimpleNamespace(apps_loader=SimpleNamespace(manifest_sources=lambda: [source]))
+        monkeypatch.setattr(platform_mod, "current_context", lambda: context)
+
+        assert "unregistered-app" not in execution.builtin_app_names()
+
+    def test_builtin_app_mcp_servers_declared_and_owned(self, tmp_path, monkeypatch) -> None:
+        # builtin_app_mcp_servers emits <app>:<server> for every mcpServers key a
+        # builtin-owned shipped manifest declares; a shadowing user app (install
+        # not builtin-owned) contributes nothing.
+        import kiro_crew.platform as platform_mod
+        from kiro_crew.apps import execution
+        from kiro_crew.apps.manager import InstalledApp, _write_installed
+
+        home = tmp_path / "kirocrew-home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        source = tmp_path / "edition-builtins"
+        # Builtin-owned app declaring two MCP servers.
+        owned_root = source / "edition-app"
+        owned_root.mkdir(parents=True)
+        (owned_root / "app.json").write_text(
+            json.dumps({"name": "edition-app", "mcpServers": {"srv": {}, "srv2": {}}}),
+            encoding="utf-8",
+        )
+        # Shadowed app: shipped manifest declares a server, but the active
+        # install is third-party → must NOT contribute.
+        shadow_root = source / "shadowed-app"
+        shadow_root.mkdir(parents=True)
+        (shadow_root / "app.json").write_text(
+            json.dumps({"name": "shadowed-app", "mcpServers": {"evil": {}}}),
+            encoding="utf-8",
+        )
+        context = SimpleNamespace(apps_loader=SimpleNamespace(manifest_sources=lambda: [source]))
+        monkeypatch.setattr(platform_mod, "current_context", lambda: context)
+
+        _write_installed(
+            "edition-app", InstalledApp(name="edition-app", source="builtin", origin="builtin")
+        )
+        _write_installed(
+            "shadowed-app",
+            InstalledApp(name="shadowed-app", source="registry:evil", origin="registry"),
+        )
+
+        servers = execution.builtin_app_mcp_servers()
+        assert "edition-app:srv" in servers
+        assert "edition-app:srv2" in servers
+        assert "shadowed-app:evil" not in servers  # shadowing install excluded
+
     def test_denial_is_audited_with_action_and_app(self, monkeypatch) -> None:
         from kiro_crew.apps import execution
 

--- a/test/test_app_manager.py
+++ b/test/test_app_manager.py
@@ -16,12 +16,14 @@ from kiro_crew.apps.manager import (
     InstalledApp,
     _read_installed,
     _validate_source_path,
+    _write_installed,
     disable_app,
     enable_app,
     get_app,
     get_app_manifest,
     install_app,
     list_apps,
+    register_external_app,
     uninstall_app,
 )
 
@@ -1677,3 +1679,47 @@ class TestMalformedMcpUrlIsSkippedNotFatal:
             resolve_mcp_backend_url({"crew-companion": {"url": "http://127.0.0.1:7778/mcp"}})
             == "http://127.0.0.1:7778"
         )
+
+
+class TestRegisterExternalDoesNotTakeOverBuiltin:
+    """Self-registration must not overwrite a builtin-owned installed record.
+
+    Otherwise a POST /api/apps/register could downgrade a shipped builtin's
+    provenance to external and hand its execution/auto-approve exemption to a
+    third-party app — while leaving the boot-warmed first-party sets stale.
+    """
+
+    def test_register_external_refuses_builtin_owned_record(self, app_home):
+        # A builtin-owned record exists (as register_builtin_apps would write).
+        _write_installed(
+            "meetings",
+            InstalledApp(
+                name="meetings",
+                version="1.0.0",
+                displayName="Meetings",
+                source="builtin",
+                origin="builtin",
+                lifecycle="locked",
+            ),
+        )
+
+        result = register_external_app(
+            "meetings",
+            version="9.9.9",
+            display_name="Evil Meetings",
+            source="/tmp/evil",
+            origin="external",
+            resources="app",
+            lifecycle="app",
+        )
+
+        assert result.ok is False
+        assert "builtin" in result.error.lower()
+        # Record is untouched — provenance stays builtin, so the warmed
+        # first-party set remains valid.
+        after = _read_installed("meetings")
+        assert after is not None
+        assert after.origin == "builtin"
+        assert after.source == "builtin"
+        assert after.lifecycle == "locked"
+        assert after.version == "1.0.0"

--- a/test/test_governance_chokepoints.py
+++ b/test/test_governance_chokepoints.py
@@ -1321,6 +1321,8 @@ class TestPermissionEventCarriesRawParams:
         client._tool_call_inputs = {}
         client._tool_call_params = {}
         client._tool_call_is_shell = {}
+        client._tool_call_mcp_server = {}
+        client._tool_call_tool_name = {}
         client._permission_options = {}
         # Simulate the ToolCall notification caching structured params...
         client._tool_call_params["tc-1"] = {"path": "/etc/passwd", "command": None}

--- a/test/test_hooks.py
+++ b/test/test_hooks.py
@@ -715,3 +715,265 @@ class TestMutatingKindBeatsTheTitle:
         ctx = MagicMock()
         ctx.hooks = None
         assert _should_auto_approve_spawn(ctx, "spawn_run") is False
+
+
+class TestAppOwnMcpServerAutoApprove:
+    """A FIRST-PARTY (builtin) app agent calling its OWN app-scoped MCP server
+    (identified by the trusted, non-model-authored ``mcp_server_name`` =
+    ``<app>:<server>``) is auto-approved intra-app, without re-widening any host
+    grant, and only AFTER the always-on deny floor + governance (which still
+    win). The decision keys on ``mcp_server_name``, NEVER the LLM-authored title,
+    so a forged ``mcp__…`` title on a shell/host tool cannot win auto-approval. A
+    THIRD-PARTY app's own server is NOT auto-approved."""
+
+    @pytest.fixture
+    def _builtin(self, monkeypatch):
+        """Treat the test app names as first-party builtins whose shipped
+        manifest declares the ``myapp:srv`` MCP server."""
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(
+            hooks_mod,
+            "_is_first_party_app",
+            lambda app: app.casefold() in {"myapp"},
+        )
+        monkeypatch.setattr(
+            hooks_mod, "_BUILTIN_APP_MCP_SERVERS", frozenset({"myapp:srv"})
+        )
+
+    def test_own_server_tool_auto_approved(self, _builtin):
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="myapp",
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="do_thing",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_AUTO_APPROVE
+
+    def test_own_server_without_trusted_tool_name_not_auto_approved(self, _builtin):
+        # No trusted _meta.kiro.toolName → we cannot identify WHICH tool this is
+        # to govern it, so the app-own-server auto-approve does NOT fire; the
+        # call falls through to interactive approval (fail-closed), never a
+        # silent execute. select_tool_title prefers the model's prose
+        # description, so a real MCP call can arrive with a non-canonical title.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Do a thing",
+            app="myapp",
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_own_server_governs_canonical_tool_not_prose_title(self, monkeypatch):
+        # The auto-approve must govern the REAL tool (trusted mcp_server_name +
+        # mcp_tool_name → canonical mcp__server__tool), NOT the LLM prose title.
+        # A per-tool policy denying mcp__myapp:srv__danger must block the call
+        # even though the prose title never matches that policy — closing the
+        # bypass where an own-server auto-approve skipped per-tool governance.
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(hooks_mod, "_is_first_party_app", lambda app: True)
+        monkeypatch.setattr(hooks_mod, "_is_declared_builtin_mcp_server", lambda name: True)
+        seen: list[str] = []
+
+        def fake_gov(ctx, name, *a, **k):
+            seen.append(name)
+            if name == "mcp__myapp:srv__danger":
+                return "Blocked by governance policy: denied"
+            return None
+
+        monkeypatch.setattr(hooks_mod, "_governance_denial", fake_gov)
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Do a risky thing",  # prose title → upstream governance permits it
+            app="myapp",
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="danger",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+        # BOTH governance calls ran: the prose title (permitted) AND the
+        # reconstructed canonical name (denied).
+        assert "Do a risky thing" in seen
+        assert "mcp__myapp:srv__danger" in seen
+
+    def test_own_server_honors_canonical_deny_rule(self, monkeypatch):
+        # The always-on deny floor (auto_deny_tools / denied regexes) must apply
+        # to the canonical mcp__server__tool, not just the prose title. A deny
+        # rule keyed on the canonical name blocks the own-server auto-approve
+        # even when the LLM title is non-canonical prose that never matched it.
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(hooks_mod, "_is_first_party_app", lambda app: True)
+        monkeypatch.setattr(hooks_mod, "_is_declared_builtin_mcp_server", lambda name: True)
+        cfg = HooksConfig(auto_deny_tools=["mcp__myapp:srv__danger"])
+        mgr = HookManager(cfg)
+        r = mgr.on_tool_call(
+            "Do a risky thing",  # prose title: the top-of-method deny check misses it
+            app="myapp",
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="danger",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_undeclared_own_prefix_server_not_auto_approved(self, _builtin):
+        # A ``<app>:``-prefixed server the app's SHIPPED manifest does NOT declare
+        # (e.g. injected into the mutable global MCP config as ``myapp:evil``)
+        # must NOT auto-approve, even though the prefix matches a first-party app
+        # and a trusted tool name is present. Only manifest-declared servers
+        # (here ``myapp:srv``) are trusted → this falls through to interactive
+        # approval (fail-closed).
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:evil__x",
+            app="myapp",
+            mcp_server_name="myapp:evil",
+            mcp_tool_name="x",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_set_builtin_app_mcp_servers_populates_gate(self, monkeypatch):
+        # Boot pushes the shipped-manifest-declared <app>:<server> names in; the
+        # gate then does a pure in-memory, case-insensitive membership test.
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(hooks_mod, "_BUILTIN_APP_MCP_SERVERS", frozenset())
+        hooks_mod.set_builtin_app_mcp_servers(["MyApp:Srv", "other:s", "", None])  # junk ignored
+        assert hooks_mod._is_declared_builtin_mcp_server("myapp:srv") is True  # casefolded
+        assert hooks_mod._is_declared_builtin_mcp_server("OTHER:S") is True
+        assert hooks_mod._is_declared_builtin_mcp_server("myapp:nope") is False
+        assert hooks_mod._is_declared_builtin_mcp_server("") is False  # fail-closed
+
+    def test_forged_title_on_shell_tool_not_approved(self, _builtin):
+        # GPT's attack: a prompt-injected builtin agent titles a Bash call
+        # `mcp__myapp:srv__x`, but a genuine shell tool carries NO server name
+        # (kiro-cli only sets mcp_server_name for MCP-served calls). Keying on the
+        # trusted server name (empty here) means the forged title never wins —
+        # the real command falls through to interactive approval.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__x",
+            app="myapp",
+            mcp_server_name="",
+            command="curl http://example.com/data",
+            is_shell=True,
+            tool_kind="execute",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_forged_title_without_server_name_not_approved(self, _builtin):
+        # Same principle for a non-shell host tool: a forged MCP-looking title
+        # with an empty trusted server name does not auto-approve.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__x", app="myapp", mcp_server_name="", tool_kind="other"
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_third_party_own_server_not_auto_approved(self, monkeypatch):
+        # A third-party app (no builtin provenance) is NOT blanket-trusted.
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(hooks_mod, "_is_first_party_app", lambda app: False)
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="myapp",
+            mcp_server_name="myapp:srv",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_other_apps_server_not_auto_approved(self, _builtin):
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="otherapp",
+            mcp_server_name="myapp:srv",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_blank_app_cannot_match(self, _builtin):
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing", app="", mcp_server_name="myapp:srv", tool_kind="other"
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_host_managed_server_not_matched(self, _builtin):
+        # Host/managed servers (kirocrew-cron) are not `<app>:`-namespaced.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__kirocrew-cron__cron_add",
+            app="myapp",
+            mcp_server_name="kirocrew-cron",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_owning_app_match_is_case_insensitive(self, _builtin):
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__MyApp:srv__do_thing",
+            app="myapp",
+            mcp_server_name="MyApp:srv",
+            mcp_tool_name="do_thing",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_AUTO_APPROVE
+
+    def test_governance_deny_wins_over_own_server(self, monkeypatch):
+        # The app-own-server branch is placed AFTER `_governance_denial`, so a
+        # ceiling/profile that denies the app's own server still blocks it.
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(hooks_mod, "_is_first_party_app", lambda app: True)
+        monkeypatch.setattr(
+            hooks_mod,
+            "_governance_denial",
+            lambda *a, **k: "Blocked by governance policy: denied",
+        )
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="myapp",
+            mcp_server_name="myapp:srv",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_ownership_helper_direct(self):
+        from kiro_crew.hooks import _app_owns_mcp_server
+
+        assert _app_owns_mcp_server("myapp:srv", "myapp") is True
+        assert _app_owns_mcp_server("MyApp:srv", "myapp") is True  # case-insensitive
+        assert _app_owns_mcp_server("other:srv", "myapp") is False
+        assert _app_owns_mcp_server("myapp:srv", "") is False
+        assert _app_owns_mcp_server("", "myapp") is False  # no server → fail closed
+        assert _app_owns_mcp_server("kirocrew-cron", "myapp") is False  # no colon
+
+    def test_set_builtin_app_names_populates_gate(self, monkeypatch):
+        # Boot pushes the builtin names in; the gate then does a pure in-memory,
+        # case-insensitive membership test (no filesystem I/O on the event loop).
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(hooks_mod, "_BUILTIN_APP_NAMES", frozenset())
+        hooks_mod.set_builtin_app_names(["MyApp", "other", "", None])  # junk ignored
+        assert hooks_mod._is_first_party_app("myapp") is True  # casefolded on ingest
+        assert hooks_mod._is_first_party_app("OTHER") is True
+        assert hooks_mod._is_first_party_app("nope") is False
+
+    def test_unwarmed_builtin_set_fails_closed(self, monkeypatch):
+        # Before boot warms the set, provenance is unknown → treated as
+        # third-party (own-server calls prompt, never wrongly auto-approved).
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(hooks_mod, "_BUILTIN_APP_NAMES", frozenset())
+        assert hooks_mod._is_first_party_app("myapp") is False


### PR DESCRIPTION
## Summary

A **builtin** app agent calling its **own** app-scoped MCP server (registered as `<app>:<server>`) is *intra-app* — the app talking to its own gateway-shipped code — not a host surface (fs/network/exec/exfil). This PR auto-approves those calls at the PreToolUse gate so an app whose agent no longer pre-authorizes tools can still invoke its own server without an approval prompt the user can't meaningfully act on.

### Why

The **"no template pre-authorizes tools"** invariant (shipped agents carry no `allowedTools`) is correct for *host* tools (`fs_read`, `web_fetch`, `execute_bash`). But it also routed an app's calls to its **own** declared server through the gate, where they fell through to interactive approval — so the app was effectively blocked from talking to itself, with nothing the user could sensibly decide.

### What

- **`hooks.py`** — new auto-approve branch in `HookManager.on_tool_call`, placed **AFTER** the always-on deny floor and `_governance_denial` (a ceiling/profile can still deny even a builtin's own server, and every sensitive-path / keystone / exfil deny still wins) and **before** the interactive fall-through. Independent of the Normal/Read/Trust tier — that tier governs the *host* tools an app may reach, not the app talking to itself.
  - `_app_owns_mcp_server_tool(title, app)` — pure ownership check: canonicalizes `mcp__<app>:<server>__<tool>` → `@<app>:<server>/<tool>` (reusing `mcp_title_to_ref`) and compares the owning app (segment before the first `:`, case-insensitive) to the calling `app`.
  - `_is_first_party_app(app)` — cached shipped-manifest provenance check (`shipped_builtin_app_root`). **Restricted to builtins on purpose**: only a builtin's server is provably first-party. A third-party app's server is arbitrary installed code whose internals the gate cannot see — its own-server calls are **not** auto-approved; the OS sandbox it runs under + the third-party admission gate bound its behavior instead.
- **`dashboard/chat_runner.py`** — threads the slot's app identity (`slot._app`) into the gate call, which previously passed only the agent name. (The subagent path already threads `app`.)
- **`docs/system-specs/modules/governance.md`** — documents the new step in the gate pipeline order.

### Security notes

- Blank `app` (an ordinary user/host turn) can never match — no app identity to spoof.
- Host/managed servers (`kirocrew-cron`, `playwright`, …) are not `<app>:`-namespaced, so they never match.
- The PreToolUse gate governs the **agent's tool calls**, not an MCP server's internal syscalls; this change removes a prompt that was never a control over server internals, and does not widen any server's actual capabilities.

### Tests

`test/test_hooks.py::TestAppOwnMcpServerAutoApprove` (9 cases): own-server auto-approved; **third-party own-server NOT auto-approved**; other app's server not matched; blank app; host/managed server not matched; case-insensitive owning app; **governance deny wins**; server-level ref; pure ownership-helper unit test. Full `test_hooks.py` suite green (91), flake8 + isort clean.

This is a generic App Kit contract keyed on the `<app>:<server>` convention + shipped-manifest provenance — no per-app special-casing.
