### PR TITLE
fix(security): audit Teams inbound auth failures + version audit LogBucket

### DIFF
--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
@@ -120,12 +120,26 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      # Versioning makes the audit trail tamper-evident and recoverable: an
+      # overwrite or delete of a CloudTrail data-event or S3 access-log object
+      # leaves the prior version behind rather than being unrecoverable
+      # (CWE-1188, SAX-05/06/08 — audit buckets MUST enable versioning).
+      VersioningConfiguration:
+        Status: Enabled
       LifecycleConfiguration:
         Rules:
           - Id: expire-logs
             Status: Enabled
             Prefix: ''
             ExpirationInDays: 365
+          # Bound noncurrent versions so tamper-evidence retention does not grow
+          # storage without limit: prior versions of overwritten log objects are
+          # kept for the same 365-day audit window, then expired.
+          - Id: expire-noncurrent-logs
+            Status: Enabled
+            Prefix: ''
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 365
           - Id: abort-incomplete-multipart
             Status: Enabled
             Prefix: ''

--- a/src/kiro_crew/teams/client.py
+++ b/src/kiro_crew/teams/client.py
@@ -286,12 +286,39 @@ class TeamsClient:
         """
         auth = request.headers.get("Authorization", "")
         token = auth[7:].strip() if auth[:7].lower() == "bearer " else ""
+        # request.remote is the peer IP when present (real aiohttp request); the
+        # bearer failed before any Activity is parsed, so it is the only caller
+        # correlator available. getattr keeps this safe for lightweight test
+        # doubles that omit .remote.
+        peer = getattr(request, "remote", "") or "unknown"
+
+        def _audit_denied(outcome: str) -> None:
+            # Detective-control audit for a failed inbound authentication
+            # (CWE-778), mirroring the serviceUrl-mismatch deny below. Best-effort
+            # by design: the 401 denial is the security decision and MUST stand
+            # even if the audit sink is unavailable (e.g. a corrupt SEL key), so a
+            # sink failure is swallowed to a warning rather than surfacing as a
+            # 500 that masks the denial.
+            try:
+                sel().log_api_access(
+                    caller=peer,
+                    operation="teams_client.on_activity",
+                    outcome=outcome,
+                    source="teams",
+                )
+            except Exception:
+                logger.warning(
+                    "Teams: failed to audit inbound auth denial (%s)", outcome
+                )
+
         try:
             claims = await asyncio.to_thread(self._validator.verify, token)
         except TeamsAuthError:
+            _audit_denied("denied_invalid_token")
             return web.Response(status=401, text="invalid bearer token")
         except Exception:
             logger.exception("Teams: unexpected error validating inbound token")
+            _audit_denied("denied_token_validation_error")
             return web.Response(status=401, text="token validation error")
 
         try:

--- a/test/test_deploy_web_iam.py
+++ b/test/test_deploy_web_iam.py
@@ -65,6 +65,47 @@ def test_policy_prefix_matches_template_bucket():
     assert iam_mod.S3_PREFIX == expected_prefix
 
 
+def test_audit_log_bucket_has_versioning_enabled():
+    """Regression (CWE-1188 / SEC-EE0CD7B3): the dedicated audit LogBucket -- the
+    delivery target for CloudTrail S3 data events and S3 server access logs --
+    MUST enable versioning for tamper-evidence, with a bounded
+    noncurrent-version expiration so retention does not grow storage forever.
+    """
+    import yaml
+
+    class _CfnLoader(yaml.SafeLoader):
+        pass
+
+    _CfnLoader.add_constructor(
+        "!Sub", lambda loader, node: {"Fn::Sub": loader.construct_scalar(node)})
+
+    def _cfn_ignore(loader, tag_suffix, node):
+        if isinstance(node, yaml.ScalarNode):
+            return loader.construct_scalar(node)
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node, deep=True)
+        return loader.construct_mapping(node, deep=True)
+
+    _CfnLoader.add_multi_constructor(None, _cfn_ignore)
+
+    template_path = _PKG / "skills" / "artifact-deploy" / "templates" / "base-stack.yaml"
+    with open(template_path) as f:
+        tmpl = yaml.load(f, Loader=_CfnLoader)  # noqa: S506
+
+    resources = tmpl["Resources"]
+    for name in ("OriginBucket", "LogBucket"):
+        props = resources[name]["Properties"]
+        assert props.get("VersioningConfiguration", {}).get("Status") == "Enabled", (
+            f"{name} must have VersioningConfiguration Status=Enabled"
+        )
+    # Versioning must not grow storage unbounded: the log bucket lifecycle must
+    # also expire noncurrent versions.
+    log_rules = resources["LogBucket"]["Properties"]["LifecycleConfiguration"]["Rules"]
+    assert any("NoncurrentVersionExpiration" in r for r in log_rules), (
+        "LogBucket lifecycle must expire noncurrent versions"
+    )
+
+
 def test_policy_covers_engine_bucket_prefix():
     """Regression (R8→R9): engine.py creates kirocrew-web-* buckets; IAM must cover them."""
     doc = iam_mod.policy_document()

--- a/test/test_teams_client.py
+++ b/test/test_teams_client.py
@@ -145,6 +145,40 @@ class TestInboundWebhook:
         assert seen == []
 
     @pytest.mark.asyncio
+    async def test_invalid_token_401_is_audited(self) -> None:
+        # Regression (CWE-778 / SEC-E9FBAC19): a failed inbound-token attempt on
+        # this external, cookie-auth-exempt surface MUST emit a structured SEL
+        # audit line so the denial is visible to security monitoring.
+        from unittest import mock
+
+        c = _client_with_validator(accept=False)
+        with mock.patch("kiro_crew.teams.client.sel") as m_sel:
+            resp = await c.on_activity(
+                _FakeRequest({"Authorization": "Bearer bad"}, _msg_activity())
+            )
+        assert resp.status == 401
+        m_sel.return_value.log_api_access.assert_called_once()
+        kwargs = m_sel.return_value.log_api_access.call_args.kwargs
+        assert kwargs["source"] == "teams"
+        assert kwargs["operation"] == "teams_client.on_activity"
+        assert kwargs["outcome"] == "denied_invalid_token"
+
+    @pytest.mark.asyncio
+    async def test_401_survives_audit_sink_failure(self) -> None:
+        # The 401 denial is the security decision and MUST stand even if the
+        # audit sink raises (e.g. a corrupt SEL key) -- a sink failure must not
+        # surface as a 500 that masks the denial.
+        from unittest import mock
+
+        c = _client_with_validator(accept=False)
+        with mock.patch("kiro_crew.teams.client.sel") as m_sel:
+            m_sel.return_value.log_api_access.side_effect = RuntimeError("corrupt SEL key")
+            resp = await c.on_activity(
+                _FakeRequest({"Authorization": "Bearer bad"}, _msg_activity())
+            )
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
     async def test_valid_message_fast_ack_and_dispatch(self) -> None:
         c = _client_with_validator(accept=True)
         gate = asyncio.Event()


### PR DESCRIPTION
## Problem

Two CSE Medium findings, both on audit / detective-control surfaces.

- **`SEC-E9FBAC19` (CWE-778)** — `TeamsClient.on_activity` (`src/kiro_crew/teams/client.py`) is an external, cookie-auth-exempt webhook that authenticates inbound Bot Framework JWTs itself. Its two 401 failure branches (invalid/forged/expired token; unexpected validation error) returned **without any structured audit line**, so failed inbound-auth attempts were invisible to security monitoring.
- **`SEC-EE0CD7B3` (CWE-1188)** — the deploy-web audit `LogBucket` in `base-stack.yaml` (delivery target for the `DeployTrail` CloudTrail S3 data-event logs and OriginBucket's S3 server access logs) had encryption, lifecycle, and public-access-block but **no `VersioningConfiguration`**.

## Why it matters

- The Teams 401 path is exactly the event a detective control must capture; the module already audits its sibling serviceUrl-mismatch deny via `sel()`, so the gap was an inconsistency, not a missing subsystem.
- Without versioning on the audit bucket, an accidental or malicious overwrite/delete of a CloudTrail or access-log object is unrecoverable and leaves no tamper-evidence — undermining the audit trail those logs exist to provide.

## Fix (symptom → root cause → change)

- **Teams:** symptom — failed inbound auth is unlogged; root cause — the 401 branches skipped the `sel()` audit the rest of the module uses; change — emit `sel().log_api_access(operation="teams_client.on_activity", outcome="denied_invalid_token" | "denied_token_validation_error", source="teams")` on both branches, correlated by peer IP (`getattr(request, "remote", "") or "unknown"`, safe for test doubles). Synchronous `sel()` matches the existing in-handler call.
- **LogBucket:** symptom — audit objects are unrecoverable/non-tamper-evident; root cause — bucket declared no versioning; change — add `VersioningConfiguration: Status: Enabled`, plus a `NoncurrentVersionExpiration` (365d) lifecycle rule so versioning does not grow storage without bound. Mirrors the sibling `OriginBucket`.

## Tests

- `test_teams_client.py::TestInboundWebhook::test_invalid_token_401_is_audited` — asserts the 401 path emits exactly one `sel().log_api_access` with the expected `source`/`operation`/`outcome`.
- `test_deploy_web_iam.py::test_audit_log_bucket_has_versioning_enabled` — parses `base-stack.yaml` (CFN-intrinsic-tolerant loader) and asserts both `OriginBucket` and `LogBucket` have `VersioningConfiguration` Enabled and the log bucket expires noncurrent versions.

## Manual verification

N/A — backend audit-logging + CloudFormation template change; unit coverage is the meaningful evidence. Targeted suites (`test_teams_client.py`, `test_deploy_web_iam.py`) pass; isort/flake8/mypy clean. `cfn-lint` runs in CI (CloudFormation Lint check).

## Screenshots

N/A — no user-visible UI change.
