### PR TITLE
docs(security): use the Kiro Crew product name in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,5 +24,5 @@ running the most recent version.
 
 ## Scope
 
-This policy covers the KiroCrew source code and its bundled dependencies. It does not cover
-third-party services (LLM providers, Ollama, etc.) that KiroCrew connects to.
+This policy covers the Kiro Crew source code and its bundled dependencies. It does not cover
+third-party services (LLM providers, Ollama, etc.) that Kiro Crew connects to.


### PR DESCRIPTION
SECURITY.md prose referred to the product as "KiroCrew". The display name is "Kiro Crew" (space separated); the closed-up form is reserved for technical identifiers such as the repo, package, and binary names.

Both occurrences are in the Scope section. No other change.

## Notes

- The `Ollama` mention in the same sentence is left as-is. Ollama is still a real optional integration (`src/kiro_crew/config/loader.py`, the knowledge and memory handlers), so it is an accurate example of a third-party service the project connects to.
- The rest of the file was already clean.

The same defect exists in `README.md` (2 prose occurrences in the Contributors section) and `CONTRIBUTING.md` (5, including the title). Both files have PRs already open, so those are handled separately rather than here.