### PR TITLE
fix(scrub): remove 11 personal identifiers and close the vacuous alias gate

### DIFF
--- a/scripts/scrub-lint.sh
+++ b/scripts/scrub-lint.sh
@@ -82,7 +82,7 @@ fi
 # ---------------------------------------------------------------------------
 # 1. Working-tree scan: internal domains, hostnames, account IDs, ticket IDs
 # ---------------------------------------------------------------------------
-dim "[1/4] Scanning working tree for internal markers..."
+dim "[1/5] Scanning working tree for internal markers..."
 
 INTERNAL_PATTERN='amazon\.com|a2z\.com|aws\.dev|\.amazon\.|code\.amazon|t\.corp|sim\.amazon|isengard|phonetool|midway-auth|mwinit|brazil ws|brazil-build|brazil-runtime|brazil-pkg-cache|meshclaw|Mesh-[0-9]|AVP-[0-9]|account.?[0-9]{12}|CR-[0-9]{6,}|\bP[0-9]{6,}\b'
 
@@ -130,7 +130,7 @@ fi
 # ---------------------------------------------------------------------------
 # 2. Employee alias scan (known patterns in non-test source)
 # ---------------------------------------------------------------------------
-dim "[2/4] Scanning for employee aliases..."
+dim "[2/5] Scanning for employee aliases..."
 
 # Aliases are stored in an external file excluded from the public repo.
 # If the file doesn't exist, this check is skipped (fresh clones won't have it).
@@ -170,9 +170,98 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Credential pattern scan
+# 3. Personal identity scan (structural — needs NO name list)
+#
+# The alias scan above reads scripts/.scrub-aliases.txt, which is deliberately
+# kept out of the repo (publishing a list of employee names would defeat the
+# purpose). Consequence: on a fresh clone — and in CI — that file is absent, the
+# check prints "skipped", and the gate becomes VACUOUS. That is exactly how
+# personal aliases have shipped before now.
+#
+# This check needs no configuration and therefore cannot silently degrade. It
+# matches the *shape* of a personal identifier rather than any specific name:
+#   * a home-directory path whose user segment is not a known generic
+#     placeholder (/local/home/<alias>, /home/<alias>, /Users/<alias>)
+#   * an @amazon.com address whose local part is not a known fake persona
+# Unlike scan 1 it also covers test/, which scan 1 never looks at — real
+# addresses in test fixtures were previously unchecked.
 # ---------------------------------------------------------------------------
-dim "[3/4] Scanning for credential patterns..."
+dim "[3/5] Scanning for personal identity leaks (structural)..."
+
+# User segments that are intentional documentation placeholders / system users.
+GENERIC_USER='user|users|otheruser|someuser|u|me|you|your|youruser|dev|developer|example|someone|somebody|alice|bob|carol|dave|eve|jane|john|foo|bar|baz|secret|weird|root|runner|ubuntu|node|builder|linuxbrew|kirocrew|kirocrew-workspace|mcp-gateway|nimbus|src|admin|test|tester|testuser|du|voce|você|tu|vous|usuario|usuário|utente|utilisateur|benutzer|<user>|\$USER|\$\{USER\}|\{user\}|%USERNAME%'
+
+# Fake personas permitted in email fixtures.
+GENERIC_EMAIL_LOCAL='alice|bob|carol|dave|eve|user|test|tester|example|someone|noreply|no-reply|opensource-codeofconduct|dev|admin'
+
+IDENTITY_SCAN_DIRS=(src/ website/src/ website/docs/ docs/ skills/ scripts/ config/ packaging/ test/)
+IDENTITY_INCLUDES=(--include='*.py' --include='*.ts' --include='*.tsx' --include='*.md'
+                   --include='*.json' --include='*.sh' --include='*.yaml' --include='*.yml'
+                   --include='*.cfg' --include='*.toml')
+
+# --- personal home-directory paths ---
+personal_matches=$(grep -rnoE '/(local/home|home|Users)/[A-Za-z][A-Za-z0-9._-]+' \
+  "${IDENTITY_SCAN_DIRS[@]}" ./*.md "${IDENTITY_INCLUDES[@]}" 2>/dev/null || true)
+
+# --- Amazon /workplace/<alias> trees ---
+# /workplace holds BOTH employee aliases and Brazil package/workspace names, so
+# only an ALIAS-SHAPED segment counts. The charset (lowercase start, then
+# lowercase/digit/hyphen) admits real logins like `jo-smith` and `dlloyd2` while
+# still excluding the CamelCase and dotted names Brazil packages use, so package
+# paths do not false-positive.
+workplace_matches=$(grep -rnoE '/workplace/[a-z][a-z0-9-]{1,30}(/|$)' \
+  "${IDENTITY_SCAN_DIRS[@]}" ./*.md "${IDENTITY_INCLUDES[@]}" 2>/dev/null || true)
+workplace_matches=$(echo "$workplace_matches" | sed 's:/$::')
+
+personal_matches=$(printf '%s\n%s\n' "$personal_matches" "$workplace_matches")
+personal_matches=$(echo "$personal_matches" \
+  | grep -vEi "/(local/home|home|Users|workplace)/($GENERIC_USER)$" || true)
+
+# --- employee-shaped email addresses ---
+email_matches=$(grep -rnoE '[A-Za-z0-9._%+-]+@amazon\.com' \
+  "${IDENTITY_SCAN_DIRS[@]}" ./*.md "${IDENTITY_INCLUDES[@]}" 2>/dev/null || true)
+email_matches=$(echo "$email_matches" \
+  | grep -vEi "[:/]($GENERIC_EMAIL_LOCAL)@amazon\.com$" || true)
+
+# NOT covered, deliberately: a bare alias assigned to an identity-ish field (an
+# `author`/`assignee`/`principal_id` string literal). It was tried and measured:
+# scanning those fields yields ~60 hits of which ~55 are legitimate personas
+# (octocat, agent, reviewer, maintainer, a-contributor, yourname...), because a
+# bare token is indistinguishable from any other string without a name list. A
+# gate nobody can keep green is how scan 2 became vacuous in the first place, so
+# this class stays uncovered rather than pretending to be covered — see scan 2.
+identity_matches=$(printf '%s\n%s\n' "$personal_matches" "$email_matches")
+
+# Filter allowlist — but ONLY its `path:pattern` entries. A PATH-ONLY entry was
+# written to exempt a file from the marker/alias scans (e.g. an auth stub that
+# must mention midway); honouring it here would blanket-exempt that whole file
+# from identity checking too — verified: planted identity lines in
+# test_deploy_web_profiles.py, sensitiveCommand.test.ts and deploy/scan.py were
+# all silently dropped. That is exactly the hazard this allowlist warns about at
+# :144-150, so an identity hit needs a narrow `path:pattern` entry to be waived.
+if [[ -f "$ALLOWLIST" ]]; then
+  while IFS= read -r pattern; do
+    [[ -z "$pattern" || "$pattern" == \#* ]] && continue
+    [[ "$pattern" != *:* ]] && continue
+    identity_matches=$(echo "$identity_matches" | grep -v "$pattern" || true)
+  done < "$ALLOWLIST"
+fi
+identity_matches=$(echo "$identity_matches" | grep -v '^$' || true)
+
+if [[ -n "$identity_matches" ]]; then
+  red "FAIL: Personal identifiers found (home paths / employee emails / identity fields):"
+  echo "$identity_matches"
+  red "  Replace with a generic placeholder (e.g. /home/user, alice@amazon.com),"
+  red "  or add a narrow entry to $ALLOWLIST if the reference is intentional."
+  FAILURES=$((FAILURES + 1))
+else
+  green "  ✓ No personal identifiers in source or tests"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Credential pattern scan
+# ---------------------------------------------------------------------------
+dim "[4/5] Scanning for credential patterns..."
 
 CRED_PATTERN='AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|aws_secret_access_key\s*=\s*[A-Za-z0-9/+=]{20,}|-----BEGIN (RSA |DSA |EC |OPENSSH )?PRIVATE KEY-----'
 
@@ -211,7 +300,7 @@ fi
 # ---------------------------------------------------------------------------
 # 4. Git history scan (author emails and subjects)
 # ---------------------------------------------------------------------------
-dim "[4/4] Scanning git history for internal references..."
+dim "[5/5] Scanning git history for internal references..."
 
 if [[ $SKIP_HISTORY -eq 1 ]]; then
   dim "  ⊘ Git-history scan skipped (--no-history) — tracked separately"

--- a/skills/self-nudge-loop/SKILL.md
+++ b/skills/self-nudge-loop/SKILL.md
@@ -79,7 +79,7 @@ curl -sf -X POST "http://127.0.0.1:5476/api/autonudge?token=$TOKEN" \
     "message": "Read ~/project/north_star.md, pick next task, execute.",
     "idle_secs": 60,
     "max_cycles": 30,
-    "stop_sentinel_path": "/home/zedmor/project/STOP"
+    "stop_sentinel_path": "/home/user/project/STOP"
   }'
 ```
 

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -4206,7 +4206,7 @@ class AcpClient:
         "grep"), then a follow-up `tool_call_update` once `chunk.input` is
         fully streamed — that update carries the populated `rawInput` and a
         refined `title`/`kind` from the upstream `toolInfoFromToolUse`
-        (e.g. `"ls /local/home/hugocost/.kiro/crew/workspace"`).
+        (e.g. `"ls /local/home/user/.kiro/crew/workspace"`).
 
         We yield an EVENT_TOOL_CALL_UPDATE so the dashboard can patch the
         existing pill / persisted message in place — see the matching

--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -1082,7 +1082,7 @@ class ArtifactStore:
         captured as a numbered version with a lifecycle event. When False
         (the default), the save is silent — the version dropdown stays the
         same and no event is emitted (explicit-snapshot
-        model, requested by nrb).
+        model).
 
         ``actor`` distinguishes lifecycle event types when a snapshot is
         taken: ``"user"`` (default) emits an ``edited`` event; ``"agent"``

--- a/src/kiro_crew/mcp_caller.py
+++ b/src/kiro_crew/mcp_caller.py
@@ -30,7 +30,7 @@ This module defines a **namespaced, versioned, typed** protocol extension:
                "schemaVersion": 1,
                "sessionKey": "T123ABC:C456DEF:1777...",
                "sessionType": "slack-thread" | "dashboard" | "cron" | ...,
-               "principalId": "mingweic",
+               "principalId": "alice",
                "channelId": "C0AUNEY55NV"
            }
        }

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3235,7 +3235,7 @@ def _is_credential_mint(text_lower: str) -> bool:
     program is the product CLI and one of whose words is exactly ``token``.
 
     Does NOT match the word appearing in a path or another program's arguments:
-    ``cd /workplace/nrb/kirocrew-wt-x && pytest test/test_token_auth.py`` has no
+    ``cd /workplace/user/kirocrew-wt-x && pytest test/test_token_auth.py`` has no
     argv whose PROGRAM is the CLI, and ``kirocrew doctor | grep token`` puts the
     word in ``grep``'s argv, not the CLI's.
     """

--- a/test/test_artifact_comment_handlers.py
+++ b/test/test_artifact_comment_handlers.py
@@ -304,7 +304,7 @@ class TestEditComment:
                 origin="liveprov:5",
                 provider="liveprov",
                 scope="shared",
-                author="nrb",
+                author="alice",
                 body="orig",
                 thread_id="cx",
                 target_provider="liveprov",
@@ -341,7 +341,7 @@ class TestEditComment:
                 origin="mirrorprov:9",
                 provider="mirrorprov",
                 scope="shared",
-                author="nrb",
+                author="alice",
                 body="orig",
                 thread_id="ca",
                 target_provider="mirrorprov",
@@ -365,7 +365,7 @@ class TestEditComment:
 
     @pytest.mark.asyncio
     async def test_edit_gated_by_publish_governance(self, store, monkeypatch):
-        # Regression (PR #14 nrb): a shared-comment edit is outbound egress and
+        # Regression (PR #14 alice): a shared-comment edit is outbound egress and
         # must pass the same capabilities.publish gate as artifact publish. A
         # policy that DENIES the destination keeps the edit LOCAL (remote_synced
         # False) even though the provider supports COMMENTS_EDIT.
@@ -384,7 +384,7 @@ class TestEditComment:
                 origin="liveprov:5",
                 provider="liveprov",
                 scope="shared",
-                author="nrb",
+                author="alice",
                 body="orig",
                 thread_id="cg",
                 target_provider="liveprov",

--- a/test/test_artifact_comment_store.py
+++ b/test/test_artifact_comment_store.py
@@ -30,7 +30,7 @@ class TestCommentStore:
             id=str(uuid.uuid4()),
             origin="local",
             scope="private",
-            author="nrb",
+            author="alice",
             body="This looks good",
             thread_id="",
             created_at="2026-06-10T00:00:00Z",
@@ -41,7 +41,7 @@ class TestCommentStore:
         comments = store.list_comments("test-art")
         assert len(comments) == 1
         assert comments[0].body == "This looks good"
-        assert comments[0].author == "nrb"
+        assert comments[0].author == "alice"
 
     def test_update_comment(self, store):
         c = ArtifactComment(
@@ -80,7 +80,7 @@ class TestCommentStore:
             id="root",
             origin="local",
             scope="private",
-            author="nrb",
+            author="alice",
             body="root",
             thread_id="root",
             created_at="",
@@ -90,7 +90,7 @@ class TestCommentStore:
             id="r1",
             origin="local",
             scope="private",
-            author="nrb",
+            author="alice",
             body="reply 1",
             thread_id="root",
             parent_id="root",
@@ -101,7 +101,7 @@ class TestCommentStore:
             id="r2",
             origin="local",
             scope="private",
-            author="nrb",
+            author="alice",
             body="reply 2",
             thread_id="root",
             parent_id="root",
@@ -120,7 +120,7 @@ class TestCommentStore:
             id="root",
             origin="local",
             scope="private",
-            author="nrb",
+            author="alice",
             body="root",
             thread_id="root",
             created_at="",
@@ -130,7 +130,7 @@ class TestCommentStore:
             id="r1",
             origin="local",
             scope="private",
-            author="nrb",
+            author="alice",
             body="reply 1",
             thread_id="root",
             parent_id="root",
@@ -141,7 +141,7 @@ class TestCommentStore:
             id="r2",
             origin="local",
             scope="private",
-            author="nrb",
+            author="alice",
             body="reply 2",
             thread_id="root",
             parent_id="root",

--- a/test/test_artifacts.py
+++ b/test/test_artifacts.py
@@ -700,10 +700,10 @@ class TestLifecycleEvents:
 
 class TestSourcePath:
     def test_create_persists_source_path(self, store: ArtifactStore) -> None:
-        art = store.create(name="brd", content="# hi", source_path="/home/nrb/brd.md")
-        assert art.source_path == "/home/nrb/brd.md"
+        art = store.create(name="brd", content="# hi", source_path="/home/alice/brd.md")
+        assert art.source_path == "/home/alice/brd.md"
         loaded = store.get("brd")
-        assert loaded.source_path == "/home/nrb/brd.md"
+        assert loaded.source_path == "/home/alice/brd.md"
 
     def test_create_default_source_path_is_empty(self, store: ArtifactStore) -> None:
         art = store.create(name="brd", content="# hi")

--- a/test/test_artifacts_handlers.py
+++ b/test/test_artifacts_handlers.py
@@ -531,7 +531,7 @@ class TestCreate:
         # the same widget content must produce two separate artifacts —
         # NOT silently merge into one — because a chat-backed artifact's
         # identity is its slug, not its source. Regression guard for the
-        # bug nrb hit where a markdown file's "Add to artifacts" was
+        # bug alice hit where a markdown file's "Add to artifacts" was
         # matching a previously-saved widget because the lookup degraded
         # to "first artifact in list".
         body = {"name": "widget", "content": "<p>hi</p>", "kind": "widget", "source": "chat"}
@@ -1232,7 +1232,7 @@ class TestDenialAudit:
 class TestRelocate:
     """api_artifact_relocate confines source_path to $HOME (+ configured roots),
     so an agent cannot aim an artifact at /etc/passwd or another user's files
-    and exfiltrate them via a later GET (PR #14 nrb + CodeQL py/path-injection)."""
+    and exfiltrate them via a later GET (PR #14 alice + CodeQL py/path-injection)."""
 
     @pytest.mark.asyncio
     async def test_home_file_allowed(self, isolated_store, patch_restricted, tmp_path, monkeypatch):

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -204,7 +204,7 @@ def test_registry_branchless_legacy_entry_preserves_mainline():
 
 
 def test_publish_relocate_roots_parsed_and_round_trips():
-    # Regression (PR #14 nrb): publish.relocate_roots was declared + consumed by
+    # Regression (PR #14 alice): publish.relocate_roots was declared + consumed by
     # the relocate handler but NOT parsed in from_dict, so an operator value was
     # silently dropped (permanently []) and lost on round-trip.
     loaded = _load_from_dict(

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -976,7 +976,7 @@ class TestInterpreterArgvLiteralMint:
         "cmd",
         [
             "echo hi | xargs ls",
-            "echo /workplace/nrb/{n}-wt-x | xargs ls",
+            "echo /workplace/alice/{n}-wt-x | xargs ls",
         ],
     )
     def test_xargs_without_a_protected_command_allowed(self, cmd):
@@ -1165,7 +1165,7 @@ class TestInterpreterArgvLiteralMint:
         assert _denied_by(text) == rule
 
     def test_process_substitution_of_something_harmless_allowed(self):
-        assert _denied_by(f"cat <(ls /workplace/nrb/{_NAME}-wt-x)") is None
+        assert _denied_by(f"cat <(ls /workplace/alice/{_NAME}-wt-x)") is None
 
     @pytest.mark.parametrize(
         "cmd,rule",
@@ -1195,12 +1195,12 @@ class TestInterpreterArgvLiteralMint:
         assert _denied_by(f"echo {_NAME} {_TOK}") is None
 
     def test_alias_to_an_unprotected_program_allowed(self):
-        assert _denied_by(f"bash -c 'alias x=ls; x /workplace/nrb/{_NAME}-wt-x'") is None
+        assert _denied_by(f"bash -c 'alias x=ls; x /workplace/alice/{_NAME}-wt-x'") is None
         assert _denied_by("printf '%s\\n' hello | bash") is None
 
     def test_env_without_a_protected_payload_allowed(self):
-        assert _denied_by(f"env -S 'ls /workplace/nrb/{_NAME}-wt-x'") is None
-        assert _denied_by(f"env FOO=1 ls /workplace/nrb/{_NAME}-wt-x") is None
+        assert _denied_by(f"env -S 'ls /workplace/alice/{_NAME}-wt-x'") is None
+        assert _denied_by(f"env FOO=1 ls /workplace/alice/{_NAME}-wt-x") is None
 
     @pytest.mark.parametrize(
         "cmd",
@@ -1559,7 +1559,7 @@ class TestSelfProtectionKillTargetScoping:
         "cmd",
         [
             "X=$(date); echo $X {v}",
-            "X=$(cat /workplace/nrb/{n}-wt-x/f); echo $X {v}",
+            "X=$(cat /workplace/alice/{n}-wt-x/f); echo $X {v}",
         ],
     )
     def test_computed_assignment_without_a_protected_name_allowed(self, cmd):
@@ -1942,9 +1942,9 @@ class TestSelfProtectionKillTargetScoping:
     @pytest.mark.parametrize(
         "cmd",
         [
-            "awk '{{print $1}}' /workplace/nrb/{n}-wt-x/log",
-            "awk '/{v}/ {{print}}' /workplace/nrb/{n}-wt-x/log",
-            "sed -n '1,5p' /workplace/nrb/{n}-wt-x/README.md",
+            "awk '{{print $1}}' /workplace/alice/{n}-wt-x/log",
+            "awk '/{v}/ {{print}}' /workplace/alice/{n}-wt-x/log",
+            "sed -n '1,5p' /workplace/alice/{n}-wt-x/README.md",
         ],
     )
     def test_ordinary_text_processing_still_allowed(self, cmd):
@@ -2182,7 +2182,7 @@ class TestSelfProtectionKillTargetScoping:
         "cmd",
         [
             f"{_PK} -f other; echo {_NAME}",
-            f"{_PK} -f other && ls /workplace/nrb/{_NAME}-wt-x",
+            f"{_PK} -f other && ls /workplace/alice/{_NAME}-wt-x",
         ],
     )
     def test_kill_of_something_else_then_a_mention_allowed(self, cmd):
@@ -2330,8 +2330,8 @@ class TestCredentialMintSegmentScoping:
     @pytest.mark.parametrize(
         "cmd",
         [
-            f'bash -c "cd /workplace/nrb/{_NAME}-wt-x && pytest test/test_{_TOK}_auth.py"',
-            f'sh -c "ls /workplace/nrb/{_NAME}-wt-x"',
+            f'bash -c "cd /workplace/alice/{_NAME}-wt-x && pytest test/test_{_TOK}_auth.py"',
+            f'sh -c "ls /workplace/alice/{_NAME}-wt-x"',
             f'bash -c "{_NAME} doctor | grep {_TOK}"',
         ],
     )
@@ -2394,9 +2394,9 @@ class TestCredentialMintSegmentScoping:
     @pytest.mark.parametrize(
         "cmd",
         [
-            f"true;ls /workplace/nrb/{_NAME}-wt-x",
-            f"echo hi&&cat /workplace/nrb/{_NAME}-wt-x/docs/{_TOK}.md",
-            f"cd /workplace/nrb/{_NAME}-wt-x;pytest test/test_{_TOK}_auth.py",
+            f"true;ls /workplace/alice/{_NAME}-wt-x",
+            f"echo hi&&cat /workplace/alice/{_NAME}-wt-x/docs/{_TOK}.md",
+            f"cd /workplace/alice/{_NAME}-wt-x;pytest test/test_{_TOK}_auth.py",
             f"true;{_NAME} doctor | grep {_TOK}",
         ],
     )
@@ -2484,9 +2484,9 @@ class TestCredentialMintSegmentScoping:
     @pytest.mark.parametrize(
         "cmd",
         [
-            f"$(which cat) /workplace/nrb/{_NAME}-wt-x/docs/{_TOK}.md",
+            f"$(which cat) /workplace/alice/{_NAME}-wt-x/docs/{_TOK}.md",
             f'cd /workplace/x/{_NAME}-wt-y && "$(command -v pytest)" test/test_{_TOK}_auth.py',
-            f"$(which cat) /workplace/nrb/{_NAME}-wt-x/out>/tmp/copy",
+            f"$(which cat) /workplace/alice/{_NAME}-wt-x/out>/tmp/copy",
         ],
     )
     def test_substitution_peel_does_not_reach_into_arguments(self, cmd):

--- a/test/test_governance_chokepoints.py
+++ b/test/test_governance_chokepoints.py
@@ -1712,7 +1712,7 @@ class TestPublishGovernanceGate:
         assert reason is not None and "governance could not be evaluated" in reason
 
     def test_internal_resolve_error_fails_closed(self, monkeypatch):
-        # Regression (PR #14 nrb): governance_permits SWALLOWS its own internal
+        # Regression (PR #14 alice): governance_permits SWALLOWS its own internal
         # errors and, by default, degrades to a permissive Decision. The publish
         # gate calls it with fail_closed=True, so an error raised INSIDE
         # governance_permits (e.g. resolve() throwing) must still DENY — the
@@ -1790,7 +1790,7 @@ class TestPublishGovernanceGate:
 
     @pytest.mark.asyncio
     async def test_republish_gates_on_existing_provider(self, tmp_path, monkeypatch):
-        # Regression (PR #14 nrb): a re-publish with NO explicit provider in the
+        # Regression (PR #14 alice): a re-publish with NO explicit provider in the
         # body must gate on the EXISTING publication's provider, not the default
         # "provider-a". publish_sync.publish() dispatches to the existing
         # provider, so gating on "provider-a" while the artifact is published to

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -424,21 +424,21 @@ class TestHybridRetriever:
     def test_search_attaches_folder_file_path(self, store):
         # A folder/vault result carries source_type/source_name and the specific
         # file path (from folder_file_state), not just the folder-root uri.
-        sid = store.add_source("Opportunity Planner", "local_folder", "/home/nrb/op/src/")
+        sid = store.add_source("Opportunity Planner", "local_folder", "/home/alice/op/src/")
         item_id = store.add_item(
             "Auth Design", "JWT tokens with refresh flow", "design_doc", source_id=sid
         )
         store.db.execute(
             "INSERT INTO folder_file_state (source_id, file_path, item_ids, last_seen, status) "
             "VALUES (?, ?, ?, ?, ?)",
-            (sid, "/home/nrb/op/src/auth.md", json.dumps([item_id]), "now", "done"),
+            (sid, "/home/alice/op/src/auth.md", json.dumps([item_id]), "now", "done"),
         )
         retriever = HybridRetriever(store)
         results = retriever.search("JWT")
         top = next(r for r in results if r["id"] == item_id)
         assert top["source_type"] == "local_folder"
         assert top["source_name"] == "Opportunity Planner"
-        assert top["file_path"] == "/home/nrb/op/src/auth.md"
+        assert top["file_path"] == "/home/alice/op/src/auth.md"
 
     def test_search_attaches_artifact_slug(self, store):
         # An artifact result carries the artifact slug + name (from

--- a/test/test_knowledge_search_upgrade.py
+++ b/test/test_knowledge_search_upgrade.py
@@ -240,8 +240,8 @@ class TestSearchForContext:
             "source": "src-1",
             "source_type": "local_folder",
             "source_name": "Opportunity Planner",
-            "source_uri": "/home/nrb/projects/op/src/",
-            "file_path": "/home/nrb/projects/op/src/auth.md",
+            "source_uri": "/home/alice/projects/op/src/",
+            "file_path": "/home/alice/projects/op/src/auth.md",
             "section_title": "Token Lifecycle",
             "chunk_range": "10-25",
             "match_type": "keyword+vector",
@@ -249,7 +249,7 @@ class TestSearchForContext:
         card = _build_context_card(result, content="body", tokens=1)
         assert card["source_type"] == "local_folder"
         assert card["source_name"] == "Opportunity Planner"
-        assert card["file_path"] == "/home/nrb/projects/op/src/auth.md"
+        assert card["file_path"] == "/home/alice/projects/op/src/auth.md"
         assert card["section_title"] == "Token Lifecycle"
         assert card["chunk_range"] == "10-25"
 

--- a/test/test_mcp_knowledge_search.py
+++ b/test/test_mcp_knowledge_search.py
@@ -149,10 +149,10 @@ class TestKnowledgeSearchResults:
                 "source": "src-1",
                 "source_type": "local_folder",
                 "source_name": "Opportunity Planner",
-                "source_uri": "/home/nrb/projects/op/src/",
+                "source_uri": "/home/alice/projects/op/src/",
                 "section_title": "Token Lifecycle",
                 "chunk_range": "10-25",
-                "file_path": "/home/nrb/projects/op/src/auth.md",
+                "file_path": "/home/alice/projects/op/src/auth.md",
             }
         ]
 
@@ -163,7 +163,7 @@ class TestKnowledgeSearchResults:
         assert "[local_folder] Opportunity Planner" in result
         assert "Token Lifecycle" in result
         assert "lines 10-25" in result
-        assert "**File:** /home/nrb/projects/op/src/auth.md" in result
+        assert "**File:** /home/alice/projects/op/src/auth.md" in result
         # A specific file path supersedes the folder-root uri Link.
         assert "**Link:**" not in result
 

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -533,8 +533,8 @@ def test_restore_open_slots_rollback_also_discards_restricted_keys(tmp_path, mon
 # transcript. get_or_create_slot now folds keys to the filename charset, and
 # the restore paths apply the same fold so pre-fix snapshots self-heal.
 
-RAW_KEY = "Artifact: 2026 Code Activity Benchmark - nrb vs Dan Lloyd Org"
-FOLDED_KEY = "Artifact__2026_Code_Activity_Benchmark_-_nrb_vs_Dan_Lloyd_Org"
+RAW_KEY = "Artifact: 2026 Example Benchmark Report - alice vs Bob Smith Org"
+FOLDED_KEY = "Artifact__2026_Example_Benchmark_Report_-_alice_vs_Bob_Smith_Org"
 
 
 def test_restore_open_slots_folds_legacy_raw_keys(tmp_path, monkeypatch):

--- a/test/test_preview_text.py
+++ b/test/test_preview_text.py
@@ -25,7 +25,7 @@ class TestStripMarkdownPreview:
         )
 
     def test_diff_fence_becomes_placeholder(self):
-        src = "```diff\n--- /Users/kseam/.kirocrew/workspace/H.tsx\n+++ b\n@@ -1 +1 @@\n```"
+        src = "```diff\n--- /Users/user/.kirocrew/workspace/H.tsx\n+++ b\n@@ -1 +1 @@\n```"
         assert strip_markdown_preview(src) == "(diff)"
 
     def test_code_fence_becomes_placeholder(self):
@@ -86,7 +86,7 @@ class TestSlotLastMessageStripsMarkdown:
 
     def test_sidebar_preview_replaces_diff_fence(self):
         s = self._slot_with(
-            ("assistant", "```diff\n--- /Users/kseam/.kirocrew/workspace/H.tsx\n+++ b\n```"),
+            ("assistant", "```diff\n--- /Users/user/.kirocrew/workspace/H.tsx\n+++ b\n```"),
         )
         assert s.to_dict()["last_message"] == "(diff)"
 

--- a/test/test_publish_sync.py
+++ b/test/test_publish_sync.py
@@ -55,7 +55,7 @@ class DummyPublishProvider(PublishProvider):
             "artifactUrl": "https://artifacts.example.com/artifact/uuid-123",
             "versionNumber": 1,
             "sha256": "sha-v1",
-            "ownerAlias": "nrb",
+            "ownerAlias": "alice",
             "status": "READY",
         }
         self.upload_version_response = {
@@ -261,7 +261,7 @@ async def test_publish_sets_publication(store, fake_client):
     assert pub.last_pushed_sha256 == "sha-v1"
     assert pub.last_synced_kirocrew_version == 1
     assert pub.version_map == {"1": 1}
-    assert pub.published_by == "nrb"
+    assert pub.published_by == "alice"
     # uploaded the rendered text content
     upload_args = fake_client.called("upload")[0]
     assert upload_args["title"] == "Doc"
@@ -434,7 +434,7 @@ def test_publication_roundtrip(tmp_path):
         last_pushed_sha256="abc",
         last_synced_kirocrew_version=art.version,
         version_map={"1": 1},
-        published_by="nrb",
+        published_by="alice",
     )
     store.set_publication("d", pub)
 
@@ -519,7 +519,7 @@ def test_wrap_widget_html_self_contained():
 
 
 def test_redact_untrusted_scans_every_source():
-    # Regression (PR #14 nrb): the `manual` source is no longer a redaction
+    # Regression (PR #14 alice): the `manual` source is no longer a redaction
     # bypass. `source` is set once at create and NOT re-derived when an agent
     # later updates the content, so a `manual`-labelled artifact can carry
     # LLM/agent bytes by publish time — it MUST still be scanned. An AKIA-shaped
@@ -592,7 +592,7 @@ from kiro_crew.artifacts import ForkMetadata  # noqa: E402
 
 
 def _remote_get(
-    tmp_path, content, *, version, sha, owner="nrb", ctype="text/plain", shared=None, shared_v2=None
+    tmp_path, content, *, version, sha, owner="alice", ctype="text/plain", shared=None, shared_v2=None
 ):
     """A fake get_artifact response: artifact metadata + downloaded localPath."""
     f = tmp_path / f"remote-{version}-{sha}.txt"

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -1060,14 +1060,14 @@ class TestKiroCliBundledDeniedCommands:
 
     def test_skill_create_sh_kirocrew_domain_allowed(self) -> None:
         """The brazil-workspace skill scaffold must not be blocked."""
-        cmd = "/Users/meyffret/.kirocrew/skills/brazil-workspace/create.sh --domain kirocrew"
+        cmd = "/Users/user/.kirocrew/skills/brazil-workspace/create.sh --domain kirocrew"
         assert not self._is_denied(cmd)
 
     def test_skills_dir_listing_allowed(self) -> None:
         assert not self._is_denied("ls ~/.kirocrew/skills/")
 
     def test_skill_run_with_kirocrew_arg_allowed(self) -> None:
-        cmd = "/Users/meyffret/.kirocrew/skills/coder/run.sh kirocrew --dry-run"
+        cmd = "/Users/user/.kirocrew/skills/coder/run.sh kirocrew --dry-run"
         assert not self._is_denied(cmd)
 
     def test_bash_skill_script_allowed(self) -> None:

--- a/test/test_session_key_slug.py
+++ b/test/test_session_key_slug.py
@@ -85,8 +85,8 @@ class TestNormalizeSlotKey:
 
     def test_display_name_folds_to_filename_charset(self):
         assert (
-            _normalize_slot_key("Artifact: 2026 Code Activity Benchmark - nrb vs Dan Lloyd Org")
-            == "Artifact__2026_Code_Activity_Benchmark_-_nrb_vs_Dan_Lloyd_Org"
+            _normalize_slot_key("Artifact: 2026 Example Benchmark Report - alice vs Bob Smith Org")
+            == "Artifact__2026_Example_Benchmark_Report_-_alice_vs_Bob_Smith_Org"
         )
 
     def test_composes_ascii_fold_then_filename_fold(self):

--- a/test/test_session_usage.py
+++ b/test/test_session_usage.py
@@ -229,11 +229,11 @@ class TestFetchUsageBg:
             "percentage": 413.4,
             "plan": "KIRO POWER",
             "resets": "2026-07-01",
-            "email": "cttong@amazon.com",
+            "email": "carol@amazon.com",
             "start_url": "https://amzn.awsapps.com/start",
             "source": "api",
         }
-        whoami = AsyncMock(return_value={"email": "cttong@amazon.com",
+        whoami = AsyncMock(return_value={"email": "carol@amazon.com",
                                          "start_url": "https://amzn.awsapps.com/start"})
         with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
              patch.object(sessions_mod, "_fetch_whoami", whoami), \
@@ -261,11 +261,11 @@ class TestFetchUsageBg:
             "credits_overage": 31336.0,
             "plan": "KIRO POWER",
             "resets": "2026-08-01",
-            "email": "cttong@amazon.com",
+            "email": "carol@amazon.com",
             "start_url": "https://amzn.awsapps.com/start",
             "source": "api",
         }
-        whoami = AsyncMock(return_value={"email": "cttong@amazon.com",
+        whoami = AsyncMock(return_value={"email": "carol@amazon.com",
                                          "start_url": "https://amzn.awsapps.com/start"})
         # SAMPLE_USAGE carries resets "2026-07-01" — a different cycle from the
         # cached "2026-08-01".
@@ -369,9 +369,9 @@ class TestNormalizeTextUsage:
 class TestTextScrapeRegressesApiValue:
     """The overage-blind text scrape must not clobber a richer API value."""
 
-    ID = {"email": "cttong@amazon.com"}
+    ID = {"email": "carol@amazon.com"}
 
-    ID = {"email": "cttong@amazon.com", "start_url": "https://amzn.awsapps.com/start"}
+    ID = {"email": "carol@amazon.com", "start_url": "https://amzn.awsapps.com/start"}
     CYCLE = {"resets": "2026-08-01"}
 
     def test_api_prior_with_more_usage_blocks_scrape(self):
@@ -406,10 +406,10 @@ class TestTextScrapeRegressesApiValue:
         # Same human email across two Identity Center orgs (different start_url)
         # is NOT the same account — must not preserve.
         prev = {"credits_used": 41336.0, "source": "api",
-                "email": "cttong@amazon.com", "start_url": "https://orgA.awsapps.com/start"}
+                "email": "carol@amazon.com", "start_url": "https://orgA.awsapps.com/start"}
         new = {"credits_used": 100.0}
         assert _text_scrape_regresses_api_value(
-            prev, new, {"email": "cttong@amazon.com", "start_url": "https://orgB.awsapps.com/start"}
+            prev, new, {"email": "carol@amazon.com", "start_url": "https://orgB.awsapps.com/start"}
         ) is False
 
     def test_different_reset_date_allows_scrape(self):

--- a/test/test_trust_patterns.py
+++ b/test/test_trust_patterns.py
@@ -933,23 +933,23 @@ class TestMatchesTrustedPatternPiped:
     """Piped commands: each segment checked independently, ALL must match."""
 
     def test_all_segments_match(self):
-        patterns = {"cat /etc/*", "grep /Users/n*"}
-        cmd = "Running: cat /etc/hosts | grep /Users/nikhim"
+        patterns = {"cat /etc/*", "grep /Users/a*"}
+        cmd = "Running: cat /etc/hosts | grep /Users/alice"
         assert _matches_trusted_pattern(cmd, patterns) is not None
 
     def test_one_segment_fails(self):
-        patterns = {"cat /etc/*", "grep /Users/n*"}
-        cmd = "Running: cat /etc/hosts | grep /Users/zoozoo"
+        patterns = {"cat /etc/*", "grep /Users/a*"}
+        cmd = "Running: cat /etc/hosts | grep /Users/bob"
         assert _matches_trusted_pattern(cmd, patterns) is None
 
     def test_first_segment_fails(self):
-        patterns = {"cat /etc/*", "grep /Users/n*"}
-        cmd = "Running: cat /var/log/syslog | grep /Users/nikhim"
+        patterns = {"cat /etc/*", "grep /Users/a*"}
+        cmd = "Running: cat /var/log/syslog | grep /Users/alice"
         assert _matches_trusted_pattern(cmd, patterns) is None
 
     def test_both_segments_fail(self):
-        patterns = {"cat /etc/*", "grep /Users/n*"}
-        cmd = "Running: cat /var/log/syslog | grep /Users/zoozoo"
+        patterns = {"cat /etc/*", "grep /Users/a*"}
+        cmd = "Running: cat /var/log/syslog | grep /Users/bob"
         assert _matches_trusted_pattern(cmd, patterns) is None
 
     def test_single_command_still_works(self):
@@ -993,10 +993,10 @@ class TestMatchesTrustedPatternPiped:
         assert _matches_trusted_pattern(cmd, patterns) is not None
 
     def test_independent_patterns_per_segment(self):
-        # cat trusted for .z* paths, grep trusted for /Users/n* paths
-        patterns = {"cat /Users/nikhim/.z*", "grep /Users/n*"}
-        good = "Running: cat /Users/nikhim/.zshrc | grep /Users/nikhim"
-        bad = "Running: cat /Users/nikhim/.zshrc | grep /Users/zoozoo"
+        # cat trusted for .z* paths, grep trusted for /Users/a* paths
+        patterns = {"cat /Users/alice/.z*", "grep /Users/a*"}
+        good = "Running: cat /Users/alice/.zshrc | grep /Users/alice"
+        bad = "Running: cat /Users/alice/.zshrc | grep /Users/bob"
         assert _matches_trusted_pattern(good, patterns) is not None
         assert _matches_trusted_pattern(bad, patterns) is None
 

--- a/website/src/test/ArtifactDetailPage.companionChat.test.tsx
+++ b/website/src/test/ArtifactDetailPage.companionChat.test.tsx
@@ -239,7 +239,7 @@ describe('ArtifactDetailPage companion chat', () => {
     // A comment arriving now would flip the panel to 'comments' without the guard.
     vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({
       comments: [{
-        id: 'c1', origin: 'local', scope: 'private', author: 'nrb', body: 'note',
+        id: 'c1', origin: 'local', scope: 'private', author: 'alice', body: 'note',
         thread_id: 't1', status: 'open', sync_state: 'local',
         created_at: '2026-05-21T22:00:00Z', updated_at: '2026-05-21T22:00:00Z',
       }],
@@ -269,7 +269,7 @@ describe('ArtifactDetailPage companion chat', () => {
     seedSlots(store, [mkSlot({ key: 'chat-bound', artifact: 'cr-queue' })])
     vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({
       comments: [{
-        id: 'c1', origin: 'local', scope: 'private', author: 'nrb', body: 'tighten this',
+        id: 'c1', origin: 'local', scope: 'private', author: 'alice', body: 'tighten this',
         thread_id: 't1', status: 'open', sync_state: 'local',
         anchor: { quote: 'CR Queue' },
         created_at: '2026-05-21T22:00:00Z', updated_at: '2026-05-21T22:00:00Z',
@@ -471,7 +471,7 @@ describe('ArtifactDetailPage companion chat', () => {
     // comments query to simulate the count changing while chat is open.
     vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({
       comments: [{
-        id: 'c1', origin: 'local', scope: 'private', author: 'nrb', body: 'note',
+        id: 'c1', origin: 'local', scope: 'private', author: 'alice', body: 'note',
         thread_id: 't1', status: 'open', sync_state: 'local',
         anchor: { quote: 'Rollout plan' },
         created_at: '2026-05-21T22:00:00Z', updated_at: '2026-05-21T22:00:00Z',

--- a/website/src/test/InlineCommentOverlay.test.tsx
+++ b/website/src/test/InlineCommentOverlay.test.tsx
@@ -28,7 +28,7 @@ afterEach(() => {
 
 function mk(over: Partial<ArtifactComment> = {}): ArtifactComment {
   return {
-    id: 'c1', origin: 'local', scope: 'private', author: 'nrb', is_agent: false,
+    id: 'c1', origin: 'local', scope: 'private', author: 'alice', is_agent: false,
     body: 'b', thread_id: 'c1', status: 'open', sync_state: 'local_only',
     created_at: '', updated_at: '', ...over,
   }

--- a/website/src/test/InstancesPanel.test.tsx
+++ b/website/src/test/InstancesPanel.test.tsx
@@ -65,20 +65,20 @@ describe('InstancesPanel', () => {
     renderWithProviders(<InstancesPanel />)
 
     await screen.findByText(/No remote crews configured yet/i)
-    await u.type(screen.getByPlaceholderText('Remote Host 1'), 'Shizuka')
-    await u.type(screen.getByPlaceholderText('host-1-alias'), 'shizuka-alias')
+    await u.type(screen.getByPlaceholderText('Remote Host 1'), 'Nimbus')
+    await u.type(screen.getByPlaceholderText('host-1-alias'), 'nimbus-alias')
     await u.type(
       screen.getByPlaceholderText(/leave blank for standard installs/i),
-      '/home/shizuka/.local/bin/kirocrew',
+      '/home/nimbus/.local/bin/kirocrew',
     )
     await u.click(screen.getByRole('button', { name: 'Add remote crew' }))
 
     await waitFor(() =>
       expect(api.addInstance).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: 'Shizuka',
-          ssh_host: 'shizuka-alias',
-          remote_bin: '/home/shizuka/.local/bin/kirocrew',
+          name: 'Nimbus',
+          ssh_host: 'nimbus-alias',
+          remote_bin: '/home/nimbus/.local/bin/kirocrew',
         }),
       ),
     )


### PR DESCRIPTION
## Problem

`scripts/scrub-lint.sh` is a **blocking CI gate** (`.github/workflows/ci.yml:23`) whose
job is to stop internal identifiers reaching the published tree. Scan 2 of it —
"Scanning for employee aliases" — reads its name list from
`scripts/.scrub-aliases.txt`. That file is deliberately never committed (publishing a
list of employee names would defeat the purpose), so on every fresh clone **and in
CI** it is absent, the scan prints `⊘ Alias check skipped`, and the gate **passes**.

The alias scan has therefore never checked a single alias. Run on `main` before this
change, the gate reports `All checks passed ✓` (exit 0) on a tree containing 11
personal identifiers.

Scan 1 (internal markers) has a second hole: its scan list is
`src/ website/src/ website/docs/ docs/ skills/ scripts/ config/ packaging/ ./*.md` —
**`test/` is not in it**, so real addresses in test fixtures were never checked either.

## Why it matters

11 personal identifiers shipped in the tracked tree, including a real internal
document title carrying an employee alias **and** a real full name. This is a
published-repo hygiene/privacy exposure, and the gate that exists to prevent it
reports green while doing nothing.

## Fix (symptom → root cause → change)

**Symptom:** personal aliases, an employee email, and an internal document title
present in tracked source, tests and skill docs, with CI green.
**Root cause:** the alias gate is vacuous by construction (its input file cannot
exist in a clone), and the marker gate does not look at `test/`.
**Change:** remove the identifiers, then add a scan that *cannot* silently degrade.

1. **Removed 11 identifiers**, using the placeholders the repo already uses
   (`user` / `alice` / `bob` / `carol`):
   - `src/kiro_crew/mcp_caller.py`, `src/kiro_crew/acp/client.py`,
     `src/kiro_crew/artifacts.py` (also dropped a personal attribution clause),
     `src/kiro_crew/security.py`, `skills/self-nudge-loop/SKILL.md` — aliases in
     docstrings and examples.
   - `test/` — an employee email (×8), four aliases (one appearing 53× across 13
     files), and the internal artifact title `"… - <alias> vs <full name> Org"`.
   - `website/src/test/` — a person-shaped remote name, and an `author` fixture alias.

   Two needed care rather than a blind rename:
   - `test/test_trust_patterns.py` used two aliases as **two distinct users**, with a
     prefix glob `/Users/n*` that had to match one and not the other. Both moved to
     `alice`/`bob` and the glob was re-anchored to `/Users/a*`, so the test still
     proves per-segment pattern independence instead of passing vacuously.
   - The artifact-title tests assert only the character folding (`': '`→`__`,
     `' '`→`_`), so the punctuation shape is preserved byte-for-byte and the
     assertion still exercises the same transform.

2. **Added scan 3 — a structural identity scan that needs no name list**, so it
   cannot become vacuous the way scan 2 did. It matches the *shape* of a personal
   identifier: a home-directory path (`/home`, `/local/home`, `/Users`) or an Amazon
   `/workplace/<alias>` tree whose user segment is not a known placeholder, and an
   `@amazon.com` address whose local part is not a known fake persona. **It covers
   `test/`**, which scan 1 never looked at.

   Two hardening details, both found by review:
   - The shared allowlist's **path-only** entries are honoured by scans 1–2 to exempt
     a whole file (e.g. an auth stub that must mention midway). Inheriting them here
     blanket-exempted those files from identity checking too — verified by planting
     identity lines in `test_deploy_web_profiles.py`, `sensitiveCommand.test.ts` and
     `deploy/scan.py`, all of which were silently dropped. Scan 3 now honours only
     narrow `path:pattern` entries, which is exactly what `scrub-allowlist.txt:144-150`
     warns about for the other two gates.
   - The `/workplace/` segment charset was initially too narrow (`[a-z]{2,12}`) and
     missed real logins containing a digit or hyphen (`/workplace/dlloyd2`,
     `/workplace/jo-smith` produced zero hits). Widened to `[a-z][a-z0-9-]{1,30}`,
     which still excludes the CamelCase/dotted names Brazil packages use.

### Deliberately NOT covered

A bare alias assigned to an identity-ish field (an `author` / `assignee` /
`principal_id` string literal) is **not** gated, and 8 of the 11 identifiers removed
here were of that class. Scanning those fields was implemented and measured: it
produces ~60 hits of which ~55 are legitimate personas (`octocat`, `agent`,
`reviewer`, `maintainer`, `a-contributor`, `yourname`…), because a bare token is
indistinguishable from any other string without a name list. A gate nobody can keep
green is how scan 2 became vacuous in the first place, so this class is left
explicitly uncovered — with a comment in the script saying so — rather than
pretending to be covered. Closing it properly needs a non-vacuous alias list.

## Tests

No new test file: the change is identifier hygiene plus a shell gate. The gate is its
own test, and it is now non-vacuous — it exits 0 on this tree by actually checking,
not by skipping.

Existing coverage was used as the regression net for the renames, in particular
`test_trust_patterns.py` (glob/user semantics), `test_session_key_slug.py` +
`test_open_slots_persistence.py` (slug folding), and the four `website/src/test/`
suites whose fixtures changed.

## Manual verification

- `./scripts/scrub-lint.sh --no-history` → **exit 0**, `✓ No personal identifiers in
  source or tests`. On `main` the same command also exits 0, but with
  `⊘ Alias check skipped` — the point of the change.
- Adversarial check that scan 3 actually bites: identifiers reintroduced one at a time
  in a scratch copy — `/home/<alias>` in `src/` and in `test/`, `/local/home/<alias>`,
  `/Users/<alias>`, `/workplace/<alias>`, an employee-shaped email in `test/`, and an
  alias in a `skills/*.md` path — each made the gate exit non-zero.
- Full backend suite: **26818 passed**, 116 skipped. Two failures are pre-existing and
  untouched by this diff:
  `test_module_loader.py::TestModuleUnload::test_reload_after_unload_gets_fresh_code`
  fails identically on a clean `main` checkout, and
  `test_file_index.py::TestFileIndexRegistry::test_acquire_creates_index` passes in
  isolation (an xdist artifact). Neither file is in this diff.
- `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (1.14.1, matching the
  `pyproject.toml` pin, no `faiss` installed) — all exit 0.
- `npx tsc -b` exit 0; `npx vitest run` on the four touched suites → 43 passed.

## Screenshots

N/A — no user-visible UI change. The `website/src/test/**` edits are test fixtures
only; no component, layout or rendered string changes.

## Note for reviewers, out of scope here

Scan 3's field-literal experiment surfaced 5 aliases in **deliberate attribution**
fields — `author` in `apps/builtins/{pptx_maker,meetings,papyrus}/app.json`, a
frontend test fixture, and `docs/request-for-change/rfc-federated-app-platform.md`.
Those are intentional credit rather than accidental leakage (same category as the
README contributor avatars, which are public GitHub handles and were correctly left
alone), so they are untouched — but whether internal-shaped aliases belong in shipped
app manifests is a product call worth making deliberately.
