### PR TITLE
docs: add GOVERNANCE.md and MAINTAINERS.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,35 @@
+# Governance
+
+This document covers who makes decisions in Kiro Crew, how those decisions get made, and how someone becomes one of the people making them. [CONTRIBUTING.md](CONTRIBUTING.md) covers how to contribute, and the two are meant to be read together.
+
+## Who decides
+
+**Maintainers** decide. A maintainer is someone with commit access to this repository, and the current list is in [MAINTAINERS.md](MAINTAINERS.md). Maintainers review incoming work, help contributors get a change to the point where it can land, and decide what lands. There is no separate governing body above them.
+
+**Contributors** are everyone who sends code, documentation, apps, skills, tests, or translations, and everyone who takes part in feature discussion. Contributing does not require permission, only [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+**Users** are everyone running Kiro Crew. Filing an issue about what is broken or missing is a real contribution to the project's direction, and most changes in direction start there.
+
+## How decisions get made
+
+Decisions happen in public, on the issue or pull request they belong to, with the reasoning written down. That applies to accepting a change and to declining one, because a contributor who gets a no deserves to know why.
+
+Architectural changes get written up first as an RFC, so the design can be argued over before anyone writes the code, and so the reasoning survives after the thread scrolls away. An RFC is its own pull request adding a document to [docs/request-for-change/](docs/request-for-change/). Once it lands, the pull requests that implement it reference it by number, which leaves a trail from the finished code back to the argument that produced it.
+
+That applies to changes to a public interface, changes other parts of the project would have to build around, and anything that would be expensive to reverse. Everything else skips it. A bug fix should never wait on a design document, and an RFC does not have to be long to count. If you are unsure which side of the line your change falls on, open an issue and ask.
+
+Maintainers aim for agreement, and in practice most decisions are made by whichever maintainer is reviewing. Where maintainers disagree and talking it through does not resolve it, a majority of maintainers decides. There are no scheduled meetings and no formal votes to call.
+
+The one exception to working in public is an unfixed security vulnerability, which is handled privately under [SECURITY.md](SECURITY.md) until a fix ships.
+
+## Becoming a maintainer
+
+Any maintainer can propose adding a new one, and the change goes ahead if the other maintainers agree. What earns the proposal is a track record: changes that landed, reviews that showed good judgment, and dependable engagement with other contributors. There is no contribution count that qualifies someone automatically.
+
+Maintainers can step down whenever they want. A maintainer who has been unreachable for an extended stretch gets moved to the emeritus list in [MAINTAINERS.md](MAINTAINERS.md), and coming back later is just a matter of asking. Commit access can also be withdrawn for a Code of Conduct violation.
+
+## Trademarks and amendments
+
+**Trademarks are governed separately.** The Kiro and Kiro Crew names and logos are trademarks, and they are not licensed under this project's software license. See [NOTICE](NOTICE) for ownership. Maintainers have no authority to license, transfer, or redefine their use. The code in this repository is open source. The marks are not.
+
+**This document changes the same way anything else does**, by a pull request that maintainers agree to. Governance is expected to grow as the project does, and a project with more maintainers than this one may well need more structure than this. One constraint holds regardless. Any change that makes this project less open breaks a promise already made to the people depending on it, and this project does not do rug pulls. Opening governance further is always available. Closing it back down is not.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,29 @@
+# Maintainers
+
+Maintainers have commit access to this repository and decide what lands in it. If you need a review, an answer on a design question, or a decision unstuck, these are the people to reach. Tagging the whole list on a pull request is fine.
+
+How maintainers are added, how they step down, and how decisions get made are covered in [GOVERNANCE.md](GOVERNANCE.md).
+
+## Current maintainers
+
+| Name | GitHub |
+|---|---|
+| Bolin Chen | [@bolichen97](https://github.com/bolichen97) |
+| Joe Guo | [@iamwhatever](https://github.com/iamwhatever) |
+| Zezhen Xu | [@CrysisDeu](https://github.com/CrysisDeu) |
+
+Every path in this repository is owned by `@kirodotdev/kirocrew-team` in [CODEOWNERS](.github/CODEOWNERS), so reviewers are requested automatically and you do not need to pick one by hand.
+
+## Emeritus
+
+Maintainers who have stepped back. Their past work stands, and any of them can pick commit access back up by asking.
+
+None yet.
+
+## Reaching maintainers
+
+For anything about the project itself, open a [GitHub issue](https://github.com/kirodotdev/KiroCrew/issues) rather than contacting a maintainer directly. Public questions get answered where the next person with the same question can find them.
+
+Do not use this list to report a security vulnerability. Follow [SECURITY.md](SECURITY.md) instead, which routes reports privately so a fix can ship before the problem is public.
+
+Conduct concerns are handled under the [Code of Conduct](CODE_OF_CONDUCT.md), which names where those reports go.


### PR DESCRIPTION
## Description

The project has no written statement of who decides what lands, how a disagreement gets resolved, or who holds commit access. An outside contributor has to infer all of it from `CODEOWNERS`. These two files state it.

**`GOVERNANCE.md`** describes the model actually in use rather than an invented one. Maintainers decide, most decisions are made by whichever maintainer is reviewing, and where they disagree a majority settles it. There is no separate governing body, no chair, and no scheduled votes, because documenting apparatus nobody follows is worse than documenting little. It also names `docs/request-for-change/` as the venue for architectural decisions and states the scope test for when an RFC is required, matching how RFC #1280 and its implementing PR #1295 actually worked.

**`MAINTAINERS.md`** lists the three current maintainers and the emeritus policy for someone who steps back.

Trademarks are called out as explicitly outside maintainer authority. The code here is open source and the marks are not, so a governance document that stayed silent on it would imply more than it should.

## Related Issues

None.

## Type of Change

Documentation update

## Testing

Documentation only, no runtime behaviour changes.

- Both files pass `./scripts/scrub-lint.sh --no-history`
- Every relative link in both files resolves against the repo root, verified by checking each target exists: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `NOTICE`, `.github/CODEOWNERS`, `docs/request-for-change/`, and each other

**One pre-existing CI failure to expect, unrelated to this PR.** The De-Amazon Scrub Lint job currently fails on `main` itself, on four occurrences of an alias-shaped `/workplace/` path in `src/kiro_crew/artifacts.py`, `src/kiro_crew/artifact_source.py`, and `test/test_artifact_source.py`. Those arrived in #1083 and are not touched here. Removing the two files in this PR and re-running the gate reproduces the same failure, so it is inherited from the base rather than introduced. It needs its own fix.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line in this PR
- [x] My change is focused and reasonably small
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings