### PR TITLE
fix(chat): resolve the real context window on a model switch, not one turn later

### DIFF
--- a/website/src/providers/adapters/acp.ts
+++ b/website/src/providers/adapters/acp.ts
@@ -18,6 +18,25 @@ const MODEL_TOKENS: Record<string, number> = Object.fromEntries(
 )
 const DEFAULT_CONTEXT = 200_000
 
+// Windows learned from GET /api/models, which enriches every row with the
+// backend's centrally-resolved `context_window` (kiro `--list-models` cache >
+// static registry > supplementary map > [1m] heuristic). That resolver knows
+// every model kiro actually serves; the bundled static map above is a 21-entry
+// snapshot that does NOT (claude-opus-5, gpt-5.6-sol, glm-5, kimi-k3, grok-4.3,
+// …). Without this cache, `getContextWindow` fell through to DEFAULT_CONTEXT for
+// those, so the composer's context meter read "0% of 200K" right after a model
+// switch and only became correct once the first turn's live usage_update landed.
+// Keyed by the same model id the picker sends and slot.model stores.
+const LIVE_WINDOWS: Record<string, number> = {}
+
+/** Record an authoritative per-model window so the window lookup no longer
+ *  depends on the bundled snapshot. Non-positive values are ignored: a row that
+ *  reports no window must not overwrite a previously-learned good one, and it
+ *  must not record the caller's own default as if the backend had said it. */
+function learnWindow(name: string, window: number): void {
+  if (name && Number.isFinite(window) && window > 0) LIVE_WINDOWS[name] = window
+}
+
 /** Narrow view of GET /api/config/kirocrew — only the fields the composer needs
  *  to resolve what a new session will actually run on. */
 interface KirocrewAgentConfig {
@@ -67,6 +86,15 @@ function readCachedModels(): ModelInfo[] | null {
   }
 }
 
+/** Seed `LIVE_WINDOWS` from the persisted list at module load so a cold start
+ *  (first paint, before /api/models resolves) already resolves the real window
+ *  for the slot's current model instead of falling back to DEFAULT_CONTEXT. The
+ *  cached rows carry whatever `fetchAvailableModels` stored — the reported window
+ *  when the backend gave one, else its own fallback, which is the value the
+ *  lookup would have produced anyway. Either way the next live response corrects
+ *  it. */
+for (const m of readCachedModels() ?? []) learnWindow(m.name, m.contextWindow ?? 0)
+
 /** Persist a live model list with a timestamp. Best-effort — storage errors
  *  (quota, disabled, SSR) are swallowed so caching never breaks the picker. */
 function writeCachedModels(models: ModelInfo[]): void {
@@ -106,6 +134,22 @@ interface RawPlugin {
 interface RawModel {
   model_name: string
   description?: string
+  /** Backend-resolved context window. Two spellings because the endpoint has two
+   *  branches: the kiro path returns `kiro-cli --list-models` rows verbatim
+   *  (`context_window_tokens`), the claude_code path enriches its merged rows via
+   *  the central resolver (`context_window`). Both are authoritative and cover
+   *  models the bundled static map has never heard of. Optional so a gateway
+   *  predating either field still works (we fall back to the map). */
+  context_window?: number
+  context_window_tokens?: number
+}
+
+/** The window a /api/models row reports, or 0 when it reports none. */
+function rowWindow(m: RawModel): number {
+  for (const v of [m.context_window, m.context_window_tokens]) {
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) return v
+  }
+  return 0
 }
 
 export class AcpAdapter implements ProviderAdapter {
@@ -289,11 +333,20 @@ export class AcpAdapter implements ProviderAdapter {
         markModelsDegraded(this.id, true)
         return readCachedModels() ?? this._defaultModels()
       }
-      const result = models.map((m: RawModel) => ({
-        name: m.model_name,
-        description: m.description || '',
-        contextWindow: MODEL_TOKENS[m.model_name] ?? DEFAULT_CONTEXT,
-      }))
+      const result = models.map((m: RawModel) => {
+        // Prefer the backend's resolved window over the bundled snapshot: the
+        // gateway reads kiro's own --list-models output, so it is right for
+        // models this bundle does not list. Learn only the reported value — never
+        // the fallback, or a row with no window would record 200K as fact and
+        // clobber a window learned from an earlier, better-informed response.
+        const reported = rowWindow(m)
+        learnWindow(m.model_name, reported)
+        return {
+          name: m.model_name,
+          description: m.description || '',
+          contextWindow: reported || MODEL_TOKENS[m.model_name] || DEFAULT_CONTEXT,
+        }
+      })
       writeCachedModels(result) // remember this good live list for next hiccup
       markModelsDegraded(this.id, false) // live success → self-heal can stop polling
       return result
@@ -318,12 +371,16 @@ export class AcpAdapter implements ProviderAdapter {
     return [{
       name: 'auto',
       description: 'Models chosen by task for optimal usage and consistent quality',
-      contextWindow: MODEL_TOKENS['auto'] ?? DEFAULT_CONTEXT,
+      contextWindow: this.getContextWindow('auto'),
     }]
   }
 
   getContextWindow(model: string): number {
-    return MODEL_TOKENS[model] ?? DEFAULT_CONTEXT
+    // Learned-from-backend first, bundled snapshot second, reference default
+    // last. This is the value the composer's context meter shows between a model
+    // switch and the next turn's live usage_update, so a miss here is what made
+    // a 1M model read as 200K until a message was sent.
+    return LIVE_WINDOWS[model] ?? MODEL_TOKENS[model] ?? DEFAULT_CONTEXT
   }
 
   getDefaultModel(): string {

--- a/website/src/test/AcpAdapter.contextWindow.test.ts
+++ b/website/src/test/AcpAdapter.contextWindow.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The composer's context meter reads `provider.getContextWindow(slot.model)`
+ * whenever the store has no live `{used, window}` for the slot — which is exactly
+ * the window between a model switch (the backend broadcasts a `reset`, dropping
+ * the previous model's counts) and the next turn's `usage_update`.
+ *
+ * That lookup used to consult ONLY the bundled `model_tokens.json` snapshot,
+ * which lists neither the models kiro serves today (claude-opus-5, gpt-5.6-sol,
+ * glm-5, kimi-k3, grok-4.3, …) nor `auto`. Every one of them fell through to the
+ * 200K default, so switching to a 1M model showed "0% of 200K" until a message
+ * was sent. /api/models already carries the backend's resolved window per row;
+ * these tests pin that the adapter learns it and serves it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../api/client', () => ({
+  api: {
+    models: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+import { AcpAdapter } from '../providers/adapters/acp'
+
+describe('AcpAdapter context-window resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('learns windows from the kiro branch field (context_window_tokens)', async () => {
+    const adapter = new AcpAdapter()
+    // Before the list loads there is nothing to learn — the bundled snapshot has
+    // no entry for these ids, so both read as the reference default.
+    expect(adapter.getContextWindow('claude-opus-5')).toBe(200_000)
+    expect(adapter.getContextWindow('gpt-5.6-sol')).toBe(200_000)
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'claude-opus-5', context_window_tokens: 1_000_000 },
+      { model_name: 'gpt-5.6-sol', context_window_tokens: 272_000 },
+    ])
+    const models = await adapter.fetchAvailableModels()
+    expect(models.map(m => m.contextWindow)).toEqual([1_000_000, 272_000])
+    // …and the per-model lookup the context meter uses now agrees.
+    expect(adapter.getContextWindow('claude-opus-5')).toBe(1_000_000)
+    expect(adapter.getContextWindow('gpt-5.6-sol')).toBe(272_000)
+  })
+
+  it('learns windows from the claude_code branch field (context_window)', async () => {
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'kimi-k3', context_window: 1_000_000 },
+    ])
+    const adapter = new AcpAdapter()
+    await adapter.fetchAvailableModels()
+    expect(adapter.getContextWindow('kimi-k3')).toBe(1_000_000)
+  })
+
+  it('keeps the bundled snapshot for a row that reports no window', async () => {
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'claude-opus-4.8' }, // gateway predating the enrichment
+    ])
+    const adapter = new AcpAdapter()
+    const models = await adapter.fetchAvailableModels()
+    expect(models[0].contextWindow).toBe(1_000_000) // from model_tokens.json
+    expect(adapter.getContextWindow('claude-opus-4.8')).toBe(1_000_000)
+  })
+
+  it('ignores a non-positive window rather than overwriting a learned one', async () => {
+    const adapter = new AcpAdapter()
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'minimax-m2.5', context_window_tokens: 196_000 },
+    ])
+    await adapter.fetchAvailableModels()
+    expect(adapter.getContextWindow('minimax-m2.5')).toBe(196_000)
+    // A later list that cannot resolve the window must not clobber the good one.
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'minimax-m2.5', context_window_tokens: 0 },
+    ])
+    await adapter.fetchAvailableModels()
+    expect(adapter.getContextWindow('minimax-m2.5')).toBe(196_000)
+  })
+
+  it('serves the learned window for a model still unknown to the bundle', async () => {
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'grok-4.3', context_window_tokens: 1_000_000 },
+    ])
+    const adapter = new AcpAdapter()
+    await adapter.fetchAvailableModels()
+    // A brand-new id the bundled map will never list resolves correctly with no
+    // frontend release, which is the point of reading it from the backend.
+    expect(adapter.getContextWindow('grok-4.3')).toBe(1_000_000)
+    // An id nobody has reported still degrades to the reference default.
+    expect(adapter.getContextWindow('some-unreleased-model')).toBe(200_000)
+  })
+
+  it('reports the learned window for the auto sentinel in the degraded list', async () => {
+    ;(api.models as any).mockResolvedValue([
+      { model_name: 'auto', context_window_tokens: 1_000_000 },
+    ])
+    const adapter = new AcpAdapter()
+    await adapter.fetchAvailableModels()
+    expect(adapter.getContextWindow('auto')).toBe(1_000_000)
+    // The auto-only degraded fallback quotes the same learned figure instead of
+    // hardcoding 200K (model_tokens.json has no 'auto' entry at all).
+    ;(api.models as any).mockRejectedValue(new Error('503'))
+    localStorage.clear()
+    const degraded = await adapter.fetchAvailableModels()
+    expect(degraded).toHaveLength(1)
+    expect(degraded[0].name).toBe('auto')
+    expect(degraded[0].contextWindow).toBe(1_000_000)
+  })
+})


### PR DESCRIPTION
## Symptom

After switching models, the composer's context meter is wrong until a turn/message
is sent. It reads `0%` of a `200K` window regardless of which model you picked,
then jumps to the real figure once the first turn completes.

## Why

The meter reads `provider.getContextWindow(slot.model)` whenever the store has no
live `{used, window}` for the slot. That is *exactly* the state a model switch
produces: the backend broadcasts a `context_usage` event with `reset: true`, which
by design drops the previous model's counts (they no longer describe the session),
so the frontend falls back to its own model-derived window.

That fallback consulted only the bundled `model_tokens.json` snapshot — 21 entries
that list neither the models kiro serves today nor the `auto` sentinel:

| model id | real window | what the meter said |
|---|---|---|
| `claude-opus-5` | 1,000,000 | 200,000 |
| `gpt-5.6-sol` | 272,000 | 200,000 |
| `kimi-k3` | 1,000,000 | 200,000 |
| `grok-4.3` | 1,000,000 | 200,000 |
| `minimax-m2.5` | 196,000 | 200,000 |
| `deepseek-3.2` | 164,000 | 200,000 |
| `auto` | (per resolved model) | 200,000 |

`GET /api/models` already carries the right answer per row and the adapter threw it
away. The kiro branch returns kiro's own `--list-models` rows verbatim
(`context_window_tokens`); the claude_code branch enriches its merged rows through
`model_registry.model_window` (`context_window`). Both are authoritative — the
backend's resolver is seeded from kiro's own list, which is why the backend has
always known these windows while the frontend did not.

## Fix

Frontend only, one file plus tests.

- The adapter learns the reported window per model id from `/api/models`, and
  `getContextWindow` consults that before the bundled snapshot.
- Only the **reported** value is learned, never the fallback — otherwise a row that
  reports no window would record `200K` as fact and clobber a window learned from a
  better-informed response.
- Seeded at module load from the persisted last-good list, so a cold start resolves
  correctly before `/api/models` returns.
- Both field spellings accepted, so the fix covers either endpoint branch and a
  gateway predating the enrichment still degrades to the bundled map.

A brand-new model id now resolves correctly with no frontend release, which is the
point of reading it from the backend rather than a hand-maintained bundle.

## Verification

- 6 new tests in `website/src/test/AcpAdapter.contextWindow.test.ts`; **5 fail on
  `origin/main`** with the adapter reverted (the 6th pins the preserved
  bundled-snapshot fallback).
- `npx tsc -b` clean.
- `eslint` 0 errors on the changed files (8 `no-explicit-any` warnings matching the
  sibling `AcpAdapter.models.test.ts` mock style).
- `I18N_BASE_REF=origin/main npm run i18n:check` at baseline (1201 / 1833).
- Full frontend suite: 8103 passed. One unrelated failure,
  `src/i18n/format.test.ts`, asserts `Intl.DurationFormat` is `undefined` and is
  node-version-dependent — it fails identically on clean `origin/main` under
  Node 24 locally.

No backend change: the data was already being served.
