### PR TITLE
fix(dashboard): stop a meta dict race aborting chat-history saves

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -667,6 +667,17 @@ def _flush_file_changes(slot: "_ChatSlot") -> None:
             meta={"file_changes": fc_list},
         )
     logger.info("Attached %d file_changes to slot %s", len(fc_list), slot.key)
+    # Honour the in-place-mutation contract (see resolve_permission_message in
+    # state.py): "the periodic flush skips non-dirty slots, so an unflagged
+    # in-place mutation can be lost on restart". The assistant-message branch
+    # above mutates meta in place without appending, so nothing else marks the
+    # slot dirty. That matters on the error/cancel call path, which — unlike the
+    # success path — is NOT followed by an explicit save_slot_off_loop: without
+    # this flag a periodic flush that snapshotted the message just before this
+    # write clears _dirty, and the file_changes never reach disk.
+    # (slot.append in the else branch already sets it; setting it once here
+    # covers both branches and cannot be missed by a later edit.)
+    slot._dirty = True
     slot._file_changes = []
 
 

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -503,13 +503,27 @@ def _redact_value(v):  # type: ignore[no-untyped-def]
     if isinstance(v, dict):
         return _redact_meta(v)
     if isinstance(v, list):
-        return [_redact_value(i) for i in v]
+        # Snapshot for the same reason as _redact_meta — the flush thread reads
+        # containers the event loop is still appending to.
+        return [_redact_value(i) for i in list(v)]
     return v
 
 
 def _redact_meta(meta: dict) -> dict:
-    """Recursively redact string values in meta dict."""
-    return {k: _redact_value(v) for k, v in meta.items()}
+    """Recursively redact string values in meta dict.
+
+    Iterates a SNAPSHOT of the dict, never the live object. ``_redact_meta`` is
+    reached from ``_save_slot_to_history``, which runs in the flush executor
+    thread while the event loop is still mutating that same message's meta
+    (streaming tool calls, growing file-change lists). Iterating ``meta.items()``
+    directly therefore raised ``RuntimeError: dictionary changed size during
+    iteration``, which propagated out of ``_save_slot_to_history`` and aborted
+    the whole slot's save — the transcript for that flush was lost.
+
+    A shallow copy per level suffices: the copy's key set is stable, and nested
+    containers get their own snapshot from the recursive call.
+    """
+    return {k: _redact_value(v) for k, v in list(meta.items())}
 
 
 def _redact_meta_for_role(role: str, meta: dict) -> dict:
@@ -522,7 +536,7 @@ def _redact_meta_for_role(role: str, meta: dict) -> dict:
     """
     if role == "mcp_oauth":
         out: dict = {}
-        for k, v in meta.items():
+        for k, v in list(meta.items()):
             if k == "oauth_url" and isinstance(v, str):
                 # Two gates, and deliberately NOT a third:
                 #   1. http(s)-only — a tampered history line can't smuggle a

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -790,7 +790,8 @@ class _ChatSlot:
         "_stop_event_id",
         "_stop_escalated_card_id",
         "_pending_reset_history_key",
-        "_dirty",
+        "_dirty_flag",
+        "_dirty_gen",
         "_orch_tracker",
         "_auto_run",
         "_recovery_chat_triggered",
@@ -928,7 +929,10 @@ class _ChatSlot:
         # inline because the endpoint can be reached from inside the kiro-cli
         # process group via the set_project MCP tool.
         self._pending_reset_history_key: str | None = None
-        self._dirty: bool = False  # True when messages changed since last flush
+        self._dirty_flag: bool = False  # True when messages changed since last flush
+        # Bumped by the _dirty setter on every True. Lets the periodic flush tell
+        # "the True I started this save under" from "a NEW True set during it".
+        self._dirty_gen: int = 0
         self._orch_tracker: Any = None  # OrchestrationTracker, set by gateway
         self._auto_run: bool = False  # "Go All" — skip stage gates
         self._recovery_chat_triggered: bool = False  # guard against concurrent failure recovery
@@ -1085,6 +1089,40 @@ class _ChatSlot:
         # STOP, error). Without this, a steer swallowed by a dying turn
         # vanished with no trace (see the requeue site).
         self._pending_steers: list[str] = []
+
+    @property
+    def _dirty(self) -> bool:
+        """True while this slot holds state not yet confirmed on disk.
+
+        Deliberately a property so that ``_dirty_gen`` is bumped centrally by the
+        ~20 existing ``slot._dirty = True`` sites without editing any of them.
+
+        Two independent readers depend on this staying True for the WHOLE
+        duration of a save, not just until the save starts:
+
+        * ``chat_fork`` treats it as "unpersisted in-memory state exists". A False
+          read makes it skip both the in-memory tail append and the durable
+          pre-fork save, so it forks from stale disk and the new session silently
+          omits the newest messages.
+        * ``_save_slot_to_history``'s resumed-slot no-op guard skips when
+          ``_resumed_count > 0 and len(window) <= _resumed_count and not _dirty``;
+          its comment states the assumption directly — "a dirty slot whose length
+          merely equals the resumed count still falls through ... otherwise an
+          in-place edit after resume would never reach disk."
+
+        So the periodic flush must NOT clear this early to protect itself against
+        clobbering a concurrent mark. It compares ``_dirty_gen`` instead.
+        """
+        return self._dirty_flag
+
+    @_dirty.setter
+    def _dirty(self, value: bool) -> None:
+        self._dirty_flag = value
+        if value:
+            # Monotonic: only ever advances, so a wrapped-around compare is
+            # impossible and a missed bump can only cause an extra (harmless)
+            # flush, never a skipped one.
+            self._dirty_gen += 1
 
     @property
     def _plan_stage_count(self) -> int:
@@ -2349,11 +2387,29 @@ class DashboardState:
         for slot in list(self._slots.values()):
             if not slot._dirty or not slot.messages:
                 continue
+            # Clear the dirty bit only if NOTHING re-marked the slot while this
+            # save was running. This runs on an executor thread and the event loop
+            # keeps mutating the slot underneath it, so a plain post-save
+            # `_dirty = False` would overwrite a mark set DURING the save (e.g.
+            # _flush_file_changes attaching file_changes) — the stale snapshot
+            # would be the last thing written and every later pass would skip the
+            # slot, so the late mutation would never reach disk.
+            #
+            # The generation compare is used instead of consuming the bit up front
+            # because `_dirty` must stay True for the whole save: `chat_fork` reads
+            # it as "unpersisted state exists" (a False read makes it fork from
+            # stale disk), and `_save_slot_to_history`'s resumed-slot no-op guard
+            # is written assuming a dirty slot still reads dirty during the save.
+            # See the `_dirty` property for both contracts.
+            gen = slot._dirty_gen
             try:
                 _save_slot_to_history(self, slot)
-                slot._dirty = False
             except Exception:
+                # Leave _dirty set so the next 5s pass retries.
                 logger.warning("Flush failed for slot %s", slot.key, exc_info=True)
+            else:
+                if slot._dirty_gen == gen:
+                    slot._dirty = False
         # Snapshot the live tab set so a gateway restart can restore exactly
         # the tabs the user had open, regardless of last-message age. Without
         # this, restore_recent_sessions only brings back sessions whose

--- a/test/test_redact_meta_snapshot.py
+++ b/test/test_redact_meta_snapshot.py
@@ -1,0 +1,269 @@
+"""Regression test: meta redaction must iterate a snapshot, not the live dict.
+
+``_redact_meta`` is reached from ``_save_slot_to_history``, which runs in the
+flush executor thread. The event loop keeps mutating that same message's meta
+while the flush runs (streaming tool calls, growing file-change lists), so
+iterating ``meta.items()`` directly raised
+
+    RuntimeError: dictionary changed size during iteration
+
+That exception propagated out of ``_save_slot_to_history`` and aborted the whole
+slot's save. Observed twice in the gateway log:
+
+    ERROR kiro_crew.dashboard.chat_persistence: Failed to save slot
+    chat-73-... to history
+    WARNING kiro_crew.dashboard.state: Flush failed for slot chat-73-...
+
+Scope of the damage, stated precisely: ``_flush_dirty_slots`` clears
+``slot._dirty`` only on success, so the aborted flush left the slot dirty and the
+next 5s flush retried it, and shutdown re-serialises via
+``save_all_slots_to_history(force=True)``. ``atomic_write`` is the last step and
+the raise happens before it, so no partial or corrupt file was ever produced.
+The reliable costs are therefore a failed flush interval and the repeating
+ERROR/WARNING pair; PERMANENT transcript loss additionally required a hard kill
+inside the failing window.
+
+The mutation here is driven deterministically by a nested value that writes to
+its own parent when redacted, rather than by a real thread — same failure, no
+timing dependence. Reverting either ``list(...)`` snapshot makes these fail.
+"""
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.dashboard.chat_utils import (
+    _redact_meta,
+    _redact_meta_for_role,
+    _redact_value,
+)
+
+
+class _MutatesParentWhenRead(dict):
+    """A nested meta value that grows its PARENT dict the moment it is redacted.
+
+    Stands in for the event loop appending a new meta key while the flush thread
+    is midway through iterating the same dict.
+    """
+
+    def __init__(self, parent: dict) -> None:
+        super().__init__(inner="value")
+        self._parent = parent
+
+    def items(self):  # type: ignore[no-untyped-def]
+        self._parent[f"appended_{len(self._parent)}"] = "by-event-loop"
+        return super().items()
+
+
+def _meta_that_mutates_mid_iteration() -> dict:
+    meta: dict = {"first": "a", "second": "b"}
+    meta["nested"] = _MutatesParentWhenRead(meta)
+    meta["last"] = "c"
+    return meta
+
+
+def test_redact_meta_survives_concurrent_key_insertion() -> None:
+    """_redact_meta does not raise when meta grows during the redaction pass."""
+    meta = _meta_that_mutates_mid_iteration()
+
+    out = _redact_meta(meta)
+
+    # The pre-mutation key set is what gets persisted; the point is that the
+    # save completes at all rather than aborting the whole slot.
+    assert {"first", "second", "nested", "last"} <= set(out)
+    assert out["first"] == "a"
+    # The racing write did land on the live dict — proving the mutation fired
+    # and that the snapshot, not luck, is what kept the pass alive.
+    assert any(k.startswith("appended_") for k in meta)
+
+
+def test_redact_meta_for_role_survives_concurrent_key_insertion() -> None:
+    """The mcp_oauth branch iterates meta directly and needs the same snapshot."""
+    meta = _meta_that_mutates_mid_iteration()
+    meta["oauth_url"] = "https://example.com/authorize?client_id=abc"
+
+    out = _redact_meta_for_role("mcp_oauth", meta)
+
+    assert out["oauth_url"] == "https://example.com/authorize?client_id=abc"
+    assert any(k.startswith("appended_") for k in meta)
+
+
+def test_redact_value_snapshots_lists() -> None:
+    """A list value is snapshotted too — same live-container exposure.
+
+    Note this asserts snapshot SEMANTICS, not crash avoidance: unlike a dict, a
+    list never raises on concurrent resize. Without the snapshot the appended
+    element is redacted into the output (len 4); with it, it is not (len 3).
+    """
+    live: list = ["a", "b"]
+
+    class _GrowsSibling(dict):
+        def items(self):  # type: ignore[no-untyped-def]
+            live.append("appended-by-event-loop")
+            return super().items()
+
+    live.append(_GrowsSibling(inner="x"))
+
+    out = _redact_value(live)
+
+    assert isinstance(out, list)
+    # Snapshot taken before the mutation, so the appended element is absent from
+    # this pass's output.
+    assert len(out) == 3
+    assert "appended-by-event-loop" in live
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        {},
+        {"plain": "value"},
+        {"nested": {"deep": {"deeper": "value"}}},
+        {"listy": ["a", {"b": "c"}]},
+    ],
+)
+def test_redact_meta_preserves_structure(meta: dict) -> None:
+    """Snapshotting must not change ordinary redaction behaviour."""
+    out = _redact_meta(meta)
+    assert out == meta
+    assert out is not meta
+
+
+def test_flush_file_changes_marks_slot_dirty() -> None:
+    """An in-place meta write must flag the slot, or the snapshot can drop it.
+
+    Counterpart to the snapshot above. Before the snapshot existed, a flush
+    racing `_flush_file_changes` RAISED, which left `slot._dirty` set and got the
+    key persisted on the next 5s retry -- the crash was accidentally standing in
+    for the missing dirty flag. With the race fixed the flush SUCCEEDS without
+    the late key and clears `_dirty`, so on the error/cancel path (which, unlike
+    the success path, is not followed by an explicit `save_slot_off_loop`) the
+    `file_changes` would never reach disk.
+
+    `state.py`'s in-place-mutation contract states it directly: "the periodic
+    flush skips non-dirty slots, so an unflagged in-place mutation can be lost on
+    restart."
+    """
+    from kiro_crew.dashboard.chat_runner import _flush_file_changes
+
+    class _Slot:
+        key = "chat-1-test"
+
+        def __init__(self) -> None:
+            self.messages = [{"role": "assistant", "content": "hi", "meta": {}}]
+            self._file_changes = [{"path": "/tmp/x.txt", "content": "before"}]
+            self._dirty = False
+
+    slot = _Slot()
+    _flush_file_changes(slot)  # type: ignore[arg-type]
+
+    assert slot.messages[0]["meta"]["file_changes"], "meta written in place"
+    assert slot._dirty is True, (
+        "in-place meta write must mark the slot dirty, else the periodic flush "
+        "skips it and the file_changes are lost on restart"
+    )
+
+
+def _flush_harness(save_fn):
+    """Drive DashboardState._flush_dirty_slots with a stubbed save.
+
+    Returns the slot so a test can assert on `_dirty` after the pass.
+    """
+    from kiro_crew.dashboard import chat as chat_mod
+    from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+    class _Slot:
+        key = "chat-1-test"
+        # Reuse the REAL property descriptor rather than reimplementing it, so
+        # this harness exercises the actual generation-bump logic.
+        _dirty = _ChatSlot._dirty
+
+        def __init__(self) -> None:
+            self.messages = [{"role": "assistant", "content": "hi", "meta": {}}]
+            self._dirty_flag = False
+            self._dirty_gen = 0
+            self._dirty = True  # through the setter, so _dirty_gen advances
+
+    class _State:
+        conversation_log = True
+
+        def __init__(self) -> None:
+            self._slots = {"chat-1-test": slot}
+
+        def _persist_open_slots(self) -> None:
+            pass
+
+        def _persist_context_snapshots(self) -> None:
+            pass
+
+    slot = _Slot()
+    original = chat_mod._save_slot_to_history
+    chat_mod._save_slot_to_history = save_fn
+    try:
+        DashboardState._flush_dirty_slots(_State())  # type: ignore[arg-type]
+    finally:
+        chat_mod._save_slot_to_history = original
+    return slot
+
+
+def test_flush_dirty_slots_keeps_dirty_visible_during_save() -> None:
+    """`_dirty` must read True for the WHOLE save, not just until it starts.
+
+    Two independent readers depend on this, which is why the flush compares
+    `_dirty_gen` instead of consuming the bit up front:
+
+    * `chat_fork` (chat_fork.py:137,141) treats `_dirty` as "unpersisted
+      in-memory state exists". A False read makes it skip BOTH the in-memory tail
+      append and the durable pre-fork save, so it forks from stale disk and the
+      new session permanently omits the newest messages.
+    * `_save_slot_to_history`'s resumed-slot no-op guard skips when
+      `_resumed_count > 0 and len(window) <= _resumed_count and not _dirty`.
+    """
+    seen: list[bool] = []
+
+    def save_observing_dirty(state, slot, **kwargs) -> None:
+        # Stands in for a concurrent chat_fork / the no-op guard reading _dirty
+        # from inside the save window.
+        seen.append(slot._dirty)
+
+    _flush_harness(save_observing_dirty)
+
+    assert seen == [True], (
+        "_dirty must still read True inside the save, else a concurrent fork "
+        "reads stale disk and drops the newest messages"
+    )
+
+
+def test_flush_dirty_slots_preserves_concurrent_dirty_mark() -> None:
+    """A mark set DURING the save must survive the post-save clear.
+
+    This is the ordering the snapshot fix exposed. The worker thread reads the
+    messages, the event loop then attaches `file_changes` and sets
+    `_dirty=True`, and the worker writes its now-stale snapshot. If the worker
+    clears `_dirty` AFTER saving, it overwrites that request with False and the
+    late key is skipped by every later pass — silent loss. Clearing before the
+    save keeps the request alive.
+    """
+
+    def save_with_concurrent_mutation(state, slot, **kwargs) -> None:
+        # Stands in for the event loop running _flush_file_changes while this
+        # save is in flight: new meta lands, and the slot is re-marked dirty.
+        slot.messages[0]["meta"]["file_changes"] = [{"path": "/tmp/x.txt"}]
+        slot._dirty = True
+
+    slot = _flush_harness(save_with_concurrent_mutation)
+
+    assert slot._dirty is True, (
+        "a dirty mark set during the save must survive, or the concurrently "
+        "attached file_changes are never written to disk"
+    )
+
+
+def test_flush_dirty_slots_rearms_dirty_on_failure() -> None:
+    """A failed save must leave the slot dirty so the next pass retries."""
+
+    def save_that_raises(state, slot, **kwargs) -> None:
+        raise OSError("disk full")
+
+    slot = _flush_harness(save_that_raises)
+
+    assert slot._dirty is True, "a failed flush must stay dirty to be retried"


### PR DESCRIPTION
## Problem

Chat-history flushes were failing outright. The gateway log carried, twice on one slot:

```
ERROR kiro_crew.dashboard.chat_persistence: Failed to save slot chat-73-… to history
RuntimeError: dictionary changed size during iteration
WARNING kiro_crew.dashboard.state: Flush failed for slot chat-73-…
```

The failure was not scoped to the offending message — it aborted the **whole slot's** save for that interval.

## Why it matters

The crash itself was self-healing: `_flush_dirty_slots` left the slot dirty, so the next 5s flush retried, and `atomic_write` runs after the raise so no partial file was written. The reliable costs were a lost flush interval and repeating log noise.

The more important finding came out of review. Removing the crash **without** fixing the dirty-flag bookkeeping would have been a net regression: the exception was accidentally providing the retry that the bookkeeping was failing to provide. Snapshotting alone makes the racing flush *succeed* while missing the late key and then clear `_dirty` — turning a loud, recovered abort into silent, permanent loss of that message's `file_changes`. Both holes are fixed here; see change 2 and 3.

## Fix (symptom → root cause → change)

**Symptom.** `RuntimeError: dictionary changed size during iteration` out of `_redact_meta`, aborting the slot save.

**Root cause.** `_flush_loop` dispatches `_flush_dirty_slots` via `run_in_executor(None, …)`, so `_save_slot_to_history` → `_build_message_entry` → `_redact_meta_for_role(role, m["meta"])` walks message `meta` on a **worker thread**, while the event loop inserts into those same live dicts (`m.setdefault("meta", {})["file_changes"] = fc_list` in `_flush_file_changes`). `_redact_meta` iterated the live dict; because the comprehension calls Python (`_redact_value`) between successive `__next__` calls, the GIL is yielded mid-iteration and a concurrent insert makes the next `dictiter_iternextitem` observe `di_used != ma_used`. Nothing contained it, so it propagated to `_save_slot_to_history`.

**Three changes**, because the first alone is not safe:

1. **`chat_utils.py` — snapshot before iterating**, at all three sites (`_redact_meta`, the list branch of `_redact_value`, the `mcp_oauth` branch of `_redact_meta_for_role`). `list()` materialises the pairs in one C-level step with no interpreted callback interleaved, so no other thread can run mid-build; recursion re-snapshots each nested level, so no live container is ever the iteration target.

2. **`chat_runner.py` — mark the slot dirty after the in-place meta write.** `state.py`'s own contract requires it: *"the periodic flush skips non-dirty slots, so an unflagged in-place mutation can be lost on restart."* This bites on the error/cancel path (~line 5387), which — unlike the success path — is **not** followed by an explicit `save_slot_off_loop`, so `_dirty` is its only route to disk.

3. **`state.py` — clear `_dirty` after the save only if nothing re-marked the slot during it**, via a generation counter.

   Two earlier revisions tried simpler shapes here and each exposed the next hole, because **`_dirty` carries two meanings**:
   - *"the periodic flush has work to do"* — the clear must not clobber a mark set **during** the save. A plain post-save `_dirty = False` does exactly that: the stale snapshot is the last thing written and every later pass skips the slot.
   - *"unpersisted in-memory state exists"* — `chat_fork` (`chat_fork.py:137,141`) reads it this way. A False read makes the fork skip **both** the in-memory tail append **and** the durable pre-fork save, so it forks from stale disk and the new session permanently omits the newest messages. `_save_slot_to_history`'s resumed-slot no-op guard reads it the same way.

   Clearing the bit up front satisfies the first meaning and breaks the second. So `_dirty` becomes a **property whose setter bumps `_dirty_gen`** — this centralises the bump across the ~20 existing `slot._dirty = True` sites without editing any of them. The flush records the generation, saves with `_dirty` still reading **True** (both readers above stay correct), and clears only if the generation is unchanged. A failed save leaves the bit set, so the retry stands. This also **removes** the `force=True` guard-bypass an earlier revision needed.

**Why this layer.** `chat_persistence.py` already documents the same hazard one level up ("Concurrency (#4) … We snapshot `list(slot.messages)`") and cannot lock: `slot._lock` is an `asyncio.Lock`, unacquirable from this thread. Changes 1 and 3 extend that existing snapshot-and-retry discipline rather than adding a new mechanism. Containing the exception per-message instead would trade one loud whole-slot retry for silent per-message meta loss, and keep `RuntimeError` as control flow.

**Not a security change.** This is redaction code, so worth being explicit: `list(meta.items())` yields the identical `(k, v)` pairs and every value still flows through `_redact_value`. The `mcp_oauth` body is byte-identical — only its `for` line changed — so the `http(s)`-only scheme gate, the `redact_credentials` probe, and the fail-closed `else ""` are untouched. A key inserted *after* the snapshot is absent from that pass, and absent is not unredacted.

## Tests

New `test/test_redact_meta_snapshot.py`, one test per failure mode:

- `test_redact_meta_survives_concurrent_key_insertion` — the dict path no longer raises.
- `test_redact_meta_for_role_survives_concurrent_key_insertion` — same for the `mcp_oauth` branch.
- `test_redact_value_snapshots_lists` — snapshot *semantics* for the list branch (a list never raises on concurrent resize, so this is not a crash test).
- `test_redact_meta_preserves_structure` — parametrized; snapshotting must not alter ordinary redaction output.
- `test_flush_file_changes_marks_slot_dirty` — locks the contract from change 2.
- `test_flush_dirty_slots_preserves_concurrent_dirty_mark` — drives `_flush_dirty_slots` with a save that mutates meta and re-marks dirty **mid-save**. Fails against the old post-save clear.
- `test_flush_dirty_slots_keeps_dirty_visible_during_save` — pins the fork contract: `_dirty` must still read True *inside* the save window.
- `test_flush_dirty_slots_rearms_dirty_on_failure` — a failed save stays dirty.

The redaction race is reproduced **deterministically** rather than with threads: a nested value whose `items()` writes into its own parent, so recursing into it mutates the dict the outer comprehension is iterating. The container actually iterated by the code under test stays a plain `dict`, so the test cannot pass for a wrong reason. Every behavioural test was mutation-proven — each fails with its specific fix reverted.

Not covered, deliberately: no real two-thread interleaving (the deterministic hooks trade timing fidelity for CI reliability) and no free-threaded build.

## Manual verification

N/A — unit coverage is sufficient, and both races are reproduced deterministically rather than by timing.

Full backend suite: **26,428 passed / 36 failed**, and the 36 are pre-existing. Verified rather than asserted: the same files on pristine `origin/main` fail **40**, and the two entries that looked branch-only (`test_pptx_maker_library` concurrent-renames, `test_dashboard_origin` malformed-URL) fail **identically on pristine main in isolation** — the split was a parallel-sharding artifact. Neither file references dashboard state, flush, or `_dirty`. `isort`, `flake8`, `mypy` (631 files) clean. `test_cli_manifest_signature.py` was excluded: it hangs indefinitely on this host, confirmed pre-existing on pristine main.

## Two CI failures that are not from this diff

- **`Dependency Audit / Audit Production Dependencies`** — fails on `website/electron/package-lock.json: fast-uri GHSA-7p8r-x3mc-p8w7 (high)`. This diff contains **zero** dependency-manifest files (3 Python modules + 1 test), and `fast-uri` is still `3.1.4` on latest `main`, so the advisory blocks the repo rather than this branch. It needs a lockfile bump on `main` (or Dependabot), not a race fix.
- **`Backend Tests (3.12, 2)` — `test_first_empty_response_requeues_message`, `assert 10 == 1`** — a documented pre-existing flake. The test's own comment names this exact mode: *"the loop can schedule that task (and its own cascading re-drains) before the assertions run, each calling the patched `_flush_file_changes` again (observed flaking as `assert 6 == 1`)."* Decisive point: that test **patches `_flush_file_changes` entirely**, so change 2's added line cannot execute inside it — the count it asserts on is unreachable from this diff. Passes 10/10 locally and on the other shards.

## Known, out of scope

Review also flagged that graceful shutdown force-saves slots *before* cancelling in-flight handlers (`slack/gateway.py`), so a cancellation-time `file_changes` write can land after the final save. That ordering is **pre-existing and independent of this diff** — it behaves identically on `main` — and reordering gateway shutdown has a much wider blast radius than a race fix warrants. Flagging it rather than folding it in.

## Screenshots

N/A — no user-visible UI change; this is backend persistence.
