### PR TITLE
fix(macos): stop File Explorer search tripping ~/Pictures & ~/Music TCC prompts

### DIFF
--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -40,6 +40,7 @@ import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+from kiro_crew import platform_compat
 from kiro_crew.apps.proxy_auth import verify_proxy_request
 from kiro_crew.hooks import safe_read_file_bytes
 from kiro_crew.sandbox import cgroup_scope_argv, resource_limit_preexec, wrap_argv
@@ -658,6 +659,21 @@ def _search_rg(root: Path, query: str, include: str, exclude: str) -> list[dict]
     if not _under_crew_home(root):
         cmd += ["--glob", "!**/.kiro/crew/**"]
         cmd += ["--glob", "!**/.kirocrew/**"]
+    # macOS TCC: when the search root is the bare $HOME, exclude the gated
+    # top-level folders so ripgrep never descends into ~/Pictures (the Photos
+    # library) or ~/Music (the media library). Recursing into them makes macOS
+    # pop a per-folder consent dialog -- attributed to the bundled ``rg`` binary
+    # separately from KiroCrew itself, which is why the same folder gets prompted
+    # more than once. The leading-slash glob anchors to the search root, so only
+    # the TOP level of $HOME is pruned: a nested project ``Music/`` is untouched,
+    # and an explicit search rooted AT one of these folders (root != $HOME, so
+    # the set below is empty) is still searched in full. Kept in lockstep with
+    # the ``_search_python`` fallback so both engines return the same results.
+    # (Only the six top-level folders are excluded, not the ~/Library allowlist
+    # that platform_compat applies to os.walk: ripgrep cannot re-include a subdir
+    # of an excluded dir without flipping its whole glob set into allowlist mode.)
+    for name in platform_compat.tcc_protected_dirs_for_walk(root):
+        cmd += ["--glob", f"!/{name}"]
     cmd += ["--", query, str(root)]
     try:
         wrapped_cmd, _ = wrap_argv(cmd)
@@ -725,6 +741,17 @@ def _search_python(root: Path, query: str, include: str, exclude: str) -> list[d
             break
         # In-place prune ignored dirs
         dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS and d not in SENSITIVE_DIRS]
+        # macOS TCC: at the bare $HOME root, drop the gated top-level folders so
+        # the walk never descends into ~/Pictures (Photos library) or ~/Music
+        # (media library) and macOS never pops a per-folder consent dialog. Only
+        # the TOP level of $HOME is gated -- a nested project ``Music/`` and an
+        # explicit search rooted at one of these folders (root != $HOME, so the
+        # set is empty) are unaffected. Kept in lockstep with the ripgrep globs
+        # above so both engines return the same results.
+        if dirpath == str(root):
+            gated = platform_compat.tcc_protected_dirs_for_walk(root)
+            if gated:
+                dirnames[:] = [d for d in dirnames if d not in gated]
         # Crew data-home deny-by-default: match rg behavior.
         # - If search root is OUTSIDE the crew home: skip entirely (rg blocks all).
         # - If search root is INSIDE a safe subdir: allow safe subdirs only.

--- a/test/test_file_explorer_app.py
+++ b/test/test_file_explorer_app.py
@@ -5,6 +5,7 @@ search, git status parsing, and HTTP handler routing. Targets ≥60% new line
 coverage for Coverlay.
 """
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -269,6 +270,83 @@ class TestSearch:
     def test_search_empty_query(self, tmp_tree):
         results = server._search(tmp_tree, "", "", "")
         assert results == []
+
+
+class TestSearchTccPruning:
+    """macOS TCC: a search rooted at the bare ``$HOME`` must not descend into the
+    gated top-level folders. Recursing into ``~/Pictures`` (the Photos library)
+    or ``~/Music`` (the media library) makes macOS pop a per-folder consent
+    dialog -- once for the bundled ``rg`` binary and again for the Python
+    fallback, which is why the same folder gets prompted more than once. A search
+    rooted AT such a folder (root != ``$HOME``) is deliberate and stays fully
+    searched. Off macOS the prune is a no-op.
+    """
+
+    @staticmethod
+    def _home_ctx(tmp_tree):
+        # expanduser("~") reads $HOME on POSIX and %USERPROFILE% on Windows;
+        # pin both so the "is root the home directory" test in platform_compat
+        # fires on every CI shard.
+        return patch.dict(
+            os.environ,
+            {"HOME": str(tmp_tree), "USERPROFILE": str(tmp_tree)},
+            clear=False,
+        )
+
+    def test_python_fallback_prunes_gated_dirs_at_home(self, tmp_tree):
+        for name in ("Pictures", "Music", "Downloads"):
+            (tmp_tree / name).mkdir()
+            (tmp_tree / name / "note.txt").write_text("needle here")
+        (tmp_tree / "code").mkdir()
+        (tmp_tree / "code" / "keep.txt").write_text("needle here")
+        with patch.object(server.platform_compat, "IS_MACOS", True), self._home_ctx(tmp_tree):
+            results = server._search_python(tmp_tree, "needle", "", "")
+        names = {Path(r["file"]).name for r in results}
+        assert "keep.txt" in names, "a non-gated top-level dir must still be searched"
+        assert "note.txt" not in names, "Pictures/Music/Downloads must not be descended"
+
+    def test_python_fallback_scoped_gated_dir_is_searched(self, tmp_tree):
+        music = tmp_tree / "Music"
+        music.mkdir()
+        (music / "note.txt").write_text("needle here")
+        # root == ~/Music (NOT $HOME) -> deliberate navigation, searched in full.
+        with patch.object(server.platform_compat, "IS_MACOS", True), self._home_ctx(tmp_tree):
+            results = server._search_python(music, "needle", "", "")
+        assert any(Path(r["file"]).name == "note.txt" for r in results)
+
+    def test_python_fallback_no_prune_off_macos(self, tmp_tree):
+        (tmp_tree / "Music").mkdir()
+        (tmp_tree / "Music" / "note.txt").write_text("needle here")
+        with patch.object(server.platform_compat, "IS_MACOS", False), self._home_ctx(tmp_tree):
+            results = server._search_python(tmp_tree, "needle", "", "")
+        assert any(Path(r["file"]).name == "note.txt" for r in results)
+
+    def _capture_rg_cmd(self, root, home):
+        captured: dict = {}
+
+        def fake_run(cmd, *a, **k):
+            captured["cmd"] = list(cmd)
+            return MagicMock(stdout="", returncode=0)
+
+        with patch.object(server.platform_compat, "IS_MACOS", True), self._home_ctx(home), \
+                patch.object(server, "cgroup_scope_argv", lambda argv: argv), \
+                patch.object(server, "resource_limit_preexec", lambda: None), \
+                patch("subprocess.run", fake_run):
+            server._search_rg(root, "needle", "", "")
+        return captured["cmd"]
+
+    def test_rg_excludes_gated_dirs_at_home(self, tmp_tree):
+        cmd = self._capture_rg_cmd(tmp_tree, tmp_tree)
+        assert "!/Pictures" in cmd
+        assert "!/Music" in cmd
+
+    def test_rg_no_tcc_globs_for_scoped_root(self, tmp_tree):
+        music = tmp_tree / "Music"
+        music.mkdir()
+        # HOME is tmp_tree; the search root is ~/Music, so it is NOT home.
+        cmd = self._capture_rg_cmd(music, tmp_tree)
+        assert "!/Music" not in cmd
+        assert "!/Pictures" not in cmd
 
 
 class TestSelAudit:


### PR DESCRIPTION
## Problem

On macOS, KiroCrew repeatedly prompts for access to **Apple Photos** and **Music** — "at least twice for each folder." The prompts recur and are attributed to more than one binary.

## Why it matters

Every prompt is a modal the user has to dismiss, and dismissing one doesn't stop the next (macOS records consent per `(binary, protected-location)` pair). It reads as the app clawing at private media libraries it has no reason to touch, which is both annoying and trust-eroding.

## Fix (symptom → root cause → change)

- **Symptom:** consent dialogs for `~/Pictures` (Photos) and `~/Music` (media library), repeated per folder.
- **Root cause:** the File Explorer built-in app's search recurses from `$HOME` (`ALLOWED_ROOTS[0]`) with **no** TCC pruning. It searches with a bundled `rg` binary **and** an `os.walk` Python fallback — two separately-signed binaries, each descending **into** `~/Pictures` and `~/Music`. You only hit the *media-library* prompts by descending into those folders (their `.photoslibrary` / media bundles), and macOS charges consent per binary — hence "twice for each folder." The dashboard indexers were already hardened in #1073; `?project=$HOME` file-search is deliberate-and-tested; depth-1 folder browsing never opens the libraries. This app was the remaining unpruned recursive `$HOME` walker.
- **Change:** extend the existing `platform_compat.tcc_protected_dirs_for_walk` invariant to **both** search engines. When the search root is exactly `$HOME`, drop the gated top-level folders — via an anchored `!/<name>` glob for `rg`, and a top-level `dirnames` prune for the `os.walk` fallback, kept in lockstep so both engines return the same results. Gated on `root == $HOME` and top-level only, so a nested project's `Music/` and an **explicit** search rooted *at* a gated folder (`root != $HOME`) are still searched in full — consistent with #1073's "prune incidental recursion, never explicit navigation" contract.

Note: `rg` cannot express the `~/Library` cloud-mount allowlist (`platform_compat.tcc_prune_walk_dirs`) without flipping its whole glob set into allowlist mode, so only the six top-level gated folders (which include the reported Photos/Music) are excluded here; the `~/Library` refinement stays with the dashboard `os.walk` sites.

## Tests

`test/test_file_explorer_app.py::TestSearchTccPruning` (5 new tests):
- `_search_python` prunes `Pictures`/`Music`/`Downloads` at a `$HOME` root, keeps a non-gated top-level dir.
- `_search_python` still searches a gated folder when it is the explicit root (`root != $HOME`).
- `_search_python` is a no-op off macOS.
- `_search_rg` emits the anchored `!/Pictures` / `!/Music` globs at a `$HOME` root, and omits them for a scoped root.

Full affected-suite run (`test_file_explorer_app.py`, `test_tcc_protected_dirs.py`, `test_file_search.py`): **113 passed, 1 skipped** — the deliberate `test_explicit_home_as_project_is_not_pruned` still passes (no behavior change to file-search).

## Manual verification

N/A for automated CI — the TCC dialog only fires in a signed macOS app bundle. Verified by unit tests that the gated folders are excluded from the search walk / rg argv at a `$HOME` root and preserved for explicit navigation.

## Screenshots

N/A — backend-only change, no user-visible UI.
