### PR TITLE
docs(rfc): add a status-audited index and front matter to every RFC

### DIFF
--- a/docs/request-for-change/README.md
+++ b/docs/request-for-change/README.md
@@ -1,0 +1,127 @@
+# Request for Change
+
+Design documents for changes that are large enough, risky enough, or contested
+enough to be worth writing down before building. An RFC here is a **proposal and
+a record of a decision** — not a description of what the code does today. For
+that, read the code, or the `status` field described below.
+
+## Index
+
+Last audited **2026-08-03** against main `0ab6ed48`. Every status below was
+verified against the code (definitions *and* callers) and against merged/open PR
+history, not taken from the document's own claims.
+
+| Document | Status | What is actually on main |
+|---|---|---|
+| [rfc-orchestrator-chat-sessions.md](rfc-orchestrator-chat-sessions.md) | `in-progress` | Nothing yet — all of it is in open PR [#1295](https://github.com/kirodotdev/KiroCrew/pull/1295) (`feat/crew-mode`) |
+| [rfc-channel-plugin-architecture.md](rfc-channel-plugin-architecture.md) | `partial` | Shared turn pipeline shipped; **4 of 7** channels adopted. Registry/seam collapse, telegram+discord, Feishu unstarted |
+| [rfc-local-notification-bus.md](rfc-local-notification-bus.md) | `partial` | Phases 1/3/4 complete. Phase 2 wired but has no producer; Phase 5 shipped 2 of 3 |
+| [rfc-federated-app-platform.md](rfc-federated-app-platform.md) | `partial` | Phase 1 substantially shipped, Phase 3 half-built. Phase 2, Phase 1's removals, Phase 4, Phase 5 unstarted |
+| [rfc-workspace-config-evolution.md](rfc-workspace-config-evolution.md) | `partial` | Phases 1–2 shipped. Phase 3's vector isolation was **reversed** on purpose; Phase 4 unstarted |
+| [rfc-resumable-subagent-sessions.md](rfc-resumable-subagent-sessions.md) | `partial` | Phase 0 ran and **redirected the design**: continuable conversations shipped instead of the record-store ladder |
+| [rfc-i18n-measurement.md](rfc-i18n-measurement.md) | `partial` | Overflow gate shipped, `localeCompare` migration partial. All three *measurement* proposals unstarted |
+| [rfc-appstore-official-registry.md](rfc-appstore-official-registry.md) | `accepted` | Nothing in this repo. Rollout R1 merged in the sibling `KiroCrewApps` repo |
+| [rfc-notification-bridge.md](rfc-notification-bridge.md) | `accepted` | Nothing — zero implementation code |
+| [rfc-tips-kit.md](rfc-tips-kit.md) | `draft` | Nothing. T1 was built and **retracted** ([#775](https://github.com/kirodotdev/KiroCrew/pull/775)); the design section needs revising first |
+| [rfc-update-architecture.md](rfc-update-architecture.md) | `draft` | Nothing — zero of three phases |
+| [version-compliance-framework.md](version-compliance-framework.md) | `draft` | Nothing. Framework doc, not an RFC; premise is pre-fork and stale |
+
+Nothing in this directory is `implemented` or `superseded` today.
+
+## Front matter
+
+Every document carries YAML front matter as the machine-readable record. The
+prose header below it stays human-readable and carries the *why*; front matter
+carries the *what*.
+
+```yaml
+---
+title: Channel Plugin Architecture — shared runtime, channels as app extension points
+status: partial            # see vocabulary below
+author: zezhexu
+created: 2026-07-28
+last-audited: 2026-08-03   # when status was last verified against code
+audited-at: 0ab6ed48       # the commit it was verified against
+doc-pr: 689                # the PR that merged this document
+implementation-prs: [777, 1019, 1234]
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
+```
+
+Optional keys: `kind: framework` for docs that are policy rather than a
+reviewable change to a named component, and `revision:` where a document is
+versioned across review rounds.
+
+`last-audited` and `audited-at` exist because a bare `status: partial` rots
+silently. If those two fields are far behind main, distrust the status.
+
+### Status vocabulary
+
+| Status | Meaning |
+|---|---|
+| `draft` | Proposed. Nothing built. |
+| `accepted` | Design agreed and locked. Nothing built yet. |
+| `in-progress` | Implementation is live in an open PR or an active branch. |
+| `partial` | Some phases are on main; the rest are open. The prose status line names which. |
+| `implemented` | Every phase is verifiably on main. |
+| `superseded` | Replaced. `superseded-by` names the replacement. |
+
+`partial` is the most common status and the most dangerous one to read
+carelessly — several documents here describe a plan that main only partly
+follows, and two describe a plan main **deliberately diverged from**.
+
+## Reading a `partial` or divergent RFC
+
+Three failure modes are live in this directory. Each document's prose status line
+calls out its own, but the patterns are worth knowing before you trust any of them:
+
+1. **The plan was overtaken.** `rfc-resumable-subagent-sessions.md` had its
+   Phase 0 probe return a negative verdict, which redirected the whole design —
+   what shipped (continuable conversations) is not what the phases below it
+   describe. `rfc-workspace-config-evolution.md` had its Phase 3 vector-store
+   isolation affirmatively reversed by a later commit. Neither document was
+   revised afterwards.
+2. **The credit is not the RFC's.** `rfc-i18n-measurement.md` shows `partial`,
+   but the proposals that shipped were already in flight under a separate
+   program, one of them merging 18 hours before the document did.
+3. **A dependency claim is overstated.** `rfc-notification-bridge.md` asserts the
+   bus RFC's phases "all shipped". The phases the bridge actually needs are real;
+   the blanket claim is not.
+
+When a document and the code disagree, the code wins and the document is a bug.
+Fix it in the same PR that discovers the drift.
+
+## Writing a new RFC
+
+- File as `rfc-<topic>.md`, kebab-case. Framework or policy docs that propose no
+  reviewable change to a named component drop the prefix and set `kind: framework`.
+- Open with front matter, then an H1 `# RFC: <Title>`, then the prose header.
+- Write in English.
+- Structure that has worked here: Summary → Motivation (current state, problems)
+  → Goals → Non-goals → Design → Migration plan (phased, each phase PR-sized with
+  **exit criteria**) → Backward compatibility → Security considerations →
+  Alternatives considered → Open questions.
+- Phases earn their keep by being independently shippable and independently
+  abandonable. State exit criteria as assertions someone can test, and mark any
+  phase whose entry depends on an unanswered open question as blocked on it.
+- **Verify before asserting.** Claims of the form "X does not exist" or "Y is
+  unused" are the ones that most often turn out wrong. Grep for callers, not just
+  definitions — a defined-but-uncalled symbol means the behavior does not happen,
+  which is a different (and usually more interesting) finding than absence.
+  Quote `file:line`. Name the commit you measured at, as
+  `rfc-i18n-measurement.md` does.
+- A probe phase that exists to answer a question must write its verdict down
+  somewhere durable and the RFC must be updated to point at it. PR #1023 recorded
+  its Phase 0 verdict in the PR description; the RFC still does not reference it,
+  which is why that document now needs a reader's warning.
+
+## Keeping this honest
+
+When you land an implementation PR for anything here, update the document's
+`status`, `implementation-prs`, `last-audited` and `audited-at` in the same PR,
+and re-audit the whole directory whenever the table above starts feeling
+plausible rather than checked. The audit is cheap: for each document, extract its
+named deliverables, grep for each one's definition and callers, and check the PR
+history for the phase that claims to have landed it.

--- a/docs/request-for-change/rfc-appstore-official-registry.md
+++ b/docs/request-for-change/rfc-appstore-official-registry.md
@@ -1,8 +1,21 @@
+---
+title: Official App Registry + Editorial Feed
+status: accepted
+author: KiroCrew contributors
+created: 2026-07-29
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: 807
+implementation-prs: []
+tracking-issues: [581]
+supersedes: []
+superseded-by: []
+---
 # RFC: Official App Registry + Editorial Feed
 
 **Author:** KiroCrew contributors
 **Date:** 2026-07-29
-**Status:** Draft
+**Status:** accepted — design decisions are locked and rollout step R1 has merged **in the sibling `kirodotdev/KiroCrewApps` repo** (PRs #1, #2). Zero client-side deliverables exist in KiroCrew: the `_registry` → `_tier` refactor (R2), the official fetch + signature gate + tombstones + tagged `source` union (R3), and editorial-driven Discover (R4) are all unstarted, and `pickFeatured()` / `categoryFor` / `detectInstalled` are each still the live path. Scoped strictly to this repo the status is `draft`.
 
 ---
 

--- a/docs/request-for-change/rfc-channel-plugin-architecture.md
+++ b/docs/request-for-change/rfc-channel-plugin-architecture.md
@@ -1,6 +1,19 @@
+---
+title: Channel Plugin Architecture — shared runtime, channels as app extension points
+status: partial
+author: zezhexu
+created: 2026-07-28
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: 689
+implementation-prs: [777, 1019, 1234]
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
 # RFC: Channel Plugin Architecture — shared runtime, channels as app extension points
 
-- Status: DRAFT
+- Status: partial — PRs ① and ② are shipped and load-bearing: the shared turn pipeline lives at `messaging/dispatch.py` and **4 of 7 channels** drive turns through it (weixin, wecom, webex, teams). PRs ③ (registry + `ChannelDescriptor`/`ChannelHooks`, the 9→1 seam collapse), ④ (telegram + discord adoption) and ⑤ (Feishu) are unstarted, and all nine hand-edited seams are still hand-edited. Slack is out of scope by §2 principle 4. The §9 amendment is only partly honored: rule 5 (address-agnostic pipeline) is pinned in code, but rule 1 (`session_key` as the control-plane address) and rule 4 (one builder/parser) are unstarted. Measured effect: dispatcher lines went 3,796 → 3,455, not the predicted ~1,300, because the reduction depended on PR ④ — discord actually grew ~355 lines.
 - Author: zezhexu
 - Created: 2026-07-28
 - Related: rfc-federated-app-platform.md (frontend loading + registry this RFC rides), PR #572 + PR #627 (the parallel channel landings that produced the 9-file conflict set cited below), `kiro_crew/apps/module_loader.py` (SEC-012 trust model this RFC adopts)

--- a/docs/request-for-change/rfc-federated-app-platform.md
+++ b/docs/request-for-change/rfc-federated-app-platform.md
@@ -1,8 +1,21 @@
+---
+title: Federated App Platform — Dynamic ESM Loading with Import Maps
+status: partial
+author: KiroCrew contributors
+created: 2026-04-18
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: null
+implementation-prs: [4, 284, 297]
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
 # RFC: Federated App Platform — Dynamic ESM Loading with Import Maps
 
 **Author:** KiroCrew contributors  
 **Date:** 2026-04-18  
-**Status:** Draft
+**Status:** partial — Phase 1 is substantially on main (import map, vendored ESM shims, `AppHost.tsx`, `@kirocrew/app-sdk`, static app-UI serving); Phase 3 is half-built (`app init --ui` shipped, `app dev` reinterpreted as a dev-mode toggle, no `kirocrewApp()` Vite plugin, no `app publish`). Unstarted: Phase 2 (Agent Worlds extraction — contradicted by the compiled-in builtin-apps pattern that shipped instead), Phase 1's entire removal table (app backends are alive and load-bearing), Phase 4's bundle+hash+CDN lane, Phase 5's CSP/monitoring. §3.3 and §3.7 are superseded by `rfc-appstore-official-registry.md`; this RFC's loading model is not.
 
 ---
 

--- a/docs/request-for-change/rfc-i18n-measurement.md
+++ b/docs/request-for-change/rfc-i18n-measurement.md
@@ -1,6 +1,20 @@
+---
+title: i18n — closing the measurement gap
+status: partial
+author: zezhexu
+created: 2026-08-01
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: 1075
+implementation-prs: [1009, 1047, 1107, 1123, 1321]
+tracking-issues: [1004]
+supersedes: []
+superseded-by: []
+---
 # RFC: i18n — closing the measurement gap
 
-- Status: DRAFT
+- Status: partial — 1 of 6 proposals shipped, 1 partial, 3 unstarted, 1 deliberately deferred. **Shipped:** #3, the pseudolocale overflow gate (`website/scripts/check-i18n-render.mjs` + `lib/render-scan.mjs`, real `scrollWidth − clientWidth` measurement against the IBM expansion curve, wired into CI at `ci.yml:775`, PR #1107). **Partial:** #4, the `localeCompare` migration — the ceiling went 97 → 62 → **37** and `compareText` now has real consumers, but `SessionGridView.tsx:214` still sorts a timestamp through `localeCompare`. **Unstarted:** #1 source-hash staleness, #2 GEMBA-MQM/MQM 2.0 scoring, #6 `saveMissing` + word-count coverage. **Deferred by decision, not neglect:** #5 lazy-loading, recorded as out-of-scope in issue #1004 pending a 25%-of-JS-gzip or >20-language trigger.
+- **Attribution caveat:** the two proposals that moved were already in flight under the pre-existing remediation program (issue #1004, which predates this RFC and already owned the pseudolocale assertions and locale-aware formatting). PR #1009 merged **18 hours before this document did**. The three genuinely novel *measurement* proposals — the ones the title is about — have zero code. Read "partial" accordingly.
 - Author: zezhexu
 - Created: 2026-08-01
 - Audited at: `f6ec5834`; every number re-verified against `5ec356d5` before publication

--- a/docs/request-for-change/rfc-local-notification-bus.md
+++ b/docs/request-for-change/rfc-local-notification-bus.md
@@ -1,6 +1,19 @@
+---
+title: Local Notification Bus
+status: partial
+author: KiroCrew contributors
+created: 2026-07-10
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: null
+implementation-prs: [185, 189, 273, 345, 399, 422]
+tracking-issues: [589]
+supersedes: []
+superseded-by: []
+---
 # RFC: Local Notification Bus
 
-- Status: DRAFT
+- Status: partial — Phases 1, 3 and 4 are fully on main (bus core + schema v2, per-channel settings + priority UX, inline actions + `group_key` stacking + dock badge). Phase 2's mechanism is complete and wired (`POST /api/notifications/push`, manifest `notifications.channels`, rate limiter) but has **no producer**: zero shipped `app.json` declares a channel, so its exit criterion is unproven end-to-end. Phase 5 shipped 2 of 3 (the `send_notification` MCP tool and the TTL sweeper); removing the kind-based routing fallbacks is unstarted — `NotificationDetailPanel.tsx` still branches on `n.kind`. Slack escalation was **withdrawn**, not shipped, and is superseded by `rfc-notification-bridge.md`.
 - Author: KiroCrew contributors
 - Created: 2026-07-10
 - Related: rfc-federated-app-platform.md (apps as notification producers), rfc-event-loop-fault-isolation.md (gateway process boundaries)

--- a/docs/request-for-change/rfc-notification-bridge.md
+++ b/docs/request-for-change/rfc-notification-bridge.md
@@ -1,6 +1,20 @@
+---
+title: Notification Bridge (bus egress fanout to chat transports)
+status: accepted
+author: zezhexu
+created: 2026-07-28
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: 670
+implementation-prs: []
+tracking-issues: [589]
+supersedes: ["rfc-local-notification-bus.md#resolved-design-questions-1"]
+superseded-by: []
+---
 # RFC: Notification Bridge (bus egress fanout to chat transports)
 
-- Status: DRAFT
+- Status: accepted — the document is merged (PR #670) with an open tracking issue, but **zero implementation code exists**. `notifications/bridge.py` and `BridgeDispatcher` do not exist; `ChannelSettings` carries only `muted` + `priority`, with no `deliver_to` / `deliver_min_priority`; egress is still the single hardcoded dashboard sink at `dashboard/state.py:1758`. No open PR and no live branch is building B1–B4.
+- Correction to the Summary below: it says the bus RFC's "Phases 1–5, all shipped". Phases 1/3/4 are complete, but Phase 2 has no producer app and Phase 5's kind-routing cleanup is still present in `NotificationDetailPanel.tsx`. Every dependency **this** RFC actually needs is real; the blanket claim is not.
 - Author: zezhexu
 - Created: 2026-07-28
 - Related: rfc-local-notification-bus.md (the bus this RFC extends), issue #589 (tracking), PR #422 (Phase 5 delivery + the withdrawn escalation prototype)

--- a/docs/request-for-change/rfc-orchestrator-chat-sessions.md
+++ b/docs/request-for-change/rfc-orchestrator-chat-sessions.md
@@ -1,6 +1,27 @@
+---
+title: Orchestrator Chat Sessions — an engineered pipeline with a decision-only agent
+status: in-progress
+revision: v5
+author: kirocrew agent session, directed by zezhexu
+created: 2026-08-03
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: 1280
+implementation-prs: [1295]
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
 # RFC: Orchestrator Chat Sessions — an engineered pipeline with a decision-only agent
 
-Status: v5 — post-second-council revision; proposed as design of record
+Status: in-progress — v5, post-second-council revision; accepted as design of record (PR #1280).
+Implementation lives entirely in **open PR #1295** (`feat/crew-mode`): `src/kiro_crew/crew_chat.py`
+does not exist on main, nor does `OrchestratorManager`, the `queue.json`/`topics.json` store, the
+`<<<SUMMARY` contract, `SubagentInfo.summary`, or any Crew Mode i18n key. Phase 0's routing-quality
+probe is zero-core by design and left no repo artifact, so it cannot be confirmed either way.
+Disambiguation: main's existing `orchestrator` symbols (`channel.py:121 is_orchestrator`,
+`config/prompt-orchestrator.md`) are a **pre-existing channel-level feature** that predates this RFC,
+and "Crews" (agent templates, #1331/#1335) is not "Crew Mode". Neither counts as implementation.
 Councils: round 1 (v1 draft, 4-member cross-vendor, REVISE — every structural
 BLOCKER traced to simulating engineering in a prompt) → v4 architecture rewrite
 (heavy engineering, light agent) → round 2 (v4, same roster, unanimous REVISE:

--- a/docs/request-for-change/rfc-resumable-subagent-sessions.md
+++ b/docs/request-for-change/rfc-resumable-subagent-sessions.md
@@ -1,6 +1,19 @@
+---
+title: Resumable Subagent Sessions
+status: partial
+author: zezhexu
+created: 2026-07-28
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: 806
+implementation-prs: [1023, 1246]
+tracking-issues: [1113, 1114, 1115]
+supersedes: []
+superseded-by: []
+---
 # RFC: Resumable Subagent Sessions
 
-- Status: DRAFT
+- Status: partial, and **what shipped diverges from this plan** — Phase 0 ran and its verdict is recorded in PR #1023's description (a shared-arm sid is *not* loadable after `session/terminate`). That negative verdict redirected the work: instead of the record store → record view → promotion ladder below, PRs #1023 and #1246 shipped **continuable conversations** — `spawn_continue` / `spawn_steer` / `spawn_release` MCP tools, `keep_transcript` on the session handle, and a conversation TTL registry that survives gateway restart. Still unbuilt: Phase 1's record store (no `SubagentRecord`, no records file), Phase 2's `subagent_record_retention_enabled` / `_days` config keys (retention is conversation-TTL based instead), Phase 3's record view (`GET /api/spawn/{id}/record` does not exist), and Phase 4's guaranteed deliverable — promoting a run into an **ordinary chat session labelled a replay**. Note "promotion" in the shipped code means promoting a *conversation's retention*, not seeding a dashboard chat session. This document was never revised after Phase 0; read it as the original plan, not as a description of main.
 - Author: zezhexu
 - Created: 2026-07-28
 - Related: `subagents.md` (current user-facing contract), rfc-local-notification-bus.md (subagent completions as notification producers), #658 / #751 / #752 (subagent surfacing in chat, sidebar, nav rail)

--- a/docs/request-for-change/rfc-tips-kit.md
+++ b/docs/request-for-change/rfc-tips-kit.md
@@ -1,6 +1,21 @@
+---
+title: Tips Kit (activity-aware, self-learning recommendations)
+status: draft
+author: zezhexu
+created: 2026-07-29
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: 720
+implementation-prs: []
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
 # RFC: Tips Kit (activity-aware, self-learning recommendations)
 
-- Status: DRAFT
+- Status: draft — **nothing from this RFC is on main.** T1 was fully implemented in PR #775 and then **retracted 42 minutes later despite green CI**, because its `_FEATURE_RULES` regex table made feature matching a hardcoded rulebook instead of LLM-driven, and because `tips_appearance_decay` keyed off id-keyed state that resets every 6h regeneration. The work survives on branch `feat/tips-kit-t1` @ `a9c84a5c`; no successor PR is open. T2 and T3 are unstarted. `tips_analyzer.py`, `CandidateRec`, `cron_create`, `setting_toggle` and `TipsState.weights` have zero hits repo-wide; `_TIP_ACTION_KINDS` is still `("route",)`.
+- **Unresolved tension:** the Design section below prescribes *deterministic detectors* with the LLM only phrasing and ranking, and Alternative 2 explicitly rejects LLM-led analysis. That is the shape #775 was retracted for. A faithful T1 implementation of this text would reproduce the rejected design — the doc needs revising before T1 is re-attempted.
+- **Baseline correction:** the claim that the engine "never analyzes the daily history" is imprecise — `tips.py:504` already reads `memory/history/*.md` and feeds it to the LLM. What is missing is deterministic pattern detection over a wider window. Also unmentioned: `_TIP_ALLOWED_FIELDS` (`tips.py:515`) excludes `action`, so LLM-authored executable targets require widening that projection first.
 - Author: zezhexu
 - Created: 2026-07-29
 - Related: `src/kiro_crew/tips.py` (the feature-tips engine this RFC extends), rfc-federated-app-platform.md (App Store install path), rfc-local-notification-bus.md + rfc-notification-bridge.md (delivery seam), `cron.py` (scheduling target)

--- a/docs/request-for-change/rfc-update-architecture.md
+++ b/docs/request-for-change/rfc-update-architecture.md
@@ -1,6 +1,20 @@
+---
+title: Update Architecture (install-shape capability contract)
+status: draft
+author: zezhexu
+created: 2026-07-31
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: 1003
+implementation-prs: []
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
 # RFC: Update Architecture (install-shape capability contract)
 
-- Status: DRAFT
+- Status: draft — the document is merged (PR #1003) but **zero of its three phases has any implementation on main.** `platform/update_capability.py` does not exist; `KIROCREW_DISTRIBUTION` is still telemetry-only with one caller (`beacon.py:438`); the three divergent `.git` derivations are intact; boot-time git auto-apply is still armed (`slack/gateway.py:5145`); all three SPA surfaces remain install-shape-coupled; no wheel/pipx self-replacement path exists; no on-disk update lease. Adjacent in-flight under a **different** design: PR #999 (`feat/emergency-release-controls`, open) adds a feed-served minimum version + mandatory-update modal for the desktop lane only, without the capability contract.
+- Correction to the reference below: KiroCrew ships **five** distribution shapes, not the set implied — `beacon.py:155` lists `{dmg, appimage, wheel, source, docker}`.
 - Author: zezhexu
 - Created: 2026-07-31
 - Related: `docs/release-process-design.md` (channels, release branches, promotion), `docs/request-for-change/version-compliance-framework.md` (the policy ceiling this RFC must honor)

--- a/docs/request-for-change/rfc-workspace-config-evolution.md
+++ b/docs/request-for-change/rfc-workspace-config-evolution.md
@@ -1,8 +1,22 @@
+---
+title: Config System, Named Memory Stores & Plugin Architecture
+status: partial
+author: KiroCrew contributors
+created: 2026-03-25
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: null
+implementation-prs: []
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
 # RFC: Config System, Named Memory Stores & Plugin Architecture
 
 **Author:** KiroCrew contributors  
 **Date:** 2026-03-25 (rev 2: 2026-03-25)  
-**Status:** Draft  
+**Status:** partial — Phases 1 and 2 are verifiably on main (schema registry + `/api/config/schema`; `WorkspaceConfig`, `MemoryStoreConfig`, `resolve_agent_bindings` with seven real callers, auto-migration). Phase 3 is half-built: the markdown/lesson layer is store-scoped, but **per-store `memory.db`/`memory.faiss` isolation was affirmatively reversed** by commit `7d1ff74e`, which shares one `VectorMemoryStore` across all stores — this doc's Phase 3 text is stale on that point. Phase 4 (`MemoryBackend` / `EmbeddingBackend` plugin entry points) is unstarted. Two deviations: the merge shipped as `resolve_memory_store_config`, not `resolve_effective_config`, and per-workspace `agent` overrides were never built.
+**Branches:** both named below are **gone** — neither `feat/workspace-scoped-vector-memory` nor `config-standarize-` exists on the remote; Phases 1–2 landed via the pre-fork import commit `64e47961`.
 **Branch (parked):** `feat/workspace-scoped-vector-memory`  
 **Branch (active):** `config-standarize-`
 

--- a/docs/request-for-change/version-compliance-framework.md
+++ b/docs/request-for-change/version-compliance-framework.md
@@ -1,7 +1,23 @@
+---
+title: Version Compliance Framework for KiroCrew
+kind: framework
+status: draft
+author: KiroCrew contributors
+created: 2026-05-26
+last-audited: 2026-08-03
+audited-at: 0ab6ed48
+doc-pr: null
+implementation-prs: []
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
 # Version Compliance Framework for KiroCrew
 
 **Author:** KiroCrew contributors
-**Status:** Draft
+**Status:** draft — **nothing is built at the platform level.** No version authority document, no compliance heartbeat, no startup gate, no `kirocrew admin` command, no `block` mode, no deny-pattern propagation mechanism. `version_authority`, `version_compliance`, `set-min-version`, `recommended_version` all have zero hits repo-wide. The nearest live behavior is a *different* architecture: `update_governance.update_required()` enforces a min-version floor from the **local** trust-root `security_policy.json` and explicitly "never refuses to boot" — the opposite of Layer 2's `block`. `is_toolbox_install()` (`env.py:68`), cited below as existing infrastructure, now has **zero callers**.
+**Framing:** this is a framework/policy recommendation doc, not an RFC — note it has no `RFC:` title prefix and no `rfc-` filename prefix, unlike its ten siblings.
+**Two staleness warnings:** (1) It **predates the public repo** — it arrived at `64e47961`, so the 2026-05-26 date is pre-fork and the anonymized phrasing ("the managed distribution tool") is a scrub artifact. (2) Its §2 premise is stale: KiroCrew now ships five shapes over three channels with two independent feeds, not one managed tool with a 180-day pause window. `rfc-update-architecture.md` nonetheless cites this doc as "the policy ceiling this RFC must honor". Partially overtaken by PR #999 + the release-feed controls, which cover a subset of Layer 2 for 2 of 5 shapes.
 **Date:** 2026-05-26
 
 ---


### PR DESCRIPTION
## Problem

All twelve documents under `docs/request-for-change/` said `Draft`. Several were substantially or wholly shipped. A reader could not tell a designed-but-unbuilt RFC from a largely-landed one, and there was no index.

## What this does

Adds YAML front matter to every document as the machine-readable record, rewrites each prose status line to name what is actually on main, and adds a `README.md` with the index, status vocabulary, front-matter schema, and authoring guidance.

```yaml
---
title: Channel Plugin Architecture — shared runtime, channels as app extension points
status: partial
author: zezhexu
created: 2026-07-28
last-audited: 2026-08-03   # when status was last verified
audited-at: 0ab6ed48       # the commit it was verified against
doc-pr: 689
implementation-prs: [777, 1019, 1234]
tracking-issues: []
supersedes: []
superseded-by: []
---
```

`last-audited` / `audited-at` exist because a bare `status: partial` rots silently. Vocabulary: `draft` · `accepted` · `in-progress` · `partial` · `implemented` · `superseded`.

## Audit result

Verified against main `0ab6ed48` by grepping each named deliverable's definition **and its callers**, plus merged and open PR history — not taken from the documents' own claims.

| Document | Status | On main |
|---|---|---|
| rfc-orchestrator-chat-sessions | `in-progress` | Nothing — all in open #1295 |
| rfc-channel-plugin-architecture | `partial` | Shared pipeline shipped, 4 of 7 channels; PRs ③④⑤ unstarted |
| rfc-local-notification-bus | `partial` | Phases 1/3/4 complete; P2 has no producer, P5 is 2 of 3 |
| rfc-federated-app-platform | `partial` | P1 substantially, P3 half; P2/P4/P5 + P1's removals unstarted |
| rfc-workspace-config-evolution | `partial` | P1–2 shipped; P3 reversed on purpose; P4 unstarted |
| rfc-resumable-subagent-sessions | `partial` | Phase 0 redirected the design |
| rfc-i18n-measurement | `partial` | Overflow gate shipped; all 3 measurement proposals unstarted |
| rfc-appstore-official-registry | `accepted` | Nothing here; R1 merged in `KiroCrewApps` |
| rfc-notification-bridge | `accepted` | Nothing |
| rfc-tips-kit | `draft` | Nothing; T1 built then retracted (#775) |
| rfc-update-architecture | `draft` | Nothing — zero of three phases |
| version-compliance-framework | `draft` | Nothing; framework doc, stale premise |

1 in-progress · 6 partial · 2 accepted · 3 draft · **0 implemented**.

## Drift the audit surfaced

Each item is now recorded in the affected document, so a reader is warned before trusting it:

- **resumable-subagent-sessions** — Phase 0's probe returned a *negative* verdict (a shared-arm sid is not loadable after `session/terminate`), which redirected the whole design. What shipped (continuable conversations, #1023/#1246) is not the record-store → record-view → promotion ladder the phases describe. The verdict is recorded in #1023's description; the RFC never referenced it.
- **workspace-config-evolution** — Phase 3's per-store `memory.db`/`memory.faiss` isolation was affirmatively reversed by `7d1ff74e` (one shared `VectorMemoryStore`). The doc still specifies isolation. Also: both branches it names are gone from the remote.
- **i18n-measurement** — shows `partial`, but the two proposals that moved were already in flight under the separate program tracked by #1004; #1009 merged **18 hours before this document did**. The three genuinely novel measurement proposals have zero code.
- **notification-bridge** — its claim that the bus RFC's "Phases 1–5, all shipped" is overstated: Phase 2 has no producer app and Phase 5's kind-routing cleanup is still present in `NotificationDetailPanel.tsx`. Every dependency the bridge actually needs is real; the blanket claim is not.
- **tips-kit** — T1 was built and retracted 42 minutes later (#775) for making feature matching a hardcoded rulebook. The Design section below it *prescribes* that shape and explicitly rejects LLM-led analysis, so a faithful T1 implementation would reproduce the rejected design. Flagged as needing revision first.
- **version-compliance-framework** — pre-fork (arrived at `64e47961`), and its single-managed-tool premise is stale against today's five distribution shapes. Marked `kind: framework` since it proposes no reviewable change to a named component. `is_toolbox_install()`, cited as existing infrastructure, now has zero callers.
- **update-architecture** — corrected to five distribution shapes (`beacon.py:155`).
- **appstore-official-registry** — R1 merged in the sibling `KiroCrewApps` repo (PRs #1, #2); zero client-side deliverables here. Also noted: issue **#581** was closed-as-completed one second after the docs-only RFC PR merged, with the hardcoded taxonomy it describes still in the code.

## Testing

- Front matter parses on all 12 with the full required key set present, a valid `status`, and the H1 immediately following.
- `scripts/scrub-lint.sh` content scan: zero hits under `docs/request-for-change`. Its one `FAIL` is the pre-existing commit-history condition (1,146 commits) that reproduces on clean main.
- Inclusive-language check over added lines: clean.

Docs-only; no code paths touched.

## Follow-ups not in this PR

Two findings worth acting on independently: the `detectInstalled` shell exec on the App Store **browse** path (`src/kiro_crew/apps/registry.py:1379`), reachable from less-trusted external registries and classified as a defect by the registry RFC's own §3.7; and the stale closure of #581.
