### PR TITLE
feat(chat): rove the session list with ArrowUp / ArrowDown

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -63,6 +63,7 @@ import {
   isWithinRecentWindow,
 } from './recentWindow'
 import { loadChatConfig, saveChatConfig } from './chat/ChatSettings'
+import { focusSiblingSessionRow } from './chat/sessionRowNav'
 
 import { i18nT } from '../i18n/t'
 import { compareText, fmtDateFields } from '../i18n/format'
@@ -1968,7 +1969,11 @@ function ChatSidebar({
               const isActive = activeSlot === s.key
               const nextIsActive = i < childSlots.length - 1 && activeSlot === childSlots[i + 1].key
               const showDivider = i < childSlots.length - 1 && !isActive && !nextIsActive
-              return renderSessionRow(s, 1, showDivider, `${columnId}:${folder.id}`)
+              // `scope` stays per-folder so the Framer layoutId and the inline
+              // rename target remain unique, but the arrow rove is scoped to the
+              // COLUMN: a board column's foldered and ungrouped rows are one
+              // visible list, so ArrowDown has to cross the folder boundary.
+              return renderSessionRow(s, 1, showDivider, `${columnId}:${folder.id}`, columnId)
             })}
           </div>
         </FolderBody>
@@ -1979,7 +1984,7 @@ function ChatSidebar({
   // scope namespaces the Framer layoutId per render location. A multi-tag slot
   // can render in several columns at once; same layoutId in one LayoutGroup
   // collides (Framer paints one, hides the rest). Distinct scope = distinct id.
-  const renderSessionRow = (s: Slot, _indent: number, showDivider: boolean, scope = 'list') => {
+  const renderSessionRow = (s: Slot, _indent: number, showDivider: boolean, scope = 'list', navScope = scope) => {
     // Flat view shares the tree's layoutId namespace so Framer Motion treats a
     // row as the SAME element across the view toggle and animates it from its
     // tree position into the flat lane (and back). Safe: the two views are
@@ -2083,9 +2088,31 @@ function ChatSidebar({
           {...offlineProps(connected, 'switch sessions')}
           role="button"
           tabIndex={0}
+          data-session-row={s.key}
+          data-session-scope={navScope}
           aria-current={isActive ? 'true' : undefined}
           aria-disabled={!connected}
           onKeyDown={e => {
+            // ArrowUp/ArrowDown rove focus through the rows of THIS list (see
+            // chat/sessionRowNav for why the rove is scope-bounded and clamped).
+            // Focus-only, so walking the list doesn't load every session on the
+            // way — Enter/Space below still switches. Bare arrows only: the
+            // modified forms belong to other gestures (Alt+←/→ cycles sessions,
+            // ⌘/Ctrl+arrow is OS text/scroll movement), and Shift is left free.
+            // Skipped while a drag is in flight so dnd-kit keeps the arrows for
+            // moving the dragged row, and skipped for a keystroke aimed at an
+            // inner control so the rename input keeps its own caret keys.
+            const roveStep = e.key === 'ArrowDown' ? 1 : e.key === 'ArrowUp' ? -1 : 0
+            if (roveStep !== 0 && !activeDrag && !e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey
+                && (e.target as HTMLElement) === e.currentTarget) {
+              // Only claim the keystroke when focus actually moved; at the list
+              // edge it falls through and still scrolls the list.
+              if (focusSiblingSessionRow(e.currentTarget as HTMLElement, roveStep)) {
+                e.preventDefault()
+                e.stopPropagation()
+              }
+              return
+            }
             // WCAG 2.1.1: session rows must be operable via keyboard.
             // Enter/Space activates the row (same as click). Other keys are
             // forwarded to dnd-kit's listener (this prop appears after the

--- a/website/src/pages/chat/sessionRowNav.ts
+++ b/website/src/pages/chat/sessionRowNav.ts
@@ -1,0 +1,66 @@
+/**
+ * Arrow-key roving for the sidebar session rows.
+ *
+ * Each keyboard-focusable session row carries `data-session-row="<slot key>"`
+ * and `data-session-scope="<render scope>"`. The scope is what bounds a rove:
+ * the sidebar renders the same slot in more than one place (the folder list,
+ * the flat list, one board column per tag), so ArrowDown has to walk the list
+ * the focused row actually sits in instead of jumping between them. Scope is
+ * compared through `dataset` rather than baked into the selector because a
+ * board scope is a column id, which is not guaranteed to be selector-safe.
+ *
+ * The rove moves FOCUS only — Enter/Space on a row still switches to it — so a
+ * keyboard user can read down the list without loading every session on the way.
+ */
+
+/** Marks a row as a rove stop. Rows without it are skipped. */
+export const SESSION_ROW_SELECTOR = '[data-session-row]'
+
+/**
+ * Every row rendered in the same scope as `row`, in DOM order, minus the ones
+ * that cannot take focus.
+ *
+ * A collapsed folder still renders its rows — `FolderBody` hides them with
+ * `inert` + `visibility: hidden` rather than unmounting, so the collapse can
+ * animate to intrinsic height. Those rows are unfocusable, so leaving them in
+ * would stall the rove on an invisible row instead of carrying on to the next
+ * visible session. `row` itself is always kept so the caller's `indexOf` holds.
+ */
+export function sessionRowsInScope(row: HTMLElement): HTMLElement[] {
+  const scope = row.dataset.sessionScope ?? ''
+  const all = row.ownerDocument.querySelectorAll<HTMLElement>(SESSION_ROW_SELECTOR)
+  return Array.from(all).filter(el =>
+    (el.dataset.sessionScope ?? '') === scope && (el === row || el.closest('[inert]') === null))
+}
+
+/**
+ * The row `step` places from `row` inside its scope, clamped at both ends, or
+ * null when there is nowhere to go.
+ *
+ * Clamping rather than wrapping: this is a focus rove over a visible list, so
+ * it follows the ARIA listbox default (and `useListKeyboardNav`'s `wrap: false`
+ * default). Wrapping is what the ⌘[ / ⌘] and Alt+arrow session-cycle chords do,
+ * and those are a different gesture — they switch the session from anywhere,
+ * including the composer, so there is no list edge to stop at.
+ */
+export function siblingSessionRow(row: HTMLElement, step: number): HTMLElement | null {
+  const rows = sessionRowsInScope(row)
+  const cur = rows.indexOf(row)
+  if (cur < 0) return null
+  const next = cur + step
+  if (next < 0 || next >= rows.length) return null
+  return rows[next]
+}
+
+/**
+ * Move focus to the neighbouring row. Returns true when focus moved, so the
+ * caller only claims the keystroke (preventDefault) when there was somewhere to
+ * go — at the list edge the arrow key falls through and still scrolls the list.
+ */
+export function focusSiblingSessionRow(row: HTMLElement, step: number): boolean {
+  const target = siblingSessionRow(row, step)
+  if (!target) return false
+  target.focus()
+  if (typeof target.scrollIntoView === 'function') target.scrollIntoView({ block: 'nearest' })
+  return target.ownerDocument.activeElement === target
+}

--- a/website/src/test/ChatSidebar.arrowNav.test.tsx
+++ b/website/src/test/ChatSidebar.arrowNav.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Arrow-key roving over the sidebar session list.
+ *
+ * Covers the two halves separately: the scope-bounded/clamped index maths as a
+ * plain-DOM unit test, and the wiring (bare arrows only, focus-only rove, Enter
+ * still activates) against a rendered ChatSidebar.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import { sessionRowsInScope, siblingSessionRow, focusSiblingSessionRow } from '../pages/chat/sessionRowNav'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+// Board view is per-describe: the list-view suites need it off, the board suite
+// needs it on, and loadChatConfig is called at render time so a mutable flag is
+// enough (a vi.mock factory only runs once per module).
+const chatConfig = { tagColumnsEnabled: false, confirmCloseSession: false }
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => chatConfig,
+  saveChatConfig: vi.fn(),
+}))
+
+// Board fixtures are per-describe too. They have to come back from the api mock,
+// not just be seeded into the query cache: the seeded entry is stale on mount, so
+// react-query refetches and a blanket `[]` mock would erase it.
+const fixtures: { chatTags: unknown[]; tagColumns: unknown[]; chatFolders: unknown[] } = {
+  chatTags: [], tagColumns: [], chatFolders: [],
+}
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: (_t, prop: string) => {
+      if (prop in fixtures) return vi.fn().mockResolvedValue(fixtures[prop as keyof typeof fixtures])
+      return vi.fn().mockResolvedValue([])
+    },
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+function renderSidebar(slots: any[]) {
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: { activeSlot: null, slotStatusDetail: {} } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { ...utils, store }
+}
+
+const THREE = [
+  { key: 'k1', title: 'first', running: false, messages: 1 },
+  { key: 'k2', title: 'second', running: false, messages: 1 },
+  { key: 'k3', title: 'third', running: false, messages: 1 },
+]
+
+/** The focusable row element for a slot key, in list scope. */
+function row(key: string): HTMLElement {
+  const el = document.querySelector<HTMLElement>(`[data-session-row="${key}"][data-session-scope="list"]`)
+  if (!el) throw new Error(`no list-scope row for ${key}`)
+  return el
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('sessionRowNav', () => {
+  /**
+   * Built with createElement rather than an HTML-string template: the blocking
+   * `frontend-security` AUTOSDE rule forbids assigning to the innerHTML property
+   * anywhere under `src/**`, with no test exemption.
+   */
+  function mkRow(key: string, scope: string): HTMLElement {
+    const el = document.createElement('div')
+    el.dataset.sessionRow = key
+    el.dataset.sessionScope = scope
+    el.tabIndex = 0
+    return el
+  }
+
+  function scopedDom(): HTMLElement {
+    const host = document.createElement('div')
+    host.append(mkRow('a', 'list'), mkRow('b', 'board-1'), mkRow('c', 'list'))
+    document.body.appendChild(host)
+    return host
+  }
+
+  afterEach(() => { document.body.replaceChildren() })
+
+  it('collects only the rows sharing the scope, in DOM order', () => {
+    const host = scopedDom()
+    const first = host.querySelector<HTMLElement>('[data-session-row="a"]')!
+    expect(sessionRowsInScope(first).map(el => el.dataset.sessionRow)).toEqual(['a', 'c'])
+  })
+
+  it('steps past a foreign-scope row rather than into it', () => {
+    const host = scopedDom()
+    const first = host.querySelector<HTMLElement>('[data-session-row="a"]')!
+    expect(siblingSessionRow(first, 1)?.dataset.sessionRow).toBe('c')
+  })
+
+  it('clamps at both ends instead of wrapping', () => {
+    const host = scopedDom()
+    const first = host.querySelector<HTMLElement>('[data-session-row="a"]')!
+    const last = host.querySelector<HTMLElement>('[data-session-row="c"]')!
+    expect(siblingSessionRow(first, -1)).toBeNull()
+    expect(siblingSessionRow(last, 1)).toBeNull()
+    expect(focusSiblingSessionRow(last, 1)).toBe(false)
+  })
+
+  it('skips rows hidden inside an inert subtree (a collapsed folder)', () => {
+    // A collapsed folder keeps its rows mounted under an [inert] wrapper, so
+    // without the filter ArrowDown would stall on an unfocusable row.
+    const host = document.createElement('div')
+    const folder = document.createElement('div')
+    folder.setAttribute('inert', '')
+    folder.append(mkRow('hidden', 'list'))
+    host.append(mkRow('a', 'list'), folder, mkRow('c', 'list'))
+    document.body.appendChild(host)
+    const first = host.querySelector<HTMLElement>('[data-session-row="a"]')!
+    expect(sessionRowsInScope(first).map(el => el.dataset.sessionRow)).toEqual(['a', 'c'])
+    expect(siblingSessionRow(first, 1)?.dataset.sessionRow).toBe('c')
+  })
+})
+
+describe('chat sidebar — session list arrow navigation', () => {
+  it('ArrowDown moves focus to the next row', async () => {
+    const { findByText } = renderSidebar(THREE)
+    await findByText('third')
+    row('k1').focus()
+    fireEvent.keyDown(row('k1'), { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(row('k2'))
+  })
+
+  it('ArrowUp moves focus to the previous row', async () => {
+    const { findByText } = renderSidebar(THREE)
+    await findByText('third')
+    row('k2').focus()
+    fireEvent.keyDown(row('k2'), { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(row('k1'))
+  })
+
+  it('roving does not switch the session — only Enter does', async () => {
+    const { findByText, store } = renderSidebar(THREE)
+    await findByText('third')
+    row('k1').focus()
+    fireEvent.keyDown(row('k1'), { key: 'ArrowDown' })
+    fireEvent.keyDown(row('k2'), { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(row('k3'))
+    expect(store.getState().chat.activeSlot).toBeNull()
+    // Enter is still claimed by the row (the activation path), unchanged.
+    expect(fireEvent.keyDown(row('k3'), { key: 'Enter' })).toBe(false)
+  })
+
+  it('leaves the arrow alone at the last row so the list can still scroll', async () => {
+    const { findByText } = renderSidebar(THREE)
+    await findByText('third')
+    row('k3').focus()
+    // fireEvent returns false when the handler called preventDefault.
+    expect(fireEvent.keyDown(row('k3'), { key: 'ArrowDown' })).toBe(true)
+    expect(document.activeElement).toBe(row('k3'))
+  })
+
+  it('ignores a modified arrow so Alt+arrow session cycling still reaches its handler', async () => {
+    const { findByText } = renderSidebar(THREE)
+    await findByText('third')
+    row('k1').focus()
+    fireEvent.keyDown(row('k1'), { key: 'ArrowDown', altKey: true })
+    expect(document.activeElement).toBe(row('k1'))
+  })
+})
+
+/**
+ * A board column's foldered and ungrouped rows are ONE visible list, so the rove
+ * has to cross the folder boundary. The row's `scope` stays per-folder (Framer
+ * layoutId + rename target uniqueness), so the nav scope is threaded separately.
+ */
+describe('chat sidebar — board column arrow navigation', () => {
+  const TAG = '11111111-1111-1111-1111-111111111111'
+  const COL = 'col-aaaa'
+  const FOLDER = 'folder-zzzz'
+  const boardTags = [{ id: TAG, name: 'Blocked', color: '#e11', order: 0, status: true }]
+  const boardColumns = [{ id: COL, name: 'Blocked', tag_ids: [TAG], mode: 'any', order: 0 }]
+  const boardFolders = [{ id: FOLDER, name: 'CDF', order: 0, collapsed: false }]
+  const boardSlots = [
+    { key: 'b1', title: 'in folder', running: false, messages: 1, tags: [TAG], folder_id: FOLDER },
+    { key: 'b2', title: 'at column root', running: false, messages: 1, tags: [TAG] },
+  ]
+
+  function renderBoard() {
+    const store = createTestStore({
+      dashboard: {
+        status: {}, connected: true, slots: boardSlots, approvalMode: 'normal',
+        channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+        slotsLoaded: true,
+        subagentRunning: {}, subagentDetails: {}, subagentText: {},
+        sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+      } as any,
+      chat: { activeSlot: null, slotStatusDetail: {} } as any,
+    })
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+    qc.setQueryData(['chat-tags'], boardTags)
+    qc.setQueryData(['tag-columns'], boardColumns)
+    qc.setQueryData(['chat-folders'], boardFolders)
+    return render(
+      <QueryClientProvider client={qc}>
+        <Provider store={store}>
+          <ThemeProvider>
+            <MemoryRouter>
+              <ChatSidebar
+                slots={boardSlots} activeSlot={null} unreadSlots={[]}
+                history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+              />
+            </MemoryRouter>
+          </ThemeProvider>
+        </Provider>
+      </QueryClientProvider>,
+    )
+  }
+
+  beforeEach(() => {
+    chatConfig.tagColumnsEnabled = true
+    fixtures.chatTags = boardTags
+    fixtures.tagColumns = boardColumns
+    fixtures.chatFolders = boardFolders
+  })
+  afterEach(() => {
+    chatConfig.tagColumnsEnabled = false
+    fixtures.chatTags = []
+    fixtures.tagColumns = []
+    fixtures.chatFolders = []
+  })
+
+  it('scopes a foldered board row to its column, not its folder', async () => {
+    const { findByText } = renderBoard()
+    await findByText('in folder')
+    const foldered = document.querySelector<HTMLElement>('[data-session-row="b1"]')!
+    const rooted = document.querySelector<HTMLElement>('[data-session-row="b2"]')!
+    expect(foldered.dataset.sessionScope).toBe(COL)
+    expect(rooted.dataset.sessionScope).toBe(COL)
+    // …and the rove therefore reaches across the boundary in one step.
+    expect(siblingSessionRow(foldered, 1)).toBe(rooted)
+  })
+})


### PR DESCRIPTION
## What

A focused session row in the sidebar was a keyboard dead end. Enter and Space activated it (WCAG 2.1.1, added earlier), but there was no way to move to the next row without Tab — which walks every control on the way, including each row's ⋯ / duplicate / close buttons. Arrow keys did nothing.

`ArrowUp` / `ArrowDown` now rove focus between rows of the list the focused row is in.

## Behaviour

- **Focus-only.** The rove moves focus; Enter and Space still do the switch. So a keyboard user can read down the list without loading every session on the way. This is deliberately different from the existing session-cycle chords (`Alt`+`←`/`→`, `⌘`/`Ctrl`+`[`/`]`), which switch immediately from anywhere including the composer.
- **Scope-bounded.** The sidebar renders the same slot in more than one place (folder list, flat list, one board column per tag), so the rove is bounded by the row's render scope and walks the list you're actually in instead of jumping between them.
- **Clamped, not wrapped.** ARIA-listbox behaviour, matching `useListKeyboardNav`'s `wrap: false` default. The keystroke is only claimed when focus actually moved, so at the list edge the arrow falls through and still scrolls the list.
- **Bare arrows only.** No Alt / ⌘ / Ctrl / Shift, so the existing chords keep theirs and Shift stays free for a future range-select.
- **Skipped while a drag is in flight** so dnd-kit keeps the arrows, and skipped for a keystroke aimed at an inner control so the inline rename input keeps its caret keys.

## Files

- `website/src/pages/chat/sessionRowNav.ts` — new. Scope collection + clamped neighbour lookup + focus move. Scope is compared through `dataset` rather than baked into the selector because a board scope is a column id and is not guaranteed to be selector-safe.
- `website/src/pages/ChatSidebar.tsx` — rows carry `data-session-row` / `data-session-scope`; the existing row `onKeyDown` gains the rove branch ahead of the Enter/Space branch.
- `website/src/test/ChatSidebar.arrowNav.test.tsx` — new, 8 tests.

## Tested

- 8 new tests: 3 plain-DOM unit tests for the index maths (scope isolation, stepping past a foreign-scope row, clamping at both ends) and 5 wiring tests against a rendered `ChatSidebar` (down, up, no session switch during a rove, edge falls through, modified arrow ignored).
- Revert-verified: with `ChatSidebar.tsx` reverted to HEAD, the 5 wiring tests fail and the 3 unit tests still pass.
- Full frontend suite: 8105 passed / 624 files. The one failure, `src/i18n/format.test.ts`, is environmental — it asserts `Intl.DurationFormat` is unavailable and the local Node 24 has it.
- `tsc -b` clean. `npm run lint` unchanged (the one error, a parse error in `src/vite-env.d.ts`, is inherited from main). `I18N_BASE_REF=origin/main npm run i18n:check` OK — no new user-facing strings.
- Browser-verified on a throwaway dev gateway (isolated `KIROCREW_HOME`, torn down after): focus ring on row 1, two real `ArrowDown` keystrokes, focus ring on row 3, active session and transcript pane unchanged.
