### PR TITLE
chore(docs): Update security email contact address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a potential security issue in this project, please **do not** create a public
 GitHub issue. Instead, report it privately:
 
-- **Email:** [security@kirocrew.dev](mailto:security@kirocrew.dev)
+- **Email:** [kiro-crew-security-support@amazon.com](mailto:kiro-crew-security-support@amazon.com)
 - **Subject prefix:** `[SECURITY]`
 
 Please include:

--- a/scripts/scrub-allowlist.txt
+++ b/scripts/scrub-allowlist.txt
@@ -121,6 +121,14 @@ src/kiro_crew/cloud/ssm.py:.*docs\.aws\.amazon\.com
 # anywhere in this file is still caught.
 CODE_OF_CONDUCT.md:.*opensource-codeofconduct@amazon\.com
 
+# Security-issue intake contact. ``kiro-crew-security-support@amazon.com`` is the
+# monitored shared mailbox that receives vulnerability reports; the project-domain
+# address it replaces is not a monitored inbox. Like the code-of-conduct address
+# above it is a published, public-facing intake — SECURITY.md is unusable without
+# naming where reports go — not an employee alias or an internal coupling.
+# Line-anchored so a NEW @amazon.com address anywhere in this file is still caught.
+SECURITY.md:.*kiro-crew-security-support@amazon\.com
+
 # Live public AWS service class-name string the dashboard credit pill calls
 # (CodeWhisperer RTS GetUsageLimits) — a functional API identifier, not a leak.
 src/kiro_crew/dashboard/handlers/kiro_usage_api.py:.*codewhisperer


### PR DESCRIPTION
Updated the security contact email for reporting issues.

## Description

Updates the security-reporting email in `SECURITY.md` from `security@kirocrew.dev` to `kiro-crew-security-support@amazon.com`.

**Why:** `kiro-crew-security-support@amazon.com` is a monitored shared mailbox stood up to receive vulnerability reports. The previous project-domain address (`security@kirocrew.dev`) is not a monitored inbox, so reports sent there would go unread. This points the published intake at the address the team actually watches.

Because `SECURITY.md` is in `scrub-lint.sh`'s scan roots and `INTERNAL_PATTERN` matches `amazon.com`, the address trips the blocking de-Amazonization gate. This PR pairs the change with a **line-anchored** allowlist entry in `scripts/scrub-allowlist.txt`, mirroring the existing `CODE_OF_CONDUCT.md` published-intake precedent: this one published, public-facing address is permitted, while a NEW `amazon.com` address anywhere in the file is still caught. The scrub-lint self-test (`scripts/scrub-lint.sh --test`) still passes, confirming the gate was not over-broadened.

## Related Issues

<!-- Link to relevant issues, e.g. Fixes #123 -->

## Testing

- [x] Existing tests pass (`make test`)
- [x] `scripts/scrub-lint.sh --no-history` passes (previously failed on `SECURITY.md:8`)
- [x] `scripts/scrub-lint.sh --test` passes (allowlist entry does not over-broaden the scan)
- [x] Manual verification performed

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
