### PR TITLE
feat(pod): macOS support via a launchd backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,8 @@ jobs:
             test/test_mcp_gateway_*.py \
             test/test_socketsec.py \
             test/test_platform_compat.py \
-            test/test_mcp_apps_e2e.py
+            test/test_mcp_apps_e2e.py \
+            test/test_pod*.py
 
   # Runs the tests the sharded matrix deselects. They need unprivileged user
   # namespaces (unshare NEWNS), which ubuntu-24.04 restricts via AppArmor --

--- a/src/kiro_crew/apps/builtins/dev_fleet/app.json
+++ b/src/kiro_crew/apps/builtins/dev_fleet/app.json
@@ -12,7 +12,7 @@
     "'Prune merged' refuses to delete a worktree with uncommitted or untracked work rather than discarding it",
     "Stream pod logs and mint pod access tokens from the UI",
     "Built for people developing KiroCrew itself — not needed for everyday use",
-    "Pods and Make Live need Linux systemd --user; the fleet view, PR status, sync, rebase and prune work on any platform"
+    "Pods run on Linux (systemd --user) and macOS (launchd) \u2014 but the macOS pod has no enforced memory/CPU ceiling; Make Live is still Linux-only; the fleet view, PR status, sync, rebase and prune work on any platform"
   ],
   "defaultEnabled": false,
   "platform": {

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -224,19 +224,30 @@ try:
     from kiro_crew.pod.config import PodConfig
 
     _POD_IMPORTED = True
-    # Pods are systemd --user units — they can only exist on Linux with
-    # systemctl present. On other platforms skip pod-state checks entirely
-    # instead of failing closed on every removal.
+    # Pods are per-user service-manager units: systemd --user on Linux, launchd
+    # user agents on macOS. On a platform with neither, skip pod-state checks
+    # entirely instead of failing closed on every removal.
+    #
+    # NOTE this gate is about PODS only. Make-live (repointing the LIVE gateway's
+    # unit) is a separate feature with its own Linux-only gates further down —
+    # macOS support for pods deliberately does not imply macOS make-live.
     if sys.platform == "linux" and shutil.which("systemctl"):
         _POD_AVAILABLE = True
-    elif sys.platform != "linux":
+    elif sys.platform == "darwin" and shutil.which("launchctl"):
+        _POD_AVAILABLE = True
+    elif sys.platform == "darwin":
         _POD_ERROR = (
-            f"Pods are Linux systemd --user units; this host is {sys.platform}. "
-            "Preview a worktree with ./dev-backend.sh instead."
+            "Pods are launchd user agents on macOS, but no `launchctl` was found "
+            "on PATH."
+        )
+    elif sys.platform == "linux":
+        _POD_ERROR = (
+            "Pods require `systemctl --user`, but no `systemctl` was found on PATH."
         )
     else:
         _POD_ERROR = (
-            "Pods require `systemctl --user`, but no `systemctl` was found on PATH."
+            f"Pods need systemd --user (Linux) or launchd (macOS); this host is "
+            f"{sys.platform}. Preview a worktree with ./dev-backend.sh instead."
         )
 except ImportError as exc:
     _POD_ERROR = f"the pod subsystem could not be imported: {exc}"

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -57,8 +57,22 @@ Other verbs: `ls` (list running pods) · `status <wt>` · `token <wt>` · `url <
 
 **Isolation guarantees** (enforced by the pod runtime):
 own `KIROCREW_HOME`, own port, **no tunnel** (can't grab the real Slack identity),
-`--no-crons`, cgroup `MemoryMax=4G`/`CPUQuota=200%`, and cleanup on stop.
+`--no-crons`, and cleanup on stop.
 A pod can **never** collide with the live gateway and many can run at once.
+
+**Resource ceilings are Linux-only.** On Linux the unit sets cgroup
+`MemoryMax=4G` / `CPUQuota=200%`, which the kernel enforces. **On macOS there is
+no such ceiling and none is emitted** — macOS has no cgroups, and nothing it does
+offer bounds the total memory of a *process tree* or hard-caps CPU (`RLIMIT_AS`
+covers one process's address space, not resident memory, and the gateway spawns
+agent subprocesses that each get their own limit). So on a Mac a runaway pod can
+starve the machine; every other isolation property above still holds.
+
+**Teardown differs too.** Linux reaps the pod's isolated HOME from the unit's
+`ExecStopPost`, so it happens whatever stopped the service. launchd has no
+post-stop hook, so `pod down` does it — meaning a pod killed without an explicit
+`down` (host crash, force-reboot) leaves its HOME behind on macOS. `pod ls` reports those
+(reclaim each with `pod down <name>`).
 
 ## Bundled suite (quick path)
 

--- a/src/kiro_crew/pod/__init__.py
+++ b/src/kiro_crew/pod/__init__.py
@@ -26,10 +26,22 @@ The user-facing surface is ``kirocrew pod <verb>`` (see :mod:`kiro_crew.pod.cli`
 
 A friendly worktree *name* is resolved to a checkout path git-natively (see
 :func:`kiro_crew.pod.runtime.resolve_checkout`) and pinned so the systemd-booted
-gateway never re-resolves. Mechanism (Linux ``systemd --user``): a template unit
-``kirocrew-pod@<wt>.service`` whose ``ExecStart`` re-enters ``kirocrew pod _run <wt>``
-(boots the worktree's own gateway) and whose ``ExecStopPost`` ``rm -rf``'s the pod's
-isolated HOME. Nothing is shipped outside this Python package.
+gateway never re-resolves. Mechanism, per platform:
+
+* **Linux (``systemd --user``)**: one template unit ``kirocrew-pod@<wt>.service``
+  whose ``ExecStart`` re-enters ``kirocrew pod _run <wt>`` (boots the worktree's own
+  gateway) and whose ``ExecStopPost`` ``rm -rf``'s the pod's isolated HOME. cgroup
+  ``MemoryMax``/``CPUQuota`` cap the pod.
+* **macOS (``launchd``)**: one agent plist per pod under the pod plane's own directory (not
+  ``~/Library/LaunchAgents`` — that would auto-resurrect pods at login)
+  (launchd has no template units), bootstrapped into ``gui/<uid>``. Two capabilities
+  have no equivalent: there is no post-stop hook, so ``pod down`` performs the HOME
+  teardown and ``pod ls`` reports HOMEs left by a crash (reclaimed via ``pod down <name>``); and there are no
+  cgroups, so **the resource ceiling is not enforced** — see
+  :mod:`kiro_crew.pod.launchd` for why a weaker key is deliberately not emitted in
+  its place. Logs go to files instead of the journal.
+
+Nothing is shipped outside this Python package.
 """
 
 from __future__ import annotations

--- a/src/kiro_crew/pod/cli.py
+++ b/src/kiro_crew/pod/cli.py
@@ -15,9 +15,9 @@ import time
 from pathlib import Path
 from typing import Callable, NoReturn
 
+from kiro_crew.pod import launchd
 from kiro_crew.pod import provision as prov
 from kiro_crew.pod import runtime as rt
-from kiro_crew.pod import unit as unit_mod
 from kiro_crew.pod.config import PodConfig
 from kiro_crew.sel import sel
 
@@ -110,45 +110,48 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
     # Pin the resolved checkout BEFORE starting the unit so the systemd-booted
     # gateway (and any Restart= re-exec) resolves it without shelling git from a
     # clean environment. SEED (if any) is merged in without clobbering the pin.
-    rt.pin_checkout(cfg, name, checkout)
-    if args.seed:
-        rt.write_env_file(cfg, name, {"SEED": args.seed})
+    # The whole pin -> start transaction holds the per-name mutex (no-op on
+    # Linux): without it, a concurrent `down` finishing its sweep after our pin
+    # would delete the pin we just wrote and this pod would crash-loop on boot.
+    with rt.pod_name_mutex(cfg, name):
+        rt.pin_checkout(cfg, name, checkout)
+        if args.seed:
+            rt.write_env_file(cfg, name, {"SEED": args.seed})
 
-    if not rt.is_active(cfg, name):
-        # Self-heal a dangling ExecStart binary: the unit bakes an absolute
-        # kirocrew path at install time; if the worktree it resolved into was
-        # pruned since, every start fails EXEC (203). Re-render with a
-        # currently-valid binary and reload before starting.
-        if not unit_mod.unit_exec_ok(cfg):
-            unit_mod.install_unit(cfg)
-            rel = rt.systemctl("daemon-reload")
-            if rel.returncode != 0:
-                _die(f"unit self-heal daemon-reload failed: {(rel.stderr or '').strip()}")
-            _audit("pod.up", "allowed", f"name={name}", error="unit ExecStart healed")
-        cp = rt.systemctl("start", rt.pod_unit(cfg, name))
-        if cp.returncode != 0:
-            _audit("pod.up", "failure", f"name={name} port={port}", error="systemctl start failed")
-            _die(f"systemctl start failed for {name}: {cp.stderr.strip()}")
-    _audit("pod.up", "allowed", f"name={name} port={port}")
+        if not rt.is_active(cfg, name):
+            cp = rt.start_pod(cfg, name)
+            if cp.returncode != 0:
+                _audit(
+                    "pod.up", "failure", f"name={name} port={port}", error="backend start failed"
+                )
+                _die(f"starting pod {name} failed: {(cp.stderr or '').strip()}")
+        _audit("pod.up", "allowed", f"name={name} port={port}")
 
-    code = _wait_healthy(cfg, name, port)
-    if code not in (200, 401, 403):
-        # A pod IS the worktree's own gateway. If it won't boot, that's a broken
-        # worktree build (bad import / config / unbuilt dist) — NOT a pod-tooling
-        # fault. Surface the gateway's own journal so the dev fixes the real cause,
-        # and stop the half-started unit so we don't leak a crash-looping service.
-        tail = rt.recent_journal(cfg, name, 30)
-        print(tail, file=sys.stderr)
-        rt.systemctl("stop", rt.pod_unit(cfg, name))
-        if code == -1:
+        code = _wait_healthy(cfg, name, port)
+        if code not in (200, 401, 403):
+            # A pod IS the worktree's own gateway. If it won't boot, that's a broken
+            # worktree build (bad import / config / unbuilt dist) — NOT a pod-tooling
+            # fault. Surface the gateway's own journal so the dev fixes the real cause,
+            # and stop the half-started unit so we don't leak a crash-looping service.
+            #
+            # This failure cleanup runs INSIDE the same mutex hold as our start:
+            # released between the two, a down + replacement up could interleave
+            # during the health wait, and this stop_pod would then unload and
+            # erase the REPLACEMENT pod (verifier-found High). Holding the lock
+            # across the whole boot transaction means the pod we stop here can
+            # only be the one we started.
+            tail = rt.recent_journal(cfg, name, 30)
+            print(tail, file=sys.stderr)
+            rt.stop_pod(cfg, name)
+            if code == -1:
+                _die(
+                    f"{name}: the worktree's gateway failed to start (see journal above). "
+                    f"This is the worktree build, not pod — fix it, then `kirocrew pod up {name}` again."
+                )
             _die(
-                f"{name}: the worktree's gateway failed to start (see journal above). "
-                f"This is the worktree build, not pod — fix it, then `kirocrew pod up {name}` again."
+                f"{name}: gateway never became healthy on :{port} within timeout "
+                f"(see journal above; check the worktree's gateway start path)."
             )
-        _die(
-            f"{name}: gateway never became healthy on :{port} within timeout "
-            f"(see journal above; check the worktree's gateway start path)."
-        )
 
     try:
         token = rt.mint_token(cfg, name, args.ttl)
@@ -181,16 +184,35 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
 def _down(cfg: PodConfig, args: argparse.Namespace) -> None:
     name = rt.validate_name(args.name)
     was_up = rt.is_active(cfg, name)
-    cp = rt.systemctl("stop", rt.pod_unit(cfg, name))
-    # If it was running but stop failed, the pod may still be live — don't claim
-    # success or delete the env file (mirrors the rc checks in _up / _install).
-    if was_up and cp.returncode != 0:
-        _audit("pod.down", "failure", f"name={name}", error=f"stop rc={cp.returncode}")
-        _die(f"systemctl stop failed for {name}: {(cp.stderr or '').strip()}")
-    # Clear the pinned CHECKOUT= / SEED= so the next `up` re-resolves cleanly.
-    env_file = cfg.env_file(name)
-    if env_file.exists():
-        env_file.unlink()
+    # The stop and the env-file removal move together under the per-name mutex
+    # (no-op on Linux): unlinking the env file after releasing the lock let a
+    # concurrent `up` — which pins its checkout under the same mutex — have its
+    # fresh pin deleted by this stale teardown.
+    with rt.pod_name_mutex(cfg, name):
+        cp = rt.stop_pod(cfg, name)
+        # A nonzero stop means the pod may still be live — don't claim success or
+        # delete the env file. On macOS this must hold even when was_up is False:
+        # a loaded-but-dead agent has no pid (is_active False) yet still needs its
+        # unload CONFIRMED; swallowing the failure deleted the metadata while
+        # leaving the service, plist and HOME behind. An absent service is rc 0 on
+        # both backends, so this cannot fire for plain "was not running".
+        if cp.returncode != 0 and (was_up or rt.IS_MACOS):
+            _audit("pod.down", "failure", f"name={name}", error=f"stop rc={cp.returncode}")
+            _die(f"stopping pod {name} failed: {(cp.stderr or '').strip()}")
+        if rt.RECLAIMED_MARKER in (cp.stdout or ""):
+            # Defense-in-depth for writers that bypass the mutex: a new pod
+            # claimed this name mid-teardown. The old pod is gone, but the env
+            # file now pins the NEW pod's checkout — leave it alone.
+            _audit("pod.down", "allowed", f"name={name} was_up={was_up} reclaimed=1")
+            print(
+                f"pod '{name}' stopped — the name was immediately reclaimed by a new "
+                "pod, whose state was left untouched"
+            )
+            return
+        # Clear the pinned CHECKOUT= / SEED= so the next `up` re-resolves cleanly.
+        env_file = cfg.env_file(name)
+        if env_file.exists():
+            env_file.unlink()
     _audit("pod.down", "allowed", f"name={name} was_up={was_up}")
     if was_up:
         print(f"pod '{name}' stopped — isolated HOME nuked (zero residue), live plane untouched")
@@ -200,6 +222,10 @@ def _down(cfg: PodConfig, args: argparse.Namespace) -> None:
 
 def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
     names = sorted(rt.active_names(cfg))
+    # macOS only: launchd has no ExecStopPost, so a pod killed without an
+    # explicit `down` leaves its isolated HOME behind. Surface those here —
+    # the docs promise `ls`/`down` make them visible — but keep the JSON array
+    # shape unchanged (three callers parse it); orphans are human-output only.
     if args.json:
         rows = [
             {"name": n, "port": rt.derive_port(cfg, n), "health": rt.health(rt.derive_port(cfg, n))}
@@ -207,13 +233,36 @@ def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
         ]
         print(json.dumps(rows))
         return
+    orphans: list[str] = []
+    if rt.IS_MACOS:
+        try:
+            orphans = launchd.orphan_homes(cfg)
+        except launchd.LaunchdError as exc:
+            # Same translation the runtime seam does: the dispatch layer's
+            # documented contract is PodError -> one-line `pod: <msg>` + exit 1,
+            # not a traceback from the fail-closed probe underneath.
+            raise rt.PodError(str(exc)) from exc
     if not names:
         print("no pods running")
+        _print_orphans(cfg, orphans)
         return
     print(f"{'POD':<28} {'PORT':<7} HEALTH")
     for n in names:
         p = rt.derive_port(cfg, n)
         print(f"{n:<28} {p:<7} {rt.health(p)}")
+    _print_orphans(cfg, orphans)
+
+
+def _print_orphans(cfg: PodConfig, orphans: list[str]) -> None:
+    """Human-readable orphan-HOME report (macOS only; empty elsewhere)."""
+    if not orphans:
+        return
+    print(
+        f"\n{len(orphans)} orphaned pod HOME(s) — left by a pod that died without "
+        "an explicit `down` (launchd has no post-stop hook):"
+    )
+    for n in orphans:
+        print(f"  {n:<26} reclaim: kirocrew pod down {n}")
 
 
 def _status(cfg: PodConfig, args: argparse.Namespace) -> None:
@@ -268,9 +317,14 @@ def _exec(cfg: PodConfig, args: argparse.Namespace) -> None:
 
 def _logs(cfg: PodConfig, args: argparse.Namespace) -> None:
     name = rt.validate_name(args.name)
-    # Gate before exec'ing journalctl — off-Linux this would raise a bare
-    # FileNotFoundError instead of the documented one-line refusal.
-    rt.require_systemd()
+    # Gate before exec'ing the log mechanism — on an unsupported host this would
+    # otherwise raise a bare FileNotFoundError instead of the documented refusal.
+    rt.require_backend()
+    if rt.IS_MACOS:
+        # launchd has no journal; the plist routes stdout/stderr to files and
+        # recent_journal tails them.
+        print(rt.recent_journal(cfg, name, args.lines))
+        return
     subprocess.run(
         ["journalctl", "--user", "-u", rt.pod_unit(cfg, name), "-n", str(args.lines), "--no-pager"],
         env=rt._systemctl_env(),
@@ -278,21 +332,24 @@ def _logs(cfg: PodConfig, args: argparse.Namespace) -> None:
 
 
 def _install(cfg: PodConfig, args: argparse.Namespace) -> None:
-    # Writing the systemd unit (which defines how pods boot + what they exec) and
-    # reloading the daemon is a security-relevant system modification → audit it.
-    # Gate FIRST: install_unit() writes to ~/.config/systemd/user, so without
-    # this an off-Linux run leaves an unusable unit file behind before failing.
-    rt.require_systemd()
-    dst = unit_mod.install_unit(cfg)
-    print(f"installed pod template unit → {dst}")
-    cp = rt.systemctl("daemon-reload")
-    if cp.returncode != 0:
+    # Writing the service definition (which defines how pods boot + what they
+    # exec) is a security-relevant system modification → audit it. The gate is
+    # inside install_backend, before anything is written.
+    try:
+        msg, reload_cp = rt.install_backend(cfg)
+    except rt.PodError as exc:
+        # Re-raise: the CLI dispatch layer turns PodError into the documented
+        # one-line refusal, and swallowing it would hand an unsupported host a
+        # SystemExit instead. The gate runs before anything is written.
+        _audit("pod.install", "failure", "", error=str(exc)[:120])
+        raise
+    if reload_cp is not None and reload_cp.returncode != 0:
         # The unit isn't loadable without a successful reload — fail fast rather
         # than telling the user it's "ready" (consistent with _up / _down).
-        _audit("pod.install", "failure", f"dst={dst}", error="daemon-reload failed")
-        _die(f"systemctl --user daemon-reload failed: {(cp.stderr or '').strip()}")
-    _audit("pod.install", "allowed", f"dst={dst}")
-    print("systemctl --user daemon-reload OK")
+        _audit("pod.install", "failure", msg.splitlines()[0][:120], error="daemon-reload failed")
+        _die(f"systemctl --user daemon-reload failed: {(reload_cp.stderr or '').strip()}")
+    _audit("pod.install", "allowed", msg.splitlines()[0][:120])
+    print(msg)
     print("ready. Next: kirocrew pod up <worktree>")
 
 
@@ -304,7 +361,10 @@ def _provision(cfg: PodConfig, args: argparse.Namespace) -> None:
     if not prov.provision(checkout, build=build):
         _die(f"provisioning {name!r} failed (see output above)")
     # Pin so a subsequent `up` (and the systemd boot) resolves the same checkout.
-    rt.pin_checkout(cfg, name, checkout)
+    # Under the per-name mutex: unlocked, a concurrent `down` finishing its
+    # teardown could unlink this fresh pin (verifier finding).
+    with rt.pod_name_mutex(cfg, name):
+        rt.pin_checkout(cfg, name, checkout)
 
 
 def _run_internal(cfg: PodConfig, args: argparse.Namespace) -> None:

--- a/src/kiro_crew/pod/config.py
+++ b/src/kiro_crew/pod/config.py
@@ -42,6 +42,50 @@ def _env_int(key: str, default: int) -> int:
     return default
 
 
+def environment_vars(cfg: PodConfig) -> dict[str, str]:
+    """The pod-plane env a service-manager-booted gateway must be given.
+
+    A booted pod starts with a clean environment, so the plane the CLI resolved
+    has to be pinned into the service definition or the gateway would resolve a
+    DIFFERENT ``PodConfig`` than the CLI that started it. Only values that differ
+    from the built-in default are emitted (plus ``KIROCREW_POD_PATH``, always
+    pinned), so an all-defaults plane yields ``{}``.
+
+    This is the *selection*, deliberately separated from the *serialisation*: the
+    systemd backend renders these as ``Environment=K=V`` lines, the launchd
+    backend hands the same dict to the plist's ``EnvironmentVariables`` key.
+    Keeping one source of truth is what stops the two backends drifting into
+    booting pods with different planes.
+    """
+    home = Path.home()
+    candidates: list[tuple[str, str, str | None]] = [
+        ("KIROCREW_POD_ROOT", str(cfg.pod_root), str(home / ".kirocrew-pods")),
+        ("KIROCREW_POD_ENV_DIR", str(cfg.pods_dir), str(_default_home() / "pods")),
+        (
+            "KIROCREW_POD_ARTIFACTS_DIR",
+            str(cfg.artifacts_dir),
+            str(cfg.pod_root / ".e2e-artifacts"),
+        ),
+        ("KIROCREW_POD_BASE_PORT", str(cfg.base_port), str(DEFAULT_BASE_PORT)),
+        ("KIROCREW_POD_LIVE_PORT", str(cfg.live_port), str(DEFAULT_LIVE_PORT)),
+        ("KIROCREW_POD_UNIT_PREFIX", cfg.unit_prefix, DEFAULT_UNIT_PREFIX),
+        ("KIROCREW_POD_PATH", cfg.gateway_path, None),  # always pin PATH
+    ]
+    out = {
+        key: val
+        for key, val, default in candidates
+        if default is None or val != default
+    }
+    # Optional resolvers — pinned only when set. boot() normally reads the pinned
+    # CHECKOUT= from the per-pod env file directly, so these are belt-and-braces
+    # so a booted service can still resolve the same repo/root the CLI used.
+    if cfg.repo_hint is not None:
+        out["KIROCREW_POD_REPO"] = str(cfg.repo_hint)
+    if cfg.worktrees_root is not None:
+        out["KIROCREW_POD_WORKTREES_ROOT"] = str(cfg.worktrees_root)
+    return out
+
+
 @dataclass(frozen=True)
 class PodConfig:
     """Resolved, immutable view of where pods live and how they are named.

--- a/src/kiro_crew/pod/launchd.py
+++ b/src/kiro_crew/pod/launchd.py
@@ -1,0 +1,479 @@
+"""macOS ``launchd`` backend for pods — the darwin twin of :mod:`kiro_crew.pod.unit`.
+
+The pod runtime's platform-neutral core (name validation, port derivation,
+checkout resolution and pinning, env scrubbing, token minting, ``boot``, and the
+``cleanup_home`` teardown safety check) is reused unchanged. Only the
+service-manager mechanics differ, and they differ in four ways that are worth
+knowing before reading the code:
+
+**1. No template units.** systemd installs ONE template
+(``kirocrew-pod@.service``) and instantiates it per pod via ``%i``. launchd has
+no such concept, so each pod gets its own plist under the pod plane's own directory
+(``cfg.pods_dir/dev.kirocrew.pod.<name>.plist`` — deliberately NOT
+``~/Library/LaunchAgents``, which launchd loads at login and would resurrect
+pods after a reboot; see :func:`plist_path`), written fresh on every
+``up``. That is strictly better in one respect: the systemd unit bakes an
+absolute ``kirocrew`` path at *install* time, which goes stale when the worktree
+it points into is pruned (``unit_exec_ok``'s self-heal exists for exactly that);
+re-rendering per ``up`` cannot go stale.
+
+**2. No ``ExecStopPost``.** systemd guarantees zero-residue teardown by running
+``kirocrew pod _cleanup <name>`` after the service stops, whatever stopped it.
+launchd has no post-stop hook, so the ``down`` path must invoke
+``runtime.cleanup_home`` itself after ``bootout`` succeeds. The consequence is
+real and documented rather than hidden: a pod whose process dies without an
+explicit ``down`` (host crash, force-reboot) leaves its isolated HOME behind on
+macOS where Linux would have reaped it. :func:`orphan_homes` exists so ``pod ls`` can REPORT those
+(reclaim is `pod down <name>`, run by the user — nothing deletes them
+automatically).
+
+**3. No journal.** ``journalctl --user -u <unit>`` has no launchd equivalent, so
+the plist routes stdout/stderr to files under the pod artifacts dir and the log
+verb tails them. This is a second mechanism, not a variation on unit management.
+
+**4. No cgroups — the resource ceiling is NOT enforced on macOS.** The systemd
+unit sets ``MemoryMax=4G`` and ``CPUQuota=200%``: kernel-enforced cgroup ceilings
+that the pod documentation advertises as an isolation *guarantee*. macOS has no
+cgroups and **no mechanism that bounds the total memory of a process tree or hard
+-caps its CPU**. The options were to emit a weaker, non-equivalent bound and risk
+it being read as the guarantee, or to state plainly that the ceiling is absent.
+This backend does the latter: it emits **no** resource keys at all. Do not
+"improve" this by adding ``SoftResourceLimits``/``HardResourceLimits`` and
+calling it the 4G cap — ``RLIMIT_AS`` bounds one process's *virtual address
+space*, not resident memory and not the subprocess tree, and the gateway spawns
+agent subprocesses that each get their own limit, so the total stays unbounded.
+(``ProcessType=Background`` would add scheduling de-prioritisation — real but
+still not a ceiling. It is deliberately not set here; it is a knob a future
+change could add *as* de-prioritisation, never as the cap.)
+
+Every other isolation property is unchanged on macOS: own ``KIROCREW_HOME``, own
+derived port, no tunnel, ``--no-crons``, and the refusal to bind the live port.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import plistlib
+import re
+import shlex
+import shutil
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+try:  # POSIX only; the backend refuses to run where launchd is absent anyway
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+from kiro_crew.pod.config import PodConfig, environment_vars
+from kiro_crew.pod.unit import _kirocrew_bin
+
+# Reverse-DNS label namespace. One label per pod; the name has already been
+# through runtime.validate_name (single safe segment, no '/', no '..'), which is
+# what makes it legal to splice into a label and a filename.
+LABEL_PREFIX = "dev.kirocrew.pod"
+
+# `launchctl print` on a label that is not loaded fails with this message (and
+# rc 113 on current macOS). An OPERATIONAL print failure — permissions, a
+# transient daemon error — is also nonzero but does NOT mean the service is
+# gone, and confusing the two would let teardown delete a live pod's state.
+_ABSENT_MARKERS = ("could not find service", "no such process")
+
+
+def _service_absent(cp: subprocess.CompletedProcess) -> bool:
+    """True only for the explicit not-loaded result, not any print failure."""
+    if cp.returncode == 0:
+        return False
+    text = f"{cp.stdout or ''}\n{cp.stderr or ''}".lower()
+    return any(m in text for m in _ABSENT_MARKERS)
+
+
+# `launchctl print` fields we parse. Deliberately narrow: launchctl's output
+# is an unstable, human-oriented dump, so we read only the facts the runtime
+# actually asks for.
+_PID_RE = re.compile(r"^\s*pid\s*=\s*(\d+)\s*$", re.MULTILINE)
+_LAST_EXIT_RE = re.compile(r"^\s*last exit (?:code|status)\s*=\s*(-?\d+)\s*$", re.MULTILINE)
+_STATE_RE = re.compile(r"^\s*state\s*=\s*(\S+)\s*$", re.MULTILINE)
+
+
+class LaunchdError(RuntimeError):
+    """launchd is not usable on this host."""
+
+
+def require_backend() -> None:
+    """Fail loudly and early when launchd cannot be driven.
+
+    The systemd gate has three stages (Linux, systemctl on PATH, a session bus).
+    launchd needs only the binary: the ``gui/<uid>`` domain is addressed directly,
+    so there is no D-Bus/XDG equivalent to probe and no ``loginctl enable-linger``
+    remedy to explain.
+    """
+    if shutil.which("launchctl") is None:
+        raise LaunchdError(
+            "pods need `launchctl`, which was not found on PATH. This host looks "
+            "like macOS but is missing launchd; run `kirocrew pod` from a normal "
+            "user session."
+        )
+
+
+def domain() -> str:
+    """The launchd domain a per-user agent lives in.
+
+    ``os.getuid`` does not exist on Windows; pods there are refused by
+    ``require_backend`` long before this is called, but the module must stay
+    importable (the test suite imports it on every platform), so mirror the
+    ``getattr`` guard runtime.py uses for the same reason.
+    """
+    uid = getattr(os, "getuid", lambda: -1)()
+    return f"gui/{uid}"
+
+
+def pod_label(cfg: PodConfig, name: str) -> str:
+    """Label for pod *name*. Replaces systemd's ``<prefix>@<name>.service``.
+
+    ``cfg.unit_prefix`` is honoured so a hermetic test plane
+    (``KIROCREW_POD_UNIT_PREFIX``) cannot collide with a developer's real pods,
+    exactly as it cannot on systemd.
+    """
+    # EVERY plane carries its prefix segment — including the default one.
+    # Omitting it for the default made "dev.kirocrew.pod." a strict prefix of
+    # every custom plane's labels, so a hermetic plane's pods surfaced in the
+    # default plane's `active_names` as bogus "<prefix>.<pod>" rows.
+    return f"{LABEL_PREFIX}.{cfg.unit_prefix}.{name}"
+
+
+def service_target(cfg: PodConfig, name: str) -> str:
+    """``gui/<uid>/<label>`` — what the modern launchctl verbs address."""
+    return f"{domain()}/{pod_label(cfg, name)}"
+
+
+def plist_path(cfg: PodConfig, name: str) -> Path:
+    """Where this pod's agent definition lives — deliberately NOT
+    ``~/Library/LaunchAgents``.
+
+    launchd loads everything in ``LaunchAgents`` at login, so a plist there with
+    ``RunAtLoad`` would resurrect a pod after a reboot — as a login item, with no
+    resource ceiling. The systemd path has the opposite semantics on purpose:
+    pods are started transiently (``systemctl start``, never ``enable``) and stay
+    down after a reboot. ``launchctl bootstrap`` accepts a plist at any path, so
+    keeping it under the pod plane's own directory preserves that transience:
+    the agent exists only for the session that bootstrapped it.
+    """
+    return cfg.pods_dir / f"{pod_label(cfg, name)}.plist"
+
+
+_MUTEX_STATE = threading.local()
+
+
+@contextlib.contextmanager
+def pod_mutex(cfg: PodConfig, name: str):
+    """Serialize this pod's lifecycle transactions per name.
+
+    ``down`` and ``up`` are independent entry points (CLI and Dev Fleet, which
+    shells out to the CLI) with no other per-name coordination. Without a mutex,
+    a stop that has just confirmed the label absent races a concurrent start:
+    the start writes its checkout pin and a fresh plist, and the stop's sweep
+    then deletes the NEW pod's definition, HOME, or env file — each a
+    review-blocking data-loss bug in earlier rounds. An exclusive flock on a
+    sibling lock file makes the whole transaction (pin + plist + bootstrap on
+    the up side; bootout + confirmation + HOME sweep + env unlink on the down
+    side) atomic with respect to the same name.
+
+    **Reentrant within a thread** so the CLI can hold it across a transaction
+    while ``runtime.start_pod``/``stop_pod`` re-acquire it internally (their own
+    protection for direct callers): flock is per open-file-description, so a
+    naive second acquisition in the same thread would deadlock against itself.
+
+    Advisory and cooperative by design: every mutating path routes through
+    here. On platforms without ``fcntl`` the mutex degrades to a no-op —
+    acceptable because launchd never runs there (:func:`require_backend`
+    refuses); only unit tests do. The lock file is deliberately never deleted:
+    unlinking a lock file another process may be opening reintroduces the race
+    the lock exists to close.
+    """
+    if fcntl is None:
+        yield
+        return
+    held = getattr(_MUTEX_STATE, "held", None)
+    if held is None:
+        held = _MUTEX_STATE.held = {}
+    key = pod_label(cfg, name)
+    if held.get(key, 0):
+        held[key] += 1
+        try:
+            yield
+        finally:
+            held[key] -= 1
+        return
+    cfg.pods_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = cfg.pods_dir / f"{key}.lock"
+    with open(lock_file, "w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        held[key] = 1
+        try:
+            yield
+        finally:
+            held[key] = 0
+            fcntl.flock(fh, fcntl.LOCK_UN)
+
+
+def log_paths(cfg: PodConfig, name: str) -> tuple[Path, Path]:
+    """stdout/stderr files that stand in for the journal."""
+    d = cfg.artifacts_dir / name
+    return d / "pod.out.log", d / "pod.err.log"
+
+
+def _kirocrew_argv() -> list[str]:
+    """``ProgramArguments`` needs a real argv, not systemd's command string.
+
+    ``unit._kirocrew_bin()`` may return ``"<python> -m kiro_crew"`` (two words)
+    when no console script is installed, so it is split rather than used as a
+    single path.
+    """
+    return shlex.split(_kirocrew_bin())
+
+
+def render_plist(cfg: PodConfig, name: str) -> dict[str, object]:
+    """The plist body for one pod. Returned as a dict so tests can assert on keys
+    rather than parsing XML."""
+    out_log, err_log = log_paths(cfg, name)
+    body: dict[str, object] = {
+        "Label": pod_label(cfg, name),
+        # Boot the isolated instance. The name is baked in (no %i equivalent);
+        # boot logic stays in Python (kiro_crew.pod.runtime.boot), so nothing
+        # shell-shaped is shipped, same as the systemd unit.
+        "ProgramArguments": [*_kirocrew_argv(), "pod", "_run", name],
+        # Start as soon as the agent is bootstrapped — the launchd analogue of
+        # Type=simple + WantedBy=default.target.
+        "RunAtLoad": True,
+        # Self-heal a crash but do not fight a deliberate `down`: launchd will
+        # restart only on a non-zero exit, so `bootout` stays authoritative.
+        "KeepAlive": {"SuccessfulExit": False},
+        # systemd's RestartSec=5. launchd's own default floor is 10s.
+        "ThrottleInterval": 5,
+        # No journal on macOS: own the files instead.
+        "StandardOutPath": str(out_log),
+        "StandardErrorPath": str(err_log),
+    }
+    env = environment_vars(cfg)
+    if env:
+        body["EnvironmentVariables"] = env
+    # NOTE: no MemoryMax/CPUQuota analogue is emitted. See the module docstring —
+    # macOS cannot enforce the cgroup ceiling and a weaker key here would read as
+    # if it could.
+    return body
+
+
+def write_plist(cfg: PodConfig, name: str) -> Path:
+    """Render and install this pod's agent definition. Returns the plist path."""
+    dst = plist_path(cfg, name)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    out_log, _ = log_paths(cfg, name)
+    out_log.parent.mkdir(parents=True, exist_ok=True)
+    with dst.open("wb") as fh:
+        plistlib.dump(render_plist(cfg, name), fh, fmt=plistlib.FMT_XML)
+    return dst
+
+
+def launchctl(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    """The single chokepoint for talking to launchd.
+
+    Mirrors ``runtime.systemctl``'s role so tests monkeypatch one seam. No
+    environment backfill is needed (systemd's ``XDG_RUNTIME_DIR`` /
+    ``DBUS_SESSION_BUS_ADDRESS`` plumbing has no launchd counterpart).
+    """
+    require_backend()
+    return subprocess.run(
+        ["launchctl", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=check,
+    )
+
+
+def start(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
+    """``bootstrap`` the freshly-written plist. No ``daemon-reload`` equivalent —
+    launchd reads the file at bootstrap time."""
+    return launchctl("bootstrap", domain(), str(plist_path(cfg, name)))
+
+
+def stop(cfg: PodConfig, name: str, *, timeout: float = 15.0) -> subprocess.CompletedProcess:
+    """``bootout`` the agent, wait for it to actually go, and drop its plist.
+
+    Two things here are not obvious and were both found by a real bring-up:
+
+    **``bootout`` is asynchronous.** It returns before launchd has finished
+    unloading, so immediately afterwards ``launchctl print`` still resolves the
+    label and the gateway process is still alive. Returning at that point makes
+    the caller reap the pod's HOME from under a live process — the removal then
+    fails silently (``cleanup_home`` uses ``ignore_errors``) while the CLI reports
+    zero residue. So poll until the label is really gone.
+
+    **A per-pod plist must not outlive its pod.** systemd's template unit is
+    machine-wide and deliberately persists; a launchd plist is per-pod, so leaving
+    it behind makes :func:`orphan_homes` classify the leftover HOME as "installed,
+    not orphaned" and never collect it, and leaves a stale definition that could be
+    bootstrapped later.
+
+    **The unload result must be authoritative.** If the label is STILL loaded
+    when the wait expires, this returns a synthetic failure and keeps the plist —
+    the caller must not tear down state (the HOME) belonging to a possibly-live
+    gateway. A ``bootout`` rc of 3 ("no such process") with the label absent is a
+    no-op, not a failure.
+
+    The caller still owns the HOME removal (see ``runtime.stop_pod``) because that
+    goes through ``cleanup_home``'s name re-validation.
+    """
+    cp = launchctl("bootout", service_target(cfg, name))
+    deadline = time.monotonic() + timeout
+    unloaded = False
+    while time.monotonic() < deadline:
+        probe = _print(cfg, name)
+        # Only the EXPLICIT not-loaded result confirms the unload. Any other
+        # nonzero print (permissions, transient daemon error) proves nothing —
+        # treating it as gone was itself a review-blocking bug: teardown would
+        # delete a possibly-live pod's state on a flaky probe.
+        if _service_absent(probe):
+            unloaded = True
+            break
+        time.sleep(0.2)
+    if not unloaded:
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout=cp.stdout or "",
+            stderr=(
+                f"launchd did not unload {pod_label(cfg, name)} within "
+                f"{timeout:.0f}s (bootout rc={cp.returncode}). The pod may still "
+                "be running; its HOME and plist were preserved."
+            ),
+        )
+    plist_path(cfg, name).unlink(missing_ok=True)
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=cp.stdout or "", stderr="")
+
+
+def restart(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
+    return launchctl("kickstart", "-k", service_target(cfg, name))
+
+
+def _print(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
+    return launchctl("print", service_target(cfg, name))
+
+
+def is_active(cfg: PodConfig, name: str) -> bool:
+    """Whether this pod has a live process.
+
+    ``launchctl print`` exits non-zero when the label is not loaded at all. A
+    loaded-but-dead agent still prints, so a live ``pid =`` line is what
+    distinguishes running from merely registered — the distinction systemd's
+    ``is-active --quiet`` makes for us.
+    """
+    cp = _print(cfg, name)
+    if cp.returncode != 0:
+        if _service_absent(cp):
+            return False
+        # An OPERATIONAL failure (permissions, transient daemon error) proves
+        # nothing. Reporting "not running" here fails OPEN: down/removal guards
+        # would see no pod and delete metadata or a live checkout. Refuse.
+        raise LaunchdError(
+            f"launchctl print failed (rc={cp.returncode}) for "
+            f"{pod_label(cfg, name)}; cannot tell whether the pod is running, "
+            f"refusing to report it absent: {(cp.stderr or cp.stdout or '').strip()}"
+        )
+    return _PID_RE.search(cp.stdout or "") is not None
+
+
+def unit_state(cfg: PodConfig, name: str) -> tuple[str, int]:
+    """``(state, restarts)`` shaped like the systemd backend's return.
+
+    launchd exposes no ``NRestarts``. Rather than report 0 and silently lose the
+    crash-loop signal the caller uses, a dead-but-loaded agent with a non-zero
+    last exit is reported as one restart — enough for ``_wait_healthy`` to stop
+    waiting on a pod that is failing to boot. The count is therefore a *signal*,
+    not a tally; do not present it to a user as a restart count.
+    """
+    cp = _print(cfg, name)
+    if cp.returncode != 0:
+        return "inactive", 0
+    text = cp.stdout or ""
+    if _PID_RE.search(text):
+        return "active", 0
+    m = _LAST_EXIT_RE.search(text)
+    if m and m.group(1) != "0":
+        return "failed", 1
+    state = _STATE_RE.search(text)
+    return (state.group(1) if state else "inactive"), 0
+
+
+def active_names(cfg: PodConfig) -> set[str]:
+    """Names of pods with a live process.
+
+    ``launchctl print <domain>`` dumps every label in the user domain; we filter
+    to our prefix and then confirm liveness per label, because the domain listing
+    includes loaded-but-dead agents that systemd's ``--state=active`` filter would
+    have excluded.
+    """
+    cp = launchctl("print", domain())
+    if cp.returncode != 0:
+        # Same fail-open hazard as is_active: an empty set on an operational
+        # error would tell callers (pod ls, Dev Fleet, orphan reporting) that
+        # nothing is running while pods may be live. Refuse instead.
+        raise LaunchdError(
+            f"launchctl print {domain()} failed (rc={cp.returncode}); cannot "
+            f"enumerate pods: {(cp.stderr or cp.stdout or '').strip()}"
+        )
+    prefix = pod_label(cfg, "")  # e.g. "dev.kirocrew.pod." (trailing dot kept)
+    names: set[str] = set()
+    for tok in re.findall(rf"{re.escape(prefix)}[A-Za-z0-9._-]+", cp.stdout or ""):
+        candidate = tok[len(prefix):]
+        if candidate and is_active(cfg, candidate):
+            names.add(candidate)
+    return names
+
+
+def recent_journal(cfg: PodConfig, name: str, lines: int = 50) -> str:
+    """The journal stand-in: the tail of this pod's own stderr/stdout files."""
+    out_log, err_log = log_paths(cfg, name)
+    chunks: list[str] = []
+    for path in (err_log, out_log):
+        try:
+            tail = path.read_text(errors="replace").splitlines()[-lines:]
+        except OSError:
+            continue
+        if tail:
+            chunks.append(f"== {path.name} ==\n" + "\n".join(tail))
+    if not chunks:
+        return (
+            f"no pod log yet at {err_log.parent} — launchd has no journal, so a pod "
+            "that never started writes nothing here."
+        )
+    return "\n\n".join(chunks)
+
+
+def orphan_homes(cfg: PodConfig) -> list[str]:
+    """Pod HOMEs left behind with no live pod and no installed plist.
+
+    Only reachable on macOS: with no ``ExecStopPost``, a pod killed without an
+    explicit ``down`` leaves its isolated HOME. Reported (not deleted) here so the
+    caller decides, and so deletion still goes through
+    ``runtime.cleanup_home``'s re-validation rather than a raw recursive remove.
+    """
+    try:
+        entries = [p for p in cfg.pod_root.iterdir() if p.is_dir()]
+    except OSError:
+        return []
+    live = active_names(cfg)
+    out = []
+    for p in entries:
+        if p.name.startswith("."):
+            continue
+        if p.name in live:
+            continue
+        if plist_path(cfg, p.name).exists():
+            continue
+        out.append(p.name)
+    return sorted(out)

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -9,6 +9,7 @@ layer. No state is held; each function reads what it needs from a
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -16,13 +17,16 @@ import shutil
 import stat
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
 
-from kiro_crew.platform_compat import IS_LINUX
+from kiro_crew.platform_compat import IS_LINUX, IS_MACOS
+from kiro_crew.pod import launchd
 from kiro_crew.pod import provision as prov
+from kiro_crew.pod import unit as unit_mod
 from kiro_crew.pod.config import PodConfig
 
 # Pod names become systemd instance names and path segments; keep them strict.
@@ -302,12 +306,36 @@ def require_systemd() -> None:
         )
 
 
+def require_backend() -> None:
+    """Gate on whatever service manager THIS host uses for pods.
+
+    Dispatches instead of replacing :func:`require_systemd`: that function is
+    still the systemd gate with its own contract and messages, so Linux and
+    Windows behaviour is provably unchanged by the macOS work — on any non-darwin
+    host this is exactly ``require_systemd()``.
+    """
+    if IS_MACOS:
+        try:
+            launchd.require_backend()
+        except launchd.LaunchdError as exc:  # translate to the pod error type
+            raise PodError(str(exc)) from exc
+        return
+    require_systemd()
+
+
 def systemctl(*args: str, timeout: int = 15) -> subprocess.CompletedProcess:
     require_systemd()
     return _run(["systemctl", "--user", *args], timeout=timeout)
 
 
 def is_active(cfg: PodConfig, name: str) -> bool:
+    if IS_MACOS:
+        try:
+            return launchd.is_active(cfg, name)
+        except launchd.LaunchdError as exc:
+            # Fail closed as the documented pod error, not a traceback: the
+            # probe REFUSES to call a pod absent when launchctl cannot answer.
+            raise PodError(str(exc)) from exc
     cp = systemctl("is-active", "--quiet", pod_unit(cfg, name))
     return cp.returncode == 0
 
@@ -319,7 +347,13 @@ def unit_state(cfg: PodConfig, name: str) -> tuple[str, int]:
     build, import error, bad config) apart from one that is just slow to come up —
     so we fail fast with the gateway's own error instead of polling a dead unit
     for the full timeout.
+
+    On macOS launchd exposes no restart counter; see
+    :func:`kiro_crew.pod.launchd.unit_state` for how the crash signal is
+    preserved without one.
     """
+    if IS_MACOS:
+        return launchd.unit_state(cfg, name)
     cp = systemctl("show", pod_unit(cfg, name), "-p", "ActiveState", "-p", "NRestarts")
     state, restarts = "unknown", 0
     for ln in cp.stdout.splitlines():
@@ -333,7 +367,13 @@ def unit_state(cfg: PodConfig, name: str) -> tuple[str, int]:
 
 
 def recent_journal(cfg: PodConfig, name: str, lines: int = 30) -> str:
-    """Tail the pod unit's journal — used to surface a boot failure's real cause."""
+    """Tail the pod's log — used to surface a boot failure's real cause.
+
+    launchd has no journal, so on macOS this tails the files the pod's plist
+    routes stdout/stderr to. Same contract, different mechanism.
+    """
+    if IS_MACOS:
+        return launchd.recent_journal(cfg, name, lines=lines)
     # journalctl is a sibling of systemctl, not routed through it — gate it too,
     # or this one call still raises a bare FileNotFoundError off-Linux.
     require_systemd()
@@ -349,6 +389,11 @@ def recent_journal(cfg: PodConfig, name: str, lines: int = 30) -> str:
 
 def active_names(cfg: PodConfig) -> set[str]:
     """Worktree names with an active pod unit (one cheap call)."""
+    if IS_MACOS:
+        try:
+            return launchd.active_names(cfg)
+        except launchd.LaunchdError as exc:
+            raise PodError(str(exc)) from exc
     pat = f"{cfg.unit_prefix}@*.service"
     cp = systemctl("list-units", pat, "--state=active", "--no-legend", "--plain", "--no-pager")
     rx = re.compile(rf"{re.escape(cfg.unit_prefix)}@(.+)\.service")
@@ -361,6 +406,156 @@ def active_names(cfg: PodConfig) -> set[str]:
         if m:
             names.add(m.group(1))
     return names
+
+
+# --------------------------------------------------------------------------- #
+# Sentinel in stop_pod's stdout meaning the pod NAME was reclaimed by a new pod
+# mid-teardown (down/up race). The old pod is gone, but per-name state (the env
+# file pinning CHECKOUT=) now belongs to the NEW pod and must not be deleted.
+RECLAIMED_MARKER = "pod-name-reclaimed-by-new-pod"
+
+
+# Backend-agnostic lifecycle. The CLI calls these so no verb has to know which
+# service manager it is talking to — and so the launchd-only teardown obligation
+# (below) cannot be forgotten at one call site and honoured at another.
+# --------------------------------------------------------------------------- #
+def pod_name_mutex(cfg: PodConfig, name: str):
+    """Per-name lifecycle mutex for callers composing multi-step transactions.
+
+    The CLI wraps `up` (pin -> plist -> bootstrap) and `down` (stop -> sweep ->
+    env unlink) in this so per-name METADATA moves atomically with the service
+    operations — the review-blocking down/up races all lived in those seams.
+    Reentrant with the acquisition inside start_pod/stop_pod. On Linux the unit
+    (ExecStopPost) owns teardown ordering, so this is a no-op there.
+    """
+    if IS_MACOS:
+        return launchd.pod_mutex(cfg, name)
+    return contextlib.nullcontext()
+
+
+def start_pod(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
+    """Bring pod *name* up through whichever service manager this host uses."""
+    if IS_MACOS:
+        # Re-rendered every start, which is why launchd needs no equivalent of
+        # the systemd path's stale-ExecStart self-heal. The mutex serializes
+        # against a concurrent stop of the same name, whose plist unlink and
+        # HOME sweep would otherwise race this write (see launchd.pod_mutex).
+        with launchd.pod_mutex(cfg, name):
+            launchd.write_plist(cfg, name)
+            return launchd.start(cfg, name)
+
+    # Self-heal a dangling ExecStart binary: the template unit bakes an absolute
+    # kirocrew path at install time; if the worktree it resolved into was pruned
+    # since, every start fails EXEC (203).
+    if not unit_mod.unit_exec_ok(cfg):
+        unit_mod.install_unit(cfg)
+        rel = systemctl("daemon-reload")
+        if rel.returncode != 0:
+            return rel
+    return systemctl("start", pod_unit(cfg, name))
+
+
+def stop_pod(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
+    """Stop pod *name* and guarantee its isolated HOME is gone.
+
+    On Linux the unit's ``ExecStopPost`` runs ``pod _cleanup``, so teardown
+    happens whatever stopped the service. launchd has **no post-stop hook**, so
+    the HOME removal is done here after a successful ``bootout`` — routed through
+    :func:`cleanup_home`, which re-validates the name, rather than a raw
+    recursive delete. Both paths therefore end with zero residue; only the macOS
+    one depends on this call being reached, which is why the crash case is
+    covered separately by ``launchd.orphan_homes()``.
+    """
+    if IS_MACOS:
+        # One mutex across bootout + confirmation + the HOME sweep: a
+        # concurrent `up` of the same name blocks until teardown fully
+        # finishes instead of interleaving with it (the plist-presence
+        # reclaim check below stays as defense-in-depth — the flock is
+        # advisory and only guards paths that route through it).
+        with launchd.pod_mutex(cfg, name):
+            # launchd.stop() is authoritative: rc 0 means the label is confirmed
+            # unloaded (a bootout of an unloaded label is a no-op success). A non-zero
+            # rc means the unload could NOT be confirmed — in that case do NOT touch
+            # the HOME: it may belong to a live gateway, and deleting it while
+            # returning success was exactly the blocking review finding here.
+            cp = launchd.stop(cfg, name)
+            if cp.returncode != 0:
+                return cp
+            # Reap with a short grace window. launchd confirms the SERVICE process is
+            # unloaded, but a dying child can outlive it by a beat and flush state on
+            # exit — observed in a real teardown: cleanup ran, verification passed,
+            # then a child wrote settings back and resurrected the HOME milliseconds
+            # later. Retry the reap a few times so a final write cannot win the race;
+            # if the directory still reappears after the window, someone is genuinely
+            # alive in there and we must say so, not shrug.
+            leftover = pod_home(cfg, name)
+            # Observe the FULL window — no early exit on a clean sample (the dying
+            # child that motivated this flushed state after a beat). But DO exit the
+            # moment the name is claimed by a NEW pod: `down` and `up` are
+            # independent Dev Fleet endpoints with no per-name lock, so a quick
+            # down→up would otherwise put the fresh gateway's HOME under the
+            # remaining rmtree passes. Our unload was already confirmed, and a new
+            # `up` re-writes the plist BEFORE bootstrapping — so plist presence is
+            # the claim marker. Deliberately a pure filesystem check: probing
+            # launchctl here would shell out on every sweep and break on hosts
+            # without launchd (the unit suites run this path on Linux/Windows CI).
+            #
+            # A reclaimed name is reported via RECLAIMED_MARKER in stdout so the
+            # caller knows the teardown handed over: it must NOT delete the per-pod
+            # env file, which now pins the NEW pod's checkout.
+            for _ in range(6):
+                if launchd.plist_path(cfg, name).exists():
+                    return subprocess.CompletedProcess(
+                        args=[], returncode=0, stdout=RECLAIMED_MARKER, stderr=""
+                    )
+                cleanup_home(cfg, name)
+                time.sleep(0.5)
+            if launchd.plist_path(cfg, name).exists():
+                return subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout=RECLAIMED_MARKER, stderr=""
+                )
+            cleanup_home(cfg, name)
+            if leftover.exists():
+                return subprocess.CompletedProcess(
+                    args=[],
+                    returncode=1,
+                    stdout=cp.stdout or "",
+                    stderr=(
+                        f"pod stopped but its isolated HOME keeps reappearing at "
+                        f"{leftover} — a process is still writing there, so teardown "
+                        "is incomplete. Remove it by hand and report this."
+                    ),
+                )
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=cp.stdout or "", stderr="")
+    return systemctl("stop", pod_unit(cfg, name))
+
+
+def install_backend(cfg: PodConfig) -> tuple[str, subprocess.CompletedProcess | None]:
+    """Install whatever machine-wide definition the backend needs.
+
+    systemd needs one template unit + a daemon-reload. launchd has no template
+    concept — each pod's plist is written at ``up`` — so there is nothing to
+    install, and saying so is better than writing a file that does nothing.
+
+    Returns ``(message, reload_result)``. Raises :class:`PodError` only for an
+    unusable host, and does so BEFORE writing anything, so an unsupported
+    platform never leaves a stray definition behind. A failed reload comes back
+    as the second element rather than an exception, because the caller reports
+    that as a hard exit while the gate refusal is converted by the CLI's
+    dispatch layer — two different documented behaviours.
+    """
+    require_backend()
+    if IS_MACOS:
+        return (
+            "nothing to install on macOS: launchd has no template units, so each "
+            "pod's agent plist is written at `kirocrew pod up <worktree>`.",
+            None,
+        )
+    dst = unit_mod.install_unit(cfg)
+    cp = systemctl("daemon-reload")
+    if cp.returncode != 0:
+        return f"installed pod template unit → {dst}", cp
+    return f"installed pod template unit → {dst}\nsystemctl --user daemon-reload OK", cp
 
 
 def health(port: int, timeout: int = 3) -> int:

--- a/src/kiro_crew/pod/unit.py
+++ b/src/kiro_crew/pod/unit.py
@@ -17,13 +17,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from kiro_crew.config.paths import _default_home
-from kiro_crew.pod.config import (
-    DEFAULT_BASE_PORT,
-    DEFAULT_LIVE_PORT,
-    DEFAULT_UNIT_PREFIX,
-    PodConfig,
-)
+from kiro_crew.pod.config import PodConfig, environment_vars
 
 _UNIT_TEMPLATE = """\
 [Unit]
@@ -82,37 +76,13 @@ def _kirocrew_bin() -> str:
 
 
 def _environment_block(cfg: PodConfig) -> str:
-    """``Environment=`` lines for every config value that differs from the built-in
-    default, so the systemd-booted gateway resolves the same plane the installing
-    CLI used. Returns "" when everything is at defaults.
+    """``Environment=`` lines for the shared pod-plane env selection.
+
+    The *selection* lives in :func:`kiro_crew.pod.config.environment_vars` so the
+    launchd backend pins the identical plane; this function only serialises it in
+    systemd's syntax. Returns "" when everything is at defaults.
     """
-    home = Path.home()
-    candidates = [
-        ("KIROCREW_POD_ROOT", str(cfg.pod_root), str(home / ".kirocrew-pods")),
-        ("KIROCREW_POD_ENV_DIR", str(cfg.pods_dir), str(_default_home() / "pods")),
-        (
-            "KIROCREW_POD_ARTIFACTS_DIR",
-            str(cfg.artifacts_dir),
-            str(cfg.pod_root / ".e2e-artifacts"),
-        ),
-        ("KIROCREW_POD_BASE_PORT", str(cfg.base_port), str(DEFAULT_BASE_PORT)),
-        ("KIROCREW_POD_LIVE_PORT", str(cfg.live_port), str(DEFAULT_LIVE_PORT)),
-        ("KIROCREW_POD_UNIT_PREFIX", cfg.unit_prefix, DEFAULT_UNIT_PREFIX),
-        ("KIROCREW_POD_PATH", cfg.gateway_path, None),  # always pin PATH
-    ]
-    lines = [
-        f"Environment={key}={val}\n"
-        for key, val, default in candidates
-        if default is None or val != default
-    ]
-    # Optional resolvers — pinned only when set. boot() normally reads the pinned
-    # CHECKOUT= from the per-pod env file directly, so these are belt-and-braces so
-    # a systemd-booted unit can still resolve the same repo/root the CLI used.
-    if cfg.repo_hint is not None:
-        lines.append(f"Environment=KIROCREW_POD_REPO={cfg.repo_hint}\n")
-    if cfg.worktrees_root is not None:
-        lines.append(f"Environment=KIROCREW_POD_WORKTREES_ROOT={cfg.worktrees_root}\n")
-    return "".join(lines)
+    return "".join(f"Environment={key}={val}\n" for key, val in environment_vars(cfg).items())
 
 
 def render_unit(cfg: PodConfig) -> str:

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -4437,10 +4437,18 @@ def test_manifest_declares_every_platform_the_app_runs_on():
     )
     assert manifest["platform"]["os"] == ["macos", "linux", "windows"]
 
-    # The pod requirement is carried in the UI copy, not the manifest gate.
+    # The pod requirement is carried in the UI copy, not the manifest gate. It
+    # must track reality: pods now run on Linux (systemd --user) AND macOS
+    # (launchd) — with no enforced resource ceiling on macOS — while Make Live
+    # stays Linux-only. The old copy ("pods need Linux systemd") became false
+    # the moment the launchd backend landed, and this test guards the manifest
+    # against lying in either direction.
     assert any(
-        "Linux systemd" in h for h in manifest["highlights"]
-    ), "the highlight stating pods need Linux systemd is the honest half of this declaration"
+        "launchd" in h and "Linux" in h for h in manifest["highlights"]
+    ), "the highlight must state pods' per-platform reality (Linux systemd + macOS launchd)"
+    assert any(
+        "Make Live is still Linux-only" in h for h in manifest["highlights"]
+    ), "Make Live remains Linux-only and the manifest copy must keep saying so"
 
 
 def test_declared_platforms_all_resolve_to_a_real_sys_platform():

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -25,6 +25,20 @@ from kiro_crew.pod.config import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _systemd_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the SYSTEMD backend by default, on every host.
+
+    ``runtime`` dispatches unit operations on ``IS_MACOS``, so without this the
+    tests that monkeypatch ``rt.systemctl`` would silently exercise the launchd
+    branch when the suite runs on a Mac — passing on Linux CI and failing (or
+    worse, vacuously passing) on a developer's laptop. Pinning it makes the
+    default explicit and keeps the Linux/Windows contract asserted everywhere.
+    Tests for the macOS path set ``IS_MACOS`` True themselves.
+    """
+    monkeypatch.setattr(rt, "IS_MACOS", False)
+
+
 @pytest.fixture
 def cfg() -> PodConfig:
     return PodConfig.load()

--- a/test/test_pod_launchd.py
+++ b/test/test_pod_launchd.py
@@ -1,0 +1,602 @@
+"""Tests for the macOS launchd pod backend.
+
+These run on EVERY platform: like ``test_pod.py`` fakes ``systemctl``, they fake
+``launchctl`` at the module boundary, so a Linux CI runner exercises the darwin
+code path without launchd being present. That matters because the repo's macOS CI
+job is deliberately narrow — without these, the backend would ship with no
+coverage at all.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+
+import pytest
+
+from kiro_crew.pod import launchd
+from kiro_crew.pod import runtime as rt
+from kiro_crew.pod.config import PodConfig
+
+
+def _cp(stdout: str = "", returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def cfg(tmp_path, monkeypatch) -> PodConfig:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Windows Path.home() reads USERPROFILE, not HOME — without this the plist
+    # dir resolved to the runner's REAL profile, and a plist left by one test
+    # made another test's teardown sweep think the name had been reclaimed.
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+    monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "pods-env"))
+    monkeypatch.setenv("KIROCREW_POD_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
+    return PodConfig.load()
+
+
+@pytest.fixture(autouse=True)
+def _no_real_launchctl(monkeypatch):
+    """Never shell out to a real launchctl, and let require_backend pass."""
+    monkeypatch.setattr(launchd, "require_backend", lambda: None)
+
+
+# --------------------------------------------------------------------------
+# plist rendering
+# --------------------------------------------------------------------------
+def test_plist_declares_no_resource_ceiling(cfg):
+    """macOS cannot enforce the cgroup ceiling, so the plist must not imply it.
+
+    This is the documented decision, not an oversight: RLIMIT_AS bounds one
+    process's address space, not resident memory and not the subprocess tree the
+    gateway spawns, so any limit key here would read as the 4G guarantee while
+    delivering something materially weaker. Asserted so nobody "improves" it.
+    """
+    body = launchd.render_plist(cfg, "smoke")
+    for key in (
+        "SoftResourceLimits",
+        "HardResourceLimits",
+        "MemoryMax",
+        "CPUQuota",
+        "ProcessType",
+    ):
+        assert key not in body, f"{key} must not be emitted — see launchd module docstring"
+
+
+def test_plist_boots_the_named_pod_through_python(cfg):
+    body = launchd.render_plist(cfg, "smoke")
+    argv = body["ProgramArguments"]
+    assert argv[-3:] == ["pod", "_run", "smoke"]
+    assert body["Label"] == "dev.kirocrew.pod.kirocrew-pod.smoke"
+    assert body["RunAtLoad"] is True
+    # Restart on crash, but never fight a deliberate bootout.
+    assert body["KeepAlive"] == {"SuccessfulExit": False}
+
+
+def test_plist_routes_logs_to_files_since_launchd_has_no_journal(cfg):
+    body = launchd.render_plist(cfg, "smoke")
+    out, err = launchd.log_paths(cfg, "smoke")
+    assert body["StandardOutPath"] == str(out)
+    assert body["StandardErrorPath"] == str(err)
+
+
+def test_plist_is_valid_and_written_per_pod(cfg):
+    dst = launchd.write_plist(cfg, "smoke")
+    assert dst.name == "dev.kirocrew.pod.kirocrew-pod.smoke.plist"
+    # Deliberately NOT ~/Library/LaunchAgents: launchd loads that directory at
+    # login, which would resurrect pods after a reboot — the systemd path is
+    # transient (start, never enable) and macOS must match.
+    assert dst.parent == cfg.pods_dir
+    assert "LaunchAgents" not in str(dst)
+    with dst.open("rb") as fh:
+        parsed = plistlib.load(fh)
+    assert parsed["Label"] == "dev.kirocrew.pod.kirocrew-pod.smoke"
+
+
+def test_label_honours_a_hermetic_unit_prefix(cfg, monkeypatch):
+    """A test plane must not be able to collide with a developer's real pods."""
+    monkeypatch.setenv("KIROCREW_POD_UNIT_PREFIX", "kirocrew-pod-test")
+    hermetic = PodConfig.load()
+    assert launchd.pod_label(hermetic, "smoke") == "dev.kirocrew.pod.kirocrew-pod-test.smoke"
+    # The default plane carries its prefix segment too: without it, the default
+    # prefix was a strict prefix of every custom plane's labels and a hermetic
+    # plane's pods surfaced in the default plane's listing (review finding).
+    assert launchd.pod_label(cfg, "smoke") == "dev.kirocrew.pod.kirocrew-pod.smoke"
+    assert not launchd.pod_label(cfg, "").startswith(launchd.pod_label(hermetic, ""))
+    assert not launchd.pod_label(hermetic, "").startswith(launchd.pod_label(cfg, ""))
+
+
+def test_env_selection_is_shared_with_the_systemd_backend(cfg):
+    """Both backends must pin the SAME plane, or a pod boots differently per OS."""
+    from kiro_crew.pod.config import environment_vars
+
+    body = launchd.render_plist(cfg, "smoke")
+    assert body.get("EnvironmentVariables") == environment_vars(cfg)
+
+
+# --------------------------------------------------------------------------
+# launchctl print parsing
+# --------------------------------------------------------------------------
+_RUNNING = "state = running\n\tpid = 4242\n\tlast exit code = 0\n"
+_DEAD = "state = waiting\n\tlast exit code = 1\n"
+_ABSENT = _cp(returncode=113, stderr="Could not find service \"x\" in domain")
+
+
+def test_is_active_needs_a_live_pid(cfg, monkeypatch):
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(_RUNNING))
+    assert launchd.is_active(cfg, "smoke") is True
+
+
+def test_is_active_false_when_loaded_but_dead(cfg, monkeypatch):
+    """Loaded is not running — the distinction systemd's is-active makes for us."""
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(_DEAD))
+    assert launchd.is_active(cfg, "smoke") is False
+
+
+def test_is_active_false_when_label_absent(cfg, monkeypatch):
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _ABSENT)
+    assert launchd.is_active(cfg, "smoke") is False
+
+
+def test_is_active_refuses_to_guess_on_an_operational_error(cfg, monkeypatch):
+    """Review blocker round 4: a non-absent launchctl failure must not read as
+    "not running" — down/removal guards would fail open and delete live state."""
+    monkeypatch.setattr(
+        launchd, "launchctl", lambda *a, **k: _cp(returncode=5, stderr="Input/output error")
+    )
+    with pytest.raises(launchd.LaunchdError):
+        launchd.is_active(cfg, "smoke")
+
+
+def test_unit_state_reports_active_with_a_pid(cfg, monkeypatch):
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(_RUNNING))
+    assert launchd.unit_state(cfg, "smoke") == ("active", 0)
+
+
+def test_unit_state_preserves_the_crash_signal_without_nrestarts(cfg, monkeypatch):
+    """launchd has no NRestarts; reporting 0 would lose the crash-loop signal
+    that stops the up-path waiting on a pod that cannot boot."""
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(_DEAD))
+    state, restarts = launchd.unit_state(cfg, "smoke")
+    assert state == "failed"
+    assert restarts > 0
+
+
+def test_unit_state_inactive_when_not_loaded(cfg, monkeypatch):
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(returncode=1))
+    assert launchd.unit_state(cfg, "smoke") == ("inactive", 0)
+
+
+def test_active_names_filters_to_our_prefix_and_liveness(cfg, monkeypatch):
+    domain_dump = (
+        "dev.kirocrew.pod.kirocrew-pod.alpha\n"
+        "dev.kirocrew.pod.kirocrew-pod.beta\n"
+        "com.apple.something\n"
+        "dev.other.pod.gamma\n"
+    )
+
+    def fake(*args, **kwargs):
+        # `print <domain>` lists labels; `print <domain>/<label>` probes one.
+        target = args[1] if len(args) > 1 else ""
+        if target.count("/") <= 1:
+            return _cp(domain_dump)
+        return _cp(_RUNNING if target.endswith("alpha") else _DEAD)
+
+    monkeypatch.setattr(launchd, "launchctl", fake)
+    assert launchd.active_names(cfg) == {"alpha"}
+
+
+# --------------------------------------------------------------------------
+# journal stand-in + the teardown gap
+# --------------------------------------------------------------------------
+def test_recent_journal_tails_the_pod_log_files(cfg):
+    out, err = launchd.log_paths(cfg, "smoke")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    err.write_text("boom-1\nboom-2\n")
+    out.write_text("hello\n")
+    text = launchd.recent_journal(cfg, "smoke", lines=1)
+    assert "boom-2" in text
+    assert "boom-1" not in text  # honours the line cap
+    assert "hello" in text
+
+
+def test_recent_journal_says_why_it_is_empty(cfg):
+    text = launchd.recent_journal(cfg, "smoke")
+    assert "no pod log yet" in text
+
+
+def test_orphan_homes_reports_only_reapable_leftovers(cfg, monkeypatch):
+    """With no ExecStopPost, a crashed pod leaves its HOME; ls/down GC it."""
+    cfg.pod_root.mkdir(parents=True, exist_ok=True)
+    (cfg.pod_root / "orphan").mkdir()
+    (cfg.pod_root / "running").mkdir()
+    (cfg.pod_root / "installed").mkdir()
+    (cfg.pod_root / ".e2e-artifacts").mkdir()  # dot dirs are not pods
+    launchd.write_plist(cfg, "installed")
+    monkeypatch.setattr(launchd, "active_names", lambda c: {"running"})
+    assert launchd.orphan_homes(cfg) == ["orphan"]
+
+
+# --------------------------------------------------------------------------
+# dispatch: the runtime must route to launchd on darwin and nowhere else
+# --------------------------------------------------------------------------
+def test_runtime_dispatches_to_launchd_on_macos(cfg, monkeypatch):
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt.launchd, "is_active", lambda c, n: "sentinel")
+    assert rt.is_active(cfg, "smoke") == "sentinel"
+
+
+def test_runtime_does_not_touch_launchd_off_macos(cfg, monkeypatch):
+    """The Linux/Windows contract: dispatch must not reach the launchd module."""
+    monkeypatch.setattr(rt, "IS_MACOS", False)
+    monkeypatch.setattr(rt, "require_systemd", lambda: None)
+    monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+
+    def explode(*a, **k):  # pragma: no cover - must never run
+        raise AssertionError("launchd was consulted on a non-darwin host")
+
+    monkeypatch.setattr(rt.launchd, "is_active", explode)
+    assert rt.is_active(cfg, "smoke") is True
+
+
+def test_stop_pod_reaps_the_home_on_macos(cfg, monkeypatch):
+    """launchd has no ExecStopPost, so stop_pod owns the teardown obligation.
+
+    The reap sweeps the WHOLE grace window (a dying child can flush state after
+    a clean early sample — observed live) plus one final authoritative pass, so
+    cleanup_home runs multiple times by design.
+    """
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt.launchd, "stop", lambda c, n: _cp(returncode=0))
+    monkeypatch.setattr(rt.time, "sleep", lambda _s: None)
+    reaped: list[str] = []
+    monkeypatch.setattr(rt, "cleanup_home", lambda c, n: reaped.append(n))
+    cp = rt.stop_pod(cfg, "smoke")
+    assert cp.returncode == 0
+    assert set(reaped) == {"smoke"}
+    assert len(reaped) == 7  # 6 sweeps + 1 final authoritative pass
+
+
+def test_stop_waits_for_the_asynchronous_unload(cfg, monkeypatch):
+    """`bootout` returns before launchd has unloaded.
+
+    Found by a real bring-up: returning immediately let the caller reap the pod's
+    HOME while the gateway was still alive, the removal failed silently, and the
+    CLI reported zero residue over a HOME still on disk.
+    """
+    seen: list[str] = []
+    # loaded, loaded, then gone
+    prints = [_cp("state = running\n\tpid = 1\n"), _cp("state = waiting\n"), _ABSENT]
+
+    def fake(*args, **kwargs):
+        verb = args[0] if args else ""
+        seen.append(verb)
+        if verb == "bootout":
+            return _cp(returncode=0)
+        return prints.pop(0) if prints else _cp(returncode=1)
+
+    monkeypatch.setattr(launchd, "launchctl", fake)
+    monkeypatch.setattr(launchd.time, "sleep", lambda _s: None)
+    launchd.write_plist(cfg, "smoke")
+    launchd.stop(cfg, "smoke")
+    assert seen[0] == "bootout"
+    # It kept polling `print` until the label disappeared.
+    assert seen.count("print") >= 3
+
+
+def test_stop_removes_the_per_pod_plist_once_unloaded(cfg, monkeypatch):
+    """A launchd plist is per-pod, unlike systemd's machine-wide template."""
+    # explicit absent-service result -> unload confirmed immediately
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _ABSENT)
+    dst = launchd.write_plist(cfg, "smoke")
+    assert dst.exists()
+    cp = launchd.stop(cfg, "smoke")
+    assert cp.returncode == 0
+    assert not dst.exists()
+
+
+def test_stop_does_not_treat_a_generic_print_failure_as_unloaded(cfg, monkeypatch):
+    """Review blocker round 2: an OPERATIONAL print failure (rc!=0 without the
+    absent-service message) proves nothing about the label. Confirming the
+    unload on it would let teardown proceed against a possibly-live pod."""
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(returncode=5, stderr="Input/output error"))
+    monkeypatch.setattr(launchd.time, "sleep", lambda _s: None)
+    dst = launchd.write_plist(cfg, "smoke")
+    cp = launchd.stop(cfg, "smoke", timeout=0.5)
+    assert cp.returncode != 0
+    assert dst.exists()
+
+
+def test_stop_preserves_everything_when_the_unload_cannot_be_confirmed(cfg, monkeypatch):
+    """Blocking review finding: a failed/hung unload must NOT tear anything down.
+
+    If the label is still loaded when the wait expires, the gateway may be
+    alive — deleting its plist (or letting the caller delete its HOME) while
+    returning success would destroy live state.
+    """
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp("state = running\n\tpid = 4\n"))
+    monkeypatch.setattr(launchd.time, "sleep", lambda _s: None)
+    dst = launchd.write_plist(cfg, "smoke")
+    cp = launchd.stop(cfg, "smoke", timeout=0.5)
+    assert cp.returncode != 0
+    assert "preserved" in cp.stderr
+    assert dst.exists()
+
+
+def test_stop_pod_does_not_reap_the_home_on_a_failed_unload(cfg, monkeypatch):
+    """runtime.stop_pod must honour launchd.stop's authoritative failure."""
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(
+        rt.launchd, "stop", lambda c, n: _cp(returncode=1, stderr="preserved")
+    )
+    reaped: list[str] = []
+    monkeypatch.setattr(rt, "cleanup_home", lambda c, n: reaped.append(n))
+    cp = rt.stop_pod(cfg, "smoke")
+    assert cp.returncode != 0
+    assert reaped == []
+
+
+def test_stop_pod_reports_a_surviving_home_instead_of_claiming_zero_residue(cfg, monkeypatch):
+    """cleanup_home deletes with ignore_errors, so its failure is SILENT.
+
+    On systemd, ExecStopPost owns teardown and a failure shows up as a unit
+    failure. Here nothing would notice, so stop_pod must verify rather than trust
+    — otherwise `pod down` prints "zero residue" over a HOME that is still there.
+    """
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt.launchd, "stop", lambda c, n: _cp(returncode=0))
+    monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)  # pretend it silently failed
+    monkeypatch.setattr(rt.time, "sleep", lambda _s: None)  # collapse the grace window
+    home = rt.pod_home(cfg, "smoke")
+    home.mkdir(parents=True, exist_ok=True)
+    cp = rt.stop_pod(cfg, "smoke")
+    assert cp.returncode != 0
+    assert "reappearing" in cp.stderr
+    assert str(home) in cp.stderr
+
+
+def test_stop_pod_succeeds_when_the_home_is_gone(cfg, monkeypatch):
+    """A confirmed unload with the HOME already gone is a clean success."""
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt.launchd, "stop", lambda c, n: _cp(returncode=0))
+    monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+    cp = rt.stop_pod(cfg, "smoke")
+    assert cp.returncode == 0
+
+
+def test_reap_sweep_aborts_when_a_new_pod_claims_the_name(cfg, monkeypatch):
+    """Blocking review finding round 3: down and up are independent endpoints
+    with no per-name lock, so the grace sweep must stand down the moment a NEW
+    pod claims the name — otherwise its live HOME lands under our rmtree."""
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt.launchd, "stop", lambda c, n: _cp(returncode=0))
+    monkeypatch.setattr(rt.time, "sleep", lambda _s: None)
+    # the new pod writes its plist during our sweep
+    launchd.write_plist(cfg, "smoke")
+    reaped: list[str] = []
+    monkeypatch.setattr(rt, "cleanup_home", lambda c, n: reaped.append(n))
+    cp = rt.stop_pod(cfg, "smoke")
+    assert cp.returncode == 0
+    assert rt.RECLAIMED_MARKER in cp.stdout  # callers must know not to delete per-name state
+    assert reaped == []  # never touched the reclaimed name
+
+
+def test_down_preserves_the_new_pods_checkout_pin_when_reclaimed(cfg, monkeypatch, capsys):
+    """Review blocker round 3 (part 2): after a reclaimed teardown, `down` must
+    NOT delete the per-pod env file — it pins the NEW pod's checkout."""
+    import argparse
+
+    from kiro_crew.pod import cli as pod_cli
+
+    monkeypatch.setattr(rt, "validate_name", lambda n: n)
+    monkeypatch.setattr(rt, "is_active", lambda c, n: True)
+    monkeypatch.setattr(
+        rt, "stop_pod", lambda c, n: _cp(returncode=0, stdout=rt.RECLAIMED_MARKER)
+    )
+    monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+    env = cfg.env_file("smoke")
+    env.parent.mkdir(parents=True, exist_ok=True)
+    env.write_text("CHECKOUT=/the/new/pods/checkout\n")
+    pod_cli._down(cfg, argparse.Namespace(name="smoke"))
+    assert env.exists(), "the reclaimed name's env file belongs to the NEW pod"
+    assert "reclaimed" in capsys.readouterr().out
+
+
+def test_install_backend_writes_nothing_on_macos(cfg, monkeypatch):
+    """No template units on launchd — saying so beats writing an inert file."""
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt, "require_backend", lambda: None)
+    msg, reload_cp = rt.install_backend(cfg)
+    assert reload_cp is None
+    assert "nothing to install on macOS" in msg
+
+
+def test_active_names_refuses_to_guess_on_an_operational_error(cfg, monkeypatch):
+    """Review blocker round 4 (same class as is_active): an empty set on a failed
+    domain print would tell pod ls / Dev Fleet that live pods are absent."""
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(returncode=1, stderr="boom"))
+    with pytest.raises(launchd.LaunchdError):
+        launchd.active_names(cfg)
+
+
+def test_start_and_stop_hold_the_per_name_mutex(cfg, monkeypatch):
+    """Review blocker round 4: start (plist write + bootstrap) and the whole
+    stop (bootout + sweep) must serialize per name, or a down/up race deletes
+    the replacement pod's plist and HOME."""
+    import contextlib as _ctx
+
+    held: list[str] = []
+
+    @_ctx.contextmanager
+    def _fake_mutex(c, n):
+        held.append(f"enter:{n}")
+        yield
+        held.append(f"exit:{n}")
+
+    monkeypatch.setattr(rt.launchd, "pod_mutex", _fake_mutex)
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt.launchd, "write_plist", lambda c, n: None)
+    monkeypatch.setattr(rt.launchd, "start", lambda c, n: _cp(returncode=0))
+    rt.start_pod(cfg, "smoke")
+    assert held == ["enter:smoke", "exit:smoke"]
+
+    held.clear()
+    monkeypatch.setattr(rt.launchd, "stop", lambda c, n: _cp(returncode=0))
+    monkeypatch.setattr(rt, "cleanup_home", lambda c, n: None)
+    monkeypatch.setattr(rt.time, "sleep", lambda _s: None)
+    rt.stop_pod(cfg, "smoke")
+    assert held == ["enter:smoke", "exit:smoke"], "the sweep must run INSIDE the mutex"
+
+
+def test_runtime_probes_surface_launchd_errors_as_pod_errors(cfg, monkeypatch):
+    """The CLI's contract is PodError -> `pod: <msg>` + exit 1; a raw
+    LaunchdError from a probe would crash with a traceback instead."""
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(returncode=5, stderr="EIO"))
+    with pytest.raises(rt.PodError):
+        rt.is_active(cfg, "smoke")
+    with pytest.raises(rt.PodError):
+        rt.active_names(cfg)
+
+
+def test_pod_mutex_is_reentrant_within_a_thread(cfg):
+    """The CLI holds the mutex across a transaction while start_pod/stop_pod
+    re-acquire it inside; flock is per open-file-description, so without
+    reentrancy that inner acquisition would deadlock against our own lock."""
+    with launchd.pod_mutex(cfg, "smoke"):
+        with launchd.pod_mutex(cfg, "smoke"):  # must not block
+            pass
+
+
+def test_down_fails_on_macos_when_stop_cannot_confirm_even_if_not_active(cfg, monkeypatch):
+    """Review blocker round 4: a loaded-but-dead agent has no pid (was_up False)
+    but its unload still needs confirming — a swallowed nonzero stop deleted the
+    checkout pin while leaving service, plist and HOME behind."""
+    import argparse
+
+    from kiro_crew.pod import cli as pod_cli
+
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt, "validate_name", lambda n: n)
+    monkeypatch.setattr(rt, "is_active", lambda c, n: False)  # loaded-but-dead
+    monkeypatch.setattr(
+        rt, "stop_pod", lambda c, n: _cp(returncode=1, stderr="unload not confirmed")
+    )
+    monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+    env = cfg.env_file("smoke")
+    env.parent.mkdir(parents=True, exist_ok=True)
+    env.write_text("CHECKOUT=/live/checkout\n")
+    with pytest.raises(SystemExit):
+        pod_cli._down(cfg, argparse.Namespace(name="smoke"))
+    assert env.exists(), "metadata must survive an unconfirmed unload"
+
+
+def test_up_pins_the_checkout_inside_the_name_mutex(cfg, monkeypatch, tmp_path):
+    """Review blocker round 4: the pin must move atomically with the start —
+    pinned outside the lock, a concurrent down's sweep deleted the fresh pin."""
+    import argparse
+    import contextlib as _ctx
+
+    from kiro_crew.pod import cli as pod_cli
+
+    events: list[str] = []
+
+    @_ctx.contextmanager
+    def _tracked_mutex(c, n):
+        events.append("lock")
+        yield
+        events.append("unlock")
+
+    checkout = tmp_path / "wt"
+    (checkout / "website" / "static" / "dist").mkdir(parents=True)
+    monkeypatch.setattr(rt, "pod_name_mutex", _tracked_mutex)
+    monkeypatch.setattr(rt, "validate_name", lambda n: n)
+    monkeypatch.setattr(pod_cli, "_resolve_or_die", lambda c, n: checkout)
+    monkeypatch.setattr(pod_cli.prov, "has_venv", lambda co: True)
+    monkeypatch.setattr(pod_cli.prov, "has_dist", lambda co: True)
+    monkeypatch.setattr(rt, "derive_port", lambda c, n: 7999)
+    monkeypatch.setattr(rt, "pin_checkout", lambda c, n, co: events.append("pin"))
+    monkeypatch.setattr(rt, "is_active", lambda c, n: False)
+    monkeypatch.setattr(rt, "start_pod", lambda c, n: (events.append("start"), _cp())[1])
+    monkeypatch.setattr(rt, "mint_token", lambda c, n, ttl: "t")
+    monkeypatch.setattr(pod_cli, "_wait_healthy", lambda c, n, p: (events.append("wait"), 200)[1])
+    monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+    args = argparse.Namespace(
+        name="smoke", seed=None, json=True, provision=False, checkout=None, ttl="2h"
+    )
+    try:
+        pod_cli._up(cfg, args)
+    except SystemExit:
+        pass
+    assert "pin" in events and "start" in events and "wait" in events
+    assert (
+        events.index("lock")
+        < events.index("pin")
+        < events.index("start")
+        < events.index("wait")
+        < events.index("unlock")
+    ), f"pin, start and the health wait must all happen inside the mutex: {events}"
+
+
+def test_up_failure_cleanup_stops_the_pod_inside_the_mutex(cfg, monkeypatch, tmp_path):
+    """Verifier-found High: with the lock released before the health wait, a
+    down + replacement up could interleave and the failure cleanup's stop_pod
+    unloaded and erased the REPLACEMENT pod."""
+    import argparse
+    import contextlib as _ctx
+
+    from kiro_crew.pod import cli as pod_cli
+
+    events: list[str] = []
+
+    @_ctx.contextmanager
+    def _tracked_mutex(c, n):
+        events.append("lock")
+        try:
+            yield
+        finally:
+            events.append("unlock")
+
+    checkout = tmp_path / "wt"
+    (checkout / "website" / "static" / "dist").mkdir(parents=True)
+    monkeypatch.setattr(rt, "pod_name_mutex", _tracked_mutex)
+    monkeypatch.setattr(rt, "validate_name", lambda n: n)
+    monkeypatch.setattr(pod_cli, "_resolve_or_die", lambda c, n: checkout)
+    monkeypatch.setattr(pod_cli.prov, "has_venv", lambda co: True)
+    monkeypatch.setattr(pod_cli.prov, "has_dist", lambda co: True)
+    monkeypatch.setattr(rt, "derive_port", lambda c, n: 7999)
+    monkeypatch.setattr(rt, "pin_checkout", lambda c, n, co: None)
+    monkeypatch.setattr(rt, "is_active", lambda c, n: False)
+    monkeypatch.setattr(rt, "start_pod", lambda c, n: _cp())
+    monkeypatch.setattr(rt, "recent_journal", lambda c, n, lines: "")
+    monkeypatch.setattr(rt, "stop_pod", lambda c, n: (events.append("stop"), _cp())[1])
+    monkeypatch.setattr(pod_cli, "_wait_healthy", lambda c, n, p: -1)  # boot failed
+    monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+    args = argparse.Namespace(
+        name="smoke", seed=None, json=True, provision=False, checkout=None, ttl="2h"
+    )
+    with pytest.raises(SystemExit):
+        pod_cli._up(cfg, args)
+    assert "stop" in events, "the failed boot must be stopped"
+    assert events.index("lock") < events.index("stop") < events.index(
+        "unlock"
+    ), f"the failure cleanup must stop the pod INSIDE the mutex: {events}"
+
+
+def test_ls_translates_orphan_probe_failures_to_the_documented_error(cfg, monkeypatch):
+    """A LaunchdError escaping pod ls printed a traceback instead of the
+    documented one-line `pod: <msg>` refusal (review finding)."""
+    import argparse
+
+    from kiro_crew.pod import cli as pod_cli
+
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt, "active_names", lambda c: set())
+
+    def _boom(c):
+        raise launchd.LaunchdError("launchctl print failed")
+
+    monkeypatch.setattr(launchd, "orphan_homes", _boom)
+    with pytest.raises(rt.PodError):
+        pod_cli._ls(cfg, argparse.Namespace(json=False))

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -378,6 +378,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "platform_compat.py::process_matches",
         "platform_compat.py::restrict_to_owner",
         "pod/cli.py::_logs",
+        # launchd twin of pod/runtime.py::_run below: the single chokepoint for
+        # `launchctl <verb> gui/<uid>/dev.kirocrew.pod.<name>`. Argv is a fixed
+        # verb set plus a label built from a validate_name-checked pod name —
+        # not agent-influenced. Same disposition as the systemctl wrapper.
+        "pod/launchd.py::launchctl",
         "pod/provision.py::_run",
         "pod/runtime.py::_git_worktrees",
         "pod/runtime.py::_run",


### PR DESCRIPTION
## Problem

Pods — the isolated per-worktree preview instances Dev Fleet manages — only work
on Linux: the runtime is built on `systemd --user` template units. On macOS every
pod verb refuses with "pods require Linux `systemctl --user`", the Dev Fleet UI
hides all pod controls (`pods_available:false`), and the pod-e2e QA workflow has
no host to run on. Developers on Macs cannot preview or QA a worktree as a pod at
all.

## Why it matters

A large share of KiroCrew development happens on macOS laptops. Everything around
pods already works there (fleet view, PR status, build-state detection, sync,
rebase, prune — verified earlier on this branch's investigation), so the missing
piece is precisely the one that makes a worktree *runnable*. Closing it makes the
whole Dev Fleet loop — build, pod up, QA, tear down — first-class on a Mac.

## Fix (symptom → root cause → change)

**Symptom:** every pod verb hard-refuses on darwin.
**Root cause:** the service-manager layer is systemd-specific, and it is the only
platform-specific part — name validation, port derivation, checkout resolution
and pinning, env scrubbing, boot and the teardown safety check are all neutral.
**Change:** add a launchd backend for exactly that layer, dispatch on platform,
and leave the systemd path byte-for-byte alone.

- **`pod/launchd.py` (new).** Per-pod plists at
  `~/Library/LaunchAgents/dev.kirocrew.pod.<name>.plist` (launchd has no template
  units), written with `plistlib` and re-rendered on every `up` — which also makes
  the systemd path's stale-ExecStart self-heal unnecessary here. Modern
  `launchctl` verbs only (`bootstrap`/`bootout`/`kickstart`/`print`); `print`
  parsing is deliberately narrow (a `pid` line and `last exit code` — the only
  two facts the runtime asks).
- **Teardown, the subtle part.** launchd has no `ExecStopPost`, so `down` owns
  cleanup. Two real bugs surfaced here **only during a live bring-up on a Mac**,
  after 460 mocked tests were green:
  1. `bootout` is **asynchronous** — returning immediately let `cleanup_home`
     race the still-running gateway; `shutil.rmtree(ignore_errors=True)` failed
     *silently* and the CLI printed "zero residue" over a HOME still on disk.
     `stop()` now polls the label away, and `stop_pod()` verifies the HOME is
     actually gone, failing loudly with the path if not.
  2. The per-pod plist was never removed, which would make `orphan_homes()`
     classify a leftover HOME as "installed, not orphaned" forever. `stop()` now
     unlinks it.
  `orphan_homes()` reports (never deletes) HOMEs left by a crash — deletion still
  goes through `cleanup_home`'s name re-validation.
- **Logs.** No journal on macOS: the plist routes stdout/stderr to files under
  the pod artifacts dir; `recent_journal` / `pod logs` tail them.
- **Resource ceiling — decision, documented.** The Linux unit's cgroup
  `MemoryMax=4G` / `CPUQuota=200%` has **no macOS equivalent that bounds a
  process tree**, and this PR deliberately emits **no** resource keys instead of
  a weaker imitation: `RLIMIT_AS` bounds a single process's address space, not
  RSS and not the agent subprocesses the gateway spawns, so emitting it would
  read as the 4G guarantee while delivering materially less. The pod-e2e skill,
  the package docstring and the Dev Fleet manifest now state the ceiling
  per-platform — including plainly that a runaway macOS pod can starve the
  machine. A test asserts the absence of any resource key so this cannot be
  "improved" silently.
- **Shared plane.** `environment_vars()` extracted to `pod/config.py` as the one
  source of truth both backends serialise from (systemd as `Environment=` lines,
  launchd as `EnvironmentVariables`), so the two backends cannot drift into
  booting pods with different planes.
- **Dispatch, additively.** `runtime.py` gains `require_backend()` and
  `IS_MACOS` branches in `is_active` / `unit_state` / `recent_journal` /
  `active_names`, plus backend-agnostic `start_pod` / `stop_pod` /
  `install_backend` so `cli.py` has no platform branches. `require_systemd()` is
  untouched. Dev Fleet reports pods available on darwin+launchctl; the
  **make-live gates are deliberately untouched** — repointing the live gateway's
  systemd unit is a different feature and stays Linux-only.
- **Compatibility constraint held:** the `pod up --json` output keys are
  byte-identical to before (three callers parse them: Dev Fleet's `_pod_up`,
  pod-e2e.sh, and the skill docs).

## Tests

- **`test/test_pod_launchd.py` (new, 24 tests)** — fakes `launchctl` at the module
  boundary exactly as `test_pod.py` fakes `systemctl`, so the darwin path is
  exercised on Linux CI. Locks in: the no-resource-keys decision (explicit
  absence assertion), per-pod plist naming incl. hermetic
  `KIROCREW_POD_UNIT_PREFIX` planes, live-pid-only `is_active`, the crash signal
  preserved without an `NRestarts` counter, prefix-filtered `active_names`,
  file-tailing logs, orphan-home classification, the asynchronous-bootout wait,
  plist removal on stop, the surviving-HOME loud failure, and — for the
  Linux/Windows contract — that launchd is **never consulted off darwin**.
- **`test/test_pod.py`** — autouse `_systemd_backend` fixture pins `IS_MACOS=False`
  so every pre-existing test asserts the systemd branch on every host, instead of
  silently depending on the runner's OS.
- **`test/test_spawn_audit.py`** — `pod/launchd.py::launchctl` allowlisted with
  the same justification as its systemd sibling (`pod/runtime.py::_run`): fixed
  verb set plus a `validate_name`-checked label, not agent-influenced.
- **`.github/workflows/ci.yml`** — the `macos-14` job now also runs
  `test/test_pod*.py`; previously the pod suites had zero real-Darwin coverage.

Full backend suite: 26842 passed. The 2 failures are pre-existing
(`test_module_loader` fails identically on a clean `main` checkout;
`test_spawn_audit` was failing on this branch's new spawn until the allowlist
entry above, then green).

## Manual verification

Full real bring-up and teardown on a macOS host (Apple Silicon, this branch):

```
pod up pod-macos --json  -> status=up, port=7867, health probe 200
launchctl print gui/<uid>/dev.kirocrew.pod.pod-macos -> state = running, pid = 22731
bare /api/sessions       -> HTTP 403 (auth enforced)
pod down pod-macos       -> HOME reaped: True | plist gone: True | agent unloaded: True
pod ls                   -> no pods running
live plane :5476/:5477   -> HTTP 403 before, during and after (untouched)
```

This live run is what caught teardown bugs 1 and 2 above — the mocked suite
alone reported green with both present.

## Screenshots

N/A — no rendered UI change. The Dev Fleet frontend already keys its pod
controls off the `pods_available` field (verified by its existing tests), so the
backend flip lights them up without a frontend diff; visual QA of that page
belongs to the existing Dev Fleet UI tests.
