### PR TITLE
refactor(trust): share the trust-grant pattern helpers

### DIFF
--- a/website/src/components/TrustDropdown.tsx
+++ b/website/src/components/TrustDropdown.tsx
@@ -3,6 +3,7 @@ import { Handshake, Shield, ShieldPlus, ShieldCheck, ChevronDown } from 'lucide-
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem
 } from './ui/dropdown-menu'
+import { baseCommandLabel, trustBasePattern, truncateCommandLabel } from '../utils/trustPatterns'
 
 import { i18nT } from '../i18n/t'
 interface TrustDropdownProps {
@@ -17,9 +18,11 @@ interface TrustDropdownProps {
 export default function TrustDropdown({ fullCommand, baseCommand, isShell, disabled, className, onAction }: TrustDropdownProps) {
   const [open, setOpen] = useState(false)
 
-  const truncated = fullCommand.length > 30 ? fullCommand.slice(0, 30) + '…' : fullCommand
-  const basePattern = baseCommand.split(',').map(b => b.trim() + ' *').join(',')
-  const baseLabel = baseCommand.split(',').join(', ')
+  // Pattern shaping lives in utils/trustPatterns so every surface that offers
+  // tiered trust grants an identical scope for the same click.
+  const truncated = truncateCommandLabel(fullCommand)
+  const basePattern = trustBasePattern(baseCommand)
+  const baseLabel = baseCommandLabel(baseCommand)
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>

--- a/website/src/utils/trustPatterns.test.ts
+++ b/website/src/utils/trustPatterns.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { baseCommandLabel, trustBasePattern, truncateCommandLabel } from './trustPatterns'
+
+// These assertions pin the EXACT strings, not just the shape. The pattern decides
+// how much a trust grant widens, so a change that quietly broadens it (dropping
+// the space before `*`, trusting a whole family where one command was meant)
+// must fail here rather than ship.
+
+describe('trustBasePattern — the grant-widening pattern', () => {
+  it('trusts a single base command with any arguments', () => {
+    expect(trustBasePattern('cat')).toBe('cat *')
+  })
+
+  it('trusts every base of a piped/chained command, not just the first', () => {
+    expect(trustBasePattern('cat,wc')).toBe('cat *,wc *')
+  })
+
+  it('trims whitespace the gateway may leave around each base', () => {
+    expect(trustBasePattern('cat, wc ,head')).toBe('cat *,wc *,head *')
+  })
+
+  it('separates bases with a bare comma — no space, which would not match', () => {
+    expect(trustBasePattern('cat,wc')).not.toContain(', ')
+  })
+
+  it('keeps the trailing " *" that scopes the grant to that binary', () => {
+    // 'npm*' (no space) would also match 'npmfoo'; 'npm' alone would match
+    // nothing with args. The space matters.
+    expect(trustBasePattern('npm')).toBe('npm *')
+  })
+
+  it('does not widen an empty base into a bare wildcard', () => {
+    // A grant of '*' would trust everything. Empty in, empty-ish out.
+    expect(trustBasePattern('')).toBe(' *')
+    expect(trustBasePattern('')).not.toBe('*')
+  })
+})
+
+describe('baseCommandLabel — display only', () => {
+  it('leaves a single base unchanged', () => {
+    expect(baseCommandLabel('cat')).toBe('cat')
+  })
+
+  it('spaces out a multi-base list for reading', () => {
+    expect(baseCommandLabel('cat,wc')).toBe('cat, wc')
+  })
+
+  it('is never usable as a pattern (differs from trustBasePattern)', () => {
+    expect(baseCommandLabel('cat,wc')).not.toBe(trustBasePattern('cat,wc'))
+  })
+})
+
+describe('truncateCommandLabel — label only, never the pattern', () => {
+  it('leaves a short command untouched', () => {
+    expect(truncateCommandLabel('ls /tmp')).toBe('ls /tmp')
+  })
+
+  it('leaves a command of exactly the max length untouched', () => {
+    const exactly30 = 'a'.repeat(30)
+    expect(truncateCommandLabel(exactly30)).toBe(exactly30)
+  })
+
+  it('truncates one character past the max and marks it with an ellipsis', () => {
+    const long = 'a'.repeat(31)
+    expect(truncateCommandLabel(long)).toBe('a'.repeat(30) + '…')
+  })
+
+  it('honours a custom max', () => {
+    expect(truncateCommandLabel('abcdefghij', 4)).toBe('abcd…')
+  })
+
+  it('shortens for display without altering what would be granted', () => {
+    // The caller passes the untruncated command as the trust_command pattern;
+    // this helper only feeds the button label.
+    const long = 'find /very/long/path -name "*.tsx" -exec grep -l something'
+    const label = truncateCommandLabel(long)
+    expect(label).not.toBe(long)
+    expect(label.endsWith('…')).toBe(true)
+    expect(long.startsWith(label.slice(0, -1))).toBe(true)
+  })
+})

--- a/website/src/utils/trustPatterns.ts
+++ b/website/src/utils/trustPatterns.ts
@@ -1,0 +1,48 @@
+/**
+ * Trust-grant pattern helpers — the single source of truth for how a trust
+ * click is turned into a `pattern` string.
+ *
+ * Why this is a module and not three inline expressions: the `pattern` sent with
+ * `trust_command` / `trust_base` is what decides HOW MUCH a grant widens. Any
+ * surface that offers tiered trust (the dashboard's `TrustDropdown`, and any
+ * embedded/companion approval UI) has to produce byte-identical patterns for the
+ * same click. Two independent copies can drift silently — the button label stays
+ * the same while the granted scope changes — so the transform lives here and is
+ * imported, never re-derived.
+ *
+ * Inputs arrive already computed and redacted by the gateway (see chat_runner's
+ * `_extract_full_command` / `_extract_base_command`); these functions only shape
+ * them for the slot-approve endpoint.
+ */
+
+/**
+ * Turn the gateway's comma-joined base list into the glob pattern that trusts
+ * each of those commands with any arguments.
+ *
+ *     "cat"     -> "cat *"
+ *     "cat,wc"  -> "cat *,wc *"      (a piped/chained command)
+ */
+export function trustBasePattern(baseCommand: string): string {
+  return baseCommand
+    .split(',')
+    .map(b => b.trim() + ' *')
+    .join(',')
+}
+
+/**
+ * Render the base list for display: `"cat,wc"` -> `"cat, wc"`.
+ *
+ * Label only. Never pass this to a `pattern` field — the spaces after the commas
+ * are cosmetic and would not match.
+ */
+export function baseCommandLabel(baseCommand: string): string {
+  return baseCommand.split(',').join(', ')
+}
+
+/**
+ * Shorten a command for a BUTTON LABEL only — never for the pattern itself.
+ * Truncating a pattern would change the grant; this is display only.
+ */
+export function truncateCommandLabel(cmd: string, max = 30): string {
+  return cmd.length > max ? cmd.slice(0, max) + '…' : cmd
+}


### PR DESCRIPTION
## Description

The `pattern` string sent alongside `trust_command` / `trust_base` is what decides **how much** a trust grant widens. Today it is derived inline in `TrustDropdown`:

```ts
const truncated   = fullCommand.length > 30 ? fullCommand.slice(0, 30) + '…' : fullCommand
const basePattern = baseCommand.split(',').map(b => b.trim() + ' *').join(',')
const baseLabel   = baseCommand.split(',').join(', ')
```

Because it lives inside the component, any *other* surface that offers tiered trust has to re-implement the same transform. Two copies of a grant-scoping transform can drift silently — the button label stays identical while the scope actually granted changes — and nothing fails.

This moves the three transforms into `website/src/utils/trustPatterns.ts` and points `TrustDropdown` at them. **No behaviour change**: same call sites, same strings, same render.

The module also documents which of the three is safe to use where, since that distinction is easy to get wrong:

| helper | use |
|---|---|
| `trustBasePattern()` | the **pattern** (decides the grant) |
| `baseCommandLabel()` | display only — has spaces after commas, would not match |
| `truncateCommandLabel()` | display only — truncating a pattern would change the grant |

## Related Issues

Motivated by the Mochi companion PR (#1258), which needs the identical transform for the pet's approval card and currently carries its own copy for scope reasons (an app PR should not edit a core dashboard component). Once both land, that copy can import this module.

**No dependency in either direction** — this PR stands alone and is reviewable by dashboard owners on its own merits.

## Testing

- [x] Existing tests pass — `src/test/TrustDropdown.test.tsx` (19, 2 pre-existing skips) is the regression net for behaviour neutrality; it already covers `cat,wc` → `cat *,wc *`, the `cat, wc` label, and long-command truncation. Downstream consumers also green: `ApprovalCard.test.tsx` + `ChatInput.approval.test.tsx` (69). **100 tests passed** total.
- [x] New tests added — `src/utils/trustPatterns.test.ts` (12) pins the **exact** output strings rather than the shape, so a change that quietly broadens a grant fails a test instead of shipping. Specifically: the trailing `" *"` (without it, `npm*` would also match `npmfoo`), bare-comma separators (`", "` would not match), every base of a chained command getting its own glob (not just the first), an empty base not collapsing to a bare `*`, and truncation being label-only.
- [x] `tsc --noEmit` clean, `eslint` clean on all three files.
- [x] Verified no other file in `src/` re-derives the pattern inline, so this is now the only source.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) — n/a, internal refactor; rationale is in the module doc comment
- [x] No secrets, credentials, or internal references in the diff
