### PR TITLE
test: make CI-flaky tests deterministic and halve suite runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -819,6 +819,29 @@ Apps can register gateway-level hooks via the App SDK:
 - Backend: pytest-timeout enforced, xdist loadgroup mode for parallel execution (`--dist loadgroup` so `xdist_group`-marked tests serialize on one worker)
 - Backend: security-critical modules require 80%+ coverage
 
+**Determinism and speed: read `docs/system-specs/common/testing-conventions.md`
+before "fixing" a flaky test or optimizing the suite.** It carries the four flake
+classes with their one correct fix each, and the profiling method. The short version:
+
+- **Never** fix a flake with a rerun, a longer `sleep`, or a weakened assertion. Seed
+  nondeterministic input; **poll** for a condition instead of sleeping a fixed span
+  (Windows' ~15.6ms timer granularity is what turns a 50ms wait into a CI failure); use
+  `MagicMock` for synchronous methods (an `AsyncMock` `write()` leaks a coroutine that
+  is reported against a *later* test); `await` a task after `cancel()`.
+- The suite is ~26.5k tests, so **per-test setup cost dominates, not slow tests**. An
+  autouse fixture chain cost 9.2ms per test before these fixes. Build expensive
+  immutable fixtures (real `git` repos above all) **once** at `scope="session"` and
+  `copytree` per test, copying from the template rather than yielding it.
+- Measure back to back on one machine (`git stash`, run, pop, run). `--store-durations`
+  numbers taken under `-n auto` include worker contention and overstate single tests, so
+  never *sum* them to predict a shard; run the shard (`--splits 4 --group N`) instead.
+- After any speedup, mutate the covered production code and confirm the test still
+  fails, because a test made faster by checking less is a regression. Restore it from
+  a `cp` backup, never `git checkout --` (that resets to HEAD and discards any unrelated
+  uncommitted work in the file, unrecoverably).
+- CI's 4 shards split by test count (no `.test_durations` is committed), which measures a
+  1.5× spread, close enough that outlier files, not the split, are the lever.
+
 ## Gateway Test Harness
 
 For integration tests and eval harnesses, use composable CLI flags:

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -105,6 +105,183 @@ test). The sweep's own behavior belongs in its own module's tests.
 - Tests SHOULD be fast (< 1s each)
 - Async tests MUST use `@pytest.mark.asyncio`
 
+## Determinism: the four flake classes
+
+A test that fails on CI but not locally is almost always one of these. Each has one
+correct fix; reruns and `sleep` increases are not among them.
+
+### 1. Nondeterministic input
+
+Feeding `os.urandom` / `random` / `uuid4` into an assertion that depends on a property
+the RNG does not guarantee. A random opaque id is fine; a random *payload* asserted to
+NOT match a pattern is a coin flip.
+
+Fix: seed it. `random.Random(_SEED).randbytes(n)` keeps the payload high-entropy,
+which is usually the property under test, while fixing the outcome. Verify the chosen
+seed against the real predicate, and say in a comment that you did.
+
+```python
+# WRONG: ~1% of runs match a credential prefix and the exemption assert fails
+body = os.urandom(20_000)
+# RIGHT: same entropy, same code path, one outcome
+body = random.Random(20260803).randbytes(20_000)
+```
+
+### 2. Wall-clock races
+
+Asserting a *rate* or a *count* that the host controls. Windows rounds `time.sleep` /
+`Event.wait` up to ~15.6ms and a loaded runner starves threads, so "burn 0.25s at a 2ms
+interval, expect ~125 samples" observed **one** sample in CI.
+
+Fix: poll for the condition with a generous deadline, and keep the assertion. Never
+extend a fixed sleep, which trades flakiness for wall-clock and still races.
+
+```python
+# WRONG: assumes the scheduler cooperates
+do_work_for(0.25); assert observed()
+# RIGHT: returns as soon as it is true, fails loudly if it never is
+give_up_at = time.monotonic() + 30.0
+while not observed():
+    assert time.monotonic() < give_up_at, "never happened"
+    do_work_for(0.05)
+```
+
+Where a test wants a timeout to *expire*, set it to `0` rather than a small value: the
+same branch is reached with no clock dependency at all.
+
+### 3. Leaked async objects
+
+An `AsyncMock` standing in for a **synchronous** method (`StreamWriter.write`,
+`stdin.close`) returns a coroutine nobody awaits. A `cancel()` that is never awaited
+leaves a live task at loop teardown. Both surface as `RuntimeWarning: coroutine ... was
+never awaited` / `coroutine ignored GeneratorExit`, attributed to whichever *later* test
+happened to trigger the GC, so the reported test is rarely the guilty one.
+
+Fix: `MagicMock()` for sync methods; `await` the task after `cancel()`, absorbing
+`CancelledError`.
+
+### 4. Order dependence and shared state
+
+Under `-n auto --dist loadgroup` the scheduling unit is a test's **own nodeid** unless it
+carries an `xdist_group` mark: `LoadGroupScheduling._split_scope` returns the nodeid
+verbatim and only collapses to a shared scope for tests marked `@<group>`. So ordinary
+tests are distributed freely and independently: which worker any given test lands on, and
+which tests precede it there, changes run to run. That is exactly why cross-test pollution
+surfaces as flakiness rather than as a reproducible ordering bug, and why an `xdist_group`
+mark is the tool for a test that genuinely cannot share a worker.
+
+Mutate process globals through `monkeypatch`, which reverts on teardown even when the
+test fails. Raw assignment does not.
+
+## Keeping the suite fast
+
+The suite is ~26.5k tests. At that count a per-test cost is multiplied by 26,500, so
+setup overhead, not any single slow test, is what dominates. Profile before optimizing:
+
+```bash
+# Per-test durations for the whole suite (writes a JSON map)
+pytest -q -n auto --dist loadgroup --no-cov --store-durations --durations-path=/tmp/d.json
+# One file, serially, with its own worst offenders
+pytest test/test_foo.py -n0 -q --no-cov --durations=10
+```
+
+Note that `--store-durations` numbers taken under `-n auto` include worker contention
+and overstate individual tests. Compare candidates **back to back** on the same machine
+(`git stash` / run / `git stash pop` / run); a number from an idle machine measured an
+hour earlier is not a baseline.
+
+### The three highest-leverage patterns
+
+1. **Audit what the autouse fixtures cost, before anything else.** Every one of them is
+   paid ~26.5k times, so a few milliseconds there outweighs any single slow test. Two
+   things to look for: a fixture requesting a fixture it never uses (one unused
+   `tmp_path` allocated a directory for every test in the suite), and repeated
+   `tmp_path_factory.mktemp` calls, which pick a numbered suffix by scanning the whole
+   basetemp, so it gets slower as siblings accumulate. Allocate one session-scoped
+   parent and `mkdir` under it instead. Measure the whole chain against a file of
+   trivial `assert True` tests, which isolates setup cost from any real work:
+
+   ```bash
+   # 600 trivial tests, with the real conftest vs without it
+   python -c "
+   for i in range(600): print(f'def test_t{i}(): assert True')" > /tmp/probe/test_p.py
+   cp test/conftest.py /tmp/probe/ && cd /tmp/probe && pytest test_p.py -n0 -q --no-cov
+   ```
+
+   That probe read 6.35s here before these fixes and 0.82s after: **9.2ms per test**,
+   which is where most of the suite-wide win came from.
+2. **Function-scoped construction of an immutable, expensive thing.** Real `git`
+   repos are the worst offender here: seeding one costs ~1–1.6s in subprocesses, paid
+   per test. Build it **once** in a `scope="session"` fixture and `shutil.copytree` it
+   per test. This is safe only if the template is never handed to a test: copy from
+   it rather than yielding it, so nothing one test does can reach another's. Re-point any
+   absolute path the tool recorded (e.g. `git remote set-url`) in the copy.
+3. **A production timeout or poll the test never asserts on.** Fake fixtures are often
+   small enough to trip a real retry heuristic, then pay its full budget every test.
+   `monkeypatch` the interval to `0`: the branch still executes, only the waiting
+   goes. Confirm first that no test asserts on the interval itself.
+
+Measured on this suite: `test_computer_use_snapshot_macos.py` 143.9s → 2.0s (pattern 3),
+`test_md_notebook.py` 78.5s → 37.0s and `test_worktree_create.py` 61.3s → 40.6s
+(pattern 2). Applying all three across ~16 files took the full suite from 281s to 130s
+wall on one host, and most of that came from the *shared* fixes, which is why the
+conftest audit is item 1.
+
+A fourth, adjacent pattern: **a patch target that misses.** Both this and § Patch the
+defining module, not a re-export are the same one rule, *patch the namespace whose
+globals the code under test actually reads*, and they are the two directions it fails
+in. There, the caller reads its own defining module and the test patched a package
+re-export. Here it is the reverse: the caller did `from pkg.mod import fn`, so it holds
+its **own** binding, and patching `pkg.mod.fn` leaves that binding untouched. Either way
+the REAL function runs, the assertion passes for the wrong reason, and the test pays real
+time. One such target cost 6.1s and left a live transcriber running. Ask which module's
+globals the call resolves through, and treat an unexpectedly slow "mocked" test as
+evidence the mock missed.
+
+### Verify an optimization did not weaken the test
+
+A fix that makes a test faster by making it check less is a regression. Mutate the
+production code the test covers and confirm the test still **fails**:
+
+Restore from a **copy of the file you mutated**, not from git. `git checkout --` resets
+the path to HEAD, which silently discards any unrelated uncommitted work in that file and
+cannot be undone. And sequence it with `;`, not `&&`: with `&&` the restore runs only when
+pytest exits 0, i.e. only in the case where the mutation did *not* do its job, leaving a
+correctly-failing mutation in your tree.
+
+```bash
+f=src/kiro_crew/foo.py
+cp "$f" "$f.premutation"                 # back up whatever is there now
+# ...edit $f to invert the branch the test covers...
+pytest test/test_foo.py -n0 -q           # expect RED; if it passes, the test is weak
+mv "$f.premutation" "$f"                 # exact pre-mutation bytes, unrelated edits kept
+git diff --stat "$f"                     # should show only what you had before
+```
+
+### Shard balance
+
+`ci.yml` splits the backend suite into 4 `pytest-split` groups. Splitting is balanced by
+recorded runtime **only when a `.test_durations` file is committed**; without one
+pytest-split falls back to an even split by test *count*. No such file is committed here:
+`test-durations.yml` would generate one weekly but has failed on a transient `git push`
+502 both times it ran, so it has never landed.
+
+**Measure a shard by running it, not by summing durations.** Each shard runs its own
+tests at `-n 4`, so per-test times from a `--store-durations` run include worker
+contention and do not add up to a shard's wall clock. Summing them predicted a 3× spread
+here. Running the four shards the way CI does,
+
+```bash
+pytest -q -n 4 --no-cov --splits 4 --group <N>
+```
+
+measures **54.8 / 59.9 / 81.1 / 62.4s**, a 1.5× spread. Count-based splitting is
+already close enough that committing `.test_durations` would save on the order of
+seconds, so it is not the lever it looks like. The lever is the outliers: a single file
+paying a 2s production poll 119 times moves a shard far more than the split ever does,
+and it was the two files carrying that kind of cost that sat on the shards which failed
+most.
+
 ## Exploratory Testing via Manual Command Execution
 
 For integration issues involving external processes (kiro-cli, MCP servers, build

--- a/skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
+++ b/skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
@@ -105,6 +105,38 @@ checkout — if it fails there too, it's pre-existing and can be noted rather
 than fixed; if it only fails on your branch, it's yours. Never label a failure
 "known flaky" without that main-vs-branch comparison.
 
+**A confirmed flake is a bug with a root cause, not noise to retry.** Do NOT add a
+rerun, lengthen a `sleep`, or relax an assertion. Read
+`docs/system-specs/common/testing-conventions.md` § Determinism for the four classes
+and the one correct fix for each: seed nondeterministic input, poll instead of
+sleeping, `MagicMock` for sync methods, `await` after `cancel()`. To find what is
+actually flaky rather than guessing, mine CI instead of the local suite (a real flake
+often will not reproduce on macOS at all):
+
+```bash
+gh run list --workflow=ci.yml --limit 250 --json databaseId,conclusion \
+  --jq '.[]|select(.conclusion=="failure")|.databaseId' > /tmp/ids
+xargs -P 10 -I{} sh -c 'gh run view {} --log-failed 2>/dev/null \
+  | sed "s/\x1b\[[0-9;]*m//g" | grep -oE "_{3,} ?[A-Za-z_][A-Za-z0-9_.]* ?_{3,}"' \
+  < /tmp/ids | sort | uniq -c | sort -rn | head -30
+```
+
+Rank by that frequency, and check each candidate against `origin/main` before fixing:
+a ratchet/contract test failing on feature branches is a TRUE POSITIVE, not a flake.
+The Windows shards fail far more than Linux, so expect timer-granularity and
+process-semantics causes there.
+
+**Suite speed: profile, don't guess.** At ~26.5k tests, per-test setup cost dominates
+any single slow test. Time one file with `pytest test/test_x.py -n0 -q --no-cov
+--durations=10` and compare a candidate fix **back to back** on the same machine
+(`git stash`, run, pop, run), because a loaded host makes an absolute number
+meaningless.
+The recurring wins are an autouse fixture requesting an unused `tmp_path`, a real
+`git` repo rebuilt per test instead of `copytree`d from a session template, and a
+production poll the test never asserts on. After any speedup, mutate the covered
+production code and confirm the test still fails. Full method and measured numbers:
+`docs/system-specs/common/testing-conventions.md` § Keeping the suite fast.
+
 **mypy must reproduce CI, not just "run".** CI installs `-e ".[voice]" --group
 dev` (mypy pinned in `pyproject.toml` `[dependency-groups] dev`) and does NOT
 install `faiss`. Two things make a local run diverge from CI:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -116,7 +116,7 @@ def _windows_restrict_to_owner_stub(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_aim_skills_dir(tmp_path, monkeypatch):
+def _isolate_aim_skills_dir(monkeypatch):
     """Prevent SkillsLoader from discovering edition-contributed skill roots.
 
     SkillsLoader now sources extra skill roots from the CPP seam
@@ -125,6 +125,10 @@ def _isolate_aim_skills_dir(tmp_path, monkeypatch):
     composed companion (or leftover roots) can't inflate session context beyond
     _MAX_CONTEXT_CHARS and cause silent truncation / non-deterministic xdist
     failures.
+
+    Does NOT request ``tmp_path``: this fixture only patches a method, and being
+    autouse it made every one of the suite's ~26k tests allocate a temp directory it
+    never touched -- the single largest fixed cost in the suite's setup path.
     """
     from kiro_crew.platform.defaults import DefaultMcpToolingProvider
 
@@ -400,8 +404,51 @@ def _reset_reasoning_effort_globals():
         _cp._reasoning_effort_ordered = saved_ordered
 
 
+@pytest.fixture(scope="session")
+def _isolation_root(tmp_path_factory):
+    """One session-scoped parent for the per-test isolation dirs below.
+
+    ``tmp_path_factory.mktemp`` picks its numbered suffix by scanning the whole
+    basetemp, so its cost grows with the number of entries already there. Four autouse
+    fixtures called it per test, adding thousands of siblings to one directory. Those
+    fixtures now ``mkdir`` under this root instead, which is a single syscall and does
+    not scan.
+
+    Named ``i`` rather than something descriptive to keep the paths short: Windows
+    still caps a path at 260 characters unless long paths are enabled, and everything
+    a test writes under ``KIROCREW_HOME`` nests inside here.
+    """
+    return tmp_path_factory.mktemp("i")
+
+
+@pytest.fixture
+def _isolation_dirs(_isolation_root):
+    """Return an allocator for this test's isolation dirs, created on demand.
+
+    Each call returns ``<root>/<counter>-<name>``, so one test's dirs cannot collide
+    with another's (the counter is per-process, and pytest-xdist gives every worker its
+    own ``basetemp`` -- verified: workers report ``popen-gw0``/``popen-gw1`` roots).
+    Flat rather than nested, again to keep Windows paths short.
+    """
+    made: dict[str, pathlib.Path] = {}
+    _isolation_dirs.seq += 1  # type: ignore[attr-defined]
+    stem = _isolation_dirs.seq  # type: ignore[attr-defined]
+
+    def _get(name: str) -> pathlib.Path:
+        if name not in made:
+            path = _isolation_root / f"{stem}-{name}"
+            path.mkdir(parents=True, exist_ok=True)
+            made[name] = path
+        return made[name]
+
+    return _get
+
+
+_isolation_dirs.seq = 0  # type: ignore[attr-defined]
+
+
 @pytest.fixture(autouse=True)
-def _isolate_kirocrew_home(tmp_path_factory, monkeypatch):
+def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
     """Pin ``KIROCREW_HOME`` to a per-test tmp dir as a safety net.
 
     ``config_dir()`` reads ``KIROCREW_HOME`` on every call and falls back to the
@@ -434,7 +481,7 @@ def _isolate_kirocrew_home(tmp_path_factory, monkeypatch):
     behavior — green in CI (env unset there), red locally. Tests that need a
     project dir set it themselves via ``monkeypatch`` (which still wins).
     """
-    home = tmp_path_factory.mktemp("kirocrew-home")
+    home = _isolation_dirs("kirocrew-home")
     monkeypatch.setenv("KIROCREW_HOME", str(home))
     monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
     monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
@@ -476,7 +523,7 @@ def _isolate_kiro_window_cache():
 
 
 @pytest.fixture(autouse=True)
-def _isolate_subagents_dir(tmp_path_factory, monkeypatch):
+def _isolate_subagents_dir(_isolation_dirs, monkeypatch):
     """Pin the subagent registry dir to a tmp dir for the whole suite.
 
     ``kiro_crew.subagent_persistence._SUBAGENTS_DIR`` is bound at import time to
@@ -490,12 +537,12 @@ def _isolate_subagents_dir(tmp_path_factory, monkeypatch):
     """
     monkeypatch.setattr(
         "kiro_crew.subagent_persistence._SUBAGENTS_DIR",
-        tmp_path_factory.mktemp("subagents"),
+        _isolation_dirs("subagents"),
     )
 
 
 @pytest.fixture(autouse=True)
-def _no_model_download(monkeypatch, tmp_path_factory):
+def _no_model_download(monkeypatch, _isolation_dirs):
     """Never let a test trigger the 610MB embedding-model download.
 
     Embeddings are always-on, so any test that boots the gateway/server
@@ -512,11 +559,19 @@ def _no_model_download(monkeypatch, tmp_path_factory):
     Ollama-era embeddings.
     """
     monkeypatch.setenv("KIROCREW_SKIP_MODEL_DOWNLOAD", "1")
-    monkeypatch.setenv("OLLAMA_MODELS", str(tmp_path_factory.mktemp("ollama-models")))
+    monkeypatch.setenv("OLLAMA_MODELS", str(_isolation_dirs("ollama-models")))
+    # Force telemetry OFF for every test. `_consent_enabled` reads this env var BEFORE
+    # the config flag, which is what makes it a reliable gate: ~15 tests patch
+    # `KiroCrewConfig.load` with a bare MagicMock, whose `telemetry.enabled` is TRUTHY,
+    # so a real recorder starts and `Path(cfg.local_dir)` resolves the mock to the
+    # RELATIVE path `MagicMock/load().telemetry.local_dir/...` -- writing metrics and a
+    # lock file into the repo root, plus a background reader thread that outlives the
+    # test. Tests that exercise telemetry delete this var themselves (test/metrics/).
+    monkeypatch.setenv("KIROCREW_TELEMETRY", "0")
 
 
 @pytest.fixture(autouse=True)
-def _isolate_agent_state_sidecar(tmp_path_factory, monkeypatch):
+def _isolate_agent_state_sidecar(_isolation_dirs, monkeypatch):
     """Pin the agent_state sidecar to a tmp dir for the whole suite.
 
     ``kiro_crew.agent_state`` stores per-agent bookkeeping (model_managed,
@@ -526,7 +581,7 @@ def _isolate_agent_state_sidecar(tmp_path_factory, monkeypatch):
     ``config_dir`` — referenced as a module attribute at call time — to a fresh
     tmp dir so every test starts from empty state.
     """
-    sidecar_root = tmp_path_factory.mktemp("agent-state-isolation")
+    sidecar_root = _isolation_dirs("agent-state")
     monkeypatch.setattr("kiro_crew.agent_state.config_dir", lambda: sidecar_root)
 
 

--- a/test/test_acp_runtime_kill.py
+++ b/test/test_acp_runtime_kill.py
@@ -43,8 +43,16 @@ def _bare_runtime(pid: int = 54321) -> rt.AcpRuntime:
 
 @pytest.fixture(autouse=True)
 def _fast_kill_windows(monkeypatch):
-    monkeypatch.setattr(rt.AcpRuntime, "_KILL_TERM_TIMEOUT", 0.05)
-    monkeypatch.setattr(rt.AcpRuntime, "_KILL_REAP_TIMEOUT", 0.05)
+    """Make the two escalation waits time out without waiting for a real clock.
+
+    `kill()` only reaches the SIGKILL escalation and the liveness probe after both
+    `wait_for`s expire. At 0.05s that depended on the scheduler resuming a coroutine
+    inside 50ms, which a loaded runner (and Windows, ~15.6ms timer granularity) does
+    not promise. Zero makes `wait_for` raise on its first check: same code path,
+    reached deterministically with no sleeping.
+    """
+    monkeypatch.setattr(rt.AcpRuntime, "_KILL_TERM_TIMEOUT", 0)
+    monkeypatch.setattr(rt.AcpRuntime, "_KILL_REAP_TIMEOUT", 0)
 
 
 @pytest.mark.asyncio

--- a/test/test_ask_question_roundtrip.py
+++ b/test/test_ask_question_roundtrip.py
@@ -556,7 +556,10 @@ async def test_dashboard_user_token_is_still_allowed() -> None:
         return {
             "session_key": "dashboard:chat-1",
             "questions": _questions(),
-            "timeout_secs": 15,
+            # 1s, not 15s: the assertion below is only that the owner-gate does not
+            # REFUSE this caller, and the handler waits out this whole window to reach
+            # it. At 15s this was the slowest test in the suite.
+            "timeout_secs": 1,
         }
 
     request.json = _json

--- a/test/test_beacon.py
+++ b/test/test_beacon.py
@@ -537,10 +537,23 @@ class TestFailOpen:
 
         Pins the boot-path contract: even a beacon that hangs far past its own
         timeout costs the caller only the thread spawn.
+
+        The hang is RELEASED at the end rather than left running. ``beacon.send``
+        resolves state through the module-global ``config_dir``, which
+        ``_isolated_home`` repoints per test -- so a thread still inside ``send``
+        when this test ends goes on to mint ``beacon_install_id`` in whichever
+        LATER test's home is installed by then, and
+        ``TestStatusOutput.test_status_does_not_create_id`` then fails for
+        something this test did. Reproduced by running this file followed by any
+        second file; a uuid4 stack trace showed the id being minted on this thread.
         """
+        released = threading.Event()
 
         def hang(*_a, **_k):
-            time.sleep(30)
+            # Indistinguishable from a 30s hang at the assertion below -- still
+            # unfinished when it runs -- but releasable before teardown.
+            released.wait(30)
+            raise OSError("released")
 
         monkeypatch.setattr(beacon.urllib.request, "urlopen", hang)
         start = time.monotonic()
@@ -554,6 +567,9 @@ class TestFailOpen:
         elapsed = time.monotonic() - start
         assert elapsed < 1.0, f"spawning the beacon cost {elapsed:.2f}s"
         assert thread.daemon, "must not pin interpreter exit"
+        released.set()
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "the beacon thread outlived its test"
 
     def test_gateway_wiring_is_detached_and_daemon(self):
         """The gateway must never await the beacon.

--- a/test/test_computer_use_snapshot_macos.py
+++ b/test/test_computer_use_snapshot_macos.py
@@ -86,6 +86,12 @@ _APP = AppRef(name="Fixture", pid=4242, bundle_id="dev.kirocrew.fixture", window
 def fakes(monkeypatch: pytest.MonkeyPatch):
     """Install the fake frameworks and force a re-bind (see test_computer_use_ffi)."""
     fake = _Fakes()
+    # The fake trees are deliberately smaller than ELECTRON_STUB_NODE_THRESHOLD, so
+    # nearly every test took the opt-in retry path and slept its full 2s budget --
+    # ~2s x 119 tests, the slowest file in the suite. Nothing asserts on the poll
+    # interval, only on the retry behaviour, which still runs.
+    monkeypatch.setattr(macos_ffi, "ELECTRON_OPT_IN_WAIT_SECS", 0.0)
+    monkeypatch.setattr(macos_ffi, "ELECTRON_OPT_IN_POLL_SECS", 0.0)
     monkeypatch.setattr(platform_compat, "IS_MACOS", True)
     monkeypatch.setattr(macos_ffi.platform_compat, "IS_MACOS", True, raising=False)
     monkeypatch.setattr(permissions.platform_compat, "IS_MACOS", True, raising=False)

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -114,6 +114,20 @@ def _context_builder(hook_result: ToolHookResult = ToolHookResult.allow()) -> Ma
     return cb
 
 
+async def _drain(task: asyncio.Task) -> None:
+    """Cancel *task* and await it, so it cannot outlive the test.
+
+    A helper task left running is garbage-collected on a later test's loop, which
+    reports "coroutine ignored GeneratorExit" against an innocent test.
+    """
+    if not task.done():
+        task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
 # ── Tests ──
 
 
@@ -127,16 +141,23 @@ class TestApprovalModes:
         slot = _make_slot()
         _set_stream(client, [_permission_event(), _complete_event()])
 
+        # Poll for the future rather than sleeping a fixed 0.05s and hoping the chat
+        # has registered it by then, and keep a handle so the helper is cancelled
+        # instead of being GC'd mid-flight during a later test.
         async def _auto_approve():
-            await asyncio.sleep(0.05)
-            fut = slot._approval_futures.get("req-1")
-            if fut and not fut.done():
-                fut.set_result("approved")
+            for _ in range(600):
+                fut = slot._approval_futures.get("req-1")
+                if fut is not None:
+                    if not fut.done():
+                        fut.set_result("approved")
+                    return
+                await asyncio.sleep(0.01)
 
-        asyncio.get_event_loop().create_task(_auto_approve())
+        approver = asyncio.get_event_loop().create_task(_auto_approve())
 
         with _patch_stats():
             await _run_chat(state, slot, "hello")
+        await _drain(approver)
 
         msgs = _tool_messages(slot)
         assert any(
@@ -385,15 +406,19 @@ class TestApprovalModes:
         _set_stream(client, [_permission_event(), _complete_event()])
 
         async def _auto_approve():
-            await asyncio.sleep(0.05)
-            fut = slot._approval_futures.get("req-1")
-            if fut and not fut.done():
-                fut.set_result("approved")
+            for _ in range(600):
+                fut = slot._approval_futures.get("req-1")
+                if fut is not None:
+                    if not fut.done():
+                        fut.set_result("approved")
+                    return
+                await asyncio.sleep(0.01)
 
-        asyncio.get_event_loop().create_task(_auto_approve())
+        approver = asyncio.get_event_loop().create_task(_auto_approve())
 
         with _patch_stats():
             await _run_chat(state, slot, "hello")
+        await _drain(approver)
 
         msgs = _tool_messages(slot)
         assert not any(

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -1515,6 +1515,11 @@ class TestProbeServerTimeout:
 
         mock_proc = AsyncMock()
         mock_proc.stdin = AsyncMock()
+        # `StreamWriter.write` is synchronous; only `drain()` is awaited. As an
+        # AsyncMock auto-child it returned a coroutine nobody awaits, surfacing later
+        # as an unraisable "never awaited" warning attributed to whichever test
+        # triggered the GC. The sibling test above already pins this.
+        mock_proc.stdin.write = MagicMock()
         mock_proc.stdin.close = MagicMock()
         mock_proc.stdout = AsyncMock()
         mock_proc.stdout.readline = AsyncMock(side_effect=asyncio.TimeoutError)

--- a/test/test_md_notebook.py
+++ b/test/test_md_notebook.py
@@ -15,6 +15,7 @@ import hmac
 import importlib
 import json
 import os
+import shutil
 import subprocess
 import time
 from contextlib import asynccontextmanager
@@ -29,6 +30,24 @@ from kiro_crew.apps.builtins.md_notebook import git_ops
 SECRET = "test-proxy-secret"
 
 
+"""Env that makes a git call hermetic regardless of fixture scope.
+
+``test/conftest.py``'s ``_git_identity`` closes the same two host bleeds (identity,
+and ``~/.gitconfig`` reaching in via e.g. ``core.excludesFile``), but it is autouse
+and FUNCTION-scoped -- so the session-scoped template builder below runs before it and
+would otherwise read the developer's real global config. Applied here explicitly
+rather than widening that fixture's scope, which would stop it reverting per test.
+"""
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.invalid",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.invalid",
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+}
+
+
 def _git(*args: str, cwd: Path) -> str:
     """Run git in a fixture repo, failing loudly on error."""
     return subprocess.run(
@@ -37,11 +56,12 @@ def _git(*args: str, cwd: Path) -> str:
         capture_output=True,
         text=True,
         check=True,
+        env={**os.environ, **_GIT_ENV},
     ).stdout.strip()
 
 
-def _seed_repo(base: Path) -> tuple[Path, Path]:
-    """Create a bare remote plus a working checkout holding two notes."""
+def _build_seed_repo(base: Path) -> None:
+    """Create a bare remote plus a working checkout holding two notes, under *base*."""
     remote = base / "remote.git"
     _git("init", "--bare", "-b", "main", str(remote), cwd=base)
     seed = base / "seed"
@@ -56,6 +76,35 @@ def _seed_repo(base: Path) -> tuple[Path, Path]:
     _git("commit", "-m", "seed", cwd=seed)
     _git("remote", "add", "origin", str(remote), cwd=seed)
     _git("push", "-u", "origin", "main", cwd=seed)
+
+
+@pytest.fixture(scope="session")
+def _seed_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build the seed repo pair once per session; tests get a copy.
+
+    ``_build_seed_repo`` spawns nine git subprocesses, and ``fixtures`` is
+    function-scoped over 120 tests -- ~1.6s of setup each, which made this the most
+    expensive file in the suite. Copying a prebuilt tree is ~5x cheaper.
+
+    Session scope is safe because the template is never yielded to a test, only
+    copied from, so no test can reach another's repo.
+    """
+    template = tmp_path_factory.mktemp("md-notebook-seed")
+    _build_seed_repo(template)
+    return template
+
+
+def _seed_repo(base: Path, template: Path) -> tuple[Path, Path]:
+    """Copy the session seed *template* into *base*, returning ``(remote, seed)``.
+
+    ``git`` records the remote as an absolute path, so the copied checkout is
+    re-pointed at the copied bare remote rather than the template's -- otherwise
+    every test would push into one shared remote and see each other's commits.
+    """
+    remote, seed = base / "remote.git", base / "seed"
+    shutil.copytree(template / "remote.git", remote)
+    shutil.copytree(template / "seed", seed)
+    _git("remote", "set-url", "origin", str(remote), cwd=seed)
     return remote, seed
 
 
@@ -99,7 +148,7 @@ class SignedClient:
 
 
 @pytest.fixture
-def fixtures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def fixtures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _seed_template: Path):
     """A fresh backend module bound to a temp home, plus git fixture repos."""
     monkeypatch.setenv("MD_NOTEBOOK_HOME", str(tmp_path / "home"))
     # The PAT lives under the crew data home (config_dir), never MD_NOTEBOOK_HOME,
@@ -112,7 +161,7 @@ def fixtures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     # HOME and friends are resolved at import time, so rebind them to the temp
     # home rather than relying on import order.
     server_mod = importlib.reload(server_mod)
-    remote, seed = _seed_repo(tmp_path)
+    remote, seed = _seed_repo(tmp_path, _seed_template)
     return server_mod, remote, seed
 
 

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -751,6 +751,13 @@ def test_restore_open_slots_async_yields_between_tabs(tmp_path, monkeypatch):
         restored = await restore_open_slots_async(state2)
         stop = True
         t.cancel()
+        # `cancel()` only requests cancellation; without awaiting it the ticker is
+        # still live when `asyncio.run` tears the loop down, leaving a "coroutine
+        # ignored GeneratorExit" for a later test to trip over.
+        try:
+            await t
+        except asyncio.CancelledError:
+            pass
         return restored
 
     restored = asyncio.run(_drive())

--- a/test/test_perf_sampler.py
+++ b/test/test_perf_sampler.py
@@ -88,11 +88,18 @@ class TestParserWiring:
 # ── The in-process sampler ──
 
 
-def _recognisable_workload() -> None:
-    """Burn CPU inside a uniquely named frame so the profile is checkable."""
-    deadline = time.time() + 0.25
+def _recognisable_workload(deadline: float | None = None) -> None:
+    """Burn CPU inside a uniquely named frame so the profile is checkable.
+
+    With *deadline* (an absolute :func:`time.monotonic` value) the burn runs until
+    then, so a caller can keep this frame on the stack until the sampler has actually
+    observed it instead of guessing how long that takes. The default keeps the
+    original fixed 0.25s span for callers that only need the frame to exist.
+    """
+    if deadline is None:
+        deadline = time.monotonic() + 0.25
     total = 0
-    while time.time() < deadline:
+    while time.monotonic() < deadline:
         total += sum(i * i for i in range(2000))
 
 
@@ -103,9 +110,29 @@ class TestStackSampler:
             perf_sampler.StackSampler(interval=bad)
 
     def test_collects_samples_and_names_the_frame(self):
+        # Poll for the frame rather than burning a fixed span and hoping a sample
+        # landed. The requested 2ms interval is only a request: Windows rounds
+        # `Event.wait` up to ~15.6ms and a loaded runner starves the daemon thread,
+        # so the old fixed 0.25s burn expected ~125 samples and CI observed one (of
+        # an unrelated frame). Holding the frame until it is seen makes this
+        # independent of the achieved rate, and the deadline still fails loudly.
         sampler = perf_sampler.StackSampler(interval=0.002)
         sampler.start()
-        _recognisable_workload()
+        give_up_at = time.monotonic() + 30.0
+
+        def _seen() -> bool:
+            # Snapshot before scanning: the sampler thread inserts into `_counts` on
+            # every tick, and iterating it live can raise "dictionary changed size
+            # during iteration" -- which would be a NEW flake in the test that exists
+            # to remove one. `list()` on a dict is atomic under the GIL.
+            return any("_recognisable_workload" in stack for stack in list(sampler._counts))
+
+        while not _seen():
+            assert time.monotonic() < give_up_at, (
+                "the sampler never sampled _recognisable_workload in 30s "
+                f"(samples={sampler._samples})"
+            )
+            _recognisable_workload(min(time.monotonic() + 0.05, give_up_at))
         report = sampler.stop()
 
         assert report.samples > 0

--- a/test/test_pptx_maker_decks.py
+++ b/test/test_pptx_maker_decks.py
@@ -23,6 +23,9 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
+
+import pytest
 
 from kiro_crew.apps.builtins.pptx_maker.backend import decks, paths
 
@@ -245,9 +248,13 @@ class TestListDecks(_DeckTree):
         )
 
     def test_listing_is_capped(self) -> None:
-        for i in range(decks.MAX_DECKS + 5):
-            self._write(self._deck(f"2026-{i:04d}") / "deck.json", "{}")
-        self.assertEqual(len(decks.list_decks()), decks.MAX_DECKS)
+        # Shrink the cap instead of materializing MAX_DECKS+5 (505) real directories.
+        # The break being tested is the same at 5; building 505 deck trees was ~1010
+        # filesystem syscalls for no extra coverage.
+        with mock.patch.object(decks, "MAX_DECKS", 5):
+            for i in range(decks.MAX_DECKS + 5):
+                self._write(self._deck(f"2026-{i:04d}") / "deck.json", "{}")
+            self.assertEqual(len(decks.list_decks()), decks.MAX_DECKS)
 
 
 class TestDeckDetail(_DeckTree):
@@ -414,7 +421,7 @@ class TestAgentMetadataIsRedacted:
         assert _FAKE_AWS_SECRET not in name
         assert "REDACTED" in name
 
-    def test_a_credential_shaped_deck_ID_is_refused_entirely(self, tmp_path: Path):
+    def test_a_credential_shaped_deck_ID_is_refused_entirely(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """The deck ID is the one agent-authored field that cannot be redacted on the
         way out — it is the directory name, the `preview/<deckId>/...` URL segment and
         the handle every later request sends back, so rewriting it would break the deck.
@@ -432,7 +439,7 @@ class TestAgentMetadataIsRedacted:
             (deck / "specs").mkdir(parents=True)
             (deck / "deck.json").write_text("{}", encoding="utf-8")
             (deck / "specs" / "brief.md").write_text("ordinary brief", encoding="utf-8")
-        os.environ[paths.DECK_ROOT_ENV] = str(root)
+        monkeypatch.setenv(paths.DECK_ROOT_ENV, str(root))
 
         rows = decks.list_decks()
 
@@ -441,7 +448,7 @@ class TestAgentMetadataIsRedacted:
         # And the deck cannot be reached by asking for it directly either.
         assert decks.deck_detail(f"20260101-{_FAKE_AKIA}") is None
 
-    def test_a_credential_shaped_slide_slug_is_skipped(self, tmp_path: Path):
+    def test_a_credential_shaped_slide_slug_is_skipped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """The same leak as the deck ID, one level down — and reachable only by the
         FALLBACK slug path, which is why the outline's grammar is not a defence.
 
@@ -469,7 +476,7 @@ class TestAgentMetadataIsRedacted:
         for slug in (_FAKE_AKIA, "intro"):
             (deck / "slides" / f"{slug}.json").write_text("{}", encoding="utf-8")
             (deck / "compose" / f"{slug}.json").write_text("{}", encoding="utf-8")
-        os.environ[paths.DECK_ROOT_ENV] = str(root)
+        monkeypatch.setenv(paths.DECK_ROOT_ENV, str(root))
 
         detail = decks.deck_detail("20260101-demo")
 
@@ -479,7 +486,7 @@ class TestAgentMetadataIsRedacted:
         # the previewUrl / composeUrl strings built from it.
         assert _FAKE_AKIA not in json.dumps(detail)
 
-    def test_a_credential_shaped_thumbnail_filename_is_refused(self, tmp_path: Path):
+    def test_a_credential_shaped_thumbnail_filename_is_refused(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Third instance of one class, which is why the guard is in `_preview_url`.
 
         The engine names preview PNGs, so the filename is agent-authored and
@@ -497,7 +504,7 @@ class TestAgentMetadataIsRedacted:
         (deck / "specs" / "brief.md").write_text("ordinary brief", encoding="utf-8")
         (deck / "deck.json").write_text("{}", encoding="utf-8")
         (deck / "preview" / f"{_FAKE_AKIA}.png").write_bytes(b"\x89PNG\r\n\x1a\n")
-        os.environ[paths.DECK_ROOT_ENV] = str(root)
+        monkeypatch.setenv(paths.DECK_ROOT_ENV, str(root))
 
         rows = decks.list_decks()
 
@@ -505,7 +512,7 @@ class TestAgentMetadataIsRedacted:
         assert rows[0]["thumbnailUrl"] is None
         assert _FAKE_AKIA not in json.dumps(rows)
 
-    def test_an_ordinary_thumbnail_is_still_linked(self, tmp_path: Path):
+    def test_an_ordinary_thumbnail_is_still_linked(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """The screen must not drop honest artifact URLs — a refusal-only test would
         pass against a builder that returned `None` for everything."""
         root = tmp_path / "decks"
@@ -515,14 +522,14 @@ class TestAgentMetadataIsRedacted:
         (deck / "specs" / "brief.md").write_text("ordinary brief", encoding="utf-8")
         (deck / "deck.json").write_text("{}", encoding="utf-8")
         (deck / "preview" / "page_1.png").write_bytes(b"\x89PNG\r\n\x1a\n")
-        os.environ[paths.DECK_ROOT_ENV] = str(root)
+        monkeypatch.setenv(paths.DECK_ROOT_ENV, str(root))
 
         rows = decks.list_decks()
 
         assert rows[0]["thumbnailUrl"] == "preview/20260102-demo/preview/page_1.png"
 
     @unittest.skipUnless(hasattr(os, "link"), "needs hardlinks")
-    def test_hardlinked_deck_files_are_not_read(self, tmp_path: Path):
+    def test_hardlinked_deck_files_are_not_read(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """A HARDLINK is what `contained_deck_file` cannot see.
 
         It resolves and re-checks containment, which stops a symlink — but a hardlink
@@ -551,7 +558,7 @@ class TestAgentMetadataIsRedacted:
         (good / "deck.json").write_text(json.dumps({"name": "Quarterly"}), encoding="utf-8")
         (good / "specs" / "brief.md").write_text("a real brief", encoding="utf-8")
 
-        os.environ[paths.DECK_ROOT_ENV] = str(root)
+        monkeypatch.setenv(paths.DECK_ROOT_ENV, str(root))
         rows = decks.list_decks()
 
         assert "SECRETUSER" not in json.dumps(rows)

--- a/test/test_pptx_maker_routes.py
+++ b/test/test_pptx_maker_routes.py
@@ -27,6 +27,7 @@ import asyncio
 import base64
 import json
 import os
+import random
 import shutil
 import tempfile
 import unittest
@@ -43,6 +44,23 @@ from kiro_crew.apps.builtins.pptx_maker.backend import engine, paths, provision,
 # An AKIA-shaped access key ID. The canonical AWS documentation example, so it is
 # a real pattern match without being a live secret.
 _FAKE_AKIA = "AKIAIOSFODNN7EXAMPLE"
+
+# Verified clean against `_ENCODED_CREDENTIAL_RE` at every size used below.
+_RASTER_SEED = 20260803
+
+
+def _raster_body(size: int) -> bytes:
+    """`size` bytes of high-entropy but DETERMINISTIC raster payload.
+
+    These tests assert a genuine raster is *exempted* from redaction, which needs its
+    base64 body to carry no credential pattern. `os.urandom` cannot promise that:
+    `_ENCODED_CREDENTIAL_RE` matches the bare prefixes `xox[abposr]` and `sk-ant`, and
+    random base64 produces one ~1.07% of the time per 20 KB (measured 32/3000), which
+    made two of these the 3rd and 4th most frequent failures in CI. A fixed seed keeps
+    the payload high-entropy, which is the property under test since it is what makes
+    the bare-secret heuristic fire, while fixing the outcome on every host.
+    """
+    return random.Random(_RASTER_SEED).randbytes(size)
 
 
 def _enabled(value: bool):
@@ -375,7 +393,7 @@ class TestPreviewRedaction(_RoutesFixture):
         long base64-alphabet-looking runs, and rewriting one corrupts the image."""
         png = self.deck / "preview"
         png.mkdir()
-        raw = b"\x89PNG\r\n\x1a\n" + os.urandom(4096)
+        raw = b"\x89PNG\r\n\x1a\n" + _raster_body(4096)
         (png / "page1-x.png").write_bytes(raw)
         resp = await self._preview("preview/page1-x.png")
         self.assertEqual(resp.status, 200)
@@ -403,7 +421,7 @@ class TestPreviewRedaction(_RoutesFixture):
         # A real WebP header, then random compressed-image bytes — which is what
         # makes the bare-secret heuristic fire without the excision.
         webp = b"RIFF" + (20 * 1024).to_bytes(4, "little") + b"WEBP"
-        raster = base64.b64encode(webp + os.urandom(20 * 1024)).decode()
+        raster = base64.b64encode(webp + _raster_body(20 * 1024)).decode()
         (self.deck / "compose" / "intro_1.json").write_text(
             json.dumps(
                 {
@@ -451,7 +469,7 @@ class TestPreviewRedaction(_RoutesFixture):
         }
         for subtype, magic in rasters.items():
             with self.subTest(subtype=subtype):
-                blob = base64.b64encode(magic + os.urandom(9000)).decode()
+                blob = base64.b64encode(magic + _raster_body(9000)).decode()
                 (self.deck / "compose" / "intro_1.json").write_text(
                     json.dumps(
                         {
@@ -567,7 +585,7 @@ class TestRedactArtifactHelper(unittest.TestCase):
         self.assertIsNone(routes._scanned_bitmap_bytes("!!!not base64!!!"))
 
     def test_the_bitmap_probe_accepts_a_real_raster(self) -> None:
-        blob = base64.b64encode(b"\x89PNG\r\n\x1a\n" + os.urandom(64)).decode()
+        blob = base64.b64encode(b"\x89PNG\r\n\x1a\n" + _raster_body(64)).decode()
         self.assertIsNotNone(routes._scanned_bitmap_bytes(blob))
 
 
@@ -856,7 +874,7 @@ class TestLibraryRoutes(_RoutesFixture):
         This is the guard against over-redacting — an unguarded `redact()` eats a
         random raster as a bare secret and blanks every picture in every deck.
         """
-        clean = base64.b64encode(b"\x89PNG\r\n\x1a\n" + os.urandom(20000)).decode()
+        clean = base64.b64encode(b"\x89PNG\r\n\x1a\n" + _raster_body(20000)).decode()
         doc = '{"img": "data:image/png;base64,' + clean + '"}'
         self.assertIsNotNone(routes._scanned_bitmap_bytes(clean))
         self.assertEqual(routes._redact_artifact(doc.encode("utf-8")).decode("utf-8"), doc)
@@ -941,7 +959,7 @@ class TestLibraryRoutes(_RoutesFixture):
         """...and it goes through the bitmap-aware helper, not a bare redact():
         an unguarded pass over a raster eats it as a bare secret, which would
         silently blank the style preview."""
-        raster = base64.b64encode(b"\x89PNG\r\n\x1a\n" + os.urandom(4096)).decode()
+        raster = base64.b64encode(b"\x89PNG\r\n\x1a\n" + _raster_body(4096)).decode()
         styled = f'<html><body><img src="data:image/png;base64,{raster}"></body></html>'
         with _enabled(True), mock.patch.object(
             routes.library, "style_html", return_value=styled

--- a/test/test_project_git.py
+++ b/test/test_project_git.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import threading
@@ -65,14 +66,30 @@ def _git(cwd, *args) -> None:
         cwd=str(cwd),
         check=True,
         capture_output=True,
-        env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"},
+        # Identity is pinned here as well as in conftest's autouse ``_git_identity``,
+        # which is FUNCTION-scoped and so does not cover the session-scoped template
+        # builder below. os.devnull rather than a literal /dev/null: this file is
+        # collected on Windows, where that path does not exist.
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "T",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "T",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+        },
     )
 
 
-@pytest.fixture()
-def repo(tmp_path):
-    """A real git repo with one commit on branch ``trunk``."""
-    root = tmp_path / "proj"
+@pytest.fixture(scope="session")
+def _repo_template(tmp_path_factory):
+    """Build the one-commit ``trunk`` repo once per session; ``repo`` copies it.
+
+    The five git subprocesses below cost ~0.6s per test across 32 invocations. Session
+    scope is safe because the template is never handed to a test, only copied from.
+    """
+    root = tmp_path_factory.mktemp("project-git-seed") / "proj"
     root.mkdir()
     _git(root, "init", "-q", "-b", "trunk")
     _git(root, "config", "user.email", "t@example.com")
@@ -80,6 +97,14 @@ def repo(tmp_path):
     (root / "f.txt").write_text("x")
     _git(root, "add", "f.txt")
     _git(root, "commit", "-qm", "init")
+    return root
+
+
+@pytest.fixture()
+def repo(tmp_path, _repo_template):
+    """A real git repo with one commit on branch ``trunk``."""
+    root = tmp_path / "proj"
+    shutil.copytree(_repo_template, root)
     return root
 
 

--- a/test/test_runtime_home_write_paths.py
+++ b/test/test_runtime_home_write_paths.py
@@ -39,7 +39,9 @@ detecting it (``home_migration.py``, ``config/paths.py``, ``security.py``,
 
 from __future__ import annotations
 
+import functools
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -70,6 +72,24 @@ LEGACY_READER_SCRIPTS = frozenset(
 
 # Directories that are vendored, generated, or dependency trees.
 SKIP_DIR_PARTS = frozenset({"node_modules", "_vendor", ".venv", "build", "dist", ".git"})
+
+
+@functools.lru_cache(maxsize=1)
+def _repo_python_files() -> tuple[Path, ...]:
+    """Every repo ``*.py`` outside :data:`SKIP_DIR_PARTS`, pruned DURING the walk.
+
+    ``REPO_ROOT.rglob("*.py")`` enumerates the skipped trees before the caller can
+    filter them out -- measured 4946 files walked in ~4s to keep 665, on a checkout
+    with a ``.venv``. ``os.walk`` lets the skip list prune ``dirnames`` in place, so
+    those subtrees are never descended into. Same file set, same assertions.
+    """
+    found: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIR_PARTS]
+        for name in filenames:
+            if name.endswith(".py"):
+                found.append(Path(dirpath) / name)
+    return tuple(sorted(found))
 
 
 def _shell_scripts() -> list[Path]:
@@ -223,9 +243,9 @@ def test_no_python_expands_a_hardcoded_legacy_home() -> None:
     """
     pattern = re.compile(r"expanduser\(\s*[^)]*\.kirocrew(?![-.])")
     offenders: list[str] = []
-    for path in sorted(REPO_ROOT.rglob("*.py")):
+    for path in _repo_python_files():
         rel = path.relative_to(REPO_ROOT)
-        if SKIP_DIR_PARTS.intersection(rel.parts) or rel.parts[0] == "test":
+        if rel.parts[0] == "test":
             continue
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
             if pattern.search(line):

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -227,6 +227,17 @@ class TestResultHash:
 class TestOpenDmWithRetry:
     """Retry logic for open_dm."""
 
+    @pytest.fixture(autouse=True)
+    def _no_backoff(self, monkeypatch):
+        """Skip the production linear backoff's real sleep (1s then 2s).
+
+        These tests assert the retry COUNT and the final result, never the delay, so
+        the 5s this class spent asleep bought no coverage. The retry loop still runs.
+        """
+        monkeypatch.setattr(
+            "kiro_crew.slack.retry.asyncio.sleep", AsyncMock(return_value=None)
+        )
+
     @pytest.mark.asyncio
     async def test_success_first_attempt(self):
         orch = _make_orchestrator(slack_enabled=True)

--- a/test/test_spawn_preexec_guard.py
+++ b/test/test_spawn_preexec_guard.py
@@ -21,6 +21,7 @@ the follow-up to issue #935.
 from __future__ import annotations
 
 import ast
+import functools
 from pathlib import Path
 
 _SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
@@ -45,11 +46,23 @@ _ALLOWED = frozenset(
 )
 
 
+@functools.lru_cache(maxsize=1)
 def _async_spawns_with_preexec() -> dict[str, int]:
-    """Map ``<relpath>::<func>`` -> line for async spawns passing ``preexec_fn``."""
+    """Map ``<relpath>::<func>`` -> line for async spawns passing ``preexec_fn``.
+
+    Cached: this AST-parses all ~630 files under ``src/kiro_crew`` and both tests in
+    this file call it, so an unmemoized second pass re-parsed the whole tree for the
+    same answer. The source tree cannot change mid-run. Callers must not mutate the
+    returned dict -- both only read it.
+    """
     found: dict[str, int] = {}
     for path in sorted(_SRC_ROOT.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+        # Cheap substring pre-filter: parsing is the expensive step, and a file with
+        # no `preexec_fn` text cannot contain a match.
+        source = path.read_text(encoding="utf-8")
+        if "preexec_fn" not in source:
+            continue
+        tree = ast.parse(source, str(path))
         funcs = [
             n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
         ]

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -568,8 +568,13 @@ class TestTranscribeFiles:
             },
         ]
 
+        # Patch where events.py BOUND the symbol, not where it is defined: events.py
+        # does `from kiro_crew.transcribe import transcribe_audio`, so it holds its own
+        # module global. Patching the definition left the REAL transcriber running --
+        # the assertion passed for the wrong reason and the test was the 3rd slowest in
+        # the suite. Matches the sibling test above.
         with patch(
-            "kiro_crew.transcribe.transcribe_audio", new_callable=AsyncMock, return_value=None
+            "kiro_crew.slack.events.transcribe_audio", new_callable=AsyncMock, return_value=None
         ):
             result = await _transcribe_files(mock_orch, files)
         assert result == []

--- a/test/test_worktree_create.py
+++ b/test/test_worktree_create.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import functools
 import os
 import pathlib
+import shutil
 import subprocess
 import tempfile
 from unittest.mock import MagicMock, patch
@@ -72,6 +73,19 @@ def _make_app(
     return app
 
 
+# conftest's autouse ``_git_identity`` closes the identity + host-``~/.gitconfig``
+# bleeds, but it is FUNCTION-scoped, so the session-scoped template builder below runs
+# before it. Pin the same env here so the template is hermetic at either scope.
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+}
+
+
 def _git(*args: str, cwd) -> None:
     subprocess.run(
         ["git", *args],
@@ -79,6 +93,7 @@ def _git(*args: str, cwd) -> None:
         check=True,
         capture_output=True,
         text=True,
+        env={**os.environ, **_GIT_ENV},
     )
 
 
@@ -124,23 +139,44 @@ def _passthrough_spawn(argv, mode="standard", **kw):
     return list(argv), {}, None
 
 
+@pytest.fixture(scope="session")
+def _repo_template(tmp_path_factory):
+    """Build the one-commit git repo once per session; `repo` copies it per test.
+
+    The five git subprocesses below cost ~1s of setup on each of the 81 tests here,
+    which made this the heaviest file on the slowest CI shard.
+
+    Session scope is safe because the template is never handed to a test, only copied
+    from, so a test that adds a worktree, branch or commit cannot reach another's.
+    """
+    template = tmp_path_factory.mktemp("worktree-seed") / "proj"
+    template.mkdir()
+    _git("init", "-q", "-b", "main", cwd=template)
+    _git("config", "user.email", "test@example.com", cwd=template)
+    _git("config", "user.name", "Test", cwd=template)
+    (template / "README.md").write_text("hi\n")
+    _git("add", "README.md", cwd=template)
+    _git("commit", "-q", "-m", "init", cwd=template)
+    return template
+
+
 @pytest.fixture
-def repo(tmp_path):
+def repo(tmp_path, request):
     """A minimal git repo with one commit on branch `main`.
 
     Requests :func:`sandbox_can_exec` so every git-touching test skips (rather
     than fails) on a host where isolation cannot be established — see that
     fixture for why the backend probe is not sufficient.
+
+    The template is resolved through ``request.getfixturevalue`` AFTER that skip
+    check, not as a parameter: pytest sets a declared fixture up before the body
+    runs, which would build the template on a host that then skips every test using
+    it -- turning a clean skip into five pointless git spawns (or a hard error where
+    git is unusable).
     """
     _require_sandbox_exec()
     root = tmp_path / "proj"
-    root.mkdir()
-    _git("init", "-q", "-b", "main", cwd=root)
-    _git("config", "user.email", "test@example.com", cwd=root)
-    _git("config", "user.name", "Test", cwd=root)
-    (root / "README.md").write_text("hi\n")
-    _git("add", "README.md", cwd=root)
-    _git("commit", "-q", "-m", "init", cwd=root)
+    shutil.copytree(request.getfixturevalue("_repo_template"), root)
     return root
 
 


### PR DESCRIPTION
## Problem

Six of the seven most frequent CI test failures were nondeterminism in the **tests**, not in the code under test. Mined from `gh run view --log-failed` across the last ~250 `ci.yml` runs (64 failures), ranked by how many distinct runs each appeared in:

| × | test | class |
|---|---|---|
| 7 + 4 | `test_pptx_maker_routes` raster redaction (2 tests) | nondeterministic input |
| 3 | `TestStackSampler.test_collects_samples_and_names_the_frame` | wall-clock race |
| 3 | `test_kill_untracks_pid_when_process_died` | wall-clock race |
| 3 | `test_restore_open_slots_async_yields_between_tabs` | leaked async task |
| n/a | `test_probe_server_config_fallback_on_error` | leaked coroutine |

Separately, the suite had grown to 281s wall over ~26.5k tests, with per-test setup, not any individual slow test, as the dominant cost.

## Why it matters

A flaky suite is worse than a slow one: it trains everyone to re-run red CI instead of reading it, so the next real regression gets re-run too. The pptx pair alone failed ~5% of runs, and Windows shards 3 and 4 failed far more often than any Linux shard, which is where the two heaviest files happened to land.

## Fix (symptom, root cause, change)

Each is fixed at its cause. **No reruns, no lengthened sleeps, no weakened assertions.** Every fix was mutation-tested by breaking the production code it covers and confirming the test still fails.

**1. Nondeterministic input.** Six `os.urandom` payloads were asserted *not* to match a credential pattern. But `_ENCODED_CREDENTIAL_RE` matches the bare prefixes `xox[abposr]` and `sk-ant`, which random base64 produces **1.07% of the time per 20 KB body** (measured 32/3000). The production comment claimed "measured at 0/300", which was underpowered: at p=1.07%, 0/300 has a 4% chance of occurring. Now seeded via one `_raster_body` helper, verified clean at every size and header used.

**2. Wall-clock races.** The sampler test burned a fixed 0.25s at a 2ms interval expecting ~125 samples. Windows rounds `Event.wait` up to ~15.6ms and CI observed **one** sample, of an unrelated frame. It now polls until the frame is seen. I reproduced the Windows condition by monkeypatching `Event.wait` to a 15.6ms floor: the poll converges on 4 samples where the old code needed 125. `test_acp_runtime_kill`'s 0.05s timeouts became `0`, since `asyncio.wait_for(coro, timeout=0)` raises unconditionally (verified, including for an already-ready coroutine), so the same branch is reached with no clock dependency.

**3. Leaked async objects.** An `AsyncMock` stood in for the **synchronous** `StreamWriter.write`, so every call returned a coroutine nobody awaits, surfacing later as `coroutine ... was never awaited` attributed to whichever test next triggered the GC. A `cancel()` without an `await` left a live task at loop teardown. Both fixed; the sibling test already had the correct form.

**Not a flake:** `test_no_new_error_response_without_a_code` (12 failures, the #2 entry by raw count) is a ratchet firing **correctly** on feature branches. It passes 5/5 on `main` and is untouched.

**One flake surfaced by the speedups themselves,** and fixed here: `test_a_hanging_beacon_does_not_delay_the_caller` spawned a daemon thread running the real `beacon.send` against a 30s hang and never released it. `send` resolves state through the module-global `config_dir`, which that file's `_isolated_home` repoints per test, so the thread went on to mint `beacon_install_id` inside a *later* test's home and failed `test_status_does_not_create_id` for something it did not do. Latent on `main`; a `uuid4` stack trace pinned the write to that thread. The hang is now releasable and joined.

### Speed

281s to **116s** wall on one host (26,521 tests), from:

- **`conftest.py`**: four autouse fixtures called `tmp_path_factory.mktemp` per test (its suffix scan grows with sibling count) and a fifth requested a `tmp_path` it never used. Measured against a probe file of 600 trivial `assert True` tests: **6.35s to 0.82s**, i.e. 9.2ms per test across the suite. This is where most of the win came from.
- **Real git repos** rebuilt per test in three files, now built once per session and `copytree`d. Safe because the template is never handed to a test, only copied from.
- **`test_computer_use_snapshot_macos`** 142.0s to 1.5s (serially, `-n0 --no-cov`): the fake trees are smaller than `ELECTRON_STUB_NODE_THRESHOLD`, so nearly every test paid the 2s Electron opt-in poll for a retry path it asserts the *behaviour* of, never the interval.
- **`test_transcribe`** patched `kiro_crew.transcribe.transcribe_audio` while `events.py` holds its own binding, so the **real** transcriber ran and the assertion passed for the wrong reason (6.1s to 0.3s).
- An unmemoized AST walk of ~630 source files called by both tests in its file (11.4s to 3.3s); a repo-wide `rglob` that walked `.venv` before filtering it (2.9s to 1.0s); a 15s timeout window asserted only *not to be refused* (now 1s); 505 real deck directories built to test a cap that breaks identically at 5.
- **A telemetry leak fixed as a side effect:** ~15 tests patch `KiroCrewConfig.load` with a bare `MagicMock`, whose `telemetry.enabled` is truthy, so a real recorder started and `Path(cfg.local_dir)` resolved the mock to the *relative* path `MagicMock/load().telemetry.local_dir/…`, writing metrics and a lock file into the repo root plus a background thread outliving the test. Pinned off via `KIROCREW_TELEMETRY=0`, which `_consent_enabled` reads before the config flag.

### A methodology correction worth calling out

I first derived shard balance by **summing** per-test `--store-durations` values and concluded a 3× imbalance. That was wrong, because those numbers carry xdist worker contention. **Running** the four shards the way CI does (`--splits 4 --group N`, `-n 4`) measures **54.8 / 59.9 / 81.1 / 62.4s**, a 1.5× spread. So committing `.test_durations` would buy seconds, not minutes; the lever is the outlier files. Both the wrong method and the right one are now documented so the next person does not repeat it.

## Tests

No new tests, because this **is** the test suite. What locks the work in:

- The full suite passes with **0 failures**. The baseline had 1: the pptx flake reproduced locally on the first run.
- The pptx pair passed **15/15** consecutive runs (previously ~5% failure per run); `open_slots` **40/40**.
- Every behavioural fix was **mutation-tested**: inverting `pid_exists` fails both kill tests; forcing `_should_retry_electron` to `False` fails a snapshot test; planting a `preexec_fn` call site fails the spawn guard; planting a legacy-home expansion fails the home scan; breaking the deck cap fails the cap test.
- CI: all four **Windows** shards green, including 3 and 4, the pair that dominated the original failure data.

## Manual verification

Backend gates on a CI-parity venv (no `faiss`, mypy pinned): `isort`, `flake8`, `mypy` (632 files), `scrub-lint` all pass. Frontend `tsc -b` passes.

`vitest` has 2 pre-existing failures in `src/i18n/format.test.ts` that are **not from this PR** (`website/` is untouched). Both are environmental: one is a local-timezone assumption the test file's own comment documents ("pass in UTC CI and fail on a developer" box), the other asserts `Intl.DurationFormat` is absent but local Node ships it. Confirmed by reproducing them on a clean, older `main` checkout.

One CI failure during the loop was `TestIsDeniedReDoSResistance.test_mid_dotstar_chain_spam_returns_fast` at 5.33s against its own 5.0s budget, a 7% overshoot on a loaded runner. That file is not in this diff, the test appears in the pre-branch failure mine, and it runs in 0.65s locally (an 8x margin). Re-ran the job; it passed.

## Screenshots

N/A, no user-visible UI change.

## Docs

`docs/system-specs/common/testing-conventions.md` gains the four flake classes with the one correct fix each, the profiling method (including the summing trap above), the three highest-leverage speedup patterns, and the mutation check. `AGENTS.md` and the worktree-dev skill point at it and carry the CI-mining recipe for finding what is *actually* flaky.

Two doc bugs fixed while there. The mutation-verify recipe used `&&` before `git checkout --`, so the restore ran only when the test *passed*, i.e. only in the case where you do not want it, leaving a mutation in the tree exactly when it correctly went red. And `git checkout --` was the wrong restore verb at all: it resets to HEAD and silently discards unrelated uncommitted work in that file. The recipe now backs the file up with `cp` and restores with `mv`.

