### PR TITLE
fix(ci): include registry.json in i18n-render base export

### DIFF
--- a/website/scripts/check-i18n-render.mjs
+++ b/website/scripts/check-i18n-render.mjs
@@ -412,11 +412,20 @@ function resolveBaseScope() {
  * did exactly that to me once. `git archive` touches no repo state at all, needs no
  * cleanup, cannot corrupt anything, and works on the shallow clone CI checks out.
  *
- * Only `website/` is exported: nothing in its build config reaches outside it.
- * `node_modules` is symlinked rather than installed — a second `npm ci` would cost
- * minutes, and the base's dependency set only matters if the lockfile changed, which
- * a render gate is not the right place to police.
+ * Mostly `website/` is exported, plus the handful of files it imports ACROSS the
+ * repo boundary at build time (`CROSS_BOUNDARY_BUILD_DEPS`): those escape `website/`
+ * via `../../../../src/kiro_crew/...`, so without them in the export vite cannot
+ * resolve the import and the base build dies. `node_modules` is symlinked rather
+ * than installed — a second `npm ci` would cost minutes, and the base's dependency
+ * set only matters if the lockfile changed, which a render gate is not the right
+ * place to police.
  */
+const CROSS_BOUNDARY_BUILD_DEPS = [
+  // website/src/pages/connections/registry.ts imports this JSON via
+  // ../../../../src/kiro_crew/connections/registry.json, reaching outside website/.
+  'src/kiro_crew/connections/registry.json',
+]
+
 function buildBaseBundle(sha) {
   const dir = join(tmpdir(), `i18n-render-base-${sha.slice(0, 12)}`)
   rmSync(dir, { recursive: true, force: true })
@@ -424,9 +433,23 @@ function buildBaseBundle(sha) {
   out(`[i18n-render] [vs-base] exporting base tree ${sha.slice(0, 8)}`)
 
   const tarball = join(dir, 'base.tar')
+  // `git archive` fatals on a pathspec that matches nothing, so include each
+  // cross-boundary dep only when it exists at THIS base sha (older bases predate
+  // it). `website` is always present.
+  const extraPaths = CROSS_BOUNDARY_BUILD_DEPS.filter((p) => {
+    try {
+      execFileSync('git', ['cat-file', '-e', `${sha}:${p}`], { cwd: REPO, stdio: 'ignore' })
+      return true
+    } catch {
+      return false
+    }
+  })
   try {
-    const out = execFileSync('git', ['archive', '--format=tar', '-o', tarball, sha, 'website'],
-      { cwd: REPO, stdio: 'pipe' })
+    const out = execFileSync(
+      'git',
+      ['archive', '--format=tar', '-o', tarball, sha, 'website', ...extraPaths],
+      { cwd: REPO, stdio: 'pipe' },
+    )
     void out
     execFileSync('tar', ['-xf', tarball, '-C', dir], { stdio: 'pipe' })
     rmSync(tarball, { force: true })


### PR DESCRIPTION
## Problem

The `i18n:render` gate (`website/scripts/check-i18n-render.mjs`) fails the base build on every PR:

```
Could not resolve "../../../../src/kiro_crew/connections/registry.json"
  from "src/pages/connections/registry.ts"
[base 0e3544b0] vite build failed (exit 1)
```

## Root cause

`buildBaseBundle()` materializes the base commit with `git archive <sha> website` — **only** the `website/` subtree, on the documented assumption that "nothing in its build config reaches outside it."

That invariant no longer holds: `website/src/pages/connections/registry.ts` imports

```ts
import registryJson from '../../../../src/kiro_crew/connections/registry.json'
```

which escapes `website/` into the backend tree. The archived base lacks that file, so vite cannot resolve the import and the base build dies. HEAD builds fine because CI checks it out in full; only the partial base archive breaks. The gate therefore red-flags **every** PR, independent of its diff.

## Fix

Export the small set of cross-boundary build deps alongside `website/`:

- Add a `CROSS_BOUNDARY_BUILD_DEPS` list (currently just `src/kiro_crew/connections/registry.json`).
- Include each in the `git archive` pathspec, guarded by a `git cat-file -e <sha>:<path>` existence check so `git archive` does not fatal on an older base that predates the file.

Extraction preserves the repo-relative layout, so `../../../../src/kiro_crew/connections/registry.json` resolves from `website/src/pages/connections/` in the exported tree.

## Validation

- `node --check website/scripts/check-i18n-render.mjs` passes.
- Simulated the fixed archive at `origin/main`: both `src/kiro_crew/connections/registry.json` and `website/src/pages/connections/registry.ts` land in the export root, so the previously-failing import now resolves.

Full `i18n:render` runs in CI.
