### PR TITLE
fix: default agent model to auto so free-tier first chat works

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2650,7 +2650,7 @@ def _install_lite_agent_fallback() -> None:
     lite_path = kiro_agents_dir_path() / _LITE_AGENT_FILENAME
     lite_config = {
         "name": "kirocrew-lite",
-        "model": "claude-opus-4.6",
+        "model": "auto",
         "tools": [],
         "mcpServers": {},
         "prompt": "",
@@ -2659,8 +2659,10 @@ def _install_lite_agent_fallback() -> None:
     # Cheap model for the claude_code (CC) provider. kiro-cli resolves the lite
     # model from `model` via --agent; the CC backend can't, so the provider
     # factory reads this cc_model for the lite agent. Sonnet is plenty for
-    # background title/compaction/heartbeat work and far cheaper than the global
-    # Opus 4.8 default. Stored in the sidecar (kiro spec stays schema-clean).
+    # background title/compaction/heartbeat work. "auto" for the kiro spec keeps
+    # the lite agent usable on every subscription tier (a pinned premium model
+    # is rejected outright on accounts that lack it). Stored in the sidecar
+    # (kiro spec stays schema-clean).
     agent_state.set_cc_model("kirocrew-lite", _BACKGROUND_CC_MODEL)
 
 

--- a/src/kiro_crew/config/defaults.json
+++ b/src/kiro_crew/config/defaults.json
@@ -1,7 +1,7 @@
 {
   "name": "kirocrew",
   "description": "Autonomous personal AI agent — schedules recurring tasks, spawns parallel workers, learns from corrections, and operates independently via Slack",
-  "model": "claude-opus-4.8",
+  "model": "auto",
   "tools": [
     "execute_bash",
     "fs_read",

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -41,8 +41,8 @@ _TITLE_SOURCE_SCAN_LIMIT = _TITLE_TEXT_LIMIT + _TITLE_MAX_ATTACHMENT_FILES * (
     _TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32
 )
 
-# Titling is a trivial 3-6 word task, so run it on the cheapest/fastest model
-# (Haiku) rather than the kirocrew-lite default (Opus 4.6 on the kiro-cli path).
+# Titling is a trivial 3-6 word task, so pin it to the cheapest/fastest model
+# (Haiku) rather than the kirocrew-lite default ("auto" on the kiro-cli path).
 # Applied per-session via set_model so heavier background work (compaction,
 # optimizer) keeps the lite agent's default model. Best-effort: a failed
 # override just falls back to the session's default model.


### PR DESCRIPTION
## Problem

On a fresh install with a free-tier Kiro account, the very first chat crashes with an ACP model rejection. The shipped `kirocrew` agent template (`src/kiro_crew/config/defaults.json`) pins `claude-opus-4.8`, and the `kirocrew-lite` background agent pins `claude-opus-4.6` — models that free-tier subscriptions don't have. The pinned model also doesn't appear in the dashboard's model selector (the selector lists only models the account can use), making the failure look inexplicable.

## Why it matters

The first-ever chat experience on a fresh install is a crash for any user whose tier lacks Opus. The same pin breaks background work (title generation, compaction, optimizer, issue triage) that runs on `kirocrew-lite`.

## Fix (symptoms → root cause → change)

Crash on first chat → kiro-cli boots `--agent kirocrew` and resolves the model from the installed spec, which KiroCrew generates from the shipped template's hard Opus pin → default both specs to `auto`, kiro-cli's own default model id (`*` in `kiro-cli chat --list-models`), available on every tier.

- `config/defaults.json`: `"model": "claude-opus-4.8"` → `"auto"` (the installed `~/.kiro/agents/kirocrew.json` is generated from this).
- `agent.py` `_install_lite_agent_fallback`: `"claude-opus-4.6"` → `"auto"` for the same reason on the background path. The `cc_model` sidecar write is untouched (claude_code-provider seam; unread on the kiro-cli path).
- `dashboard/chat_title.py`: stale comment referencing the old Opus 4.6 lite default updated.

Existing installs heal automatically: the `model_managed` sidecar re-sync in `build_agent_config` re-reads the shipped default on gateway start for agents whose model was never explicitly picked; explicit user picks stay frozen (`mc_model != "auto"` guard).

Plumbing verified: `to_acp_id("auto")` maps to `""` by design (registry `auto → ""` for acp), which `AcpClient` treats as the let-kiro-resolve sentinel; kiro-cli accepts `"model": "auto"` in an agent spec (verified live with a throwaway agent).

## Tests

Existing coverage exercises the changed paths: `test_agent.py` (config install/refresh, managed-model re-sync), `test_agent_default_model.py` (model precedence + `auto` normalization), `test_lite_agent_duplicate.py`, `test_chat_title.py` — 281 passed. No new tests: the change is two data values; the resolution behavior for `auto` is already locked in by the existing precedence tests.

## Manual verification

- `kiro-cli chat --model auto` works and `auto` is listed as the default in `--list-models`.
- A throwaway agent spec with `"model": "auto"` boots and answers via `kiro-cli chat --agent …`.
- Free-tier end-to-end (fresh Mac, free account) still worth a smoke test — the report this fixes came from that setup.

## Screenshots

N/A — no UI change.
