### PR TITLE
fix(scrub): replace a real workplace alias with an allowlisted placeholder

### DIFF
--- a/src/kiro_crew/artifact_source.py
+++ b/src/kiro_crew/artifact_source.py
@@ -25,7 +25,7 @@ A ``link`` verdict returns the directory that authorises later reads of the
 file. :class:`~kiro_crew.artifacts.ArtifactStore` re-validates ``source_path``
 containment on **every** read (a symlink swap after the fact must not escape),
 and its default roots are the user's home dir plus the data home. A project at
-``/workplace/nrb/repo`` is outside both, so a linked project file would be
+``/workplace/alice/repo`` is outside both, so a linked project file would be
 refused on read — and the store would silently fall back to its stale snapshot.
 Recording the authorising root on the artifact (``source_root``) is what makes
 an out-of-home link actually work. It has to be recorded at create time because

--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -353,7 +353,7 @@ class Artifact:
     #: Recorded at CREATE time on purpose: :class:`ArtifactStore` re-validates
     #: root containment on every read, but it has no session handle then and so
     #: cannot ask "what project is open?". Without a recorded root, a linked
-    #: file outside ``$HOME`` (e.g. ``/workplace/nrb/repo/doc.md``) is refused
+    #: file outside ``$HOME`` (e.g. ``/workplace/alice/repo/doc.md``) is refused
     #: on read and the artifact silently serves its stale snapshot instead.
     #: Added to the allowed-roots set by :meth:`allowed_source_roots`; the
     #: sensitive-path denylist still applies inside it.
@@ -1067,7 +1067,7 @@ class ArtifactStore:
         * every operator-configured ``publish.relocate_roots`` entry;
         * when supplied, the artifact's own ``source_root`` — the project root
           that authorized the link at create time. This is what lets a linked
-          project file outside ``$HOME`` (``/workplace/nrb/repo/doc.md``) be
+          project file outside ``$HOME`` (``/workplace/alice/repo/doc.md``) be
           read at all, without widening the default set for every artifact.
 
         Callers MUST keep the ``p == r or p.is_relative_to(r)`` comparison

--- a/test/test_artifact_source.py
+++ b/test/test_artifact_source.py
@@ -296,7 +296,7 @@ class TestClassifySourceProjectWalk:
         # the KiroCrew development layout itself.
         wt = tmp_path / "kirocrew-wt-feature"
         wt.mkdir()
-        (wt / ".git").write_text("gitdir: /workplace/nrb/KiroCrew/.git/worktrees/feature\n")
+        (wt / ".git").write_text("gitdir: /workplace/alice/KiroCrew/.git/worktrees/feature\n")
         target = _file(wt / "src" / "mod.md")
         assert classify_source(target) == (LINK, str(wt))
 


### PR DESCRIPTION
## Problem

`De-Amazon Scrub Lint` fails on **every open PR** since ~04:04 UTC:

```
FAIL: Personal identifiers found (home paths / employee emails / identity fields):
src/kiro_crew/artifact_source.py:28:/workplace/nrb
src/kiro_crew/artifacts.py:356:/workplace/nrb
src/kiro_crew/artifacts.py:1070:/workplace/nrb
test/test_artifact_source.py:299:/workplace/nrb
```

## Why it matters

The scrub lint scans the whole working tree, not the PR diff — so this base-branch leak blocks CI for every PR currently open, none of which touch these files. It is also a real personal-identity leak (`/workplace/<alias>` paths embed an employee alias), which is exactly what the check exists to catch.

## Fix (symptom → root cause → change)

- **Symptom:** step 3/5 (personal identity leaks) fails repo-wide.
- **Root cause:** PR #1083 (artifacts/files stack reconcile) used a real workplace path as the example in three docstrings and one test fixture.
- **Change:** replace the alias with `alice`, which is already in the scrubber's `GENERIC_USER` allowlist. Docstring/comment text and one fixture string only — zero behavior change.

## Tests

- `bash scripts/scrub-lint.sh --no-history` → **All checks passed** locally on this branch.
- `test/test_artifact_source.py` → 36/36 pass (the fixture string is parsed for its `gitdir:` shape, not its alias).
- flake8 (`-j 1`, sandbox) + isort clean on the three touched files.

## Manual verification

N/A — lint + unit coverage sufficient (comment-only change).
