### PR TITLE
feat(apps): add the LaunchDarkly app to the curated registry

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -1,1 +1,8 @@
-[]
+[
+  {
+    "name": "launchdarkly",
+    "gitUrl": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
+    "repo": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
+    "branch": "main"
+  }
+]


### PR DESCRIPTION
> ### ⚠️ Read this before merging
>
> `launchdarkly-labs/launchdarkly-kiro-crew-app` is **currently a private repo.**
> Until it is public, this entry renders a **degraded card for every user** —
> `version="0.0.0"`, empty description/author, placeholder icon, not verified —
> and none of the curated-entry review criteria in
> `docs/app-store-guidelines.md` can be checked by a reviewer, by CI, or by the
> store. Details and the reasoning in **Known limitation** below.
>
> I am opening this now so the precedent question gets maintainer eyes, not
> because it is ready to land. **My recommendation is to hold this until the app
> repo is public**, at which point the entry needs no edit — the card fills
> itself in from the app's own `app.json`.

## Problem

The bundled curated catalog `src/kiro_crew/apps/app-registry.json` has been an
empty array `[]` since the repo rename, so the App Store's Discover surface has
never had a single non-builtin entry to show. Everything visible in the store
today is a builtin merged in client-side.

## Why it matters

The registry is the only mechanism by which an app that does not ship inside the
wheel can reach users. With an empty catalog the whole browse-and-install path is
dead code in practice: it has never been exercised end to end by a real entry.
This adds the first one, which is also how we find out what that path actually
does with a real third-party app.

## Fix (symptom → root cause → change)

The symptom is an empty Discover list; the root cause is simply that no entry was
ever added after the rename. So the change is one row of data — no code.

Only the four registry-owned fields are listed. Every display field —
description, version, author, tags, permissions, icon, screenshots — is resolved
at browse time by `_resolve_manifest` from the app's own `app.json` and cached for
24h (`_MANIFEST_CACHE_TTL`). That is the documented point of keeping this index
minimal: the app author never touches this file to change their copy.

## Tests

No new tests. This is a data row against an existing, already-tested loader, and
the repo has no fixture that asserts the catalog's contents (deliberately — it
would have to change with every entry).

What I did verify, by running the entry through each gate it has to pass:

| Gate | Result |
|---|---|
| `_looks_like_git_url` | ✅ |
| `is_clone_host_trusted` | ✅ (`github.com` ∈ `_PUBLIC_GIT_HOSTS`) |
| `_is_safe_repo_identifier` (blob-proxy param) | ✅ |
| `_is_safe_registry_subdir` | ✅ (empty = repo root) |
| `known_registry_repos()` | ✅ contains the repo, so the icon blob proxy will serve it |
| `_clone_sandbox_mode` | `strict` — correct for an https remote, which never needs `~/.ssh` |

`test_apps_registry.py`, `test_external_registry.py`, `test_app_routes.py`:
**144 passed**.

## Manual verification

I installed this app locally from its source clone earlier and it registers
cleanly (`origin=registry`, `lifecycle=gateway`, `schemaVersion=2`, 1 skill), so
the manifest is valid and the install path works for an authenticated user. That
was via `kirocrew app install <dir>`, not through this catalog entry, because the
running build's bundled catalog is the shipped `[]` — this entry only takes effect
in a build that contains it.

## Screenshots

N/A — no UI code changes. The user-visible effect is the Discover card, and what
it will look like is described precisely under **Known limitation**; I can attach
a capture of the degraded state on request.

## Known limitation (deliberately shipped, please weigh in)

The app repo is **private**, and that interacts badly with the credential model:

- **Browse is credential-free by design.** For a bundled row there is no
  `_registry` marker, so `_is_owner_designated_repo` returns `False` and
  `_resolve_manifest` fetches `app.json` under `anonymous_git_env` — no SSH agent,
  `GIT_CONFIG_NOSYSTEM=1`, `GIT_TERMINAL_PROMPT=0`. That is the confused-deputy
  defence and it is correct: a catalog row must never be able to make the gateway
  read a private repo with the operator's identity. The consequence here is that
  the clone can **never** authenticate, `manifest` stays `None`, and the raw row is
  returned. After `normalizeRegistryApp` the store renders
  `displayName="launchdarkly"`, `description=""`, `version="0.0.0"`, `author=""`,
  no icon or screenshots (gradient fallback), and `isVerified()` false — for
  every user, including those who have access to the repo.
- **Install is unaffected** for a user whose git can already reach the repo: a
  bundled entry carries no `_registry` marker, so `_git_clone_or_pull` runs with
  `index_originated=False` and keeps the operator's ambient git identity.
- **Not a security exposure.** `install_from_registry` calls
  `app_execution_denied` first, and `third_party_execution_allowed()` requires
  `agent.apps_allow_third_party` to be the JSON boolean `true`, which defaults to
  `False`. A default user cannot reach the clone or any `onInstall` script at all.

The part worth a maintainer's judgement is **reviewability, not security**.
`docs/app-store-guidelines.md` requires a curated entry's `app.json` to pass
validation, its icon to be a committed square PNG ≥256×256, at least one committed
screenshot, a non-interactive install script, and minimal permissions.
`src/kiro_crew/apps/registry.py` states the trust model's load-bearing assumption
outright: *"The registry entry itself is curated/reviewed before being shipped."*
None of that is checkable for a private repo. No doc explicitly requires a public
repo — but the requirement is reviewability, and private-ness defeats it.

So this PR is really asking: **does the first-party catalog accept an entry whose
repo cannot be reviewed?** If the answer is no, hold this until the repo is public.
The entry itself needs no change either way.
