### PR TITLE
fix(slack): keep one Slack thread bound to one session

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -29,7 +29,12 @@ from kiro_crew.constants import OPTIONS_RE_LINE
 from kiro_crew.dashboard.chat_compaction_notice import deliver_channel_compaction_notice
 from kiro_crew.dashboard.side_state import SideState
 from kiro_crew.knowledge.store import KnowledgeStore
-from kiro_crew.messaging.link import SLACK_NAMESPACE, ChannelLink, is_channel_session_key
+from kiro_crew.messaging.link import (
+    SLACK_NAMESPACE,
+    ChannelLink,
+    channel_namespace_of,
+    is_channel_session_key,
+)
 from kiro_crew.notifications.bus import (
     NotificationBus,
     NotificationValidationError,
@@ -3263,6 +3268,19 @@ class DashboardState:
         slack_channel = persisted_channel or slot._slack_channel
         namespaced_origin = _split_namespaced_channel_id(persisted_channel)
         genuine_slack = _is_genuine_slack_link(slack_ts, slack_channel)
+        # A Slack-BORN session's ``slack_thread_ts`` names the thread it LIVES
+        # in, not a mirror target somewhere else: the Slack inbound handler
+        # writes it every turn as the thread registry that routes replies back.
+        # That makes it a self-reference, and the sidebar already draws an origin
+        # glyph from the slot key -- so surfacing it as an outbound mirror badges
+        # one conversation twice and offers a session its own origin thread as a
+        # releasable mirror. A Slack-born session that genuinely mirrors to a
+        # DIFFERENT thread still carries a different ts, so it is unaffected.
+        slack_origin_self_link = (
+            channel_namespace_of(session_key) == SLACK_NAMESPACE
+            and bool(slack_ts)
+            and session_key.endswith(slack_ts)
+        )
         links: list[dict[str, Any]] = []
 
         def append_link(link: ChannelLink, direction: str) -> None:
@@ -3299,7 +3317,7 @@ class DashboardState:
                 # get_mirror_link synthesizes Slack for the legacy fields. If
                 # those fields actually hold a namespaced non-Slack origin, the
                 # origin above is the only truthful representation.
-                if not namespaced_origin and genuine_slack:
+                if not namespaced_origin and genuine_slack and not slack_origin_self_link:
                     append_link(
                         ChannelLink(SLACK_NAMESPACE, slack_channel, slack_ts),
                         "out",
@@ -3321,7 +3339,7 @@ class DashboardState:
                     # degrade to the outbound reading rather than dropping the link.
                     inbound = False
                 append_link(mirror, "both" if inbound else "out")
-        elif genuine_slack:
+        elif genuine_slack and not slack_origin_self_link:
             # Defensive fallback for SessionManager test doubles or older
             # implementations that expose get_slack_link but not get_mirror_link.
             append_link(
@@ -3329,7 +3347,7 @@ class DashboardState:
                 "out",
             )
 
-        if genuine_slack:
+        if genuine_slack and not slack_origin_self_link:
             slack_namespace = _split_namespaced_channel_id(slack_channel)
             visible_slack_channel = slack_namespace[1] if slack_namespace else (slack_channel or "")
             return links, True, visible_slack_channel, slack_ts or ""

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -134,12 +134,38 @@ class SessionMap:
             self._data = {}
 
     def _rebuild_thread_index(self) -> None:
-        """Rebuild _thread_to_session from current _data."""
+        """Rebuild _thread_to_session from current _data.
+
+        Two entries can claim the same ``slack_thread_ts``: a dashboard session
+        that created the thread via send-to-Slack, and a ``slack:<ts>`` session
+        forked by an inbound reply that ignored the existing binding. A plain
+        last-write-wins pass resolves the thread by dict order, which is file
+        order -- so the fork usually wins and the thread keeps routing to the
+        wrong session even after the fork bug is fixed.
+
+        Break that tie in favour of the session that does NOT derive its key from
+        this thread. A ``slack:<ts>`` key whose ts IS the thread is the fork (or
+        a self-link, which is a no-op rewrite); any other key holds the real
+        conversation. This heals maps corrupted before the fix, on load, with no
+        migration pass.
+        """
         self._thread_to_session.clear()
+        derived: dict[str, str] = {}
         for key, entry in self._data.items():
             ts = entry.get("slack_thread_ts")
-            if ts:
-                self._thread_to_session[ts] = key
+            if not ts or not isinstance(ts, str):
+                # A hand-edited or legacy file can hold a non-string ts. The old
+                # index only ever used it as a dict key, so it survived; the
+                # tie-break below calls str.endswith, which would raise
+                # TypeError here and take gateway startup down with it.
+                continue
+            if is_channel_session_key(key) and key.endswith(ts):
+                # Self-derived: only usable if nothing else claims the thread.
+                derived.setdefault(ts, key)
+                continue
+            self._thread_to_session[ts] = key
+        for ts, key in derived.items():
+            self._thread_to_session.setdefault(ts, key)
 
     def _save(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -101,6 +101,56 @@ async def handle_message_transport(
     reply_ts = thread_ts or msg_ts
     session_key = canonical_key(reply_ts)
 
+    # ── Resolve the thread to its OWNING session (mirrors native handle_message) ──
+    # canonical_key above is purely syntactic: it namespaces the bare thread ts
+    # into ``slack:<ts>``. That is only the right session when this thread was
+    # BORN in Slack. A thread created by the dashboard's send-to-Slack action
+    # belongs to that dashboard session, and the binding lives in the thread
+    # index (keyed by the bare thread_ts, not the namespaced key). Without this
+    # lookup a reply in such a thread mints a brand-new ``slack:<ts>`` session
+    # -- forking one conversation into two, with the reply landing in a session
+    # that has none of the dashboard context. reply_ts stays untouched: it is
+    # still the Slack timestamp we post and react to.
+    linked_session_key: str | None = None
+
+    def _resolve_thread_owner(stage: str) -> None:
+        """Re-read which session owns this thread, and route this turn there.
+
+        Ownership is RE-READ at each decision point rather than cached, because
+        this function awaits many times before the turn is acquired: inbound
+        governance, the hook path, the privacy modifiers and session acquisition
+        all yield. A dashboard send-to-Slack landing in any of those windows
+        claims the thread, and every decision taken from a stale reading
+        afterwards is wrong -- the reply runs in a session with none of the
+        dashboard context, and an unguarded ``set_slack_link`` overwrites the
+        newer binding so all later replies misroute too. Cheap to repeat: it is
+        an in-memory dict read off the thread index.
+        """
+        nonlocal session_key, linked_session_key
+        owner = sessions.get_session_for_thread(reply_ts)
+        if not owner:
+            return
+        if owner != session_key:
+            logger.info(
+                "🔗 Slack thread %s owned by %s (at %s) — routing there",
+                session_key,
+                owner,
+                stage,
+            )
+            session_key = owner
+            # Durable privacy state is keyed BY SESSION, and the hydration at
+            # entry ran for the previous key. Re-hydrate for the new owner in
+            # the same breath as the reroute -- otherwise _is_slack_restricted()
+            # consults an unpopulated flag map, and an incognito or temporary
+            # session's turn gets persisted to disk. Keeping this inside the
+            # helper makes it structurally impossible to reroute without it.
+            # Both helpers guard repeated I/O per session, so this is cheap.
+            _hydrate_thread_overrides(session_key, conversation_log)
+            _hydrate_conv_flags(sessions, session_key)
+        linked_session_key = owner
+
+    _resolve_thread_owner("inbound")
+
     # Inbound channels-governance gate (off-loop), same as native handle_message:
     # a ``channels`` policy that denies ``slack`` drops the message before any
     # processing. Default build (no policy) permits — behavior unchanged.
@@ -172,6 +222,11 @@ async def handle_message_transport(
     # the LLM, so incognito/temporary actually take effect on the default-ON
     # transport path and the modifier token never leaks into the prompt. Mirrors
     # native ordering (modifiers before spawn/run/cron).
+    # Re-read ownership BEFORE the modifiers run: they call set_slack_link
+    # unconditionally (handler.py), so acting on a key that went stale while
+    # governance and the hook path awaited would overwrite a dashboard binding
+    # created in that window and misroute every later reply in this thread.
+    _resolve_thread_owner("pre-privacy")
     _cmd_text = re.sub(r"^<@[A-Z0-9]+(?:\|[^>]*)?>\s*", "", text.strip())
     text, _cmd_text, _only_modifier = await maybe_apply_privacy_modifiers(
         text, _cmd_text, session_key, user_id, channel, slack, sessions, reply_ts
@@ -239,6 +294,25 @@ async def handle_message_transport(
         # of this function (before the hook/privacy/keyword early paths), so we
         # do not re-hydrate here.
 
+        # ── Final ownership check, as late as possible before we commit ──
+        # The resolution at the top of this function is the one hydration and the
+        # !temporary / !incognito handlers needed, but it is many awaits old by
+        # now (inbound governance, the hook path, renderer start). Re-resolve
+        # here so the turn is ACQUIRED under the thread's current owner instead
+        # of a stale one -- otherwise a Link-to-Dashboard click landing in that
+        # window leaves this reply running in a contextless Slack session.
+        # Deliberately before the _agent resolution below, which is keyed by
+        # session_key. A change that lands DURING get_or_create is not handled
+        # here: the turn stays in whoever owned the thread at acquisition, and
+        # the self-link guard below keeps the index uncorrupted either way.
+        _resolve_thread_owner("pre-acquisition")
+        if decider is not None:
+            # The decider was constructed with the pre-reroute key, and that key
+            # is what maps a human's Trust click back to a session. Leaving it
+            # stale would apply Trust to the wrong session. Same object the
+            # renderer and driver hold, so re-pointing it here is sufficient.
+            decider.session_key = session_key
+
         # Resolve the kiro-cli agent. Thread override (set via !agent), then the
         # per-channel override (slack.channels.<id>.agent), then the configured
         # default win; otherwise fall back to the canonical "kirocrew" agent so
@@ -257,7 +331,20 @@ async def handle_message_transport(
         _acquired = True
         if is_new:
             await sessions.set_channel(session_key, channel)
-        sessions.set_slack_link(session_key, reply_ts, channel)
+        if not linked_session_key and not sessions.get_session_for_thread(reply_ts):
+            # Two conditions, deliberately. The first is the routing decision
+            # made at the top of this function. The second is a FRESH read,
+            # because that decision is many awaits old by now -- inbound
+            # governance, the hook path and session acquisition all yield -- and
+            # a dashboard send-to-Slack landing in that window would claim this
+            # thread after we looked. Self-linking on the stale value would
+            # overwrite that newer binding and send every later reply to the
+            # wrong session. Only claim a thread that is STILL unclaimed; the
+            # turn itself continues on the session we already acquired.
+            #
+            # reply_ts (not session_key) is the true Slack timestamp -- storing
+            # the namespaced key as slack_thread_ts would corrupt reply routing.
+            sessions.set_slack_link(session_key, reply_ts, channel)
         # Publish this turn's session identity so managed MCP tools resolve
         # X-Session-Key; one shared writer lives in messaging.identity.
         await publish_turn_identity(sessions, session_key)

--- a/test/test_slack_thread_session_binding.py
+++ b/test/test_slack_thread_session_binding.py
@@ -1,0 +1,419 @@
+"""Regression tests: one Slack thread belongs to exactly one session.
+
+Three defects shipped together after the channel-session unification, all
+rooted in the fact that ``slack_thread_ts`` on a session-map entry means two
+different things depending on who wrote it -- "the thread I live in" for a
+Slack-born session, versus "the thread I mirror to" for a dashboard-born one.
+
+1. ``handle_message_transport`` resolved the session key syntactically from the
+   thread timestamp and never consulted the thread index, so replying in a
+   thread the dashboard had created forked a second session with none of the
+   original context. The native path had always done this lookup; the transport
+   rewrite (which is the default) dropped it.
+2. The same path then self-linked unconditionally, overwriting the dashboard's
+   binding in the thread index -- so the corruption outlived the reply and
+   re-pointed the thread at the wrong session permanently.
+3. ``_slot_links`` surfaced a Slack-born session's own origin thread as an
+   outbound *mirror*, so its dashboard tab drew the Slack brand icon twice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.messaging.link import ChannelLink, canonical_key
+from kiro_crew.session_map import SessionMap
+from kiro_crew.slack import transport_dispatch
+
+_test_dir = Path(__file__).parent
+if str(_test_dir) not in sys.path:  # pragma: no cover
+    sys.path.insert(0, str(_test_dir))
+_golden = importlib.import_module("test_slack_golden_transcript")
+
+FakeSessions = _golden.FakeSessions
+RecordingSlackClient = _golden.RecordingSlackClient
+ScriptedProvider = _golden.ScriptedProvider
+make_event = _golden.make_event
+
+# The dashboard created this thread when the user linked their session to Slack.
+_THREAD_TS = "1785861292.072329"
+_DASHBOARD_KEY = "dashboard:chat-68-1785861270"
+_CHANNEL = "D0AP0870FFH"
+
+
+@pytest.fixture()
+def session_map(tmp_path):
+    with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+        yield SessionMap()
+
+
+# ── 1 + 2: inbound routing and index integrity ───────────────────────────────
+
+
+class _RoutingSessions(FakeSessions):
+    """FakeSessions with a real thread index and a record of key resolution."""
+
+    def __init__(self, provider, thread_index=None):
+        super().__init__(provider)
+        self._thread_index = dict(thread_index or {})
+        self.acquired_keys: list[str] = []
+
+    def get_session_for_thread(self, thread_ts):
+        return self._thread_index.get(thread_ts)
+
+    async def get_or_create(self, session_key, agent=None, channel_id=None):
+        self.acquired_keys.append(session_key)
+        return await super().get_or_create(session_key, agent=agent, channel_id=channel_id)
+
+    def set_slack_link(self, key, thread_ts, channel_id):
+        super().set_slack_link(key, thread_ts, channel_id)
+        self._thread_index[thread_ts] = key
+
+
+def _drive_transport(monkeypatch, sessions, *, hydrate_conv_flags=True, hydrate_overrides=True):
+    """Run one inbound Slack reply through the transport path."""
+    monkeypatch.setattr(transport_dispatch, "_get_default_agent", lambda: "")
+    if hydrate_overrides:
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", lambda *a, **k: None)
+    if hydrate_conv_flags:
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", lambda *a, **k: None)
+    monkeypatch.setattr(transport_dispatch, "_thread_agents", {})
+
+    asyncio.run(
+        transport_dispatch.handle_message_transport(
+            RecordingSlackClient(),
+            sessions,
+            _CHANNEL,
+            "Awesome - this reply is from Slack.",
+            _THREAD_TS,
+            "1785861317.000100",
+            "W017SQBPZBN",
+        )
+    )
+
+
+def test_reply_in_dashboard_linked_thread_does_not_fork(monkeypatch):
+    """A reply routes into the dashboard session that owns the thread."""
+    provider = ScriptedProvider([make_event("ok")])
+    sessions = _RoutingSessions(provider, {_THREAD_TS: _DASHBOARD_KEY})
+
+    _drive_transport(monkeypatch, sessions)
+
+    assert _DASHBOARD_KEY in sessions.acquired_keys, (
+        "reply must resume the dashboard session that owns this thread"
+    )
+    assert canonical_key(_THREAD_TS) not in sessions.acquired_keys, (
+        "a second slack:<ts> session was minted -- the fork bug is back"
+    )
+
+
+def test_reply_does_not_overwrite_the_dashboard_binding(monkeypatch):
+    """The thread index still points at the dashboard session afterwards."""
+    provider = ScriptedProvider([make_event("ok")])
+    sessions = _RoutingSessions(provider, {_THREAD_TS: _DASHBOARD_KEY})
+
+    _drive_transport(monkeypatch, sessions)
+
+    assert sessions.get_session_for_thread(_THREAD_TS) == _DASHBOARD_KEY, (
+        "self-link clobbered the dashboard binding; the thread now resolves to "
+        "the wrong session for every later reply"
+    )
+
+
+def test_slack_born_thread_still_self_links(monkeypatch):
+    """An unclaimed thread must still register itself, or replies never route."""
+    provider = ScriptedProvider([make_event("ok")])
+    sessions = _RoutingSessions(provider, {})
+
+    _drive_transport(monkeypatch, sessions)
+
+    assert sessions.acquired_keys == [canonical_key(_THREAD_TS)]
+    assert sessions.get_session_for_thread(_THREAD_TS) == canonical_key(_THREAD_TS)
+
+
+def test_a_link_created_before_acquisition_routes_to_the_owner(monkeypatch):
+    """Ownership resolved late: the turn runs in the owner, not a stale key.
+
+    The routing lookup at the top of the handler is many awaits old by the time
+    the session is acquired. If a Link-to-Dashboard click lands in that window,
+    acquiring under the stale key would run this reply in a contextless Slack
+    session, so ownership is re-resolved immediately before acquisition.
+    """
+    provider = ScriptedProvider([make_event("ok")])
+    sessions = _RoutingSessions(provider, {})
+
+    # Stand in for the click landing after the early lookup but before acquire.
+    def claim_before_acquisition(*_a, **_k):
+        sessions._thread_index[_THREAD_TS] = _DASHBOARD_KEY
+
+    monkeypatch.setattr(
+        transport_dispatch, "_hydrate_conv_flags", lambda *a, **k: claim_before_acquisition()
+    )
+    _drive_transport(monkeypatch, sessions, hydrate_conv_flags=False)
+
+    assert _DASHBOARD_KEY in sessions.acquired_keys, (
+        "the turn was acquired under a stale key and ran in the wrong session"
+    )
+    assert canonical_key(_THREAD_TS) not in sessions.acquired_keys
+
+
+def test_a_reroute_rehydrates_privacy_state_for_the_new_owner(monkeypatch):
+    """Durable incognito/temporary flags must follow the session, not the key.
+
+    Hydration at entry runs for the entry key. If a reroute leaves it there,
+    ``_is_slack_restricted()`` consults an unpopulated flag map for the session
+    the turn actually runs in -- so an incognito session's turn is written to
+    disk. This is the privacy consequence of making ownership mobile.
+    """
+    provider = ScriptedProvider([make_event("ok")])
+    sessions = _RoutingSessions(provider, {})
+    hydrated_overrides: list[str] = []
+    hydrated_flags: list[str] = []
+
+    async def claim_during_governance(_channel):
+        sessions._thread_index[_THREAD_TS] = _DASHBOARD_KEY
+        return True
+
+    monkeypatch.setattr(transport_dispatch, "channel_inbound_permitted", claim_during_governance)
+    monkeypatch.setattr(
+        transport_dispatch,
+        "_hydrate_thread_overrides",
+        lambda key, _log=None: hydrated_overrides.append(key),
+    )
+    monkeypatch.setattr(
+        transport_dispatch,
+        "_hydrate_conv_flags",
+        lambda _s, key: hydrated_flags.append(key),
+    )
+    _drive_transport(monkeypatch, sessions, hydrate_overrides=False, hydrate_conv_flags=False)
+
+    assert _DASHBOARD_KEY in hydrated_overrides, (
+        "thread overrides were never hydrated for the rerouted owner"
+    )
+    assert _DASHBOARD_KEY in hydrated_flags, (
+        "durable privacy flags were never hydrated for the rerouted owner -- an "
+        "incognito turn would be persisted to disk"
+    )
+
+
+def test_privacy_modifiers_receive_the_current_owner(monkeypatch):
+    """The privacy handlers must not act on a key that went stale.
+
+    ``maybe_apply_privacy_modifiers`` calls ``set_slack_link`` unconditionally,
+    so if it is handed a key that went stale while inbound governance awaited,
+    it overwrites the dashboard's binding and every later reply misroutes.
+    """
+    provider = ScriptedProvider([make_event("ok")])
+    sessions = _RoutingSessions(provider, {})
+    seen: list[str] = []
+
+    async def claim_during_governance(_channel):
+        # Stand in for a Link-to-Dashboard click landing during governance.
+        sessions._thread_index[_THREAD_TS] = _DASHBOARD_KEY
+        return True
+
+    async def spy_modifiers(text, cmd_text, session_key, *a, **k):
+        seen.append(session_key)
+        return text, cmd_text, False
+
+    monkeypatch.setattr(transport_dispatch, "channel_inbound_permitted", claim_during_governance)
+    monkeypatch.setattr(transport_dispatch, "maybe_apply_privacy_modifiers", spy_modifiers)
+    _drive_transport(monkeypatch, sessions)
+
+    assert seen == [_DASHBOARD_KEY], (
+        f"privacy modifiers got a stale key {seen!r}; they would overwrite the "
+        "dashboard binding for this thread"
+    )
+
+
+def test_approval_decider_follows_a_reroute(monkeypatch):
+    """Trust must apply to the session the turn actually runs in.
+
+    The decider is constructed before ownership is re-resolved, and its
+    session_key is what maps a human's Trust click back to a session. If a
+    reroute leaves it stale, the click lands on the wrong session.
+    """
+    provider = ScriptedProvider([make_event("ok")])
+    sessions = _RoutingSessions(provider, {})
+    made: list = []
+
+    real_decider = transport_dispatch.SlackApprovalDecider
+
+    def spy_decider(*a, **k):
+        d = real_decider(*a, **k)
+        made.append(d)
+        return d
+
+    def claim_before_acquisition(*_a, **_k):
+        sessions._thread_index[_THREAD_TS] = _DASHBOARD_KEY
+
+    monkeypatch.setattr(transport_dispatch, "SlackApprovalDecider", spy_decider)
+    monkeypatch.setattr(
+        transport_dispatch, "_hydrate_conv_flags", lambda *a, **k: claim_before_acquisition()
+    )
+    _drive_transport(monkeypatch, sessions, hydrate_conv_flags=False)
+
+    assert made, "no approval decider was constructed"
+    assert made[0].session_key == _DASHBOARD_KEY, (
+        "decider kept the pre-reroute key -- a Trust click would be applied to "
+        "the wrong session"
+    )
+
+
+def test_a_link_created_mid_turn_is_not_clobbered(monkeypatch):
+    """A dashboard link landing during session acquisition must survive.
+
+    The routing lookup happens many awaits before the self-link -- inbound
+    governance, the hook path and ``get_or_create`` all yield. If the dashboard
+    claims this thread inside that window, self-linking on the stale "unclaimed"
+    reading would overwrite the newer binding and send every later reply to the
+    wrong session.
+    """
+    provider = ScriptedProvider([make_event("ok")])
+    sessions = _RoutingSessions(provider, {})
+
+    original = sessions.get_or_create
+
+    async def claim_during_acquisition(session_key, agent=None, channel_id=None):
+        # Stand in for the dashboard's send-to-Slack landing mid-turn.
+        sessions._thread_index[_THREAD_TS] = _DASHBOARD_KEY
+        return await original(session_key, agent=agent, channel_id=channel_id)
+
+    monkeypatch.setattr(sessions, "get_or_create", claim_during_acquisition)
+    _drive_transport(monkeypatch, sessions)
+
+    assert sessions.get_session_for_thread(_THREAD_TS) == _DASHBOARD_KEY, (
+        "a self-link decided on a stale lookup clobbered a newer dashboard binding"
+    )
+
+
+# ── 2b: the index heals a map already corrupted by the fork ──────────────────
+
+
+def _corrupted_map(session_map, first, second):
+    """Two entries claiming one thread, written in the given order."""
+    for key in (first, second):
+        session_map.set_slack_link(key, _THREAD_TS, _CHANNEL)
+    session_map._rebuild_thread_index()
+    return session_map
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        (_DASHBOARD_KEY, canonical_key(_THREAD_TS)),
+        (canonical_key(_THREAD_TS), _DASHBOARD_KEY),
+    ],
+)
+def test_thread_index_prefers_the_owning_session(session_map, first, second):
+    """Order-independent: the non-derived key wins the thread."""
+    sm = _corrupted_map(session_map, first, second)
+    assert sm.get_session_for_thread(_THREAD_TS) == _DASHBOARD_KEY
+
+
+def test_thread_index_keeps_a_lone_slack_session(session_map):
+    """A self-derived key is still used when nothing else claims the thread."""
+    session_map.set_slack_link(canonical_key(_THREAD_TS), _THREAD_TS, _CHANNEL)
+    session_map._rebuild_thread_index()
+    assert session_map.get_session_for_thread(_THREAD_TS) == canonical_key(_THREAD_TS)
+
+
+def test_thread_index_survives_reload(session_map, tmp_path):
+    """The tie-break is applied on load, so corrupted files heal without a migration.
+
+    Write order matters and mirrors what actually happened on disk: the dashboard
+    claimed the thread first, then the forked ``slack:<ts>`` session claimed it.
+    A plain last-write-wins rebuild therefore resolves to the fork -- which is
+    exactly the state this test must reject.
+    """
+    _corrupted_map(session_map, _DASHBOARD_KEY, canonical_key(_THREAD_TS))
+    with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+        reloaded = SessionMap()
+    assert reloaded.get_session_for_thread(_THREAD_TS) == _DASHBOARD_KEY
+
+
+def test_thread_index_ignores_a_non_string_timestamp(session_map):
+    """A numeric ts must not crash the rebuild.
+
+    The pre-fix index only ever used ``slack_thread_ts`` as a dict key, so a
+    hand-edited or legacy file holding a number survived. The tie-break calls
+    ``str.endswith``, which would raise TypeError inside ``_load`` and take
+    gateway startup down with it.
+    """
+    session_map._data["slack:1"] = {"sid": "x", "slack_thread_ts": 1785861292.072329}
+    session_map._data[_DASHBOARD_KEY] = {"sid": "y", "slack_thread_ts": _THREAD_TS}
+    session_map._rebuild_thread_index()  # must not raise
+    assert session_map.get_session_for_thread(_THREAD_TS) == _DASHBOARD_KEY
+
+
+# ── 3: the Slack-born tab is badged once ─────────────────────────────────────
+
+
+def _links_for(session_key, thread_ts):
+    """Run _slot_links against a slot whose session carries thread_ts."""
+    from kiro_crew.dashboard.state import DashboardState
+
+    class _Sessions:
+        def get_mirror_link(self, key):
+            return ChannelLink("slack", _CHANNEL, thread_ts)
+
+        def get_slack_link(self, key):
+            return (thread_ts, _CHANNEL)
+
+        def mirror_accepts_inbound(self, key):
+            return False
+
+    class _Slot:
+        key = session_key
+        linked_session_key = session_key
+        _slack_thread_ts = thread_ts
+        _slack_channel = _CHANNEL
+
+    state = DashboardState.__new__(DashboardState)
+    state.sessions = _Sessions()
+    with patch(
+        "kiro_crew.dashboard.chat_utils.effective_session_key",
+        return_value=session_key,
+    ):
+        return state._slot_links(_Slot())
+
+
+def _slack_out(links):
+    return [x for x in links if x["channel"] == "slack" and x["direction"] == "out"]
+
+
+def test_slack_born_session_is_not_badged_twice():
+    """Its own origin thread is not an outbound mirror."""
+    links, slack_linked, _, _ = _links_for(canonical_key(_THREAD_TS), _THREAD_TS)
+    assert _slack_out(links) == [], (
+        "a Slack-born session's own thread was surfaced as a mirror -- the "
+        "sidebar draws the brand icon twice and offers it as releasable"
+    )
+    # The detail panel synthesizes its own Slack row from slack_linked whenever
+    # no slack wire link is present, so dropping the link alone would just move
+    # the phantom mirror from the sidebar into that panel.
+    assert slack_linked is False, (
+        "slack_linked stayed true, so LinkedSurfacesSection rebuilds the "
+        "releasable Slack mirror it was just stopped from showing"
+    )
+
+
+def test_dashboard_mirror_still_shows_its_slack_target():
+    """A genuine dashboard->Slack mirror keeps its outbound link."""
+    links, slack_linked, channel, ts = _links_for(_DASHBOARD_KEY, _THREAD_TS)
+    assert len(_slack_out(links)) == 1, "the real mirror link must survive the fix"
+    assert slack_linked is True
+    assert (channel, ts) == (_CHANNEL, _THREAD_TS)
+
+
+def test_slack_session_mirroring_elsewhere_keeps_its_link():
+    """Only the SELF-reference is suppressed, not a different thread."""
+    links, slack_linked, _, _ = _links_for(canonical_key("1785861252.833429"), _THREAD_TS)
+    assert len(_slack_out(links)) == 1
+    assert slack_linked is True


### PR DESCRIPTION
## Problem

Three defects, all observed live, after channel sessions became surface-aware.

1. **A Slack reply forked the conversation.** Start a session in the dashboard, link
   it to Slack, then reply in that Slack thread. The reply did not continue the
   session — it created a brand-new one with none of the dashboard context, which
   then answered confidently from an empty transcript. Two dashboard tabs, two
   `sid`s, two kiro-cli process groups, for one thread.
2. **The fork was permanent.** The forked session overwrote the dashboard's entry
   in the thread index, so every later reply in that thread also routed to the
   wrong session — including on the native code path, which had the correct
   lookup all along.
3. **A Slack-born session's tab showed the Slack icon twice.**

## Why it matters

Defect 1 silently loses a conversation: the user is talking to a session that
cannot see what they just did, and the reply *looks* legitimate. Defect 2 makes
that state stick, so it is not recoverable by retrying. On this machine both
dashboard sessions that had ever been linked to Slack were already forked — 2 of
2 — including one holding 448 messages, split against a 4-message stub.

## Fix (symptoms → root cause → change)

There are two inbound Slack implementations. `messaging.use_transport` defaults
to `True`, so `handle_message_transport` is the live one — and it is a partial
copy of the native path, missing two hops.

The native path resolves a thread to its owning session through the thread index
and only claims an unclaimed thread (`slack/handler.py`):

```python
linked_session_key = sessions.get_session_for_thread(reply_ts)
if linked_session_key and linked_session_key != session_key:
    session_key = linked_session_key
...
if not linked_session_key:
    sessions.set_slack_link(session_key, reply_ts, channel)
```

The transport path did neither. It derived the key syntactically —
`session_key = canonical_key(reply_ts)` — which is only correct for a thread that
was *born* in Slack, and then self-linked unconditionally, clobbering any
existing binding.

The deeper cause is that `slack_thread_ts` on a session-map entry means two
different things depending on who wrote it: for a Slack-born session it is *the
thread I live in* (written every turn as the routing registry); for a
dashboard-born session it is *the thread I mirror to*. Nothing distinguished
them, so one meaning was read as the other (defect 3) and overwritten by the
other (defect 2).

Changes:

- **`slack/transport_dispatch.py`** — resolve which session owns the thread, and
  route the turn there. The key correction is that ownership is **re-read at each
  decision point rather than cached**: this function awaits many times before the
  turn is acquired (inbound governance, the hook path, the privacy modifiers,
  session acquisition), and a dashboard send-to-Slack landing in any of those
  windows claims the thread. Every decision taken from a stale reading
  afterwards is wrong. Concretely it is re-read at three points — on entry, before
  the `!temporary` / `!incognito` modifiers (which call `set_slack_link`
  unconditionally, so a stale key there overwrites the dashboard binding), and
  immediately before `get_or_create`. The self-link site takes its own fresh read
  so an unclaimed thread is only claimed if it is *still* unclaimed. Two things
  are re-done inside the helper whenever ownership moves, so it is structurally
  impossible to reroute without them: the durable privacy hydration
  (`!temporary` / `!incognito` flags are keyed by session, and leaving them
  hydrated for the previous key means `_is_slack_restricted()` reads an
  unpopulated map and an incognito turn gets written to disk), and the approval
  decider's `session_key`, which is what maps a human's Trust click back to a
  session and would otherwise apply Trust to the wrong one.
- **`session_map.py`** — `_rebuild_thread_index` broke duplicate-thread
  collisions by dict order, i.e. file order, so the fork usually won. It now
  prefers the entry whose key is *not* derived from the thread. Because the index
  is rebuilt from persisted fields on every load, maps already corrupted by this
  bug heal on the next start with no migration pass.
- **`dashboard/state.py`** — `_slot_links` no longer surfaces a Slack-born
  session's own origin thread as an outbound mirror, and reports
  `slack_linked: false` for it. Both halves are needed:
  `LinkedSurfacesSection` synthesizes its own Slack row whenever `slack_linked`
  is set and no Slack wire link is present, so dropping only the link would have
  moved the phantom mirror from the sidebar into that panel rather than removing
  it. Fixed at the payload layer so every consumer is corrected at once. This
  field is presentation-only — reply mirroring reads the in-memory
  `slot._slack_linked` and the session map, neither of which is touched here. A
  Slack-born session that genuinely mirrors to a *different* thread carries a
  different ts and is unaffected.

## Tests

New `test/test_slack_thread_session_binding.py` — 16 tests. Every fix in this PR
has at least one test that fails when that fix **alone** is reverted, verified by
reverting each independently:

| Test | Locks |
|---|---|
| `test_reply_in_dashboard_linked_thread_does_not_fork` | the reply resumes the owning session |
| `test_reply_does_not_overwrite_the_dashboard_binding` | the index still points at it afterwards |
| `test_a_reroute_rehydrates_privacy_state_for_the_new_owner` | an incognito/temporary turn is not persisted to disk after a reroute |
| `test_privacy_modifiers_receive_the_current_owner` | `!temporary` / `!incognito` cannot overwrite a binding made while governance awaited |
| `test_approval_decider_follows_a_reroute` | Trust applies to the session the turn actually runs in |
| `test_a_link_created_before_acquisition_routes_to_the_owner` | late resolution: the turn runs in the owner, not a stale key |
| `test_a_link_created_mid_turn_is_not_clobbered` | a dashboard link landing during session acquisition survives |
| `test_thread_index_prefers_the_owning_session` (2 params) | order-independent tie-break |
| `test_thread_index_survives_reload` | corrupted maps heal on load |
| `test_slack_born_session_is_not_badged_twice` | no phantom mirror link, and `slack_linked` false so the detail panel cannot rebuild one |
| `test_thread_index_ignores_a_non_string_timestamp` | a numeric persisted ts cannot crash `_load` |

The remaining tests are controls that must keep passing: an unclaimed thread
still self-links, a lone Slack session still owns its thread, a genuine
dashboard→Slack mirror keeps its link and its `slack_linked`/channel/ts triple,
and a Slack session mirroring elsewhere keeps its link. One parametrised case
passes on `main` by construction — that is the write order last-write-wins
happened to get right, and its sibling is the one that catches the bug.

Gates: isort, flake8, mypy clean on all changed files. Full suite 28021 passed.
The residual failures are environment-dependent (`sandbox_argv` subprocess spawn,
`artifacts` xattr, `source_providers` / `issue_radar` binary resolution), vary
between runs on this host, and reproduce on unmodified `main` (16 failures
baseline). None are in Slack routing, session-map, or dashboard-state tests.

## Manual verification

The defects were found by live reproduction before the fix — dashboard session
linked to Slack, reply sent from Slack, resulting in transcripts
`dashboard_chat-68-*.jsonl` and a forked `slack_*.jsonl` with a stub metadata
header and zero shared content, plus two entries in `session_map.json` carrying
the same `slack_thread_ts` with different `sid`s. Post-fix behaviour is covered
by the unit tests above rather than re-staged by hand, because reproducing it
live requires a real Slack workspace, a real thread ts, and deliberately
corrupted on-disk state.

## Screenshots

N/A — no frontend files changed. The visual delta for defect 3 is one fewer
brand glyph on a Slack-born tab row, produced entirely by the backend link
payload (`ChatSidebar.tsx` renders one icon per `out` link and is untouched).
The new test asserts the payload directly: zero `slack`/`out` links for a
Slack-born session, exactly one for a real mirror. Staging a screenshot would
require a live Slack-linked session; say the word if a reviewer wants one.

## Known limitation (deliberate)

If a thread changes owner *while* `get_or_create` is still running — a
Link-to-Dashboard click landing inside session acquisition — this reply runs in
the session that owned the thread when acquisition started, and only subsequent
replies route to the new owner. The thread index is never corrupted either way.

Re-routing that in-flight turn would mean releasing the acquired session and
reacquiring the new owner mid-turn. That was considered and not done, because
`get_or_create` "acquires the per-session semaphore before returning — caller
MUST call `release(key)`": the `finally` releases whatever `session_key` holds, so
reassigning it after acquisition would leak the real session's semaphore and
release one never held; reacquiring blocks on the new owner's semaphore if that
session is mid-turn; and a discarded `is_new` session leaves an orphaned kiro-cli
process. That is a lot of new failure surface for a window that requires a click
to land inside one `await`, and it is strictly riskier than the residual it
removes. Flagged rather than silently accepted.

## Not in this PR

- **Options rendering + stale option controls** — the link-time backfill in
  `dashboard/chat_slack.py` posts message bodies verbatim, so an `[OPTIONS: …]`
  tag reaches Slack as literal text when the link is created mid-turn or after
  it; and previously-posted option controls stay clickable after the turn ends.
  Being fixed separately.
- **Provenance stamping** — messages that arrived from Slack are persisted with
  `source_thread: "dashboard"`. Root cause not yet pinned (the rewrite path has a
  frozen-prefix / foreign-append mechanism that may preserve foreign lines rather
  than rebuild them), so it is deliberately excluded rather than guessed at.
