### PR TITLE
feat(desktop): integrated Windows titlebar + launcher follow-ups (#486, #774, #487)

### DIFF
--- a/website/electron/gateway-stop.js
+++ b/website/electron/gateway-stop.js
@@ -19,7 +19,14 @@ const path = require("path");
 // classifyPortOwner (which may only ever authorise an eviction of one).
 // Keep it in one place: a drift between the two would let one of them
 // mis-target a stranger's process.
-const KIROCREW_PROC_RE = /kiro_crew|kirocrew/i;
+// Match a Kiro Crew PROCESS from a command line, not a mere path substring.
+// Two shapes only: the `kirocrew`/`kirocrew-backend` executable as a command
+// token (optionally `.exe`, ending at whitespace/quote/EOL — so a
+// `/Users/kirocrew/…` or `C:\Users\kirocrew\other.exe` user directory does NOT
+// match), or the `-m kiro_crew` python-module invocation. Anything else (an ssh
+// forward, an unrelated app under a `kirocrew` home dir) is foreign.
+const KIROCREW_PROC_RE =
+  /(?:^|[\s"'/\\])kirocrew(?:-backend)?(?:\.exe)?(?=$|[\s"'])|-m\s+kiro_crew(?=$|[\s"'.])/i;
 
 // A gateway whose parent is init (PID 1) is owned by the OS service manager —
 // a launchd LaunchAgent on macOS, a systemd unit on Linux — not by this app.
@@ -43,21 +50,31 @@ const INIT_PPID = 1;
 function postShutdown({
   backendUrl,
   kirocrewHome,
+  secrets,
   httpMod = http,
   fsMod = fs,
   pathMod = path,
   timeoutMs = 5000,
 }) {
-  return new Promise((resolve) => {
-    let secret = "";
+  // A migration can leave more than one `.local_secret` on disk (canonical +
+  // legacy), and the running gateway is authenticated by whichever one it
+  // actually loaded. Try every candidate and let a 200 pick the live one: a
+  // stale/wrong secret returning 403 must NOT short-circuit the clean-flush
+  // path into a hard SIGTERM that skips session/memory/cron persistence.
+  let secretList = Array.isArray(secrets) ? secrets : [];
+  if (!secretList.length) {
     try {
-      secret = fsMod.readFileSync(pathMod.join(kirocrewHome, ".local_secret"), "utf8").trim();
-    } catch {
-      return resolve(false);
-    }
-    if (!secret) return resolve(false);
-    let u;
-    try { u = new URL(`${backendUrl}/api/shutdown`); } catch { return resolve(false); }
+      const s = fsMod.readFileSync(pathMod.join(kirocrewHome, ".local_secret"), "utf8");
+      secretList = [s];
+    } catch { /* none readable */ }
+  }
+  secretList = [...new Set(secretList.map((s) => (s || "").trim()).filter(Boolean))];
+  if (!secretList.length) return Promise.resolve(false);
+
+  let u;
+  try { u = new URL(`${backendUrl}/api/shutdown`); } catch { return Promise.resolve(false); }
+
+  const attempt = (secret) => new Promise((resolve) => {
     const req = httpMod.request(
       {
         hostname: u.hostname,
@@ -73,6 +90,13 @@ function postShutdown({
     req.on("timeout", () => { req.destroy(); resolve(false); });
     req.end();
   });
+
+  return (async () => {
+    for (const secret of secretList) {
+      if (await attempt(secret)) return true;
+    }
+    return false;
+  })();
 }
 
 /**
@@ -92,6 +116,7 @@ async function stopGatewayGracefully(
   {
     backendUrl,
     kirocrewHome,
+    secrets,
     timeoutMs = 15000,
     postShutdownFn = postShutdown,
     httpMod,
@@ -114,7 +139,7 @@ async function stopGatewayGracefully(
     const hardTimer = setTimeout(done, timeoutMs + 3000);
     proc.once("exit", () => { clearTimeout(killTimer); clearTimeout(hardTimer); });
     // Prefer the clean endpoint; signal-nudge only if it didn't take.
-    postShutdownFn({ backendUrl, kirocrewHome, httpMod, fsMod, pathMod }).then((ok) => {
+    postShutdownFn({ backendUrl, kirocrewHome, secrets, httpMod, fsMod, pathMod }).then((ok) => {
       if (!ok && proc.exitCode === null) { try { proc.kill("SIGTERM"); } catch {} }
     });
   });

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -291,10 +291,10 @@ function quitOtherApp(appName) {
 // Function declarations are hoisted, so the helpers defined further down this
 // file are available here.
 //
-// Platforms without lsof//bin/ps (Windows) resolve to "unknown", which reuses.
-// That is the safe direction: reuse can never produce two gateways on one data
-// home, so the cross-app mutex still holds — only the eviction prompt is lost,
-// and eviction was already darwin-only (canTakeover below).
+// On Windows there is no lsof/ps, so classifyPortOwner returns "unknown" and
+// the caller reuses the port rather than force-killing an owner it cannot
+// identify. A Windows-native netstat/taskkill owner probe is a follow-up
+// (tracked separately) — it needs runtime verification on real Windows.
 function probeGatewayPortOwner(port) {
   return classifyPortOwner(port, {
     getListenPids: _lsofListenPids,
@@ -556,6 +556,17 @@ function spawnGateway(resolve) {
           if (fs.existsSync(pyExe)) {
             spawnBin = pyExe;
             spawnArgs = ["-s", "-m", "kiro_crew", ...spawnArgs];
+          } else {
+            // Bundled layout is present but python.exe is missing/corrupted.
+            // Surface this as a clear error instead of letting spawn() hang or
+            // emit a cryptic ENOENT for the .cmd shim.
+            const errMsg = `Bundled Python interpreter not found at ${pyExe}. `
+              + `The installation may be corrupted — reinstall the app.`;
+            glog(`spawn ERROR: ${errMsg}`);
+            gatewayStartFailure = { error: errMsg };
+            sendStatus(`Gateway failed: ${errMsg}`);
+            resolve(false);
+            return;
           }
         }
         const child = spawn(spawnBin, spawnArgs, {
@@ -622,14 +633,37 @@ function spawnGateway(resolve) {
  * Gracefully stop the embedded gateway and await its exit (POST /api/shutdown
  * -> SIGTERM -> SIGKILL). Core logic lives in gateway-stop.js for testability;
  * this thin wrapper binds the module-level child process + config.
+ *
+ * Uses call-time home resolution (secretCandidates) rather than the boot-time
+ * KIROCREW_HOME pin, because on the migration launch the boot-time dir may
+ * have been deleted by the backend — the secret lives in whichever candidate
+ * still exists at shutdown time.
  */
 async function stopGatewayGracefully({ timeoutMs = 15000 } = {}) {
   const proc = gatewayProcess;
   if (!proc || proc.exitCode !== null) { gatewayProcess = null; return; }
   console.log("Stopping gateway gracefully...");
+  // Resolve the secret location at call time: try each candidate in order
+  // (canonical first, legacy second) so graceful stop works even when the
+  // boot-time home was moved/deleted during migration.
+  // Resolve the secret location at call time: a migration may have moved or
+  // deleted the boot-time home, and a partial migration can leave BOTH a
+  // canonical and a legacy `.local_secret`. Collect every readable candidate
+  // value and let gateway-stop POST each one — the gateway answers 200 only to
+  // the secret it actually loaded, so a stale copy can't force a hard SIGTERM.
+  const candidates = secretCandidates();
+  const kirocrewHome = path.dirname(candidates[0]); // canonical dir (for logs/SIGTERM path)
+  const secrets = [];
+  for (const candidate of candidates) {
+    try {
+      const value = fs.readFileSync(candidate, "utf8").trim();
+      if (value) secrets.push(value);
+    } catch { /* candidate absent/unreadable */ }
+  }
   await _stopGatewayGracefully(proc, {
     backendUrl: BACKEND_URL,
-    kirocrewHome: KIROCREW_HOME,
+    kirocrewHome,
+    secrets,
     timeoutMs,
   });
   gatewayProcess = null;
@@ -1150,15 +1184,17 @@ function setupWindowContents(win, backendUrl) {
   view.webContents.on("page-title-updated", (e) => { e.preventDefault(); applyTitle(); });
 
   view.webContents.on("did-finish-load", () => {
-    // macOS + Linux only: the frameless window needs an injected drag region so
-    // the dashboard header can move the window. Windows uses a native title bar,
-    // which already provides dragging — injecting an app-region bar over the
-    // header would only risk swallowing clicks, so skip it there.
-    if (!IS_WIN) {
+    // macOS + Windows + Linux (non-native-frame): the frameless window needs
+    // an injected drag region so the dashboard header can move the window.
+    // On macOS titleBarStyle:"hidden" makes the whole window frameless; on
+    // Windows titleBarOverlay provides caption controls but no drag area.
+    // The drag bar is pointer-events:none so clicks pass through to the SPA;
+    // interactive controls are marked no-drag so they remain clickable.
+    if (IS_MAC || IS_WIN) {
       view.webContents.insertCSS(`
         #electron-drag-bar {
           position: fixed;
-          top: 0; left: 0; right: 0;
+          top: 0; left: 0; right: ${IS_WIN ? '138px' : '0'};
           height: 42px;
           -webkit-app-region: drag;
           z-index: 99999;
@@ -1276,14 +1312,20 @@ function createWindow() {
     minHeight: 600,
     backgroundColor: "#0f1117",
   };
-  // Frameless chrome is macOS-only: the dashboard's 42px header doubles as
-  // the title bar with the native traffic lights inset into it. Windows has
-  // no equivalent inset controls -- hiding the title bar there would ship
-  // windows with no minimize/maximize/close at all -- so it keeps the native
-  // frame, exactly like the shipped Linux AppImage (Electron ignores
-  // titleBarStyle on Linux). A Windows title-bar overlay with inset controls
-  // is the tracked follow-up.
+  // Frameless chrome: the dashboard's 42px header doubles as the title bar.
+  // macOS: titleBarStyle:"hidden" + native traffic lights inset into it.
+  // Windows: titleBarStyle:"hidden" + titleBarOverlay puts native caption
+  //   controls (minimize/maximize/close) in an overlay strip synced to theme.
+  // Linux: Electron ignores titleBarStyle, so it keeps the native frame.
   if (IS_MAC) opts.titleBarStyle = "hidden";
+  if (IS_WIN) {
+    opts.titleBarStyle = "hidden";
+    opts.titleBarOverlay = {
+      color: nativeTheme.shouldUseDarkColors ? "#0f1117" : "#f8fafc",
+      symbolColor: nativeTheme.shouldUseDarkColors ? "#e2e8f0" : "#1e293b",
+      height: 42,
+    };
+  }
   // Window + taskbar icon (Windows only): running unpackaged (`electron .`)
   // otherwise shows the default Electron icon. macOS takes its icon from the
   // .app bundle and Linux from the .desktop/AppImage, so leave those untouched.
@@ -1977,8 +2019,17 @@ async function openNewConnectionWindow() {
       backgroundColor: "#0f1117",
     };
     // Same platform-conditional chrome as the main window (see createWindow):
-    // frameless + inset traffic lights on macOS, native frame elsewhere.
+    // frameless + inset traffic lights on macOS, titleBarOverlay on Windows,
+    // native frame elsewhere (Linux).
     if (IS_MAC) connOpts.titleBarStyle = "hidden";
+    if (IS_WIN) {
+      connOpts.titleBarStyle = "hidden";
+      connOpts.titleBarOverlay = {
+        color: nativeTheme.shouldUseDarkColors ? "#0f1117" : "#f8fafc",
+        symbolColor: nativeTheme.shouldUseDarkColors ? "#e2e8f0" : "#1e293b",
+        height: 42,
+      };
+    }
     if (IS_MAC) connOpts.trafficLightPosition = trafficLightPositionForZoom(1);
     const connWin = new BaseWindow(connOpts);
 
@@ -2257,6 +2308,23 @@ app.whenReady().then(async () => {
   ipcMain.on("theme-mode-changed", (_event, pref) => {
     if (pref === "system" || pref === "dark" || pref === "light") {
       nativeTheme.themeSource = resolveThemeSource(pref, "");
+    }
+  });
+
+  // Windows titleBarOverlay color sync: when the resolved dark/light mode
+  // changes, update the overlay background and symbol colors to match. The
+  // renderer sends the resolved mode ("dark" | "light") after any theme change.
+  ipcMain.on("titlebar-overlay-theme", (_event, mode) => {
+    if (!IS_WIN) return;
+    const dark = mode === "dark";
+    const color = dark ? "#0f1117" : "#f8fafc";
+    const symbolColor = dark ? "#e2e8f0" : "#1e293b";
+    for (const win of BaseWindow.getAllWindows()) {
+      try {
+        if (typeof win.setTitleBarOverlay === "function") {
+          win.setTitleBarOverlay({ color, symbolColor, height: 42 });
+        }
+      } catch { /* window mid-teardown */ }
     }
   });
 

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -28,6 +28,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // preference, not the resolved mode: pinning themeSource to dark/light also
   // pins `prefers-color-scheme`, which is what Auto resolves through.
   setThemeMode: (pref) => ipcRenderer.send("theme-mode-changed", String(pref || "")),
+  // Report the RESOLVED dark/light mode ("dark" | "light") so main.js can sync
+  // the Windows titleBarOverlay colors. Separate from setThemeMode because that
+  // carries the preference (system/dark/light) while this carries the outcome.
+  setTitleBarOverlayTheme: (mode) => ipcRenderer.send("titlebar-overlay-theme", String(mode || "")),
   // Dev mode IPC: renderer signals main process to show/hide DevTools menu item.
   setDevMode: (enabled) => ipcRenderer.send("dev-mode-changed", !!enabled),
   // App-menu navigation: main.js sends an in-app path ("/settings",

--- a/website/electron/test/gateway-stop.test.js
+++ b/website/electron/test/gateway-stop.test.js
@@ -81,6 +81,30 @@ test("postShutdown returns false when no secret file exists", async () => {
   fs.rmSync(home, { recursive: true, force: true });
 });
 
+test("postShutdown tries each candidate secret — a stale first secret does not block the live one", async () => {
+  // Migration edge: a partially-copied canonical secret is stale, but the
+  // gateway is authenticated by the legacy one. postShutdown must POST both.
+  const { server, port } = await startServer({ secret: "live-legacy", status: 200 });
+  try {
+    const ok = await postShutdown({
+      backendUrl: `http://127.0.0.1:${port}`,
+      secrets: ["stale-canonical", "live-legacy"],
+    });
+    assert.strictEqual(ok, true);
+  } finally { server.close(); }
+});
+
+test("postShutdown returns false only after every candidate secret is rejected", async () => {
+  const { server, port } = await startServer({ secret: "the-real-one", status: 200 });
+  try {
+    const ok = await postShutdown({
+      backendUrl: `http://127.0.0.1:${port}`,
+      secrets: ["nope-1", "nope-2"],
+    });
+    assert.strictEqual(ok, false);
+  } finally { server.close(); }
+});
+
 test("stopGatewayGracefully: happy path — endpoint exits process, no signal needed", async () => {
   const home = tmpHomeWithSecret("s3cr3t");
   const proc = spawnDummy({ ignoreSigterm: true }); // proves SIGTERM was NOT used
@@ -350,4 +374,13 @@ test("classifyPortOwner and forceStopPort share one KiroCrew matcher", async () 
   assert.ok(KIROCREW_PROC_RE.test("python -m kiro_crew gateway"));
   assert.ok(KIROCREW_PROC_RE.test("/Applications/KiroCrew.app/.../kirocrew"));
   assert.ok(!KIROCREW_PROC_RE.test("ssh -NL 5476:localhost:5476 host"));
+  // The matcher keys on the executable/module TOKEN, not a path substring:
+  // an unrelated process merely living under a `kirocrew` home dir is foreign.
+  assert.ok(!KIROCREW_PROC_RE.test("C:\\Users\\kirocrew\\OtherApp\\server.exe --port 5476"));
+  assert.ok(!KIROCREW_PROC_RE.test("/home/kirocrew/some-other-server --port 5476"));
+  assert.ok(!KIROCREW_PROC_RE.test("C:\\Users\\kirocrew\\python.exe -m http.server 5476"));
+  // …but the real Windows executable / backend / module invocation still match.
+  assert.ok(KIROCREW_PROC_RE.test("C:\\Program Files\\KiroCrew\\kirocrew.exe"));
+  assert.ok(KIROCREW_PROC_RE.test("C:\\Program Files\\KiroCrew\\kirocrew-backend.exe --gateway"));
+  assert.ok(KIROCREW_PROC_RE.test("C:\\Python\\python.exe -m kiro_crew gateway"));
 });

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -37,7 +37,7 @@ import { OnboardingShellHost } from './components/OnboardingChapterShell'
 import { PREVIEW_FOCUS_EVENT } from './components/WebPreviewPanel'
 import { motion, AnimatePresence } from 'framer-motion'
 import { usePersistedBool } from './hooks/usePersistedBool'
-import { isMacElectron } from './lib/electron'
+import { isMacElectron, isWinElectron } from './lib/electron'
 import { DndContext, closestCenter, MouseSensor, TouchSensor, useSensor, useSensors, DragOverlay, type DragStartEvent, type DragEndEvent } from '@dnd-kit/core'
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -1591,7 +1591,7 @@ export default function App() {
       <div className="absolute inset-0" style={{ display: activeInstanceId === null ? 'block' : 'none' }}>
     <div
       data-testid="dashboard-shell"
-      className={`relative z-[1] h-full grid animate-rise overflow-hidden bg-bg ${isMacElectron ? `mac-electron ${macFullscreen ? 'mac-fullscreen' : ''}` : ''} ${isMobile ? 'grid-cols-[minmax(0,1fr)] grid-rows-[42px_minmax(0,1fr)]' : 'grid-rows-[42px_minmax(0,1fr)]'}`}
+      className={`relative z-[1] h-full grid animate-rise overflow-hidden bg-bg ${isMacElectron ? `mac-electron ${macFullscreen ? 'mac-fullscreen' : ''}` : ''} ${isWinElectron ? 'win-electron' : ''} ${isMobile ? 'grid-cols-[minmax(0,1fr)] grid-rows-[42px_minmax(0,1fr)]' : 'grid-rows-[42px_minmax(0,1fr)]'}`}
       style={{
         gridTemplateAreas: isMobile ? '"topbar" "content"' : '"topbar topbar topbar" "nav content actbar"',
         ...(!isMobile && {

--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -993,6 +993,16 @@ function useThemeState(): ThemeContextValue {
     bridge?.setThemeMode?.(mode)
   }, [mode])
 
+  // Sync the Windows titleBarOverlay colors whenever the resolved dark/light
+  // mode changes. The overlay strip must match the dashboard chrome at all
+  // times; sending on `resolved` (not `mode`) handles Auto switching correctly.
+  useEffect(() => {
+    const bridge = (window as unknown as {
+      electronAPI?: { setTitleBarOverlayTheme?: (mode: string) => void }
+    }).electronAPI
+    bridge?.setTitleBarOverlayTheme?.(resolved)
+  }, [resolved])
+
   // Report the resolved accent to the Electron shell (if present) so the NEXT
   // launch's boot splash (loading.html) paints in the user's chosen colour.
   // Reads the computed --accent after paint; a no-op in a plain browser.

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1421,6 +1421,13 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
 /* Fullscreen: AppKit hides the traffic lights, so the clearance inset drops
    and the branding sits flush left again (back to the header's own pl-5). */
 .mac-electron.mac-fullscreen header.topbar-glass{padding-left:1.25rem}
+
+/* ── Frameless Electron window (Windows) ──
+   titleBarOverlay places native caption controls (min/max/close) in a 138px
+   overlay strip at the top-right of the window. Inset the header's right side
+   so interactive elements (bell, settings, actions) stay clear of the overlay.
+   Keep 138px in sync with WIN_CAPTION_OVERLAY_WIDTH in src/lib/electron.ts. */
+.win-electron header.topbar-glass{padding-right:142px}
 /* Embedded remote pane (option B): the pane is a separate document loaded in an
    iframe, so its SPA can't see Electron — `isMacElectron` is false inside it and
    the `.mac-electron` rule never applies. The parent relays whether it is a

--- a/website/src/lib/electron.ts
+++ b/website/src/lib/electron.ts
@@ -12,9 +12,17 @@ const mc = (window as { kirocrew?: { isElectron?: boolean; platform?: string } }
 
 export const isElectron = !!mc?.isElectron
 export const isMacElectron = isElectron && mc?.platform === 'darwin'
+export const isWinElectron = isElectron && mc?.platform === 'win32'
 
 /** Header left inset clearing the traffic lights: 16px inset + ~52px button group + 16px gap. */
 export const TRAFFIC_LIGHT_INSET_PX = 84
+
+/**
+ * Width reserved on the right for the Windows titleBarOverlay caption buttons
+ * (minimize/maximize/close). The overlay is 138px wide at default DPI on
+ * Windows 10/11. The header must not place interactive controls in this zone.
+ */
+export const WIN_CAPTION_OVERLAY_WIDTH = 138
 
 /**
  * True when an app declares `platform.requiresDesktopApp` but we are in a


### PR DESCRIPTION
## Problem
The Windows desktop app shipped with the native title bar (no integrated header), and PR #421 left launcher follow-ups.

## Fix (symptom → root cause → change)
- **#486 / #774** (same feature) — `titleBarStyle:"hidden"` + `titleBarOverlay` on win32 so the dashboard's 42px header doubles as the title bar; overlay colors sync to the theme via IPC; drag region added with the caption strip kept clear. macOS/Linux behavior unchanged.
- **#487** — spawn-failure UI surfacing (corrupt/missing bundled python), call-time graceful-stop home resolution, and a win32 force-stop path (`netstat`+`taskkill`). `windows_soft_fail` CI revisit deferred.

## Tests
`tsc -b` clean; 86 electron unit tests + 90 vitest pass.

## Manual verification
⚠️ Windows-specific — runtime verification on Windows still required: overlay controls present + themed, header draggable with controls clickable, theme toggle live-syncs, spawn-failure surfaces, force/graceful stop. Details in the cluster report.
