### PR TITLE
feat(appstore): list LaunchDarkly in the bundled app registry

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -1,1 +1,8 @@
-[]
+[
+  {
+    "name": "launchdarkly",
+    "repo": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
+    "gitUrl": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
+    "branch": "main"
+  }
+]


### PR DESCRIPTION
Adds LaunchDarkly's app to the bundled registry so it appears in the App Store as an installable app — the first third-party entry.

```json
{
  "name": "launchdarkly",
  "repo": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
  "gitUrl": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
  "branch": "main"
}
```

The index is minimal by design: name plus git source. Every display field — description, screenshots, tags, version — is read from the app's own `app.json` on demand, so the store cannot drift from the app and this entry needs no edit when LaunchDarkly ships a new version. `name` matches their manifest (`launchdarkly`), and their `tags` include `developer-tools`, so the store categorises it without a frontend change.

## ⚠️ Do not merge until their repo is public

`https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app` is **private right now** — an anonymous clone returns `401`. Install clones without credentials, so merging today ships a card that fails for every user who clicks Install. The App Store page itself renders fine (`normalizeRegistryApp` fills the missing display fields), so the failure is confined to install.

One-line gate — this must print `200`:

```
curl -s -o /dev/null -w '%{http_code}\n' \
  'https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app/info/refs?service=git-upload-pack'
```

## ⚠️ It will claim a false "first-party" badge

Their `app.json` sets `author: "kirocrew"`. `isVerified()` in `website/src/components/appstore/types.ts` returns `true` for any non-`_registry` app whose author is `kirocrew` — and bundled entries carry no `_registry` tag. So this third-party app gets the verified/first-party mark **next to an Install button that runs setup code with gateway privileges**, which is exactly what that function's own comment says must never be awardable from manifest content:

> The verified mark asserts FIRST-PARTY provenance, so it must never be awardable from manifest or index content

The manifest is index-adjacent content, so the guard has a hole for bundled entries. Two ways to close it, neither in this PR:

1. **LaunchDarkly sets `author` to `LaunchDarkly`** — one line on their side, correct regardless.
2. **Tighten `isVerified`** so `author` alone cannot award the mark for a non-builtin. This is the robust fix but it risks de-badging genuine first-party apps that are not yet installed, so it wants its own change and a maintainer's call.

## Placement note

The accepted official-registry RFC makes `app-registry.json` a **generated** fallback snapshot sourced from the sibling `KiroCrewApps` repo, never hand-authored. That pipeline's client half (R3) is unstarted, so the bundled index is currently the only path that reaches users — hand-writing this entry is deliberate, and it should be re-generated rather than re-edited once the official fetch lands.

## Verification

- 131 backend registry tests pass (`test_apps_registry.py`, `test_external_registry.py`)
- Entry resolves through the real loader: `get_registry_app('launchdarkly')` returns it, `_entry_git_url` yields the https URL, and `repo` passes the blob-proxy validator (`_is_safe_repo_identifier`)
- `isort` / `flake8` clean over `src/kiro_crew` + `test`; De-Amazon scrub lint passes
- No frontend source touched — one JSON data file
