### PR TITLE
fix(backend): attribute messaging channels in SEL + totalize MCP cron create (#815, #391)

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -1116,6 +1116,9 @@ class CronService:
         agent_sequence: list[str] | None = None,
         env: dict[str, str] | None = None,
         persistent_session: bool = True,
+        session_key: str = "",
+        minimal_context: bool = False,
+        timeout: int = 0,
     ) -> CronJob:
         """Add a new job. Provide one of ``every_secs``, ``at_ts``, or ``cron_expr``.
 
@@ -1132,7 +1135,10 @@ class CronService:
         (``agent_id``/``model``/``silent``/``strict_schedule``/``hide_in_chat``,
         ``command``/``script``/``agent_sequence``/``env``/``persistent_session``)
         into the same single locked build+persist, totalizing over all fields
-        the "fully-formed on first save" invariant.
+        into the same single locked build+persist, totalizing over all fields
+        the "fully-formed on first save" invariant. The MCP create path folds
+        ``session_key``/``minimal_context``/``timeout`` here too, replacing its
+        former create-then-mutate plus second unlocked ``_save()``.
 
         Synchronous variant: the lock+save runs INLINE and so must only be
         called from a loop-less context (CLI / MCP server process / a worker
@@ -1167,6 +1173,9 @@ class CronService:
             agent_sequence=agent_sequence,
             env=env,
             persistent_session=persistent_session,
+            session_key=session_key,
+            minimal_context=minimal_context,
+            timeout=timeout,
         )
         self._persist_add_locked(job)
         self._arm_timer()
@@ -1214,6 +1223,9 @@ class CronService:
         agent_sequence: list[str] | None = None,
         env: dict[str, str] | None = None,
         persistent_session: bool = True,
+        session_key: str = "",
+        minimal_context: bool = False,
+        timeout: int = 0,
     ) -> CronJob:
         """Validate inputs and construct the :class:`CronJob` (no I/O, no lock).
 
@@ -1273,6 +1285,9 @@ class CronService:
             agent_sequence=list(agent_sequence) if agent_sequence else [],
             env=dict(env) if env else {},
             persistent_session=persistent_session,
+            session_key=session_key,
+            minimal_context=minimal_context,
+            timeout=timeout,
         )
 
     def _persist_add_locked(self, job: CronJob) -> None:
@@ -1313,6 +1328,9 @@ class CronService:
         agent_sequence: list[str] | None = None,
         env: dict[str, str] | None = None,
         persistent_session: bool = True,
+        session_key: str = "",
+        minimal_context: bool = False,
+        timeout: int = 0,
     ) -> CronJob:
         """Event-loop-safe :meth:`add_job`: the lock+save runs off the loop.
 
@@ -1355,6 +1373,9 @@ class CronService:
             agent_sequence=agent_sequence,
             env=env,
             persistent_session=persistent_session,
+            session_key=session_key,
+            minimal_context=minimal_context,
+            timeout=timeout,
         )
         await asyncio.to_thread(self._persist_add_locked, job)
         self._arm_timer()

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -1026,8 +1026,24 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             for d in skip_dates:
                 if not is_valid_skip_date(d):
                     return f"Error: invalid skip_date: {redact(str(d))!r} (expected YYYY-MM-DD)"
+        thread_ts = (args.get("thread_ts") or "").strip() or None
+        # Resolve EVERY first-save field before the single locked add_job() so
+        # the job is persisted fully-formed in one transaction (#391) -- no
+        # create-then-mutate + second unlocked _save() window that a crash or a
+        # concurrent reader could capture as a job missing its agent_id/model.
+        # Bool fields are enforced by validation.py CRON_ADD_SCHEMA (FieldSpec
+        # ... bool), so a non-bool falls back to the field default rather than
+        # being coerced from a raw-truthy value.
+        agent = args.get("agent", "")
+        silent = args.get("silent", False)
+        approval_mode = args.get("approval_mode", "")
+        session_key = _resolve_session_key()
+        persistent_session = args.get("persistent_session")
+        minimal_context = args.get("minimal_context")
+        hide_in_chat = args.get("hide_in_chat")
+        strict_schedule = args.get("strict_schedule")
+        timeout_val = args.get("timeout", 0)
         try:
-            thread_ts = (args.get("thread_ts") or "").strip() or None
             job = svc.add_job(
                 name=n,
                 message=msg,
@@ -1039,66 +1055,25 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 delete_after_run=bool(at_ts),
                 timezone=tz,
                 skip_dates=skip_dates,
+                agent_id=agent or "",
+                approval_mode=approval_mode or "",
+                model=model_arg,
+                silent=bool(silent),
+                strict_schedule=strict_schedule if isinstance(strict_schedule, bool) else False,
+                hide_in_chat=hide_in_chat if isinstance(hide_in_chat, bool) else False,
+                command=command or "",
+                script=script or "",
+                persistent_session=(
+                    persistent_session if isinstance(persistent_session, bool) else True
+                ),
+                session_key=session_key,
+                minimal_context=minimal_context if isinstance(minimal_context, bool) else False,
+                timeout=timeout_val or 0,
             )
         except CronStoreBusy:
             return "Error: cron store busy, please retry"
         except ValueError as e:
             return f"Error: {e}"
-        agent = args.get("agent", "")
-        silent = args.get("silent", False)
-        approval_mode = args.get("approval_mode", "")
-        session_key = _resolve_session_key()
-        if agent:
-            job.agent_id = agent
-        if silent:
-            job.silent = True
-        if approval_mode:
-            job.approval_mode = approval_mode
-        if model_arg:
-            job.model = model_arg
-        if session_key:
-            job.session_key = session_key
-        # timezone/skip_dates are persisted by add_job's first _save() above.
-        # persistent_session: only override the default (True) when explicitly provided.
-        # Type is enforced by validation.py CRON_ADD_SCHEMA (FieldSpec ... bool),
-        # so we do NOT accept raw-truthy values here — only a real bool.
-        persistent_session = args.get("persistent_session")
-        persistent_session_explicit = isinstance(persistent_session, bool)
-        if isinstance(persistent_session, bool):
-            job.persistent_session = persistent_session
-        minimal_context = args.get("minimal_context")
-        minimal_context_explicit = isinstance(minimal_context, bool)
-        if isinstance(minimal_context, bool):
-            job.minimal_context = minimal_context
-        hide_in_chat = args.get("hide_in_chat")
-        hide_in_chat_explicit = isinstance(hide_in_chat, bool)
-        if isinstance(hide_in_chat, bool):
-            job.hide_in_chat = hide_in_chat
-        strict_schedule = args.get("strict_schedule")
-        strict_schedule_explicit = isinstance(strict_schedule, bool)
-        if isinstance(strict_schedule, bool):
-            job.strict_schedule = strict_schedule
-        if script:
-            job.script = script
-        if command:
-            job.command = command
-        timeout_val = args.get("timeout", 0)
-        if timeout_val:
-            job.timeout = timeout_val
-        if (
-            agent
-            or silent
-            or approval_mode
-            or model_arg
-            or session_key
-            or persistent_session_explicit
-            or minimal_context_explicit
-            or hide_in_chat_explicit
-            or strict_schedule_explicit
-            or script
-            or command
-        ):
-            svc._save()
         sched_str = format_schedule(job.schedule)
         sel().log_api_access(
             caller="mcp",

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -685,6 +685,12 @@ _AUDIT_SURFACE_DETAIL: dict[str, str] = {
     "background": "Background maintenance work",
     "heartbeat": "Liveness / watchdog activity",
     "cli": "Terminal chat sessions",
+    "discord": "Discord messages, approvals, and owner-authorization decisions",
+    "telegram": "Telegram messages, approvals, and owner-authorization decisions",
+    "wecom": "WeCom messages, approvals, and owner-authorization decisions",
+    "weixin": "Weixin messages, approvals, and owner-authorization decisions",
+    "webex": "Webex messages, approvals, and owner-authorization decisions",
+    "teams": "Microsoft Teams messages, approvals, and owner-authorization decisions",
     "host": "In-process governance checks not driven by a user-facing surface",
     "unknown": "Events that carry no surface signal (classified rather than misattributed)",
 }

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -885,6 +885,24 @@ def _infer_source(session_key: str) -> str:
         return "heartbeat"
     if session_key == "cli_chat":
         return "cli"
+    # Namespaced messaging channels carry their transport as the first key
+    # segment (``{channel}:{agent}:...`` per messaging/link.build_dm_session_key,
+    # or a ``{channel}_`` prefix). Match the SAME set context._runtime_display_name
+    # uses (#979) so SEL attribution and the display name stay in lockstep.
+    # Bare/legacy Slack keys (thread timestamps like ``C08...:thread``) have no
+    # namespace prefix and correctly retain the historical ``slack`` fallback.
+    lowered_key = session_key.lower()
+    for namespace in (
+        "discord",
+        "telegram",
+        "wecom",
+        "weixin",
+        "webex",
+        "teams",
+        "slack",
+    ):
+        if lowered_key.startswith((f"{namespace}:", f"{namespace}_")):
+            return namespace
     return "slack"
 
 
@@ -898,6 +916,12 @@ _AUDIT_SOURCES: tuple[str, ...] = (
     "background",
     "heartbeat",
     "cli",
+    "discord",
+    "telegram",
+    "wecom",
+    "weixin",
+    "webex",
+    "teams",
     "slack",
 )
 

--- a/test/test_cron_approval_mode.py
+++ b/test/test_cron_approval_mode.py
@@ -243,7 +243,9 @@ class TestCronApprovalModeValidation:
                 {"name": "test", "message": "go", "every": 300, "approval_mode": "auto"},
             )
         assert "v1" in result
-        assert job.approval_mode == "auto"
+        # #391: approval_mode is folded into add_job's single locked save, not
+        # mutated onto the returned job -- assert it was passed INTO add_job.
+        assert mock_svc.return_value.add_job.call_args.kwargs["approval_mode"] == "auto"
 
     def test_valid_empty(self) -> None:
         with patch("kiro_crew.mcp_cron.CronService") as mock_svc:

--- a/test/test_mcp_cron.py
+++ b/test/test_mcp_cron.py
@@ -216,3 +216,93 @@ class TestCronAddModel:
         svc2 = CronService(base_dir=tmp_path)
         updated = next(j for j in svc2.list_jobs() if j.id == job.id)
         assert updated.model == "glm-4.7"
+
+
+class TestCronAddPersistenceOwner:
+    """#391: the MCP create path folds ALL first-save fields into add_job's
+    single locked _save(), instead of the old create-then-mutate + second
+    unlocked _save() (which could persist a job missing its agent_id/model)."""
+
+    def test_cron_add_persists_all_fields_in_one_save(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:slot9")
+        monkeypatch.delenv("KIROCREW_CHANNEL_ID", raising=False)
+
+        from kiro_crew.cron import CronService
+
+        # Count _save() calls made during the create. The old fold path saved
+        # TWICE (add_job's first save + the post-hoc svc._save()); the fix saves
+        # exactly once on a fresh (empty) home.
+        save_calls = {"n": 0}
+        orig_save = CronService._save
+
+        def counting_save(self):
+            save_calls["n"] += 1
+            return orig_save(self)
+
+        monkeypatch.setattr(CronService, "_save", counting_save)
+
+        job_name = f"owner-{uuid.uuid4().hex[:8]}"
+        result = _call_tool_inner(
+            "cron_add",
+            {
+                "name": job_name,
+                "message": "go",
+                "every": 120,
+                "agent": "kirocrew",
+                "model": "sonnet",
+                "silent": True,
+                "approval_mode": "auto",
+                "minimal_context": True,
+                "timeout": 45,
+            },
+        )
+        assert "Added job" in result
+        # Single locked persist — the second unlocked _save() is gone.
+        assert save_calls["n"] == 1
+
+        svc = CronService(base_dir=tmp_path)
+        matching = [j for j in svc.list_jobs() if j.name == job_name]
+        assert len(matching) == 1
+        job = matching[0]
+        assert job.agent_id == "kirocrew"
+        assert job.model != ""
+        assert job.silent is True
+        assert job.approval_mode == "auto"
+        assert job.minimal_context is True
+        assert job.timeout == 45
+        assert job.session_key == "dashboard:slot9"
+
+    def test_cron_add_explicit_null_fields_do_not_abort(self, monkeypatch, tmp_path):
+        """An explicit null optional field (normalized to None by validate_field)
+        must not abort creation or persist JSON null -- the always-pass fold
+        normalizes falsy values back to '' (regression guard for the
+        conditional-set -> always-pass conversion)."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        monkeypatch.delenv("KIROCREW_CHANNEL_ID", raising=False)
+
+        job_name = f"nullfields-{uuid.uuid4().hex[:8]}"
+        result = _call_tool_inner(
+            "cron_add",
+            {
+                "name": job_name,
+                "message": "go",
+                "every": 120,
+                "approval_mode": None,
+                "agent": None,
+                "command": None,
+                "script": None,
+            },
+        )
+        assert "Added job" in result
+        assert "Invalid approval_mode" not in result
+
+        from kiro_crew.cron import CronService
+
+        matching = [j for j in CronService(base_dir=tmp_path).list_jobs() if j.name == job_name]
+        assert len(matching) == 1
+        job = matching[0]
+        assert job.approval_mode == ""
+        assert job.agent_id == ""
+        assert job.command == ""
+        assert job.script == ""

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -578,6 +578,12 @@ class TestOmissionDetection:
             "_bg": "background",
             "_hb": "heartbeat",
             "cli_chat": "cli",
+            "discord:1": "discord",
+            "telegram:1": "telegram",
+            "wecom:1": "wecom",
+            "weixin:1": "weixin",
+            "webex:1": "webex",
+            "teams:1": "teams",
             "C123:456.789": "slack",
         }
         for key, expected in probes.items():

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -349,6 +349,18 @@ class TestInferSource:
         ("taskrunner:spec1", "taskrunner"),
         ("_bg", "background"),
         ("cli_chat", "cli"),
+        # Namespaced messaging channels are attributed to their transport (#815),
+        # matching context._runtime_display_name's set (#979) — via ``{ns}:`` …
+        ("discord:123:kirocrew", "discord"),
+        ("telegram:456", "telegram"),
+        ("wecom:c1", "wecom"),
+        ("weixin:c1", "weixin"),
+        ("webex:c1", "webex"),
+        ("teams:c1", "teams"),
+        ("slack:C08:thread", "slack"),
+        # … or the ``{ns}_`` prefix form.
+        ("discord_123", "discord"),
+        # Bare/legacy Slack keys (thread timestamps, no namespace) stay "slack".
         ("C08HZAWV4TP:thread123", "slack"),
         ("random_key", "slack"),
         # An empty key carries no surface signal → "unknown", NOT "slack"

--- a/test/test_validation_user_actions.py
+++ b/test/test_validation_user_actions.py
@@ -294,8 +294,9 @@ class TestMcpCronUserActions:
                 },
             )
         assert "ghi789" in result
-        # Verify agent was set on the job
-        assert job.agent_id == "customer360-code-agent"
+        # #391: the field is now folded into add_job's single locked save, not
+        # mutated onto the job afterward -- assert it was passed INTO add_job.
+        assert svc.add_job.call_args.kwargs["agent_id"] == "customer360-code-agent"
 
     # -- cron_add with approval_mode: "auto-approve tools for this cron" --
 
@@ -324,8 +325,9 @@ class TestMcpCronUserActions:
                 },
             )
         assert "appr001" in result
-        assert job.agent_id == "gaia-cr-review"
-        assert job.approval_mode == "auto"
+        # #391: folded into add_job's single locked save (not post-hoc mutation).
+        assert svc.add_job.call_args.kwargs["agent_id"] == "gaia-cr-review"
+        assert svc.add_job.call_args.kwargs["approval_mode"] == "auto"
 
     def test_add_with_approval_mode_empty(self):
         with patch("kiro_crew.mcp_cron.CronService") as mock_svc:


### PR DESCRIPTION
## Problem

Two backend "tail" defects left behind by earlier merges:

- **#815 — SEL source attribution.** `sel._infer_source` classified any session key that wasn't dashboard/cron/subagent/taskrunner/cli/host as `"slack"`. After #979 fixed the *display* half, the *audit* half still stamped every Discord/Telegram/WeCom/Weixin/Webex/Teams event `source="slack"`, so the security-posture surface inventory both **under-counted and mislabeled** those channels.
- **#391 — MCP cron create invariant.** The MCP `cron_add` path built a *partial* job via `add_job(...)`, then mutated ~12 fields (`agent_id`, `model`, `session_key`, `silent`, …) directly on the object and did a **second, UNLOCKED `_save()`**. A crash or a concurrent store reader between the two saves could persist a job missing its `agent_id`/`model` — i.e. running under the wrong agent. The dashboard path was already totalized (PR #331); the MCP path was never converted.

## Why it matters

- #815: the audit surface is a security control — a mislabeled/under-counted channel means governance events for five real transports are attributed to Slack, degrading the posture inventory's truthfulness.
- #391: a half-populated persisted job is a correctness/safety hazard (wrong-agent execution, lost first-save fields) that the single-locked-write invariant exists to prevent.

## Fix (symptoms → root cause → change)

**#815** — root cause: `_infer_source` had no namespace-prefix branch and fell through to a bare `return "slack"`. Change: mirror `context._runtime_display_name`'s exact classifier (#979) — match `{ns}:`/`{ns}_` for `discord/telegram/wecom/weixin/webex/teams/slack` before the fallback — so SEL attribution and the display name stay in lockstep and cannot drift apart. Extend `_AUDIT_SOURCES` with the five channels and add a human gloss for each in `security_posture._AUDIT_SURFACE_DETAIL` (the drift-guard test requires every audited source to carry one). **Legacy bare-Slack thread-timestamp keys (`C08…:thread`) have no namespace prefix and deliberately keep the `slack` fallback** — pinned by existing tests.

**#391** — root cause: the persistence owner (`_build_job`/`add_job`/`add_job_async`) never gained `session_key`/`minimal_context`/`timeout` params (the dashboard path didn't need them), forcing the MCP path into create-then-mutate + a second unlocked save. Change: add those three params to all three owner functions and thread them into the single `CronJob(...)` build; on the MCP path resolve every first-save field up front, pass the full set into the single locked `svc.add_job(...)`, and **delete the post-hoc fold block + second `_save()`**. Sync `add_job` is retained (the MCP server process is loop-less; the `_file_lock` guard already rejects sync on a running loop).

## Tests

- `test/test_sel.py::TestInferSource` — added a parametrized case per new channel (`{ns}:` and `{ns}_` forms) plus retained `("C08…:thread","slack")` / `("random_key","slack")` to lock the legacy fallback.
- `test/test_security_posture.py::test_audit_surfaces_are_derived_from_the_sel_vocabulary` — extended the `probes` dict so its `set(probes.values()) == set(audit_sources())` and per-source-gloss assertions cover the new channels.
- `test/test_mcp_cron.py::TestCronAddPersistenceOwner::test_cron_add_persists_all_fields_in_one_save` — counts `CronService._save` (asserts **exactly 1** on a fresh home, proving the second save is gone) and reloads the job to assert `agent_id`/`model`/`silent`/`approval_mode`/`minimal_context`/`timeout`/`session_key` all persisted.

## Manual verification

N/A — unit coverage sufficient. Backend-only change; local gates green (targeted + affected suites: `test_sel`, `test_security_posture`, `test_mcp_cron`, `test_cron`, `test_dashboard_cron_concurrent_create`, `test_cron_minimal_context`, `test_mcp_cron_persistent_session`, `test_cron_dedup` — 291 pass) plus isort / flake8 / mypy clean.

## Screenshots

N/A — no user-visible UI change (backend attribution + cron persistence only).
