### PR TITLE
fix(slack): render OPTIONS as a control in Slack (vs. a literal), and remove them when no longer relevant

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -86,7 +86,9 @@ from kiro_crew.dashboard.chat_utils import (
     _validate_tool_name,
     build_recovery_requeue,
     effective_session_key,
+    expire_slack_options,
     is_system_injection_item,
+    remember_slack_options,
     slot_history_key,
 )
 from kiro_crew.dashboard.handlers import (
@@ -179,6 +181,7 @@ from kiro_crew.security import (
 from kiro_crew.sel import sel
 from kiro_crew.session import SessionClosingError
 from kiro_crew.slack.handler import post_linked_approval, resolve_linked_approval
+from kiro_crew.slack.outbound import PostedOptions
 from kiro_crew.validation import ValidationError, infer_use_case, validate_ask_user_question
 from kiro_crew.widget_artifacts import register_widgets_off_loop
 
@@ -2929,6 +2932,21 @@ async def _run_chat(
         slot.append("done", "", "done")
         return
 
+    # A new turn supersedes whatever question the previous one ended on, so any
+    # OPTIONS control still live in this session's Slack thread stops being
+    # answerable. Guarded on _prompt_depth so the in-turn re-entry that expands
+    # a /prompts reference does not count as a new turn.
+    #
+    # Placed HERE, below every local-command return and above the turn machinery,
+    # for the same reason the Slack entry points expire here: `/goal`, a
+    # `/prompts` listing or error, and a blocked slash command all return without
+    # starting an agent turn, and spending the control on one of those would
+    # strike a still-valid question through with nothing to answer it. Moved once,
+    # rather than guarded per command, so a new local command inherits the right
+    # behaviour by default.
+    if _prompt_depth == 0:
+        await expire_slack_options(state, session_key)
+
     _acquired = False
     _mirror_stream_ts: str = ""
     _mirror_chan: str | None = ""
@@ -5540,12 +5558,52 @@ async def _run_chat(
                 for _part in render_for_slack(_mirror_body):
                     await state.slack_client.post_message(_mirror_chan, _part, _mirror_thread)
                 if _mirror_options:
-                    await state.slack_client.post_blocks(
+                    # Keep the ts this posts: the control has to be spendable
+                    # later, and discarding the ts is what leaves a superseded
+                    # question clickable forever. build_options_blocks already
+                    # redacts each choice through redact_for_display, so nothing
+                    # extra is needed here.
+                    _mirror_blocks = build_options_blocks(_mirror_options)
+                    # The thread's owner BEFORE the post. A relink landing while
+                    # post_blocks is in flight moves the conversation to another
+                    # session, and a control recorded under the key this turn
+                    # started with would be filed where that session's expiry
+                    # never looks -- and clickable into a conversation it does not
+                    # belong to. Same treatment the other two posting paths get.
+                    _pre_owner = (
+                        state.sessions.get_session_for_thread(_mirror_thread) or session_key
+                        if getattr(state, "sessions", None)
+                        else session_key
+                    )
+                    _mirror_ts = await state.slack_client.post_blocks(
                         _mirror_chan,
-                        build_options_blocks(_mirror_options),
+                        _mirror_blocks,
                         "Options",
                         _mirror_thread,
                     )
+                    if _mirror_ts:
+                        _owner = (
+                            state.sessions.get_session_for_thread(_mirror_thread)
+                            or session_key
+                            if getattr(state, "sessions", None)
+                            else session_key
+                        )
+                        remember_slack_options(
+                            state,
+                            _owner,
+                            PostedOptions(
+                                channel=_mirror_chan,
+                                ts=_mirror_ts,
+                                choices=tuple(_mirror_options),
+                                blocks=tuple(_mirror_blocks),
+                            ),
+                        )
+                        if _owner != _pre_owner:
+                            # An owner change IS supersession: the question we just
+                            # posted would be answered into a conversation that has
+                            # moved on. Narrowed to OUR ts so a control the new
+                            # owner recorded meanwhile survives.
+                            await expire_slack_options(state, _owner, ts=_mirror_ts)
             except Exception:
                 logger.debug("Failed to mirror response to Slack", exc_info=True)
 

--- a/src/kiro_crew/dashboard/chat_slack.py
+++ b/src/kiro_crew/dashboard/chat_slack.py
@@ -17,13 +17,30 @@ from kiro_crew.dashboard.chat_backfill import (
     session_deep_link,
 )
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
-from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
+from kiro_crew.dashboard.chat_utils import (
+    effective_session_key,
+    expire_slack_options,
+    options_records,
+    remember_slack_options,
+    slack_options_owner_keys_snapshot,
+    slot_history_key,
+)
 from kiro_crew.dashboard.state import DashboardState, _log_task_exception
 from kiro_crew.platform.context import redact_via_context
 from kiro_crew.security import redact_and_truncate
 from kiro_crew.sel import sel
 from kiro_crew.slack.channel_resolver import _CACHE_FILENAME, ChannelNameResolver
-from kiro_crew.slack.format import render_for_slack
+from kiro_crew.slack.format import (
+    build_options_blocks,
+    build_options_selected_blocks,
+    extract_options,
+    render_for_slack,
+)
+from kiro_crew.slack.outbound import (
+    OPTIONS_FALLBACK_TEXT,
+    PostedOptions,
+    answer_routing_in_flight,
+)
 from kiro_crew.sync_bridge import handoff_to_slack
 
 logger = logging.getLogger(__name__)
@@ -98,6 +115,22 @@ async def drain_slack_backfill(
     client = state.slack_client
     if client is None:
         return
+    # Baseline for detecting that the conversation moved on while we work. Taken
+    # BEFORE the selection await, not after: selection reads the on-disk
+    # transcript and can take a while, so a turn that completes during it would
+    # be invisible to a baseline captured afterwards -- leaving a superseded
+    # control clickable. Compared against after the posting loops.
+    #
+    # ``total_messages``, not ``len(slot.messages)``: the message list is capped
+    # at _MAX_SLOT_MESSAGES and trimmed from the front on append, so a slot
+    # sitting at the cap grows and trims in the same step and its LENGTH never
+    # changes. A turn completing mid-drain would then be undetectable on the one
+    # slot busy enough to make the race likely. total_messages is a lifetime
+    # counter and survives trimming.
+    started_running = slot.running
+    started_total = slot.total_messages
+    session_key = effective_session_key(slot)
+
     # Offloaded: selection reads the on-disk transcript when the opening turn is
     # off-window, and read_messages_chained parses every tab_id sibling file (and
     # globs the sessions dir to rebuild a stale index). On the loop thread that
@@ -117,11 +150,55 @@ async def drain_slack_backfill(
             logger.debug("slack backfill: post failed", exc_info=True)
             return False
 
+    async def _post_options(choices: list[str], *, interactive: bool) -> str | None:
+        """Post a replayed OPTIONS tag as a control instead of literal text.
+
+        The body and the control are separate Slack messages, so this composes
+        with the body pipeline above rather than replacing it -- the body keeps
+        its table-safe conversion and full-length redaction, and the choices ride
+        in a Block Kit message of their own.
+
+        *interactive* only for the newest reply. Every earlier one asked a
+        question this replay has already moved past, so it renders struck through
+        and cannot be answered.
+
+        Returns the ts of the control recorded as LIVE, so the caller can spend
+        exactly that one later without touching controls another turn recorded in
+        the same slot. ``None`` when nothing live was recorded.
+        """
+        blocks = (
+            build_options_blocks(choices)
+            if interactive
+            else build_options_selected_blocks(choices, [])
+        )
+        try:
+            ts = await client.post_blocks(channel, blocks, OPTIONS_FALLBACK_TEXT, thread_ts)
+        except Exception:
+            logger.debug("slack backfill: options control post failed", exc_info=True)
+            return None
+        if interactive and ts:
+            remember_slack_options(
+                state,
+                session_key,
+                PostedOptions(
+                    channel=channel,
+                    ts=ts,
+                    choices=tuple(choices),
+                    blocks=tuple(blocks),
+                ),
+            )
+            return ts
+        return None
+
     for row in selection.first_turn:
         icon = _USER_ICON if row.get("role") == "user" else _AGENT_ICON
-        for part in _format_backfill_parts(backfill_content(row), icon):
+        content, choices = _split_backfill_options(row)
+        for part in _format_backfill_parts(content, icon):
             if not await _post(part):
                 return
+        if choices:
+            # The opening turn is superseded by definition — spent, never live.
+            await _post_options(choices, interactive=False)
 
     if selection.skipped_turns and selection.recent:
         summary = gap_summary(selection.skipped_turns)
@@ -136,11 +213,77 @@ async def drain_slack_backfill(
         marker = f"_… {summary} — <{link}|open in the dashboard>_" if link else f"_… {summary}_"
         await _post(marker)
 
-    for row in selection.recent_rows:
+    newest = len(selection.recent_rows) - 1
+    live_ts: str | None = None
+    for idx, row in enumerate(selection.recent_rows):
         icon = _USER_ICON if row.get("role") == "user" else _AGENT_ICON
-        for part in _format_backfill_parts(backfill_content(row), icon):
+        content, choices = _split_backfill_options(row)
+        for part in _format_backfill_parts(content, icon):
             if not await _post(part):
                 return
+        if choices:
+            posted_ts = await _post_options(choices, interactive=idx == newest)
+            if posted_ts:
+                live_ts = posted_ts
+
+    # Did the conversation move past the replayed question while we were
+    # draining? A turn that was running at any point, or a transcript that grew,
+    # means the newest reply we just rendered as a LIVE control is already
+    # superseded — and that turn's own expiry ran before our record existed, so
+    # nothing else will spend it. Expire it here rather than leaving live buttons
+    # for an answer the conversation no longer wants.
+    #
+    # ``started_running or slot.running``, not a before/after comparison: a turn
+    # that is already in flight when the drain begins and is STILL in flight when
+    # it ends (a long cron or injected turn) leaves the flag identical at both
+    # ends and may not have appended a row yet, so both a `!=` on running and the
+    # total_messages check see nothing. The agent is mid-reply the whole time,
+    # which is exactly when the replayed question is most certainly stale.
+    #
+    # Narrowed to OUR ts, never a session-wide drain: the very turn that makes
+    # the replayed question stale can finish mid-drain and record its OWN fresh
+    # control in this slot, and spending the whole slot would strike that newer
+    # question through — silencing the one the conversation is now waiting on.
+    # No live control of ours means there is nothing here to spend.
+    # ...and the link itself may be gone. A link followed immediately by an unlink
+    # removes the routing before this drain finishes posting, so the control we
+    # just rendered as live belongs to a thread nothing owns any more: a click on
+    # it starts a FRESH Slack session and answers a question that session never
+    # asked. Round 32's unlink abort covers the other order (a control already
+    # tracked when the unlink arrives); this covers a control recorded after the
+    # unlink already succeeded, where there was nothing yet for it to abort on.
+    _unlinked = slot._slack_channel != channel or slot._slack_thread_ts != thread_ts
+    if live_ts and (
+        _unlinked or started_running or slot.running or slot.total_messages != started_total
+    ):
+        try:
+            await expire_slack_options(state, session_key, ts=live_ts)
+        except Exception:
+            logger.debug(
+                "slack backfill: could not expire a control superseded mid-drain",
+                exc_info=True,
+            )
+
+
+def _split_backfill_options(row: dict[str, Any]) -> tuple[str, list[str]]:
+    """Split a replayed row into body text and OPTIONS choices.
+
+    Only AGENT-authored rows are parsed. A person's own message can legitimately
+    contain the OPTIONS syntax — quoting it, or discussing it — and lifting the
+    tag out of their words would render choices they never offered, so a user row
+    is returned verbatim with no choices.
+
+    No redaction happens here on purpose. ``build_options_blocks`` runs every
+    choice through ``redact_for_display``, which canonicalises the form Slack
+    actually shows (ANSI, emphasis and backtick splits, link markup) before
+    scanning — strictly stronger than redacting the raw bytes here, and the body
+    is covered by ``_format_backfill_parts``. Duplicating the ordering in this
+    function is what previously let the two copies drift apart.
+    """
+    content = backfill_content(row)
+    if row.get("role") == "user":
+        return content, []
+    return extract_options(content)
 
 
 def _spawn_slack_backfill(
@@ -236,13 +379,84 @@ async def api_chat_slot_slack_link(request: web.Request) -> web.Response:
         if not thread_ts:
             return web.json_response({"error": "failed to create thread"}, status=500)
 
+    # Whose control is already live in this thread, captured BEFORE the reassign.
+    # ``link_slack`` moves the thread -> slot index onto THIS slot, so resolving
+    # afterwards names the new owner and the previous conversation's record
+    # becomes unreachable: no dashboard turn would ever expire it, and a click on
+    # those still-live buttons would answer into this session instead.
+    _prior_owner_keys = slack_options_owner_keys_snapshot(state, thread_ts)
+
+    # Retire the previous owner's control BEFORE the reassign, and refuse to
+    # reassign if it could not be retired.
+    #
+    # An ownership change IS supersession, the same call earlier rounds made for a
+    # control posted while the owner moved: the question belongs to a conversation
+    # that no longer owns this thread, so striking it through is right and
+    # re-keying it to us would hand this session an answer to a question it never
+    # asked. Our OWN key is skipped -- re-linking a thread to the slot that already
+    # holds it must not spend that slot's live control.
+    #
+    # Order matters, for the same reason the unlink path aborts. Linking first and
+    # expiring after leaves a window where the thread already routes HERE while the
+    # old buttons are still on screen: a transient Slack failure on the edit (429,
+    # 5xx, network) means the control stays live, and a click on it resolves
+    # through the new reverse index into THIS session, corrupting a conversation
+    # that never asked the question. A returned expiry does not prove the control
+    # was spent either -- records whose edit failed transiently stay tracked
+    # deliberately -- so the guard is "are any prior records still there", not "did
+    # the call raise".
+    _own_keys = {effective_session_key(slot), slot.key}
+    _prior_keys = [k for k in _prior_owner_keys if k not in _own_keys]
+    for _prior_key in _prior_keys:
+        try:
+            await expire_slack_options(state, _prior_key)
+        except Exception:
+            logger.debug(
+                "slack link: could not retire the previous owner's control",
+                exc_info=True,
+            )
+    _unretired = [k for k in _prior_keys if options_records(state, k)]
+    if _unretired or answer_routing_in_flight(thread_ts):
+        # Abort rather than reassign. Leaving the thread with its current owner is
+        # recoverable and visible -- the caller retries, and that owner's next turn
+        # spends the control -- whereas completing the link silently corrupts this
+        # session with an answer to someone else's question.
+        #
+        # Two reasons to refuse, the same pair the unlink path weighs. An
+        # unretired record means the buttons are still live. Answer routing IN
+        # FLIGHT means a click already WON: a successful click forgets its record
+        # before dispatching, so by the time the answer is travelling there is
+        # nothing left for the records check to see -- and reassigning the thread
+        # underneath it delivers that selection into a session that never asked
+        # the question. Same defect the unlink abort closes, on the other path.
+        sel().log_api_access(
+            caller="dashboard",
+            operation="chat.slack_link",
+            outcome="deferred",
+            source="dashboard",
+            resources=slot.key,
+            error="a prior OPTIONS control is unretired or its answer is still routing; thread not reassigned",
+        )
+        return web.json_response(
+            {
+                "error": (
+                    "The existing thread still has a pending OPTIONS control or an "
+                    "answer in flight; the thread was not relinked"
+                ),
+                "code": "slack_options_pending",
+            },
+            status=503,
+        )
+
     # Route through the ONE canonical link writer. ``link_slack`` sets the same
     # three slot fields and persists via ``set_slack_link``, but it ALSO
     # registers the thread -> slot reverse index that inbound Slack replies
     # resolve through, and releases the thread from any slot that held it
     # before. Hand-assigning the fields here duplicated everything except that
     # index, so a reply in the mirrored thread routed and persisted correctly
-    # while nothing ever told the open tab it had arrived.
+    # while nothing ever told the open tab it had arrived. That same index is
+    # what resolves an OPTIONS click on the control replayed below back to this
+    # conversation -- without it the click would answer into a separate session.
     state.link_slack(slot.key, thread_ts, target_channel)
 
     # Seed the new thread with readable history — only when we created a NEW
@@ -288,18 +502,202 @@ async def api_chat_slot_slack_unlink(request: web.Request) -> web.Response:
     # NAME instead would build "dashboard:slack:<ts>" for a channel-born slot,
     # leaving the real link untouched so mirroring silently resumes next turn.
     session_key = effective_session_key(slot)
-    cleared = state.sessions.clear_slack_link(session_key)
-    # chat_runner copies a dashboard session's link from the bare key onto the
-    # "dashboard:"-prefixed one when a turn runs, so both spellings must go or
-    # the next turn re-inherits the link. A channel key has no such twin.
-    if session_key.startswith("dashboard:"):
-        cleared = state.sessions.clear_slack_link(session_key[len("dashboard:") :]) or cleared
 
+    # Link mutations stay ON the event loop, deliberately. Moving this clear into
+    # `asyncio.to_thread` (an earlier revision of this PR) was wrong twice over:
+    # the worker runs CONCURRENTLY with the loop, so a compare-and-clear inside it
+    # is not atomic against a loop-side relink at all -- the thread can read the
+    # captured link, a relink can write its replacement, and the thread then clears
+    # that replacement, losing the routing. The session map has no cross-thread
+    # lock, so the loop is the only thing serialising its writers. `_save()` is a
+    # small atomic temp-file rename on a rare user action; that cost is the price
+    # of serialization, and it is the cheaper side of the trade.
+    def _clear_persisted_link_sync() -> bool:
+        """Clear BOTH persisted key spellings for this slot's link.
+
+        chat_runner copies a dashboard session's link from the bare key onto the
+        "dashboard:"-prefixed one when a turn runs, so both spellings must go or
+        the next turn re-inherits the link. A channel key has no such twin.
+
+        No compare-and-clear here, and none is needed: this runs on the event loop
+        with no await between the read and the write, so nothing can interleave. An
+        earlier revision of this PR did compare against a captured value, because
+        the clear had been moved into a thread — the serialization above is what
+        makes that guard unnecessary, and the test asserting no ``to_thread`` in
+        this handler is what keeps it that way.
+        """
+        done = state.sessions.clear_slack_link(session_key)
+        if session_key.startswith("dashboard:"):
+            done = state.sessions.clear_slack_link(session_key[len("dashboard:") :]) or done
+        return done
+
+    def _restore_persisted_link_sync() -> None:
+        """Put back the link this handler cleared, if nothing else claimed it.
+
+        Read first, and by PRESENCE: a link sitting here now was written during the
+        await by ``link_slack``, and that writer's value is the live one.
+        """
+        persisted, _chan = state.sessions.get_slack_link(session_key)
+        if not persisted and (prev_thread_ts or prev_channel):
+            state.sessions.set_slack_link(session_key, prev_thread_ts, prev_channel)
+
+    # Capture BEFORE the clear's await. A pure dict read, no persistence write, so
+    # it costs nothing to do inline -- and doing it here is what lets the clear be
+    # conditional on the link not having moved underneath us.
     prev_channel = slot._slack_channel
     prev_thread_ts = slot._slack_thread_ts
-    slot._slack_linked = False
-    slot._slack_channel = ""
-    slot._slack_thread_ts = ""
+    cleared = _clear_persisted_link_sync()
+    # Expire FIRST, while the routing is still intact, then clear the link only if
+    # it is still the one we captured. Neither plain ordering is safe on its own:
+    #
+    #   teardown-then-expire  -- between the two the buttons are still live while
+    #     the reverse index is already gone, so a click resolves to nothing and
+    #     starts a BRAND-NEW session carrying a stale answer.
+    #   expire-then-teardown  -- expiry awaits a Slack edit, long enough for
+    #     another tab to relink this slot mid-await; resuming would then clear the
+    #     REPLACEMENT link's in-memory fields while its persisted link survived,
+    #     leaving the two disagreeing.
+    #
+    # Compare-and-clear satisfies both. The click keeps working (and keeps
+    # resolving to THIS slot) for as long as the control is still answerable, and
+    # the teardown is conditional on the link not having moved underneath us.
+    try:
+        await expire_slack_options(state, session_key)
+    except asyncio.CancelledError:
+        # Gateway shutdown (or any handler cancellation) mid-expiry would otherwise
+        # leave this unlink half-committed: persistence was cleared at the top, the
+        # in-memory fields were never touched, and none of the restoration below
+        # runs. After a restart the routing is gone while the controls are still
+        # live on screen — a click then resolves to nothing and starts a fresh
+        # session, the exact failure the compare-and-clear ordering exists to
+        # prevent, reached by a third route.
+        #
+        # Restored INLINE, like every other link write here. Off-loading it needed
+        # a shield plus a fallback for the loop-teardown case, and the fallback was
+        # itself a blocking write on the loop -- all of that complexity bought
+        # nothing once link mutations went back to being serialized on the loop.
+        _restore_persisted_link_sync()
+        raise
+
+    # Persistence was cleared at the top, so anything here now was written DURING
+    # the await. Read once: both branches below turn on it.
+    persisted_ts, persisted_chan = state.sessions.get_slack_link(session_key)
+
+    if options_records(state, session_key) or answer_routing_in_flight(prev_thread_ts):
+        # Two reasons to keep the thread linked, both ending the same way.
+        #
+        # A tracked record: a returned expiry does NOT prove the control was
+        # spent. Records whose Slack edit failed transiently (429, 5xx, network)
+        # stay tracked deliberately, so the buttons are still live on screen — and
+        # tearing the reverse index down now is precisely the teardown-then-expire
+        # order rejected above: a later click resolves to nothing and starts a
+        # BRAND-NEW session carrying a stale answer. A failed expiry is
+        # teardown-then-NEVER-expire, which is worse.
+        #
+        # An answer still routing: a click that SUCCEEDED forgot its record and
+        # dispatched the answer as a task. The record — this guard's other signal
+        # — is already gone while the answer has not yet resolved which session it
+        # belongs to, so popping the reverse index now sends the user's selection
+        # into a brand-new session. Same corruption, reached from the other side.
+        #
+        # So abort. Keeping the thread linked is recoverable and visible — the
+        # caller retries and the next turn's expiry spends the control — whereas
+        # completing the unlink silently corrupts a future conversation. Restore
+        # the persisted link we cleared at the top so persistence agrees with the
+        # in-memory fields, which were never touched; skip that if something else
+        # wrote a link while we awaited, since that writer's value is the live one.
+        if not persisted_ts and (prev_thread_ts or prev_channel):
+            # ON the loop, deliberately, and this is the settled position after
+            # three passes over it. `_save()` serialises the whole session map, so
+            # it is a real blocking write -- measured on this box at 0.17ms for 50
+            # sessions, 1.0ms for 500 (58KB), 9.8ms at an unrealistic 5000. The two
+            # ways to avoid it are both worse:
+            #
+            #   asyncio.to_thread -- the worker runs CONCURRENTLY with the loop, so
+            #     the read-then-write below stops being atomic: a relink can land
+            #     between them and this restore would overwrite the replacement
+            #     with the link we captured. That is the exact race that forced the
+            #     earlier off-loop rewrite of this handler to be reverted.
+            #   dropping the restore -- persistence stays cleared while the
+            #     in-memory fields still hold the link, so a restart loses the
+            #     routing while the buttons are still live. That is the corruption
+            #     the abort exists to prevent.
+            #
+            # Every other session-map mutation in the codebase (including
+            # `link_slack` on the link path) writes synchronously on the loop for
+            # the same reason, so singling this line out would cost correctness and
+            # buy no measurable latency. If the blocking write is ever worth
+            # removing, the fix is to serialise ALL session-map writers behind one
+            # lock and offload them together -- not to make this one call racy.
+            state.sessions.set_slack_link(session_key, prev_thread_ts, prev_channel)
+        sel().log_api_access(
+            caller="dashboard",
+            operation="chat.slack_unlink",
+            outcome="deferred",
+            source="dashboard",
+            resources=slot.key,
+            error="an OPTIONS control could not be expired; link kept to keep it routable",
+        )
+        # 503, not a 200 that lies: the session IS still linked. The dashboard
+        # already treats a non-2xx here as "session stays linked", so its view
+        # matches the state we just restored without any client change.
+        return web.json_response(
+            {
+                "error": (
+                    "An OPTIONS control is still pending or its answer is still "
+                    "routing; the session stays linked"
+                ),
+                "code": "slack_options_pending",
+            },
+            status=503,
+        )
+
+    if slot._slack_channel == prev_channel and slot._slack_thread_ts == prev_thread_ts:
+        # Equality does NOT prove nothing moved. A relink to the SAME thread can
+        # land during the expiry await and restore the identical channel/ts, which
+        # in memory is byte-for-byte indistinguishable from an untouched link.
+        #
+        # Persistence settles it, and by PRESENCE rather than by value: it was
+        # cleared at the top of this handler, and the only writer is ``link_slack``.
+        # So a persisted link sitting here now was necessarily written DURING the
+        # await -- positive evidence of a relink -- while an empty one is positive
+        # evidence that nothing moved. Comparing the channel/ts alone can only
+        # guess, and guessing either way breaks the other case: assume "relinked"
+        # and an ordinary unlink silently no-ops, assume "nothing moved" and a
+        # successful relink is torn down behind the user's back.
+        if persisted_ts and persisted_ts == prev_thread_ts and persisted_chan == prev_channel:
+            # A relink won the race. Its link is the live one, so leave the slot
+            # fields, persistence and the reverse index exactly as it left them --
+            # they already agree with each other, which is all the teardown was
+            # ever protecting.
+            #
+            # ``cleared`` goes False so this reports as a no-op: the session is
+            # still linked, so claiming ``was_linked`` would tell the UI a teardown
+            # happened, and the courtesy note below would announce "replies here no
+            # longer sync" into the very thread that is still syncing.
+            cleared = False
+            logger.debug(
+                "slack unlink: same-thread relink landed during expiry, "
+                "leaving the replacement intact"
+            )
+        else:
+            # Nothing relinked. Re-clear persistence anyway: it is idempotent
+            # here, and it also drops the "dashboard:"-prefixed twin that a turn
+            # running mid-await could otherwise re-inherit the link from.
+            cleared = _clear_persisted_link_sync() or cleared
+            slot._slack_linked = False
+            slot._slack_channel = ""
+            slot._slack_thread_ts = ""
+            # Drop the thread -> slot reverse index too, or the thread keeps
+            # resolving to this conversation after the link is gone.
+            if prev_thread_ts:
+                state._slack_to_slot.pop(prev_thread_ts, None)
+    else:
+        # A relink landed during the expiry await. Its link is the live one now, so
+        # leave every field and the reverse index exactly as the relink left them.
+        logger.debug(
+            "slack unlink: link changed during expiry, leaving the replacement intact"
+        )
 
     # Best-effort courtesy note so a Slack watcher knows why the thread went
     # quiet. Same redaction path as the link endpoint; failure is non-fatal.

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from kiro_crew.providers.base import LLMEvent
+    from kiro_crew.slack.outbound import PostedOptions
 
 from kiro_crew.dashboard.state import (
     BUSY_RECOVERY_PREFIX,
@@ -33,10 +34,11 @@ from kiro_crew.dashboard.state import (
     parse_cls_meta,
 )
 from kiro_crew.hooks import safe_read_file
-from kiro_crew.messaging.link import is_channel_session_key
+from kiro_crew.messaging.link import canonical_key, is_channel_session_key
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import SecurityEvent, sel
 from kiro_crew.session_surface import has_dashboard_surface, set_dashboard_surfaced
+from kiro_crew.slack.outbound import expire_options, mark_options_terminal, options_edit_lock
 from kiro_crew.validation import (
     MAX_TOOL_NAME_LEN,
     THEME_CONSENT_SHA_RE,
@@ -531,6 +533,420 @@ def effective_session_key(slot: _ChatSlot) -> str:
     the cases that genuinely start from a slot key with no slot in hand.
     """
     return getattr(slot, "linked_session_key", "") or _history_key_for(slot.key)
+
+
+def slack_options_slot(state: DashboardState, session_key: str) -> _ChatSlot | None:
+    """The slot holding *session_key*'s Slack OPTIONS state, if one exists.
+
+    Deliberately not routed through :func:`dashboard_slot_key`, which answers
+    "is a tab open?". A slot can hold OPTIONS state with no tab currently open,
+    and one lookup reaches both flavours of slot: a channel-born slot
+    (``slack_<ts>``) and a dashboard slot mirroring out to Slack
+    (``chat-<n>-<epoch>``) both live in the same registry.
+
+    Returns None rather than raising for any state object that cannot answer the
+    question. OPTIONS bookkeeping is best-effort cleanup and must never be able
+    to abort the turn that triggered it.
+
+    The key is required to be a real ``str``: ``_normalize_slot_key`` strips a
+    repeated ``dashboard_`` prefix with an unbounded ``while``, which only
+    terminates for a genuine string. Handing it anything whose ``startswith``
+    is always truthy spins forever, allocating as it goes -- so a non-string
+    key is refused here rather than normalized.
+    """
+    if not isinstance(session_key, str):
+        return None
+    getter = getattr(state, "get_slot", None)
+    if not callable(getter):
+        return None
+    try:
+        slot = getter(_normalize_slot_key(session_key))
+        if slot is not None:
+            return slot
+        # The fold is FILENAME-shaped, so any slot whose name is not its session
+        # key folded is unreachable through it. A cron slot is named
+        # ``cron-<id>`` while its session key is ``cron:<id>``, which folds to
+        # ``cron_<id>`` and matches nothing — so a persistent cron's OPTIONS
+        # control was never tracked at all, and the follow-up turn had nothing
+        # to expire, leaving it clickable into a superseded question.
+        #
+        # Such a slot still knows its own identity (``linked_session_key``), so
+        # ask the slots rather than guessing at more spellings. Only on a miss,
+        # so the common path stays a single dict lookup.
+        for candidate in (getattr(state, "_slots", None) or {}).values():
+            if effective_session_key(candidate) == session_key:
+                return candidate
+        return None
+    except Exception:
+        logger.debug("Slack OPTIONS slot lookup failed", exc_info=True)
+        return None
+
+
+def slack_options_turn_counter(state: DashboardState | None, session_key: str) -> int | None:
+    """*session_key*'s monotonic turn counter, or None if it cannot be read.
+
+    Tells "a turn happened" from "a turn is running", which
+    ``SessionManager.is_busy`` cannot: a turn that starts and finishes inside a
+    single await window reports idle at both ends. ``_ChatSlot.total_messages``
+    is a lifetime count that survives the slot's trim cap, so it moves for a turn
+    that came and went.
+
+    Lives here, beside the resolver it depends on, because more than one Slack
+    posting path needs it and a second copy would drift from this one.
+
+    Returns None on any failure. This feeds best-effort OPTIONS cleanup and must
+    never abort the turn that triggered it; a None on either side of a comparison
+    simply reads as "no observed change".
+
+    Only comparable against itself: two counters read from DIFFERENT sessions say
+    nothing about each other, so a caller whose owner may have changed has to
+    treat that change as supersession instead of comparing.
+    """
+    try:
+        if state is None:
+            return None
+        slot = slack_options_slot(state, session_key)
+        return None if slot is None else int(slot.total_messages)
+    except Exception:
+        logger.debug("Could not read the turn counter for OPTIONS bookkeeping", exc_info=True)
+        return None
+
+
+def slack_options_linked_slot(state: DashboardState | None, thread_ts: str) -> _ChatSlot | None:
+    """The dashboard slot that owns *thread_ts*, if a session mirrors into it.
+
+    Prefers the thread -> slot reverse index, then falls back to scanning slots
+    for a matching ``_slack_thread_ts``. The fallback exists because the index is
+    written by one helper that a caller can forget: relying on it alone made this
+    resolver silently return nothing for a freshly-linked thread.
+    """
+    if not thread_ts or state is None:
+        return None
+    linked = getattr(state, "get_linked_slot", None)
+    if callable(linked):
+        try:
+            slot = linked(thread_ts)
+        except Exception:
+            slot = None
+        if slot is not None:
+            return slot
+    slots = getattr(state, "_slots", None)
+    if not isinstance(slots, dict):
+        return None
+    for slot in slots.values():
+        if getattr(slot, "_slack_linked", False) and (
+            getattr(slot, "_slack_thread_ts", "") == thread_ts
+        ):
+            return slot
+    return None
+
+
+def _persisted_thread_owner(state: DashboardState | None, thread_ts: str) -> str:
+    """The session key the PERSISTED thread index maps *thread_ts* to.
+
+    Distinct from :func:`slack_options_linked_slot`, which only knows the
+    dashboard SLOT index. A cron thread is linked with ``cron:<id>`` and has no
+    slot at all, so the slot index cannot see it — yet that is the key a control
+    on such a thread is recorded under, because the record sites resolve the owner
+    through this same index. Leaving it out of the ownership helpers made the
+    record and the forget disagree: the control was filed under ``cron:<id>`` and
+    then never cleared, so a later expiry found it and overwrote the selection.
+
+    Returns "" when unknown. The ``isinstance`` check is deliberate: the index is
+    typed ``str | None``, and anything else means the caller handed us a stub.
+    """
+    if state is None or not thread_ts:
+        return ""
+    sessions = getattr(state, "sessions", None)
+    if sessions is None:
+        return ""
+    try:
+        owner = sessions.get_session_for_thread(thread_ts)
+    except Exception:
+        logger.debug("Could not resolve the persisted owner of %s", thread_ts, exc_info=True)
+        return ""
+    return owner if isinstance(owner, str) and owner else ""
+
+
+def slack_options_owner_key(state: DashboardState | None, thread_ts: str) -> str:
+    """The single session key that owns the conversation living in *thread_ts*.
+
+    Use this when RECORDING a control — it has to land on the one session whose
+    next turn should spend it. Use :func:`slack_options_session_keys` when
+    CLEARING, where covering every candidate is correct.
+
+    The slot index is consulted first and the persisted thread index second. Where
+    both know the thread they agree (``link_slack`` writes both), so the order only
+    matters for a thread ONE of them can see — and a cron-linked thread is visible
+    only to the persisted one.
+    """
+    slot = slack_options_linked_slot(state, thread_ts)
+    if slot is not None:
+        mirrored = effective_session_key(slot)
+        if mirrored:
+            return mirrored
+    persisted = _persisted_thread_owner(state, thread_ts)
+    if persisted:
+        return persisted
+    return canonical_key(thread_ts) if thread_ts else ""
+
+
+def slack_options_session_keys(state: DashboardState | None, thread_ts: str) -> list[str]:
+    """Every session key under which *thread_ts*'s OPTIONS control may be recorded.
+
+    One Slack thread belongs to one conversation, but that conversation is
+    addressed by several different keys depending on which side owns it: a
+    Slack-born session is ``slack:<ts>``, a dashboard session mirroring out to the
+    thread is ``dashboard:<slot>``, and a persistent cron is ``cron:<id>``. A
+    caller holding only the thread timestamp cannot tell which, so return every
+    candidate — they name the same conversation, so acting on all of them is
+    correct rather than merely safe.
+
+    Missing the cron spelling here is what let a selection leave its record
+    behind: the forget cleared the keys it could guess, the ``cron:<id>`` record
+    survived, and the next expiry edited over the user's answer.
+    """
+    if not thread_ts:
+        return []
+    keys = [canonical_key(thread_ts)]
+    slot = slack_options_linked_slot(state, thread_ts)
+    if slot is not None:
+        mirrored = effective_session_key(slot)
+        if mirrored and mirrored not in keys:
+            keys.append(mirrored)
+    persisted = _persisted_thread_owner(state, thread_ts)
+    if persisted and persisted not in keys:
+        keys.append(persisted)
+    return keys
+
+
+def options_records(state: DashboardState | None, session_key: str) -> tuple[PostedOptions, ...]:
+    """Every OPTIONS control still outstanding for *session_key*.
+
+    The store is keyed by SESSION KEY, on ``DashboardState``, not held on the
+    slot. A plain Slack thread frequently has no dashboard slot, and a slot-held
+    record was simply dropped for those sessions — so nothing tracked the control,
+    no later turn could expire it, and the stale click this whole lifecycle exists
+    to prevent stayed possible (#1694). Keying by session key makes the slotless
+    case ordinary instead of special, and it cannot go stale when a slot appears
+    or disappears mid-conversation.
+    """
+    if state is None or not session_key:
+        return ()
+    store = getattr(state, "_slack_options_by_key", None)
+    if not isinstance(store, dict):
+        return ()
+    return store.get(canonical_key(session_key), ())
+
+
+def set_options_records(
+    state: DashboardState | None, session_key: str, records: tuple[PostedOptions, ...]
+) -> None:
+    """Replace *session_key*'s outstanding controls, dropping the key when empty.
+
+    Pruning on empty is the ONLY bound, and it is the right one: an entry exists
+    exactly as long as a question is still unanswered, and it leaves the moment the
+    lifecycle completes — the expiry settles it, a click forgets it, or an unlink
+    clears it.
+
+    Deliberately NOT capped with eviction. A cap sounds prudent and is actively
+    harmful here: evicting a record for a control that is still clickable means no
+    later turn can retire it, which is precisely the untracked control this whole
+    lifecycle exists to eliminate — so a bound would reintroduce the defect at
+    scale, silently, on the busiest instances. The footprint is also no worse than
+    what it replaced: records used to hang off ``_ChatSlot``, and slots are
+    themselves unbounded in number, so this holds strictly fewer entries (only
+    conversations with a live unanswered question) than the store it came from.
+    """
+    if state is None or not session_key:
+        return
+    store = getattr(state, "_slack_options_by_key", None)
+    if not isinstance(store, dict):
+        return
+    key = canonical_key(session_key)
+    if records:
+        store[key] = records
+    else:
+        store.pop(key, None)
+
+
+def remember_slack_options(
+    state: DashboardState | None,
+    session_key: str,
+    posted: PostedOptions | None,
+) -> None:
+    """Record the live OPTIONS control just posted for *session_key*.
+
+    APPENDS rather than replaces. A turn can post more than one OPTIONS message,
+    and the same slot is reachable from several posting paths, so overwriting
+    would leave the earlier control on screen with nothing tracking it — a click
+    on it would then answer a question the conversation has already passed.
+    Every outstanding record is kept so expiry can drain all of them.
+
+    A no-op when there is no control or no dashboard state. Note there is NO
+    slot requirement: the store is keyed by session key precisely so a plain
+    Slack thread without a slot still gets its control tracked (#1694).
+    """
+    if posted is None or state is None or not session_key:
+        return
+    current = options_records(state, session_key)
+    # Same message posted twice (a retry, or two paths recording one post)
+    # must not queue two edits for one control.
+    if posted not in current:
+        set_options_records(state, session_key, (*current, posted))
+
+
+def forget_slack_options(
+    state: DashboardState | None, session_key: str, ts: str | None = None
+) -> None:
+    """Drop the recorded control for *session_key* without editing Slack.
+
+    For when something else has already spent the control — a Send click
+    re-renders the message with the user's selection, and striking every choice
+    through afterwards would erase the choice they made.
+
+    Pass *ts* to drop ONLY the control posted as that message. A click spends one
+    control, not every control outstanding in the conversation: dropping them all
+    would leave any other one on screen with nothing tracking it, so a later click
+    on it would answer a superseded question. Omitting *ts* clears all of them,
+    which is right when the whole conversation is going away (an unlink).
+    """
+    if state is None or not session_key:
+        return
+    if ts is None:
+        set_options_records(state, session_key, ())
+        return
+    set_options_records(
+        state,
+        session_key,
+        tuple(p for p in options_records(state, session_key) if p.ts != ts),
+    )
+
+
+def slack_options_owner_keys_snapshot(
+    state: DashboardState | None, thread_ts: str
+) -> tuple[str, ...]:
+    """The keys *thread_ts*'s control could be recorded under, captured NOW.
+
+    A caller that is about to await Slack has to take this BEFORE the await and
+    forget against it afterwards. Recomputing after the fact reads the keys of
+    whoever owns the thread THEN: a relink landing during a submit's edit moves the
+    thread to another session, so the recomputed list names the new owner, the
+    previous owner's record survives the click, and that session's next turn edits
+    straight over the selection the user just made.
+    """
+    return tuple(slack_options_session_keys(state, thread_ts))
+
+
+def forget_slack_options_for_thread(
+    state: DashboardState | None,
+    thread_ts: str,
+    ts: str | None = None,
+    keys: tuple[str, ...] | None = None,
+) -> None:
+    """Drop the recorded control for the conversation living in *thread_ts*.
+
+    For callers that hold a Slack thread timestamp rather than a session key —
+    the interaction handlers, which see a click on a message and not the session
+    behind it. Clears every key the thread's conversation can be recorded under,
+    so a control posted by the dashboard mirror is forgotten too.
+
+    *ts* scopes it to the ONE control posted as that message, which is what a
+    click spends. Without it every outstanding control in the conversation is
+    dropped, leaving any other one clickable with nothing tracking it.
+
+    Pass *keys* from :func:`slack_options_owner_keys_snapshot` when an await sits
+    between reading ownership and clearing it — a relink during that window would
+    otherwise leave the previous owner's record behind. Omitting *keys* resolves
+    now, which is right only for a caller that has not awaited.
+    """
+    for key in keys if keys is not None else slack_options_session_keys(state, thread_ts):
+        forget_slack_options(state, key, ts)
+
+
+async def expire_slack_options(
+    state: DashboardState | None, session_key: str, ts: str | None = None
+) -> None:
+    """Spend the OPTIONS control left from *session_key*'s previous turn.
+
+    Called as a new turn begins, whichever surface it arrives on, so a control
+    the conversation has moved past stops inviting a click that would answer a
+    superseded question.
+
+    Records stay TRACKED across the Slack edit and are only ever REMOVED
+    afterwards, never re-added. A write-back that re-adds cannot tell "still
+    outstanding" from "deliberately removed while I was awaiting": a click landing
+    mid-await calls :func:`forget_slack_options`, and re-adding would resurrect
+    the control it just answered, so every later turn would re-edit the message
+    and overwrite the user's selected summary. Removing only what settled leaves
+    a concurrent forget authoritative. A record whose edit failed *transiently* is
+    simply never removed, so it is still retried later — dropping it would leave a
+    live control on screen with nothing tracking it, the exact stale click this
+    whole lifecycle exists to prevent. A failure that will never succeed (deleted
+    message, a channel we are not in) counts as settled, so it cannot be retried
+    on every later turn forever.
+
+    Two concurrent expiries can therefore both edit the same control. That is
+    deliberate: both write byte-identical spent blocks, so the cost is a wasted
+    API call, whereas resurrecting an answered control corrupts what the user
+    sees.
+
+    Drains EVERY outstanding control, not just the newest: a turn can leave more
+    than one on screen, and any one left untracked stays clickable into a
+    superseded question.
+
+    Pass *ts* to spend ONLY the control posted as that message. A caller that is
+    cleaning up after ITSELF has to narrow this way: a concurrent turn can record
+    its own fresh control in the same slot while this caller is still awaiting
+    Slack, and a session-wide drain would strike that newer question through too
+    — leaving the question the conversation is actually waiting on unanswerable.
+    Omitting *ts* drains all of them, which is what a NEW turn wants (it
+    supersedes everything before it) and what an unlink wants (the whole
+    conversation is going away).
+    """
+    if state is None or not session_key:
+        return
+    outstanding = options_records(state, session_key)
+    if not outstanding:
+        return
+    if ts is not None:
+        outstanding = tuple(posted for posted in outstanding if posted.ts == ts)
+        if not outstanding:
+            # Already spent by whoever else tracked it; nothing of ours to edit.
+            return
+    slack = getattr(state, "slack_client", None)
+    if slack is None:
+        # Nothing was spent, so nothing may be dropped: with no client the
+        # controls are still live on screen and must stay tracked.
+        return
+    settled: list[PostedOptions] = []
+    for posted in outstanding:
+        # Serialize against the Send handler's edit to this SAME message, and
+        # re-read the record INSIDE the lock. A click that won the race has
+        # already rewritten the message with the user's selection and dropped the
+        # record, so finding it gone means "do not edit" -- without the re-read,
+        # a late expiry would erase the answer the user just gave. The lock makes
+        # that check trustworthy; the check is what makes the lock useful.
+        async with options_edit_lock(posted.channel, posted.ts):
+            if posted not in options_records(state, session_key):
+                continue
+            if await expire_options(slack, posted):
+                # Retire the control for clicks too, not just for our records. A
+                # Send click queued behind this expiry would otherwise find the
+                # answer claim unheld, take it, and dispatch an answer to the
+                # question we just struck through. Marked while we still hold the
+                # lock, so the queued click cannot slip between the edit and this.
+                mark_options_terminal(posted.channel, posted.ts)
+                settled.append(posted)
+    if settled:
+        # Remove by identity against the CURRENT records, not by reassigning a
+        # remembered tuple: a turn that finished while we awaited Slack may have
+        # recorded its own control here, and it must survive.
+        set_options_records(
+            state,
+            session_key,
+            tuple(p for p in options_records(state, session_key) if p not in settled),
+        )
 
 
 _INCOGNITO_PREFIX = (

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -40,7 +40,12 @@ from kiro_crew.browser.setup import (
 )
 from kiro_crew.cron import CronStoreBusy
 from kiro_crew.dashboard.chat_persistence import _rehydrate_slot_from_history
-from kiro_crew.dashboard.chat_utils import _remove_queued_by_id, dashboard_slot_key
+from kiro_crew.dashboard.chat_utils import (
+    _remove_queued_by_id,
+    dashboard_slot_key,
+    remember_slack_options,
+    slack_options_owner_key,
+)
 from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.origin import is_direct_local_request, is_loopback
 from kiro_crew.dashboard.state import (
@@ -55,6 +60,7 @@ from kiro_crew.notifications.bus import (
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.session_pid_sig import verify_session_pid
 from kiro_crew.slack.format import build_options_blocks, extract_options
+from kiro_crew.slack.outbound import OPTIONS_FALLBACK_TEXT, PostedOptions
 from kiro_crew.subagent_persistence import _agent_dir, read_state
 from kiro_crew.validation import (
     _EMOJI_NAME_RE,
@@ -1336,12 +1342,41 @@ async def api_send_message(request: web.Request) -> web.Response:
                             )
                             if options:
                                 try:
-                                    await state.slack_client.post_blocks(
+                                    option_blocks = build_options_blocks(options)
+                                    # Fallback text is the SAFE stub, not the
+                                    # message body. Slack parses entities in a
+                                    # message's top-level `text` -- which is what
+                                    # notifications render -- so an agent-authored
+                                    # body containing `<!channel>` would ping the
+                                    # whole channel, and the expiry would ping it
+                                    # AGAIN every time it replays this text on its
+                                    # edit. Nothing is lost: the body was already
+                                    # posted as its own message just above, so here
+                                    # it was pure duplication. This is the same stub
+                                    # the other three posting paths use.
+                                    option_ts = await state.slack_client.post_blocks(
                                         channel,
-                                        build_options_blocks(options),
-                                        text,
+                                        option_blocks,
+                                        OPTIONS_FALLBACK_TEXT,
                                         thread_ts=thread_ts,
                                     )
+                                    # A thread IS a conversation, so bind the
+                                    # control to whichever session owns that
+                                    # thread — a dashboard session mirroring into
+                                    # it, or the Slack-born one. Without a thread
+                                    # there is no conversation to supersede it, so
+                                    # nothing is recorded.
+                                    if thread_ts and option_ts:
+                                        remember_slack_options(
+                                            state,
+                                            slack_options_owner_key(state, str(thread_ts)),
+                                            PostedOptions(
+                                                channel=channel,
+                                                ts=option_ts,
+                                                choices=tuple(options),
+                                                blocks=tuple(option_blocks),
+                                            ),
+                                        )
                                 except Exception:
                                     logger.debug(
                                         "send_message: failed to post OPTIONS blocks",

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     from kiro_crew.dashboard.loop_watchdog import LoopStallWatchdog  # noqa: F401
     from kiro_crew.messaging.transport import MessagingTransport  # noqa: F401
     from kiro_crew.power import SleepInhibitor  # noqa: F401
+    from kiro_crew.slack.outbound import PostedOptions  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -2085,6 +2086,20 @@ class DashboardState:
         self.notification_channel_settings = ChannelSettings()
         self._slots: dict[str, _ChatSlot] = {}
         self._slack_to_slot: dict[str, str] = {}  # Slack session_key → slot name
+        # Live OPTIONS controls, keyed by the SESSION KEY that owns them.
+        #
+        # Deliberately here and not on ``_ChatSlot``: a plain Slack thread often
+        # has no dashboard slot at all, and a slot-held record was simply dropped
+        # for those sessions — so the whole expiry lifecycle never engaged and the
+        # stale click it exists to prevent stayed possible (#1694). Keying by
+        # session key makes the slotless case ordinary rather than special.
+        #
+        # One store, not a slot field plus a fallback: a slot can come into
+        # existence at any moment (the channel surface reconciler creates one), so
+        # a fallback map would go invisible the instant one appeared. It also
+        # removes the two-store divergence that let a record be filed under one
+        # index and cleared under another.
+        self._slack_options_by_key: dict[str, tuple[PostedOptions, ...]] = {}
         self._slot_counter = 0
         # slot key → last context-meter reading, for seeding the bar when a
         # session is reopened after its ACP session is gone. Readings this

--- a/src/kiro_crew/slack/format.py
+++ b/src/kiro_crew/slack/format.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Callable, NamedTuple
 
 from kiro_crew.constants import OPTIONS_RE_LINE
 from kiro_crew.platform.context import redact_via_context
+
+logger = logging.getLogger(__name__)
 
 SLACK_MAX_TEXT = 39_000
 
@@ -109,6 +112,37 @@ def build_options_blocks(
     ]
 
 
+def escape_mrkdwn(text: str) -> str:
+    """Escape the three characters Slack treats as mrkdwn entity markup.
+
+    Choice text is LLM-authored, so it can carry (or be talked into carrying)
+    Slack's own entity syntax. ``<!channel>``, ``<!here>`` and ``<@U…>`` are
+    interpreted when they land in a ``mrkdwn`` field, so an OPTIONS tag reading
+    ``[OPTIONS: <!channel> | Skip]`` would notify an entire channel the moment
+    the summary is rendered -- on backfill, on submit, or on expiry.
+
+    A message's top-level ``text`` argument is the SAME kind of sink: Slack parses
+    entities there too, and it is what notifications and block-less clients show.
+    So a caller handing choice text to ``post_message`` / ``post_blocks`` /
+    ``update_message`` as the fallback text has to escape it as well -- escaping
+    only the blocks leaves the notification path wide open. Public for that
+    reason: more than one module needs it, and a second copy would drift.
+
+    Slack's documented escaping, and ``&`` MUST go first: doing it after ``<``
+    would re-escape the ampersands the earlier substitutions just introduced and
+    show ``&amp;lt;`` on screen.
+
+    Deliberately NOT folded into ``_redact_choices``, even though every mrkdwn
+    caller goes through it. Its output also feeds the ``plain_text`` checkbox
+    label -- which Slack does not interpret, so escaping there would display a
+    literal ``&lt;`` -- and the button ``value`` that is echoed back into the
+    session on submit, where an escaped entity would change the answer the user
+    actually picked. Escaping belongs at the Slack-facing sink only, never on the
+    copy the agent reads back.
+    """
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
 def build_options_selected_blocks(
     choices: list[str],
     selected_indices: list[int] | int,
@@ -121,16 +155,64 @@ def build_options_selected_blocks(
     selected_set = set(selected_indices)
     parts = []
     for i, choice in enumerate(_redact_choices(choices[:10], redactor)):
+        # Slice THEN escape -- the opposite order from redaction above, and for
+        # the mirror-image reason. Redaction runs before slicing because a cut
+        # can leave a credential prefix its regex no longer matches; escaping
+        # runs after because a cut through an already-expanded ``&amp;`` would
+        # leave a mangled half-entity on screen. Escaping a truncated ``<`` is
+        # still complete, so nothing is lost by waiting.
         if i in selected_set:
-            parts.append(f"*{choice[:72]}*")
+            parts.append(f"*{escape_mrkdwn(choice[:72])}*")
         else:
-            parts.append(f"~{choice[:73]}~")
+            parts.append(f"~{escape_mrkdwn(choice[:73])}~")
     return [
         {
             "type": "context",
             "elements": [{"type": "mrkdwn", "text": "  |  ".join(parts)}],
         }
     ]
+
+
+def replace_options_blocks(blocks: list[dict], selected_blocks: list[dict]) -> list[dict]:
+    """Replace OPTIONS actions block(s) with *selected_blocks* in place.
+
+    Walks *blocks* looking for any ``actions`` block whose elements include
+    ``OPTIONS_CHECKBOXES_ACTION``, ``OPTIONS_SUBMIT_ACTION``, or an action_id
+    starting with ``OPTIONS_ACTION_PREFIX``. The first such block is replaced
+    by *selected_blocks* (inserted in order); subsequent OPTIONS actions blocks
+    are dropped. All other blocks are preserved unchanged.
+
+    Returns a new list; the input blocks are never mutated, and preserved
+    blocks keep their identity so a caller can assert on them.
+    """
+    result: list[dict] = []
+    inserted = False
+    for block in blocks:
+        if block.get("type") != "actions":
+            result.append(block)
+            continue
+        elements = block.get("elements", [])
+        is_options_block = any(
+            el.get("action_id") in (OPTIONS_CHECKBOXES_ACTION, OPTIONS_SUBMIT_ACTION)
+            or el.get("action_id", "").startswith(OPTIONS_ACTION_PREFIX)
+            for el in elements
+        )
+        if not is_options_block:
+            result.append(block)
+            continue
+        if not inserted:
+            result.extend(selected_blocks)
+            inserted = True
+        # Drop the OPTIONS actions block itself
+    if not inserted:
+        # No OPTIONS actions block found — append selected_blocks at end so
+        # the user still sees their selection (defensive fallback).
+        logger.warning(
+            "OPTIONS actions block not found in parent message blocks; "
+            "appending selection at end"
+        )
+        result.extend(selected_blocks)
+    return result
 
 
 def build_cron_ack_block(job_id: str) -> list[dict]:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -84,7 +84,11 @@ from kiro_crew.cron_script import resolve_script_path, run_command_sandboxed, ru
 from kiro_crew.dashboard import start_dashboard
 from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
 from kiro_crew.dashboard.chat_runner import _run_chat
-from kiro_crew.dashboard.chat_utils import dashboard_slot_key, subagent_event_slot
+from kiro_crew.dashboard.chat_utils import (
+    dashboard_slot_key,
+    remember_slack_options,
+    subagent_event_slot,
+)
 from kiro_crew.dashboard.cron_inject import (
     context_meter_reading,
     inject_cron_result_to_dashboard,
@@ -190,6 +194,7 @@ from kiro_crew.slack.handler import (
     is_thread_incognito,
     is_thread_temporary,
 )
+from kiro_crew.slack.outbound import PostedOptions
 from kiro_crew.slack.retry import open_dm_with_retry
 from kiro_crew.subagent import (
     DIGEST_HOLD_SECS,
@@ -1630,6 +1635,40 @@ class GatewayOrchestrator:
             max_attempts=max_attempts,
         )
 
+    def _remember_options(
+        self,
+        session_key: str,
+        channel: str,
+        ts: str,
+        choices: list[str],
+        blocks: list[dict],
+        text: str,
+    ) -> None:
+        """Record an OPTIONS control posted into *session_key*'s Slack thread.
+
+        Lets that session's next turn strike the control through, so a delivery
+        which ended on a question stops inviting an answer once the conversation
+        has moved past it. Best-effort: losing the record only means the control
+        is left live.
+        """
+        if not ts or not choices:
+            return
+        try:
+
+            remember_slack_options(
+                self.dashboard_state,
+                session_key,
+                PostedOptions(
+                    channel=channel,
+                    ts=ts,
+                    choices=tuple(choices),
+                    blocks=tuple(blocks),
+                    text=text,
+                ),
+            )
+        except Exception:
+            logger.debug("Failed to record OPTIONS control for %s", session_key, exc_info=True)
+
     async def _deliver_cron_response(
         self, parent_key: str, text: str, *, silent: bool = False
     ) -> bool:
@@ -1667,11 +1706,15 @@ class GatewayOrchestrator:
             await self.slack.post_message(channel, part, thread_ts)
         if options:
             try:
-                await self.slack.post_blocks(
+                option_blocks = build_options_blocks(options)
+                option_ts = await self.slack.post_blocks(
                     channel,
-                    build_options_blocks(options),
+                    option_blocks,
                     "Options",
                     thread_ts,
+                )
+                self._remember_options(
+                    parent_key, channel, option_ts, options, option_blocks, "Options"
                 )
             except Exception:
                 logger.debug("Cron %s: failed to post OPTIONS blocks", parent_key, exc_info=True)
@@ -4512,11 +4555,19 @@ class GatewayOrchestrator:
                                         )
                                         if options:
                                             footer_blocks.extend(build_options_blocks(options))
-                                        await self.slack.post_blocks(
+                                        _footer_ts = await self.slack.post_blocks(
                                             channel,
                                             footer_blocks,
                                             footer_text,
                                             parent_key,
+                                        )
+                                        self._remember_options(
+                                            parent_key,
+                                            channel,
+                                            _footer_ts,
+                                            options,
+                                            footer_blocks,
+                                            footer_text,
                                         )
                                     except Exception:
                                         logger.debug(

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -29,6 +29,10 @@ from collections import OrderedDict
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from kiro_crew.dashboard.state import DashboardState
 
 from kiro_crew.acp.client import AcpError, AcpProcessDied, AcpPromptBusy, AcpTimeoutError
 from kiro_crew.acp.types import STOP_REASON_CANCELLED, STOP_REASON_END_TURN
@@ -53,6 +57,11 @@ from kiro_crew.cron import (
     compute_next_run_ts,
     format_schedule,
     get_local_tz,
+)
+from kiro_crew.dashboard.chat_utils import (
+    expire_slack_options,
+    remember_slack_options,
+    slack_options_turn_counter,
 )
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.history import ConversationLog, HistoryConsolidator
@@ -103,6 +112,7 @@ from kiro_crew.slack.format import (
     split_message,
     strip_thinking_tags,
 )
+from kiro_crew.slack.outbound import PostedOptions
 from kiro_crew.slack.sessions_view import (
     _SESSIONS_DEFAULT_LIMIT,
     _build_sessions_blocks,
@@ -2157,6 +2167,28 @@ def build_timing_footer(
     return blocks, footer_text
 
 
+def _turn_counter_for(session_key: str) -> int | None:
+    """This session's monotonic turn counter, or None if it cannot be read.
+
+    Used to tell "a turn happened" from "a turn is running", which
+    ``SessionManager.is_busy`` cannot distinguish: a turn that starts and
+    finishes inside a single await window reports as idle at both ends.
+    ``_ChatSlot.total_messages`` is a lifetime count that survives the slot's
+    trim cap, so it moves for a turn that came and went.
+
+    Returns None on any failure. This feeds best-effort OPTIONS cleanup and must
+    never be able to abort the turn that triggered it. A None on either side of
+    the comparison simply reads as "no observed change", leaving the ``is_busy``
+    half of the check to decide.
+
+    Delegates to :func:`slack_options_turn_counter` so this path and the
+    transport-dispatch path cannot drift apart on how the counter is read.
+    """
+    return slack_options_turn_counter(
+        cast("DashboardState | None", get_dashboard_state()), session_key
+    )
+
+
 def _append_footer_actions(
     footer_blocks: list[dict],
     options: list[str] | None,
@@ -2611,6 +2643,7 @@ async def handle_message(
     # ── Linked thread intercept: route to dashboard slot if linked ──
     if await maybe_route_linked_thread(text, session_key, user_id, channel, slack, reply_ts):
         return
+
     logger.info(
         "🔍 handle_message: thread_ts=%s msg_ts=%s → session_key=%s channel=%s",
         thread_ts,
@@ -2796,6 +2829,31 @@ async def handle_message(
         channel_agent=channel_agent,
     ):
         return
+
+    # A new turn supersedes whatever question the previous one ended on, so any
+    # OPTIONS control still live in this thread stops being answerable.
+    #
+    # Placed HERE, below every short-circuit above, because only a message that
+    # actually starts a turn supersedes anything. ``status``, a permission
+    # denial, a modifier-only message, a hook's canned reply and the keyword
+    # commands all answer and return WITHOUT running the agent, so the
+    # conversation has not moved and the pending question is still the one being
+    # waited on. Expiring for those spends a LIVE control and leaves valid
+    # choices unanswerable — the exact inverse of the stale click this lifecycle
+    # exists to prevent. The denial case matters most: an unauthorized caller in
+    # the thread must not be able to destroy the owner's pending question.
+    # Keeping this at one point below the short-circuits, rather than guarding
+    # each of them, means a shortcut added later inherits the right behaviour.
+    #
+    # Resolve the OWNING session, not the ``slack:<ts>`` key derived above: the
+    # control is recorded under whichever session owns the thread, and for a
+    # dashboard-linked thread that is its ``dashboard:chat-N`` key — the same
+    # distinction the linked-thread lookup relies on. Expiring under the wrong
+    # key silently no-ops and leaves the control clickable.
+    await expire_slack_options(
+        cast("DashboardState | None", get_dashboard_state()),
+        sessions.get_session_for_thread(reply_ts) or session_key,
+    )
 
     status_ctrl = StatusReactionController(
         slack,
@@ -3005,6 +3063,15 @@ async def handle_message(
             session_key, agent=_agent, channel_id=channel
         )
         _acquired = True
+        # Expire AGAIN now the turn is serialized — see the same call in
+        # transport_dispatch. The pass earlier in this function runs before
+        # `get_or_create` waits its turn, so two messages arriving together both
+        # clear the OLD control and neither clears the NEW one the first turn
+        # posts on its way out, leaving live buttons for a superseded question.
+        await expire_slack_options(
+            cast("DashboardState | None", get_dashboard_state()),
+            sessions.get_session_for_thread(reply_ts) or session_key,
+        )
         if is_new:
             await sessions.set_channel(session_key, channel)
         if not linked_session_key:
@@ -3825,7 +3892,108 @@ async def handle_message(
         linked_session_key,
         _dashboard_state,
     )
-    await slack.post_blocks(channel, footer_blocks, footer_text, reply_ts)
+    # Baseline BEFORE the footer post. `is_busy` alone only answers "is a turn in
+    # flight right now", so a superseding turn that both STARTS and FINISHES
+    # inside this window reads as not-busy and the check below would miss it.
+    # total_messages is monotonic and survives the slot's trim cap, so it moves
+    # for a turn that came and went.
+    #
+    # Sampled on the thread's owner AT THIS MOMENT, not on the key this turn
+    # started under: a dashboard link landing during the post moves the
+    # conversation to a different session, and a baseline taken on the old key can
+    # never observe the new owner's turns — so the guard would report "nothing
+    # moved" precisely when everything had.
+    _pre_owner = sessions.get_session_for_thread(reply_ts) or session_key
+    _pre_footer_total = _turn_counter_for(_pre_owner)
+    _footer_ts = await slack.post_blocks(channel, footer_blocks, footer_text, reply_ts)
+    if options and _footer_ts:
+        # Remember this turn's OPTIONS control so the next turn can strike it
+        # through once the conversation has moved past the question it asked.
+        #
+        # Resolved ONCE and reused by the cleanup below. The record and the
+        # expiry have to agree on the owner key or they can never pair up: a
+        # thread linked to a dashboard mid-turn changes owner, so recording under
+        # the key this turn started with files the control where the next turn's
+        # expiry will not look. Reading it twice would reopen the same split if a
+        # link landed in between.
+        _options_owner = sessions.get_session_for_thread(reply_ts) or session_key
+        try:
+
+            remember_slack_options(
+                cast("DashboardState | None", get_dashboard_state()),
+                _options_owner,
+                PostedOptions(
+                    channel=channel,
+                    ts=_footer_ts,
+                    choices=tuple(options),
+                    blocks=tuple(footer_blocks),
+                    text=footer_text,
+                ),
+            )
+        except Exception:
+            logger.debug("Failed to record OPTIONS control", exc_info=True)
+
+        # The session permit was released well before this footer went up (the
+        # `finally` above), so a message that queued behind this turn can have
+        # acquired it and run ITS expiry pass already — over a record that did
+        # not exist yet. That leaves this control live for a question the
+        # conversation has moved past, which is the defect this PR exists to
+        # remove. If a turn is in flight now, OR one came and went while the
+        # footer was posting, we lost that race: spend the control ourselves
+        # rather than leaving it clickable.
+        #
+        # Both halves are needed. `is_busy` catches the turn still running;
+        # the counter catches the turn that already finished, which `is_busy`
+        # reports as idle.
+        #
+        # And an owner CHANGE is supersession in its own right: the thread now
+        # belongs to a different session, so the question we just posted would be
+        # answered into a conversation that has moved on. It short-circuits before
+        # the counter comparison on purpose — counters read from two different
+        # sessions say nothing about each other, so comparing them would be
+        # meaningless rather than merely unhelpful.
+        def _counter_moved() -> bool:
+            """True only when BOTH readings exist and differ.
+
+            ``_turn_counter_for`` returns None when the counter cannot be read at
+            all — most often because the session has no dashboard slot, which is
+            the normal state for a Slack conversation until something surfaces
+            one. A slot appearing (the channel surface reconciler creates one) or
+            vanishing mid-post would otherwise flip None against an int and read
+            as "a turn happened", expiring the control we just posted the instant
+            it landed. A slot's existence is not a turn, so an unreadable
+            counter must ABSTAIN rather than vote — which is what the helper's
+            own contract already promises.
+            """
+            after = _turn_counter_for(_options_owner)
+            return (
+                _pre_footer_total is not None
+                and after is not None
+                and after != _pre_footer_total
+            )
+
+        _superseded = (
+            _options_owner != _pre_owner
+            or sessions.is_busy(_options_owner)
+            or _counter_moved()
+        )
+        if _superseded:
+            try:
+                # Narrowed to OUR footer's ts, never a session-wide drain: the
+                # very turn that superseded us can finish while we were awaiting
+                # post_blocks and record its OWN live control on this session, and
+                # draining the slot would strike that newer question through --
+                # silencing the one the conversation is now waiting on.
+                await expire_slack_options(
+                    cast("DashboardState | None", get_dashboard_state()),
+                    _options_owner,
+                    ts=_footer_ts,
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to expire OPTIONS control superseded mid-post",
+                    exc_info=True,
+                )
 
     # ── Voice reply (fire-and-forget, non-blocking) ──
     # Triggers when: (a) user has opted in globally or per-thread via !voice,

--- a/src/kiro_crew/slack/interactions.py
+++ b/src/kiro_crew/slack/interactions.py
@@ -30,6 +30,10 @@ from kiro_crew.config.loader import (
     write_config_atomically,
 )
 from kiro_crew.cron import CronStoreBusy
+from kiro_crew.dashboard.chat_utils import (
+    forget_slack_options_for_thread,
+    slack_options_owner_keys_snapshot,
+)
 from kiro_crew.messaging.identity import channel_inbound_permitted
 from kiro_crew.security import redact_and_truncate, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -47,6 +51,8 @@ from kiro_crew.slack.format import (
     OPTIONS_CHECKBOXES_ACTION,
     OPTIONS_SUBMIT_ACTION,
     build_options_selected_blocks,
+    escape_mrkdwn,
+    replace_options_blocks,
 )
 from kiro_crew.slack.handler import (
     APPROVAL_INTERACTIVE,
@@ -57,6 +63,13 @@ from kiro_crew.slack.handler import (
     is_owner,
     set_allowed_users,
     set_tracking_channels,
+)
+from kiro_crew.slack.outbound import (
+    claim_options_answer,
+    options_edit_lock,
+    release_options_answer,
+    settle_options_answer,
+    track_answer_routing,
 )
 from kiro_crew.slack.renderer import (
     TOOL_APPROVE_ACTION_PREFIX,
@@ -1252,43 +1265,29 @@ def _mark_button_clicked(blocks: list[dict], clicked_action_id: str, label: str)
 _ACTION_PREFIX = "action::"
 
 
-def _replace_options_blocks(blocks: list[dict], selected_blocks: list[dict]) -> list[dict]:
-    """Replace OPTIONS actions block(s) with *selected_blocks* in place.
+def _forget_options_control(
+    thread_ts: str, ts: str | None = None, keys: tuple[str, ...] | None = None
+) -> None:
+    """Drop the recorded OPTIONS control for *thread_ts*'s conversation.
 
-    Walks *blocks* looking for any ``actions`` block whose elements include
-    ``OPTIONS_CHECKBOXES_ACTION``, ``OPTIONS_SUBMIT_ACTION``, or an action_id
-    starting with ``OPTIONS_ACTION_PREFIX``. The first such block is replaced
-    by *selected_blocks* (inserted in order); subsequent OPTIONS actions blocks
-    are dropped. All other blocks are preserved unchanged.
+    A click has just re-rendered the message with the user's selection, so the
+    turn-start expiry must not run over it afterwards — striking every choice
+    through would erase the choice they made. A thread can be owned either by a
+    Slack-born session or by a dashboard session mirroring into it, so this
+    clears every key that one conversation can be recorded under.
+
+    *keys* is a snapshot taken BEFORE the Slack edit. A relink landing during that
+    edit moves the thread to another session, so resolving the keys afterwards
+    names the NEW owner and leaves the previous owner's record behind — whose next
+    turn then edits over the selection.
     """
-    result: list[dict] = []
-    inserted = False
-    for block in blocks:
-        if block.get("type") != "actions":
-            result.append(block)
-            continue
-        elements = block.get("elements", [])
-        is_options_block = any(
-            el.get("action_id") in (OPTIONS_CHECKBOXES_ACTION, OPTIONS_SUBMIT_ACTION)
-            or el.get("action_id", "").startswith(OPTIONS_ACTION_PREFIX)
-            for el in elements
-        )
-        if not is_options_block:
-            result.append(block)
-            continue
-        if not inserted:
-            result.extend(selected_blocks)
-            inserted = True
-        # Drop the OPTIONS actions block itself
-    if not inserted:
-        # No OPTIONS actions block found — append selected_blocks at end so
-        # the user still sees their selection (defensive fallback).
-        logger.warning(
-            "OPTIONS actions block not found in parent message blocks; "
-            "appending selection at end"
-        )
-        result.extend(selected_blocks)
-    return result
+    if not _orch or not thread_ts:
+        return
+    try:
+
+        forget_slack_options_for_thread(_orch.dashboard_state, thread_ts, ts, keys=keys)
+    except Exception:
+        logger.debug("Failed to clear recorded OPTIONS control", exc_info=True)
 
 
 def _extract_selected_value(action: dict) -> tuple[str, str]:
@@ -1494,48 +1493,120 @@ async def _handle_options_submit(payload: dict, channel: str, msg_ts: str) -> No
     all_choices = [redact_credentials(redact_exfiltration_urls(c)[0])[0] for c in all_choices]
 
     combined = ", ".join(selected)
+    # The Slack-facing FALLBACK TEXT, escaped. Slack parses entities in a
+    # message's top-level `text` too, not just in mrkdwn blocks -- and `text` is
+    # what notifications and block-less clients render, so an unescaped
+    # `<!channel>` here pages a whole channel even though the blocks are safe.
+    #
+    # A SEPARATE variable on purpose: `combined` itself must stay raw, because it
+    # is also the answer echoed back into the session below. Escaping in place
+    # would change what the user actually picked -- the same trap that keeps the
+    # escape out of `_redact_choices`.
+    combined_fallback = escape_mrkdwn(combined)
 
     # Edit-in-place: replace only the OPTIONS actions block(s) with the
     # styled selection, preserving every other surrounding block. Falls back
     # to post-and-delete if update_message raises (resilience).
     selected_blocks = build_options_selected_blocks(all_choices, selected_indices)
     parent_blocks = payload.get("message", {}).get("blocks", [])
-    new_blocks = _replace_options_blocks(parent_blocks, selected_blocks)
+    new_blocks = replace_options_blocks(parent_blocks, selected_blocks)
     new_ts = msg_ts
     edited = False
-    try:
-        await _orch.slack.update_message(channel, msg_ts, text=combined, blocks=new_blocks)
-        edited = True
-    except Exception:
-        logger.debug(
-            "update_message failed for options_submit, falling back to post+delete",
-            exc_info=True,
-        )
-
-    if not edited:
-        posted_ts = await _orch.slack.post_blocks(channel, selected_blocks, combined, thread_ts)
-        if not posted_ts:
-            logger.warning("Failed to post options choice — aborting")
-            sel().log_tool_invocation(
-                session_key=thread_ts,
-                agent="kirocrew",
-                source="slack",
-                tool_name="options_submit",
-                tool_kind="interaction",
-                outcome="failure",
-                metadata={"reason": "post_blocks_failed"},
+    # Set when the original message survives our attempt to remove it: the
+    # control is then STILL on screen and still clickable, so its record has to
+    # outlive this submit for a later turn to expire it.
+    original_still_live = False
+    # Serialize against a concurrent expiry of this SAME message. The expiry
+    # re-reads the record inside this lock and skips its edit once the forget
+    # below has dropped it, so the user's selection cannot be overwritten by an
+    # expiry that started first. Held across the edit AND the forget: releasing
+    # between them would let an expiry observe a still-tracked record and edit
+    # over the selection we just wrote.
+    async with options_edit_lock(channel, msg_ts):
+        # One answer per control. A second Send click on this message would
+        # otherwise render the selection again and dispatch a second turn -- a
+        # duplicate, or once the first turn has moved on, a superseded one.
+        # Claimed under the lock so the check and the claim cannot interleave,
+        # and BEFORE the edit so a loser touches nothing at all.
+        if not claim_options_answer(channel, msg_ts):
+            logger.debug(
+                "options_submit: control %s/%s was already answered; dropping the "
+                "duplicate click",
+                channel,
+                msg_ts,
             )
             return
-        new_ts = posted_ts
+        # Whose record this control is, captured BEFORE the edit. A relink landing
+        # during the edit would move the thread to another session, so resolving
+        # after the fact names the NEW owner and leaves the previous owner's record
+        # in place -- and that session's next turn would edit over this selection.
+        _owner_keys = slack_options_owner_keys_snapshot(
+            _orch.dashboard_state if _orch else None, thread_ts
+        )
         try:
-            await _orch.slack.delete_message(channel, msg_ts)
-        except Exception:
-            logger.warning(
-                "Failed to delete original OPTIONS message after fallback "
-                "post_blocks succeeded; user may see both the original "
-                "and the new selection message",
-                exc_info=True,
-            )
+            try:
+                await _orch.slack.update_message(
+                    channel, msg_ts, text=combined_fallback, blocks=new_blocks
+                )
+                edited = True
+            except Exception:
+                logger.debug(
+                    "update_message failed for options_submit, falling back to post+delete",
+                    exc_info=True,
+                )
+
+            if not edited:
+                posted_ts = await _orch.slack.post_blocks(
+                    channel, selected_blocks, combined_fallback, thread_ts
+                )
+                if not posted_ts:
+                    logger.warning("Failed to post options choice — aborting")
+                    sel().log_tool_invocation(
+                        session_key=thread_ts,
+                        agent="kirocrew",
+                        source="slack",
+                        tool_name="options_submit",
+                        tool_kind="interaction",
+                        outcome="failure",
+                        metadata={"reason": "post_blocks_failed"},
+                    )
+                    return
+                new_ts = posted_ts
+                try:
+                    await _orch.slack.delete_message(channel, msg_ts)
+                except Exception:
+                    original_still_live = True
+                    logger.warning(
+                        "Failed to delete original OPTIONS message after fallback "
+                        "post_blocks succeeded; user may see both the original "
+                        "and the new selection message",
+                        exc_info=True,
+                    )
+        finally:
+            # Give the claim back only when the selection never reached Slack at
+            # all -- neither the in-place edit nor the replacement post. Holding it
+            # then would refuse every retry forever, leaving a control permanently
+            # visible and permanently unanswerable. Once the selection IS on screen
+            # the claim stays, even if a later step stumbles: the answer is
+            # rendered and the turn is on its way.
+            if not edited and new_ts == msg_ts:
+                release_options_answer(channel, msg_ts)
+
+        # The control is spent only once the original is actually gone — either
+        # rewritten in place, or posted-and-deleted. When the delete failed those
+        # buttons are still sitting in the channel, so the record has to stay:
+        # dropping it is exactly what leaves a permanently clickable control, the
+        # defect this PR exists to remove.
+        #
+        # Inside the lock with the edit above: an expiry that observed a
+        # still-tracked record between the two would edit straight over the
+        # selection we just wrote.
+        if not original_still_live:
+            # The buttons are provably off screen, so the claim on this control no
+            # longer has to be pinned against a late click and may be evicted if
+            # the map fills. While the original IS still live the claim stays put.
+            settle_options_answer(channel, msg_ts)
+            _forget_options_control(thread_ts, msg_ts, keys=_owner_keys)
 
     action_context = (
         "--- CONTEXT ENTRY BEGIN ---\n"
@@ -1563,6 +1634,10 @@ async def _handle_options_submit(payload: dict, channel: str, msg_ts: str) -> No
             action_context=action_context,
         )
     )
+    # The record is already forgotten, so until this task has found its session
+    # the thread's reverse index is the only thing pointing the answer at the
+    # right conversation. Hold the unlink off until then.
+    track_answer_routing(thread_ts, t)
     _orch._handler_tasks.add(t)
     t.add_done_callback(_orch._handler_tasks.discard)
     sel().log_tool_invocation(
@@ -1675,43 +1750,93 @@ async def _handle_options(payload: dict, action: dict, channel: str, msg_ts: str
     # Edit-in-place: replace only the OPTIONS actions block with the styled
     # selection, preserving every other surrounding block. Falls back to
     # post-and-delete if update_message raises.
-    selected_blocks = build_options_selected_blocks(all_choices, selected_index)
-    new_blocks = _replace_options_blocks(blocks, selected_blocks)
-    new_ts = msg_ts
-    edited = False
-    try:
-        await _orch.slack.update_message(channel, msg_ts, text=choice, blocks=new_blocks)
-        edited = True
-    except Exception:
-        logger.debug(
-            "update_message failed for options choice, falling back to post+delete",
-            exc_info=True,
-        )
-
-    if not edited:
-        posted_ts = await _orch.slack.post_blocks(channel, selected_blocks, choice, thread_ts)
-        if not posted_ts:
-            logger.warning("Failed to post options choice — aborting")
-            sel().log_tool_invocation(
-                session_key=thread_ts,
-                agent="kirocrew",
-                source="slack",
-                tool_name="options",
-                tool_kind="interaction",
-                outcome="failure",
-                metadata={"reason": "post_blocks_failed"},
+    # Every guarantee the multi-select submit path has, this path needs too: it
+    # renders a selection into the SAME message and dispatches a turn, so two
+    # rapid clicks on a legacy single-click control would otherwise produce two
+    # dispatches and two turns. The lock serialises against the turn-start
+    # expiry's edit; the claim makes the answer once-only.
+    async with options_edit_lock(channel, msg_ts):
+        if not claim_options_answer(channel, msg_ts):
+            logger.debug(
+                "options click: control %s/%s was already answered; dropping the "
+                "duplicate",
+                channel,
+                msg_ts,
             )
             return
-        new_ts = posted_ts
+        # Owner keys BEFORE the edit -- a relink landing during it would move the
+        # thread, and forgetting against the new owner orphans the old record.
+        _owner_keys = slack_options_owner_keys_snapshot(
+            _orch.dashboard_state if _orch else None, thread_ts
+        )
+        edited = False
+        new_ts = msg_ts
         try:
-            await _orch.slack.delete_message(channel, msg_ts)
-        except Exception:
-            logger.warning(
-                "Failed to delete original OPTIONS message after fallback "
-                "post_blocks succeeded; user may see both the original "
-                "and the new selection message",
-                exc_info=True,
-            )
+            selected_blocks = build_options_selected_blocks(all_choices, selected_index)
+            new_blocks = replace_options_blocks(blocks, selected_blocks)
+            new_ts = msg_ts
+            edited = False
+            # See the multi-select submit path: set when the original message outlives
+            # our attempt to remove it, so its still-clickable control keeps a record.
+            original_still_live = False
+            # Escaped for the FALLBACK text only. Slack parses entities in a
+            # message's top-level `text` -- which is what notifications render --
+            # so a legacy choice containing `<!channel>` would ping the whole
+            # channel from a click. The blocks are already escaped by
+            # `build_options_selected_blocks`; `choice` itself stays RAW below,
+            # because that is the answer echoed into the session.
+            _choice_fallback = escape_mrkdwn(choice)
+            try:
+                await _orch.slack.update_message(
+                    channel, msg_ts, text=_choice_fallback, blocks=new_blocks
+                )
+                edited = True
+            except Exception:
+                logger.debug(
+                    "update_message failed for options choice, falling back to post+delete",
+                    exc_info=True,
+                )
+
+            if not edited:
+                posted_ts = await _orch.slack.post_blocks(
+                    channel, selected_blocks, _choice_fallback, thread_ts
+                )
+                if not posted_ts:
+                    logger.warning("Failed to post options choice — aborting")
+                    sel().log_tool_invocation(
+                        session_key=thread_ts,
+                        agent="kirocrew",
+                        source="slack",
+                        tool_name="options",
+                        tool_kind="interaction",
+                        outcome="failure",
+                        metadata={"reason": "post_blocks_failed"},
+                    )
+                    return
+                new_ts = posted_ts
+                try:
+                    await _orch.slack.delete_message(channel, msg_ts)
+                except Exception:
+                    original_still_live = True
+                    logger.warning(
+                        "Failed to delete original OPTIONS message after fallback "
+                        "post_blocks succeeded; user may see both the original "
+                        "and the new selection message",
+                        exc_info=True,
+                    )
+
+            # Same rule as the multi-select submit path: only forget the control once
+            # the original message is genuinely gone. A failed delete leaves the buttons
+            # live, and a forgotten record can never be expired.
+            if not original_still_live:
+                # Buttons provably gone: the claim may be reclaimed under pressure.
+                settle_options_answer(channel, msg_ts)
+                _forget_options_control(thread_ts, msg_ts, keys=_owner_keys)
+        finally:
+            # Only when the selection never reached Slack at all. Once it is on
+            # screen the claim stays, or a duplicate click is re-admitted.
+            if not edited and new_ts == msg_ts:
+                release_options_answer(channel, msg_ts)
 
     t = asyncio.create_task(
         handle_message(
@@ -1732,6 +1857,10 @@ async def _handle_options(payload: dict, action: dict, channel: str, msg_ts: str
             task_runner=_orch.task_runner,
         )
     )
+    # Same reason as the multi-select submit path: the record is already gone, so
+    # the reverse index is all that points this answer at the right conversation
+    # until the task resolves it. Hold the unlink off until then.
+    track_answer_routing(thread_ts, t)
     _orch._handler_tasks.add(t)
     t.add_done_callback(_orch._handler_tasks.discard)
 

--- a/src/kiro_crew/slack/outbound.py
+++ b/src/kiro_crew/slack/outbound.py
@@ -1,0 +1,346 @@
+"""The lifecycle of a posted Slack OPTIONS control.
+
+Rendering text for Slack is NOT this module's job. ``slack.format`` owns that —
+``render_for_slack`` for bodies and ``build_options_blocks`` for the control,
+which redacts every choice through ``redact_for_display`` so a key split by ANSI,
+emphasis, backticks or link markup is caught in the form Slack actually shows.
+This module deliberately holds no second copy of that pipeline: an earlier
+version did, and the two drifted apart until the same credential-exposure bug
+had to be fixed twice, three review rounds apart.
+
+What is left here is the part ``slack.format`` has no opinion about: a posted
+control stays answerable until something spends it. ``PostedOptions`` carries
+enough to find the control again, and ``expire_options`` renders it spent once
+the conversation has moved past the question it asked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from kiro_crew.slack.format import build_options_selected_blocks, replace_options_blocks
+from kiro_crew.slack.retry import is_retryable_slack_error
+
+if TYPE_CHECKING:
+    from kiro_crew.slack.client import SlackClientOps
+
+logger = logging.getLogger(__name__)
+
+#: Notification/fallback text for the message carrying an OPTIONS control.
+OPTIONS_FALLBACK_TEXT = "Options"
+
+
+@dataclass(frozen=True)
+class PostedOptions:
+    """A posted OPTIONS control, addressed well enough to expire it later.
+
+    ``blocks`` is the block list exactly as posted. Keeping it means expiry can
+    run the same block surgery the Send button uses, editing only the OPTIONS
+    block and leaving any surrounding blocks (a timing footer, a
+    Link-to-Dashboard button) intact — without re-fetching the message.
+    """
+
+    channel: str
+    ts: str
+    choices: tuple[str, ...]
+    blocks: tuple[dict, ...]
+    text: str = OPTIONS_FALLBACK_TEXT
+
+
+_MAX_EDIT_LOCKS = 512
+_EDIT_LOCKS: dict[tuple[str, str], asyncio.Lock] = {}
+_ANSWERED: dict[tuple[str, str], bool] = {}
+# Threads with an OPTIONS answer currently routing: thread_ts -> the dispatch
+# tasks carrying it. See :func:`track_answer_routing`.
+_ANSWER_ROUTING: dict[str, set[asyncio.Task[Any]]] = {}
+# Interested parties per edit-lock key: holders plus coroutines waiting to hold.
+_LOCK_USERS: dict[tuple[str, str], int] = {}
+
+
+def claim_options_answer(channel: str, ts: str) -> bool:
+    """Claim the right to answer the OPTIONS control posted as *ts*. Once only.
+
+    Returns True for the FIRST caller and False for every later one, so a second
+    Send click on the same message is a no-op instead of a second turn. Two rapid
+    clicks produce two handler tasks; without this the first would render the
+    selection and dispatch it, and the second would dispatch the same answer
+    again, giving the conversation a duplicate (or, once the first turn has moved
+    on, a superseded) turn.
+
+    MUST be called while holding :func:`options_edit_lock` for the same message —
+    the check and the claim are only atomic under that lock.
+
+    Deliberately NOT "is a record still tracked". ``remember_slack_options`` is a
+    documented no-op when the session has no dashboard slot, which is the normal
+    state for a plain Slack conversation, so keying click validity on record
+    presence would reject every legitimate click in those threads. "Has this
+    control already been answered" is a different question and is answerable here
+    without a slot.
+
+    Bounded, but NEVER at the cost of a control that can still be clicked. The
+    value records whether the control's buttons are provably GONE from Slack --
+    the in-place edit landed, the original was deleted, or the expiry's
+    strike-through succeeded. Only such settled entries are evictable.
+
+    An earlier version evicted the oldest entry outright, justified as "a dropped
+    entry can only re-admit a click on a control old enough to have aged out of a
+    512-message window, which the turn-start expiry has long since struck
+    through". That is wrong, and wrong in the same way this PR's other bounds
+    were: eviction here is by insertion order across the WHOLE workspace, not by
+    age within one conversation, so traffic in busy channels can evict the claim
+    on a control still sitting unanswered in a quiet thread. When the render or
+    the strike-through failed those buttons are genuinely still on screen, and
+    this entry is the only thing standing between a second click and a duplicate
+    -- or superseded -- turn. Unsettled entries are inherently few (one per
+    control mid-edit or whose edit failed), so refusing to evict them keeps the
+    bound meaningful while making it safe.
+    """
+    key = (channel, ts)
+    if key in _ANSWERED:
+        return False
+    _ANSWERED[key] = False
+    _evict_settled_answers()
+    return True
+
+
+def _evict_settled_answers() -> None:
+    """Trim the claim map, dropping ONLY controls whose buttons are gone.
+
+    Stops at the first pass that finds nothing evictable, so a map full of live
+    claims grows past the cap rather than re-admitting a click. That is the right
+    trade: the cap exists to bound memory, not to bound correctness.
+    """
+    if len(_ANSWERED) <= _MAX_EDIT_LOCKS:
+        return
+    for key, settled in list(_ANSWERED.items()):
+        if len(_ANSWERED) <= _MAX_EDIT_LOCKS:
+            return
+        if settled:
+            _ANSWERED.pop(key, None)
+
+
+def settle_options_answer(channel: str, ts: str) -> None:
+    """Mark this control's buttons as provably gone, making the claim evictable.
+
+    Called once the original message is known to be off screen -- rewritten in
+    place, or replaced and successfully deleted. Until then the claim is pinned:
+    a click can still arrive and must still lose.
+    """
+    if (channel, ts) in _ANSWERED:
+        _ANSWERED[(channel, ts)] = True
+
+
+def track_answer_routing(thread_ts: str, task: asyncio.Task[Any]) -> None:
+    """Remember that an OPTIONS answer for *thread_ts* is on its way to a session.
+
+    A click that succeeds does two things: it FORGETS the record (the control is
+    spent) and it dispatches the answer as a task. Between those, the record --
+    which is what the unlink handler consults to decide whether the thread is
+    still needed -- is already gone, while the answer has not yet resolved which
+    session it belongs to. An unlink landing in that window pops the thread from
+    the reverse index and the answer starts a BRAND-NEW Slack session carrying the
+    user's selection: the same corruption the unlink ordering was built to
+    prevent, reached from the other side.
+
+    Registered by task, not by a counter, so nothing can leak: a task that
+    finishes -- or raises, or is cancelled -- stops counting as in flight by
+    itself, and a stuck counter that made unlink refuse forever would be a worse
+    bug than the one being fixed.
+    """
+    bucket = _ANSWER_ROUTING.setdefault(thread_ts, set())
+    bucket.add(task)
+
+    def _done(finished: asyncio.Task[Any]) -> None:
+        live = _ANSWER_ROUTING.get(thread_ts)
+        if live is None:
+            return
+        live.discard(finished)
+        if not live:
+            _ANSWER_ROUTING.pop(thread_ts, None)
+
+    task.add_done_callback(_done)
+
+
+def answer_routing_in_flight(thread_ts: str) -> bool:
+    """Is an OPTIONS answer for *thread_ts* still finding its session?
+
+    Prunes finished tasks on the way past, so a missed callback cannot pin a
+    thread as busy forever.
+    """
+    if not thread_ts:
+        return False
+    live = _ANSWER_ROUTING.get(thread_ts)
+    if not live:
+        return False
+    for task in list(live):
+        if task.done():
+            live.discard(task)
+    if not live:
+        _ANSWER_ROUTING.pop(thread_ts, None)
+        return False
+    return True
+
+
+def release_options_answer(channel: str, ts: str) -> None:
+    """Give the claim back, because nothing was actually answered.
+
+    A claim means "this control's answer has been dealt with". If the submit that
+    took it then fails to render the selection at all -- the in-place edit fails
+    AND the replacement post fails -- nothing happened, the buttons are still on
+    screen, and holding the claim would refuse every retry forever: a control
+    permanently visible and permanently unanswerable.
+
+    Only for the no-op case. Once the message shows the selection the claim must
+    STAY, even if a later step stumbles, because the answer is on screen and the
+    turn is on its way.
+    """
+    _ANSWERED.pop((channel, ts), None)
+
+
+def mark_options_terminal(channel: str, ts: str) -> None:
+    """Record that this control can never be answered again.
+
+    Called by the expiry once it has struck the choices through, while it still
+    holds the message's edit lock. Without this, a Send click queued behind a
+    successful expiry would find the claim unheld, take it, and dispatch an answer
+    to the question the expiry just retired -- the stale click this whole lifecycle
+    exists to prevent, arriving through the one door the click-vs-click claim does
+    not cover.
+
+    Same store as :func:`claim_options_answer`, so the loser is refused by exactly
+    the check a duplicate click hits.
+
+    Recorded as SETTLED: the caller only reaches here once ``expire_options``
+    confirmed the strike-through edit landed, so the buttons are gone and this
+    entry may be evicted under memory pressure.
+    """
+    _ANSWERED[(channel, ts)] = True
+    _evict_settled_answers()
+
+
+def options_edit_lock(channel: str, ts: str) -> "_OptionsEditLock":
+    """The one lock guarding edits to a single OPTIONS message.
+
+    Two writers race for the same Slack message: this module's expiry, and the
+    Send handler rewriting it with the user's selection. Without a shared lock the
+    expiry's edit can land AFTER the selection's and erase the answer the user
+    just gave. Slack offers no compare-and-set on an edit, so ordering has to be
+    imposed here — and it can be, because both writers run in this one gateway
+    process. (Two gateways driving the same workspace would defeat it; that is not
+    a supported topology.)
+
+    Holding this lock is not sufficient on its own: the expiry must ALSO re-read,
+    inside the lock, whether its record is still tracked — a Send that won the
+    race forgets the record, and that is what tells the expiry to skip its edit.
+
+    Created lazily and never awaited between lookup and insert, so no registry
+    lock is needed on a single-threaded event loop. Bounded: once the registry
+    exceeds ``_MAX_EDIT_LOCKS``, uncontended entries are dropped, since a lock
+    nobody holds carries no state worth keeping.
+    """
+    key = (channel, ts)
+    lock = _EDIT_LOCKS.get(key)
+    if lock is None:
+        lock = _EDIT_LOCKS[key] = asyncio.Lock()
+    _prune_edit_locks(key)
+    return _OptionsEditLock(key, lock)
+
+
+def _prune_edit_locks(keep: tuple[str, str]) -> None:
+    """Trim the registry, dropping ONLY entries nobody is using.
+
+    ``not lock.locked()`` is not that test. A lock that was just released still
+    has its next waiter scheduled but not yet resumed, and it reads as unlocked in
+    that window: evicting it there hands the following caller a BRAND-NEW lock for
+    the same message while the waiter proceeds on the old one, so two coroutines
+    edit one Slack message at once and every guarantee built on this lock is off.
+
+    So interest is counted explicitly, registered before the acquire and dropped
+    after the release, and an entry with any interest is never evicted. As in the
+    answer-claim map, the cap bounds memory, not correctness: a registry full of
+    live locks grows past it rather than splitting synchronization.
+    """
+    if len(_EDIT_LOCKS) <= _MAX_EDIT_LOCKS:
+        return
+    for stale_key, stale in list(_EDIT_LOCKS.items()):
+        if len(_EDIT_LOCKS) <= _MAX_EDIT_LOCKS:
+            return
+        if stale_key != keep and not stale.locked() and not _LOCK_USERS.get(stale_key):
+            del _EDIT_LOCKS[stale_key]
+
+
+class _OptionsEditLock:
+    """Async context manager that pins its registry entry while anyone wants it.
+
+    Holds a direct reference to the lock, so even a pathological eviction could
+    not swap it for a different object mid-flight.
+    """
+
+    __slots__ = ("_key", "_lock")
+
+    def __init__(self, key: tuple[str, str], lock: asyncio.Lock) -> None:
+        self._key = key
+        self._lock = lock
+
+    async def __aenter__(self) -> "_OptionsEditLock":
+        # Registered BEFORE the await: a coroutine waiting on the lock has to be
+        # visible to the pruner, and after `acquire()` suspends it is too late.
+        _LOCK_USERS[self._key] = _LOCK_USERS.get(self._key, 0) + 1
+        try:
+            await self._lock.acquire()
+        except BaseException:
+            # Cancelled while waiting -- give the interest back or the entry is
+            # pinned forever, which is the leak the answer-claim map avoids too.
+            self._drop_interest()
+            raise
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        self._lock.release()
+        self._drop_interest()
+        return False
+
+    def _drop_interest(self) -> None:
+        remaining = _LOCK_USERS.get(self._key, 1) - 1
+        if remaining > 0:
+            _LOCK_USERS[self._key] = remaining
+        else:
+            _LOCK_USERS.pop(self._key, None)
+
+
+async def expire_options(slack: SlackClientOps, posted: PostedOptions) -> bool:
+    """Render a previously-posted OPTIONS control as spent.
+
+    Strikes every choice through, so a control the conversation has moved past
+    reads as unanswerable rather than inviting a click that would answer a
+    superseded question. Only the OPTIONS block is replaced; surrounding blocks
+    survive.
+
+    Returns True when the record is SETTLED and the caller should stop tracking
+    it — either the edit landed, or it failed in a way that will fail identically
+    forever (a deleted message, a channel we are not in, a malformed payload).
+    Returns False only for a transient failure, so the caller can keep the record
+    and try again on a later turn instead of leaving a live control on screen
+    with nothing tracking it.
+
+    Still never raises: a thread that keeps a stale control is bad, but it is not
+    worth disrupting the turn that triggered the cleanup.
+    """
+    try:
+        spent = build_options_selected_blocks(list(posted.choices), [])
+        blocks = replace_options_blocks(list(posted.blocks), spent)
+        await slack.update_message(posted.channel, posted.ts, text=posted.text, blocks=blocks)
+        return True
+    except Exception as exc:
+        if is_retryable_slack_error(exc):
+            logger.debug(
+                "Slack OPTIONS control expiry failed transiently; keeping the "
+                "record so a later turn retries it",
+                exc_info=True,
+            )
+            return False
+        logger.debug("Failed to expire Slack OPTIONS control", exc_info=True)
+        return True

--- a/src/kiro_crew/slack/renderer.py
+++ b/src/kiro_crew/slack/renderer.py
@@ -36,6 +36,7 @@ from kiro_crew.slack.handler import (
     _tool_to_phase,
     build_timing_footer,
 )
+from kiro_crew.slack.outbound import PostedOptions
 from kiro_crew.slack.transport import SLACK_CAPABILITIES
 
 #: Block Kit action_id prefixes for tool approve/deny buttons.
@@ -239,6 +240,9 @@ class SlackRenderer(Renderer):
         self._now = now or time.monotonic
         self._stream_ts: str | None = None
         self._use_slack_stream = True  # False => chat.update cursor fallback
+        # Set at turn end when this turn's footer carried an OPTIONS control, so
+        # the dispatcher can record it against the session and expire it later.
+        self.posted_options: PostedOptions | None = None
         self._accumulated = ""
         self._bracket_hold = ""  # held text from '[' until ']' to filter [OPTIONS:]
         self._stream_buffer = ""  # unsent text buffered between throttled flushes
@@ -595,4 +599,17 @@ class SlackRenderer(Renderer):
         turn_elapsed = (self._now() - self._t0) if self._t0 else 0.0
         footer_blocks, footer_text = build_timing_footer(turn_elapsed, None)
         footer_blocks = _append_footer_actions(footer_blocks, options, self.thread_ts, None, None)
-        await self.slack.post_blocks(self.channel, footer_blocks, footer_text, self.thread_ts)
+        footer_ts = await self.slack.post_blocks(
+            self.channel, footer_blocks, footer_text, self.thread_ts
+        )
+        if options and footer_ts:
+            # The footer carries this turn's OPTIONS control. Record where it
+            # landed so the next turn can strike it through once the
+            # conversation has moved past the question it asked.
+            self.posted_options = PostedOptions(
+                channel=self.channel,
+                ts=footer_ts,
+                choices=tuple(options),
+                blocks=tuple(footer_blocks),
+                text=footer_text,
+            )

--- a/src/kiro_crew/slack/retry.py
+++ b/src/kiro_crew/slack/retry.py
@@ -30,6 +30,31 @@ _RETRYABLE_EXCEPTIONS = (
 )
 
 
+def is_retryable_slack_error(exc: BaseException) -> bool:
+    """True when *exc* is worth another attempt rather than treating as final.
+
+    The one classification rule, shared so callers cannot drift (this module's
+    whole reason for existing): a ``SlackApiError`` carrying a 4xx other than
+    429 is the caller's own fault — a deleted message, a channel we are not in,
+    a malformed payload — and will fail identically forever, so retrying it only
+    burns quota. Everything else (429, 5xx, DNS/connector blips, timeouts) is
+    transient. Anything outside the retryable classes is not a transport failure
+    at all and is likewise final.
+
+    A ``SlackApiError`` whose response carries no integer status is treated as
+    final: without a status there is nothing to suggest the next attempt would
+    differ.
+    """
+    if not isinstance(exc, _RETRYABLE_EXCEPTIONS):
+        return False
+    if not isinstance(exc, SlackApiError):
+        return True
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if not isinstance(status, int):
+        return False
+    return status == 429 or status >= 500
+
+
 async def open_dm_with_retry(
     slack: Any,
     user_id: str,
@@ -48,12 +73,7 @@ async def open_dm_with_retry(
         try:
             return await slack.open_dm(user_id)
         except _RETRYABLE_EXCEPTIONS as exc:
-            retryable = (
-                not isinstance(exc, SlackApiError)
-                or exc.response.status_code == 429
-                or exc.response.status_code >= 500
-            )
-            if not retryable:
+            if not is_retryable_slack_error(exc):
                 raise
             if attempt < max_attempts:
                 logger.warning(

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -20,8 +20,12 @@ import asyncio
 import logging
 import re
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
+from kiro_crew.dashboard.chat_utils import (
+    expire_slack_options,
+    remember_slack_options,
+)
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import HOOK_REPLY, TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.llm_helpers import save_conversation_turn_off_loop
@@ -50,6 +54,7 @@ from kiro_crew.stats import Stats
 if TYPE_CHECKING:
     from kiro_crew.context import ContextBuilder
     from kiro_crew.cron import CronService
+    from kiro_crew.dashboard.state import DashboardState
     from kiro_crew.history import ConversationLog, HistoryConsolidator
     from kiro_crew.providers.base import LLMProvider
     from kiro_crew.session import SessionManager
@@ -296,6 +301,29 @@ async def handle_message_transport(
     ):
         return
 
+    # A new turn supersedes whatever question the previous one ended on, so any
+    # OPTIONS control still live in this thread stops being answerable.
+    #
+    # Placed HERE, below every short-circuit above, because only a message that
+    # actually starts a turn supersedes anything. ``ping``, ``status``, a
+    # modifier-only message, a hook's canned reply and the keyword commands all
+    # answer and return WITHOUT running the agent, so the conversation has not
+    # moved and the pending question is still the one being waited on --
+    # expiring for those spends a live control and leaves valid choices
+    # unanswerable, the exact inverse of the stale click this lifecycle exists to
+    # prevent. Keeping it at one point below the short-circuits, rather than
+    # guarding each of them, means a shortcut added later inherits the right
+    # behaviour instead of silently reintroducing this.
+    #
+    # Resolve the OWNING session, not the key derived above: the control is
+    # recorded under whichever session owns the thread, and for a
+    # dashboard-linked thread that is its ``dashboard:chat-N`` key. Expiring
+    # under the wrong key silently no-ops and leaves the control clickable.
+    await expire_slack_options(
+        cast("DashboardState | None", get_dashboard_state()),
+        sessions.get_session_for_thread(reply_ts) or session_key,
+    )
+
     client: LLMProvider | None = None
     _acquired = False
     renderer: SlackRenderer | None = None
@@ -365,6 +393,19 @@ async def handle_message_transport(
             session_key, agent=_agent, channel_id=channel
         )
         _acquired = True
+        # Expire AGAIN, now that the turn is serialized. The pass above (just
+        # before the turn machinery) runs before `get_or_create` waits its turn,
+        # so two messages arriving together both clear the control while it is
+        # still the OLD one — then the first turn ends by posting a NEW control,
+        # which the second turn never expires because its only pass already
+        # happened. The user is left with live buttons from a question the
+        # conversation has already moved past, which is the exact defect this
+        # path exists to prevent. Same staleness reasoning as the FRESH thread
+        # read below.
+        await expire_slack_options(
+            cast("DashboardState | None", get_dashboard_state()),
+            sessions.get_session_for_thread(reply_ts) or session_key,
+        )
         if is_new:
             await sessions.set_channel(session_key, channel)
         if not linked_session_key and not sessions.get_session_for_thread(reply_ts):
@@ -498,6 +539,11 @@ async def handle_message_transport(
             # a DENY is un-overridable by auto/trust/YOLO).
             tool_gate=_tool_gate,
         )
+        # The thread's owner as of the moment the turn starts producing output.
+        # A dashboard link landing during the run moves the conversation to a
+        # different session, which makes any control this turn posts stale the
+        # instant it lands — compared after the run below.
+        _pre_run_owner = sessions.get_session_for_thread(reply_ts) or session_key
         accumulated = await driver.run(full_message)
 
         # ── Post-turn bookkeeping ──
@@ -507,6 +553,48 @@ async def handle_message_transport(
         # to the outer except and double-record the turn as a failure.
         sessions.record_success(session_key)
         Stats().inc_message_success()
+
+        # Remember this turn's OPTIONS control, if it posted one, so the next
+        # turn on this thread can strike it through.
+        try:
+            # The LIVE owner of the thread, not the key this turn started
+            # under. A thread linked to a dashboard mid-turn changes owner,
+            # and the next turn's expiry looks the control up under the new
+            # key — so recording under the old one files it where nothing
+            # will ever find it, leaving the control clickable into a
+            # question the conversation has already passed.
+            _options_owner = sessions.get_session_for_thread(reply_ts) or session_key
+            remember_slack_options(
+                cast("DashboardState | None", get_dashboard_state()),
+                _options_owner,
+                renderer.posted_options,
+            )
+            # An owner change during the run IS supersession: the thread now
+            # belongs to a different session, so the control this turn just
+            # posted asks a question the conversation has moved past. Spend it
+            # ourselves — narrowed to our own ts, so a control the new owner
+            # recorded meanwhile survives.
+            #
+            # Deliberately NOT also checking ``sessions.is_busy`` here, unlike the
+            # native footer path. There the permit is released before the footer
+            # goes up, so a busy session means somebody ELSE. Here the turn still
+            # holds its semaphore at this point (``record_success`` resets the
+            # failure counter, it does not release), so ``is_busy`` would report
+            # OUR OWN turn and strike every fresh control through the moment it
+            # was posted — a worse defect than the one this guards.
+            _posted = renderer.posted_options
+            if _posted is not None and _options_owner != _pre_run_owner:
+                await expire_slack_options(
+                    cast("DashboardState | None", get_dashboard_state()),
+                    _options_owner,
+                    ts=_posted.ts,
+                )
+        except Exception:
+            logger.debug(
+                "transport_dispatch: failed to record OPTIONS control session=%s",
+                session_key,
+                exc_info=True,
+            )
 
         try:
             sessions.check_context_usage(session_key, client)

--- a/test/chat_test_helpers.py
+++ b/test/chat_test_helpers.py
@@ -37,6 +37,28 @@ def _make_state(tmp_path, **kwargs):
     sessions.remove = AsyncMock()
     sessions.recycle_background = AsyncMock()
     sessions.get_pid = MagicMock(return_value=None)
+    # Real in-memory Slack-link store rather than bare MagicMocks. The unlink
+    # path unpacks get_slack_link into (thread_ts, channel_id) and branches on
+    # whether a link is PRESENT, and a MagicMock satisfies neither: it iterates
+    # empty (ValueError on unpack) and is unconditionally truthy. Parity with
+    # SessionStore: absent -> (None, None); clear -> True iff a link was there.
+    _slack_links: dict[str, tuple[str, str]] = {}
+
+    def _set_slack_link(key, thread_ts, channel_id):
+        if thread_ts or channel_id:
+            _slack_links[key] = (thread_ts, channel_id)
+        else:
+            _slack_links.pop(key, None)
+
+    def _get_slack_link(key):
+        return _slack_links.get(key, (None, None))
+
+    def _clear_slack_link(key):
+        return _slack_links.pop(key, None) is not None
+
+    sessions.set_slack_link = MagicMock(side_effect=_set_slack_link)
+    sessions.get_slack_link = MagicMock(side_effect=_get_slack_link)
+    sessions.clear_slack_link = MagicMock(side_effect=_clear_slack_link)
     state = DashboardState(
         sessions=sessions,
         crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -585,6 +585,34 @@ def _isolate_kiro_window_cache():
 
 
 @pytest.fixture(autouse=True)
+def _reset_options_control_state():
+    """Clear the per-message OPTIONS registries between tests.
+
+    ``kiro_crew.slack.outbound`` holds two process-global maps keyed by
+    ``(channel, ts)``: the per-message edit lock, and the once-only answer claim
+    that stops a second Send click dispatching a duplicate turn. Both are
+    correct as process state in the gateway, where a control's ts is unique and
+    lives as long as the message does.
+
+    Tests are the opposite: fixtures reuse a fixed pair like ``("CH1", "msg1")``
+    across unrelated cases, so without this the first test to submit claims the
+    control and every later test's click is silently dropped as a duplicate.
+    Reset per test rather than making production defensive about it.
+    """
+    from kiro_crew.slack import outbound
+
+    outbound._ANSWERED.clear()
+    outbound._EDIT_LOCKS.clear()
+    outbound._ANSWER_ROUTING.clear()
+    outbound._LOCK_USERS.clear()
+    yield
+    outbound._ANSWERED.clear()
+    outbound._EDIT_LOCKS.clear()
+    outbound._ANSWER_ROUTING.clear()
+    outbound._LOCK_USERS.clear()
+
+
+@pytest.fixture(autouse=True)
 def _isolate_subagents_dir(_isolation_dirs, monkeypatch):
     """Pin the subagent registry dir to a tmp dir for the whole suite.
 

--- a/test/test_options_submit.py
+++ b/test/test_options_submit.py
@@ -195,6 +195,68 @@ class TestHandleOptionsSubmit:
             mock_hm.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_delete_failure_keeps_the_record_for_a_later_turn(self, orch, monkeypatch):
+        """A failed delete leaves the original buttons on screen — keep the record.
+
+        update_message fails, the fallback post succeeds, then delete_message
+        fails. The original OPTIONS message is therefore still in the channel and
+        still clickable, so forgetting its record here would strand it: nothing
+        later could ever expire it. That is the exact defect this PR removes, so
+        the record has to survive the submit.
+        """
+        import asyncio as _aio
+
+        from kiro_crew.slack import interactions
+
+        monkeypatch.setattr(interactions, "_orch", orch)
+        monkeypatch.setattr(interactions, "is_allowed_user", lambda uid: True)
+        orch.slack.update_message = AsyncMock(side_effect=Exception("API error"))
+        orch.slack.delete_message = AsyncMock(side_effect=Exception("cant_delete"))
+
+        forgotten: list[str] = []
+        monkeypatch.setattr(
+            interactions,
+            "_forget_options_control",
+            lambda ts, msg=None, keys=None: forgotten.append(ts),
+        )
+
+        payload = _make_payload(["A"], ["A", "B"])
+        with patch.object(interactions, "handle_message", new_callable=AsyncMock):
+            await interactions._handle_options_submit(payload, "CH1", "msg1")
+            await _aio.sleep(0)
+
+        orch.slack.delete_message.assert_called_once_with("CH1", "msg1")
+        assert forgotten == []
+
+    @pytest.mark.asyncio
+    async def test_successful_edit_does_forget_the_record(self, orch, monkeypatch):
+        """Companion to the above, so the retention check cannot pass vacuously.
+
+        When the edit lands, the buttons are genuinely gone and the record SHOULD
+        be dropped.
+        """
+        import asyncio as _aio
+
+        from kiro_crew.slack import interactions
+
+        monkeypatch.setattr(interactions, "_orch", orch)
+        monkeypatch.setattr(interactions, "is_allowed_user", lambda uid: True)
+
+        forgotten: list[str] = []
+        monkeypatch.setattr(
+            interactions,
+            "_forget_options_control",
+            lambda ts, msg=None, keys=None: forgotten.append(ts),
+        )
+
+        payload = _make_payload(["A"], ["A", "B"])
+        with patch.object(interactions, "handle_message", new_callable=AsyncMock):
+            await interactions._handle_options_submit(payload, "CH1", "msg1")
+            await _aio.sleep(0)
+
+        assert forgotten == ["t1"]
+
+    @pytest.mark.asyncio
     async def test_post_blocks_failure_aborts(self, orch, monkeypatch):
         """When update fails AND post_blocks fallback also returns None, abort."""
         from kiro_crew.slack import interactions

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -107,6 +107,12 @@ class FakeSessionManager:
     def release(self, key):
         pass
 
+    def is_busy(self, key):
+        # Interface parity with the real SessionManager. False = no other turn is
+        # in flight, so the post-footer re-check treats a recorded OPTIONS control
+        # as still current — which is what these single-turn tests exercise.
+        return False
+
     def begin_turn(self, key):
         # Pre-dispatch gate parity with the real SessionManager (open state).
         pass

--- a/test/test_slack_options_lifecycle.py
+++ b/test/test_slack_options_lifecycle.py
@@ -1,0 +1,3134 @@
+"""OPTIONS lifecycle on the Slack surface.
+
+Two behaviours are locked in here:
+
+* every outbound path renders a trailing ``[OPTIONS: …]`` tag as a control,
+  never as literal text — including the link-time backfill, which used to post
+  message bodies verbatim;
+* a control stops being answerable once the conversation moves past the question
+  it asked, whichever surface the next turn arrives on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+
+from kiro_crew.slack.format import (
+    OPTIONS_CHECKBOXES_ACTION,
+    OPTIONS_SUBMIT_ACTION,
+    build_options_blocks,
+    replace_options_blocks,
+)
+from kiro_crew.slack.outbound import PostedOptions, expire_options
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _slack() -> MagicMock:
+    slack = MagicMock()
+    slack.post_message = AsyncMock(return_value="body_ts")
+    slack.post_blocks = AsyncMock(return_value="opt_ts")
+    slack.update_message = AsyncMock()
+    return slack
+
+
+def _recs(state, key):
+    """The OPTIONS records for *key*, read through the accessor the code uses.
+
+    Accepts a slot or a key. Given a slot it looks under the slot's EFFECTIVE
+    session key and, failing that, under its bare name -- test fixtures record
+    under whichever of the two reads more naturally, and the point of an assertion
+    here is which records exist, not which spelling filed them. Production has no
+    such ambiguity: record and expiry both resolve the live owner the same way, and
+    the accessor canonicalises what it is given.
+    """
+    from kiro_crew.dashboard.chat_utils import effective_session_key, options_records
+
+    if hasattr(key, "key"):
+        slot = key
+        return options_records(state, effective_session_key(slot)) or options_records(
+            state, slot.key
+        )
+    return options_records(state, key)
+
+
+def _set_recs(state, key, records):
+    """Seed OPTIONS records for *key* (the store is keyed by session key)."""
+    from kiro_crew.dashboard.chat_utils import effective_session_key, set_options_records
+
+    if hasattr(key, "key"):
+        key = effective_session_key(key)
+    set_options_records(state, key, records)
+
+
+def _posted_texts(slack: MagicMock) -> list[str]:
+    return [c.args[1] for c in slack.post_message.await_args_list]
+
+
+def _stub_non_turn_paths(monkeypatch, module) -> None:
+    """Let a plain message walk past the answer-and-return short-circuits.
+
+    The OPTIONS expiry deliberately sits BELOW every path that replies without
+    running the agent, so a test that wants to observe the expiry has to drive a
+    message that is not a command and get it past the modifier and keyword-command
+    gates. Both take a MagicMock ``sessions`` otherwise.
+    """
+
+    async def _no_modifiers(text, cmd_text, *_a, **_k):
+        return text, cmd_text, False
+
+    async def _no_keyword(*_a, **_k):
+        return False
+
+    monkeypatch.setattr(module, "maybe_apply_privacy_modifiers", _no_modifiers)
+    monkeypatch.setattr(module, "maybe_handle_keyword_command", _no_keyword)
+
+
+def _is_live_control(blocks: list[dict]) -> bool:
+    """True when *blocks* contain a clickable OPTIONS control."""
+    return any(
+        el.get("action_id") in (OPTIONS_CHECKBOXES_ACTION, OPTIONS_SUBMIT_ACTION)
+        for b in blocks
+        if b.get("type") == "actions"
+        for el in b.get("elements", [])
+    )
+
+
+def _context_text(blocks: list[dict]) -> str:
+    return " ".join(
+        el.get("text", "")
+        for b in blocks
+        if b.get("type") == "context"
+        for el in b.get("elements", [])
+    )
+
+
+class TestExpireOptions:
+    """Spending a control the conversation has moved past."""
+
+    @pytest.mark.asyncio
+    async def test_every_choice_is_struck_through(self):
+        slack = _slack()
+        blocks = build_options_blocks(["A", "B"])
+        posted = PostedOptions(
+            channel="C1", ts="opt_ts", choices=("A", "B"), blocks=tuple(blocks)
+        )
+
+        await expire_options(slack, posted)
+
+        blocks = slack.update_message.await_args.kwargs["blocks"]
+        assert not _is_live_control(blocks)
+        assert _context_text(blocks) == "~A~  |  ~B~"
+        assert slack.update_message.await_args.args == ("C1", "opt_ts")
+
+    @pytest.mark.asyncio
+    async def test_surrounding_blocks_survive(self):
+        """A turn's timing footer shares the message with its control."""
+        slack = _slack()
+        footer = {"type": "section", "text": {"type": "mrkdwn", "text": "12.3s"}}
+        control = {
+            "type": "actions",
+            "elements": [
+                {"type": "checkboxes", "action_id": OPTIONS_CHECKBOXES_ACTION},
+                {"type": "button", "action_id": OPTIONS_SUBMIT_ACTION},
+            ],
+        }
+        posted = PostedOptions(
+            channel="C1",
+            ts="opt_ts",
+            choices=("A", "B"),
+            blocks=(footer, control),
+            text="12.3s",
+        )
+
+        await expire_options(slack, posted)
+
+        blocks = slack.update_message.await_args.kwargs["blocks"]
+        assert footer in blocks
+        assert control not in blocks
+        assert not _is_live_control(blocks)
+
+    @pytest.mark.asyncio
+    async def test_slack_failure_is_swallowed(self):
+        """A thread keeping a live control is the status quo, not a new failure."""
+        slack = _slack()
+        slack.update_message = AsyncMock(side_effect=Exception("channel_not_found"))
+        posted = PostedOptions(
+            channel="C1", ts="opt_ts", choices=("A",), blocks=({"type": "actions"},)
+        )
+
+        await expire_options(slack, posted)  # must not raise
+
+        slack.update_message.assert_awaited_once()
+
+
+class TestReplaceOptionsBlocks:
+    """The block surgery shared by the click path and the expiry path."""
+
+    def test_replaces_control_in_place_and_preserves_the_rest(self):
+        top = {"type": "section", "text": {"type": "mrkdwn", "text": "top"}}
+        control = {
+            "type": "actions",
+            "elements": [{"type": "checkboxes", "action_id": OPTIONS_CHECKBOXES_ACTION}],
+        }
+        tail = {"type": "context", "elements": [{"type": "mrkdwn", "text": "tail"}]}
+        spent = [{"type": "context", "elements": [{"type": "mrkdwn", "text": "~A~"}]}]
+
+        result = replace_options_blocks([top, control, tail], spent)
+
+        assert result == [top, spent[0], tail]
+
+    def test_unrelated_actions_block_is_left_alone(self):
+        other = {
+            "type": "actions",
+            "elements": [{"type": "button", "action_id": "mc_link_dashboard"}],
+        }
+        spent = [{"type": "context", "elements": [{"type": "mrkdwn", "text": "~A~"}]}]
+
+        result = replace_options_blocks([other], spent)
+
+        assert other in result
+
+    def test_appends_when_no_control_is_present(self):
+        spent = [{"type": "context", "elements": [{"type": "mrkdwn", "text": "~A~"}]}]
+
+        result = replace_options_blocks([], spent)
+
+        assert result == spent
+
+    def test_input_blocks_are_not_mutated(self):
+        control = {
+            "type": "actions",
+            "elements": [{"type": "checkboxes", "action_id": OPTIONS_CHECKBOXES_ACTION}],
+        }
+        blocks = [control]
+
+        replace_options_blocks(blocks, [{"type": "context", "elements": []}])
+
+        assert blocks == [control]
+
+
+class TestLifecycleOnTheSlot:
+    """remember / expire / forget against a real slot registry."""
+
+    def _state(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+        state.push_slots_update = MagicMock()
+        state.slack_client = _slack()
+        return state
+
+    def _posted(self) -> PostedOptions:
+        return PostedOptions(
+            channel="C1",
+            ts="opt_ts",
+            choices=("A", "B"),
+            blocks=(
+                {
+                    "type": "actions",
+                    "elements": [
+                        {"type": "checkboxes", "action_id": OPTIONS_CHECKBOXES_ACTION}
+                    ],
+                },
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_recorded_control_is_expired_on_the_next_turn(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.dashboard.chat_utils import (
+            effective_session_key,
+            expire_slack_options,
+            remember_slack_options,
+        )
+
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        key = effective_session_key(slot)
+
+        remember_slack_options(state, key, self._posted())
+        assert _recs(state, slot)
+
+        await expire_slack_options(state, key)
+
+        state.slack_client.update_message.assert_awaited_once()
+        assert _recs(state, slot) == ()
+
+    @pytest.mark.asyncio
+    async def test_expiry_runs_once_even_if_more_turns_follow(
+        self, tmp_path, monkeypatch
+    ):
+        """The record is cleared before the edit, so a failure is not retried."""
+        from kiro_crew.dashboard.chat_utils import (
+            effective_session_key,
+            expire_slack_options,
+            remember_slack_options,
+        )
+
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        key = effective_session_key(slot)
+        remember_slack_options(state, key, self._posted())
+
+        await expire_slack_options(state, key)
+        await expire_slack_options(state, key)
+
+        assert state.slack_client.update_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_forget_stops_expiry_erasing_the_users_selection(
+        self, tmp_path, monkeypatch
+    ):
+        """A Send click already re-rendered the message with the choice made.
+
+        Striking every choice through afterwards would erase it, so the click
+        drops the record instead.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            effective_session_key,
+            expire_slack_options,
+            forget_slack_options,
+            remember_slack_options,
+        )
+
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        key = effective_session_key(slot)
+        remember_slack_options(state, key, self._posted())
+
+        forget_slack_options(state, key)
+        await expire_slack_options(state, key)
+
+        state.slack_client.update_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_state_without_slots_cannot_break_the_turn(
+        self, tmp_path, monkeypatch
+    ):
+        """Bookkeeping is cleanup, so it must never abort the turn it runs in.
+
+        ``_run_chat`` takes whatever state object its caller passes; several
+        callers pass a stand-in that has no slot registry at all.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            forget_slack_options,
+            remember_slack_options,
+        )
+
+        class _NoSlots:
+            slack_client = None
+
+        bare = _NoSlots()
+
+        remember_slack_options(bare, "dashboard:s1", self._posted())
+        await expire_slack_options(bare, "dashboard:s1")
+        forget_slack_options(bare, "dashboard:s1")
+
+    @pytest.mark.asyncio
+    async def test_a_raising_slot_registry_cannot_break_the_turn(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.dashboard.chat_utils import expire_slack_options
+
+        state = self._state(tmp_path, monkeypatch)
+        state.get_slot = MagicMock(side_effect=RuntimeError("registry down"))
+
+        await expire_slack_options(state, "dashboard:s1")
+
+        state.slack_client.update_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_click_clears_the_record_a_mirroring_session_holds(
+        self, tmp_path, monkeypatch
+    ):
+        """A thread can be owned by a dashboard session mirroring into it.
+
+        The control is then recorded under the dashboard key, so clearing only
+        the ``slack:<ts>`` key leaves it live — and the next dashboard turn
+        strikes it through, erasing the selection the user just made.
+
+        The link is established through the real endpoint, not by seeding the
+        thread index by hand: an earlier version of this test set
+        ``state._slack_to_slot`` itself and so passed while production never
+        registered that mapping at all.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            effective_session_key,
+            expire_slack_options,
+            remember_slack_options,
+        )
+        from kiro_crew.slack import interactions
+
+        state = self._state(tmp_path, monkeypatch)
+        state.slack_client.open_dm = AsyncMock(return_value="C1")
+        state.slack_client.post_message = AsyncMock(return_value="1785370133.085469")
+        state.owner_id = "U1"
+        state.sessions.set_slack_link = MagicMock()
+        slot = state.get_or_create_slot("s1")
+
+        async with TestClient(TestServer(_slack_app(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/slack-link", json={})
+            assert resp.status == 200
+            thread_ts = (await resp.json())["thread_ts"]
+
+        key = effective_session_key(slot)
+        remember_slack_options(state, key, self._posted())
+
+        orch = MagicMock()
+        orch.dashboard_state = state
+        monkeypatch.setattr(interactions, "_orch", orch)
+        interactions._forget_options_control(thread_ts)
+
+        await expire_slack_options(state, key)
+
+        state.slack_client.update_message.assert_not_awaited()
+        assert _recs(state, slot) == ()
+
+    def test_linking_registers_the_thread_so_a_click_can_route_back(
+        self, tmp_path, monkeypatch
+    ):
+        """The reverse index is what resolves a click back to this conversation.
+
+        The link handler used to assign the slot's fields directly and skip the
+        state helper that writes it, so a click on the replayed control could
+        not find the slot and answered into a separate Slack session.
+        """
+        from kiro_crew.dashboard.chat_utils import slack_options_owner_key
+
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        thread_ts = "1785370133.085469"
+
+        state.link_slack("s1", thread_ts, "C1")
+
+        assert state.get_linked_slot(thread_ts) is slot
+        assert slack_options_owner_key(state, thread_ts) == "dashboard:s1"
+
+    def test_the_owner_key_survives_a_missing_thread_index(
+        self, tmp_path, monkeypatch
+    ):
+        """The index is written by a helper a caller can forget.
+
+        Resolving through it alone is what made this silently return the wrong
+        session, so the resolver also matches on the slot's own link fields.
+        """
+        from kiro_crew.dashboard.chat_utils import slack_options_owner_key
+
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        thread_ts = "1785370133.085469"
+        slot._slack_linked = True
+        slot._slack_channel = "C1"
+        slot._slack_thread_ts = thread_ts
+        state._slack_to_slot.clear()
+
+        assert slack_options_owner_key(state, thread_ts) == "dashboard:s1"
+
+    def test_an_unowned_thread_resolves_to_its_own_slack_key(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.dashboard.chat_utils import slack_options_owner_key
+
+        state = self._state(tmp_path, monkeypatch)
+
+        assert (
+            slack_options_owner_key(state, "1785370133.085469")
+            == "slack:1785370133.085469"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_slotless_session_is_still_tracked_and_expired(
+        self, tmp_path, monkeypatch
+    ):
+        """No dashboard slot must NOT mean no lifecycle (#1694).
+
+        This test previously asserted the opposite -- that a slotless session was a
+        no-op -- which was the defect: a plain Slack thread usually has no slot, so
+        the control was never recorded, no later turn could expire it, and the stale
+        click this whole lifecycle exists to prevent stayed possible. The store is
+        keyed by session key now, so the slotless case is ordinary.
+
+        Only a missing STATE is a genuine no-op: with nowhere to record, there is
+        nothing to expire.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            forget_slack_options,
+            options_records,
+            remember_slack_options,
+        )
+
+        state = self._state(tmp_path, monkeypatch)
+
+        remember_slack_options(state, "slack:1.0", self._posted())
+        assert options_records(state, "slack:1.0"), (
+            "a session with no dashboard slot must still have its control tracked"
+        )
+        await expire_slack_options(state, "slack:1.0")
+        state.slack_client.update_message.assert_awaited_once()
+        assert options_records(state, "slack:1.0") == ()
+
+        forget_slack_options(state, "slack:1.0")
+
+        # No state at all: nowhere to record, so nothing happens and nothing raises.
+        state.slack_client.update_message.reset_mock()
+        remember_slack_options(None, "slack:1.0", self._posted())
+        await expire_slack_options(None, "slack:1.0")
+        state.slack_client.update_message.assert_not_awaited()
+
+
+class TestTurnEntryWiring:
+    """The expiry has to actually fire on a new turn, from either surface.
+
+    The lifecycle helpers above are exercised directly, which would stay green
+    if the calls into them were deleted. These tests cover the call sites.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dashboard_turn_expires_before_doing_anything_else(
+        self, tmp_path, monkeypatch
+    ):
+        """Covers dashboard sends, queue drains, regenerate, rewind, cron
+        injection and the Slack-linked-thread route — every turn that runs
+        through the dashboard engine."""
+        from kiro_crew.dashboard import chat_runner
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+        state.push_slots_update = MagicMock()
+        slot = state.get_or_create_slot("s1")
+
+        calls: list[str] = []
+
+        async def _record(_state, session_key):
+            calls.append(session_key)
+
+        monkeypatch.setattr(chat_runner, "expire_slack_options", _record)
+        # The turn itself is irrelevant — the expiry runs before any provider
+        # work, so let the turn fail however it likes.
+        try:
+            await chat_runner._run_chat(state, slot, "hello")
+        except Exception:
+            pass
+
+        assert calls == ["dashboard:s1"]
+
+    @pytest.mark.asyncio
+    async def test_dashboard_prompt_expansion_is_not_a_new_turn(
+        self, tmp_path, monkeypatch
+    ):
+        """A /prompts reference re-enters the same turn; re-expiring there would
+        spend a control the user has not been shown an answer to yet."""
+        from kiro_crew.dashboard import chat_runner
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+        state.push_slots_update = MagicMock()
+        slot = state.get_or_create_slot("s1")
+
+        calls: list[str] = []
+
+        async def _record(_state, session_key):
+            calls.append(session_key)
+
+        monkeypatch.setattr(chat_runner, "expire_slack_options", _record)
+        try:
+            await chat_runner._run_chat(state, slot, "hello", _prompt_depth=1)
+        except Exception:
+            pass
+
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_slack_inbound_turn_expires(self, monkeypatch):
+        """Covers the live Slack path, which never reaches the dashboard engine."""
+        from kiro_crew.slack import transport_dispatch
+
+        calls: list[str] = []
+
+        async def _record(_state, session_key):
+            calls.append(session_key)
+
+        async def _no_linked_thread(*_a, **_k):
+            return False
+
+        # Patch the binding the module actually calls, not the definition site:
+        # the import is module-scope, so `transport_dispatch` holds its own
+        # reference and patching `chat_utils` would not intercept it.
+        monkeypatch.setattr(transport_dispatch, "expire_slack_options", _record)
+        monkeypatch.setattr(
+            transport_dispatch, "maybe_route_linked_thread", _no_linked_thread
+        )
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", MagicMock())
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", MagicMock())
+        _stub_non_turn_paths(monkeypatch, transport_dispatch)
+
+        slack = _slack()
+        sessions = MagicMock()
+        # Slack-born: the thread index has no owner for it, so the turn runs
+        # under the syntactic slack:<ts> key. Must be set explicitly — a bare
+        # MagicMock returns a truthy stub and the dispatcher would reroute to it.
+        sessions.get_session_for_thread.return_value = None
+        # A PLAIN message, not "ping". The expiry deliberately sits below every
+        # short-circuit, so only a message that actually starts a turn reaches
+        # it -- see test_a_non_conversational_command_does_not_spend_a_live_control.
+        # The turn machinery past the expiry needs no provider to get that far.
+        try:
+            await transport_dispatch.handle_message_transport(
+                slack,
+                sessions,
+                "C1",
+                "hello",
+                "1785370133.085469",
+                "1785370133.085469",
+                "U1",
+            )
+        except Exception:
+            pass
+
+        assert calls == ["slack:1785370133.085469"]
+
+    @pytest.mark.asyncio
+    async def test_ping_does_not_spend_the_control(self, monkeypatch):
+        """The behavioural half of the ordering guarantee.
+
+        ``ping`` answers and returns without running the agent, so the pending
+        question is still the one being waited on and its control must survive.
+        This test previously used ``ping`` merely because it short-circuited
+        just after the old expiry -- which encoded the defect as the expectation.
+        """
+        from kiro_crew.slack import transport_dispatch
+
+        calls: list[str] = []
+
+        async def _record(_state, session_key):
+            calls.append(session_key)
+
+        async def _no_linked_thread(*_a, **_k):
+            return False
+
+        monkeypatch.setattr(transport_dispatch, "expire_slack_options", _record)
+        monkeypatch.setattr(
+            transport_dispatch, "maybe_route_linked_thread", _no_linked_thread
+        )
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", MagicMock())
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", MagicMock())
+
+        slack = _slack()
+        sessions = MagicMock()
+        sessions.get_session_for_thread.return_value = None
+        await transport_dispatch.handle_message_transport(
+            slack, sessions, "C1", "ping", "1785370133.085469", "1785370133.085469", "U1"
+        )
+
+        assert calls == [], (
+            "a health command must not spend a live OPTIONS control -- it answers "
+            "without advancing the conversation"
+        )
+        slack.post_message.assert_awaited_once()
+
+    @pytest.mark.parametrize(
+        "module_name,func_name",
+        [
+            ("kiro_crew.slack.transport_dispatch", "handle_message_transport"),
+            ("kiro_crew.slack.handler", "handle_message"),
+        ],
+    )
+    def test_slack_inbound_expires_again_after_the_turn_serializes(
+        self, module_name, func_name
+    ):
+        """Expiry must run BOTH before and after the turn serializes.
+
+        `get_or_create` is where a turn waits for its session, so an expiry that
+        only runs before it is decided on pre-wait state. Two messages arriving
+        together both clear the OLD control; the first turn then ends by posting a
+        NEW one, which the second turn never expires because its only pass already
+        happened — leaving the user live buttons for a question the conversation
+        has moved past.
+
+        This is a STRUCTURAL check on call order rather than a behavioural one:
+        the inbound path bails long before session acquisition under any harness
+        cheap enough to build here (governance, hooks and provider setup all sit
+        in between), so driving it end-to-end would test the stubs. Asserting the
+        order in the source is what actually fails when someone deletes the second
+        pass, which is the regression worth catching. Same omission-detector shape
+        the rest of this class uses.
+        """
+        import importlib
+        import inspect
+
+        module = importlib.import_module(module_name)
+        source = inspect.getsource(getattr(module, func_name))
+
+        acquire = source.find("get_or_create(")
+        assert acquire != -1, f"{func_name} no longer calls get_or_create"
+
+        before = source.find("expire_slack_options(")
+        after = source.find("expire_slack_options(", acquire)
+
+        assert before != -1 and before < acquire, (
+            f"{func_name} must expire the control BEFORE acquiring the session"
+        )
+        assert after != -1, (
+            f"{func_name} must expire AGAIN after get_or_create returns, or a "
+            "control posted while this turn was queued stays clickable"
+        )
+
+    @pytest.mark.asyncio
+    async def test_slack_inbound_expires_the_threads_owning_session(self, monkeypatch):
+        """A Slack reply in a dashboard-owned thread must spend THAT session's control.
+
+        The dispatcher resolves the thread to its owning session before the turn
+        begins, so a thread the dashboard created answers under its own key. The
+        expiry has to run after that resolution — expiring ``slack:<ts>`` would
+        leave the dashboard session's control live and strike through nothing.
+        """
+        from kiro_crew.slack import transport_dispatch
+
+        calls: list[str] = []
+
+        async def _record(_state, session_key):
+            calls.append(session_key)
+
+        async def _no_linked_thread(*_a, **_k):
+            return False
+
+        # Patch the binding the module actually calls, not the definition site:
+        # the import is module-scope, so `transport_dispatch` holds its own
+        # reference and patching `chat_utils` would not intercept it.
+        monkeypatch.setattr(transport_dispatch, "expire_slack_options", _record)
+        monkeypatch.setattr(
+            transport_dispatch, "maybe_route_linked_thread", _no_linked_thread
+        )
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", MagicMock())
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", MagicMock())
+        _stub_non_turn_paths(monkeypatch, transport_dispatch)
+
+        slack = _slack()
+        sessions = MagicMock()
+        sessions.get_session_for_thread.return_value = "dashboard:chat-7-1785370000"
+        try:
+            await transport_dispatch.handle_message_transport(
+                slack,
+                sessions,
+                "C1",
+                "hello",
+                "1785370133.085469",
+                "1785370133.085469",
+                "U1",
+            )
+        except Exception:
+            pass
+
+        assert calls == ["dashboard:chat-7-1785370000"]
+
+
+def _slack_app(state):
+    from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_link
+
+    app = web.Application()
+    app["state"] = state
+    app.router.add_post("/api/chat/slots/{slot}/slack-link", api_chat_slot_slack_link)
+    return app
+
+
+class TestLinkTimeBackfill:
+    """Replaying context into a freshly-linked thread."""
+
+    def _state(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.slack_client = MagicMock()
+        state.slack_client.open_dm = AsyncMock(return_value="C1")
+        state.slack_client.post_message = AsyncMock(return_value="ts1")
+        state.slack_client.post_blocks = AsyncMock(return_value="opt_ts")
+        state.owner_id = "U1"
+        state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+        state.sessions.set_slack_link = MagicMock()
+        state.push_slots_update = MagicMock()
+        return state
+
+    @pytest.mark.asyncio
+    async def test_replayed_options_are_a_control_not_literal_text(
+        self, tmp_path, monkeypatch
+    ):
+        """The backfill posted bodies verbatim, so the tag arrived as text.
+
+        This is the path that carries the reply when the Slack link is created
+        after the turn already finished — the mirror has nothing to send by
+        then, so the backfill is the only thing that puts the answer in Slack.
+        """
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "which one?")
+        slot.append("assistant", "Your call.\n\n[OPTIONS: Ship it | Hold off]")
+        slot.drain()
+
+        async with TestClient(TestServer(_slack_app(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/slack-link", json={})
+            assert resp.status == 200
+
+        texts = [c.args[1] for c in state.slack_client.post_message.await_args_list]
+        assert all("[OPTIONS:" not in t for t in texts)
+        blocks = state.slack_client.post_blocks.await_args.args[1]
+        assert _is_live_control(blocks)
+
+    @pytest.mark.asyncio
+    async def test_the_newest_reply_stays_answerable_and_is_recorded(
+        self, tmp_path, monkeypatch
+    ):
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("assistant", "Latest.\n\n[OPTIONS: A | B]")
+        slot.drain()
+
+        async with TestClient(TestServer(_slack_app(state))) as client:
+            await client.post("/api/chat/slots/s1/slack-link", json={})
+
+        assert _is_live_control(state.slack_client.post_blocks.await_args.args[1])
+        assert _recs(state, slot)
+        assert _recs(state, slot)[0].choices == ("A", "B")
+
+    @pytest.mark.asyncio
+    async def test_a_superseded_question_is_replayed_spent(
+        self, tmp_path, monkeypatch
+    ):
+        """The user already answered it — replaying it live would re-ask it."""
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("assistant", "Older.\n\n[OPTIONS: A | B]")
+        slot.append("user", "A")
+        slot.drain()
+
+        async with TestClient(TestServer(_slack_app(state))) as client:
+            await client.post("/api/chat/slots/s1/slack-link", json={})
+
+        blocks = state.slack_client.post_blocks.await_args.args[1]
+        assert not _is_live_control(blocks)
+        assert _context_text(blocks) == "~A~  |  ~B~"
+        assert _recs(state, slot) == ()
+
+    @pytest.mark.asyncio
+    async def test_a_trailing_system_row_does_not_spend_the_newest_reply(
+        self, tmp_path, monkeypatch
+    ):
+        """The transcript holds rows that are never replayed.
+
+        A completed turn appends one, so the last reply is not the last row.
+        Judging "newest" by raw position spent the very control the replay
+        exists to deliver — the user saw a struck-through question again.
+        """
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("assistant", "Your call.\n\n[OPTIONS: Ship it | Hold off]")
+        slot.append("done", "turn complete")
+        slot.drain()
+
+        async with TestClient(TestServer(_slack_app(state))) as client:
+            await client.post("/api/chat/slots/s1/slack-link", json={})
+
+        blocks = state.slack_client.post_blocks.await_args.args[1]
+        assert _is_live_control(blocks)
+        assert _recs(state, slot)
+
+    @pytest.mark.asyncio
+    async def test_a_users_own_options_syntax_survives_the_replay(
+        self, tmp_path, monkeypatch
+    ):
+        """A person can type the OPTIONS syntax — quoting it, or discussing it.
+
+        Routing user rows through the agent-authored path lifted the tag out of
+        their words and rendered it as struck-through choices they never offered.
+        Their text has to come back verbatim.
+        """
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        # The tag must END the message: the parser is line-anchored, so trailing
+        # words after it would make this pass whatever the code did.
+        slot.append("user", "should I paste this?\n\n[OPTIONS: A | B]")
+        slot.drain()
+
+        async with TestClient(TestServer(_slack_app(state))) as client:
+            await client.post("/api/chat/slots/s1/slack-link", json={})
+
+        texts = [c.args[1] for c in state.slack_client.post_message.await_args_list]
+        assert any("[OPTIONS: A | B]" in t for t in texts)
+        state.slack_client.post_blocks.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_only_the_newest_reply_is_answerable(self, tmp_path, monkeypatch):
+        state = self._state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("assistant", "First.\n\n[OPTIONS: A | B]")
+        slot.append("user", "A")
+        slot.append("assistant", "Second.\n\n[OPTIONS: C | D]")
+        slot.drain()
+
+        async with TestClient(TestServer(_slack_app(state))) as client:
+            await client.post("/api/chat/slots/s1/slack-link", json={})
+
+        posts = state.slack_client.post_blocks.await_args_list
+        assert len(posts) == 2
+        assert not _is_live_control(posts[0].args[1])
+        assert _is_live_control(posts[1].args[1])
+
+
+class TestNonStringKeyIsRefused:
+    """A key that is not a real string must never reach slot-key normalization.
+
+    ``_normalize_slot_key`` strips a repeated ``dashboard_`` prefix with an
+    unbounded ``while`` loop, which terminates only for a genuine ``str``.
+    Anything whose ``startswith`` is always truthy -- a MagicMock standing in
+    for a Slack payload field, for instance -- spins forever AND manufactures a
+    fresh child object every iteration. Silent, so no test fails and no timeout
+    trips; it simply eats memory until the process dies. On CI that presented
+    as a runner shutdown at a random point in the shard with zero FAILED lines.
+
+    The click path reaches this lookup with a thread id taken straight off the
+    interaction payload, so the type is not guaranteed at the call site -- the
+    guard belongs here.
+    """
+
+    @pytest.mark.timeout(5)
+    def test_a_non_string_key_returns_none_instead_of_spinning(self):
+        from kiro_crew.dashboard import chat_utils
+
+        state = MagicMock()
+
+        assert chat_utils.slack_options_slot(state, MagicMock()) is None
+        # Refused before any lookup: proves we never entered normalization.
+        state.get_slot.assert_not_called()
+
+    @pytest.mark.timeout(5)
+    def test_a_real_string_key_still_reaches_the_lookup(self):
+        from kiro_crew.dashboard import chat_utils
+
+        state = MagicMock()
+        sentinel = object()
+        state.get_slot.return_value = sentinel
+
+        assert chat_utils.slack_options_slot(state, "chat-1-123") is sentinel
+        state.get_slot.assert_called_once()
+
+
+class TestUnlinkSpendsTheControl:
+    """Unlinking must EXPIRE the OPTIONS control, not merely orphan the record.
+
+    Two failure modes, both closed by expiring rather than forgetting:
+
+    1. Forget-only leaves the buttons live in Slack. After the link is gone a
+       click answers a question from a conversation this thread is no longer
+       attached to, landing that stale answer in a brand-new session.
+    2. Doing nothing leaves the record unreachable once the thread -> slot
+       reverse index is popped, so the next dashboard turn's expiry strikes every
+       choice through — erasing an answer the user had already given.
+
+    Expiry does both halves: it strikes the choices through in Slack AND clears
+    the record. It has to run before the link is torn down, because popping the
+    index is what makes the record unreachable.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unlink_expires_a_live_options_control(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_unlink
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_slack.sel", lambda: MagicMock())
+
+        state = _make_state(tmp_path)
+        # Returns into the JSON body, so it has to be a real bool not a mock.
+        state.sessions.clear_slack_link = MagicMock(return_value=True)
+        slack = MagicMock()
+        slack.update_message = AsyncMock()
+        slack.post_message = AsyncMock()
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+        slot._slack_linked = True
+        slot._slack_channel = "C-1"
+        slot._slack_thread_ts = "thread-1"
+        state._slack_to_slot["thread-1"] = slot.key
+
+        _set_recs(
+            state,
+            slot,
+            (
+                PostedOptions(
+                    channel="C-1",
+                    ts="opt-1",
+                    choices=("A", "B"),
+                    blocks=(),
+                ),
+            ),
+        )
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-unlink", api_chat_slot_slack_unlink)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{slot.key}/slack-unlink")
+            assert resp.status == 200
+
+        # The buttons are struck through in Slack, so a click after the unlink
+        # cannot inject a stale answer into a new session.
+        slack.update_message.assert_awaited_once()
+        assert slack.update_message.await_args.args[0] == "C-1"
+        assert slack.update_message.await_args.args[1] == "opt-1"
+        # And the record is gone, so a later dashboard turn has nothing to strike
+        # through and cannot erase the user's selection.
+        assert _recs(state, slot) == ()
+        # The reverse index is still dropped — spending the control must not come
+        # at the cost of the thread continuing to resolve here.
+        assert "thread-1" not in state._slack_to_slot
+
+    @pytest.mark.asyncio
+    async def test_a_relink_during_the_expiry_await_is_not_clobbered(
+        self, tmp_path, monkeypatch
+    ):
+        """Unlink must not tear down a link that replaced the one it captured.
+
+        Neither plain ordering is safe. Tearing down BEFORE expiry leaves the
+        buttons live with the reverse index already gone, so a click resolves to
+        nothing and starts a brand-new session with a stale answer. Expiring
+        first, then tearing down unconditionally, lets a relink that landed during
+        the (Slack-bound) await get its in-memory fields wiped while its persisted
+        link survives. Compare-and-clear is the only ordering that closes both, so
+        this test pins the relink half.
+        """
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_unlink
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_slack.sel", lambda: MagicMock())
+
+        state = _make_state(tmp_path)
+        state.sessions.clear_slack_link = MagicMock(return_value=True)
+        slack = MagicMock()
+        slack.post_message = AsyncMock()
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+        slot._slack_linked = True
+        slot._slack_channel = "C-1"
+        slot._slack_thread_ts = "thread-1"
+        state._slack_to_slot["thread-1"] = slot.key
+
+        # Another tab relinks the slot to a NEW thread while expiry awaits Slack.
+        async def _relink_midway(_state, _session_key):
+            slot._slack_linked = True
+            slot._slack_channel = "C-2"
+            slot._slack_thread_ts = "thread-2"
+            _state._slack_to_slot["thread-2"] = slot.key
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_slack.expire_slack_options", _relink_midway
+        )
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-unlink", api_chat_slot_slack_unlink)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{slot.key}/slack-unlink")
+            assert resp.status == 200
+
+        # The replacement link survives intact -- fields AND reverse index.
+        assert slot._slack_linked is True
+        assert slot._slack_channel == "C-2"
+        assert slot._slack_thread_ts == "thread-2"
+        assert state._slack_to_slot.get("thread-2") == slot.key
+
+    @pytest.mark.asyncio
+    async def test_a_same_target_relink_does_not_leave_persistence_linked(
+        self, tmp_path, monkeypatch
+    ):
+        """A relink to the SAME thread must SURVIVE the unlink that raced it.
+
+        Persistence is cleared before the expiry await, so a relink landing during
+        it restores the identical channel/ts and the compare-and-clear sees equal
+        values -- in memory, indistinguishable from "nothing moved". Resolving that
+        by value can only guess. Persistence resolves it by PRESENCE: we cleared it,
+        and only ``link_slack`` writes it, so a link sitting there afterwards was
+        written during the await. It must be left alone -- link, persistence,
+        reverse index -- and the unlink must report a no-op rather than announcing
+        into a thread that is still syncing.
+        """
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_unlink
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_slack.sel", lambda: MagicMock())
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.post_message = AsyncMock()
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+        slot._slack_linked = True
+        slot._slack_channel = "C-1"
+        slot._slack_thread_ts = "thread-1"
+        state._slack_to_slot["thread-1"] = slot.key
+        session_key = effective_session_key(slot)
+        state.sessions.set_slack_link(session_key, "thread-1", "C-1")
+
+        # A relink to the SAME thread lands mid-await. Faithful to link_slack: it
+        # sets the slot fields, registers the reverse index, AND persists.
+        async def _same_target_relink(_state, _session_key, ts=None):
+            slot._slack_linked = True
+            slot._slack_channel = "C-1"
+            slot._slack_thread_ts = "thread-1"
+            _state._slack_to_slot["thread-1"] = slot.key
+            _state.sessions.set_slack_link(session_key, "thread-1", "C-1")
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_slack.expire_slack_options", _same_target_relink
+        )
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-unlink", api_chat_slot_slack_unlink)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{slot.key}/slack-unlink")
+            assert resp.status == 200
+            assert (await resp.json())["was_linked"] is False, (
+                "a superseded unlink must report a no-op, not claim it tore a link down"
+            )
+
+        # The relink survives, in memory AND in persistence -- they agree.
+        assert slot._slack_linked is True
+        assert slot._slack_channel == "C-1"
+        assert slot._slack_thread_ts == "thread-1"
+        assert state._slack_to_slot.get("thread-1") == slot.key
+        assert state.sessions.get_slack_link(session_key) == ("thread-1", "C-1"), (
+            "the relink's persisted link must not be cleared by the unlink it raced"
+        )
+        # ...and nothing was announced into the still-live thread.
+        assert slack.post_message.await_count == 0, (
+            "no 'replies here no longer sync' note may go into a thread that is "
+            "still syncing"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_unexpired_control_aborts_the_unlink(self, tmp_path, monkeypatch):
+        """A control we could not retire must keep its routing.
+
+        Round 29 deliberately keeps a record whose Slack edit failed transiently,
+        so a returned expiry does not prove the control was spent. Dropping the
+        reverse index while the buttons are still live is teardown-then-NEVER-
+        expire: a later click resolves to nothing and starts a BRAND-NEW session
+        carrying a stale answer -- the hazard the expire-first ordering exists to
+        avoid. Aborting is recoverable and visible; completing silently corrupts a
+        future conversation.
+        """
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_unlink
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_slack.sel", lambda: MagicMock())
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.post_message = AsyncMock()
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+        slot._slack_linked = True
+        slot._slack_channel = "C-1"
+        slot._slack_thread_ts = "thread-1"
+        state._slack_to_slot["thread-1"] = slot.key
+        session_key = effective_session_key(slot)
+        state.sessions.set_slack_link(session_key, "thread-1", "C-1")
+
+        # The expiry runs but leaves the record tracked -- a 429 that will be
+        # retried, exactly what round 29 guarantees.
+        stuck = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+
+        async def _expiry_fails(_state, _key, ts=None):
+            _set_recs(state, slot, (stuck,))
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_slack.expire_slack_options", _expiry_fails)
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-unlink", api_chat_slot_slack_unlink)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{slot.key}/slack-unlink")
+            assert resp.status == 503, (
+                "the unlink must refuse rather than orphan a live control; the "
+                "dashboard reads a non-2xx as 'session stays linked'"
+            )
+
+        # Routing survives, in memory AND in persistence, so a click still lands
+        # in the right conversation where a later turn can spend it.
+        assert slot._slack_linked is True
+        assert state._slack_to_slot.get("thread-1") == slot.key
+        assert state.sessions.get_slack_link(session_key) == ("thread-1", "C-1"), (
+            "the persisted link cleared at the top must be restored on abort"
+        )
+        assert slack.post_message.await_count == 0, (
+            "no 'unlinked' note may be posted for an unlink that did not happen"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_unraced_unlink_still_tears_the_link_down(self, tmp_path, monkeypatch):
+        """The other half: with no relink, persistence stays clear and teardown completes.
+
+        Guards the opposite failure from the test above -- treating every equal
+        comparison as "a relink landed" would turn every ordinary unlink into a
+        silent no-op.
+        """
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_unlink
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_slack.sel", lambda: MagicMock())
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.post_message = AsyncMock()
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+        slot._slack_linked = True
+        slot._slack_channel = "C-1"
+        slot._slack_thread_ts = "thread-1"
+        state._slack_to_slot["thread-1"] = slot.key
+        session_key = effective_session_key(slot)
+        state.sessions.set_slack_link(session_key, "thread-1", "C-1")
+
+        async def _no_relink(_state, _session_key, ts=None):
+            return None
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_slack.expire_slack_options", _no_relink)
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-unlink", api_chat_slot_slack_unlink)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{slot.key}/slack-unlink")
+            assert resp.status == 200
+            assert (await resp.json())["was_linked"] is True
+
+        assert slot._slack_linked is False
+        assert slot._slack_channel == ""
+        assert "thread-1" not in state._slack_to_slot
+        assert state.sessions.get_slack_link(session_key) in ((None, None), ("", "")), (
+            "an unraced unlink must leave persistence clear"
+        )
+
+
+class TestEveryOutstandingControlIsExpired:
+    """A newer control must not displace the record of an older live one.
+
+    One turn can post more than one OPTIONS message, and a single slot is
+    reachable from several posting paths. When the record was a single slot the
+    newer post overwrote the older one, so the older control stayed on screen
+    with nothing tracking it — clicking it answered a question the conversation
+    had already moved past, and the answer landed as if it were current.
+    """
+
+    @pytest.mark.asyncio
+    async def test_expiry_drains_all_recorded_controls(self, tmp_path):
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            remember_slack_options,
+        )
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.update_message = AsyncMock()
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+
+        first = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        second = PostedOptions(channel="C-1", ts="opt-2", choices=("B",), blocks=())
+        remember_slack_options(state, slot.key, first)
+        remember_slack_options(state, slot.key, second)
+
+        # Both are tracked — the second did not displace the first.
+        assert _recs(state, slot) == (first, second)
+
+        await expire_slack_options(state, slot.key)
+
+        edited = {call.args[1] for call in slack.update_message.await_args_list}
+        assert edited == {"opt-1", "opt-2"}, edited
+        assert _recs(state, slot) == ()
+
+    @pytest.mark.asyncio
+    async def test_a_cron_control_is_tracked_and_spent_under_its_session_key(self, tmp_path):
+        """A cron slot's name is not its session key folded, so it must still resolve.
+
+        A persistent cron runs on ``cron:<id>`` but its slot is named
+        ``cron-<id>``. The filename fold turns the colon into an underscore, so
+        the lookup asked for ``cron_<id>`` and matched nothing: the control was
+        never recorded, and the follow-up turn had nothing to expire — leaving a
+        live control answerable into a question the cron had moved past. The
+        resolver falls back to asking the slots their own identity, so both the
+        record and the expiry reach the same slot.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            remember_slack_options,
+            slack_options_slot,
+        )
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.update_message = AsyncMock()
+        state.slack_client = slack
+
+        # Exactly how cron_inject builds it: slot named cron-<id>, real key on
+        # linked_session_key.
+        slot = state.get_or_create_slot("cron-42")
+        slot.linked_session_key = "cron:42"
+        session_key = "cron:42"
+
+        # The folded spelling really does miss -- that is the defect.
+        assert state.get_slot("cron_42") is None
+        assert slack_options_slot(state, session_key) is slot
+
+        posted = PostedOptions(channel="C-1", ts="opt-cron", choices=("A",), blocks=())
+        remember_slack_options(state, session_key, posted)
+        assert _recs(state, slot) == (posted,), "the cron control must be tracked"
+
+        await expire_slack_options(state, session_key)
+
+        edited = {call.args[1] for call in slack.update_message.await_args_list}
+        assert edited == {"opt-cron"}, edited
+        assert _recs(state, slot) == ()
+
+    @pytest.mark.asyncio
+    async def test_a_transient_edit_failure_keeps_the_record_for_a_later_retry(self, tmp_path):
+        """A failed Slack edit must not orphan a control that is still live.
+
+        Records stay tracked across the edit and only settled ones are removed, so
+        a transient failure is simply never removed and a later turn retries it.
+        Dropping it would leave the buttons on screen with nothing tracking them —
+        a later click then injects an answer to a superseded question.
+        """
+        from slack_sdk.errors import SlackApiError
+
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            remember_slack_options,
+        )
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.update_message = AsyncMock(
+            side_effect=SlackApiError("ratelimited", MagicMock(status_code=429))
+        )
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+        posted = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        remember_slack_options(state, slot.key, posted)
+
+        await expire_slack_options(state, slot.key)
+
+        assert _recs(state, slot) == (posted,), (
+            "a transient edit failure must leave the control tracked so a later "
+            "turn can spend it, not orphan it live on screen"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_permanent_edit_failure_is_not_retried_forever(self, tmp_path):
+        """A message that can never be edited must not be retried every turn.
+
+        The mirror of the test above: keeping EVERY failure would mean a deleted
+        message or a channel we are no longer in burns an API call on every
+        subsequent turn, forever. A 4xx that is not a rate limit will fail
+        identically next time, so the record is settled.
+        """
+        from slack_sdk.errors import SlackApiError
+
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            remember_slack_options,
+        )
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.update_message = AsyncMock(
+            side_effect=SlackApiError("message_not_found", MagicMock(status_code=404))
+        )
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+        posted = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        remember_slack_options(state, slot.key, posted)
+
+        await expire_slack_options(state, slot.key)
+
+        assert _recs(state, slot) == (), (
+            "a permanently-failing edit must be treated as spent, or every later "
+            "turn retries it forever"
+        )
+
+    def test_a_cron_owned_control_is_forgotten_on_selection(self):
+        """The forget must cover the key the record actually used.
+
+        The record sites resolve the owner through the PERSISTED thread index, so
+        a control on a cron-linked thread is filed under ``cron:<id>``. The
+        ownership helpers only consulted the dashboard SLOT index (plus the
+        syntactic ``slack:<ts>``), which cannot see a cron link -- so the
+        selection's forget missed the record entirely and the next expiry edited
+        over the user's answer. It also defeated round 33's under-lock skip, which
+        relies on the forget having removed the record.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            slack_options_owner_key,
+            slack_options_session_keys,
+        )
+
+        state = MagicMock()
+        state._slack_to_slot = {}
+        state._slots = {}
+        state.get_linked_slot = MagicMock(return_value=None)
+        state.sessions.get_session_for_thread = MagicMock(return_value="cron:job-7")
+
+        assert slack_options_owner_key(state, "thread-1") == "cron:job-7", (
+            "recording must file the control under the cron session that owns the "
+            "thread, not the syntactic slack:<ts> key"
+        )
+        keys = slack_options_session_keys(state, "thread-1")
+        assert "cron:job-7" in keys, (
+            "clearing must cover the cron key or the record outlives the selection"
+        )
+
+    def test_an_unresolvable_owner_falls_back_without_inventing_a_key(self):
+        """A stub or a miss must not become a bogus session key.
+
+        The persisted index is typed ``str | None``; anything else means a caller
+        handed us a mock. Guards the helper against silently recording under a
+        MagicMock's repr.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            canonical_key,
+            slack_options_owner_key,
+            slack_options_session_keys,
+        )
+
+        state = MagicMock()
+        state._slack_to_slot = {}
+        state._slots = {}
+        state.get_linked_slot = MagicMock(return_value=None)
+        state.sessions.get_session_for_thread = MagicMock(return_value=MagicMock())
+
+        assert slack_options_owner_key(state, "thread-1") == canonical_key("thread-1")
+        assert slack_options_session_keys(state, "thread-1") == [canonical_key("thread-1")]
+
+    @pytest.mark.asyncio
+    async def test_a_selection_made_under_the_lock_is_not_overwritten(self, tmp_path):
+        """A click that wins the race must not have its answer erased.
+
+        Expiry and the Send handler both edit the SAME Slack message, and Slack
+        offers no compare-and-set. They now share ``options_edit_lock`` per
+        message, and the expiry re-reads its record INSIDE that lock -- so a Send
+        that already rewrote the message and dropped the record makes the expiry
+        skip its edit entirely, rather than landing late and replacing the
+        selection with a spent summary.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            forget_slack_options,
+            remember_slack_options,
+        )
+        from kiro_crew.slack.outbound import options_edit_lock
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        posted = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        remember_slack_options(state, slot.key, posted)
+
+        slack = MagicMock()
+        slack.update_message = AsyncMock()
+        state.slack_client = slack
+
+        # Hold the lock, then let a "click" rewrite the message and forget the
+        # record while the expiry is queued behind us.
+        lock = options_edit_lock("C-1", "opt-1")
+        async with lock:
+            expiring = asyncio.create_task(expire_slack_options(state, slot.key))
+            await asyncio.sleep(0)  # let the expiry reach the lock and block
+            forget_slack_options(state, slot.key, "opt-1")
+        await expiring
+
+        assert slack.update_message.await_count == 0, (
+            "the expiry must skip its edit once the click dropped the record -- "
+            "editing anyway erases the answer the user just gave"
+        )
+        assert _recs(state, slot) == ()
+
+    @pytest.mark.asyncio
+    async def test_a_click_during_a_failing_edit_is_not_resurrected(self, tmp_path):
+        """A control answered mid-await must stay answered.
+
+        The hazard is specific to retaining transient failures. A click landing
+        while the expiry's edit is being rate-limited renders the SELECTED summary
+        and forgets the record. If the expiry then wrote its unsettled records
+        back, it would resurrect the one just answered, and every later turn would
+        re-edit that message -- replacing the user's visible answer with a spent
+        summary. Only settled records may be removed; nothing is ever re-added.
+        """
+        from slack_sdk.errors import SlackApiError
+
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            forget_slack_options,
+            remember_slack_options,
+        )
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        posted = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+
+        async def _rate_limited_then_click(*_a, **_k):
+            # The click lands while this edit is in flight: it answers the
+            # control and drops the record, exactly as the submit path does.
+            forget_slack_options(state, slot.key, "opt-1")
+            raise SlackApiError("ratelimited", MagicMock(status_code=429))
+
+        slack = MagicMock()
+        slack.update_message = AsyncMock(side_effect=_rate_limited_then_click)
+        state.slack_client = slack
+
+        remember_slack_options(state, slot.key, posted)
+        await expire_slack_options(state, slot.key)
+
+        assert _recs(state, slot) == (), (
+            "a control answered while the edit was failing must NOT come back -- "
+            "re-adding it makes every later turn overwrite the user's answer"
+        )
+
+    @pytest.mark.asyncio
+    async def test_recording_the_same_control_twice_queues_one_edit(self, tmp_path):
+        """A retry, or two paths recording one post, is not two live controls."""
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            remember_slack_options,
+        )
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.update_message = AsyncMock()
+        state.slack_client = slack
+
+        slot = state.get_or_create_slot("s1")
+        posted = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        remember_slack_options(state, slot.key, posted)
+        remember_slack_options(state, slot.key, posted)
+
+        assert _recs(state, slot) == (posted,)
+
+        await expire_slack_options(state, slot.key)
+        slack.update_message.assert_awaited_once()
+
+
+class TestForgettingIsScopedToTheClickedControl:
+    """Answering one control must not un-track the others.
+
+    Once several controls can be outstanding at once, clearing the whole
+    collection on a click leaves the other ones on screen with nothing tracking
+    them — so a later click on one answers a superseded question and no expiry
+    can ever reach it. A click spends exactly the control it was made on.
+
+    The unscoped form is still correct for an unlink, where the entire
+    conversation is detaching and every control should stop being tracked.
+    """
+
+    def test_a_click_forgets_only_the_control_it_answered(self, tmp_path):
+        from kiro_crew.dashboard.chat_utils import (
+            forget_slack_options,
+            remember_slack_options,
+        )
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+
+        first = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        second = PostedOptions(channel="C-1", ts="opt-2", choices=("B",), blocks=())
+        remember_slack_options(state, slot.key, first)
+        remember_slack_options(state, slot.key, second)
+
+        forget_slack_options(state, slot.key, "opt-1")
+
+        # The answered one is spent; the other is STILL tracked, so a later turn
+        # can expire it instead of leaving it clickable forever.
+        assert _recs(state, slot) == (second,)
+
+    def test_omitting_the_ts_still_clears_everything(self, tmp_path):
+        """The unlink path detaches the whole conversation, so all of them go."""
+        from kiro_crew.dashboard.chat_utils import (
+            forget_slack_options,
+            remember_slack_options,
+        )
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        remember_slack_options(
+            state, slot.key, PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        )
+        remember_slack_options(
+            state, slot.key, PostedOptions(channel="C-1", ts="opt-2", choices=("B",), blocks=())
+        )
+
+        forget_slack_options(state, slot.key)
+
+        assert _recs(state, slot) == ()
+
+
+class TestControlPostedAfterTheWindowIsSpent:
+    """A control recorded after its expiry window closed must be spent on the spot.
+
+    Both sites post the control AFTER the point where a concurrent turn's expiry
+    pass would have seen it — the native handler releases the session permit long
+    before the timing footer goes up, and the link backfill awaits a Slack post per
+    replayed message. In both cases the superseding turn's expiry runs over a record
+    that does not exist yet, so nothing else will ever spend it. Each site therefore
+    re-checks after recording and expires immediately if the conversation moved on.
+    """
+
+    def test_native_footer_path_rechecks_business_after_recording(self):
+        """Structural: the recheck must sit AFTER remember_slack_options.
+
+        Driving `handle_message` to the footer requires a provider, a stream and a
+        full turn; the assertion that actually protects this is that the recheck
+        exists and comes after the record, so deleting it fails here.
+        """
+        import inspect
+
+        from kiro_crew.slack import handler
+
+        source = inspect.getsource(handler.handle_message)
+        record = source.find("remember_slack_options(")
+        assert record != -1, "handle_message no longer records the control"
+        recheck = source.find("is_busy(", record)
+        assert recheck != -1, (
+            "handle_message must re-check is_busy AFTER recording, or a control "
+            "posted once the permit is released stays live for a superseded question"
+        )
+        expire_after = source.find("expire_slack_options(", recheck)
+        assert expire_after != -1, "the is_busy re-check must lead to an expiry"
+
+    def test_native_footer_path_also_catches_a_turn_that_already_finished(self):
+        """Structural: the recheck must not rely on is_busy alone.
+
+        is_busy answers "is a turn in flight right now". A superseding turn that
+        both STARTS and FINISHES while the footer is being posted reads as idle at
+        both ends, so is_busy misses exactly the race this guard exists for. The
+        monotonic turn counter has to be sampled BEFORE the footer post and
+        compared after, which is what the assertions below pin.
+        """
+        import inspect
+
+        from kiro_crew.slack import handler
+
+        source = inspect.getsource(handler.handle_message)
+        baseline = source.find("_turn_counter_for(")
+        assert baseline != -1, (
+            "handle_message must sample the turn counter, or a superseding turn "
+            "that completes during the footer post leaves its control clickable"
+        )
+        post = source.find("post_blocks(", baseline)
+        assert post != -1, "the counter must be sampled BEFORE the footer post_blocks"
+        compare = source.find("_turn_counter_for(", post)
+        assert compare != -1, "the counter must be re-read AFTER the footer post"
+        # And the comparison has to feed the same expiry the is_busy half feeds.
+        expiry = source.find("expire_slack_options(", compare)
+        assert expiry != -1
+        # Narrowed to the footer's OWN ts. A session-wide drain here would strike
+        # through a control the superseding turn recorded while we awaited Slack,
+        # silencing the question the conversation is now waiting on.
+        call = source[expiry : expiry + 400]
+        assert "ts=_footer_ts" in call, (
+            "the footer's superseded-cleanup must expire only its own control "
+            "(ts=_footer_ts), not drain every control on the session"
+        )
+
+    def test_options_are_recorded_under_the_threads_live_owner(self):
+        """Structural: the record and the expiry must key off the SAME owner.
+
+        A thread linked to a dashboard mid-turn changes owner. Recording under the
+        key the turn started with files the control where the next turn's expiry
+        — which resolves the current owner — will never look, leaving it clickable
+        into a question the conversation has already passed. Both Slack posting
+        paths have to resolve the live owner, and the footer path has to resolve it
+        ONCE so a link landing between its record and its cleanup cannot split them.
+        """
+        import inspect
+
+        from kiro_crew.slack import handler, transport_dispatch
+
+        dispatch = inspect.getsource(transport_dispatch.handle_message_transport)
+        owner_expr = "get_session_for_thread(reply_ts) or session_key"
+        d_owner = dispatch.find("_options_owner =")
+        assert d_owner != -1, "transport_dispatch must resolve the owner into a variable"
+        assert owner_expr in dispatch[d_owner : d_owner + 200], (
+            "transport_dispatch must resolve the thread's LIVE owner, not the key "
+            "the turn started under"
+        )
+        rec = dispatch.find("remember_slack_options(")
+        assert rec != -1
+        assert "_options_owner" in dispatch[rec : rec + 300], (
+            "the record must consume the resolved owner, not a re-derived key"
+        )
+
+        footer = inspect.getsource(handler.handle_message)
+        owner = footer.find("_options_owner =")
+        assert owner != -1, "the footer path must resolve the owner once, into a variable"
+        assert "get_session_for_thread(reply_ts) or session_key" in footer[owner : owner + 200]
+        # Both the record and the cleanup must consume that one resolution.
+        assert footer.count("_options_owner") >= 3, (
+            "the footer's record AND its superseded-cleanup must both use the "
+            "single resolved owner, or a mid-turn relink can split them"
+        )
+
+    def test_an_owner_change_counts_as_supersession_in_both_paths(self):
+        """Structural: a mid-post owner change must supersede on its own.
+
+        The counter is only comparable against itself. If the thread's owner
+        changes while the control is being posted, the baseline was sampled on a
+        DIFFERENT session, so comparing counters is meaningless — it would read
+        "nothing moved" exactly when the conversation moved to another session.
+        Both paths therefore treat an owner change as supersession outright, and
+        the footer's baseline is sampled on the pre-post owner rather than on the
+        key the turn started under.
+        """
+        import inspect
+
+        from kiro_crew.slack import handler, transport_dispatch
+
+        footer = inspect.getsource(handler.handle_message)
+        pre = footer.find("_pre_owner =")
+        assert pre != -1, "the footer must resolve the owner BEFORE posting"
+        baseline = footer.find("_pre_footer_total =", pre)
+        assert baseline != -1, "the baseline must be sampled after resolving that owner"
+        assert "_pre_owner" in footer[baseline : baseline + 120], (
+            "the baseline must be sampled on the PRE-POST OWNER, not on the key "
+            "the turn started under -- otherwise it cannot observe the new owner"
+        )
+        sup = footer.find("_superseded =")
+        assert sup != -1
+        guard = footer[sup : sup + 400]
+        assert "_options_owner != _pre_owner" in guard, (
+            "an owner change must itself count as supersession"
+        )
+        # ...and it must come FIRST, so two incomparable counters are never compared.
+        assert guard.find("!= _pre_owner") < guard.find("_counter_moved()"), (
+            "the owner-change check must short-circuit before the counter compare"
+        )
+
+        dispatch = inspect.getsource(transport_dispatch.handle_message_transport)
+        assert "_pre_run_owner =" in dispatch, (
+            "transport_dispatch must capture the owner before the run to detect a "
+            "mid-turn relink"
+        )
+        assert "_options_owner != _pre_run_owner" in dispatch, (
+            "transport_dispatch must spend its own control when the owner changed"
+        )
+
+    def test_an_unreadable_turn_counter_abstains_instead_of_superseding(self):
+        """A slot appearing or vanishing mid-post is not a turn.
+
+        ``_turn_counter_for`` returns None when there is no dashboard slot, which
+        is the normal state for a Slack conversation until something surfaces one
+        -- and the channel-surface reconciler can create one DURING the footer
+        post. A bare ``!=`` then compares None against an int, reads "a turn
+        happened", and expires the control the instant it lands. Both sides must
+        be present before the comparison counts, which is what
+        ``slack_options_turn_counter``'s own docstring already promises.
+        """
+        import inspect
+
+        from kiro_crew.slack import handler
+
+        footer = inspect.getsource(handler.handle_message)
+        moved = footer.find("def _counter_moved")
+        assert moved != -1, "the counter comparison must be guarded, not bare"
+        body = footer[moved : moved + 1400]
+        assert "_pre_footer_total is not None" in body, (
+            "the BEFORE reading must be required to exist"
+        )
+        assert "after is not None" in body, "the AFTER reading must be required to exist"
+        # ...and the guards must gate the same comparison that feeds supersession.
+        assert "!= _pre_footer_total" in body
+        assert "or _counter_moved()" in footer[moved:], (
+            "supersession must consume the guarded form, so the owner-change check "
+            "still short-circuits ahead of any counter read"
+        )
+        assert "or _turn_counter_for(_options_owner) != _pre_footer_total" not in footer, (
+            "the unguarded comparison must be gone, not merely shadowed"
+        )
+
+    def test_a_non_conversational_command_does_not_spend_a_live_control(self):
+        """`ping`/`status`/denial must not expire a still-pending question.
+
+        Purely an ordering guarantee, so asserted on source order. The entry
+        expiry used to run before the shortcuts: a pending
+        ``[OPTIONS: Deploy | Abort]`` plus a `ping` in the thread struck the
+        control through, posted `pong`, and returned without running the agent --
+        so the conversation had NOT moved, yet the buttons were spent and the
+        question became unanswerable. That is the inverse of the stale click this
+        whole lifecycle prevents.
+
+        The expiry must therefore sit BELOW every short-circuit that answers
+        without starting a turn, in both entry points. One position below them all
+        (rather than a guard per command) also means a shortcut added later
+        inherits the correct behaviour.
+        """
+        import inspect
+
+        from kiro_crew.slack import handler, transport_dispatch
+
+        for name, src, shortcuts in (
+            (
+                "transport_dispatch",
+                inspect.getsource(transport_dispatch.handle_message_transport),
+                ('_lower == "ping"', '_lower == "status"', "if _only_modifier:"),
+            ),
+            (
+                "handler",
+                inspect.getsource(handler.handle_message),
+                ('.lower() == "status"', "if _only_modifier:", "_Permission denied._"),
+            ),
+        ):
+            expiry = src.find("await expire_slack_options(")
+            assert expiry != -1, f"{name} must still expire on a real turn"
+            for shortcut in shortcuts:
+                at = src.find(shortcut)
+                assert at != -1, f"{name}: shortcut {shortcut!r} not found -- test is stale"
+                assert at < expiry, (
+                    f"{name}: the OPTIONS expiry must come AFTER {shortcut!r}; a path "
+                    "that answers without running the agent has not superseded the "
+                    "pending question and must not spend its control"
+                )
+            # ...and it must still precede the turn itself.
+            keyword = src.find("maybe_handle_keyword_command")
+            assert keyword != -1 and keyword < expiry, (
+                f"{name}: keyword commands dispatch elsewhere and must not expire either"
+            )
+
+    @pytest.mark.asyncio
+    async def test_backfill_expires_when_the_transcript_advanced_mid_drain(
+        self, tmp_path, monkeypatch
+    ):
+        """The seeding drain is backgrounded, so a reply can land while it runs.
+
+        Every post awaits Slack (roughly one message per second), so the newest
+        reply's control can be recorded AFTER a new turn already ran its expiry
+        pass — leaving live buttons for a superseded question. The drain re-checks
+        and spends it itself.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_backfill import BackfillSelection
+
+        expired: list[str] = []
+
+        async def _record_expire(_state, session_key, ts=None):
+            expired.append(session_key)
+
+        monkeypatch.setattr(chat_slack, "expire_slack_options", _record_expire)
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        reply = {"role": "assistant", "content": "pick one [OPTIONS: A | B]"}
+        slot.messages.extend([{"role": "user", "content": "hi"}, reply])
+
+        monkeypatch.setattr(
+            chat_slack,
+            "select_backfill_messages",
+            lambda _s, _sl: BackfillSelection(first_turn=[], recent=[[reply]], skipped_turns=0),
+        )
+
+        slack = MagicMock()
+        slack.post_blocks = AsyncMock(return_value="opt-1")
+        state.slack_client = slack
+
+        # A reply lands mid-drain: the transcript grows while we are posting.
+        # Bump total_messages too — that is what state.add_message does, and it is
+        # the signal the drain compares.
+        async def _grow(*_a, **_k):
+            slot.messages.append({"role": "user", "content": "actually, neither"})
+            slot.total_messages += 1
+            return "p1"
+
+        slack.post_message = _grow
+
+        # Production links BEFORE spawning the drain (link_slack is the canonical
+        # writer), so a faithful drain test starts from a linked slot.
+        state.link_slack(slot.key, "thread-1", "C-1")
+        await chat_slack.drain_slack_backfill(state, slot, "C-1", "thread-1")
+
+        assert expired, "a transcript that advanced during the drain must spend the control"
+
+    @pytest.mark.asyncio
+    async def test_mid_drain_expiry_spends_only_the_control_the_drain_posted(
+        self, tmp_path, monkeypatch
+    ):
+        """The drain's own cleanup must not spend a control a newer turn recorded.
+
+        The turn that makes the replayed question stale can finish DURING the
+        drain and record its own live control in the same slot. A session-wide
+        expiry would strike that newer question through as well, silencing the
+        very question the conversation is now waiting on — so the drain narrows
+        its cleanup to the ts it posted itself.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_backfill import BackfillSelection
+        from kiro_crew.slack.outbound import PostedOptions
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        reply = {"role": "assistant", "content": "pick one [OPTIONS: A | B]"}
+        slot.messages.extend([{"role": "user", "content": "hi"}, reply])
+
+        monkeypatch.setattr(
+            chat_slack,
+            "select_backfill_messages",
+            lambda _s, _sl: BackfillSelection(first_turn=[], recent=[[reply]], skipped_turns=0),
+        )
+
+        newer = PostedOptions(channel="C-1", ts="opt-NEWER", choices=("X",), blocks=())
+
+        slack = MagicMock()
+        slack.post_blocks = AsyncMock(return_value="opt-REPLAYED")
+        edited: list[str] = []
+
+        async def _update(channel, ts, **_kw):
+            edited.append(ts)
+
+        slack.update_message = _update
+        state.slack_client = slack
+
+        # A brand-new turn completes mid-drain: the transcript grows AND it
+        # records its own live control in the same slot.
+        async def _grow(*_a, **_k):
+            slot.messages.append({"role": "assistant", "content": "new q [OPTIONS: X]"})
+            slot.total_messages += 1
+            _set_recs(state, slot, (*_recs(state, slot), newer))
+            return "p1"
+
+        slack.post_message = _grow
+
+        # Production links BEFORE spawning the drain (link_slack is the canonical
+        # writer), so a faithful drain test starts from a linked slot.
+        state.link_slack(slot.key, "thread-1", "C-1")
+        await chat_slack.drain_slack_backfill(state, slot, "C-1", "thread-1")
+
+        assert "opt-REPLAYED" in edited, "the drain must spend the control it posted"
+        assert "opt-NEWER" not in edited, "a newer turn's live control must NOT be struck through"
+        assert newer in _recs(state, slot), "the newer control must stay tracked"
+
+    @pytest.mark.asyncio
+    async def test_backfill_renders_the_newest_reply_as_a_live_control(
+        self, tmp_path, monkeypatch
+    ):
+        """An OPTIONS tag in replayed history must be a control, not literal text.
+
+        Guards the headline defect of this PR against the seeding rewrite: the
+        drain posts bodies as plain text, so without lifting the tag out the
+        choices would arrive as the characters `[OPTIONS: A | B]`. Only the newest
+        reply is answerable; an earlier one renders struck through.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_backfill import BackfillSelection
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        older = {"role": "assistant", "content": "an old question [OPTIONS: X | Y]"}
+        newest = {"role": "assistant", "content": "pick one [OPTIONS: A | B]"}
+        typed = {"role": "user", "content": "I typed [OPTIONS: not | mine] myself"}
+
+        monkeypatch.setattr(
+            chat_slack,
+            "select_backfill_messages",
+            lambda _s, _sl: BackfillSelection(
+                first_turn=[], recent=[[older], [typed], [newest]], skipped_turns=0
+            ),
+        )
+
+        slack = MagicMock()
+        slack.post_message = AsyncMock(return_value="p1")
+        slack.post_blocks = AsyncMock(return_value="opt-1")
+        state.slack_client = slack
+
+        # Production links BEFORE spawning the drain (link_slack is the canonical
+        # writer), so a faithful drain test starts from a linked slot.
+        state.link_slack(slot.key, "thread-1", "C-1")
+        await chat_slack.drain_slack_backfill(state, slot, "C-1", "thread-1")
+
+        # Two agent tags become two control messages; the user's typed tag does not.
+        assert slack.post_blocks.await_count == 2, slack.post_blocks.await_args_list
+        # Only the newest is recorded, so only it can be expired later — the older
+        # one was posted already spent and there is nothing to strike through.
+        assert [p.ts for p in _recs(state, slot)] == ["opt-1"]
+        # The user's own words survive verbatim, tag included.
+        posted_text = " ".join(str(c.args[1]) for c in slack.post_message.await_args_list)
+        assert "[OPTIONS: not | mine]" in posted_text
+
+    @pytest.mark.asyncio
+    async def test_backfill_redacts_credentials_inside_options_choices(
+        self, tmp_path, monkeypatch
+    ):
+        """Choices bypass the body pipeline, so they need their own redaction.
+
+        The body goes through _format_backfill_parts, which redacts. The choices
+        go out as Block Kit label/value instead, so extracting them from raw
+        history would put a credential into Slack with no redaction anywhere on
+        that path.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_backfill import BackfillSelection
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        reply = {"role": "assistant", "content": f"which key? [OPTIONS: {secret} | cancel]"}
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        monkeypatch.setattr(
+            chat_slack,
+            "select_backfill_messages",
+            lambda _s, _sl: BackfillSelection(first_turn=[], recent=[[reply]], skipped_turns=0),
+        )
+
+        slack = MagicMock()
+        slack.post_message = AsyncMock(return_value="p1")
+        slack.post_blocks = AsyncMock(return_value="opt-1")
+        state.slack_client = slack
+
+        # Production links BEFORE spawning the drain (link_slack is the canonical
+        # writer), so a faithful drain test starts from a linked slot.
+        state.link_slack(slot.key, "thread-1", "C-1")
+        await chat_slack.drain_slack_backfill(state, slot, "C-1", "thread-1")
+
+        blocks_text = json.dumps(slack.post_blocks.await_args_list[0].args[1])
+        assert secret not in blocks_text, "a credential must never reach an OPTIONS control"
+
+    @pytest.mark.asyncio
+    async def test_backfill_expiry_survives_a_slot_at_the_trim_cap(self, tmp_path, monkeypatch):
+        """At the message cap, a new turn does not change len(slot.messages).
+
+        add_message trims from the front once the list exceeds
+        _MAX_SLOT_MESSAGES, so a slot sitting at the cap appends and trims in the
+        same step and its length is identical before and after. Comparing lengths
+        would miss the advancement on exactly the busiest slots — where the race
+        is most likely. total_messages is a lifetime counter, so it still moves.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_backfill import BackfillSelection
+
+        expired: list[str] = []
+
+        async def _record_expire(_state, session_key, ts=None):
+            expired.append(session_key)
+
+        monkeypatch.setattr(chat_slack, "expire_slack_options", _record_expire)
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        reply = {"role": "assistant", "content": "pick one [OPTIONS: A | B]"}
+        monkeypatch.setattr(
+            chat_slack,
+            "select_backfill_messages",
+            lambda _s, _sl: BackfillSelection(first_turn=[], recent=[[reply]], skipped_turns=0),
+        )
+
+        slack = MagicMock()
+        slack.post_blocks = AsyncMock(return_value="opt-1")
+        state.slack_client = slack
+
+        # A turn lands mid-drain on a slot AT the cap: one row in, one row out, so
+        # the list length is unchanged while total_messages advances.
+        async def _grow_at_cap(*_a, **_k):
+            slot.messages.append({"role": "user", "content": "actually, neither"})
+            del slot.messages[:1]
+            slot.total_messages += 1
+            return "p1"
+
+        slack.post_message = _grow_at_cap
+        before = len(slot.messages)
+
+        # Production links BEFORE spawning the drain (link_slack is the canonical
+        # writer), so a faithful drain test starts from a linked slot.
+        state.link_slack(slot.key, "thread-1", "C-1")
+        await chat_slack.drain_slack_backfill(state, slot, "C-1", "thread-1")
+
+        assert len(slot.messages) == before, "the length must be unchanged for this test to bite"
+        assert expired, "advancement must be detected via total_messages, not list length"
+
+    @pytest.mark.asyncio
+    async def test_backfill_spends_the_control_when_a_turn_runs_throughout(
+        self, tmp_path, monkeypatch
+    ):
+        """A turn in flight for the WHOLE drain moves neither baseline.
+
+        A long cron or injected turn that is already running when the drain starts
+        and still running when it ends leaves slot.running identical at both ends,
+        and it may not have appended a row yet — so a before/after comparison sees
+        nothing. The agent is mid-reply the entire time, which is precisely when
+        the replayed question is stale, so the control must still be spent.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_backfill import BackfillSelection
+
+        expired: list[str] = []
+
+        async def _record_expire(_state, session_key, ts=None):
+            expired.append(session_key)
+
+        monkeypatch.setattr(chat_slack, "expire_slack_options", _record_expire)
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        reply = {"role": "assistant", "content": "pick one [OPTIONS: A | B]"}
+        # Running before, during and after — and no new row lands. `running` is a
+        # derived property (task is not None and not task.done()), so an in-flight
+        # turn is simulated with a pending future rather than by assignment.
+        slot.task = asyncio.get_running_loop().create_future()
+        assert slot.running, "the test must actually present an in-flight turn"
+        before_total = slot.total_messages
+
+        monkeypatch.setattr(
+            chat_slack,
+            "select_backfill_messages",
+            lambda _s, _sl: BackfillSelection(first_turn=[], recent=[[reply]], skipped_turns=0),
+        )
+
+        slack = MagicMock()
+        slack.post_message = AsyncMock(return_value="p1")
+        slack.post_blocks = AsyncMock(return_value="opt-1")
+        state.slack_client = slack
+
+        # Production links BEFORE spawning the drain (link_slack is the canonical
+        # writer), so a faithful drain test starts from a linked slot.
+        state.link_slack(slot.key, "thread-1", "C-1")
+        await chat_slack.drain_slack_backfill(state, slot, "C-1", "thread-1")
+
+        assert slot.total_messages == before_total, "no row may land for this test to bite"
+        assert expired, "a turn running throughout the drain must spend the control"
+        slot.task.cancel()
+
+    def test_an_ansi_split_credential_in_a_choice_does_not_reach_slack(self):
+        """A credential broken up by escapes must not survive into a choice.
+
+        This guarantee moved owners. It used to live in this PR's own render
+        helper; `slack.format.build_options_blocks` now redacts every choice
+        through `redact_for_display`, which canonicalises the form Slack actually
+        DISPLAYS (ANSI, emphasis, backticks, link markup) before scanning. That
+        is strictly stronger, so the test asserts against the real owner rather
+        than keeping a second copy of the pipeline alive to test.
+        """
+        from kiro_crew.slack.format import strip_ansi
+
+        # An AWS key broken up by a colour escape mid-token.
+        secret = "AKIA\x1b[0mIOSFODNN7EXAMPLE"
+        blocks = build_options_blocks([secret, "cancel"])
+
+        rendered = strip_ansi(json.dumps(blocks))
+        # Assert on the ANSI-STRIPPED render: leaving the escape in is not a
+        # defence, because whatever shows the choice strips it and the reader
+        # sees the key whole. Asserting on the raw bytes would pass vacuously --
+        # the escape splits the token, so the contiguous secret is absent either
+        # way.
+        assert AWS_KEY not in rendered
+
+    @pytest.mark.asyncio
+    async def test_expiry_marks_the_control_terminal(self, tmp_path):
+        """A click queued behind a successful expiry must not dispatch.
+
+        The once-only claim defends click-against-click. It does not, on its own,
+        defend click-against-completed-expiry: a Send queued behind the expiry
+        would find the claim unheld, take it, and answer the very question the
+        expiry just struck through. The expiry therefore marks the control terminal
+        while it still holds the message's edit lock, so the queued click is refused
+        by exactly the check a duplicate click hits.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            remember_slack_options,
+        )
+        from kiro_crew.slack.outbound import claim_options_answer
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        posted = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        remember_slack_options(state, slot.key, posted)
+
+        slack = MagicMock()
+        slack.update_message = AsyncMock()
+        state.slack_client = slack
+
+        await expire_slack_options(state, slot.key)
+
+        assert claim_options_answer("C-1", "opt-1") is False, (
+            "a click queued behind a settled expiry must be refused -- otherwise it "
+            "answers the question the expiry just retired"
+        )
+        assert _recs(state, slot) == ()
+
+    def test_a_submission_that_rendered_nothing_gives_the_claim_back(self):
+        """A wholly failed submit must not consume the answer forever.
+
+        If neither the in-place edit nor the replacement post lands, nothing
+        happened: the buttons are still on screen. Holding the claim would refuse
+        every retry, leaving a control permanently visible and permanently
+        unanswerable. Once the selection IS rendered the claim stays, even if a
+        later step stumbles.
+        """
+        import inspect
+
+        from kiro_crew.slack import interactions
+
+        src = inspect.getsource(interactions._handle_options_submit)
+        assert "release_options_answer(channel, msg_ts)" in src, (
+            "a submit that rendered nothing must give the claim back"
+        )
+        rel = src.find("release_options_answer(channel, msg_ts)")
+        guard = src[max(0, rel - 200) : rel]
+        assert "not edited and new_ts == msg_ts" in guard, (
+            "the rollback must be gated on NOTHING having been rendered -- releasing "
+            "after a successful edit would re-admit a duplicate click"
+        )
+        assert "finally:" in src[max(0, rel - 600) : rel], (
+            "the rollback must run on the abort path too, which returns early"
+        )
+
+    def test_all_three_posting_paths_resolve_the_live_owner(self):
+        """The dashboard mirror path must do what the other two already do.
+
+        Rounds 23 and 26 gave the native footer and the transport path an
+        owner-resolved record plus owner-change supersession. The dashboard mirror
+        in ``chat_runner`` recorded under the bare ``session_key`` -- so a thread
+        relinked while ``post_blocks`` was in flight got its control filed where
+        the new owner's expiry never looks, and clickable into a conversation it
+        does not belong to.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner)
+        mirror = src[src.find("_mirror_blocks = build_options_blocks(") :][:2600]
+        assert "_pre_owner" in mirror, "the mirror path must capture the owner before posting"
+        assert "remember_slack_options(\n                            state,\n                            _owner," in mirror, (
+            "the record must use the re-resolved owner, not the key the turn started with"
+        )
+        assert "_owner != _pre_owner" in mirror, "an owner change must supersede"
+        assert "ts=_mirror_ts" in mirror, (
+            "the supersession expiry must be narrowed to OUR ts, or it strikes "
+            "through a control the new owner recorded meanwhile"
+        )
+
+    def test_the_forget_uses_owner_keys_snapshotted_before_the_edit(self):
+        """A relink during the submit's edit must not orphan the old owner's record.
+
+        ``forget_slack_options_for_thread`` resolved its key list when called --
+        after the edit. A relink landing during that edit moves the thread, so the
+        recomputed list names the NEW owner, the previous owner's record survives
+        the click, and that session's next turn edits over the selection.
+        """
+        import inspect
+
+        from kiro_crew.dashboard.chat_utils import (
+            slack_options_owner_keys_snapshot,
+        )
+        from kiro_crew.slack import interactions
+
+        state = MagicMock()
+        state._slots = {}
+        state.get_linked_slot = MagicMock(return_value=None)
+        state.sessions.get_session_for_thread = MagicMock(return_value="dashboard:chat-A")
+        before = slack_options_owner_keys_snapshot(state, "thread-1")
+        assert "dashboard:chat-A" in before
+
+        # The thread moves to B. The snapshot must still name A.
+        state.sessions.get_session_for_thread = MagicMock(return_value="dashboard:chat-B")
+        after = slack_options_owner_keys_snapshot(state, "thread-1")
+        assert "dashboard:chat-B" in after and "dashboard:chat-A" not in after, (
+            "coherence check: resolving after the relink names only the new owner"
+        )
+
+        src = inspect.getsource(interactions._handle_options_submit)
+        snap = src.find("slack_options_owner_keys_snapshot(")
+        edit = src.find("update_message(")
+        forget = src.find("_forget_options_control(")
+        assert snap != -1 and snap < edit, "the snapshot must be taken BEFORE the edit"
+        assert "keys=_owner_keys" in src[forget : forget + 120], (
+            "the forget must consume the pre-edit snapshot, not re-resolve"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_unlink_puts_the_link_back(self, tmp_path, monkeypatch):
+        """Shutdown mid-expiry must not leave the unlink half-committed.
+
+        Persistence is cleared at the TOP of the handler and the in-memory fields
+        are only touched at the end, so a cancellation during the expiry await
+        leaves the two disagreeing: after a restart the routing is gone while the
+        controls are still live on screen, and a click resolves to nothing and
+        starts a fresh session.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_unlink
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slack = MagicMock()
+        slack.update_message = AsyncMock(return_value=True)
+        state.slack_client = slack
+        state.link_slack(slot.key, "thread-1", "C-1")
+        key = effective_session_key(slot)
+        assert state.sessions.get_slack_link(key)[0] == "thread-1", "precondition: linked"
+
+        async def _cancelled_expiry(*_a, **_k):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(chat_slack, "expire_slack_options", _cancelled_expiry)
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-unlink", api_chat_slot_slack_unlink)
+        async with TestClient(TestServer(app)) as client:
+            # A propagated CancelledError tears the connection down rather than
+            # producing a response -- that disconnect IS the handler re-raising
+            # instead of swallowing it, which is half of what this test asserts.
+            with pytest.raises(Exception) as excinfo:
+                await client.post(f"/api/chat/slots/{slot.key}/slack-unlink")
+            assert "disconnect" in str(excinfo.value).lower() or isinstance(
+                excinfo.value, asyncio.CancelledError
+            ), f"expected the cancellation to propagate, got {excinfo.value!r}"
+
+        assert state.sessions.get_slack_link(key)[0] == "thread-1", (
+            "a cancelled unlink must leave the persisted link exactly as it found it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_eviction_never_splits_one_message_lock(self):
+        """A released lock with a scheduled waiter reads as UNLOCKED.
+
+        Evicting it there hands the next caller a brand-new lock for the same
+        message while the waiter proceeds on the old one, so two coroutines edit
+        one Slack message at once and every guarantee built on this lock is off.
+        """
+        from kiro_crew.slack import outbound
+
+        key = ("CH-split", "msg-split")
+        inside: list[str] = []
+        overlap: list[str] = []
+
+        async def _worker(name: str, hold: asyncio.Event) -> None:
+            async with outbound.options_edit_lock(*key):
+                if inside:
+                    overlap.append(name)
+                inside.append(name)
+                await hold.wait()
+                inside.remove(name)
+
+        a_hold, b_hold = asyncio.Event(), asyncio.Event()
+        a = asyncio.create_task(_worker("A", a_hold))
+        await asyncio.sleep(0)
+        # B is now a WAITER on the same lock.
+        b = asyncio.create_task(_worker("B", b_hold))
+        await asyncio.sleep(0)
+
+        # Flood the registry past its cap while B waits, then let A go so the lock
+        # is released with B still only scheduled -- the exact split window.
+        for i in range(outbound._MAX_EDIT_LOCKS + 20):
+            outbound.options_edit_lock("CH-bulk", f"t{i}")
+        a_hold.set()
+        await asyncio.sleep(0)
+        for i in range(outbound._MAX_EDIT_LOCKS + 20):
+            outbound.options_edit_lock("CH-bulk", f"u{i}")
+
+        assert key in outbound._EDIT_LOCKS, (
+            "a lock with a pending waiter must never be evicted"
+        )
+        b_hold.set()
+        await asyncio.gather(a, b)
+        assert overlap == [], f"two coroutines held one message lock at once: {overlap}"
+        # And once nobody wants it the entry is reclaimable again.
+        assert not outbound._LOCK_USERS.get(key)
+
+    def test_send_message_options_use_the_safe_fallback_stub(self):
+        """The `send_message` control must not carry the agent's body as fallback.
+
+        Slack parses entities in a message's top-level ``text``, which is what
+        notifications render, so an agent-authored body containing `<!channel>`
+        would ping the whole channel -- and the expiry replays the STORED text on
+        its edit, so it would ping again on every retirement. Nothing is lost by
+        using the stub: the body is already posted as its own Slack message
+        immediately above, so on the control it was pure duplication.
+        """
+        import inspect
+
+        from kiro_crew.dashboard.handlers import messaging
+
+        src = inspect.getsource(messaging)
+        at = src.find("option_blocks = build_options_blocks(options)")
+        assert at != -1, "the send_message OPTIONS post should be findable"
+        window = src[at : at + 1200]
+        assert "OPTIONS_FALLBACK_TEXT," in window, (
+            "the control's post-time fallback must be the safe stub"
+        )
+        assert "text=text," not in window, (
+            "and the stored record must not carry the raw body -- the expiry "
+            "replays it as top-level text on every edit"
+        )
+        # The body itself still reaches Slack, as its own message.
+        assert "post_message(" in src, "the message body is still posted normally"
+
+    def test_a_local_dashboard_command_does_not_spend_the_control(self):
+        """`/goal` and `/prompts` return without an agent turn.
+
+        Round 31 moved each SLACK entry point's expiry below its short-circuits;
+        the dashboard path kept its expiry at the very top of ``_run_chat``, so a
+        local command that never starts a turn still struck a pending question
+        through -- leaving valid choices unanswerable with nothing on the way to
+        answer them.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner._run_chat)
+        expiry = src.find("await expire_slack_options(state, session_key)")
+        assert expiry != -1, "the dashboard turn must still expire the control"
+        for local in ('if first_word == "/goal"', 'if first_word == "/prompts"'):
+            at = src.find(local)
+            assert at != -1, f"expected {local} in _run_chat"
+            assert at < expiry, (
+                f"{local} returns without a turn, so it must sit ABOVE the expiry"
+            )
+        assert expiry < src.find("_acquired = False"), (
+            "the expiry must still run before the turn is acquired"
+        )
+
+    @pytest.mark.asyncio
+    async def test_linking_an_existing_thread_retires_its_prior_control(self, tmp_path):
+        """Reassigning a thread must not strand the previous owner's buttons.
+
+        A live control is recorded under the thread's own conversation key. Linking
+        a dashboard session to that existing thread moves the thread -> slot index,
+        so no dashboard turn would ever expire that record and a click on those
+        buttons would answer into the dashboard session instead.
+        """
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_link
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.update_message = AsyncMock(return_value=True)
+        slack.post_message = AsyncMock(return_value="thread-1")
+        state.slack_client = slack
+        state.owner_id = "U-owner"
+
+        prior = state.get_or_create_slot("slack-prior")
+        state.link_slack(prior.key, "thread-1", "C-1")
+        _set_recs(
+            state,
+            prior,
+            (PostedOptions(channel="C-1", ts="opt-1", choices=("A", "B"), blocks=()),),
+        )
+
+        dash = state.get_or_create_slot("s1")
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-link", api_chat_slot_slack_link)
+        async with TestClient(TestServer(app)) as client:
+            await client.post(
+                f"/api/chat/slots/{dash.key}/slack-link",
+                json={"channel": "C-1", "thread_ts": "thread-1"},
+            )
+
+        assert slack.update_message.await_count >= 1, (
+            "the previous owner's control must be struck through on reassign"
+        )
+        assert _recs(state, prior) == (), (
+            "and it must not stay tracked under a key nothing will ever expire"
+        )
+
+    @pytest.mark.asyncio
+    async def test_link_aborts_when_the_prior_control_cannot_be_retired(self, tmp_path):
+        """A thread must not change owner while its old buttons are still live.
+
+        Linking first and expiring after leaves a window where the thread already
+        routes to the NEW session while the previous owner's control is still on
+        screen: a transient Slack failure on the strike-through means a click
+        resolves through the new reverse index into a conversation that never asked
+        the question. A returned expiry does not prove the control was spent, so the
+        guard is "are any prior records still there".
+        """
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_link
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        # A TRANSIENT strike-through failure (the retryable class), so the record
+        # stays tracked deliberately -- which is exactly the state the guard reads.
+        slack.update_message = AsyncMock(side_effect=TimeoutError("slack timed out"))
+        slack.post_message = AsyncMock(return_value="thread-1")
+        state.slack_client = slack
+        state.owner_id = "U-owner"
+
+        prior = state.get_or_create_slot("slack-prior")
+        state.link_slack(prior.key, "thread-1", "C-1")
+        _set_recs(
+            state,
+            prior,
+            (PostedOptions(channel="C-1", ts="opt-1", choices=("A", "B"), blocks=()),),
+        )
+
+        dash = state.get_or_create_slot("s1")
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-link", api_chat_slot_slack_link)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                f"/api/chat/slots/{dash.key}/slack-link",
+                json={"channel": "C-1", "thread_ts": "thread-1"},
+            )
+            assert resp.status == 503, "an unretired control must refuse the relink"
+            payload = await resp.json()
+            assert payload["code"] == "slack_options_pending"
+
+        # The thread still belongs to the session that asked the question.
+        assert state._slack_to_slot.get("thread-1") == prior.key, (
+            "the thread must NOT be reassigned while the old control is live"
+        )
+        assert _recs(state, prior) != (), "and the prior record must stay tracked"
+
+    @pytest.mark.asyncio
+    async def test_link_aborts_while_an_answer_is_still_routing(self, tmp_path):
+        """A won click has already forgotten its record, so records alone miss it.
+
+        A successful click forgets the record BEFORE dispatching, so once the answer
+        is travelling there is nothing left for the records check to see. Reassigning
+        the thread underneath it delivers that selection into a session that never
+        asked the question -- the same defect the unlink abort closes, on the link
+        path.
+        """
+        import asyncio
+
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_link
+        from kiro_crew.slack.outbound import track_answer_routing
+
+        state = _make_state(tmp_path)
+        slack = MagicMock()
+        slack.update_message = AsyncMock(return_value=None)
+        slack.post_message = AsyncMock(return_value="thread-1")
+        state.slack_client = slack
+        state.owner_id = "U-owner"
+
+        prior = state.get_or_create_slot("slack-prior")
+        state.link_slack(prior.key, "thread-1", "C-1")
+        # No records at all: the click already won and forgot its own.
+        _set_recs(state, prior, ())
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _dispatching():
+            started.set()
+            await release.wait()
+
+        task = asyncio.ensure_future(_dispatching())
+        track_answer_routing("thread-1", task)
+        await started.wait()
+
+        try:
+            dash = state.get_or_create_slot("s1")
+            app = web.Application()
+            app["state"] = state
+            app.router.add_post(
+                "/api/chat/slots/{slot}/slack-link", api_chat_slot_slack_link
+            )
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    f"/api/chat/slots/{dash.key}/slack-link",
+                    json={"channel": "C-1", "thread_ts": "thread-1"},
+                )
+                assert resp.status == 503, (
+                    "an answer still routing must refuse the relink even with no records"
+                )
+                assert (await resp.json())["code"] == "slack_options_pending"
+
+            assert state._slack_to_slot.get("thread-1") == prior.key, (
+                "the thread must NOT move while an answer is travelling to its owner"
+            )
+        finally:
+            release.set()
+            await task
+
+    def test_link_expires_the_prior_control_before_reassigning(self):
+        """Ordering is the fix, not just the presence of an expiry."""
+        import inspect
+
+        from kiro_crew.dashboard import chat_slack
+
+        src = inspect.getsource(chat_slack.api_chat_slot_slack_link)
+        snap = src.find("_prior_owner_keys = slack_options_owner_keys_snapshot(")
+        expire = src.find("await expire_slack_options(state, _prior_key)")
+        guard = src.find("_unretired = [")
+        link = src.find("state.link_slack(slot.key, thread_ts, target_channel)")
+        assert -1 not in (snap, expire, guard, link), "all four steps must be present"
+        assert snap < expire < guard < link, (
+            "capture, then expire, then the records-remain guard, and only then link"
+        )
+
+    def test_link_captures_the_prior_owner_before_reassigning(self):
+        """The keys must be read BEFORE link_slack moves the index."""
+        import inspect
+
+        from kiro_crew.dashboard import chat_slack
+
+        src = inspect.getsource(chat_slack.api_chat_slot_slack_link)
+        snap = src.find("_prior_owner_keys = slack_options_owner_keys_snapshot(")
+        link = src.find("state.link_slack(slot.key, thread_ts, target_channel)")
+        assert snap != -1 and link != -1, "both the snapshot and the link must be present"
+        assert snap < link, (
+            "resolving after link_slack names the NEW owner, so the previous "
+            "conversation's record would never be found"
+        )
+        assert "_own_keys" in src, (
+            "re-linking a thread to the slot that already holds it must not spend "
+            "that slot's own live control"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_different_thread_relink_during_the_expiry_survives(
+        self, tmp_path, monkeypatch
+    ):
+        """A relink to a DIFFERENT thread during the expiry must not be torn down.
+
+        The existing round-27 guard covers a same-thread relink; this is the other
+        branch, where the slot's in-memory fields moved too. Naming this honestly:
+        it is the compare-and-clear-free path -- what protects the replacement is
+        the compare of the slot's live fields against the ones captured before the
+        await, not any check inside the clear.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_unlink
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slack = MagicMock()
+        slack.update_message = AsyncMock(return_value=True)
+        state.slack_client = slack
+        state.link_slack(slot.key, "thread-1", "C-1")
+        key = effective_session_key(slot)
+
+        async def _relink_mid_expiry(*_a, **_k):
+            state.link_slack(slot.key, "thread-2", "C-2")
+
+        monkeypatch.setattr(chat_slack, "expire_slack_options", _relink_mid_expiry)
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-unlink", api_chat_slot_slack_unlink)
+        async with TestClient(TestServer(app)) as client:
+            await client.post(f"/api/chat/slots/{slot.key}/slack-unlink")
+
+        assert state.sessions.get_slack_link(key)[0] == "thread-2", (
+            "the replacement written during the expiry await must survive"
+        )
+
+    def test_link_mutations_stay_serialized_on_the_event_loop(self):
+        """Link writes must NOT be moved off-loop, in any path.
+
+        An earlier revision of this PR ran the clear in ``asyncio.to_thread`` to
+        keep a whole-session-map save off the loop. That was wrong twice over: the
+        worker runs CONCURRENTLY with the loop, so the compare-and-clear inside it
+        was never atomic against a loop-side relink -- the thread could read the
+        captured link, a relink could write its replacement, and the thread would
+        then clear that replacement. The session map has no cross-thread lock, so
+        the event loop is the only thing serialising its writers.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_slack
+
+        src = inspect.getsource(chat_slack.api_chat_slot_slack_unlink)
+        assert "asyncio.to_thread(" not in src, (
+            "no link mutation in the unlink handler may run off the loop"
+        )
+        assert "cleared = _clear_persisted_link_sync()" in src, (
+            "the clear runs inline, on the loop"
+        )
+        cancel = src[src.find("except asyncio.CancelledError:") :]
+        assert "_restore_persisted_link_sync()" in cancel and "asyncio.shield(" not in cancel, (
+            "the cancellation restore is a plain inline write -- the shield and its "
+            "fallback existed only to serve the off-loop rewrite"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unlink_waits_for_an_answer_that_is_still_routing(self):
+        """A spent control is forgotten BEFORE its answer has found a session.
+
+        The click's own success is what opens this window: it drops the record --
+        the unlink handler's other signal -- and dispatches the answer as a task.
+        An unlink landing between the two sees nothing tracked, pops the thread
+        from the reverse index, and the user's selection arrives at a brand-new
+        Slack session. Same corruption the unlink ordering was built to prevent,
+        reached from the other side.
+        """
+        from kiro_crew.slack import outbound
+
+        assert outbound.answer_routing_in_flight("thread-1") is False
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _routing() -> None:
+            started.set()
+            await release.wait()
+
+        task = asyncio.create_task(_routing())
+        outbound.track_answer_routing("thread-1", task)
+        await started.wait()
+
+        assert outbound.answer_routing_in_flight("thread-1") is True, (
+            "while the answer is routing the thread must stay linked"
+        )
+        assert outbound.answer_routing_in_flight("other-thread") is False, (
+            "and only THAT thread -- an unrelated unlink must not be blocked"
+        )
+
+        release.set()
+        await task
+        assert outbound.answer_routing_in_flight("thread-1") is False, (
+            "once routed the hold must lift, or the unlink refuses forever"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failed_answer_task_does_not_pin_the_thread_forever(self):
+        """Registration is by task so nothing can leak.
+
+        A counter incremented at dispatch and decremented on success would, on a
+        raising or cancelled task, leave the thread permanently unlinkable -- a
+        worse bug than the one being fixed. A task that ends in ANY way stops
+        counting by itself.
+        """
+        from kiro_crew.slack import outbound
+
+        async def _boom() -> None:
+            raise RuntimeError("routing blew up")
+
+        task = asyncio.create_task(_boom())
+        outbound.track_answer_routing("thread-2", task)
+        with pytest.raises(RuntimeError):
+            await task
+        assert outbound.answer_routing_in_flight("thread-2") is False
+        assert "thread-2" not in outbound._ANSWER_ROUTING, "and the entry is reclaimed"
+
+        cancelled = asyncio.create_task(asyncio.Event().wait())
+        outbound.track_answer_routing("thread-3", cancelled)
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        assert outbound.answer_routing_in_flight("thread-3") is False
+
+    def test_the_unlink_guard_consults_the_routing_signal(self):
+        """The abort predicate must ask BOTH questions.
+
+        A tracked record covers a control still on screen; the routing signal
+        covers a control already spent whose answer has not landed. Dropping
+        either leaves one half of the window open.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_slack
+
+        src = inspect.getsource(chat_slack)
+        guard = [
+            ln
+            for ln in src.splitlines()
+            if "options_records(state, session_key)" in ln and ln.strip().startswith("if ")
+        ]
+        assert guard, "the unlink abort guard should be findable"
+        assert any("answer_routing_in_flight(prev_thread_ts)" in ln for ln in guard), (
+            "the unlink must also abort while an answer is still routing"
+        )
+
+    def test_both_click_paths_register_their_dispatch(self):
+        """Neither click path may dispatch an answer the unlink cannot see."""
+        import inspect
+
+        from kiro_crew.slack import interactions
+
+        for fn in (interactions._handle_options_submit, interactions._handle_options):
+            src = inspect.getsource(fn)
+            dispatch = src.find("_orch._handler_tasks.add(t)")
+            assert dispatch != -1, f"{fn.__name__} should dispatch a task"
+            window = src[max(0, dispatch - 400) : dispatch]
+            assert "track_answer_routing(thread_ts, t)" in window, (
+                f"{fn.__name__} must register its dispatch before handing it off"
+            )
+
+    def test_the_legacy_click_escapes_its_slack_fallback_text_too(self):
+        """Round 35 escaped the submit path's fallback; the legacy path was missed.
+
+        Slack parses entities in a message's top-level ``text``, which is what
+        notifications render, so a legacy choice containing ``<!channel>`` would
+        ping the whole channel from one click. The answer echoed into the session
+        must stay RAW -- only the fallback is escaped.
+        """
+        import inspect
+
+        from kiro_crew.slack import interactions
+
+        src = inspect.getsource(interactions._handle_options)
+        tail = src[src.find("Standard OPTIONS choice") :]
+        assert "_choice_fallback = escape_mrkdwn(choice)" in tail, (
+            "the legacy path must escape its fallback text"
+        )
+        assert "text=choice" not in tail, "the raw choice must not reach the top-level text"
+        assert "selected_blocks, choice," not in tail, (
+            "nor the post_blocks fallback argument"
+        )
+        # The dispatched answer stays raw: escaping there would corrupt what the
+        # session receives.
+        dispatch = tail[tail.find("handle_message(") :]
+        assert "_choice_fallback" not in dispatch, (
+            "the turn must receive the raw choice, not the escaped fallback"
+        )
+
+    def test_the_legacy_single_click_path_is_claimed_once_too(self):
+        """A legacy control renders into the same message and dispatches a turn.
+
+        ``_handle_options`` is the older path where each choice is its own button
+        and the click itself is the answer -- no Send. It had none of the submit
+        path's protection, so two rapid clicks meant two handler tasks, two
+        renders of the same message and two turns injected. Every guarantee the
+        submit path has this path needs, for the same reasons.
+        """
+        import inspect
+
+        from kiro_crew.slack import interactions
+
+        src = inspect.getsource(interactions._handle_options)
+        # Locate the standard-OPTIONS section; the action-button branches above it
+        # return early and are a different feature.
+        tail = src[src.find("Standard OPTIONS choice") :]
+        assert "async with options_edit_lock(channel, msg_ts):" in tail, (
+            "the render must serialise against the turn-start expiry's edit"
+        )
+        claim = tail.find("claim_options_answer(channel, msg_ts)")
+        edit = tail.find("update_message(")
+        assert claim != -1 and claim < edit, "the claim must be taken BEFORE the first edit"
+        assert "keys=_owner_keys" in tail, "the forget must use the pre-edit owner snapshot"
+        assert "settle_options_answer(channel, msg_ts)" in tail, (
+            "and must settle the claim once the buttons are provably gone"
+        )
+        assert "release_options_answer(channel, msg_ts)" in tail, (
+            "a render that reached Slack not at all must give the claim back"
+        )
+
+    @pytest.mark.asyncio
+    async def test_backfill_spends_its_control_when_the_link_is_already_gone(
+        self, tmp_path, monkeypatch
+    ):
+        """Link then immediate unlink must not leave live buttons behind.
+
+        The unlink removes the routing before the drain finishes posting, so a
+        click on the replayed control would start a FRESH Slack session and answer
+        a question that session never asked. Round 32's unlink abort covers the
+        other order -- a control already tracked when the unlink arrives -- and had
+        nothing to abort on here, because the record did not exist yet.
+        """
+        from kiro_crew.dashboard import chat_slack
+        from kiro_crew.dashboard.chat_backfill import BackfillSelection
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        newest = {"role": "assistant", "content": "pick one [OPTIONS: A | B]"}
+        monkeypatch.setattr(
+            chat_slack,
+            "select_backfill_messages",
+            lambda _s, _sl: BackfillSelection(
+                first_turn=[], recent=[[newest]], skipped_turns=0
+            ),
+        )
+        slack = MagicMock()
+        slack.post_message = AsyncMock(return_value="p1")
+        slack.post_blocks = AsyncMock(return_value="opt-1")
+        slack.update_message = AsyncMock(return_value=True)
+        state.slack_client = slack
+
+        # Linked, then unlinked while the drain is in flight: the slot's link now
+        # points somewhere else entirely.
+        state.link_slack(slot.key, "thread-1", "C-1")
+        slot._slack_channel = ""
+        slot._slack_thread_ts = ""
+
+        await chat_slack.drain_slack_backfill(state, slot, "C-1", "thread-1")
+
+        assert slack.update_message.await_count == 1, (
+            "a control posted into a thread the slot no longer owns must be "
+            "struck through, not left clickable"
+        )
+        assert [p.ts for p in _recs(state, slot)] == [], (
+            "and it must not stay tracked as a live control"
+        )
+
+    def test_an_unsettled_answer_claim_is_never_evicted(self):
+        """The claim map's bound must not re-admit a click on live buttons.
+
+        Eviction is by insertion order across the WHOLE workspace, so traffic in
+        busy channels could drop the claim on a control still sitting unanswered
+        in a quiet thread. When the render or the strike-through failed those
+        buttons really are still on screen, and this entry is the only thing
+        standing between a second click and a duplicate turn.
+        """
+        from kiro_crew.slack import outbound
+
+        cap = outbound._MAX_EDIT_LOCKS
+        # One claim whose buttons may still be live -- never settled.
+        assert outbound.claim_options_answer("C-live", "live-1") is True
+        # Then flood well past the cap with controls that DID settle.
+        for i in range(cap + 50):
+            assert outbound.claim_options_answer("C-bulk", f"t{i}") is True
+            outbound.settle_options_answer("C-bulk", f"t{i}")
+
+        assert ("C-live", "live-1") in outbound._ANSWERED, (
+            "the unsettled claim must survive the flood -- evicting it re-admits "
+            "a click on a control still showing buttons"
+        )
+        assert outbound.claim_options_answer("C-live", "live-1") is False, (
+            "and the surviving claim must still refuse a second click"
+        )
+        assert len(outbound._ANSWERED) <= cap + 1, (
+            "settled entries must still be reclaimed, or the cap means nothing"
+        )
+
+    def test_a_settled_claim_is_reclaimable(self):
+        """Settling is what makes the bound work at all.
+
+        A claim settles once the buttons are provably gone -- the in-place edit
+        landed, the original was deleted, or the expiry's strike-through
+        succeeded. Only then may memory pressure reclaim it.
+        """
+        from kiro_crew.slack import outbound
+
+        assert outbound.claim_options_answer("C1", "s1") is True
+        assert outbound._ANSWERED[("C1", "s1")] is False
+        outbound.settle_options_answer("C1", "s1")
+        assert outbound._ANSWERED[("C1", "s1")] is True
+        # mark_options_terminal only runs after a confirmed strike-through, so it
+        # records a settled entry directly.
+        outbound.mark_options_terminal("C2", "s2")
+        assert outbound._ANSWERED[("C2", "s2")] is True
+
+    def test_a_live_control_is_never_evicted_to_bound_the_store(self):
+        """No cap may drop a record for a control that is still clickable.
+
+        An earlier revision capped the store with FIFO eviction. That is worse than
+        unbounded: evicting a live record means no later turn can retire that
+        control, which is exactly the untracked control this lifecycle exists to
+        eliminate -- so the bound would reintroduce the defect at scale, silently,
+        on the busiest instances. The only bound is the lifecycle itself: a key
+        exists while a question is unanswered and is pruned the moment it is not.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_utils
+        from kiro_crew.dashboard.chat_utils import options_records, set_options_records
+
+        src = inspect.getsource(chat_utils.set_options_records)
+        assert "_MAX_OPTION_KEYS" not in src and "del store[" not in src, (
+            "the store must not evict live records to stay small"
+        )
+
+        state = MagicMock()
+        state._slack_options_by_key = {}
+        posted = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        for i in range(1200):
+            set_options_records(state, f"slack:{i}", (posted,))
+        assert options_records(state, "slack:0") == (posted,), (
+            "the oldest live control must still be tracked after 1200 sessions"
+        )
+        # ...and an emptied key is still pruned, so the store is not a leak.
+        set_options_records(state, "slack:0", ())
+        assert options_records(state, "slack:0") == ()
+        assert "slack:0" not in state._slack_options_by_key
+
+    def test_the_store_is_not_held_on_the_slot(self):
+        """Structural: one store, keyed by session key, on DashboardState.
+
+        A slot-held record was the #1694 defect: a plain Slack thread has no slot,
+        so the control was dropped and no later turn could expire it. It also must
+        not be a slot field PLUS a keyed fallback -- a slot can come into existence
+        at any moment (the channel-surface reconciler creates one), so a fallback
+        map would go invisible the instant one appeared, and two stores are how a
+        record gets filed under one index and cleared under another.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_utils
+        from kiro_crew.dashboard import state as state_mod
+
+        assert "_slack_options_posted" not in inspect.getsource(state_mod), (
+            "the slot-held OPTIONS field must be gone, not shadowed by a fallback"
+        )
+        utils_src = inspect.getsource(chat_utils)
+        assert "_slack_options_by_key" in utils_src
+        assert "_slack_options_posted" not in utils_src, (
+            "every accessor must go through the keyed store"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_slotless_thread_gets_the_whole_lifecycle(self, tmp_path):
+        """End to end for the case #1694 was filed about.
+
+        Record, expire and forget must all work for a session that has no dashboard
+        slot at any point -- which is the normal state of a plain Slack thread.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            expire_slack_options,
+            forget_slack_options,
+            options_records,
+            remember_slack_options,
+        )
+
+        state = _make_state(tmp_path)
+        state._slots = {}
+        state.get_linked_slot = MagicMock(return_value=None)
+        slack = MagicMock()
+        slack.update_message = AsyncMock()
+        state.slack_client = slack
+
+        key = "slack:1785370133.085469"
+        first = PostedOptions(channel="C-1", ts="opt-1", choices=("A",), blocks=())
+        second = PostedOptions(channel="C-1", ts="opt-2", choices=("B",), blocks=())
+
+        remember_slack_options(state, key, first)
+        remember_slack_options(state, key, second)
+        assert options_records(state, key) == (first, second), (
+            "a slotless session must accumulate every outstanding control"
+        )
+
+        forget_slack_options(state, key, "opt-1")
+        assert options_records(state, key) == (second,), "the forget must be ts-scoped"
+
+        await expire_slack_options(state, key)
+        assert slack.update_message.await_count == 1, (
+            "the remaining control must actually be struck through"
+        )
+        assert options_records(state, key) == ()
+
+    def test_only_the_first_click_on_a_control_is_answered(self):
+        """A second Send on the same message must dispatch nothing.
+
+        Two rapid clicks produce two handler tasks. Both serialize on
+        ``options_edit_lock``, so without a once-only claim the first renders the
+        selection and dispatches it and the second dispatches the same answer
+        again -- a duplicate turn, or a superseded one once the first has moved on.
+
+        The claim is deliberately NOT "is a record still tracked":
+        ``remember_slack_options`` no-ops when the session has no dashboard slot,
+        which is the normal state for a plain Slack conversation, so keying
+        validity on record presence would reject every legitimate click there.
+        """
+        from kiro_crew.slack.outbound import claim_options_answer
+
+        assert claim_options_answer("C-1", "opt-1") is True
+        assert claim_options_answer("C-1", "opt-1") is False, (
+            "a second click on the same control must not be answered again"
+        )
+        # A different control in the same channel is unaffected.
+        assert claim_options_answer("C-1", "opt-2") is True
+        # ...and so is the same ts in a different channel.
+        assert claim_options_answer("C-2", "opt-1") is True
+
+    def test_the_duplicate_click_is_dropped_before_any_side_effect(self):
+        """Structural: the claim gates the edit, the forget AND the dispatch.
+
+        Claiming after the edit would still leave two messages rewritten and two
+        turns dispatched; claiming outside the lock would let both clicks pass the
+        check before either set it.
+        """
+        import inspect
+
+        from kiro_crew.slack import interactions
+
+        src = inspect.getsource(interactions._handle_options_submit)
+        lock_at = src.find("async with options_edit_lock(")
+        claim_at = src.find("if not claim_options_answer(")
+        edit_at = src.find("update_message(")
+        assert lock_at != -1 and claim_at != -1 and edit_at != -1
+        assert lock_at < claim_at < edit_at, (
+            "the claim must sit INSIDE the lock and BEFORE the first edit, so a "
+            "duplicate click touches nothing"
+        )
+
+    def test_the_slack_fallback_text_is_escaped_but_the_answer_is_not(self):
+        """A mention must not survive into the message's top-level `text`.
+
+        Round 28 escaped the mrkdwn BLOCKS. Slack parses entities in a message's
+        `text` argument too -- and `text` is what notifications and block-less
+        clients show -- so the submit handler handing the raw selection to
+        `update_message` / `post_blocks` left the notification path open even
+        though the rendered blocks were safe.
+
+        The escape must NOT touch the copy echoed back into the session: that is
+        the answer the user picked, and escaping it would change it.
+        """
+        import inspect
+
+        from kiro_crew.slack import interactions
+
+        src = inspect.getsource(interactions._handle_options_submit)
+
+        assert "combined_fallback = escape_mrkdwn(combined)" in src, (
+            "the Slack-facing fallback text must be escaped"
+        )
+        assert "text=combined_fallback" in src, "update_message must use the escaped text"
+        assert "selected_blocks, combined_fallback" in src, (
+            "the post_blocks fallback must use the escaped text"
+        )
+        assert "text=combined," not in src, "no raw selection may reach Slack as text"
+        # ...and the agent-facing answer stays verbatim.
+        assert "[OPTIONS multi-select: {combined}]" in src, (
+            "the answer echoed into the session must stay raw -- escaping it would "
+            "change what the user picked"
+        )
+
+    def test_a_channel_mention_in_a_choice_is_inert_in_the_mrkdwn_summary(self):
+        """A choice cannot notify a channel just by being rendered.
+
+        Choice text is LLM-authored, so it can carry Slack's own entity syntax.
+        The summary that backfill, submit and expiry all render is a ``mrkdwn``
+        field, where ``<!channel>`` is INTERPRETED -- so an OPTIONS tag reading
+        ``[OPTIONS: <!channel> | Skip]`` would page a whole channel on render.
+        """
+        from kiro_crew.slack.format import build_options_selected_blocks
+
+        blocks = build_options_selected_blocks(["<!channel>", "Skip & go <b>"], [0])
+        text = blocks[0]["elements"][0]["text"]
+
+        assert "<!channel>" not in text, "a raw channel mention must never reach mrkdwn"
+        assert "&lt;!channel&gt;" in text
+        # `&` first, or the earlier substitutions get re-escaped into `&amp;lt;`.
+        assert "&amp;lt;" not in text
+        assert "Skip &amp; go &lt;b&gt;" in text
+
+    def test_escaping_does_not_leak_into_the_label_or_the_submit_value(self):
+        """The escape belongs to the mrkdwn sink only.
+
+        ``plain_text`` is not interpreted by Slack, so escaping there would show
+        a literal ``&lt;``; and the button ``value`` is echoed back into the
+        session on submit, so escaping it would change the answer the user
+        picked. Guards against "fixing" this in the shared `_redact_choices`.
+        """
+        choice = "Skip & go <b>"
+        blocks = build_options_blocks([choice])
+        opt = blocks[0]["elements"][0]["options"][0]
+
+        assert opt["text"]["text"] == choice, "plain_text labels must stay unescaped"
+        assert opt["value"] == choice, "the submit value must round-trip verbatim"


### PR DESCRIPTION
## Problem

Two defects in how Slack renders and retires an agent's `[OPTIONS: …]` control.

1. **The control renders as literal text in some paths.** When a thread is seeded
   with history (link-time backfill) the tag arrives as the raw string
   `[OPTIONS: Deploy | Abort]` instead of clickable checkboxes, so the reader sees
   markup rather than a question they can answer.
2. **A spent control stays clickable forever.** Nothing retires an OPTIONS control
   once the conversation moves past the question it asked. The buttons sit in the
   thread indefinitely, and a click days later injects that stale answer into
   whatever the session is doing now.

## Why it matters

The second one silently corrupts conversations. An OPTIONS click is not a comment —
it is injected as the user's next turn, so a click on a superseded question makes
the agent act on an answer to a question nobody is asking. In a shared channel any
member can trip it, and there is no visual cue that the question is dead. The first
defect is cosmetic by comparison but breaks the feature outright on the backfill
path: a control that renders as text cannot be answered at all.

## Fix (symptoms → root cause → change)

**Symptom 1 → root cause.** The Slack egress paths each built their own message.
Only the live-turn path knew to extract the OPTIONS tag and emit Block Kit; backfill
and mirror wrote the text through verbatim. So the behaviour depended on which code
path a message happened to take.

**Symptom 2 → root cause.** There was no lifecycle at all. A posted control had no
recorded identity, so nothing could later find it to retire it. "Stale" was never
represented anywhere.

**Change.** One posting helper, one lifecycle, one store:

- `slack/outbound.py` owns the control's lifecycle: `PostedOptions` records what was
  posted (channel, ts, choices, blocks) and `expire_options` rewrites that message
  with every choice struck through, so a dead question reads as unanswerable.
  Rendering itself stays in `slack/format.py`, the canonical renderer (#1760) — this
  PR deliberately adds no second renderer.
- Every path that can emit assistant text to Slack — the handler footer,
  `transport_dispatch`, the `chat_runner` mirror, backfill, `send_message`, and the two
  cron delivery sites — extracts the OPTIONS tag and renders the same blocks through
  `slack/format.py`. There is no single posting helper: each site keeps its own
  sequence, so the choreography is repeated rather than shared. Collapsing the six
  into one helper is tracked separately (#1658) and deliberately not attempted here.
- `chat_utils` holds the bookkeeping: `remember_slack_options` files a control under
  the session that owns the thread, `expire_slack_options` retires it, and
  `forget_slack_options` drops it when a click already answered it. Records live in
  **one store keyed by session key** on `DashboardState` — see the first invariant
  below, which is what closes **#1694**.

The lifecycle is where the real difficulty was, and the invariants below are each
there because a specific concurrency or ownership case broke without them. They are
stated as rules because every one of them is load-bearing:

| Invariant | Why |
|---|---|
| Records live in **one store keyed by session key**, never on the slot, and are **never evicted to stay small** (**closes #1694**) | A plain Slack thread usually has no dashboard slot, and a slot-held record was simply dropped for those sessions — so nothing tracked the control, no turn could expire it, and the stale click above stayed possible. Not a slot field *plus* a fallback either: a slot can appear at any moment (the channel-surface reconciler creates one), so a fallback map would go invisible the instant one did, and two stores are how a record gets filed under one index and cleared under another. And no size cap: evicting a live record means no later turn can retire that control, so a bound would reintroduce the untracked control at scale. The lifecycle is the bound — a key exists while a question is unanswered and is pruned the moment it is not. |
| Record and expiry must resolve the **same live owner**, on ALL THREE posting paths, and a forget must use keys snapshotted **before** its edit | A thread linked to a dashboard mid-turn changes session key. Filing under the key the turn started with puts the control where the expiry never looks. |
| Cleaning up after your own post must narrow to **your own ts** | A concurrent turn can record its own fresh control in the same slot; a session-wide drain would strike through the question the conversation is now waiting on. |
| Slot lookup must survive a slot name that is **not its session key folded** | A cron runs on `cron:<id>` but its slot is `cron-<id>`; the filename fold asked for `cron_<id>` and matched nothing, so the control was never recorded. |
| Ownership must consult the **persisted thread index**, not only the dashboard slot index | A cron links its thread as `cron:<id>` with no slot at all. The record used one index and the forget used the other, so a cron control was filed and never cleared. |
| A transiently-failed expiry must **keep** its record | Dropping it leaves live buttons with nothing tracking them — the exact stale click this PR exists to prevent. A permanent 4xx counts as settled so it is not retried forever. |
| Expiry only ever **removes** records, never re-adds them | A write-back cannot tell "still outstanding" from "deliberately removed while I awaited". Re-adding resurrected a control a click had just answered. |
| The supersession baseline is sampled on the owner it will **expire under**, and an owner change alone counts as superseded | Counters from two different sessions are not comparable. |
| An unreadable counter **abstains** rather than voting | No dashboard slot means `None`, and a slot can appear mid-post; a bare `!=` read that as "a turn happened" and struck the control through the instant it appeared. |
| Only a message that **starts a turn** spends the control | `ping`, `status`, a modifier-only message, a hook's canned reply, the keyword commands and a permission denial all answer without running the agent, so the pending question is still live. The dashboard turn path needed the same move: its expiry sat at the top of `_run_chat`, above the `/goal` and `/prompts` returns, so a local command that never starts a turn struck a pending question through and left valid choices unanswerable. |
| Linking to an **existing** thread retires that thread's prior control **before** reassigning it, and **aborts** while a prior record is unretired OR an answer is still routing | A live control is recorded under the thread's own conversation key. `link_slack` moves the thread -> slot index onto the new session, so no turn of the new owner would ever expire that record, and a click on those still-live buttons would answer into a session that never asked the question. The prior owner's keys are captured BEFORE the reassign -- resolving afterwards names the new owner -- and the control is struck through rather than re-keyed, because an ownership change is supersession. Re-linking a thread to the slot that already holds it skips its own key. Order is the fix, not just the presence of an expiry: linking first and expiring after leaves a window where the thread already routes to the NEW session while the old buttons are still on screen, so a transient failure on the strike-through (429, 5xx, network) lets a click resolve through the new reverse index into a conversation that never asked the question. A returned expiry does not prove the control was spent -- a transiently-failed record stays tracked deliberately -- so the guard reads "are any prior records still there" and returns 503 `slack_options_pending` rather than reassigning, exactly as the unlink path does. Records alone are not enough: a successful click forgets its record BEFORE dispatching, so once the answer is travelling there is nothing left for the records check to see -- the abort therefore also refuses while `answer_routing_in_flight(thread_ts)`, the same pair the unlink path weighs. |
| Unlink **aborts** while a control could not be retired, or while a spent control's answer is **still routing**, and its link writes stay **serialized on the event loop**, cancellation included | Tearing down thread routing while buttons are live is teardown-then-never-expire: a click then resolves to nothing and starts a fresh session carrying a stale answer. The second signal closes the mirror-image window: a click that SUCCEEDS forgets its record and dispatches the answer as a task, so between those steps the record this guard consults is already gone while the answer has not yet resolved its session. Registered by task, not counted, so a raising or cancelled turn cannot pin a thread as unlinkable forever. Cancellation is a third route to the same corruption: persistence is cleared at the top and the in-memory fields only at the end, so a shutdown during the expiry await leaves the two disagreeing and a restart loses the routing while the buttons stay live -- so the await is guarded and the captured link restored before re-raising. Every link write here runs ON the event loop: the session map has no cross-thread lock, so moving a write into a thread makes it race a loop-side relink rather than protecting anything. The blocking cost was measured rather than assumed -- 0.17ms for 50 sessions, 1.0ms for 500 (58KB), 9.8ms at an unrealistic 5000 -- on a path that runs only when an unlink aborts after a FAILED expiry, and every other session-map mutation in the codebase writes synchronously for the same reason. Removing the blocking write properly means serialising ALL session-map writers behind one lock and offloading them together, not making this one call racy. |
| Expiry and the Send edit **serialize per message**, and the expiry re-reads its record inside the lock | Slack has no compare-and-set on an edit. Without this a late expiry erases the answer the user just gave. The registry is bounded but an entry is evicted only when nobody holds OR awaits it: `not lock.locked()` reads False for a lock just released with its next waiter still scheduled, and evicting there hands the following caller a brand-new lock for the same message while the waiter proceeds on the old one -- two coroutines editing one message, with every guarantee built on this lock off. Interest is counted explicitly, registered before the acquire. |
| A control's answer is **claimed once**, under that same lock, and a settled expiry marks it **terminal** | Two rapid Send clicks are two handler tasks; without a once-only claim the second dispatches the same answer again. This covers BOTH click paths -- the multi-select submit and the legacy single-click control, where the click itself is the answer -- because both render into the same message and dispatch a turn. And a click queued behind a *successful expiry* would find the claim unheld and answer the question the expiry just retired, so the expiry takes the claim too. A submit that rendered nothing gives the claim back, or a control stays visible and permanently unanswerable. The claim map is bounded, but an entry is evictable only once the buttons are provably gone (the edit landed, the original was deleted, or the strike-through succeeded): eviction is workspace-wide insertion order, so dropping a live claim would let busy channels re-admit a duplicate click on a control still sitting unanswered in a quiet thread. |
| Choice text is **escaped at every Slack sink** — mrkdwn blocks *and* the top-level `text` | Choice text is LLM-authored, so `[OPTIONS: <!channel> | Skip]` would page a whole channel. `text` is a sink too: it is what notifications render. Both click paths, not just the multi-select submit: the legacy single-click handler passed the raw choice as its own fallback text, so one click on a choice containing `<!channel>` notified the whole channel. The answer echoed into the session stays RAW -- only the fallback is escaped. The `send_message` control is handled differently and deliberately: its fallback is the safe `OPTIONS_FALLBACK_TEXT` stub rather than an escaped body, because the body is already posted as its own Slack message immediately above, so on the control it was pure duplication -- and the expiry replays that stored text on every edit, which would have notified the channel again each time. |

Two places deliberately do **not** get a guard, and say so in the code:

- `transport_dispatch` does not check `sessions.is_busy` around its own record.
  `is_busy` means "the semaphore is held", and the turn still holds its own at that
  point — checking it would strike every fresh control through the instant it was
  posted. The native footer path differs and does check it, because its permit is
  released before the footer goes up.
- The escape is not folded into `_redact_choices`, even though every renderer passes
  through it. That output also feeds the `plain_text` checkbox label (Slack does not
  interpret it, so escaping would display a literal `&lt;`) and the button `value`
  echoed back into the session, where an escaped entity would change the answer the
  user picked.

## Tests

`test/test_slack_options_lifecycle.py` is new and carries the lifecycle contract
(~94 tests). Each guarantee above has a test that fails when its mechanism is
removed — every one was verified non-vacuous by reverting the mechanism and watching
its own assertion fail. Grouped by what they lock in:

- **Rendering** — a control reaches Slack as Block Kit on every path, never as
  literal text; a credential split by ANSI, emphasis or link markup is caught in the
  form Slack actually displays; a `<!channel>` in a choice is inert in both the
  mrkdwn summary and the fallback `text`, while the `plain_text` label and the submit
  `value` stay verbatim.
- **Recording** — a slotless Slack thread gets the whole lifecycle (record, ts-scoped
  forget, expire), which is the case #1694 was filed about; the control is filed under
  the thread's live owner, including a `cron:<id>` owner with no dashboard slot, and a
  slot whose name is not its key folded.
- **Retiring** — a new turn spends the previous control; `ping`/`status`/denial do
  not; the expiry narrows to its own ts; a transient Slack failure keeps the record
  and a permanent one settles it; a click that wins the race is not overwritten; a
  second click on the same control is dropped rather than dispatched twice; a click
  queued behind a settled expiry is refused; a submit that rendered nothing gives
  its claim back; an answered control is never resurrected.
- **Unlink** — the teardown is conditional on the link not having moved, a same-thread
  relink that lands mid-await survives, and the unlink refuses rather than orphaning a
  control it could not retire.

`test/test_options_submit.py`, `test/test_slack_handler.py` and
`test/chat_test_helpers.py` are extended for interface parity — the shared state
double grew a real in-memory Slack-link store, because the unlink path unpacks
`get_slack_link` into a pair and branches on presence, and a bare `MagicMock`
satisfies neither. `test/conftest.py` gains an autouse fixture that clears the two
per-message OPTIONS registries (edit lock, answer claim) between tests: they are
correct as process state in the gateway, where a control's ts is unique, but test
fixtures reuse a fixed pair across unrelated cases.

## Manual verification

N/A — unit coverage is sufficient. Every path here is server-side Slack bookkeeping
with no UI surface, and the concurrency cases (a click racing an expiry, two clicks
racing each other, a relink landing mid-await, a slot appearing mid-post) are
reachable in tests but not reliably reproducible by hand against live Slack.

Local gates on this head: **9982 passed** across every consumer of the touched
modules plus the repo-wide error-code contract. A full-suite run gives **30937
passed**; its 36 failures are pre-existing environment failures on the dev box
(sandbox userns, missing binaries, systemd), every one in a file with an empty diff
against `main`. `mypy` clean on 824 source files; `flake8` + `isort` clean.














