### PR TITLE
fix(acp): buffer OAuth notifications raised during session init

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -209,7 +209,19 @@ Step 5 drains MCP server init notifications (both after `session/load` and
 
 ### Notification Buffering
 
-`_wait_for_response()` buffers ALL JSON-RPC notifications in `_mcp_notifications` list instead of discarding them. `_drain_notifications()` processes buffered notifications first, then reads any remaining from stdout. This ensures no MCP `server_initialized` notifications are lost during `session/new` — all servers load reliably within ~2.4s.
+`AcpClient._wait_for_response()` buffers all JSON-RPC notifications in
+`_mcp_notifications` instead of discarding them. `_drain_notifications()`
+processes buffered notifications first, then reads any remaining from stdout.
+
+The multiplexed `AcpRuntime` has the same guarantee for session-scoped OAuth
+requests even though it cannot register the session queue until `session/new`
+or `session/load` returns the session id. While either request is in flight, the
+runtime stages matching `_kiro.dev/mcp/oauth_request` notifications in a bounded
+buffer, transfers them into the new handle's queue once the id is known, and
+`AcpSessionHandle.drain_init()` retains them for
+`pop_pending_oauth_requests()`. Staging is cleared when the last concurrent init
+finishes, including failure paths, so a stale approval URL cannot leak into a
+later session.
 
 ## Key APIs
 
@@ -257,7 +269,8 @@ When kiro-cli needs OAuth authentication for an MCP server, `AcpClient` surfaces
 
 **Persistence**: Role-aware redaction (`_redact_meta_for_role`) preserves `oauth_url` for `mcp_oauth` messages so the Authorize link survives history rehydrate, while still scrubbing unsafe schemes on the read path.
 
-**API**: `pop_pending_oauth_requests()` drains requests captured during init (called after `ensure_ready()`).
+**API**: `pop_pending_oauth_requests()` drains requests captured during init on
+both `AcpClient` and `AcpSessionProvider` (called after `ensure_ready()`).
 
 **Remote-gateway callback relay**: The Connections waiting card accepts the failed browser return address when the browser and gateway run on different machines. `POST /api/mcp/oauth/relay` sends that address from the gateway host to kiro-cli's local callback listener. The handler is intentionally not a generic proxy: it accepts only plain-HTTP IP-literal loopback URLs (`127.0.0.0/8` or `::1`) with an explicit port and exactly one non-empty `code` value; it rejects userinfo, fragments, hostnames, non-loopback addresses, oversized input, and does not follow redirects. The callback URL and authorization code are never logged or returned; SEL records only the provider slug and completed/failed outcome.
 

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -20,6 +20,7 @@ import os
 import subprocess
 import sys
 import time
+from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,7 @@ from kiro_crew.acp.session_handle import (
 )
 from kiro_crew.acp.types import (
     ACP_CLIENT_CAPABILITIES,
+    METHOD_MCP_OAUTH_REQUEST,
     METHOD_SESSION_LOAD,
     METHOD_SESSION_NEW,
     METHOD_SESSION_TERMINATE,
@@ -86,6 +88,7 @@ __all__ = [
 _STDOUT_BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB
 _INIT_TIMEOUT = 30.0
 _REQUEST_TIMEOUT = 30.0
+_INIT_NOTIFICATION_BUFFER_LIMIT = 100
 # Teardown must be snappy: a session is usually terminated on a hot path
 # (background task done, subagent reaped). kiro-cli's terminate handler responds
 # as soon as it enqueues the eviction (the actual shutdown runs in its actor
@@ -363,6 +366,16 @@ class AcpRuntime:
         # (e.g. session/prompt response signals turn completion and must reach the session)
         self._routed_requests: dict[int, str] = {}
         self._session_queues: dict[str, asyncio.Queue[JsonRpcMessage | None]] = {}
+        # OAuth notifications can precede the session/new or session/load
+        # response that reveals which queue to register. Stage only those
+        # frames while an init is active, then transfer the matching session's
+        # frames into its queue. The bounded buffer is cleared when the last
+        # concurrent init finishes so an abandoned URL cannot reach a later
+        # session that happens to reuse the same id.
+        self._session_inits_in_flight = 0
+        self._pending_init_notifications: deque[JsonRpcMessage] = deque(
+            maxlen=_INIT_NOTIFICATION_BUFFER_LIMIT
+        )
         self._next_id = 1
         self._initialized = False
         # Whether kiro-cli advertised session/load support in its initialize
@@ -862,6 +875,13 @@ class AcpRuntime:
                     queue = self._session_queues.get(session_id)
                     if queue is not None:
                         await queue.put(msg)
+                    elif self._session_inits_in_flight and msg.is_method(
+                        METHOD_MCP_OAUTH_REQUEST
+                    ):
+                        # session/new can emit OAuth before its response. The
+                        # response is what gives create_session the id needed to
+                        # register this queue, so retain the frame until then.
+                        self._pending_init_notifications.append(msg)
                     else:
                         # Counted, not logged per frame: this is the measured
                         # flood (transcript replay during session/load, plus any
@@ -936,6 +956,7 @@ class AcpRuntime:
             if not future.done():
                 future.set_exception(exc)
         self._pending_requests.clear()
+        self._pending_init_notifications.clear()
         # Also drop routed-request correlations: on death no reader will pop
         # them, and if a session is never destroyed the entry would otherwise
         # linger. unregister_session() also sweeps these per-session; this is
@@ -1097,6 +1118,24 @@ class AcpRuntime:
 
     # ── Session Management ──
 
+    def _finish_session_init(self, session_id: str) -> list[JsonRpcMessage]:
+        """Take staged init frames for one session and close its init scope."""
+        matched: list[JsonRpcMessage] = []
+        retained: deque[JsonRpcMessage] = deque(maxlen=_INIT_NOTIFICATION_BUFFER_LIMIT)
+        for msg in self._pending_init_notifications:
+            params = msg.params if isinstance(msg.params, dict) else {}
+            if session_id and str(params.get("sessionId") or "") == session_id:
+                matched.append(msg)
+            else:
+                retained.append(msg)
+        self._pending_init_notifications = retained
+        self._session_inits_in_flight -= 1
+        if self._session_inits_in_flight == 0:
+            # Anything unmatched belongs to a failed/abandoned init. Never let
+            # it survive into the next session creation attempt.
+            self._pending_init_notifications.clear()
+        return matched
+
     async def create_session(
         self,
         cwd: str | Path | None = None,
@@ -1120,15 +1159,21 @@ class AcpRuntime:
             mcp_servers=mcp_servers,
         )
 
-        resp = await self._send_and_await(METHOD_SESSION_NEW, params)
-
-        session_id = resp.get("sessionId")
-        if not session_id:
-            raise AcpRuntimeError(f"session/new did not return sessionId: {resp}")
+        self._session_inits_in_flight += 1
+        session_id = ""
+        try:
+            resp = await self._send_and_await(METHOD_SESSION_NEW, params)
+            session_id = str(resp.get("sessionId") or "")
+            if not session_id:
+                raise AcpRuntimeError(f"session/new did not return sessionId: {resp}")
+        finally:
+            buffered_init = self._finish_session_init(session_id)
 
         # Register session queue
         queue: asyncio.Queue[JsonRpcMessage | None] = asyncio.Queue()
         self._session_queues[session_id] = queue
+        for msg in buffered_init:
+            queue.put_nowait(msg)
 
         handle = AcpSessionHandle(
             session_id=session_id,
@@ -1191,12 +1236,20 @@ class AcpRuntime:
             "mcpServers": [],  # kiro-cli gets its servers via --agent
             "_meta": {"_kiro.dev/session_file": session_file},
         }
-        resp = await self._send_and_await(METHOD_SESSION_LOAD, load_params)
+        self._session_inits_in_flight += 1
+        loaded_session_id = ""
+        try:
+            resp = await self._send_and_await(METHOD_SESSION_LOAD, load_params)
 
-        # A genuine resume echoes "modes" in the response (same signal AcpClient
-        # keys on). Anything else means load did not actually restore state.
-        if "modes" not in resp:
-            raise AcpRuntimeError(f"session/load did not resume session {resume_sid}: {resp}")
+            # A genuine resume echoes "modes" in the response (same signal AcpClient
+            # keys on). Anything else means load did not actually restore state.
+            if "modes" not in resp:
+                raise AcpRuntimeError(
+                    f"session/load did not resume session {resume_sid}: {resp}"
+                )
+            loaded_session_id = resume_sid
+        finally:
+            buffered_init = self._finish_session_init(loaded_session_id)
 
         # Register the queue AFTER _send_and_await returns. During session/load
         # kiro-cli replays the full prior transcript on stdout; without a
@@ -1207,6 +1260,8 @@ class AcpRuntime:
         # queue, so this reorder is safe.
         queue: asyncio.Queue[JsonRpcMessage | None] = asyncio.Queue()
         self._session_queues[resume_sid] = queue
+        for msg in buffered_init:
+            queue.put_nowait(msg)
 
         handle = AcpSessionHandle(
             session_id=resume_sid,

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -291,6 +291,9 @@ class AcpSessionHandle:
         # retry can re-surface. Instance-scoped (NOT reset per turn) — mirrors
         # AcpClient._oauth_emitted_servers.
         self._oauth_emitted_servers: set[str] = set()
+        # OAuth requests collected by drain_init(). Dashboard startup drains
+        # this list through AcpSessionProvider after create_session returns.
+        self._pending_oauth_requests: list[dict[str, str]] = []
         # JSON-RPC request id -> {"once","always","reject"} optionId map, so
         # approve_tool / reject_tool echo the exact ids the agent advertised
         # (kiro "allow_once"/"allow_always"; claude-agent-acp "allow"/"reject").
@@ -1330,39 +1333,13 @@ class AcpSessionHandle:
                             text=redact_text(su_text),
                         )
                 elif action == "mcp_oauth_request":
-                    params = msg.params or {}
-                    server_name = str(params.get("serverName") or params.get("name") or "")
-                    oauth_url = str(params.get("oauthUrl") or params.get("url") or "")
-                    # Parity with AcpClient (client.py mcp_oauth_request): reject
-                    # unsafe-scheme URLs BEFORE recording dedupe (so a later safe
-                    # retry still gets through), drop empty serverName (can't
-                    # correlate the later initialized/failure discard), and dedupe
-                    # per server so token-expiry retries don't spam banners. MCP
-                    # server names/URLs can be LLM-influenced, so the scheme check
-                    # is defense-in-depth.
-                    if not _is_safe_oauth_url(oauth_url):
-                        if oauth_url:
-                            logger.warning(
-                                "ACP: refusing unsafe mid-session MCP OAuth URL for %s",
-                                server_name or "(unknown)",
-                            )
+                    request = self._accept_oauth_request(msg)
+                    if request is None:
                         continue
-                    if not server_name:
-                        logger.warning(
-                            "ACP: dropping mid-session MCP OAuth request with empty serverName"
-                        )
-                        continue
-                    if server_name in self._oauth_emitted_servers:
-                        logger.debug(
-                            "ACP: dropping duplicate mid-session MCP OAuth request for %s",
-                            server_name,
-                        )
-                        continue
-                    self._oauth_emitted_servers.add(server_name)
                     yield AcpEvent(
                         kind=EVENT_MCP_OAUTH_REQUEST,
-                        server_name=server_name,
-                        oauth_url=oauth_url,
+                        server_name=request["serverName"],
+                        oauth_url=request["oauthUrl"],
                     )
                 elif action == "mcp_server_initialized":
                     params = msg.params or {}
@@ -1582,6 +1559,33 @@ class AcpSessionHandle:
                 "SEL audit failed for tool_interrupted at %s", site, exc_info=True
             )
 
+    def _accept_oauth_request(self, msg: JsonRpcMessage) -> dict[str, str] | None:
+        """Validate and deduplicate one MCP OAuth notification."""
+        params = msg.params if isinstance(msg.params, dict) else {}
+        server_name = str(params.get("serverName") or params.get("name") or "")
+        oauth_url = str(params.get("oauthUrl") or params.get("url") or "")
+        if not _is_safe_oauth_url(oauth_url):
+            if oauth_url:
+                logger.warning(
+                    "ACP: refusing unsafe MCP OAuth URL for %s",
+                    server_name or "(unknown)",
+                )
+            return None
+        if not server_name:
+            logger.warning("ACP: dropping MCP OAuth request with empty serverName")
+            return None
+        if server_name in self._oauth_emitted_servers:
+            logger.debug("ACP: dropping duplicate MCP OAuth request for %s", server_name)
+            return None
+        self._oauth_emitted_servers.add(server_name)
+        return {"serverName": server_name, "oauthUrl": oauth_url}
+
+    def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+        """Drain OAuth requests captured while this session initialized."""
+        pending = list(self._pending_oauth_requests)
+        self._pending_oauth_requests.clear()
+        return pending
+
     async def drain_init(
         self,
         duration: float = _MCP_DRAIN_DURATION,
@@ -1595,7 +1599,8 @@ class AcpSessionHandle:
         turn's event stream and gives MCP servers a brief window to report in
         before the first prompt races ahead. Bounded by ``duration`` with early
         exit after ``idle_exit`` seconds of silence. ``config_option_update``
-        frames refresh cached configOptions; everything else is logged/discarded.
+        frames refresh cached configOptions; OAuth requests remain drainable via
+        ``pop_pending_oauth_requests``; everything else is logged/discarded.
         Best-effort — never raises.
         """
         deadline = time.monotonic() + duration
@@ -1626,6 +1631,10 @@ class AcpSessionHandle:
                         if isinstance(cfg, list):
                             self._config_options = cfg
                             self._sync_effort_levels()
+                elif action == "mcp_oauth_request":
+                    request = self._accept_oauth_request(msg)
+                    if request is not None:
+                        self._pending_oauth_requests.append(request)
                 elif action == "mcp_server_init_failure":
                     p = msg.params or {}
                     logger.info(

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -524,6 +524,10 @@ class AcpSessionProvider(LLMProvider):
         """Models advertised by the backend."""
         return self._handle.available_models
 
+    def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+        """Drain OAuth requests captured while the shared session initialized."""
+        return self._handle.pop_pending_oauth_requests()
+
     def get_valid_effort_levels(self) -> list[str]:
         """Valid effort levels from config options."""
         return self._handle.get_valid_effort_levels()

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -40,6 +40,7 @@ from kiro_crew.acp.types import (
     EVENT_COMPLETE,
     EVENT_TEXT_CHUNK,
     METHOD_COMMANDS_EXECUTE,
+    METHOD_MCP_OAUTH_REQUEST,
     METHOD_SESSION_LOAD,
     METHOD_SESSION_NEW,
     METHOD_SESSION_TERMINATE,
@@ -3120,6 +3121,88 @@ async def test_create_session_registers_queue_on_success(monkeypatch):
     handle = await rt.create_session(cwd="/w", agent="kirocrew")
     assert handle.session_id == "sid-ok"
     assert "sid-ok" in rt._session_queues
+
+
+@pytest.mark.asyncio
+async def test_create_session_buffers_oauth_emitted_before_response():
+    """OAuth emitted during session/new survives until the provider can drain it."""
+    from kiro_crew.acp.session_provider import AcpSessionProvider
+
+    rt, reader, _ = _make_runtime()
+    reader_task = await _start_reader(rt)
+    create_task = asyncio.create_task(rt.create_session(cwd="/w"))
+    try:
+        await asyncio.sleep(0)
+        request_id = next(iter(rt._pending_requests))
+        oauth_url = "https://mcp.linear.app/authorize?client_id=shared"
+        _feed(
+            reader,
+            {
+                "method": METHOD_MCP_OAUTH_REQUEST,
+                "params": {
+                    "sessionId": "sid-new",
+                    "serverName": "linear",
+                    "oauthUrl": oauth_url,
+                },
+            },
+        )
+        _feed(reader, {"id": request_id, "result": {"sessionId": "sid-new"}})
+
+        handle = await asyncio.wait_for(create_task, timeout=3.0)
+        provider = AcpSessionProvider(handle, rt)
+        assert provider.pop_pending_oauth_requests() == [
+            {"serverName": "linear", "oauthUrl": oauth_url}
+        ]
+        assert provider.pop_pending_oauth_requests() == []
+    finally:
+        if not create_task.done():
+            create_task.cancel()
+        await _stop_reader(reader_task)
+
+
+@pytest.mark.asyncio
+async def test_failed_session_init_oauth_does_not_leak_to_reused_id():
+    """A failed init cannot leave an approval URL for a later shared session."""
+    rt, reader, _ = _make_runtime()
+    reader_task = await _start_reader(rt)
+    failed_task = asyncio.create_task(rt.create_session(cwd="/w"))
+    fresh_task = None
+    try:
+        await asyncio.sleep(0)
+        failed_request_id = next(iter(rt._pending_requests))
+        _feed(
+            reader,
+            {
+                "method": METHOD_MCP_OAUTH_REQUEST,
+                "params": {
+                    "sessionId": "sid-reused",
+                    "serverName": "linear",
+                    "oauthUrl": "https://mcp.linear.app/authorize?client_id=stale",
+                },
+            },
+        )
+        _feed(
+            reader,
+            {
+                "id": failed_request_id,
+                "error": {"code": -32603, "message": "session init failed"},
+            },
+        )
+        with pytest.raises(AcpRuntimeError, match="session init failed"):
+            await asyncio.wait_for(failed_task, timeout=3.0)
+        assert not rt._pending_init_notifications
+
+        fresh_task = asyncio.create_task(rt.create_session(cwd="/w"))
+        await asyncio.sleep(0)
+        fresh_request_id = next(iter(rt._pending_requests))
+        _feed(reader, {"id": fresh_request_id, "result": {"sessionId": "sid-reused"}})
+        handle = await asyncio.wait_for(fresh_task, timeout=3.0)
+        assert handle.pop_pending_oauth_requests() == []
+    finally:
+        for task in (failed_task, fresh_task):
+            if task is not None and not task.done():
+                task.cancel()
+        await _stop_reader(reader_task)
 
 
 # ── Drift-parity fixes (AcpRuntime ↔ AcpClient): #1-#4 + #5b ──

--- a/test/test_acp_runtime_kill.py
+++ b/test/test_acp_runtime_kill.py
@@ -9,6 +9,7 @@ every sweep and leak until reboot.
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from unittest.mock import MagicMock
 
 import pytest
@@ -21,6 +22,7 @@ def _bare_runtime(pid: int = 54321) -> rt.AcpRuntime:
     r = rt.AcpRuntime.__new__(rt.AcpRuntime)
     r._dead = False
     r._pending_requests = {}
+    r._pending_init_notifications = deque()
     r._routed_requests = {}
     r._session_queues = {}
     r._stderr_lines = []


### PR DESCRIPTION
## Problem

Clicking **Connect** on a Connections card could fail on the first attempt with nothing shown to the user. The runtime raises its OAuth approval request while the ACP session is being created, and on the default **shared** runtime path that notification was discarded — only the direct `AcpClient` path buffered it into `_pending_oauth_requests`.

## Why it matters

This is the headline journey of the Connections feature. The card sits on "waiting for the approval address" while the request that would have produced that address has already been thrown away, so the user's first click appears to do nothing and the only recovery is unrelated activity that happens to create a fresh session.

## Fix (symptoms → root cause → change)

First click produces no approval URL → the notification is emitted *during* session initialization, before the dashboard has anything to drain, and the shared-runtime path dropped it on the floor → this PR buffers notifications raised during session init so the dashboard's existing `pop_pending_oauth_requests()` drain still sees them.

Deliberately careful about two failure modes this feature has already hit once:

- **No cross-session leakage.** Buffered state is scoped so a stale approval URL cannot resurface for a later, unrelated attempt — the same class of bug as the stale-banner defect fixed during M1's page work.
- **No unbounded growth**, and the direct-client path behaves exactly as before.

## Tests

- A notification raised during session initialization survives to `pop_pending_oauth_requests()` on the shared path.
- The pre-existing direct-path behaviour is unchanged.
- Buffered state does not leak across sessions.

## Manual verification

N/A — unit coverage is sufficient: the defect is a lost in-process notification, reproduced directly at the buffering seam. The end-to-end consent flow itself was already proven live during M0.

## Screenshots

N/A — no UI change; this makes an existing UI path (the approval banner/card) actually receive its data.
