### PR TITLE
fix: replace personal home paths flagged by the scrub gate

### DIFF
--- a/src/kiro_crew/artifact_source.py
+++ b/src/kiro_crew/artifact_source.py
@@ -25,7 +25,7 @@ A ``link`` verdict returns the directory that authorises later reads of the
 file. :class:`~kiro_crew.artifacts.ArtifactStore` re-validates ``source_path``
 containment on **every** read (a symlink swap after the fact must not escape),
 and its default roots are the user's home dir plus the data home. A project at
-``/workplace/nrb/repo`` is outside both, so a linked project file would be
+``/mnt/projects/repo`` is outside both, so a linked project file would be
 refused on read — and the store would silently fall back to its stale snapshot.
 Recording the authorising root on the artifact (``source_root``) is what makes
 an out-of-home link actually work. It has to be recorded at create time because

--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -353,7 +353,7 @@ class Artifact:
     #: Recorded at CREATE time on purpose: :class:`ArtifactStore` re-validates
     #: root containment on every read, but it has no session handle then and so
     #: cannot ask "what project is open?". Without a recorded root, a linked
-    #: file outside ``$HOME`` (e.g. ``/workplace/nrb/repo/doc.md``) is refused
+    #: file outside ``$HOME`` (e.g. ``/mnt/projects/repo/doc.md``) is refused
     #: on read and the artifact silently serves its stale snapshot instead.
     #: Added to the allowed-roots set by :meth:`allowed_source_roots`; the
     #: sensitive-path denylist still applies inside it.
@@ -1067,7 +1067,7 @@ class ArtifactStore:
         * every operator-configured ``publish.relocate_roots`` entry;
         * when supplied, the artifact's own ``source_root`` — the project root
           that authorized the link at create time. This is what lets a linked
-          project file outside ``$HOME`` (``/workplace/nrb/repo/doc.md``) be
+          project file outside ``$HOME`` (``/mnt/projects/repo/doc.md``) be
           read at all, without widening the default set for every artifact.
 
         Callers MUST keep the ``p == r or p.is_relative_to(r)`` comparison

--- a/test/test_artifact_source.py
+++ b/test/test_artifact_source.py
@@ -296,7 +296,7 @@ class TestClassifySourceProjectWalk:
         # the KiroCrew development layout itself.
         wt = tmp_path / "kirocrew-wt-feature"
         wt.mkdir()
-        (wt / ".git").write_text("gitdir: /workplace/nrb/KiroCrew/.git/worktrees/feature\n")
+        (wt / ".git").write_text("gitdir: /mnt/projects/KiroCrew/.git/worktrees/feature\n")
         target = _file(wt / "src" / "mod.md")
         assert classify_source(target) == (LINK, str(wt))
 


### PR DESCRIPTION
## Problem
De-Amazon Scrub Lint fails on every PR since #1083 merged: its identity check flags `/workplace/<alias>` dev-desktop home paths in `src/kiro_crew/artifact_source.py`, `src/kiro_crew/artifacts.py` (x2), and `test/test_artifact_source.py`. First observed blocking the docs-only #1392.

## Why it matters
The gate is repo-wide, so main is currently unpublishable by the scrub's own standard and every open PR inherits a red check it cannot fix in scope.

## Fix (symptom -> root cause -> change)
The failing check is structural (personal identity leak), the root cause is a personal dev-desktop path used as the example for 'a file outside $HOME'. Replaced all four occurrences with `/mnt/projects`, a generic absolute path that preserves exactly that meaning, in three docstrings and one test gitdir literal.

## Tests
`test/test_artifact_source.py` passes in full (36 tests). `./scripts/scrub-lint.sh --no-history` passes locally: 'No personal identifiers in source or tests'.

## Manual verification
N/A. Comment and test-literal change only, no code paths.

## Screenshots
N/A, no UI change.