### PR TITLE
fix(deps): bump the fast-uri override to the patched 3.1.5

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1837,9 +1837,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -21,7 +21,7 @@
     "electron-builder-squirrel-windows": "^26.15.3"
   },
   "overrides": {
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "js-yaml": "4.3.0"
   },
   "build": {


### PR DESCRIPTION
## Description

`scripts/check_npm_audit.py` currently **fails closed on `main`**:

```
ERROR: unexcepted high/critical production vulnerabilities:
  website/electron/package-lock.json: fast-uri GHSA-7p8r-x3mc-p8w7 (high)
  - fast-uri vulnerable to host confusion via backslash authority introducer
```

The cause is not a missing upgrade — it's a **stale pin**. `website/electron/package.json` forces the exact version through `overrides`:

```json
"overrides": {
  "fast-uri": "3.1.4",
  "js-yaml": "4.3.0"
}
```

[GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) covers `>=3.0.0 <3.1.5`, so `3.1.4` is now inside the vulnerable range and the override is what holds the tree there. Worth knowing for anyone who hits this again: because the override is an exact version, `npm update fast-uri`, `npm audit fix --package-lock-only`, and `npm install --package-lock-only` **all no-op** (verified — zero lockfile diff from each). The pin has to move first.

This bumps it to `3.1.5`, keeping the repo's exact-version override convention, and regenerates the lockfile.

**Why it is a drop-in:** `fast-uri` reaches production only through `electron-store` → `conf` → `ajv` (`^3.0.1`), a range `3.1.5` already satisfies. The lockfile diff is that one package's `version` / `resolved` / `integrity` and nothing else. `3.1.5` is the newest `3.x` (`4.x` would be a major bump outside ajv's range).

**Exposure:** limited in practice. `fast-uri` is used by ajv's `uri` format validation, and `main.js:83` constructs the store with `defaults` only — no `schema` — so that validation path is unlikely to be exercised. The pin is stale regardless and the patched version is a drop-in, so this is worth fixing rather than excepting.

Not filed as a `.vulnerability-exceptions.json` entry: the gate's own guidance is to prefer remediation, and here remediation is a one-character version change.

## Related Issues

Pre-existing on `main` (`57bd8b98`), not introduced by any open PR — the advisory landed after the pin. It currently red-lights the audit gate for **every** open PR based on current `main`; those branches just need a rebase once this merges.

## Testing

- [x] Existing tests pass — `python scripts/check_npm_audit.py` now reports `Production dependency audit passed: 3 lockfiles, 2 governed exception(s).` (was exit 1). `npm audit --omit=dev` in `website/electron` goes from 1 high to **`found 0 vulnerabilities`**.
- [x] New tests added for new functionality — n/a, dependency bump.
- [x] Manual verification performed — confirmed the vulnerable resolution before the change (`node_modules/fast-uri` 3.1.4, required by `node_modules/ajv` `^3.0.1`, `dev: false`), confirmed `3.1.5` is published and is the newest `3.x`, and confirmed the other two audited lockfiles (`website/package-lock.json`, `site/package-lock.json`) contain no `fast-uri` at all — so `website/electron` was the only affected project.

## Checklist

- [x] Code follows the project style guidelines — exact-version override, matching the existing entries
- [x] Self-review completed
- [ ] Documentation updated (if applicable) — n/a
- [x] No secrets, credentials, or internal references in the diff
