### PR TITLE
fix(chat): default the pinned-prompt banner off and stop it double-painting

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2291,7 +2291,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const pinFoldRef = useRef<HTMLDivElement | null>(null)
   const pinCardRef = useRef<HTMLDivElement | null>(null)
   const pinEnabledRef = useRef(true)
-  const [pinned, setPinned] = useState<{ idx: number; text: string; raw: string; full: string; images: string[]; push: number; bannerH: number } | null>(null)
+  const [pinned, setPinned] = useState<{ idx: number; ts?: string; text: string; raw: string; full: string; images: string[]; push: number; bannerH: number } | null>(null)
   const [pinExpanded, setPinExpanded] = useState(false)
   // Collapsed card height — the hand-off line is derived from it, so it must be
   // known even while nothing is pinned (no card mounted to measure). Seeded with
@@ -2369,9 +2369,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // once per animation frame during a scroll, so a fresh object (or a fresh
     // `images` array) would re-render the banner on every one of them.
     setPinned(prev => (prev && prev.idx === pinIdx && prev.push === push
-      && prev.raw === full && prev.bannerH === bannerH)
+      && prev.raw === full && prev.bannerH === bannerH && prev.ts === pinItem.msg.ts)
       ? prev
-      : { idx: pinIdx, text, raw: full, full: promptBody(full), images: promptImages(full), push, bannerH })
+      : { idx: pinIdx, ts: pinItem.msg.ts, text, raw: full, full: promptBody(full), images: promptImages(full), push, bannerH })
   }, [scrollerRef])
   // rAF-throttle the per-scroll recompute: updatePinnedPrompt does a
   // querySelectorAll + getBoundingClientRect loop (a forced layout read), and a
@@ -3797,11 +3797,15 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   )
 
   // Keep the ref in sync so handleRangeChanged / updatePinnedPrompt
-  // read the latest displayItems. useEffect rather than render-body
-  // mutation keeps us in line with React's rules of render (no side
-  // effects) — the one-tick lag is irrelevant because callbacks fire
-  // after commit, by which point the ref has caught up.
-  useEffect(() => { displayItemsRef.current = displayItems }, [displayItems])
+  // read the latest displayItems. useLayoutEffect (not useEffect): the DOM's
+  // `data-display-index` attributes are updated at commit, but a scroll rAF can
+  // fire before React flushes a PASSIVE effect — so with useEffect the pin
+  // recompute could read fresh DOM indices against a stale list, mis-deriving
+  // `pinned.idx` by one row (the row-hide is identity-keyed as a second guard,
+  // see below). A layout effect runs in the commit phase, before that rAF, so
+  // the ref is caught up by the time the recompute reads it. Still a passive
+  // side effect, not render-body mutation, so React's rules of render hold.
+  useLayoutEffect(() => { displayItemsRef.current = displayItems }, [displayItems])
 
   // Pinned prompt: keep the enablement ref in sync (updatePinnedPrompt is declared
   // above chatConfig and reads it through a ref), and recompute after the list
@@ -4778,7 +4782,19 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                   // appears to simply stop travelling and stick. A row is only ever
                   // hidden once it is entirely behind the band, so a tall prompt
                   // never leaves a visible hole above the response.
-                  visibility: pinned?.idx === displayIdx ? 'hidden' : undefined,
+                  //
+                  // Match by message IDENTITY (ts), not display index. `pinned.idx`
+                  // is computed in a scroll rAF against `displayItemsRef`, which is
+                  // refreshed in a layout effect — but a streaming append or a turn
+                  // regroup can still shift the list between that read and this
+                  // render, leaving `pinned.idx` pointing one row off. When it did,
+                  // the WRONG row was hidden and the real pinned bubble painted
+                  // alongside the banner — the "two stacked boxes" bug. The ts is
+                  // stable across any index shift, so it hides the right row every
+                  // frame; fall back to the index only for a message with no ts.
+                  visibility: (pinned && (pinned.ts != null
+                    ? (item.kind === 'single' && item.msg.ts === pinned.ts)
+                    : pinned.idx === displayIdx)) ? 'hidden' : undefined,
                 }}>{item.kind === 'group' ? (() => {
                 const unresolvedGroupPerms = item.msgs.filter(m => m.role === 'permission' && !m.meta?.resolved)
                 if (item.msgs.every(m => m.role === 'permission')) return null

--- a/website/src/pages/chat/ChatSettings.tsx
+++ b/website/src/pages/chat/ChatSettings.tsx
@@ -48,7 +48,7 @@ export type FollowUpLayout = 'multiline' | 'scroll'
 export type StreamMode = 'immediate' | 'smooth'
 
 const LS_KEY = 'mc-chat-config'
-const DEFAULTS: ChatConfig = { historyExpanded: true, showTimestamps: true, showTurnStats: true, sendOnEnter: 'enter', collapseAllSteps: true, confirmCloseSession: false, simplifiedToolNames: true, contentWidth: 'compact', tagColumnsEnabled: true, fileChipStyle: 'expanded', followUpLayout: 'scroll', streamMode: 'smooth', showContextPct: false, defaultAutopilot: false, pinLastPrompt: true }
+const DEFAULTS: ChatConfig = { historyExpanded: true, showTimestamps: true, showTurnStats: true, sendOnEnter: 'enter', collapseAllSteps: true, confirmCloseSession: false, simplifiedToolNames: true, contentWidth: 'compact', tagColumnsEnabled: true, fileChipStyle: 'expanded', followUpLayout: 'scroll', streamMode: 'smooth', showContextPct: false, defaultAutopilot: false, pinLastPrompt: false }
 
 const VALID_FILE_CHIP_STYLES: ReadonlySet<FileChipStyle> = new Set(['expanded', 'minimal'])
 const VALID_FOLLOW_UP_LAYOUTS: ReadonlySet<FollowUpLayout> = new Set(['multiline', 'scroll'])
@@ -80,7 +80,7 @@ export function loadChatConfig(): ChatConfig {
     if (!VALID_STREAM_MODES.has(cfg.streamMode)) cfg.streamMode = 'smooth'
     if (typeof cfg.showContextPct !== 'boolean') cfg.showContextPct = false
     if (typeof cfg.showTurnStats !== 'boolean') cfg.showTurnStats = true
-    if (typeof cfg.pinLastPrompt !== 'boolean') cfg.pinLastPrompt = true
+    if (typeof cfg.pinLastPrompt !== 'boolean') cfg.pinLastPrompt = false
     return cfg
   }
   catch { return { ...DEFAULTS } }


### PR DESCRIPTION
## Problem
The pinned-prompt banner (the most recent prompt collapsed into a sticky card under the session title as it scrolls behind the fold, added in #950) shipped **on by default**, and it can render a **second, ghost copy of a message**: the banner and the prompt's own transcript bubble both paint at once ("two stacked input boxes").

## Why it matters
Users who dislike the banner had to discover the buried `Pin last prompt` toggle to turn it off, and the double-paint makes the transcript look broken during active/streaming sessions — exactly when the feature is most visible.

## Fix (symptom → root cause → change)
- **Default:** the banner is a stylistic preference, not core behavior, so it should be opt-in. Flip `pinLastPrompt` to `false` in both `DEFAULTS` and the config migration fallback. Users who already enabled it keep their setting; the toggle in Settings → Chat is unchanged.
- **Double-paint:** the banner is styled to sit exactly where the real bubble was, so the real row is hidden with `visibility:hidden` while pinned. That hide keyed off `pinned.idx === displayIdx`. `pinned.idx` is computed in a scroll `requestAnimationFrame` against `displayItemsRef`, which was refreshed in a **passive `useEffect`** — but a streaming append or a turn regroup can shift the display list between the DOM commit (which updates `data-display-index`) and that passive effect. The rAF then reads fresh DOM indices against a stale list and derives `pinned.idx` one row off, so the *wrong* row is hidden and the real pinned bubble paints alongside the banner. Fix: hide the real row by **message identity** (`item.kind === 'single' && item.msg.ts === pinned.ts`), falling back to the index only when a message has no `ts`; store `ts` on the `pinned` state (and in its per-frame equality short-circuit). Also promote the `displayItemsRef` sync from `useEffect` to `useLayoutEffect` so the recompute reads a fresh list, closing the window on the compute side too.

## Tests
No new tests. The existing `pinnedPrompt.test.ts` (42) and `groupDisplayItems.test.ts` (14) cover the geometry/selection helpers, which are unchanged; the hide is a render-time attribute in `ChatPage.tsx`. `ChatSettings.test.tsx` / `ChatPanel.settings.test.tsx` exercise the config round-trip and pass with the new default. Full suite touched here (pinned + groupDisplayItems + ChatSettings + ChatPanel + a ChatPage render integration): 87 pass.

## Manual verification
`tsc -p tsconfig.app.json` clean; `eslint` on both changed files reports 0 errors. Behavioral verification of the transient double-paint requires reproducing a streaming/regroup race in a live browser and is left for reviewer/manual confirmation; the identity-based hide is strictly more robust than the prior index match in every case.

## Screenshots
N/A — this change (a) flips a default so an existing banner no longer appears, and (b) fixes a transient, race-dependent double-paint that cannot be captured deterministically in a still. No new or restyled surface is introduced.
