### PR TITLE
fix(apps): bind registry app identity to its entry and record provenance

### DIFF
--- a/src/kiro_crew/apps/admission.py
+++ b/src/kiro_crew/apps/admission.py
@@ -181,6 +181,22 @@ def _signature_valid(manifest: "AppManifest", policy: AppAdmissionPolicy) -> boo
     return hmac.compare_digest(expected.encode("ascii"), signature.encode("utf-8", "ignore"))
 
 
+def verified_signer(manifest: "AppManifest | None") -> str:
+    """Return the signer id when *manifest* carries a signature this fleet can
+    verify, else ``""`` (unsigned, unknown signer, or a signature that failed).
+
+    Read-only observation of the same check :func:`app_admission_denied` runs —
+    it does NOT change whether a signature is *required*, and it never denies.
+    Callers use it to record WHO signed an app they are about to install;
+    ``""`` simply means the provenance carries no verified signer.
+    """
+    if manifest is None:
+        return ""
+    if not _signature_valid(manifest, load_app_admission_policy()):
+        return ""
+    return str(getattr(manifest, "signer", "") or "")
+
+
 def app_admission_denied(
     name: str,
     manifest: "AppManifest | None" = None,

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -110,6 +110,18 @@ class InstalledApp:
         ""  # noqa: N815  — target standalone app: "registry:{name}" or "standalone:{name}"
     )
     dev: bool = False  # dev mode: no-store UI serving + file-watch live reload
+    # Structured install provenance, recorded for registry installs (see
+    # ``set_app_provenance``).  ``source`` alone is a bare ``registry:<name>``
+    # marker that re-resolves by name, so a same-named entry from a different
+    # registry source could answer for this app; these fields pin WHICH source it
+    # actually came from.  ``sourceUrl`` is the presence discriminator: empty
+    # means a legacy record installed before provenance was captured (an empty
+    # ``sourceRegistry`` is meaningful on its own — it denotes the bundled
+    # catalog rather than a configured external registry).
+    sourceUrl: str = ""  # noqa: N815  — git URL this app was installed from
+    sourceRegistry: str = ""  # noqa: N815  — external registry id; "" = bundled catalog
+    sourceCommit: str = ""  # noqa: N815  — commit SHA resolved in the source clone
+    sourceSigner: str = ""  # noqa: N815  — verified signer id; "" = no verified signature
 
     def validate_fields(self) -> list[str]:
         """Validate classification field values. Returns error list (empty = valid)."""
@@ -141,6 +153,10 @@ class InstalledApp:
             schemaVersion=int(data.get("schemaVersion", 1)),
             migratedTo=str(data.get("migratedTo", "")),
             dev=bool(data.get("dev", False)),
+            sourceUrl=str(data.get("sourceUrl", "")),
+            sourceRegistry=str(data.get("sourceRegistry", "")),
+            sourceCommit=str(data.get("sourceCommit", "")),
+            sourceSigner=str(data.get("sourceSigner", "")),
         )
         # Migrate old "managed" field to new classification fields
         if inst.schemaVersion < 2 and "origin" not in data:
@@ -1023,6 +1039,47 @@ def set_app_source(name: str, source: str) -> bool:
         return False
     meta.source = source
     _write_installed(name, meta)
+    return True
+
+
+def set_app_provenance(
+    name: str,
+    *,
+    source: str,
+    url: str,
+    registry: str = "",
+    commit: str = "",
+    signer: str = "",
+) -> bool:
+    """Record the full install provenance of a registry-installed app.
+
+    Superset of :func:`set_app_source`: alongside the bare ``registry:<name>``
+    marker it persists WHICH source the app actually came from (*url* plus the
+    originating external *registry* id, empty for the bundled catalog), the
+    *commit* resolved in that source clone, and the verified *signer* if the
+    admission layer verified one.  Updates resolve from these fields instead of
+    re-looking-up the bare name, so a same-named entry published by a different
+    registry source cannot capture an installed app's updates.
+
+    Uses ``dataclasses.replace`` so every other persisted field (``enabled``,
+    ``dev``, ``origin``, ...) carries forward untouched.
+
+    Returns True if the update succeeded, False if the app is not installed.
+    """
+    meta = _read_installed(name)
+    if not meta:
+        return False
+    _write_installed(
+        name,
+        replace(
+            meta,
+            source=source,
+            sourceUrl=url,
+            sourceRegistry=registry,
+            sourceCommit=commit,
+            sourceSigner=signer,
+        ),
+    )
     return True
 
 

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew.apps import install_receipt
-from kiro_crew.apps.admission import app_admission_denied
+from kiro_crew.apps.admission import app_admission_denied, verified_signer
 from kiro_crew.apps.execution import app_execution_denied
 from kiro_crew.apps.manager import (
     get_app,
@@ -50,7 +50,7 @@ from kiro_crew.apps.manager import (
 )
 from kiro_crew.apps.manager import list_apps as list_installed_apps
 from kiro_crew.apps.manager import (
-    set_app_source,
+    set_app_provenance,
     update_app,
 )
 from kiro_crew.apps.manifest import AppManifest
@@ -70,6 +70,9 @@ logger = logging.getLogger(__name__)
 
 # Source type prefix for registry-installed apps.
 SOURCE_REGISTRY_PREFIX = "registry:"
+
+# A git object name: sha1 (40 hex) or sha256 (64 hex) repository format.
+_COMMIT_SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 
 
 class StreamingLogLines(list):
@@ -297,10 +300,15 @@ def _entry_git_url(entry: dict[str, Any]) -> str:
 
     Prefers an explicit ``gitUrl`` field.  Falls back to the legacy ``repo``
     field (which may itself contain a full URL).  Returns an empty string if
-    neither yields something that looks cloneable.
+    neither yields something that looks cloneable — including when an
+    index-controlled value is not a string at all (an object-valued ``gitUrl``
+    from a malformed external index must degrade to "no URL", never crash the
+    caller).
     """
-    url = (entry.get("gitUrl") or entry.get("repo") or "").strip()
-    return url
+    raw = entry.get("gitUrl") or entry.get("repo") or ""
+    if not isinstance(raw, str):
+        return ""
+    return raw.strip()
 
 
 def _sel_credential_grant(operation: str, git_url: str) -> None:
@@ -1600,6 +1608,79 @@ def get_registry_app(name: str) -> dict[str, Any] | None:
     return None
 
 
+def _registry_app_candidates(name: str) -> list[dict[str, Any]]:
+    """Every catalog row named *name*: bundled first, then each configured
+    registry in config order.
+
+    :func:`get_registry_app` returns only the FIRST match, which is precisely
+    what lets a same-named row from another source answer for an app installed
+    from somewhere else.  Provenance-pinned resolution needs the full candidate
+    set so it can select the row the app is actually pinned to.
+    """
+    candidates = [
+        entry
+        for entry in _load_registry_file()
+        if isinstance(entry, dict) and entry.get("name") == name
+    ]
+    from kiro_crew.config.loader import (
+        KiroCrewConfig,  # circular import: loader.py imports from apps/ at module level; deferring avoids ImportError
+    )
+
+    for reg in KiroCrewConfig.load().registries:
+        cached = _read_external_registry_cache(reg.name or reg.repo, ignore_ttl=True)
+        for entry in cached or []:
+            if isinstance(entry, dict) and entry.get("name") == name:
+                candidates.append(entry)
+    return candidates
+
+
+def _pinned_registry_entry(name: str, meta: dict[str, Any]) -> dict[str, Any] | None:
+    """Select the catalog row an installed app's recorded provenance pins it to.
+
+    A row matches only when BOTH the clone URL and the originating registry id
+    equal what was recorded at install time, so neither a row that reuses the
+    name on a different repo nor a different registry publishing the same
+    name/URL pair can stand in for the pinned source.  Returns None when no
+    candidate matches.
+    """
+    want_url = str(meta.get("sourceUrl", "") or "")
+    want_registry = str(meta.get("sourceRegistry", "") or "")
+    for entry in _registry_app_candidates(name):
+        if _entry_git_url(entry) != want_url:
+            continue
+        if str(entry.get("_registry", "") or "") != want_registry:
+            continue
+        return entry
+    return None
+
+
+def _resolve_install_entry(name: str) -> tuple[dict[str, Any] | None, str]:
+    """Resolve the catalog row that ``install_from_registry`` may act on.
+
+    Fresh installs — and legacy records that predate provenance capture, which
+    carry only the bare ``registry:<name>`` marker — keep the historical
+    first-match-wins :func:`get_registry_app` lookup, so no migration is needed
+    and today's behaviour is unchanged for them.  An installed app that DOES
+    carry provenance is pinned to it: its update must come from the source it was
+    installed from, never from whichever same-named row happens to resolve first.
+
+    Blocking (reads installed metadata, config, and index caches) — call it off
+    the event loop.  Returns ``(entry, error)``; a non-empty *error* means the
+    caller must refuse, and must NOT fall back to a bare-name lookup.
+    """
+    meta = get_app(name) or {}
+    pinned_url = str(meta.get("sourceUrl", "") or "")
+    if not pinned_url:
+        return get_registry_app(name), ""
+    entry = _pinned_registry_entry(name, meta)
+    if entry is None:
+        return None, (
+            f"app {name!r} was installed from {pinned_url} and no registry entry "
+            f"currently offers that source — refusing to update it from a different source"
+        )
+    return entry, ""
+
+
 def _external_registry_app_by_repo(repo: str) -> dict[str, Any] | None:
     """Look up an app entry by repo across the user's external (federated)
     registries, reading local sync caches only (``ignore_ttl`` so a stale index
@@ -1691,6 +1772,110 @@ def _app_sources_dir() -> Path:
 def app_source_dir(name: str) -> Path:
     """Return ~/.kiro/crew/app-sources/{name}/ — persistent clone directory."""
     return _app_sources_dir() / name
+
+
+def _resolved_clone_commit(clone_root: Path) -> str:
+    """Return the commit SHA checked out in *clone_root*, or ``""`` if unknown.
+
+    Reads git's own on-disk refs rather than spawning ``git rev-parse``: the SHA
+    is recorded as provenance only, so resolving it must not add a subprocess —
+    nor a new failure mode — to the install path.  Every read failure degrades to
+    ``""`` (provenance without a commit) instead of failing the install.
+    """
+    git_dir = clone_root / ".git"
+    try:
+        head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+    if not head.startswith("ref:"):
+        # Detached HEAD holds the SHA directly.
+        return head if _COMMIT_SHA_RE.match(head) else ""
+    ref = head[len("ref:") :].strip()
+    # git writes this file, not the cloned repo — belt-and-braces so a ref can
+    # never be read as a path outside the clone's own .git directory.
+    if not ref or ref.startswith("/") or ".." in ref.split("/"):
+        return ""
+    try:
+        loose = (git_dir / ref).read_text(encoding="utf-8").strip()
+        if _COMMIT_SHA_RE.match(loose):
+            return loose
+    except OSError:
+        pass
+    # A repacked clone keeps no loose ref file.
+    try:
+        for line in (git_dir / "packed-refs").read_text(encoding="utf-8").splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1] == ref and _COMMIT_SHA_RE.match(parts[0]):
+                return parts[0]
+    except OSError:
+        pass
+    return ""
+
+
+async def _refuse_identity_mismatch(
+    entry_name: str,
+    cloned_name: str,
+    repo: str,
+    clone_root: Path,
+    log_lines: list[str],
+    *,
+    created_this_run: bool,
+    pre_pull_commit: str = "",
+    manifest_relpath: str = "app.json",
+    manifest_snapshot: bytes | None = None,
+    restore_from: Path | None = None,
+) -> dict[str, Any]:
+    """Abort an install whose cloned repo claims a different app name.
+
+    A checkout **created by this run** is deleted so the squatting source (and
+    any build output) leaves no residue in the entry's ``app-sources/`` slot — a
+    leftover would also be preferred by :func:`_fetch_app_manifest` on the next
+    listing, letting a refused repo keep answering as this app.  Nothing has
+    been written under ``~/.kiro/crew/apps/`` at this point, so removing the
+    fresh clone leaves the machine exactly as it was before the install.
+
+    A checkout that **pre-existed** (the update path — ``git pull`` brought in a
+    commit whose manifest renamed itself, or a build/script rewrote it in the
+    working tree) is the installed app's source workspace, so it is preserved —
+    but rolled back to its last-good state (``git reset --keep`` to the
+    pre-pull commit plus a manifest restore from HEAD, both edit-preserving):
+    left at the renamed manifest, the prefetch would re-read it and re-reject
+    every retry before a fixed remote could ever be pulled.
+    """
+    declared = cloned_name or "<missing>"
+    if not created_this_run:
+        log_lines.append(
+            "Preserving pre-existing source checkout (rolled back to its "
+            "last-good state): the refused update installed nothing, and the "
+            "workspace belongs to the already-installed app"
+        )
+    await _unpoison_rejected_checkout(
+        entry_name,
+        clone_root,
+        log_lines,
+        checkout_preexisted=not created_this_run,
+        pre_pull_commit=pre_pull_commit,
+        manifest_relpath=manifest_relpath,
+        manifest_snapshot=manifest_snapshot,
+        restore_from=restore_from,
+    )
+    error = (
+        f"registry entry {entry_name!r} resolves to a repo whose app.json declares "
+        f"{declared!r} — refusing to install an app under an identity that differs "
+        f"from its registry entry"
+    )
+    log_lines.append(f"Refusing install: {error}")
+    try:
+        sel().log_api_access(
+            caller="app_install_from_registry",
+            operation="identity_mismatch",
+            outcome="rejected",
+            resources=f"name={entry_name!r} declared={declared!r} repo={repo}",
+            error="cloned manifest name does not match registry entry name",
+        )
+    except Exception as exc:  # an audit failure must never mask the refusal
+        logger.debug("SEL audit failed for %s identity mismatch: %s", entry_name, exc)
+    return {"ok": False, "name": entry_name, "error": error, "log": "\n".join(log_lines)}
 
 
 # ---------------------------------------------------------------------------
@@ -1974,6 +2159,10 @@ async def _git_clone_or_pull(
 
     if dest.is_dir() and (dest / ".git").is_dir():
         # Already cloned from the verified origin — fetch and fast-forward.
+        # (The origin-mismatch gate above guarantees this checkout's origin is
+        # byte-identical to git_url: a mismatched checkout was moved aside and
+        # never reused, so the fetch source and the provenance record are the
+        # same URL by construction.)
         log_lines.append(f"Updating {git_url} (branch: {branch})...")
         # Route through wrap_argv (OS sandbox) THEN cgroup_scope_argv, matching
         # the fresh-clone path below — the cgroup DoS ceiling is the outermost
@@ -1997,12 +2186,21 @@ async def _git_clone_or_pull(
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
             log_lines.append(stdout.decode(errors="replace").strip())
             if proc.returncode != 0:
-                log_lines.append(
-                    f"git pull failed (exit {proc.returncode}), building with existing code"
-                )
+                # Fail closed: installing whatever the checkout happens to hold
+                # while persisting the catalog URL as its provenance would
+                # record a source the installed code was never fetched from.
+                log_lines.append(f"git pull failed (exit {proc.returncode}) — aborting")
+                return {
+                    "ok": False,
+                    "error": f"git pull failed (exit {proc.returncode}); not installing stale code",
+                }
         except asyncio.TimeoutError:
             await _kill_process_group(proc)
-            log_lines.append("git pull timed out, building with existing code")
+            log_lines.append("git pull timed out — aborting")
+            return {
+                "ok": False,
+                "error": "git pull timed out; not installing stale code",
+            }
         return None
 
     # Fresh clone.
@@ -2110,27 +2308,148 @@ async def _clone_build_app(
     branch: str = "main",
     *,
     index_originated: bool = False,
+    subdirectory: str = "",
+    entry_repo: str = "",
 ) -> dict[str, Any]:
-    """Clone an app repo and run its build, returning the source directory.
+    """Clone an app repo, gate its identity, then run its build.
 
     Source is cloned to ``~/.kiro/crew/app-sources/{app_name}/`` (persistent;
-    survives reboots and is reused for updates).  After clone/pull, the app's
-    declared build commands run via :func:`_run_app_build`.
+    survives reboots and is reused for updates).  **The identity gate runs
+    BETWEEN clone and build**: the cloned ``app.json`` (under *subdirectory*
+    when set) must declare *app_name* before :func:`_run_app_build` executes —
+    build ecosystems run repo-authored lifecycle scripts (an npm ``preinstall``,
+    a ``setup.py``), so validating only after the build would let a mismatched
+    repo execute code despite the refusal.
 
     *index_originated* is forwarded to :func:`_git_clone_or_pull` to pick the
     credential posture (credential-free + strict sandbox for repos whose URL
     came from an external registry index — see that function's docstring).
 
     Returns ``{"ok": True, "pkg_dir": <Path>}`` on success or
-    ``{"ok": False, "error": ...}`` on failure.
+    ``{"ok": False, "error": ...}`` on failure/refusal.
     """
     # Lock-free: the caller (route handler) holds app_lifecycle_lock(name)
     # across the complete lifecycle transaction — clone/build, copy,
     # registration, and backend startup — so nested acquisition here would
     # deadlock (asyncio.Lock is not reentrant).
     return await _clone_build_app_locked(
-        git_url, app_name, log_lines, branch=branch, index_originated=index_originated
+        git_url,
+        app_name,
+        log_lines,
+        branch=branch,
+        index_originated=index_originated,
+        subdirectory=subdirectory,
+        entry_repo=entry_repo,
     )
+
+
+async def _unpoison_rejected_checkout(
+    app_name: str,
+    pkg_dir: Path,
+    log_lines: list[str],
+    *,
+    checkout_preexisted: bool,
+    pre_pull_commit: str,
+    manifest_relpath: str = "app.json",
+    manifest_snapshot: bytes | None = None,
+    restore_from: Path | None = None,
+) -> None:
+    """Un-poison a checkout after an identity/admission rejection.
+
+    The prefetch prefers the local checkout, so a checkout left sitting at a
+    rejected state makes every retry re-reject at prefetch before it could
+    ever pull a fixed remote — a permanently stuck app.
+
+    A checkout created THIS RUN is deleted (no residue) and, when the run
+    replaced a moved-aside previous checkout (*restore_from*), that previous
+    checkout is renamed back into the slot — otherwise the rejection would
+    leave the slot empty and strand the user's old workspace as a
+    sweeper-doomed ``.stale-*`` sibling.
+
+    A pre-existing workspace is rolled back to its pre-pull commit with
+    ``git reset --keep`` (preserves uncommitted local edits; aborts on
+    conflict), then the manifest is restored to its exact pre-update
+    working-tree bytes (*manifest_snapshot*) — undoing whatever the pull,
+    build, or ``onInstall`` script did to ``app.json`` WITHOUT discarding the
+    user's own uncommitted manifest edits. Only when no snapshot exists does
+    it fall back to ``git --literal-pathspecs checkout --`` from HEAD
+    (literal pathspecs keep an index-controlled subdirectory from being
+    parsed as pathspec magic). Best-effort throughout: a cleanup failure is
+    logged, never raised — the refusal it follows must stand regardless.
+    """
+    if not checkout_preexisted:
+        await asyncio.to_thread(shutil.rmtree, pkg_dir, ignore_errors=True)
+        if restore_from is not None:
+            try:
+                await asyncio.to_thread(restore_from.rename, pkg_dir)
+                log_lines.append(
+                    "Restored the previous checkout after rejecting the replacement clone"
+                )
+            except OSError as exc:
+                log_lines.append(
+                    f"WARNING: could not restore the previous checkout from "
+                    f"{restore_from.name}: {exc}; it is retained there for manual recovery"
+                )
+        return
+
+    async def _run_git(argv: list[str]) -> int:
+        cmd, _cleanup = wrap_argv(argv, mode="standard")
+        cmd = cgroup_scope_argv(cmd)
+        proc = await create_subprocess_limited(
+            *cmd,
+            cwd=str(pkg_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            start_new_session=platform_compat.IS_POSIX,
+            creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+            env=minimal_env(),
+        )
+        # Tree-killing timeout: a bare wait_for would abandon a slow git
+        # process still running, letting it race (and overwrite) the manifest
+        # restore that follows.
+        await _communicate_with_timeout(proc, timeout=15)
+        return proc.returncode or 0
+
+    try:
+        if pre_pull_commit:
+            rc = await _run_git(["git", "reset", "--keep", pre_pull_commit])
+            if rc == 0:
+                log_lines.append(
+                    f"Rolled checkout back to pre-update commit {pre_pull_commit[:12]}"
+                )
+            else:
+                log_lines.append(
+                    "WARNING: could not roll the checkout back; "
+                    "a retry may keep rejecting until the source is repaired"
+                )
+    except (asyncio.TimeoutError, OSError, RuntimeError) as exc:
+        # RuntimeError covers SandboxUnavailableError from wrap_argv — cleanup
+        # is best-effort and must never mask the refusal it follows.
+        logger.debug("post-rejection rollback failed for %s: %s", app_name, exc)
+    try:
+        # Restore the manifest regardless — in its OWN guarded block so a
+        # reset failure above cannot skip it: a build step or install script
+        # rewriting app.json is a WORKING-TREE edit the reset cannot undo
+        # (HEAD never moved), and app.json is the poison vector the next
+        # prefetch reads.
+        if manifest_snapshot is not None:
+            await asyncio.to_thread(
+                (pkg_dir / manifest_relpath).write_bytes, manifest_snapshot
+            )
+            log_lines.append(
+                f"Restored {manifest_relpath} to its exact pre-update contents"
+            )
+        else:
+            rc = await _run_git(
+                ["git", "--literal-pathspecs", "checkout", "--", manifest_relpath]
+            )
+            if rc != 0:
+                log_lines.append(
+                    f"WARNING: could not restore {manifest_relpath}; "
+                    "a retry may keep rejecting until the source is repaired"
+                )
+    except (asyncio.TimeoutError, OSError, RuntimeError) as exc:
+        logger.debug("post-rejection manifest restore failed for %s: %s", app_name, exc)
 
 
 async def _clone_build_app_locked(
@@ -2140,6 +2459,8 @@ async def _clone_build_app_locked(
     branch: str = "main",
     *,
     index_originated: bool = False,
+    subdirectory: str = "",
+    entry_repo: str = "",
 ) -> dict[str, Any]:
     """Inner implementation of _clone_build_app, called under per-app lock."""
     if not _looks_like_git_url(git_url):
@@ -2151,6 +2472,31 @@ async def _clone_build_app_locked(
 
     pkg_dir = app_source_dir(app_name)
     pending_cleanup: list[Path] = []
+    # Captured BEFORE the clone so a refusal below can tell a checkout this run
+    # created (delete: no residue) from a pre-existing app workspace (preserve).
+    checkout_preexisted = (pkg_dir / ".git").is_dir()
+    # And the pre-pull commit, so an admission rejection can ROLL BACK a
+    # pre-existing checkout: the prefetch prefers the local checkout, so a
+    # checkout left sitting at a policy-rejected commit would make every retry
+    # reject at prefetch before the pull could ever fetch a fixed remote.
+    pre_pull_commit = (
+        await asyncio.to_thread(_resolved_clone_commit, pkg_dir)
+        if checkout_preexisted
+        else ""
+    )
+    # And the manifest's exact pre-update WORKING-TREE bytes (which may carry
+    # the user's uncommitted local edits): a rejection restores THIS snapshot,
+    # so cleanup undoes whatever the pull/build/script did to app.json without
+    # discarding the user's own edits the way a checkout-from-HEAD would.
+    manifest_rel = f"{subdirectory}/app.json" if subdirectory else "app.json"
+    pre_update_manifest: bytes | None = None
+    if checkout_preexisted:
+        try:
+            pre_update_manifest = await asyncio.to_thread(
+                (pkg_dir / manifest_rel).read_bytes
+            )
+        except OSError:
+            pre_update_manifest = None
     clone_err = await _git_clone_or_pull(
         git_url,
         branch,
@@ -2161,10 +2507,108 @@ async def _clone_build_app_locked(
     )
     if clone_err is not None:
         return clone_err
+    if pending_cleanup:
+        # The origin-mismatch gate moved the old checkout aside and FRESH-CLONED
+        # into pkg_dir: whatever pre-existed is now a .stale-* sibling, and the
+        # directory at pkg_dir was created THIS RUN. The pre-clone snapshot
+        # above describes the moved-aside (different-origin) history — using it
+        # would make a later rejection try to reset the new clone to a commit
+        # from another repository, or preserve a squatting clone as if it were
+        # the user's workspace. Cleanup state must describe the ACTIVE checkout;
+        # the moved-aside path is kept so a rejection can put the previous
+        # checkout BACK instead of leaving the slot empty and the old workspace
+        # stranded as a sweeper-doomed .stale-* sibling.
+        checkout_preexisted = False
+        pre_pull_commit = ""
+        pre_update_manifest = None
+
+    # IDENTITY GATE — before the build, so a repo whose app.json declares a
+    # different name never gets to run npm/pip lifecycle scripts. Fail-closed:
+    # a missing or unparseable app.json (or name) is a mismatch, not a pass.
+    app_source = pkg_dir
+    if subdirectory:
+        contained = _contained_join(pkg_dir, subdirectory)
+        if contained is None:
+            return {
+                "ok": False,
+                "name": app_name,
+                "error": f"unsafe subdirectory {subdirectory!r} escapes the app source root",
+            }
+        app_source = contained
+    cloned_manifest: dict[str, Any] | None = None
+    try:
+        parsed = json.loads(
+            await asyncio.to_thread((app_source / "app.json").read_text, "utf-8")
+        )
+        if isinstance(parsed, dict):
+            cloned_manifest = parsed
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.debug("cloned app.json for %s is unreadable pre-build: %s", app_name, exc)
+    cloned_name = str((cloned_manifest or {}).get("name", "") or "")
+    if cloned_manifest is None or cloned_name != app_name:
+        return await _refuse_identity_mismatch(
+            app_name,
+            cloned_name,
+            entry_repo or git_url,
+            pkg_dir,
+            log_lines,
+            created_this_run=not checkout_preexisted,
+            pre_pull_commit=pre_pull_commit,
+            manifest_relpath=manifest_rel,
+            manifest_snapshot=pre_update_manifest,
+            restore_from=(pending_cleanup[0] if pending_cleanup else None),
+        )
+
+    # ADMISSION GATE, second pass — on the CLONED manifest. The first pass ran
+    # on the pre-clone prefetch, but the repository can advance between the two
+    # reads: a signed preview can resolve to an unsigned (or newly banned)
+    # manifest at clone time, and under a require-signature policy that content
+    # must not build or install. Same fail-closed policy call, different
+    # artifact.
+    denied = app_admission_denied(
+        app_name,
+        manifest=AppManifest.from_dict(cloned_manifest),
+        action="install_from_registry",
+    )
+    if denied:
+        log_lines.append(f"Refusing install: blocked by admission policy: {denied}")
+        try:
+            sel().log_api_access(
+                caller="app_install_from_registry",
+                operation="admission_cloned",
+                outcome="rejected",
+                resources=f"name={app_name!r}",
+                error=denied,
+            )
+        except Exception as exc:  # an audit failure must never mask the refusal
+            logger.debug("SEL audit failed for %s cloned admission: %s", app_name, exc)
+        # Un-poison the checkout so the rejection is retryable (see helper).
+        await _unpoison_rejected_checkout(
+            app_name,
+            pkg_dir,
+            log_lines,
+            checkout_preexisted=checkout_preexisted,
+            pre_pull_commit=pre_pull_commit,
+            manifest_relpath=manifest_rel,
+            manifest_snapshot=pre_update_manifest,
+            restore_from=(pending_cleanup[0] if pending_cleanup else None),
+        )
+        return {
+            "ok": False,
+            "name": app_name,
+            "error": f"blocked by admission policy: {denied}",
+        }
 
     result = await _run_app_build(pkg_dir, app_name, log_lines)
     if result["ok"]:
         result["pkg_dir"] = pkg_dir
+        # Surface the pre-clone checkout state so the caller's LATER gates
+        # (post-build / post-script admission) can un-poison the checkout with
+        # the same delete-fresh / roll-back-pre-existing semantics this
+        # function applies at the cloned-admission gate above.
+        result["_checkout_preexisted"] = checkout_preexisted
+        result["_pre_pull_commit"] = pre_pull_commit
+        result["_pre_update_manifest"] = pre_update_manifest
         # Do NOT delete moved-aside checkouts — even after a successful
         # install transaction the user may want to recover local edits from
         # the old checkout.  Surface the paths so the caller can log them.
@@ -2318,11 +2762,27 @@ async def install_from_registry(
     3. Build it (npm/pip, auto-detected) then run the install script from
        app.json if any (timeout: 300s)
     4. For kirocrew-managed: call install_app() or update_app()
-    5. Store ``registry:<name>`` as source for future updates
+    5. Store ``registry:<name>`` plus structured provenance (source URL,
+       originating registry, resolved commit, verified signer) for future updates
 
     Returns a dict with ok, name, message/error, and log output.
     """
-    entry = get_registry_app(name)
+    # An already-installed app that carries provenance may only be re-installed
+    # (updated) from the source it came from; fresh installs and legacy records
+    # keep the historical bare-name lookup. Blocking reads → off the loop.
+    entry, pin_error = await asyncio.to_thread(_resolve_install_entry, name)
+    if pin_error:
+        try:
+            sel().log_api_access(
+                caller="app_install_from_registry",
+                operation="provenance_mismatch",
+                outcome="rejected",
+                resources=f"name={name!r}",
+                error=pin_error,
+            )
+        except Exception as exc:  # an audit failure must never mask the refusal
+            logger.debug("SEL audit failed for %s provenance mismatch: %s", name, exc)
+        return {"ok": False, "name": name, "error": pin_error}
     if not entry:
         return {"ok": False, "error": f"app {name!r} not found in registry"}
 
@@ -2360,6 +2820,11 @@ async def install_from_registry(
     # explicitly designated the repo), but an external-index entry never becomes
     # an official-catalog entry — install receipts must not fire for it.
     official_entry = not index_originated
+    # The originating external registry id, recorded as provenance. Empty means
+    # the bundled (KiroCrew-shipped) catalog, which is itself a distinct source.
+    # Captured BEFORE the owner-designated carve-out (same reasoning as above):
+    # the entry still came from that external registry, and provenance must say so.
+    source_registry = str(entry.get("_registry", "") or "")
     if index_originated and await asyncio.to_thread(_is_owner_designated_repo, entry):
         index_originated = False
         _sel_credential_grant("install_from_registry", _entry_git_url(entry) or "")
@@ -2398,6 +2863,11 @@ async def install_from_registry(
             error=denied,
         )
         return {"ok": False, "name": name, "error": f"blocked by admission policy: {denied}"}
+
+    # NOTE: the provenance signer is computed LATER, from the identity-checked
+    # CLONED manifest — not from this pre-clone prefetch. An update can pull a
+    # commit whose manifest is no longer signed (or signed by someone else);
+    # provenance must record the artifact actually installed, not the preview.
 
     # Platform compatibility check — if the app requires a specific OS and
     # KiroCrew is running on an incompatible platform, return client install
@@ -2483,18 +2953,24 @@ async def install_from_registry(
 
         # Step 1: Clone the app repo and build it (npm/pip auto-detected).
         # `git clone` handles fetch + branch checkout; a subsequent install
-        # run fast-forwards the existing clone instead of re-cloning.
+        # run fast-forwards the existing clone instead of re-cloning. The
+        # cleanup state for later gates (_checkout_preexisted /
+        # _pre_pull_commit) rides on build_result — it describes the ACTIVE
+        # checkout, accounting for a move-aside re-clone.
         build_result = await _clone_build_app(
             git_url,
             name,
             log_lines,
             branch=branch,
             index_originated=index_originated,
+            subdirectory=subdirectory,
+            entry_repo=repo,
         )
         if not build_result["ok"]:
             return {**build_result, "log": "\n".join(log_lines)}
 
         app_source = build_result["pkg_dir"]
+        clone_root = app_source
         if subdirectory:
             # ``subdirectory`` is untrusted index-controlled content. Join it
             # under the cloned source root with symlink-resolving containment so
@@ -2510,35 +2986,105 @@ async def install_from_registry(
                 }
             app_source = contained
 
-        if not (app_source / "app.json").is_file():
-            return {
-                "ok": False,
-                "name": name,
-                "error": f"app.json not found in {app_source}",
-                "log": "\n".join(log_lines),
-            }
+        # NOTE: a missing app.json is handled by the identity gate below
+        # (fail-closed: unreadable manifest == mismatch), so a build step that
+        # DELETES the manifest still goes through the refusal path and its
+        # checkout cleanup rather than returning early with a poisoned tree.
 
-        # Read install script from the cloned repo's app.json.
+        # Read the cloned repo's app.json once: it decides both the app's
+        # IDENTITY and its install script.
         # Trust model: curated registry entry → cloned repo → app.json
         # (maintained by the app author).  The install script has the same
         # trust level as any code you clone and build locally.
-        install_script = ""
+        manifest_data: dict[str, Any] | None = None
         try:
             manifest_raw = await asyncio.to_thread(
                 (app_source / "app.json").read_text,
                 "utf-8",
             )
-            manifest_data = json.loads(manifest_raw)
-            install_script = (manifest_data.get("setup") or {}).get("onInstall", "")
-        except (json.JSONDecodeError, OSError):
-            pass
+            parsed = json.loads(manifest_raw)
+            if isinstance(parsed, dict):
+                manifest_data = parsed
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.debug("cloned app.json for %s is unreadable: %s", name, exc)
+
+        # IDENTITY GATE, second pass: the primary gate already ran inside
+        # _clone_build_app BEFORE the build (so a mismatched repo never executes
+        # npm/pip lifecycle scripts). This re-check catches the remaining
+        # window — a build step that REWRITES app.json to a different name —
+        # and stays fail-closed: a missing or unparseable name is a mismatch,
+        # not a pass. ``install_app``/``update_app`` derive the installed
+        # identity from this manifest, so it must still match the entry here.
+        if manifest_data is None or str(manifest_data.get("name", "") or "") != name:
+            return await _refuse_identity_mismatch(
+                name,
+                str((manifest_data or {}).get("name", "") or ""),
+                repo,
+                clone_root,
+                log_lines,
+                created_this_run=not bool(build_result.get("_checkout_preexisted")),
+                pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
+                manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
+                manifest_snapshot=build_result.get("_pre_update_manifest"),
+                restore_from=next(
+                    iter(build_result.get("_pending_stale_cleanup") or []), None
+                ),
+            )
+
+        # ADMISSION GATE, third pass — the post-build manifest is what
+        # install_app/update_app will actually register, and a build step can
+        # rewrite app.json; a manifest that no longer satisfies the admission
+        # policy (e.g. signature required and now absent) must not install.
+        denied = app_admission_denied(
+            name,
+            manifest=AppManifest.from_dict(manifest_data),
+            action="install_from_registry",
+        )
+        if denied:
+            log_lines.append(f"Refusing install: blocked by admission policy: {denied}")
+            try:
+                sel().log_api_access(
+                    caller="app_install_from_registry",
+                    operation="admission_postbuild",
+                    outcome="rejected",
+                    resources=f"name={name!r}",
+                    error=denied,
+                )
+            except Exception as exc:  # audit failure must never mask the refusal
+                logger.debug("SEL audit failed for %s post-build admission: %s", name, exc)
+            # Same retry-poisoning hazard as the cloned-admission gate: the
+            # checkout sits at the rejected commit and the prefetch prefers it,
+            # so clean up with the same delete-fresh/roll-back semantics.
+            await _unpoison_rejected_checkout(
+                name,
+                app_source_dir(name),
+                log_lines,
+                checkout_preexisted=bool(build_result.get("_checkout_preexisted")),
+                pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
+                manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
+                manifest_snapshot=build_result.get("_pre_update_manifest"),
+                restore_from=next(
+                    iter(build_result.get("_pending_stale_cleanup") or []), None
+                ),
+            )
+            return {
+                "ok": False,
+                "name": name,
+                "error": f"blocked by admission policy: {denied}",
+                "log": "\n".join(log_lines),
+            }
+
+        # NOTE: the provenance commit AND signer are both resolved AFTER the
+        # install-script block below — onInstall runs with write access to the
+        # checkout and can advance it to another commit or swap the manifest;
+        # provenance must record the state that actually registers.
+
+        install_script = (manifest_data.get("setup") or {}).get("onInstall", "")
 
         # Step 2: Run install script
         if install_script:
             log_lines.append(f"Running install script: {install_script}")
             # Sandboxed via wrap_argv(); consider migrating to AcpClient._spawn() for full OS-level isolation.
-            # Trust model: curated registry entry → cloned repo → app.json
-            # (maintained by the app author, same trust as any code you build locally).
             # SEL audit event emitted below for traceability.
             logger.info(
                 "Executing sandboxed install script for app %s from repo %s",
@@ -2600,8 +3146,119 @@ async def install_from_registry(
                     "log": "\n".join(log_lines),
                 }
 
+            # Reap any SURVIVING descendants of the script's process group
+            # before the final gates re-read app.json: a backgrounded child
+            # (`nohup evil &`) outlives the shell's clean exit and could
+            # rewrite the manifest AFTER the re-read below but before
+            # install_app registers it — the exact TOCTOU the final pass
+            # exists to close. The shell itself already exited, so anything
+            # still in the group is a detached straggler with no legitimate
+            # claim to keep running.
+            #
+            # POSIX: signal the KNOWN group id directly — the script was
+            # spawned with start_new_session, so its pgid equals proc.pid by
+            # construction, and the group outlives its (already-reaped)
+            # leader. Resolving the group via getpgid(proc.pid) would raise
+            # ProcessLookupError once the leader is reaped, silently skipping
+            # the very stragglers this exists to kill. The pid>1 guard keeps
+            # the killpg broadcast-safe (never signal group 0/1/self).
+            # Windows: taskkill /T on the root pid via the platform shim.
+            try:
+                if platform_compat.IS_POSIX:
+                    if type(proc.pid) is int and proc.pid > 1:
+                        await asyncio.to_thread(
+                            os.killpg, proc.pid, platform_compat.SIGKILL
+                        )
+                else:
+                    await platform_compat.kill_process_tree_async(
+                        proc.pid, platform_compat.SIGKILL
+                    )
+            except OSError:
+                # Empty group (no stragglers) — the common case.
+                pass
+
+            # IDENTITY + ADMISSION, final pass — the install script just ran
+            # with write access to the checkout and can rewrite app.json, and
+            # install_app/update_app/register_external_app re-read that file
+            # from disk. Whatever is on disk NOW is what gets registered, so it
+            # must pass the same fail-closed gates as the post-build read.
+            manifest_data = None
+            try:
+                parsed = json.loads(
+                    await asyncio.to_thread((app_source / "app.json").read_text, "utf-8")
+                )
+                if isinstance(parsed, dict):
+                    manifest_data = parsed
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.debug("post-script app.json for %s is unreadable: %s", name, exc)
+            if manifest_data is None or str(manifest_data.get("name", "") or "") != name:
+                return await _refuse_identity_mismatch(
+                    name,
+                    str((manifest_data or {}).get("name", "") or ""),
+                    repo,
+                    clone_root,
+                    log_lines,
+                    created_this_run=not bool(build_result.get("_checkout_preexisted")),
+                    pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
+                    manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
+                    manifest_snapshot=build_result.get("_pre_update_manifest"),
+                    restore_from=next(
+                        iter(build_result.get("_pending_stale_cleanup") or []), None
+                    ),
+                )
+            denied = app_admission_denied(
+                name,
+                manifest=AppManifest.from_dict(manifest_data),
+                action="install_from_registry",
+            )
+            if denied:
+                log_lines.append(f"Refusing install: blocked by admission policy: {denied}")
+                try:
+                    sel().log_api_access(
+                        caller="app_install_from_registry",
+                        operation="admission_postscript",
+                        outcome="rejected",
+                        resources=f"name={name!r}",
+                        error=denied,
+                    )
+                except Exception as exc:  # audit failure must never mask the refusal
+                    logger.debug("SEL audit failed for %s post-script admission: %s", name, exc)
+                # onInstall ran with write access to the checkout, so this
+                # denial leaves it poisoned exactly like the earlier gates —
+                # apply the same delete-fresh/roll-back cleanup so a retry
+                # can pull a fixed remote instead of re-rejecting at prefetch.
+                await _unpoison_rejected_checkout(
+                    name,
+                    app_source_dir(name),
+                    log_lines,
+                    checkout_preexisted=bool(build_result.get("_checkout_preexisted")),
+                    pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
+                    manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
+                    manifest_snapshot=build_result.get("_pre_update_manifest"),
+                    restore_from=next(
+                        iter(build_result.get("_pending_stale_cleanup") or []), None
+                    ),
+                )
+                return {
+                    "ok": False,
+                    "name": name,
+                    "error": f"blocked by admission policy: {denied}",
+                    "log": "\n".join(log_lines),
+                }
+
+        # Provenance is pinned from the FINAL state — after the build, the
+        # install script, and the last identity/admission gates: the exact
+        # commit the checkout sits at, and whoever signed the manifest that
+        # actually registers. Resolving either any earlier would let onInstall
+        # advance the checkout or swap the manifest and have provenance record
+        # a predecessor. Purely observational: never denies; unsigned yields "".
+        source_commit = await asyncio.to_thread(_resolved_clone_commit, clone_root)
+        source_signer = await asyncio.to_thread(
+            verified_signer, AppManifest.from_dict(manifest_data)
+        )
+
         # Step 3: Resolve dependencies (if declared in manifest)
-        deps_data = (manifest_data or {}).get("dependencies") if manifest_data else None
+        deps_data = manifest_data.get("dependencies")
         if deps_data and isinstance(deps_data, dict):
             from kiro_crew.apps.dependencies import resolve_dependencies as _resolve_deps
             from kiro_crew.apps.manifest import Dependencies as _Deps
@@ -2622,24 +3279,29 @@ async def install_from_registry(
             # Pre-register with manifest from the cloned repo so the app
             # appears in Installed tab immediately (with openCommand, icon, etc.)
             # The app will update its own registration on next launch.
-            manifest_data_raw = None
-            try:
-                manifest_data_raw = json.loads((app_source / "app.json").read_text("utf-8"))
-            except (json.JSONDecodeError, OSError):
-                pass
-
+            # ``manifest_data`` is the identity-checked read from above — reusing
+            # it avoids a second read that could see different bytes.
             from kiro_crew.apps.manager import register_external_app
 
-            display = (manifest_data_raw or {}).get("displayName", name)
-            version = (manifest_data_raw or {}).get("version", "0.0.0")
-            register_external_app(
+            display = manifest_data.get("displayName", name)
+            version = manifest_data.get("version", "0.0.0")
+            reg_result = register_external_app(
                 name=name,
                 version=version,
                 display_name=display,
                 source=f"{SOURCE_REGISTRY_PREFIX}{name}",
-                manifest_data=manifest_data_raw,
+                manifest_data=manifest_data,
                 origin="registry",
             )
+            if reg_result.ok:
+                set_app_provenance(
+                    name,
+                    source=f"{SOURCE_REGISTRY_PREFIX}{name}",
+                    url=git_url,
+                    registry=source_registry,
+                    commit=source_commit,
+                    signer=source_signer,
+                )
 
             log_lines.append("Pre-registered from cloned manifest (self-managed)")
             log_lines.append("App will update its own registration on next launch")
@@ -2680,9 +3342,20 @@ async def install_from_registry(
             result = await asyncio.to_thread(install_app, str(app_source))
         log_lines.append(result.message or result.error or "done")
 
-        # Mark source as registry-installed
+        # Record the source marker plus structured provenance, so a later update
+        # resolves the source this install actually came from rather than
+        # whichever entry happens to answer to the bare name. This is also what
+        # self-heals a legacy record: its next successful update writes the full
+        # provenance it was missing.
         if result.ok:
-            set_app_source(result.name, f"{SOURCE_REGISTRY_PREFIX}{name}")
+            set_app_provenance(
+                result.name,
+                source=f"{SOURCE_REGISTRY_PREFIX}{name}",
+                url=git_url,
+                registry=source_registry,
+                commit=source_commit,
+                signer=source_signer,
+            )
             # Retain moved-aside checkouts so the user can recover local
             # edits; they will be swept after _STALE_CHECKOUT_RETENTION_DAYS.
             for _stale in build_result.get("_pending_stale_cleanup") or []:

--- a/test/test_app_identity_provenance.py
+++ b/test/test_app_identity_provenance.py
@@ -1,0 +1,472 @@
+"""App identity + install provenance for registry installs.
+
+Two defects are covered here:
+
+1. ``install_from_registry`` resolved a catalog entry by name, cloned its repo,
+   then installed under the CLONED manifest's name with no check that the two
+   agreed — so a repo listed as X could install, register and run as Y.
+2. Only a bare ``registry:<name>`` marker was persisted, so an update
+   re-resolved the bare name and a same-named entry from a different registry
+   source could capture it.
+
+Mirrors the collaborator-patching style of ``test_apps_registry.py`` /
+``test_external_registry.py``: no real git, no real network, everything isolated
+via ``tmp_path`` + ``monkeypatch`` (so no xdist group marker is needed).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.apps import manager, registry
+
+GOOD_URL = "https://github.com/good-org/shared-name.git"
+EVIL_URL = "https://github.com/evil-org/shared-name.git"
+
+
+@pytest.fixture(autouse=True)
+def _admit_registry_execution(monkeypatch):
+    """These tests must reach the admitted post-clone install path."""
+    monkeypatch.setattr("kiro_crew.apps.execution.third_party_execution_allowed", lambda: True)
+    monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
+
+
+@pytest.fixture()
+def sel_calls(monkeypatch) -> MagicMock:
+    """Capture SEL audit emissions from the registry install path."""
+    recorder = MagicMock()
+    monkeypatch.setattr(registry, "sel", lambda: recorder)
+    return recorder
+
+
+def _audited_operations(recorder: MagicMock) -> list[str]:
+    return [c.kwargs.get("operation") for c in recorder.log_api_access.call_args_list]
+
+
+def _manifest(name: str, *, version: str = "1.0.0", **extra) -> dict:
+    return {
+        "name": name,
+        "version": version,
+        "displayName": name,
+        "description": "identity/provenance fixture",
+        "author": "tester",
+        **extra,
+    }
+
+
+def _write_clone(root: Path, manifest: dict, *, commit: str = "", branch: str = "main") -> Path:
+    """Materialize a fake cloned app source tree, optionally with git refs."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "app.json").write_text(json.dumps(manifest), encoding="utf-8")
+    if commit:
+        heads = root / ".git" / "refs" / "heads"
+        heads.mkdir(parents=True, exist_ok=True)
+        (root / ".git" / "HEAD").write_text(f"ref: refs/heads/{branch}\n", encoding="utf-8")
+        (heads / branch).write_text(commit + "\n", encoding="utf-8")
+    return root
+
+
+def _patch_clone(monkeypatch, clone: Path, seen: dict | None = None) -> None:
+    """Stub the clone+build step so it 'produces' *clone*, recording its args."""
+
+    async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+        if seen is not None:
+            seen["git_url"] = git_url
+            seen["branch"] = branch
+        return {"ok": True, "pkg_dir": clone}
+
+    monkeypatch.setattr(registry, "_clone_build_app", _fake_clone_build)
+
+
+def _patch_prefetch(monkeypatch, manifest: dict | None) -> None:
+    monkeypatch.setattr(registry, "_fetch_app_manifest", AsyncMock(return_value=manifest))
+
+
+def _forbid_spawn(monkeypatch) -> None:
+    """Any subprocess from here on means a refused repo got to execute."""
+
+    async def _boom(*args, **kwargs):
+        pytest.fail("a refused registry install must not spawn a subprocess")
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _boom)
+
+
+# ---------------------------------------------------------------------------
+# (a) Name squatting — entry X whose repo declares Y
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityGate:
+    @pytest.mark.asyncio
+    async def test_squatting_repo_refused_with_no_install_and_no_residue(
+        self, tmp_path, monkeypatch, sel_calls
+    ):
+        """Entry 'card-app' pointing at a repo that declares 'other-app' must be
+        refused before its install script runs, install nothing under either
+        name, and leave no clone behind."""
+        entry = {"name": "card-app", "gitUrl": EVIL_URL, "repo": EVIL_URL, "branch": "main"}
+        monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+        _patch_prefetch(monkeypatch, _manifest("card-app"))
+        # The clone's own manifest claims a DIFFERENT app, and carries a payload
+        # that must never execute.
+        clone = _write_clone(
+            tmp_path / "app-sources" / "card-app",
+            _manifest("other-app", setup={"onInstall": "touch /tmp/pwned"}),
+        )
+        _patch_clone(monkeypatch, clone)
+        _forbid_spawn(monkeypatch)
+
+        result = await registry.install_from_registry("card-app")
+
+        assert result["ok"] is False
+        # The error must name BOTH identities so an operator can see the swap.
+        assert "card-app" in result["error"]
+        assert "other-app" in result["error"]
+        # Nothing installed under either identity.
+        assert manager.get_app("card-app") is None
+        assert manager.get_app("other-app") is None
+        # No residue: a leftover clone would keep answering as this app via
+        # _fetch_app_manifest, which prefers the persistent clone.
+        assert not clone.exists()
+        # And the refusal is audited.
+        assert "identity_mismatch" in _audited_operations(sel_calls)
+
+    @pytest.mark.asyncio
+    async def test_manifest_without_a_name_is_refused_fail_closed(
+        self, tmp_path, monkeypatch, sel_calls
+    ):
+        entry = {"name": "card-app", "gitUrl": EVIL_URL, "repo": EVIL_URL, "branch": "main"}
+        monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+        _patch_prefetch(monkeypatch, _manifest("card-app"))
+        clone = tmp_path / "clone"
+        clone.mkdir()
+        (clone / "app.json").write_text(json.dumps({"version": "1.0.0"}), encoding="utf-8")
+        _patch_clone(monkeypatch, clone)
+        _forbid_spawn(monkeypatch)
+
+        result = await registry.install_from_registry("card-app")
+
+        assert result["ok"] is False
+        assert "<missing>" in result["error"]
+        assert manager.get_app("card-app") is None
+        assert "identity_mismatch" in _audited_operations(sel_calls)
+
+    @pytest.mark.asyncio
+    async def test_matching_repo_is_admitted(self, tmp_path, monkeypatch, sel_calls):
+        """Control: an entry whose repo agrees on the name installs normally."""
+        entry = {"name": "match-app", "gitUrl": GOOD_URL, "repo": GOOD_URL, "branch": "main"}
+        monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+        _patch_prefetch(monkeypatch, _manifest("match-app"))
+        _patch_clone(monkeypatch, _write_clone(tmp_path / "clone", _manifest("match-app")))
+
+        result = await registry.install_from_registry("match-app")
+
+        assert result["ok"] is True, result.get("error")
+        assert "identity_mismatch" not in _audited_operations(sel_calls)
+
+
+# ---------------------------------------------------------------------------
+# (b) Fresh install persists structured provenance
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceCapture:
+    @pytest.fixture()
+    def signing_home(self, tmp_path, monkeypatch) -> Path:
+        """An explicitly-isolated KIROCREW_HOME, so writing an admission policy
+        below can never reach the developer's real ``~/.kiro/crew``."""
+        home = tmp_path / "kirocrew-home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
+        assert manager.config_dir() == home
+        return home
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_persists_full_provenance(
+        self, tmp_path, monkeypatch, sel_calls, signing_home
+    ):
+        secret = "s3cr3t"
+        # A policy that carries the trust key but does NOT require a signature:
+        # the app is admitted either way, and the signer is still recorded. This
+        # exercises the real verified_signer(), so the signer in the provenance
+        # is one the admission layer actually verified.
+        (signing_home / "app_admission.json").write_text(
+            json.dumps({"mode": "open", "trust_keys": {"acme": secret}}), encoding="utf-8"
+        )
+
+        from kiro_crew.apps.manifest import AppManifest
+
+        manifest = _manifest("signed-app", signer="acme")
+        manifest["signature"] = hmac.new(
+            secret.encode(),
+            AppManifest.from_dict(manifest).signing_payload(),
+            hashlib.sha256,
+        ).hexdigest()
+
+        entry = {
+            "name": "signed-app",
+            "gitUrl": GOOD_URL,
+            "repo": GOOD_URL,
+            "branch": "main",
+            "_registry": "acme-index",
+        }
+        monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+        _patch_prefetch(monkeypatch, manifest)
+        _patch_clone(monkeypatch, _write_clone(tmp_path / "clone", manifest, commit="a" * 40))
+
+        result = await registry.install_from_registry("signed-app")
+        assert result["ok"] is True, result.get("error")
+
+        meta = manager.get_app("signed-app")
+        assert meta is not None
+        # The bare marker is still written (nothing downstream regresses)...
+        assert meta["source"] == "registry:signed-app"
+        # ...alongside the structured provenance that pins the actual source.
+        assert meta["sourceUrl"] == GOOD_URL
+        assert meta["sourceRegistry"] == "acme-index"
+        assert meta["sourceCommit"] == "a" * 40
+        assert meta["sourceSigner"] == "acme"
+
+    @pytest.mark.asyncio
+    async def test_bad_signature_records_no_signer(
+        self, tmp_path, monkeypatch, sel_calls, signing_home
+    ):
+        """A manifest claiming a signer but carrying a signature that does not
+        verify must not have that claim recorded as provenance."""
+        (signing_home / "app_admission.json").write_text(
+            json.dumps({"mode": "open", "trust_keys": {"acme": "s3cr3t"}}), encoding="utf-8"
+        )
+        manifest = _manifest("claim-app", signer="acme", signature="00" * 32)
+        entry = {"name": "claim-app", "gitUrl": GOOD_URL, "repo": GOOD_URL, "branch": "main"}
+        monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+        _patch_prefetch(monkeypatch, manifest)
+        _patch_clone(monkeypatch, _write_clone(tmp_path / "clone", manifest))
+
+        assert (await registry.install_from_registry("claim-app"))["ok"] is True
+
+        meta = manager.get_app("claim-app")
+        assert meta is not None
+        assert meta.get("sourceSigner", "") == ""
+
+    @pytest.mark.asyncio
+    async def test_unsigned_bundled_install_records_source_without_signer(
+        self, tmp_path, monkeypatch, sel_calls
+    ):
+        """A bundled (no ``_registry``) unsigned app still gets URL + commit; an
+        empty registry id denotes the bundled catalog, and signer stays empty."""
+        entry = {"name": "plain-app", "gitUrl": GOOD_URL, "repo": GOOD_URL, "branch": "main"}
+        monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+        _patch_prefetch(monkeypatch, _manifest("plain-app"))
+        _patch_clone(
+            monkeypatch,
+            _write_clone(tmp_path / "clone", _manifest("plain-app"), commit="b" * 40),
+        )
+
+        assert (await registry.install_from_registry("plain-app"))["ok"] is True
+
+        meta = manager.get_app("plain-app")
+        assert meta is not None
+        assert meta["sourceUrl"] == GOOD_URL
+        assert meta["sourceCommit"] == "b" * 40
+        # Falsy fields are dropped by InstalledApp.to_dict, hence .get().
+        assert meta.get("sourceRegistry", "") == ""
+        assert meta.get("sourceSigner", "") == ""
+
+
+class TestResolvedCloneCommit:
+    def test_reads_loose_ref(self, tmp_path):
+        clone = _write_clone(tmp_path / "c", _manifest("a-app"), commit="c" * 40)
+        assert registry._resolved_clone_commit(clone) == "c" * 40
+
+    def test_reads_packed_ref(self, tmp_path):
+        clone = tmp_path / "c"
+        (clone / ".git").mkdir(parents=True)
+        (clone / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+        (clone / ".git" / "packed-refs").write_text(
+            f"# pack-refs with: peeled\n{'d' * 40} refs/heads/main\n", encoding="utf-8"
+        )
+        assert registry._resolved_clone_commit(clone) == "d" * 40
+
+    def test_reads_detached_head(self, tmp_path):
+        clone = tmp_path / "c"
+        (clone / ".git").mkdir(parents=True)
+        (clone / ".git" / "HEAD").write_text("e" * 40 + "\n", encoding="utf-8")
+        assert registry._resolved_clone_commit(clone) == "e" * 40
+
+    def test_degrades_to_empty_without_git_metadata(self, tmp_path):
+        # Provenance without a commit, never an exception on the install path.
+        assert registry._resolved_clone_commit(tmp_path / "nope") == ""
+
+    def test_rejects_a_non_sha_ref_value(self, tmp_path):
+        clone = tmp_path / "c"
+        heads = clone / ".git" / "refs" / "heads"
+        heads.mkdir(parents=True)
+        (clone / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+        (heads / "main").write_text("not-a-sha\n", encoding="utf-8")
+        assert registry._resolved_clone_commit(clone) == ""
+
+
+# ---------------------------------------------------------------------------
+# (c) Updates resolve through provenance, (d) legacy records keep old behaviour
+# ---------------------------------------------------------------------------
+
+
+def _install_with_provenance(
+    tmp_path: Path,
+    name: str,
+    *,
+    url: str = GOOD_URL,
+    source_registry: str = "good-index",
+    commit: str = "1" * 40,
+) -> None:
+    """Put *name* on disk as if a previous provenance-aware install ran."""
+    source = _write_clone(tmp_path / "installed-src" / name, _manifest(name))
+    assert manager.install_app(source).ok
+    assert manager.set_app_provenance(
+        name,
+        source=f"registry:{name}",
+        url=url,
+        registry=source_registry,
+        commit=commit,
+    )
+
+
+class TestUpdateResolution:
+    @pytest.mark.asyncio
+    async def test_same_named_entry_from_another_source_cannot_capture_update(
+        self, tmp_path, monkeypatch, sel_calls
+    ):
+        _install_with_provenance(tmp_path, "shared-name")
+        # Only a hostile row is on offer: same name, different repo and registry.
+        monkeypatch.setattr(
+            registry,
+            "_registry_app_candidates",
+            lambda n: [
+                {
+                    "name": "shared-name",
+                    "gitUrl": EVIL_URL,
+                    "repo": EVIL_URL,
+                    "branch": "main",
+                    "_registry": "evil-index",
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            registry, "_clone_build_app", AsyncMock(side_effect=AssertionError("cloned!"))
+        )
+
+        result = await registry.install_from_registry("shared-name")
+
+        assert result["ok"] is False
+        assert "different source" in result["error"]
+        assert "provenance_mismatch" in _audited_operations(sel_calls)
+        # Provenance is untouched — the hostile row never took the slot.
+        meta = manager.get_app("shared-name")
+        assert meta is not None
+        assert meta["sourceUrl"] == GOOD_URL
+        assert meta["sourceRegistry"] == "good-index"
+
+    @pytest.mark.asyncio
+    async def test_update_picks_the_entry_matching_recorded_provenance(
+        self, tmp_path, monkeypatch, sel_calls
+    ):
+        """With a hostile same-named row listed FIRST — where the old
+        first-match-wins lookup would have landed — the update must still follow
+        the recorded provenance to the legitimate row."""
+        _install_with_provenance(tmp_path, "shared-name")
+        monkeypatch.setattr(
+            registry,
+            "_registry_app_candidates",
+            lambda n: [
+                {
+                    "name": "shared-name",
+                    "gitUrl": EVIL_URL,
+                    "repo": EVIL_URL,
+                    "branch": "main",
+                    "_registry": "evil-index",
+                },
+                {
+                    "name": "shared-name",
+                    "gitUrl": GOOD_URL,
+                    "repo": GOOD_URL,
+                    "branch": "main",
+                    "_registry": "good-index",
+                },
+            ],
+        )
+        _patch_prefetch(monkeypatch, _manifest("shared-name", version="2.0.0"))
+        seen: dict = {}
+        _patch_clone(
+            monkeypatch,
+            _write_clone(
+                tmp_path / "clone", _manifest("shared-name", version="2.0.0"), commit="2" * 40
+            ),
+            seen,
+        )
+
+        result = await registry.install_from_registry("shared-name")
+
+        assert result["ok"] is True, result.get("error")
+        assert seen["git_url"] == GOOD_URL
+        meta = manager.get_app("shared-name")
+        assert meta is not None
+        assert meta["version"] == "2.0.0"
+        assert meta["sourceUrl"] == GOOD_URL
+        assert meta["sourceRegistry"] == "good-index"
+        # The pinned commit advances with the update.
+        assert meta["sourceCommit"] == "2" * 40
+
+    @pytest.mark.asyncio
+    async def test_legacy_marker_app_updates_by_bare_name_and_self_heals(
+        self, tmp_path, monkeypatch, sel_calls
+    ):
+        """An app installed before provenance capture carries only
+        ``registry:<name>``. It must keep updating via the historical bare-name
+        lookup (no migration required) and gain provenance on success."""
+        source = _write_clone(tmp_path / "legacy-src", _manifest("legacy-app"))
+        assert manager.install_app(source).ok
+        assert manager.set_app_source("legacy-app", "registry:legacy-app")
+        legacy = manager.get_app("legacy-app")
+        assert legacy is not None and legacy.get("sourceUrl", "") == ""
+
+        entry = {
+            "name": "legacy-app",
+            "gitUrl": GOOD_URL,
+            "repo": GOOD_URL,
+            "branch": "main",
+            "_registry": "good-index",
+        }
+        monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+
+        def _no_pinning(name):
+            pytest.fail("a legacy record must not enter provenance-pinned resolution")
+
+        monkeypatch.setattr(registry, "_registry_app_candidates", _no_pinning)
+        _patch_prefetch(monkeypatch, _manifest("legacy-app", version="1.1.0"))
+        seen: dict = {}
+        _patch_clone(
+            monkeypatch,
+            _write_clone(
+                tmp_path / "clone", _manifest("legacy-app", version="1.1.0"), commit="3" * 40
+            ),
+            seen,
+        )
+
+        result = await registry.install_from_registry("legacy-app")
+
+        assert result["ok"] is True, result.get("error")
+        assert seen["git_url"] == GOOD_URL
+        meta = manager.get_app("legacy-app")
+        assert meta is not None
+        assert meta["version"] == "1.1.0"
+        # Self-healed: the update recorded the provenance the record lacked.
+        assert meta["sourceUrl"] == GOOD_URL
+        assert meta["sourceRegistry"] == "good-index"
+        assert meta["sourceCommit"] == "3" * 40

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -339,9 +339,11 @@ async def test_install_script_timeout_routes_through_kill_process_group(monkeypa
     monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
     monkeypatch.setattr(registry, "sel", lambda: MagicMock())
 
-    # Cloned app source carries an install script.
+    # Cloned app source carries an install script. Its manifest must declare the
+    # entry's name, or the identity gate refuses before the script ever runs.
     (tmp_path / "app.json").write_text(
-        json.dumps({"setup": {"onInstall": "sleep 999"}}), encoding="utf-8"
+        json.dumps({"name": "demoapp", "setup": {"onInstall": "sleep 999"}}),
+        encoding="utf-8",
     )
 
     async def _fake_build(git_url, name, log_lines, branch="main", **kwargs):
@@ -370,6 +372,784 @@ async def test_install_script_timeout_routes_through_kill_process_group(monkeypa
     assert "timed out" in result["error"]
     # The timeout path routed through the reaping/escalating helper.
     assert kpg_calls == [proc]
+
+
+# --------------------------------------------------------------------------
+# Identity-refusal cleanup + provenance-signer freshness
+# --------------------------------------------------------------------------
+def _identity_harness(monkeypatch, src, *, cloned_manifest, prefetched=None):
+    """Common monkeypatch set for driving install_from_registry to the identity gate."""
+    entry = {"name": "demoapp", "repo": "https://example.com/demo.git", "branch": "main"}
+    monkeypatch.setattr(registry, "get_registry_app", lambda n: entry)
+    monkeypatch.setattr(registry, "_entry_git_url", lambda e: "https://example.com/demo.git")
+
+    async def _fake_manifest(*args, **kwargs):
+        return prefetched or {}
+
+    monkeypatch.setattr(registry, "_fetch_app_manifest", _fake_manifest)
+    monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+
+    async def _fake_build(git_url, name, log_lines, branch="main", **kwargs):
+        # Capture BEFORE materializing, mirroring production's pre-clone
+        # snapshot (and its effective-fresh reset after a move-aside).
+        preexisted = (src / ".git").is_dir()
+        src.mkdir(parents=True, exist_ok=True)
+        (src / "app.json").write_text(json.dumps(cloned_manifest), encoding="utf-8")
+        return {
+            "ok": True,
+            "pkg_dir": src,
+            "_checkout_preexisted": preexisted,
+            "_pre_pull_commit": "",
+        }
+
+    monkeypatch.setattr(registry, "_clone_build_app", _fake_build)
+
+
+@pytest.mark.asyncio
+async def test_identity_refusal_preserves_preexisting_checkout(monkeypatch, tmp_path):
+    """UPDATE path: a pull that brings a self-renaming manifest is refused
+    WITHOUT deleting the installed app's pre-existing source workspace."""
+    src = tmp_path / "app-sources" / "demoapp"
+    (src / ".git").mkdir(parents=True)  # checkout pre-exists BEFORE the run
+    (src / "keep.txt").write_text("user state", encoding="utf-8")
+    _identity_harness(monkeypatch, src, cloned_manifest={"name": "renamed-app"})
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert "refusing" in result["error"].lower()
+    # The workspace survived the refusal.
+    assert (src / ".git").is_dir()
+    assert (src / "keep.txt").read_text(encoding="utf-8") == "user state"
+
+
+@pytest.mark.asyncio
+async def test_identity_refusal_deletes_fresh_clone(monkeypatch, tmp_path):
+    """FRESH install path: a clone created this run leaves no residue on refusal."""
+    src = tmp_path / "app-sources" / "demoapp"  # does NOT exist before the run
+    _identity_harness(monkeypatch, src, cloned_manifest={"name": "evil-app"})
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert "refusing" in result["error"].lower()
+    assert not src.exists()
+
+
+@pytest.mark.asyncio
+async def test_provenance_signer_comes_from_cloned_manifest(monkeypatch, tmp_path):
+    """The signer persisted as provenance is computed from the identity-checked
+    CLONED manifest — never from the pre-clone prefetch, which can be stale
+    (signed preview, unsigned pulled commit)."""
+    src = tmp_path / "app-sources" / "demoapp"
+    _identity_harness(
+        monkeypatch,
+        src,
+        cloned_manifest={"name": "demoapp", "version": "9.9.9"},
+        prefetched={"name": "demoapp", "version": "1.0.0"},
+    )
+    monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: "a" * 40)
+
+    signer_calls: list[object] = []
+
+    def _fake_signer(manifest):
+        signer_calls.append(manifest)
+        return "cloned-signer"
+
+    monkeypatch.setattr(registry, "verified_signer", _fake_signer)
+
+    provenance: dict[str, object] = {}
+
+    def _fake_set_provenance(name, **kwargs):
+        provenance.update(kwargs, name=name)
+
+    monkeypatch.setattr(registry, "set_app_provenance", _fake_set_provenance)
+    monkeypatch.setattr(registry, "get_app", lambda n: None)
+    monkeypatch.setattr(
+        registry,
+        "install_app",
+        lambda path: MagicMock(ok=True, name="demoapp", message="done", error=""),
+    )
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is True
+    # Exactly one signer computation, and it saw the CLONED manifest.
+    assert len(signer_calls) == 1
+    assert getattr(signer_calls[0], "version", "") == "9.9.9"
+    assert provenance["signer"] == "cloned-signer"
+    assert provenance["commit"] == "a" * 40
+
+
+@pytest.mark.asyncio
+async def test_identity_gate_runs_before_the_build(monkeypatch, tmp_path):
+    """A mismatched repo must be refused BEFORE _run_app_build executes — build
+    ecosystems run repo-authored lifecycle scripts (npm preinstall, setup.py),
+    so a post-build gate would let rejected code execute anyway."""
+    src = tmp_path / "app-sources" / "demoapp"
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+
+    async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "app.json").write_text(json.dumps({"name": "evil-app"}), encoding="utf-8")
+        return None
+
+    monkeypatch.setattr(registry, "_git_clone_or_pull", _fake_clone)
+
+    build_calls: list[object] = []
+
+    async def _fake_run_build(build_dir, app_name, log_lines):
+        build_calls.append(build_dir)
+        return {"ok": True}
+
+    monkeypatch.setattr(registry, "_run_app_build", _fake_run_build)
+
+    result = await registry._clone_build_app(
+        "https://example.com/demo.git", "demoapp", [], entry_repo="example/demo"
+    )
+
+    assert result["ok"] is False
+    assert "refusing" in result["error"].lower()
+    assert build_calls == []  # the build never ran
+
+
+@pytest.mark.asyncio
+async def test_cloned_manifest_admission_is_revalidated_before_build(monkeypatch, tmp_path):
+    """The repository can advance between the pre-clone prefetch and the clone:
+    a signed preview resolving to an unsigned/banned manifest must be refused
+    on the CLONED manifest, before any build command runs."""
+    src = tmp_path / "app-sources" / "demoapp"
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+
+    async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "app.json").write_text(json.dumps({"name": "demoapp"}), encoding="utf-8")
+        return None
+
+    monkeypatch.setattr(registry, "_git_clone_or_pull", _fake_clone)
+
+    admission_calls: list[object] = []
+
+    def _deny_cloned(name, *, manifest=None, action=""):
+        admission_calls.append(manifest)
+        return "signature required but manifest is unsigned"
+
+    monkeypatch.setattr(registry, "app_admission_denied", _deny_cloned)
+
+    build_calls: list[object] = []
+
+    async def _fake_run_build(build_dir, app_name, log_lines):
+        build_calls.append(build_dir)
+        return {"ok": True}
+
+    monkeypatch.setattr(registry, "_run_app_build", _fake_run_build)
+
+    result = await registry._clone_build_app(
+        "https://example.com/demo.git", "demoapp", []
+    )
+
+    assert result["ok"] is False
+    assert "admission" in result["error"]
+    assert build_calls == []  # refused before the build
+    assert len(admission_calls) == 1  # the cloned manifest was what got checked
+
+
+@pytest.mark.asyncio
+async def test_reused_checkout_pull_never_repoints_origin(monkeypatch, tmp_path):
+    """The reuse path only runs after the origin-mismatch gate has verified the
+    checkout's origin is byte-identical to the catalog URL (a mismatch is moved
+    aside and re-cloned). It must therefore pull directly — never rewrite the
+    origin remote — so the fetched code and the persisted provenance URL name
+    the same repository by construction, not by mutation."""
+    dest = tmp_path / "demoapp"
+    (dest / ".git").mkdir(parents=True)
+    monkeypatch.setattr(registry, "is_clone_host_trusted", lambda url: True)
+
+    async def _fake_origin(path):
+        return "https://example.com/new-home.git"
+
+    monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+    spawned: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        pid = 4242
+
+        async def communicate(self):
+            return b"", b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        spawned.append(list(argv))
+        return _Proc()
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+
+    err = await registry._git_clone_or_pull(
+        "https://example.com/new-home.git", "main", dest, []
+    )
+
+    assert err is None
+    assert spawned[0][:2] == ["git", "pull"]
+    assert not any(cmd[:3] == ["git", "remote", "set-url"] for cmd in spawned)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not platform_compat.IS_POSIX,
+    reason="onInstall scripts run via /bin/bash; the rewrite scenario is POSIX-only",
+)
+async def test_install_script_rewriting_manifest_is_refused(monkeypatch, tmp_path):
+    """onInstall runs with write access to the checkout; if it rewrites
+    app.json to a different identity, registration must be refused — the
+    post-script re-read is what install_app would otherwise consume."""
+    src = tmp_path / "app-sources" / "demoapp"
+    script = "python3 -c \"import json;json.dump({'name':'evil-app'},open('app.json','w'))\""
+    _identity_harness(
+        monkeypatch,
+        src,
+        cloned_manifest={"name": "demoapp", "setup": {"onInstall": script}},
+    )
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert "refusing" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_failed_pull_aborts_instead_of_installing_stale_code(monkeypatch, tmp_path):
+    """A failed fast-forward pull must abort the operation: installing the
+    checkout's stale contents while recording the catalog URL as provenance
+    would persist a source the code was never fetched from."""
+    dest = tmp_path / "demoapp"
+    (dest / ".git").mkdir(parents=True)
+    monkeypatch.setattr(registry, "is_clone_host_trusted", lambda url: True)
+
+    async def _fake_origin(path):
+        return "https://example.com/demo.git"
+
+    monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+    class _Proc:
+        pid = 4242
+
+        def __init__(self, rc):
+            self.returncode = rc
+
+        async def communicate(self):
+            return b"", b""
+
+    rcs = iter([1])  # the pull (first and only spawn) fails
+
+    async def _fake_spawn(*argv, **kwargs):
+        return _Proc(next(rcs))
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+
+    err = await registry._git_clone_or_pull(
+        "https://example.com/demo.git", "main", dest, []
+    )
+
+    assert err is not None and err["ok"] is False
+    assert "stale" in err["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not platform_compat.IS_POSIX,
+    reason="onInstall scripts run via /bin/bash; the swap scenario is POSIX-only",
+)
+async def test_provenance_signer_uses_post_script_manifest(monkeypatch, tmp_path):
+    """onInstall can replace app.json with a differently signed, still-valid
+    manifest; provenance must record the FINAL manifest's signer."""
+    src = tmp_path / "app-sources" / "demoapp"
+    script = (
+        "python3 -c \"import json;json.dump("
+        "{'name':'demoapp','version':'2.0.0'},open('app.json','w'))\""
+    )
+    _identity_harness(
+        monkeypatch,
+        src,
+        cloned_manifest={"name": "demoapp", "version": "1.0.0", "setup": {"onInstall": script}},
+    )
+    commit_reads: list[int] = []
+
+    def _commit_by_read_order(root):
+        # First read (if any) would be pre-script; the fix resolves it ONCE,
+        # post-script — emulate a script advancing the checkout by returning a
+        # different SHA per read and asserting the LAST one is persisted.
+        commit_reads.append(len(commit_reads))
+        return ("c" if len(commit_reads) == 1 else "d") * 40
+
+    monkeypatch.setattr(registry, "_resolved_clone_commit", _commit_by_read_order)
+
+    def _signer_by_version(manifest):
+        return f"signer-of-{getattr(manifest, 'version', '?')}"
+
+    monkeypatch.setattr(registry, "verified_signer", _signer_by_version)
+
+    provenance: dict[str, object] = {}
+    monkeypatch.setattr(
+        registry,
+        "set_app_provenance",
+        lambda name, **kwargs: provenance.update(kwargs, name=name),
+    )
+    monkeypatch.setattr(registry, "get_app", lambda n: None)
+    monkeypatch.setattr(
+        registry,
+        "install_app",
+        lambda path: MagicMock(ok=True, name="demoapp", message="done", error=""),
+    )
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is True
+    # The script swapped in v2.0.0; the signer must be v2's, not v1's.
+    assert provenance["signer"] == "signer-of-2.0.0"
+    # And the commit is resolved exactly once, post-script — never a stale
+    # pre-script read.
+    assert len(commit_reads) == 1
+    assert provenance["commit"] == "c" * 40
+
+
+@pytest.mark.asyncio
+async def test_admission_rejection_deletes_fresh_clone(monkeypatch, tmp_path):
+    """A fresh clone rejected by the cloned-manifest admission gate must leave
+    no residue — a leftover would be preferred by the prefetch and poison
+    every subsequent attempt."""
+    src = tmp_path / "app-sources" / "demoapp"
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+
+    async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "app.json").write_text(json.dumps({"name": "demoapp"}), encoding="utf-8")
+        return None
+
+    monkeypatch.setattr(registry, "_git_clone_or_pull", _fake_clone)
+    monkeypatch.setattr(
+        registry, "app_admission_denied", lambda *a, **k: "unsigned under policy"
+    )
+
+    result = await registry._clone_build_app("https://example.com/demo.git", "demoapp", [])
+
+    assert result["ok"] is False
+    assert not src.exists()
+
+
+@pytest.mark.asyncio
+async def test_admission_rejection_rolls_back_preexisting_checkout(monkeypatch, tmp_path):
+    """A pre-existing checkout whose pull advanced to a policy-rejected commit
+    is rolled back to its pre-pull commit, keeping retries viable."""
+    src = tmp_path / "app-sources" / "demoapp"
+    (src / ".git").mkdir(parents=True)
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+    monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: "b" * 40)
+
+    async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+        (dest / "app.json").write_text(json.dumps({"name": "demoapp"}), encoding="utf-8")
+        return None
+
+    monkeypatch.setattr(registry, "_git_clone_or_pull", _fake_clone)
+    monkeypatch.setattr(
+        registry, "app_admission_denied", lambda *a, **k: "unsigned under policy"
+    )
+
+    spawned: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        pid = 4242
+
+        async def communicate(self):
+            return b"", b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        spawned.append(list(argv))
+        return _Proc()
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+
+    result = await registry._clone_build_app("https://example.com/demo.git", "demoapp", [])
+
+    assert result["ok"] is False
+    assert (src / ".git").is_dir()  # workspace preserved
+    assert spawned and spawned[0][:4] == ["git", "reset", "--keep", "b" * 40]
+
+
+@pytest.mark.asyncio
+async def test_postbuild_admission_rejection_deletes_fresh_clone(monkeypatch, tmp_path):
+    """The POST-BUILD admission denial must clean the checkout exactly like the
+    cloned-admission gate: a fresh clone left at the rejected commit would be
+    preferred by the prefetch and poison every retry."""
+    src = tmp_path / "app-sources" / "demoapp"
+    src.mkdir(parents=True)
+    (src / "app.json").write_text(json.dumps({"name": "demoapp"}), encoding="utf-8")
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+    monkeypatch.setattr(
+        registry,
+        "get_registry_app",
+        lambda n: {"name": "demoapp", "repo": "https://example.com/demo.git", "branch": "main"},
+    )
+    monkeypatch.setattr(
+        registry,
+        "_fetch_app_manifest",
+        AsyncMock(return_value={"name": "demoapp", "version": "1.0.0"}),
+    )
+
+    async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+        return {
+            "ok": True,
+            "pkg_dir": src,
+            "_checkout_preexisted": False,
+            "_pre_pull_commit": "",
+        }
+
+    monkeypatch.setattr(registry, "_clone_build_app", _fake_clone_build)
+
+    calls = {"n": 0}
+
+    def _deny_postbuild(*a, **k):
+        calls["n"] += 1
+        # 1st call = prefetch admission (pass); 2nd = post-build (deny).
+        return "unsigned under policy" if calls["n"] >= 2 else None
+
+    monkeypatch.setattr(registry, "app_admission_denied", _deny_postbuild)
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert "admission policy" in result["error"]
+    assert not src.exists()  # fresh clone removed — retry starts clean
+
+
+@pytest.mark.asyncio
+async def test_postscript_admission_rejection_rolls_back_preexisting_checkout(
+    monkeypatch, tmp_path
+):
+    """The POST-SCRIPT admission denial must roll a pre-existing checkout back
+    to its pre-pull commit — onInstall already ran with write access, so the
+    checkout is otherwise left poisoned at the rejected state."""
+    src = tmp_path / "app-sources" / "demoapp"
+    src.mkdir(parents=True)
+    (src / "app.json").write_text(
+        json.dumps({"name": "demoapp", "setup": {"onInstall": "true"}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+    monkeypatch.setattr(
+        registry,
+        "get_registry_app",
+        lambda n: {"name": "demoapp", "repo": "https://example.com/demo.git", "branch": "main"},
+    )
+    monkeypatch.setattr(
+        registry,
+        "_fetch_app_manifest",
+        AsyncMock(return_value={"name": "demoapp", "version": "1.0.0"}),
+    )
+
+    async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+        return {
+            "ok": True,
+            "pkg_dir": src,
+            "_checkout_preexisted": True,
+            "_pre_pull_commit": "b" * 40,
+        }
+
+    monkeypatch.setattr(registry, "_clone_build_app", _fake_clone_build)
+
+    calls = {"n": 0}
+
+    def _deny_postscript(*a, **k):
+        calls["n"] += 1
+        # 1st = prefetch (pass); 2nd = post-build (pass); 3rd = post-script (deny).
+        return "unsigned under policy" if calls["n"] >= 3 else None
+
+    monkeypatch.setattr(registry, "app_admission_denied", _deny_postscript)
+
+    spawned: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        pid = 4242
+
+        async def communicate(self):
+            return b"", b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        spawned.append(list(argv))
+        return _Proc()
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+
+    reaped: list[int] = []
+
+    async def _fake_tree_kill(pid, sig):
+        reaped.append(pid)
+
+    def _fake_killpg(pgid, sig):
+        reaped.append(pgid)
+
+    monkeypatch.setattr(
+        registry.platform_compat, "kill_process_tree_async", _fake_tree_kill
+    )
+    monkeypatch.setattr(registry.os, "killpg", _fake_killpg, raising=False)
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert "admission policy" in result["error"]
+    assert (src / ".git").is_dir() or src.exists()  # workspace preserved, not deleted
+    assert any(cmd[:4] == ["git", "reset", "--keep", "b" * 40] for cmd in spawned)
+    # Surviving onInstall descendants are reaped BEFORE the final gates
+    # re-read the manifest (closes the detached-child rewrite TOCTOU).
+    assert 4242 in reaped
+    # The manifest file is restored from HEAD as well: a script rewriting
+    # app.json is a working-tree edit the reset alone cannot undo.
+    assert any(
+        cmd[:4] == ["git", "--literal-pathspecs", "checkout", "--"] for cmd in spawned
+    )
+
+
+@pytest.mark.asyncio
+async def test_moveaside_reclone_treated_as_fresh_on_rejection(monkeypatch, tmp_path):
+    """When the origin-mismatch gate moves an old checkout aside and
+    fresh-clones, a rejection must delete the fresh re-clone (never preserve it
+    or reset it toward the moved-aside repository's commit) and RESTORE the
+    moved-aside previous checkout — otherwise the slot is left empty and the
+    user's old workspace is stranded as a sweeper-doomed .stale-* sibling."""
+    src = tmp_path / "app-sources" / "demoapp"
+    (src / ".git").mkdir(parents=True)  # OLD checkout pre-exists (origin A)
+    (src / "old-work.txt").write_text("precious", encoding="utf-8")
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+    monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: "a" * 40)
+
+    async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+        # Simulate the origin-mismatch move-aside + fresh re-clone.
+        moved = dest.with_name("demoapp.stale-deadbeef")
+        dest.rename(moved)
+        cleanup = kwargs.get("pending_cleanup")
+        if cleanup is not None:
+            cleanup.append(moved)
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "app.json").write_text(json.dumps({"name": "demoapp"}), encoding="utf-8")
+        return None
+
+    monkeypatch.setattr(registry, "_git_clone_or_pull", _fake_clone)
+    monkeypatch.setattr(
+        registry, "app_admission_denied", lambda *a, **k: "unsigned under policy"
+    )
+
+    spawned: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        pid = 4242
+
+        async def communicate(self):
+            return b"", b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        spawned.append(list(argv))
+        return _Proc()
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+
+    result = await registry._clone_build_app("https://example.com/demo.git", "demoapp", [])
+
+    assert result["ok"] is False
+    # No rollback is attempted toward the moved-aside repo's commit ...
+    assert not any(cmd[:3] == ["git", "reset", "--keep"] for cmd in spawned)
+    # ... the rejected re-clone is gone, and the PREVIOUS checkout is back.
+    assert src.exists()
+    assert (src / "old-work.txt").read_text(encoding="utf-8") == "precious"
+    assert not (src / "app.json").exists()  # the rejected clone's manifest is gone
+    assert not src.with_name("demoapp.stale-deadbeef").exists()  # moved back, not stranded
+
+
+@pytest.mark.asyncio
+async def test_rejection_restores_users_pre_update_manifest_bytes(monkeypatch, tmp_path):
+    """A rejection on a pre-existing checkout must restore app.json to its
+    exact PRE-UPDATE working-tree bytes — including the user's uncommitted
+    local edits — not to HEAD's version, which would silently discard them."""
+    user_manifest = b'{"name": "demoapp", "_user_note": "my local tweak"}'
+    src = tmp_path / "app-sources" / "demoapp"
+    src.mkdir(parents=True)
+    (src / "app.json").write_bytes(b'{"name": "demoapp"}')  # post-build (poisoned) state
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+    monkeypatch.setattr(
+        registry,
+        "get_registry_app",
+        lambda n: {"name": "demoapp", "repo": "https://example.com/demo.git", "branch": "main"},
+    )
+    monkeypatch.setattr(
+        registry,
+        "_fetch_app_manifest",
+        AsyncMock(return_value={"name": "demoapp", "version": "1.0.0"}),
+    )
+
+    async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+        return {
+            "ok": True,
+            "pkg_dir": src,
+            "_checkout_preexisted": True,
+            "_pre_pull_commit": "b" * 40,
+            "_pre_update_manifest": user_manifest,
+        }
+
+    monkeypatch.setattr(registry, "_clone_build_app", _fake_clone_build)
+
+    calls = {"n": 0}
+
+    def _deny_postbuild(*a, **k):
+        calls["n"] += 1
+        return "unsigned under policy" if calls["n"] >= 2 else None
+
+    monkeypatch.setattr(registry, "app_admission_denied", _deny_postbuild)
+
+    spawned: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        pid = 4242
+
+        async def communicate(self):
+            return b"", b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        spawned.append(list(argv))
+        return _Proc()
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    # The manifest holds the user's exact pre-update bytes again ...
+    assert (src / "app.json").read_bytes() == user_manifest
+    # ... restored from the snapshot, not via a HEAD checkout.
+    assert not any(cmd[:2] == ["git", "--literal-pathspecs"] for cmd in spawned)
+    assert any(cmd[:4] == ["git", "reset", "--keep", "b" * 40] for cmd in spawned)
+
+
+@pytest.mark.asyncio
+async def test_identity_refusal_rolls_back_preexisting_checkout(monkeypatch, tmp_path):
+    """An IDENTITY refusal on a pre-existing checkout (pull brought a
+    self-renaming manifest) must roll the workspace back like the admission
+    gates do — preserved but left at the renamed manifest, the prefetch would
+    re-reject every retry before a fixed remote could be pulled."""
+    src = tmp_path / "app-sources" / "demoapp"
+    (src / ".git").mkdir(parents=True)
+    (src / "keep.txt").write_text("user state", encoding="utf-8")
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+    monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: "b" * 40)
+
+    async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+        (dest / "app.json").write_text(json.dumps({"name": "renamed-app"}), encoding="utf-8")
+        return None
+
+    monkeypatch.setattr(registry, "_git_clone_or_pull", _fake_clone)
+    monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
+
+    spawned: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        pid = 4242
+
+        async def communicate(self):
+            return b"", b""
+
+    async def _fake_spawn(*argv, **kwargs):
+        spawned.append(list(argv))
+        return _Proc()
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_spawn)
+    monkeypatch.setattr(registry, "wrap_argv", lambda cmd, mode="": (cmd, None))
+    monkeypatch.setattr(registry, "cgroup_scope_argv", lambda cmd: cmd)
+
+    result = await registry._clone_build_app("https://example.com/demo.git", "demoapp", [])
+
+    assert result["ok"] is False
+    assert "refusing" in result["error"].lower()
+    # Workspace preserved ...
+    assert (src / ".git").is_dir()
+    assert (src / "keep.txt").read_text(encoding="utf-8") == "user state"
+    # ... but un-poisoned: rolled back to the pre-pull commit AND the manifest
+    # restored from HEAD.
+    assert any(cmd[:4] == ["git", "reset", "--keep", "b" * 40] for cmd in spawned)
+    assert any(
+        cmd[:4] == ["git", "--literal-pathspecs", "checkout", "--"] for cmd in spawned
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_deleting_manifest_is_refused_with_cleanup(monkeypatch, tmp_path):
+    """A build step that DELETES app.json must go through the identity refusal
+    (fail-closed) and its checkout cleanup — not an early return that leaves a
+    fresh checkout poisoned in the app-sources slot."""
+    src = tmp_path / "app-sources" / "demoapp"
+    src.mkdir(parents=True)  # fresh clone; build "deleted" app.json — none written
+    monkeypatch.setattr(registry, "app_source_dir", lambda n: src)
+    monkeypatch.setattr(registry, "sel", lambda: MagicMock())
+    monkeypatch.setattr(
+        registry,
+        "get_registry_app",
+        lambda n: {"name": "demoapp", "repo": "https://example.com/demo.git", "branch": "main"},
+    )
+    monkeypatch.setattr(
+        registry,
+        "_fetch_app_manifest",
+        AsyncMock(return_value={"name": "demoapp", "version": "1.0.0"}),
+    )
+    monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
+
+    async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+        return {
+            "ok": True,
+            "pkg_dir": src,
+            "_checkout_preexisted": False,
+            "_pre_pull_commit": "",
+        }
+
+    monkeypatch.setattr(registry, "_clone_build_app", _fake_clone_build)
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert "refusing" in result["error"].lower()
+    assert not src.exists()  # fresh checkout removed — no poisoned residue
+
+
+def test_entry_git_url_tolerates_non_string_values():
+    """An external index can carry an object-valued gitUrl; the resolver must
+    degrade to "no URL" instead of crashing every caller with AttributeError."""
+    assert registry._entry_git_url({"gitUrl": {"evil": True}}) == ""
+    assert registry._entry_git_url({"gitUrl": ["x"], "repo": None}) == ""
+    assert registry._entry_git_url({"repo": 42}) == ""
+    assert registry._entry_git_url({"gitUrl": " https://ok.example/r.git "}) == "https://ok.example/r.git"
 
 
 class TestMinimalEnvHonorsWindowsCaseInsensitivity:

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -1261,7 +1261,7 @@ class TestInstallPathCredentialPosture:
         captured = {}
 
         async def _fake_clone_build(
-            git_url, name, log_lines, branch="main", *, index_originated=False
+            git_url, name, log_lines, branch="main", *, index_originated=False, **kwargs
         ):
             captured["index_originated"] = index_originated
             return {"ok": False, "error": "stop-after-clone-dispatch"}
@@ -1297,7 +1297,7 @@ class TestInstallPathCredentialPosture:
         captured = {}
 
         async def _fake_clone_build(
-            git_url, name, log_lines, branch="main", *, index_originated=False
+            git_url, name, log_lines, branch="main", *, index_originated=False, **kwargs
         ):
             captured["index_originated"] = index_originated
             return {"ok": False, "error": "stop-after-clone-dispatch"}
@@ -1433,7 +1433,7 @@ class TestSameRepoCredentialCarveOut:
         captured = {}
 
         async def _fake_clone_build(
-            git_url, name, log_lines, branch="main", *, index_originated=False
+            git_url, name, log_lines, branch="main", *, index_originated=False, **kwargs
         ):
             captured["index_originated"] = index_originated
             return {"ok": False, "error": "stop-after-clone-dispatch"}
@@ -1483,7 +1483,7 @@ class TestSameRepoCredentialCarveOut:
         captured = {}
 
         async def _fake_clone_build(
-            git_url, name, log_lines, branch="main", *, index_originated=False
+            git_url, name, log_lines, branch="main", *, index_originated=False, **kwargs
         ):
             captured["index_originated"] = index_originated
             return {"ok": False, "error": "stop-after-clone-dispatch"}
@@ -1534,7 +1534,7 @@ class TestSameRepoCredentialCarveOut:
         captured = {}
 
         async def _fake_clone_build(
-            git_url, name, log_lines, branch="main", *, index_originated=False
+            git_url, name, log_lines, branch="main", *, index_originated=False, **kwargs
         ):
             captured["index_originated"] = index_originated
             return {"ok": False, "error": "stop-after-clone-dispatch"}
@@ -3176,6 +3176,9 @@ class TestInstallScriptFailurePreservesStaleCheckout:
         async def _fake_create_subprocess(*args, **kwargs):
             pkg_dir.mkdir(parents=True, exist_ok=True)
             (pkg_dir / ".git").mkdir(exist_ok=True)
+            # A real clone materializes the manifest; the identity gate reads
+            # it fail-closed before the build, so the fake must provide it.
+            (pkg_dir / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
             return _SuccessProc()
 
         with (
@@ -3228,7 +3231,9 @@ class TestInstallScriptFailurePreservesStaleCheckout:
         # entry, simulating the origin-mismatch → move-aside → clone success flow.
         app_source = tmp_path / "app-source"
         app_source.mkdir()
-        (app_source / "app.json").write_text('{"setup": {"onInstall": "exit 1"}}', encoding="utf-8")
+        (app_source / "app.json").write_text(
+            '{"name": "testapp", "setup": {"onInstall": "exit 1"}}', encoding="utf-8"
+        )
 
         async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
             return {
@@ -3322,7 +3327,7 @@ class TestSuccessPathRetainsStaleCheckout:
         )
 
         async def _fake_clone_build(
-            git_url, name, log_lines, *, branch="main", index_originated=False
+            git_url, name, log_lines, *, branch="main", index_originated=False, **kwargs
         ):
             return {
                 "ok": True,
@@ -3500,7 +3505,7 @@ class TestStaleCheckoutSweep:
             sweep_called.append(True)
 
         async def _fake_clone_build(
-            git_url, name, log_lines, *, branch="main", index_originated=False
+            git_url, name, log_lines, *, branch="main", index_originated=False, **kwargs
         ):
             return {"ok": False, "error": "deliberate failure for test"}
 

--- a/test/test_install_receipt.py
+++ b/test/test_install_receipt.py
@@ -323,7 +323,7 @@ async def _run_registry_install(
         "update_app",
         lambda _source: AppResult(ok=True, name="issue-radar", message="updated"),
     )
-    monkeypatch.setattr(registry, "set_app_source", lambda *_a, **_k: True)
+    monkeypatch.setattr(registry, "set_app_provenance", lambda *_a, **_k: True)
 
     dispatched: list[tuple[str, dict[str, object]]] = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Implements M1 (App identity repair) of the design doc **Architecture & Design: App Store Popularity Ranking**. Backend-only security fix.

An app's sole identifier is its manifest `name`, first occupant wins. `install_from_registry` resolved a catalog entry by name, cloned that entry's repo, then installed under the **cloned manifest's** name with no check that the two agreed — `install_app`/`update_app` derive identity from the cloned manifest, while the card the owner saw (and the persisted source marker) came from the entry. A repo listed as X could therefore install, register, and run its `onInstall` as Y.

Provenance was then discarded: only a bare `registry:<name>` marker was persisted, so an update re-resolved that bare name through a first-match-wins lookup, and a same-named entry from a different registry source could capture it.

### Changes

**1. Identity gate** — the cloned `app.json` must declare the entry's name.
- Enforced *before* the install script runs, so a mismatched repo never executes anything.
- Fail-closed: a missing or unparseable name is a mismatch, not a pass.
- On refusal the persistent clone is deleted, so nothing is left in the entry's `app-sources/` slot — a leftover would keep being preferred by `_fetch_app_manifest` on the next listing, letting a refused repo go on answering as this app. Nothing has been written under `~/.kiro/crew/apps/` at that point, so the machine is left exactly as it was.
- The refusal is SEL-audited (`operation="identity_mismatch"`, mirroring the existing `app_install_from_registry` admission audit) and the error names both identities.

**2. Structured provenance** — extends the existing `InstalledApp` record in `installed.json` (no new store) with `sourceUrl`, `sourceRegistry` (external index id; empty denotes the bundled catalog), `sourceCommit`, and `sourceSigner`. The bare `registry:<name>` marker is still written, so nothing downstream regresses. Commit resolution reads git's own on-disk refs (loose, packed, detached) instead of spawning `git rev-parse`, so recording provenance adds neither a subprocess nor a new failure mode to the install path — every read failure degrades to an empty commit rather than failing the install.

**3. Update resolution** — an installed app that carries provenance is pinned to it: only the entry whose clone URL *and* originating registry id match what was recorded may update it. `_registry_app_candidates` enumerates every same-named row (bundled first, then each configured registry) so pinning can select the right one rather than accepting whichever resolves first; a non-match is refused and SEL-audited rather than falling back to the bare-name lookup, because that fallback is exactly the capture path. Apps installed before this change carry no provenance and keep today's bare-name behaviour — **backward compatible, no migration** — and self-heal on their next successful update.

The new `verified_signer` helper in `admission.py` only observes the signature check the gate already performs; whether a signature is *required* is unchanged. Local-path installs and self-registration are untouched.

## What was tested

New `test/test_app_identity_provenance.py` (14 tests), mirroring the collaborator-patching style of the existing registry tests — no real git, no network, isolated via `tmp_path` + `monkeypatch`:

- **Squat**: entry `card-app` whose repo declares `other-app` is refused; nothing installed under either name; the clone is gone; no subprocess spawned; the refusal is audited. Plus a fail-closed case for a manifest with no name, and a control proving a matching repo still installs.
- **Provenance**: a fresh install persists URL + registry id + commit + signer, exercising the real `verified_signer` against a written admission policy carrying the trust key; a bundled unsigned install records URL + commit with no signer; a manifest claiming a signer with a signature that does not verify records no signer.
- **Update resolution**: a same-named entry from another source cannot capture an update (and leaves the recorded provenance untouched); with a hostile same-named row listed **first** — where the old first-match-wins lookup would have landed — the update still follows provenance to the legitimate row and advances the pinned commit.
- **Legacy**: an app carrying only `registry:<name>` still updates via the bare-name lookup (the test fails if it enters pinned resolution) and gains the provenance it lacked.

One existing fixture in `test_apps_registry.py` was given the `name` its fake cloned manifest was missing; its assertions are unchanged.

Gates, all green from the worktree root: `pytest -q` (full suite, `-n auto --dist loadgroup`), `isort --check-only`, `flake8`, and CI-parity `mypy src/kiro_crew/` (632 files). The mandatory drift guards `test_security_posture.py` and `test_spawn_audit.py` pass — no new module and no new outbound call site, so no registration was needed.

The full suite reports 32 failures in this container (sandbox `unshare(CLONE_NEWUSER)` EPERM, hardlink/inode restrictions, root-owned binary resolution). All 32 were confirmed pre-existing by running the same modules against clean `origin/main` in a throwaway worktree — the set of failures unique to this branch is empty.

## Follow-ups

- Publisher-qualified app IDs, signature-requirement changes, and the app-store ranking surface itself are deliberately out of scope here (M2 and later).
- `POST /api/apps/{name}/update` still accepts a caller-supplied `source` override; provenance pinning inside `install_from_registry` now constrains where that can land, but tightening the parameter itself is a separate change.
