### PR TITLE
fix(mcp): preserve remote entry fields on sync and redact header credentials

### DIFF
--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -16,6 +16,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_local_path, config_path, write_config_atomically
 from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.mcp_discovery import redact_mcp_error, redact_mcp_headers
 from kiro_crew.mcp_gateway import is_gateway_supported
 from kiro_crew.mcp_gateway.backend import MCP_APPS_ENV_FLAG, mcp_apps_env_override
 from kiro_crew.mcp_provenance import ABSENT, resolve_write, stamp
@@ -698,7 +699,20 @@ async def api_mcp_probe_cached(request: web.Request) -> web.Response:
         task = asyncio.create_task(_bg_mcp_probe())
         state._background_tasks.add(task)
         task.add_done_callback(state._background_tasks.discard)
-    return web.json_response(_mcp_probe_cache)
+
+    result: list[dict] = []
+    for cached in _mcp_probe_cache:
+        item = dict(cached)
+        # The cache is populated from to_dict(), which already redacts headers
+        # and errors — this pass is defense-in-depth for any future cache
+        # population path that stores raw output, not the primary boundary.
+        cached_headers = item.get("headers")
+        if "error" in item:
+            item["error"] = redact_mcp_error(item["error"], cached_headers)
+        if "headers" in item:
+            item["headers"] = redact_mcp_headers(cached_headers)
+        result.append(item)
+    return web.json_response(result)
 
 
 async def api_mcp_sync(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/handlers/mcp_custom.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_custom.py
@@ -31,6 +31,7 @@ from kiro_crew.dashboard.handlers.mcp import (
     _is_valid_mcp_name,
     _replace_kirocrew_spec,
 )
+from kiro_crew.mcp_discovery import redact_mcp_headers
 from kiro_crew.mcp_provenance import MARKER_KEY
 from kiro_crew.mcp_utils import (
     INTERNAL_CLIENT_ID_KEY,
@@ -374,11 +375,12 @@ async def api_mcp_custom_add(request: web.Request) -> web.Response:
 
 
 async def api_mcp_custom_get(request: web.Request) -> web.Response:
-    """GET /api/mcp/custom/{name} — the raw editable spec of one server.
+    """GET /api/mcp/custom/{name} — the editable spec of one server.
 
     The servers list endpoint intentionally omits ``env``; the edit modal
-    must prefill from the FULL spec or a save would silently drop the
-    user's env vars.  Reads the same scope PUT writes (404 otherwise).
+    must prefill from the full spec or a save would silently drop the
+    user's env vars. Header names remain visible, but their values are
+    preserve-only redaction markers. Reads the same scope PUT writes.
     """
     name = request.match_info.get("name", "")
     if not _is_valid_mcp_name(name):
@@ -391,6 +393,8 @@ async def api_mcp_custom_get(request: web.Request) -> web.Response:
 
     enabled = not entry.get("disabled", False)
     spec = {k: v for k, v in entry.items() if k != "disabled"}
+    if "headers" in spec:
+        spec["headers"] = redact_mcp_headers(spec["headers"])
     return web.json_response({"name": name, "spec": spec, "enabled": enabled})
 
 
@@ -450,7 +454,8 @@ async def api_mcp_custom_update(request: web.Request) -> web.Response:
             return web.json_response({"error": err}, status=400)
         assert isinstance(submitted, dict)  # narrowed by _validate_spec
         for key, on_disk in carried.items():
-            if key in submitted and submitted[key] != on_disk:
+            visible_value = redact_mcp_headers(on_disk) if key == "headers" else on_disk
+            if key in submitted and submitted[key] != visible_value:
                 return web.json_response(
                     {
                         "error": f"'{key}' is managed by other flows and cannot be"
@@ -458,6 +463,22 @@ async def api_mcp_custom_update(request: web.Request) -> web.Response:
                     },
                     status=400,
                 )
+        # A headers map is scoped to the HOST it was typed for. The carried-key
+        # restore below puts the on-disk credential back verbatim, so accepting
+        # a url change here would silently re-point that credential at a
+        # different origin — the next probe would send it there. Dropping costs
+        # a re-auth; forwarding a secret cannot be undone.
+        if "headers" in carried and submitted.get("url", "") != existing.get("url", ""):
+            return web.json_response(
+                {
+                    "error": "cannot change 'url' while stored header credentials"
+                    " exist — header values are hidden and read-only here, and"
+                    " they were issued for the current URL. Remove this server"
+                    " and re-add it with the new URL and fresh headers.",
+                    "code": "url_change_with_stored_headers",
+                },
+                status=400,
+            )
         spec = _clean_spec(submitted)
         spec.update(carried)  # preserved verbatim, never dropped
         _oauth_err = _resolve_oauth_hints(spec, submitted, existing)

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -17,6 +17,7 @@ import logging
 import ntpath
 import os
 import posixpath
+import re
 import shutil
 import signal
 import subprocess
@@ -353,12 +354,151 @@ def _get_cached(name: str) -> tuple[str, list[str], str]:
 
 
 def _cache_probe(server: McpServerInfo) -> None:
-    """Store probe result in cache."""
+    """Store probe result in cache.
+
+    The error is redacted HERE, with the headers that were live when the
+    probe ran: ``list_servers()`` re-attaches cached errors to server objects
+    built from the CURRENT config, so redacting only at serialization time
+    would mask a rotated credential's NEW value while the cached error still
+    carries the OLD one.
+    """
     _probe_cache[server.name] = _ProbeResult(
         status=server.status,
         tools=list(server.tools),
-        error=server.error,
+        error=redact_mcp_error(server.error, server.headers),
         probed_at=time.monotonic(),
+    )
+
+
+MCP_REDACTED_HEADER_VALUE = "[REDACTED: credential]"
+# Two regimes, chosen by the only property that matters: whether the value could
+# plausibly occur inside ordinary prose by chance.
+#
+# At or above this length it cannot, so the credential is masked as a BARE
+# substring — a server reflecting it glued to other characters
+# ("prefix<credential>") must still be caught.
+_MCP_CREDENTIAL_UNANCHORED_MIN_LENGTH = 8
+# Below that, masking is restricted to a standalone token, because an unanchored
+# short value would corrupt unrelated words. One- and two-character values are
+# skipped entirely: no boundary rule separates them from prose words like "a".
+_MCP_CREDENTIAL_SUFFIX_MIN_LENGTH = 3
+_MCP_AUTH_VALUE_RE = re.compile(r"^\S+\s+(.+)$")
+
+
+def _mcp_credential_token_pattern(value: str) -> str:
+    """Match ``value`` with each character in literal or percent-encoded form.
+
+    A remote server can reflect a configured credential URL-encoded — e.g. a
+    padded Basic token whose ``=`` comes back as ``%3D`` inside an error URL —
+    and a literal-only pattern would hand that encoded copy to the client
+    unmasked. Every character therefore matches either itself or its UTF-8
+    ``%XX`` escape sequence, with the leading ``%`` itself allowed to be
+    percent-escaped any number of times (``%253D``, ``%25253D``, ...) so a
+    double-encoded reflection is caught by the same substitution pass. A space
+    additionally matches ``+`` (the form-urlencoded spelling) and its escape
+    ``%2B``.
+    """
+    parts: list[str] = []
+    for char in value:
+        alternatives = [re.escape(char)]
+        try:
+            # "%(?:25)*XX" per byte: a literal %XX, or the same escape with its
+            # percent sign re-encoded one or more times (%25XX, %2525XX, ...).
+            alternatives.append(
+                "".join(f"%(?:25)*{byte:02X}" for byte in char.encode("utf-8"))
+            )
+        except UnicodeEncodeError:
+            # A lone surrogate (JSON permits unpaired \uD800 escapes) has no
+            # UTF-8 spelling; keep the literal alternative so building the
+            # pattern never turns a listing request into a 500.
+            pass
+        if char == " ":
+            alternatives.append(re.escape("+"))
+            alternatives.append("%(?:25)*2B")
+        parts.append("(?:" + "|".join(alternatives) + ")")
+    return "".join(parts)
+
+
+def redact_mcp_headers(headers: object) -> dict[str, str]:
+    """Preserve header names while hiding every client-facing value.
+
+    Custom header names can carry credentials too, so only names are safe
+    metadata for dashboard responses.
+    """
+    if not isinstance(headers, dict):
+        return {}
+    return {
+        name: MCP_REDACTED_HEADER_VALUE
+        for name in headers
+        if isinstance(name, str)
+    }
+
+
+def redact_mcp_error(error: object, headers: object) -> str:
+    """Scrub credential material from a probe error before it leaves the backend.
+
+    Two layers, so every consumer (``to_dict``, the probe cache, the probe
+    endpoints) satisfies one invariant — no credential-shaped text survives to
+    serialized output:
+
+    1. The site-wide scanners (``redact_credentials`` /
+       ``redact_exfiltration_urls``) catch anything credential-SHAPED that a
+       remote server reflects, whether or not it matches configured values —
+       the same pass ``_sanitize_probe_error`` applies to probe exceptions.
+    2. The configured-value scrubber below catches the exact header values and
+       Authorization suffixes, including encoded spellings the generic
+       scanners cannot know about.
+    """
+    if not isinstance(error, str) or not isinstance(headers, dict):
+        return error if isinstance(error, str) else ""
+
+    error, _ = redact_exfiltration_urls(error)
+    error, _ = redact_credentials(error)
+
+    # Values map to whether they require lexical boundaries. Full header values
+    # and long credentials are bare substring matches; only SHORT credentials
+    # need boundaries, since only they could collide with ordinary words.
+    values: dict[str, bool] = {}
+    for name, raw_value in headers.items():
+        if not isinstance(raw_value, str):
+            continue
+        value = raw_value.strip()
+        if not value:
+            continue
+        values[value] = False
+
+        if not isinstance(name, str) or name.casefold() != "authorization":
+            continue
+        match = _MCP_AUTH_VALUE_RE.fullmatch(value)
+        if match:
+            credential = match.group(1).strip()
+            if len(credential) >= _MCP_CREDENTIAL_SUFFIX_MIN_LENGTH:
+                needs_boundary = (
+                    len(credential) < _MCP_CREDENTIAL_UNANCHORED_MIN_LENGTH
+                )
+                values.setdefault(credential, needs_boundary)
+
+    if not values:
+        return error
+
+    # Check the characters outside a suffix instead of using \b: base64 padding
+    # ends in a non-word "=", so \b would fail between that padding and ordinary
+    # punctuation. Longest-first keeps a full header ahead of its own suffix.
+    pattern = "|".join(
+        (
+            rf"(?<!\w){_mcp_credential_token_pattern(value)}(?!\w)"
+            if boundary_safe
+            else _mcp_credential_token_pattern(value)
+        )
+        for value, boundary_safe in sorted(
+            values.items(), key=lambda item: len(item[0]), reverse=True
+        )
+    )
+    return re.sub(
+        pattern,
+        MCP_REDACTED_HEADER_VALUE,
+        error,
+        flags=re.IGNORECASE,
     )
 
 
@@ -410,14 +550,14 @@ class McpServerInfo:
             "args": self.args or [],
             "status": self.status,
             "tools": self.tools,
-            "error": self.error,
+            "error": redact_mcp_error(self.error, self.headers),
             "source": self.source,
             "presence": dict(self.presence),
         }
         if self.url:
             d["url"] = self.url
             if self.headers:
-                d["headers"] = self.headers
+                d["headers"] = redact_mcp_headers(self.headers)
             # Not redacted: requested scopes and a public OAuth client id are
             # non-secret configuration the user needs to see.
             #

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -596,6 +596,27 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "abort a send when redaction would alter the content — not egress.)",
     ),
     (
+        "MCP custom server specs",
+        "dashboard/handlers/mcp_custom.py",
+        "Editable MCP server specs returned by the dashboard HTTP API to the browser. "
+        "Configured header values receive credential redaction only before they cross "
+        "that boundary.",
+    ),
+    (
+        "MCP probe results",
+        "dashboard/handlers/mcp.py",
+        "Cached MCP probe results returned by the dashboard HTTP API to the browser. "
+        "Configured header values and reflected credentials in probe errors receive "
+        "redaction before they cross that boundary.",
+    ),
+    (
+        "MCP server metadata",
+        "mcp_discovery.py",
+        "McpServerInfo.to_dict() is the serialization boundary for every dashboard "
+        "MCP listing; header values and reflected credentials in probe errors are "
+        "redacted there before the payload leaves the backend.",
+    ),
+    (
         "MCP app tool results",
         "dashboard/handlers/mcp_apps.py",
         "Recursively redacts every string leaf of an MCP app's tool result before "
@@ -802,7 +823,6 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         "dashboard/handlers/discover.py",
         "dashboard/handlers/hooks.py",
         "dashboard/handlers/knowledge.py",
-        "dashboard/handlers/mcp.py",
         "dashboard/handlers/memory.py",
         "dashboard/handlers/optimizer.py",
         "dashboard/handlers/prompts.py",
@@ -820,7 +840,6 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         "knowledge/ingestion.py",
         "mcp_core.py",
         "mcp_cron.py",
-        "mcp_discovery.py",
         "mcp_gateway/backend.py",
         "workflows/agent_exec.py",
         "workflows/agent_pool.py",

--- a/test/test_mcp_custom_api.py
+++ b/test/test_mcp_custom_api.py
@@ -430,6 +430,61 @@ class TestCustomGet:
         finally:
             await client.close()
 
+    async def test_redacted_headers_round_trip_without_overwriting_values(
+        self, sandbox, fake_sel
+    ):
+        raw_headers = {
+            "Authorization": "Bearer custom-secret",
+            "X-Api-Key": "custom-api-key",
+        }
+        entry = {"url": "https://mcp.example.com/sse", "headers": raw_headers}
+        sandbox.kirocrew_json.write_text(json.dumps({"mcpServers": {"remote": entry}}))
+        client = await _client()
+        try:
+            resp = await client.get("/api/mcp/custom/remote")
+            assert resp.status == 200
+            body = await resp.json()
+            assert set(body["spec"]["headers"]) == set(raw_headers)
+            assert set(body["spec"]["headers"].values()) == {"[REDACTED: credential]"}
+            assert "custom-secret" not in json.dumps(body)
+            assert "custom-api-key" not in json.dumps(body)
+
+            resp = await client.put(
+                "/api/mcp/custom/remote", json={"spec": body["spec"]}
+            )
+            assert resp.status == 200
+            assert _written(sandbox)["remote"]["headers"] == raw_headers
+        finally:
+            await client.close()
+
+    async def test_url_change_with_stored_headers_is_refused(self, sandbox, fake_sel):
+        """A credential is scoped to the host it was typed for.
+
+        The PUT restore path puts the on-disk header values back verbatim, so
+        accepting a url-only edit would silently point the stored secret at a
+        different origin and the next probe would send it there.
+        """
+        raw_headers = {"Authorization": "Bearer custom-secret"}
+        entry = {"url": "https://old.example.com/sse", "headers": raw_headers}
+        sandbox.kirocrew_json.write_text(json.dumps({"mcpServers": {"remote": entry}}))
+        client = await _client()
+        try:
+            resp = await client.get("/api/mcp/custom/remote")
+            assert resp.status == 200
+            spec = (await resp.json())["spec"]
+
+            spec["url"] = "https://new.example.net/sse"
+            resp = await client.put("/api/mcp/custom/remote", json={"spec": spec})
+            assert resp.status == 400
+            payload = await resp.json()
+            assert payload["code"] == "url_change_with_stored_headers"
+            # Nothing was written: the secret still sits beside its own host.
+            written = _written(sandbox)["remote"]
+            assert written["url"] == "https://old.example.com/sse"
+            assert written["headers"] == raw_headers
+        finally:
+            await client.close()
+
     async def test_unknown_404_and_bad_name_400(self, sandbox, fake_sel):
         client = await _client()
         try:

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -81,7 +81,7 @@ class TestMcpServerInfo:
         assert info.error == ""
         assert info.source == "agent"
 
-    def test_remote_server_fields(self) -> None:
+    def test_remote_server_fields_redact_header_values(self) -> None:
         info = McpServerInfo(
             name="deepwiki",
             url="https://mcp.deepwiki.com/mcp",
@@ -91,7 +91,8 @@ class TestMcpServerInfo:
         assert info.command == ""
         d = info.to_dict()
         assert d["url"] == "https://mcp.deepwiki.com/mcp"
-        assert d["headers"] == {"Authorization": "Bearer tok"}
+        assert d["headers"] == {"Authorization": "[REDACTED: credential]"}
+        assert "Bearer tok" not in json.dumps(d)
 
     def test_is_remote_false_for_local(self) -> None:
         info = McpServerInfo(name="x", command="cmd")

--- a/test/test_mcp_probe_treadmill.py
+++ b/test/test_mcp_probe_treadmill.py
@@ -16,13 +16,17 @@ probe_all's own filter.
 
 from __future__ import annotations
 
+import json
 import time
 from unittest.mock import AsyncMock
 
 import pytest
 
 from kiro_crew.dashboard.handlers import mcp as mcp_mod
-from kiro_crew.mcp_discovery import McpServerInfo
+from kiro_crew.mcp_discovery import (
+    MCP_REDACTED_HEADER_VALUE,
+    McpServerInfo,
+)
 
 
 def _request(state) -> object:
@@ -138,3 +142,368 @@ class TestDisabledServerDoesNotDefeatProbeCache:
         names = [r["name"] for r in rows]
         assert "turned-off" in names, "a disabled server must still render a row"
         assert "enabled-one" in names
+
+
+class TestMcpHeaderRedaction:
+    @pytest.mark.asyncio
+    async def test_servers_list_preserves_header_names_without_values(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        raw_headers = {
+            "Authorization": "Bearer list-secret",
+            "X-Api-Key": "list-api-key",
+        }
+        server = McpServerInfo(
+            name="remote",
+            url="https://mcp.example.com/sse",
+            headers=raw_headers,
+            status="ok",
+        )
+        cache = [{"name": "remote", "status": "ok", "tools": [], "error": ""}]
+        _arrange(monkeypatch, tmp_path, [server], cache)
+
+        resp = await mcp_mod.api_mcp_servers(_request(_State()))
+        body = json.loads(resp.text or "[]")
+
+        assert set(body[0]["headers"]) == set(raw_headers)
+        assert set(body[0]["headers"].values()) == {MCP_REDACTED_HEADER_VALUE}
+        assert "list-secret" not in (resp.text or "")
+        assert "list-api-key" not in (resp.text or "")
+
+    @pytest.mark.asyncio
+    async def test_live_probe_preserves_header_names_without_values(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        server = McpServerInfo(
+            name="remote",
+            url="https://mcp.example.com/sse",
+            headers={"Authorization": "Bearer probe-secret"},
+            status="ok",
+        )
+        monkeypatch.setattr(disc, "probe_all", AsyncMock(return_value=[server]))
+        monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", tmp_path / "absent.json")
+        monkeypatch.setattr(mcp_mod, "_mcp_probe_cache", [])
+
+        resp = await mcp_mod.api_mcp_probe(_request(_State()))
+        body = json.loads(resp.text or "[]")
+
+        assert body[0]["headers"] == {
+            "Authorization": MCP_REDACTED_HEADER_VALUE
+        }
+        assert "probe-secret" not in (resp.text or "")
+
+    @pytest.mark.asyncio
+    async def test_cached_probe_redacts_legacy_raw_header_values(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            mcp_mod,
+            "_mcp_probe_cache",
+            [
+                {
+                    "name": "remote",
+                    "headers": {"Authorization": "Bearer cached-secret"},
+                }
+            ],
+        )
+        monkeypatch.setattr(mcp_mod, "_mcp_probe_ts", time.time())
+        monkeypatch.setattr(mcp_mod, "_mcp_probe_in_progress", False)
+
+        resp = await mcp_mod.api_mcp_probe_cached(_request(_State()))
+        body = json.loads(resp.text or "[]")
+
+        assert body[0]["headers"] == {
+            "Authorization": MCP_REDACTED_HEADER_VALUE
+        }
+        assert "cached-secret" not in (resp.text or "")
+
+    @pytest.mark.asyncio
+    async def test_live_probe_redacts_reflected_header_credential_suffix(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        credential = "live-fake-credential-7e91"
+        secret = f"Bearer {credential}"
+        server = McpServerInfo(
+            name="remote",
+            url="https://mcp.example.com/sse",
+            headers={"Authorization": secret, "X-Blank": " \t "},
+            status="error",
+            error=f"Remote reflected {credential}; keep this context",
+        )
+        monkeypatch.setattr(disc, "probe_all", AsyncMock(return_value=[server]))
+        monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", tmp_path / "absent.json")
+        monkeypatch.setattr(mcp_mod, "_mcp_probe_cache", [])
+
+        resp = await mcp_mod.api_mcp_probe(_request(_State()))
+        body = json.loads(resp.text or "[]")
+
+        assert body[0]["error"] == (
+            f"Remote reflected {MCP_REDACTED_HEADER_VALUE}; keep this context"
+        )
+        assert body[0]["headers"] == {
+            "Authorization": MCP_REDACTED_HEADER_VALUE,
+            "X-Blank": MCP_REDACTED_HEADER_VALUE,
+        }
+        assert credential.casefold() not in (resp.text or "").casefold()
+
+    @pytest.mark.asyncio
+    async def test_cached_probe_redacts_reflected_header_credential_suffix(
+        self, monkeypatch
+    ) -> None:
+        credential = "cached-fake-credential-4c82"
+        secret = f"Token {credential}"
+        monkeypatch.setattr(
+            mcp_mod,
+            "_mcp_probe_cache",
+            [
+                {
+                    "name": "remote",
+                    "headers": {
+                        "Authorization": secret,
+                        "X-Whitespace": "   ",
+                    },
+                    "error": (
+                        f"Legacy server echoed {credential} while initializing"
+                    ),
+                }
+            ],
+        )
+        monkeypatch.setattr(mcp_mod, "_mcp_probe_ts", time.time())
+        monkeypatch.setattr(mcp_mod, "_mcp_probe_in_progress", False)
+
+        resp = await mcp_mod.api_mcp_probe_cached(_request(_State()))
+        body = json.loads(resp.text or "[]")
+
+        assert body[0]["error"] == (
+            f"Legacy server echoed {MCP_REDACTED_HEADER_VALUE} while initializing"
+        )
+        assert body[0]["headers"] == {
+            "Authorization": MCP_REDACTED_HEADER_VALUE,
+            "X-Whitespace": MCP_REDACTED_HEADER_VALUE,
+        }
+        assert credential.casefold() not in (resp.text or "").casefold()
+
+    def test_full_authorization_value_is_redacted_exactly_once(self) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        credential = "full-fake-credential-2a63"
+        value = f"Bearer {credential}"
+        error = f"Remote reflected {value}; keep this context"
+
+        redacted = disc.redact_mcp_error(error, {"Authorization": value})
+
+        assert redacted == (
+            f"Remote reflected {MCP_REDACTED_HEADER_VALUE}; keep this context"
+        )
+        assert redacted.count(MCP_REDACTED_HEADER_VALUE) == 1
+        assert credential not in redacted
+
+    def test_long_credential_glued_to_word_characters_is_redacted(self) -> None:
+        """A long credential cannot occur inside prose by chance, so it is
+        masked as a bare substring even when a server reflects it with no
+        surrounding whitespace. Boundary anchoring would suppress this."""
+        import kiro_crew.mcp_discovery as disc
+
+        credential = "ghp_" "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12"
+        headers = {"Authorization": f"Bearer {credential}"}
+
+        for error in (
+            f"remote said prefix{credential} bad",
+            f"remote said {credential}suffix bad",
+            f"a{credential}b",
+        ):
+            redacted = disc.redact_mcp_error(error, headers)
+            assert credential not in redacted
+            assert MCP_REDACTED_HEADER_VALUE in redacted
+
+    def test_short_basic_credential_reflected_alone_is_redacted(self) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        credential = "YTpi"
+        value = f"Basic {credential}"
+
+        redacted = disc.redact_mcp_error(
+            credential,
+            {"Authorization": value},
+        )
+
+        assert redacted == MCP_REDACTED_HEADER_VALUE
+        assert credential not in redacted
+
+    def test_padded_base64_credential_is_redacted_before_punctuation(self) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        credential = "YTpiYw=="
+        error = f"Remote reflected {credential}."
+
+        redacted = disc.redact_mcp_error(
+            error,
+            {"Authorization": f"Basic {credential}"},
+        )
+
+        assert redacted == f"Remote reflected {MCP_REDACTED_HEADER_VALUE}."
+        assert credential not in redacted
+
+    def test_percent_encoded_padded_basic_token_is_redacted(self) -> None:
+        """A URL-encoded reflection must not bypass the literal-value pattern.
+
+        A remote server embedding the configured value in an error URL returns
+        it percent-encoded — space as %20, base64 padding as %3D — which
+        contains no literal substring of the credential at all.
+        """
+        import kiro_crew.mcp_discovery as disc
+
+        headers = {"Authorization": "Basic YTpiYw=="}
+        error = "GET https://mcp.example.com/auth?hdr=Basic%20YTpiYw%3D%3D failed"
+
+        redacted = disc.redact_mcp_error(error, headers)
+
+        assert "YTpiYw" not in redacted
+        assert "%3D" not in redacted
+        assert MCP_REDACTED_HEADER_VALUE in redacted
+
+    def test_partially_percent_encoded_credential_is_redacted(self) -> None:
+        """Only the padding encoded: a mixed literal/%XX reflection is caught."""
+        import kiro_crew.mcp_discovery as disc
+
+        redacted = disc.redact_mcp_error(
+            "Remote reflected YTpiYw%3D%3D in its error",
+            {"Authorization": "Basic YTpiYw=="},
+        )
+
+        assert "YTpiYw" not in redacted
+        assert MCP_REDACTED_HEADER_VALUE in redacted
+
+    def test_fully_percent_encoded_credential_is_redacted(self) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        credential = "full-fake-credential-2a63"
+        encoded = "".join(f"%{byte:02X}" for byte in credential.encode())
+        headers = {"Authorization": f"Bearer {credential}"}
+
+        redacted = disc.redact_mcp_error(f"remote said {encoded}", headers)
+
+        assert encoded not in redacted
+        assert MCP_REDACTED_HEADER_VALUE in redacted
+
+    def test_double_percent_encoded_credential_is_redacted(self) -> None:
+        """A nested reflection re-encodes the escape's own percent sign."""
+        import kiro_crew.mcp_discovery as disc
+
+        headers = {"Authorization": "Basic YTpiYw=="}
+
+        for reflected in ("YTpiYw%253D%253D", "YTpiYw%25253D%25253D"):
+            redacted = disc.redact_mcp_error(
+                f"nested URL carried {reflected} back", headers
+            )
+            assert "YTpiYw" not in redacted, reflected
+            assert MCP_REDACTED_HEADER_VALUE in redacted
+
+    def test_cached_error_is_redacted_with_probe_time_headers(self) -> None:
+        """A rotated credential must not unmask a cached error.
+
+        ``list_servers()`` re-attaches cached errors to server objects built
+        from the CURRENT config, so an error cached raw and redacted only at
+        serialization time would be masked against the NEW credential while
+        still carrying the OLD one.
+        """
+        import kiro_crew.mcp_discovery as disc
+
+        old_credential = "old-rotated-secret-9f27"
+        server = disc.McpServerInfo(
+            name="rotating",
+            url="https://mcp.example.com/v1",
+            headers={"Authorization": f"Bearer {old_credential}"},
+            status="error",
+            error=f"remote reflected {old_credential} in its failure",
+            source="discovered",
+        )
+        disc._cache_probe(server)
+        try:
+            status, tools, error = disc._get_cached("rotating")
+            assert status == "error"
+            assert old_credential not in error
+            assert MCP_REDACTED_HEADER_VALUE in error
+        finally:
+            disc._probe_cache.pop("rotating", None)
+
+    def test_plus_encoded_space_in_reflected_value_is_redacted(self) -> None:
+        """Form-urlencoding spells the space in ``Basic <token>`` as ``+``."""
+        import kiro_crew.mcp_discovery as disc
+
+        redacted = disc.redact_mcp_error(
+            "auth failed for Basic+YTpiYw%3d%3d (lowercase hex)",
+            {"Authorization": "Basic YTpiYw=="},
+        )
+
+        assert "YTpiYw" not in redacted
+        assert MCP_REDACTED_HEADER_VALUE in redacted
+
+    def test_credential_shaped_reflection_is_masked_without_configured_match(
+        self,
+    ) -> None:
+        """The generic scanners run on every error, not only configured values.
+
+        A remote server can reflect a credential the config never mentions
+        (an access-key id, a connection string); the site-wide scrubbers must
+        catch it before serialization.
+        """
+        import kiro_crew.mcp_discovery as disc
+
+        fake_key = "AKIA" + "IOSFODNN7EXAMPLE"
+        redacted = disc.redact_mcp_error(
+            f"remote rejected key {fake_key} during handshake",
+            {"Authorization": "Bearer unrelated-configured-value"},
+        )
+
+        assert fake_key not in redacted
+
+    def test_lone_surrogate_header_value_does_not_crash(self) -> None:
+        """JSON permits unpaired surrogate escapes; building the redaction
+        pattern must never raise and turn a listing request into a 500."""
+        import kiro_crew.mcp_discovery as disc
+
+        headers = {
+            "Authorization": "Bearer bad\ud800token",
+            "X-Api-Key": "other-real-credential-77",
+        }
+
+        redacted = disc.redact_mcp_error(
+            "remote reflected other-real-credential-77 and more", headers
+        )
+
+        assert "other-real-credential-77" not in redacted
+        assert MCP_REDACTED_HEADER_VALUE in redacted
+
+    def test_short_credential_substring_in_unrelated_word_is_not_redacted(
+        self,
+    ) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        error = "Remote returned prefixYTpicalSuffix as ordinary prose"
+
+        assert disc.redact_mcp_error(
+            error,
+            {"Authorization": "Basic YTpi"},
+        ) == error
+
+    def test_short_authorization_suffix_leaves_ordinary_error_untouched(self) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        error = "A remote server returned a generic failure"
+
+        assert disc.redact_mcp_error(error, {"Authorization": "Bearer a"}) == error
+
+    def test_scheme_less_header_value_is_still_redacted(self) -> None:
+        import kiro_crew.mcp_discovery as disc
+
+        credential = "scheme-less-fake-credential-8b14"
+        error = f"Remote reflected {credential}"
+
+        assert disc.redact_mcp_error(error, {"X-Api-Key": credential}) == (
+            f"Remote reflected {MCP_REDACTED_HEADER_VALUE}"
+        )

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -401,9 +401,11 @@ export interface McpCustomSpec {
   args?: string[]
   env?: Record<string, string>
   url?: string
+  /** Present on existing remote entries; read responses redact every value. */
+  headers?: Record<string, string>
 }
 
-/** GET /api/mcp/custom/{name} — full editable spec (env included). */
+/** GET /api/mcp/custom/{name} — editable spec; header values are redacted. */
 export interface McpCustomSpecResponse {
   name: string
   spec: McpCustomSpec
@@ -422,6 +424,8 @@ export interface McpScopePresence {
 export interface McpServer {
   name: string; command: string; args?: string[]
   url?: string
+  /** Header names are preserved, but read responses redact every value. */
+  headers?: Record<string, string>
   status: string; error?: string; tools?: string[]
   source: string; enabled: boolean; disabledTools?: string[]
   presence?: McpScopePresence


### PR DESCRIPTION
## Problem

**Credentials echoed back to the dashboard.** `GET /api/mcp` (and sibling endpoints) returned configured remote-MCP `headers` verbatim, including any static `Authorization` value — and a remote server could reflect that value back inside probe error text, which was also emitted verbatim.

> Scope note: as originally opened, this PR also fixed remote fields being lost on sync (`discover_servers_to_sync()` dropping `url`/`headers`). Main independently landed that half (extended with OAuth `scopes`/`clientId`) while this PR was open, so after the rebase this diff carries only the redaction layer plus hardening found in review.

## Why it matters

A configured bearer credential reaches the browser of any user who can open the MCP surface, through four channels: the headers map itself, probe error text that reflects it, the cached copy of that error, and a URL-only edit that silently re-points the stored secret at a new host.

## Fix (symptoms → root cause → change)

Serializers assumed spec values were safe to emit → configured header values (and anything a remote server reflects) rode straight to the browser → this PR masks values at every egress and closes the editor's forwarding path:

- **Redact on read:** every site that emits a server spec masks header values — list/probe/probe-cache endpoints, the custom-MCP handlers, and `McpServerInfo.to_dict()`. Header *names* survive so the UI can show a header is configured.
- **Redact reflected credentials in errors**, in literal, percent-encoded, nested percent-encoded (`%3D`, `%253D`, ...), and `+`/`%2B` space spellings — on both the live and cached probe paths. Cached errors are redacted at store time with probe-time headers, so a later credential rotation cannot unmask them.
- **Refuse URL changes while stored header credentials exist** (`400`, code `url_change_with_stored_headers`): the PUT restore path preserves on-disk headers verbatim, so accepting a url-only edit would forward the stored secret to a different origin on the next probe.
- **Security-posture bookkeeping:** `mcp_custom.py`, `dashboard/handlers/mcp.py`, and `mcp_discovery.py` are registered as redaction egress sinks so the posture panel counts these boundaries.

## Tests

- No emitting endpoint returns a raw `Authorization` value; header names round-trip through GET→PUT without overwriting stored values.
- A reflected Authorization value never reaches serialized output — live path, cached path, and after credential rotation.
- Percent-encoded, double/nested-encoded, partially-encoded, and `+`-encoded reflections are all masked.
- A url change with stored headers is refused and nothing is written; a same-url save still succeeds.

## Manual verification

N/A — unit coverage is sufficient: every affected path is a pure serialization or handler function exercised directly by the tests above.

## Screenshots

N/A — no user-visible UI change (header *names* still render; only values are masked).

no issue closed: hardening extracted from the Connections design work, no standalone issue filed.
