### PR TITLE
docs: add a native MCP Apps guide covering enablement and side-panel docking

### DIFF
--- a/src/kiro_crew/docs/index.md
+++ b/src/kiro_crew/docs/index.md
@@ -68,6 +68,7 @@ agent backend and Slack credentials.
 - [Use Cases](use-cases.md) — Real-world workflows from the community
 - [Profiling](profiling.md) — Debug-only stack sampler (`kirocrew perf sample`) and desktop app metrics (`kirocrew desktop metrics`)
 - [Dashboard iframe hosts](dashboard-iframe-hosts.md) — Which of the four embed hosts to use, why their sandboxes differ, and why an iframe can never be moved
+- [MCP Apps](mcp-apps.md) — Render interactive MCP tool output (diagrams, viewers, forms) in chat: the two gates that enable it, what a server must declare, and why output stays plain text
 - [Troubleshooting](troubleshooting.md) — Common issues and fixes
 
 ## Security

--- a/src/kiro_crew/docs/mcp-apps.md
+++ b/src/kiro_crew/docs/mcp-apps.md
@@ -1,0 +1,245 @@
+# MCP Apps
+
+KiroCrew renders **MCP Apps** natively: when an MCP tool returns a `ui://` resource
+alongside its text, the dashboard mounts that resource as a live, interactive
+component in the chat instead of showing you a wall of JSON. Ask for a diagram and
+the excalidraw server gives you an editable Excalidraw canvas in the conversation;
+other servers ship PDF viewers, forms, and dashboards the same way. This is the
+[SEP-1865](https://modelcontextprotocol.io) `ui` extension, and it works with any
+conforming server — nothing is hardcoded per vendor.
+
+If you just want it working: **Developer → Shared MCP gateway → on**, then switch
+your server on under **Poolable MCP servers**. The rest of this page explains why
+both are needed and what to check when a render does not appear.
+
+## Enabling it
+
+Two gates must both pass. Neither is about the app itself — both are about **MCP
+pooling**, because the gateway daemon is what intercepts the tool result and
+resolves the `ui://` resource. Both have a UI toggle; you should not need to edit
+config by hand.
+
+> **Platform:** the shared gateway needs Unix-domain sockets, so it is supported on
+> **macOS and Linux only**. On Windows the toggle is disabled and MCP Apps are
+> unavailable.
+
+### From the dashboard
+
+Both live on the **Developer** page (sidebar → **Developer**):
+
+1. **Turn on "Shared MCP gateway."** ⚠️ This restarts all active sessions onto the
+   new MCP routing, so in-flight agent work is interrupted — do it between tasks,
+   not mid-turn. Your dashboard stays signed in. The toggle asks for confirmation
+   and offers a roll-back.
+2. **In "Poolable MCP servers," switch on the server whose app you want.** The
+   toggle writes the central allowlist and re-applies it in-process — no restart.
+   You can set this up before enabling the gateway; it simply has no effect until
+   the gateway is on.
+
+   A row is **read-only** when the server can't be pooled: it's denylisted, its
+   transport isn't stdio (HTTP servers aren't poolable), or it's already poolable
+   via its own `poolable: true` and so isn't governed by the allowlist.
+
+Optionally, to render apps in the right side panel instead of inline, turn on
+**Settings → Chat → Messages → "MCP Apps in Side Panel."** No restart or refresh
+needed.
+
+### The same thing in config
+
+For scripted or headless setups:
+
+```json
+{
+  "mcp_gateway": { "enabled": true, "poolable_servers": ["excalidraw"] },
+  "dashboard":   { "mcp_app_panel": true }
+}
+```
+
+A server can also opt itself in from its own MCP entry, which is the escape hatch
+for third-party configs you don't want to duplicate into the allowlist:
+
+```json
+{ "mcpServers": { "excalidraw": { "command": "...", "poolable": true } } }
+```
+
+MCP Apps have **no enablement flag of their own** — they follow
+`mcp_gateway.enabled`. The full resolution order in `_mcp_apps_enabled()` is:
+
+| Condition | Result |
+|---|---|
+| `KIROCREW_MCP_APPS` = `0`/`false`/`no`/`off` | disabled (explicit kill-switch, wins over everything) |
+| `KIROCREW_MCP_APPS` = `1`/`true`/`yes` | enabled (explicit override — tests, e2e harness) |
+| `KIROCREW_MCP_APPS` unset | follows `mcp_gateway.enabled`, read **live** from config |
+
+Read live per call, so toggling the gateway takes effect without restarting the
+daemon.
+
+### Worked example: excalidraw diagrams
+
+The excalidraw MCP server ships a `ui://` app, so it is the quickest way to see
+this working end to end:
+
+1. Add the server to your MCP config as usual and confirm the agent can call it.
+2. **Developer → Shared MCP gateway → on.**
+3. **Developer → Poolable MCP servers → `excalidraw` → on.**
+4. Ask for a diagram: *"draw me a sequence diagram of the login flow."*
+
+You should get a live, editable Excalidraw canvas in the chat — hand-drawn shapes
+that animate in as they stream, which you can then drag around and edit. If you
+instead get a wall of JSON-ish text, step 3 is almost certainly the one that
+didn't take.
+
+**Why the poolable gate is the usual culprit:** a server that isn't poolable is
+parented to `kiro-cli` and never passes through the gateway, so nothing intercepts
+its result. The tool still works — you just get its text. There is no error
+message, which is exactly what makes it confusing.
+
+**Not every server should be pooled.** A pooled backend is shared across
+sessions, so a server that reads per-session credentials or env vars from its own
+process environment must stay unpooled.
+
+## Where apps render: inline or side panel
+
+| | Inline (default) | Side panel (`mcp_app_panel: true`) |
+|---|---|---|
+| Where | in the chat bubble, capped to the content column | its own **MCP App** tab in the right panel |
+| Width | `--mc-content-width` (follows your Chat content-width setting; 900px fallback) | the panel's own resizable width |
+| Survives scrolling | the transcript is virtualized, so the row can unmount | the panel is not virtualized |
+| Chat bubble shows | the app | `▸ Opened in the side panel` (click to focus/reopen) |
+
+The flag picks the destination **at render time**, so flipping it does not move
+diagrams already in your scrollback — render a new one.
+
+## The `app` panel tab — a docking type with its own rules
+
+Side-panel hosting is not "the app, but in a tab." It is a **new tab kind** whose
+lifecycle differs from every other tab in the panel, because of one constraint:
+
+> An MCP App iframe is null-origin and sandboxed with no storage. **Unmounting it
+> reloads the app.** The rendered diagram comes back (it is rebuilt from the stored
+> payload) but anything the user drew on the canvas does not. Moving the iframe in
+> the DOM counts as unmounting — an element cannot be re-parented without
+> destroying its document, and a React portal is not an escape hatch, because it
+> changes the real DOM parent too.
+
+Every rule below exists to avoid that.
+
+**It is a `TabKind`, deliberately not a `ViewKind`.** The panel's category views
+(Files, Changes, Logs…) unmount when you switch away from them — that is fine for a
+file list and fatal for a live app. App tabs take the keep-mounted path that
+terminal and document tabs use, shown and hidden with `display`.
+
+**It auto-opens, once.** A render opens the panel and focuses a new **MCP App**
+tab. The claim is made at most once per (chat, tool call) and is held at module
+scope, so returning to the chat does not re-open a tab you closed. If you close it,
+the bubble's `▸ Opened in the side panel` control is the way back — it re-creates
+and focuses the tab, rebuilding the frame from the stored payload.
+
+**Closing the panel hides it; it does not unmount it.** So does opening the find
+pane. A live app tab keeps the panel subtree mounted regardless of those, and only
+visibility yields. With no app tab present, both behave exactly as before.
+
+**Frames from other chats stay mounted.** All app frames across all chat slots are
+rendered from one list, each keyed by *its own* slot plus tab id, with only the
+active chat's active tab visible. Keying this way is what lets a frame survive a
+chat switch: its key never changes, so React never remounts it. (Tool-call ids are
+unique per session, not globally — hence the slot in the key.)
+
+**App tabs are never persisted.** Unlike file or terminal tabs, they are stripped
+from the saved tab strip, because the payload arrives only on a live render event
+and is never written to storage — a restored tab could show nothing. A page reload
+therefore starts clean, and auto-open re-arms.
+
+**The warm set is bounded.** Each app tab holds a live multi-MB iframe, so a chat
+keeps at most three, evicting the least-recently-used one (never the tab you are
+looking at). Eviction is recoverable: the payload survives, so the bubble control
+rebuilds the frame — only in-canvas edits are lost.
+
+### Known limits
+
+Two paths still lose in-canvas edits, by design rather than oversight:
+
+- **Crossing the mobile breakpoint.** The panel is portaled into the desktop
+  activity-bar grid column and rendered inline on mobile — two different React
+  trees, so the crossing remounts the frame.
+- **Navigating away from Chat and back** (e.g. to Settings). The panel's tree is
+  owned by the chat page, so leaving the route unmounts it.
+
+In both cases the diagram returns; the canvas edits do not. Closing that class
+properly means hosting app frames above the router, which is not done yet.
+
+
+
+## What a server must do to get content rendered
+
+Nothing KiroCrew-specific. Conform to SEP-1865:
+
+1. **Serve a `ui://` resource** — the app's HTML, returned from `resources/read`.
+2. **Associate it with the tool.** Either form works:
+   - on the **tool definition**: `_meta.ui.resourceUri` (SEP-1865's primary form —
+     preferred, and what KiroCrew harvests at backend spawn), or
+   - on the **tool result**: `result._meta.ui.resourceUri` per call.
+
+   The deprecated flat key `_meta["ui/resourceUri"]` is also read, for
+   compatibility. Only a string beginning `ui://` is eligible.
+
+The per-result `_meta` is optional and some servers omit it, which is why
+KiroCrew harvests declared URIs from `tools/list` when the backend starts — a
+tool that declared a `ui://` resource renders even when its individual results
+carry no `_meta`.
+
+## How a render actually reaches your screen
+
+Useful when something renders as text and you need to find where the chain broke:
+
+1. The model calls the tool. The gateway sees the `tools/call` result.
+2. If the result (or the tool's definition) names a `ui://` resource, the gateway
+   issues its own out-of-band `resources/read` to fetch it. **Best-effort with a
+   10s deadline** — on timeout the original tool result is delivered unmodified,
+   so a slow app degrades to text rather than wedging the turn.
+3. The gateway writes the payload to a spool file at
+   `$KIROCREW_HOME/mcp-apps/<uuid4hex>.json` and injects an opaque marker
+   `[kirocrew-mcp-app:<uuid4hex>]` into the tool result *text*.
+4. That text reaches the dashboard backend as a tool result. `mcp_apps_render.py`
+   detects the marker, loads the spooled payload, pushes an `mcp_app_render`
+   websocket event to the chat slot, and strips the marker from the transcript.
+5. The frontend mounts the payload's HTML in a sandboxed iframe and completes the
+   `ui/initialize` handshake with the app.
+
+## Security posture
+
+Worth understanding before you point KiroCrew at an unfamiliar server, because
+app HTML is **server-controlled code running in your dashboard**.
+
+- **The iframe is `sandbox="allow-scripts allow-forms"`** — deliberately *without*
+  `allow-same-origin`. The app is null-origin: no access to your dashboard's DOM,
+  cookies, or storage.
+- **The spool id is validated `^[0-9a-f]{32}$`** and the path is built only from
+  that validated id, so a malicious id cannot traverse the filesystem. The model
+  never reads the payload file — only deterministic code does.
+- **Missing, corrupt, or oversized spool files are tolerated**, so a bad payload
+  cannot crash a turn.
+- **The dashboard CSP allows `https://esm.sh`.** `srcdoc` iframes inherit the
+  parent's CSP header, and apps commonly load their module graph from esm.sh via
+  importmap — without that allowance the app's scripts never execute and you get a
+  blank frame.
+- The host declares a limited capability set to the app (`serverTools`,
+  `openLinks`). Link opening is gated to `https://` only.
+
+## Troubleshooting
+
+| Symptom | Most likely cause |
+|---|---|
+| Tool output renders as plain text | the server is not switched on in **Developer → Poolable MCP servers** — check this first |
+| Still text after enabling the server | the **Shared MCP gateway** toggle is off, or `KIROCREW_MCP_APPS` is set to an off value and is overriding it |
+| The gateway toggle is disabled / greyed out | you're on Windows — the shared gateway needs Unix-domain sockets (macOS and Linux only) |
+| A server's poolable row won't toggle | it's denylisted, or not stdio transport (HTTP servers can't be pooled), or already poolable via its own `poolable: true` |
+| Frame mounts but the canvas is blank | the app's scripts did not execute — check the browser console for CSP or network errors reaching its CDN |
+| Feature toggle missing from Settings | stale frontend bundle — hard-refresh the dashboard |
+| A new render appears inline despite `mcp_app_panel: true` | the flag is read at render time; diagrams already in scrollback do not move |
+| Panel shows "This app render is no longer available" | the payload was evicted (bounded per slot) — ask the agent to render it again |
+| Agent sessions all restarted unexpectedly | expected: flipping the **Shared MCP gateway** toggle re-routes MCP and interrupts in-flight work |
+
+For **which** iframe host a new dashboard feature should use, and why an iframe
+can never be moved in the DOM without reloading it, see
+[Dashboard iframe hosts](dashboard-iframe-hosts.md).

--- a/src/kiro_crew/tips_allowlist.py
+++ b/src/kiro_crew/tips_allowlist.py
@@ -26,6 +26,7 @@ TIP_DOC_ALLOWLIST: frozenset[str] = frozenset(
         "feature-tips.md",
         "getting-started.md",
         "knowledge-library-how-it-works.md",
+        "mcp-apps.md",
         "memory-and-learning.md",
         "research-lab.md",
         "skills.md",


### PR DESCRIPTION
## Problem

MCP Apps work, but nothing documents how to turn them on — and the enablement is
not guessable. There is **no `mcp_apps` switch**: the feature follows the
MCP-pooling opt-in, and the server additionally has to be *poolable* to reach the
gateway at all. Miss the second gate and the tool still works, it just renders as
plain text with no error anywhere.

## Why it matters

That exact gap cost real debugging time on this repo: an app that had been
rendering stopped, and the cause was `poolable_servers` losing an entry — the
server's process was parented to `kiro-cli` instead of the gateway, so no
interception happened. Nothing in the docs would have pointed at it. Anyone
pointing KiroCrew at a conforming MCP server for the first time hits the same
wall, and the failure mode is silent.

## Fix (symptom → root cause → change)

**Symptom:** a conforming MCP server's output renders as text; the operator has
nothing to check.
**Root cause:** the enablement is two indirect gates plus an optional render-target
flag, and the interception pipeline is invisible — none of it was written down.
**Change:** a new guide, `src/kiro_crew/docs/mcp-apps.md`, written **UI-first** —
both gates have dashboard toggles on the Developer page, so the guide leads with
those and documents hand-edited config as the scripted alternative.

Content, all sourced from the code rather than recollection:

- **Enablement from the dashboard.** The **Shared MCP gateway** toggle — including
  its session-restart warning and the fact that it is **macOS/Linux only**, since
  the gateway needs Unix-domain sockets — and the **Poolable MCP servers** list,
  with why a row can be read-only (denylisted, non-stdio transport, or already
  poolable via its own entry). Both of these were missing from my first draft,
  which led with JSON.
- **The equivalent config** for scripted setups, the `poolable: true` escape hatch,
  the exact `_mcp_apps_enabled()` resolution order including the
  `KIROCREW_MCP_APPS` kill-switch precedence and live config read, and why a
  server reading per-session credentials must stay unpooled.
- **A worked excalidraw example** end to end, since that server ships a `ui://` app
  and is the fastest way to confirm a working setup.
- **`dashboard.mcp_app_panel`** and an inline-vs-side-panel comparison.
- **The `app` panel tab as a docking type with its own rules.** Each rule is tied
  back to the single constraint that motivates it — a null-origin sandboxed iframe
  cannot be unmounted or re-parented without losing the user's canvas: TabKind and
  not ViewKind, once-per-tool-call auto-open with the bubble control as the way
  back, hide-not-unmount on panel close and on the find pane, cross-slot frames
  keyed by slot + tab id, non-persistence, and the bounded LRU warm set.
- **What a server must declare** per SEP-1865 — `_meta.ui.resourceUri` on the tool
  definition (harvested at backend spawn) or on the result, plus the deprecated
  flat key.
- **The render path** end to end: out-of-band `resources/read` with its 10s
  best-effort deadline, the spool file, the opaque marker, the `mcp_app_render`
  websocket event, marker stripping.
- **Security posture:** `sandbox="allow-scripts allow-forms"` *without*
  `allow-same-origin`, the validated `^[0-9a-f]{32}$` spool id, tolerated
  bad payloads, and why the CSP allows `https://esm.sh`.
- **A troubleshooting table** led by the poolable gate.

The guide states the two remaining edit-loss paths plainly (crossing the mobile
breakpoint, and navigating away from Chat) rather than omitting them — they are
real, shipped behaviour that a user will hit.

## Tests

No new tests; this is documentation plus one allowlist entry. The existing
`test/test_tips.py` (117 tests) covers the catalog scanner that now picks the doc
up, and I verified the doc satisfies its contract — an H1 plus a first
non-heading paragraph — since a doc failing that is silently skipped rather than
flagged.

## Manual verification

- `test_tips.py` 117/117, `isort` clean, `flake8` 0 issues, `mypy` clean across
  660 source files.
- Every internal link in the new doc resolves to a file that exists.
- Heading structure checked for orphaned sections — an earlier edit of mine had
  swallowed the `## What a server must do to get content rendered` heading, leaving
  its body dangling under `### Known limits`. Caught and fixed before this push.
- Factual claims checked against source, and two were **wrong in my first draft**
  and corrected: the inline width is `CONTENT_WIDTH[chatConfig.contentWidth]` with
  900px only as the CSS fallback, not a flat 900px; and the enablement order came
  from `_mcp_apps_enabled()` directly, because the `mcp_apps_render.py` module
  docstring still describes `KIROCREW_MCP_APPS` as *the* opt-in gate — stale since
  it became a kill-switch that defers to config.

## Screenshots

N/A — no user-visible UI change. This PR adds a markdown file, one index line, and
one allowlist entry.

## Notes for the reviewer

- `setup.cfg` ships `docs/*.md` by glob, so the new file needs no packaging-manifest
  edit (unlike a new data file, which needs three).
- The `TIP_DOC_ALLOWLIST` addition is deliberate: the allowlist policy is that
  internal architecture and incident docs must never surface as user tips, and this
  one is user-facing operator guidance. The sibling
  `dashboard-iframe-hosts.md` is correctly *not* allowlisted — it is a
  developer decision table — and the new guide cross-links to it.
- Local model review mirrors were not run for a docs-only diff; the deterministic
  gates above plus the server-side reviewers are the check here.
