### PR TITLE
chore(cli): hide TUI command surface to avoid Kiro-CLI overlap

### DIFF
--- a/skills/kirocrew-commands/SKILL.md
+++ b/skills/kirocrew-commands/SKILL.md
@@ -96,12 +96,6 @@ See `src/kiro_crew/pod/README.md` for the full reference.
 | `kirocrew chat` | Interactive chat (REPL mode) |
 | `kirocrew chat -m "message"` | Single message (non-interactive) |
 | `kirocrew chat --model claude-opus` | Use specific model |
-| `kirocrew chat --tui` | Launch TUI instead of REPL |
-| `kirocrew tui` | Launch Terminal UI |
-| `kirocrew tui --yolo` | TUI with auto-approve all tools |
-| `kirocrew tui --session SESSION_KEY` | Resume a specific session |
-| `kirocrew tui --workspace NAME` | Start with a specific workspace |
-| `kirocrew tui --agent NAME` | Start with a specific agent |
 
 ## Browsing (Playwright MCP)
 

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -82,14 +82,14 @@ _PROJECT_MARKERS = ("skills", "src/kiro_crew")
 # builds an LLM provider factory (``build_provider_factory`` /
 # ``SessionManager``) and runs in-process agent/LLM work belongs here — so a
 # companion's ``jail=on`` isolation guarantee covers all of them, not just the
-# interactive ones.  Today that is ``chat``/``tui``/``run`` plus ``consolidate``
+# interactive ones.  Today that is ``chat``/``run`` plus ``consolidate``
 # (history consolidation LLM inference) and ``eval`` (eval turns + judge).
 # ``gateway`` is deliberately EXCLUDED despite being agent-bearing: it is the
 # long-lived service whose own execv-based self-update / restart path must not be
 # nested inside a jail re-exec (that would exhaust user namespaces); it composes
 # isolation by other means.  The public edition's JailProvider has no backend, so
 # this set only matters once a companion supplies a real one.
-_JAILED_COMMANDS = frozenset({"chat", "tui", "run", "consolidate", "eval"})
+_JAILED_COMMANDS = frozenset({"chat", "run", "consolidate", "eval"})
 
 # Env marker the gate sets BEFORE a successful re-exec into the jail.  The jailed
 # CHILD re-runs ``main`` (and so the gate) for the same command; without this
@@ -747,7 +747,7 @@ def main() -> None:
     )
     # ``--no-jail`` is shared between the top-level parser and the jailed
     # subparsers (every command in ``_JAILED_COMMANDS`` —
-    # chat/tui/run/consolidate/eval — gets ``parents=[_jail_opts]``) via a parent
+    # chat/run/consolidate/eval — gets ``parents=[_jail_opts]``) via a parent
     # parser, so BOTH ``kirocrew --no-jail <cmd>`` and ``kirocrew <cmd> --no-jail``
     # are accepted (argparse only matches a flag on the parser that declares it).
     # The PARENT copy uses ``default=argparse.SUPPRESS`` so that when the flag is
@@ -789,18 +789,6 @@ Examples:
     chat_parser.add_argument("-m", "--message", help="Single message (non-interactive)")
     chat_parser.add_argument("--model", help="Model to use (default: from config)")
     chat_parser.add_argument("--agent", help="Agent to use (default: from config)")
-    chat_parser.add_argument("--tui", action="store_true", help="Launch TUI instead of REPL")
-
-    # tui
-    tui_parser = sub.add_parser("tui", help="Launch Terminal UI", parents=[_jail_opts])
-    tui_parser.add_argument("--yolo", action="store_true", help="Auto-approve all tools")
-    tui_parser.add_argument("--port", type=int, help="Gateway port (default: from config)")
-    tui_parser.add_argument("--session", help="Resume a specific session")
-    tui_parser.add_argument(
-        "--workspace", help="Workspace name (auto-detected from CWD if omitted)"
-    )
-    tui_parser.add_argument("--agent", help="Start with a specific agent")
-    tui_parser.add_argument("--home", help="KIROCREW_HOME override (e.g. ~/.kirocrew-dev)")
 
     # doctor
     sub.add_parser("doctor", help="Verify Kiro Crew setup")
@@ -1919,17 +1907,7 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         _jail_reexec_gate(args.command, getattr(args, "no_jail", False))
 
     if args.command == "chat":
-        if getattr(args, "tui", False):
-            _tui(args)
-        else:
-            cfg = KiroCrewConfig.load()
-            if cfg.to_dict().get("dashboard", {}).get("default_mode") == "tui":
-                _tui(args)
-            else:
-                print("Tip: Try `kirocrew tui` for the new terminal UI experience")
-                asyncio.run(_chat(args.message, args.model, agent=getattr(args, "agent", None)))
-    elif args.command == "tui":
-        _tui(args)
+        asyncio.run(_chat(args.message, args.model, agent=getattr(args, "agent", None)))
     elif args.command == "gateway":
         # Seam-supplied pre-launch checks (CPP IdentityProvider seam). Runs
         # HERE in the gateway dispatch — not in boot_platform (which runs for
@@ -2092,7 +2070,7 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
 # ── Config ──
 
 
-from kiro_crew.cli_chat import _chat, _tui  # noqa: E402
+from kiro_crew.cli_chat import _chat  # noqa: E402
 from kiro_crew.cli_cloud import add_size_choices as _cloud_size_choices  # noqa: E402
 from kiro_crew.cli_cloud import handle_cloud  # noqa: E402
 from kiro_crew.cli_commands import (  # noqa: E402

--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -16,7 +16,6 @@ from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     ConfigReadError,
     build_provider_factory,
-    config_dir,
     config_path,
     read_config_for_update,
     write_config_atomically,
@@ -114,11 +113,6 @@ async def _chat(message: str | None, model: str | None, agent: str | None = None
     await provider.start()
 
     if message:
-        # Short one-time notice for single-message mode
-        notice_file = Path(config_dir()) / ".tui_notice_shown"
-        if not notice_file.exists():
-            print("💡 Try `kirocrew tui` for a richer experience.", file=sys.stderr)
-            notice_file.touch()
         await _send_and_print(provider, message)
     else:
         await _interactive(provider, cfg)
@@ -153,14 +147,6 @@ async def _interactive(provider: LLMProvider, cfg: KiroCrewConfig) -> None:
     print(BANNER)
     print(DATA_WARNING)
     print()
-
-    # One-time TUI migration notice
-    notice_file = Path(config_dir()) / ".tui_notice_shown"
-    if not notice_file.exists():
-        print("💡 Try `kirocrew tui` for a full-featured terminal UI with")
-        print("   syntax highlighting, tool approval, sessions, and more.")
-        print("   `kirocrew chat` will be merged into `kirocrew tui` in a future version.\n")
-        notice_file.touch()
 
     print("Type your message (Ctrl+D or 'exit' to quit)\n")
 

--- a/test/test_cpp_seam_failclosed.py
+++ b/test/test_cpp_seam_failclosed.py
@@ -409,8 +409,9 @@ def test_normalize_jail_unit() -> None:
 
 def test_jailed_commands_cover_agent_bearing_set() -> None:
     """consolidate + eval (both build a provider factory) are jailed too."""
-    assert {"chat", "tui", "run", "consolidate", "eval"} <= cli._JAILED_COMMANDS
+    assert {"chat", "run", "consolidate", "eval"} <= cli._JAILED_COMMANDS
     assert "gateway" not in cli._JAILED_COMMANDS  # excluded (execv self-update)
+    assert "tui" not in cli._JAILED_COMMANDS  # removed: TUI command surface hidden
 
 
 # ── R5: _child_argv reuses _resolve_kirocrew_bin incl. the sentinel branch ──


### PR DESCRIPTION
## Problem

KiroCrew ships a terminal UI (the Ink-based `kirocrew tui` / `kirocrew chat --tui`) whose look and interaction model overlap heavily with the Kiro-CLI product. The two are close enough to be confusing, and the CLI's remaining, load-bearing surfaces (`gateway`, `doctor`, `setup`, `chat`, cron, etc.) are what we actually need to keep.

## Why it matters

Two near-identical terminal chat experiences under one CLI muddies the product story and invites bug reports/support against a surface we don't want to promote. We want the TUI gone from the user-facing command set, but without the churn/risk of ripping out the implementation, its packaging, or the tests that assert on it.

## Fix (symptoms → root cause → change)

- **Symptom:** `kirocrew tui` and `kirocrew chat --tui` launch a terminal UI that duplicates Kiro-CLI.
- **Root cause:** the TUI is wired in purely as CLI surface — a `tui` subparser, a `--tui` flag on `chat`, a `default_mode == "tui"` dispatch branch, and "try the TUI" nudges — all pointing at the same `_tui()` launcher.
- **Change (deliberately the low-risk route — hide the surface, keep the code):**
  - `src/kiro_crew/cli.py`: remove the `tui` subcommand, the `chat --tui` flag, the `default_mode == "tui"` branch, the `elif args.command == "tui"` dispatch, and the "Tip: Try `kirocrew tui`" print. Drop `"tui"` from `_JAILED_COMMANDS` (there's no longer a `tui` command to jail; `chat`/`run`/`consolidate`/`eval` stay jailed, so no remaining command's isolation changes). Drop the now-unused `_tui` import. Two comments updated to drop the stale `tui` mention.
  - `src/kiro_crew/cli_chat.py`: remove both "💡 Try `kirocrew tui`" nudges (single-message + REPL) and the now-unused `config_dir` import.
  - `skills/kirocrew-commands/SKILL.md`: remove the 6 documented TUI command rows.
  - **Intentionally NOT touched:** the `_tui()` function, the `tui/` source tree, and the `tui_dist` bundle/packaging — so tests (`test_pod_self_contained.py`, `test_spawn_audit.py`) that assert on `cli_chat._tui` and packaging both keep working. The dashboard Settings "Chat / CLI" toggle (`useUIMode`) is a separate rendering style, unrelated to the terminal TUI, and is untouched.

## Tests

Updated one existing test to track the change: `test/test_cpp_seam_failclosed.py::test_jailed_commands_cover_agent_bearing_set` no longer expects `tui` in `_JAILED_COMMANDS` (the `tui` command is gone) and now asserts it is absent. The rest of existing coverage was run to confirm nothing regressed: `test_cli.py`, `test_pod_self_contained.py` (reads `cli_chat._tui` source), and `test_spawn_audit.py` (references `cli_chat.py::_tui`) — all green. The retained `_tui()` keeps those assertions valid.

## Manual verification

- `kirocrew --help` no longer lists `tui`.
- `main()` with `argv=["tui"]` → exit 2, `argument command: invalid choice: 'tui'`.
- `main()` with `argv=["chat","--tui"]` → exit 2, `unrecognized arguments: --tui`.
- Lint/type gates clean on both changed Python files: `isort --check`, `flake8`, `mypy` all exit 0.

## Screenshots

N/A — no user-visible UI (dashboard) change; this only affects CLI command registration and terminal text output.
