### PR TITLE
fix(sandbox): stop denying link/linkat in the Linux seccomp filter

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -1111,9 +1111,33 @@ def main():
                 sys.exit("sandbox: BLOCKED — failed to set NO_NEW_PRIVS (prctl returned %d)" % _ret)
 
         # ── Step 6: Install seccomp-BPF filter ──
-        # Deny mount/umount2/unshare/setns/pivot_root/link/linkat to prevent
-        # the sandboxed process from undoing bind-mounts or creating hardlinks
-        # to protected credential inodes.
+        # Deny mount/umount2/unshare/setns/pivot_root to prevent the sandboxed
+        # process from undoing the credential bind-mounts (namespace escape).
+        #
+        # NOTE: link/linkat were previously denied here to block hardlinking a
+        # credential inode out past its bind-mount (pentest finding #9). That
+        # deny has been removed; the vector is covered without a blanket syscall
+        # ban (which broke npm cacache / pnpm / ln for no gain). Masking is
+        # per-level: strict bind-masks its dir/file list PLUS ~/.ssh; cc masks
+        # the same MINUS ~/.ssh; standard masks only _STANDARD_DIRS (.gnupg,
+        # .gpg, .config/gcloud, .azure, .docker, crew-auth-staging). For a file
+        # that IS masked the credential inode has no reachable path, so no link
+        # source exists. For a file left UNMASKED at a given level (~/.ssh under
+        # cc; .aws/.ssh/_CC_FILES under standard) there is no privilege delta:
+        # it is already directly readable, so the command gate
+        # (security.is_sensitive_bash_command) is the control for BOTH reading
+        # and hardlinking it — the gate now resolves an agent-issued ln/link/cp
+        # source through is_sensitive_path(), refusing a link to a credential
+        # source at the same fidelity as a read (closing the "flatten onto a
+        # benign alias" bypass, GPT review PR #1339). npm's own fs.link() is a
+        # syscall and never transits that gate. seccomp cannot path-scope link
+        # (BPF cannot dereference the pathname pointer), so a syscall-layer form
+        # could only be all-or-nothing. NOTE: the Step-7 pre-exec nlink scan is
+        # NOT relied on here — it stats paths AFTER the masks, so it sees mask
+        # inodes, not real credential inodes. For AppSec (pre-existing / out of
+        # scope): that Step-7 gap; a hardlink alias is durable and symlink-
+        # resolution-invisible; and `mv` is not yet gate-covered. AppSec
+        # re-review required — this edits a pentest remediation.
         #
         # Additionally deny kill(-1, sig) — the signal BROADCAST that reaches
         # every same-uid process on the host (gateway, other sessions). This
@@ -1141,16 +1165,16 @@ def main():
             _BPF_K = 0x00
             _BPF_RET = 0x06
             # Syscall numbers (x86_64): mount=165, umount2=166, unshare=272,
-            # setns=308, pivot_root=155, link=86, linkat=265, kill=62
+            # setns=308, pivot_root=155, kill=62
             # aarch64: mount=40, umount2=39, unshare=97, setns=268,
-            # pivot_root=41, link=N/A(use linkat=37), linkat=37, kill=129
+            # pivot_root=41, kill=129
             import platform as _plat
             _machine = _plat.machine()
             if _machine == "x86_64":
-                _DENY_SYSCALLS = (165, 166, 272, 308, 155, 86, 265)
+                _DENY_SYSCALLS = (165, 166, 272, 308, 155)
                 _KILL_NR = 62
             elif _machine == "aarch64":
-                _DENY_SYSCALLS = (40, 39, 97, 268, 41, 37)
+                _DENY_SYSCALLS = (40, 39, 97, 268, 41)
                 _KILL_NR = 129
             else:
                 _DENY_SYSCALLS = ()  # unknown arch — skip seccomp

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4408,6 +4408,19 @@ _NORMALIZER_READ_VERBS: frozenset[str] = frozenset(
 )
 
 
+# ── Hardlink/symlink creation verbs ──
+# A hardlink (or symlink) to a credential file "flattens" it onto a benign,
+# non-sensitive alias: `ln ~/.npmrc ./x` then reading `./x` exposes the token
+# while dodging the path-based read matcher (GPT review, PR #1339 — standard
+# sandbox mode does NOT bind-mask credential paths, so the command gate is the
+# only line there). We do NOT block link/linkat at the syscall layer (that
+# banned npm cacache's internal fs.link and every benign hardlink); instead we
+# treat an AGENT-ISSUED link command like a read and resolve its operands
+# through is_sensitive_path(), so linking a sensitive SOURCE is refused at the
+# same fidelity as reading it. npm's own fs.link() never transits this gate.
+_LINK_CREATE_VERBS: frozenset[str] = frozenset({"ln", "link"})
+
+
 def is_sensitive_bash_command(command: str) -> str | None:
     """Check if a bash command reads sensitive paths, accesses IMDS, or leaks env creds.
 
@@ -4472,18 +4485,18 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
     if not tokens:
         return None
 
-    # Check if any token resolves to a known read verb (by basename, so
-    # /usr/bin/cat is recognized as "cat").
-    has_read_verb = False
+    # Check if any token resolves to a known read verb or hardlink/symlink
+    # creation verb (by basename, so /usr/bin/cat is recognized as "cat").
+    has_relevant_verb = False
     for token in tokens:
         if not token:
             continue
         basename = os.path.basename(token).lower()
-        if basename in _NORMALIZER_READ_VERBS:
-            has_read_verb = True
+        if basename in _NORMALIZER_READ_VERBS or basename in _LINK_CREATE_VERBS:
+            has_relevant_verb = True
             break
 
-    if not has_read_verb:
+    if not has_relevant_verb:
         return None
 
     # Route each path-like token through is_sensitive_path()
@@ -4493,9 +4506,9 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
         # Skip flags
         if token.startswith("-"):
             continue
-        # Skip tokens that ARE the read verb itself
+        # Skip tokens that ARE the verb itself
         basename = os.path.basename(token).lower()
-        if basename in _NORMALIZER_READ_VERBS:
+        if basename in _NORMALIZER_READ_VERBS or basename in _LINK_CREATE_VERBS:
             continue
         # Only check tokens that look like filesystem paths
         if not _is_path_like(token):

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -268,6 +268,22 @@ class TestBuildLauncherScript:
         assert ".aws" in script
         assert ".gnupg" in script
 
+    def test_strict_script_denies_namespace_escape_not_hardlinks(self):
+        """Linux seccomp deny list must contain the namespace-escape syscalls
+        (mount/umount2/unshare/setns/pivot_root) and must NOT contain
+        link/linkat -- hardlink containment is the bind-mask's job, and a
+        blanket link ban broke hardlink-using build tools (npm cacache). Guards
+        against an accidental re-add of link/linkat or drop of an escape
+        syscall (pentest finding #9 remediation)."""
+        script = _build_launcher_script("strict")
+        # x86_64: mount=165 umount2=166 unshare=272 setns=308 pivot_root=155
+        assert "_DENY_SYSCALLS = (165, 166, 272, 308, 155)" in script
+        # aarch64: mount=40 umount2=39 unshare=97 setns=268 pivot_root=41
+        assert "_DENY_SYSCALLS = (40, 39, 97, 268, 41)" in script
+        # link=86/linkat=265 (x86_64) and linkat=37 (aarch64) must be gone
+        assert "308, 155, 86, 265)" not in script
+        assert "268, 41, 37)" not in script
+
     def test_standard_script_excludes_aws(self):
         script = _build_launcher_script("standard")
         # Standard dirs don't include .aws

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -2335,6 +2335,30 @@ class TestIsSensitiveBashCommand:
         assert is_sensitive_bash_command("ln -sf ./dist/app ./app") is None
         assert is_sensitive_bash_command("ln -s ../src/main.py main.py") is None
 
+    # ── Hardlink-flatten bypass (GPT review, PR #1339) ──
+
+    def test_hardlink_to_sensitive_source_blocked(self) -> None:
+        # A HARDLINK (ln without -s, or the `link` coreutil) to a credential
+        # source flattens it onto a benign alias, dodging the path-based read
+        # matcher in standard mode (which does not bind-mask). The link verbs
+        # now route their operands through is_sensitive_path() like a read.
+        assert is_sensitive_bash_command("ln ~/.aws/credentials ws/x") is not None
+        assert is_sensitive_bash_command("link ~/.ssh/id_rsa ws/k") is not None
+
+    def test_hardlink_obfuscated_source_blocked(self) -> None:
+        # Quote-obfuscation defeats the literal regex first-pass; the normalizer
+        # (now triggered by `ln`/`link`) strips the empty quotes, expands ~, and
+        # resolves the source through is_sensitive_path(). These forms are
+        # caught ONLY via the normalizer, so they exercise the new code path for
+        # both verbs.
+        assert is_sensitive_bash_command('ln ~/.aw""s/credentials ws/x') is not None
+        assert is_sensitive_bash_command('link ~/.ss""h/id_rsa ws/k') is not None
+
+    def test_hardlink_benign_source_allowed(self) -> None:
+        # npm cacache / workspace-internal hardlinks must stay allowed.
+        assert is_sensitive_bash_command("ln node_modules/.cache/blob pkg/dep") is None
+        assert is_sensitive_bash_command("ln ./dist/a ./b") is None
+
     def test_base64_gnupg(self) -> None:
         result = is_sensitive_bash_command("base64 ~/.gnupg/secring.gpg")
         assert "blocked" in result.lower()


### PR DESCRIPTION
## Problem
Any hardlink-using tool run inside an agent session **on Linux** fails with `EPERM: operation not permitted, link ...`. Most visibly `npm install` / `npm ci` (npm's `cacache` hardlinks into its content-addressable store, and its `EPERM` fallback is Windows-only), plus pnpm and `ln`. Multiple users report NPMPM / `brazil-build` on npm-based packages failing entirely inside agent sessions; brazilpython builds are unaffected.

## Why it matters
This blocks a core value proposition — reaching a green build autonomously — for every npm/pnpm-based project on Linux. Users on a toolbox install can't even apply the local file-edit workaround, so they are fully blocked.

## Fix (symptom → root cause → change)
- **Symptom:** `EPERM ... link` on any hardlink inside a Linux agent session.
- **Root cause:** the Linux seccomp-BPF filter (`sandbox.py`, Step 6) blanket-denies `link(2)` / `linkat(2)`. seccomp filters on syscall *number*, not path, so it cannot scope the deny to credential locations — it bans **all** hardlinks. The deny was defense-in-depth for pentest **finding #9** (hardlinking a credential inode out past its bind-mount).
- **Why removing the seccomp deny is safe (two layers, no blanket ban):**
  - Masking is **per-level**: strict masks its dir/file list **plus** the ssh key dir; cc masks the same **minus** the ssh key dir; standard masks only `_STANDARD_DIRS`. For a **masked** file the credential inode has no reachable path, so no link source exists.
  - For a file left **unmasked** at a level (ssh key dir under cc; aws-creds / `.ssh` / `_CC_FILES` under standard) there is **no privilege delta** — it is already directly readable. So the command gate (`security.is_sensitive_bash_command`) is the control for *both* reading and hardlinking it. This PR makes that gate treat an agent-issued `ln`/`link` like a read: it resolves the link **source** through `is_sensitive_path()` (obfuscation-resistant via the normalizer) and refuses a link whose source lands on a credential path. That closes the "flatten a credential onto a benign alias" bypass (GPT review finding on this PR). npm's own `fs.link()` is a syscall and never transits this gate, so it keeps working.
- **Change:** remove `link`/`linkat` from `_DENY_SYSCALLS` on both arches; keep `mount/umount2/unshare/setns/pivot_root` and the `kill(-1)` broadcast guard. Add `_LINK_CREATE_VERBS={"ln","link"}` to the command gate. macOS unaffected (Seatbelt path-scopes `file-link` to credential paths only).

## Tests
- `test_strict_script_denies_namespace_escape_not_hardlinks` — pins the deny tuple to `(165,166,272,308,155)` / `(40,39,97,268,41)` and asserts `link`/`linkat` are gone.
- `TestIsSensitiveBashCommand` — `ln`/`link` to a credential source blocked (including quote-obfuscated forms that exercise the normalizer path for both verbs); benign workspace hardlinks (`ln node_modules/.cache/blob pkg/dep`, `ln ./dist/a ./b`) allowed.
- Existing macOS Seatbelt `file-link` tests unchanged and still pass.

## Manual verification
- `_build_launcher_script("strict")` emits the expected deny tuples; the link-source guard blocks obfuscated `ln`/`link` to a credential source and allows benign workspace hardlinks (verified locally).
- **Pending — needs a Linux dev desktop:** confirm `npm ci` inside a `strict`/`cc` agent session now succeeds. The Linux seccomp path cannot be exercised on macOS.

## Screenshots
N/A — no user-visible UI change.

## AppSec
This edits a pentest remediation (finding #9); requesting AppSec/Talos re-review. Pre-existing / out-of-scope items surfaced during review, **not** addressed here: (1) the Step-7 pre-exec `nlink` scan builds its protected-inode set *after* the masks, so it inspects mask inodes rather than real credential inodes; (2) a hardlink alias is durable and symlink-resolution-invisible (standing alias vs one-shot leak); (3) `mv` is not yet covered by the command-gate resolver. Tracked separately for AppSec.
