### PR TITLE
docs: show contributors as linked GitHub avatars in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ make this tool possible:
 <a href="https://github.com/hoang-phan98" title="Hoang "><img src="https://github.com/hoang-phan98.png?size=64" width="64" height="64" alt="Hoang " /></a>
 <a href="https://github.com/hugoncosta" title="Hugo Costa"><img src="https://github.com/hugoncosta.png?size=64" width="64" height="64" alt="Hugo Costa" /></a>
 <a href="https://github.com/hungtnvu" title="Hung Vu"><img src="https://github.com/hungtnvu.png?size=64" width="64" height="64" alt="Hung Vu" /></a>
-<a href="https://github.com/iamwhatever" title="iamwhatever"><img src="https://github.com/iamwhatever.png?size=64" width="64" height="64" alt="iamwhatever" /></a>
+<a href="https://github.com/iamwhatever" title="Zejiang Guo (Joe)"><img src="https://github.com/iamwhatever.png?size=64" width="64" height="64" alt="Zejiang Guo (Joe)" /></a>
 <a href="https://github.com/inaoy" title="inaoy"><img src="https://github.com/inaoy.png?size=64" width="64" height="64" alt="inaoy" /></a>
 <a href="https://github.com/IngridMorstrad" title="IngridMorstrad"><img src="https://github.com/IngridMorstrad.png?size=64" width="64" height="64" alt="IngridMorstrad" /></a>
 <a href="https://github.com/ishansmishra" title="Ishan Mishra"><img src="https://github.com/ishansmishra.png?size=64" width="64" height="64" alt="Ishan Mishra" /></a>

--- a/README.md
+++ b/README.md
@@ -479,9 +479,338 @@ feature requests. Do not file security vulnerabilities publicly.
 
 ## Contributors
 
-KiroCrew was made possible by its internal community — **494 Amazon employees** who supported the project and shipped its code. This is that founding group; as KiroCrew grows in the open, we look forward to many more contributors joining them. Thank you to everyone who helped make this tool possible:
+KiroCrew was made possible by its internal community, the people who supported the
+project and shipped its code, together with everyone who has since opened a pull
+request in the open. This is that founding group; as KiroCrew grows in the open, we
+look forward to many more contributors joining them. Thank you to everyone who helped
+make this tool possible:
 
-Bolin Chen, Zejiang Guo, Zezhen Xu, Simon Meyffret, Raymond Chen, Nick Bowers, Akim Akimov, Joe Pontone, Patrick Gao, Krish Dhasmana, Hoang Phan, Chen Tong, Yusheng Xu, Hugo Costa, Ben Grubin, Robert Noack, Rohan Khanderia, Luke Ely, Aidan Mackey, Stan Tian, Alec Douglas, James Joseph, Ethan Levine, Nick Papadopoulos, Erik Schweiss, Vitor Durante, Abhishek Mitra, Lanxiao Bai, Gabe Sanchez, Quan Nguyen, Lane Ambrose, Dan Dagayev, Tony Hardie, Nikhil Menon, Vamil Gandhi, Toby Wong, Di Wu, Aswin Damodar, Bocheng Wu, Chetan Chaku, Maksym Yachnyi, Matthew Barnum, Gavin Tse, Chen Yang Lho, Maninder Singh, Chris McMillon, David Fayerman, Naoya Ishikawa, Eduardo Vencovsky, Ezzat Qupty, Shreyas Bhise, Vishal Sreekrishnan, Swapnil Dixit, Mark Lord, Bharath Janyavula, Tyger Hugh, Jiahao Guo, Luca Chang, Yuliang Qiao, Shihao Wang, Joshua Yeung, Roman Ivanov, Bhavana Chinthalapally, Beau Taylor-Ladd, Christopher Huk, Kishore Baskar, Sugavanesh Balasubramanian, Parimal Deshmukh, Gregory Liu, Nansong Yi, Teodor Oprescu, Zhuoyu Li, Graham Roberts, Dinesh Jayapalan, Xu Deng, David Schlessman, Madhur Bajaj, David Hickox, Vishal Mawandia, Peter Vu, Angelo Yu, Uday Prakash, Yuta Tsuji, Sypher Su, Rohit Jose, Pedro Barrios, Yohanes Setiawan, Arpit Vyas, Connor LoPresti, Oscar Smith-Sieger, Sam Oldak, Kotaro Inoue, Shao-Cheng Wang, Rohan Kapadia, Robert Zhang, Arjun Soota, Himakireeti Konda, Jingjin Wei, Matt Pierringer, Jimmy Kilpatrick, Greg Rebholz, Yongbo Xiao, Kejian Wang, Gregory Chapman, Wilson Wu, Ahmed Hassanin, Chaoneng Quan, Siddartha  B V, John Law, Udit Tumuluri, Brent Naylor, Shuya Sawa, Rabinarayan Patra, Minglong Pan, Jianwen Liu, Joel Studevant, Eric Zhang, Greyson Nevins-Archer, August Vilakia, Arpan Banerjee, Rikiya Tsukidate, Yao Bian, Qusai Hussein, Zifeng Xia, Mustafa Onur AYDIN, Adam Doussan, Mikhail Kuznetsov, Tianxiang Xu, Justin Zhang, Kiavash Samadi, Adam Duncan, Rohit Mehra, Finn Haddon, Sean Iamartino, Akshit Desai, Mohammed Elansary, Matthew Nguyen, Axel Vidales, Huan He, Fei Ma, Jingchao Cao, Milos Chaloupka, Helena Stafford, John Espenhahn, Arturo Acuaviva, Hao Xu, Raghav Bhardwaj, Eric Muessel, Curtis Demerah, Dan McClain, Puneeth Nanjundaswamy, Sudhamsu Manne, Shashwat Srivastava, Eric Hays, Satheesh Prabhakaran, Nathan Beals, Krunal Patel, Yashwanth Korla, Tomas Rodriguez Sanchez, Vaibhav Bhatia, Matthieu Dufour, Mike Mayer, Sean Whipple, Dinesh Mathan, Luca Bruera, Marvellous Adedapo, Aryaman Pathania, Ravi Teja Kondisetty, Shayan Yaseen, Reece Bailey, Kyle Seaman, Koushik Ginjupally, Matt McLeod, Arnaldo Garcia, Thomas Lane, Mihir Dhamankar, Sam Cuthbertson, Nirav Adunuthula, David Lee, Thiago Andrade, Tian ZHANG, Vineeth Chinthala, Saif Rahman, Cole Whitley, Emmanuella Dasilva-Domingos, Nihal Singh, Kenneth Harrison, Ashwin Menon, Alex Truong, Ben Bloschock, Selena Wang, Amit Menon, Caillin Bathern, Naveen Adarsh Petla, Joel Blumenthal, Joshua Chang, Chris Boomhower, Matthew Pope, Takahiro Ishii, Yu Zhang, Swapnil Gaikwad, Chris Wundram, Emmanuel Okonkwo, Dhaval Soneji, Mohammed Madni Vaid, Sungjin Yoo, Carter Trpik, Shubham Gupta, David Qian, lili liu, Keshav Kumar Prabhakharan, Vasanth Subramanian, Yehui Zhang, yagna gurjala, Omar Abu Mukh, William Randall, Luis Gabriel Lima, Bobby Earl, Dallin Kooyman, Kevin Goldberg, Nitan Singh, Chen Qiu, Faizan Ali, Rishabh Agrawal, Lysander Hernandez, Emma Zhou, Barrett Karson, Ariana Morgan, Namra Alkeshbhai Saheba, Jason Sirota, Lipeng Yang, Rony Jacob John, Yifan Liu, Nick Gonzales, Maxwell Schroder, Mark Asp, David Ney Abarca, Alex Avance, Chengxi Li, Jaden Yuros, Anthony Orozco, Goutham Manjunatha, Alex Jones, Giovanni Viviani, Luu Tran, Saurav Gupta, Petter Nilsson, Rohan Rajeev, Beau Bright, Lin Zhu, Parikshit Desai, Anirudh Narayanan, Roberto Matarrita Arce, Xinyu Zhao, Tyst Marin, Nate Eklund, Marc Shelton, Pranshu Ranakoti, Dayong Li, Anchit Thakur, William Bowditch, Trevor Liberty, Matthew Muncy, Zach Akin-Amland, Abe Diaz, George Coll, Sebastian Sun, Nishant Srivastava, John Li, Ryan Reich, Zach Herridge, Kushal Jain, Jake Gordon, Tyler Barkley, Marcus Mann, Nathan L. Burns, Shailesh Agrawal, Himanish Kaul, Mariam Alaidi, Imran Baig, Giridhar Shyam Sankararaman, Jake Nocentino, Stephane Robin, Angelo Yang, Vishal Sahoo, Jack Bandon, Aiden Gaines, Leonard Al-Qaseer, Ian Auger-Juul, Juan Segura, Saran Kota, Johnny Mastin, Paul Davis, Vasudeva H, Evan Stenger, Leo Zhadanovsky, Setul Patel, Jiacheng Wang, Michael Viscardi, Hung Vu, Addison Tustin, Filippo Galli, Andrew Janzen, Rittik Gautam, Landon Coe, Khaled Sarieddine, Doruk, Yueyang Mi, Amit Chowdhary, Amr Saleh, Chenying Han, Dhaivat Patel, Avi Mikhli, Jaya Kasiraj, Mathieu Pelletan, Abhishek Sharma, Filip Godina, Viren Khatri, Qiong Liu, Parwinder Singh, Nagabharan Nagendran, Dima Sitnikov, Geet Sawhney, Abhishek Dhameja, Chanon Sinitskul, Brian Thomas, Edward Riede, Shawn Li, Alexander Yuan, SIMING DENG, Marcello Silva, Nani, Jin Cheng, Martin Rowan, Rob Chahin, David Van Winkle, Gavin Mealy, Zhe Lv, Srihari Attuluri, Xuecong Zang, Anmol Saxena, Shubhranshu Kumar, Rohan Kumar, Paxton Tomooka, Tao Jiang, Felipe Barajas, Shuli He, Sandip Dutta, Shuolei Jin, Mujahed Syed, Apoorv Srivastava, Kunal Raut, Raghu Burukunte, Shubham Agrawal, FuChen, Projjol Banerji, Jeff Neuberger, Kyjauna Marshall, Noufal Edappanoli, Wei Wei, Tomasz Lauda, Yu Cheng, Kan Zhu, Anant Kaushik, Spencer Zhang, Balaji S, Spandan Agrawal, Kyle Helmick, Pramod Dudhi, Nitin Kanigicharla, Phillip Gong, Atharwa Adawadkar, Chris Paton, Ishan Mishra, Piyush Galphat, Di Wu, Francesco Falcone, Alexander Shen, Joao Miguel, Adi Sridharan, Derek Wilson, Will Maillard, Roman Sandler, Weinan Si, Austin Goddard, Gilhong Min, Sivan Cooperman, Grant Gollier, Jim Hill, Kevin Zuern, Amir Naghibi, connor marr, Louay Morsi, Kellen Jia, Nolan Clayton, Rob Stevens, Sai Chaitanya Manchikatla, Christopher Tyndall, Nischal Kumar, Warren Bui, Chad Bailey, Manish Kumar Gupta, Jamie Gao, Lachlan Lindsay, Matthew Dwyer, Jake Zhao, Jatin Dewani, Roberto Cidade, Bhargav Mistry, Zhongkai Liu, Akash Shrestha, Alexander Blom, Chris Raley, Serena Tan, Artem Pliasunov, Chance Rebholz, Liam Wirth, Sergey Chebotarev, Zeiad Zaf, David Ramos, Ayan Das, Shameem PK, Weibin Zeng, Rahul Dabas, Indika Pathirage, Moshe Yakovson, Anjan Agarwala, Jiayi Zhang, Zihong Hao, Abhishek Aryan, Jacob Morgan, Manuel Chavez, Wenli Yan, Johnny Xue, Albert Huang, Kaiwei Luo, Alex Yelle, Hugo Wen, Jaya Prakash Reddy Gade, Lakshman sai Donavan, Mert Hizli, Anthony Dominianni, Chris Mendis, Purlaksh, Qinghua Gao, Rochak Gupta, Jonathan Cox, Qifeng Huang, Sujoy Datta, Nikitha Tejpal, Prutha Shouche, Tim Lee, Vinitra Ramasubramaniam, Vivek Sayyaparaju, Albin Shrestha, Bojin Li, Gautam Mishra, Kai Mitsuzawa, Kaique Govani, Nagarajesh Lakshmanan, ShotaroKataoka, Thomas Ricatte, Zhaolong Zhang, Albert Achtenberg, Isaac Weaver, Amulya Sahoo, MJ, Sajal Narang, Rohit Ingle, Shelby Hagman, Venkatesh Babu Ayyallu Rajan, Matt Cohen, Paul McKissock, Zhengfei Ji, Abhishek Shasthry, Amad Salmon, Artem Krivonos, Arvind Srinath Kumar, Aziz Saifuddin, Casey Huggins, Jackie Ly, Justin Treece, Lester Lee, Luke Jung, Manish Patel, Rob Wolinski, Siddhant Jain, Sugan Kumar, Wenyu Yang, Andrew Golightly, Arshdeep Takkar, Daisy Dazhen, Justin Bess, Stif Spear Subba.
+<a href="https://github.com/0618" title="MJ Zhang"><img src="https://github.com/0618.png?size=64" width="64" height="64" alt="MJ Zhang" /></a>
+<a href="https://github.com/0V" title="G2"><img src="https://github.com/0V.png?size=64" width="64" height="64" alt="G2" /></a>
+<a href="https://github.com/aahei" title="Ahei"><img src="https://github.com/aahei.png?size=64" width="64" height="64" alt="Ahei" /></a>
+<a href="https://github.com/abe238" title="Abe Diaz (@abe238)"><img src="https://github.com/abe238.png?size=64" width="64" height="64" alt="Abe Diaz (@abe238)" /></a>
+<a href="https://github.com/abhishekdhameja" title="Abhishek Dhameja"><img src="https://github.com/abhishekdhameja.png?size=64" width="64" height="64" alt="Abhishek Dhameja" /></a>
+<a href="https://github.com/Abhishekmitra-slg" title="Abhishek Mitra"><img src="https://github.com/Abhishekmitra-slg.png?size=64" width="64" height="64" alt="Abhishek Mitra" /></a>
+<a href="https://github.com/acdoussan" title="acdoussan"><img src="https://github.com/acdoussan.png?size=64" width="64" height="64" alt="acdoussan" /></a>
+<a href="https://github.com/adam-dunc" title="Adam Duncan"><img src="https://github.com/adam-dunc.png?size=64" width="64" height="64" alt="Adam Duncan" /></a>
+<a href="https://github.com/AddisonTustin" title="AddisonTustin"><img src="https://github.com/AddisonTustin.png?size=64" width="64" height="64" alt="AddisonTustin" /></a>
+<a href="https://github.com/adunuthulan" title="Nirav Adunuthula"><img src="https://github.com/adunuthulan.png?size=64" width="64" height="64" alt="Nirav Adunuthula" /></a>
+<a href="https://github.com/Aiden-Gaines" title="Aiden Gaines"><img src="https://github.com/Aiden-Gaines.png?size=64" width="64" height="64" alt="Aiden Gaines" /></a>
+<a href="https://github.com/akhjones" title="Alexander Jones"><img src="https://github.com/akhjones.png?size=64" width="64" height="64" alt="Alexander Jones" /></a>
+<a href="https://github.com/akshitdesai" title="Akshit Desai"><img src="https://github.com/akshitdesai.png?size=64" width="64" height="64" alt="Akshit Desai" /></a>
+<a href="https://github.com/Albisourous" title="Albin Shrestha"><img src="https://github.com/Albisourous.png?size=64" width="64" height="64" alt="Albin Shrestha" /></a>
+<a href="https://github.com/alecgdouglas" title="Alec Douglas"><img src="https://github.com/alecgdouglas.png?size=64" width="64" height="64" alt="Alec Douglas" /></a>
+<a href="https://github.com/AlexShen101" title="Alex Shen"><img src="https://github.com/AlexShen101.png?size=64" width="64" height="64" alt="Alex Shen" /></a>
+<a href="https://github.com/amadsalmon" title="Amad Salmon"><img src="https://github.com/amadsalmon.png?size=64" width="64" height="64" alt="Amad Salmon" /></a>
+<a href="https://github.com/amulya349" title="Amulya Kumar Sahoo"><img src="https://github.com/amulya349.png?size=64" width="64" height="64" alt="Amulya Kumar Sahoo" /></a>
+<a href="https://github.com/anant-kaushik" title="Anant Kaushik"><img src="https://github.com/anant-kaushik.png?size=64" width="64" height="64" alt="Anant Kaushik" /></a>
+<a href="https://github.com/andrewtakeshi" title="Andrew Golightly"><img src="https://github.com/andrewtakeshi.png?size=64" width="64" height="64" alt="Andrew Golightly" /></a>
+<a href="https://github.com/angeloyu" title="angeloyu"><img src="https://github.com/angeloyu.png?size=64" width="64" height="64" alt="angeloyu" /></a>
+<a href="https://github.com/anjn98" title="anjn98"><img src="https://github.com/anjn98.png?size=64" width="64" height="64" alt="anjn98" /></a>
+<a href="https://github.com/anmolsaxena10" title="Anmol Saxena"><img src="https://github.com/anmolsaxena10.png?size=64" width="64" height="64" alt="Anmol Saxena" /></a>
+<a href="https://github.com/Anthony-dominianni" title="Anthony-dominianni"><img src="https://github.com/Anthony-dominianni.png?size=64" width="64" height="64" alt="Anthony-dominianni" /></a>
+<a href="https://github.com/Anurag461" title="Anurag Kashyap"><img src="https://github.com/Anurag461.png?size=64" width="64" height="64" alt="Anurag Kashyap" /></a>
+<a href="https://github.com/apoorv06s" title="apoorv06s"><img src="https://github.com/apoorv06s.png?size=64" width="64" height="64" alt="apoorv06s" /></a>
+<a href="https://github.com/aqiaojoe08" title="aqiaojoe08"><img src="https://github.com/aqiaojoe08.png?size=64" width="64" height="64" alt="aqiaojoe08" /></a>
+<a href="https://github.com/aravance" title="Alex Avance"><img src="https://github.com/aravance.png?size=64" width="64" height="64" alt="Alex Avance" /></a>
+<a href="https://github.com/architect4dj" title="architect4dj"><img src="https://github.com/architect4dj.png?size=64" width="64" height="64" alt="architect4dj" /></a>
+<a href="https://github.com/arjunsoota" title="Arjun Soota"><img src="https://github.com/arjunsoota.png?size=64" width="64" height="64" alt="Arjun Soota" /></a>
+<a href="https://github.com/arpan98" title="Arpan Banerjee"><img src="https://github.com/arpan98.png?size=64" width="64" height="64" alt="Arpan Banerjee" /></a>
+<a href="https://github.com/arvindsrinathus-tech" title="arvindsrinathus-tech"><img src="https://github.com/arvindsrinathus-tech.png?size=64" width="64" height="64" alt="arvindsrinathus-tech" /></a>
+<a href="https://github.com/AryPathania" title="Ary Pathania"><img src="https://github.com/AryPathania.png?size=64" width="64" height="64" alt="Ary Pathania" /></a>
+<a href="https://github.com/asaifuddin18" title="Aziz Saifuddin"><img src="https://github.com/asaifuddin18.png?size=64" width="64" height="64" alt="Aziz Saifuddin" /></a>
+<a href="https://github.com/ashtnemi448" title="ashtnemi448"><img src="https://github.com/ashtnemi448.png?size=64" width="64" height="64" alt="ashtnemi448" /></a>
+<a href="https://github.com/aswindjs" title="Aswin Damodar"><img src="https://github.com/aswindjs.png?size=64" width="64" height="64" alt="Aswin Damodar" /></a>
+<a href="https://github.com/av-writes-code" title="av-writes-code"><img src="https://github.com/av-writes-code.png?size=64" width="64" height="64" alt="av-writes-code" /></a>
+<a href="https://github.com/avmikhli1" title="avmikhli1"><img src="https://github.com/avmikhli1.png?size=64" width="64" height="64" alt="avmikhli1" /></a>
+<a href="https://github.com/beau-bright" title="beau-bright"><img src="https://github.com/beau-bright.png?size=64" width="64" height="64" alt="beau-bright" /></a>
+<a href="https://github.com/berylqliu1122" title="berylqliu1122"><img src="https://github.com/berylqliu1122.png?size=64" width="64" height="64" alt="berylqliu1122" /></a>
+<a href="https://github.com/bgrubin-amzn" title="bgrubin-amzn"><img src="https://github.com/bgrubin-amzn.png?size=64" width="64" height="64" alt="bgrubin-amzn" /></a>
+<a href="https://github.com/bhargav5000" title="bhargav5000"><img src="https://github.com/bhargav5000.png?size=64" width="64" height="64" alt="bhargav5000" /></a>
+<a href="https://github.com/bigchkn" title="bigchkn"><img src="https://github.com/bigchkn.png?size=64" width="64" height="64" alt="bigchkn" /></a>
+<a href="https://github.com/bkarson" title="bkarson"><img src="https://github.com/bkarson.png?size=64" width="64" height="64" alt="bkarson" /></a>
+<a href="https://github.com/BlumenthalJD" title="Joel Blumenthal"><img src="https://github.com/BlumenthalJD.png?size=64" width="64" height="64" alt="Joel Blumenthal" /></a>
+<a href="https://github.com/bobbyearl" title="Bobby Earl"><img src="https://github.com/bobbyearl.png?size=64" width="64" height="64" alt="Bobby Earl" /></a>
+<a href="https://github.com/bolichen97" title="Bolin Chen"><img src="https://github.com/bolichen97.png?size=64" width="64" height="64" alt="Bolin Chen" /></a>
+<a href="https://github.com/brantai" title="Brent Naylor"><img src="https://github.com/brantai.png?size=64" width="64" height="64" alt="Brent Naylor" /></a>
+<a href="https://github.com/buluoray" title="Ray Xu"><img src="https://github.com/buluoray.png?size=64" width="64" height="64" alt="Ray Xu" /></a>
+<a href="https://github.com/caribbeansteve" title="George Coll"><img src="https://github.com/caribbeansteve.png?size=64" width="64" height="64" alt="George Coll" /></a>
+<a href="https://github.com/carttrp" title="carttrp"><img src="https://github.com/carttrp.png?size=64" width="64" height="64" alt="carttrp" /></a>
+<a href="https://github.com/cathar" title="cathar"><img src="https://github.com/cathar.png?size=64" width="64" height="64" alt="cathar" /></a>
+<a href="https://github.com/chancepants" title="Chance"><img src="https://github.com/chancepants.png?size=64" width="64" height="64" alt="Chance" /></a>
+<a href="https://github.com/ChaonengQuan" title="ChaonengQuan"><img src="https://github.com/ChaonengQuan.png?size=64" width="64" height="64" alt="ChaonengQuan" /></a>
+<a href="https://github.com/chenmingwei23" title="Raymond Chen"><img src="https://github.com/chenmingwei23.png?size=64" width="64" height="64" alt="Raymond Chen" /></a>
+<a href="https://github.com/chenyjade" title="Yu Cheng"><img src="https://github.com/chenyjade.png?size=64" width="64" height="64" alt="Yu Cheng" /></a>
+<a href="https://github.com/chrispaton" title="Chris Paton"><img src="https://github.com/chrispaton.png?size=64" width="64" height="64" alt="Chris Paton" /></a>
+<a href="https://github.com/cixuuz" title="cixuuuuuuuuz"><img src="https://github.com/cixuuz.png?size=64" width="64" height="64" alt="cixuuuuuuuuz" /></a>
+<a href="https://github.com/cohilla" title="Cody Hill"><img src="https://github.com/cohilla.png?size=64" width="64" height="64" alt="Cody Hill" /></a>
+<a href="https://github.com/colewhitley" title="Cole Whitley"><img src="https://github.com/colewhitley.png?size=64" width="64" height="64" alt="Cole Whitley" /></a>
+<a href="https://github.com/ConnorLoP" title="Connor LoPresti"><img src="https://github.com/ConnorLoP.png?size=64" width="64" height="64" alt="Connor LoPresti" /></a>
+<a href="https://github.com/ConstantineWang" title="Jiacheng Wang"><img src="https://github.com/ConstantineWang.png?size=64" width="64" height="64" alt="Jiacheng Wang" /></a>
+<a href="https://github.com/cruisercohen" title="Matt Cohen"><img src="https://github.com/cruisercohen.png?size=64" width="64" height="64" alt="Matt Cohen" /></a>
+<a href="https://github.com/CrysisDeu" title="Zezhen Xu"><img src="https://github.com/CrysisDeu.png?size=64" width="64" height="64" alt="Zezhen Xu" /></a>
+<a href="https://github.com/Csan25" title="Csan25"><img src="https://github.com/Csan25.png?size=64" width="64" height="64" alt="Csan25" /></a>
+<a href="https://github.com/ctyndall" title="ctyndall"><img src="https://github.com/ctyndall.png?size=64" width="64" height="64" alt="ctyndall" /></a>
+<a href="https://github.com/dagayev1" title="Dagadansbot"><img src="https://github.com/dagayev1.png?size=64" width="64" height="64" alt="Dagadansbot" /></a>
+<a href="https://github.com/darko-mesaros" title="Darko Mesaros"><img src="https://github.com/darko-mesaros.png?size=64" width="64" height="64" alt="Darko Mesaros" /></a>
+<a href="https://github.com/davidtlee-amzn" title="davidtlee-amzn"><img src="https://github.com/davidtlee-amzn.png?size=64" width="64" height="64" alt="davidtlee-amzn" /></a>
+<a href="https://github.com/derrick0714" title="Xu Deng"><img src="https://github.com/derrick0714.png?size=64" width="64" height="64" alt="Xu Deng" /></a>
+<a href="https://github.com/desaip05" title="Parikshit Desai"><img src="https://github.com/desaip05.png?size=64" width="64" height="64" alt="Parikshit Desai" /></a>
+<a href="https://github.com/DFayerman" title="DFayerman"><img src="https://github.com/DFayerman.png?size=64" width="64" height="64" alt="DFayerman" /></a>
+<a href="https://github.com/dgomesbr" title="Diego Magalhães"><img src="https://github.com/dgomesbr.png?size=64" width="64" height="64" alt="Diego Magalhães" /></a>
+<a href="https://github.com/Dhaivat717" title="Dhaivat Patel"><img src="https://github.com/Dhaivat717.png?size=64" width="64" height="64" alt="Dhaivat Patel" /></a>
+<a href="https://github.com/doc88129" title="Doc"><img src="https://github.com/doc88129.png?size=64" width="64" height="64" alt="Doc" /></a>
+<a href="https://github.com/dougclauson" title="dougclauson"><img src="https://github.com/dougclauson.png?size=64" width="64" height="64" alt="dougclauson" /></a>
+<a href="https://github.com/dsm0709" title="Siming Deng"><img src="https://github.com/dsm0709.png?size=64" width="64" height="64" alt="Siming Deng" /></a>
+<a href="https://github.com/dwu96" title="Di Wu"><img src="https://github.com/dwu96.png?size=64" width="64" height="64" alt="Di Wu" /></a>
+<a href="https://github.com/echorubisco" title="echorubisco"><img src="https://github.com/echorubisco.png?size=64" width="64" height="64" alt="echorubisco" /></a>
+<a href="https://github.com/EllaRed" title="Emmanuella Dasilva-Domingos"><img src="https://github.com/EllaRed.png?size=64" width="64" height="64" alt="Emmanuella Dasilva-Domingos" /></a>
+<a href="https://github.com/em-sec" title="Eric M"><img src="https://github.com/em-sec.png?size=64" width="64" height="64" alt="Eric M" /></a>
+<a href="https://github.com/Eng-Ahmd" title="Ahmed Hassanin"><img src="https://github.com/Eng-Ahmd.png?size=64" width="64" height="64" alt="Ahmed Hassanin" /></a>
+<a href="https://github.com/envyN" title="Naveen Adarsh"><img src="https://github.com/envyN.png?size=64" width="64" height="64" alt="Naveen Adarsh" /></a>
+<a href="https://github.com/erichays" title="Eric Hays"><img src="https://github.com/erichays.png?size=64" width="64" height="64" alt="Eric Hays" /></a>
+<a href="https://github.com/erikbomb" title="Erik Schweiss"><img src="https://github.com/erikbomb.png?size=64" width="64" height="64" alt="Erik Schweiss" /></a>
+<a href="https://github.com/estenger" title="Evan Stenger"><img src="https://github.com/estenger.png?size=64" width="64" height="64" alt="Evan Stenger" /></a>
+<a href="https://github.com/EzzatQ" title="Ezzat Qupty"><img src="https://github.com/EzzatQ.png?size=64" width="64" height="64" alt="Ezzat Qupty" /></a>
+<a href="https://github.com/felipeb" title="Felipe"><img src="https://github.com/felipeb.png?size=64" width="64" height="64" alt="Felipe" /></a>
+<a href="https://github.com/filipgodina" title="filipgodina"><img src="https://github.com/filipgodina.png?size=64" width="64" height="64" alt="filipgodina" /></a>
+<a href="https://github.com/finnhad" title="Finn H"><img src="https://github.com/finnhad.png?size=64" width="64" height="64" alt="Finn H" /></a>
+<a href="https://github.com/FlameFrost" title="FlameFrost"><img src="https://github.com/FlameFrost.png?size=64" width="64" height="64" alt="FlameFrost" /></a>
+<a href="https://github.com/FlowTable0" title="FlowTable0"><img src="https://github.com/FlowTable0.png?size=64" width="64" height="64" alt="FlowTable0" /></a>
+<a href="https://github.com/fo2rist" title="Dmitry Sitnikov"><img src="https://github.com/fo2rist.png?size=64" width="64" height="64" alt="Dmitry Sitnikov" /></a>
+<a href="https://github.com/Garnethil" title="Gabriel Sanchez"><img src="https://github.com/Garnethil.png?size=64" width="64" height="64" alt="Gabriel Sanchez" /></a>
+<a href="https://github.com/geetsawhney" title="geet sawhney"><img src="https://github.com/geetsawhney.png?size=64" width="64" height="64" alt="geet sawhney" /></a>
+<a href="https://github.com/gmealy1" title="Gavin Mealy"><img src="https://github.com/gmealy1.png?size=64" width="64" height="64" alt="Gavin Mealy" /></a>
+<a href="https://github.com/Godivamasterpiece" title="Vivek Teja Sayyaparaju"><img src="https://github.com/Godivamasterpiece.png?size=64" width="64" height="64" alt="Vivek Teja Sayyaparaju" /></a> <!-- wokeignore:rule=master -->
+<a href="https://github.com/GouthamHM" title="Goutham"><img src="https://github.com/GouthamHM.png?size=64" width="64" height="64" alt="Goutham" /></a>
+<a href="https://github.com/gragollier" title="Grant Gollier"><img src="https://github.com/gragollier.png?size=64" width="64" height="64" alt="Grant Gollier" /></a>
+<a href="https://github.com/greatfighter" title="Spencer"><img src="https://github.com/greatfighter.png?size=64" width="64" height="64" alt="Spencer" /></a>
+<a href="https://github.com/gregory-chapman" title="Gregory Chapman"><img src="https://github.com/gregory-chapman.png?size=64" width="64" height="64" alt="Gregory Chapman" /></a>
+<a href="https://github.com/haozihong" title="haozihong"><img src="https://github.com/haozihong.png?size=64" width="64" height="64" alt="haozihong" /></a>
+<a href="https://github.com/hchy0422" title="Kathy Han"><img src="https://github.com/hchy0422.png?size=64" width="64" height="64" alt="Kathy Han" /></a>
+<a href="https://github.com/helenastafford" title="helenastafford"><img src="https://github.com/helenastafford.png?size=64" width="64" height="64" alt="helenastafford" /></a>
+<a href="https://github.com/hhllii" title="hhllii"><img src="https://github.com/hhllii.png?size=64" width="64" height="64" alt="hhllii" /></a>
+<a href="https://github.com/hoang-phan98" title="Hoang "><img src="https://github.com/hoang-phan98.png?size=64" width="64" height="64" alt="Hoang " /></a>
+<a href="https://github.com/hugoncosta" title="Hugo Costa"><img src="https://github.com/hugoncosta.png?size=64" width="64" height="64" alt="Hugo Costa" /></a>
+<a href="https://github.com/hungtnvu" title="Hung Vu"><img src="https://github.com/hungtnvu.png?size=64" width="64" height="64" alt="Hung Vu" /></a>
+<a href="https://github.com/iamwhatever" title="iamwhatever"><img src="https://github.com/iamwhatever.png?size=64" width="64" height="64" alt="iamwhatever" /></a>
+<a href="https://github.com/inaoy" title="inaoy"><img src="https://github.com/inaoy.png?size=64" width="64" height="64" alt="inaoy" /></a>
+<a href="https://github.com/IngridMorstrad" title="IngridMorstrad"><img src="https://github.com/IngridMorstrad.png?size=64" width="64" height="64" alt="IngridMorstrad" /></a>
+<a href="https://github.com/ishansmishra" title="Ishan Mishra"><img src="https://github.com/ishansmishra.png?size=64" width="64" height="64" alt="Ishan Mishra" /></a>
+<a href="https://github.com/j20120307" title="j20120307"><img src="https://github.com/j20120307.png?size=64" width="64" height="64" alt="j20120307" /></a>
+<a href="https://github.com/JainSid96" title="Siddhant Jain"><img src="https://github.com/JainSid96.png?size=64" width="64" height="64" alt="Siddhant Jain" /></a>
+<a href="https://github.com/jakeg0615" title="jakeg0615"><img src="https://github.com/jakeg0615.png?size=64" width="64" height="64" alt="jakeg0615" /></a>
+<a href="https://github.com/jakeinater" title="Jake Zhao"><img src="https://github.com/jakeinater.png?size=64" width="64" height="64" alt="Jake Zhao" /></a>
+<a href="https://github.com/jakenoc" title="Jacob Nocentino"><img src="https://github.com/jakenoc.png?size=64" width="64" height="64" alt="Jacob Nocentino" /></a>
+<a href="https://github.com/JasonZhang1993" title="Jason Zhang's Git"><img src="https://github.com/JasonZhang1993.png?size=64" width="64" height="64" alt="Jason Zhang's Git" /></a>
+<a href="https://github.com/jayaprakashreddy007" title="jayaprakashreddy007"><img src="https://github.com/jayaprakashreddy007.png?size=64" width="64" height="64" alt="jayaprakashreddy007" /></a>
+<a href="https://github.com/jbandon" title="Jack Bandon"><img src="https://github.com/jbandon.png?size=64" width="64" height="64" alt="Jack Bandon" /></a>
+<a href="https://github.com/jeffn12" title="Jeff Neuberger"><img src="https://github.com/jeffn12.png?size=64" width="64" height="64" alt="Jeff Neuberger" /></a>
+<a href="https://github.com/jianwenl" title="jianwenl"><img src="https://github.com/jianwenl.png?size=64" width="64" height="64" alt="jianwenl" /></a>
+<a href="https://github.com/jkasiraj" title="jkasiraj"><img src="https://github.com/jkasiraj.png?size=64" width="64" height="64" alt="jkasiraj" /></a>
+<a href="https://github.com/jodoyodo" title="David Qian"><img src="https://github.com/jodoyodo.png?size=64" width="64" height="64" alt="David Qian" /></a>
+<a href="https://github.com/JohnEspenhahn" title="John Espenhahn"><img src="https://github.com/JohnEspenhahn.png?size=64" width="64" height="64" alt="John Espenhahn" /></a>
+<a href="https://github.com/johnnymastin" title="Johnny Mastin"><img src="https://github.com/johnnymastin.png?size=64" width="64" height="64" alt="Johnny Mastin" /></a>
+<a href="https://github.com/johnnynaught" title="johnnynaught"><img src="https://github.com/johnnynaught.png?size=64" width="64" height="64" alt="johnnynaught" /></a>
+<a href="https://github.com/Jpontone" title="JPontone"><img src="https://github.com/Jpontone.png?size=64" width="64" height="64" alt="JPontone" /></a>
+<a href="https://github.com/Jus973" title="Justin Z"><img src="https://github.com/Jus973.png?size=64" width="64" height="64" alt="Justin Z" /></a>
+<a href="https://github.com/jyuros" title="Jaden Yuros"><img src="https://github.com/jyuros.png?size=64" width="64" height="64" alt="Jaden Yuros" /></a>
+<a href="https://github.com/KaiqueGovani" title="Kaique Govani"><img src="https://github.com/KaiqueGovani.png?size=64" width="64" height="64" alt="Kaique Govani" /></a>
+<a href="https://github.com/kaizawa97" title="Kai Mitsuzawa"><img src="https://github.com/kaizawa97.png?size=64" width="64" height="64" alt="Kai Mitsuzawa" /></a>
+<a href="https://github.com/kesh97-hub" title="kesh97-hub"><img src="https://github.com/kesh97-hub.png?size=64" width="64" height="64" alt="kesh97-hub" /></a>
+<a href="https://github.com/keyejia" title="Kellen Jia"><img src="https://github.com/keyejia.png?size=64" width="64" height="64" alt="Kellen Jia" /></a>
+<a href="https://github.com/kiavashsamadi" title="Kiavash"><img src="https://github.com/kiavashsamadi.png?size=64" width="64" height="64" alt="Kiavash" /></a>
+<a href="https://github.com/kishoreb95" title="Kishore Baskar"><img src="https://github.com/kishoreb95.png?size=64" width="64" height="64" alt="Kishore Baskar" /></a>
+<a href="https://github.com/Kive1ru" title="Jiahao Guo"><img src="https://github.com/Kive1ru.png?size=64" width="64" height="64" alt="Jiahao Guo" /></a>
+<a href="https://github.com/kondisettyravi" title="Ravi Teja Kondisetty"><img src="https://github.com/kondisettyravi.png?size=64" width="64" height="64" alt="Ravi Teja Kondisetty" /></a>
+<a href="https://github.com/krishdhasmana" title="Krish Dhasmana"><img src="https://github.com/krishdhasmana.png?size=64" width="64" height="64" alt="Krish Dhasmana" /></a>
+<a href="https://github.com/krunalpa-amzn" title="krunalpa-amzn"><img src="https://github.com/krunalpa-amzn.png?size=64" width="64" height="64" alt="krunalpa-amzn" /></a>
+<a href="https://github.com/ktreharrison" title="Ken Harrison"><img src="https://github.com/ktreharrison.png?size=64" width="64" height="64" alt="Ken Harrison" /></a>
+<a href="https://github.com/Kyle-Helmick" title="Kyle Helmick"><img src="https://github.com/Kyle-Helmick.png?size=64" width="64" height="64" alt="Kyle Helmick" /></a>
+<a href="https://github.com/kyleseaman" title="Kyle Seaman"><img src="https://github.com/kyleseaman.png?size=64" width="64" height="64" alt="Kyle Seaman" /></a>
+<a href="https://github.com/LachlanLindsay" title="Lachlan Lindsay"><img src="https://github.com/LachlanLindsay.png?size=64" width="64" height="64" alt="Lachlan Lindsay" /></a>
+<a href="https://github.com/lagrider" title="Bojin Li"><img src="https://github.com/lagrider.png?size=64" width="64" height="64" alt="Bojin Li" /></a>
+<a href="https://github.com/LandonCoe" title="LandonCoe"><img src="https://github.com/LandonCoe.png?size=64" width="64" height="64" alt="LandonCoe" /></a>
+<a href="https://github.com/lcplcy" title="Lho Chen Yang"><img src="https://github.com/lcplcy.png?size=64" width="64" height="64" alt="Lho Chen Yang" /></a>
+<a href="https://github.com/LeonardALQ" title="Leonard"><img src="https://github.com/LeonardALQ.png?size=64" width="64" height="64" alt="Leonard" /></a>
+<a href="https://github.com/leozhad" title="Leo Zhadanovsky"><img src="https://github.com/leozhad.png?size=64" width="64" height="64" alt="Leo Zhadanovsky" /></a>
+<a href="https://github.com/LeTeutz" title="Teodor Oprescu"><img src="https://github.com/LeTeutz.png?size=64" width="64" height="64" alt="Teodor Oprescu" /></a>
+<a href="https://github.com/LiptonJumboTeaBag" title="John Li"><img src="https://github.com/LiptonJumboTeaBag.png?size=64" width="64" height="64" alt="John Li" /></a>
+<a href="https://github.com/lmambr2" title="lmambr2"><img src="https://github.com/lmambr2.png?size=64" width="64" height="64" alt="lmambr2" /></a>
+<a href="https://github.com/Lock128" title="Johannes Koch"><img src="https://github.com/Lock128.png?size=64" width="64" height="64" alt="Johannes Koch" /></a>
+<a href="https://github.com/logesh4v" title="LOGESH S"><img src="https://github.com/logesh4v.png?size=64" width="64" height="64" alt="LOGESH S" /></a>
+<a href="https://github.com/LucaButBoring" title="Luca Chang"><img src="https://github.com/LucaButBoring.png?size=64" width="64" height="64" alt="Luca Chang" /></a>
+<a href="https://github.com/luisgabriel" title="Luís Gabriel Lima"><img src="https://github.com/luisgabriel.png?size=64" width="64" height="64" alt="Luís Gabriel Lima" /></a>
+<a href="https://github.com/lukehjung" title="Luke Jung"><img src="https://github.com/lukehjung.png?size=64" width="64" height="64" alt="Luke Jung" /></a>
+<a href="https://github.com/Lunchb0ne" title="Abhishek Aryan"><img src="https://github.com/Lunchb0ne.png?size=64" width="64" height="64" alt="Abhishek Aryan" /></a>
+<a href="https://github.com/luokaiwei" title="Kaiwei Luo"><img src="https://github.com/luokaiwei.png?size=64" width="64" height="64" alt="Kaiwei Luo" /></a>
+<a href="https://github.com/luudtran" title="luudtran"><img src="https://github.com/luudtran.png?size=64" width="64" height="64" alt="luudtran" /></a>
+<a href="https://github.com/MacintoshPlus89" title="MacintoshPlus89"><img src="https://github.com/MacintoshPlus89.png?size=64" width="64" height="64" alt="MacintoshPlus89" /></a>
+<a href="https://github.com/maitianqcc" title="maitianqcc"><img src="https://github.com/maitianqcc.png?size=64" width="64" height="64" alt="maitianqcc" /></a>
+<a href="https://github.com/mamaiti" title="mamaiti"><img src="https://github.com/mamaiti.png?size=64" width="64" height="64" alt="mamaiti" /></a>
+<a href="https://github.com/mannitrkl2006" title="manish.gupta"><img src="https://github.com/mannitrkl2006.png?size=64" width="64" height="64" alt="manish.gupta" /></a>
+<a href="https://github.com/mariamalaidi" title="mariamalaidi"><img src="https://github.com/mariamalaidi.png?size=64" width="64" height="64" alt="mariamalaidi" /></a>
+<a href="https://github.com/martchellop" title="Marcello Pagano"><img src="https://github.com/martchellop.png?size=64" width="64" height="64" alt="Marcello Pagano" /></a>
+<a href="https://github.com/MarvellousCodes" title="Marvellous Adedapo"><img src="https://github.com/MarvellousCodes.png?size=64" width="64" height="64" alt="Marvellous Adedapo" /></a>
+<a href="https://github.com/MattMCloudy" title="Matthew McLeod"><img src="https://github.com/MattMCloudy.png?size=64" width="64" height="64" alt="Matthew McLeod" /></a>
+<a href="https://github.com/maufee" title="maufee"><img src="https://github.com/maufee.png?size=64" width="64" height="64" alt="maufee" /></a>
+<a href="https://github.com/mbajaj92" title="Madhur Bajaj"><img src="https://github.com/mbajaj92.png?size=64" width="64" height="64" alt="Madhur Bajaj" /></a>
+<a href="https://github.com/mchaloupka" title="Milos Chaloupka"><img src="https://github.com/mchaloupka.png?size=64" width="64" height="64" alt="Milos Chaloupka" /></a>
+<a href="https://github.com/mclawben" title="mclawben"><img src="https://github.com/mclawben.png?size=64" width="64" height="64" alt="mclawben" /></a>
+<a href="https://github.com/mcryan77" title="mcryan"><img src="https://github.com/mcryan77.png?size=64" width="64" height="64" alt="mcryan" /></a>
+<a href="https://github.com/Mdkar" title="Mihir Dhamankar"><img src="https://github.com/Mdkar.png?size=64" width="64" height="64" alt="Mihir Dhamankar" /></a>
+<a href="https://github.com/mdwyer223" title="Matthew Dwyer"><img src="https://github.com/mdwyer223.png?size=64" width="64" height="64" alt="Matthew Dwyer" /></a>
+<a href="https://github.com/michellemxm" title="Michelle Ma"><img src="https://github.com/michellemxm.png?size=64" width="64" height="64" alt="Michelle Ma" /></a>
+<a href="https://github.com/MikeMayer" title="Mike Mayer"><img src="https://github.com/MikeMayer.png?size=64" width="64" height="64" alt="Mike Mayer" /></a>
+<a href="https://github.com/mikkuzne" title="Mikhail Kuznetsov"><img src="https://github.com/mikkuzne.png?size=64" width="64" height="64" alt="Mikhail Kuznetsov" /></a>
+<a href="https://github.com/mkbarnum" title="mkbarnum"><img src="https://github.com/mkbarnum.png?size=64" width="64" height="64" alt="mkbarnum" /></a>
+<a href="https://github.com/molladair" title="Molly Adair"><img src="https://github.com/molladair.png?size=64" width="64" height="64" alt="Molly Adair" /></a>
+<a href="https://github.com/musaprg" title="Kotaro Inoue"><img src="https://github.com/musaprg.png?size=64" width="64" height="64" alt="Kotaro Inoue" /></a>
+<a href="https://github.com/mustafaonuraydin" title="Mustafa Onur AYDIN"><img src="https://github.com/mustafaonuraydin.png?size=64" width="64" height="64" alt="Mustafa Onur AYDIN" /></a>
+<a href="https://github.com/nadetastic" title="Dan Kiuna"><img src="https://github.com/nadetastic.png?size=64" width="64" height="64" alt="Dan Kiuna" /></a>
+<a href="https://github.com/nagabharann" title="Nagabharan Nagendran"><img src="https://github.com/nagabharann.png?size=64" width="64" height="64" alt="Nagabharan Nagendran" /></a>
+<a href="https://github.com/namrasaheba" title="Namra Saheba"><img src="https://github.com/namrasaheba.png?size=64" width="64" height="64" alt="Namra Saheba" /></a>
+<a href="https://github.com/nateeklund" title="Nate Eklund"><img src="https://github.com/nateeklund.png?size=64" width="64" height="64" alt="Nate Eklund" /></a>
+<a href="https://github.com/nathanyi96" title="Nathan"><img src="https://github.com/nathanyi96.png?size=64" width="64" height="64" alt="Nathan" /></a>
+<a href="https://github.com/NDNey" title="David Ney"><img src="https://github.com/NDNey.png?size=64" width="64" height="64" alt="David Ney" /></a>
+<a href="https://github.com/NguyenMatthew" title="Matthew Nguyen"><img src="https://github.com/NguyenMatthew.png?size=64" width="64" height="64" alt="Matthew Nguyen" /></a>
+<a href="https://github.com/NicholasRBowers" title="Nicholas Bowers"><img src="https://github.com/NicholasRBowers.png?size=64" width="64" height="64" alt="Nicholas Bowers" /></a>
+<a href="https://github.com/nihal111" title="Nihal Singh"><img src="https://github.com/nihal111.png?size=64" width="64" height="64" alt="Nihal Singh" /></a>
+<a href="https://github.com/nikhil-m-amazon" title="Nikhil Menon"><img src="https://github.com/nikhil-m-amazon.png?size=64" width="64" height="64" alt="Nikhil Menon" /></a>
+<a href="https://github.com/nikithajain888" title="nikithajain888"><img src="https://github.com/nikithajain888.png?size=64" width="64" height="64" alt="nikithajain888" /></a>
+<a href="https://github.com/NikolasPpd" title="Nick Papadopoulos"><img src="https://github.com/NikolasPpd.png?size=64" width="64" height="64" alt="Nick Papadopoulos" /></a>
+<a href="https://github.com/nishi7409" title="Nishant Srivastava"><img src="https://github.com/nishi7409.png?size=64" width="64" height="64" alt="Nishant Srivastava" /></a>
+<a href="https://github.com/nitan2k" title="nitan2k"><img src="https://github.com/nitan2k.png?size=64" width="64" height="64" alt="nitan2k" /></a>
+<a href="https://github.com/NovaPlasm" title="Beau Taylor"><img src="https://github.com/NovaPlasm.png?size=64" width="64" height="64" alt="Beau Taylor" /></a>
+<a href="https://github.com/nyclord" title="Mark Lord"><img src="https://github.com/nyclord.png?size=64" width="64" height="64" alt="Mark Lord" /></a>
+<a href="https://github.com/officialprosingh" title="Parwinder Singh"><img src="https://github.com/officialprosingh.png?size=64" width="64" height="64" alt="Parwinder Singh" /></a>
+<a href="https://github.com/OnlyOneByte" title="Rengang (Angelo) Yang"><img src="https://github.com/OnlyOneByte.png?size=64" width="64" height="64" alt="Rengang (Angelo) Yang" /></a>
+<a href="https://github.com/parimaldeshmukh" title="Parimal Deshmukh"><img src="https://github.com/parimaldeshmukh.png?size=64" width="64" height="64" alt="Parimal Deshmukh" /></a>
+<a href="https://github.com/patrigao" title="patrigao"><img src="https://github.com/patrigao.png?size=64" width="64" height="64" alt="patrigao" /></a>
+<a href="https://github.com/pbcoder" title="pbcoder"><img src="https://github.com/pbcoder.png?size=64" width="64" height="64" alt="pbcoder" /></a>
+<a href="https://github.com/pepmach" title="Stan Tian"><img src="https://github.com/pepmach.png?size=64" width="64" height="64" alt="Stan Tian" /></a>
+<a href="https://github.com/peterhieuvu" title="peterhieuvu"><img src="https://github.com/peterhieuvu.png?size=64" width="64" height="64" alt="peterhieuvu" /></a>
+<a href="https://github.com/philipjk" title="philipjk"><img src="https://github.com/philipjk.png?size=64" width="64" height="64" alt="philipjk" /></a>
+<a href="https://github.com/pierrms" title="pierrms"><img src="https://github.com/pierrms.png?size=64" width="64" height="64" alt="pierrms" /></a>
+<a href="https://github.com/pilami" title="Sai Chaitanya Manchikatla"><img src="https://github.com/pilami.png?size=64" width="64" height="64" alt="Sai Chaitanya Manchikatla" /></a>
+<a href="https://github.com/PNg-HA" title="PNg HA"><img src="https://github.com/PNg-HA.png?size=64" width="64" height="64" alt="PNg HA" /></a>
+<a href="https://github.com/popematt" title="Matthew Pope"><img src="https://github.com/popematt.png?size=64" width="64" height="64" alt="Matthew Pope" /></a>
+<a href="https://github.com/poyea" title="John Law"><img src="https://github.com/poyea.png?size=64" width="64" height="64" alt="John Law" /></a>
+<a href="https://github.com/pramod-123" title="Pramod Dudhi"><img src="https://github.com/pramod-123.png?size=64" width="64" height="64" alt="Pramod Dudhi" /></a>
+<a href="https://github.com/presidentarrow" title="presidentarrow"><img src="https://github.com/presidentarrow.png?size=64" width="64" height="64" alt="presidentarrow" /></a>
+<a href="https://github.com/ptomooka" title="ptomooka"><img src="https://github.com/ptomooka.png?size=64" width="64" height="64" alt="ptomooka" /></a>
+<a href="https://github.com/qh2244" title="Qifeng Huang"><img src="https://github.com/qh2244.png?size=64" width="64" height="64" alt="Qifeng Huang" /></a>
+<a href="https://github.com/qinghua" title="qinghua"><img src="https://github.com/qinghua.png?size=64" width="64" height="64" alt="qinghua" /></a>
+<a href="https://github.com/Qusai1201" title="Qusai Hussein"><img src="https://github.com/Qusai1201.png?size=64" width="64" height="64" alt="Qusai Hussein" /></a>
+<a href="https://github.com/r331" title="Roman Ivanov"><img src="https://github.com/r331.png?size=64" width="64" height="64" alt="Roman Ivanov" /></a>
+<a href="https://github.com/rabinarayanpatra" title="Rabinarayan Patra"><img src="https://github.com/rabinarayanpatra.png?size=64" width="64" height="64" alt="Rabinarayan Patra" /></a>
+<a href="https://github.com/radical-beard" title="radical-beard"><img src="https://github.com/radical-beard.png?size=64" width="64" height="64" alt="radical-beard" /></a>
+<a href="https://github.com/Rajnita" title="Rajnita Leichombam"><img src="https://github.com/Rajnita.png?size=64" width="64" height="64" alt="Rajnita Leichombam" /></a>
+<a href="https://github.com/rajpuram09" title="Raj Puram"><img src="https://github.com/rajpuram09.png?size=64" width="64" height="64" alt="Raj Puram" /></a>
+<a href="https://github.com/raleycs" title="Christopher Raley"><img src="https://github.com/raleycs.png?size=64" width="64" height="64" alt="Christopher Raley" /></a>
+<a href="https://github.com/ramdavid" title="ramdavid"><img src="https://github.com/ramdavid.png?size=64" width="64" height="64" alt="ramdavid" /></a>
+<a href="https://github.com/randallwc" title="William Randall"><img src="https://github.com/randallwc.png?size=64" width="64" height="64" alt="William Randall" /></a>
+<a href="https://github.com/rbcommits" title="Raghav Bhardwaj"><img src="https://github.com/rbcommits.png?size=64" width="64" height="64" alt="Raghav Bhardwaj" /></a>
+<a href="https://github.com/rcidadef" title="Roberto Cidade Fonseca"><img src="https://github.com/rcidadef.png?size=64" width="64" height="64" alt="Roberto Cidade Fonseca" /></a>
+<a href="https://github.com/Remicks1" title="Jimmy Kilpatrick"><img src="https://github.com/Remicks1.png?size=64" width="64" height="64" alt="Jimmy Kilpatrick" /></a>
+<a href="https://github.com/rishabhagrawal1" title="Rishabh Agrawal"><img src="https://github.com/rishabhagrawal1.png?size=64" width="64" height="64" alt="Rishabh Agrawal" /></a>
+<a href="https://github.com/rittikg-amazon" title="rittikg-amazon"><img src="https://github.com/rittikg-amazon.png?size=64" width="64" height="64" alt="rittikg-amazon" /></a>
+<a href="https://github.com/robchahin" title="robchahin"><img src="https://github.com/robchahin.png?size=64" width="64" height="64" alt="robchahin" /></a>
+<a href="https://github.com/rochakgupta" title="Rochak Gupta"><img src="https://github.com/rochakgupta.png?size=64" width="64" height="64" alt="Rochak Gupta" /></a>
+<a href="https://github.com/Rocketpoodle" title="Austin Goddard"><img src="https://github.com/Rocketpoodle.png?size=64" width="64" height="64" alt="Austin Goddard" /></a>
+<a href="https://github.com/RohanK6" title="RohanK6"><img src="https://github.com/RohanK6.png?size=64" width="64" height="64" alt="RohanK6" /></a>
+<a href="https://github.com/rohit-mehra" title="Rohit Mehra"><img src="https://github.com/rohit-mehra.png?size=64" width="64" height="64" alt="Rohit Mehra" /></a>
+<a href="https://github.com/ronyjacobjohn-tech" title="ronyjacobjohn-tech"><img src="https://github.com/ronyjacobjohn-tech.png?size=64" width="64" height="64" alt="ronyjacobjohn-tech" /></a>
+<a href="https://github.com/rpranshu" title="Pranshu Ranakoti"><img src="https://github.com/rpranshu.png?size=64" width="64" height="64" alt="Pranshu Ranakoti" /></a>
+<a href="https://github.com/rstomasalberto" title="Tomas Rodriguez"><img src="https://github.com/rstomasalberto.png?size=64" width="64" height="64" alt="Tomas Rodriguez" /></a>
+<a href="https://github.com/rvinitra" title="rvinitra"><img src="https://github.com/rvinitra.png?size=64" width="64" height="64" alt="rvinitra" /></a>
+<a href="https://github.com/ryancormack" title="Ryan Cormack"><img src="https://github.com/ryancormack.png?size=64" width="64" height="64" alt="Ryan Cormack" /></a>
+<a href="https://github.com/sandlerr" title="Roman Sandler"><img src="https://github.com/sandlerr.png?size=64" width="64" height="64" alt="Roman Sandler" /></a>
+<a href="https://github.com/Sapientia-PT" title="João Miguel"><img src="https://github.com/Sapientia-PT.png?size=64" width="64" height="64" alt="João Miguel" /></a>
+<a href="https://github.com/sarankota" title="Saran Kota"><img src="https://github.com/sarankota.png?size=64" width="64" height="64" alt="Saran Kota" /></a>
+<a href="https://github.com/sauravgpt" title="Saurav Kumar Gupta"><img src="https://github.com/sauravgpt.png?size=64" width="64" height="64" alt="Saurav Kumar Gupta" /></a>
+<a href="https://github.com/scuthbert" title="Sam Cuthbertson"><img src="https://github.com/scuthbert.png?size=64" width="64" height="64" alt="Sam Cuthbertson" /></a>
+<a href="https://github.com/SebastianYuSun" title="Sebastian (Yu) Sun"><img src="https://github.com/SebastianYuSun.png?size=64" width="64" height="64" alt="Sebastian (Yu) Sun" /></a>
+<a href="https://github.com/Setul0712" title="Setul0712"><img src="https://github.com/Setul0712.png?size=64" width="64" height="64" alt="Setul0712" /></a>
+<a href="https://github.com/shaochew" title="shaochew"><img src="https://github.com/shaochew.png?size=64" width="64" height="64" alt="shaochew" /></a>
+<a href="https://github.com/shawnxli" title="Shawn Li"><img src="https://github.com/shawnxli.png?size=64" width="64" height="64" alt="Shawn Li" /></a>
+<a href="https://github.com/ShayanYaseen" title="Shayan"><img src="https://github.com/ShayanYaseen.png?size=64" width="64" height="64" alt="Shayan" /></a>
+<a href="https://github.com/ShelbyZ" title="Shelby Hagman"><img src="https://github.com/ShelbyZ.png?size=64" width="64" height="64" alt="Shelby Hagman" /></a>
+<a href="https://github.com/Ship-Loop" title="Siddartha "><img src="https://github.com/Ship-Loop.png?size=64" width="64" height="64" alt="Siddartha " /></a>
+<a href="https://github.com/shortbloke" title="Martin Rowan"><img src="https://github.com/shortbloke.png?size=64" width="64" height="64" alt="Martin Rowan" /></a>
+<a href="https://github.com/ShotaroKataoka" title="Shotaro Kataoka"><img src="https://github.com/ShotaroKataoka.png?size=64" width="64" height="64" alt="Shotaro Kataoka" /></a>
+<a href="https://github.com/skagraw16" title="skagraw16"><img src="https://github.com/skagraw16.png?size=64" width="64" height="64" alt="skagraw16" /></a>
+<a href="https://github.com/smeyffret" title="smeyffret"><img src="https://github.com/smeyffret.png?size=64" width="64" height="64" alt="smeyffret" /></a>
+<a href="https://github.com/snoldak924" title="Sam Oldak"><img src="https://github.com/snoldak924.png?size=64" width="64" height="64" alt="Sam Oldak" /></a>
+<a href="https://github.com/snowoody" title="snowoody"><img src="https://github.com/snowoody.png?size=64" width="64" height="64" alt="snowoody" /></a>
+<a href="https://github.com/solnikhil" title="Nikhil Solanki"><img src="https://github.com/solnikhil.png?size=64" width="64" height="64" alt="Nikhil Solanki" /></a>
+<a href="https://github.com/Soneji" title="Dhaval Soneji"><img src="https://github.com/Soneji.png?size=64" width="64" height="64" alt="Dhaval Soneji" /></a>
+<a href="https://github.com/spandanagrawal" title="Spandan Gopal Agrawal"><img src="https://github.com/spandanagrawal.png?size=64" width="64" height="64" alt="Spandan Gopal Agrawal" /></a>
+<a href="https://github.com/stifspear" title="stifspear"><img src="https://github.com/stifspear.png?size=64" width="64" height="64" alt="stifspear" /></a>
+<a href="https://github.com/sudhamsu" title="Sudhamsu Manne"><img src="https://github.com/sudhamsu.png?size=64" width="64" height="64" alt="Sudhamsu Manne" /></a>
+<a href="https://github.com/sugavaneshb" title="Sugavanesh B"><img src="https://github.com/sugavaneshb.png?size=64" width="64" height="64" alt="Sugavanesh B" /></a>
+<a href="https://github.com/sujoydc" title="Sujoy Datta Choudhury"><img src="https://github.com/sujoydc.png?size=64" width="64" height="64" alt="Sujoy Datta Choudhury" /></a>
+<a href="https://github.com/SungjinYoo" title="Sungjin Yoo"><img src="https://github.com/SungjinYoo.png?size=64" width="64" height="64" alt="Sungjin Yoo" /></a>
+<a href="https://github.com/SwapDixit" title="Swapnil Dixit"><img src="https://github.com/SwapDixit.png?size=64" width="64" height="64" alt="Swapnil Dixit" /></a>
+<a href="https://github.com/sxhmilyoyo" title="sxhmilyoyo"><img src="https://github.com/sxhmilyoyo.png?size=64" width="64" height="64" alt="sxhmilyoyo" /></a>
+<a href="https://github.com/syedmujahedalih" title="Mujahed Syed"><img src="https://github.com/syedmujahedalih.png?size=64" width="64" height="64" alt="Mujahed Syed" /></a>
+<a href="https://github.com/t-jones" title="Tim Jones"><img src="https://github.com/t-jones.png?size=64" width="64" height="64" alt="Tim Jones" /></a>
+<a href="https://github.com/TakahiroIshii" title="Takahiro Ishii"><img src="https://github.com/TakahiroIshii.png?size=64" width="64" height="64" alt="Takahiro Ishii" /></a>
+<a href="https://github.com/the-mann" title="Marcus Mann"><img src="https://github.com/the-mann.png?size=64" width="64" height="64" alt="Marcus Mann" /></a>
+<a href="https://github.com/therohan21" title="Rohan Rajeev"><img src="https://github.com/therohan21.png?size=64" width="64" height="64" alt="Rohan Rajeev" /></a>
+<a href="https://github.com/thethomaslane" title="Thomas Lane"><img src="https://github.com/thethomaslane.png?size=64" width="64" height="64" alt="Thomas Lane" /></a>
+<a href="https://github.com/thiagoh" title="thiagoh"><img src="https://github.com/thiagoh.png?size=64" width="64" height="64" alt="thiagoh" /></a>
+<a href="https://github.com/think-imbaig" title="think-imbaig"><img src="https://github.com/think-imbaig.png?size=64" width="64" height="64" alt="think-imbaig" /></a>
+<a href="https://github.com/ThR3742" title="ThR3742"><img src="https://github.com/ThR3742.png?size=64" width="64" height="64" alt="ThR3742" /></a>
+<a href="https://github.com/tlauda" title="Tomasz Lauda"><img src="https://github.com/tlauda.png?size=64" width="64" height="64" alt="Tomasz Lauda" /></a>
+<a href="https://github.com/tlobinger" title="Thomas Lobinger"><img src="https://github.com/tlobinger.png?size=64" width="64" height="64" alt="Thomas Lobinger" /></a>
+<a href="https://github.com/toby-wong" title="Toby Wong"><img src="https://github.com/toby-wong.png?size=64" width="64" height="64" alt="Toby Wong" /></a>
+<a href="https://github.com/trekie86" title="Rob Wolinski"><img src="https://github.com/trekie86.png?size=64" width="64" height="64" alt="Rob Wolinski" /></a>
+<a href="https://github.com/tudit" title="Udit Tumuluri"><img src="https://github.com/tudit.png?size=64" width="64" height="64" alt="Udit Tumuluri" /></a>
+<a href="https://github.com/uatemycookie22" title="uatemycookie22"><img src="https://github.com/uatemycookie22.png?size=64" width="64" height="64" alt="uatemycookie22" /></a>
+<a href="https://github.com/udayprakash" title="Uday Prakash"><img src="https://github.com/udayprakash.png?size=64" width="64" height="64" alt="Uday Prakash" /></a>
+<a href="https://github.com/unstablebrainiac" title="Sajal Narang"><img src="https://github.com/unstablebrainiac.png?size=64" width="64" height="64" alt="Sajal Narang" /></a>
+<a href="https://github.com/uzumakichillu" title="uzumakichillu"><img src="https://github.com/uzumakichillu.png?size=64" width="64" height="64" alt="uzumakichillu" /></a>
+<a href="https://github.com/vaibhavbhatiadev" title="Vaibhav Bhatia"><img src="https://github.com/vaibhavbhatiadev.png?size=64" width="64" height="64" alt="Vaibhav Bhatia" /></a>
+<a href="https://github.com/vamgan" title="Vamil Gandhi"><img src="https://github.com/vamgan.png?size=64" width="64" height="64" alt="Vamil Gandhi" /></a>
+<a href="https://github.com/vdurante" title="Vitor Durante"><img src="https://github.com/vdurante.png?size=64" width="64" height="64" alt="Vitor Durante" /></a>
+<a href="https://github.com/venkatvb" title="Venkatesh Babu AR"><img src="https://github.com/venkatvb.png?size=64" width="64" height="64" alt="Venkatesh Babu AR" /></a>
+<a href="https://github.com/vishal-sahoo" title="Vishal Sahoo"><img src="https://github.com/vishal-sahoo.png?size=64" width="64" height="64" alt="Vishal Sahoo" /></a>
+<a href="https://github.com/vishalvignesh" title="Vishal Vignesh"><img src="https://github.com/vishalvignesh.png?size=64" width="64" height="64" alt="Vishal Vignesh" /></a>
+<a href="https://github.com/w-wei105" title="w-wei105"><img src="https://github.com/w-wei105.png?size=64" width="64" height="64" alt="w-wei105" /></a>
+<a href="https://github.com/wang-shihao" title="Arthur, Shihao Wang"><img src="https://github.com/wang-shihao.png?size=64" width="64" height="64" alt="Arthur, Shihao Wang" /></a>
+<a href="https://github.com/wannaFlyKa" title="Yao"><img src="https://github.com/wannaFlyKa.png?size=64" width="64" height="64" alt="Yao" /></a>
+<a href="https://github.com/wbowditch" title="Will Bowditch"><img src="https://github.com/wbowditch.png?size=64" width="64" height="64" alt="Will Bowditch" /></a>
+<a href="https://github.com/weinansi" title="weinansi"><img src="https://github.com/weinansi.png?size=64" width="64" height="64" alt="weinansi" /></a>
+<a href="https://github.com/werainkhatri" title="Viren Khatri"><img src="https://github.com/werainkhatri.png?size=64" width="64" height="64" alt="Viren Khatri" /></a>
+<a href="https://github.com/wu5bocheng" title="wu5bocheng"><img src="https://github.com/wu5bocheng.png?size=64" width="64" height="64" alt="wu5bocheng" /></a>
+<a href="https://github.com/wundram" title="wundram"><img src="https://github.com/wundram.png?size=64" width="64" height="64" alt="wundram" /></a>
+<a href="https://github.com/xiaochao17" title="xiaochao17"><img src="https://github.com/xiaochao17.png?size=64" width="64" height="64" alt="xiaochao17" /></a>
+<a href="https://github.com/XTX-TXT" title="XTX-TXT"><img src="https://github.com/XTX-TXT.png?size=64" width="64" height="64" alt="XTX-TXT" /></a>
+<a href="https://github.com/xuejinT" title="Serena Tan"><img src="https://github.com/xuejinT.png?size=64" width="64" height="64" alt="Serena Tan" /></a>
+<a href="https://github.com/Xyand" title="Albert"><img src="https://github.com/Xyand.png?size=64" width="64" height="64" alt="Albert" /></a>
+<a href="https://github.com/yashwanthkorla" title="Yashwanth Korla"><img src="https://github.com/yashwanthkorla.png?size=64" width="64" height="64" alt="Yashwanth Korla" /></a>
+<a href="https://github.com/yehuizhang" title="Yehui"><img src="https://github.com/yehuizhang.png?size=64" width="64" height="64" alt="Yehui" /></a>
+<a href="https://github.com/YifanL9" title="Yifan"><img src="https://github.com/YifanL9.png?size=64" width="64" height="64" alt="Yifan" /></a>
+<a href="https://github.com/yohanesss" title="Yohanes Setiawan"><img src="https://github.com/yohanesss.png?size=64" width="64" height="64" alt="Yohanes Setiawan" /></a>
+<a href="https://github.com/yuwesu" title="Sypher Su"><img src="https://github.com/yuwesu.png?size=64" width="64" height="64" alt="Sypher Su" /></a>
+<a href="https://github.com/yytdfc" title="yytdfc"><img src="https://github.com/yytdfc.png?size=64" width="64" height="64" alt="yytdfc" /></a>
+<a href="https://github.com/zach-herridge" title="Zach Herridge"><img src="https://github.com/zach-herridge.png?size=64" width="64" height="64" alt="Zach Herridge" /></a>
+<a href="https://github.com/zachakin" title="Zach Akin-Amland"><img src="https://github.com/zachakin.png?size=64" width="64" height="64" alt="Zach Akin-Amland" /></a>
+<a href="https://github.com/zander8807" title="zander8807"><img src="https://github.com/zander8807.png?size=64" width="64" height="64" alt="zander8807" /></a>
+<a href="https://github.com/Zedmor" title="Akim Akimov"><img src="https://github.com/Zedmor.png?size=64" width="64" height="64" alt="Akim Akimov" /></a>
+<a href="https://github.com/zeiadzaf" title="Zeiad"><img src="https://github.com/zeiadzaf.png?size=64" width="64" height="64" alt="Zeiad" /></a>
+<a href="https://github.com/Zhang-Zhaolong" title="Zhaolong Zhang"><img src="https://github.com/Zhang-Zhaolong.png?size=64" width="64" height="64" alt="Zhaolong Zhang" /></a>
+<a href="https://github.com/ZheLyu" title="Zhe Lyu"><img src="https://github.com/ZheLyu.png?size=64" width="64" height="64" alt="Zhe Lyu" /></a>
+<a href="https://github.com/ZhengfeiJi" title="Ji"><img src="https://github.com/ZhengfeiJi.png?size=64" width="64" height="64" alt="Ji" /></a>
+<a href="https://github.com/ZhongkaiLiu" title="Zhongkai Liu"><img src="https://github.com/ZhongkaiLiu.png?size=64" width="64" height="64" alt="Zhongkai Liu" /></a>
+<a href="https://github.com/zhulinn" title="Lin Zhu"><img src="https://github.com/zhulinn.png?size=64" width="64" height="64" alt="Lin Zhu" /></a>
+<a href="https://github.com/zifengxiazx" title="zifengxiazx"><img src="https://github.com/zifengxiazx.png?size=64" width="64" height="64" alt="zifengxiazx" /></a>
+
+Listed alphabetically by GitHub username. Internal contributors appear here if they
+consented to public recognition in the contributor survey; open-source contributors are
+included from this repository's pull request history. If you contributed and would like
+to be added, corrected, or removed, please open an issue or a pull request.
 
 ## License
 


### PR DESCRIPTION
## Problem

The README's Contributors section was a single comma-separated paragraph of 494
plain-text names. A reader could not tell who any contributor actually is or find
them on GitHub, because there was not one link in the whole list. The section also opened
with the claim **"494 Amazon employees"**, which framed the project as
internal-only even though the repository has been taking public pull requests for
some time and those authors were credited nowhere.

## Why it matters

The contributor list is how this project says thank you, and it is one of the first
things a prospective contributor reads. An unlinked wall of names is unreadable at
that length, gives no one credit they can point at, and the employee-count framing
tells an outside contributor that this is not a project they are part of.

## Fix (symptoms → root cause → change)

The symptom is an unreadable, unlinkable list; the root cause is that the section
was generated as plain names with no identity attached to them, from one internal
source. So the fix is to attach a real GitHub identity to each entry and to widen
the source set:

- The plain-name paragraph is replaced with a grid of **321 linked avatars**. Each
  entry links to the contributor's GitHub profile and carries their name as both
  hover text and image `alt` text.
- The list is the **union of two sources**: the contributor survey, restricted to
  respondents who consented to public recognition; and **every human pull request
  author in this repository**, so open-source contributors are credited alongside
  the founding internal group. 20 PR authors were credited nowhere before this
  change.
- The `**494 Amazon employees**` count is dropped, because it no longer describes the
  contributor set once public PR authors are included.
- A closing note states the inclusion criteria and how to be added, corrected, or
  removed.

Entries are ordered **alphabetically by GitHub username**. The previous ordering
could not be carried over: only 142 of the resolved handles map back to a name in
the old list, so any attempt to preserve it would have ordered a majority of the
grid arbitrarily while implying the order still meant something.

### Data quality

Publishing a wrong handle would link someone's real name to a stranger's account,
and a wrong URL renders as a broken image, so both were checked mechanically:

- Every handle was resolved through the **GitHub users API**; only confirmed
  accounts are included.
- Every avatar URL was probed, and **321/321 returned HTTP 200**, so no entry renders
  broken.
- Six survey responses were not usable handles (three gave an email address, one a
  display name, one an invalid string, one handle 404s). Five were recoverable from
  the respondent's alias and are included; one could not be resolved either way and
  is not published rather than guessed.
- Avatars are requested from `https://github.com/<login>.png`, which is same-origin for a
  GitHub README, so they are not Camo-blocked and no third-party image host sees
  traffic from the page.

## Tests

No automated tests were added, because the change is markdown-only and adds no code path
to cover. The tests that read a README (`test_workflows_audit.py`,
`test_workflows_registry.py`, `test_cpp_seam_failclosed.py`,
`test_chat_turn_timeout_consistency.py`) were run to confirm nothing asserts on the
contributor section: **94 passed**.

## Manual verification

- `scripts/scrub-lint.sh`: checks 1 through 3 (internal markers, aliases, credentials)
  pass. Check 4 (internal references in **git history**) fails identically on a
  clean `origin/main` checkout with this change stashed, so it is pre-existing and
  tracked separately, not introduced here.
- Markup verified by parse: **321/321** anchor+`img` pairs are well-formed, with
  zero unbalanced tags. No contributor display name contains a character that could
  break out of an HTML attribute (the one name containing an apostrophe is safe
  inside double quotes).
- `git grep` confirms no file still asserts the old 494 count.
- Backend/frontend gates (isort, flake8, mypy, tsc, vitest) have no reachable input,
  because the diff touches no `.py`, `.ts`, or `.tsx` file.

### Inclusive-language scan

One contributor's real GitHub handle is `Godivamasterpiece`, which contains the
string `master` inside the word "masterpiece". The `Inclusive Language` gate flags
it on the added line. The handle belongs to a person and cannot be rewritten, so the
avatar grid is emitted **one entry per line** and that single line carries a scoped
`<!-- wokeignore:rule=master -->` comment, the same inline-ignore mechanism already
used in `security.py`, `kiro_prerequisite.py`, `terminal.py`, and
`test_terminal_handler.py`. The ignore covers exactly one contributor's line rather
than the whole section, so any genuinely non-inclusive term added here in future
still fails the gate. No other flagged term appears in the section.

## Screenshots

N/A. This changes a markdown file rendered by GitHub, not a KiroCrew UI surface.
The avatar grid is best reviewed on the **Files changed** tab of this PR, which
renders the README as published.


