### PR TITLE
test: stop fixtures leaking /tmp dirs and waiting out fixed budgets

### DIFF
--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -221,11 +221,13 @@ hour earlier is not a baseline.
    `monkeypatch` the interval to `0`: the branch still executes, only the waiting
    goes. Confirm first that no test asserts on the interval itself.
 
-Measured on this suite: `test_computer_use_snapshot_macos.py` 143.9s → 2.0s (pattern 3),
-`test_md_notebook.py` 78.5s → 37.0s and `test_worktree_create.py` 61.3s → 40.6s
-(pattern 2). Applying all three across ~16 files took the full suite from 281s to 130s
-wall on one host, and most of that came from the *shared* fixes, which is why the
-conftest audit is item 1.
+Measured on this suite, each file run serially with `-n0 --no-cov` back to back on one
+host (state the regime whenever you quote a number, because these do not compare across
+regimes): `test_computer_use_snapshot_macos.py` 142.0s to 1.5s (pattern 3),
+`test_md_notebook.py` 54.2s to 27.1s and `test_worktree_create.py` 20.7s to 15.8s
+(pattern 2). Applying all three across ~16 files took the full suite from 281s to 116s
+wall, and most of that came from the *shared* fixes, which is why the conftest audit is
+item 1.
 
 A fourth, adjacent pattern: **a patch target that misses.** Both this and § Patch the
 defining module, not a re-export are the same one rule, *patch the namespace whose

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -38,6 +38,13 @@ logger = logging.getLogger(__name__)
 # Configurable via dashboard.mcp_probe_timeout_secs in <config_dir>/config.json.
 _PROBE_TIMEOUT_SECS = 15  # fallback if config not loaded yet
 
+# Teardown budget for a probed child, paid TWICE on a server that ignores a
+# closed stdin: once waiting for a graceful exit, then again after SIGKILL. A
+# server that hangs rather than exiting therefore costs 2x this before the
+# process-group reap runs, which is why it is a named constant -- tests that
+# deliberately probe a never-exiting child shrink it instead of waiting it out.
+_PROBE_TEARDOWN_WAIT_SECS = 5
+
 
 def _get_probe_timeout() -> int:
     try:
@@ -1053,11 +1060,11 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
             try:
                 if proc.stdin:
                     proc.stdin.close()
-                await asyncio.wait_for(proc.wait(), timeout=5)
+                await asyncio.wait_for(proc.wait(), timeout=_PROBE_TEARDOWN_WAIT_SECS)
             except (asyncio.TimeoutError, Exception):
                 try:
                     proc.kill()
-                    await asyncio.wait_for(proc.wait(), timeout=5)
+                    await asyncio.wait_for(proc.wait(), timeout=_PROBE_TEARDOWN_WAIT_SECS)
                 except Exception:
                     pass
         if proc is not None and platform_compat.IS_POSIX:

--- a/test/test_file_change_snapshots.py
+++ b/test/test_file_change_snapshots.py
@@ -14,9 +14,12 @@ touching the live ACP runtime — every test stays in pure-Python land.
 
 from __future__ import annotations
 
+import shutil
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 from kiro_crew.dashboard.chat_runner import (
     _MAX_SNAPSHOT,
@@ -26,6 +29,25 @@ from kiro_crew.dashboard.chat_runner import (
     _truncate_snapshot,
 )
 from kiro_crew.dashboard.state import _ChatSlot
+
+
+@pytest.fixture
+def short_tmp_dir():
+    """A short-path temp dir under ``/tmp``, removed on teardown.
+
+    These tests assert on a file's PATH as it appears in message metadata, and a
+    macOS ``tmp_path`` carries high-entropy directory ids that trip
+    ``redact_credentials()`` on that field -- so the path has to come from ``/tmp``
+    rather than from ``tmp_path``. ``mkdtemp`` registers no finalizer, though, so
+    the nine inline calls this replaces each leaked a directory that survived the
+    run; ``/tmp`` is not swept per-run the way pytest's own basetemp is.
+    """
+    base = Path(tempfile.mkdtemp(dir="/tmp"))
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
 
 # ── _truncate_snapshot ──────────────────────────────────────────────────────
 
@@ -171,10 +193,8 @@ class TestFlushFileChanges:
         # No synthetic message created.
         assert slot.messages == []
 
-    def test_attaches_to_last_assistant_message(self):
-        # Use /tmp directly — macOS tmp_path contains high-entropy dir IDs that
-        # trigger redact_credentials() on the path field, breaking the assertion.
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+    def test_attaches_to_last_assistant_message(self, short_tmp_dir: Path):
+        d = short_tmp_dir
         f = d / "x.py"
         f.write_text("after\n")
         slot = _make_slot_with_assistant_message()
@@ -189,9 +209,8 @@ class TestFlushFileChanges:
         # Slot's accumulator is reset for the next turn.
         assert slot._file_changes == []
 
-    def test_dedup_keeps_first_before(self):
-        # Use /tmp directly — see test_attaches_to_last_assistant_message.
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+    def test_dedup_keeps_first_before(self, short_tmp_dir: Path):
+        d = short_tmp_dir
         f = d / "loop.py"
         f.write_text("v3\n")
         slot = _make_slot_with_assistant_message()
@@ -207,9 +226,8 @@ class TestFlushFileChanges:
         # After-content is read from disk once.
         assert changes[0]["after"] == "v3\n"
 
-    def test_dedup_across_multiple_files(self):
-        # Use /tmp directly — see test_attaches_to_last_assistant_message.
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+    def test_dedup_across_multiple_files(self, short_tmp_dir: Path):
+        d = short_tmp_dir
         a = d / "a.py"
         b = d / "b.py"
         a.write_text("a-after")
@@ -257,10 +275,9 @@ class TestFlushFileChanges:
         changes = slot.messages[-1]["meta"]["file_changes"]
         assert "AKIAIOSFODNN7EXAMPLE" not in changes[0]["before"]
 
-    def test_synthetic_message_created_when_no_assistant_text(self):
+    def test_synthetic_message_created_when_no_assistant_text(self, short_tmp_dir: Path):
         """User stopped before any assistant chunk: still surface modified files."""
-        # Use /tmp directly — see test_attaches_to_last_assistant_message.
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+        d = short_tmp_dir
         f = d / "edit.py"
         f.write_text("after\n")
         slot = _ChatSlot("aborted-turn")
@@ -638,10 +655,10 @@ class TestNoOpPassThrough:
     redacted spans (PR #920 review finding).
     """
 
-    def test_noop_write_is_surfaced(self):
+    def test_noop_write_is_surfaced(self, short_tmp_dir: Path):
         """A write with identical before/after still generates an entry
         (the frontend labels it "no changes")."""
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+        d = short_tmp_dir
         f = d / "unchanged.py"
         f.write_text("same content\n")
         slot = _make_slot_with_assistant_message()
@@ -654,9 +671,9 @@ class TestNoOpPassThrough:
         assert len(changes) == 1
         assert changes[0]["before"] == changes[0]["after"] == "same content\n"
 
-    def test_noop_and_real_change_both_surfaced(self):
+    def test_noop_and_real_change_both_surfaced(self, short_tmp_dir: Path):
         """No-op and real-change entries both survive the flush."""
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+        d = short_tmp_dir
         changed = d / "changed.py"
         changed.write_text("new content\n")
         unchanged = d / "unchanged.py"
@@ -676,11 +693,11 @@ class TestNoOpPassThrough:
         assert changes[str(changed)]["after"] == "new content\n"
         assert changes[str(unchanged)]["before"] == changes[str(unchanged)]["after"]
 
-    def test_flush_always_resets_accumulator(self):
+    def test_flush_always_resets_accumulator(self, short_tmp_dir: Path):
         """The accumulator is cleared on every flush path, so an all-no-op
         turn can never leak its entries into a later turn (stale-entry
         misattribution, PR #920 review finding)."""
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+        d = short_tmp_dir
         f = d / "a.py"
         f.write_text("content_a\n")
 
@@ -711,10 +728,10 @@ class TestContentBlockRedactionAndTruncation:
         assert "(truncated at" in result["content"]
         assert result["content"].startswith("x" * 100)
 
-    def test_redaction_applies_to_content_block_before_in_flush(self):
+    def test_redaction_applies_to_content_block_before_in_flush(self, short_tmp_dir: Path):
         """Credentials in content-block-sourced 'before' are redacted by
         _flush_file_changes, just like disk-sourced content."""
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+        d = short_tmp_dir
         f = d / "config.yml"
         # After content is different (clean) so the entry isn't dropped as no-op
         f.write_text("aws_access_key_id=REPLACED_SAFELY\nversion=2\n")
@@ -742,9 +759,9 @@ class TestContentBlockRedactionAndTruncation:
         # Must be None — sensitive path refusal takes priority
         assert result is None
 
-    def test_exfil_url_redacted_in_content_block_before(self):
+    def test_exfil_url_redacted_in_content_block_before(self, short_tmp_dir: Path):
         """Exfiltration URLs in content-block before text are scrubbed."""
-        d = Path(tempfile.mkdtemp(dir="/tmp"))
+        d = short_tmp_dir
         f = d / "script.sh"
         # After content is clean
         f.write_text("echo 'clean'\n")

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -2329,6 +2329,12 @@ class TestProbeGroupReap:
         script.chmod(0o755)
 
         monkeypatch.setattr("kiro_crew.mcp_discovery._get_probe_timeout", lambda: 1)
+        # The child deliberately never exits, so `probe_server`'s teardown pays its
+        # graceful-exit budget AND its post-SIGKILL budget in full (2 x 5s) before
+        # reaching the process-group reap this test is about. Shrink both: the reap
+        # is what is asserted, and waiting out the real budget made this the single
+        # slowest test in the suite at 12s.
+        monkeypatch.setattr("kiro_crew.mcp_discovery._PROBE_TEARDOWN_WAIT_SECS", 0.5)
         server = McpServerInfo(name="fake", command=str(script))
         result = await probe_server(server)
         assert result.status == "error"  # timed out, as designed

--- a/test/test_mcp_gateway_claim.py
+++ b/test/test_mcp_gateway_claim.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
@@ -566,11 +565,11 @@ def _endpoint_dir() -> str | None:
 
 
 @pytest.mark.asyncio
-async def test_send_claim_roundtrip() -> None:
+async def test_send_claim_roundtrip(short_sock_dir) -> None:
     """The sender round-trips a claim frame over a real unix socket and treats
     a ``claimed`` ack as success, anything else as failure."""
     received: list[dict[str, Any]] = []
-    sock = Path(tempfile.mkdtemp(dir=_endpoint_dir())) / "gw.sock"
+    sock = short_sock_dir / "gw.sock"
 
     async def _serve(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         raw = await reader.readline()
@@ -592,9 +591,9 @@ async def test_send_claim_roundtrip() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_claim_failure_paths() -> None:
+async def test_send_claim_failure_paths(short_sock_dir) -> None:
     """A missing socket or a non-ack response returns False without raising."""
-    base = Path(tempfile.mkdtemp(dir=_endpoint_dir()))
+    base = short_sock_dir
     assert await claim_mod.send_claim(str(base / "absent.sock"), 7, "dashboard:x") is False
 
     sock = base / "nak.sock"
@@ -614,14 +613,12 @@ async def test_send_claim_failure_paths() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_claim_aggregate_timeout_bound(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_send_claim_aggregate_timeout_bound(monkeypatch: pytest.MonkeyPatch, short_sock_dir) -> None:
     """A gatewayd that accepts but never responds is bounded by ONE aggregate
     budget — not one budget per phase (connect/drain/readline), which would
     triple the worst-case stall (review-bot finding f-d76c6f17)."""
     monkeypatch.setattr(claim_mod, "_CLAIM_TIMEOUT_SECS", 0.3)
-    sock = Path(tempfile.mkdtemp(dir=_endpoint_dir())) / "stall.sock"
+    sock = short_sock_dir / "stall.sock"
     stalled = asyncio.Event()
 
     async def _serve(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:

--- a/test/test_mcp_gateway_pool_integ.py
+++ b/test/test_mcp_gateway_pool_integ.py
@@ -40,7 +40,6 @@ import ast
 import asyncio
 import json
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -179,7 +178,7 @@ def _launch_count(log: Path) -> int:
 
 
 @pytest.mark.asyncio
-async def test_real_stubs_sharing_a_key_share_one_backend(tmp_path: Path) -> None:
+async def test_real_stubs_sharing_a_key_share_one_backend(tmp_path: Path, short_sock_dir) -> None:
     """THE pooling assertion: 3 real stub processes -> exactly 1 MCP server.
 
     Also asserts partitioning in the same run: a fourth stub under a DIFFERENT
@@ -187,7 +186,7 @@ async def test_real_stubs_sharing_a_key_share_one_backend(tmp_path: Path) -> Non
     ignored the agent entirely, which would silently break isolation between
     agents -- a correctness bug, not merely a lost optimisation.
     """
-    endpoint_root = Path(tempfile.mkdtemp(dir=_endpoint_dir()))
+    endpoint_root = short_sock_dir
     sock = endpoint_root / "gw.sock"
     work_dir = tmp_path / "ws"
     work_dir.mkdir()

--- a/test/test_mcp_gateway_session_inject.py
+++ b/test/test_mcp_gateway_session_inject.py
@@ -199,7 +199,7 @@ _PROBE_SNIPPET = (
 )
 
 _DRIVER = r"""
-import json, os, subprocess, sys, time
+import json, os, subprocess, sys, threading, time
 w = sys.argv[1]
 p = subprocess.Popen(["kiro-cli", "acp", "--agent", "pooltest"], cwd=w + "/proj",
                      stdin=subprocess.PIPE, stdout=subprocess.PIPE,
@@ -209,12 +209,32 @@ send = lambda o: (p.stdin.write(json.dumps(o) + "\n"), p.stdin.flush())
 send({"jsonrpc": "2.0", "id": 1, "method": "initialize",
       "params": {"protocolVersion": 1, "clientCapabilities":
                  {"fs": {"readTextFile": False, "writeTextFile": False}}}})
-time.sleep(3)
+# Wait for the initialize RESPONSE rather than a fixed span, but on a THREAD with
+# a bound: a bare readline() on a stalled CLI blocks forever, and this driver's
+# own 180s subprocess timeout is longer than the suite's --timeout=120, so the
+# hang would surface as a pytest timeout kill rather than the clean failure
+# below. A cooperative CLI answers in well under a second.
+_line = []
+_t = threading.Thread(target=lambda: _line.append(p.stdout.readline()), daemon=True)
+_t.start()
+_t.join(30)
+if not _line:
+    p.kill()
+    sys.exit("kiro-cli never answered initialize within 30s")
 send({"jsonrpc": "2.0", "id": 2, "method": "session/new",
       "params": {"cwd": w + "/proj", "mcpServers": [
           {"name": "shared", "command": sys.executable,
            "args": ["-c", sys.argv[2], w + "/marks/INJECTED"], "env": []}]}})
-time.sleep(8)
+# Poll for the marker the injected server writes, with a deadline generous
+# enough for a cold CLI. The old 8s sleep was paid in full on every run.
+deadline = time.time() + 20
+injected = os.path.join(w, "marks", "INJECTED")
+while time.time() < deadline and not os.path.exists(injected):
+    time.sleep(0.05)
+# Give a same-named spec server, if injection ever became additive, the same
+# chance to write its own marker -- otherwise this driver could exit before the
+# thing the test asserts is ABSENT would have appeared, making it pass vacuously.
+time.sleep(1)
 p.kill()
 """
 

--- a/test/test_mcp_gateway_stub_admission_fallback.py
+++ b/test/test_mcp_gateway_stub_admission_fallback.py
@@ -40,7 +40,6 @@ Linux-and-Windows-only -- which is the failure mode the glob exists to avoid.
 from __future__ import annotations
 
 import asyncio
-import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -70,15 +69,15 @@ def _register_payload() -> dict[str, Any]:
     return {"type": "register", "stub_uuid": "admission-fallback-probe"}
 
 
-async def _serve(handler: Any) -> tuple[Any, Path]:
-    sock = Path(tempfile.mkdtemp(dir=_endpoint_dir())) / "gw.sock"
+async def _serve(handler: Any, sock_dir: Path) -> tuple[Any, Path]:
+    sock = sock_dir / "gw.sock"
     transport.prepare_dir(sock)
     server = await transport.serve(sock, handler, limit=1 << 16)
     return server, sock
 
 
 @pytest.mark.asyncio
-async def test_handshake_requests_fallback_when_admission_closes_the_connection() -> None:
+async def test_handshake_requests_fallback_when_admission_closes_the_connection(short_sock_dir) -> None:
     """The exact shape of a principal-check refusal: closed before any reply."""
     accepted = asyncio.Event()
 
@@ -88,7 +87,7 @@ async def test_handshake_requests_fallback_when_admission_closes_the_connection(
         accepted.set()
         writer.close()
 
-    server, sock = await _serve(on_connect)
+    server, sock = await _serve(on_connect, short_sock_dir)
     try:
         with pytest.raises(stub.FallbackRequestedError) as excinfo:
             await asyncio.wait_for(
@@ -113,7 +112,7 @@ async def test_handshake_requests_fallback_when_admission_closes_the_connection(
 
 
 @pytest.mark.asyncio
-async def test_handshake_requests_fallback_on_an_explicit_rejection() -> None:
+async def test_handshake_requests_fallback_on_an_explicit_rejection(short_sock_dir) -> None:
     """A ``rejected`` reply degrades too, and carries the daemon's reason through.
 
     Distinct from the close above: this is the path where gatewayd got far enough
@@ -129,7 +128,7 @@ async def test_handshake_requests_fallback_on_an_explicit_rejection() -> None:
     def _spawn(reader: Any, writer: Any) -> None:
         asyncio.get_running_loop().create_task(on_connect(reader, writer))
 
-    server, sock = await _serve(_spawn)
+    server, sock = await _serve(_spawn, short_sock_dir)
     try:
         with pytest.raises(stub.FallbackRequestedError) as excinfo:
             await asyncio.wait_for(
@@ -143,14 +142,14 @@ async def test_handshake_requests_fallback_on_an_explicit_rejection() -> None:
 
 
 @pytest.mark.asyncio
-async def test_handshake_requests_fallback_when_no_endpoint_exists() -> None:
+async def test_handshake_requests_fallback_when_no_endpoint_exists(short_sock_dir) -> None:
     """Daemon absent entirely -- the baseline degrade case.
 
     Included so the three refusal shapes gatewayd can present (never there,
     closed at admission, answered with a rejection) are pinned together rather
     than one of them being covered by accident.
     """
-    missing = Path(tempfile.mkdtemp(dir=_endpoint_dir())) / "absent.sock"
+    missing = short_sock_dir / "absent.sock"
     with pytest.raises(stub.FallbackRequestedError) as excinfo:
         await stub.handshake(str(missing), _register_payload())
     assert "connect failed" in excinfo.value.reason

--- a/test/test_outbox_binary.py
+++ b/test/test_outbox_binary.py
@@ -34,11 +34,21 @@ def outbox(tmp_path):
     # Use /tmp as a stable base — macOS tmp_path contains high-entropy directory
     # IDs that trigger the bare-secret heuristic in redact_credentials(), causing
     # api_outbox_notify to reject the path with 400 before any test logic runs.
+    #
+    # Removed on teardown: `mkdtemp` registers no finalizer, so each test otherwise
+    # left a directory in /tmp forever. Same fixture as
+    # test_outbox_notify_broadcast.py.
+    import shutil
     import tempfile
-    odir = Path(tempfile.mkdtemp(dir="/tmp")) / "outbox"
+
+    base = Path(tempfile.mkdtemp(dir="/tmp"))
+    odir = base / "outbox"
     odir.mkdir()
-    with patch("kiro_crew.config.loader.outbox_dir", return_value=odir):
-        yield odir
+    try:
+        with patch("kiro_crew.config.loader.outbox_dir", return_value=odir):
+            yield odir
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
 
 
 class TestOutboxNotifyBinary:

--- a/test/test_outbox_notify_broadcast.py
+++ b/test/test_outbox_notify_broadcast.py
@@ -135,11 +135,22 @@ def outbox(tmp_path):
     # Use /tmp as a stable base — macOS tmp_path contains high-entropy directory
     # IDs that trigger the bare-secret heuristic in redact_credentials(), causing
     # api_outbox_notify to reject the path with 400 before any test logic runs.
+    #
+    # Removed on teardown: `mkdtemp` does not register a finalizer, so without this
+    # every test left a directory in /tmp forever (one per test, thousands over a
+    # dev's history). tmp_path is still requested so pytest's own numbered-dir
+    # retention policy keeps this fixture tied to the test that used it.
+    import shutil
     import tempfile
-    odir = Path(tempfile.mkdtemp(dir="/tmp")) / "outbox"
+
+    base = Path(tempfile.mkdtemp(dir="/tmp"))
+    odir = base / "outbox"
     odir.mkdir()
-    with patch("kiro_crew.config.loader.outbox_dir", return_value=odir):
-        yield odir
+    try:
+        with patch("kiro_crew.config.loader.outbox_dir", return_value=odir):
+            yield odir
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
 
 
 class TestOutboxNotifyBroadcast:

--- a/test/test_socketsec.py
+++ b/test/test_socketsec.py
@@ -10,6 +10,7 @@ that cannot be reached from Linux.
 from __future__ import annotations
 
 import os
+import shutil
 import socket
 import struct
 import tempfile
@@ -639,7 +640,11 @@ def test_macos_check_matches_a_socket_we_connected_to_ourselves(
 
     from kiro_crew.mcp_gateway import transport
 
-    sock = Path(tempfile.mkdtemp(dir="/tmp")) / "gw.sock"
+    # Removed at the end: `mkdtemp` registers no finalizer, so this otherwise left a
+    # directory in /tmp for good. /tmp (not tmp_path) because an AF_UNIX sun_path is
+    # capped at 104 bytes on macOS and a tmp_path under xdist exceeds it.
+    sock_base = Path(tempfile.mkdtemp(dir="/tmp"))
+    sock = sock_base / "gw.sock"
     transport.prepare_dir(sock)
     outcome: list[PeerCredResult] = []
     done = asyncio.Event()
@@ -661,5 +666,8 @@ def test_macos_check_matches_a_socket_we_connected_to_ourselves(
             server.close()
             await server.wait_closed()
 
-    asyncio.run(run())
-    assert outcome == [PeerCredResult.MATCH]
+    try:
+        asyncio.run(run())
+        assert outcome == [PeerCredResult.MATCH]
+    finally:
+        shutil.rmtree(sock_base, ignore_errors=True)

--- a/test/test_stop_kill_cancel.py
+++ b/test/test_stop_kill_cancel.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import json
 import signal
-import tempfile
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -749,14 +748,12 @@ class TestAbortAckLogging:
     """Tests for abort.send_abort acknowledgment handling and logging."""
 
     @pytest.mark.asyncio
-    async def test_send_abort_logs_ack_from_real_roundtrip(self, caplog):
+    async def test_send_abort_logs_ack_from_real_roundtrip(self, caplog, short_sock_dir):
         """A real socket round-trip through send_abort() logs the ack produced
         by production code (not a manually-emitted log line)."""
         import logging
 
-        # Use /tmp directly — macOS tmp_path exceeds the 104-char AF_UNIX
-        # sun_path limit under xdist (same convention as test_mcp_gateway_claim).
-        socket_path = str(Path(tempfile.mkdtemp(dir="/tmp")) / "gw.sock")
+        socket_path = str(short_sock_dir / "gw.sock")
 
         async def _fake_gatewayd(reader, writer):
             frame = json.loads((await reader.readline()).decode("utf-8"))
@@ -782,12 +779,11 @@ class TestAbortAckLogging:
             await server.wait_closed()
 
     @pytest.mark.asyncio
-    async def test_send_abort_logs_warning_on_bad_ack(self, caplog):
+    async def test_send_abort_logs_warning_on_bad_ack(self, caplog, short_sock_dir):
         """A malformed ack from gatewayd logs a warning via production code."""
         import logging
 
-        # Short dir: macOS sun_path limit (see test above).
-        socket_path = str(Path(tempfile.mkdtemp(dir="/tmp")) / "gw.sock")
+        socket_path = str(short_sock_dir / "gw.sock")
 
         async def _fake_gatewayd(reader, writer):
             await reader.readline()


### PR DESCRIPTION
## Problem

Fourteen sites across eight test files call `tempfile.mkdtemp()` and never remove the result. `mkdtemp` registers no finalizer, and unlike pytest's own basetemp (which retains the last three runs and prunes the rest) nothing sweeps `/tmp`, so every affected test leaves a directory behind permanently.

Measured on one machine: **41 directories per full-suite run**, and **7,000+** accumulated over this checkout's history.

```
$ B=$(ls -d /tmp/tmp* | wc -l); pytest -q -n auto --dist loadgroup --no-cov; \
  A=$(ls -d /tmp/tmp* | wc -l); echo $((A-B))
41
```

## Why it matters

Nothing fails today, which is exactly why it accumulated unnoticed. What it costs: a dev box slowly filling with thousands of orphan directories, and a `/tmp` that grows large enough to make anything scanning it slower. It is also the same defect shape as the fixture-teardown gaps fixed in #1353 (a fixture that acquires a real resource and does not release it), so it belongs with that work rather than in a backlog.

## Fix (symptom, root cause, change)

Every one of these sites uses `/tmp` **deliberately**, for two reasons the fix preserves rather than reverts:

- `sockaddr_un.sun_path` caps a unix-socket path at ~104 bytes on macOS, and a `tmp_path` under xdist already exceeds it.
- A macOS `tmp_path` carries high-entropy directory ids that trip `redact_credentials()` when a test asserts on the path itself.

So this is **cleanup, not relocation**. Moving them to `tmp_path` would have broken both constraints.

- **`test/conftest.py` already has a `short_sock_dir` fixture that does this correctly**: short root, `kcsock-` prefix, `rmtree` on teardown, and a `tmp_path` fallback where no short root exists. Six socket sites across three `test_mcp_gateway_*` files plus two in `test_stop_kill_cancel.py` now take that fixture instead of calling `mkdtemp` inline. (I first wrote a near-duplicate fixture, then found the shared one and deleted mine.)
- `_serve` in `test_mcp_gateway_stub_admission_fallback.py` takes the dir as a parameter, since a plain helper cannot request a fixture; its two callers pass it through.
- The nine inline calls in `test_file_change_snapshots.py` become one `short_tmp_dir` fixture in that file. Those need `/tmp` for the redaction reason rather than the socket one, so they do not share the conftest fixture.
- The `outbox` fixture duplicated in `test_outbox_notify_broadcast.py` and `test_outbox_binary.py` wraps its yield in `try/finally`.
- `test_socketsec.py`'s single site gets a `try/finally` around the body.

### One thing I checked and did NOT change

A related report claimed `test_app_backend.py`'s per-worker port window (`base = 9100 + idx * 20`) puts 4 of 10 xdist workers outside the range `test_find_free_port` asserts. **That is wrong and no code changed.** `app_env` is not autouse and `test_find_free_port` does not request it, so the narrowed window never applies to that assertion. Verified: the file's 50 tests pass 3/3 at `-n 10`.


## Second change: the two slowest tests waited out production timeouts

Profiling the suite after the leak fix, the top two were both paying a real timeout in full rather than detecting the thing they assert. Together, 23s of a 114s wall.

**`test_real_grandchild_is_reaped` (12.0s to 3.0s).** It probes a server that never answers and never exits, to prove `probe_server` reaps the whole process **group** rather than just the leader. Because the child ignores a closed stdin, teardown pays its graceful-exit budget *and* its post-SIGKILL budget in full before the reap runs: 2 x 5s. Those were bare `timeout=5` literals, so the test had nothing to shrink. They are now `_PROBE_TEARDOWN_WAIT_SECS` (also satisfying the AGENTS.md rule against hardcoded values in business logic) and the test monkeypatches it to 0.5. Verified the reap is still covered by disabling that branch and confirming the test goes red.

**`test_real_kiro_cli_prefers_session_injected_server` (11.2s to 4.3s).** Its driver slept a fixed 3s for the ACP `initialize` handshake and a fixed 8s for the injected MCP server to write its marker. Both now wait on the actual event: `readline()` on the initialize response, then a poll with a 20s deadline. Note the deadline is *longer* than the old sleep, so a cold CLI is more tolerated than before while a warm one costs only what it takes. The negative half of the test (the agent spec's same-named server must NOT also launch) keeps a 1s settle so it cannot pass vacuously by exiting before a second marker would have appeared. Verified by pointing the injected server at a different marker path and confirming the positive assertion fails.

### Why I stopped here

Nothing else in the profile is worth cutting, and I checked rather than assumed. Every other test in the top twelve runs **2.3-4.5s serially** versus 5-7s under `-n auto`, so the gap is xdist worker contention, not wasted work. `test_spawn_audit.py`'s five ~4.8s entries already share one memoized AST scan (2.5s for the whole file serially). The profile is now flat: the worst single test is 7.6s against a 114s wall.

## Tests

No new tests, because this is test-infrastructure cleanup. What locks it in:

- **26,703 passed, 0 failures, with 0 `/tmp` directories leaked** by a full run, down from 41; suite wall clock 114s.
- Each touched file also passes on its own and under `-n 4`, since the socket fixtures are the kind that only misbehave in parallel.
- The `short_sock_dir` reuse is strictly safer than what it replaced: it adds a `tmp_path` fallback for platforms with no `/tmp` (Windows), which the inline `mkdtemp(dir="/tmp")` calls did not have.

## Manual verification

Backend gates on a CI-parity venv (no `faiss`, mypy pinned): `isort`, `flake8`, `mypy` (632 files), `scrub-lint` all pass.

One error appeared in an intermediate run: `test_eval_harness.py::TestEvalRunner::test_tool_calls_captured` with `RuntimeError: Event loop is closed`, in a file this PR does not touch. It did not recur on re-run and the file passes standalone on both this branch and clean `main`. The log immediately above it shows a leaked `SessionManager._cleanup_loop` task and an un-awaited `AsyncMockMixin` coroutine, i.e. the pre-existing async-teardown class documented in `testing-conventions.md` § Leaked async objects. Flagging rather than claiming it fixed: a clean baseline run does not by itself prove a pre-existing intermittent.

## Screenshots

N/A, no user-visible change.

## Docs

Corrects three per-file numbers in `docs/system-specs/common/testing-conventions.md` that mixed measurement regimes: one came from a `--store-durations` file (which carries xdist worker contention) while the other two came from serial runs, so they were never comparable. All three are re-measured the same way, serially with `-n0 --no-cov` back to back on one host, and the doc now states the regime alongside the numbers so the next reader does not repeat the mistake. This correction was authored during #1353 but missed its merge.


