### PR TITLE
docs: add TENETS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ performance metrics that never leave your machine. See
 | Channels | [Slack](docs/slack-setup.md), [Discord](src/kiro_crew/docs/discord-integration.md), [Telegram](src/kiro_crew/docs/telegram-integration.md), [Teams](src/kiro_crew/docs/teams-integration.md), [Webex](src/kiro_crew/docs/webex-integration.md), [WeCom](src/kiro_crew/docs/wecom-integration.md), [WeChat (Weixin)](src/kiro_crew/docs/weixin-integration.md) |
 | Architecture | [System architecture](docs/project-architecture.md), [Memory](docs/memory-architecture.md), [MCP](docs/mcp-architecture.md), [App Kit](docs/app-kit/getting-started.md) |
 | Trust and dependencies | [Security](docs/security-deep-dive.md), [Security policy](SECURITY.md) |
-| Project work | [Contributing](CONTRIBUTING.md), [Governance](GOVERNANCE.md), [Maintainers](MAINTAINERS.md), [AI assistant rules](AGENTS.md), [Changelog](CHANGELOG.md) |
+| Project work | [Contributing](CONTRIBUTING.md), [Tenets](TENETS.md), [Governance](GOVERNANCE.md), [Maintainers](MAINTAINERS.md), [AI assistant rules](AGENTS.md), [Changelog](CHANGELOG.md) |
 
 Contributions are welcome. Create a branch from `main`, keep changes focused,
 and run the relevant checks before opening a pull request:

--- a/TENETS.md
+++ b/TENETS.md
@@ -1,0 +1,19 @@
+# Tenets
+
+These are the principles we design and build Kiro Crew by. They are ordered. When two pull against each other, the earlier one wins and the trade-off gets written down.
+
+1. **Safety first.** Every action is gated, auditable, and reversible where it can be, and where it cannot be you are asked first. Security is the foundation, not a feature.
+
+2. **Build in the open.** Every feature goes in the public project, and what we run is what you run. Where a feature lands is decided in public with the reasoning written down, even when the answer is obvious, so nobody has to guess why something was or was not included.
+
+3. **Easy to use.** Productive in 60 seconds. No configuration required to start, nothing to read first, and no AI expertise. Low floor, high ceiling, smooth path between them. The same goes for working on it: if you can run it, you should be able to change it.
+
+4. **The gateway, not the replacement.** Kiro Crew connects the tools you already use rather than asking you to abandon them. It routes, it remembers across them, and it makes each one more useful than it is alone.
+
+5. **Built as a community.** No two people work the same way, and that is a feature rather than something to normalize away. Skills, agents, and apps exist so anyone can shape Kiro Crew around how they already work, and what one person builds becomes something everyone can use.
+
+6. **Knowledge that flows, with boundaries.** Memory is local-first and private by default. Sharing is explicit, controlled, and auditable. Knowledge should propagate from a person to a team to an organization to a company, but sensitive information must never spread, and the right to forget is built in.
+
+7. **Teammates, not tools.** Agents have names, roles, and memory. They collaborate the way colleagues do, delegating work, learning preferences, and composing into teams.
+
+[GOVERNANCE.md](GOVERNANCE.md) covers who decides what lands and how. [CONTRIBUTING.md](CONTRIBUTING.md) covers how to contribute.


### PR DESCRIPTION
## Problem

The project has no written statement of what it optimizes for. `GOVERNANCE.md` says who decides and how, but not what they are deciding toward, so any disagreement about a trade-off has to be re-litigated from first principles with no shared reference to point at.

## Why it matters

Tenets earn their keep in exactly one situation: two reasonable people want opposite things and both are right about their own concern. Without a written order, that argument is settled by whoever is more persistent or more senior. With one, it is settled by a document both of them agreed to earlier. This matters most for an outside contributor, who has no way to infer the priorities from the inside and currently finds out what the project values only when a PR is declined.

## Fix

Seven principles in one ordered list, at `TENETS.md` in the repo root alongside `GOVERNANCE.md` and `MAINTAINERS.md`.

**The order is load-bearing, and it is stated as such.** When two tenets pull against each other the earlier one wins and the trade-off gets written down. Safety is first and openness is second, which is the ordering `GOVERNANCE.md` already implies: it carves out exactly one exception to working in public, an unfixed security vulnerability handled privately until a fix ships. That is tenet 1 beating tenet 2 in the one case it should, and it was already merged in #1396 before this document existed.

**Tenet 1 is deliberately narrower than the obvious phrasing.** It says every action is gated, auditable, and reversible *where it can be*, and where it cannot be you are asked first. The stronger claim, that every action is reversible, is disprovable by anyone who has used the product: agents execute shell commands and delete files, and there is an approval mode called `yolo`. A top-ranked tenet that fails on contact is worse than a precise one, so this describes the mechanisms that actually exist, which are approval modes, deny patterns, sensitive-path blocking, and the audit log.

**Tenets 3 and 5 deliberately speak to using the project and building on it in the same breath.** "If you can run it, you should be able to change it" and "no two people work the same way, and that is a feature" are both statements about the product and about the contributor experience. That is intentional: an earlier draft separated product tenets from project tenets into two ranked lists, which left nothing to resolve a conflict across the boundary.

**One line is also added to the README docs table**, so the file is reachable. The preceding PR in this series, #1411, existed only because `GOVERNANCE.md` and `MAINTAINERS.md` landed unlinked and nothing a contributor opens pointed at them. Repeating that would have been avoidable.

## Tests

None. Documentation-only change with no runtime behaviour.

## Manual verification

- `./scripts/scrub-lint.sh --no-history` passes
- Both relative links in `TENETS.md` resolve: `GOVERNANCE.md`, `CONTRIBUTING.md`
- The README link to `TENETS.md` resolves
- Checked that no internal product name, internal tool name, or working note survived into the shipping file, since the product tenets derive from an internal design document

## Screenshots

N/A. No user-visible UI surface is touched.

## Notes for reviewers

Two things in this document are judgment calls rather than wording, and are worth an explicit opinion from maintainers rather than a silent approval.

**Tenet 6 states memory propagating from a person to a team to an organization to a company.** Only personal memory ships today, so this reads publicly as describing something that exists. It is stated as intent, and an earlier draft softened it before that softening was deliberately reversed. If it should read as direction rather than description, say so and it changes.

**Tenet 7 is the most descriptive item in the set**, stating product facts about names, roles, and memory rather than a principle someone could violate. For a multi-agent product it is arguably the core thesis, so the fix is probably sharpening it into a principle rather than cutting it.
