### PR TITLE
fix(acp): cap inlined image dimensions at 2000px to prevent session poisoning

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -403,12 +403,16 @@ The `audit_source` constructor param (default `None`) tags an `AcpClient` that r
 
 `_send_prompt()` auto-detects image file paths in messages (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`) via regex. When a valid image path is found:
 
-1. Reads the file and base64-encodes it
-2. Appends an image content block: `{"type": "image", "data": "<base64>", "mimeType": "image/png"}`
-3. Replaces the path in the text with `[image: filename.png]`
-4. Sends both text and image blocks in the `prompt` array
+1. Reads the file (paths over `MAX_IMAGE_BYTES` = 10 MB stay as text, not inlined)
+2. Downscales so the longest edge is <= `MAX_IMAGE_EDGE_PX` (2000 px), preserving aspect ratio and re-encoding to the same format (an oversized GIF becomes a PNG still frame)
+3. Base64-encodes the (possibly downscaled) bytes
+4. Appends an image content block: `{"type": "image", "data": "<base64>", "mimeType": "image/png"}`
+5. Replaces the path in the text with `[image: filename.png]`
+6. Sends both text and image blocks in the `prompt` array
 
 This leverages kiro-cli's `promptCapabilities.image: true` capability. The LLM receives the image inline — no tool call needed.
+
+**Dimension backstop** (`build_prompt_blocks` in `acp/prompt_blocks.py`). This shared builder is the single funnel every channel's images cross before reaching kiro-cli, so the `MAX_IMAGE_EDGE_PX` (2000 px) downscale runs for all of them — dashboard upload/paste/screenshot, Slack, Discord. Anthropic rejects the ENTIRE request when a many-image conversation (>20 images) carries any image over 2000 px on a side; because kiro-cli replays the full message history every turn, one oversized image would otherwise sit at a fixed history index and wedge the session permanently (a follow-up resize cannot evict the original). The browser's client-side resize (1568 px, `website/src/utils/resizeImage.ts`) is a token-cost optimization on top; this server-side cap is the correctness guarantee that still holds when that resize is skipped or bypassed (e.g. the native `/api/screenshot` capture, or non-dashboard channels).
 
 
 ## AcpRuntime & AcpSessionHandle (session multiplexing)

--- a/src/kiro_crew/acp/prompt_blocks.py
+++ b/src/kiro_crew/acp/prompt_blocks.py
@@ -27,12 +27,19 @@ Wire shape (per docs/kiro-cli/acp.md):
 from __future__ import annotations
 
 import base64
+import io
 import logging
 import os
 import re
 from pathlib import Path
 
 from kiro_crew.hooks import safe_read_file_bytes
+
+try:
+    from PIL import Image, ImageOps
+    _HAS_PIL = True
+except ImportError:  # pragma: no cover - Pillow ships via qrcode[pil]/pdfplumber
+    _HAS_PIL = False
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +60,30 @@ IMAGE_MEDIA_TYPES: dict[str, str] = {
 #: unbounded image becomes an unbounded write. Matches the Slack producer cap so
 #: a file that passed ingestion is not silently dropped here.
 MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+#: Longest-edge cap (px) enforced on every inlined image. Anthropic rejects the
+#: ENTIRE request when a many-image conversation (more than 20 images) carries
+#: any image whose width or height exceeds 2000px. Because kiro-cli replays the
+#: full message history to the model every turn, a single oversized image
+#: permanently wedges the session -- the offending block sits at a fixed history
+#: index and re-uploading a smaller copy cannot evict it. This builder is the
+#: one funnel every channel's images cross before reaching kiro-cli, so capping
+#: here protects all of them (dashboard upload/paste/screenshot, Slack, Discord)
+#: regardless of any best-effort client-side resize. 2000 is the hard limit
+#: itself: valid even past 20 images, yet it keeps more detail than the browser's
+#: 1568px pre-upload downscale, which only ever covers dashboard uploads.
+MAX_IMAGE_EDGE_PX = 2000
+
+#: mime -> Pillow save format for a re-encoded downscale. GIF collapses to a PNG
+#: first frame: vision models read frame 0 only (animation is invisible to them)
+#: and rescaling a palette image is lossy, so a lossless still is faithful.
+_PIL_SAVE_FORMAT: dict[str, str] = {
+    "image/png": "PNG",
+    "image/jpeg": "JPEG",
+    "image/webp": "WEBP",
+    "image/bmp": "BMP",
+    "image/gif": "PNG",
+}
 
 # Absolute paths ending in a supported raster suffix.
 #
@@ -109,11 +140,74 @@ _WINDOWS_PATH_RE = re.compile(
 _PATH_RE = _WINDOWS_PATH_RE if os.name == "nt" else _POSIX_PATH_RE
 
 
+def _downscale_within_limits(raw_bytes: bytes, mime: str, max_edge: int) -> tuple[bytes, str] | None:
+    """Downscale *raw_bytes* so its longest edge is <= *max_edge*, keeping aspect.
+
+    Returns ``(bytes, mime)`` -- the ORIGINAL pair when the image is already
+    within the cap, the downscaled pair otherwise. The mime can change
+    (``image/gif`` -> ``image/png``) because the re-encode picks a still format.
+
+    Returns ``None`` when the image is oversized (or its size is unknowable) but
+    a compliant copy could NOT be produced -- an undecodable file, or a Pillow
+    decompression-bomb rejection on a huge-but-small-bytes raster. The caller
+    must then NOT inline it: shipping the un-shrunk original is precisely the
+    >2000px payload that poisons the session, so a failure fails CLOSED (leave
+    the path as text) rather than open. Pillow is a guaranteed runtime dep; the
+    ``_HAS_PIL`` guard only keeps image support alive on a hand-stripped install
+    where dimensions cannot be verified at all.
+    """
+    if not _HAS_PIL or max_edge <= 0:
+        return raw_bytes, mime
+    try:
+        with Image.open(io.BytesIO(raw_bytes)) as img:
+            # Header read only -- no decompression -- so a within-cap image never
+            # pays for a decode and rides through byte-identical.
+            if max(img.width, img.height) <= max_edge:
+                return raw_bytes, mime
+            # Bake EXIF orientation into the pixels BEFORE resizing: the re-encode
+            # (PNG in particular) drops the orientation tag, so a phone photo
+            # would otherwise reach the model rotated.
+            oriented = ImageOps.exif_transpose(img) or img
+            # Palette frames upsample poorly; promote to RGBA so the resample
+            # interpolates real channels rather than palette indices.
+            src = oriented.convert("RGBA") if oriented.mode in ("P", "PA") else oriented
+            long_edge = max(src.width, src.height)
+            scale = max_edge / long_edge
+            new_size = (max(1, round(src.width * scale)), max(1, round(src.height * scale)))
+            resample = getattr(Image, "LANCZOS", getattr(Image, "ANTIALIAS", 1))
+            resized = src.resize(new_size, resample)
+            fmt = _PIL_SAVE_FORMAT.get(mime, "PNG")
+            if fmt in ("JPEG", "BMP") and resized.mode not in ("RGB", "L"):
+                # JPEG/BMP carry no alpha channel; flatten before encoding.
+                resized = resized.convert("RGB")
+            buf = io.BytesIO()
+            if fmt == "JPEG":
+                resized.save(buf, format="JPEG", quality=90)
+            elif fmt == "WEBP":
+                # A source WEBP may be lossless; PIL defaults to lossy q80, so
+                # stay lossless to avoid re-encode artifacts on the downscale.
+                resized.save(buf, format="WEBP", lossless=True)
+            else:
+                resized.save(buf, format=fmt)
+            out_mime = "image/png" if mime == "image/gif" else mime
+            return buf.getvalue(), out_mime
+    except Exception:
+        # Fail CLOSED: an oversized image we could not shrink must not be inlined,
+        # or the original >2000px payload reaches the model and poisons the session.
+        logger.warning(
+            "acp prompt: could not downscale oversized image (mime=%s); leaving as path",
+            mime,
+            exc_info=True,
+        )
+        return None
+
+
 def build_prompt_blocks(
     message: str,
     *,
     allow_image: bool = True,
     max_image_bytes: int = MAX_IMAGE_BYTES,
+    max_image_edge: int = MAX_IMAGE_EDGE_PX,
 ) -> list[dict]:
     """Return ACP prompt blocks for *message*.
 
@@ -126,6 +220,11 @@ def build_prompt_blocks(
     is still on disk, so a tool-capable agent can open it, which is a strictly
     better fallback than dropping the reference. The result is always at least
     one text block, so a caller can pass it straight to ``session/prompt``.
+
+    Inlined images are downscaled so their longest edge is at most
+    ``max_image_edge`` px -- the server-side backstop for Anthropic's many-image
+    dimension limit, applied for EVERY channel here regardless of any
+    client-side resize that was skipped or bypassed.
     """
     text = message
     images: list[dict] = []
@@ -166,9 +265,21 @@ def build_prompt_blocks(
                 # stays in the text; it is NOT inlined.
                 logger.warning("acp prompt: image read refused for %s", path.name)
                 continue
-            data = base64.b64encode(raw_bytes).decode("ascii")
+            downscaled = _downscale_within_limits(raw_bytes, mime, max_image_edge)
+            if downscaled is None:
+                # Oversized and un-shrinkable (decompression-bomb / undecodable):
+                # leave the path as text rather than inline a >2000px payload that
+                # would poison the session. A tool-capable agent can still open it.
+                logger.warning(
+                    "acp prompt: image %s exceeds the dimension cap and could not be "
+                    "downscaled - sending path, not inline",
+                    path.name,
+                )
+                continue
+            out_bytes, out_mime = downscaled
+            data = base64.b64encode(out_bytes).decode("ascii")
             seen.add(raw)
-            images.append({"type": "image", "data": data, "mimeType": mime})
+            images.append({"type": "image", "data": data, "mimeType": out_mime})
             text = text.replace(raw, f"[image: {path.name}]")
 
     return [{"type": "text", "text": text}, *images]

--- a/test/test_acp_prompt_blocks.py
+++ b/test/test_acp_prompt_blocks.py
@@ -9,6 +9,7 @@ replaces. An image therefore never reached the model as vision input.
 from __future__ import annotations
 
 import base64
+import io
 import os
 
 import pytest
@@ -18,6 +19,7 @@ from kiro_crew.acp.prompt_blocks import (
     _POSIX_PATH_RE,
     IMAGE_MEDIA_TYPES,
     MAX_IMAGE_BYTES,
+    MAX_IMAGE_EDGE_PX,
     build_prompt_blocks,
 )
 
@@ -159,12 +161,20 @@ class TestSensitivePathGate:
 
     def test_encoded_bytes_come_from_the_gate(self, tmp_path, monkeypatch):
         """The wire payload is the gate's output, not a second unguarded read."""
-        p = _png(tmp_path)
-        monkeypatch.setattr(prompt_blocks, "safe_read_file_bytes", lambda raw: b"FROM GATE")
+        pil = pytest.importorskip("PIL.Image")
+        p = _png(tmp_path)  # on-disk content is the 1x1 _PNG
+        # The gate returns DIFFERENT (valid, within-cap) bytes; prove the wire
+        # carries THOSE, not a re-read of the file. A non-image sentinel would be
+        # dropped now: undecodable bytes fail closed (see TestImageDownscale).
+        buf = io.BytesIO()
+        pil.new("RGB", (2, 2), (1, 2, 3)).save(buf, format="PNG")
+        gate_bytes = buf.getvalue()
+        assert gate_bytes != p.read_bytes()
+        monkeypatch.setattr(prompt_blocks, "safe_read_file_bytes", lambda raw: gate_bytes)
 
         blocks = build_prompt_blocks(f"look at {p}")
 
-        assert base64.b64decode(blocks[1]["data"]) == b"FROM GATE"
+        assert base64.b64decode(blocks[1]["data"]) == gate_bytes
 
 
 class TestPlatformPathGrammar:
@@ -271,3 +281,120 @@ class TestPathsAdjacentToUrls:
         p = _png(tmp_path)
         blocks = build_prompt_blocks(f"![image]({p})")
         assert [b["type"] for b in blocks] == ["text", "image"]
+
+
+def _sized_image(tmp_path, w, h, fmt="PNG", name=None):
+    """Write a solid-colour raster of exactly ``w``x``h`` and return its path.
+
+    Solid colour keeps PNG/JPEG/WEBP encodings tiny so they clear the byte gate
+    and the downscale (not the byte cap) is what the test exercises.
+    """
+    pil = pytest.importorskip("PIL.Image")
+    ext = {"PNG": "png", "JPEG": "jpg", "WEBP": "webp", "BMP": "bmp", "GIF": "gif"}[fmt]
+    p = tmp_path / (name or f"big.{ext}")
+    pil.new("RGB", (w, h), (123, 200, 60)).save(p, format=fmt)
+    return p
+
+
+def _decoded_size(block):
+    pil = pytest.importorskip("PIL.Image")
+    with pil.open(io.BytesIO(base64.b64decode(block["data"]))) as im:
+        return im.size
+
+
+class TestImageDownscale:
+    """The server-side dimension backstop: no image reaches kiro-cli over the
+    Anthropic many-image cap, whatever channel (or skipped client resize) it
+    came from."""
+
+    def test_default_cap_is_2000(self):
+        assert MAX_IMAGE_EDGE_PX == 2000
+
+    def test_oversized_image_is_downscaled(self, tmp_path):
+        p = _sized_image(tmp_path, 4000, 3000)
+        blocks = build_prompt_blocks(f"see {p}")
+        w, h = _decoded_size(blocks[1])
+        # Longest edge capped, aspect preserved (4000x3000 -> 2000x1500).
+        assert max(w, h) <= MAX_IMAGE_EDGE_PX
+        assert (w, h) == (2000, 1500)
+
+    def test_portrait_image_downscaled_on_its_long_edge(self, tmp_path):
+        p = _sized_image(tmp_path, 1000, 4000)
+        blocks = build_prompt_blocks(f"see {p}")
+        assert _decoded_size(blocks[1]) == (500, 2000)
+
+    def test_image_within_cap_is_byte_identical(self, tmp_path):
+        """At/under the cap the original bytes ride through untouched -- no
+        needless re-encode (which would recompress and drift quality)."""
+        p = _sized_image(tmp_path, 1600, 1200)
+        original = p.read_bytes()
+        blocks = build_prompt_blocks(f"see {p}")
+        assert base64.b64decode(blocks[1]["data"]) == original
+
+    def test_custom_edge_param_is_honoured(self, tmp_path):
+        p = _sized_image(tmp_path, 40, 20)
+        blocks = build_prompt_blocks(f"see {p}", max_image_edge=10)
+        assert _decoded_size(blocks[1]) == (10, 5)
+
+    def test_edge_zero_disables_downscale(self, tmp_path):
+        """The escape hatch: a non-positive cap leaves bytes exactly as-is."""
+        p = _sized_image(tmp_path, 4000, 10)
+        original = p.read_bytes()
+        blocks = build_prompt_blocks(f"see {p}", max_image_edge=0)
+        assert base64.b64decode(blocks[1]["data"]) == original
+
+    def test_oversized_jpeg_keeps_jpeg_mime(self, tmp_path):
+        p = _sized_image(tmp_path, 3000, 1000, fmt="JPEG")
+        blocks = build_prompt_blocks(f"see {p}")
+        assert blocks[1]["mimeType"] == "image/jpeg"
+        assert max(_decoded_size(blocks[1])) <= MAX_IMAGE_EDGE_PX
+
+    def test_oversized_gif_becomes_png_still(self, tmp_path):
+        """GIF re-encodes to a PNG first frame: the vision model reads frame 0
+        only, and palette rescaling is lossy, so a lossless still is faithful."""
+        p = _sized_image(tmp_path, 3000, 100, fmt="GIF")
+        blocks = build_prompt_blocks(f"see {p}")
+        assert blocks[1]["mimeType"] == "image/png"
+        assert max(_decoded_size(blocks[1])) <= MAX_IMAGE_EDGE_PX
+
+    def test_oversized_bmp_is_capped(self, tmp_path):
+        # A thin BMP stays under the 10 MB byte gate yet over the edge cap, so
+        # the downscale (not the byte gate) is what fires.
+        p = _sized_image(tmp_path, 2400, 80, fmt="BMP")
+        blocks = build_prompt_blocks(f"see {p}")
+        assert max(_decoded_size(blocks[1])) <= MAX_IMAGE_EDGE_PX
+
+    def test_oversized_webp_keeps_webp_mime(self, tmp_path):
+        p = _sized_image(tmp_path, 3000, 1000, fmt="WEBP")
+        blocks = build_prompt_blocks(f"see {p}")
+        assert blocks[1]["mimeType"] == "image/webp"
+        assert max(_decoded_size(blocks[1])) <= MAX_IMAGE_EDGE_PX
+
+    def test_undecodable_oversized_image_is_not_inlined(self, tmp_path, monkeypatch):
+        """Fail CLOSED: an oversized raster we cannot shrink (here a Pillow
+        decompression-bomb rejection) must NOT reach the model as the original
+        >2000px payload -- that is exactly what poisons the session. The path is
+        left as text instead."""
+        pil = pytest.importorskip("PIL.Image")
+        p = _sized_image(tmp_path, 2001, 2001)  # over the edge cap
+        # Force a decompression-bomb ERROR on decode/resize (pixels > 2 x limit).
+        monkeypatch.setattr(pil, "MAX_IMAGE_PIXELS", 1_000_000)
+        blocks = build_prompt_blocks(f"see {p}")
+        assert [b["type"] for b in blocks] == ["text"]  # no image block
+        assert str(p) in blocks[0]["text"]  # path preserved for a tool-capable agent
+
+    def test_exif_orientation_is_baked_on_downscale(self, tmp_path):
+        """A re-encode drops the EXIF orientation tag, so orientation must be
+        baked into the pixels first or the model sees a rotated photo."""
+        pil = pytest.importorskip("PIL.Image")
+        p = tmp_path / "rot.jpg"
+        img = pil.new("RGB", (3000, 1000), (10, 20, 30))
+        exif = img.getexif()
+        exif[0x0112] = 6  # Orientation = rotate 90 CW -> displayed as 1000x3000
+        img.save(p, format="JPEG", exif=exif)
+        blocks = build_prompt_blocks(f"see {p}")
+        with pil.open(io.BytesIO(base64.b64decode(blocks[1]["data"]))) as out:
+            w, h = out.size
+            assert 0x0112 not in out.getexif()  # tag baked away, not carried
+            assert h > w  # rotation applied to the pixels -> portrait
+            assert max(w, h) <= MAX_IMAGE_EDGE_PX


### PR DESCRIPTION
## What is the problem?
A single oversized image (longest edge > 2000px) pasted or uploaded into a chat permanently wedges the whole session. Every following turn fails with:

```
ACP error ... image dimensions exceed max allowed size for many-image requests: 2000 pixels
```

and re-uploading a smaller image does not recover it.

## Why this issue matters to the user
The session is dead and unrecoverable through normal UI actions — regenerate, edit-resend, switching model/agent, and even closing/reopening the tab all reload the poisoned transcript. The user loses the conversation (must rewind past the image, fork the tab, or start fresh). It is trivially triggerable: a Retina screenshot is often wider than 2000px, and the native screenshot button plus Slack/Discord uploads have no client-side resize at all.

## How our fix solves it (symptom → root cause → change)
- **Symptom:** an oversized image → `many-image requests: 2000 pixels` rejection on every turn.
- **Root cause:** kiro-cli replays the full `messages[]` history to Anthropic each turn, so one image over the 2000px many-image cap sits at a fixed index and fails forever. KiroCrew inlines images in `build_prompt_blocks` with only a 10 MB **byte** cap — no pixel check. The browser resize (`website/src/utils/resizeImage.ts`, 1568px) is best-effort and bypassed by the native `/api/screenshot` capture, Slack/Discord, and its own fallbacks.
- **Change:** add a server-side dimension backstop in `build_prompt_blocks` — the single builder every channel's images cross before reaching kiro-cli. It downscales the longest edge to ≤ `MAX_IMAGE_EDGE_PX` (2000px), preserving aspect ratio and re-encoding to the same format (an oversized GIF → PNG still frame; WEBP stays lossless). 2000 is the hard limit itself, so it keeps more detail than the browser's 1568px path for high-resolution model tiers while guaranteeing no request is ever rejected. Pillow is already a runtime dependency (`qrcode[pil]` + pdfplumber); a soft-import degrades to byte-cap-only if it is ever absent.

## What tests we did
`test/test_acp_prompt_blocks.py::TestImageDownscale` (10 new cases): oversized landscape/portrait downscale with aspect preserved (4000×3000 → 2000×1500), at/under-cap images pass through **byte-identical** (no needless re-encode), custom cap honoured, non-positive cap escape hatch, per-format handling (PNG / JPEG / WEBP-lossless / BMP), GIF → PNG-still with the mime updated, and the `MAX_IMAGE_EDGE_PX == 2000` constant. Full local gate green: pytest (46 passed), isort, flake8, mypy.

## Manual verification
N/A for the model path — the unit tests exercise the real Pillow decode/resize/encode and decode the produced block to assert ≤ 2000px on the longest edge, which is exactly the condition that caused the rejection. No user-visible UI change (backend builder only), so no screenshots.

## Any other suggestions
Two follow-ups worth filing separately (out of scope here): (1) route the native `/api/screenshot` capture and screen-snip through the same client-side resize for token savings; (2) add a poison-safe "reset ACP transcript" action, since today only rewind / fork / new-chat can evict an already-poisoned image and `destroy()` is wired to no chat-slot endpoint.

Fixes #1404
