### PR TITLE
fix(mcp-apps): slow the reveal and stop batching so progress reads as drawing

### DIFF
--- a/website/src/components/mcpAppReveal.ts
+++ b/website/src/components/mcpAppReveal.ts
@@ -27,16 +27,19 @@
  *  the pre-existing behaviour.
  */
 
-/** Gap between frames. Matched deliberately to excalidraw's OWN reference
- *  harness (`dev-mock.ts` `streamElements(elements, intervalMs = 120)`), which
- *  posts one element per 120ms with no total budget — that cadence is what the
- *  project's sample recordings show, and its tool description promises
- *  "elements stream in one by one with draw-on animations".
+/** Gap between frames, per element.
  *
- *  A previous revision used a fixed ~700ms TOTAL budget instead. That squeezed
- *  a whole diagram into under a second and batched several elements per frame,
- *  which reads as a flicker rather than a draw-on: the animation was there but
- *  not perceptible. Pace per element, not per payload.
+ *  excalidraw's own reference harness (`dev-mock.ts`
+ *  `streamElements(elements, intervalMs = 120)`) posts one element per 120ms
+ *  with no total budget, and its tool description promises "elements stream in
+ *  one by one with draw-on animations". We deliberately run SLOWER than that
+ *  reference: at 120ms a 10-element diagram was over in 1.0s, which reads as a
+ *  flash rather than as drawing. 200ms keeps each element individually legible.
+ *
+ *  An earlier revision used a fixed ~700ms TOTAL budget instead of a per-element
+ *  step. That squeezed a whole diagram into under a second and batched several
+ *  elements per frame — the animation was present but not perceptible. Pace per
+ *  element, not per payload.
  *
  *  PROVENANCE (this is a sibling checkout, NOT a dependency — nothing in CI can
  *  notice if these upstream numbers change, so they are pinned here by hand):
@@ -61,11 +64,17 @@
  *  would switch the animation off for the very app that implements it. The cost
  *  of shape-gating is that an app which ignores partials still waits out the
  *  reveal for its complete input; REVEAL_MAX_TOTAL_MS bounds that wait. */
-export const REVEAL_STEP_MS = 120
+export const REVEAL_STEP_MS = 200
 /** Ceiling on the whole reveal, so a 400-element diagram does not hold the
  *  app's complete input for the best part of a minute. Past this, frames carry
- *  more than one element each (see prefixLengths). */
-export const REVEAL_MAX_TOTAL_MS = 7_200
+ *  more than one element each (see prefixLengths).
+ *
+ *  Sized so that BATCHING is the exception, not the rule: at 200ms this allows
+ *  80 frames, so every diagram up to ~80 elements reveals exactly one element
+ *  per step. Batching is what actually destroys the sense of progress — two or
+ *  five elements appearing together reads as a jump, not as drawing — so the
+ *  ceiling has to be high enough that realistic diagrams never reach it. */
+export const REVEAL_MAX_TOTAL_MS = 16_000
 /** Frame ceiling implied by the interval and the total cap. */
 export const REVEAL_MAX_FRAMES = Math.floor(REVEAL_MAX_TOTAL_MS / REVEAL_STEP_MS)
 /** Cap on the encoded size of the WHOLE arguments object.

--- a/website/src/test/mcpAppReveal.test.ts
+++ b/website/src/test/mcpAppReveal.test.ts
@@ -112,7 +112,32 @@ describe('planReveal', () => {
     expect(planReveal(circular)).toBeNull()
   })
 
-  it('paces per element at excalidraw\'s reference interval, not a total budget', () => {
+  it('reveals ONE element per frame for realistic diagram sizes', () => {
+    // The property that actually makes the draw-on legible. Batching (two or
+    // more elements appearing in one step) reads as a jump rather than as
+    // drawing, so the frame ceiling must be high enough that diagrams of a
+    // realistic size never reach it. Regression guard: an earlier revision
+    // capped at 60 frames, which started batching at ~62 elements.
+    //
+    // 82 is the exact knee: frames = n-2, capped at REVEAL_MAX_FRAMES.
+    // Past that, batching is accepted deliberately — holding one element per
+    // step for a 300-element diagram would run ~60s.
+    //
+    // Derived from the constant rather than hardcoded, so a legitimate retune
+    // of the step or the total cap does not fail this for no defect.
+    for (const n of [20, 40, REVEAL_MAX_FRAMES, REVEAL_MAX_FRAMES + 2]) {
+      const plan = planReveal({ elements: JSON.stringify(elements(n)) })!
+      const lengths = plan.frames.map(
+        (f) => (JSON.parse(f.elements as string) as unknown[]).length,
+      )
+      const steps = lengths.slice(1).map((len, i) => len - lengths[i])
+      expect(steps.every((s) => s === 1)).toBe(true)
+      // And the last partial stops one short of the whole diagram.
+      expect(lengths[lengths.length - 1]).toBe(n - 1)
+    }
+  })
+
+  it('paces per element rather than squeezing a diagram into a fixed budget', () => {
     // The reference harness (dev-mock streamElements) uses 120ms per element.
     const small = planReveal({ elements: elements(6) })!
     const large = planReveal({ elements: elements(400) })!


### PR DESCRIPTION
# Problem

#1265 made the progressive draw-on visible, but user testing on the live dashboard found it still too quick to follow, and a **complex** diagram appeared to jump rather than draw — elements arriving in clumps instead of one at a time.

# Why it matters

The draw-on is the entire point of the feature. "Technically animating but too fast to read" is close to not having it: the user cannot follow what the assistant is drawing, which is the difference between watching work happen and a picture appearing.

# Fix (symptom → root cause → change)

**Symptom:** small diagrams flash by; large diagrams appear in clumps.

**Two distinct root causes**, measured on the real planner rather than guessed:

1. **Step too short.** 120 ms/element was chosen in #1265 to match excalidraw's reference harness (`dev-mock.ts` `streamElements(elements, intervalMs = 120)`). At that rate a 10-element diagram finishes in **1.0 s** — a flash, not drawing.
2. **Frame ceiling too low — this is the one that made complex diagrams jump.** `REVEAL_MAX_FRAMES = REVEAL_MAX_TOTAL_MS / REVEAL_STEP_MS` was 60, so any diagram past ~62 elements revealed **2+ elements per step**. Slowing the step alone would not have fixed this: the elements would still arrive in clumps, just slower clumps.

**Change:** `REVEAL_STEP_MS` 120 → **200** (deliberately slower than the upstream reference), and `REVEAL_MAX_TOTAL_MS` 7 200 → **16 000**, giving 80 frames.

Measured result — one element per step now holds to exactly **82** elements (`frames = n-2`, capped at 80):

| elements | frames | total | max elements/frame |
|---|---|---|---|
| 20 / 40 / 60 / 80 | 18 / 38 / 58 / 78 | 3.6 / 7.6 / 11.6 / 15.6 s | 1 |
| **82** | 80 | 16.0 s | **1** ← knee |
| 83 → 120 | 80 | 16.0 s | 2 |
| 300 | 80 | 16.0 s | 4 |

Past 82 elements batching resumes **deliberately**: one element per step for a 300-element diagram would run ~60 s.

# Tests

`website/src/test/mcpAppReveal.test.ts` — one new guard, `reveals ONE element per frame for realistic diagram sizes`, which locks the property this PR is actually about (no batching up to the ceiling) rather than the timing numbers. It is **mutation-verified**: reverting `REVEAL_MAX_TOTAL_MS` to `7_200` makes it fail. Bounds are derived from `REVEAL_MAX_FRAMES` rather than hardcoded, so a legitimate future retune does not break it for no defect.

Existing 16 planner tests and 51 frame tests unchanged and passing — the no-complete-array-in-a-partial invariant, prefix start at 2, reduced-motion skip, duplicate-`initialized` guard, and unmount cancellation all still hold.

# Manual verification

**Confirmed working on the live dashboard by the user** — this is the first revision of this feature where the draw-on has actually been observed animating. Worth recording why that took three PRs: the previous round appeared broken because the browser was serving a **stale bundle**; a hard refresh was what revealed the fix. I had put forward a plausible-but-wrong root cause for that (an async render race inside excalidraw's `renderSvgPreview`) — it was a code reading, not an observation, and it was incorrect.

Gates: `tsc --noEmit` ✓, vitest 623 files / 8099 tests ✓, `isort` / `flake8` / `mypy` (627 files) ✓ — no Python touched.

# Screenshots

Not attached. This is a motion change, so a still frame is not valid evidence and a GIF is the correct artifact; it needs a live dashboard capture of `excalidraw/create_view`. The behaviour **is** user-confirmed live, which is stronger than a screenshot, but weaker than a recording a reviewer can watch. Carried over from #1143/#1265.

# Known limitations, deliberately shipped

Both were raised by the local Opus review mirror as advisory (nothing blocking), and both are stated here rather than left for a reviewer to find:

1. **A 16 s auto-starting animation has no skip control.** The only escape is `prefers-reduced-motion`, which is OS-level and all-or-nothing (it suppresses the feature entirely). WCAG 2.2.2 uses a 5 s threshold for auto-starting motion needing a pause/stop mechanism. There is a defensible argument that this motion is the *primary content* rather than parallel decoration, but the honest fix is a click-to-complete affordance in `McpAppFrame.tsx` — out of scope here because it needs a new visible string across every locale. Nearest in-repo precedent, `ThemeExperienceLayer.tsx`, pairs `prefers-reduced-motion` with a user mute toggle, which argues for adding one.
2. **The reveal is gated on argument *shape*, not app capability**, so a non-diagram tool whose arguments merely contain a ≥3-item array also has its complete `tool-input`/`tool-result` withheld — up to 16 s. `pdf::interact` with a `commands` batch is the concrete candidate. Whether that app ignores `tool-input-partial` could not be verified (external server, not in this repo), so the harm is inferred rather than confirmed. A capability gate is genuinely unavailable: excalidraw declares `capabilities: {}` while implementing `ontoolinputpartial`, so gating on a declared capability would disable the animation for its only consumer. This is documented in the code.

Note the pattern: this is the **third** PR turning these same two constants (0.7 s → 7.2 s → 16 s). Both the review mirror and I read that as a signal that the *shape* — a fixed step plus a hard ceiling, which also creates the visible knee at 82 — is what wants revisiting, not the values. A target-total-duration or min/max envelope would remove the knee. That is a new mechanism and deliberately not in this PR.
