### PR TITLE
fix: Agent Templates default selection writes to wrong config field

### DIFF
--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -225,11 +225,11 @@ async def api_default_agent(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": "failed to read config file", "code": "config_unreadable"}, status=500
             )
-        data.setdefault("agent", {})["default_agent"] = name
+        data["default_agent"] = name
         write_config_atomically(path, data)
         return web.json_response({"ok": True, "default_agent": name})
     cfg = KiroCrewConfig.load()
-    return web.json_response({"default_agent": cfg.agent.default_agent})
+    return web.json_response({"default_agent": cfg.default_agent})
 
 
 # ── Config Schema ──


### PR DESCRIPTION
## Description

The "Set as default" button in Agent Capabilities → Agent Templates writes to `data["agent"]["default_agent"]` (the kiro-cli backend agent name), but new sessions resolve their agent template from the **top-level** `config.default_agent` via `resolve_agent_bindings()`. This means the UI selection is silently ignored and new sessions always start with the previous default.

This PR fixes the `api_default_agent` handler to read/write the correct top-level field.

## Related Issues

Fixes #1471

## Changes

Two lines in `src/kiro_crew/dashboard/handlers/agents.py`:

- **PUT path**: `data.setdefault("agent", {})["default_agent"] = name` → `data["default_agent"] = name`
- **GET path**: `cfg.agent.default_agent` → `cfg.default_agent`

## Testing

- [ ] Existing tests pass (`make test`)
- [x] Manual verification: traced the config read/write paths to confirm `resolve_agent_bindings()` at line 5583 of `config/loader.py` reads `config.default_agent` (top-level), and the `/api/agents` list endpoint at line 1107 also returns `cfg.default_agent` — both now aligned with this handler.
- [ ] New tests added for new functionality

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable) — no doc change needed, this is a bug fix
- [x] No secrets, credentials, or internal references in the diff