### PR TITLE
fix(agents): send `auto` to kiro-cli instead of treating it as "no model"

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -95,6 +95,7 @@ from kiro_crew.acp.types import (
     JsonRpcMessage,
     JsonRpcRequest,
     TurnUsage,
+    advertises_model,
 )
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
@@ -2322,8 +2323,22 @@ class AcpClient:
             )
             logger.info("ACP agent activated: %s", self._agent)
 
-        # 5. Set model — override if KiroCrew config specifies non-default.
-        if self._model and self._model != DEFAULT_MODEL:
+        # 5. Set model.
+        #
+        # A concrete model is always sent. DEFAULT_MODEL ("auto") is sent too,
+        # but ONLY when this backend advertised it: kiro-cli serves `auto` as a
+        # real model id (its own default_model, task-routing, 1.0x credit rate),
+        # so skipping the call does NOT select it — kiro instead resolves the
+        # model from `--agent`, and a spec that pins one (the shipped default)
+        # silently wins. That made an explicit Auto pick run on a fixed model at
+        # that model's credit rate, with nothing in the UI showing the drift.
+        # The claude backend has no server-side router and never advertises
+        # `auto`, so it keeps the historical skip via the same gate.
+        _wants_default = self._model == DEFAULT_MODEL
+        _send_model = bool(self._model) and (
+            not _wants_default or advertises_model(self._available_models, DEFAULT_MODEL)
+        )
+        if _send_model:
             if self._is_claude:
                 await self.set_config_option("model", self._model)
             else:

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -29,7 +29,7 @@ from kiro_crew.acp.client import (
     AcpProcessDied,
 )
 from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeDead, AcpRuntimeError, AcpSessionHandle
-from kiro_crew.acp.types import STOP_REASON_END_TURN
+from kiro_crew.acp.types import STOP_REASON_END_TURN, advertises_model
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.mcp_gateway.claim import schedule_claim
 from kiro_crew.providers.base import CancelOutcome, LLMEvent, LLMProvider
@@ -100,12 +100,14 @@ class AcpSessionProvider(LLMProvider):
             cwd=self._runtime._work_dir,
             agent=self._runtime._agent or None,
         )
-        # Re-apply the configured non-default model to the fresh session. A new
-        # session/new reverts to the agent-config default model, so a warm worker
-        # configured with a non-default model (via the cold-start set_model in
+        # Re-apply the configured model to the fresh session. A new session/new
+        # reverts to the agent-config default model, so a warm worker configured
+        # with a specific model (via the cold-start set_model in
         # AcpProvider._start_kiro_runtime_impl, recorded on the old handle) would
         # silently run every reused task on the wrong model without this. Mirrors
-        # that cold-start handshake: skip the "auto" sentinel (let kiro pick).
+        # that cold-start handshake, including the "auto" sentinel: kiro serves
+        # `auto` as a real routing model, so a worker that WAS on auto must be
+        # put back on it rather than inheriting the agent spec's pinned model.
         #
         # If the re-apply FAILS we must NOT commit the fresh handle — a
         # wrong-model session would silently run every subsequent pooled step on
@@ -113,7 +115,14 @@ class AcpSessionProvider(LLMProvider):
         # (WorkerPool) performs its hard-reset fallback and the old, correctly
         # configured handle is not destroyed below.
         prior_model = getattr(old, "model", "")
-        if isinstance(prior_model, str) and prior_model and prior_model != DEFAULT_MODEL:
+        if (
+            isinstance(prior_model, str)
+            and prior_model
+            and (
+                prior_model != DEFAULT_MODEL
+                or advertises_model(new_handle.available_models, DEFAULT_MODEL)
+            )
+        ):
             try:
                 await new_handle.set_model(prior_model)
             except Exception as exc:

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -91,6 +91,32 @@ ACP_CLIENT_CAPABILITIES: dict = {
     "elicitation": {"form": {}, "url": {}},
 }
 
+
+def advertises_model(advertised: list[dict[str, str]], model_id: str) -> bool:
+    """True when the backend advertised ``model_id`` as a selectable model id.
+
+    ``advertised`` is the normalized ``{modelId, name, description}`` list an
+    ACP ``session/new`` response carries (``AcpClient._capture_available_models``
+    / ``AcpSessionHandle._normalize_models``).
+
+    This is the ONE gate every caller uses before sending ``session/set_model``
+    for the ``auto`` sentinel. kiro-cli serves ``auto`` as a real model id (its
+    own ``default_model``, with a task-routing description and a 1.0 credit
+    multiplier), so it must be SET explicitly rather than treated as "no model
+    chosen" — but the claude backend has no server-side router and never
+    advertises it, so the same call there must stay skipped. Asking the backend
+    what it offers keeps both behaviours correct without hardcoding either.
+
+    Returns False for an empty ``model_id`` or an unadvertised list, so a
+    backend that reported no models at all (a lazy or older agent) degrades to
+    the historical "let the backend pick" behaviour instead of sending an id it
+    might reject with -32603.
+    """
+    if not model_id:
+        return False
+    return any(isinstance(m, dict) and m.get("modelId") == model_id for m in advertised)
+
+
 # ── ACP Backend Identifiers ──
 
 ACP_BACKEND_CLAUDE = "claude"

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -20,6 +20,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 
 from kiro_crew import model_registry
+from kiro_crew.acp.types import advertises_model
 from kiro_crew.config.loader import (
     KiroCrewConfig,
     _workspace_name_for_dir,
@@ -1880,8 +1881,7 @@ def _wire_model_id(provider: AcpProvider, model_name: str) -> str:
     if is_default:
         # kiro DOES express Auto as a real model id — but only switch to it when
         # this session's backend actually advertised it.
-        advertised = {m.get("modelId", "") for m in provider.available_models()}
-        return "auto" if "auto" in advertised else ""
+        return "auto" if advertises_model(provider.available_models(), "auto") else ""
     return model_registry.to_acp_id(model_name)
 
 

--- a/src/kiro_crew/model_registry.json
+++ b/src/kiro_crew/model_registry.json
@@ -84,8 +84,8 @@
   },
   "auto": {
     "display": "Auto",
-    "description": "Let the provider pick the model",
-    "window": 200000,
+    "description": "Models chosen by task for optimal usage and consistent quality",
+    "window": 1000000,
     "providers": { "claude_code": "", "acp": "" }
   }
 }

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -25,6 +25,7 @@ from kiro_crew.acp.types import (
     EVENT_COMPACTION_STATUS,
     STOP_REASON_CANCELLED,
     STOP_REASON_END_TURN,
+    advertises_model,
 )
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import kiro_sessions_dir
@@ -607,9 +608,15 @@ class AcpProvider(LLMProvider):
             # session/new (or session/load) + MCP-toolset/system-prompt load done.
             phases["session_new"] = (time.monotonic() - _t_sess) * 1000.0
 
-            # Apply the configured model override (mirrors AcpClient handshake).
-            # DEFAULT_MODEL ("auto") means "let kiro-cli pick per agent config".
-            if configured_model and configured_model != DEFAULT_MODEL:
+            # Apply the configured model (mirrors AcpClient handshake). A
+            # concrete model is always set; DEFAULT_MODEL ("auto") is set too,
+            # but only when this session advertised it — kiro-cli serves `auto`
+            # as a real, task-routing model id, so skipping the call leaves the
+            # session on whatever `--agent` resolved to instead of selecting it.
+            if configured_model and (
+                configured_model != DEFAULT_MODEL
+                or advertises_model(handle.available_models, DEFAULT_MODEL)
+            ):
                 _t_model = time.monotonic()
                 try:
                     await handle.set_model(configured_model)

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -3676,8 +3676,13 @@ class TestInitializeSession:
         assert "session/set_model" in send_calls
 
     @pytest.mark.asyncio
-    async def test_no_set_model_when_auto(self, tmp_path):
-        """Default model 'auto' skips set_model request."""
+    async def test_no_set_model_when_auto_not_advertised(self, tmp_path):
+        """'auto' is skipped when the backend does not advertise it as a model.
+
+        The claude backend has no server-side router, and a lazy/older agent may
+        report no models at all — either way we must not send an id the backend
+        would reject. Degrades to the historical "let the backend pick".
+        """
         client = self._make_client(tmp_path)
         client._model = "auto"
 
@@ -3688,6 +3693,90 @@ class TestInitializeSession:
                 return {"protocolVersion": "2025-08-22", "agentCapabilities": {}}
             if req_id == 2:
                 return {"sessionId": "s1"}
+            return {}
+
+        client._wait_for_response = AsyncMock(side_effect=fake_wait)
+        client._drain_notifications = AsyncMock()
+
+        original_send_request = client._send_request
+
+        async def tracking_send(method, params):
+            send_calls.append(method)
+            return await original_send_request(method, params)
+
+        client._send_request = tracking_send
+
+        await client._initialize_session()
+
+        assert "session/set_model" not in send_calls
+
+    @pytest.mark.asyncio
+    async def test_set_model_auto_when_advertised(self, tmp_path):
+        """'auto' IS sent when the backend advertises it (kiro-cli does).
+
+        Regression for the auto-never-selected bug: kiro-cli serves `auto` as a
+        real, task-routing model id, so treating it as "no model chosen" and
+        skipping set_model left the session on whatever `--agent` resolved to
+        (the agent spec's pinned model) at that model's credit rate.
+        """
+        client = self._make_client(tmp_path)
+        client._model = "auto"
+
+        sent: list[tuple[str, dict]] = []
+
+        async def fake_wait(req_id, timeout=50.0):
+            if req_id == 1:
+                return {"protocolVersion": "2025-08-22", "agentCapabilities": {}}
+            if req_id == 2:
+                return {
+                    "sessionId": "s1",
+                    "models": {
+                        "currentModelId": "claude-opus-4.8",
+                        "availableModels": [
+                            {"modelId": "auto", "name": "auto", "description": "routed"},
+                            {"modelId": "claude-opus-4.8", "name": "claude-opus-4.8"},
+                        ],
+                    },
+                }
+            return {}
+
+        client._wait_for_response = AsyncMock(side_effect=fake_wait)
+        client._drain_notifications = AsyncMock()
+
+        original_send_request = client._send_request
+
+        async def tracking_send(method, params):
+            sent.append((method, params))
+            return await original_send_request(method, params)
+
+        client._send_request = tracking_send
+
+        await client._initialize_session()
+
+        set_model = [p for m, p in sent if m == "session/set_model"]
+        assert set_model, "set_model must be sent for an advertised 'auto'"
+        assert set_model[0]["modelId"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_no_set_model_when_model_empty(self, tmp_path):
+        """An empty model still sends nothing, even if 'auto' is advertised.
+
+        AcpClient.__init__ normalizes "" to DEFAULT_MODEL, so this only guards
+        a client whose _model was cleared after construction.
+        """
+        client = self._make_client(tmp_path)
+        client._model = ""
+
+        send_calls = []
+
+        async def fake_wait(req_id, timeout=50.0):
+            if req_id == 1:
+                return {"protocolVersion": "2025-08-22", "agentCapabilities": {}}
+            if req_id == 2:
+                return {
+                    "sessionId": "s1",
+                    "models": {"availableModels": [{"modelId": "auto", "name": "auto"}]},
+                }
             return {}
 
         client._wait_for_response = AsyncMock(side_effect=fake_wait)

--- a/test/test_auto_model_sentinel.py
+++ b/test/test_auto_model_sentinel.py
@@ -1,0 +1,143 @@
+"""Tests for the `auto` model sentinel reaching kiro-cli as a real model id.
+
+`auto` is not "no model chosen": kiro-cli serves it as an advertised model id
+(its own ``default_model``) that routes per task at a 1.0 credit multiplier.
+Treating it as a sentinel and skipping ``session/set_model`` left every cold
+session on whatever ``--agent`` resolved to — the agent spec's pinned model —
+while the picker still reported ``auto``.
+
+These tests pin the gate that decides when the sentinel is sent: ask the backend
+what it advertised, rather than hardcoding either behaviour. The claude backend
+never advertises ``auto`` and must keep the historical skip.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.acp.client import DEFAULT_MODEL
+from kiro_crew.acp.types import advertises_model
+from kiro_crew.dashboard.chat_handlers import _wire_model_id
+
+_KIRO_MODELS = [
+    {"modelId": "auto", "name": "auto", "description": "Models chosen by task"},
+    {"modelId": "claude-opus-4.8", "name": "claude-opus-4.8", "description": ""},
+    {"modelId": "gpt-5.6-sol", "name": "gpt-5.6-sol", "description": ""},
+]
+
+
+class TestAdvertisesModel:
+    """The single gate shared by the handshake, the runtime cold start, the
+    warm-worker re-apply, and the live dashboard switch."""
+
+    def test_true_for_advertised_id(self):
+        assert advertises_model(_KIRO_MODELS, "auto") is True
+        assert advertises_model(_KIRO_MODELS, "claude-opus-4.8") is True
+
+    def test_false_for_unadvertised_id(self):
+        assert advertises_model(_KIRO_MODELS, "claude-fable-5") is False
+
+    def test_false_for_empty_list(self):
+        """A backend that reported no models degrades to the historical skip."""
+        assert advertises_model([], "auto") is False
+
+    def test_false_for_empty_model_id(self):
+        assert advertises_model(_KIRO_MODELS, "") is False
+
+    def test_ignores_malformed_entries(self):
+        """A non-dict row must not raise — the list comes off the wire."""
+        assert advertises_model(["auto", None, {"modelId": "auto"}], "auto") is True  # type: ignore[list-item]
+        assert advertises_model(["auto", None], "auto") is False  # type: ignore[list-item]
+
+    def test_does_not_match_on_name_or_description(self):
+        """Only ``modelId`` is a selectable id; ``name`` is display copy."""
+        rows = [{"modelId": "claude-opus-4.8", "name": "auto", "description": "auto"}]
+        assert advertises_model(rows, "auto") is False
+
+
+class TestWireModelIdAuto:
+    """`_wire_model_id` translates slot.model into the id THIS backend accepts."""
+
+    @staticmethod
+    def _provider(models, *, is_claude=False):
+        provider = MagicMock()
+        provider.is_claude_backend = is_claude
+        provider.available_models = MagicMock(return_value=models)
+        return provider
+
+    @pytest.mark.parametrize("stored", ["", "auto"])
+    def test_auto_wired_when_kiro_advertises_it(self, stored):
+        """Both spellings of "provider default" resolve to the real `auto` id."""
+        assert _wire_model_id(self._provider(_KIRO_MODELS), stored) == "auto"
+
+    @pytest.mark.parametrize("stored", ["", "auto"])
+    def test_empty_when_backend_does_not_advertise_auto(self, stored):
+        """No advertised `auto` means the caller must fall back to a reset."""
+        assert _wire_model_id(self._provider([]), stored) == ""
+
+    def test_concrete_model_passes_through(self):
+        assert _wire_model_id(self._provider(_KIRO_MODELS), "gpt-5.6-sol") == "gpt-5.6-sol"
+
+    def test_canonical_key_translated_to_kiro_id(self):
+        assert _wire_model_id(self._provider(_KIRO_MODELS), "opus-4.8-1m") == "claude-opus-4.8"
+
+    def test_claude_backend_never_wires_auto(self):
+        """The claude backend has no id meaning "let the server choose", so a
+        return to default still needs a session reset."""
+        provider = self._provider(_KIRO_MODELS, is_claude=True)
+        assert _wire_model_id(provider, "auto") == ""
+        assert _wire_model_id(provider, "") == ""
+
+
+class TestSessionProviderAutoReapply:
+    """`AcpSessionProvider.new_conversation` re-applies the model to the fresh
+    session. A worker that was on `auto` must be put back on `auto`, not left to
+    inherit the agent spec's pinned model."""
+
+    @staticmethod
+    def _handles(advertised):
+        old = MagicMock()
+        old.model = DEFAULT_MODEL
+        new_handle = MagicMock()
+        new_handle.available_models = advertised
+        new_handle.set_model = AsyncMock()
+        new_handle.destroy = AsyncMock()
+        return old, new_handle
+
+    @pytest.mark.asyncio
+    async def test_reapplies_auto_when_advertised(self):
+        from kiro_crew.acp import session_provider as sp
+
+        old, new_handle = self._handles(_KIRO_MODELS)
+        provider = object.__new__(sp.AcpSessionProvider)
+        provider._handle = old
+        runtime = MagicMock()
+        runtime._agent = "kirocrew"
+        runtime.create_session = AsyncMock(return_value=new_handle)
+        provider._runtime = runtime
+        old.destroy = AsyncMock()
+
+        await provider.new_conversation()
+
+        new_handle.set_model.assert_awaited_once_with(DEFAULT_MODEL)
+        assert provider._handle is new_handle
+
+    @pytest.mark.asyncio
+    async def test_skips_auto_when_not_advertised(self):
+        from kiro_crew.acp import session_provider as sp
+
+        old, new_handle = self._handles([])
+        provider = object.__new__(sp.AcpSessionProvider)
+        provider._handle = old
+        runtime = MagicMock()
+        runtime._agent = "kirocrew"
+        runtime.create_session = AsyncMock(return_value=new_handle)
+        provider._runtime = runtime
+        old.destroy = AsyncMock()
+
+        await provider.new_conversation()
+
+        new_handle.set_model.assert_not_awaited()
+        assert provider._handle is new_handle

--- a/test/test_model_registry.py
+++ b/test/test_model_registry.py
@@ -133,34 +133,36 @@ class TestModelRegistry:
         assert mr.window("nonexistent-zzz") == mr.REFERENCE_WINDOW_TOKENS
 
     def test_refresh_kiro_windows_overrides_and_extends_registry(self, tmp_path, monkeypatch):
-        # The kiro-list cache wins over the static registry (corrects stale
-        # values) AND covers models the registry lacks (GPT). Uses 'auto' for the
-        # override case: the registry lists auto=200k but kiro serves it at 1M.
+        # The kiro-list cache wins over the static registry (it is the ground
+        # truth for what kiro actually serves) AND covers models the registry
+        # lacks (GPT). Uses 'auto' for the override case: the registry carries a
+        # literal for it, and a served window that disagrees must win.
         # Manipulate the in-memory cache directly (restored in teardown) to avoid
         # a module reload that would leak state into other tests.
         monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
         saved = dict(mr._KIRO_WINDOWS)
         try:
             mr._KIRO_WINDOWS.clear()
-            assert mr.model_window("auto") == 200_000  # stale registry literal
+            assert mr.model_window("auto") == 1_000_000  # static registry literal
+            assert mr.window_source("auto") == "registry"
             assert mr.model_window("unlisted-model-zzz") is None  # neither registry nor supplementary
             # refresh does the in-memory update synchronously and returns True
             # when the cache changed (signalling the async caller to persist).
             changed = mr.refresh_kiro_windows(
                 [
-                    {"model_id": "auto", "context_window_tokens": 1000000},
+                    {"model_id": "auto", "context_window_tokens": 900000},
                     {"model_id": "unlisted-model-zzz", "context_window_tokens": 272000},
                     {"model_id": "bad", "context_window_tokens": 0},  # skipped
                     {"model_id": "alsobad"},  # missing field, skipped
                 ]
             )
             assert changed is True
-            assert mr.model_window("auto") == 1000000  # cache corrects stale registry 200k
+            assert mr.model_window("auto") == 900000  # cache overrides the registry literal
             assert mr.window_source("auto") == "kiro-list"
             assert mr.model_window("unlisted-model-zzz") == 272000
             assert mr.model_window("bad") is None  # 0 not cached
             # A no-op refresh (same data) returns False — no persist needed.
-            assert mr.refresh_kiro_windows([{"model_id": "auto", "context_window_tokens": 1000000}]) is False
+            assert mr.refresh_kiro_windows([{"model_id": "auto", "context_window_tokens": 900000}]) is False
             # persist is a separate step (offloaded to an executor by the caller).
             mr.persist_kiro_windows()
             assert (tmp_path / "model_windows.json").is_file()  # persisted

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -118,7 +118,12 @@ export default function ChatPane({
     queryKey: ['available-models', provider.id],
     queryFn: async () => {
       const models = await provider.fetchAvailableModels()
-      return [{ name: 'auto', description: 'Default' }, ...models.filter((m) => m.name !== 'auto')]
+      // Auto pinned first, described by what the backend advertised for it —
+      // see the matching comment in pages/ChatPage.tsx for why it is not
+      // relabelled "Default".
+      const advertisedAuto = models.find((m) => m.name === 'auto')
+      const rest = models.filter((m) => m.name !== 'auto')
+      return advertisedAuto ? [advertisedAuto, ...rest] : rest
     },
     refetchInterval: modelListRefetchInterval,
   })

--- a/website/src/model_registry.json
+++ b/website/src/model_registry.json
@@ -84,8 +84,8 @@
   },
   "auto": {
     "display": "Auto",
-    "description": "Let the provider pick the model",
-    "window": 200000,
+    "description": "Models chosen by task for optimal usage and consistent quality",
+    "window": 1000000,
     "providers": { "claude_code": "", "acp": "" }
   }
 }

--- a/website/src/model_tokens.json
+++ b/website/src/model_tokens.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Model → context window tokens, read by the ACP provider adapter (providers/adapters/acp.ts) for getContextWindow. Default fallback: 200,000.",
+  "auto": 1000000,
   "claude-fable-5": 1000000,
   "claude-opus-4.8": 1000000,
   "claude-opus-4.7": 1000000,

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -908,7 +908,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     queryKey: ['available-models', provider.id],
     queryFn: async () => {
       const models = await provider.fetchAvailableModels()
-      return [{ name: 'auto', description: 'Default' }, ...models.filter(m => m.name !== 'auto')]
+      // Keep Auto pinned first, but present the row the BACKEND advertised for
+      // it — description included — instead of relabelling it "Default". `auto`
+      // is a real task-routing model with its own credit rate, and calling it
+      // the default made it read as "no model chosen": the labelling half of
+      // the auto-never-selected bug. A backend that does not advertise `auto`
+      // gets no Auto row at all, because selecting it there would fail and
+      // _wire_model_id already refuses to wire an unadvertised sentinel.
+      const advertisedAuto = models.find(m => m.name === 'auto')
+      const rest = models.filter(m => m.name !== 'auto')
+      return advertisedAuto ? [advertisedAuto, ...rest] : rest
     },
     refetchInterval: modelListRefetchInterval,
   })


### PR DESCRIPTION
Fixes #1355

## Problem

Selecting `auto` in the model picker did not put the session on kiro-cli's `auto` router. The session ran whatever the agent spec pinned, and the picker went on reporting `auto` — so nothing surfaced the difference.

## Why it matters

`auto` routes per task at a 1.0 credit multiplier; a pinned premium model costs up to 2.2x. Anyone selecting `auto` to spread load or reduce spend got the opposite, silently. #1423 has since removed the shipped pin, so the default install is no longer affected — but any spec that still pins a model still overrides an explicit `auto` selection (see *Relationship to #1423*).

## Fix (symptom → root cause → change)

**Symptom:** picker says `auto`; session runs the agent spec's pinned model.

**Root cause:** `auto` was read as "no model chosen", but kiro-cli serves it as a genuine advertised model id — its own `default_model`, with a task-routing description and a 1.0 credit multiplier. So the session-init handshake skipped the call outright:

```python
if self._model and self._model != DEFAULT_MODEL:   # False for "auto"
    await self._send_request(METHOD_SET_MODEL, ...)
```

kiro then resolved the model from `--agent`, and a spec that pins one wins. Three cold-start paths shared that skip: the `AcpClient` handshake, `AcpProvider._start_kiro_runtime_impl`, and the warm-worker re-apply in `AcpSessionProvider.new_conversation`. Only the live dashboard switch (`_wire_model_id`) got it right, by checking what the backend advertised — which is why a running idle session switched correctly while every respawn silently reverted. The drift stayed invisible because `_backfill_canonical_model` deliberately skips the `auto` sentinel, leaving `slot.model` and the dropdown both reading `auto`.

**Change:** promote `_wire_model_id`'s rule into one shared gate — `advertises_model()` in the leaf `acp/types.py` — and use it at all four sites. `auto` is sent when the backend advertised it and skipped when it did not, so the claude backend (no server-side router, never advertises `auto`) keeps its existing behaviour, and a backend reporting no models degrades to "let the backend pick" rather than being sent an id it would reject with `-32603`.

Two adjacent corrections:

- **`auto`'s registry entry was wrong twice over:** a 200k window where kiro reports 1M, and a `description` ("Let the provider pick the model") that restated the sentinel misreading. The window self-healed once `/api/models` seeded the `_KIRO_WINDOWS` cache, but a headless Slack/cron start that never hits that endpoint under-reported the budget by 5x. Fixed in both `model_registry.json` copies (held in parity by `test_model_registry_parity.py`) plus the frontend window map, which was resolving `auto` to its 200k default.
- **Both pickers synthesized their own Auto row** and relabelled it `"Default"`, discarding what the backend advertised — the labelling half of the same confusion. They now use the advertised row verbatim, and synthesize nothing when `auto` is not advertised, since selecting it there would fail and `_wire_model_id` already refuses to wire it. `ChatPage.tsx` and `ChatPane.tsx` carried identical copies.

### Relationship to #1423

#1423 set the shipped `defaults.json` model to `auto`, making the agent spec and `config.json` agree, which fixes the default install on its own. This change is the complement: it stops `auto` depending on that agreement. Still broken without it —

- a **grandfathered install** (no `model_managed` sidecar entry) is deliberately *never* force-changed, so it keeps its existing pin;
- an **explicit user pick** in the spec likewise outranks the shipped default;
- a **named custom agent** resolves its own pinned model;
- the **warm-worker path** reverts to the spec's model on every fresh `session/new`.

In all four, selecting `auto` silently ran the pinned model. Sending it explicitly is what makes the selection mean what it says.

## Tests

New `test/test_auto_model_sentinel.py` (15 cases):

- `advertises_model` — matches an advertised id; rejects unadvertised ids, an empty list, an empty id, and malformed non-dict rows off the wire; matches on `modelId` only, never `name`/`description`.
- `_wire_model_id` — both spellings of "provider default" (`""` and `"auto"`) resolve to the real `auto` id when kiro advertises it, and to `""` (caller falls back to a reset) when it does not; concrete ids pass through; canonical keys still translate (`opus-4.8-1m` → `claude-opus-4.8`); the claude backend never wires `auto`.
- `AcpSessionProvider.new_conversation` — a warm worker that was on `auto` is put back on `auto`, and left alone when the fresh session does not advertise it.

`test/test_acp_client.py` — the old `test_no_set_model_when_auto` asserted the buggy behaviour. It is now `test_no_set_model_when_auto_not_advertised` (the genuine skip), joined by `test_set_model_auto_when_advertised` (asserts `modelId == "auto"` is really sent) and `test_no_set_model_when_model_empty`.

`test/test_model_registry.py` — one test used `auto`'s 200k as its example of a *stale* registry literal the kiro-list cache corrects. Since it is no longer stale, it now proves the same override precedence with a value that simply disagrees.

**Frontend coverage gap, stated plainly:** the picker changes have no new unit test, and had none before. `AcpAdapter.models.test.ts` covers the adapter that produces the list; nothing asserts how the components compose the dropdown from it. The change is a three-line list transform covered by `tsc -b` and the full frontend suite. Happy to add a component test if a reviewer wants it pinned.

## Manual verification

Verified against **kiro-cli 2.15.2** over a raw ACP handshake, because the bug is invisible from inside the app — `slot.model` and the picker report `auto` either way:

```
# kiro-cli chat --list-models --format json
{"model_name":"auto","model_id":"auto",
 "description":"Models chosen by task for optimal usage and consistent quality",
 "context_window_tokens":1000000,"rate_multiplier":1.0}
... "default_model":"auto"

# session/new against a model-pinned `--agent`
currentModelId     : claude-opus-4.8      <- the bug: the spec pin wins
'auto' advertised  : True
set_model('auto')  : OK {}                <- kiro accepts it
```

Gates run locally on the rebased tree: `isort`, `flake8`, `mypy src/kiro_crew/` (632 files), `tsc -b`, `npm run i18n:check`, the full frontend suite (7003 passed), and 691 targeted backend tests. The full backend suite was not run locally; CI covers it.

One local frontend failure is a pre-existing environment artifact, not a regression: `fileExplorer.test.tsx:100` asserts `formatTime(-1)` contains `1969`, true only in UTC — under BST it renders `1/1/1970`. CI runs UTC and its Frontend Tests job passes.

## Screenshots

No new or restructured surface, so none. The UI delta is confined to the existing model dropdown's Auto row: its subtitle now carries the backend's advertised copy ("Models chosen by task for optimal usage and consistent quality") instead of the word "Default", and against a backend that does not advertise `auto` the row is absent rather than present-but-unselectable. Against kiro-cli — the only backend this fork drives — `auto` is always advertised, so in practice the visible change is the subtitle text.
