### PR TITLE
fix(apps): derive a builtin app's identity from its agent for own-MCP auto-approve

### DIFF
--- a/src/kiro_crew/apps/execution.py
+++ b/src/kiro_crew/apps/execution.py
@@ -200,6 +200,93 @@ def builtin_app_mcp_servers() -> frozenset[str]:
     return frozenset(servers)
 
 
+def builtin_app_agents() -> dict[str, str]:
+    """Map each agent DECLARED by a shipped builtin manifest to its owning app.
+
+    For every first-party manifest (the SAME sources and builtin-owned-install
+    narrowing as :func:`builtin_app_names`), read each entry of its ``agents``
+    list and map that agent's declared ``name`` to the app that ships it. Both
+    the bare name and the ``f"{app}--{agent}"`` link form (the filename
+    ``bridges._safe_link_name`` registers it under) are emitted, because a chat
+    slot may carry either spelling depending on which surface bound it; both are
+    derived from the same IMMUTABLE manifest and identify the same app agent.
+
+    This exists so the PreToolUse gate can recover an app identity for a slot
+    that has none. ``Slot._app`` is set from the request's AUTHENTICATED app
+    scope, so a builtin whose UI is not an app iframe — e.g. an Electron window
+    authenticating with the dashboard session cookie — creates its slot with an
+    empty ``_app`` and its calls to its OWN MCP server never satisfy the
+    app-own-server auto-approve. Deriving the owner from the agent restores that
+    intra-app UX without trusting anything the client sent: the mapping comes
+    only from shipped manifests, exactly like :func:`builtin_app_mcp_servers`.
+
+    An agent name declared by MORE than one app is dropped entirely rather than
+    resolved arbitrarily — ambiguous provenance must not grant either app's
+    identity (fail-closed). Filesystem I/O (manifest + one read per declared
+    agent file); callers warm it ONCE off the event loop. A source, manifest, or
+    agent file that fails to read is skipped, never widening the mapping.
+    """
+    # Deferred import: manager imports this module at load time (see
+    # builtin_app_names), so the reverse edge resolves lazily.
+    from kiro_crew.apps.manager import builtin_owns_installed
+
+    mapping: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    owned: dict[str, bool] = {}
+    for source in _builtin_manifest_sources():
+        try:
+            entries = sorted(source.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                root = entry.resolve(strict=True)
+                if not root.is_dir() or not root.is_relative_to(source):
+                    continue
+                manifest_path = (root / "app.json").resolve(strict=True)
+                if not manifest_path.is_file() or not manifest_path.is_relative_to(root):
+                    continue
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                continue
+            if not isinstance(manifest, dict):
+                continue
+            name = manifest.get("name")
+            agents = manifest.get("agents")
+            if not (isinstance(name, str) and name and isinstance(agents, list)):
+                continue
+            if name not in owned:
+                owned[name] = builtin_owns_installed(name)
+            if not owned[name]:
+                continue
+            for rel in agents:
+                if not isinstance(rel, str) or not rel:
+                    continue
+                try:
+                    # Confine the declared path to the app root: a manifest is
+                    # immutable shipped data, but resolving before the
+                    # containment check keeps a symlinked entry from reading an
+                    # agent file outside the app it claims to ship.
+                    agent_path = (root / rel).resolve(strict=True)
+                    if not agent_path.is_file() or not agent_path.is_relative_to(root):
+                        continue
+                    agent_doc = json.loads(agent_path.read_text(encoding="utf-8"))
+                except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(agent_doc, dict):
+                    continue
+                agent_name = agent_doc.get("name")
+                if not (isinstance(agent_name, str) and agent_name):
+                    continue
+                for key in (agent_name, f"{name}--{agent_name}"):
+                    if mapping.get(key, name) != name:
+                        ambiguous.add(key)
+                    mapping[key] = name
+    for key in ambiguous:
+        mapping.pop(key, None)
+    return mapping
+
+
 def shipped_builtin_module_path(app_name: str, module_name: str) -> Path | None:
     """Resolve a ``python -m`` target only when it belongs to ``app_name``'s package."""
     root = shipped_builtin_app_root(app_name)

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3714,6 +3714,11 @@ async def _run_chat(
                         is_shell=event.is_shell,
                         mcp_server_name=event.mcp_server_name,
                         mcp_tool_name=event.tool_name,
+                        # The RESOLVED agent (what actually served the turn), not
+                        # slot.agent — that is an alias resolve_agent_bindings
+                        # maps to a concrete kiro agent, so it must never decide
+                        # which builtin app an agent belongs to.
+                        resolved_agent=read_effective_agent(client),
                     )
                     if tool_result.action == TOOL_DENY:
                         await client.reject_tool(event.request_id)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2417,8 +2417,16 @@ async def start_dashboard(
     # empty set (should this fail) simply fails closed (owns-server calls prompt).
     async def _warm_builtin_app_names() -> None:
         try:
-            from kiro_crew.apps.execution import builtin_app_mcp_servers, builtin_app_names
-            from kiro_crew.hooks import set_builtin_app_mcp_servers, set_builtin_app_names
+            from kiro_crew.apps.execution import (
+                builtin_app_agents,
+                builtin_app_mcp_servers,
+                builtin_app_names,
+            )
+            from kiro_crew.hooks import (
+                set_builtin_app_agents,
+                set_builtin_app_mcp_servers,
+                set_builtin_app_names,
+            )
 
             names = await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), builtin_app_names
@@ -2428,6 +2436,12 @@ async def start_dashboard(
                 subprocess_executor(), builtin_app_mcp_servers
             )
             set_builtin_app_mcp_servers(servers)
+            # Agent → owning app, so a builtin whose UI is not an app iframe
+            # (empty Slot._app) can still auto-approve calls to its OWN server.
+            agents = await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), builtin_app_agents
+            )
+            set_builtin_app_agents(agents)
         except Exception:  # noqa: BLE001 — a warm failure only costs an extra prompt
             logger.warning("Failed to warm builtin app-name set for the gate", exc_info=True)
 

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -15,7 +15,7 @@ import os
 import stat as _stat
 import time
 import uuid
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -410,6 +410,7 @@ class HookManager:
         is_shell: bool = False,
         mcp_server_name: str = "",
         mcp_tool_name: str = "",
+        resolved_agent: str = "",
     ) -> ToolHookResult:
         """Check if a tool should be auto-approved, denied, or handled normally.
 
@@ -635,9 +636,28 @@ class HookManager:
         # SHIPPED manifest (``_is_declared_builtin_mcp_server``, an in-memory set
         # warmed at boot from immutable manifests — same discipline as
         # ``_BUILTIN_APP_NAMES``) so only a genuinely app-own server auto-approves.
+        #
+        # Recover an app identity for a builtin whose slot carries NONE. Only a
+        # request with an authenticated app scope sets ``Slot._app``, so a
+        # builtin whose UI is not an app iframe (an Electron window using the
+        # dashboard session cookie) binds its slot with an empty app and every
+        # condition below keyed on it fails — the app could not talk to its own
+        # server. Prefer the slot's own ``app`` whenever it HAS one, so an
+        # app-scoped session behaves exactly as before; the derived value is used
+        # ONLY for this auto-approve and is never written back to the slot (see
+        # ``_builtin_app_for_agent`` — ``_app`` also drives app isolation).
+        #
+        # Keyed on ``resolved_agent`` (what ACTUALLY ran), NEVER on ``agent``:
+        # the latter is the slot's ALIAS, which ``resolve_agent_bindings`` maps to
+        # a concrete kiro agent before dispatch, so a user-defined alias named
+        # after a builtin's agent could otherwise borrow that app's identity for
+        # a completely different runtime agent. An empty ``resolved_agent`` (an
+        # uncached permission event, or a caller that does not thread it through)
+        # yields no identity — fail-closed to interactive approval.
+        owner_app = app or _builtin_app_for_agent(resolved_agent)
         if (
-            _app_owns_mcp_server(mcp_server_name, app)
-            and _is_first_party_app(app)
+            _app_owns_mcp_server(mcp_server_name, owner_app)
+            and _is_first_party_app(owner_app)
             and _is_declared_builtin_mcp_server(mcp_server_name)
         ):
             # Govern the REAL tool by its TRUSTED _meta.kiro identity before
@@ -1051,6 +1071,63 @@ def _is_first_party_app(app: str) -> bool:
     Fail-closed before the set is warmed.
     """
     return bool(app) and app.casefold() in _BUILTIN_APP_NAMES
+
+
+# Agent name → owning builtin app, populated ONCE at gateway boot via
+# ``set_builtin_app_agents``. Parallel to ``_BUILTIN_APP_NAMES`` /
+# ``_BUILTIN_APP_MCP_SERVERS`` and kept as a plain module global for the same
+# reason — the PreToolUse gate does ZERO filesystem I/O. Keys are casefolded on
+# ingest so the lookup is a pure dict hit. Empty until warmed → fail-closed: an
+# unrecognised agent yields no app identity and its own-server calls simply
+# prompt, exactly as before this map existed.
+_BUILTIN_APP_AGENTS: dict[str, str] = {}
+
+
+def set_builtin_app_agents(mapping: "Mapping[str, str]") -> None:
+    """Install the agent → owning-builtin-app map for the gate.
+
+    Called once at gateway boot with ``apps.execution.builtin_app_agents()`` —
+    derived only from shipped manifests whose install is builtin-owned, with
+    ambiguous names already dropped. Dependency-inverted like
+    ``set_builtin_app_names`` so ``hooks`` never imports ``apps``. Idempotent; a
+    later call replaces the map.
+    """
+    global _BUILTIN_APP_AGENTS
+    _BUILTIN_APP_AGENTS = {
+        agent.casefold(): app
+        for agent, app in mapping.items()
+        if isinstance(agent, str) and agent and isinstance(app, str) and app
+    }
+
+
+def _builtin_app_for_agent(resolved_agent: str) -> str:
+    """The builtin app that SHIPS *resolved_agent*, or ``""`` when none provably does.
+
+    Recovers an app identity for a slot whose ``_app`` is empty. ``Slot._app``
+    comes from the request's AUTHENTICATED app scope, so a builtin app whose UI
+    is not an app iframe — e.g. an Electron window that authenticates with the
+    dashboard session cookie — binds its slot with NO app identity, and its
+    calls to its OWN MCP server never satisfy the app-own-server auto-approve
+    below (``_app_owns_mcp_server`` returns False for a blank app).
+
+    The argument MUST be the RESOLVED agent (what actually served the turn, i.e.
+    ``AcpClient._agent`` / ``read_effective_agent``), never ``Slot.agent``. The
+    slot's agent is an ALIAS that ``resolve_agent_bindings`` maps to a concrete
+    kiro agent before dispatch — a slot set to ``default`` can be served by
+    ``kirocrew`` — so an alias NAMED after a builtin's agent would otherwise lend
+    that app's identity to a different runtime agent entirely. Keying on the
+    resolved id makes the grant follow what ran, matching the precedence
+    ``read_effective_agent`` already establishes for usage attribution. The map
+    itself is built solely from IMMUTABLE shipped manifests, so nothing the
+    client sent decides which app an agent belongs to.
+
+    Used ONLY to satisfy the app-own-server auto-approve. Deliberately NOT
+    written back to ``Slot._app``: that field also drives app ISOLATION (which
+    app may delete or retitle a slot), so marking a dashboard-created slot
+    app-owned would widen those checks. Pure in-memory lookup; fail-closed before
+    the map is warmed and for an empty resolved agent.
+    """
+    return _BUILTIN_APP_AGENTS.get(resolved_agent.casefold(), "") if resolved_agent else ""
 
 
 def _cu_read_only_auto_approve(tool_name: str) -> bool:

--- a/test/test_app_execution.py
+++ b/test/test_app_execution.py
@@ -317,6 +317,59 @@ class TestExecutionDecision:
         assert "edition-app:srv2" in servers
         assert "shadowed-app:evil" not in servers  # shadowing install excluded
 
+    def test_builtin_app_agents_maps_declared_agents_to_owning_app(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # builtin_app_agents maps every agent a builtin-owned shipped manifest
+        # declares to its app, under both the bare and `app--agent` spellings. A
+        # shadowing user app contributes nothing, and a name two apps both
+        # declare is dropped entirely (ambiguous provenance must grant neither).
+        import kiro_crew.platform as platform_mod
+        from kiro_crew.apps import execution
+        from kiro_crew.apps.manager import InstalledApp, _write_installed
+
+        home = tmp_path / "kirocrew-home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        source = tmp_path / "edition-builtins"
+
+        def _app(name: str, agents: dict[str, str]) -> None:
+            root = source / name
+            (root / "agents").mkdir(parents=True)
+            (root / "app.json").write_text(
+                json.dumps({"name": name, "agents": [f"agents/{f}" for f in agents]}),
+                encoding="utf-8",
+            )
+            for filename, agent_name in agents.items():
+                (root / "agents" / filename).write_text(
+                    json.dumps({"name": agent_name}), encoding="utf-8"
+                )
+
+        _app("edition-app", {"main.json": "edition-main", "bg.json": "clash"})
+        _app("other-app", {"main.json": "clash"})  # same agent name → ambiguous
+        _app("shadowed-app", {"main.json": "shadow-main"})
+
+        context = SimpleNamespace(apps_loader=SimpleNamespace(manifest_sources=lambda: [source]))
+        monkeypatch.setattr(platform_mod, "current_context", lambda: context)
+
+        for name in ("edition-app", "other-app"):
+            _write_installed(name, InstalledApp(name=name, source="builtin", origin="builtin"))
+        _write_installed(
+            "shadowed-app",
+            InstalledApp(name="shadowed-app", source="registry:evil", origin="registry"),
+        )
+
+        agents = execution.builtin_app_agents()
+        assert agents["edition-main"] == "edition-app"
+        assert agents["edition-app--edition-main"] == "edition-app"
+        # Ambiguous across two builtins → neither app's identity is granted.
+        assert "clash" not in agents
+        # Per-app link spelling stays unambiguous, so it survives.
+        assert agents["edition-app--clash"] == "edition-app"
+        # Shadowing install contributes nothing.
+        assert "shadow-main" not in agents
+
     def test_denial_is_audited_with_action_and_app(self, monkeypatch) -> None:
         from kiro_crew.apps import execution
 

--- a/test/test_hooks.py
+++ b/test/test_hooks.py
@@ -752,6 +752,118 @@ class TestAppOwnMcpServerAutoApprove:
         )
         assert r.action == TOOL_AUTO_APPROVE
 
+    @pytest.fixture
+    def _agent_owned(self, monkeypatch):
+        """``myagent`` is declared by builtin ``myapp``'s shipped manifest."""
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(hooks_mod, "_BUILTIN_APP_AGENTS", {"myagent": "myapp"})
+
+    def test_own_server_auto_approved_when_slot_app_empty(self, _builtin, _agent_owned):
+        # A builtin whose UI is not an app iframe (e.g. an Electron window using
+        # the dashboard session cookie) binds its slot with NO authenticated app
+        # scope, so Slot._app is empty and every app-keyed condition would fail —
+        # the app could not call its OWN server. The owner is recovered from the
+        # non-model-authored agent via shipped-manifest provenance.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="",
+            agent="myalias",
+            resolved_agent="myagent",
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="do_thing",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_AUTO_APPROVE
+
+    def test_unmapped_agent_with_empty_app_not_auto_approved(self, _builtin, _agent_owned):
+        # No shipped manifest declares this agent, so no app identity can be
+        # proven: fail closed to interactive approval rather than guessing.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="",
+            resolved_agent="stranger",
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="do_thing",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_slot_agent_alias_cannot_impersonate_app_agent(self, _builtin, _agent_owned):
+        # The slot's `agent` is an ALIAS that resolve_agent_bindings maps to a
+        # concrete kiro agent before dispatch, so an alias NAMED after a builtin's
+        # agent must NOT lend that app's identity to whatever actually ran. Only
+        # the resolved identity decides ownership.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="",
+            agent="myagent",  # alias spelled like the builtin's agent
+            resolved_agent="kirocrew",  # …but a different agent served the turn
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="do_thing",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_missing_resolved_agent_not_auto_approved(self, _builtin, _agent_owned):
+        # Without a resolved identity we cannot prove WHICH agent ran, so the
+        # alias is never used as a substitute — fail closed.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="",
+            agent="myagent",
+            resolved_agent="",
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="do_thing",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_derived_owner_cannot_reach_another_apps_server(self, _agent_owned, monkeypatch):
+        # The derived identity is still only ITS OWN server: it must not
+        # auto-approve a different app's app-scoped server. Both apps are
+        # first-party and both servers declared, so ONLY the ownership check can
+        # be what rejects this.
+        import kiro_crew.hooks as hooks_mod
+
+        monkeypatch.setattr(
+            hooks_mod, "_is_first_party_app", lambda app: app.casefold() in {"myapp", "otherapp"}
+        )
+        monkeypatch.setattr(
+            hooks_mod, "_BUILTIN_APP_MCP_SERVERS", frozenset({"myapp:srv", "otherapp:srv"})
+        )
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__otherapp:srv__do_thing",
+            app="",
+            agent="myalias",
+            resolved_agent="myagent",
+            mcp_server_name="otherapp:srv",
+            mcp_tool_name="do_thing",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
+    def test_slot_app_takes_precedence_over_derived_owner(self, _builtin, _agent_owned):
+        # An app-scoped session keeps its AUTHENTICATED identity: the agent map is
+        # a fallback for an empty _app, never an override that could lend one app
+        # another's identity.
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "mcp__myapp:srv__do_thing",
+            app="otherapp",
+            agent="myalias",
+            resolved_agent="myagent",
+            mcp_server_name="myapp:srv",
+            mcp_tool_name="do_thing",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_ALLOW
+
     def test_own_server_without_trusted_tool_name_not_auto_approved(self, _builtin):
         # No trusted _meta.kiro.toolName → we cannot identify WHICH tool this is
         # to govern it, so the app-own-server auto-approve does NOT fire; the


### PR DESCRIPTION
## Problem

The app-own-MCP auto-approve added in #1307 requires a non-empty **app identity**, which it reads from `Slot._app`:

```python
_app_owns_mcp_server(mcp_server_name, app)
and _is_first_party_app(app)
and _is_declared_builtin_mcp_server(mcp_server_name)
```

`Slot._app` is set from `request["app"]`, which the auth middleware populates from the request's **authenticated app scope**. That works for an app **iframe** (its credential is app-scoped — note `app-sdk/useChatSession.ts` doesn't send an `app` field either, the middleware fills it in). It does **not** work for a builtin whose UI is not an iframe: Mochi's Electron windows authenticate with the dashboard session cookie, so `request["app"]` is empty and `slot._app == ""`.

`_app_owns_mcp_server` documents *"Returns `False` for a blank `app`"*, so **the first two conditions can never hold** and Mochi's calls to its own `mochi:mochi` server always fell through to an interactive prompt — the exact UX #1307 set out to fix, for the app that most needs it.

Verified the other conditions are fine: `builtin_app_mcp_servers()` contains `mochi:mochi`, `mochi` is in `builtin_app_names()`, and its install record is builtin-owned (`source=builtin`, `origin=builtin`).

Letting the request body declare `app` is **not** an option — that is precisely what the middleware design prevents.

## Fix

Derive the owner from the **agent the slot is bound to**, via a boot-warmed map built only from **shipped builtin manifests whose install is builtin-owned** — the same immutable provenance `_is_declared_builtin_mcp_server` already relies on. Nothing the client sent is trusted; the agent binding is not model-authored.

- **`apps/execution.py`** — new `builtin_app_agents()`, mirroring `builtin_app_mcp_servers()` (same sources, same builtin-owned narrowing, same fail-closed skips, same path-containment guard). Emits both the bare name and the `app--agent` link form. An agent name **two apps both declare is dropped**, not resolved arbitrarily.
- **`hooks.py`** — `_BUILTIN_APP_AGENTS` + `set_builtin_app_agents()` + `_builtin_app_for_agent()`, dependency-inverted exactly like the existing setters so `hooks` never imports `apps` and the gate does zero filesystem I/O. The branch now uses `owner_app = app or _builtin_app_for_agent(agent)`.
- **`dashboard/server.py`** — warm it alongside the other two, on the executor.

## Deliberately NOT done

`Slot._app` is **not** written back to. That field also drives app **isolation** (which app may delete or retitle a slot, and "app cannot delete unscoped slots"), so marking a dashboard-created slot app-owned would widen those checks. The derived value is scoped to this one auto-approve branch; the inner `_governance_denial` still receives the original `app`, so scope resolution is unchanged.

## Security properties preserved

- A slot that **has** an app keeps its authenticated identity (`app or …`), so the map can never lend one app another's identity.
- Still requires all three original conditions, plus the missing-`mcp_tool_name` fail-closed fall-through.
- The deny floor and governance re-check on the canonical `mcp__server__tool` are untouched.
- Empty until warmed → fail-closed.

Verified against the real manifest tree — **rejected** as before: `kirocrew-cron` (host server), empty server name, undeclared `mochi:evil`, an unmapped agent name, and **cross-app** (`mochi`'s agent reaching `crew-companion:crew-companion`). **Approved**: `mochi` / `mochi-bg` with an empty `_app`.

## Tests

`test_hooks.py` — auto-approve with empty `_app` via the agent; unmapped agent fails closed; derived owner cannot reach another app's server (both apps first-party and both servers declared, so only the ownership check can reject); `_app` takes precedence over the derived owner.

`test_app_execution.py` — `builtin_app_agents()` maps both spellings, drops the ambiguous cross-app name, and excludes a shadowing install.

201 passed across `test_hooks.py` / `test_app_execution.py` / `test_app_manifest.py`. flake8 + isort clean. The 3 mypy `os.xattr` errors in `hooks.py` are pre-existing on `main` (verified by stashing).

## Out of scope

Trust level (`trust` / `trust_reads`) resetting on gateway restart is a **separate** issue with a different cause: those flags are never persisted. `open_slots.json` stores only slot keys, and the rehydrate path restores `model` / `workspace` / `project` / `mode` / `folder_id` / `app` / `artifact` / `pinned` but no trust — so every restart returns the slot to the `Slot.__init__` default (`_trust=False`, `_trust_reads=False`). Persisting a security grant across restarts deserves its own review.
