### PR TITLE
feat(apps): add kodama to app-registry

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -4,5 +4,11 @@
     "gitUrl": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
     "repo": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
     "branch": "main"
+  },
+  {
+    "name": "kodama",
+    "gitUrl": "https://github.com/amergrgic/kodama",
+    "repo": "https://github.com/amergrgic/kodama",
+    "branch": "main"
   }
 ]


### PR DESCRIPTION
## Description

Adds **Kodama** to the Kiro Crew App Store — a portable, provider-neutral multi-agent pack for the Kiro CLI.

Kodama provides one orchestrator and eight specialists (scout, scholar, sage, artist, smith, critic, forge, scribe) with clear permission boundaries, structured delegation, and project memory. It ships as an agent-only app: 9 agent configs and 3 skills, no backend, no cron.

- GitHub: https://github.com/amergrgic/kodama
- License: MIT
- Manifest: `app.json` in repo root

Screenshot of App page, showing the different agents and explaining how to use Kodama. 
<img width="2816" height="1822" alt="Screenshot 2026-08-04 at 23 50 20" src="https://github.com/user-attachments/assets/7fd337c6-ed75-4a15-a4a5-551c3f4d87a3" />

Small video showing kodama results from calling a subagent (scout)

https://github.com/user-attachments/assets/6ad077d6-5de0-41a0-b9e3-166001500a9a

## Related Issues

None — new App Store listing.

## Testing

- [x] Existing tests pass (`make test`)
- [ ] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

Verified that the `app.json` manifest validates against the manifest reference schema (required fields: name, version, displayName, description; resources: agents array, skills array). Installed locally via `kirocrew app install` from the repo path — all 9 agents and 3 skills registered successfully.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->