### PR TITLE
docs: use the two-word product name in prose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to KiroCrew
+# Contributing to Kiro Crew
 
-Thanks for your interest in contributing! KiroCrew is an open-source project and
+Thanks for your interest in contributing! Kiro Crew is an open-source project and
 we welcome issues and pull requests.
 
 ## Reporting Bugs and Requesting Features
@@ -10,7 +10,7 @@ do, search the open issues, because the fastest resolution is often a thread tha
 already exists.
 
 For a bug, what actually helps is a way to reproduce it, the version you are on,
-your operating system, and anything unusual about how KiroCrew is installed or
+your operating system, and anything unusual about how Kiro Crew is installed or
 where it runs. A stack trace beats a description of a stack trace. If it only
 happens on one surface, say which one, because the dashboard, the CLI, and a chat
 channel take different paths through the code.
@@ -84,7 +84,7 @@ how code gets written, tested, and reviewed here:
 - **`babysit`** — same-session monitoring loop that keeps a PR moving through
   CI and review rounds.
 
-An agent contributing to KiroCrew loads this suite and follows the same
+An agent contributing to Kiro Crew loads this suite and follows the same
 worktree → build gate → prepare-pr → review loop human contributors use, so
 the PR process stays consistent regardless of who is writing the code. If you
 change the workflow, change it THERE — those files are the single source of
@@ -315,7 +315,7 @@ Key entry points:
 
 Full reference: [AGENTS.md](AGENTS.md)
 
-## Extending KiroCrew
+## Extending Kiro Crew
 
 - **Skills** — drop markdown files in `skills/` or `~/.kiro/crew/skills/`. See [skills/README.md](skills/README.md) for the full format reference
 - **MCP tools** — add to `mcp_core.py` or `mcp_cron.py`. Every LLM-facing command must have an MCP tool
@@ -480,7 +480,7 @@ means following it, and the file names where to report a concern.
 
 ## Licensing
 
-KiroCrew is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for the
+Kiro Crew is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for the
 full text and [NOTICE](NOTICE) for attribution. Third-party components carry their
 own licenses, recorded in [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES).
 

--- a/README.md
+++ b/README.md
@@ -494,9 +494,9 @@ feature requests. Do not file security vulnerabilities publicly.
 
 ## Contributors
 
-KiroCrew was made possible by its internal community, the people who supported the
+Kiro Crew was made possible by its internal community, the people who supported the
 project and shipped its code, together with everyone who has since opened a pull
-request in the open. This is that founding group; as KiroCrew grows in the open, we
+request in the open. This is that founding group; as Kiro Crew grows in the open, we
 look forward to many more contributors joining them. Thank you to everyone who helped
 make this tool possible:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,5 +24,5 @@ running the most recent version.
 
 ## Scope
 
-This policy covers the KiroCrew source code and its bundled dependencies. It does not cover
-third-party services (LLM providers, Ollama, etc.) that KiroCrew connects to.
+This policy covers the Kiro Crew source code and its bundled dependencies. It does not cover
+third-party services (LLM providers, etc.) that Kiro Crew connects to.


### PR DESCRIPTION
## Problem
Prose in README.md (Contributors intro), SECURITY.md (policy scope), and CONTRIBUTING.md (title plus five body spots) uses the one-word 'KiroCrew'. The product name in prose is Kiro Crew.

## Why it matters
These are the repo's public-facing docs and the naming is inconsistent across them.

## Fix
Two-word form in all prose and headings. Technical identifiers are unchanged and verified as the only remaining one-word occurrences: the `kirodotdev/KiroCrew` repository path in URLs, `KiroCrew.dmg` / `KiroCrew-x86_64.AppImage` artifact filenames, and the `cd KiroCrew` clone directory. Also drops the stale Ollama mention from SECURITY.md's scope line, consistent with its earlier removal from the README (the project uses in-process embeddings, not Ollama).

## Tests
Docs-only. Grepped all four community files; MAINTAINERS.md and CODE_OF_CONDUCT.md were already clean. No internal links reference the renamed '## Extending' heading anchor.

## Manual verification
N/A beyond the greps above.

## Screenshots
N/A.