### PR TITLE
fix(dashboard): stop session-row menu clicks bubbling into switchSlot

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -2412,9 +2412,9 @@ function ChatSidebar({
             <div className="absolute top-1/2 -translate-y-1/2 right-1.5 flex items-center gap-0.5">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <button type="button" className="text-muted/50 active:text-text p-1 cursor-pointer bg-transparent border-none" aria-label={i18nT('pages.chatSidebar.more_options')} onMouseDown={e => e.stopPropagation()}><MoreVertical size={14} /></button>
+                  <button type="button" className="text-muted/50 active:text-text p-1 cursor-pointer bg-transparent border-none" aria-label={i18nT('pages.chatSidebar.more_options')} onMouseDown={e => e.stopPropagation()} onClick={e => e.stopPropagation()}><MoreVertical size={14} /></button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-[160px]" onCloseAutoFocus={onMenuCloseAutoFocus}>
+                <DropdownMenuContent align="end" className="min-w-[160px]" onClick={e => e.stopPropagation()} onCloseAutoFocus={onMenuCloseAutoFocus}>
                   <SessionActionsMenu variant="dropdown" {...rowMenuProps} />
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -2423,9 +2423,9 @@ function ChatSidebar({
             <IconButtonGroup reveal className="absolute top-1/2 -translate-y-1/2 right-1.5 has-[[data-state=open]]:opacity-100">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <IconButton title={i18nT('pages.chatSidebar.more')} aria-label={i18nT('pages.chatSidebar.more_options')} onMouseDown={e => e.stopPropagation()}><MoreVertical size={12} /></IconButton>
+                  <IconButton title={i18nT('pages.chatSidebar.more')} aria-label={i18nT('pages.chatSidebar.more_options')} onMouseDown={e => e.stopPropagation()} onClick={e => e.stopPropagation()}><MoreVertical size={12} /></IconButton>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-[160px]" onCloseAutoFocus={onMenuCloseAutoFocus}>
+                <DropdownMenuContent align="end" className="min-w-[160px]" onClick={e => e.stopPropagation()} onCloseAutoFocus={onMenuCloseAutoFocus}>
                   <SessionActionsMenu variant="dropdown" {...rowMenuProps} />
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -2435,7 +2435,7 @@ function ChatSidebar({
           ))}
         </div>
           </ContextMenuTrigger>
-          <ContextMenuContent className="min-w-[160px]" onCloseAutoFocus={onMenuCloseAutoFocus}>
+          <ContextMenuContent className="min-w-[160px]" onClick={e => e.stopPropagation()} onCloseAutoFocus={onMenuCloseAutoFocus}>
             <SessionActionsMenu variant="context" {...rowMenuProps} />
           </ContextMenuContent>
         </ContextMenu>


### PR DESCRIPTION
Fixes #1462

## Problem

"Mark as unread" on a sidebar session row's ⋯ menu opened the conversation instead of marking it unread.

The session row is a click-to-switch surface, and its ⋯ menu trigger + menu content live inside it in the React tree. Radix portals the menu content, but React synthetic clicks still propagate through the **React** tree — so opening the menu or selecting an item bubbled a `click` into the row's `switchSlot` handler. `switchSlot` both opens the conversation **and** dispatches `markSlotRead` as its first step, instantly reverting the `markSlotUnread` the menu action had just applied. Net effect: the action appeared to do nothing except open the conversation.

## Fix

Add the same `onClick={e => e.stopPropagation()}` guard the folder-header menu in the same file already carries to:

- both session-row `⋯` `DropdownMenuTrigger` buttons (mobile + desktop)
- both session-row `DropdownMenuContent` instances
- the row's right-click `ContextMenuContent`

5 lines, no behavior change beyond containing menu clicks to the menu.

## Verification

Live A/B against the same gateway and sessions:

| Build | "Mark as unread" switched sessions? | Unread mark stuck? |
|---|---|---|
| unfixed | yes ❌ | no ❌ |
| fixed | no ✅ | yes ✅ |

Added `website/playwright/mark-unread-propagation.spec.ts` encoding both assertions plus the menu flipping to "Mark as read". The spec **fails against the unfixed build** (at the "active session unchanged" assertion) and passes with the fix. A happy-dom component test could not exercise this path (it passed with and without the fix), which is why the regression lives in the E2E suite — noted in the spec header.

`tsc --noEmit` clean, eslint warnings-only (pre-existing), all 131 ChatSidebar unit tests pass. The 13 `npm run test` failures on this machine are in electron/MacUpdater contract suites, untouched by this change.

## Notes

- Contribution developed with agent assistance per CONTRIBUTING.md's "Using AI Tools" section; I can walk through every line.
- No doc change: this restores intended documented behavior; no subsystem doc describes the buggy behavior.

## Before
https://github.com/user-attachments/assets/716bbf26-3c76-42cf-8d69-5b51d3dd601e

## After
https://github.com/user-attachments/assets/d716e535-3054-442d-8c51-419df43ef232

