### PR TITLE
fix(deps): bump fast-uri override to 3.1.5 for GHSA-7p8r-x3mc-p8w7

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1837,9 +1837,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -21,7 +21,7 @@
     "electron-builder-squirrel-windows": "^26.15.3"
   },
   "overrides": {
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "js-yaml": "4.3.0"
   },
   "build": {


### PR DESCRIPTION
## Problem

`GHSA-7p8r-x3mc-p8w7` (**high**) — *fast-uri vulnerable to host confusion via backslash authority introducer* — was published against `fast-uri`, which `website/electron/package.json` pins to `3.1.4` in its `overrides` block. The Dependency Audit gate fails on high/critical production advisories, so it now reports:

```
ERROR: unexcepted high/critical production vulnerabilities:
  website/electron/package-lock.json: fast-uri GHSA-7p8r-x3mc-p8w7 (high)
```

## Why it matters

This turns `PR Readiness` red on **every open PR in the repo**, including ones that touch no dependencies at all — I hit it simultaneously on five unrelated Connections PRs. Nothing can merge until the pin moves, and the failure is misleading: it looks like each PR introduced a vulnerability when none did.

The advisory itself is also worth taking seriously on its own merits rather than just as a gate failure. Host confusion via a backslash authority introducer means a parser disagrees with a browser about which host a URL points at — `https://evil.example\@trusted.example/` resolving one way in the library and another in a navigation context. That is a URL-spoofing primitive.

## Fix (symptoms → root cause → change)

Gate fails on `fast-uri` → the version is not floating, it is **explicitly pinned** to the now-vulnerable `3.1.4` by an `overrides` entry, so `npm audit fix` cannot move it → bump the override to the patched release.

`fast-uri` is not a direct dependency; it arrives transitively via `ajv` (pulled in by `electron-builder`). Per the advisory, the `3.x` line is patched in **3.1.5** (the `2.x` and `4.x` lines are patched in `2.4.4` / `4.1.2`, not applicable here). The override moves `3.1.4` → `3.1.5` and the lockfile is regenerated to match.

Two files, four changed lines, no source change.

## Tests

No new tests — this is a dependency pin bump with no source change, so there is no new behaviour to lock in.

## Manual verification

- `npm install --ignore-scripts` in `website/electron`, then `node -e 'require("./node_modules/fast-uri/package.json").version'` → **`3.1.5`** (confirms the override actually took effect rather than just editing a string).
- `npm audit --omit=dev --audit-level=high` → **`found 0 vulnerabilities`**, run against a real installed tree, not lockfile-only.
- `npm test` in `website/electron` → **467 tests pass, 40 suites, 0 failures**. This matters because `fast-uri` reaches the tree through `electron-builder`'s `ajv`, so the packaging path is what a bad bump would break.
- Confirmed `website/electron/package-lock.json` is the **only** lockfile in the repo carrying `fast-uri`, so no other tree needs the same bump.

## Screenshots

N/A — dependency metadata only, no user-visible surface.
