### PR TITLE
feat(github): add issue forms for bug, feature, and docs reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Something in KiroCrew is broken or behaves differently than documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing. The fields below are the ones a maintainer would
+        otherwise have to ask for, so filling them in usually saves a round trip.
+
+        Do NOT use this form for a security vulnerability. Report those privately
+        per [SECURITY.md](https://github.com/kirodotdev/KiroCrew/blob/main/SECURITY.md).
+
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Existing issues
+      options:
+        - label: I searched open issues and this is not already reported.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: KiroCrew version
+      description: Output of `kirocrew --version`.
+      placeholder: 1.2.3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How is it installed?
+      options:
+        - Desktop app
+        - pip / pipx
+        - Docker
+        - From source
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: >-
+        Pick "Not platform-specific" if it reproduces everywhere, or if you have
+        only tried one platform and have no reason to think it is specific to it.
+        Triage reads this answer to decide the platform label, so a guess here
+        becomes a wrong label.
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Not platform-specific
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you observed, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        Numbered steps from a known starting state. If it is intermittent, say
+        roughly how often it happens.
+      placeholder: |
+        1. Start the gateway with `kirocrew gateway`
+        2. Open the dashboard and ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >-
+        From `kirocrew logs -n 200`, or the browser console for a dashboard
+        issue. Redact anything sensitive — this is a public issue.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: >-
+        Screenshots, related config, workarounds you tried, or anything else that
+        adds context. Do not paste credentials or session cookies.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Blank issues stay ENABLED deliberately. issue-triage.yml allows six type
+# labels (bug, enhancement, documentation, refactor, security, question) and the
+# three forms here cover only the first three. Disabling blank issues would push
+# every question-, refactor-, or security-shaped report into whichever form fits
+# it worst. A blank issue also arrives with every label dimension empty, which is
+# the case the triage model classifies best.
+blank_issues_enabled: true
+contact_links:
+  - name: Question or idea
+    url: https://github.com/kirodotdev/KiroCrew/discussions
+    about: Ask how something works, or float an idea before it is a request.
+  - name: Security vulnerability
+    url: https://github.com/kirodotdev/KiroCrew/blob/main/SECURITY.md
+    about: Report privately by email. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,41 @@
+name: Documentation
+description: Something in the docs is wrong, missing, or misleading.
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This covers the README, `CONTRIBUTING.md`, the docs under `src/kiro_crew/docs/`,
+        skill files, and in-product help text. If the docs are correct but the
+        behaviour is wrong, file a bug report instead.
+
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: >-
+        File path, doc page, or the UI surface carrying the text. A permalink is
+        ideal.
+      placeholder: src/kiro_crew/docs/... , or Settings > Channels help text
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong
+      description: >-
+        Quote the passage if it is short. For missing docs, say what you were
+        trying to find out and where you looked for it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: correction
+    attributes:
+      label: Suggested correction
+      description: >-
+        What it should say, if you know. Leave blank if you only know the current
+        text is wrong.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature request
+description: Propose a new capability or a change to how KiroCrew behaves.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For anything significant, this issue is the right place to agree on the
+        approach before code gets written — see
+        [CONTRIBUTING.md](https://github.com/kirodotdev/KiroCrew/blob/main/CONTRIBUTING.md).
+
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Existing issues
+      options:
+        - label: I searched open issues and this is not already requested.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: >-
+        What are you trying to do, and what stops you today? Describe the
+        situation rather than the solution — it often admits a simpler fix than
+        the one you had in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: >-
+        What should happen instead. Concrete beats abstract: name the command,
+        surface, or setting where you would expect to find it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >-
+        Other approaches you weighed, including whether an existing feature gets
+        you part of the way. "None" is a fine answer.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Mockups, prior art in other tools, or links to related discussion.
+    validations:
+      required: false


### PR DESCRIPTION
## Description

Opening an issue from the GitHub web UI gave you an empty text box. There was no
`.github/ISSUE_TEMPLATE/` directory, so a first-time contributor got no prompt for a
version, a platform, or reproduction steps, and a maintainer had to ask for them in a
round trip. `.github/PULL_REQUEST_TEMPLATE.md` already existed, so issues were the
remaining gap.

Adds three forms plus `config.yml`:

| File | Captures | Applies |
|---|---|---|
| `bug_report.yml` | version, install method, platform, what happened, repro steps, logs | `bug` |
| `feature_request.yml` | problem, proposed behaviour, alternatives | `enhancement` |
| `documentation.yml` | where, what is wrong, suggested correction | `documentation` |
| `config.yml` | `blank_issues_enabled: true`, links to Discussions and SECURITY.md | — |

### Label ownership is split deliberately

`issue-triage.yml` fills only the dimensions that are **empty** — its header says
"if the issue already carries an `area:` label, the model's area suggestion is
discarded rather than added alongside." That rule cuts both ways: anything a form
pre-applies is permanently out of the model's reach for every issue filed through
that form.

So each form applies **only its static type label**. No form names an `area:` label.
Choosing among the 12 `area:` labels is the semantic judgement that workflow exists
to make ("is this a dashboard bug or a gateway bug?"), and an `area:` dropdown would
ask a first-time reporter to know KiroCrew's internal module boundaries — then
disable model classification on exactly the issues that need it most.

### Platform is a body field, not a label

The linked issue proposed mapping the platform dropdown to a `platform:` label.
**That is not possible** — GitHub's form schema makes `labels` a static top-level
key, with no mechanism to derive a label from a dropdown answer
([syntax for issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax)).

The dropdown therefore lands in the issue body and triage reads it from there, which
is the better outcome anyway: the model gets the reporter's first-hand answer
("Platform: macOS") instead of inferring from prose, and platform labelling stays
out of self-service reach. The dropdown carries a `Not platform-specific` choice, and
its description warns that a guess becomes a wrong label.

### Blank issues stay enabled

`issue-triage.yml` allows six type labels:

```
TYPE_LABELS='["bug","enhancement","documentation","refactor","security","question"]'
```

`question`, `refactor`, and `security` are all live (#1109 is `question`, #1070
carries `security`). These three forms cover three of the six, and one form per type
would make the chooser its own friction. Blank issues remain the path for the rest,
and they arrive with every dimension empty — the case triage classifies best. The
reasoning is recorded as a comment at the top of `config.yml` so a later change does
not flip it by accident.

## Related Issues

Closes #1393

## Testing

- [x] Existing tests pass — no Python or TypeScript is touched, so no suite changes behaviour.
- [x] `./scripts/scrub-lint.sh --no-history` passes (the one CI gate that scans these new files).
- [x] All four files parse as YAML, and every top-level key is legal per GitHub's form schema.
- [x] Every `labels:` value was checked against live `gh label list` output. No form names an `area:`, `platform:`, or process label.
- [x] Every non-`markdown` block has a unique `id` and a `label`; every `dropdown` and `checkboxes` block has `options`.
- [x] The platform dropdown offers the `Not platform-specific` no-label choice.
- [x] Contact-link targets verified to exist: Discussions is enabled on the repo, and `SECURITY.md` is present.

**Not verified — and not verifiable from a branch.** The GitHub "New issue" chooser
and the rendered forms only ever read the **default branch**, the same constraint
`issue-triage.yml` documents for `on: issues`. There is no way to click through these
forms before merge, so the schema validation above is the substitute. Likewise,
end-to-end confirmation that triage leaves `area:` empty and reads platform from the
body has to happen after merge — the workflow's `workflow_dispatch` entry point
(issue number + `dry_run`, default true) is the way to check it without opening
throwaway issues.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) — no doc references `.github/ISSUE_TEMPLATE`; `CONTRIBUTING.md` links the issues page generically and stays correct.
- [x] No secrets, credentials, or internal references in the diff
