### PR TITLE
fix: pool package-prefixed MCP-gateway agents + share profile slug constant (#925, #557)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -2124,7 +2124,7 @@ class AcpClient:
             # how pooling takes effect without writing a spec anywhere.
             "mcpServers": [
                 *self._claude_session_mcp_servers(),
-                *self._pooled_mcp_servers(),
+                *(await asyncio.to_thread(self._pooled_mcp_servers)),
             ],
         }
         if self._is_claude:
@@ -2237,7 +2237,7 @@ class AcpClient:
                         # resumed session keeps talking to the broker.
                         "mcpServers": [
                             *self._claude_session_mcp_servers(),
-                            *self._pooled_mcp_servers(),
+                            *(await asyncio.to_thread(self._pooled_mcp_servers)),
                         ],
                     }
                     if self._is_claude:

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -1112,8 +1112,10 @@ class AcpRuntime:
         # in the agent spec, so this is what actually pools the servers — no file
         # is written anywhere. Empty when the gateway is disabled.
         if mcp_servers is None:
-            mcp_servers = pooled_session_servers(
-                self._mcp_gateway_overlay, agent or self._agent
+            # Resolve the overlay off the event loop: the lookup stats/reads
+            # files, and blocking the loop stalls every other session's I/O.
+            mcp_servers = await asyncio.to_thread(
+                pooled_session_servers, self._mcp_gateway_overlay, agent or self._agent
             )
         params = build_session_new_params(
             cwd if cwd else self._work_dir,

--- a/src/kiro_crew/mcp_gateway/session_servers.py
+++ b/src/kiro_crew/mcp_gateway/session_servers.py
@@ -92,6 +92,60 @@ def _acp_server_entry(
     return shaped
 
 
+def _load_overlay_for_agent(overlay_dir: Path, agent: str) -> dict[str, Any] | None:
+    """Locate the rewritten overlay spec for *agent*, or ``None``.
+
+    Package-installed agents are written to the overlay directory under a
+    package-qualified filename (e.g. ``Pkg-gpu-dev.json``) while the session
+    requests them by bare name (``gpu-dev``). A filename-only lookup therefore
+    silently misses and disables pooling for every packaged agent. Match the
+    bare filename first (fast path for unprefixed agents), then fall back to a
+    filename-qualified overlay (``*<agent>.json``) whose parsed ``name`` equals
+    *agent*. (#925)
+
+    Fail-soft: an unreadable/malformed overlay yields ``None`` (unpooled), never
+    an exception.
+    """
+    direct = overlay_dir / f"{agent}.json"
+    try:
+        return json.loads(direct.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        pass  # not emitted under the bare name — try a name-field match below
+    except (OSError, ValueError):
+        logger.warning("MCP-gateway: cannot read overlay spec %s", direct, exc_info=True)
+        return None
+    # Fallback: a package-installed agent's overlay keeps its package-qualified
+    # source filename (e.g. ``Pkg-gpu-dev.json``) while the session requests it
+    # by bare name. Restrict the scan to filenames that END with the agent name
+    # so at most a handful of plausible candidates are read on the async
+    # session-creation path — never the whole directory — then confirm each
+    # against the authoritative ``name`` field so a coincidental filename suffix
+    # can't mismatch.
+    try:
+        candidates = sorted(overlay_dir.glob(f"*{agent}.json"))
+    except (OSError, ValueError):
+        # ValueError: an agent name carrying glob metacharacters (e.g. ``*`` ->
+        # ``**.json``) is an invalid pattern; fail soft to unpooled rather than
+        # aborting session creation.
+        return None
+    for path in candidates:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, dict) and data.get("name") == agent:
+            return data
+    if candidates:
+        # Distinguish "packaged agent not found" from "gateway disabled" / "agent
+        # declared nothing poolable" for an operator debugging a low backend count.
+        logger.debug(
+            "MCP-gateway: no overlay with name %r among %d filename-qualified "
+            "candidate(s) in %s; session runs unpooled",
+            agent, len(candidates), overlay_dir,
+        )
+    return None
+
+
 def pooled_session_servers(
     overlay_dir: str | Path | None,
     agent: str | None,
@@ -118,16 +172,7 @@ def pooled_session_servers(
     """
     if not overlay_dir or not agent:
         return []
-    src = Path(overlay_dir) / f"{agent}.json"
-    try:
-        spec = json.loads(src.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        # Normal for an agent the rewriter did not emit (e.g. it declared no
-        # poolable servers at all) — not worth a warning.
-        return []
-    except (OSError, ValueError):
-        logger.warning("MCP-gateway: cannot read overlay spec %s", src, exc_info=True)
-        return []
+    spec = _load_overlay_for_agent(Path(overlay_dir), agent)
     if not isinstance(spec, dict):
         return []
     servers = spec.get("mcpServers")

--- a/test/test_session_servers_name_match_925.py
+++ b/test/test_session_servers_name_match_925.py
@@ -1,0 +1,54 @@
+"""Regression: package-prefixed agents are matched by overlay `name` (#925).
+
+Package-installed agents are written under a package-qualified filename while
+the session requests them by bare name, so a filename-only lookup silently
+missed and disabled pooling. `_load_overlay_for_agent` now falls back to the
+overlay whose parsed `name` equals the requested agent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kiro_crew.mcp_gateway.session_servers import _load_overlay_for_agent
+
+
+def test_bare_filename_fast_path(tmp_path: Path) -> None:
+    spec = {"name": "gpu-dev", "mcpServers": {}}
+    (tmp_path / "gpu-dev.json").write_text(json.dumps(spec), encoding="utf-8")
+    assert _load_overlay_for_agent(tmp_path, "gpu-dev") == spec
+
+
+def test_package_qualified_matched_by_name(tmp_path: Path) -> None:
+    spec = {"name": "gpu-dev", "mcpServers": {"x": {}}}
+    (tmp_path / "AIPowerUserCapabilities-gpu-dev.json").write_text(
+        json.dumps(spec), encoding="utf-8"
+    )
+    got = _load_overlay_for_agent(tmp_path, "gpu-dev")
+    assert got is not None and got["name"] == "gpu-dev"
+
+
+def test_no_matching_overlay_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "Other-thing.json").write_text(
+        json.dumps({"name": "thing", "mcpServers": {}}), encoding="utf-8"
+    )
+    assert _load_overlay_for_agent(tmp_path, "gpu-dev") is None
+
+
+def test_empty_dir_returns_none(tmp_path: Path) -> None:
+    assert _load_overlay_for_agent(tmp_path, "gpu-dev") is None
+
+
+def test_glob_metacharacter_agent_fails_soft(tmp_path: Path) -> None:
+    """An agent name with glob metacharacters must not raise (issue #925).
+
+    ``Path.glob('**.json')`` raises ``ValueError``; the lookup runs on the
+    session-creation path, so it must fail soft to ``None`` (unpooled) rather
+    than aborting the turn.
+    """
+    (tmp_path / "star.json").write_text(
+        json.dumps({"name": "star", "mcpServers": {}}), encoding="utf-8"
+    )
+    assert _load_overlay_for_agent(tmp_path, "*") is None
+    assert _load_overlay_for_agent(tmp_path, "**") is None

--- a/website/src/components/OnboardingFlow.tsx
+++ b/website/src/components/OnboardingFlow.tsx
@@ -14,6 +14,7 @@ import {
 } from './PrivacyDisclosure'
 import { api } from '../api/client'
 import { capRoleOther, clampRoleOther } from '../lib/userProfile'
+import { ROLE_SLUGS, TECH_SLUGS } from '../lib/profileOptions'
 
 import { i18nT } from '../i18n/t'
 /**
@@ -96,19 +97,8 @@ const LAST_POP_STEP = 5
 // dashboard.user_role / dashboard.user_technical_level enums in the config
 // PATCH allowlist (handlers/core.py) and mapped to prompt descriptions in
 // context.py — keep all three in sync.
-const ROLE_OPTIONS: ReadonlyArray<{ value: string }> = [
-  { value: 'developer' },
-  { value: 'designer' },
-  { value: 'product-manager' },
-  { value: 'data-ml' },
-  { value: 'it-ops' },
-  { value: 'other' },
-]
-const TECH_OPTIONS: ReadonlyArray<{ value: string }> = [
-  { value: 'codes' },
-  { value: 'somewhat-technical' },
-  { value: 'non-technical' },
-]
+const ROLE_OPTIONS: ReadonlyArray<{ value: string }> = ROLE_SLUGS.map(value => ({ value }))
+const TECH_OPTIONS: ReadonlyArray<{ value: string }> = TECH_SLUGS.map(value => ({ value }))
 
 /**
  * Catalog KEY for each chip's visible text, keyed by the enum slug above. Flat

--- a/website/src/lib/profileOptions.ts
+++ b/website/src/lib/profileOptions.ts
@@ -1,0 +1,20 @@
+// Canonical user-profile option slugs, shared by the onboarding flow (step 2)
+// and Settings > Chat so the two UIs cannot drift. These slugs are the enum
+// values in the dashboard.user_role / dashboard.user_technical_level config
+// PATCH allowlist (backend `dashboard/handlers/core.py`) and are mapped to
+// prompt descriptions in `context.py` — keep all in sync. Visible labels stay
+// per-surface (each screen resolves them through its own i18n keys). (#557)
+export const ROLE_SLUGS = [
+  'developer',
+  'designer',
+  'product-manager',
+  'data-ml',
+  'it-ops',
+  'other',
+] as const
+
+export const TECH_SLUGS = [
+  'codes',
+  'somewhat-technical',
+  'non-technical',
+] as const

--- a/website/src/pages/settings/ChatPanel.tsx
+++ b/website/src/pages/settings/ChatPanel.tsx
@@ -8,6 +8,7 @@ import { modelListRefetchInterval } from '../../providers/modelListHealth'
 import { EFFORT_LEVELS, effortLabel, modelSupportsEffort } from '../../lib/effort'
 import { isMac } from '../../utils/platform'
 import { capRoleOther, clampRoleOther } from '../../lib/userProfile'
+import { ROLE_SLUGS, TECH_SLUGS } from '../../lib/profileOptions'
 
 import { i18nT } from '../../i18n/t'
 /**
@@ -33,7 +34,7 @@ const COMPACT_OPTIONS = ['20', '40', '60', '80', '90']
 const COMPACT_LABELS = ['20% (aggressive)', '40%', '60%', '80%', '90% (default)']
 
 // About You — slugs shared with onboarding step 2 and context.py's prompt maps.
-const ROLE_OPTIONS = ['', 'developer', 'designer', 'product-manager', 'data-ml', 'it-ops', 'other']
+const ROLE_OPTIONS = ['', ...ROLE_SLUGS]
 function roleLabels(): string[] {
   return [
     i18nT('pages.settings.chatPanel.not_set'),
@@ -45,7 +46,7 @@ function roleLabels(): string[] {
     i18nT('pages.settings.chatPanel.other'),
   ]
 }
-const TECH_OPTIONS = ['', 'codes', 'somewhat-technical', 'non-technical']
+const TECH_OPTIONS = ['', ...TECH_SLUGS]
 function techLabels(): string[] {
   return [
     i18nT('pages.settings.chatPanel.not_set'),


### PR DESCRIPTION
## What & why
Two related fixes, folded into one PR. (Originally a 4-issue cluster; **#490 and #1086 were dropped after main's PR #1314 landed equivalent `read_bounded_json` + `_persist_turn_row` helpers** — this PR is rebased onto that and carries only the two issues still unique to it.)

### #925 — pooling silently skipped for package-prefixed agents (behavioral fix)
`session_servers.py` looked up the MCP-gateway overlay only by bare `<agent>.json`, but package-installed agents keep a package-qualified filename (`Pkg-gpu-dev.json`) while requesting by bare name — so every packaged agent silently ran **unpooled**. Fix: match by the parsed `name` field (bare-filename fast path → a **bounded, glob-metacharacter-safe** `*<agent>.json` fallback confirmed against `name`), and resolve the overlay **off the event loop** via `asyncio.to_thread` at the two async session-creation sites (`acp/runtime.py`, `acp/client.py`) so the filesystem access never blocks the loop. Fail-soft (`None` → unpooled) preserved.

### #557 — shared profile slug constant
`OnboardingFlow` and Settings `ChatPanel` each hardcoded the same role/tech enum slug lists (which must match the backend `dashboard.user_role`/`user_technical_level` allowlist in `handlers/core.py` + `context.py`). Extracted the canonical slugs into `website/src/lib/profileOptions.ts`, consumed by both so they can't drift. Labels keep each surface's existing i18n — **no new i18n keys**.

## Tests
- Backend: `isort`/`flake8`/`mypy` clean; `pytest` green for `test_session_servers_name_match_925.py` (new), `test_mcp_gateway_pool_integ.py`, `test_acp_runtime.py`, `test_acp_client.py`.
- Frontend: `tsc -b` clean; `vitest` green; `i18n:check` vs base — `[added-lines] 0`, no new keys.

## Manual verification
N/A — backend is unit-covered; the #557 change is slug plumbing with no visual change (labels render identically via the existing i18n keys).

## Issues
Closes #925, #557. (#490 and #1086 resolved on main via #1314.)
