### PR TITLE
fix(ci): omit ephemeral worktree-fixture path from coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -239,6 +239,16 @@ looponfailroots = src test
 [coverage:run]
 branch = true
 parallel = true
+# Ephemeral pytest tmp fixtures fabricate a worktree layout at
+# <tmp>/kirocrew-wt-example/src/kiro_crew/agent.py (see
+# test/test_agent_home_isolation.py::_make_linked_worktree). No real file is
+# ever written there, but the phantom path lands in the coverage data and makes
+# `coverage xml`/`coverage report` in the Coverage Combine job abort with
+# "No source for code: .../kirocrew-wt-example/.../agent.py" (the step runs
+# under `bash -e`, so the non-zero exit fails the whole gate — and Coverage Gate
+# then fails closed, blocking PR Readiness on every open PR). Never measure it.
+omit =
+    */kirocrew-wt-example/*
 
 [coverage:paths]
 source =
@@ -250,6 +260,12 @@ source =
 # opt-in.
 [coverage:report]
 show_missing = true
+# Also omit at report time: the Coverage Combine job reads shards produced by
+# the test job, and `[coverage:run] omit` only governs collection. Without this
+# a shard that already recorded the phantom fixture path would still trip
+# `coverage xml`/`coverage report` with "No source for code". Keep both in sync.
+omit =
+    */kirocrew-wt-example/*
 
 [coverage:html]
 directory = build/coverage


### PR DESCRIPTION
## Problem
`Coverage Combine` fails on **every open PR** with:
```
No source for code: '/tmp/pytest-of-runner/pytest-0/popen-gw0/test_symlinked_shared_home_sti0/kirocrew-wt-example/src/kiro_crew/agent.py'.
Process completed with exit code 1.
```
That failure cascades: `Coverage Gate` fails closed (`coverage-combine=failure`), which fails `PR Readiness`. Observed on #1460, #1458, #1371 — none of which touch coverage — confirming a base-branch regression, not a per-PR issue.

## Why it matters
No same-repo PR can reach `readiness: passed` while `main` is in this state, so the whole review pipeline is blocked repo-wide until it's fixed.

## Fix (symptoms → root cause → change)
- **Symptom:** `coverage xml`/`coverage report` in the Coverage Combine job abort with `No source for code` at a `.../kirocrew-wt-example/.../agent.py` tmp path.
- **Root cause:** `test/test_agent_home_isolation.py::_make_linked_worktree` fabricates a worktree layout under a pytest tmp dir and monkeypatches `agent.__file__` to `<tmp>/kirocrew-wt-example/src/kiro_crew/agent.py`. **No file is ever written there** — only the parent dirs are `mkdir`'d. The phantom path nonetheless lands in the combined coverage data (surfaced via coverage's package source scan under the full parallel suite). When the Combine job later reads that path to compute missing lines / emit XML, the tmp dir is long gone, so coverage errors. The step runs under `bash -e`, so the non-zero exit fails the job; `Coverage Gate` then fails closed.
- **Change:** `omit` the ephemeral fixture path `*/kirocrew-wt-example/*` in **both** `[coverage:run]` (so the test job never records it) and `[coverage:report]` (so the Combine job doesn't error on shards that already recorded it before this change ships). Because the path is a phantom test fixture and never real source, `omit` is the correct mechanism here — a `[coverage:paths]` remap would misattribute a non-existent file into real `src/`.

## Tests
No unit test added — the regression lives in coverage.py's report/xml phase (a CI-tooling concern), not in product code, and is not observable from a normal pytest run. Validated instead by reproduction (see below).

## Manual verification
Reproduced the exact CI failure signature against the repo's pinned `coverage==7.10.6`: synthesized combined coverage data referencing `<tmp>/kirocrew-wt-example/src/kiro_crew/agent.py`, deleted the source (as the pytest tmp cleanup does), then ran the Combine sequence:
- **Without omit:** `No source for code: '.../kirocrew-wt-example/src/kiro_crew/agent.py'`, `coverage report` rc=1 and `coverage xml` rc=1 — matches CI.
- **With this omit:** the `No source for code` error is gone for both `report` and `xml`. (Real CI has abundant other coverage data, so the Combine step exits 0.)

Also ran `test/test_agent_home_isolation.py` (26 passed, 2 skipped) to confirm the guard tests themselves are unaffected.

## Screenshots
N/A — CI config change, no user-visible UI.
