### PR TITLE
fix(dev-fleet): stop listing worktrees that no longer exist

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -15,7 +15,9 @@ Gateway session auth (token/cookie) gates the proxy entrance as with all builtin
 
 ## Responsibilities
 
-1. **Worktree discovery** — enumerates git worktrees via `git worktree list --porcelain`
+1. **Worktree discovery** — enumerates git worktrees via `git worktree list --porcelain`,
+   dropping records git flags `prunable` (checkout directory deleted without a
+   `git worktree prune`); the primary checkout is never dropped, since it anchors `is_main`
 2. **Pod integration** — spin up/down/restart isolated pod instances per worktree
 3. **Pull+Build sync** — pull origin/main and rebuild (venv + frontend dist)
 4. **Prune** — safely remove merged/empty worktrees with PR-shipped verification
@@ -193,7 +195,18 @@ after the unit was installed.
   without a restart. Cycles that remove or fail anything are SEL-audited under
   `dev_fleet_auto_prune`. Cancelled on `dev_fleet_cleanup`.
 - **Fleet cache** — 10s TTL. Cold requests block on fresh data; warm requests serve stale
-  and background-refresh.
+  and background-refresh. Concurrent rebuilds (the background revalidate plus any number
+  of `?fresh=1` requests) coalesce onto a single in-flight build, so a rebuild never costs
+  more than one `gh pr` round-trip per branch. A successful `_worktree_remove` evicts that
+  worktree from the cached snapshot and zeroes the timestamp, so the next response stops
+  listing a removed worktree without waiting for a rebuild. An eviction also tombstones the
+  name against an eviction counter: a rebuild that started before the removal still read the
+  worktree from git, so it re-applies any eviction recorded after it began rather than
+  storing a snapshot that would resurrect the row. Tombstones are reaped by the first build
+  that started after them, so a worktree later re-created under the same name is not hidden.
+  The dashboard refreshes with
+  `?fresh=1` after every mutating action (and on the explicit Refresh button) so it never
+  renders the pre-mutation snapshot.
 
 ## Async Runs
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1230,6 +1230,11 @@ def _parse_worktree_porcelain(raw: str) -> list[dict]:
             current["branch"] = ref.split("refs/heads/", 1)[-1] if "refs/heads/" in ref else ref
         elif line == "detached":
             current["branch"] = None
+        elif line == "prunable" or line.startswith("prunable "):
+            # git flags an entry `prunable` when its checkout directory is gone
+            # but the admin record survives (a `rm -rf` with no
+            # `git worktree prune`). The reason text is optional.
+            current["prunable"] = line[len("prunable"):].strip() or "unknown"
     if current:
         entries.append(current)
     return entries
@@ -1260,7 +1265,13 @@ async def _discover_worktrees() -> list[dict]:
     # repository discovery hint).
     for i, e in enumerate(entries):
         e["is_main"] = (i == 0)
-    return entries
+    # A `prunable` entry has no checkout on disk, so every git call against its
+    # path fails and it renders as a ghost row with no branch, behind count or
+    # timestamp — and no refresh ever clears it, because git keeps reporting the
+    # record until `git worktree prune` runs. Drop those. The primary checkout
+    # is never filtered: it anchors `is_main`, and losing it would promote a
+    # linked worktree to main.
+    return [e for e in entries if e.get("is_main") or not e.get("prunable")]
 
 
 async def _git(
@@ -1320,32 +1331,107 @@ async def _real_dirty(path: str) -> bool | None:
 # --- fleet cache ---
 _FLEET_TTL = 10.0
 _FLEET_CACHE: dict[str, Any] = {"data": None, "ts": 0.0}
-_FLEET_REFRESHING = False
+# The single in-flight rebuild. A rebuild costs one `gh pr` round-trip per
+# branch, so the background revalidate and every `fresh=1` request coalesce onto
+# the SAME task instead of each starting their own. Holding the reference here
+# also keeps a fire-and-forget rebuild from being garbage-collected mid-flight.
+_FLEET_INFLIGHT: asyncio.Task[dict] | None = None
+# Worktrees evicted by `_fleet_forget`, keyed to an eviction counter. A rebuild
+# that started BEFORE an eviction still reads the worktree from git, so storing
+# its result would resurrect the row the eviction just dropped. Entries are
+# reaped by the first build that started after them.
+_FLEET_EPOCH = 0
+_FLEET_TOMBSTONES: dict[str, int] = {}
 
 
-async def _fleet_refresh() -> dict:
+def _drop_worktrees(data: dict, names: set[str]) -> dict:
+    """A copy of ``data`` without the named worktrees.
+
+    Copies rather than mutates: a concurrent response may still hold the old
+    dict while aiohttp serializes it.
+    """
+    wts = data.get("worktrees")
+    if not isinstance(wts, list):
+        return data
+    kept = [w for w in wts if w.get("name") not in names]
+    if len(kept) == len(wts):
+        return data
+    return {**data, "worktrees": kept}
+
+
+async def _fleet_build() -> dict:
+    global _FLEET_TOMBSTONES
+    started = _FLEET_EPOCH
     data = await _build_fleet()
+    # Removals that landed DURING this build are invisible to it — the git state
+    # it read predates them. Re-apply them so a slow build cannot put back a row
+    # an eviction already removed.
+    data = _drop_worktrees(
+        data, {n for n, e in _FLEET_TOMBSTONES.items() if e > started}
+    )
+    # Evictions that predate this build's start need no tombstone: `_fleet_forget`
+    # runs only after git has removed the worktree, so no later build can see it.
+    _FLEET_TOMBSTONES = {n: e for n, e in _FLEET_TOMBSTONES.items() if e > started}
     _FLEET_CACHE["data"] = data
     _FLEET_CACHE["ts"] = time.monotonic()
     return data
 
 
+def _fleet_rebuild_task() -> asyncio.Task[dict]:
+    """The in-flight rebuild, starting one if none is running."""
+    global _FLEET_INFLIGHT
+    task = _FLEET_INFLIGHT
+    if task is None or task.done():
+        task = asyncio.ensure_future(_fleet_build())
+        _FLEET_INFLIGHT = task
+    return task
+
+
+async def _fleet_refresh() -> dict:
+    # shield: a client disconnecting mid-request must not cancel a rebuild that
+    # other waiters (and the cache) depend on. Coalescing onto a build already in
+    # flight is safe even for a `fresh=1` request that raced a removal:
+    # `_fleet_build` re-applies any eviction that landed mid-build.
+    return await asyncio.shield(_fleet_rebuild_task())
+
+
+def _fleet_forget(name: str) -> None:
+    """Evict one worktree from the cached snapshot and mark it for rebuild.
+
+    ``_fleet_cached`` is stale-while-revalidate: once past the TTL it serves the
+    PREVIOUS snapshot and only schedules a rebuild behind it. Without this hook a
+    just-removed worktree keeps rendering for the length of a full rebuild, so
+    the UI shows rows that no longer exist and refreshing does not help. Evicting
+    the row makes the very next response truthful at zero rebuild latency, and
+    zeroing the timestamp schedules the rebuild that refreshes the rest.
+    """
+    global _FLEET_EPOCH
+    _FLEET_EPOCH += 1
+    _FLEET_TOMBSTONES[name] = _FLEET_EPOCH
+    data = _FLEET_CACHE["data"]
+    if isinstance(data, dict):
+        _FLEET_CACHE["data"] = _drop_worktrees(data, {name})
+    _FLEET_CACHE["ts"] = 0.0
+
+
+def _log_fleet_rebuild_failure(task: asyncio.Task) -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning("dev-fleet: background fleet rebuild failed: %s", exc)
+
+
 async def _fleet_cached() -> dict:
-    global _FLEET_REFRESHING
     data, ts = _FLEET_CACHE["data"], _FLEET_CACHE["ts"]
     if data is None:
         return await _fleet_refresh()
-    if time.monotonic() - ts > _FLEET_TTL and not _FLEET_REFRESHING:
-        _FLEET_REFRESHING = True
-
-        async def _bg():
-            global _FLEET_REFRESHING
-            try:
-                await _fleet_refresh()
-            finally:
-                _FLEET_REFRESHING = False
-
-        asyncio.create_task(_bg())
+    if time.monotonic() - ts > _FLEET_TTL:
+        task = _fleet_rebuild_task()
+        # This caller does not await the rebuild, so consume its exception here
+        # or asyncio reports it as never-retrieved.
+        if not task.done():
+            task.add_done_callback(_log_fleet_rebuild_failure)
     return data
 
 
@@ -2074,6 +2160,10 @@ async def _worktree_remove(
                     f"refs/heads/{branch}", verdict_oid.strip(), timeout=10,
                 )
 
+    # Every removal path lands here — the single-worktree handler, each parallel
+    # prune worker, and the auto-prune reaper — so this is the one place the
+    # cached snapshot has to be told the row is gone.
+    _fleet_forget(name)
     return {"ok": True, "removed": True, "stopped_pod": stopped_pod, "pr": _redact_pr(pr)}
 
 

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -54,6 +54,90 @@ def test_parse_worktree_porcelain_empty():
     assert _parse_worktree_porcelain("") == []
 
 
+def test_parse_worktree_porcelain_captures_prunable():
+    """`prunable` marks a record whose checkout directory is gone."""
+    from kiro_crew.apps.builtins.dev_fleet.server import _parse_worktree_porcelain
+
+    raw = textwrap.dedent("""\
+        worktree /home/user/kirocrew
+        HEAD abc1234567890abcdef1234567890abcdef123456
+        branch refs/heads/main
+
+        worktree /home/user/kirocrew-wt-deleted
+        HEAD def4567890abcdef1234567890abcdef12345678
+        branch refs/heads/gone
+        prunable gitdir file points to non-existent location
+
+        worktree /home/user/kirocrew-wt-bare-flag
+        HEAD def4567890abcdef1234567890abcdef12345678
+        detached
+        prunable
+
+    """)
+    entries = _parse_worktree_porcelain(raw)
+    assert len(entries) == 3
+    assert "prunable" not in entries[0]
+    assert entries[1]["prunable"] == "gitdir file points to non-existent location"
+    # A bare `prunable` line (no reason) must still register as prunable.
+    assert entries[2]["prunable"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_discover_worktrees_drops_prunable():
+    """A `rm -rf`'d worktree must not appear in the fleet.
+
+    git keeps reporting the admin record until `git worktree prune` runs, so
+    without this filter the ghost row survives every refresh.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    stdout = textwrap.dedent("""\
+        worktree /home/user/kirocrew
+        HEAD abc1234567890abcdef1234567890abcdef123456
+        branch refs/heads/main
+
+        worktree /home/user/kirocrew-wt-alive
+        HEAD def4567890abcdef1234567890abcdef12345678
+        branch refs/heads/alive
+
+        worktree /home/user/kirocrew-wt-deleted
+        HEAD 1234567890abcdef1234567890abcdef12345678
+        branch refs/heads/deleted
+        prunable gitdir file points to non-existent location
+
+    """)
+    with patch.object(mod, "_run_cmd", new=AsyncMock(return_value=(0, stdout, ""))):
+        entries = await mod._discover_worktrees()
+    paths = [e["path"] for e in entries]
+    assert paths == ["/home/user/kirocrew", "/home/user/kirocrew-wt-alive"]
+    assert entries[0]["is_main"] is True
+    assert entries[1]["is_main"] is False
+
+
+@pytest.mark.asyncio
+async def test_discover_worktrees_keeps_prunable_main():
+    """The primary checkout anchors is_main and is never filtered out."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    stdout = textwrap.dedent("""\
+        worktree /home/user/kirocrew
+        HEAD abc1234567890abcdef1234567890abcdef123456
+        branch refs/heads/main
+        prunable gitdir file points to non-existent location
+
+        worktree /home/user/kirocrew-wt-alive
+        HEAD def4567890abcdef1234567890abcdef12345678
+        branch refs/heads/alive
+
+    """)
+    with patch.object(mod, "_run_cmd", new=AsyncMock(return_value=(0, stdout, ""))):
+        entries = await mod._discover_worktrees()
+    assert [e["path"] for e in entries] == [
+        "/home/user/kirocrew", "/home/user/kirocrew-wt-alive",
+    ]
+    assert entries[0]["is_main"] is True
+
+
 # --- PR status ---
 def test_pr_status_merged():
     from kiro_crew.apps.builtins.dev_fleet.server import _is_pr_merged
@@ -4104,3 +4188,236 @@ def test_health_registered_on_proxied_api_path():
     }
     assert "/health" in paths        # gateway-internal liveness poll (exempt)
     assert "/api/health" in paths    # proxied path the dashboard actually polls
+
+
+# =============================================================================
+# fleet cache: eviction on removal + single-flight rebuilds
+# =============================================================================
+
+
+@pytest.fixture
+def _clean_fleet_cache():
+    """Isolate the module-level fleet cache from other tests."""
+    saved = dict(mod._FLEET_CACHE)
+    saved_inflight = mod._FLEET_INFLIGHT
+    saved_epoch = mod._FLEET_EPOCH
+    saved_tombs = dict(mod._FLEET_TOMBSTONES)
+    mod._FLEET_CACHE.update({"data": None, "ts": 0.0})
+    mod._FLEET_INFLIGHT = None
+    mod._FLEET_EPOCH = 0
+    mod._FLEET_TOMBSTONES = {}
+    try:
+        yield
+    finally:
+        mod._FLEET_CACHE.clear()
+        mod._FLEET_CACHE.update(saved)
+        mod._FLEET_INFLIGHT = saved_inflight
+        mod._FLEET_EPOCH = saved_epoch
+        mod._FLEET_TOMBSTONES = saved_tombs
+
+
+def test_fleet_forget_evicts_row(_clean_fleet_cache):
+    """A removed worktree must vanish from the cached snapshot immediately.
+
+    Without this the stale-while-revalidate cache serves the pre-removal
+    snapshot, so the pruned row keeps rendering for a whole rebuild.
+    """
+    mod._FLEET_CACHE.update({
+        "data": {"worktrees": [{"name": "main"}, {"name": "wt-gone"}], "base_branch": "main"},
+        "ts": time.monotonic(),
+    })
+    mod._fleet_forget("wt-gone")
+
+    names = [w["name"] for w in mod._FLEET_CACHE["data"]["worktrees"]]
+    assert names == ["main"]
+    # Unrelated snapshot fields survive the surgical eviction.
+    assert mod._FLEET_CACHE["data"]["base_branch"] == "main"
+    # Timestamp zeroed so the next read schedules a rebuild for the rest.
+    assert mod._FLEET_CACHE["ts"] == 0.0
+
+
+def test_fleet_forget_no_cache_is_noop(_clean_fleet_cache):
+    """Removal before any snapshot exists must not crash or fabricate one."""
+    mod._fleet_forget("wt-gone")
+    assert mod._FLEET_CACHE["data"] is None
+
+
+def test_fleet_forget_does_not_mutate_served_dict(_clean_fleet_cache):
+    """The old dict may still be mid-serialization in a concurrent response."""
+    served = {"worktrees": [{"name": "main"}, {"name": "wt-gone"}]}
+    mod._FLEET_CACHE.update({"data": served, "ts": time.monotonic()})
+    mod._fleet_forget("wt-gone")
+    assert [w["name"] for w in served["worktrees"]] == ["main", "wt-gone"]
+    assert mod._FLEET_CACHE["data"] is not served
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_evicts_from_cache(_clean_fleet_cache):
+    """_worktree_remove is the single choke point for ALL removal paths
+    (manual remove, each prune worker, the auto-prune reaper)."""
+    mod._FLEET_CACHE.update({
+        "data": {"worktrees": [{"name": "main"}, {"name": "wt-x"}]},
+        "ts": time.monotonic(),
+    })
+    with patch.object(mod, "_find_worktree", new=AsyncMock(
+        return_value=({"path": "/repo/wt-x", "branch": "feat/x", "is_main": False}, None)
+    )), \
+            patch.object(mod, "_live_worktree_path", new=AsyncMock(return_value=None)), \
+            patch.object(mod, "_own_checkout_path", return_value=None), \
+            patch.object(mod, "_real_dirty", new=AsyncMock(return_value=False)), \
+            patch.object(mod, "_pr_status_cached", new=AsyncMock(
+                return_value={"state": "MERGED"})), \
+            patch.object(mod, "_own_commits_count", new=AsyncMock(return_value=0)), \
+            patch.object(mod, "_fetch_pr_head_oid", new=AsyncMock(return_value="deadbeef")), \
+            patch.object(mod, "_head_contained_in_pr", new=AsyncMock(return_value=True)), \
+            patch.object(mod, "_git", new=AsyncMock(return_value="deadbeef")), \
+            patch.object(mod, "_load_cfg", return_value=None), \
+            patch.object(mod, "_POD_AVAILABLE", False), \
+            patch.object(mod, "_run_cmd", new=AsyncMock(return_value=(0, "", ""))):
+        res = await mod._worktree_remove("wt-x")
+
+    assert res["ok"] is True
+    assert [w["name"] for w in mod._FLEET_CACHE["data"]["worktrees"]] == ["main"]
+
+
+@pytest.mark.asyncio
+async def test_inflight_rebuild_cannot_resurrect_an_evicted_worktree(_clean_fleet_cache):
+    """A rebuild that started BEFORE a removal must not put the row back.
+
+    Such a build read git before the worktree was removed, so its snapshot still
+    contains it. Storing that verbatim would undo the eviction and the deleted
+    row would reappear.
+    """
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_build():
+        entered.set()
+        await release.wait()
+        # The pre-removal view of git: wt-gone still present.
+        return {"worktrees": [{"name": "main"}, {"name": "wt-gone"}]}
+
+    with patch.object(mod, "_build_fleet", new=_slow_build):
+        task = mod._fleet_rebuild_task()
+        await entered.wait()
+        # Removal lands while that build is in flight.
+        mod._fleet_forget("wt-gone")
+        release.set()
+        built = await task
+
+    assert [w["name"] for w in built["worktrees"]] == ["main"]
+    assert [w["name"] for w in mod._FLEET_CACHE["data"]["worktrees"]] == ["main"]
+
+
+@pytest.mark.asyncio
+async def test_fresh_request_coalescing_onto_a_racing_build_still_omits_the_row(
+    _clean_fleet_cache,
+):
+    """The post-removal `fresh=1` refresh may coalesce onto a build that started
+    BEFORE the removal. That is safe only because the build re-applies the
+    eviction — otherwise the request would answer with the deleted row."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_build():
+        entered.set()
+        await release.wait()
+        return {"worktrees": [{"name": "main"}, {"name": "wt-gone"}]}
+
+    with patch.object(mod, "_build_fleet", new=_slow_build):
+        background = mod._fleet_rebuild_task()
+        await entered.wait()
+        mod._fleet_forget("wt-gone")
+        waiter = asyncio.create_task(mod._fleet_refresh())
+        await asyncio.sleep(0)
+        release.set()
+        served = await waiter
+        await background
+
+    assert [w["name"] for w in served["worktrees"]] == ["main"]
+
+
+@pytest.mark.asyncio
+async def test_tombstones_are_reaped_by_a_later_build(_clean_fleet_cache):
+    """Tombstones must not accumulate: once a build that started after the
+    eviction completes, git no longer reports the worktree and the entry is dead
+    weight. A stale tombstone would also hide a worktree later re-created under
+    the same name."""
+    mod._fleet_forget("wt-gone")
+    assert "wt-gone" in mod._FLEET_TOMBSTONES
+
+    with patch.object(mod, "_build_fleet", new=AsyncMock(
+        return_value={"worktrees": [{"name": "main"}]}
+    )):
+        await mod._fleet_refresh()
+    assert mod._FLEET_TOMBSTONES == {}
+
+    # Re-created under the same name: no stale tombstone hides it.
+    with patch.object(mod, "_build_fleet", new=AsyncMock(
+        return_value={"worktrees": [{"name": "main"}, {"name": "wt-gone"}]}
+    )):
+        again = await mod._fleet_refresh()
+    assert [w["name"] for w in again["worktrees"]] == ["main", "wt-gone"]
+
+
+@pytest.mark.asyncio
+async def test_fleet_refresh_coalesces_concurrent_builds(_clean_fleet_cache):
+    """Concurrent rebuilds share ONE build.
+
+    A rebuild costs a `gh pr` round-trip per branch, so parallel `fresh=1`
+    requests (Refresh clicked twice, several row actions finishing together)
+    must not each start their own.
+    """
+    calls = 0
+    gate = asyncio.Event()
+
+    async def _slow_build():
+        nonlocal calls
+        calls += 1
+        await gate.wait()
+        return {"worktrees": [{"name": "main"}]}
+
+    with patch.object(mod, "_build_fleet", new=_slow_build):
+        waiters = [asyncio.create_task(mod._fleet_refresh()) for _ in range(4)]
+        await asyncio.sleep(0)  # let every waiter reach the shared task
+        gate.set()
+        results = await asyncio.gather(*waiters)
+
+    assert calls == 1
+    assert all(r == {"worktrees": [{"name": "main"}]} for r in results)
+    assert mod._FLEET_CACHE["data"] == {"worktrees": [{"name": "main"}]}
+
+
+@pytest.mark.asyncio
+async def test_fleet_cached_serves_stale_and_schedules_rebuild(_clean_fleet_cache):
+    """Past the TTL the cached read stays non-blocking but does trigger a rebuild."""
+    mod._FLEET_CACHE.update({
+        "data": {"worktrees": [{"name": "stale"}]},
+        "ts": time.monotonic() - (mod._FLEET_TTL + 1),
+    })
+    with patch.object(mod, "_build_fleet", new=AsyncMock(
+        return_value={"worktrees": [{"name": "fresh"}]}
+    )):
+        served = await mod._fleet_cached()
+        assert served == {"worktrees": [{"name": "stale"}]}
+        assert mod._FLEET_INFLIGHT is not None
+        await mod._FLEET_INFLIGHT
+    assert mod._FLEET_CACHE["data"] == {"worktrees": [{"name": "fresh"}]}
+
+
+@pytest.mark.asyncio
+async def test_fleet_cached_background_failure_is_swallowed(_clean_fleet_cache):
+    """A failed background rebuild keeps serving the last good snapshot and must
+    not surface as an unretrieved task exception."""
+    mod._FLEET_CACHE.update({
+        "data": {"worktrees": [{"name": "stale"}]},
+        "ts": time.monotonic() - (mod._FLEET_TTL + 1),
+    })
+    with patch.object(mod, "_build_fleet", new=AsyncMock(side_effect=RuntimeError("git blew up"))):
+        served = await mod._fleet_cached()
+        assert served == {"worktrees": [{"name": "stale"}]}
+        task = mod._FLEET_INFLIGHT
+        assert task is not None
+        await asyncio.gather(task, return_exceptions=True)
+    assert task.exception() is not None
+    assert mod._FLEET_CACHE["data"] == {"worktrees": [{"name": "stale"}]}

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -517,12 +517,27 @@ export default function DevFleetPage() {
     refetchInterval: 30000,
   })
 
-  const invalidateFleet = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ['dev-fleet', 'fleet'] })
+  // Every call below happens right after a user-initiated mutation (or the
+  // explicit Refresh button), so the fleet has to be REBUILT rather than
+  // re-read: a plain refetch hits the backend's stale-while-revalidate cache,
+  // which serves the PRE-mutation snapshot and only rebuilds behind it — so a
+  // pruned worktree would keep rendering until that rebuild lands. `fresh=1`
+  // forces the rebuild and the backend coalesces concurrent ones onto a single
+  // build. Falls back to a plain invalidate if the fresh fetch fails.
+  const refetchFleetFresh = useCallback(async () => {
+    try {
+      const data = await api.get<FleetData>('/fleet?fresh=1')
+      if (data) queryClient.setQueryData(['dev-fleet', 'fleet'], data)
+      else queryClient.invalidateQueries({ queryKey: ['dev-fleet', 'fleet'] })
+    } catch {
+      queryClient.invalidateQueries({ queryKey: ['dev-fleet', 'fleet'] })
+    }
   }, [queryClient])
+  const invalidateFleet = useCallback(() => { void refetchFleetFresh() }, [refetchFleetFresh])
   const invalidateAll = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ['dev-fleet'] })
-  }, [queryClient])
+    void refetchFleetFresh()
+    queryClient.invalidateQueries({ queryKey: ['dev-fleet', 'disk'] })
+  }, [refetchFleetFresh, queryClient])
 
   const [busy, setBusy] = useState<Record<string, boolean>>({})
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -810,6 +810,43 @@ describe('DevFleetPage', () => {
     expect(screen.getByText('pod still active after shutdown')).toBeInTheDocument()
     expect(screen.getByText('Prune complete')).toBeInTheDocument()
   }, 15000)
+
+  it('refetches the fleet with fresh=1 once a prune finishes', async () => {
+    // The backend serves /fleet from a stale-while-revalidate cache, so a plain
+    // refetch after a prune returns the PRE-prune snapshot and the removed rows
+    // keep rendering. The post-action refresh must force a rebuild.
+    const fleetUrls: string[] = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) {
+        fleetUrls.push(u)
+        return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      }
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/prune-candidates')) return Promise.resolve(new Response(JSON.stringify({
+        ok: true, candidates: [{ name: 'wt-a', code: 'merged' }], kept: [], scanned: 1,
+      }), { status: 200 }))
+      if (u.includes('/prune-run')) return Promise.resolve(new Response(JSON.stringify({ ok: true, total: 1 }), { status: 200 }))
+      if (u.includes('/prune-status')) return Promise.resolve(new Response(JSON.stringify({
+        running: false, total: 1, done: 1, current: null,
+        results: [{ name: 'wt-a', ok: true }],
+        items: { 'wt-a': { status: 'done', error: null } },
+      }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    // The initial load must NOT force a rebuild — only post-action refreshes do.
+    expect(fleetUrls.every((u) => !u.includes('fresh=1'))).toBe(true)
+
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Remove selected'))
+    await waitFor(
+      () => expect(fleetUrls.some((u) => u.includes('fresh=1'))).toBe(true),
+      { timeout: 8000 },
+    )
+  }, 15000)
 })
 
 // The overlap-merge algorithm behind client-side log accumulation — dedupes


### PR DESCRIPTION
## 1. What is the problem?

Dev Fleet lists worktrees that no longer exist. Prune a worktree and its row stays on screen; **Refresh** does not clear it. Delete a worktree directory with `rm -rf` and its row never goes away at all.

Two independent defects:

**A. No destructive path invalidates the fleet cache.** `_fleet_cached()` is stale-while-revalidate — past its 10s TTL it returns the **previous** snapshot immediately and only schedules a rebuild behind it. `_FLEET_CACHE` had exactly one writer (`_fleet_refresh`); no removal path touched it. So the refetch the dashboard fires when a prune finishes got the pre-prune snapshot and re-rendered the rows that had just been deleted. The frontend also never used the `?fresh=1` the route already supported, and its poll interval (12s) is longer than the cache TTL (10s), so the ghosts survived a full rebuild cycle — and a rebuild costs one `gh pr` round-trip per branch: measured 1.3–3.7s warm, **~56s cold** on a live gateway, with `_PR_TTL` at 55s making cold the common case.

**B. `prunable` records were never filtered.** `git worktree list --porcelain` keeps reporting a worktree whose directory is gone, flagged `prunable`, until someone runs `git worktree prune`. `_parse_worktree_porcelain()` read only `worktree` / `HEAD` / `branch` / `detached` and `_discover_worktrees()` did no existence check, so that row survived **every** refresh permanently — rendering with no behind count and no timestamp, because every git call against the missing path fails.

## 2. Why this issue matters to the user

The worktree list is the page's whole purpose, and it was lying about the one action the user had just taken. Ghost rows offer actions (Provision, Pod, Rebase) that cannot possibly succeed, and nothing distinguishes them from real worktrees. Because no part of the UI mentions `git worktree prune`, the natural conclusion is that the delete silently failed.

## 3. How our fix solves it

Symptom → root cause → fix:

| Symptom | Root cause | Fix |
| --- | --- | --- |
| Pruned row still listed, Refresh doesn't help | stale-while-revalidate cache has no eviction on removal | `_worktree_remove` calls `_fleet_forget(name)` on success — the single choke point shared by the manual-remove handler, every parallel prune worker and the auto-prune reaper. It drops the row from the cached snapshot (copying rather than mutating a dict a concurrent response may still be serializing) and zeroes the timestamp so the rest rebuilds. The next response is truthful at zero rebuild latency. |
| An in-flight rebuild could put the evicted row back | a rebuild that started before the removal still read the worktree from git, so storing its result verbatim undid the eviction | rebuilds are versioned against an eviction counter. `_fleet_forget` bumps it and tombstones the name; `_fleet_build` re-applies every eviction recorded after its own start before storing. Tombstones are reaped by the first build that started after them — `_fleet_forget` runs only after git removed the worktree, so no later build can see it — which bounds the map and keeps a worktree re-created under the same name from being hidden. |
| Dashboard re-renders pre-mutation state after any action | frontend refetched `/fleet` without `fresh=1`, hitting the stale cache | post-action refreshes (and the Refresh button) fetch `/fleet?fresh=1` and seed the query cache, falling back to a plain invalidate if that fetch fails. The 12s poll still uses the cheap cached path. |
| A `fresh=1` stampede would multiply `gh` calls | `fresh=1` bypassed the `_FLEET_REFRESHING` single-flight guard entirely | rebuilds coalesce onto one in-flight task (`_FLEET_INFLIGHT`), awaited under `asyncio.shield` so a disconnecting client cannot cancel a build others depend on. Coalescing is safe even for a `fresh=1` that raced a removal, because the versioning above re-applies the eviction. This also replaces a bare `create_task` whose exception was never retrieved and whose task was not strongly referenced. |
| `rm -rf`'d worktree listed forever | `prunable` field parsed and filtered nowhere | `_parse_worktree_porcelain` captures `prunable` (with or without a reason string) and `_discover_worktrees` drops those entries — never the primary checkout, which anchors `is_main`. |

## 4. What tests we did

**Real-backend before/after proof.** Built an actual git repo with two worktrees, `rm -rf`'d one without pruning, then ran the real `_discover_worktrees()` against it — real git subprocesses, no mocks:

```
--- raw `git worktree list` (what git still reports) ---
/tmp/.../main-repo  941e85c [master]
/tmp/.../wt-alive   941e85c [feat/alive]
/tmp/.../wt-gone    941e85c [feat/gone] prunable

--- with the fix ---
  is_main=True   branch=master      /tmp/.../main-repo
  is_main=False  branch=feat/alive  /tmp/.../wt-alive
PASS: deleted worktree is gone from the fleet; live one and main survive

--- without the fix (same script, changes stashed) ---
AssertionError: ghost row still present: ['main-repo', 'wt-alive', 'wt-gone']
```

**Both race guards verified to bite.** With the eviction re-apply disabled, `test_inflight_rebuild_cannot_resurrect_an_evicted_worktree` and `test_fresh_request_coalescing_onto_a_racing_build_still_omits_the_row` both fail; restored, both pass. They are real regression guards, not tautologies.

**Live-gateway diagnosis** that motivated the fix: `.git/worktrees` mtime put the prune at 22:38:50 UTC, while the UI at ~22:39 still showed 8 rows against a repo holding 5. A signed probe of the backend's own `/api/fleet` returned the correct 5 rows once its rebuild landed — confirming the divergence is the cache window, not git.

**New tests** (13 total):
- porcelain parsing captures `prunable`, including a bare `prunable` line with no reason
- discovery drops prunable entries; discovery keeps a prunable **primary** so `is_main` cannot shift onto a linked worktree
- `_fleet_forget` evicts the row, preserves unrelated snapshot fields, zeroes the timestamp, no-ops with no snapshot, and does not mutate the previously served dict
- `_worktree_remove` evicts from the cache on success (covers all three removal paths)
- an eviction landing mid-rebuild does not resurrect the row, in the cache or in the build's return value
- a `fresh=1` request coalescing onto a build that started before the removal still omits the row
- tombstones are reaped by a later build, and a worktree re-created under the same name is not hidden
- four concurrent `_fleet_refresh()` callers trigger exactly **one** build
- `_fleet_cached` past TTL serves stale and schedules a rebuild; a failing background rebuild keeps serving the last good snapshot without an unretrieved-exception report
- frontend: a finished prune refetches with `fresh=1`, and the initial page load does **not**

**Gates:** `test_dev_fleet_app.py` 212 passed; `isort`, `flake8`, `mypy` (632 files) clean; `tsc -b` clean; vitest 8175 passed / 627 files, and the DevFleetPage suite 53/53 after the amend. One pre-existing failure, `test_trusted_bin_pins_the_resolved_target_not_the_symlink`, reproduces identically on unmodified `main` on this host (it resolves the host's real `gh`) — unrelated to this change.

## 5. Any other suggestions on the work

- `_PR_TTL` (55s) is shorter than the polling cadence, so most rebuilds pay full `gh` cost. Raising it, or caching terminal PR states longer, would cut rebuild latency well below the ~56s cold figure. Not changed here — it is a tuning decision with its own staleness tradeoff.
- Hidden prunable records still linger in git metadata. Surfacing a "N stale worktree records — run `git worktree prune`" hint (or offering the prune as a row action) would let users clean them up instead of just not seeing them. Left out to keep this fix scoped; happy to file it as a follow-up.
- Only removals get backend eviction. Non-removal mutations (pod up/down, provision, rebase, Make Live) rely on the frontend's `fresh=1` for promptness rather than on backend eviction, which is sufficient because they change fields rather than row membership.

Closes #1351
