### PR TITLE
refactor: extract shared read_bounded_json + _persist_turn_row helpers (#490, #1086)

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1479,
+    "missing_code": 1471,
     "opaque_body": 18,
     "dynamic_status": 41
   },
-  "_compliant": 8,
+  "_compliant": 12,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -129,10 +129,10 @@
     },
     "dashboard/handlers/messaging.py": {
       "dynamic_status": 6,
-      "missing_code": 97
+      "missing_code": 93
     },
     "dashboard/handlers/notifications_push.py": {
-      "missing_code": 13
+      "missing_code": 9
     },
     "dashboard/handlers/onboarding_import.py": {
       "missing_code": 7

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import web
+
 from kiro_crew.agent_discovery import (
     SKILL_URI_PREFIX,
     expand_skill_uri,
@@ -24,6 +26,55 @@ if TYPE_CHECKING:
     from kiro_crew.platform.interfaces import CapabilityManager
 
 logger = logging.getLogger(__name__)
+
+
+# Shared body cap for the small JSON-object endpoints that must bound the
+# request BEFORE decoding (the strict-internal notification routes). Kept
+# module-level and in one place so the security-relevant cap cannot drift
+# between the two call sites (issue #490). 64 KB is generous — payload fields
+# have their own caps.
+_MAX_BODY_BYTES = 64 * 1024
+
+
+async def read_bounded_json(
+    request: web.Request, max_bytes: int = _MAX_BODY_BYTES
+) -> tuple[dict[str, Any] | None, web.Response | None]:
+    """Read and parse a JSON *object* request body, capped at *max_bytes*.
+
+    Returns ``(body, None)`` on success, or ``(None, error_response)`` when the
+    caller should return early. The cap is enforced BEFORE decoding: a
+    Content-Length precheck rejects an oversized declared body, and the stream
+    is then read incrementally so a chunked body (which carries no
+    Content-Length) cannot buffer past ``max_bytes + one chunk`` on the
+    event-loop thread. Consolidates the previously-duplicated block in
+    ``messaging.api_notification_agent_push`` and
+    ``notifications_push.api_push_notification`` so the cap and the 413/400
+    contract stay identical across both (issue #490).
+    """
+    if request.content_length and request.content_length > max_bytes:
+        return None, web.json_response(
+            {"error": "payload too large", "code": "payload_too_large"}, status=413
+        )
+    chunks: list[bytes] = []
+    received = 0
+    async for chunk in request.content.iter_chunked(8192):
+        received += len(chunk)
+        if received > max_bytes:
+            return None, web.json_response(
+                {"error": "payload too large", "code": "payload_too_large"}, status=413
+            )
+        chunks.append(chunk)
+    try:
+        body = json.loads(b"".join(chunks))
+    except Exception:
+        return None, web.json_response(
+            {"error": "invalid JSON body", "code": "invalid_json"}, status=400
+        )
+    if not isinstance(body, dict):
+        return None, web.json_response(
+            {"error": "body must be a JSON object", "code": "body_not_object"}, status=400
+        )
+    return body, None
 
 
 def _capability_manager() -> "CapabilityManager":

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -25,6 +25,7 @@ from kiro_crew.constants import CHAT_TURN_TIMEOUT
 from kiro_crew.cron import CronStoreBusy
 from kiro_crew.dashboard.chat_persistence import _rehydrate_slot_from_history
 from kiro_crew.dashboard.chat_utils import _remove_queued_by_id
+from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.origin import is_direct_local_request, is_loopback
 from kiro_crew.dashboard.state import (
     CRON_NOTIFY_END,
@@ -837,27 +838,15 @@ async def api_notification_agent_push(request: web.Request) -> web.Response:
             error="internal-secret authentication required (cookie callers forbidden)",
         )
         return web.json_response({"error": "internal-secret authentication required"}, status=403)
-    # Bound the body BEFORE decoding, mirroring the app push endpoint:
-    # without this the strict-internal route inherits the server-wide
-    # client_max_size, and a large JSON object would be buffered and decoded
-    # on the event-loop thread (GPT 5.6 round 11). 64 KB is generous --
-    # payload fields have their own caps.
-    _max_body = 64 * 1024
-    if request.content_length and request.content_length > _max_body:
-        return web.json_response({"error": "payload too large"}, status=413)
-    chunks: list[bytes] = []
-    received = 0
-    async for chunk in request.content.iter_chunked(8192):
-        received += len(chunk)
-        if received > _max_body:
-            return web.json_response({"error": "payload too large"}, status=413)
-        chunks.append(chunk)
-    try:
-        body = json.loads(b"".join(chunks))
-    except Exception:
-        return web.json_response({"error": "invalid JSON body"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response({"error": "body must be a JSON object"}, status=400)
+    # Bound the body BEFORE decoding, mirroring the app push endpoint: without
+    # this the strict-internal route inherits the server-wide client_max_size,
+    # and a large JSON object would be buffered and decoded on the event-loop
+    # thread (GPT 5.6 round 11). Shared helper so the cap and the 413/400
+    # contract cannot drift from the app push endpoint (issue #490).
+    body, _cap_err = await read_bounded_json(request)
+    if _cap_err is not None:
+        return _cap_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     # Type-check optional fields BEFORE payload construction: the bus
     # validator assumes str/list shapes, so a non-string url or non-list
     # actions would raise AttributeError/TypeError past the

--- a/src/kiro_crew/dashboard/handlers/notifications_push.py
+++ b/src/kiro_crew/dashboard/handlers/notifications_push.py
@@ -16,7 +16,6 @@ considerations"):
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from typing import Any
 
@@ -24,6 +23,7 @@ from aiohttp import web
 
 from kiro_crew.apps.manager import app_lifecycle_lock, get_app_manifest, is_app_enabled
 from kiro_crew.apps.manifest import RESERVED_APP_NAMES
+from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.notifications.bus import (
     NotificationPayload,
     NotificationValidationError,
@@ -31,8 +31,6 @@ from kiro_crew.notifications.bus import (
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
-
-_MAX_BODY_BYTES = 64 * 1024  # generous; payload fields have their own caps
 
 
 def _resolve_app_channels(app_name: str) -> dict[str, str] | None:
@@ -74,27 +72,15 @@ async def api_push_notification(request: web.Request) -> web.Response:
             {"error": "app token required"}, status=403
         )
 
-    if request.content_length and request.content_length > _MAX_BODY_BYTES:
-        return web.json_response({"error": "payload too large"}, status=413)
-
-    # Enforce the cap while streaming: chunked transfer-encoding carries no
-    # Content-Length header, and buffering the whole body first
-    # (request.read()) would allocate up to the server-wide client_max_size
-    # before any check runs. Reading incrementally bounds the allocation to
-    # _MAX_BODY_BYTES + one chunk.
-    chunks: list[bytes] = []
-    received = 0
-    async for chunk in request.content.iter_chunked(8192):
-        received += len(chunk)
-        if received > _MAX_BODY_BYTES:
-            return web.json_response({"error": "payload too large"}, status=413)
-        chunks.append(chunk)
-    try:
-        body: dict[str, Any] = json.loads(b"".join(chunks))
-    except Exception:
-        return web.json_response({"error": "invalid JSON body"}, status=400)
-    if not isinstance(body, dict):
-        return web.json_response({"error": "body must be a JSON object"}, status=400)
+    # Bound the body BEFORE decoding via the shared helper so the cap and the
+    # 413/400 contract cannot drift from the strict-internal push endpoint
+    # (issue #490). Chunked transfer-encoding carries no Content-Length, so the
+    # helper reads incrementally, bounding the allocation to the cap + one chunk
+    # instead of buffering the whole body on the event-loop thread.
+    body, _cap_err = await read_bounded_json(request)
+    if _cap_err is not None:
+        return _cap_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
 
     state = request.app["state"]
     bus = state.notification_bus

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -36,7 +36,7 @@ import webbrowser
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
 from slack_sdk.socket_mode.websockets import SocketModeClient as WSSocketModeClient
@@ -202,6 +202,55 @@ if TYPE_CHECKING:
     from kiro_crew.webex.client import WebexClient
     from kiro_crew.wecom.client import WeComClient
     from kiro_crew.weixin.client import WeixinClient
+
+
+async def _persist_turn_row(
+    client: Any,
+    session_key: str,
+    *,
+    provider: str,
+    surface: str,
+    agent_fallback: Callable[[], str],
+    t0: float,
+) -> None:
+    """Persist one per-turn usage row for a background dispatch surface.
+
+    Extracted so the heartbeat and monitor surfaces — each with a success and a
+    timeout twin that were byte-identical copies — share one implementation
+    instead of cloning the block a fourth (and fifth, sixth…) time (issue
+    #1086, following the usage-row wiring from issue #647). Best-effort: a
+    persistence failure is logged at debug and never propagates into the
+    background loop, since a dropped analytics row must not abort a live turn.
+
+    ``agent_fallback`` is a zero-arg callable, invoked INSIDE the try/except and
+    only when ``read_effective_agent`` yields nothing — preserving the original
+    short-circuit (``read_effective_agent(client) or _get_agent_for_session(key)``)
+    so a cold-cache ``KiroCrewConfig.load()`` neither runs on every turn nor
+    escapes the best-effort guard.
+
+    NOTE: ``test_turn_duration_recorded.py`` counts ``persist_token_record_async``
+    call sites per file and requires every one to pass ``elapsed_ms``. This
+    helper is the single heartbeat/monitor call site; the two cron sites persist
+    directly (they carry a ``model`` argument). Adding a new surface that
+    bypasses this helper changes the count and fails that guard by design.
+    """
+    try:
+        _used, _window = read_context_tokens(client)
+        await persist_token_record_async(
+            session_key,
+            "",
+            provider_last_turn_usage(client),
+            provider=provider,
+            surface=surface,
+            agent=read_effective_agent(client) or agent_fallback(),
+            context_used=_used,
+            context_window=_window,
+            elapsed_ms=int((time.monotonic() - t0) * 1000),
+            model_source=client,
+        )
+    except Exception:
+        logger.debug("usage row (%s) persist failed", surface, exc_info=True)
+
 
 # Chunked wave-digest size: every multi-task wave delivers its completed
 # results to the parent in digest CHUNKS of this many members (queue-style —
@@ -2617,23 +2666,14 @@ class GatewayOrchestrator:
                     result_text = "_No response._"
 
                 # ── Per-turn usage row (issue #647): attribute heartbeat spend. ──
-                try:
-
-                    _used, _window = read_context_tokens(client)
-                    await persist_token_record_async(
-                        session_key,
-                        "",
-                        provider_last_turn_usage(client),
-                        provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
-                        surface="heartbeat",
-                        agent=read_effective_agent(client) or "kirocrew-heartbeat",
-                        context_used=_used,
-                        context_window=_window,
-                        elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
-                        model_source=client,
-                    )
-                except Exception:
-                    logger.debug("usage row (heartbeat) persist failed", exc_info=True)
+                await _persist_turn_row(
+                    client,
+                    session_key,
+                    provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                    surface="heartbeat",
+                    agent_fallback=lambda: "kirocrew-heartbeat",
+                    t0=_turn_t0,
+                )
             except asyncio.TimeoutError:
                 # Tear down the in-flight turn so the underlying claude-agent-acp
                 # process/turn doesn't linger holding the heartbeat session.
@@ -2657,25 +2697,14 @@ class GatewayOrchestrator:
                 # success/failure outcome for ANY surface, so a timeout row is
                 # no less honest than any other row. The duration recorded is
                 # the real elapsed time, which for a timeout is ~the ceiling.
-                try:
-
-                    _used, _window = read_context_tokens(client)
-                    await persist_token_record_async(
-                        session_key,
-                        "",
-                        provider_last_turn_usage(client),
-                        provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
-                        surface="heartbeat",
-                        agent=read_effective_agent(client) or "kirocrew-heartbeat",
-                        context_used=_used,
-                        context_window=_window,
-                        elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
-                        model_source=client,
-                    )
-                except Exception:
-                    logger.debug(
-                        "usage row (heartbeat timeout) persist failed", exc_info=True
-                    )
+                await _persist_turn_row(
+                    client,
+                    session_key,
+                    provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                    surface="heartbeat",
+                    agent_fallback=lambda: "kirocrew-heartbeat",
+                    t0=_turn_t0,
+                )
                 try:
                     await self.sessions.reset(session_key)
                 except Exception:
@@ -2812,23 +2841,14 @@ class GatewayOrchestrator:
             )
 
             # ── Per-turn usage row (issue #647): attribute monitor spend. ──
-            try:
-
-                _used, _window = read_context_tokens(client)
-                await persist_token_record_async(
-                    key,
-                    "",
-                    provider_last_turn_usage(client),
-                    provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
-                    surface="monitor",
-                    agent=read_effective_agent(client) or _get_agent_for_session(key),
-                    context_used=_used,
-                    context_window=_window,
-                    elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
-                    model_source=client,
-                )
-            except Exception:
-                logger.debug("usage row (monitor) persist failed", exc_info=True)
+            await _persist_turn_row(
+                client,
+                key,
+                provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                surface="monitor",
+                agent_fallback=lambda: _get_agent_for_session(key),
+                t0=_turn_t0,
+            )
         except asyncio.TimeoutError:
             # ── Timeout spend is REAL spend (issue #874 follow-up). ──
             # A timed-out nudge turn previously fell through to the generic
@@ -2845,25 +2865,14 @@ class GatewayOrchestrator:
                 key,
                 loop.id,
             )
-            try:
-
-                _used, _window = read_context_tokens(client)
-                await persist_token_record_async(
-                    key,
-                    "",
-                    provider_last_turn_usage(client),
-                    provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
-                    surface="monitor",
-                    agent=read_effective_agent(client) or _get_agent_for_session(key),
-                    context_used=_used,
-                    context_window=_window,
-                    elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
-                    model_source=client,
-                )
-            except Exception:
-                logger.debug(
-                    "usage row (monitor timeout) persist failed", exc_info=True
-                )
+            await _persist_turn_row(
+                client,
+                key,
+                provider=(self._cfg.agent.provider if hasattr(self, "_cfg") else "acp"),
+                surface="monitor",
+                agent_fallback=lambda: _get_agent_for_session(key),
+                t0=_turn_t0,
+            )
             return False
         except Exception:
             logger.exception("AutoNudge: slack nudge turn failed for %s (loop %s)", key, loop.id)

--- a/test/test_notifications_push.py
+++ b/test/test_notifications_push.py
@@ -408,7 +408,7 @@ class TestPushHandler:
         # exactly _MAX_BODY_BYTES must pass the size gate (it then fails
         # payload validation with 400 because the body field exceeds its own
         # cap, which proves the 413 gate was cleared), one byte more -> 413.
-        from kiro_crew.dashboard.handlers.notifications_push import _MAX_BODY_BYTES
+        from kiro_crew.dashboard.handlers._shared import _MAX_BODY_BYTES
 
         prefix = b'{"channel": "ticket-update", "title": "t", "body": "'
         suffix = b'"}'

--- a/test/test_read_bounded_json.py
+++ b/test/test_read_bounded_json.py
@@ -1,0 +1,84 @@
+"""Unit tests for the shared ``read_bounded_json`` body-cap helper (issue #490).
+
+The two 64 KB body-capped notification endpoints
+(``messaging.api_notification_agent_push`` and
+``notifications_push.api_push_notification``) previously each inlined a
+byte-identical Content-Length precheck + incremental read + 413/400 block, with
+the cap as a function-local. Extracting the helper means the cap and the
+413/400 contract live in exactly one place and cannot drift. These tests pin
+that contract directly against the helper.
+"""
+
+import pytest
+
+from kiro_crew.dashboard.handlers._shared import _MAX_BODY_BYTES, read_bounded_json
+
+
+class _FakeContent:
+    """Minimal stand-in for ``aiohttp.StreamReader`` exposing ``iter_chunked``."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+
+    async def iter_chunked(self, n: int):
+        for i in range(0, len(self._data), n):
+            yield self._data[i : i + n]
+
+
+class _FakeRequest:
+    def __init__(self, data: bytes, content_length: int | None = None):
+        self.content = _FakeContent(data)
+        self.content_length = content_length
+
+
+class TestReadBoundedJson:
+    @pytest.mark.asyncio
+    async def test_valid_object_returns_body_and_no_error(self):
+        raw = b'{"channel": "x", "title": "t"}'
+        body, err = await read_bounded_json(_FakeRequest(raw, content_length=len(raw)))
+        assert err is None
+        assert body == {"channel": "x", "title": "t"}
+
+    @pytest.mark.asyncio
+    async def test_content_length_precheck_rejects_before_reading(self):
+        # Declared size over the cap -> 413 without draining the stream.
+        body, err = await read_bounded_json(
+            _FakeRequest(b"{}", content_length=_MAX_BODY_BYTES + 1)
+        )
+        assert body is None
+        assert err is not None and err.status == 413
+
+    @pytest.mark.asyncio
+    async def test_streamed_oversize_rejects_when_no_content_length(self):
+        # Chunked bodies carry no Content-Length; the incremental read must
+        # still enforce the cap. Use a small explicit cap to keep the test fast.
+        body, err = await read_bounded_json(
+            _FakeRequest(b"x" * 100, content_length=None), max_bytes=16
+        )
+        assert body is None
+        assert err is not None and err.status == 413
+
+    @pytest.mark.asyncio
+    async def test_exact_cap_passes_size_gate(self):
+        # A body of exactly max_bytes clears the 413 gate (it may still fail
+        # later validation, but that is the caller's concern, not the cap's).
+        raw = b'"' + b"a" * 12 + b'"'  # 15 bytes, valid JSON string (not a dict)
+        body, err = await read_bounded_json(
+            _FakeRequest(raw, content_length=len(raw)), max_bytes=len(raw)
+        )
+        # Cleared 413; rejected as non-object with 400.
+        assert body is None
+        assert err is not None and err.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_400(self):
+        body, err = await read_bounded_json(_FakeRequest(b"{not json", content_length=9))
+        assert body is None
+        assert err is not None and err.status == 400
+
+    @pytest.mark.asyncio
+    async def test_non_object_body_returns_400(self):
+        raw = b"[1, 2, 3]"
+        body, err = await read_bounded_json(_FakeRequest(raw, content_length=len(raw)))
+        assert body is None
+        assert err is not None and err.status == 400

--- a/test/test_turn_duration_recorded.py
+++ b/test/test_turn_duration_recorded.py
@@ -89,8 +89,10 @@ def test_non_numeric_elapsed_cannot_break_serialization(junk):
 EXPECTED_SITES = {
     "dashboard/chat_runner.py": 1,
     "dashboard/handlers/hooks.py": 1,
-    "slack/gateway.py": 6,          # 2 cron + heartbeat + its timeout
-                                    #          + monitor + its timeout
+    "slack/gateway.py": 3,          # 2 cron + _persist_turn_row helper
+                                    # (the helper is the single call site for
+                                    # heartbeat + its timeout + monitor + its
+                                    # timeout, extracted in issue #1086)
     "task_executor.py": 2,          # task step + self-review
     "subagent.py": 1,
     "workflows/agent_exec.py": 1,


### PR DESCRIPTION
## Problem
Two Design/Arbiter-flagged dedup follow-ups (#490, #1086): a spend/security-relevant block was copy-pasted, so the two copies could silently drift.

- **#490** — the 64 KB request-body cap (Content-Length precheck + incremental `iter_chunked` read + 413/400 contract) was inlined **twice**: in `messaging.api_notification_agent_push` (cap as a function-local `_max_body`) and in `notifications_push.api_push_notification` (cap as a module const `_MAX_BODY_BYTES`). Two definitions of a security cap is exactly how they drift apart.
- **#1086** — the per-turn usage-row persistence block (issue #647) was cloned **four** times in `slack/gateway.py`: heartbeat success + timeout, monitor success + timeout, each a byte-identical copy of its twin. A fifth background surface would clone it a fifth time.

## Why it matters
A drifting body cap is a real security/DoS regression risk (one endpoint could quietly accept a larger body than the other). Four byte-identical persistence copies are a maintenance hazard: a fix to one (or a new surface) silently diverges, and dropped usage rows mean unattributed spend.

## Fix (symptom → root cause → change)
Root cause is duplication, so the fix is consolidation into one authority each — no behavior change (apart from additive error `code` fields, below):

- **#490:** extract `read_bounded_json(request, max_bytes=_MAX_BODY_BYTES)` + a single module-level `_MAX_BODY_BYTES` into `dashboard/handlers/_shared.py`; both endpoints call it and early-return on its `(None, error_response)`. The consolidated 413/400 responses now carry machine-readable `code` fields (`payload_too_large` / `invalid_json` / `body_not_object`) per the error-code contract, so the new helper file is fully compliant and the two source files' `error-code-baseline.json` counts drop accordingly (messaging 97→93, notifications_push 13→9; `_totals.missing_code` 1479→1471, `_compliant` 8→12). Net error-code debt **drops by 8**.
- **#1086:** extract `_persist_turn_row(...)` into `slack/gateway.py`, collapsing the 4 heartbeat/monitor blocks to one call site each. The 2 cron sites (which pass a `model` arg) stay inline. The agent fallback is passed as a **zero-arg callable** so it keeps the original short-circuit + best-effort (in-`try`) evaluation — a cold-cache `KiroCrewConfig.load()` neither runs per-turn nor escapes the guard. `EXPECTED_SITES['slack/gateway.py']` updated 6→3 in the turn-duration guard, preserving its every-site-passes-`elapsed_ms` forcing function.

## Tests
- New `test/test_read_bounded_json.py` (6 cases): valid object, Content-Length precheck 413, streamed-oversize 413, exact-cap passes the size gate, invalid-JSON 400, non-object 400 — locks the 413/400 contract to the shared helper.
- `test/test_notifications_push.py` — repointed the `_MAX_BODY_BYTES` import to `_shared` (single source).
- `test/test_turn_duration_recorded.py` — `EXPECTED_SITES` 6→3; the AST guard still asserts every remaining persist site passes `elapsed_ms`.
- `error-code-baseline.json` — reconciled for the genuine debt reduction (decreases only; `_shared` is compliant and absent from the `files` map).

## Manual verification
N/A — unit coverage is sufficient. Local gates all green: isort, flake8, mypy (CI-parity, no faiss); `test_error_code_contract` 6/6; `test_read_bounded_json` + `test_notifications_push` + `test_notification_phase5` + `test_turn_duration_recorded` = 117 passed.

## Screenshots
N/A — backend-only, no user-visible UI change.

Fixes #490, #1086.
