### PR TITLE
fix(chat): keep tool-call labels in the active UI language

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -21,6 +21,8 @@ import { shallowEqual } from 'react-redux'
 import { motion, AnimatePresence } from 'framer-motion'
 import { sanitizeLlmOutput } from '../utils/sanitize'
 import { useSimplifiedToolNames } from '../hooks/useSimplifiedToolNames'
+import { useLanguage } from '../i18n/LanguageProvider'
+import { pickToolLabel } from '../utils/toolLabel'
 import TrustDropdown from './TrustDropdown'
 import AutoNudgePopover, { type AutoNudgeLoop } from './AutoNudgePopover'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -536,6 +538,7 @@ function ChatInput({
     || ''
   const approvalIsUnattended = UNATTENDED_APPROVAL_SOURCES.has(approvalSource)
   const simplified = useSimplifiedToolNames()
+  const uiLang = useLanguage().resolved
   const approvalLabelRaw = sanitizeLlmOutput(pendingApproval?.content || '').replace(/^🔧\s*/, '')
 
   const approvalToolCallId = (approvalMeta?.tool_call_id as string) || null
@@ -549,7 +552,7 @@ function ChatInput({
   const approvalPurpose = approvalToolEntry?.purpose || ''
   const approvalTs = approvalToolEntry?.ts || 0
 
-  const approvalLabel = (simplified && approvalPurpose) ? approvalPurpose : approvalLabelRaw
+  const approvalLabel = pickToolLabel({ simplified, purpose: approvalPurpose, rawLabel: approvalLabelRaw, uiLang })
 
   // Subscribe to the inline pill's viewport visibility. While the pill is in
   // view, the bar collapses to just the always-visible button row; the moment

--- a/website/src/components/commandPalette/providers/recentsProvider.ts
+++ b/website/src/components/commandPalette/providers/recentsProvider.ts
@@ -2,6 +2,7 @@ import { createElement, useMemo } from 'react'
 import { MessageSquare, Clock } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
+import i18next from 'i18next'
 
 import { api } from '../../../api/client'
 import { useSimplifiedToolNames } from '../../../hooks/useSimplifiedToolNames'
@@ -197,7 +198,7 @@ export function sessionStatus(
       colorVar: '--accent',
       pulse: true,
       label:
-        toolStatusLabel(statusDetail, simplifiedToolNames) ||
+        toolStatusLabel(statusDetail, simplifiedToolNames, i18next.language) ||
         i18nT('components.commandPalette.providers.recentsProvider.thinking'),
     }
   }

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -32,6 +32,7 @@ import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
 import { useSessionPalette } from '../hooks/useSessionPalette'
 import { useMoveSlotToFolder } from '../hooks/useMoveSlotToFolder'
 import { useSimplifiedToolNames } from '../hooks/useSimplifiedToolNames'
+import { useLanguage } from '../i18n/LanguageProvider'
 import { useSessionActions } from '../hooks/useSessionActions'
 import { useAutoGrowTextarea } from '../hooks/useAutoGrowTextarea'
 import { useChatPopouts } from '../hooks/useChatPopouts'
@@ -82,10 +83,10 @@ const RENAME_MAX_H = 120
  *  A `tool` phase honors the user's `simplifiedToolNames` preference (purpose vs
  *  raw tool title) via toolStatusLabel, so the row agrees with the inline tool
  *  pill in the transcript rather than always showing the purpose. */
-function slotStatusText(detail: { kind?: string; text?: string; toolName?: string } | undefined, simplifiedToolNames: boolean): string {
+function slotStatusText(detail: { kind?: string; text?: string; toolName?: string } | undefined, simplifiedToolNames: boolean, uiLang: string): string {
   if (detail?.kind === 'streaming') return i18nT('pages.chatSidebar.streaming')
   if (detail?.kind === 'thinking' && detail.text === 'Thinking…') return i18nT('pages.chatSidebar.thinking')
-  return toolStatusLabel(detail, simplifiedToolNames) || i18nT('pages.chatSidebar.thinking')
+  return toolStatusLabel(detail, simplifiedToolNames, uiLang) || i18nT('pages.chatSidebar.thinking')
 }
 /** Telegram-style relative time: time today, "Yesterday hh:mm", weekday+time this week,
  *  short date this year, full date otherwise.
@@ -805,6 +806,7 @@ function ChatSidebar({
   const slotStatusDetail = useAppSelector(s => s.chat.slotStatusDetail, shallowEqual)
   // Purpose-vs-raw-tool-title preference, shared with the inline tool pills.
   const simplifiedToolNames = useSimplifiedToolNames()
+  const uiLang = useLanguage().resolved
   // Presence in this map means "this session is in an active goal loop".
   const goalLoops = useAppSelector(s => s.chat.goalLoops)
   // Live subagent activity per slot, for the sidebar row's "N agents running"
@@ -2047,7 +2049,7 @@ function ChatSidebar({
       : subagentCount > 0
         ? subagentLabel
         : s.running
-          ? slotStatusText(slotStatusDetail[s.key], simplifiedToolNames)
+          ? slotStatusText(slotStatusDetail[s.key], simplifiedToolNames, uiLang)
           : (s.last_message || '')
     const ci = s.color_index != null && s.color_index >= 0 && s.color_index < paletteColors.length ? s.color_index : null
     const rowColor = ci != null ? paletteColors[ci] : null
@@ -2296,7 +2298,7 @@ function ChatSidebar({
                 <span className="truncate">{subagentLabel}</span>
               </div>
             ) : s.running ? (
-              <div className="text-[12px] text-accent leading-snug truncate mt-0.5 flex items-center gap-1"><span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse shrink-0" />{slotStatusText(slotStatusDetail[s.key], simplifiedToolNames)}</div>
+              <div className="text-[12px] text-accent leading-snug truncate mt-0.5 flex items-center gap-1"><span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse shrink-0" />{slotStatusText(slotStatusDetail[s.key], simplifiedToolNames, uiLang)}</div>
             ) : s.last_message ? (
               <div className="text-[12px] text-muted leading-snug truncate mt-0.5">{s.last_message}</div>
             ) : null}

--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -4,6 +4,8 @@ import { shallowEqual } from 'react-redux'
 import { useAppSelector, useAppDispatch } from '../../store'
 import { clearFocusToolCallId, mcpAppKey } from '../../store/chatSlice'
 import { useSimplifiedToolNames } from '../../hooks/useSimplifiedToolNames'
+import { useLanguage } from '../../i18n/LanguageProvider'
+import { pickToolLabel } from '../../utils/toolLabel'
 import { LoaderCircle, CircleSlash, CircleDot, Lock } from 'lucide-react'
 import { PanelRightSolid } from '../../components/icons/panels'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -38,6 +40,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   const label = message.content.replace(/^🔧\s*/, '')
   const toolCallId = message.meta?.tool_call_id as string | undefined
   const simplified = useSimplifiedToolNames()
+  const uiLang = useLanguage().resolved
 
   // MCP App (SEP-1865) render payload attached to this tool call, if any.
   // Rendered as an inline sandboxed iframe below the tool-call row. Selected
@@ -241,7 +244,16 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
     ? (isRejected ? 'var(--danger)' : 'var(--ok)')
     : hasPendingPerm ? 'var(--warn)' : 'var(--accent)'
   const barStyle = `color-mix(in srgb, ${barColor} 70%, transparent)`
-  const toolLabel = (simplified && (purpose || message.meta?.purpose)) ? (purpose || message.meta?.purpose as string) : label
+  // Purpose is the agent's prose label (simplified mode). Guard it against the
+  // active UI language so a purpose written in another language (e.g. a Chinese
+  // label persisted before the user switched to English) falls back to the
+  // language-neutral raw tool label instead of showing foreign-script text.
+  const toolLabel = pickToolLabel({
+    simplified,
+    purpose: purpose || (message.meta?.purpose as string | undefined),
+    rawLabel: label,
+    uiLang,
+  })
 
   // Design C: surface the file basename as a chip that hugs the open-in-pane
   // icon, so the affordance names the file it opens — crucial in simplified /

--- a/website/src/utils/toolLabel.test.ts
+++ b/website/src/utils/toolLabel.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { labelMatchesLanguage, pickToolLabel } from './toolLabel'
+
+describe('labelMatchesLanguage', () => {
+  it('accepts same-script prose', () => {
+    expect(labelMatchesLanguage('Reading the config file', 'en')).toBe(true)
+    expect(labelMatchesLanguage('获取第一个 Figma 节点的设计上下文', 'zh-CN')).toBe(true)
+    expect(labelMatchesLanguage('스크린샷 캡처', 'ko')).toBe(true)
+    expect(labelMatchesLanguage('Проверка статуса шлюза', 'ru')).toBe(true)
+  })
+
+  it('rejects foreign hard-script prose under a Latin UI (the reported bug)', () => {
+    expect(labelMatchesLanguage('获取第一个 Figma 节点的设计上下文', 'en')).toBe(false)
+    expect(labelMatchesLanguage('查看第二个节点的视觉设计', 'en')).toBe(false)
+    expect(labelMatchesLanguage('스크린샷 캡처', 'en')).toBe(false)
+    expect(labelMatchesLanguage('Проверка статуса', 'de')).toBe(false)
+  })
+
+  it('rejects Latin-only prose under a non-Latin UI (reverse direction)', () => {
+    expect(labelMatchesLanguage('Reading the config file', 'zh-CN')).toBe(false)
+    expect(labelMatchesLanguage('Capture screenshot', 'ko')).toBe(false)
+  })
+
+  it('keeps a purpose that mixes an English identifier into native prose', () => {
+    // A Latin tool/id token inside otherwise-Chinese prose still carries Han
+    // characters, so it must NOT be treated as a mismatch under a Chinese UI.
+    expect(labelMatchesLanguage('调用 figma_get_design_context 工具', 'zh-CN')).toBe(true)
+    // ...and the same string under an English UI is a mismatch (has Han).
+    expect(labelMatchesLanguage('调用 figma_get_design_context 工具', 'en')).toBe(false)
+  })
+
+  it('treats truly neutral text (digits, punctuation, empty) as compatible everywhere', () => {
+    expect(labelMatchesLanguage('12345', 'ko')).toBe(true)
+    expect(labelMatchesLanguage('12345', 'en')).toBe(true)
+    expect(labelMatchesLanguage('- • / :', 'zh-CN')).toBe(true)
+    expect(labelMatchesLanguage('', 'en')).toBe(true)
+  })
+
+  it('a Latin path/identifier passes under a Latin UI but not a non-Latin one', () => {
+    expect(labelMatchesLanguage('/tmp/ghosts/p1.svg', 'en')).toBe(true)
+    // Under a Chinese UI an all-Latin string is the wrong writing system, so
+    // the caller falls back to the (also-Latin) raw tool label — no worse, and
+    // a correctly-written Chinese purpose always carries Han characters.
+    expect(labelMatchesLanguage('/tmp/ghosts/p1.svg', 'zh-CN')).toBe(false)
+  })
+
+  it('matches on the primary subtag, ignoring region', () => {
+    expect(labelMatchesLanguage('查看节点', 'zh-TW')).toBe(true)
+    expect(labelMatchesLanguage('Reading file', 'pt-BR')).toBe(true)
+  })
+
+  it('falls back to Latin for unknown tags (only suppresses clear foreign script)', () => {
+    expect(labelMatchesLanguage('Reading file', 'xx')).toBe(true)
+    expect(labelMatchesLanguage('获取节点', 'xx')).toBe(false)
+  })
+})
+
+describe('pickToolLabel', () => {
+  const rawLabel = 'Running: figma_get_design_context'
+
+  it('returns the raw label when simplified names are off', () => {
+    expect(pickToolLabel({ simplified: false, purpose: 'Fetch the node', rawLabel, uiLang: 'en' })).toBe(rawLabel)
+  })
+
+  it('returns the raw label when there is no purpose', () => {
+    expect(pickToolLabel({ simplified: true, purpose: '', rawLabel, uiLang: 'en' })).toBe(rawLabel)
+    expect(pickToolLabel({ simplified: true, purpose: '   ', rawLabel, uiLang: 'en' })).toBe(rawLabel)
+    expect(pickToolLabel({ simplified: true, purpose: null, rawLabel, uiLang: 'en' })).toBe(rawLabel)
+  })
+
+  it('returns the purpose when its script matches the UI language', () => {
+    expect(pickToolLabel({ simplified: true, purpose: 'Fetch the ghost node', rawLabel, uiLang: 'en' }))
+      .toBe('Fetch the ghost node')
+    expect(pickToolLabel({ simplified: true, purpose: '获取 ghost 节点', rawLabel, uiLang: 'zh-CN' }))
+      .toBe('获取 ghost 节点')
+  })
+
+  it('falls back to the raw label when the purpose language does not match', () => {
+    // The exact reported case: Chinese purpose lingering under an English UI.
+    expect(pickToolLabel({ simplified: true, purpose: '获取第一个 Figma 节点的设计上下文', rawLabel, uiLang: 'en' }))
+      .toBe(rawLabel)
+  })
+
+  it('trims the purpose before deciding', () => {
+    expect(pickToolLabel({ simplified: true, purpose: '  Fetch the node  ', rawLabel, uiLang: 'en' }))
+      .toBe('Fetch the node')
+  })
+})

--- a/website/src/utils/toolLabel.ts
+++ b/website/src/utils/toolLabel.ts
@@ -1,0 +1,126 @@
+/**
+ * Deterministic tool-label language guard.
+ *
+ * A tool call's "purpose" is model-authored prose (the agent's one-line
+ * description of what the call does). The dashboard shows it as the tool-pill
+ * label when the user has `simplifiedToolNames` on, and it is persisted
+ * verbatim into session history. The agent writes it in whatever UI language
+ * was active at the time and only follows the `[UI LANGUAGE]` steer on a
+ * best-effort basis, so a transcript can end up holding purposes in a language
+ * that no longer matches the user's current interface (e.g. Chinese labels
+ * lingering after the user switched the dashboard to English).
+ *
+ * Rather than trust the model, we decide at RENDER time whether a saved purpose
+ * is written in a script compatible with the active UI language. When it is
+ * not, callers fall back to the language-neutral raw tool label (the same thing
+ * shown when `simplifiedToolNames` is off) so the user never sees
+ * foreign-script prose. This is deterministic and history-safe: it corrects old
+ * frozen labels and newly-written ones alike, with no dependency on model
+ * compliance.
+ *
+ * SCOPE: the guard operates at the level of WRITING SYSTEM (script), which is
+ * all that can be detected reliably from a short string. It catches the jarring
+ * cases — CJK / Hangul / Cyrillic / Devanagari / Bengali prose under a
+ * Latin-script UI, and vice versa. It cannot distinguish two languages that
+ * share the Latin script (e.g. an English purpose under a German UI); those
+ * pass through unchanged.
+ */
+
+type Script = 'latin' | 'han' | 'kana' | 'hangul' | 'cyrillic' | 'devanagari' | 'bengali'
+
+/** "Hard" (non-Latin) scripts whose mere presence unambiguously signals a
+ *  specific language family. Latin is treated as the neutral default and is
+ *  not listed here. */
+const HARD_SCRIPT_RANGES: Record<Exclude<Script, 'latin'>, RegExp> = {
+  han: /[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/,
+  kana: /[\u3040-\u30FF]/,
+  hangul: /[\uAC00-\uD7AF\u1100-\u11FF]/,
+  cyrillic: /[\u0400-\u04FF]/,
+  devanagari: /[\u0900-\u097F]/,
+  bengali: /[\u0980-\u09FF]/,
+}
+
+/** A Latin letter (ASCII + Latin-1 Supplement / Extended-A accented forms). */
+const LATIN_LETTER = /[A-Za-z\u00C0-\u024F]/
+
+/** Expected script(s) for a resolved UI language tag. Matches on the primary
+ *  subtag, so `zh-CN`, `zh-TW`, `pt-BR` etc. all resolve correctly. Anything
+ *  unknown falls back to Latin, which is the safe default (it only ever
+ *  suppresses clearly-foreign hard-script prose). */
+function expectedScripts(lang: string): Set<Script> {
+  const primary = (lang || '').toLowerCase().split('-')[0]
+  switch (primary) {
+    case 'zh':
+      return new Set<Script>(['han'])
+    case 'ja':
+      return new Set<Script>(['han', 'kana'])
+    case 'ko':
+      return new Set<Script>(['hangul'])
+    case 'ru':
+      return new Set<Script>(['cyrillic'])
+    case 'hi':
+      return new Set<Script>(['devanagari'])
+    case 'bn':
+      return new Set<Script>(['bengali'])
+    // en, es, fr, pt, de, it, and any unrecognized tag → Latin.
+    default:
+      return new Set<Script>(['latin'])
+  }
+}
+
+/**
+ * True when `text` is written in a script compatible with the UI language
+ * `lang`. Empty / script-neutral text (a bare path, a tool identifier, digits
+ * and punctuation only) is always considered compatible — there is nothing to
+ * suppress.
+ */
+export function labelMatchesLanguage(text: string, lang: string): boolean {
+  if (!text) return true
+  const expected = expectedScripts(lang)
+
+  // Which hard (non-Latin) scripts actually appear in the text?
+  const present: Exclude<Script, 'latin'>[] = []
+  for (const key of Object.keys(HARD_SCRIPT_RANGES) as Exclude<Script, 'latin'>[]) {
+    if (HARD_SCRIPT_RANGES[key].test(text)) present.push(key)
+  }
+
+  // Forward mismatch: any hard script present that the UI language does not
+  // expect (Han/Hangul/Cyrillic/... prose while the UI is, say, English). A
+  // Latin tool identifier mixed into a Chinese purpose still carries Han
+  // characters, so a genuine same-language purpose is never suppressed.
+  for (const s of present) {
+    if (!expected.has(s)) return false
+  }
+
+  // Reverse mismatch: a non-Latin UI language expects its own script, so
+  // purely Latin/neutral prose (English written while the UI is Chinese) does
+  // not match. Only trips when the text actually contains Latin letters, so a
+  // script-neutral path/identifier still passes.
+  const uiIsNonLatin = !expected.has('latin')
+  if (uiIsNonLatin) {
+    const hasExpectedScript = present.some(s => expected.has(s))
+    if (!hasExpectedScript && LATIN_LETTER.test(text)) return false
+  }
+
+  return true
+}
+
+/**
+ * Choose the text a tool pill / session-row / approval bar should display.
+ *
+ * - Raw mode (`simplified` off): always the raw tool label.
+ * - Simplified mode: the agent's `purpose`, UNLESS its script does not match
+ *   the active UI language, in which case fall back to `rawLabel` so the user
+ *   never sees prose in a language other than their interface.
+ */
+export function pickToolLabel(opts: {
+  simplified: boolean
+  purpose?: string | null
+  rawLabel: string
+  uiLang: string
+}): string {
+  const { simplified, purpose, rawLabel, uiLang } = opts
+  const trimmed = (purpose ?? '').trim()
+  if (!simplified || !trimmed) return rawLabel
+  return labelMatchesLanguage(trimmed, uiLang) ? trimmed : rawLabel
+}

--- a/website/src/utils/toolStatusLabel.ts
+++ b/website/src/utils/toolStatusLabel.ts
@@ -1,7 +1,8 @@
+import { pickToolLabel } from './toolLabel'
+
 /** The pair of labels a live `tool` status carries — the same pair an inline
  *  tool pill chooses between (see ToolCallLine's `toolLabel`). */
 export type ToolStatusDetail = { kind?: string; text?: string; toolName?: string }
-
 /**
  * Resolve a live session status to the label the user's `simplifiedToolNames`
  * preference asks for, so a session-list row agrees with the inline tool pill
@@ -20,10 +21,22 @@ export type ToolStatusDetail = { kind?: string; text?: string; toolName?: string
 export function toolStatusLabel(
   detail: ToolStatusDetail | undefined,
   simplifiedToolNames: boolean,
+  uiLang = '',
 ): string {
   if (!detail) return ''
   // Raw mode: prefer the tool title, but fall back to `text` for statuses that
   // predate `toolName` (restored/legacy details) rather than blanking the row.
   if (detail.kind === 'tool' && !simplifiedToolNames) return detail.toolName || detail.text || ''
+  // Simplified mode on a tool phase: `text` is the agent purpose. Guard it
+  // against the active UI language (see pickToolLabel) so a purpose written in
+  // another language falls back to the language-neutral tool title.
+  if (detail.kind === 'tool') {
+    return pickToolLabel({
+      simplified: true,
+      purpose: detail.text,
+      rawLabel: detail.toolName || detail.text || '',
+      uiLang,
+    })
+  }
   return detail.text || ''
 }


### PR DESCRIPTION
## Problem

Tool-call **purpose labels** (the grey one-liners under each tool call when *Simplified tool names* is on) are model-authored prose, persisted verbatim into session history. The agent writes them in whatever UI language was active at the time, and the `[UI LANGUAGE]` steer is documented as *best-effort, not enforcement*. Result: a transcript can show labels in a language that no longer matches the user's interface — e.g. Chinese labels lingering after the user switched the dashboard to English, even in brand-new chats when the model drifts.

## Fix

Guard the label at **render time** instead of trusting the model. New pure helper `pickToolLabel()` (in `website/src/utils/toolLabel.ts`) keeps the agent's purpose **only when its writing system matches the active UI language**; otherwise it falls back to the language-neutral raw tool label (the same thing shown when *Simplified tool names* is off).

- Deterministic and history-safe: corrects **old frozen labels and new ones alike**, with no dependency on model compliance.
- Operates at the **script** level (all that is reliable for a short string): catches CJK / Hangul / Cyrillic / Devanagari / Bengali prose under a Latin UI, and vice-versa. It intentionally does not distinguish two languages that share the Latin script (e.g. English vs German).

Wired into every surface that shows this label: inline tool pill (`ToolCallLine.tsx`), approval bar (`ChatInput.tsx`), session-list live status (`ChatSidebar.tsx` via `toolStatusLabel.ts`), and command-palette recents (`recentsProvider.ts`).

## Dependency audit (readiness unblock)

Also bumps the electron `fast-uri` override **3.1.4 → 3.1.5** to clear a **pre-existing** production-dependency audit failure — `GHSA-7p8r-x3mc-p8w7` / `CVE-2026-18446` (host confusion via backslash authority introducer; patched in 3.1.5). The vulnerable pin arrived on main via the electron 33→43 upgrade (#1236) and the advisory landed in GitHub's database on 2026-08-03, so it currently blocks the `PR Readiness` gate on every open PR. 3.1.5 stays within the `^3.0.1` range `ajv` requires (patch-level, no API change).

## Tests

- New `toolLabel.test.ts` (13 cases): forward/reverse mismatch, mixed-script purposes, neutral text, region subtags, unknown tags.
- Existing `toolStatusLabel`, `ToolCallLine`, `CollapsibleToolGroup`, `CommandPalette`, `ChatSidebar.toolStatusSetting` suites pass (69 tests).
- `npm run build` clean; `npm run lint` 0 errors; `lint:i18n` under baseline; production dependency audit passes locally.

## Manual verification

N/A for the dependency bump (audit-driven). The label behavior is covered by unit tests; the render path is a direct swap of the label-selection expression at four call sites.
