### PR TITLE
chore(apps): hide Crew Companion from the App Store

### DIFF
--- a/src/kiro_crew/apps/builtins/crew_companion/app.json
+++ b/src/kiro_crew/apps/builtins/crew_companion/app.json
@@ -15,6 +15,7 @@
     "Floats on your desktop with a swappable avatar"
   ],
   "defaultEnabled": false,
+  "hidden": true,
   "mcpServers": {
     "crew-companion": {
       "url": "http://127.0.0.1:7778/mcp",


### PR DESCRIPTION
## Problem
The **Crew Companion** app in the App Store cannot be enabled. Clicking Enable flips it on, then immediately rolls back to disabled.

## Why it matters
It presents a broken affordance to every user: a first-party app tile that fails every time it's toggled, with no path to make it work from the dashboard. The working companion (**Mochi**) already covers this use case.

## Fix (symptom -> root cause -> change)
- **Symptom:** Enable fails and the toggle snaps back to off.
- **Root cause:** Crew Companion is only a *connector* to a separate macOS desktop app (`Crew Companion.app`). Its `setup.onEnable` runs `open "$HOME/Applications/Crew Companion.app"`; that app is not shipped, downloadable, or listed in the app registry, so `open` exits non-zero and `handle_enable_app` rolls the enable back (stop backend, deregister, `disable_app`). There is no acquisition path anywhere in the repo, so the tile is inert for everyone.
- **Change:** Set `"hidden": true` on the builtin manifest (`crew_companion/app.json`) so it drops out of the App Store Browse grid — the same mechanism `workflows` and `channels` use. Backend code, routes, and the manifest's other fields are untouched; this is grid-visibility only. Mochi (a fully in-process companion, no second app) remains the visible companion.

## Tests
No new tests: the existing manifest contract suite (`crew_companion/tests/test_manifest.py`) already asserts the manifest validates and its field invariants, and it passes unchanged with the added flag. `test_app_manager.py` (registration/discovery) also passes. `hidden` is a tolerated manifest field (validation returns no errors), matching `workflows/app.json`.

## Manual verification
Ran source-tree discovery after the edit:
`discover_builtin_apps(src) -> {crew-companion: True, mochi: None, workflows: True}` — Crew Companion is now hidden (matching `workflows`) while Mochi stays visible. `AppManifest.validate()` returns `[]`. Full command output: 107 passed (manifest + app-manager/discovery).

## Screenshots
N/A — the change removes a tile from the App Store grid rather than altering a rendered surface; the meaningful evidence is the discovery `hidden` flag above. Can attach a before/after Browse-grid capture from a pod if a reviewer wants it.
