### PR TITLE
fix(issue-radar): make connected-repo authz gate provider-case-aware

### DIFF
--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -518,17 +518,18 @@ def add_connected_repo(
     the UI can badge Read/Write access without a live call; updates it on
     reconnect if a fresh value is supplied.
 
-    Identity is CASE-INSENSITIVE for the owner/repo pair. GitHub names are
-    case-preserving but not case-sensitive, so ``acme/widget`` and ``Acme/Widget``
-    are one repo -- a case-sensitive match would append a second entry for it, and
-    that duplicate would carry its own independent caches and triage settings. The
-    first spelling connected stays the stored one, so existing entries are never
+    Identity follows the provider's own case semantics (see :func:`_same_repo`).
+    GitHub names are case-preserving but not case-sensitive, so ``acme/widget``
+    and ``Acme/Widget`` are one repo -- a case-sensitive match would append a
+    second entry with its own independent caches and triage settings; the first
+    spelling connected stays the stored one, so existing entries are never
     rewritten.
 
-    GitLab project paths ARE case-sensitive, but folding case here would only ever
-    merge two entries a user cannot distinguish in the UI anyway, and treating the
-    two providers differently would mean two identity rules to keep in sync. The
-    conservative single rule is kept.
+    GitLab project paths ARE case-sensitive, so ``group/Project`` and
+    ``group/project`` are distinct projects and are stored as distinct entries --
+    matching how the provider API and cache paths resolve them. Folding case for
+    GitLab would let the authorization gate admit a case-variant of a connected
+    project that the data-plane then resolves to a different project.
     """
     with _config_lock(root):
         config = read_config(root)
@@ -552,10 +553,41 @@ def add_connected_repo(
         write_config(config, root)
 
 
+# Providers whose owner/repo names are case-INSENSITIVE at the source. GitHub
+# names are case-preserving but not case-sensitive, so ``acme/widget`` and
+# ``Acme/Widget`` address the same repository. GitLab project paths ARE
+# case-sensitive: ``group/Project`` and ``group/project`` are different projects
+# on the server. Any provider not listed here is matched case-SENSITIVELY -- the
+# fail-safe default for an authorization gate, so an unknown/self-managed
+# provider never silently widens the allowlist to case-variants.
+_CASE_INSENSITIVE_NAME_PROVIDERS = frozenset({"github"})
+
+
+def _name_matches(a: str, b: str, provider: str) -> bool:
+    """Compare two owner/repo name segments using ``provider``'s case semantics.
+
+    Load-bearing for authorization: the gate MUST interpret the name exactly as
+    the data-plane does. The data-plane (``repo_data_dir`` and the provider API
+    call -- e.g. ``gitlab_client.project_path`` which addresses the raw-case
+    slug) is case-sensitive for GitLab, so casefolding here would let a
+    case-variant of a connected GitLab project pass the gate and then resolve to
+    a DIFFERENT project under the owner's credentials.
+    """
+    if provider.lower() in _CASE_INSENSITIVE_NAME_PROVIDERS:
+        return a.casefold() == b.casefold()
+    return a == b
+
+
 def _same_repo(
     entry: dict, owner: str, repo: str, *, provider: str = "github", host: str = "github.com"
 ) -> bool:
-    """Provider-, host-, and case-insensitive-name identity for a config entry.
+    """Provider-, host-, and provider-aware-case identity for a config entry.
+
+    Name case sensitivity follows the provider (see :func:`_name_matches`):
+    case-insensitive for GitHub, case-sensitive for GitLab and any other
+    provider. This keeps the authorization gate's interpretation of owner/repo
+    identical to the data-plane's, so a case-variant of a connected GitLab
+    project is NOT authorized against a different project.
 
     An entry missing ``provider``/``host`` predates GitLab support and therefore
     means public GitHub; it is treated as such rather than as a non-match, so
@@ -566,8 +598,8 @@ def _same_repo(
     return (
         entry_provider == provider.lower()
         and entry_host == host.lower()
-        and str(entry.get("owner", "")).casefold() == owner.casefold()
-        and str(entry.get("repo", "")).casefold() == repo.casefold()
+        and _name_matches(str(entry.get("owner", "")), owner, entry_provider)
+        and _name_matches(str(entry.get("repo", "")), repo, entry_provider)
     )
 
 

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_gitlab.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_gitlab.py
@@ -417,6 +417,59 @@ class TestConnectedIdentity(unittest.TestCase):
         gl = store.read_repo_settings("g", "p", self.root, provider="gitlab", host="gitlab.com")
         self.assertEqual(gl["triage_labels"], [])
 
+    def test_gate_rejects_case_variant_gitlab_project(self):
+        # GitLab project paths are case-sensitive: group/Project and
+        # group/project are DIFFERENT projects. The gate must not authorize a
+        # request for a case-variant the owner never connected -- otherwise the
+        # raw-case data-plane (project_path + cache dir) would resolve it to a
+        # different project under the owner's credentials.
+        store.add_connected_repo(
+            "group", "project", provider="gitlab", host="gitlab.com", root=self.root
+        )
+        self.assertTrue(
+            store.is_repo_connected(
+                "group", "project", self.root, provider="gitlab", host="gitlab.com"
+            )
+        )
+        for owner, repo in (("group", "Project"), ("Group", "project"), ("GROUP", "PROJECT")):
+            self.assertFalse(
+                store.is_repo_connected(
+                    owner, repo, self.root, provider="gitlab", host="gitlab.com"
+                ),
+                f"case-variant {owner}/{repo} must NOT be authorized for GitLab",
+            )
+            self.assertIsNone(
+                store.find_connected_repo(
+                    owner, repo, self.root, provider="gitlab", host="gitlab.com"
+                )
+            )
+
+    def test_gate_still_case_insensitive_for_github(self):
+        # GitHub names are case-preserving but not case-sensitive, so a
+        # case-variant of a connected GitHub repo MUST still authorize.
+        store.add_connected_repo("Acme", "Widget", root=self.root)
+        for owner, repo in (("acme", "widget"), ("ACME", "WIDGET"), ("Acme", "Widget")):
+            self.assertTrue(
+                store.is_repo_connected(owner, repo, self.root),
+                f"case-variant {owner}/{repo} must remain authorized for GitHub",
+            )
+
+    def test_case_variant_gitlab_projects_stored_as_distinct_entries(self):
+        # Because GitLab is case-sensitive, connecting group/Project after
+        # group/project yields two entries, not a dedup collision.
+        store.add_connected_repo(
+            "group", "project", provider="gitlab", host="gitlab.com", root=self.root
+        )
+        store.add_connected_repo(
+            "group", "Project", provider="gitlab", host="gitlab.com", root=self.root
+        )
+        gitlab_entries = [
+            r
+            for r in store.list_connected_repos(self.root)
+            if r.get("provider") == "gitlab"
+        ]
+        self.assertEqual(len(gitlab_entries), 2)
+
 
 class TestNormalization(unittest.TestCase):
     def test_issue_row_matches_the_github_shape(self):


### PR DESCRIPTION
## Problem

Issue Radar's connected-repo **authorization gate** interprets a repo identifier differently from the data-plane that acts on it. `store._same_repo` / `is_repo_connected` compares owner/repo with `.casefold()` (case-insensitive) for **every** provider, but the same request's raw owner/repo (from `_key_from_body` / `_key_from_request`, which only `.strip()`) flow unchanged into both the cache path (`repo_data_dir`) and the provider API call. For GitLab, `gitlab_client.project_path(owner, repo)` addresses the raw-case slug, and **GitLab project paths are case-sensitive**.

## Why it matters

The connected-repo allowlist is the deliberate authorization boundary confining which projects Issue Radar's credential-bearing CLI may touch. Because the gate casefolds but GitLab resolves raw case, a request naming `group/Project` — a project the user never connected — passes `is_repo_connected` by casefold-matching a connected `group/project`, then a **mutating** action (`_handle_pull_merge` → `_pr_action_preamble` → `_connected` → `_run_pr_action` → `client.merge_pull_request`, and likewise approve/close/comment/label/state) executes against the *different* `group/Project` project using the owner's `glab` credentials. The allowlist is bypassed for a case-variant — a prompt-injection→destructive-action surface. (CSE `SEC-1D4950B4`, CWE-178 / CWE-863 / CWE-706.)

## Fix (symptom → root cause → change)

- **Symptom:** a case-variant GitLab project passes the connected-repo gate and mutating actions hit an unconnected project.
- **Root cause:** the authorization key is normalized (casefold) differently from the lookup key (raw case) — an authz-vs-data-plane canonicalization asymmetry. Only GitHub is case-insensitive at the source; GitLab is case-sensitive.
- **Change:** name matching in `_same_repo` is now **provider-aware** via a small `_name_matches(a, b, provider)` helper: casefold for GitHub (`_CASE_INSENSITIVE_NAME_PROVIDERS = {"github"}`), exact-match for GitLab **and any other/self-managed provider** — the fail-safe default for an authorization gate, so an unknown provider never silently admits case-variants. This makes the gate interpret owner/repo identically to the data-plane. Docstrings on `_same_repo` and `add_connected_repo` updated to state the provider-aware semantics.

GitHub behavior is unchanged (still case-insensitive). Legacy entries lacking `provider`/`host` still read as GitHub. As a correct side effect, `add_connected_repo` now stores case-variant GitLab projects as distinct entries (they are genuinely different projects).

## Tests

Added to `TestConnectedIdentity` in `test_gitlab.py`:
- `test_gate_rejects_case_variant_gitlab_project` — the gate (and `find_connected_repo`) reject `group/Project`, `Group/project`, `GROUP/PROJECT` when only `group/project` is connected on GitLab.
- `test_gate_still_case_insensitive_for_github` — case-variants of a connected GitHub repo remain authorized (no regression).
- `test_case_variant_gitlab_projects_stored_as_distinct_entries` — connecting `group/Project` after `group/project` on GitLab yields two entries, not a dedup collision.

## Manual verification

N/A — backend authorization logic; unit coverage over the gate is the meaningful evidence. Full `test_gitlab.py` (101 tests) plus `test_store_settings.py` / `test_members.py` (36 tests) pass; isort / flake8 / mypy clean.

## Screenshots

N/A — no user-visible UI change.
