### PR TITLE
feat(windows): switch the desktop target from Squirrel.Windows to NSIS

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,19 +1,19 @@
 name: Build Windows Desktop (reusable)
 
-# Reusable workflow: build the Windows desktop installer (Squirrel.Windows
-# Setup.exe) and Authenticode-sign it through AWS Signer during the build.
+# Reusable workflow: build the Windows desktop installer (NSIS Setup.exe) and
+# Authenticode-sign it through AWS Signer during the build.
 # Called by nightly.yml and release.yml beside build-desktop.yml.
 #
 # WHY THIS IS NOT A LEG OF build-desktop.yml
 #
-# Signing has to happen INSIDE the build here. Squirrel nests its outputs:
-# electron-builder signs KiroCrew.exe and Update.exe, packs them into the
-# .nupkg, embeds that .nupkg into Setup.exe (WriteZipToSetup.exe), then signs
-# Setup.exe last. Signing afterwards would mean unpacking and rebuilding that
-# structure by hand, so website/electron/scripts/sign-windows.js hooks
-# electron-builder wherever it would have called signtool. macOS can do the
-# opposite -- ship an unsigned .app to sign-and-notarize.yml -- because a .app
-# is a directory, not a self-extracting archive of signed parts.
+# Signing has to happen INSIDE the build here. electron-builder signs the app
+# executable, compresses it into the installer payload, then signs the
+# installer and its uninstaller -- so signing afterwards would mean unpacking
+# and rebuilding a self-extracting archive by hand. Instead
+# website/electron/scripts/sign-windows.js hooks electron-builder wherever it
+# would have called signtool. macOS can do the opposite -- ship an unsigned
+# .app to sign-and-notarize.yml -- because a .app is a directory, not a
+# self-extracting archive of signed parts.
 #
 # The consequence is that this job holds a production signing identity, and
 # build-desktop.yml deliberately holds NO credentials at all
@@ -24,11 +24,14 @@ name: Build Windows Desktop (reusable)
 # A separate workflow keeps the credentialed surface to exactly the platform
 # that cannot avoid it.
 #
-# INSTALLER-ONLY LANE for now: auto-update.js does not consume the Squirrel
-# feed on win32 yet -- RELEASES/.nupkg are produced dormant so the upcoming
-# publish+updater lane needs no packaging change. Unattested for now too: no
-# publish lane consumes these artifacts, so SLSA provenance lands in-lane with
-# publish-windows.yml (same pattern as publish-linux.yml).
+# INSTALLER-ONLY LANE for now: win32 is still outside SUPPORTED_PLATFORMS in
+# auto-update.js, because electron-updater needs a published latest.yml feed
+# and verifies Authenticode fail-closed -- neither exists yet. The NSIS target
+# is the prerequisite for both (electron-updater's win32 path is NsisUpdater and
+# has no Squirrel support at all), so packaging lands first and the
+# publish+updater lane follows in publish-windows.yml. Unattested for now too:
+# no publish lane consumes these artifacts, so SLSA provenance lands in-lane
+# with publish-windows.yml (same pattern as publish-linux.yml).
 
 on:
   workflow_call:
@@ -240,12 +243,11 @@ jobs:
           # policy requires it as sts:ExternalId.
           WINDOWS_SIGNING_EXTERNAL_ID: ${{ env.HAS_WINDOWS_SIGNING && 'KiroCrewWindows' || '' }}
 
-      # Squirrel.Windows output: electron-builder 25.x emits into
-      # dist/squirrel-windows/ (proven live: probe run 30150819154 uploaded
-      # Setup.exe + .nupkg + RELEASES from exactly these paths). The flat dist/
-      # set guards against the output dir moving across electron-builder
-      # versions -- upload-artifact errors only when NO pattern matches
-      # anything.
+      # NSIS output: electron-builder emits the installer flat into dist/ as
+      # "<productName> Setup <version>.exe", alongside a .blockmap (the
+      # differential-download index electron-updater consumes) and latest.yml
+      # when a publish provider is configured. dist/win-unpacked/ is the staged
+      # app tree, not a distributable, so it is deliberately not uploaded.
       #
       # These comments sit ABOVE the step, not inside `path:`. In a `|` block
       # scalar every line is literal text, so a '#' line there is not a comment
@@ -255,10 +257,8 @@ jobs:
         with:
           name: build-windows-x64
           path: |
-            website/electron/dist/squirrel-windows/*.exe
-            website/electron/dist/squirrel-windows/*.nupkg
-            website/electron/dist/squirrel-windows/RELEASES
-            website/electron/dist/*.nupkg
-            website/electron/dist/RELEASES
+            website/electron/dist/*.exe
+            website/electron/dist/*.exe.blockmap
+            website/electron/dist/latest.yml
           if-no-files-found: error
           retention-days: 14

--- a/docs/install.md
+++ b/docs/install.md
@@ -199,11 +199,12 @@ the audit chain; none of the repository-controlled uninstall paths remove it:
 There is intentionally no implicit whole-home purge. Back up with `kirocrew
 snapshot` before manually removing a data home you no longer need.
 
-**External certification dependency.** Windows desktop releases use
-Squirrel.Windows, whose generated uninstaller is external to this repository.
-The repository's `--squirrel-uninstall` handler removes only the application
-shortcut and exits; it never resolves or removes the KiroCrew home, which is
-outside Squirrel's application install directory. Each signed Windows installer
+**External certification dependency.** Windows desktop releases use an NSIS
+installer, whose uninstaller electron-builder generates. `nsis.oneClick` is
+false and `nsis.deleteAppDataOnUninstall` is left false, so the uninstaller
+removes only the application install directory and its shortcuts; it never
+resolves or removes the KiroCrew home, which lives outside the install
+directory. Each signed Windows installer
 must nevertheless pass an install → create sentinel under
 `~/.kiro/crew` → uninstall → verify sentinel smoke test before release. A
 separate Kiro-family uninstaller could remove the parent `~/.kiro/` directory;

--- a/docs/release-process-design.md
+++ b/docs/release-process-design.md
@@ -147,7 +147,7 @@ CLI/EC2 distribution design, while this section covers the design shape.)
 The platform matrix today: `macos-14` builds the universal macOS app
 (DMG + zip), and `ubuntu-22.04` builds `linux-x64` (AppImage). The wheel is
 `py3-none-any`; KiroCrew is pure Python, so the same wheel serves every OS.
-Windows x64 builds a Squirrel.Windows `Setup.exe` as a CI artifact
+Windows x64 builds an NSIS `Setup.exe` as a CI artifact
 (installer-only; not yet published to the CDN), Linux arm64 remains TODO,
 and the supported Windows install path is still source
 (`docs/windows-install.md`).
@@ -335,10 +335,11 @@ Electron's built-in `autoUpdater` replaced is the hand-rolled wrapper
 around it (feed fetching, version compare, and publish-metadata authoring
 are now the library's). On Linux it replaces the AppImage in place, a new
 capability — the AppImage previously had no desktop update path. Windows
-is not migrated: its packaging is still Squirrel.Windows, which
-electron-updater's NSIS-based win32 path cannot drive, so win32 is
-excluded from the client's supported platforms until the NSIS migration
-lands (#598).
+is not migrated yet: its packaging is now NSIS, which
+electron-updater's win32 path (`NsisUpdater`) can drive, but win32 stays
+excluded from the client's supported platforms until a `latest.yml` feed is
+published and Authenticode signing is active — `NsisUpdater` verifies
+signatures fail-closed (#598).
 
 The feed contract: the client resolves `{feedBase}/{channel}/` as a
 directory and fetches the static electron-updater channel file from it —
@@ -481,7 +482,7 @@ Open as of 2026-07-28:
 | Rollback automation (P4) | **dropped** | Superseded by process decision: **there is no rollback — we roll forward by cutting a new version.** The `rollback.yml` + `blocked-versions` design described in P4/P5 above is not being built. The client-side capability remains (`allowDowngrade=true`, so a repointed feed *would* be offered), but the operational answer to a bad release is a new version cut from the release branch, not a feed rewind |
 | Forced minimum version (P5) | roadmap | Unbuilt and independent of rollback: a feed-served minimum-version floor that force-triggers the update flow for a critical security patch |
 | S3 lifecycle rules | roadmap | Designed (intermediates 7d, nightly 30d, insider 180d, stable forever); unmanaged growth is ~1 TB/year |
-| Windows lane | roadmap | CI builds a Squirrel.Windows `Setup.exe` (installer-only, unpublished); win32 auto-update stays disabled in the client until the NSIS migration (#598); the supported install path is still source |
+| Windows lane | roadmap | CI builds an NSIS `Setup.exe` (installer-only, unpublished); win32 auto-update stays disabled in the client until a `latest.yml` feed is published and signing is active (#598); the supported install path is still source |
 | Update-consent nudge polish, custom icon setting | roadmap | Nudge dots shipped; Settings card for custom icons deliberately deferred |
 
 ## 9. Design history and authorship

--- a/docs/request-for-change/rfc-update-architecture.md
+++ b/docs/request-for-change/rfc-update-architecture.md
@@ -52,7 +52,7 @@ Each packaging path stamps that value at build time into a generated
 `beacon.distribution()` prefers over the `KIROCREW_DISTRIBUTION` env var: a
 baked module ships with the artifact and a running install cannot change it,
 whereas the env var is inherited by child processes and settable by anyone with
-a shell. Windows (Squirrel) has no value in the set and reports `source`. The
+a shell. Windows (NSIS) has no value in the set and reports `source`. The
 field is read **only by telemetry**; no update code consults it.
 
 Three mechanisms:

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -137,8 +137,9 @@ start, never blocks startup), and is a quiet no-op once both are gone.
 **Repository-controlled uninstall contract.** Every uninstall path owned by this
 repository preserves the KiroCrew data home by default. `kirocrew service
 uninstall` removes only its service definition; the Python/npm packages define
-no uninstall lifecycle hook; and the desktop shell's
-`--squirrel-uninstall` handler removes only its application shortcut, without
+no uninstall lifecycle hook; and the desktop shell's generated NSIS uninstaller
+removes only its install directory and shortcuts (`deleteAppDataOnUninstall`
+stays false), without
 resolving or removing the KiroCrew home. App Kit uninstall also preserves the
 app's `data/` subtree unless the dedicated `purge_data=true` API action (CLI
 `--purge-data`, or an explicit dashboard choice) is supplied. The API checks

--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -542,7 +542,7 @@ Two non-obvious constraints:
   because the baked value outranks the env var by design.
 - The value is derived from the electron-builder **target**, not the host OS
   (`mac.target: dmg`, `linux.target: AppImage`). A Linux host also builds wheels,
-  so branching on the host would mislabel them. Windows ships a Squirrel
+  so branching on the host would mislabel them. Windows ships an NSIS
   installer, which has no value in `KNOWN_DISTRIBUTIONS`, and reports `source`
   until one is added to both the frozenset and the stamping script.
 

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -7,13 +7,13 @@ the same code path also runs on Windows.
 
 ## Desktop installer (preview, CI-built)
 
-CI's Windows lane (`build-windows.yml`) also builds a Windows desktop app:
-`KiroCrew Setup.exe` plus the Squirrel.Windows `RELEASES`/`.nupkg` pair, with
-the backend bundled (no separate Python install needed). It has its own
-workflow rather than being a leg of `build-desktop.yml` because Authenticode
-signing has to happen *during* the build — a Squirrel `Setup.exe` embeds its
-own already-signed executables — so that job needs AWS credentials the shared
-build workflow deliberately does not hold. Current status:
+CI's Windows lane (`build-windows.yml`) also builds a Windows desktop app: an
+NSIS `KiroCrew Setup <version>.exe` with the backend bundled (no separate Python
+install needed). It has its own workflow rather than being a leg of
+`build-desktop.yml` because Authenticode signing has to happen *during* the
+build — the installer compresses its own already-signed executable — so that job
+needs AWS credentials the shared build workflow deliberately does not hold.
+Current status:
 
 - **CI artifact only** — produced on nightly/release runs and the manual
   `workflow_dispatch` probe; not yet published to the download CDN (that is
@@ -22,12 +22,25 @@ build workflow deliberately does not hold. Current status:
   skips cleanly until the signing profiles are provisioned, so today's
   installers are still unsigned and SmartScreen shows an "unrecognized app"
   interstitial (More info > Run anyway).
-- **No auto-update yet** — the macOS/Linux client moved to
-  electron-updater (`latest-mac.yml` / `latest-linux.yml` feeds), but its
-  win32 path drives NSIS installers, not Squirrel.Windows, so win32 stays
-  excluded from the updater (`SUPPORTED_PLATFORMS` in `auto-update.js`)
-  until the NSIS migration lands (issue #598); installs update by running
-  a newer Setup.exe.
+- **No auto-update yet** — win32 remains outside `SUPPORTED_PLATFORMS` in
+  `auto-update.js`. The NSIS target removes the *packaging* blocker
+  (electron-updater's win32 path is `NsisUpdater`, and it has no
+  Squirrel.Windows support at all), but two prerequisites remain: a published
+  `latest.yml` feed alongside `latest-mac.yml`/`latest-linux.yml`, and active
+  signing — `NsisUpdater` verifies Authenticode fail-closed, so an unsigned
+  installer makes every update fail rather than merely warn. Tracked in
+  [issue #598](https://github.com/kirodotdev/KiroCrew/issues/598); until then,
+  installs update by running a newer Setup.exe.
+- **Assisted installer, per user by default** — `nsis.oneClick` is false and
+  `perMachine` is false, so the installer offers an install-mode page whose
+  default is a per-user install into a directory named from the product name,
+  with no UAC prompt. Choosing "for all users" on that page opts into an
+  elevated install under Program Files instead. The per-user default is what
+  keeps a nightly install (`KiroCrew Nightly`) side by side with a stable one
+  rather than replacing it; nightly additionally pins its own `nsis.guid` so
+  the two channels do not share an uninstall registry key. Either mode leaves
+  the KiroCrew home alone (`deleteAppDataOnUninstall` stays false, and
+  `~/.kiro/crew` is outside the install directory).
 
 The source install below remains the fully supported path.
 

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -48,8 +48,8 @@ HOST_ARCH="$(uname -m)"
 # electron-builder target rather than the host: mac.target is dmg, linux.target
 # is AppImage (website/electron/package.json). Reading the host OS instead would
 # be wrong on Linux, where the same machine also builds wheels.
-# Windows ships a Squirrel installer, which has no KNOWN_DISTRIBUTIONS value;
-# "source" is the honest answer until one is added on both sides.
+# Windows ships an NSIS installer, which has no KNOWN_DISTRIBUTIONS value yet;
+# "source" is the honest answer until "nsis" is added on both sides.
 case "$OS" in
   darwin)  KC_DISTRIBUTION="dmg" ;;
   windows) KC_DISTRIBUTION="source" ;;
@@ -316,9 +316,9 @@ build_backend_windows() {
     echo "ERROR: dashboard dist not staged" >&2; exit 1
   }
 
-  # Beacon provenance. Squirrel has no KNOWN_DISTRIBUTIONS value, so the honest
-  # answer is "source", but stamp it explicitly rather than relying on the
-  # module's absence: pip installed from $ROOT, and a stale stamp left in a
+  # Beacon provenance. The NSIS installer has no KNOWN_DISTRIBUTIONS value, so
+  # the honest answer is "source", but stamp it explicitly rather than relying on
+  # the module's absence: pip installed from $ROOT, and a stale stamp left in a
   # developer's checkout would otherwise be copied in and mislabel the build.
   bash "$ROOT/scripts/stamp-distribution.sh" "$KC_DISTRIBUTION" "$sp/kiro_crew"
 
@@ -447,16 +447,27 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
       # space-free makes the packaged app abort with "Unable to find helper
       # app". Nightly re-overrides the static display name to keep its suffix.
       "-c.mac.extendInfo.CFBundleDisplayName=Kiro Crew Nightly"
-      # Squirrel.Windows keys the INSTALL identity off squirrelWindows.name
-      # (install dir %LocalAppData%\<name>, shortcuts, and the RELEASES/
-      # .nupkg feed identity). On mac, a distinct productName alone gives
-      # side-by-side installs; on Windows the package name is the
-      # separator, so nightly MUST get its own -- otherwise a nightly
-      # install replaces a stable install in place. This identity persists
-      # on user machines at first install: changing it later orphans
-      # installed updaters, so it is pinned from the first shipped build.
-      "-c.squirrelWindows.name=KiroCrewNightly"
-      "-c.squirrelWindows.iconUrl=https://raw.githubusercontent.com/kirodotdev/KiroCrew/main/website/electron/icon-nightly.ico"
+      # Squirrel.Windows keyed the INSTALL identity off squirrelWindows.name;
+      # NSIS keys it off two separate things, and nightly needs both:
+      #
+      # 1. The uninstall/upgrade registry key is a GUID, defaulting to
+      #    UUID v5(appId) (app-builder-lib NsisTarget.js: `options.guid ||
+      #    UUID.v5(appInfo.id, ELECTRON_BUILDER_NS_UUID)`). Nightly shares
+      #    appId with production (see above), so WITHOUT an explicit guid both
+      #    channels claim one registry key and an assisted nightly install
+      #    adopts -- then on uninstall removes -- the stable entry. The value
+      #    below is exactly what electron-builder would derive from a
+      #    hypothetical `com.amazon.kiro.crew.nightly` appId, so it is stable,
+      #    reproducible, and collision-free without moving the real appId.
+      # 2. The install DIRECTORY comes from productFilename (i.e. the spaced
+      #    productName above) only because nsis.oneClick is false --
+      #    getWindowsInstallationDirName() falls back to the npm package name
+      #    under one-click. That is why the target is an assisted installer.
+      #
+      # As on mac, this identity persists on user machines from first install:
+      # changing it later orphans installed updaters, so it is pinned from the
+      # first shipped build.
+      "-c.nsis.guid=0f417bf9-2759-51d6-acfb-f864805d1f41"
     )
   fi
   if [ "$OS" = "darwin" ]; then
@@ -522,6 +533,6 @@ if [ "$UNIVERSAL" = "1" ]; then
 fi
 
 log "Done. Installer(s) are in $ELECTRON_DIR/dist/"
-ls -1 "$ELECTRON_DIR/dist/"*.{dmg,AppImage,zip} "$ELECTRON_DIR/dist/squirrel-windows/"*.{exe,nupkg} "$ELECTRON_DIR/dist/squirrel-windows/"RELEASES 2>/dev/null | sed 's/^/   /' || true
+ls -1 "$ELECTRON_DIR/dist/"*.{dmg,AppImage,zip,exe} 2>/dev/null | sed 's/^/   /' || true
 echo ""
 echo "    The .app embeds the backend, so it runs with no PATH kirocrew needed."

--- a/test/test_nightly_version_contract.py
+++ b/test/test_nightly_version_contract.py
@@ -6,14 +6,18 @@ of them in a way no PR-level check exercises (the probe builds that gate
 ``build-desktop.yml`` use ``0.0.0-probe.N``, whose prerelease identifier is a
 single digit -- so a malformed *real* stamp only fails on the nightly run):
 
-* **Squirrel.Windows** -- its bundled NuGet compares NUMERIC prerelease
+* **Int32-safe numeric identifiers** (HISTORICAL, still enforced) -- the Windows
+  target was Squirrel.Windows, whose bundled NuGet compared NUMERIC prerelease
   identifiers with ``Int32.Parse``
   (``NuGet.SemanticVersion.CompareTo`` -> ``ParseInt32``). An identifier above
-  ``2147483647`` throws ``System.OverflowException`` inside
-  ``ReleaseEntry.WriteReleaseFile``, so ``Update.com --releasify`` dies and
-  the whole Windows desktop leg fails. A single ``YYYYMMDDHHMMSS`` identifier
-  (~2.0e13) always overflows; ``YYYYMMDD`` (~2.0e7) and ``HHMMSS``
-  (<= 235959) as SEPARATE identifiers always fit.
+  ``2147483647`` threw ``System.OverflowException`` inside
+  ``ReleaseEntry.WriteReleaseFile``, killing ``Update.com --releasify``: a single
+  ``YYYYMMDDHHMMSS`` identifier (~2.0e13) always overflowed, while ``YYYYMMDD``
+  (~2.0e7) and ``HHMMSS`` (<= 235959) as SEPARATE identifiers always fit. The
+  target is now NSIS, which imposes neither this bound nor NuGet's 20-character
+  prerelease cap, so the constraint is no longer live -- but the assertion is
+  kept as a regression guard: shortening the stamp buys nothing, and any future
+  NuGet-based target (msi, appx) would re-impose it silently.
 * **Channel routing** -- the literal ``-nightly.`` substring is what
   ``auto-update.js`` ``channelForVersion``, ``instance-guard.js``
   ``identityFamily``, and ``packaging/build-desktop.sh``'s ``*-nightly.*``
@@ -78,12 +82,16 @@ def _rendered_nightly_version() -> str:
 
 
 def test_prerelease_fits_nuget_special_version_cap() -> None:
-    """NuGet / Squirrel reject a prerelease part longer than 20 characters.
+    """NuGet rejects a prerelease part longer than 20 characters.
 
-    The Squirrel target bundled with electron-builder-squirrel-windows 26.x
-    fails releasify with "The special version part cannot exceed 20 characters."
-    The old "nightly.<YYYYMMDD>t<HHMMSS>" was 23 chars and broke every Windows
-    nightly; the compact "nightly.<YYDDD>t<HHMMSS>" is exactly 20."""
+    HISTORICAL, still enforced. The Squirrel.Windows target bundled with
+    electron-builder-squirrel-windows 26.x failed releasify with "The special
+    version part cannot exceed 20 characters": the old
+    "nightly.<YYYYMMDD>t<HHMMSS>" was 23 chars and broke every Windows nightly,
+    and the compact "nightly.<YYDDD>t<HHMMSS>" is exactly 20. The target is now
+    NSIS, which imposes no such cap, so the bound is no longer live -- but the
+    assertion is kept as a regression guard: lengthening the stamp buys nothing,
+    and a future NuGet-based target (msi, appx) would re-impose it silently."""
     version = _rendered_nightly_version()
     _, _, prerelease = version.partition("-")
     assert prerelease, f"nightly version carries no prerelease part: {version!r}"
@@ -251,8 +259,9 @@ def test_documented_probe_example_satisfies_the_same_rules() -> None:
     overflow teaches the exact failure this PR fixes. Every semver-looking
     example is held to the same digit-run rule as the real stamp.
     """
-    # Both workflows document a probe stamp, and the Int32 hazard is Squirrel's
-    # -- so it is the WINDOWS workflow that actually releasifies. Checking only
+    # Both workflows document a probe stamp, and the version-format hazards
+    # these examples guard were Squirrel's -- so it is the WINDOWS workflow
+    # whose example historically had to satisfy them. Checking only
     # build-desktop.yml would leave the example that matters unguarded.
     for workflow in (DESKTOP_WORKFLOW, WINDOWS_WORKFLOW):
         text = workflow.read_text(encoding="utf-8")

--- a/test/test_windows_signing_contract.py
+++ b/test/test_windows_signing_contract.py
@@ -1,11 +1,11 @@
 """Contract tests for Windows Authenticode signing via AWS Signer.
 
 Windows signing is unlike the macOS path in one structural way, and every
-property below follows from it: **signing happens INSIDE the build**. Squirrel
-nests its outputs -- ``KiroCrew.exe`` and ``Update.exe`` are signed, packed into
-the ``.nupkg``, that ``.nupkg`` is embedded into ``Setup.exe``
-(``WriteZipToSetup.exe``), and ``Setup.exe`` is signed last -- so signing
-afterwards would mean rebuilding that structure by hand. Instead
+property below follows from it: **signing happens INSIDE the build**. The NSIS
+installer is a self-extracting archive -- the app executable is signed, then
+compressed into the installer payload, then the installer and its generated
+uninstaller are signed -- so signing afterwards would mean unpacking and
+rebuilding that structure by hand. Instead
 ``website/electron/scripts/sign-windows.js`` hooks electron-builder wherever it
 would have called ``signtool``.
 

--- a/test/test_workflow_permissions.py
+++ b/test/test_workflow_permissions.py
@@ -173,8 +173,8 @@ class TestReusableWorkflowPermissions:
         must never hold OIDC or write capabilities.
 
         build-windows.yml is deliberately NOT in this list: it Authenticode-signs
-        during the build (a Squirrel installer embeds its own already-signed
-        executables, so signing cannot be a downstream job) and therefore needs
+        during the build (the NSIS installer compresses its own already-signed
+        executable, so signing cannot be a downstream job) and therefore needs
         OIDC. Keeping it a separate workflow is what lets these two stay
         credential-free -- putting the Windows leg back into build-desktop.yml
         would hand OIDC to the mac and Linux legs as well. See

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -67,7 +67,12 @@ const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // every 4h while running
 const LAUNCH_CHECK_DELAY_MS = 30 * 1000; // let startup settle first
 const FORCE_EXIT_AFTER_MS = 5 * 1000; // failsafe: guarantee exit after quitAndInstall
 
-/** Platforms with a working publish lane + updater. win32 lands with NSIS (#598). */
+/**
+ * Platforms with a working publish lane + updater. win32 is packaged as NSIS
+ * (which NsisUpdater can drive) but still waits on a published latest.yml feed
+ * and active Authenticode signing -- NsisUpdater verifies fail-closed, so an
+ * unsigned installer would fail every update rather than warn (#598).
+ */
 const SUPPORTED_PLATFORMS = new Set(["darwin", "linux"]);
 
 // Byte host for human (manual) downloads -- deliberately the same CDN the
@@ -164,7 +169,7 @@ function buildFeedBase({ base, channel }) {
 
 /**
  * Human download permalink for a channel + platform, or null when there is no
- * publish lane (dev builds, Windows until the NSIS migration).
+ * publish lane (dev builds, Windows until publish-windows.yml lands).
  *
  * Why the UI needs this: an update that downloads but fails to APPLY leaves the
  * user with no next step -- the card simply re-offers the same update after

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -6,41 +6,6 @@ const { spawn, execFile } = require("child_process");
 const path = require("path");
 const http = require("http");
 
-// Squirrel.Windows fires the app with --squirrel-install / -updated /
-// -uninstall / -obsolete during install lifecycle events; the app must
-// handle them (shortcut creation/removal) and exit WITHOUT starting the
-// gateway or opening windows. No-op on macOS/Linux. Kept dependency-free
-// (no electron-squirrel-startup package) to match the repo's built-in
-// updater philosophy.
-(function handleSquirrelEvents() {
-  if (process.platform !== "win32" || process.argv.length < 2) return;
-  const cmd = process.argv[1];
-  if (!cmd.startsWith("--squirrel-")) return;
-  const { app } = require("electron");
-  const { spawn } = require("child_process");
-  const updateExe = path.resolve(path.dirname(process.execPath), "..", "Update.exe");
-  const target = path.basename(process.execPath);
-  const run = (args) => {
-    try {
-      spawn(updateExe, args, { detached: true, stdio: "ignore" }).unref();
-    } catch (_) {
-      /* Update.exe missing (dev run) -- nothing to do */
-    }
-  };
-  if (cmd === "--squirrel-install" || cmd === "--squirrel-updated") {
-    run(["--createShortcut=" + target]);
-  } else if (cmd === "--squirrel-uninstall") {
-    run(["--removeShortcut=" + target]);
-  } else if (cmd !== "--squirrel-obsolete") {
-    // --squirrel-firstrun (Squirrel's normal launch after a fresh install)
-    // and any unknown --squirrel-* flag: continue normal startup. Quitting
-    // here would make the app exit on every first launch.
-    return;
-  }
-  // Lifecycle events (install/updated/uninstall/obsolete) end here.
-  app.quit();
-  process.exit(0);
-})();
 const { findKirocrewBin } = require("./find-bin");
 const { findConfiguredDashboardPort } = require("./data-home");
 const { createTokenRetryHandler } = require("./token-retry");

--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -14,8 +14,7 @@
       "devDependencies": {
         "@electron/notarize": "^3.1.1",
         "electron": "^43.2.0",
-        "electron-builder": "^26.15.3",
-        "electron-builder-squirrel-windows": "^26.15.3"
+        "electron-builder": "^26.15.3"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
@@ -286,6 +285,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -307,6 +307,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1230,7 +1231,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1588,6 +1590,7 @@
       "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -1660,6 +1663,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -1680,6 +1684,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -1695,6 +1700,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -1705,6 +1711,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -2674,6 +2681,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -3043,6 +3051,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -3060,6 +3069,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -3264,6 +3274,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -3546,6 +3557,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -17,8 +17,7 @@
   "devDependencies": {
     "@electron/notarize": "^3.1.1",
     "electron": "^43.2.0",
-    "electron-builder": "^26.15.3",
-    "electron-builder-squirrel-windows": "^26.15.3"
+    "electron-builder": "^26.15.3"
   },
   "overrides": {
     "fast-uri": "3.1.5",
@@ -126,15 +125,18 @@
     "win": {
       "icon": "icon.png",
       "target": [
-        "squirrel"
+        "nsis"
       ],
       "signtoolOptions": {
         "sign": "./scripts/sign-windows.js"
       }
     },
-    "squirrelWindows": {
-      "name": "KiroCrew",
-      "iconUrl": "https://raw.githubusercontent.com/kirodotdev/KiroCrew/main/website/electron/icon.ico"
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": false,
+      "deleteAppDataOnUninstall": false,
+      "runAfterFinish": true
     }
   },
   "author": "Kiro Crew"

--- a/website/electron/scripts/sign-windows.js
+++ b/website/electron/scripts/sign-windows.js
@@ -1,13 +1,11 @@
 // electron-builder custom Windows sign hook: Authenticode-sign via AWS Signer.
 //
-// WHY A HOOK RATHER THAN A POST-BUILD STEP: Squirrel.Windows nests its outputs.
-// electron-builder signs KiroCrew.exe and Update.exe, packs them into the
-// .nupkg, embeds that .nupkg INTO Setup.exe (WriteZipToSetup.exe), then signs
-// Setup.exe last. Signing after the build would mean unpacking and rebuilding
+// WHY A HOOK RATHER THAN A POST-BUILD STEP: the NSIS installer is a
+// self-extracting archive. electron-builder signs the app executable, compresses
+// it into the installer payload, and signs the installer and its generated
+// uninstaller -- so signing after the build would mean unpacking and rebuilding
 // that structure by hand. A hook signs each file at the moment electron-builder
-// would have called signtool, so the ordering stays theirs. It is also why the
-// .nupkg itself is never signed -- it only ever contains already-signed
-// binaries, which is fortunate because the service cannot sign Nuget packages.
+// would have called signtool, so the ordering stays theirs.
 //
 // There is no certificate on this machine: the private key lives in the signing
 // service and never leaves it. Signing is an S3 round-trip -- upload the file,
@@ -216,7 +214,8 @@ exports.default = async function signWindows(configuration) {
   // key, so collapse to a safe set.
   const safeName = fileName.replace(/[^A-Za-z0-9._-]/g, '-')
   // Unique per invocation: electron-builder signs several files per build and
-  // may sign the same basename more than once (Squirrel's stub executables).
+  // may sign the same basename more than once (the app exe is signed both in
+  // win-unpacked and again as the installer payload's copy).
   const key = `${profileId}/${PLATFORM}/${Date.now()}-${crypto.randomBytes(4).toString('hex')}-${safeName}`
 
   ensureCredentialProfile(artifactRole, externalId)

--- a/website/electron/test/auto-update-errors.test.js
+++ b/website/electron/test/auto-update-errors.test.js
@@ -197,8 +197,8 @@ test("manualDownloadUrl: per-platform artifact on the byte host", () => {
 });
 
 test("manualDownloadUrl: null wherever there is no publish lane", () => {
-  // A dev build has no channel lane, and Windows has none until the NSIS
-  // migration -- offering a 404 is worse than offering nothing.
+  // A dev build has no channel lane, and Windows has none until
+  // publish-windows.yml lands -- offering a 404 is worse than offering nothing.
   assert.strictEqual(manualDownloadUrl("dev", "darwin"), null);
   assert.strictEqual(manualDownloadUrl("", "darwin"), null);
   assert.strictEqual(manualDownloadUrl("nightly", "win32"), null);

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -214,20 +214,42 @@ describe("uninstall data preservation contract", () => {
     }
   });
 
-  it("keeps the Squirrel uninstall handler shortcut-only", () => {
-    const match = main.match(
-      /else if \(cmd === "--squirrel-uninstall"\) \{([\s\S]*?)\n  \} else if/
-    );
-    assert.ok(match, "expected an explicit Squirrel uninstall branch");
-    assert.equal(
-      match[1].trim(),
-      'run(["--removeShortcut=" + target]);',
-      "Squirrel uninstall must remain shortcut-only and never touch the data home"
-    );
+  it("keeps the data home out of the Windows uninstaller's reach", () => {
+    // NSIS generates its own uninstaller, so there is no in-app uninstall
+    // handler to audit any more -- the guarantee moves entirely into config.
+    // deleteAppDataOnUninstall MUST stay false/absent: it would delete the
+    // Electron userData dir on uninstall, and the KiroCrew home under
+    // ~/.kiro/crew is user data that survives an uninstall by design.
     assert.notEqual(
       electronPkg.build.nsis?.deleteAppDataOnUninstall,
       true,
       "desktop uninstall must not opt into deleting app data"
     );
+  });
+
+  it("carries no Squirrel.Windows lifecycle handling", () => {
+    // Squirrel spawned the app with --squirrel-install/-updated/-uninstall and
+    // gave it ~15s to create/remove shortcuts and exit. NSIS does that itself,
+    // so the handler is gone; a re-introduction would be a silent regression
+    // back to a target electron-updater cannot drive.
+    assert.equal(main.includes("--squirrel-"), false, "no Squirrel lifecycle flags in main.js");
+    assert.equal(main.includes("Update.exe"), false, "no Squirrel Update.exe resolution in main.js");
+    assert.equal(
+      Object.hasOwn(electronPkg.build, "squirrelWindows"),
+      false,
+      "squirrelWindows config must not come back"
+    );
+    assert.deepEqual(electronPkg.build.win.target, ["nsis"]);
+  });
+
+  it("uses an assisted installer so nightly installs beside stable", () => {
+    // getWindowsInstallationDirName(appInfo, !oneClick || isPerMachine) in
+    // app-builder-lib only uses productFilename ("KiroCrew" / "KiroCrew
+    // Nightly") when that flag is true. Under oneClick+perUser it falls back to
+    // appInfo.sanitizedName -- the npm package name, "kirocrew-electron-mac" --
+    // which would put both channels in ONE directory with a nonsense name.
+    // build-desktop.sh's -c.nsis.guid override separates the registry half.
+    assert.equal(electronPkg.build.nsis.oneClick, false);
+    assert.equal(electronPkg.build.nsis.perMachine, false);
   });
 });


### PR DESCRIPTION
## Problem

Windows desktop is packaged with **Squirrel.Windows**, a target that can never
auto-update. `electron-updater`'s win32 path unconditionally constructs
`NsisUpdater` and ships no `SquirrelWindowsUpdater` at all, so Windows either has
no auto-update or needs a second, parallel update path that macOS and Linux do
not use. Upstream agrees: electron-builder documents the target as *"maintained,
but deprecated — please use nsis instead"* and lists it as *"Legacy (not
recommended)"*; Squirrel.Windows itself has no recent release and a README asking
for maintainers.

The visible symptom has been version-string pressure. electron-builder
25.1.8 → 26.15.3 (8887f489) changed the vendored Squirrel from `1.9.0` to
`2.0.1-patched`, whose NuGet enforces a 20-character `SpecialVersion` cap that
1.9.0 ignored, and the nightly Windows lane went red. #1409 has since compressed
the desktop stamp's date to `YYDDD`, which fits — at exactly 20 of 20:

```
nightly.26216t075917   <- 20/20, no headroom
```

So the lane is repairable, but the format is now pinned by a foreign constraint
with nothing left to give, on top of Squirrel's own version regex rejecting
dotted prerelease identifiers outright.

## Why it matters

Windows is the one desktop platform with no update path, and it cannot get one
without this change. Separately, **the cost of switching only goes up from
here**: Windows currently has *zero installed base* — `publish-windows.yml` does
not exist, artifacts expire with 14-day Actions retention, and `auto-update.js`
already excludes win32. Today the switch moves no users. After a first Windows
publish it would mean migrating users between two installers that share no
identity, no install directory, and no registry key.

## Fix (symptoms → root cause → change)

The 20-char failure is a symptom of the target, not of the stamp: a version
format squeezed to fit NuGet is managing a constraint that NSIS does not impose
at all. So the change swaps the target rather than the format.

- `website/electron/package.json` — `win.target: ["squirrel"]` → `["nsis"]`, add
  an `nsis` block, drop the `electron-builder-squirrel-windows` devDependency.
- `website/electron/main.js` — delete the `handleSquirrelEvents` IIFE and its
  `Update.exe`-relative path assumption. NSIS creates and removes its own
  shortcuts via `installer.nsh` / `uninstaller.nsh`; `--squirrel-firstrun`
  already fell through to normal startup, and `--squirrel-obsolete` has no NSIS
  analogue because NSIS has no side-by-side `app-<version>` layout.
- `packaging/build-desktop.sh` — nightly's `-c.squirrelWindows.name` override
  becomes `-c.nsis.guid`.
- `.github/workflows/build-windows.yml` — artifact globs move from
  `dist/squirrel-windows/{*.exe,*.nupkg,RELEASES}` to `dist/*.exe` (+ blockmap,
  + `latest.yml` when a publish provider is configured).

Two config choices are forced by `app-builder-lib` internals rather than taste:

**`nsis.oneClick: false`.** `getWindowsInstallationDirName(appInfo, !oneClick || isPerMachine)`
(`out/targets/targetUtil.js:40-42`) only uses `productFilename` when that flag is
true. Under one-click + per-user it falls back to `appInfo.sanitizedName` — which
here is the npm package name **`kirocrew-electron-mac`**, so both channels would
land in one directory with that name. Assisted mode yields `KiroCrew` /
`KiroCrew Nightly`, which is what keeps a nightly install beside a stable one.

**An explicit `nsis.guid` for nightly.** `NsisTarget.js:157` derives the uninstall
registry key as `UUID.v5(appId)`, and nightly deliberately shares `appId` with
production (that decision is unchanged and documented in `build-desktop.sh`). With
no override, both channels claim one registry key and a nightly install would
adopt — then on uninstall remove — the stable entry. The pinned value is exactly
what electron-builder would derive from `com.amazon.kiro.crew.nightly`.

**win32 stays out of `SUPPORTED_PLATFORMS`.** NSIS removes the *packaging*
blocker, but `NsisUpdater` verifies Authenticode fail-closed
(`out/NsisUpdater.js:52-57`), so switching updates on before signing is
provisioned would make every update *fail* rather than warn. The feed + updater
half follows in `publish-windows.yml` (#598).

## Tests

- `website/electron/test/packaging.test.js` — the Squirrel-uninstall regex
  assertion is replaced by three NSIS contracts: (1) `deleteAppDataOnUninstall`
  must not be `true`, (2) no Squirrel lifecycle flags, `Update.exe` reference, or
  `squirrelWindows` block may come back and the target must be `["nsis"]`,
  (3) `oneClick`/`perMachine` are both `false`, with the `sanitizedName`
  fallback spelled out so the reason survives a future edit.
  **This is strictly stronger than what it replaces** — at base the
  `deleteAppDataOnUninstall` assertion was *vacuous*, because no `nsis` block
  existed for `electronPkg.build.nsis?.deleteAppDataOnUninstall` to read.
- `test/test_nightly_version_contract.py` — the NuGet-cap and Int32 assertions are
  **kept and relabelled historical**, not deleted. NSIS imposes neither bound, but
  the stamp still renders as asserted, changing it buys nothing, and a future
  NuGet-based target (msi, appx) would re-impose both silently.
- `test/test_windows_signing_contract.py`, `test/test_workflow_permissions.py` —
  docstrings corrected to the NSIS structure; the assertions themselves are
  unchanged and still pass (20 + 10 tests).

Local: 1221 backend tests over the 50 test files that read any changed file,
695/695 electron tests, isort + flake8 clean, `scrub-lint.sh` clean. mypy has 3
pre-existing `os.*xattr` errors in `src/kiro_crew/hooks.py` (untouched here,
darwin-only — those attrs exist on the Linux runners CI uses).

## Manual verification

N/A on this host — the packaging change only takes effect on a `windows-latest`
runner, and the Windows lane is `soft_fail: true` and publishes nothing, so CI's
own run of `build-windows.yml` is the verification. Two things were verified
directly against the vendored `app-builder-lib@26.15.3` rather than assumed:

- The pinned nightly GUID `0f417bf9-2759-51d6-acfb-f864805d1f41` was recomputed
  with the in-tree `builder-util-runtime` `UUID.v5` helper under namespace
  `50e065bc-3134-11e6-9bab-38c9862bdaf3`, and is distinct from stable's derived
  `67c9cbdc-0708-5589-adc4-9c43c4e62ddb`.
- `deleteAppDataOnUninstall` is read at `NsisTarget.js:462`, **outside** the
  `if (oneClick)` branch, so the setting is honoured under an assisted installer
  despite the upstream docstring saying one-click only. `uninstaller.nsh` gates
  its `$APPDATA` deletes on that flag, and `~/.kiro/crew` resolves under
  `$PROFILE`, so the KiroCrew home is unreachable from the uninstaller on either
  path.

## Screenshots

N/A — no user-visible UI surface changes. The only user-facing difference is the
Windows installer's own chrome, which is generated by electron-builder's NSIS
templates and cannot be rendered on this host.

## Follow-ups (deliberately not in this PR)

- `publish-windows.yml` + a `latest.yml` feed + adding `win32` to
  `SUPPORTED_PLATFORMS`, gated on Authenticode signing going live (#598).
- The beacon still reports `source` for Windows; adding an `nsis` value to
  `KNOWN_DISTRIBUTIONS` touches `beacon.py`, `stamp-distribution.sh`,
  `test_beacon.py` and the metrics docs, so it is kept out of this diff.
- Now that the NuGet cap no longer binds, the nightly stamp could go back to a
  readable `YYYYMMDD`. Left alone here to keep the version contract green.
