### PR TITLE
ci: pin ota-test.yml actions to full commit SHAs

### DIFF
--- a/.github/workflows/ota-test.yml
+++ b/.github/workflows/ota-test.yml
@@ -61,13 +61,13 @@ jobs:
       UPDATE_VER: "1.0.1"
       CDP_PORT: "9222"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -176,7 +176,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ota-logs
           path: |


### PR DESCRIPTION
## Problem
`.github/workflows/ota-test.yml` was the last workflow still referencing GitHub Actions by moving tag (`actions/checkout@v7`, `actions/setup-node@v7`, `actions/setup-python@v7`, `actions/upload-artifact@v7`). Every other workflow in the repo (145 `uses:` refs) is already pinned to a full-length commit SHA.

## Why it matters
A tag like `@v7` is mutable — the owner (or an attacker who compromises the action's repo) can repoint it at new code, which then runs automatically in our CI with whatever permissions the job holds. This is the classic Actions supply-chain vector (e.g. the `tj-actions/changed-files` incident). Pinning to an immutable commit SHA means a run only ever executes the exact code we vetted; Dependabot still proposes SHA bumps via the trailing `# vX.Y.Z` comment, so we keep updates without keeping the mutable-tag risk.

This file is also the sole blocker to turning on the repo-level **Settings → Actions → "Require actions to be pinned to a full-length commit SHA"** policy. That setting fails any workflow using a tag/branch ref, and the only exemption is same-repo `./` reusable-workflow references — GitHub-authored `actions/*` are **not** exempt. With this merged, the policy can be enabled with no CI breakage.

## Fix (symptom → root cause → change)
- Symptom: `ota-test.yml` uses tag refs while the rest of the repo is SHA-pinned; the pinning policy can't be enabled without breaking this workflow.
- Root cause: this workflow was added/updated without applying the repo's existing SHA-pinning convention.
- Change: pinned all four `actions/*@v7` refs to their exact `v7` release commit SHAs — the **same SHAs already used by the other workflows** — each with a `# vX.Y.Z` comment so Dependabot can continue to bump them:
  - `actions/checkout` → `3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1
  - `actions/setup-node` → `820762786026740c76f36085b0efc47a31fe5020` # v7.0.0
  - `actions/setup-python` → `5fda3b95a4ea91299a34e894583c3862153e4b97` # v7.0.0
  - `actions/upload-artifact` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` # v7.0.1

No behavior change — the SHAs resolve to the same `v7` releases the workflow already ran, and match what the rest of CI uses.

## Tests
N/A — CI-config-only change. Verified mechanically: repo-wide grep confirms zero remaining tag/branch-pinned action refs after this change, and the resolved SHAs are byte-identical to the ones the other workflows already pin.

## Manual verification
- `gh api repos/actions/<name>/commits/v7` for each action confirms the pinned SHA is the current `v7` tip.
- `grep -rnE 'uses:\s*[^./][^@]*@v[0-9]' .github/workflows` → no matches (this was the last file).
