### PR TITLE
fix(test): repair acp_runtime OAuth tests failing with coroutine-raised StopIteration

### DIFF
--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -138,6 +138,45 @@ async def _await_routed(
         await asyncio.sleep(0.001)
 
 
+async def _await_pending(
+    rt: AcpRuntime, *, exclude: set[int] | None = None, timeout: float = 5.0
+) -> int:
+    """Wait for an in-flight control-plane request and return its id.
+
+    The ``_pending_requests`` counterpart to :func:`_await_routed`, and it exists
+    for the same reason. It replaces the
+    ``await asyncio.sleep(0); next(iter(rt._pending_requests))`` idiom, which
+    assumes one loop iteration is enough for the caller to reach
+    ``_send_and_await``. ``create_session`` first awaits ``asyncio.to_thread`` to
+    resolve the MCP-gateway overlay off the loop, so a single yield leaves
+    ``_pending_requests`` empty — and ``next()`` on an empty iterator raises
+    ``StopIteration``, which PEP 479 converts into
+    ``RuntimeError("coroutine raised StopIteration")`` on its way out of a
+    coroutine. That names neither the stale assumption nor the line that made it.
+
+    ``_send_and_await`` registers the future in the same synchronous block that
+    allocates the id (``runtime.py``), so the entry is visible as soon as the
+    request exists. ``exclude`` drops ids the caller already consumed, so a test
+    driving a second request cannot pick up a leftover entry from the first.
+    """
+    seen = exclude or set()
+    deadline = time.monotonic() + timeout
+    while True:
+        fresh = [rid for rid in rt._pending_requests if rid not in seen]
+        if fresh:
+            # These tests keep exactly one control-plane request in flight, so
+            # more than one means the id being returned is a coin flip.
+            assert len(fresh) == 1, f"expected one in-flight request, got {fresh}"
+            return fresh[0]
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"timed out after {timeout}s waiting for an in-flight request; "
+                f"currently pending: {sorted(rt._pending_requests)}"
+            )
+        # Yield rather than spin: the caller needs the loop to progress.
+        await asyncio.sleep(0.001)
+
+
 # ── The _await_routed helper itself ──
 
 
@@ -3132,8 +3171,7 @@ async def test_create_session_buffers_oauth_emitted_before_response():
     reader_task = await _start_reader(rt)
     create_task = asyncio.create_task(rt.create_session(cwd="/w"))
     try:
-        await asyncio.sleep(0)
-        request_id = next(iter(rt._pending_requests))
+        request_id = await _await_pending(rt)
         oauth_url = "https://mcp.linear.app/authorize?client_id=shared"
         _feed(
             reader,
@@ -3168,8 +3206,7 @@ async def test_failed_session_init_oauth_does_not_leak_to_reused_id():
     failed_task = asyncio.create_task(rt.create_session(cwd="/w"))
     fresh_task = None
     try:
-        await asyncio.sleep(0)
-        failed_request_id = next(iter(rt._pending_requests))
+        failed_request_id = await _await_pending(rt)
         _feed(
             reader,
             {
@@ -3193,8 +3230,7 @@ async def test_failed_session_init_oauth_does_not_leak_to_reused_id():
         assert not rt._pending_init_notifications
 
         fresh_task = asyncio.create_task(rt.create_session(cwd="/w"))
-        await asyncio.sleep(0)
-        fresh_request_id = next(iter(rt._pending_requests))
+        fresh_request_id = await _await_pending(rt, exclude={failed_request_id})
         _feed(reader, {"id": fresh_request_id, "result": {"sessionId": "sid-reused"}})
         handle = await asyncio.wait_for(fresh_task, timeout=3.0)
         assert handle.pop_pending_oauth_requests() == []


### PR DESCRIPTION
## Problem

Two tests in `test/test_acp_runtime.py` fail **deterministically** on Python 3.10 on the current `main` tip:

- `test_create_session_buffers_oauth_emitted_before_response`
- `test_failed_session_init_oauth_does_not_leak_to_reused_id`

Both fail with:

```
RuntimeError: coroutine raised StopIteration
```

This breaks the required **Backend Tests (3.10, shard 1)** check on every PR built on the current `main`, not just this one. Reproduce on a clean `origin/main` checkout:

```
python3 -m pytest \
  "test/test_acp_runtime.py::test_failed_session_init_oauth_does_not_leak_to_reused_id" \
  "test/test_acp_runtime.py::test_create_session_buffers_oauth_emitted_before_response" \
  --no-cov -p no:randomly
```

## Root cause

Both tests read the in-flight JSON-RPC request id like this:

```python
create_task = asyncio.create_task(rt.create_session(cwd="/w"))
await asyncio.sleep(0)
request_id = next(iter(rt._pending_requests))   # <-- raises
```

The timing assumption is stale. A single `await asyncio.sleep(0)` is not enough for `create_session` to reach `_send_and_await`: it first does

```python
mcp_servers = await asyncio.to_thread(
    pooled_session_servers, self._mcp_gateway_overlay, agent or self._agent
)
```

which is a real thread hop. Instrumenting the runtime shows `_pending_requests` is still empty after one and two yields, and the entry only appears on the **third** loop iteration. So at the point the test reads it, `rt._pending_requests` is `{}`.

`next(iter({}))` raises `StopIteration`. Per **PEP 479** (Python 3.7+), a `StopIteration` that escapes a coroutine is replaced by `RuntimeError("coroutine raised StopIteration")` — which is why the failure names neither the empty dict nor the line that assumed otherwise.

The timing assumption arrived with the tests themselves in #1327 (`fix(acp): buffer init OAuth notifications`, 8a28f1fe). I verified this by checking out that merge commit directly: both tests fail there too, so they were red on arrival rather than broken later by drift. The production code is fine — the `create_session` init-buffering loop works, and the `asyncio.to_thread` overlay hop predates #1327 (added in #1312). The defect is purely the tests' assumption about how many loop iterations that takes.

## Fix

Test-only. No production behaviour is altered; `src/` is untouched.

This file already solved exactly this class of bug once: `_await_routed()` was introduced to replace an `await asyncio.sleep(0.05); rt._next_id - 1` idiom that flaked on loaded Windows runners. This change adds `_await_pending()`, the `_pending_requests` counterpart, following that helper's shape and rationale:

- polls until the request is genuinely registered rather than assuming a fixed number of yields;
- bounded by a deadline, and on expiry raises an `AssertionError` that says what it waited for and what was actually pending (so a future regression fails at the line that is wrong, not later as an opaque `wait_for` timeout);
- waits on the same signal `_await_routed` does — `_send_and_await` registers the future in the same synchronous block that allocates the id, so the entry is visible the moment the request exists;
- takes an `exclude` set so the second `create_session` in the leak test cannot pick up the first request's leftover id, and asserts a single fresh id so the returned value is never a coin flip.

## Verification

Ran on Python 3.10 (the shard that was failing):

- the two target tests: **pass** (were: 2 failed)
- whole `test/test_acp_runtime.py` + `test/test_acp_runtime_kill.py` (also touched by #1327): **178 passed**, with `-p no:randomly` and again under the repo's default random ordering
- `flake8 test/test_acp_runtime.py`: clean
- `isort --check-only`: clean
- `./scripts/scrub-lint.sh --no-history`: all checks passed

No `src/` file changed, so no mypy surface. Scope is limited to `test/test_acp_runtime.py`.