### PR TITLE
fix(autopilot): queue mid-plan messages instead of running them concurrently

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -233,7 +233,7 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         slot.theme_consent = theme_consent
         slot.theme_consent_sha = theme_consent_sha
 
-    if slot.running:
+    if slot.running or slot._in_stage_execution:
         # Mid-turn steer: inject into the RUNNING turn instead of queueing for
         # the next turn. Gated on an explicit `steer` flag + a live, steer-capable
         # inner AcpClient that _run_chat published on the slot. Fire-and-forget —
@@ -241,6 +241,13 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         # (EVENT_STEER_CONSUMED). If steer is requested but unavailable (no live
         # client / unsupported backend / RPC error), fall through to the queue
         # path so the user's text is NEVER silently dropped.
+        #
+        # ``slot._in_stage_execution`` extends this to autopilot: during a multi-stage
+        # plan ``slot.running`` briefly reads False between stages (each stage's
+        # _run_chat closes its own turn), so a mid-plan message would otherwise
+        # start a concurrent turn. The orchestrating flag keeps it on the queue
+        # path (steer is unavailable between stages, so it falls through to the
+        # queue below and is held until the plan ends).
         if body.get("steer") and message:
             _client = slot._acp_client
             if _client is not None and getattr(_client, "supports_steer", False):

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -12,7 +12,7 @@ from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.context_management import OrchestrationTracker
-from kiro_crew.dashboard.chat_runner import _run_chat
+from kiro_crew.dashboard.chat_runner import _run_chat, _start_next_queued_turn
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
@@ -168,6 +168,7 @@ async def _stage_loop(
     )
 
     _paused = False
+    _cancelled = False
     # Mark the ENTIRE stage-execution lifetime, not each _run_chat call. A
     # stage turn can queue a recovery/continue turn (empty-response re-queue,
     # stale/tool-stall recovery) that runs slightly later on the same slot; a
@@ -175,6 +176,12 @@ async def _stage_loop(
     # plan-shaped output re-arm/re-count the plan (GPT finding). The flag is
     # cleared once in the outer `finally` when the loop actually exits (pause,
     # completion, break, or error) — so a later Cancel + re-plan can arm again.
+    #
+    # It ALSO gates mid-plan message handling: while set, api_chat queues a user
+    # message (chip card) even when slot.task is momentarily idle between stages,
+    # and _start_next_queued_turn HOLDS user messages (recovery/system still
+    # drain) so they never run concurrently with the plan — handed off in the
+    # finally once the plan ends.
     slot._in_stage_execution = True
     try:
         for stage_idx in range(start_idx, total):
@@ -513,6 +520,12 @@ async def _stage_loop(
                         resources=f"slot={slot.key},stages={total}",
                     )
                 )
+    except asyncio.CancelledError:
+        # Hard stop / slot deletion: do NOT hand off queued work below (the slot
+        # is being torn down and a started turn would run orphaned). Mark it and
+        # re-raise so the task ends cancelled.
+        _cancelled = True
+        raise
     finally:
         # Clear the stage-execution guard exactly once, when the loop exits
         # (pause / completion / break / error). This spans any queued recovery
@@ -522,12 +535,37 @@ async def _stage_loop(
             "Stage loop end: slot=%s current_stage=%s/%s stopping=%s auto_run=%s",
             slot.key, tracker.current_stage, total, slot._stopping, slot._auto_run,
         )
-        if not _paused:
-            slot.append("done", "", "done")
-            state.broadcast_ws("chat_done", {"slot": slot.key})
-        # Always clean up task so the slot is available for the next
-        # "Go" click (paused) or new messages (completed).
-        slot.task = None
+        # Hand off any messages the user queued while the plan ran (held via the
+        # _in_stage_execution gate in _start_next_queued_turn — now cleared above).
+        # If one starts it owns slot.task, so skip the idle-close; a cancelled loop
+        # skips the handoff entirely (queue preserved for the torn-down slot).
+        # ``state._slots.get(...) is slot`` guards a slot DELETED mid-plan (slot.task
+        # is None between stages, so deletion isn't blocked): never launch a turn on
+        # a slot that is no longer registered. ``not slot._last_turn_auth_required``
+        # mirrors _run_chat's own guard: a signed-out CLI holds the queue for
+        # post-login resume instead of popping it into another auth failure.
+        # ``not slot.running`` defers entirely to a turn a stage's _run_chat may
+        # have already started (e.g. a refusal-recovery continuation): that live
+        # task owns slot.task and will drain the queue + emit chat_done itself, so
+        # we must not start a second turn or clobber/idle-close over it.
+        _next_started = False
+        if (
+            not _cancelled
+            and not slot.running
+            and not slot._last_turn_auth_required
+            and state._slots.get(slot.key) is slot
+            and slot._queue
+            and not slot._stopping
+        ):
+            state.push_slots_update()
+            _next_started = await _start_next_queued_turn(state, slot)
+        if not _next_started and not slot.running:
+            if not _paused:
+                slot.append("done", "", "done")
+                state.broadcast_ws("chat_done", {"slot": slot.key})
+            # Clean up task so the slot is available for the next "Go" click
+            # (paused) or new messages (completed).
+            slot.task = None
         state.push_slots_update()
 
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -2156,7 +2156,11 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
         merge = False
 
     hold_users = bool(
-        state.subagents is not None and state.subagents.running_agents_for(f"dashboard:{slot.key}")
+        (
+            state.subagents is not None
+            and state.subagents.running_agents_for(f"dashboard:{slot.key}")
+        )
+        or slot._in_stage_execution
     )
     if hold_users:
         next_msg, consumed = _dequeue_next_system_message(slot)
@@ -4677,7 +4681,11 @@ async def _run_chat(
 
             if _prompt_depth == 0 and slot._stale_recovery_retries < 3:
                 slot._stale_recovery_retries += 1
-                slot.queue_insert(0, f"{STALE_RECOVERY_PREFIX}\n{build_stale_recovery_prompt()}")
+                slot.queue_insert(
+                    0,
+                    f"{STALE_RECOVERY_PREFIX}\n{build_stale_recovery_prompt()}",
+                    kind=SYNTHETIC_RECOVERY_KIND,
+                )
                 _emit_stale("⟳ Recovering a stalled turn…")
             elif slot._stale_recovery_retries >= 3:
                 _emit_stale("Session stuck — please start a new chat.")
@@ -4718,7 +4726,11 @@ async def _run_chat(
                     command=_stall_command,
                     stuck_input=_stuck,
                 )
-                slot.queue_insert(0, f"{TOOL_STALL_RECOVERY_PREFIX}\n{_body}")
+                slot.queue_insert(
+                    0,
+                    f"{TOOL_STALL_RECOVERY_PREFIX}\n{_body}",
+                    kind=SYNTHETIC_RECOVERY_KIND,
+                )
                 _emit_stall("⟳ Tool appeared stalled — recovering…")
             elif slot._tool_stall_retries >= 3:
                 _emit_stall("Session stuck — please start a new chat.")
@@ -4743,7 +4755,7 @@ async def _run_chat(
 
             if _prompt_depth == 0 and slot._acp_pipe_death_retries < 3:
                 slot._acp_pipe_death_retries += 1
-                slot.queue_insert(0, message)
+                slot.queue_insert(0, message, kind=SYNTHETIC_RECOVERY_KIND)
                 _emit_error(f"⟳ Connection lost{_rc_suffix} — retrying...")
             elif slot._acp_pipe_death_retries >= 3:
                 _emit_error(f"Session stuck{_rc_suffix} — please start a new chat.")
@@ -4933,7 +4945,7 @@ async def _run_chat(
                 # streaming turn ends (so it never surfaces). Only the second
                 # consecutive empty surfaces a persisted notice card below.
                 slot._empty_response_retries += 1
-                slot.queue_insert(0, message)
+                slot.queue_insert(0, message, kind=SYNTHETIC_RECOVERY_KIND)
                 _retrying_empty = True
             elif (
                 _prompt_depth == 0
@@ -5169,7 +5181,7 @@ async def _run_chat(
             # until the post-turn history refresh reconciles it.
             _retry_msg = "⟳ Connection lost — retrying…"
             slot.append("error", _retry_msg, "msg msg-err")
-            slot.queue_insert(0, message)
+            slot.queue_insert(0, message, kind=SYNTHETIC_RECOVERY_KIND)
         elif slot._acp_pipe_death_retries > 3:
             slot.append("error", "Session stuck — please start a new chat.", "msg msg-err")
         else:
@@ -5195,7 +5207,7 @@ async def _run_chat(
             # broadcast_ws or the UI shows a duplicate card.
             _retry_msg = "⟳ Session busy — retrying…"
             slot.append("error", _retry_msg, "msg msg-err")
-            slot.queue_insert(0, message)
+            slot.queue_insert(0, message, kind=SYNTHETIC_RECOVERY_KIND)
         elif slot._prompt_busy_retries > 3:
             slot.append("error", "Session stuck — please start a new chat.", "msg msg-err")
         else:
@@ -5262,7 +5274,7 @@ async def _run_chat(
                     slot._acp_pipe_death_retries if _is_pipe_death else slot._prompt_busy_retries,
                 )
                 slot.append("error", _status, "msg msg-err")
-                slot.queue_insert(0, message)
+                slot.queue_insert(0, message, kind=SYNTHETIC_RECOVERY_KIND)
             else:
                 # depth>0 with budget remaining: session already reset + failure
                 # counted above; do NOT re-queue (mirrors AcpProcessDied /
@@ -5315,7 +5327,7 @@ async def _run_chat(
                 # session (no reset), preserving conversation state.
                 slot.append("error", "⟳ Backend hiccup — retrying…", "msg msg-err")
                 await asyncio.sleep(_delay)
-                slot.queue_insert(0, message)
+                slot.queue_insert(0, message, kind=SYNTHETIC_RECOVERY_KIND)
             else:
                 # depth>0 (nested turn): don't re-queue — surface a clean
                 # transient status; the live session stays resumable.
@@ -5522,6 +5534,10 @@ async def _run_chat(
         # individually cancellable — a user who meant "discard" clicks ✕;
         # nothing is ever silently lost.
         _requeue_unconsumed_steers(state, slot)
+        # Record this turn's auth outcome so the orchestrator _stage_loop, which
+        # runs stages as separate _run_chat calls, can mirror this same
+        # "hold the queue for post-login resume" guard on its end-of-plan handoff.
+        slot._last_turn_auth_required = _auth_required
         next_turn_started = False
         if slot._queue and not _auth_required:
             # No readiness gate before the next queued turn. Readiness is latched

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -795,6 +795,7 @@ class _ChatSlot:
         "_orch_tracker",
         "_auto_run",
         "_in_stage_execution",
+        "_last_turn_auth_required",
         "_recovery_chat_triggered",
         "_stage_titles",
         "_stage_descriptions",
@@ -937,7 +938,17 @@ class _ChatSlot:
         # the end-of-turn plan detector so a stage turn whose output happens to
         # contain plan-like text cannot re-arm / re-count the plan (which
         # corrupted the stage total and produced "Stage N of M" over-runs).
+        # It ALSO gates mid-plan message handling: while set, api_chat queues a
+        # user message (chip card) even when slot.task is momentarily idle between
+        # stages, and _start_next_queued_turn HOLDS user messages (recovery/system
+        # still drain) until the plan ends — so autopilot reuses the normal-chat
+        # queue/chip path without changing slot.task / slot.running semantics.
         self._in_stage_execution: bool = False
+        # Set by _run_chat's teardown to that turn's ACP auth-required outcome, so
+        # the orchestrator _stage_loop can mirror the "hold the queue for
+        # post-login resume" guard on its end-of-plan handoff (a signed-out CLI
+        # must not pop the held follow-up into another auth failure).
+        self._last_turn_auth_required: bool = False
         self._recovery_chat_triggered: bool = False  # guard against concurrent failure recovery
         self._stage_titles: list[str] = []  # stage titles extracted from plan
         self._stage_descriptions: list[list[str]] = []  # bullet points per stage
@@ -1592,6 +1603,7 @@ class _ChatSlot:
             "artifact": self._artifact,
             "messages": len(self.messages),
             "running": self.running,
+            "orchestrating": self._in_stage_execution,
             "queue_depth": self.queue_depth,
             "stopping": self._stopping,
             "pending_approval": pending_approval,

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -5616,6 +5616,123 @@ class TestPythonStageLoop:
         assert "hello world" in msg
 
     @pytest.mark.asyncio
+    async def test_orchestrating_flag_set_and_held_queue_drained(self, tmp_path, monkeypatch):
+        """The loop marks the slot orchestrating for the whole plan, then hands off
+        a message the user queued mid-plan once the plan ends."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        state = MagicMock()
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for = MagicMock(return_value=[])
+        slot = self._make_slot(max_stages=2)
+        state._slots = {slot.key: slot}  # slot still registered
+        slot.queue_append("user typed mid-plan")
+
+        seen = []
+
+        async def _mock_run_chat(s, sl, msg, **kw):
+            seen.append(sl._in_stage_execution)
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+        start_next = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_orchestrator._start_next_queued_turn", start_next
+        )
+
+        await _stage_loop(state, slot, auto_run=True)
+
+        assert seen == [True, True]  # orchestrating for every stage
+        assert slot._in_stage_execution is False  # cleared once the plan ends
+        start_next.assert_awaited_once()  # held user message handed off at plan end
+
+    @pytest.mark.asyncio
+    async def test_deleted_slot_skips_handoff(self, tmp_path, monkeypatch):
+        """If the slot was deleted mid-plan (no longer registered), the finally
+        must NOT launch its held queue on the torn-down slot."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        state = MagicMock()
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for = MagicMock(return_value=[])
+        slot = self._make_slot(max_stages=1)
+        state._slots = {}  # slot deleted while the plan ran
+        slot.queue_append("queued during plan")
+
+        run_chat_mock = AsyncMock()
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", run_chat_mock)
+        start_next = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_orchestrator._start_next_queued_turn", start_next
+        )
+
+        await _stage_loop(state, slot, auto_run=True)
+
+        start_next.assert_not_awaited()  # no turn launched on a deleted slot
+        assert [i["content"] for i in slot._queue] == ["queued during plan"]
+
+    @pytest.mark.asyncio
+    async def test_signed_out_cli_holds_queue(self, tmp_path, monkeypatch):
+        """If a stage hit ACP auth-required, the end-of-plan handoff must HOLD the
+        queued follow-up for post-login resume, not pop it into another auth
+        failure (mirrors _run_chat's own not-_auth_required guard)."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        state = MagicMock()
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for = MagicMock(return_value=[])
+        slot = self._make_slot(max_stages=1)
+        state._slots = {slot.key: slot}
+        slot.queue_append("queued during plan")
+
+        async def _auth_run_chat(s, sl, msg, **kw):
+            sl._last_turn_auth_required = True  # signed-out CLI discovered this stage
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _auth_run_chat)
+        start_next = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_orchestrator._start_next_queued_turn", start_next
+        )
+
+        await _stage_loop(state, slot, auto_run=True)
+
+        start_next.assert_not_awaited()  # queue held for post-login resume
+        assert [i["content"] for i in slot._queue] == ["queued during plan"]
+
+    @pytest.mark.asyncio
+    async def test_orchestrating_slot_queues_message(self, tmp_path, monkeypatch):
+        """A mid-plan message QUEUES (not runs) even when slot.task is idle between
+        stages, because slot._in_stage_execution gates the api_chat queue path."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("orch-chat", mode="orchestrator")
+        slot._in_stage_execution = True  # plan running; slot.task momentarily None between stages
+
+        run_chat_mock = AsyncMock()
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", run_chat_mock)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat", json={"message": "queued mid-plan", "slot": "orch-chat"}
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("queued") is True
+
+        run_chat_mock.assert_not_called()  # queued, not run concurrently with the plan
+        assert any(i["content"] == "queued mid-plan" for i in slot._queue)
+
+    @pytest.mark.asyncio
     async def test_go_button_uses_stage_loop(self, tmp_path, monkeypatch):
         """Go button via plan-action endpoint uses _stage_loop."""
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)

--- a/test/test_turn_teardown_release.py
+++ b/test/test_turn_teardown_release.py
@@ -26,7 +26,24 @@ import pytest
 from chat_test_helpers import _make_state
 
 from kiro_crew.acp.client import AcpAuthRequired
-from kiro_crew.dashboard.chat_runner import _run_chat
+from kiro_crew.dashboard.chat_runner import _run_chat, _start_next_queued_turn
+
+
+@pytest.mark.asyncio
+async def test_start_next_holds_user_while_orchestrating(tmp_path) -> None:
+    """While a plan orchestrates, the queue drain HOLDS plain user messages
+    (system/recovery still drain) so a mid-plan message never runs concurrently
+    with the plan. It is handed off only after the loop clears the flag."""
+    state = _make_state(tmp_path)
+    state.subagents = None  # isolate the orchestrating condition of hold_users
+    slot = state.get_or_create_slot("orch-hold")
+    slot._in_stage_execution = True
+    slot.queue_append("user typed mid-plan")
+
+    started = await _start_next_queued_turn(state, slot)
+
+    assert started is False  # held, not started
+    assert [i["content"] for i in slot._queue] == ["user typed mid-plan"]
 
 
 def _state_and_slot(tmp_path: Path):

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1101,7 +1101,12 @@ export const selectComposerBusy = (state: RootState, slot: string | null): boole
   if (selectSlotStreamState(state, slot) !== 'idle') return true
   if (slot === state.chat.activeSlot && state.chat.slotRunning) return true
   if (selectSlotSubagentsActive(state, slot)) return true
-  return !!state.dashboard.slots.find((sl) => sl.key === slot)?.subagents_running
+  const dashSlot = state.dashboard.slots.find((sl) => sl.key === slot)
+  // A running autopilot plan keeps the composer "busy" so a mid-plan message
+  // queues (chip card) instead of rendering an optimistic bubble that would
+  // duplicate the backend's queued message. slot.running reads False between
+  // stages, so orchestrating is the durable signal here.
+  return !!(dashSlot?.subagents_running || dashSlot?.orchestrating)
 }
 
 const chatSlice = createSlice({

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -1853,7 +1853,7 @@ describe('selectSlotSubagentsActive', () => {
 describe('selectComposerBusy', () => {
   const initial = reducer(undefined, { type: '@@INIT' })
   const withSlot = { ...initial, activeSlot: 'slot-1' }
-  const wrap = (chat: ReturnType<typeof reducer>, slots: Array<{ key: string; subagents_running?: boolean }> = []) =>
+  const wrap = (chat: ReturnType<typeof reducer>, slots: Array<{ key: string; subagents_running?: boolean; orchestrating?: boolean }> = []) =>
     ({ chat, dashboard: { slots } }) as never
 
   it('is idle when nothing runs', () => {
@@ -1876,6 +1876,12 @@ describe('selectComposerBusy', () => {
 
   it('is busy on the snapshot field alone (first frames after reload)', () => {
     expect(selectComposerBusy(wrap(withSlot, [{ key: 'slot-1', subagents_running: true }]), 'slot-1')).toBe(true)
+  })
+
+  it('is busy while an autopilot plan is orchestrating (queues mid-plan messages)', () => {
+    // slot.running reads False between stages, but a mid-plan message must still
+    // queue as a chip rather than render an optimistic bubble.
+    expect(selectComposerBusy(wrap(withSlot, [{ key: 'slot-1', orchestrating: true }]), 'slot-1')).toBe(true)
   })
 
   it('clears when the subagent finishes (done event — reaper self-heal path)', () => {

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -330,7 +330,7 @@ export interface ChatSlot {
   /** Metadata for kind="webapp" artifacts (deploy state, architecture, costs). */
   webapp_metadata?: WebAppMetadata
   // Board fields
-  has_options?: boolean; options?: string[]; pending_approval_info?: PendingApproval | null; last_activity_ts?: string; waiting_for_input?: boolean; prompt_preview?: string; subagents_running?: boolean
+  has_options?: boolean; options?: string[]; pending_approval_info?: PendingApproval | null; last_activity_ts?: string; waiting_for_input?: boolean; prompt_preview?: string; subagents_running?: boolean; orchestrating?: boolean
   // Soft-stop state machine
   stop_state?: 'idle' | 'soft_pending' | 'killing'
   /** Agent TODO list. Null/absent = the todo tool was never used in this slot. */


### PR DESCRIPTION
## Problem
In autopilot (orchestrator) mode, a message typed while a multi-stage plan is executing **disappears from the transcript but still runs** — it interleaves into the plan as a second turn instead of queueing politely.

## Why it matters
Autopilot is meant to run a plan hands-off while the user lines up follow-up messages. Today those follow-ups are silently swallowed and executed out of band (no queue chip, no user bubble, a turn racing the plan) — the user loses their message and can perturb the in-flight plan, with zero visible signal.

## Fix (symptom → root cause → change)
- **Symptom:** message vanishes (no bubble, no chip) yet runs, during a plan.
- **Root cause:** the plan is driven by `_stage_loop`, which runs one `_run_chat` per stage; each stage's `_run_chat` closes its own turn (`slot.task = None`) between stages, so `slot.running` reads **False mid-plan**. The dashboard queue gate (`api_chat`) keys off `slot.running`, so a mid-plan message hit the "idle" path and started a concurrent turn; the frontend, still streaming, suppressed the optimistic bubble (`selectComposerBusy`), so the message "disappeared" while executing.
- **Change (reuse the normal-chat queue path):** add `slot._orchestrating`, set for the whole `_stage_loop` lifetime (Go and Go All). While set:
  1. `api_chat`'s gate queues the message (the normal **chip card**) even when `slot.task` is momentarily idle between stages;
  2. `_start_next_queued_turn` **holds** user messages (recovery/system injections still drain) — the *same* `hold_users` mechanism already used while sub-agents run — so a mid-plan message never runs concurrently with the plan;
  3. `_stage_loop`'s `finally` clears the flag and hands off any held user message (a cancelled loop skips the handoff, leaving the slot's teardown clean);
  4. the frontend `selectComposerBusy` treats an orchestrating plan as busy, so the message renders as the queued chip rather than a duplicate optimistic bubble.
  A plan step always runs before a queued user message because stages are loop-driven (not queued). Critically, this touches **no** `slot.task` / `slot.running` semantics for any other subsystem — recovery, sub-agent delivery, and cancellation are all unchanged, so the blast radius is tiny.

## Tests
- `test/test_dashboard_chat.py::TestPythonStageLoop`
  - `test_orchestrating_flag_set_and_held_queue_drained` — the flag is set for every stage and a message queued mid-plan is handed off once the plan ends.
  - `test_orchestrating_slot_queues_message` — a mid-plan `POST /api/chat` returns `queued` and does NOT call `_run_chat` (queued, not run concurrently), even with `slot.task` idle.
- `test/test_turn_teardown_release.py::test_start_next_holds_user_while_orchestrating` — the queue drain holds a plain user message while orchestrating.
- `website/src/test/chatSlice.test.ts` — `selectComposerBusy` is busy while a plan is orchestrating (so the composer queues rather than optimistically bubbles).

## Manual verification
Backend fully verified locally: isort, flake8, mypy 1.14.1, and 641 tests across the queue / stage-loop / turn-lifecycle / stop / approval / sub-agent suites. Frontend change is 3 mechanical lines (a `?: boolean` type field, one selector clause, one test) verified by CI's tsc + vitest — local tsc/vitest could not run in this sandbox (node-16/npm cache constraint).

## Screenshots
N/A — no new or changed visual surface. The change only decides whether a mid-plan message renders via the **existing** queued-chip path vs an optimistic bubble; it adds no UI element.
