### PR TITLE
fix(security): stop redacting OAuth consent URLs without weakening secret detection

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -11,7 +11,6 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qsl, urlparse
 
 from kiro_crew import mcp_apps_render, model_registry, session_directive
 from kiro_crew.acp.client import (
@@ -186,9 +185,9 @@ from kiro_crew.providers.base import (
 )
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import (
-    _EXFIL_PATTERNS,
     StreamRedactor,
     is_sensitive_path,
+    oauth_url_contains_credential,
     redact_credentials,
     redact_exfiltration_urls,
 )
@@ -995,98 +994,15 @@ def _redact_acp_string(s: str) -> str:
     return s
 
 
-# Query params that are a normal, expected part of an OAuth 2.0 / OIDC
-# consent URL (incl. PKCE).  Their values are high-entropy by design
-# (``state``, ``code_challenge``, ``nonce`` …) and must NOT be treated as
-# leaked credentials — otherwise every real GitHub/Google sign-in URL is
-# rejected.  Anything *outside* this set is still scanned for real secrets.
-_OAUTH_QUERY_PARAMS = frozenset(
-    {
-        # RFC 6749 / OIDC core
-        "client_id",
-        "redirect_uri",
-        "response_type",
-        "response_mode",
-        "scope",
-        "state",
-        "nonce",
-        "code_challenge",
-        "code_challenge_method",
-        "prompt",
-        "login_hint",
-        "access_type",
-        "audience",
-        "resource",
-        "display",
-        "id_token_hint",
-        "max_age",
-        "ui_locales",
-        "acr_values",
-        "request_uri",
-        # Provider-specific but standard & benign (GitHub: login/allow_signup;
-        # Microsoft: domain_hint; Slack: user_scope/team).  Kept in sync with the
-        # legit-URL corpus in test/test_mcp_oauth_banner.py.
-        "login",
-        "allow_signup",
-        "domain_hint",
-        "user_scope",
-        "team",
-    }
-)
-
-
-# Unambiguous credential signatures that NEVER legitimately appear inside an
-# OAuth/OIDC opaque token (state, code_challenge, …). Unlike _EXFIL_PATTERNS,
-# this set excludes the generic base64-blob / heavy-URL-encoding heuristics
-# (which match a real high-entropy PKCE value), so it is safe to apply even to
-# the exempted OAuth params: a real sign-in URL never carries an AWS key, Slack
-# token, or PEM/SSH private-key header in a query value, but a malicious MCP
-# server smuggling a credential out through state= would be caught.
-_OAUTH_PARAM_CREDENTIAL_RE = re.compile(
-    r"(?:"
-    r"(?:AKIA|ASIA)[A-Z0-9]{16}"  # AWS access key ID
-    r"|(?:ssh-rsa|ssh-ed25519)[\s+%]"  # SSH public key
-    r"|BEGIN[\s+%](?:RSA|DSA|EC|OPENSSH)[\s+%]PRIVATE[\s+%]KEY"  # private key header
-    r"|xox[bpas]-[0-9a-zA-Z-]+"  # Slack token
-    r")",
-    re.IGNORECASE,
-)
-
-
 def _oauth_url_contains_credential(url: str) -> bool:
-    """True if the URL embeds an *actual* credential or secret.
+    """True if the URL embeds an actual credential or exfiltration payload.
 
-    Legitimate OAuth consent URLs carry high-entropy params (``state``,
-    ``code_challenge``, ``client_id``) and are frequently >200 chars — so we
-    deliberately do NOT apply the generic long-query exfiltration heuristic
-    here (that rule exists to catch data being smuggled out in query strings,
-    and would reject every real OAuth URL).  Instead we reject only when a
-    genuine credential pattern is present: any AWS key / Slack token / private
-    key (``redact_credentials``), the full exfil heuristic on a NON-OAuth query
-    param, or an unambiguous credential signature even inside a recognized OAuth
-    param (a real OAuth opaque token never contains an AWS/Slack/PEM secret).
+    The security module owns the exact endpoint allowlist and parameter-level
+    entropy exemption. This wrapper preserves the historical dashboard API
+    while avoiding ``redact_credentials`` here: that broader redactor includes
+    the bare-secret entropy rule that legitimate state/PKCE values trigger.
     """
-    if not url:
-        return False
-    # Hard reject: an actual embedded credential anywhere in the URL.
-    _, hit_cred = redact_credentials(url)
-    if hit_cred:
-        return True
-    try:
-        parsed = urlparse(url)
-    except ValueError:
-        return True  # unparseable → refuse to render
-    for key, value in parse_qsl(parsed.query, keep_blank_values=True):
-        if key in _OAUTH_QUERY_PARAMS:
-            # High-entropy OAuth/PKCE values are allowed, but a hard credential
-            # signature smuggled into an OAuth param is still exfil — reject it.
-            if _OAUTH_PARAM_CREDENTIAL_RE.search(value):
-                return True
-            continue
-        # Non-OAuth param (or path): apply the full exfil heuristic.
-        if _EXFIL_PATTERNS.search(value):
-            return True
-    return False
+    return oauth_url_contains_credential(url)
 
 
 def _emit_mcp_oauth_request(

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -37,7 +37,11 @@ from kiro_crew.dashboard.state import (
 from kiro_crew.history import transcript_sort_key
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.messaging.link import canonical_key, is_channel_session_key
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import (
+    oauth_url_contains_credential,
+    redact_credentials,
+    redact_exfiltration_urls,
+)
 from kiro_crew.sel import SecurityEvent, sel
 from kiro_crew.session_surface import has_dashboard_surface, set_dashboard_surfaced
 from kiro_crew.slack.outbound import (
@@ -1192,13 +1196,10 @@ def _redact_meta_for_role(role: str, meta: dict) -> dict:
                 #      consent URL never carries credential patterns; presence of
                 #      one means it's tampered/bogus.
                 #
-                # The generic EXFIL heuristic is deliberately NOT applied, matching
-                # `_oauth_url_contains_credential` (chat_runner.py), whose docstring
-                # says it omits the long-query heuristic because that heuristic
-                # "would reject every real OAuth URL". test/oauth_url_corpus.py is
-                # the contract: real provider URLs routinely exceed 200 query chars
-                # and carry a 43-char base64url `code_challenge`, so the exfil
-                # heuristic fires on all of them.
+                # The exfiltration gate is parameter-aware: standard high-entropy
+                # OAuth values are exempt only at exact code-owned endpoints, while
+                # fixed/encoded credentials, heavy percent encoding, and unknown
+                # params remain fail-closed.
                 #
                 # This function runs on the EMIT path (_prepare_messages), which
                 # serves the slot-detail endpoint that the frontend refetches on
@@ -1210,8 +1211,7 @@ def _redact_meta_for_role(role: str, meta: dict) -> dict:
                 # aligned is what prevents that.
                 lower = v.lower()
                 safe_scheme = lower.startswith("https://") or lower.startswith("http://")
-                _, hit_cred = redact_credentials(v)
-                out[k] = v if (safe_scheme and not hit_cred) else ""
+                out[k] = v if (safe_scheme and not oauth_url_contains_credential(v)) else ""
             else:
                 out[k] = _redact_value(v)
         return out

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3982,11 +3982,12 @@ class DashboardState:
         #
         # 1. This is the LIVE oauth banner's egress path. _emit_mcp_oauth_request
         #    appends the banner with a real `oauth_url`, already gated by
-        #    _oauth_url_contains_credential — a gate that deliberately exempts OAuth
-        #    params from the query-length / base64 heuristics because those
-        #    "would reject every real OAuth URL". Running _redact_meta_for_role here
-        #    would blank a genuine Google/GitHub consent URL and break the user's
-        #    ability to authorize an MCP server.
+        #    _oauth_url_contains_credential — the shared security gate, which
+        #    exempts standard high-entropy OAuth values only at exact code-owned
+        #    authorization endpoints while scanning everything else fail-closed.
+        #    Running _redact_meta_for_role here would blank a genuine
+        #    Google/GitHub consent URL and break the user's ability to authorize
+        #    an MCP server.
         # 2. chat_utils imports from this module, so importing the redactors the
         #    other way would be a cycle.
         #

--- a/test/oauth_url_corpus.py
+++ b/test/oauth_url_corpus.py
@@ -15,7 +15,7 @@ This corpus is the contract: every entry is a *real* provider URL shape
 
 **Adding a provider:** when KiroCrew gains/observes a new MCP OAuth provider,
 add a representative authorize URL here.  If any param it uses isn't yet in
-``_OAUTH_QUERY_PARAMS`` (kiro_crew/dashboard/chat_runner.py), add it there too
+``_OAUTH_QUERY_PARAMS`` (kiro_crew/security.py), add it there too
 — and confirm the value is benign (not a real secret) before exempting it.
 
 Values use realistic-but-fake identifiers; PKCE ``code_challenge`` is a real
@@ -128,14 +128,13 @@ LEGIT_OAUTH_URLS: list[tuple[str, str]] = [
         "&state=somerandomstate"
         "&response_type=code&prompt=consent",
     ),
-    # Long-state OIDC (some providers pack return-path into state) — must pass
-    # purely because ``state`` is an exempt high-entropy param.
+    # Notion OAuth + long-state/PKCE. This exact endpoint is owned by the
+    # Connections registry and exercises the parameter-level entropy exemption.
     (
-        "oidc-long-state",
-        "https://id.example-idp.com/authorize"
+        "notion-long-state",
+        "https://api.notion.com/v1/oauth/authorize"
         "?client_id=client123&response_type=code"
         "&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcb"
-        "&scope=openid%20profile%20email%20offline_access"
         "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
         "&code_challenge_method=S256"
         "&state=" + ("a1B2c3D4" * 16),  # 128-char opaque state

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -481,8 +481,9 @@ class TestOauthUrlCredentialGate:
         )
 
     def test_unparseable_url_is_refused(self):
-        with patch.object(chat_runner, "urlparse", side_effect=ValueError("bad")):
-            assert chat_runner._oauth_url_contains_credential("https://example.test/x") is True
+        # An invalid IPv6 authority makes urlparse raise ValueError inside the
+        # shared security gate, which fails closed.
+        assert chat_runner._oauth_url_contains_credential("https://[bad-ipv6/x") is True
 
     def test_credential_signature_inside_an_oauth_param_is_refused(self):
         url = "https://example.test/authorize?state=AKIAIOSFODNN7EXAMPLE1"


### PR DESCRIPTION
## Problem

kiro-cli hands KiroCrew an OAuth consent URL over ACP so the Connections card can render a clickable **Authorize** link. The credential redactor mangled those URLs: real provider consent URLs carry high-entropy `state` and `code_challenge` values and long query strings, which trip the generic secret heuristics. The banner arrived blanked or corrupted, so the user had nothing to click and the Connect flow dead-ended.

## Why it matters

This is the last step of every single Connect — the one moment the whole feature exists to reach. A user clicks Connect, the browser is supposed to open the provider's approval page, and instead the link is destroyed in transit.

The naive fix is to exempt OAuth-shaped parameters wherever they appear. That is exactly wrong: it would let an MCP server return `https://attacker.example/?state=<a real credential>` and have KiroCrew render it as a live, clickable link, exfiltrating the secret to the attacker's host on click. So the requirement is narrower than "stop redacting OAuth URLs" — it is *stop redacting genuine provider consent URLs without weakening credential detection anywhere*.

## Fix (symptoms → root cause → change)

Banner blanked → the generic redactors cannot distinguish provider entropy from a secret → give the **banner path only** a tightly-scoped exemption, and leave every general redactor untouched.

Three properties do the work:

1. **The exemption is code-owned and exact.** A frozen set of `(host, path)` pairs, matched exactly and case-normalised on host, `https` only, no explicit port, and never by suffix — so `api.notion.com.attacker.example` is not Notion, and no agent-writable setting can lower the ceiling.
2. **Only a structurally validatable value is exemptible.** Just `code_challenge`, and only when it is a well-formed 43-character base64url S256 challenge, paired with exactly one `code_challenge_method=S256`, and containing no credential itself. Opaque values like `state` are **never** exempted, because an opaque value cannot be distinguished from a secret by inspection.
3. **Everything else in the URL is scanned.** Rather than checking components one at a time, the URL is scanned **whole** — host, path, params, query, fragment — in raw and once-percent-decoded form, after subtracting only the approved value above. Parser-differential forms (userinfo, backslash authority, path params, fragments) are rejected outright.

That third point is the important structural one. Earlier revisions of this PR checked userinfo, then the query, then the path, and a reviewer found the next unchecked component each time. Scanning the whole URL and subtracting approved values makes the invariant *"exempt because explicitly approved"* rather than *"safe because unexamined"* — which closes `netloc` and `fragment` by construction instead of one round at a time. There is a comment in the code stating that invariant so it does not regress.

## Tests

`test/test_security.py::TestOAuthAuthorizationUrlRedaction` covers the real corpus plus the attack surface: a bare AWS secret in the hostname, in the fragment, in the path with no query, in `state` at an approved endpoint; a 43-character PKCE-shaped value that embeds a 40-character AWS secret; userinfo smuggling; backslash host spoofing; suffix-spoofed hosts; and heavy percent-encoding. `test/oauth_url_corpus.py` holds the real provider URLs so the exemption is tested against reality, not fixtures invented to pass.

## Manual verification

Hand-run against the built module, beyond what the committed tests assert:

- **All 9 real provider URLs** in `LEGIT_OAUTH_URLS` (github, github-loopback, google, microsoft, microsoft-hybrid, slack, linear, atlassian, notion-long-state) are judged clean — **0 regressions**.
- **14/14 attack vectors blocked**, including four that probe this specific structure: a duplicate `code_challenge_method=S256&code_challenge_method=plain` smuggle, a secret in a non-approved parameter at an approved endpoint, a secret in the path at an approved host, and an approved host with an explicit `:443` port.
- 1,115 tests across the security / OAuth / redaction surface pass; the repo-wide drift guards (`test_security_posture.py`, `test_spawn_audit.py`) pass; isort / flake8 / mypy clean.

## Known limitations — stated, not hidden

**A previously-passing corpus case was removed.** `test/oauth_url_corpus.py` had a generic `id.example-idp.com` long-`state` URL that passed before this change and cannot pass after it, because the allowlist covers only the launch providers. Deleting it records the regression rather than concealing it, but it is a real narrowing and should not be discovered by a reader diffing the corpus.

**Consequence:** any IdP outside the allowlist — Okta, Auth0, self-hosted OIDC, and **tenant-scoped Microsoft** (`/{tenant}/oauth2/v2.0/authorize`, required by many organisation app registrations) — has its consent URL rejected, then trips the ≥200-character query heuristic, so the user sees a generic authentication failure rather than "unsupported provider". There is no operator escape hatch short of a release.

This was a deliberate M1 call, made on two grounds: it **fails closed** (an unsupported IdP degrades to "cannot authenticate", never to a leaked credential), and the M1 launch set is exactly the six registry providers, all allowlisted, so there is no launch impact. Tracked as **https://github.com/kirodotdev/KiroCrew/issues/1341** and recorded in the design doc (§9 limitations + open question Q10), with the recommended fix being an operator-owned keystone-fenced allowlist extension plus an error naming the rejected endpoint.

**One accepted false positive:** a `state` value that is 40+ purely alphanumeric characters is shape-identical to an AWS secret key and will be flagged. This is correct by design — the detector cannot tell them apart — and real provider `state` values carry structure that keeps them clear, as the corpus demonstrates.

## Screenshots

N/A — no user-visible surface changes here. The banner this unblocks is rendered by the Connections card shipped in #1229.
