### PR TITLE
fix(subagent): suppress duplicate injection for spawn_sub_agents results

### DIFF
--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -249,6 +249,7 @@ from kiro_crew.dashboard.handlers.messaging import (  # noqa: E402, F401
     api_spawn_delete,
     api_spawn_list,
     api_spawn_lost,
+    api_spawn_mark_collected,
     api_spawn_release,
     api_spawn_retry,
     api_spawn_status,

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -30,7 +30,7 @@ from kiro_crew.browser.setup import (
 )
 from kiro_crew.cron import CronStoreBusy
 from kiro_crew.dashboard.chat_persistence import _rehydrate_slot_from_history
-from kiro_crew.dashboard.chat_utils import _remove_queued_by_id
+from kiro_crew.dashboard.chat_utils import _remove_queued_by_id, dashboard_slot_key
 from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.origin import is_direct_local_request, is_loopback
 from kiro_crew.dashboard.state import (
@@ -339,6 +339,38 @@ async def api_spawn_lost(request: web.Request) -> web.Response:
         batch_id, batch_total, reason, parent_session_key=parent_session
     )
     return web.json_response({"status": "reconciled", "batch_id": batch_id})
+
+
+async def api_spawn_mark_collected(request: web.Request) -> web.Response:
+    """POST /api/spawn/mark-collected — suppress injection for blocking tool.
+
+    Called by the spawn_sub_agents MCP tool after it has polled and collected
+    results inline.  Records the agent IDs on the parent slot so that the
+    subsequent _subagent_done callback skips the _run_chat injection (the model
+    already processed these results as a tool-call return value).  Without this,
+    each completion event triggers a redundant LLM turn whose response shadows
+    any [OPTIONS:] buttons the synthesis message rendered.
+    """
+    state: DashboardState = request.app["state"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    ids = body.get("ids")
+    if not ids or not isinstance(ids, list):
+        return web.json_response({"error": "'ids' array required", "code": "ids_required"}, status=400)
+    parent_session = str(body.get("parent_session", "") or "")
+    slot_name = dashboard_slot_key(parent_session)
+    if not slot_name:
+        return web.json_response({"status": "no_slot"})
+    slot = state.get_slot(slot_name)
+    if not slot:
+        return web.json_response({"status": "no_slot"})
+    # Record the IDs (bounded to 200 to prevent unbounded growth)
+    for aid in ids[:200]:
+        if isinstance(aid, str) and aid:
+            slot._subagents_inline_collected.add(aid)
+    return web.json_response({"status": "ok", "marked": len(ids)})
 
 
 def _redact(text: str) -> str:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -854,6 +854,7 @@ def _register_mcp_routes(app: web.Application) -> None:
     """Register API routes used by MCP tools (spawn, lessons, crons, etc.)."""
     app.router.add_post("/api/spawn", handlers.api_spawn)
     app.router.add_post("/api/spawn/lost", handlers.api_spawn_lost)
+    app.router.add_post("/api/spawn/mark-collected", handlers.api_spawn_mark_collected)
     # MCP Apps (SEP-1865): embedded app iframe -> gateway tool callback.
     app.router.add_post("/api/mcp-apps/call", handlers.api_mcp_apps_call)
     app.router.add_get("/api/spawn", handlers.api_spawn_list)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -816,6 +816,7 @@ class _ChatSlot:
         "_pending_synthesis",
         "_synthesis_inflight",
         "_subagent_deliveries_inflight",
+        "_subagents_inline_collected",
         "_recovery_retrigger_count",
         "_prompt_busy_retries",
         "_acp_pipe_death_retries",
@@ -981,6 +982,10 @@ class _ChatSlot:
         # fire-gate requires this to be 0 so a concurrently-finishing sibling
         # can't let an earlier turn fire synthesis before its result lands.
         self._subagent_deliveries_inflight: int = 0
+        # IDs of sub-agents whose results were already delivered inline via the
+        # blocking spawn_sub_agents MCP tool.  _subagent_done skips injection
+        # for these to prevent a duplicate turn that clobbers [OPTIONS:] buttons.
+        self._subagents_inline_collected: set[str] = set()
         self._recovery_retrigger_count: int = 0
         self._prompt_busy_retries: int = 0
         self._acp_pipe_death_retries: int = 0

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -3718,12 +3718,18 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         completed = 0
         timed_out = 0
         errored = 0
+        _settled_ids: set[str] = set()  # agents confirmed settled (done or error)
         for aid in sa_ids:
             sa_st = _get(f"/api/spawn/{aid}")
             sa_name = _redact_sa(sa_st.get("agent", ""))
             label = sa_name if sa_name else aid
             if sa_st.get("error"):
                 errored += 1
+                # Only mark as settled if done is also true (confirmed terminal
+                # state). An "error" without "done" could be a transport failure
+                # from _get() — the agent may still be running.
+                if sa_st.get("done"):
+                    _settled_ids.add(aid)
                 sa_results.append(
                     json.dumps(
                         {
@@ -3738,6 +3744,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 sa_results.append(json.dumps({"agent": label, "status": "timed_out"}))
             else:
                 completed += 1
+                _settled_ids.add(aid)
                 result_text = _redact_sa(sa_st.get("result", ""))
                 # Apply the same summarize_result treatment as spawn_run:
                 # when results exceed completion_keep threshold, return a
@@ -3774,6 +3781,22 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 "errored": errored,
             },
         )
+        # Mark collected IDs so _subagent_done skips redundant injection.
+        # The blocking tool already delivered results inline; without this the
+        # on_done callback triggers a new _run_chat turn that clobbers any
+        # [OPTIONS:] buttons rendered in the synthesis.
+        # Only mark agents whose results were actually delivered inline
+        # (completed or errored) — timed-out agents may still complete later
+        # and their real result must not be suppressed.
+        if _settled_ids and parent_session:
+            try:
+                _post(
+                    "/api/spawn/mark-collected",
+                    {"ids": list(_settled_ids), "parent_session": parent_session},
+                    timeout=5,
+                )
+            except Exception:
+                pass  # best-effort; worst case = duplicate turn (pre-existing behavior)
         return "\n\n".join(sa_results)
 
     if name == "spawn_list":

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -4030,6 +4030,32 @@ class GatewayOrchestrator:
                         if _still_running == []:
                             _injection_slot._pending_synthesis = True
 
+                    # ── Skip injection for blocking-tool-collected results ──
+                    # spawn_sub_agents (blocking MCP tool) already delivered
+                    # this result inline as a tool-call return value. Injecting
+                    # it again would trigger a redundant _run_chat turn whose
+                    # assistant response shadows any [OPTIONS:] buttons from the
+                    # synthesis message. Mark delivered and return.
+                    # NOTE: This check is placed BEFORE the inflight counter and
+                    # busy-wait because at this point the blocking tool's
+                    # mark-collected POST has already landed (the tool returns
+                    # before its turn ends, and _subagent_done fires only after
+                    # the agent's terminal report, which is after the tool has
+                    # finished). However, if the slot is busy (turn still
+                    # running) we must wait first, then re-check — see the
+                    # second check after the busy-wait below.
+                    if info.id in _injection_slot._subagents_inline_collected:
+                        _injection_slot._subagents_inline_collected.discard(info.id)
+                        # Disarm synthesis — the blocking tool already delivered
+                        # all results and the model synthesized inline.
+                        if not _injection_slot._subagents_inline_collected:
+                            _injection_slot._pending_synthesis = False
+                        logger.info(
+                            "Subagent %s: skipping injection (already collected inline by spawn_sub_agents)",
+                            info.id,
+                        )
+                        return
+
                     # Fix 2 (B1) race guard: count this completion as an
                     # in-flight delivery from entry until it is handed off (turn
                     # launched or queued). The synthesis fire-gate in chat_runner
@@ -4059,6 +4085,19 @@ class GatewayOrchestrator:
                             # Re-check: another injection may have claimed the slot
                             # during the await above.
                             if _injection_slot.running:
+                                # Check inline-collected before queuing — if the
+                                # blocking tool already handled this result, don't
+                                # queue it for a later redundant turn.
+                                if info.id in _injection_slot._subagents_inline_collected:
+                                    _injection_slot._subagents_inline_collected.discard(info.id)
+                                    if not _injection_slot._subagents_inline_collected:
+                                        _injection_slot._pending_synthesis = False
+                                    logger.info(
+                                        "Subagent %s: skipping queue "
+                                        "(already collected inline)",
+                                        info.id,
+                                    )
+                                    return
                                 logger.info(
                                     "Subagent %s: slot %s claimed by another injection, queuing",
                                     info.id,
@@ -4070,6 +4109,20 @@ class GatewayOrchestrator:
                                 self.dashboard_state.push_slots_update()
                                 logger.info("Subagent %s → queued in %s", info.id, _slot_name)
                                 return
+
+                        # Slot is idle — re-check inline-collected (the
+                        # blocking tool's mark-collected POST has now landed,
+                        # since the tool returns before its owning turn ends).
+                        if info.id in _injection_slot._subagents_inline_collected:
+                            _injection_slot._subagents_inline_collected.discard(info.id)
+                            if not _injection_slot._subagents_inline_collected:
+                                _injection_slot._pending_synthesis = False
+                            logger.info(
+                                "Subagent %s: skipping injection after wait "
+                                "(already collected inline by spawn_sub_agents)",
+                                info.id,
+                            )
+                            return
 
                         # Slot is idle — start _run_chat.
                         _task = asyncio.create_task(

--- a/test/test_mcp_core_spawn_sub_agents.py
+++ b/test/test_mcp_core_spawn_sub_agents.py
@@ -235,7 +235,9 @@ class TestSpawnSubAgents:
                 "cwd": "/workspace/project",
             })
 
-            body = mock_post.call_args[0][1]
+            # The spawn call is the first _post; mark-collected is the last.
+            spawn_call = mock_post.call_args_list[0]
+            body = spawn_call[0][1]
             assert body["cwd"] == "/workspace/project"
 
     def test_multiple_agents_spawned_in_parallel(self):
@@ -243,7 +245,7 @@ class TestSpawnSubAgents:
              patch("kiro_crew.mcp_core._get") as mock_get, \
              patch("kiro_crew.mcp_core.sel"), \
              patch.dict("os.environ", {"KIROCREW_SESSION_KEY": "s"}):
-            mock_post.side_effect = [{"id": "a1"}, {"id": "a2"}]
+            mock_post.side_effect = [{"id": "a1"}, {"id": "a2"}, {}]
             mock_get.return_value = {"done": True, "agent": "w", "result": "done"}
 
             result = _call_tool("spawn_sub_agents", {
@@ -253,7 +255,8 @@ class TestSpawnSubAgents:
                 ],
             })
 
-            assert mock_post.call_count == 2
+            # 2 spawn calls + 1 mark-collected call = 3 total
+            assert mock_post.call_count == 3
             assert result.count('"completed"') == 2
 
     def test_truncates_oversized_prompt(self):
@@ -269,7 +272,9 @@ class TestSpawnSubAgents:
                 "agents": [{"prompt": long_prompt}],
             })
 
-            body = mock_post.call_args[0][1]
+            # The spawn call is the first _post; mark-collected is the last.
+            spawn_call = mock_post.call_args_list[0]
+            body = spawn_call[0][1]
             assert len(body["task"]) <= 5000
 
     def test_truncates_oversized_agent_or_mode(self):
@@ -284,7 +289,9 @@ class TestSpawnSubAgents:
                 "agents": [{"agent_or_mode": "x" * 5000, "prompt": "task"}],
             })
 
-            body = mock_post.call_args[0][1]
+            # The spawn call is the first _post; mark-collected is the last.
+            spawn_call = mock_post.call_args_list[0]
+            body = spawn_call[0][1]
             assert len(body["agent"]) < 5000  # truncated to MAX_SHORT_STRING
 
 


### PR DESCRIPTION
## Problem

When the blocking `spawn_sub_agents` MCP tool collects results inline (as a tool-call return value), the `_subagent_done` gateway callback **also** fires and injects each result as a new `_run_chat` turn. The model responds to these redundant turns with trivial acknowledgments, and those assistant messages shadow any `[OPTIONS:]` buttons the synthesis message rendered — the frontend's `deriveFollowUpOptions` scans backward and hits the acknowledgment instead of the options-bearing message.

## Why it matters

Any session using `spawn_sub_agents` (the blocking parallel tool) loses its interactive option buttons after the subagent results arrive. The user sees no Go/Go All/Cancel buttons in Autopilot mode, and no follow-up choice buttons in regular chat — making the conversation feel dead until they type manually.

## Fix (symptoms → root cause → change)

**Symptom:** `[OPTIONS:]` buttons vanish after `spawn_sub_agents` returns.  
**Root cause:** `spawn_sub_agents` and `_subagent_done` are independent delivery paths with no coordination — the tool polls `GET /api/spawn/{id}` while `_on_done` fires the gateway callback after the agent's terminal report. Both deliver the same result.  
**Change:** Add a mark-collected protocol between the two paths:

1. `_ChatSlot` gains `_subagents_inline_collected` (a bounded set of agent IDs)
2. `spawn_sub_agents` calls `POST /api/spawn/mark-collected` after polling, recording which IDs it already delivered inline
3. `_subagent_done` checks the set before injection — if the ID is present, it skips `_run_chat` and returns (the subagent manager still marks it delivered)

## Tests

- No new automated tests in this PR (the fix is a coordination protocol between two async paths that requires a live gateway to exercise end-to-end)
- Verified: syntax check passes on all 6 modified files, flake8 clean

## Manual verification

1. Open a dashboard chat session (regular mode, not orchestrator)
2. Ask a question that triggers `spawn_sub_agents` (e.g. "do a deep review of X" which fans out 3-4 parallel agents)
3. After results arrive and the model synthesizes with `[OPTIONS:]`, verify the buttons remain visible
4. Previously: buttons disappeared as redundant completion-event turns shadowed them

## Screenshots

N/A — backend-only change, no UI modifications.