### PR TITLE
fix(theme): stop Auto dark/light freezing in the desktop app

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -51,6 +51,7 @@ const {
   createPermissionCheckHandler,
 } = require("./permission-handler");
 const { createWindowOpenHandler } = require("./external-scheme");
+const { resolveThemeSource } = require("./native-theme");
 const { initAutoUpdate } = require("./auto-update");
 const {
   classifyBundleLocation,
@@ -768,12 +769,38 @@ async function getModalCSS() {
 
 // ── Window ──
 
+// Mirror the dashboard's dark/light MODE PREFERENCE onto Chromium's native
+// theme, so native chrome (tab bar, context menus, DevTools, macOS window
+// frame) matches the dashboard.
+//
+// Reads `data-mode-pref` (the preference), NOT `data-mode` (the resolved
+// mode). `themeSource = 'dark' | 'light'` does not only restyle native chrome:
+// it also OVERRIDES `prefers-color-scheme` in every renderer, which is the
+// media query the dashboard's Auto mode resolves through. Feeding the resolved
+// mode back in therefore pinned that query to whatever Auto happened to
+// resolve at first load, and OS appearance changes stopped propagating — Auto
+// froze. Electron's own docs prescribe exactly this mapping:
+//   Follow OS -> 'system', Dark -> 'dark', Light -> 'light'.
+//
+// `data-mode-pref` is absent on a dashboard build older than the field, so an
+// unrecognised value falls back to the resolved mode: the pre-fix behaviour for
+// explicit dark/light (correct), and no worse than before for Auto.
 function syncNativeTheme(view, win) {
   if (win.isDestroyed()) return;
   view.webContents.executeJavaScript(
-    `document.documentElement.dataset.mode || ""`
-  ).then(mode => {
-    if (mode === "dark" || mode === "light") nativeTheme.themeSource = mode;
+    `JSON.stringify({` +
+      `pref: document.documentElement.dataset.modePref || "",` +
+      `mode: document.documentElement.dataset.mode || ""` +
+    `})`
+  ).then(raw => {
+    let pref = "";
+    let mode = "";
+    try {
+      const parsed = JSON.parse(raw);
+      pref = parsed.pref || "";
+      mode = parsed.mode || "";
+    } catch { return; }
+    nativeTheme.themeSource = resolveThemeSource(pref, mode);
   }).catch(() => {});
 }
 
@@ -1966,6 +1993,17 @@ app.whenReady().then(async () => {
   ipcMain.on("theme-accent-changed", (_event, hex) => {
     if (typeof hex === "string" && /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(hex)) {
       store.set("themeAccent", hex);
+    }
+  });
+
+  // The renderer reports its dark/light mode PREFERENCE whenever it changes (see
+  // useTheme.tsx). Pushed rather than only pulled on window focus so that
+  // switching back to Auto un-pins `prefers-color-scheme` right away — while it
+  // stays pinned, Auto cannot see the OS appearance at all. Unrecognised values
+  // are ignored; the focus/load pull remains the fallback.
+  ipcMain.on("theme-mode-changed", (_event, pref) => {
+    if (pref === "system" || pref === "dark" || pref === "light") {
+      nativeTheme.themeSource = resolveThemeSource(pref, "");
     }
   });
 

--- a/website/electron/native-theme.js
+++ b/website/electron/native-theme.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/**
+ * Map the dashboard's dark/light MODE PREFERENCE onto `nativeTheme.themeSource`.
+ *
+ * `themeSource` is not just a native-chrome switch: setting it to `dark` or
+ * `light` also overrides `prefers-color-scheme` in every renderer. That is the
+ * media query the dashboard's Auto mode resolves through, so feeding the
+ * *resolved* mode back in pins the query to whatever Auto resolved to at first
+ * load and OS appearance changes stop propagating — Auto freezes. Electron's
+ * docs prescribe the mapping this function implements:
+ *
+ *   Follow OS -> "system" · Dark -> "dark" · Light -> "light"
+ *
+ * @param {unknown} pref  `data-mode-pref`: "system" | "dark" | "light", or ""
+ *   on a dashboard build predating that attribute.
+ * @param {unknown} resolvedMode  `data-mode`: "dark" | "light". Used only as the
+ *   fallback when `pref` is missing/unrecognised, which keeps an older bundle at
+ *   its previous behaviour instead of forcing it to "system".
+ * @returns {"system" | "dark" | "light"}
+ */
+function resolveThemeSource(pref, resolvedMode) {
+  if (pref === "system" || pref === "dark" || pref === "light") return pref;
+  if (resolvedMode === "dark" || resolvedMode === "light") return resolvedMode;
+  return "system";
+}
+
+module.exports = { resolveThemeSource };

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -60,6 +60,7 @@
       "main.js",
       "app-menu.js",
       "badge.js",
+      "native-theme.js",
       "zoom.js",
       "instance-guard.js",
       "context-menu.js",

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -23,6 +23,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // boot splash (loading.html) can paint in the user's chosen colour. Read back
   // by main.js and injected as a query param — see showLoadingThenConnect.
   setThemeAccent: (hex) => ipcRenderer.send("theme-accent-changed", String(hex || "")),
+  // Report the user's dark/light mode PREFERENCE ("system" | "dark" | "light")
+  // so main.js can set `nativeTheme.themeSource` to match. Must be the
+  // preference, not the resolved mode: pinning themeSource to dark/light also
+  // pins `prefers-color-scheme`, which is what Auto resolves through.
+  setThemeMode: (pref) => ipcRenderer.send("theme-mode-changed", String(pref || "")),
   // Dev mode IPC: renderer signals main process to show/hide DevTools menu item.
   setDevMode: (enabled) => ipcRenderer.send("dev-mode-changed", !!enabled),
   // App-menu navigation: main.js sends an in-app path ("/settings",

--- a/website/electron/test/native-theme.test.js
+++ b/website/electron/test/native-theme.test.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { resolveThemeSource } = require("../native-theme");
+
+test("Auto maps to 'system' regardless of what it resolved to", () => {
+  // The regression this guards: returning the RESOLVED mode here pins
+  // prefers-color-scheme and freezes Auto at its first-load value.
+  assert.equal(resolveThemeSource("system", "dark"), "system");
+  assert.equal(resolveThemeSource("system", "light"), "system");
+});
+
+test("explicit preferences are forwarded verbatim", () => {
+  assert.equal(resolveThemeSource("dark", "dark"), "dark");
+  assert.equal(resolveThemeSource("light", "light"), "light");
+});
+
+test("preference wins over a disagreeing resolved mode", () => {
+  assert.equal(resolveThemeSource("light", "dark"), "light");
+  assert.equal(resolveThemeSource("dark", "light"), "dark");
+});
+
+test("missing preference falls back to the resolved mode", () => {
+  // Older dashboard bundle with no data-mode-pref: keep the pre-fix behaviour
+  // rather than silently forcing 'system'.
+  assert.equal(resolveThemeSource("", "dark"), "dark");
+  assert.equal(resolveThemeSource(undefined, "light"), "light");
+});
+
+test("unusable input defaults to 'system'", () => {
+  assert.equal(resolveThemeSource("", ""), "system");
+  assert.equal(resolveThemeSource(null, null), "system");
+  assert.equal(resolveThemeSource("Dark", "Light"), "system");
+  assert.equal(resolveThemeSource({}, []), "system");
+});

--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -144,7 +144,7 @@ function resolveMode(pref: ModePreference): ResolvedMode {
   return pref === 'system' ? getSystemMode() : pref
 }
 
-function applyTheme(colorTheme: ColorTheme, mode: ResolvedMode) {
+function applyTheme(colorTheme: ColorTheme, mode: ResolvedMode, pref: ModePreference) {
   const el = document.documentElement
   if (colorTheme.startsWith('custom-')) {
     el.dataset.theme = `${colorTheme}-${mode}`
@@ -152,6 +152,13 @@ function applyTheme(colorTheme: ColorTheme, mode: ResolvedMode) {
     el.dataset.theme = colorTheme === 'emerald' ? mode : `${colorTheme}-${mode}`
   }
   el.dataset.mode = mode
+  // The PREFERENCE, exposed separately from the resolved mode because the two
+  // mean different things to the Electron shell. `data-mode` is what to paint;
+  // `data-mode-pref` is whether the user asked to follow the OS. main.js maps
+  // this onto `nativeTheme.themeSource`, which must stay `system` under Auto —
+  // pinning it to dark/light also pins `prefers-color-scheme` in every renderer,
+  // which is the media query Auto resolves through. See syncNativeTheme.
+  el.dataset.modePref = pref
 }
 
 // Allowlist of allowed CSS custom property names for themes.
@@ -937,9 +944,21 @@ function useThemeState(): ThemeContextValue {
   }, [bootData, themeBootFetched])
 
   useEffect(() => {
-    applyTheme(colorTheme, resolved)
+    applyTheme(colorTheme, resolved, mode)
     bumpThemeVersion()
-  }, [resolved, colorTheme, bumpThemeVersion])
+  }, [resolved, colorTheme, mode, bumpThemeVersion])
+
+  // Tell the Electron shell which mode PREFERENCE is active, so it can set
+  // `nativeTheme.themeSource` to match ('system' under Auto). Pushed on change
+  // rather than only pulled on window focus so switching Dark → Auto un-pins
+  // `prefers-color-scheme` immediately; Chromium then fires a change event on
+  // the media query below if the effective value moved. No-op in a browser.
+  useEffect(() => {
+    const bridge = (window as unknown as {
+      electronAPI?: { setThemeMode?: (pref: string) => void }
+    }).electronAPI
+    bridge?.setThemeMode?.(mode)
+  }, [mode])
 
   // Report the resolved accent to the Electron shell (if present) so the NEXT
   // launch's boot splash (loading.html) paints in the user's chosen colour.

--- a/website/src/test/useTheme.test.tsx
+++ b/website/src/test/useTheme.test.tsx
@@ -45,6 +45,8 @@ describe('useTheme', () => {
   beforeEach(() => {
     localStorage.clear()
     delete document.documentElement.dataset.theme
+    delete document.documentElement.dataset.mode
+    delete document.documentElement.dataset.modePref
   })
 
   it('defaults to system preference (dark OS)', () => {
@@ -118,8 +120,42 @@ describe('useTheme', () => {
     expect(document.documentElement.dataset.theme).toBe('dark')
   })
 
-  it('treats previously onboarded users as import-onboarded', () => {
+  it('exposes the mode PREFERENCE separately from the resolved mode', () => {
+    // The Electron shell maps data-mode-pref onto nativeTheme.themeSource.
+    // It must see 'system' under Auto: themeSource='dark'/'light' also pins
+    // prefers-color-scheme, which is what Auto resolves through, so feeding the
+    // resolved mode back froze Auto at whatever it read on first load.
     mockMatchMedia(true)
+    const { result } = renderThemeHook()
+    expect(document.documentElement.dataset.mode).toBe('dark')
+    expect(document.documentElement.dataset.modePref).toBe('system')
+
+    act(() => result.current.setTheme('light'))
+    expect(document.documentElement.dataset.mode).toBe('light')
+    expect(document.documentElement.dataset.modePref).toBe('light')
+  })
+
+  it('pushes the mode preference to the Electron shell on change', () => {
+    mockMatchMedia(true)
+    const setThemeMode = vi.fn()
+    ;(window as unknown as { electronAPI: unknown }).electronAPI = { setThemeMode }
+    try {
+      const { result } = renderThemeHook()
+      expect(setThemeMode).toHaveBeenCalledWith('system')
+
+      act(() => result.current.setTheme('dark'))
+      expect(setThemeMode).toHaveBeenLastCalledWith('dark')
+
+      // Back to Auto must push too — otherwise themeSource stays pinned and the
+      // media query keeps lying until the next window focus.
+      act(() => result.current.setTheme('system'))
+      expect(setThemeMode).toHaveBeenLastCalledWith('system')
+    } finally {
+      delete (window as unknown as { electronAPI?: unknown }).electronAPI
+    }
+  })
+
+  it('treats previously onboarded users as import-onboarded', () => {    mockMatchMedia(true)
     localStorage.setItem('mc-onboarded', '1')
     const { result } = renderThemeHook()
     expect(result.current.importOnboarded).toBe(true)


### PR DESCRIPTION
## Problem

In the desktop app, **Auto** (Settings → Display → Appearance) stops following the OS. It picks up the right appearance at launch, then freezes: changing macOS light/dark while the app is running does nothing.

## Root cause

`website/electron/main.js` mirrored the dashboard's mode onto Chromium's native theme so native chrome (tab bar, context menus, macOS window frame) matched:

```js
view.webContents.executeJavaScript(`document.documentElement.dataset.mode || ""`)
  .then(mode => { if (mode === "dark" || mode === "light") nativeTheme.themeSource = mode; });
```

`data-mode` is the **resolved** mode, and `themeSource = 'dark' | 'light'` does more than restyle native chrome — per [Electron's docs](https://www.electronjs.org/docs/latest/api/native-theme#nativethemethemesource) it also makes *"the `prefers-color-scheme` CSS query match"* that value in every renderer.

That query is exactly how `useTheme` resolves Auto (`getSystemMode()` + a `matchMedia` change listener). So:

1. Auto resolves through the real OS value at boot → say `dark` → `data-mode="dark"`.
2. `did-finish-load` → main sets `themeSource = 'dark'`.
3. `prefers-color-scheme` is now pinned to `dark`. The OS is no longer observable, and the `change` listener never fires again.
4. `win.on("focus")` re-reads the stale `data-mode` and re-pins it.

The docs prescribe the exact state machine this violated: `Follow OS → 'system'`, `Dark → 'dark'`, `Light → 'light'`.

## Fix

Feed the shell the **preference**, not the resolved mode.

- `useTheme` sets `data-mode-pref` (`system` | `dark` | `light`) alongside the existing resolved `data-mode`.
- New `website/electron/native-theme.js` — `resolveThemeSource(pref, resolvedMode)` maps preference → `themeSource`. When `pref` is absent (a dashboard bundle predating the attribute) it falls back to the resolved mode, so explicit dark/light behaves exactly as before rather than silently becoming `system`.
- The preference is also **pushed** over a new `theme-mode-changed` IPC on change, not only pulled on window focus, so switching Dark → Auto un-pins the query immediately instead of at the next focus. Chromium then fires the `matchMedia` change event if the effective value moved, and the dashboard re-resolves.

Native chrome still tracks the dashboard: under Auto, `themeSource = 'system'` is the correct value for it too.

Browser-only usage was never affected — nothing overrides the media query there.

## Verification

- New `website/electron/test/native-theme.test.js` — 5 cases, including the regression itself (Auto must map to `system` regardless of what it resolved to).
- New `useTheme` cases asserting `data-mode-pref` tracks the preference while `data-mode` tracks the resolved mode, and that Dark → Auto pushes to the shell.
- `website/electron`: `npm test` → 472/472.
- `website`: `npx tsc -b` clean, `npx eslint` clean, `npx vitest run` → 8189 passed / 628 files. One unrelated failure in `src/i18n/format.test.ts` is a host-timezone artifact (expects UTC formatting, host is `America/Los_Angeles`); it passes under `TZ=UTC`, which is how CI runs, and is untouched by this change.
- No Python touched.

Not verified live end-to-end: proving it in the running app means installing a build from this branch and toggling the OS appearance, which the unit-level contract plus Electron's documented `themeSource` semantics already pin down.
