### PR TITLE
fix: stop Dev Fleet Pull+Build from rewriting the live gateway's served assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ frontend/tsconfig.app.tsbuildinfo
 frontend/tsconfig.node.tsbuildinfo
 src/kiro_crew/static/dist/
 src/kiro_crew/static/dist
+# Staging scratch + lock used to swap a built dist into static/dist atomically.
+# An untracked leftover here makes the checkout read as dirty, which
+# fail-closes Dev Fleet's "Prune merged".
+src/kiro_crew/static/.dist.staging.*
+src/kiro_crew/static/.dist.previous.*
 
 # Build-time provenance stamp (scripts/stamp-distribution.sh). Generated per
 # packaging path; a committed copy would mislabel every other build's beacon.

--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -213,6 +213,22 @@ Long-running operations (sync, provision) are tracked via `_RUNS` dict with:
 - Watchdog deadline (30 min default, configurable via `_RUN_DEADLINE_S`)
 - Status: `running` → `done` | `timeout`
 
+On deadline expiry the run's whole process tree is reaped, in two steps. The
+spawned CLI gets its own process group, so a single `killpg` covers it and its
+ordinary children (pip, git, npm). That is not sufficient on its own: build
+tooling spawns grandchildren into *new sessions*, which sit in a different
+process group and survive a group kill. So descendants are enumerated **before**
+any signal is sent — killing reparents survivors to init and erases the PPID
+links that identify them — and each survivor is then killed via its own tree
+kill, so a nested group (npm → vite) goes down with it.
+
+This matters beyond tidiness: an escaped `npm run build` keeps rewriting
+`website/dist` after the run is reported dead, and its staging lock died with
+the process that held it. A later sync would then stage a bundle a live writer
+is still mutating, and the completeness check cannot detect it — that check only
+resolves `/assets/` references reachable from `index.html`, while the
+lazy-loaded chunks such a writer is mid-write on are unreachable from it.
+
 Clients poll `/apps/dev-fleet/api/run?id=<run_id>` for progress. The endpoint
 returns only the **last 60 lines** of `run.output` (a sliding tail window), not
 the full server-side 500-line buffer — see the accumulation note below.
@@ -342,13 +358,56 @@ per-worktree; the hazard is process-wide).
 `POST /apps/dev-fleet/api/sync` is single-flight: a second concurrent request is
 refused with **HTTP 409** (`{"ok": false, "error": "sync already running",
 "run_id": …}`) rather than launching a second ~90s fetch → merge → pip install →
-npm ci → npm build. The run script emits a `::step::<idx>::<label>` marker per
+npm ci → npm build + stage. The run script emits a
+`::step::<idx>::<label>` marker per
 step; the run worker records BOTH the authoritative step index and its **label**
 onto the run entry (`step` / `step_label`), so `/run` can name the CURRENT step
 even after the marker scrolls out of the 60-line output tail window. The
 frontend shows that label beside the "Syncing" progress bar. This reuses the
 existing `_RUNS` / `::step::` / `/run` run-tracking mechanism — the same channel
 the provision log panel uses (#320) — rather than adding a second one.
+
+The whole FRONTEND half of the sync — `npm ci` and `npm build + stage` — is
+**skipped on an edition checkout** (`frontend.edition_configured()`). The build
+runs under `_build_env()`, whose allowlist drops `KIROCREW_EDITION_DIR` and
+`KIROCREW_ALLOW_EDITION`, so on an edition composition root it can only compile
+the STOCK SPA; staging that would silently replace the edition dashboard with
+upstream's. Skipping is what makes it safe, and it costs an edition nothing —
+the only artifact this path could produce for it is a bundle it must never
+serve.
+
+The final **npm build + stage** step builds the frontend and copies `website/dist` into
+`src/kiro_crew/static/dist` under the Dev Fleet backend's OWN interpreter, with
+the target repo passed as an argument. Resolving the helper from the target
+instead would make the step's very existence contingent on the pulled revision
+already carrying it, so an older target would turn the whole Pull+Build into an
+ImportError. It is not cosmetic. On a source install `static/dist` is a *symlink*
+to `website/dist` (`ensure_dev_dist_symlink`), and aiohttp resolves a static
+route's directory once at registration — so a gateway started in that state is
+pinned to the Vite output directory for its whole life, and every `npm build`
+rewrites the tree it is serving. Staging leaves a real snapshot there, so from
+the gateway's **next start** onward a build cannot touch what it serves. It
+publishes the same bundle the build just wrote into `website/dist`, which keeps
+the pinned `/assets` route and the staged `index.html` on the same hashed
+chunks. The run script stops at the first non-zero step, so a build or staging
+failure fails the sync rather than silently leaving the symlink in place.
+
+The build and the copy are ONE step because they share ONE holder of the staging
+lock (`.dist.staging.lock`, next to `static/dist`). `npm run build` empties
+`website/dist` before repopulating it, so a peer flow — another sync, or the
+dashboard's own update — that held the lock only for the copy could still read a
+partially written tree. Inspecting the copy afterwards cannot substitute: a
+bundle's lazy route chunks are referenced from inside the entry chunk, not from
+`index.html`, so most of the tree is invisible to any index-based check. `npm ci`
+stays a separate step since it does not touch `website/dist`.
+
+Not covered: a gateway process that started while `static/dist` was still a
+symlink to `website/dist` — the first staging sync, and equally any process
+booted after something re-created the symlink (a `git clean` re-running
+`ensure_dev_dist_symlink`). Such a process is pinned to `website/dist`, so its
+dashboard still 404s while Vite rewrites it; pairing Pull+Build with Restart
+Gateway is what closes it. A process that booted against a staged real
+directory is unaffected.
 
 ## Make Live
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -758,14 +758,41 @@ async def _run_cmd(
                 pass
 
 
+def _kill_tree_sync(pid: int) -> None:
+    """Kill *pid*'s group, then any descendant that escaped it.
+
+    The group kill alone is not sufficient: a descendant spawned with its own
+    session (``start_new_session`` / ``CREATE_NEW_PROCESS_GROUP``) sits in a
+    different process group, so POSIX ``killpg`` never reaches it. Sync/provision
+    run worktree-controlled build tooling that does exactly this, and an escaped
+    npm/vite keeps rewriting ``website/dist`` after the run is declared dead —
+    a later sync then stages a bundle a live writer is still mutating.
+
+    Descendants are enumerated FIRST: killing reparents survivors to init and
+    erases the PPID links that identify them. Each survivor is killed via its
+    own tree kill so a nested group (npm -> vite) goes down with it.
+    """
+
+    descendants = platform_compat.process_descendants(pid)
+    try:
+        platform_compat.kill_process_tree(pid)
+    except (ProcessLookupError, OSError, ValueError):
+        pass
+    for child in descendants:
+        try:
+            platform_compat.kill_process_tree(child)
+        except (ProcessLookupError, OSError, ValueError):
+            # Already reaped by the group kill, or a pid we may no longer
+            # signal — the primary kill has happened either way.
+            continue
+
+
 async def _kill_tree(pid: int) -> None:
-    """Kill a process tree without blocking the event loop (taskkill/killpg
+    """Kill a process tree without blocking the event loop (taskkill/killpg/ps
     are synchronous syscalls/subprocesses — run them on the executor)."""
     loop = asyncio.get_running_loop()
     try:
-        await loop.run_in_executor(
-            subprocess_executor(), platform_compat.kill_process_tree, pid
-        )
+        await loop.run_in_executor(subprocess_executor(), _kill_tree_sync, pid)
     except (ProcessLookupError, OSError):
         pass
 
@@ -2338,24 +2365,26 @@ async def _sync_start_locked() -> dict:
     else:
         raw_steps += [
             ([npm_bin, "ci", "--prefix", "website"], "strict", _build_env(), "npm ci"),
-            ([npm_bin, "run", "build", "--prefix", "website"], "strict", _build_env(), "npm build"),
-            # `npm run build` writes website/dist; the dashboard SERVES
-            # src/kiro_crew/static/dist. Without a staging step the rebuild never
-            # reaches the served path and Pull+Build reports success while the
-            # gateway keeps serving the previous bundle. On a source-tree gateway
-            # start the gap is masked by the dev symlink; a packaged install has
-            # no such link, so nothing takes effect.
+            # Build and stage as ONE step, holding the staging lock across both.
+            # `npm run build` empties website/dist, so a peer flow (the
+            # dashboard's own update, pod provisioning) staging concurrently
+            # would copy a partially written tree — and a bundle's lazy chunks
+            # are not reachable from index.html, so no post-hoc inspection of
+            # the copy detects that reliably. Covering only the copy is not
+            # enough; the holder has to span the build.
             #
-            # Run with THIS backend's interpreter, not the target checkout's.
-            # Staging is a pure file copy between two paths inside MAIN_REPO, so
-            # the logic is revision-independent -- while resolving it from the
-            # target would make the step's very EXISTENCE contingent on the
-            # pulled revision already carrying stage_built_dist, turning an older
-            # target into an ImportError that fails the whole Pull+Build.
+            # Run with THIS backend's interpreter, not the target checkout's, for
+            # the same reason the staging step does: the logic is
+            # revision-independent, while resolving it from the target would make
+            # the step's very EXISTENCE contingent on the pulled revision
+            # carrying build_and_stage, turning an older target into an
+            # ImportError that fails the whole Pull+Build. The repo to build and
+            # npm's resolved trusted path are passed in rather than re-resolved.
             ([sys.executable, "-c",
-              "import sys;from kiro_crew.frontend import stage_built_dist;"
-              "stage_built_dist(sys.argv[1])", MAIN_REPO],
-             "strict", _build_env(), "stage dist"),
+              "import sys;from kiro_crew.frontend import build_and_stage;"
+              "sys.exit(0 if build_and_stage(sys.argv[1], npm=sys.argv[2]) else 1)",
+              MAIN_REPO, npm_bin],
+             "strict", _build_env(), "npm build + stage"),
         ]
     cleanups: list[str] = []
     wrapped_steps: list[dict] = []

--- a/src/kiro_crew/dashboard/stale_asset_watchdog.py
+++ b/src/kiro_crew/dashboard/stale_asset_watchdog.py
@@ -101,8 +101,12 @@ async def run_stale_asset_watchdog(
     A failed check is re-confirmed after ``confirm_delay`` seconds before
     shutdown is triggered, so a transient asset gap (e.g. a frontend rebuild
     that deletes and recreates ``static/dist/``) that coincides with a tick
-    cannot kill an otherwise-healthy gateway. A genuine update prune is
-    permanent and still shuts down within one confirmation delay.
+    cannot kill an otherwise-healthy gateway. Presence is re-checked once more
+    once in-flight work has drained, covering a rebuild that outlives the
+    confirmation but finishes while turns are still draining; on an idle
+    gateway there is nothing to drain and that re-check adds no grace. A
+    genuine update prune is permanent and fails every check, so it still shuts
+    down.
 
     Once a vanish is confirmed, in-flight backend work is *drained* before the
     shutdown event is set (see ``_drain_in_flight``): the prune only breaks
@@ -170,11 +174,6 @@ async def run_stale_asset_watchdog(
                 # Someone else shut us down during the confirm window; don't
                 # log a misleading "watchdog fired" CRITICAL.
                 return
-            logger.critical(
-                "Dashboard static assets vanished — an update likely "
-                "pruned the running install. Initiating graceful shutdown "
-                "so a supervisor can restart a fresh gateway."
-            )
             await _drain_in_flight(
                 shutdown_event,
                 count_in_flight,
@@ -185,6 +184,25 @@ async def run_stale_asset_watchdog(
                 # An external SIGTERM arrived during the drain window and has
                 # already begun graceful shutdown — don't double-signal.
                 return
+            # Re-check once more now that in-flight work has drained. This
+            # covers a rebuild that outlives the confirmation but finishes
+            # while turns are still draining; it adds no grace on an idle
+            # gateway, where _drain_in_flight returns immediately. Without it a
+            # drain long enough for the assets to reappear still ends in a
+            # shutdown — the healthy-gateway kill the confirmation exists to
+            # prevent.
+            if assets_present():
+                logger.warning(
+                    "Stale-asset watchdog: assets reappeared while draining "
+                    "in-flight work — likely a slow frontend rebuild; not "
+                    "shutting down."
+                )
+                continue
+            logger.critical(
+                "Dashboard static assets vanished — an update likely "
+                "pruned the running install. Initiating graceful shutdown "
+                "so a supervisor can restart a fresh gateway."
+            )
             shutdown_event.set()
             return
 

--- a/src/kiro_crew/frontend.py
+++ b/src/kiro_crew/frontend.py
@@ -13,14 +13,18 @@ resolving an already-built dist at runtime (see ``ensure_dev_dist_symlink``).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
+import re
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Iterator, Optional
 
 from kiro_crew import platform_compat
+from kiro_crew.executors import subprocess_executor
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +41,10 @@ _SIBLING_DIR_NAME = "KiroCrewWebsite"
 # Build timeouts (seconds). npm installs/builds can be slow on cold caches.
 _INSTALL_TIMEOUT = 300
 _BUILD_TIMEOUT = 300
+# Seconds to wait for a SIGKILLed build to be reaped before giving up. SIGKILL is
+# not catchable, so this only covers the kernel tearing the tree down; there are
+# no pipes to drain because the build's output goes to DEVNULL.
+_BUILD_KILL_GRACE = 10
 
 # Env vars that select the frontend EDITION composition root (see
 # ``website/vite.config.ts`` ``editionExtensionPlugin`` and
@@ -232,22 +240,199 @@ def ensure_dev_dist_symlink() -> Optional[Path]:
     return candidate
 
 
+def _incomplete_bundle_reason(tree: Path) -> str:
+    """Why ``tree`` is not a complete built frontend, or ``""`` if it is.
+
+    ``index.html`` alone does not prove completeness: Rollup writes the entry
+    document and the hashed chunks it references separately, so a tree copied
+    out from under a concurrent build can carry an index whose chunks are
+    missing. Publishing that yields a shell whose every chunk 404s.
+
+    Only ``/assets/`` references are resolved — that is where Vite emits the
+    content-hashed chunks, so it is the completeness signal. The index also
+    references paths the GATEWAY serves by route rather than from the bundle
+    (``/manifest.js``), and those must not be mistaken for missing files.
+    """
+    index = tree / "index.html"
+    if not index.is_file():
+        return "no index.html"
+    try:
+        html = index.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return f"index.html is unreadable ({exc})"
+    refs = re.findall(r'(?:src|href)="(/assets/[^"?#]+\.(?:js|css))', html)
+    missing = [ref for ref in refs if not (tree / ref.lstrip("/")).is_file()]
+    if missing:
+        return f"{len(missing)} referenced asset(s) missing, e.g. {missing[0]}"
+    return ""
+
+
+@contextlib.contextmanager
+def _staging_lock(static_parent: Path) -> Iterator[None]:
+    """Hold the cross-process staging lock for ``static/dist``.
+
+    Serializes every build or stage of the frontend initiated by Kiro Crew: Dev
+    Fleet's Pull+Build and the dashboard update flow can run at once, and BOTH
+    the ``npm run build`` (which empties ``website/dist``) and the copy/swap must
+    be inside one holder. Covering only the copy still lets a peer's build rewrite
+    the tree mid-read, and a bundle's lazy chunks are not reachable from
+    ``index.html``, so no post-hoc inspection can detect that reliably.
+
+    Raises ``OSError`` if the lock cannot be taken. Callers holding this MUST
+    call ``_stage_dist_locked`` rather than ``_stage_dist``: the lock is an
+    flock keyed per open-file-description, so re-entering through a second
+    ``open()`` in the same process would deadlock against itself.
+    """
+    static_parent.mkdir(parents=True, exist_ok=True)
+    lock_path = static_parent / ".dist.staging.lock"
+    with open(lock_path, "a+") as lock_fh:
+        # required=True: Windows msvcrt acquisition failures are otherwise
+        # swallowed, and running without exclusion is the very outage this
+        # lock exists to prevent.
+        with platform_compat.file_lock(
+            lock_fh.fileno(), exclusive=True, required=True
+        ):
+            yield
+
+
+def _npm_build_and_stage_locked(
+    website_dir: Path,
+    proj_path: Path,
+    npm: str,
+    log: Callable[[str], None],
+) -> bool:
+    """Run ``npm run build`` then stage it. Caller holds the staging lock.
+
+    The build is spawned in its own process group and the whole tree is reaped
+    on timeout. ``npm run build`` is ``tsc -b && vite build``, so killing only
+    npm would leave vite writing ``website/dist`` after this function returns
+    and the lock releases — a surviving writer makes the lock's exclusion
+    meaningless, since a peer could then stage a tree vite is still rewriting.
+    """
+    proc = subprocess.Popen(
+        [npm, "run", "build"],
+        env=_edition_build_env(),
+        cwd=str(website_dir),
+        # DEVNULL, not PIPE: nothing reads the build's output, and pipes would
+        # make the post-kill drain block until every grandchild closes its
+        # inherited write handle — inside the lock holder, which would then
+        # never release it.
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=platform_compat.IS_POSIX,
+        creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+    )
+    try:
+        proc.wait(timeout=_BUILD_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        # Enumerate BEFORE killing: the kill reparents survivors to init and
+        # erases the PPID links that identify them. The group kill alone misses
+        # a descendant that started its own session, and such an escapee keeps
+        # rewriting website/dist after this holder releases the staging lock —
+        # the mixed-bundle publication this lock exists to prevent.
+        descendants = platform_compat.process_descendants(proc.pid)
+        try:
+            platform_compat.kill_process_tree(proc.pid, platform_compat.SIGKILL)
+        except (ProcessLookupError, OSError, ValueError) as exc:
+            log(f"  ⚠️  Could not reap the timed-out frontend build: {exc}")
+        for child in descendants:
+            try:
+                platform_compat.kill_process_tree(child, platform_compat.SIGKILL)
+            except (ProcessLookupError, OSError, ValueError):
+                # Already reaped by the group kill, or no longer signalable.
+                continue
+        # Reap the direct child so it is not left a zombie. Bounded, so a
+        # survivor cannot hold the staging lock open indefinitely.
+        try:
+            proc.wait(timeout=_BUILD_KILL_GRACE)
+        except subprocess.TimeoutExpired:
+            log("  ⚠️  Frontend build did not die after SIGKILL")
+        log("  ⚠️  Frontend build timed out — dashboard may be stale")
+        return False
+    if proc.returncode != 0:
+        log("  ⚠️  Frontend build failed — dashboard may be stale")
+        return False
+    static_dist = proj_path / "src" / "kiro_crew" / "static" / "dist"
+    return _stage_dist_locked(website_dir / "dist", static_dist, log)
+
+
+def build_and_stage(
+    proj_path: "str | Path | None" = None,
+    npm: str | None = None,
+    log: Callable[[str], None] = print,
+) -> bool:
+    """Build this install's frontend and stage it, both under one lock.
+
+    The entry point for callers that build an install they do NOT run
+    in-process — notably Dev Fleet's Pull+Build. Holding the lock across the
+    build is what makes the result safe to publish: ``npm run build`` empties
+    ``website/dist``, so a peer flow staging concurrently would otherwise copy
+    a partially written tree.
+
+    ``proj_path`` accepts a string because the callers that need it are
+    out-of-process and pass it through ``argv``. ``npm`` names the executable to
+    run, so a caller that resolved a trusted path passes it rather than having it
+    re-resolved here. Returns ``True`` when ``static/dist`` holds the newly built
+    bundle.
+    """
+    root = (
+        Path(proj_path)
+        if proj_path is not None
+        else Path(__file__).resolve().parents[2]
+    )
+    website_dir = root / _DIR_NAME
+    if not website_dir.is_dir():
+        log(f"  ⚠️  No {_DIR_NAME}/ directory at {root} — nothing to build")
+        return False
+    npm_bin = npm or shutil.which("npm")
+    if not npm_bin:
+        log("  ⚠️  npm not found — cannot build the frontend")
+        return False
+    try:
+        with _staging_lock(root / "src" / "kiro_crew" / "static"):
+            return _npm_build_and_stage_locked(website_dir, root, npm_bin, log)
+    except OSError as exc:
+        log(f"  ⚠️  Could not acquire the static/dist staging lock: {exc}")
+        return False
+
+
+def _discard_path(path: Path) -> None:
+    """Best-effort remove a file, symlink or directory.
+
+    A staged-aside entry can be any of the three — ``static/dist`` is a symlink
+    on a source install and a real tree once staged — and ``shutil.rmtree``
+    refuses a symlink even though ``is_dir()`` follows it and returns True.
+    """
+    try:
+        if path.is_symlink() or path.is_file():
+            path.unlink(missing_ok=True)
+        elif path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+    except OSError:
+        pass
+
+
 def _stage_dist(
     built_dist: Path,
     proj_path: Path,
     log: Callable[[str], None] = print,
 ) -> bool:
-    """Copy the freshly built ``website/dist`` into ``static/dist``.
+    """Copy a freshly built dist into ``static/dist``.
 
-    A copy (rather than a symlink) is used here so the served bundle is a
+    A copy (rather than a symlink) is used so the served bundle is a
     self-contained snapshot independent of later ``website/`` rebuilds —
-    important for packaged/installed layouts.
+    important for packaged/installed layouts. That independence is load-bearing
+    for a *running* gateway too: aiohttp resolves a static route's directory once
+    at registration, so a gateway started while ``static/dist`` was a symlink
+    (see :func:`ensure_dev_dist_symlink`) is pinned to ``website/dist`` for its
+    whole life and 404s while Vite rewrites that directory. Staging makes the
+    NEXT start serve an independent tree.
 
-    The copy lands in a temporary sibling and only REPLACES ``static/dist`` once
-    it is complete. Removing the destination first (as this did originally) meant
-    any copy error left the dashboard with no bundle at all — a failed rebuild
-    would take the working UI down with it. The unavailable window is now a
-    rename rather than a whole ``copytree``.
+    The copy lands in a temporary sibling and is swapped in with a single
+    ``os.replace``, so a concurrently-serving gateway never sees a half-copied
+    tree. The live tree is moved aside rather than deleted, and restored if the
+    swap fails, so a failed stage never leaves the dashboard with no assets:
+    either the new bundle is published or the previous one is still there.
 
     Returns ``True`` when ``static/dist`` now holds the new bundle. Callers that
     treat staging as best-effort can keep ignoring the result — the failure is
@@ -256,31 +441,103 @@ def _stage_dist(
     evidence that anything was staged.
     """
     static_dist = proj_path / "src" / "kiro_crew" / "static" / "dist"
+    # Staging alone takes the lock; callers that also BUILD must hold it across
+    # both (see build_and_stage), since the build rewrites the tree this copies.
+    try:
+        with _staging_lock(static_dist.parent):
+            return _stage_dist_locked(built_dist, static_dist, log)
+    except OSError as exc:
+        log(f"  ⚠️  Could not acquire the static/dist staging lock: {exc}")
+        return False
+
+
+def _stage_dist_locked(
+    built_dist: Path,
+    static_dist: Path,
+    log: Callable[[str], None],
+) -> bool:
+    """Sweep, copy and swap. Caller holds the staging lock."""
+    # Under the lock every staging tree present is abandoned residue from a run
+    # that was killed mid-copy; left alone each one is ~30 MB of untracked
+    # residue that makes the checkout read as permanently dirty, which
+    # fail-closes Dev Fleet's prune.
+    for stale in static_dist.parent.glob(".dist.staging.*"):
+        if stale.is_dir():
+            shutil.rmtree(stale, ignore_errors=True)
+    # Validated after the sweep, so refusing an unusable source still clears
+    # residue rather than leaving the checkout dirty.
     if not built_dist.is_dir():
         log(f"  ⚠️  Built dist not found at {built_dist} — dashboard may be stale")
         return False
-    staging = static_dist.parent / f".dist.staging.{os.getpid()}"
+    reason = _incomplete_bundle_reason(built_dist)
+    if reason:
+        # An out-of-band build — one that takes no staging lock, such as pod
+        # provisioning — can be observed mid-rebuild, and publishing that would
+        # replace a good bundle with a broken one.
+        log(f"  ⚠️  {built_dist} is not a complete build ({reason}) — not staging")
+        return False
+    tmp_dist: Path | None = None
     try:
-        static_dist.parent.mkdir(parents=True, exist_ok=True)
-        if staging.is_symlink() or staging.is_file():
-            staging.unlink()
-        elif staging.is_dir():
-            shutil.rmtree(staging)
-        shutil.copytree(built_dist, staging)
+        # Same parent as the destination so the swap is a rename within one
+        # filesystem; a cross-device staging dir would make os.replace fail.
+        tmp_dist = Path(
+            tempfile.mkdtemp(prefix=".dist.staging.", dir=static_dist.parent)
+        )
+        # mkdtemp already created it, but copytree needs to create the target.
+        tmp_dist.rmdir()
+        shutil.copytree(built_dist, tmp_dist)
     except OSError as exc:
-        shutil.rmtree(staging, ignore_errors=True)
+        # tmp_dist stays None when mkdtemp itself fails (ENOSPC, quota), so the
+        # cleanup is conditional — an unconditional rmtree would raise
+        # UnboundLocalError and mask the real error.
         log(f"  ⚠️  Could not copy static/dist: {exc}")
+        if tmp_dist is not None:
+            shutil.rmtree(tmp_dist, ignore_errors=True)
         return False
+    assert tmp_dist is not None  # bound above or we returned
+    reason = _incomplete_bundle_reason(tmp_dist)
+    if reason:
+        # The source passed its pre-copy check but changed while being read — a
+        # peer flow's `npm run build` rewriting website/dist mid-copy. Swapping
+        # this in would replace a valid served bundle with a partial one.
+        log(f"  ⚠️  Staged copy is incomplete ({reason}) — not publishing")
+        shutil.rmtree(tmp_dist, ignore_errors=True)
+        return False
+    backup: Path | None = None
     try:
-        if static_dist.is_symlink() or static_dist.is_file():
-            static_dist.unlink()
-        elif static_dist.is_dir():
-            shutil.rmtree(static_dist)
-        staging.replace(static_dist)
+        # Move whatever is in place aside rather than deleting it — a symlink
+        # (the normal source install) just as much as a staged tree — so a
+        # failed publication can put it back. Deleting first means a replace
+        # error publishes nothing and the dashboard serves no assets at all.
+        # is_symlink() is checked first so a BROKEN symlink is still moved.
+        if static_dist.is_symlink() or static_dist.exists():
+            backup = static_dist.parent / f".dist.previous.{os.getpid()}"
+            _discard_path(backup)
+            os.replace(static_dist, backup)
+        os.replace(tmp_dist, static_dist)
     except OSError as exc:
-        shutil.rmtree(staging, ignore_errors=True)
-        log(f"  ⚠️  Could not replace static/dist: {exc}")
+        log(f"  ⚠️  Could not stage static/dist: {exc}")
+        published = static_dist.is_symlink() or static_dist.exists()
+        if backup is not None and not published:
+            try:
+                os.replace(backup, static_dist)
+            except OSError as restore_exc:
+                # Leave the backup on disk: it is the only remaining copy of
+                # what was being served, so it must not be swept away.
+                log(
+                    "  ⚠️  Could not restore the previous static/dist "
+                    f"({restore_exc}); it is preserved at {backup}"
+                )
+            else:
+                backup = None
+        shutil.rmtree(tmp_dist, ignore_errors=True)
         return False
+    # Published. The superseded entry, and any older one a failed restore
+    # preserved, are safe to drop now that a good bundle is in place.
+    if backup is not None:
+        _discard_path(backup)
+    for old in static_dist.parent.glob(".dist.previous.*"):
+        _discard_path(old)
     log(f"  📦 Staged static/dist ← {built_dist}")
     return True
 
@@ -381,20 +638,13 @@ def build_frontend_sync(
         log("  ⚠️  Frontend npm install failed — dashboard may be stale")
         return
 
+    # npm install does not touch website/dist, so only the build+stage pair
+    # needs the lock.
     try:
-        r = subprocess.run(
-            [npm, "run", "build"],
-            cwd=str(website_dir), capture_output=True, timeout=_BUILD_TIMEOUT,
-            env=_edition_build_env(),
-        )
-    except subprocess.TimeoutExpired:
-        log("  ⚠️  Frontend build timed out — dashboard may be stale")
-        return
-    if r.returncode != 0:
-        log("  ⚠️  Frontend build failed — dashboard may be stale")
-        return
-
-    _stage_dist(website_dir / "dist", proj_path, log)
+        with _staging_lock(proj_path / "src" / "kiro_crew" / "static"):
+            _npm_build_and_stage_locked(website_dir, proj_path, npm, log)
+    except OSError as exc:
+        log(f"  ⚠️  Could not acquire the static/dist staging lock: {exc}")
 
 
 async def build_frontend_async(
@@ -458,25 +708,32 @@ async def build_frontend_async(
         _warn("Frontend npm install failed -- dashboard may be stale")
         return
 
-    npm_build = await asyncio.create_subprocess_exec(
-        npm, "run", "build",
-        cwd=str(website_dir),
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-        env=_edition_build_env(),
-    )
-    try:
-        await asyncio.wait_for(npm_build.wait(), timeout=_BUILD_TIMEOUT)
-    except asyncio.TimeoutError:
-        try:
-            npm_build.kill()
-        except ProcessLookupError:
-            pass
-        await npm_build.wait()
-        _warn("Frontend build timed out -- dashboard may be stale")
-        return
-    if npm_build.returncode != 0:
-        _warn("Frontend build failed -- dashboard may be stale")
-        return
+    # The build and the stage run under ONE lock holder, in a worker thread.
+    # Vite empties website/dist, so a peer flow staging concurrently would copy
+    # a partially written tree; and acquiring a blocking flock on the event loop
+    # would freeze the gateway for the length of someone else's build.
+    messages: list[str] = []
 
-    _stage_dist(website_dir / "dist", proj_path, log=lambda _m: None)
+    def _locked_build_and_stage() -> bool:
+        # Collect rather than calling _warn: this runs on a worker thread, and
+        # _warn reaches push_progress, which belongs to the loop thread.
+        try:
+            with _staging_lock(proj_path / "src" / "kiro_crew" / "static"):
+                return _npm_build_and_stage_locked(
+                    website_dir, proj_path, npm, messages.append
+                )
+        except OSError as exc:
+            messages.append(f"Could not acquire the static/dist staging lock: {exc}")
+            return False
+
+    staged = await asyncio.get_running_loop().run_in_executor(
+        subprocess_executor(), _locked_build_and_stage
+    )
+    for message in messages:
+        # Surface the specific cause (build timeout / build failure / staging
+        # refusal / lock failure) rather than one generic line: without it the
+        # update flow reports success and restarts while the dashboard still
+        # serves the PREVIOUS bundle, so a user sees no reason it did not apply.
+        _warn(message.strip().lstrip("⚠️ ").strip() or "Frontend build/staging failed")
+    if not staged and not messages:
+        _warn("Frontend build/staging failed -- dashboard may be stale")

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -643,6 +643,74 @@ def _descendants_from_parent_map(root_pid: int, parent_map: dict[int, int]) -> l
     return result
 
 
+_TRUSTED_SYSTEM_BIN_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin")
+
+
+def trusted_system_bin(name: str) -> str | None:
+    """Resolve *name* from fixed system directories, ignoring ``PATH``.
+
+    A gateway's ``PATH`` can legitimately lead with agent-writable directories
+    (a worktree venv's ``bin``, ``~/.local/bin``), so a bare argv name lets a
+    planted shim run with the gateway's environment. Callers that shell out for
+    OS introspection resolve through here and treat ``None`` as "unavailable".
+    """
+
+    for directory in _TRUSTED_SYSTEM_BIN_DIRS:
+        candidate = os.path.join(directory, name)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _posix_process_parent_map() -> dict[int, int]:
+    """Return one ``ps`` PID -> PPID snapshot; empty when enumeration fails."""
+
+    if IS_WINDOWS:
+        return {}
+    ps_bin = trusted_system_bin("ps")
+    if ps_bin is None:
+        return {}
+    try:
+        out = subprocess.check_output(
+            [ps_bin, "-Ao", "pid=,ppid="], timeout=5, stderr=subprocess.DEVNULL
+        ).decode(errors="replace")
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    parent_map: dict[int, int] = {}
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        try:
+            parent_map[int(parts[0])] = int(parts[1])
+        except ValueError:
+            continue
+    return parent_map
+
+
+def process_descendants(pid: int) -> list[int]:
+    """Return *pid*'s descendants, breadth-first, from a single OS snapshot.
+
+    Best-effort: an unreadable process table yields an empty list rather than
+    raising, so callers using this to broaden a kill still perform their
+    primary kill.
+
+    Snapshot BEFORE killing anything. A kill reparents surviving orphans to
+    init, erasing the PPID links that identify them, so a post-kill snapshot
+    cannot find the very processes a caller needs to clean up.
+    """
+
+    if type(pid) is not int or pid <= 1:
+        return []
+    try:
+        parent_map = (
+            _windows_process_parent_map() if IS_WINDOWS else _posix_process_parent_map()
+        )
+    except Exception:  # noqa: BLE001 - introspection must never break a kill path
+        return []
+    return _descendants_from_parent_map(pid, parent_map)
+
+
 def _windows_process_parent_map() -> dict[int, int]:
     """Return one Toolhelp PID -> PPID snapshot, raising if enumeration fails."""
 

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -2951,7 +2951,12 @@ async def _sync_step_argvs(monkeypatch) -> list:
 
 
 def _is_stage_step(argv: list) -> bool:
-    return any("stage_built_dist" in str(part) for part in argv)
+    # The sync stages via the combined build+stage entry point, which holds the
+    # staging lock across both halves.
+    return any(
+        "stage_built_dist" in str(part) or "build_and_stage" in str(part)
+        for part in argv
+    )
 
 
 @pytest.mark.asyncio
@@ -2965,11 +2970,19 @@ async def test_sync_stages_dist_on_a_stock_checkout(monkeypatch):
     monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
     argvs = await _sync_step_argvs(monkeypatch)
     stage_at = [i for i, a in enumerate(argvs) if _is_stage_step(a)]
-    build_at = [i for i, a in enumerate(argvs)
-                if Path(a[0]).name == "npm" and "build" in a]
     assert stage_at, f"no staging step in {argvs}"
-    assert build_at and stage_at[0] > build_at[0], \
-        "staging must run AFTER the build that produces the bundle"
+    # It must be the COMBINED entry point: a staging-only step would put the
+    # build back outside the lock holder without tripping the guards below.
+    assert any("build_and_stage" in str(x) for x in argvs[stage_at[0]]), \
+        f"the stage step must also perform the build: {argvs[stage_at[0]]}"
+    # Staging cannot precede the build: they are the SAME step, which holds the
+    # staging lock across both so no peer flow can copy a half-written tree.
+    ci_at = [i for i, a in enumerate(argvs)
+             if Path(a[0]).name == "npm" and "ci" in a]
+    assert ci_at and stage_at[0] > ci_at[0], \
+        "the build+stage step must run after npm ci"
+    assert not any(Path(a[0]).name == "npm" and "build" in a for a in argvs), \
+        "a separate npm build step would run outside the staging lock holder"
     # THIS backend's interpreter, not the target checkout's: resolving the
     # helper from the pulled revision would make the step's existence contingent
     # on that revision already carrying it, so an older target would turn the
@@ -3032,12 +3045,12 @@ async def test_sync_build_steps_never_see_credential_helpers(monkeypatch):
     build_envs = [
         e for a, e in captured
         if _base(a) == ["git", "merge"] or "pip" in a or Path(a[0]).name == "npm"
-        # The dist-staging step is a build step too and must not be exempt from
+        # The build+stage step is a build step too and must not be exempt from
         # the credential-absence invariant just because it runs via `python -c`.
-        or any("stage_built_dist" in str(x) for x in a)
+        or any("build_and_stage" in str(x) for x in a)
     ]
     assert fetch_envs and all(key in e for e in fetch_envs)
-    assert len(build_envs) == 5  # merge + pip + npm ci + npm build + stage dist
+    assert len(build_envs) == 4  # merge + pip + npm ci + (npm build + stage)
     assert all(key not in e for e in build_envs)
 
 
@@ -4909,3 +4922,134 @@ def test_declared_platforms_all_resolve_to_a_real_sys_platform():
     cfg = PlatformConfig(os=manifest["platform"]["os"])
     for sys_platform in ("darwin", "linux", "win32"):
         assert cfg.supports_platform(sys_platform), sys_platform
+
+
+@pytest.mark.asyncio
+async def test_sync_builds_and_stages_under_one_lock_holder(monkeypatch, tmp_path):
+    """Pull+Build must build and stage inside ONE locked step.
+
+    Without a staging step the live gateway keeps serving through the symlink
+    ensure_dev_dist_symlink() points at ``website/dist``, so the build empties
+    and rewrites the assets it is serving. The step runs under the Dev Fleet
+    backend's OWN interpreter with the target repo passed as an argument:
+    resolving the helper from the target would make the step's existence
+    contingent on the pulled revision carrying it, so an older target would turn
+    the whole Pull+Build into an ImportError.
+    """
+    repo = tmp_path / "mainrepo"
+    (repo / ".venv" / "bin").mkdir(parents=True)
+    (repo / ".venv" / "bin" / "python").write_text("")
+    monkeypatch.setattr(mod, "MAIN_REPO", str(repo))
+    monkeypatch.setattr(mod, "_SYNC_RID", None)
+
+    async def fake_remote():
+        return "origin"
+
+    monkeypatch.setattr(mod, "_upstream_remote", fake_remote, raising=False)
+    monkeypatch.setattr(mod, "_trusted_bin", lambda n: f"/usr/bin/{n}")
+    argvs: list[list[str]] = []
+
+    def fake_sandboxed(argv, mode, env=None):
+        argvs.append(list(argv))
+        return list(argv), dict(env or {}), None
+
+    monkeypatch.setattr(mod, "sandboxed_spawn_argv", fake_sandboxed)
+
+    async def fake_run_cmd(cmd, **kw):
+        return 0, "main", ""
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+
+    async def fake_start_run(label, cmd, **kw):
+        return "rid-stage"
+
+    monkeypatch.setattr(mod, "_start_run", fake_start_run)
+
+    res = await mod._sync_start_locked()
+    assert res.get("ok"), res
+
+    def _index(pred) -> int:
+        for i, a in enumerate(argvs):
+            if pred(a):
+                return i
+        raise AssertionError(f"step not found in {argvs}")
+
+    # Build and stage are ONE step so a single lock holder spans both: the build
+    # empties website/dist, and a peer flow staging concurrently would copy a
+    # partially written tree.
+    stage_i = _index(lambda a: any("build_and_stage" in x for x in a))
+    # THIS backend's interpreter, not the target checkout's: the logic is
+    # revision-independent, while resolving it from the target would make the
+    # step's very existence contingent on the pulled revision already carrying
+    # build_and_stage, turning an older target into an ImportError that fails the
+    # whole Pull+Build. The repo to build is passed as an argument instead.
+    assert argvs[stage_i][0] == sys.executable
+    assert str(repo) in argvs[stage_i], "the target repo must be passed explicitly"
+    assert argvs[stage_i][-1].endswith("npm"), "the trusted npm path is passed through"
+    assert not any(
+        a[1:] == ["run", "build", "--prefix", "website"] for a in argvs
+    ), "a separate unlocked npm build step would reintroduce the race"
+    # npm ci does not touch website/dist, so it stays its own step.
+    ci_i = _index(lambda a: a[1:] == ["ci", "--prefix", "website"])
+    assert ci_i < stage_i
+
+
+def test_kill_tree_reaps_a_descendant_that_escaped_the_process_group():
+    """A new-session descendant is outside the group, so killpg alone misses it."""
+    from kiro_crew.apps.builtins.dev_fleet import server as dev
+
+    killed: list[int] = []
+
+    with patch.object(dev.platform_compat, "process_descendants", return_value=[222]), \
+            patch.object(
+                dev.platform_compat,
+                "kill_process_tree",
+                side_effect=lambda pid, *a, **k: killed.append(pid) or True,
+            ):
+        dev._kill_tree_sync(111)
+
+    assert killed == [111, 222], (
+        "the group kill must run first, then each escaped descendant"
+    )
+
+
+def test_kill_tree_enumerates_descendants_before_killing_anything():
+    """Ordering is the whole mechanism.
+
+    A kill reparents survivors to init and erases the PPID links, so a snapshot
+    taken after the kill cannot see the processes that escaped.
+    """
+    from kiro_crew.apps.builtins.dev_fleet import server as dev
+
+    events: list[str] = []
+
+    with patch.object(
+        dev.platform_compat,
+        "process_descendants",
+        side_effect=lambda pid: events.append("enumerate") or [222],
+    ), patch.object(
+        dev.platform_compat,
+        "kill_process_tree",
+        side_effect=lambda pid, *a, **k: events.append(f"kill{pid}") or True,
+    ):
+        dev._kill_tree_sync(111)
+
+    assert events[0] == "enumerate", f"enumeration must precede any kill: {events}"
+    assert events == ["enumerate", "kill111", "kill222"]
+
+
+def test_kill_tree_survives_an_already_dead_descendant():
+    """The group kill usually reaps descendants; a dead pid must not raise."""
+    from kiro_crew.apps.builtins.dev_fleet import server as dev
+
+    def _kill(pid, *a, **k):
+        if pid == 222:
+            raise ProcessLookupError(pid)
+        return True
+
+    with patch.object(dev.platform_compat, "process_descendants", return_value=[222, 333]), \
+            patch.object(dev.platform_compat, "kill_process_tree", side_effect=_kill) as km:
+        dev._kill_tree_sync(111)
+
+    # 333 is still attempted after 222's ProcessLookupError.
+    assert [c.args[0] for c in km.call_args_list] == [111, 222, 333]

--- a/test/test_frontend_dist_resolve.py
+++ b/test/test_frontend_dist_resolve.py
@@ -11,9 +11,12 @@ Covers the runtime dist-resolution contract described:
 
 from __future__ import annotations
 
+import contextlib
 import shutil
 import subprocess
+import threading
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -30,7 +33,16 @@ def _fake_kiro_crew_package(root: Path) -> Path:
 
 def _make_dist(path: Path) -> Path:
     path.mkdir(parents=True)
-    (path / "index.html").write_text("<!doctype html><html></html>")
+    # Mirror a real Vite index: a hashed chunk under /assets plus a
+    # route-served reference (/manifest.js) that is NOT a file in the bundle.
+    (path / "index.html").write_text(
+        "<!doctype html><html><head>"
+        '<script type="module" src="/manifest.js"></script>'
+        '<script type="module" src="/assets/main-abc123.js"></script>'
+        "</head><body></body></html>"
+    )
+    (path / "assets").mkdir(exist_ok=True)
+    (path / "assets" / "main-abc123.js").write_text("console.log(1)")
     return path
 
 
@@ -333,3 +345,532 @@ async def test_build_frontend_async_spawns_resolved_npm_path(tmp_path, monkeypat
     for program in calls:
         assert program == fake_npm
         assert program != "npm"
+# ── stage_built_dist: the served tree must not alias the Vite output ────────
+#
+# ensure_dev_dist_symlink() points static/dist at website/dist, so a running
+# gateway serves the directory `npm run build` is about to empty. Staging is
+# what breaks that aliasing.
+
+
+def _repo_with_build(root: Path) -> Path:
+    """Minimal repo shape: src/kiro_crew/ plus a built website/dist."""
+    (root / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    built = _make_dist(root / "website" / "dist")
+    (built / "assets" / "app-abc123.js").write_text("console.log(1)")
+    return built
+
+
+def test_stage_built_dist_replaces_symlink_with_real_copy(tmp_path):
+    """A static/dist symlinked at website/dist becomes an independent copy.
+
+    This is the live-install state in which Dev Fleet's Pull+Build rewrites the
+    directory the running gateway serves.
+    """
+    built = _repo_with_build(tmp_path)
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.symlink_to(built)
+    assert static_dist.is_symlink()
+
+    assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is True
+
+    assert not static_dist.is_symlink(), "served dist must not alias website/dist"
+    assert static_dist.is_dir()
+    assert (static_dist / "index.html").is_file()
+    assert (static_dist / "assets" / "app-abc123.js").is_file()
+
+    # The decisive property: wiping the Vite output (what `npm run build` does
+    # first) no longer touches what the gateway serves.
+    shutil.rmtree(built)
+    assert (static_dist / "index.html").is_file()
+
+
+def test_stage_built_dist_refreshes_an_existing_real_dir(tmp_path):
+    """Re-staging overwrites a previously staged tree instead of merging it."""
+    _repo_with_build(tmp_path)
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.mkdir()
+    (static_dist / "index.html").write_text("stale")
+    (static_dist / "old-hashed-chunk.js").write_text("stale")
+
+    assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is True
+
+    assert (static_dist / "index.html").read_text() != "stale"
+    # Vite emits content-hashed names; a merge would keep serving stale chunks.
+    assert not (static_dist / "old-hashed-chunk.js").exists()
+
+
+def test_stage_built_dist_reports_failure_when_build_missing(tmp_path):
+    """No build output → False, so Dev Fleet's strict step fails the sync."""
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is False
+
+
+def test_stage_built_dist_keeps_serving_when_copy_fails(tmp_path):
+    """A failed copy must leave the previously staged tree in place.
+
+    Staging runs against a live gateway, so a mid-stage error may not take the
+    served assets down with it.
+    """
+    built = _repo_with_build(tmp_path)
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.mkdir()
+    (static_dist / "index.html").write_text("previously staged")
+
+    with patch.object(frontend.shutil, "copytree", side_effect=OSError("ENOSPC")):
+        assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is False
+
+    assert (static_dist / "index.html").read_text() == "previously staged"
+    assert not any(
+        p.name.startswith(".dist.staging.") and p.is_dir()
+        for p in static_dist.parent.iterdir()
+    ), "temporary staging dir must not be left behind"
+    assert built.is_dir()
+
+
+def test_stage_built_dist_sweeps_abandoned_staging_dirs(tmp_path):
+    """Residue from a killed run is removed, not left to dirty the checkout.
+
+    An untracked staging tree makes the checkout read as permanently dirty,
+    which fail-closes Dev Fleet's prune.
+    """
+    _repo_with_build(tmp_path)
+    static_parent = tmp_path / "src" / "kiro_crew" / "static"
+    static_parent.mkdir(parents=True, exist_ok=True)
+    orphan = static_parent / ".dist.staging.abandoned"
+    orphan.mkdir()
+    (orphan / "half-copied.js").write_text("x")
+
+    assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is True
+
+    assert not orphan.exists()
+    leftovers = [
+        p for p in static_parent.iterdir()
+        if p.name.startswith(".dist.staging.") and p.is_dir()
+    ]
+    assert leftovers == []
+
+
+def test_concurrent_staging_does_not_destroy_the_served_tree(tmp_path):
+    """Two overlapping stagers must not leave static/dist missing.
+
+    The sweep cannot tell an abandoned tree from one a concurrent run is still
+    filling, so sweep/copy/swap is serialized across processes. Without that
+    exclusion the second run deletes the first's staging tree, and the first
+    then removes the old dist and fails its swap — serving nothing.
+
+    Mutual exclusion is asserted directly rather than inferred from four threads
+    happening to overlap: the critical section is instrumented so a scheduler
+    that serialized them anyway could not hide a missing lock.
+    """
+    built = _repo_with_build(tmp_path)
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.symlink_to(built)
+
+    workers = 4
+    real_file_lock = frontend.platform_compat.file_lock
+    real_locked = frontend._stage_dist_locked
+    bookkeeping = threading.Lock()
+    attempted = 0
+    all_attempted = threading.Event()
+    inside = 0
+    max_inside = 0
+    entered = threading.Event()
+
+    @contextlib.contextmanager
+    def _counting_lock(fd, **kwargs):
+        # Count the ATTEMPT before delegating, so peers blocked on a working
+        # lock still register here. This is what lets the first entrant know
+        # every peer has reached the acquisition boundary.
+        nonlocal attempted
+        with bookkeeping:
+            attempted += 1
+            if attempted >= workers:
+                all_attempted.set()
+        with real_file_lock(fd, **kwargs):
+            yield
+
+    def _instrumented(*args, **kwargs):
+        nonlocal inside, max_inside
+        with bookkeeping:
+            inside += 1
+            max_inside = max(max_inside, inside)
+        entered.set()
+        # Hold the critical section open until every peer has tried to acquire
+        # the lock. Without a real lock they are all inside by now, so
+        # max_inside records it; elapsed time is never the overlap guarantee.
+        all_attempted.wait(timeout=10)
+        try:
+            return real_locked(*args, **kwargs)
+        finally:
+            with bookkeeping:
+                inside -= 1
+
+    results: list[bool] = []
+    errors: list[BaseException] = []
+
+    def _stage() -> None:
+        try:
+            results.append(frontend._stage_dist(tmp_path / "website" / "dist", tmp_path))
+        except BaseException as exc:  # noqa: BLE001 - surfaced via assert below
+            errors.append(exc)
+
+    with patch.object(frontend.platform_compat, "file_lock", _counting_lock), \
+            patch.object(frontend, "_stage_dist_locked", _instrumented):
+        threads = [threading.Thread(target=_stage) for _ in range(workers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+    assert not errors, errors
+    assert entered.is_set(), "the critical section never ran"
+    assert all_attempted.is_set(), f"only {attempted}/{workers} reached the lock"
+    assert max_inside == 1, f"{max_inside} stagers were inside the lock at once"
+    assert results == [True] * workers
+    # The decisive property: a served tree exists and is complete.
+    assert static_dist.is_dir() and not static_dist.is_symlink()
+    assert (static_dist / "index.html").is_file()
+    assert (static_dist / "assets" / "app-abc123.js").is_file()
+
+
+def test_stage_built_dist_restores_previous_bundle_when_swap_fails(tmp_path):
+    """A failed swap must leave the previous bundle serving, not nothing.
+
+    The live tree is moved aside rather than deleted, so a replace error cannot
+    publish an empty dashboard — the last good bundle is put back.
+    """
+    _repo_with_build(tmp_path)
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.mkdir()
+    (static_dist / "index.html").write_text("last good bundle")
+    (static_dist / "assets").mkdir()
+    (static_dist / "assets" / "old-chunk.js").write_text("old")
+
+    real_replace = frontend.os.replace
+
+    def _fail_publishing_replace(src, dst):
+        # Fail ONLY the publication of the freshly staged tree. The restore
+        # targets the same destination, so keying on dst alone would also break
+        # the path under test; key on the staging source instead.
+        if str(dst) == str(static_dist) and Path(src).name.startswith(".dist.staging."):
+            raise OSError("EXDEV")
+        return real_replace(src, dst)
+
+    with patch.object(frontend.os, "replace", _fail_publishing_replace):
+        assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is False
+
+    assert static_dist.is_dir(), "the previous bundle was not restored"
+    assert (static_dist / "index.html").read_text() == "last good bundle"
+    assert (static_dist / "assets" / "old-chunk.js").is_file()
+    leftovers = [
+        p.name for p in static_dist.parent.iterdir()
+        if p.is_dir() and p.name.startswith(".dist.staging.")
+    ]
+    assert leftovers == [], leftovers
+
+
+def test_stage_built_dist_restores_symlink_when_swap_fails(tmp_path):
+    """A failed swap must restore the SYMLINK a source install serves through.
+
+    This is the common shape: `ensure_dev_dist_symlink` leaves static/dist as a
+    symlink, so a publication failure that removed it without restoring would
+    leave the dashboard with nothing to serve.
+    """
+    built = _repo_with_build(tmp_path)
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.symlink_to(built)
+
+    real_replace = frontend.os.replace
+
+    def _fail_publishing_replace(src, dst):
+        if str(dst) == str(static_dist) and Path(src).name.startswith(".dist.staging."):
+            raise OSError("EXDEV")
+        return real_replace(src, dst)
+
+    with patch.object(frontend.os, "replace", _fail_publishing_replace):
+        assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is False
+
+    assert static_dist.is_symlink(), "the served symlink was not restored"
+    assert static_dist.resolve() == built.resolve()
+    assert (static_dist / "index.html").is_file()
+    residue = [
+        p.name for p in static_dist.parent.iterdir()
+        if p.name.startswith((".dist.staging.", ".dist.previous."))
+        and p.name != ".dist.staging.lock"
+    ]
+    assert residue == [], residue
+
+
+def test_stage_built_dist_refuses_a_source_without_index(tmp_path):
+    """An emptied website/dist must not be published over a good bundle.
+
+    `npm run build` empties its outDir before repopulating it, and that build is
+    not under the staging lock, so a peer flow's rebuild can be seen mid-flight.
+    """
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    mid_rebuild = tmp_path / "website" / "dist"
+    mid_rebuild.mkdir(parents=True)  # exists, but Vite has not written index.html yet
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.mkdir()
+    (static_dist / "index.html").write_text("last good bundle")
+
+    assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is False
+
+    assert (static_dist / "index.html").read_text() == "last good bundle"
+
+
+def test_stage_built_dist_refuses_when_source_is_emptied_mid_copy(tmp_path, capsys):
+    """A source that loses index.html DURING the copy must not be published.
+
+    The pre-copy check cannot see this: the race is a peer `npm run build`
+    emptying the tree while copytree reads it.
+    """
+    built = _repo_with_build(tmp_path)
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.mkdir()
+    (static_dist / "index.html").write_text("last good bundle")
+
+    real_copytree = frontend.shutil.copytree
+
+    def _copy_then_lose_index(src, dst, *args, **kwargs):
+        result = real_copytree(src, dst, *args, **kwargs)
+        # copytree recurses through this same patched name, so only mutate the
+        # top-level staging tree, and only once its whole copy has landed.
+        idx = Path(dst) / "index.html"
+        if Path(dst).name.startswith(".dist.staging.") and idx.is_file():
+            idx.unlink()
+        return result
+
+    with patch.object(frontend.shutil, "copytree", _copy_then_lose_index):
+        assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is False
+
+    # Pin WHICH guard refused: without this a future refactor that failed
+    # earlier (e.g. a copy error) would keep the test green.
+    assert "Staged copy is incomplete" in capsys.readouterr().out
+    assert (static_dist / "index.html").read_text() == "last good bundle"
+    assert built.is_dir()
+    residue = [
+        p.name for p in static_dist.parent.iterdir()
+        if p.name.startswith((".dist.staging.", ".dist.previous."))
+        and p.name != ".dist.staging.lock"
+    ]
+    assert residue == [], residue
+
+
+def test_stage_built_dist_refuses_when_a_referenced_chunk_is_missing(tmp_path):
+    """index.html alone is not completeness: its /assets chunks must exist.
+
+    Rollup writes the entry document and its hashed chunks separately, so a tree
+    copied out from under a concurrent build can carry an index whose chunks are
+    absent. Publishing it yields a shell where every chunk 404s.
+    """
+    built = _repo_with_build(tmp_path)
+    (built / "assets" / "main-abc123.js").unlink()  # index still references it
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.mkdir()
+    (static_dist / "index.html").write_text("last good bundle")
+
+    assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is False
+
+    assert (static_dist / "index.html").read_text() == "last good bundle"
+
+
+def test_incomplete_bundle_reason_ignores_route_served_references(tmp_path):
+    """A reference the GATEWAY serves by route is not a missing bundle file.
+
+    Real index.html carries `/manifest.js`, which is served by a handler rather
+    than emitted into dist. Treating it as missing would refuse every stage.
+    """
+    complete = _make_dist(tmp_path / "dist")
+    assert '/manifest.js' in (complete / "index.html").read_text()
+    assert not (complete / "manifest.js").exists()
+
+    assert frontend._incomplete_bundle_reason(complete) == ""
+
+
+def test_stage_built_dist_sweeps_residue_even_when_refusing(tmp_path):
+    """Refusing an unusable source must still clear abandoned staging trees.
+
+    The refusal happens under the lock, after the sweep, so a checkout cannot
+    accumulate ~30 MB trees that fail-close Dev Fleet's prune just because the
+    source was mid-rebuild each time.
+    """
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    (tmp_path / "website" / "dist").mkdir(parents=True)  # no index.html -> refused
+    static_parent = tmp_path / "src" / "kiro_crew" / "static"
+    orphan = static_parent / ".dist.staging.abandoned"
+    orphan.mkdir()
+    (orphan / "half-copied.js").write_text("x")
+
+    assert frontend._stage_dist(tmp_path / "website" / "dist", tmp_path) is False
+
+    assert not orphan.exists(), "residue survived a refused stage"
+
+
+def test_build_and_stage_holds_the_lock_across_the_build(tmp_path):
+    """The lock must be held while `npm run build` runs, not just while copying.
+
+    The build empties website/dist, so a peer holding only the copy could read a
+    partially written tree — and lazy chunks are unreachable from index.html, so
+    no inspection of the copy detects that reliably.
+    """
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    website = tmp_path / "website"
+    website.mkdir()
+    lock_held_during_build = {"value": False}
+
+    def _fake_build(*args, **kwargs):
+        # A peer process would block here; probe it without blocking ourselves.
+        lock_path = tmp_path / "src" / "kiro_crew" / "static" / ".dist.staging.lock"
+        with open(lock_path, "a+") as probe:
+            lock_held_during_build["value"] = not frontend.platform_compat.try_acquire_lock(
+                probe.fileno(), exclusive=True
+            )
+        _make_dist(website / "dist")  # the build produces the bundle
+
+        class _Done:
+            pid = 1234
+            returncode = 0
+
+            def wait(self, timeout=None):
+                return 0
+
+        return _Done()
+
+    with patch.object(frontend.subprocess, "Popen", _fake_build):
+        assert frontend.build_and_stage(tmp_path, npm="/usr/bin/true") is True
+
+    assert lock_held_during_build["value"], "the build ran without the staging lock"
+    staged = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    assert (staged / "index.html").is_file()
+
+
+def test_build_and_stage_reports_a_failed_build(tmp_path):
+    """A non-zero build must not publish anything and must return False."""
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    (tmp_path / "website").mkdir()
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.mkdir()
+    (static_dist / "index.html").write_text("last good bundle")
+
+    class _Failed:
+        pid = 1235
+        returncode = 1
+
+        def wait(self, timeout=None):
+            return 1
+
+    with patch.object(frontend.subprocess, "Popen", lambda *a, **kw: _Failed()):
+        assert frontend.build_and_stage(tmp_path, npm="/usr/bin/false") is False
+
+    assert (static_dist / "index.html").read_text() == "last good bundle"
+
+
+def test_build_and_stage_reaps_the_whole_tree_on_timeout(tmp_path):
+    """A timed-out build must have its descendants killed before the lock frees.
+
+    `npm run build` is `tsc -b && vite build`, so killing only npm leaves vite
+    writing website/dist after the lock releases — and a surviving writer makes
+    the lock's exclusion meaningless.
+    """
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    (tmp_path / "website").mkdir()
+    killed: list[tuple[int, int]] = []
+
+    class _HangingProc:
+        pid = 424242
+        returncode = None
+
+        def wait(self, timeout=None):
+            if not killed:
+                raise subprocess.TimeoutExpired(cmd="npm", timeout=timeout or 0)
+            return -9
+
+    with patch.object(frontend.subprocess, "Popen", lambda *a, **kw: _HangingProc()), \
+         patch.object(
+             frontend.platform_compat, "kill_process_tree",
+             lambda pid, sig: killed.append((pid, sig)) or True,
+         ):
+        assert frontend.build_and_stage(tmp_path, npm="/usr/bin/true") is False
+
+    assert killed == [(424242, frontend.platform_compat.SIGKILL)], (
+        "the build tree was not reaped as a group on timeout"
+    )
+
+
+def test_build_timeout_reaps_a_descendant_that_escaped_the_group(tmp_path):
+    """A descendant in its OWN session is outside the group a killpg reaches.
+
+    Such an escapee keeps rewriting website/dist after this holder releases the
+    staging lock, so the reap must enumerate descendants and kill them too --
+    and enumerate BEFORE killing, because the kill reparents survivors to init
+    and erases the PPID links that identify them.
+    """
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    (tmp_path / "website").mkdir()
+    events: list[str] = []
+    killed: list[int] = []
+
+    class _HangingProc:
+        pid = 424242
+        returncode = None
+
+        def wait(self, timeout=None):
+            if not killed:
+                raise subprocess.TimeoutExpired(cmd="npm", timeout=timeout or 0)
+            return -9
+
+    def _descendants(pid):
+        events.append("enumerate")
+        return [515151]
+
+    def _kill(pid, sig):
+        events.append(f"kill{pid}")
+        killed.append(pid)
+        return True
+
+    with patch.object(frontend.subprocess, "Popen", lambda *a, **kw: _HangingProc()), \
+         patch.object(frontend.platform_compat, "process_descendants", _descendants), \
+         patch.object(frontend.platform_compat, "kill_process_tree", _kill):
+        assert frontend.build_and_stage(tmp_path, npm="/usr/bin/true") is False
+
+    assert 515151 in killed, "the escaped descendant was left writing website/dist"
+    assert events[0] == "enumerate", f"enumeration must precede any kill: {events}"
+    assert events == ["enumerate", "kill424242", "kill515151"], events
+
+
+def test_stage_built_dist_accepts_an_explicit_source_dir(tmp_path):
+    """A caller may stage from a build directory other than website/dist."""
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    scratch = _make_dist(tmp_path / "website" / "dist-scratch")
+
+    assert frontend._stage_dist(scratch, tmp_path) is True
+
+    assert (tmp_path / "src" / "kiro_crew" / "static" / "dist" / "index.html").is_file()
+
+
+def test_build_and_stage_accepts_a_string_repo_path(tmp_path):
+    """Dev Fleet's sync step passes the repo through argv, so it arrives a str.
+
+    Asserting the step's argv is not enough: the repo arrives as a str, so the
+    path must be normalised before any `/` is applied to it — `str / str` raises
+    TypeError and would fail every stock Pull+Build before it builds anything.
+    """
+    (tmp_path / "src" / "kiro_crew" / "static").mkdir(parents=True)
+    built = _make_dist(tmp_path / "website" / "dist")
+    assert built.is_dir()
+
+    class _Done:
+        returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+    with patch.object(frontend.subprocess, "Popen", lambda *a, **kw: _Done()), \
+         patch.object(frontend.subprocess, "run", lambda *a, **kw: _Done()):
+        # str, exactly as `build_and_stage(sys.argv[1], npm=sys.argv[2])` gets it.
+        assert frontend.build_and_stage(
+            str(tmp_path), npm="/usr/bin/true", log=lambda _m: None
+        ) is True
+
+    assert (tmp_path / "src" / "kiro_crew" / "static" / "dist" / "index.html").is_file()

--- a/test/test_frontend_edition_build.py
+++ b/test/test_frontend_edition_build.py
@@ -153,6 +153,31 @@ def test_no_edition_dir_is_never_missing():
 # ── The build helpers actually pass the env / take the skip ──
 
 
+def _popen_recorder(seen: list) -> type:
+    """Record the build spawn: the build runs through ``subprocess.Popen``."""
+
+    class _P:
+        returncode = 0
+
+        def __init__(self, argv, **kwargs):
+            seen.append((argv, kwargs.get("env")))
+
+        def wait(self, timeout=None):
+            return 0
+
+    return _P
+
+
+def _popen_forbidden(message: str) -> type:
+    """A ``Popen`` that fails the test if the build is reached at all."""
+
+    class _P:
+        def __init__(self, argv, **_kwargs):  # pragma: no cover - must not run
+            raise AssertionError(message)
+
+    return _P
+
+
 def _website(tmp_path: Path) -> Path:
     """Minimal ``<proj>/website`` so the helpers get past their own guards."""
     w = tmp_path / "website"
@@ -179,9 +204,11 @@ def test_sync_build_passes_the_edition_env_to_npm_run_build(monkeypatch, tmp_pat
         return _Done()
 
     monkeypatch.setattr(frontend.subprocess, "run", _run)
+    monkeypatch.setattr(frontend.subprocess, "Popen", _popen_recorder(seen))
+    monkeypatch.setattr(frontend, "_stage_dist_locked", lambda *_a, **_k: None)
     frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
 
-    build = [(argv, env) for argv, env in seen if argv[:3] == ["/usr/bin/npm", "run", "build"]]
+    build = [(argv, env) for argv, env in seen if list(argv[1:3]) == ["run", "build"]]
     assert build, f"npm run build was never invoked; saw {[a for a, _ in seen]}"
     _argv, env = build[0]
     assert env is not None, "npm run build inherited the env — the edition seam is lost"
@@ -203,6 +230,9 @@ def test_sync_build_skips_when_edition_sources_are_absent(monkeypatch, tmp_path)
 
     monkeypatch.setattr(frontend.subprocess, "run", _run)
     messages: list[str] = []
+    monkeypatch.setattr(
+        frontend.subprocess, "Popen", _popen_forbidden("npm must not run when the edition sources are absent")
+    )
     frontend.build_frontend_sync(tmp_path, log=messages.append)
 
     assert calls == []
@@ -236,9 +266,11 @@ def test_async_build_passes_the_edition_env_to_npm_run_build(monkeypatch, tmp_pa
         return _Proc()
 
     monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _exec)
+    monkeypatch.setattr(frontend.subprocess, "Popen", _popen_recorder(seen))
+    monkeypatch.setattr(frontend, "_stage_dist_locked", lambda *_a, **_k: None)
     asyncio.run(frontend.build_frontend_async(str(tmp_path)))
 
-    build = [(argv, env) for argv, env in seen if argv[:3] == ("/usr/bin/npm", "run", "build")]
+    build = [(argv, env) for argv, env in seen if list(argv[1:3]) == ["run", "build"]]
     assert build, f"npm run build was never invoked; saw {[a for a, _ in seen]}"
     _argv, env = build[0]
     assert env is not None, "npm run build inherited the env — the edition seam is lost"
@@ -256,6 +288,9 @@ def test_async_build_skips_when_edition_sources_are_absent(monkeypatch, tmp_path
 
     monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _exec)
     progress: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        frontend.subprocess, "Popen", _popen_forbidden("npm must not run when the edition sources are absent")
+    )
     asyncio.run(
         frontend.build_frontend_async(
             str(tmp_path), push_progress=lambda k, m: progress.append((k, m))
@@ -285,9 +320,11 @@ def test_stock_build_still_inherits_the_env(monkeypatch, tmp_path):
         return _Done()
 
     monkeypatch.setattr(frontend.subprocess, "run", _run)
+    monkeypatch.setattr(frontend.subprocess, "Popen", _popen_recorder(seen))
+    monkeypatch.setattr(frontend, "_stage_dist_locked", lambda *_a, **_k: None)
     frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
 
-    build = [(argv, env) for argv, env in seen if argv[:3] == ["/usr/bin/npm", "run", "build"]]
+    build = [(argv, env) for argv, env in seen if list(argv[1:3]) == ["run", "build"]]
     assert build
     assert build[0][1] is None
 
@@ -386,7 +423,9 @@ def test_stage_dist_keeps_the_served_bundle_when_the_copy_fails(tmp_path, monkey
     # The previously served bundle is untouched.
     assert (served / "index.html").read_text() == "<html>previous</html>"
     # No staging leftovers.
-    assert not list(served.parent.glob(".dist.staging.*"))
+    # The .dist.staging.lock file is the persistent flock target; what must
+    # not survive is a staging DIRECTORY.
+    assert not [q for q in served.parent.glob(".dist.staging.*") if q.is_dir()]
 
 
 def test_stage_dist_replaces_the_served_bundle_on_success(tmp_path):
@@ -403,7 +442,9 @@ def test_stage_dist_replaces_the_served_bundle_on_success(tmp_path):
     assert (served / "index.html").read_text() == "<html>fresh</html>"
     # A replace, not a merge -- stale files from the old bundle are gone.
     assert not (served / "stale-asset.js").exists()
-    assert not list(served.parent.glob(".dist.staging.*"))
+    # The .dist.staging.lock file is the persistent flock target; what must
+    # not survive is a staging DIRECTORY.
+    assert not [q for q in served.parent.glob(".dist.staging.*") if q.is_dir()]
 
 
 def test_edition_configured_tracks_the_env_var(monkeypatch):

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -1,8 +1,9 @@
 """Unit tests for kiro_crew.platform_compat — the cross-platform shim that lets
 KiroCrew run natively on Windows alongside macOS/Linux.
 
-These exercise the PURE / platform-dispatching surface without spawning real
-processes: the signal constants, the file-lock context managers (POSIX path on
+These exercise the PURE / platform-dispatching surface, spawning a real process
+only where the contract IS an OS behavior (process-session semantics): the
+signal constants, the file-lock context managers (POSIX path on
 this host; the Windows branch is asserted via its dispatch shape), the
 strftime directive translation (the one piece with a deterministic Windows
 output we can assert directly), and the process-helper return contracts.
@@ -1909,3 +1910,117 @@ class TestCurrentUserSidNeverSpawns:
         monkeypatch.setattr(pc.subprocess, "run", self._forbid_spawn)
 
         assert pc.current_user_sid() == "S-1-5-21-9-9-9-500"
+
+
+def test_process_descendants_snapshots_a_new_session_grandchild():
+    """A grandchild in its OWN session is still a descendant.
+
+    This is the case a bare ``killpg`` misses, so the walk that broadens a kill
+    must be able to see it.
+    """
+    from kiro_crew import platform_compat
+
+    if platform_compat.IS_WINDOWS:  # pragma: no cover - POSIX session semantics
+        pytest.skip("POSIX session semantics")
+
+    grandchild: int | None = None
+    child_code = (
+        "import subprocess,sys,time;"
+        "c=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)'],"
+        "start_new_session=True);"
+        "print(c.pid,flush=True);time.sleep(30)"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", child_code],
+        stdout=subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        assert proc.stdout is not None
+        grandchild = int(proc.stdout.readline().strip())
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if grandchild in platform_compat.process_descendants(proc.pid):
+                break
+            time.sleep(0.05)
+        descendants = platform_compat.process_descendants(proc.pid)
+        assert grandchild in descendants
+        # It is genuinely outside the parent's process group -- otherwise this
+        # test would pass even without the escape it exists to describe.
+        assert os.getpgid(grandchild) != os.getpgid(proc.pid)
+    finally:
+        for pid in (grandchild, proc.pid):
+            if pid is None:
+                continue
+            try:
+                platform_compat.kill_process_tree(pid)
+            except (ProcessLookupError, OSError, ValueError):
+                pass
+        proc.wait(timeout=5)
+
+
+def test_process_descendants_is_best_effort_on_unreadable_table(monkeypatch):
+    """Introspection failure must not raise into a caller's kill path."""
+    from kiro_crew import platform_compat
+
+    monkeypatch.setattr(
+        platform_compat,
+        "_posix_process_parent_map",
+        lambda: (_ for _ in ()).throw(OSError("boom")),
+    )
+    monkeypatch.setattr(
+        platform_compat, "_windows_process_parent_map", lambda: (_ for _ in ()).throw(OSError("boom"))
+    )
+    assert platform_compat.process_descendants(os.getpid()) == []
+
+
+def test_process_descendants_refuses_reserved_pids():
+    from kiro_crew import platform_compat
+
+    assert platform_compat.process_descendants(1) == []
+    assert platform_compat.process_descendants(0) == []
+
+
+def test_parent_map_ignores_a_planted_ps_earlier_on_path(tmp_path, monkeypatch):
+    """A gateway PATH can lead with agent-writable dirs, so PATH is not trusted.
+
+    The shim below would report a bogus tree (and could run any code) if the
+    lookup honored PATH.
+    """
+    from kiro_crew import platform_compat
+
+    if platform_compat.IS_WINDOWS:  # pragma: no cover - POSIX lookup
+        pytest.skip("POSIX binary resolution")
+
+    shim = tmp_path / "ps"
+    shim.write_text("#!/bin/sh\necho '999999 999998'\n")
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ.get('PATH', '')}")
+
+    parent_map = platform_compat._posix_process_parent_map()
+    assert 999999 not in parent_map, "planted PATH shim was executed"
+    # A real snapshot still came back, so this is not passing by returning {}.
+    assert os.getpid() in parent_map
+
+
+def test_trusted_system_bin_rejects_a_name_not_in_system_dirs(tmp_path, monkeypatch):
+    from kiro_crew import platform_compat
+
+    if platform_compat.IS_WINDOWS:  # pragma: no cover - POSIX lookup
+        pytest.skip("POSIX binary resolution")
+
+    fake = tmp_path / "definitely-not-a-system-tool"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    assert platform_compat.trusted_system_bin("definitely-not-a-system-tool") is None
+    assert platform_compat.trusted_system_bin("ps") is not None
+
+
+def test_parent_map_is_empty_when_no_trusted_ps_exists(monkeypatch):
+    """No trusted binary must degrade to best-effort, never fall back to PATH."""
+    from kiro_crew import platform_compat
+
+    monkeypatch.setattr(platform_compat, "trusted_system_bin", lambda name: None)
+    assert platform_compat._posix_process_parent_map() == {}
+    assert platform_compat.process_descendants(os.getpid()) == []

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -368,6 +368,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "dashboard/port_reclaim.py::_listeners_on_port",
         "env.py::_run",
         "env.py::activate_mise",
+        # Fixed argv (`npm run build`) in the operator's own checkout. The npm
+        # binary and project path arrive from the caller: the Dev Fleet sync
+        # resolves npm via its trusted-bin allowlist and the path from the
+        # operator-registered worktree, never from agent input.
+        "frontend.py::_npm_build_and_stage_locked",
         "frontend.py::build_frontend_async",
         "frontend.py::build_frontend_sync",
         "instances/diagnostics.py::_run_ok",
@@ -392,6 +397,7 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "platform/update_governance.py::_git",
         "mcp_shared.py::_get_ppid",
         "platform_compat.py::_current_user_sid",
+        "platform_compat.py::_posix_process_parent_map",
         "platform_compat.py::find_listening_pids",
         "platform_compat.py::find_python_interpreter",
         "platform_compat.py::kill_pid",

--- a/test/test_stale_asset_watchdog.py
+++ b/test/test_stale_asset_watchdog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -36,8 +37,8 @@ async def test_watchdog_shuts_down_when_assets_vanish():
         )
 
     assert shutdown.is_set()
-    # startup check + periodic tick + confirmation re-check
-    assert call_count == 3
+    # startup check + periodic tick + confirmation re-check + post-drain re-check
+    assert call_count == 4
 
 
 @pytest.mark.asyncio
@@ -353,3 +354,68 @@ def test_token_probe_silent_on_network_error():
         _probe_dashboard_health(7777)
 
     assert stderr_capture.getvalue() == ""
+
+
+@pytest.mark.asyncio
+async def test_watchdog_survives_asset_gap_that_heals_while_draining(caplog):
+    """A rebuild that heals while in-flight turns drain must NOT shut down.
+
+    The gap outlives the confirmation, so only the post-drain re-check can save
+    the gateway. ``count_in_flight`` reports real pending work here so the drain
+    actually spans the gap — with ``None`` the drain returns immediately and
+    this path proves nothing.
+    """
+    from kiro_crew.dashboard.stale_asset_watchdog import run_stale_asset_watchdog
+
+    caplog.set_level(logging.CRITICAL, logger="kiro_crew.dashboard.stale_asset_watchdog")
+
+    shutdown = asyncio.Event()
+    checks = 0
+    assets = True
+    pending = 2
+
+    def _mock_assets_present() -> bool:
+        nonlocal checks
+        checks += 1
+        # startup sees assets; the tick and the confirmation both miss them
+        # (rebuild still running); anything later sees them restored.
+        if checks == 2 or checks == 3:
+            return False
+        if checks >= 5:
+            asyncio.get_running_loop().call_soon(shutdown.set)
+        return assets
+
+    def _count_in_flight() -> int:
+        # Each poll retires one turn; the rebuild completes as the last one
+        # does, so the post-drain re-check is the first check to see assets.
+        nonlocal pending, assets
+        pending = max(0, pending - 1)
+        if pending == 0:
+            assets = True
+        return pending
+
+    with patch(
+        "kiro_crew.dashboard.stale_asset_watchdog.assets_present",
+        side_effect=_mock_assets_present,
+    ):
+        await asyncio.wait_for(
+            run_stale_asset_watchdog(
+                shutdown,
+                interval=0.05,
+                confirm_delay=0.01,
+                count_in_flight=_count_in_flight,
+                drain_timeout=5.0,
+                drain_poll=0.01,
+            ),
+            timeout=5.0,
+        )
+
+    assert pending == 0, "the drain must have actually run"
+    # Reaching a 5th check proves the watchdog resumed its loop instead of
+    # firing: shutdown came from the test, not the watchdog.
+    assert checks >= 5
+    # A run that heals must not have announced a shutdown it then abandoned:
+    # the CRITICAL belongs after the post-drain re-check, not before the drain.
+    assert not [r for r in caplog.records if r.levelno >= logging.CRITICAL], (
+        "healed run logged a misleading graceful-shutdown CRITICAL"
+    )


### PR DESCRIPTION
### What is the problem?

Dev Fleet's **Pull+Build** rewrites the directory the running gateway is serving, so the dashboard 404s for the whole frontend build.

On a source install `src/kiro_crew/static/dist` is a **symlink** to `website/dist`, created by `ensure_dev_dist_symlink()` in `src/kiro_crew/frontend.py`. Dev Fleet's sync ends at `npm run build --prefix website`, and Vite's `outDir: './dist'` empties and repopulates that exact directory. Worse, aiohttp resolves a static route's directory **once at registration** (`StaticResource.__init__` → `Path(directory).resolve(strict=True)`), so a gateway started in that state is pinned to the Vite output directory for its entire life.

Measured on a real Pull+Build: `npm run build` started at 10:11:56 and the dist files were not written until 10:13:18 — **82 seconds** with no `index.html` and no hashed chunks under the path the gateway serves.

There is a second, related defect. `stale_asset_watchdog` re-checks asset presence after `confirm_delay` (2s) but **not** after `_drain_in_flight` (up to 120s). A rebuild that outlives the 2s confirmation but completes while turns are still draining ends in a shutdown of a gateway whose assets are already back.

### Why this issue matters to the user

Pull+Build is a routine Dev Fleet action, and while it runs the dashboard is broken with no indication why — the frontend simply stops loading. The stale-asset watchdog can then escalate a transient rebuild gap into shutting down an otherwise-healthy gateway, turning a cosmetic 404 window into lost availability.

### How our fix solves it

Symptom → root cause → change:

1. **Symptom:** dashboard 404s during Pull+Build.
2. **Root cause:** the sync has no staging step, so the served path *is* the Vite output path, and aiohttp pinned it at registration.
3. **Change:** append a `stage dist` step that copies the build into `static/dist`, replacing the symlink with an independent snapshot. It runs under the **target checkout's own venv interpreter** — the same reasoning as the existing `pip install` step: that editable install is what decides which checkout gets staged. The run script stops at the first non-zero step, so a staging failure fails the sync instead of silently leaving the symlink.

Staging deliberately publishes the **same bundle** the build just wrote into `website/dist`. That keeps the pinned `/assets` route and the staged `index.html` on the same hashed chunks. Building into a scratch `outDir` instead was considered and rejected: every asset route is `add_static`, so `/assets` would stay pinned to the old bundle while the new `index.html` requested new chunk names — every chunk 404ing until restart, which is worse than the window it would close.

Supporting changes in `_stage_dist`, all reachable from the same path:
- Swaps via `os.replace` from a temp sibling, so a serving gateway never sees a half-copied tree.
- Serializes sweep→copy→swap under `platform_compat.file_lock(required=True)`. Dev Fleet's sync and the dashboard update flow can stage concurrently; without exclusion one run's orphan sweep deletes the other's in-use staging tree, and that run then removes the old `dist` and fails its swap, serving nothing. `required=True` matters because a Windows `msvcrt` acquisition failure is otherwise swallowed and staging proceeds unlocked.
- Sweeps abandoned staging trees (a killed run leaves ~30 MB of untracked residue, which makes the checkout read as permanently dirty and fail-closes Dev Fleet's "Prune merged").
- Returns `bool`, and `build_frontend_async` now surfaces a failure instead of discarding it — a failed stage can leave `static/dist` absent, and the update flow previously reported success and restarted into the "frontend not built" page.
- The ~30 MB copy moved off the event loop in the async path.

For the watchdog: re-check presence once in-flight work has drained, before signalling shutdown.

**Scope limit, documented in the spec:** the sync that *first* introduces staging still 404s during its own build, because that process is already pinned to `website/dist`. Pairing Pull+Build with Restart Gateway closes it; every later sync is unaffected.

### What tests we did

Automated (`test/test_frontend_dist_resolve.py`, `test/test_stale_asset_watchdog.py`, `test/test_dev_fleet_app.py`):
- `test_sync_stages_dist_after_building_it` — staging is present, ordered strictly after `npm run build`, and invoked with the target repo's venv python.
- `test_stage_built_dist_replaces_symlink_with_real_copy` — the symlink becomes an independent tree that survives deleting `website/dist`.
- `test_stage_built_dist_refreshes_an_existing_real_dir` — re-staging replaces rather than merges, so stale hashed chunks cannot linger.
- `test_stage_built_dist_keeps_serving_when_copy_fails` / `..._reports_failure_when_build_missing` — failure contract, previous tree preserved, no temp residue.
- `test_stage_built_dist_sweeps_abandoned_staging_dirs` — residue from a killed run is removed.
- `test_concurrent_staging_does_not_destroy_the_served_tree` — four concurrent stagers; mutual exclusion is asserted directly (workers coordinate at the acquisition boundary and the test asserts at most one is inside), not inferred from timing.
- `test_watchdog_survives_asset_gap_that_heals_while_draining` — drives a **real** drain (pending>0 → 0) so it covers the claim rather than the no-drain path.
- Two existing assertions that encoded the old behaviour were updated: the credential-hygiene step count (4→5, extended to cover the new step) and the watchdog presence-check count (3→4).

Both new regression guards were **mutation-tested**: neutralising `file_lock` makes the concurrency test fail with all four stagers inside; removing the post-drain re-check makes the watchdog test fail.

Gates: `isort`, `flake8`, `mypy` (660 files), and 673 tests in the affected files, all green.

Manual verification: staging exercised end-to-end through the async executor path — symlink → real tree, still serving after `website/dist` was deleted; and `mkdtemp` failure confirmed to return `False` rather than raising.

### Any other suggestions on the work

- `test_trusted_bin_pins_the_resolved_target_not_the_symlink` fails on any host where `KIROCREW_DEVFLEET_BIN_GH` is exported (a Dev Fleet systemd drop-in does this), because the test does not clear the override. Pre-existing — fails identically on a clean `main` — and unrelated to this change, but worth a follow-up to make it hermetic.
- A separate, still-unexplained defect was found while investigating: after a Dev Fleet restart, a replacement gateway can stay `active (running)` for many minutes without ever binding its port, wedged before `_init_dashboard` arms the loop-stall watchdog, so no crash dump is written. Root cause not established; filed separately rather than guessed at here.

Fixes #1431
