### PR TITLE
fix(chat): preserve streamed-row identity across the chat_done transcript reload

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -661,6 +661,103 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
   return result
 }
 
+/** Carry the client-stamped `meta.clientTs` from the current messages onto the
+ *  server copies returned by a slot-detail reload (the refreshSlot fired on
+ *  chat_done). A message STREAMED this session is born with only
+ *  `meta.clientTs` (a minted bornKey, no server `ts`); the reloaded server copy
+ *  has an authoritative `ts` but NO `clientTs`. The renderer keys virtual rows
+ *  by `clientTs ?? ts`, so without this the row's key flips bornKey → serverTs
+ *  on the reload, remounting the row and DROPPING its measured height in the
+ *  virtualizer's HeightCache — a visible scroll jump on every turn (the "reload
+ *  the whole history, scroll bar keeps moving up, can't reach the bottom"
+ *  report).
+ *
+ *  Matching is two-pass so a duplicate-content row can never steal a live
+ *  identity (forward-first content matching would let an OLDER duplicate
+ *  consume the newest stamp, flipping two rows' keys instead of zero):
+ *    1. Durable identities — a stamp that already carries a server `ts` (it was
+ *       reloaded before) matches its incoming copy by EXACT `ts`. Collision-proof.
+ *    2. Freshly-streamed identities — a stamp with NO `ts` (born this session,
+ *       not yet reloaded) has nothing to match on, but its server copy is the
+ *       NEWEST message of that role, so pair newest-first: walk the ts-less
+ *       stamps from the transcript tail and scan `incoming` in REVERSE for the
+ *       first unused (normalized-role, trimmed-content) match. 'streaming' is
+ *       normalized to 'assistant' since finalization flips the role.
+ *  Returns `incoming` unchanged (reference-equal) when nothing needs carrying. */
+function mergePreservedClientTs<M extends { role: string; content: string; ts?: string; meta?: Record<string, unknown> }>(
+  existing: M[],
+  incoming: M[],
+): M[] {
+  const norm = (r: string): string => (r === 'streaming' ? 'assistant' : r)
+  const stamped = existing.filter(m => typeof m.meta?.clientTs === 'string')
+  if (!stamped.length) return incoming
+  const carried = new Array<string | undefined>(incoming.length)
+  const usedIncoming = new Set<number>()
+  let changed = false
+
+  // Pass 1: durable (already-reloaded) stamps — same server `ts` AND matching
+  // (normalized-role, trimmed-content). A `ts` is NOT unique (a coarse OS clock
+  // can stamp two fast tool-delimited rows with the same tick) and is NOT
+  // role-specific (a tool row can share the assistant's tick), so keying on ts
+  // alone would (a) collapse two distinct same-ts identities or (b) hand a
+  // stamp to the wrong row (e.g. an unstamped tool row ahead of the stamped
+  // assistant). Bucket the stamps per ts and consume the first bucket entry
+  // that also matches role+content, so each identity lands on its own row.
+  const byTs = new Map<string, { ct: string; role: string; content: string }[]>()
+  for (const s of stamped) {
+    if (typeof s.ts === 'string' && s.ts) {
+      const e = { ct: s.meta!.clientTs as string, role: norm(s.role), content: s.content.trimEnd() }
+      const q = byTs.get(s.ts)
+      if (q) q.push(e)
+      else byTs.set(s.ts, [e])
+    }
+  }
+  if (byTs.size) {
+    for (let i = 0; i < incoming.length; i++) {
+      const item = incoming[i]
+      if (item.meta?.clientTs) continue
+      if (!(typeof item.ts === 'string' && item.ts)) continue
+      const q = byTs.get(item.ts)
+      if (!q || !q.length) continue
+      const irole = norm(item.role)
+      const icontent = item.content.trimEnd()
+      const qi = q.findIndex(e => e.role === irole && e.content === icontent)
+      if (qi >= 0) { carried[i] = q[qi].ct; q.splice(qi, 1); usedIncoming.add(i); changed = true }
+    }
+  }
+
+  // Pass 2: freshly-streamed (ts-less) stamps — pair newest-first from the tail.
+  // Exclude still-'streaming' stamps (a partial in-progress row has no server
+  // copy yet, so a content match could only hit an older duplicate) and
+  // 'thinking' stamps (client-only, never present in the server payload — and
+  // re-inserted separately by mergePreservedThinking), which also keeps this
+  // pass from scanning one dead thinking stamp per turn.
+  const tsLess = stamped.filter(
+    s => !(typeof s.ts === 'string' && s.ts) && s.role !== 'streaming' && s.role !== 'thinking',
+  )
+  for (let p = tsLess.length - 1; p >= 0; p--) {
+    const s = tsLess[p]
+    for (let i = incoming.length - 1; i >= 0; i--) {
+      if (usedIncoming.has(i)) continue
+      const item = incoming[i]
+      if (item.meta?.clientTs) continue
+      if (norm(s.role) === norm(item.role) && s.content.trimEnd() === item.content.trimEnd()) {
+        carried[i] = s.meta!.clientTs as string
+        usedIncoming.add(i)
+        changed = true
+        break
+      }
+    }
+  }
+
+  if (!changed) return incoming
+  return incoming.map((item, i) =>
+    carried[i] !== undefined
+      ? { ...item, meta: { ...(item.meta || {}), clientTs: carried[i] as string } }
+      : item,
+  )
+}
+
 export const refreshSlot = createAsyncThunk(
   'chat/refreshSlot',
   async (key: string, { getState }) => {
@@ -2201,7 +2298,7 @@ const chatSlice = createSlice({
           : mergedWithPastes
         // Reasoning is client-only (never persisted server-side); re-insert it so
         // a finished turn's thinking block survives this refresh.
-        state.messages = mergePreservedThinking(state.messages, sorted)
+        state.messages = mergePreservedThinking(state.messages, mergePreservedClientTs(state.messages, sorted))
         // Re-hydrate queued bubbles through the SAME shared path as
         // switchSlot/warmSlotCache. The merge above is rebuilt from server
         // history + preserved perms/thinking and carries no `queued` bubbles, so

--- a/website/src/test/chatSlice.streamingKeyStability.test.ts
+++ b/website/src/test/chatSlice.streamingKeyStability.test.ts
@@ -17,7 +17,7 @@
  * the birth identity — they cannot be satisfied by the test's own resolver.
  */
 import { describe, it, expect } from 'vitest'
-import reducer, { sseChatMessage, sseThinkingChunk } from '../store/chatSlice'
+import reducer, { sseChatMessage, sseThinkingChunk, refreshSlot } from '../store/chatSlice'
 import { virtualKeyFor, messageRowKey } from '../pages/ChatPage'
 import type { ChatMessage } from '../types'
 import type { DisplayItem } from '../pages/chat/types'
@@ -143,5 +143,172 @@ describe('messageRowKey — inner bubble identity across finalization', () => {
     const c = { role: 'assistant', content: 'a2', cls: '', ts: 't2' }
     expect(messageRowKey(a, 0)).not.toBe(messageRowKey(b, 1))
     expect(messageRowKey(b, 1)).not.toBe(messageRowKey(c, 2))
+  })
+})
+
+describe('virtual key stability across the chat_done full-transcript reload (refreshSlot)', () => {
+  // Bug: refreshSlot fires on every chat_done and refetches the ENTIRE
+  // transcript, replacing state.messages with the server copies. A message
+  // STREAMED this session was born with only meta.clientTs (a minted bornKey,
+  // no ts); the server copy has a real ts and NO clientTs. Since the virtual
+  // key is `clientTs ?? ts`, the row's key flips bornKey → serverTs on that
+  // reload, remounting the row and DROPPING its measured height in the
+  // virtualizer's HeightCache — a visible scroll jump every turn (the user's
+  // "reload the whole history, scroll bar keeps moving up, can't reach bottom").
+  // The fix carries the client-stamped clientTs onto the reloaded message so
+  // the row identity (and its cached height) is continuous.
+  const detailPayload = (key: string, messages: ChatMessage[]) => ({
+    key, messages, running: false, stopping: false, hasMore: false, total: messages.length,
+    queue: [] as { content: string; queueId: string; ts: string }[], context: undefined,
+  })
+
+  it('keeps the streamed-then-finalized assistant row key stable across refreshSlot', () => {
+    let state = chunk(withSlot, 'The answer', 1)
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '', ts: 'server-ts-1' }))
+    const finalized = state.messages.find(m => m.role === 'assistant')!
+    const keyBefore = messageRowKey(finalized, state.messages.indexOf(finalized))
+
+    // chat_done → refreshSlot: server returns the full transcript. The server
+    // copy carries an authoritative ts but NO clientTs.
+    const server: ChatMessage[] = [{ role: 'assistant', content: 'The answer', cls: 'msg msg-a', ts: 'server-ts-1' }]
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, server), 'req-1', SLOT))
+
+    const reloaded = state.messages.find(m => m.role === 'assistant')!
+    const keyAfter = messageRowKey(reloaded, state.messages.indexOf(reloaded))
+    expect(keyAfter).toBe(keyBefore)
+  })
+
+  it('keeps the row key stable across a SECOND refreshSlot (identity stays durable)', () => {
+    let state = chunk(withSlot, 'Durable answer', 1)
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '' }))
+    const keyBefore = messageRowKey(state.messages.find(m => m.role === 'assistant')!, 0)
+
+    const server: ChatMessage[] = [{ role: 'assistant', content: 'Durable answer', cls: 'msg msg-a', ts: 'server-ts-2' }]
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, server), 'r1', SLOT))
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, server), 'r2', SLOT))
+
+    const keyAfter = messageRowKey(state.messages.find(m => m.role === 'assistant')!, 0)
+    expect(keyAfter).toBe(keyBefore)
+  })
+
+  it('does not fabricate a clientTs on a plain server message that was never streamed here', () => {
+    // A history message the user never streamed this session has no clientTs
+    // in state; the reload must not invent one (its ts is already stable).
+    let state = chunk(withSlot, 'streamed', 1)
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '' }))
+    const server: ChatMessage[] = [
+      { role: 'user', content: 'old question', cls: '', ts: 'hist-1' },
+      { role: 'assistant', content: 'streamed', cls: 'msg msg-a', ts: 'server-ts-3' },
+    ]
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, server), 'r', SLOT))
+    const hist = state.messages.find(m => m.role === 'user')!
+    expect(hist.meta?.clientTs).toBeUndefined()
+    expect(messageRowKey(hist, 0)).toBe('user-hist-1')
+  })
+
+  it('does NOT let an older duplicate-content row steal the freshly-streamed identity', () => {
+    // Reviewers' blocker: a pre-session assistant row with the SAME content as
+    // the newest streamed response must NOT receive the live clientTs (forward
+    // matching would flip TWO rows' keys — the history row and the streamed
+    // row — instead of zero). Newest-first pairing keeps the history row keyed
+    // on its own ts and the streamed row on its clientTs.
+    // Seed a history "Done" (server ts, no clientTs) via an initial reload.
+    let state = reducer(withSlot, refreshSlot.fulfilled(
+      detailPayload(SLOT, [{ role: 'assistant', content: 'Done', cls: 'msg msg-a', ts: 'hist-ts' }]), 'r0', SLOT))
+    // Stream a NEW response with identical content, then finalize.
+    state = chunk(state, 'Done', 1)
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '' }))
+    const assistants = state.messages.filter(m => m.role === 'assistant')
+    expect(assistants).toHaveLength(2)
+    const histKeyBefore = messageRowKey(assistants[0], 0)   // 'assistant-hist-ts'
+    const streamKeyBefore = messageRowKey(assistants[1], 1) // 'assistant-born-...'
+    expect(histKeyBefore).toBe('assistant-hist-ts')
+
+    // chat_done reload: server returns both "Done" rows with their server ts.
+    const server: ChatMessage[] = [
+      { role: 'assistant', content: 'Done', cls: 'msg msg-a', ts: 'hist-ts' },
+      { role: 'assistant', content: 'Done', cls: 'msg msg-a', ts: 'new-ts' },
+    ]
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, server), 'r1', SLOT))
+    const after = state.messages.filter(m => m.role === 'assistant')
+    expect(after).toHaveLength(2)
+    // History row keeps its own ts identity; streamed row keeps its clientTs.
+    expect(messageRowKey(after[0], 0)).toBe(histKeyBefore)
+    expect(messageRowKey(after[1], 1)).toBe(streamKeyBefore)
+  })
+
+  it('does not carry a still-streaming partial identity onto an older duplicate (reconnect mid-stream)', () => {
+    // A reconnect refresh can fire while a row is still 'streaming' with partial
+    // text not yet in server history. If an older row's content equals that
+    // partial string, pass 2 must NOT hand the live clientTs to the older row.
+    let state = reducer(withSlot, refreshSlot.fulfilled(
+      detailPayload(SLOT, [{ role: 'assistant', content: 'Done', cls: 'msg msg-a', ts: 'hist-ts' }]), 'r0', SLOT))
+    state = chunk(state, 'Done', 1) // still 'streaming', NOT finalized
+    expect(state.messages.some(m => m.role === 'streaming')).toBe(true)
+
+    // Reconnect reload: server history has only the old row (partial not persisted).
+    const server: ChatMessage[] = [{ role: 'assistant', content: 'Done', cls: 'msg msg-a', ts: 'hist-ts' }]
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, server), 'r1', SLOT))
+    const hist = state.messages.find(m => m.role === 'assistant')!
+    expect(hist.meta?.clientTs).toBeUndefined()
+    expect(messageRowKey(hist, 0)).toBe('assistant-hist-ts')
+  })
+
+  it('keeps distinct identities when two durable rows share the same server ts (coarse clock)', () => {
+    // Two fast tool-delimited assistant segments can be stamped with the SAME
+    // server ts by a coarse OS clock. A plain ts→clientTs map would collapse
+    // them and hand both reloaded rows one clientTs (duplicate keys). Per-ts
+    // FIFO queues must preserve each row's own identity.
+    // Two streamed segments this session (distinct clientTs, no ts yet).
+    let state = chunk(withSlot, 'seg one', 1)
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '' }))
+    state = chunk(state, 'seg two', 2)
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '' }))
+    // First reload: server assigns BOTH the same ts. Pass 2 pairs them by content.
+    const shared: ChatMessage[] = [
+      { role: 'assistant', content: 'seg one', cls: 'msg msg-a', ts: 'tick' },
+      { role: 'assistant', content: 'seg two', cls: 'msg msg-a', ts: 'tick' },
+    ]
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, shared), 'r1', SLOT))
+    const a1 = state.messages.filter(m => m.role === 'assistant')
+    const k1 = messageRowKey(a1[0], 0)
+    const k2 = messageRowKey(a1[1], 1)
+    expect(k1).not.toBe(k2) // distinct clientTs carried
+
+    // Second reload: now both existing rows carry clientTs AND the shared ts,
+    // so this exercises the Pass-1 ts-queue. Identities must stay distinct.
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, shared), 'r2', SLOT))
+    const a2 = state.messages.filter(m => m.role === 'assistant')
+    expect(messageRowKey(a2[0], 0)).toBe(k1)
+    expect(messageRowKey(a2[1], 1)).toBe(k2)
+    expect(messageRowKey(a2[0], 0)).not.toBe(messageRowKey(a2[1], 1))
+  })
+
+  it('does not transfer a stamped assistant identity onto an unstamped tool row sharing its ts', () => {
+    // Coarse clock: an unstamped tool row can share the stamped assistant's tick
+    // and precede it. Pass 1 must match role+content, not ts alone — else the
+    // tool row steals the assistant's clientTs and the assistant remounts.
+    let state = chunk(withSlot, 'answer', 1)
+    state = reducer(state, sseChatMessage({ slot: SLOT, role: '_done', content: '' }))
+    // First reload: a tool row and the assistant share ts 'tick'. Pass 2 pairs
+    // the ts-less assistant stamp to the assistant by content.
+    const server: ChatMessage[] = [
+      { role: 'tool', content: 'ran a tool', cls: '', ts: 'tick', meta: { tool_call_id: 'tc1' } },
+      { role: 'assistant', content: 'answer', cls: 'msg msg-a', ts: 'tick' },
+    ]
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, server), 'r1', SLOT))
+    const tool1 = state.messages.find(m => m.role === 'tool')
+    const asst1 = state.messages.find(m => m.role === 'assistant')!
+    expect(tool1).toBeDefined()
+    expect(tool1!.meta?.clientTs).toBeUndefined()
+    const asstKey = messageRowKey(asst1, 0) // 'assistant-<bornKey>'
+
+    // Second reload exercises Pass 1 (assistant is now durable: clientTs + ts).
+    state = reducer(state, refreshSlot.fulfilled(detailPayload(SLOT, server), 'r2', SLOT))
+    const tool2 = state.messages.find(m => m.role === 'tool')!
+    const asst2 = state.messages.find(m => m.role === 'assistant')!
+    expect(tool2.meta?.clientTs).toBeUndefined()            // tool did NOT steal the stamp
+    expect(messageRowKey(tool2, 0)).toBe('tool-tick')
+    expect(messageRowKey(asst2, 1)).toBe(asstKey)           // assistant keeps its identity
   })
 })


### PR DESCRIPTION
## Problem
After loading/resuming a chat session, clicking the "scroll to bottom" button reaches the bottom, but then the scroll bar keeps creeping upward "like new content is being added" and the view can never settle at the bottom while a response streams — the whole transcript appears to reload on every turn.

## Why it matters
The chat becomes unusable during an active response in any non-trivial session: the user cannot watch the latest output because the viewport is repeatedly yanked away from the growing bottom. It reproduces on every `chat_done`, so any multi-turn or actively-streaming session is affected.

## Fix (symptom → root cause → change)
- **Symptom:** jump-to-bottom works, then the row visibly remounts and the scroll position drifts every turn.
- **Root cause:** on every `chat_done` the client refetches the full transcript (`refreshSlot`) and replaces `state.messages` with the server copies. A message *streamed this session* is born with only `meta.clientTs` (a minted `bornKey`, no server `ts`) and `_done` finalizes it to `assistant` still keyed on that `clientTs`. The server copy has an authoritative `ts` but **no** `clientTs`. The virtualizer keys each row by `clientTs ?? ts` (`messageRowKey`), so on that reload the just-finished row's key flips `assistant-<bornKey>` → `assistant-<serverTs>`, React remounts it, and the virtualizer's `HeightCache` entry (keyed on the old identity) is orphaned → the row reverts to an estimated height → the content re-inflates and the viewport is pushed off the bottom. `overflow-anchor` cannot compensate because the DOM node was destroyed.
- **Change:** a new `mergePreservedClientTs` helper carries the client-stamped `meta.clientTs` from the current messages onto the reloaded server copies in `refreshSlot.fulfilled`, so the row identity (and its cached height) stays continuous across the reload. Matching is two-pass to avoid a duplicate-content row stealing a live identity: (1) durable stamps that already carry a server `ts` match their incoming copy by **exact `ts`**; (2) freshly-streamed (ts-less) stamps are paired **newest-first** — ts-less stamps are walked from the transcript tail and `incoming` is scanned in reverse for the first unused (normalized-role, trimmed-content) match. Still-`streaming` and client-only `thinking` stamps are excluded from pass 2 (they have no server copy to match). Returns `incoming` reference-equal when nothing needs carrying, so history-only reloads are untouched. Mirrors the existing `mergePreservedThinking` pattern in the same reducer.

The unbounded full-transcript refetch itself is intentionally left as-is — it exists to reconcile missed chunks and reordering across gateway restarts. Preserving row identity is the correct, low-risk fix for the scroll symptom.

## Tests
`website/src/test/chatSlice.streamingKeyStability.test.ts` — new `describe` block driving the real reducer:
- streamed→finalized assistant row keeps its virtual key across `refreshSlot` (the core fix).
- key stays stable across a **second** reload (durable identity).
- a plain history message is never given a fabricated `clientTs`.
- an **older duplicate-content** row does not steal the freshly-streamed identity (both local reviewers' blocker).
- a still-`streaming` partial identity is not carried onto an older duplicate on a reconnect-mid-stream reload.

Full suite: 200 backend-store tests pass (`chatSlice` + `chatSlice.streamingKeyStability`), `tsc --noEmit` clean, eslint clean.

## Manual verification
N/A for a still frame — this is a scroll/virtualizer behavioral fix that only manifests in a real browser (jsdom has no `overflow-anchor` / layout). Unit coverage locks the identity-stability invariant that is the root cause; the visual "stays pinned at bottom across turns" behavior is best confirmed live by resuming a long session and streaming a response.

## Screenshots
N/A — no user-visible UI surface changed (store-reducer identity fix); the effect is scroll behavior, not a new/changed visual component.
