### PR TITLE
fix(dev-fleet): declare the platforms the app actually runs on

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -505,13 +505,25 @@ All user-visible output passes through `redact_credentials()` and
 
 ## Platform Behavior
 
-The app declares `platform.os: ["linux"]` in `app.json`. That declaration is
-**informational** — `installMode` is the default `"server"`, and the App Store's
-platform gate only refuses `installMode: "client"` apps — so the app still
-installs and enables anywhere. What it buys is an honest App Store detail page
-(which renders the requirement) instead of the previous silence, where an absent
-`platform` block defaulted to `["macos", "linux"]` and advertised macOS support
-the app does not have.
+The app declares `platform.os: ["macos", "linux", "windows"]` in `app.json`,
+because that is where it genuinely runs: the fleet view, PR status, commit and
+disk figures, Provision, Sync, Rebase and Prune are git and filesystem work with
+no systemd in them. Only the pod plane and Make Live need Linux, and the app now
+says so in the UI rather than in the manifest — a `highlights` line states the
+requirement, and `GET /api/fleet` carries the reason that renders as a banner.
+
+Declaring one platform per capability is not expressible here: `os` is a single
+list describing the whole app, so any value is a summary. `["linux"]` was the
+wrong summary — it read as "does not run on macOS" for an app whose non-pod half
+runs there fine, which is the same misinformation in the opposite direction from
+the pre-#1254 silence (an absent `platform` block defaults to
+`["macos", "linux"]`, quietly advertising macOS parity).
+
+The declaration is **not** an install gate for this app: `installMode` is the
+default `"server"` and the App Store's platform check at `registry.py` only
+refuses `installMode: "client"` apps, so dev-fleet installs and enables
+everywhere regardless. What the list drives is the App Store detail page, which
+renders it verbatim (`AppDetailPage.tsx` → "Platform: macos, linux, windows").
 
 Two separate capability flags drive the degradation, because they gate different
 things:

--- a/src/kiro_crew/apps/builtins/dev_fleet/app.json
+++ b/src/kiro_crew/apps/builtins/dev_fleet/app.json
@@ -16,7 +16,7 @@
   ],
   "defaultEnabled": false,
   "platform": {
-    "os": ["linux"]
+    "os": ["macos", "linux", "windows"]
   },
   "permissions": {
     "api": ["/apps/dev-fleet/api", "/apps/dev-fleet/api/*"],

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -4421,3 +4421,40 @@ async def test_fleet_cached_background_failure_is_swallowed(_clean_fleet_cache):
         await asyncio.gather(task, return_exceptions=True)
     assert task.exception() is not None
     assert mod._FLEET_CACHE["data"] == {"worktrees": [{"name": "stale"}]}
+
+
+# --- manifest platform declaration ---
+def test_manifest_declares_every_platform_the_app_runs_on():
+    """`platform.os` summarises the whole app, and the non-pod half (fleet view,
+    Provision, Sync, Rebase, Prune) is git + filesystem work that runs anywhere.
+
+    Pinned because both narrower answers misinform: `["linux"]` reads as "does
+    not run on macOS", and omitting the block falls back to the implicit
+    ``["macos", "linux"]`` default, which silently drops Windows.
+    """
+    manifest = json.loads(
+        (Path(mod.__file__).parent / "app.json").read_text(encoding="utf-8")
+    )
+    assert manifest["platform"]["os"] == ["macos", "linux", "windows"]
+
+    # The pod requirement is carried in the UI copy, not the manifest gate.
+    assert any(
+        "Linux systemd" in h for h in manifest["highlights"]
+    ), "the highlight stating pods need Linux systemd is the honest half of this declaration"
+
+
+def test_declared_platforms_all_resolve_to_a_real_sys_platform():
+    """Every declared name must map to a sys.platform value.
+
+    An unmapped name is silently accepted into the list and then never matches,
+    so a declaration can claim a platform the gate rejects. `windows` was in
+    exactly that state until the mapping row landed.
+    """
+    from kiro_crew.apps.manifest import PlatformConfig
+
+    manifest = json.loads(
+        (Path(mod.__file__).parent / "app.json").read_text(encoding="utf-8")
+    )
+    cfg = PlatformConfig(os=manifest["platform"]["os"])
+    for sys_platform in ("darwin", "linux", "win32"):
+        assert cfg.supports_platform(sys_platform), sys_platform


### PR DESCRIPTION
## What is the problem?

Dev Fleet's manifest declares `platform.os: ["linux"]`, and since #1254 that is
no longer true. The app's non-pod half — fleet view, PR status, commit counts,
disk usage, Provision, Sync, Rebase, Prune — is git and filesystem work with no
systemd in it, and #1254 is precisely what made that half report correctly on
macOS and Windows instead of labelling every worktree `not built`. Only the pod
plane and Make Live need Linux.

The App Store detail page renders the list verbatim:

```tsx
// website/src/pages/AppDetailPage.tsx
{app.platform?.os && <div>{i18nT('pages.appDetailPage.platform')} {app.platform.os.join(', ')}</div>}
```

So a macOS user reading the page is told **"Platform: linux"** for an app that
would work for them.

## Why this issue matters to the user

This is the same class of misinformation #1254 set out to remove, pointing the
other way. Before #1254 the app declared no `platform` block at all, inherited the
implicit `["macos", "linux"]` default, and quietly advertised macOS parity it did
not have. #1254 corrected that with `["linux"]` — accurate about pods, wrong about
the app — and now *understates* it.

The cost is a user steered away from a tool that works for them. A macOS
developer who wants the worktree fleet view and `Provision` reads "Platform:
linux" and does not enable the app. The pod limitation they would actually hit is
already explained *inside* the app, by the banner #1254 added and by a
`highlights` line — so the manifest is turning away users the UI was just taught
to serve honestly.

## How our fix solves it

**Symptom:** the detail page tells macOS and Windows users the app does not run
on their machine.

**Immediate cause:** `platform.os: ["linux"]` in
`src/kiro_crew/apps/builtins/dev_fleet/app.json`, rendered verbatim by
`AppDetailPage.tsx`.

**Root cause:** `platform.os` is a *single list describing the whole app*, so any
value is a summary, and dev-fleet is the case where the app's halves disagree —
pods need Linux, everything else does not. #1254 picked the summary that matched
its own subject (pods) rather than the one that matches the app. There is no way
to say "pods need Linux but the rest does not" in this field; that nuance has to
live in the UI.

The fix is to make the summary describe the app:

```json
"platform": { "os": ["macos", "linux", "windows"] }
```

Three things make this the right value rather than one of the two alternatives:

- **Deleting the block is not the fix.** It falls back to the implicit
  `["macos", "linux"]` default in `apps/manifest.py`, which excludes Windows —
  a third wrong answer, and the one that looks like a cleanup.
- **`windows` is expressible now.** #1316 added the `"windows": "win32"` mapping
  rows. Before that, a declared `windows` was accepted into the list and then
  matched no host, so `supports_platform("win32")` returned `False` for an app
  claiming Windows. `papyrus` already declares all three, so this follows an
  established precedent rather than inventing one.
- **The pod requirement stays stated, just not here.** It is carried by the
  `highlights` line ("Pods and Make Live need Linux systemd --user; the fleet
  view, PR status, sync, rebase and prune work on any platform") and by the
  banner fed from `pods_unavailable_reason`.

**Install behaviour is unchanged.** The platform check in `registry.py` only runs
for `installMode: "client"` apps; dev-fleet has no `installMode` and defaults to
`"server"`, so it installed and enabled everywhere before this change and still
does. What changes is what the detail page says.

The spec's Platform Behavior section is updated in the same commit, including a
claim of its own that had drifted: it said the declaration buys "an honest App
Store detail page", which was right about the mechanism but was describing
`["linux"]` as the honest value.

## What tests we did

**Two new tests**, both in `test/test_dev_fleet_app.py`:

- `test_manifest_declares_every_platform_the_app_runs_on` pins the value and also
  asserts the `highlights` line stating the Linux requirement still exists —
  widening `os` is only honest while that copy is there, so the two are pinned
  together.
- `test_declared_platforms_all_resolve_to_a_real_sys_platform` asserts every
  declared name maps to a live `sys.platform` value (`darwin`, `linux`, `win32`).
  This is the test that would have caught the pre-#1316 state, where an unmapped
  name was accepted and then silently never matched.

**Verified the unmapped-name failure mode is real** rather than assumed, by
running the resolution against the pre-#1316 map:

| declared | resolves to | `supports_platform('win32')` |
|---|---|---|
| `["macos","linux","windows"]` before #1316 | `{darwin, linux, windows}` | **False** — claims Windows, gate refuses |
| `["macos","linux","windows"]` after #1316 | `{darwin, linux, win32}` | **True** |

That is why this PR is only the declaration: the mapping prerequisite already
landed. Had it not, this change would have been a manifest that lies.

**Gate:** `isort`, `flake8 -j 1`, `mypy` (632 source files, clean), and the four
affected suites — `test_dev_fleet_app.py`, `test_app_manifest.py`,
`test_builtin_app_assets.py`, `test_apps_registry.py` — **294 passed**. The one
failure is pre-existing and unrelated: `test_trusted_bin_pins_the_resolved_target_not_the_symlink`
resolves a real `~/.local/bin/gh` on this dev host ahead of the test's fixture
path, and reproduces on clean `main`.

No frontend change and no new i18n key: the row is data-driven and
`pages.appDetailPage.platform` already exists.

## Any other suggestions on the work

**The field's shape is the underlying limitation.** One flat `os` list per app
cannot describe an app whose capabilities have different platform floors, and
dev-fleet is not going to be the only one — any app with an optional
platform-specific backend lands here. A per-capability declaration
(`platform.features.pods.os`) would let the App Store render "runs everywhere,
these two actions need Linux" instead of forcing the manifest to round to one
answer and the UI to carry the rest. Worth its own discussion, not a follow-up
commit here.

**`current_os()` returns raw `sys.platform` for anything unmapped.** It falls back
to the input (`PlatformConfig._PLATFORM_TO_OS.get(sys.platform, sys.platform)`),
so an unrecognised host reports e.g. `freebsd` into a field whose vocabulary is
the friendly names. It is inert today because the three mapped platforms are the
three KiroCrew supports, but it is the same silent-fallthrough shape that made
`windows` unexpressible before #1316 — a validation error on an unknown `os`
value at manifest load would have surfaced both.

Fixes #1375
