### PR TITLE
fix(deps): bump the fast-uri override past GHSA-7p8r-x3mc-p8w7

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1837,9 +1837,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -21,7 +21,7 @@
     "electron-builder-squirrel-windows": "^26.15.3"
   },
   "overrides": {
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "js-yaml": "4.3.0"
   },
   "build": {


### PR DESCRIPTION
## Problem

`Dependency Audit / Audit Production Dependencies` fails on `main` and on every open PR whose audit ran after the advisory was published:

```
website/electron/package-lock.json: fast-uri GHSA-7p8r-x3mc-p8w7 (high)
  — fast-uri vulnerable to host confusion via backslash authority introducer
```

## Why it matters

**Nobody's diff caused it.** The advisory landed against a version that was already in the lockfile, so the audit turned red without any dependency changing. #1294, #1322, #1323, #1325 and #1331 all inherited the failure; PRs whose audit had run earlier still show green, which makes it look like a per-PR problem rather than a repo-wide one.

That is the same stale-green shape as a whole-repo ledger check — the failure names no diff anyone can fix, so it blocks every author until someone bumps the dep centrally.

It is also a real high-severity advisory, not just a red check: host confusion via a backslash authority introducer means a URL parser can disagree with the consumer about which host a URI points at.

## Fix (symptom → root cause → change)

`fast-uri` is transitive — `ajv` requires `^3.0.1`, reached through the `electron-builder` chain. `website/electron/package.json` already pins it via an `overrides` entry from a previous advisory, so the whole fix is that pin moving:

```diff
   "overrides": {
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "js-yaml": "4.3.0"
   }
```

GHSA-7p8r-x3mc-p8w7 lists `3.1.5` as the first patched version on the 3.x line (`2.4.4` and `4.1.2` for the 2.x and 4.x lines). `^3.0.1` is satisfied, so no consumer constraint changes.

Regenerated with `npm install --package-lock-only`, which touched exactly the three lines that identify the package:

```
-      "version": "3.1.4",
-      "resolved": ".../fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8Jnbk…",
+      "version": "3.1.5",
+      "resolved": ".../fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1…",
```

No other dependency moved.

## Tests

None added — there is nothing to assert beyond the resolved version, and `Dependency Audit` is itself the test. It goes from failing on this advisory to clean.

## Manual verification

N/A — unit coverage is not the right instrument for a lockfile pin. The signal is the `Dependency Audit` check on this PR, plus the advisory API confirming the patched range:

```
$ gh api /advisories/GHSA-7p8r-x3mc-p8w7
severity: high
fast-uri  < 2.4.4            → patched 2.4.4
fast-uri  >= 3.0.0, < 3.1.5  → patched 3.1.5
fast-uri  >= 4.0.0, < 4.1.2  → patched 4.1.2
```

## Screenshots

N/A — no user-visible change.
