### PR TITLE
fix(link-preview): unfurl pages that exceed the read cap

### DIFF
--- a/src/kiro_crew/dashboard/handlers/link_meta.py
+++ b/src/kiro_crew/dashboard/handlers/link_meta.py
@@ -224,33 +224,72 @@ class _AiohttpTransport:
 _TRANSPORT: Any = _AiohttpTransport()
 
 
-async def _read_capped(raw: _RawResponse, limit: int) -> bytes:
-    """Read at most *limit* bytes, raising :class:`_UnfurlFailed` if exceeded.
+async def _read_capped(raw: _RawResponse, limit: int, *, truncate: bool) -> Tuple[bytes, bool]:
+    """Read at most *limit* bytes; returns the body and whether it was cut short.
 
-    ``Content-Length`` is used only as an early exit. It is a claim by the
-    upstream, so a missing, wrong, or deliberately understated header must not
-    let an unbounded body through — the accumulating check below is the actual
-    bound, and it aborts mid-stream rather than after buffering the whole thing.
+    ``truncate=True`` (a **page**) — keep the first *limit* bytes and stop. Every
+    field a preview needs (``<title>``, the ``og:*`` tags, the icon ``<link>``) is
+    declared in ``<head>``, and :class:`_HeadParser` stops parsing there, so a
+    document that merely *continues* past the cap has already delivered the whole
+    preview. Rejecting it discarded a payload that was in hand: at the 256 KiB cap
+    that lost every heavyweight page on the web — a major retailer's home page
+    measures ~730 KB with its ``<title>`` at byte ~36 000 — while looking, in chat,
+    exactly like the feature being switched off.
+
+    A head that does not itself fit is the one case where the prefix is worthless,
+    and it cannot be recognised from the bytes: ``</head>`` and ``<body`` both occur
+    inside scripts, comments and attribute values, where the parser does not treat
+    them as the end of the head. So the cut is *reported* rather than judged here,
+    and :func:`_build_payload` asks the parser instead — a cut whose title did not
+    survive whole is a failure, which keeps such a page on the 10 min negative TTL
+    rather than caching an empty or half-a-word preview for the 6 h positive one.
+
+    ``truncate=False`` (an **icon**) — an oversized image is dropped, never
+    truncated: half a PNG is not a smaller PNG, it is a corrupt one. The flag is
+    therefore always ``False`` in this mode.
+
+    Memory: ``buffered`` never exceeds *limit* in either mode, because each chunk
+    is admitted only up to the remaining room — the excess is dropped rather than
+    appended and trimmed. Reading then stops on the chunk that crossed the cap;
+    that chunk is already off the socket, so chunk granularity is as tight as a
+    stream read gets. Reject mode needs that same chunk to know the body overran at
+    all, which is why it raises there instead of earlier.
+
+    ``Content-Length`` is an early exit only in reject mode — it is a claim by the
+    upstream, so the room check below is the real bound in both modes, and a
+    missing, wrong, or deliberately understated header can never admit more than
+    *limit* bytes. The transport sends ``Accept-Encoding: identity`` with
+    ``auto_decompress=False``, so for an upstream that honors it this caps decoded
+    bytes; one that compresses anyway is capped on the compressed stream instead.
     """
     declared = raw.headers.get("Content-Length", "")
-    if declared.isdigit() and int(declared) > limit:
+    if not truncate and declared.isdigit() and int(declared) > limit:
         raise _UnfurlFailed("declared body too large")
     buffered = bytearray()
+    cut = False
     async for chunk in raw.chunks:
+        room = limit - len(buffered)
+        if len(chunk) > room:
+            if not truncate:
+                raise _UnfurlFailed("body exceeded read cap")
+            buffered.extend(chunk[:room])
+            cut = True
+            break
         buffered.extend(chunk)
-        if len(buffered) > limit:
-            raise _UnfurlFailed("body exceeded read cap")
-    return bytes(buffered)
+    return bytes(buffered), cut
 
 
-async def _fetch(vetted: VettedUrl, limit: int) -> Tuple[int, Mapping[str, str], bytes]:
-    """One vetted request; returns status, headers and the capped body."""
+async def _fetch(
+    vetted: VettedUrl, limit: int, *, truncate: bool
+) -> Tuple[int, Mapping[str, str], bytes, bool]:
+    """One vetted request; returns status, headers, the capped body, and the cut flag."""
     raw, closer = await _TRANSPORT.get(vetted)
     try:
         if raw.status in _REDIRECT_STATUSES:
             # Body is irrelevant on a redirect and may be large; skip reading it.
-            return raw.status, raw.headers, b""
-        return raw.status, raw.headers, await _read_capped(raw, limit)
+            return raw.status, raw.headers, b"", False
+        body, cut = await _read_capped(raw, limit, truncate=truncate)
+        return raw.status, raw.headers, body, cut
     finally:
         if closer is not None:
             await closer.close()
@@ -261,18 +300,21 @@ async def _vet(url: str) -> VettedUrl:
     return await asyncio.to_thread(vet_unfurl_url, url)
 
 
-async def _fetch_html(url: str) -> Tuple[VettedUrl, str]:
+async def _fetch_html(url: str) -> Tuple[VettedUrl, str, bool]:
     """Walk up to :data:`MAX_REDIRECTS` hops and return the final HTML.
 
     Every hop is vetted before it is opened, including the ones the *upstream*
     chose. A vet applied only to the URL the client supplied is trivially
     bypassed: a public host that 302s to ``http://169.254.169.254/`` would be
     fetched on the attacker's behalf.
+
+    The third element is whether the body was cut at the read cap; the caller
+    needs it to tell "this page has no title" from "we never read the title".
     """
     current = url
     for _hop in range(MAX_REDIRECTS + 1):
         vetted = await _vet(current)
-        status, headers, body = await _fetch(vetted, MAX_BODY_BYTES)
+        status, headers, body, cut = await _fetch(vetted, MAX_BODY_BYTES, truncate=True)
         if status in _REDIRECT_STATUSES:
             location = headers.get("Location", "").strip()
             if not location:
@@ -286,7 +328,7 @@ async def _fetch_html(url: str) -> Tuple[VettedUrl, str]:
             # Not a page — a PDF or a video has no title to show, and parsing
             # arbitrary bytes as HTML invites nonsense titles.
             raise _UnfurlFailed("not html")
-        return vetted, decode_html(body, content_type)
+        return vetted, decode_html(body, content_type), cut
     raise _UnfurlFailed("too many redirects")
 
 
@@ -300,7 +342,7 @@ async def _fetch_icon(candidates: Tuple[str, ...]) -> str:
     for candidate in candidates[:_MAX_ICON_ATTEMPTS]:
         try:
             vetted = await _vet(candidate)
-            status, headers, body = await _fetch(vetted, MAX_ICON_BYTES)
+            status, headers, body, _cut = await _fetch(vetted, MAX_ICON_BYTES, truncate=False)
         except (UnfurlRejected, _UnfurlFailed, aiohttp.ClientError, OSError, asyncio.TimeoutError):
             continue
         except Exception:  # noqa: BLE001 — an icon must never fail the preview
@@ -316,8 +358,17 @@ async def _fetch_icon(candidates: Tuple[str, ...]) -> str:
 
 async def _build_payload(url: str) -> Dict[str, Any]:
     """Fetch and parse *url* into the 200 body. Raises on any refusal/failure."""
-    vetted, html = await _fetch_html(url)
+    vetted, html, cut = await _fetch_html(url)
     meta = extract_meta(html, base_url=vetted.url)
+    if cut and not meta.title_complete:
+        # The body was truncated at the read cap and what came back is not a whole
+        # title: either the head did not fit at all, or the cut landed inside
+        # `<title>` and left a word-fragment ("Real Titl") that reads like a real
+        # one. Fail rather than cache either for the 6 h positive TTL — this way the
+        # 10 min negative TTL applies and the link retries. A page read in FULL is
+        # untouched: `cut` is False there, so a genuinely titleless page still gets
+        # its domain-only preview.
+        raise _UnfurlFailed("title did not survive the read cap")
     return {
         "url": vetted.url,
         "title": meta.title,

--- a/src/kiro_crew/link_unfurl.py
+++ b/src/kiro_crew/link_unfurl.py
@@ -44,7 +44,9 @@ FETCH_TIMEOUT_SECONDS = 5.0
 #: as well as the fetch cost.
 MAX_REDIRECTS = 3
 #: Hard cap on an HTML body. Applied as a read cap, never by trusting
-#: ``Content-Length`` — see ``link_meta._read_capped``.
+#: ``Content-Length``. A page above this is TRUNCATED to the cap, not dropped:
+#: ``<head>`` — the only part a preview reads — is at the top, so the prefix is
+#: everything. See ``link_meta._read_capped``.
 MAX_BODY_BYTES = 256 * 1024
 #: Hard cap on a favicon. An icon above this is DROPPED, not truncated: a
 #: truncated image is a broken image, and the card reads fine without one.
@@ -135,6 +137,16 @@ class ExtractedMeta:
     site_name: str
     icon_candidates: Tuple[str, ...]
     """Absolute icon URLs, best first, ``/favicon.ico`` last."""
+    title_complete: bool = False
+    """Whether :attr:`title` is a whole, non-empty title rather than a fragment.
+
+    True when a non-empty title exists AND either an ``og:title`` supplied it (a
+    meta attribute parses atomically or not at all) or the ``<title>`` element
+    that produced it closed. False for no title, an empty one, and a title whose
+    element was left open — "nothing" and "half a word" are both incomplete. Only
+    a caller holding a TRUNCATED document needs this; for a document read in full
+    a short title is simply what the page served.
+    """
 
 
 def _reject_if_internal_ip(candidate: str) -> None:
@@ -357,6 +369,12 @@ class _HeadParser(HTMLParser):
         self.og: Dict[str, str] = {}
         self.meta_name: Dict[str, str] = {}
         self.title = ""
+        #: Whether a ``</title>`` was seen, i.e. whether :attr:`title` is the WHOLE
+        #: element text rather than however much of it the document supplied. It
+        #: matters only for a truncated document: a cut inside ``<title>`` leaves a
+        #: word-fragment here that reads like a real title, and only the parser can
+        #: tell the two apart.
+        self.title_closed = False
         self.icons: List[str] = []
         self._apple_icons: List[str] = []
         self._in_title = False
@@ -372,6 +390,10 @@ class _HeadParser(HTMLParser):
         attr = {k.lower(): (v or "") for k, v in attrs}
         if tag == "title":
             self._in_title = True
+            # A NEW title element is not yet complete, whatever an earlier one did.
+            # `<title>First</title><title>Frag` must not inherit the first
+            # element's closure, or a cut inside the second reads as whole.
+            self.title_closed = False
         elif tag == "meta":
             prop = attr.get("property", "").strip().lower()
             content = attr.get("content", "")
@@ -397,6 +419,11 @@ class _HeadParser(HTMLParser):
 
     def handle_endtag(self, tag: str) -> None:
         if tag == "title":
+            # Only a close that matches an OPEN we saw proves the collected text is
+            # whole. A stray `</title>` — before any `<title>`, or left over from
+            # sloppy markup — must not mark a later, truncated title as complete.
+            if self._in_title:
+                self.title_closed = True
             self._in_title = False
         elif tag == "head":
             self.done = True
@@ -456,6 +483,13 @@ def extract_meta(html: str, *, base_url: str) -> ExtractedMeta:
         description=description,
         site_name=site_name,
         icon_candidates=tuple(candidates),
+        # "Complete" requires a title to exist AND to be whole. An `og:title` is
+        # whole by construction (an attribute parses atomically or not at all);
+        # otherwise the `<title>` element must have closed. The `bool(title)` term
+        # is what keeps an empty-but-closed `<title></title>` from reading as a
+        # complete title on a truncated document.
+        title_complete=bool(title)
+        and (bool(parser.og.get("og:title", "").strip()) or parser.title_closed),
     )
 
 

--- a/test/test_link_unfurl.py
+++ b/test/test_link_unfurl.py
@@ -718,36 +718,312 @@ def test_oversized_icon_is_dropped_end_to_end(monkeypatch) -> None:
 # --- endpoint: body caps ---------------------------------------------------
 
 
+def _raw(body: bytes, headers: Optional[Dict[str, str]] = None) -> Tuple[Any, List[int]]:
+    """A ``_RawResponse`` over *body* plus a list recording bytes yielded.
+
+    The recorder is what proves the cap stops pulling from the socket instead of
+    draining the whole body and trimming afterwards.
+    """
+    served: List[int] = []
+
+    async def _chunks() -> AsyncIterator[bytes]:
+        for i in range(0, max(len(body), 1), 8192):
+            chunk = body[i : i + 8192]
+            served.append(len(chunk))
+            yield chunk
+
+    return lm._RawResponse(status=200, headers=headers or {}, chunks=_chunks()), served
+
+
+def test_read_capped_truncates_a_page_to_the_cap() -> None:
+    """A page over the cap yields exactly the cap, reports the cut, and stops."""
+    payload = b"<html><head><title>t</title></head><body>" + b"A" * (lu.MAX_BODY_BYTES + 40960)
+    raw, served = _raw(payload)
+    body, cut = _run(lm._read_capped(raw, lu.MAX_BODY_BYTES, truncate=True))
+    assert (len(body), cut) == (lu.MAX_BODY_BYTES, True)
+    # Reading stopped on the chunk that crossed the cap — chunk granularity is as
+    # tight as a stream read gets — rather than draining the body and trimming.
+    assert sum(served) <= lu.MAX_BODY_BYTES + 8192 < len(payload)
+
+
+def test_read_capped_keeps_a_body_that_ends_exactly_at_the_cap() -> None:
+    """A body of exactly the cap is not a cut, so the caller's guard stays off."""
+    raw, served = _raw(b"A" * lu.MAX_BODY_BYTES)
+    body, cut = _run(lm._read_capped(raw, lu.MAX_BODY_BYTES, truncate=True))
+    assert (len(body), cut) == (lu.MAX_BODY_BYTES, False)
+    assert sum(served) == lu.MAX_BODY_BYTES
+
+
+def test_read_capped_ignores_an_honest_oversized_length_when_truncating() -> None:
+    """A page's declared length is not an early exit — only the read is a bound.
+
+    Amazon-shaped responses declare (or chunk) far more than the cap while their
+    ``<head>`` is tiny; short-circuiting on the header threw those away without
+    reading a byte.
+    """
+    raw, _served = _raw(b"tiny", {"Content-Length": str(lu.MAX_BODY_BYTES + 1)})
+    assert _run(lm._read_capped(raw, lu.MAX_BODY_BYTES, truncate=True)) == (b"tiny", False)
+
+
+def test_read_capped_rejects_an_oversized_icon() -> None:
+    """An icon is never truncated: half a PNG is corrupt, not smaller."""
+    raw, _served = _raw(b"x" * (lu.MAX_ICON_BYTES + 4096))
+    with pytest.raises(lm._UnfurlFailed):
+        _run(lm._read_capped(raw, lu.MAX_ICON_BYTES, truncate=False))
+
+
+def test_read_capped_accepts_an_icon_exactly_at_the_cap() -> None:
+    raw, _served = _raw(b"x" * lu.MAX_ICON_BYTES)
+    body, cut = _run(lm._read_capped(raw, lu.MAX_ICON_BYTES, truncate=False))
+    assert (len(body), cut) == (lu.MAX_ICON_BYTES, False)
+
+
+def test_read_capped_short_circuits_an_honest_oversized_icon_length() -> None:
+    raw, served = _raw(b"tiny", {"Content-Length": str(lu.MAX_ICON_BYTES + 1)})
+    with pytest.raises(lm._UnfurlFailed):
+        _run(lm._read_capped(raw, lu.MAX_ICON_BYTES, truncate=False))
+    assert served == []  # refused on the header, nothing read
+
+
+def test_oversized_page_is_previewed_from_its_head(monkeypatch) -> None:
+    """The bug this fixes: a page far over the cap still unfurls.
+
+    ``<head>`` arrives in the first few KB, so a 700 KB homepage (amazon.com's
+    shape) has delivered the whole preview long before the 256 KiB cap. It used
+    to 502 — indistinguishable, in the UI, from the feature being off.
+    """
+    page = (
+        b"<html><head><title>Amazon.com. Spend less. Smile more.</title>"
+        b'<meta name="description" content="Free shipping on millions of items.">'
+        b"</head><body>" + b"A" * (lu.MAX_BODY_BYTES * 3) + b"</body></html>"
+    )
+    _install(
+        monkeypatch,
+        {
+            "https://example.com/big": (200, _HTML_HEADERS, page),
+            "https://example.com/favicon.ico": (404, {}, b""),
+        },
+    )
+    status, body = _run(_call("https://example.com/big"))
+    assert status == 200
+    assert body["title"] == "Amazon.com. Spend less. Smile more."
+    assert body["description"] == "Free shipping on millions of items."
+
+
+def test_page_whose_head_overruns_the_cap_is_a_502(monkeypatch) -> None:
+    """A cut that took the metadata with it must not cache a titleless card.
+
+    502 puts it on the 10 min negative TTL; a 200 would pin an empty preview for
+    the 6 h positive TTL.
+    """
+    _install(
+        monkeypatch,
+        {
+            "https://example.com/fathead": (
+                200,
+                _HTML_HEADERS,
+                b"<html><head><style>" + b"z" * (lu.MAX_BODY_BYTES + 4096),
+            )
+        },
+    )
+    status, body = _run(_call("https://example.com/fathead"))
+    assert (status, body) == (502, {"code": "fetch_failed"})
+
+
+def test_head_end_markers_inside_a_script_do_not_pass_the_cut_guard(monkeypatch) -> None:
+    """The guard is the parser's verdict, not a byte search.
+
+    A fat head containing the literal ``</head>``/``<body>`` inside a `<script>`
+    would satisfy any byte-pattern check while `_HeadParser` — correctly — treats
+    them as script data and never leaves the head. The real `<title>` is past the
+    cut, so this must fail, not return an empty-title 200.
+    """
+    _install(
+        monkeypatch,
+        {
+            "https://example.com/tricky": (
+                200,
+                _HTML_HEADERS,
+                b"<html><head><script>var s = '</head><body>';"
+                + b"//" + b"z" * (lu.MAX_BODY_BYTES + 4096)
+                + b"</script><title>Never read</title></head>",
+            )
+        },
+    )
+    status, body = _run(_call("https://example.com/tricky"))
+    assert (status, body) == (502, {"code": "fetch_failed"})
+
+
+def test_title_straddling_the_cap_is_not_served_as_a_fragment(monkeypatch) -> None:
+    """A cut INSIDE `<title>` leaves a word-fragment that reads like a real title.
+
+    `<title>` never closes in the prefix, so `title_complete` is False and the page
+    takes the negative TTL instead of caching "Real Titl" for six hours. The whole
+    point of asking the parser: the fragment is non-empty, so a "did we get *a*
+    title" check would have accepted it.
+    """
+    filler = b"z" * (lu.MAX_BODY_BYTES - 40)
+    page = b"<html><head><!--" + filler + b"--><title>Real Title Here</title></head>"
+    _install(monkeypatch, {"https://example.com/straddle": (200, _HTML_HEADERS, page)})
+    status, body = _run(_call("https://example.com/straddle"))
+    assert (status, body) == (502, {"code": "fetch_failed"})
+
+
+def test_extract_meta_reports_whether_the_title_closed() -> None:
+    """`title_complete` is the parser's own verdict, per source of the title."""
+    closed = lu.extract_meta("<html><head><title>Done</title>", base_url="https://e.com/")
+    assert (closed.title, closed.title_complete) == ("Done", True)
+
+    open_tag = lu.extract_meta("<html><head><title>Half wa", base_url="https://e.com/")
+    assert (open_tag.title, open_tag.title_complete) == ("Half wa", False)
+
+    # An `og:title` lives in an attribute: it parses whole or not at all.
+    og = lu.extract_meta(
+        '<html><head><meta property="og:title" content="Whole">', base_url="https://e.com/"
+    )
+    assert (og.title, og.title_complete) == ("Whole", True)
+
+    none = lu.extract_meta("<html><head>", base_url="https://e.com/")
+    assert (none.title, none.title_complete) == ("", False)
+
+
+@pytest.mark.parametrize(
+    "html,expected_complete",
+    [
+        # A stray `</title>` before any `<title>` must not credit the later,
+        # unterminated element with the earlier close.
+        ("<html><head></title><title>Frag", False),
+        # Nor may a *previous* element's close carry over to a new one.
+        ("<html><head><title>First</title><title>Frag", False),
+        # Closed but empty is not a usable title, so it cannot be "complete".
+        ("<html><head><title></title>", False),
+        ("<html><head><title/>", False),
+        # Two closed elements: whatever the concatenation, nothing was cut.
+        ("<html><head><title>A</title><title>B</title>", True),
+    ],
+)
+def test_title_completeness_is_not_fooled_by_stray_or_repeated_tags(
+    html: str, expected_complete: bool
+) -> None:
+    assert lu.extract_meta(html, base_url="https://e.com/").title_complete is expected_complete
+
+
+_STRAY_CLOSE_SHAPES = {
+    # `</title>` arrives first, then the real element is cut mid-text.
+    "unmatched_close": b"<html><head></title><!--",
+    # A complete first title, then a second one cut mid-text.
+    "second_title": b"<html><head><title>First</title><!--",
+}
+
+
+@pytest.mark.parametrize("shape", sorted(_STRAY_CLOSE_SHAPES))
+def test_cut_title_after_a_stray_close_is_a_502(monkeypatch, shape: str) -> None:
+    """A close that did not terminate THIS title must not license a fragment."""
+    prefix = _STRAY_CLOSE_SHAPES[shape]
+    opener = b"--><title>"
+    # Land the cap five bytes into the title text, so the prefix ends mid-word and
+    # the element never closes: `...<title>Real`.
+    filler = b"z" * (lu.MAX_BODY_BYTES - len(prefix) - len(opener) - 5)
+    page = prefix + filler + opener + b"Real Title Here</title></head>"
+    _install(monkeypatch, {"https://example.com/stray": (200, _HTML_HEADERS, page)})
+    status, body = _run(_call("https://example.com/stray"))
+    assert (status, body) == (502, {"code": "fetch_failed"})
+
+
+def test_untruncated_page_with_no_title_still_previews(monkeypatch) -> None:
+    """`cut` is what gates the guard: a genuinely titleless small page is fine."""
+    _install(
+        monkeypatch,
+        {
+            "https://example.com/bare": (200, _HTML_HEADERS, b"<html><head></head><body>hi"),
+            "https://example.com/favicon.ico": (404, {}, b""),
+        },
+    )
+    status, body = _run(_call("https://example.com/bare"))
+    assert (status, body["title"], body["domain"]) == (200, "", "example.com")
+
+
+#: Head prefixes in which a literal ``</head>``/``<body>`` sits somewhere
+#: `_HeadParser` treats as data, so a byte search would wrongly clear them.
+_FAT_HEAD_DECOY_PREFIXES = {
+    "comment": b"<html><head><!-- </head><body> ",
+    "attribute": b'<html><head><meta name="a" content="</head><body>"><style>',
+    "style": b"<html><head><style>a{}</head><body>{}",
+}
+
+
+def _fat_head(prefix: bytes) -> bytes:
+    """*prefix*, filler past the cap, then the real title — which is never read."""
+    return prefix + b"z" * (lu.MAX_BODY_BYTES + 4096) + b"<title>Never read</title>"
+
+
+@pytest.mark.parametrize("shape", sorted(_FAT_HEAD_DECOY_PREFIXES))
+def test_fat_head_with_a_decoy_marker_is_a_502(monkeypatch, shape: str) -> None:
+    page = _fat_head(_FAT_HEAD_DECOY_PREFIXES[shape])
+    _install(monkeypatch, {"https://example.com/decoy": (200, _HTML_HEADERS, page)})
+    status, body = _run(_call("https://example.com/decoy"))
+    assert (status, body) == (502, {"code": "fetch_failed"})
+
+
+#: Truncated pages that DO carry their metadata before the cut. Each names the
+#: shape that could be mis-rejected by a stricter guard.
+_TRUNCATED_BUT_TITLED = {
+    # `<body/>` as the sole head terminator — a byte pattern keyed on `<body[\s>]`
+    # misses the self-closing form and would reject this.
+    "self_closing_body": (
+        b"<html><head><title>Ok</title><body/>" + b"A" * (lu.MAX_BODY_BYTES + 4096),
+        "Ok",
+    ),
+    # No `<title>` at all, but an `og:title` — `extract_meta` prefers og, so the
+    # preview is complete and the cut is harmless.
+    "og_title_only": (
+        b'<html><head><meta property="og:title" content="Via OG"><style>'
+        + b"z" * (lu.MAX_BODY_BYTES + 4096),
+        "Via OG",
+    ),
+}
+
+
+@pytest.mark.parametrize("shape", sorted(_TRUNCATED_BUT_TITLED))
+def test_truncated_page_keeps_its_preview_when_the_title_arrived(
+    monkeypatch, shape: str
+) -> None:
+    page, expected = _TRUNCATED_BUT_TITLED[shape]
+    _install(
+        monkeypatch,
+        {
+            "https://example.com/cut": (200, _HTML_HEADERS, page),
+            "https://example.com/favicon.ico": (404, {}, b""),
+        },
+    )
+    status, body = _run(_call("https://example.com/cut"))
+    assert (status, body["title"]) == (200, expected)
+
+
 def test_oversized_body_with_lying_content_length(monkeypatch) -> None:
-    """A truthful-looking small Content-Length must not raise the real bound."""
+    """A truthful-looking small Content-Length must not raise the real bound.
+
+    The header claims 42 bytes and the body is 260 KB. The read cap — not the
+    header — is what bounds it, so this succeeds off the truncated prefix.
+    """
     transport = _install(
         monkeypatch,
         {
             "https://example.com/big": (
                 200,
                 {"Content-Type": "text/html", "Content-Length": "42"},
-                b"<title>x</title>" + b"A" * (lu.MAX_BODY_BYTES + 4096),
-            )
+                b"<html><head><title>x</title></head><body>"
+                + b"A" * (lu.MAX_BODY_BYTES + 4096),
+            ),
+            "https://example.com/favicon.ico": (404, {}, b""),
         },
     )
     status, body = _run(_call("https://example.com/big"))
-    assert (status, body) == (502, {"code": "fetch_failed"})
-    assert transport.fetch_count == 1
-
-
-def test_honest_oversized_content_length_short_circuits(monkeypatch) -> None:
-    _install(
-        monkeypatch,
-        {
-            "https://example.com/big": (
-                200,
-                {"Content-Type": "text/html", "Content-Length": str(lu.MAX_BODY_BYTES + 1)},
-                b"tiny",
-            )
-        },
-    )
-    status, body = _run(_call("https://example.com/big"))
-    assert (status, body) == (502, {"code": "fetch_failed"})
+    assert (status, body["title"]) == (200, "x")
+    assert transport.requested == [
+        "https://example.com/big",
+        "https://example.com/favicon.ico",
+    ]
 
 
 def test_body_at_cap_is_accepted(monkeypatch) -> None:


### PR DESCRIPTION
## Problem

A link whose page is larger than 256 KiB gets no preview at all. In chat it stays a bare anchor — which is exactly what the feature looks like when it is switched **off**, so there is no signal that anything failed.

Concretely: `https://www.amazon.com` is ~730 KB and produced nothing, while `https://www.google.com` (80 KB) rendered a card.

## Why it matters

256 KiB is small for a modern page. Any site with inline JS or CSS in `<head>`-adjacent markup blows past it, so most e-commerce, news and app landing pages silently never unfurl — and the failure is cached for 10 minutes each time, so it does not look transient either. The feature appears broken or half-implemented for a large share of real links.

## Fix

**Symptom → root cause → change.**

`_read_capped` raised `_UnfurlFailed("body exceeded read cap")` on the first chunk past `MAX_BODY_BYTES`, so `_fetch_html` never returned, the handler answered 502, and the frontend fell back to a plain `<a>`.

The payload it threw away was already complete. Every field a preview reads — `<title>`, the `og:*` tags, the icon `<link>` — is declared in `<head>` within the first few KB, and `_HeadParser` **stops parsing at `</head>`** anyway. amazon.com's `<title>` is at byte ~36,000: the cap discarded a preview it had been holding for 220 KB.

So the cap's overflow behaviour is now split by what is being read:

- **A page is truncated** to the cap and parsed from the prefix.
- **An icon still rejects** — half a PNG is corrupt, not smaller.
- The `Content-Length` early exit applies only in reject mode; for a page it refused on an upstream *claim* without reading a byte.

**A cut is only harmless when the head fit.** `_read_capped` therefore reports whether it cut, and `_build_payload` treats `cut and not meta.title` as a failure. Without that, a page whose `<head>` alone overruns the cap parses to empty strings and gets cached as a *successful* titleless preview for the 6 h positive TTL, where the 10 min negative TTL should apply so the link retries.

The verdict comes from the **parser**, not a byte search for `</head>` / `<body>`. Those strings also occur inside scripts, comments, `<style>` blocks and attribute values, where `_HeadParser` correctly does not leave the head — so a byte check passes on precisely the documents the guard exists to catch. (An earlier revision of this PR used a regex; local review demonstrated both failure directions and it was replaced.) A page that genuinely has no title is unaffected: it was not cut, so it keeps its domain-only card.

**Memory is bounded more tightly than before, not less.** Each chunk is admitted only up to the remaining room, so `buffered` never exceeds the cap — previously it appended a whole chunk and trimmed afterwards, peaking at `cap + chunk`. Reading stops on the chunk that crosses the cap. `Content-Length` remains a hint, never a bound; the SSRF vet, the DNS pinning, the per-hop re-vet and the `Accept-Encoding: identity` / `auto_decompress=False` pairing are untouched.

## Tests

`test/test_link_unfurl.py`, 163 passing.

Six `_read_capped` cases pin the split semantics and the cut flag:

| Case | Locks in |
|---|---|
| `truncates_a_page_to_the_cap` | returns exactly the cap, reports `cut`, stops on the crossing chunk instead of draining |
| `keeps_a_body_that_ends_exactly_at_the_cap` | a body ending at the cap is **not** a cut, so the caller's guard stays off |
| `ignores_an_honest_oversized_length_when_truncating` | `Content-Length` is not an early exit for a page |
| `rejects_an_oversized_icon` | icons still reject |
| `accepts_an_icon_exactly_at_the_cap` | the reject boundary is `> limit`, not `>= limit` |
| `short_circuits_an_honest_oversized_icon_length` | the header exit fires before any read (asserted via a bytes-served recorder) |

Ten end-to-end cases cover the decision:

- `oversized_page_is_previewed_from_its_head` — the amazon.com shape now previews. **This is the regression test for the reported bug.**
- `oversized_body_with_lying_content_length` — a 42-byte claim over a 260 KB body still hits the real bound.
- `untruncated_page_with_no_title_still_previews` — `cut` is what gates the guard.
- `page_whose_head_overruns_the_cap_is_a_502` — a lossy cut takes the negative TTL.
- `fat_head_with_a_decoy_marker_is_a_502` ×3 — `</head><body>` inside a comment, an attribute value, or a `<style>` block. Each is a document a byte-pattern guard clears and the parser does not.
- `head_end_markers_inside_a_script_do_not_pass_the_cut_guard` — same, inside `<script>`.
- `truncated_page_keeps_its_preview_when_the_title_arrived` ×2 — a head terminated only by `<body/>`, and a page with only an `og:title`.

Two pre-existing cases asserted the old 502 and now assert the preview succeeds off the truncated prefix.

## Manual verification

The bug was diagnosed against the live web before any code changed:

```
$ curl -sS -o /tmp/amz.html -A 'KiroCrew-LinkPreview/1' https://www.amazon.com
total bytes: 730093
  <title> offset = 35847        # in hand 694 KB before the body ended
  in 256KB = True
$ curl -sS -o /dev/null -w '%{size_download}\n' https://www.google.com
80653                          # under the cap, which is why this one worked
```

The parser-vs-bytes distinction was verified against the real `_read_capped` + `extract_meta` for each decoy shape:

```
comment    cut=True title=''  parser_guard_fires=True  byte_guard_would_pass=True
attribute  cut=True title=''  parser_guard_fires=True  byte_guard_would_pass=True
style      cut=True title=''  parser_guard_fires=True  byte_guard_would_pass=True
```

No UI change, so no screenshots — the rendered card is the existing `LinkCard`; only whether it appears changes.

## Gates

`pytest` 26594 passed / 1 pre-existing failure (`test_module_loader.py::TestModuleUnload::test_reload_after_unload_gets_fresh_code`, which fails identically on the base commit with this branch's changes stashed), `isort` clean, `flake8` clean, `mypy` clean over 632 files. No frontend files touched, so the `website` gates do not apply.
