### PR TITLE
docs: make GOVERNANCE.md and MAINTAINERS.md reachable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -404,6 +404,19 @@ instead of describing the steps yourself.
 6. A maintainer will review. Address feedback by pushing additional commits to
    your branch.
 
+Two things are worth knowing before you start something large.
+[GOVERNANCE.md](GOVERNANCE.md) covers who decides what lands and how a
+disagreement gets resolved, and [MAINTAINERS.md](MAINTAINERS.md) lists the
+people doing it.
+
+Architectural changes get written up as an RFC first, in
+[docs/request-for-change/](docs/request-for-change/), so the design can be
+argued over before anyone writes the code. That applies to changes to a public
+interface, changes other parts of the project would have to build around, and
+anything that would be expensive to reverse. Everything else skips it, and a bug
+fix should never wait on a design document. If you are unsure which side of the
+line your change falls on, open an issue and ask.
+
 ### CI checks on your PR (forks vs. direct branches)
 
 GitHub deliberately withholds repository secrets and OIDC credentials from

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ performance metrics that never leave your machine. See
 | Channels | [Slack](docs/slack-setup.md), [Discord](src/kiro_crew/docs/discord-integration.md), [Telegram](src/kiro_crew/docs/telegram-integration.md), [Teams](src/kiro_crew/docs/teams-integration.md), [Webex](src/kiro_crew/docs/webex-integration.md), [WeCom](src/kiro_crew/docs/wecom-integration.md), [WeChat (Weixin)](src/kiro_crew/docs/weixin-integration.md) |
 | Architecture | [System architecture](docs/project-architecture.md), [Memory](docs/memory-architecture.md), [MCP](docs/mcp-architecture.md), [App Kit](docs/app-kit/getting-started.md) |
 | Trust and dependencies | [Security](docs/security-deep-dive.md), [Security policy](SECURITY.md) |
-| Project work | [Contributing](CONTRIBUTING.md), [AI assistant rules](AGENTS.md), [Changelog](CHANGELOG.md) |
+| Project work | [Contributing](CONTRIBUTING.md), [Governance](GOVERNANCE.md), [Maintainers](MAINTAINERS.md), [AI assistant rules](AGENTS.md), [Changelog](CHANGELOG.md) |
 
 Contributions are welcome. Create a branch from `main`, keep changes focused,
 and run the relevant checks before opening a pull request:

--- a/docs/request-for-change/README.md
+++ b/docs/request-for-change/README.md
@@ -95,6 +95,9 @@ Fix it in the same PR that discovers the drift.
 
 ## Writing a new RFC
 
+[GOVERNANCE.md](../../GOVERNANCE.md) covers who decides whether an RFC is
+accepted, and the scope test for when a change needs one at all.
+
 - File as `rfc-<topic>.md`, kebab-case. Framework or policy docs that propose no
   reviewable change to a named component drop the prefix and set `kind: framework`.
 - Open with front matter, then an H1 `# RFC: <Title>`, then the prose header.


### PR DESCRIPTION
## Problem

`GOVERNANCE.md` and `MAINTAINERS.md` landed in #1396, but nothing a contributor actually opens points at them. Before this change, the only file in the repository linking `GOVERNANCE.md` was `MAINTAINERS.md`, which itself is unlinked. So the governance model was reachable only by already knowing it exists and typing the filename.

## Why it matters

The two documents exist to answer a new contributor's questions: who decides what lands, how a disagreement gets resolved, and when a change needs a design document before code. A contributor following the natural path, README to CONTRIBUTING to a pull request, never encounters either answer. The most common failure mode is exactly the one governance is meant to prevent: someone builds a large change, then finds out an RFC was expected.

It also leaves `docs/request-for-change/` half-wired. `GOVERNANCE.md` names that directory as the venue for architectural decisions, but the directory's own index never said who accepts an RFC, so the reference pointed one way only.

## Fix

Three links, and only as much prose as makes them useful.

**README, `Docs and contributing` table.** The `Project work` row listed Contributing, AI assistant rules, and Changelog. Governance and Maintainers now sit alongside Contributing, which is the row a reader scanning for project process already lands on.

**`CONTRIBUTING.md`, Pull Request Workflow.** After the review step, two short paragraphs: where to find who decides, and the RFC scope test stated in the same words `GOVERNANCE.md` uses rather than a paraphrase that could drift. Placed so a contributor reads it before starting work, not after. This is the follow-up the CONTRIBUTING additions in #1398 deliberately deferred, because `GOVERNANCE.md` was not on `main` yet and the link would have been broken.

**`docs/request-for-change/README.md`, Writing a new RFC.** One sentence pointing at `../../GOVERNANCE.md` for who accepts an RFC and the scope test for needing one. The index already described how to write an RFC in detail; it just never said who decides.

No content is moved or rewritten, and no existing wording changes apart from the one table row.

## Tests

None. Documentation-only change with no runtime behaviour.

## Manual verification

- `./scripts/scrub-lint.sh --no-history` passes
- Every new relative link resolves against the repo root, checked by asserting each target exists: `GOVERNANCE.md`, `MAINTAINERS.md`, `docs/request-for-change/`
- `../../GOVERNANCE.md` verified from inside `docs/request-for-change/`, since that is the one link with a relative prefix that could be wrong
- Files linking `GOVERNANCE.md` went from one (`MAINTAINERS.md`) to four (adding `README.md`, `CONTRIBUTING.md`, `docs/request-for-change/README.md`)

## Screenshots

N/A. No user-visible UI surface is touched.
