### PR TITLE
fix(pod-e2e): make the harness runnable on symlinked-HOME and BSD hosts

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
@@ -61,29 +61,44 @@ fi
 
 # Resolve the checkout path for $NAME via `git worktree list --porcelain`.
 # We search from either KIROCREW_POD_REPO or the script's own directory.
+#
+# This MUST mirror pod/runtime.py resolve_checkout(), or the harness can test a
+# different checkout than `kirocrew pod up` booted — a silently wrong QA verdict.
+# That function builds one keyspace with dict.setdefault (first occurrence wins)
+# over each worktree's basename, absolute path and FULL branch name (minus
+# refs/heads/), then does exactly two lookups:
+#     wts.get(name) or wts.get(f"feat/{name}")
+# Both are EXACT. Matching a branch *leaf* instead would pick `fix/foo` for
+# NAME=foo when the CLI picks `feat/foo`.
 _resolve_checkout() {
   local name="$1"
   local repo_hint="${KIROCREW_POD_REPO:-$HERE}"
   local wt_path=""
+  # Stage 1 = wts.get(name): first worktree, in porcelain order, whose directory
+  # basename or whose exact branch equals $name. Basename is checked as the
+  # `worktree` line is read, mirroring setdefault's within-record ordering.
   wt_path=$(git -C "$repo_hint" worktree list --porcelain 2>/dev/null | awk -v n="$name" '
-    /^worktree / { path = substr($0, 10) }
-    /^branch /   {
-      if (path != "") {
-        bname = path
-        gsub(/.*\//, "", bname)
-        if (bname == n) { print path; exit }
-      }
+    /^worktree / {
+      path = substr($0, 10)
+      bname = path
+      sub(/.*\//, "", bname)
+      if (bname == n) { print path; exit }
+      next
+    }
+    /^branch / {
+      ref = $2
+      sub(/^refs\/heads\//, "", ref)
+      if (ref == n) { print path; exit }
     }
   ')
-  # Fallback: match by directory basename (bare worktree, no branch line yet)
+  # Stage 2 = wts.get("feat/" + name): exact `feat/<name>` branch only.
   if [ -z "$wt_path" ]; then
     wt_path=$(git -C "$repo_hint" worktree list --porcelain 2>/dev/null | awk -v n="$name" '
-      /^worktree / {
-        path = substr($0, 10)
-        # basename match
-        bname = path
-        gsub(/.*\//, "", bname)
-        if (bname == n) { print path; exit }
+      /^worktree / { path = substr($0, 10) }
+      /^branch / {
+        ref = $2
+        sub(/^refs\/heads\//, "", ref)
+        if (ref == "feat/" n) { print path; exit }
       }
     ')
   fi
@@ -108,9 +123,49 @@ PW_RUNNER="$HERE/pod-playwright.py"
 # Artifact dir for this run (logs + results).
 # NAME was validated above (pod-name charset, no slashes or dots) so it
 # cannot traverse outside .e2e-artifacts; belt-and-braces verify anyway.
-ARTIFACT_DIR="$HOME/.kirocrew-pods/.e2e-artifacts/$NAME"
-case "$(readlink -f -- "$ARTIFACT_DIR" 2>/dev/null || echo "$ARTIFACT_DIR")" in
-  "$HOME/.kirocrew-pods/.e2e-artifacts/"*) : ;;
+#
+# The verification must resolve BOTH sides the same way. It previously resolved
+# the candidate with `readlink -f` but compared it against a pattern built from
+# the UNRESOLVED $HOME, so on any host where ~ is a symlink (the standard Amazon
+# dev-desktop layout, /home/<u> -> /local/home/<u>) the resolved candidate began
+# /local/home/... while the pattern began /home/... — every path "escaped" and
+# the suite aborted with exit 65 before running anything.
+#
+# `readlink -f` is also a GNU extension: BSD/macOS readlink has no -f before
+# Ventura, so it silently fell back to the unresolved path there. _realpath_dir
+# resolves physically with cd -P/pwd -P (POSIX) and tolerates a not-yet-created
+# leaf by resolving the deepest existing ancestor.
+_realpath_dir() {
+  local p="$1" tail="" seg out=""
+  while [ ! -d "$p" ] && [ "$p" != "/" ] && [ -n "$p" ]; do
+    tail="$(basename -- "$p")${tail:+/$tail}"
+    p="$(dirname -- "$p")"
+  done
+  if [ -d "$p" ]; then
+    p="$(cd -P -- "$p" 2>/dev/null && pwd -P)" || return 1
+  fi
+  out="${p%/}"
+  # Lexically normalise the not-yet-created tail. `readlink -f` collapses `..`;
+  # a bare cd/pwd loop does not, and re-appending the tail verbatim would let
+  # `<base>/../../x` keep the base as a literal prefix and satisfy a containment
+  # check it should fail. Collapse here so the guard stays at least as strict as
+  # the GNU implementation it replaces.
+  local IFS=/
+  for seg in $tail; do
+    case "$seg" in
+      '' | .) ;;
+      ..) out="${out%/*}" ;;
+      *) out="$out/$seg" ;;
+    esac
+  done
+  printf '%s\n' "${out:-/}"
+}
+
+E2E_ARTIFACT_BASE="$(_realpath_dir "$HOME/.kirocrew-pods/.e2e-artifacts")" \
+  || E2E_ARTIFACT_BASE="$HOME/.kirocrew-pods/.e2e-artifacts"
+ARTIFACT_DIR="$E2E_ARTIFACT_BASE/$NAME"
+case "$(_realpath_dir "$ARTIFACT_DIR")" in
+  "$E2E_ARTIFACT_BASE"/*) : ;;
   *) echo "FATAL: artifact dir escapes .e2e-artifacts: $ARTIFACT_DIR" >&2; exit 65 ;;
 esac
 mkdir -p "$ARTIFACT_DIR"

--- a/test/test_pod_e2e_harness_paths.py
+++ b/test/test_pod_e2e_harness_paths.py
@@ -1,0 +1,253 @@
+"""Path handling in the pod-e2e harness shell script.
+
+Two bugs made this suite unrunnable or unresolvable on real hosts, and neither
+was covered:
+
+* The artifact-dir containment guard resolved the CANDIDATE path but compared it
+  against a pattern built from the UNRESOLVED ``$HOME``. On a host where ``~`` is
+  a symlink (the standard Amazon dev-desktop layout, ``/home/<u>`` ->
+  ``/local/home/<u>``) the two sides disagreed and every run aborted with exit 65
+  before executing a single phase. It only reproduced where ``readlink -f``
+  exists: on macOS, whose BSD ``readlink`` has no ``-f`` before Ventura, the
+  command failed and both sides fell back to the unresolved path, hiding it.
+* ``_resolve_checkout`` matched only the worktree DIRECTORY basename, including
+  in the branch-matching awk branch, so a short pod name that ``kirocrew pod up``
+  accepts (it resolves ``feat/<name>``) was unresolvable whenever the directory
+  basename differed from the branch leaf.
+
+These tests drive the real shell fragments out of the shipped script, so they
+fail if either regresses.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh"
+)
+
+
+def _bash_works() -> bool:
+    """A *working* bash, not merely a file named bash.
+
+    Windows runners ship C:\\Windows\\System32\\bash.exe — the WSL launcher —
+    ahead of Git Bash on PATH. `shutil.which` finds it, but with no WSL distro
+    installed it prints "Windows Subsystem for Linux has no installed
+    distributions" (in UTF-16) and runs nothing, so an existence check let these
+    shell-fragment tests run against a stub and fail on its error banner.
+    """
+    if shutil.which("bash") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["bash", "-c", "echo ok"], capture_output=True, text=True, timeout=15
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return probe.returncode == 0 and probe.stdout.strip() == "ok"
+
+
+pytestmark = pytest.mark.skipif(
+    not _bash_works(), reason="harness fragments need a working bash (not the WSL stub)"
+)
+
+
+def _fragment(start: str, end: str) -> str:
+    """Slice a fragment out of the shipped script (inclusive of *end*).
+
+    The script contains UTF-8 punctuation; without an explicit encoding this
+    raised UnicodeDecodeError at import time on Windows (cp1252 default),
+    erroring the module before its bash skipif could even apply.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    i = src.index(start)
+    j = src.index(end, i) + len(end)
+    return src[i:j]
+
+
+def _run(
+    snippet: str,
+    home: str,
+    extra_path: str | None = None,
+    stdin: str | None = None,
+) -> subprocess.CompletedProcess:
+    path = "/usr/bin:/bin:/usr/sbin:/sbin"
+    if extra_path:
+        path = f"{extra_path}:{path}"
+    return subprocess.run(
+        ["bash", "-c", snippet],
+        env={"HOME": home, "PATH": path},
+        capture_output=True,
+        text=True,
+        input=stdin,
+    )
+
+
+@pytest.fixture()
+def gnu_readlink(tmp_path: Path) -> str:
+    """A `readlink -f` that really resolves, so the bug's precondition holds.
+
+    macOS ships a BSD readlink without -f; without this shim the original bug is
+    invisible on a Mac and the test would vacuously pass there.
+    """
+    bindir = tmp_path / "shim"
+    bindir.mkdir()
+    shim = bindir / "readlink"
+    shim.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import os, sys
+            args = [a for a in sys.argv[1:] if a not in ("-f", "--")]
+            print(os.path.realpath(args[0]))
+            """
+        )
+    )
+    shim.chmod(0o755)
+    return str(bindir)
+
+
+@pytest.fixture()
+def symlinked_home(tmp_path: Path) -> str:
+    """`$HOME` that is a symlink to its physical location."""
+    real = tmp_path / "physical"
+    real.mkdir()
+    link = tmp_path / "home"
+    link.symlink_to(real)
+    return str(link)
+
+
+# --------------------------------------------------------------------------
+# guard: symmetric resolution, no GNU readlink dependency
+# --------------------------------------------------------------------------
+
+HELPER = _fragment("_realpath_dir() {", "\n}")
+# Anchor the guard on its own assignment: the helper now contains an internal
+# case/esac for `..` normalisation, so anchoring the whole block on "esac" would
+# truncate at the helper's.
+GUARD = HELPER + "\n" + _fragment("E2E_ARTIFACT_BASE=", "esac")
+
+
+def test_guard_accepts_a_normal_name_under_a_symlinked_home(symlinked_home, gnu_readlink):
+    """The regression: this aborted with exit 65 on every symlinked-HOME host."""
+    res = _run(f'NAME=smoke\n{GUARD}\necho "OK:$ARTIFACT_DIR"', symlinked_home, gnu_readlink)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "escapes .e2e-artifacts" not in res.stderr
+    assert "OK:" in res.stdout
+
+
+def test_guard_works_without_any_readlink_at_all(symlinked_home, tmp_path):
+    """`readlink -f` is a GNU extension; the guard must not depend on it."""
+    empty = tmp_path / "no-readlink"
+    empty.mkdir()
+    res = subprocess.run(
+        ["bash", "-c", f'NAME=smoke\n{GUARD}\necho OK'],
+        env={"HOME": symlinked_home, "PATH": f"{empty}:/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    # basename/dirname/cd/pwd are all we may rely on
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "OK" in res.stdout
+
+
+def test_guard_still_rejects_an_escaping_name(symlinked_home, gnu_readlink):
+    """The guard's actual purpose must survive the fix."""
+    res = _run(f'NAME=../../escape\n{GUARD}\necho SHOULD_NOT_REACH', symlinked_home, gnu_readlink)
+    assert res.returncode == 65, res.stdout + res.stderr
+    assert "escapes .e2e-artifacts" in res.stderr
+    assert "SHOULD_NOT_REACH" not in res.stdout
+
+
+def test_realpath_dir_tolerates_a_missing_leaf(symlinked_home):
+    """It must resolve before `mkdir -p`, i.e. on the first ever run."""
+    helper = _fragment("_realpath_dir() {", "\n}")
+    res = _run(f'{helper}\n_realpath_dir "$HOME/nope/not/created/yet"', symlinked_home)
+    assert res.returncode == 0, res.stderr
+    out = res.stdout.strip()
+    assert out.endswith("/nope/not/created/yet")
+    assert os.path.realpath(symlinked_home) in out
+
+
+def test_realpath_dir_collapses_dotdot_in_a_missing_tail(symlinked_home):
+    """`readlink -f` normalises `..`; the portable replacement must too.
+
+    Without this, `<base>/../../x` keeps `<base>` as a literal prefix and slips
+    through the containment guard below.
+    """
+    helper = _fragment("_realpath_dir() {", "\n}")
+    res = _run(f'{helper}\n_realpath_dir "$HOME/a/b/../../c"', symlinked_home)
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == f"{os.path.realpath(symlinked_home)}/c"
+
+
+# --------------------------------------------------------------------------
+# resolver: must mirror pod/runtime.py resolve_checkout() exactly
+# --------------------------------------------------------------------------
+
+RESOLVER = _fragment("_resolve_checkout() {", "\n}")
+
+PORCELAIN = (
+    "worktree /repo\nHEAD aaa\nbranch refs/heads/main\n\n"
+    # directory basename deliberately differs from the branch leaf
+    "worktree /repo-wt-podsmoke\nHEAD bbb\nbranch refs/heads/feat/podsmoke\n\n"
+)
+
+# `fix/foo` is listed BEFORE `feat/foo`. A leaf-matching resolver picks fix/foo;
+# the CLI picks feat/foo, because wts.get("foo") misses (no basename or exact
+# branch equals "foo") and wts.get("feat/foo") hits.
+PORCELAIN_AMBIGUOUS = (
+    "worktree /repo-wt-fix\nHEAD aaa\nbranch refs/heads/fix/foo\n\n"
+    "worktree /repo-wt-feat\nHEAD bbb\nbranch refs/heads/feat/foo\n\n"
+)
+
+
+def _resolve(name: str, home: str, porcelain: str = PORCELAIN, tmp: Path | None = None) -> str:
+    """Run the REAL _resolve_checkout with a fake `git` feeding *porcelain*."""
+    assert tmp is not None
+    bindir = tmp / "gitshim"
+    bindir.mkdir(exist_ok=True)
+    fake = bindir / "git"
+    fake.write_text("#!/bin/sh\ncat <<'PORC'\n" + porcelain + "PORC\n")
+    fake.chmod(0o755)
+    snippet = f'HERE=/repo\n{RESOLVER}\n_resolve_checkout {name!r}'
+    return _run(snippet, home, extra_path=str(bindir)).stdout.strip()
+
+
+def test_resolver_matches_the_branch_via_feat_prefix(tmp_path):
+    """`podsmoke` resolves through branch feat/podsmoke, as the CLI does."""
+    assert _resolve("podsmoke", str(tmp_path), tmp=tmp_path) == "/repo-wt-podsmoke"
+
+
+def test_resolver_matches_an_exact_branch(tmp_path):
+    assert _resolve("feat/podsmoke", str(tmp_path), tmp=tmp_path) == "/repo-wt-podsmoke"
+
+
+def test_resolver_matches_a_plain_branch(tmp_path):
+    assert _resolve("main", str(tmp_path), tmp=tmp_path) == "/repo"
+
+
+def test_resolver_matches_a_directory_basename(tmp_path):
+    assert _resolve("repo-wt-podsmoke", str(tmp_path), tmp=tmp_path) == "/repo-wt-podsmoke"
+
+
+def test_resolver_prefers_feat_over_another_branch_with_the_same_leaf(tmp_path):
+    """Regression: a leaf match would pick fix/foo and test the WRONG checkout.
+
+    `kirocrew pod up foo` resolves feat/foo, so the harness must too — otherwise
+    the suite reports a verdict for a branch nobody booted.
+    """
+    got = _resolve("foo", str(tmp_path), porcelain=PORCELAIN_AMBIGUOUS, tmp=tmp_path)
+    assert got == "/repo-wt-feat", f"picked {got!r}, must mirror the CLI's feat/ preference"
+
+
+def test_resolver_reports_nothing_for_an_unknown_name(tmp_path):
+    assert _resolve("nosuchpod", str(tmp_path), tmp=tmp_path) == ""


### PR DESCRIPTION
## Problem

Two path bugs made the bundled pod-e2e suite unusable on hosts we actually develop on.

1. **The suite aborted before running anything on any symlinked-`$HOME` host.** The
   artifact-dir containment guard resolved the *candidate* path with `readlink -f`
   but compared the result against a `case` pattern built from the **unresolved**
   `$HOME`. On the standard Amazon dev-desktop layout (`/home/<u>` →
   `/local/home/<u>`) the resolved candidate begins `/local/home/…` while the
   pattern begins `/home/…`, so every path "escaped" and the run died with
   `FATAL: artifact dir escapes .e2e-artifacts` (exit 65).
2. **`_resolve_checkout` could not resolve a name the CLI accepts.** Its
   branch-matching awk branch compared the worktree *directory basename*, not the
   branch: `bname` was assigned from `path` and stripped with `gsub(/.*\//)`. So a
   short name that `kirocrew pod up` resolves (via `feat/<name>`) failed here
   whenever the directory basename differed from the branch leaf — e.g. directory
   `kirocrew-wt-foo` on branch `feat/foo`.

`readlink -f` was a third, latent bug in the same guard: it is a GNU extension,
and BSD/macOS `readlink` has no `-f` before Ventura, where the command simply
failed and both sides fell back to the unresolved path. That accidental symmetry
is why bug 1 was invisible on a Mac and only bit on Linux.

## Why it matters

Bug 1 means the QA suite this repo relies on cannot be run at all on a large class
of developer machines — the failure is total and happens before the first phase.
Bug 2 is worse than a hard failure would be in one respect: it makes a name work
in one tool and not the other, so the harness and the CLI disagree about what a
"worktree name" means.

## Fix (symptom → root cause → change)

**Symptom:** exit 65 on every run under a symlinked home; `could not resolve
worktree checkout` for a name `pod up` accepts.
**Root cause:** an asymmetric comparison (one side resolved, one side not) plus a
GNU-only resolver; and an awk branch that compared the wrong field.
**Change:**

- Both sides of the containment check now go through one `_realpath_dir` helper,
  so the comparison is symmetric by construction. It uses only POSIX `cd -P` /
  `pwd -P` plus `basename`/`dirname`, so it no longer depends on `readlink -f`,
  and it tolerates a not-yet-created leaf by resolving the deepest existing
  ancestor (the guard runs before `mkdir -p`).
- **It also normalises `..` in the unresolved tail.** This is the subtle part:
  `readlink -f` collapses `..`, a plain `cd`/`pwd` loop does not, and re-appending
  the tail verbatim would let `<base>/../../x` keep `<base>` as a literal prefix
  and **pass** a containment check it must fail. Without this the "portability
  fix" would have quietly weakened a security guard. The new test
  `test_guard_still_rejects_an_escaping_name` is what caught it.
- `_resolve_checkout` now **mirrors `pod/runtime.py` `resolve_checkout()`
  exactly**. That function builds one keyspace with `dict.setdefault` (first
  occurrence wins) over each worktree's basename, absolute path and full branch
  name minus `refs/heads/`, then performs exactly two lookups:
  `wts.get(name) or wts.get(f"feat/{name}")` — both **exact**. Stage 1 here is the
  first worktree whose basename or exact branch equals the name (basename checked
  as the `worktree` line is read, mirroring `setdefault`'s within-record order);
  stage 2 is an exact `feat/<name>` branch.

  A leaf match would have been wrong in a way that is worse than the original bug:
  with `fix/foo` listed before `feat/foo`, `NAME=foo` would select `fix/foo` while
  `kirocrew pod up foo` boots `feat/foo` — the suite would report a **verdict for a
  branch nobody built**. Verified against the same fixture: the leaf-matching form
  returns `/repo-wt-fix`, the mirrored form returns `/repo-wt-feat`.

## Tests

New `test/test_pod_e2e_harness_paths.py` (11 tests) drives the **real shell
fragments out of the shipped script**, so it fails if either fix regresses:

- guard accepts a normal name under a symlinked `$HOME` — the original regression.
  A fake GNU `readlink -f` shim is installed on `PATH` for this, because without
  it the bug's precondition does not exist on macOS and the test would pass
  vacuously.
- guard works with **no `readlink` on `PATH` at all**.
- `_realpath_dir` tolerates a missing leaf, and collapses `..` in it.
- guard still rejects an escaping name with exit 65 (the guard's actual purpose).
- resolver: `feat/`-prefix match, exact-branch match, plain branch, directory
  basename, unknown name, and **prefers `feat/foo` over `fix/foo`** for `foo`.

The resolver tests run the real `_resolve_checkout` function with a fake `git`
supplying porcelain output, rather than testing an awk slice in isolation.

## Manual verification

- 13 pathological inputs to `_realpath_dir` (`""`, `/`, `//`, `..`, `///////`,
  `/a/../../../../..`, `/a/./b/../c`, relative paths, …) all terminate with sane
  output — no hang, and `..` collapses correctly.
- Adjacent suites unaffected: `test_pod.py`, `test_pod_self_contained.py`,
  `test_pod_e2e_video_guard.py`, `test_dev_fleet_app.py` → 393 passed, 1 skipped.
- `isort --check-only` and `flake8` clean on the new test; `bash -n` clean on the
  script.

## Screenshots

N/A — a shell script and a test file; no user-visible UI change.
