### PR TITLE
fix(sessions): keep a message's real origin through the save round trip

### DIFF
--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -60,6 +60,7 @@ import weakref
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.dashboard.state import _normalize_slot_key
+from kiro_crew.history import carry_provenance
 from kiro_crew.messaging.link import channel_namespace_of, is_channel_session_key
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -329,6 +330,12 @@ def _rebuild_window(slot: "_ChatSlot", messages: list[dict[str, Any]]) -> None:
             broadcast=False,
             meta=(msg["meta"] if isinstance(msg.get("meta"), dict) else None),
         )
+        # This transcript is the CHANNEL's, so most of these lines arrived from
+        # Slack/Discord and carry a real origin. Provenance is not a
+        # slot.append() argument, so copy it onto the message the append just
+        # created — the save path re-serializes this window and would otherwise
+        # restamp every line "dashboard".
+        carry_provenance(slot.messages[-1], msg)
     slot.drain()
     slot._resumed_count = len(slot.messages)
     slot._disk_window_len = len(slot.messages)
@@ -426,6 +433,8 @@ def refresh_channel_window(
             ts=msg.get("ts", ""),
             meta=(msg["meta"] if isinstance(msg.get("meta"), dict) else None),
         )
+        # See the equivalent call in _rebuild_window.
+        carry_provenance(slot.messages[-1], msg)
     slot.drain()
     slot._resumed_count = len(slot.messages)
     slot._disk_window_len = len(slot.messages)

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -13,6 +13,7 @@ from kiro_crew.dashboard.chat_utils import (
     effective_session_key,
 )
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import carry_provenance
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
@@ -227,6 +228,10 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                 content, _ = redact_credentials(content)
             cls = "msg msg-u" if role == "user" else "msg msg-a"
             new_slot.append(role, content, cls, ts=m.get("ts", ""), meta=m.get("meta"), broadcast=False)
+            # A fork copies the parent's messages into a new session. Origin is
+            # a property of the message, not of the file, so a copied inbound
+            # channel turn keeps the origin it actually had.
+            carry_provenance(new_slot.messages[-1], m)
         new_slot.drain()
         await save_slot_off_loop(state, new_slot)
         new_slot._resumed_count = len(new_slot.messages)

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -59,6 +59,7 @@ from kiro_crew.dashboard.state import (
     _normalize_slot_key,
 )
 from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
+from kiro_crew.history import carry_provenance
 from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.providers.acp import AcpProvider
 from kiro_crew.providers.base import LLMProvider
@@ -2720,6 +2721,9 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
                 _redact_meta_for_role(role, m["meta"]) if isinstance(m.get("meta"), dict) else None
             ),
         )
+        # See the equivalent call in _rehydrate_slot_from_history: resume loads
+        # the window that the next save re-serializes.
+        carry_provenance(slot.messages[-1], m)
         _attach_variants(slot, m)
     slot.drain()
     slot._resumed_count = len(slot.messages)

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -28,6 +28,7 @@ from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _normalize_slot
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
 from kiro_crew.history import (
     _archive_lines,
+    carry_provenance,
     transcript_sort_key,
     update_metadata_off_loop,
 )
@@ -562,6 +563,10 @@ def _rehydrate_slot_from_history(
             # meta to a client.
             meta=(m["meta"] if isinstance(m.get("meta"), dict) else None),
         )
+        # Provenance is not a slot.append() argument, so carry it onto the
+        # message the append just created. Without this the window loses where
+        # each turn came from and the next flush restamps it "dashboard".
+        carry_provenance(slot.messages[-1], m)
         _attach_variants(slot, m)
     slot.drain()
     slot._resumed_count = len(slot.messages)
@@ -791,6 +796,8 @@ def _restore_recent_sessions_steps(
                 broadcast=False,
                 meta=(m["meta"] if isinstance(m.get("meta"), dict) else None),
             )
+            # See the equivalent call in _rehydrate_slot_from_history.
+            carry_provenance(slot.messages[-1], m)
             _attach_variants(slot, m)
         slot.drain()
         slot._resumed_count = len(slot.messages)
@@ -916,9 +923,18 @@ def _build_message_entry(m: dict) -> dict | None:
         "role": role,
         "content": content,
         "ts": m.get("ts", ""),
+        # "dashboard" is the fallback, not the answer. A channel tab shares the
+        # channel's transcript, so the window this re-serializes can hold turns
+        # that arrived FROM Slack or Discord with their own recorded origin; the
+        # load paths carry that origin onto the in-memory message so it survives
+        # the round trip. Hardcoding "dashboard" flattened it on the next flush,
+        # making the audit trail claim inbound channel traffic was typed into
+        # the dashboard. A message with no recorded origin genuinely IS a
+        # dashboard-authored turn, so it keeps these defaults.
         "source_thread": "dashboard",
         "source_user": "dashboard",
     }
+    carry_provenance(entry, m)
     if m.get("variants"):
         redacted_variants: list[dict] = []
         for v in m["variants"]:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -422,6 +422,32 @@ _SEARCH_SCAN_WINDOW = 500  # cap files scanned per search to bound I/O
 # can't silently diverge between surfaces.
 INCOGNITO_MEMORY_MODES = frozenset({"incognito", "temporary"})
 
+# The fields that record where a message came from: the session key it arrived
+# on (``source_thread``, e.g. ``slack:1785861252.833429``) and the platform user
+# who sent it (``source_user``). Written by :meth:`ConversationLog.append`, read
+# by :meth:`ConversationLog.get_source_threads` for cross-session citation and
+# by SEL attribution.
+PROVENANCE_FIELDS = ("source_thread", "source_user")
+
+
+def carry_provenance(dest: dict, src: dict) -> None:
+    """Copy *src*'s recorded provenance onto *dest*, leaving absent fields out.
+
+    A message's origin is a property of the message, not of the file it happens
+    to be stored in, so any path that copies or re-serializes a persisted line
+    must carry these fields across or the copy claims a different origin than
+    the original.
+
+    Absent stays absent, and an empty or non-string value is treated as absent:
+    :meth:`ConversationLog.append` writes each field only when it is truthy and
+    :meth:`get_source_threads` filters on the same truthiness, so writing
+    ``""`` would create a third state that reads as present-but-unusable.
+    """
+    for field in PROVENANCE_FIELDS:
+        value = src.get(field)
+        if isinstance(value, str) and value:
+            dest[field] = value
+
 
 def _safe_mtime(path: Path) -> float | None:
     """Return a file's mtime, or None if it can't be stat'd."""

--- a/test/test_message_provenance.py
+++ b/test/test_message_provenance.py
@@ -1,0 +1,351 @@
+"""A message's recorded origin survives being loaded and written back.
+
+A channel tab and its channel share ONE transcript, so the window a dashboard
+save re-serializes can hold turns that arrived from Slack or Discord. Those
+turns must still name their real origin afterwards: ``source_thread`` is what
+``ConversationLog.get_source_threads`` cites across sessions and what SEL
+attribution and per-surface filtering read.
+
+The load paths are the load-bearing half. Preserving provenance only in the
+write path is silently vacuous for anything read back from disk, because the
+in-memory message dict is built by ``_ChatSlot.append``, which has no
+provenance argument — so a save would find nothing to preserve and fall back to
+"dashboard" on every restored line.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.chat_persistence import (
+    _build_message_entry,
+    _rehydrate_slot_from_history,
+    _save_slot_to_history,
+    restore_recent_sessions,
+)
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import ConversationLog, carry_provenance
+
+SLACK_THREAD = "slack:1785861252.833429"
+SLACK_USER = "W017SQBPZBN"
+
+
+def _make_state(tmp_path: Path) -> DashboardState:
+    sessions = MagicMock(count=0)
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.remove = AsyncMock()
+    sessions.channel_key_for_stem = MagicMock(return_value=None)
+    return DashboardState(
+        sessions=sessions,
+        crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        start_time=0.0,
+        conversation_log=ConversationLog(base_dir=tmp_path),
+    )
+
+
+def _write_session(
+    tmp_path: Path, key: str, messages: list[dict], meta: dict | None = None
+) -> Path:
+    path = tmp_path / f"{key}.jsonl"
+    meta_line: dict[str, Any] = {
+        "_type": "metadata",
+        "created_at": "2026-08-04T16:34:22.412779",
+        "last_consolidated": 0,
+    }
+    if meta:
+        meta_line.update(meta)
+    lines = [json.dumps(meta_line)] + [json.dumps(m) for m in messages]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _message_lines(path: Path) -> list[dict]:
+    """Parse a transcript's message lines (metadata line excluded)."""
+    out = []
+    for ln in path.read_text(encoding="utf-8").splitlines():
+        if not ln.strip():
+            continue
+        entry = json.loads(ln)
+        if entry.get("_type") == "metadata":
+            continue
+        out.append(entry)
+    return out
+
+
+def _inbound_slack_turn(ts: str = "2026-08-04T16:34:22.500000") -> dict:
+    """A line as ``ConversationLog.append`` writes it for an inbound Slack DM."""
+    return {
+        "role": "user",
+        "content": "This is a test session from Slack.",
+        "ts": ts,
+        "source_thread": SLACK_THREAD,
+        "source_user": SLACK_USER,
+    }
+
+
+class TestCarryProvenance:
+    def test_copies_both_fields(self) -> None:
+        dest: dict = {}
+        carry_provenance(dest, _inbound_slack_turn())
+        assert dest == {"source_thread": SLACK_THREAD, "source_user": SLACK_USER}
+
+    def test_absent_stays_absent(self) -> None:
+        """No key at all, rather than an empty string.
+
+        ``ConversationLog.append`` writes each field only when truthy and
+        ``get_source_threads`` filters on the same truthiness, so an empty
+        string would be a third state that reads as present-but-unusable.
+        """
+        dest: dict = {}
+        carry_provenance(dest, {"role": "user", "content": "typed here"})
+        assert dest == {}
+
+    @pytest.mark.parametrize("bad", ["", None, 0, [], {"a": 1}, 17])
+    def test_empty_and_non_string_values_are_absent(self, bad: Any) -> None:
+        dest: dict = {}
+        carry_provenance(dest, {"source_thread": bad, "source_user": bad})
+        assert dest == {}
+
+    def test_does_not_overwrite_with_an_absent_value(self) -> None:
+        dest = {"source_thread": "dashboard", "source_user": "dashboard"}
+        carry_provenance(dest, {"source_thread": SLACK_THREAD})
+        assert dest["source_thread"] == SLACK_THREAD
+        assert dest["source_user"] == "dashboard"
+
+
+class TestBuildMessageEntry:
+    def test_preserves_a_real_origin(self) -> None:
+        entry = _build_message_entry(_inbound_slack_turn())
+        assert entry is not None
+        assert entry["source_thread"] == SLACK_THREAD
+        assert entry["source_user"] == SLACK_USER
+
+    def test_dashboard_authored_turn_keeps_the_dashboard_default(self) -> None:
+        """"dashboard" is not invented provenance -- it is the right answer for a
+        message with no recorded origin, which is a dashboard-authored turn."""
+        entry = _build_message_entry({"role": "user", "content": "typed here", "ts": "t"})
+        assert entry is not None
+        assert entry["source_thread"] == "dashboard"
+        assert entry["source_user"] == "dashboard"
+
+    def test_never_writes_an_empty_origin(self) -> None:
+        entry = _build_message_entry(
+            {"role": "user", "content": "x", "ts": "t", "source_thread": "", "source_user": ""}
+        )
+        assert entry is not None
+        assert entry["source_thread"] == "dashboard"
+        assert entry["source_user"] == "dashboard"
+
+
+class TestRehydrateThenFlushRoundTrip:
+    """The regression test for the bug: load a transcript, then save it back.
+
+    Asserting on a fresh in-memory message instead would pass even with the
+    load paths left unfixed.
+    """
+
+    def _rehydrated(self, tmp_path: Path, monkeypatch: Any, messages: list[dict]) -> Any:
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        _write_session(tmp_path, "dashboard_chat1", messages, meta={"title": "T"})
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        return state, slot
+
+    def test_slack_origin_survives_the_flush(self, tmp_path: Path, monkeypatch: Any) -> None:
+        state, slot = self._rehydrated(tmp_path, monkeypatch, [_inbound_slack_turn()])
+
+        # The load path must put provenance where the save path can find it.
+        assert slot.messages[0]["source_thread"] == SLACK_THREAD
+        assert slot.messages[0]["source_user"] == SLACK_USER
+
+        slot.append("user", "and now from the dashboard")
+        slot.drain()
+        _save_slot_to_history(state, slot)
+
+        lines = _message_lines(tmp_path / "dashboard_chat1.jsonl")
+        assert len(lines) == 2
+        assert lines[0]["source_thread"] == SLACK_THREAD
+        assert lines[0]["source_user"] == SLACK_USER
+        # The dashboard-authored turn appended alongside it is genuinely ours.
+        assert lines[1]["source_thread"] == "dashboard"
+        assert lines[1]["source_user"] == "dashboard"
+
+    def test_every_role_in_the_window_keeps_its_origin(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """A reply the agent produced FOR a Slack thread belongs to that thread
+        too -- the restamp flattened assistant and tool lines as well."""
+        messages = [
+            _inbound_slack_turn("2026-08-04T16:34:22.500000"),
+            {
+                "role": "assistant",
+                "content": "Test session received.",
+                "ts": "2026-08-04T16:34:25.000000",
+                "source_thread": SLACK_THREAD,
+                "source_user": SLACK_USER,
+            },
+            {
+                "role": "tool",
+                "content": "Running: ls",
+                "ts": "2026-08-04T16:34:26.000000",
+                "source_thread": SLACK_THREAD,
+                "source_user": SLACK_USER,
+            },
+        ]
+        state, slot = self._rehydrated(tmp_path, monkeypatch, messages)
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+
+        lines = _message_lines(tmp_path / "dashboard_chat1.jsonl")
+        assert [m["role"] for m in lines] == ["user", "assistant", "tool"]
+        assert {m["source_thread"] for m in lines} == {SLACK_THREAD}
+        assert {m["source_user"] for m in lines} == {SLACK_USER}
+
+    def test_repeated_flushes_do_not_erode_provenance(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """The dashboard flushes every few seconds; one surviving round trip is
+        not enough if the save's own output cannot be reloaded."""
+        state, slot = self._rehydrated(tmp_path, monkeypatch, [_inbound_slack_turn()])
+        path = tmp_path / "dashboard_chat1.jsonl"
+        for _ in range(3):
+            slot._dirty = True
+            _save_slot_to_history(state, slot)
+        assert _message_lines(path)[0]["source_thread"] == SLACK_THREAD
+
+        # Reload from the file the saves produced and flush once more.
+        state2 = _make_state(tmp_path)
+        slot2 = _rehydrate_slot_from_history(state2, "chat1")
+        assert slot2 is not None
+        slot2._dirty = True
+        _save_slot_to_history(state2, slot2)
+        assert _message_lines(path)[0]["source_thread"] == SLACK_THREAD
+
+    def test_frozen_prefix_and_window_agree(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """The prefix keeps provenance because it is copied verbatim; the window
+        must now match it instead of contradicting it in the same file."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        messages = [
+            {**_inbound_slack_turn(f"2026-08-04T16:{i:02d}:00.000000"), "content": f"m{i}"}
+            for i in range(6)
+        ]
+        _write_session(tmp_path, "dashboard_chat1", messages)
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        # Pretend the first three lines are older than the loaded window.
+        slot._disk_older_count = 3
+        slot._disk_window_len = 3
+        del slot.messages[:3]
+        slot._frozen_prefix_cache = None
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+
+        lines = _message_lines(tmp_path / "dashboard_chat1.jsonl")
+        assert [m["content"] for m in lines] == [f"m{i}" for i in range(6)]
+        assert {m["source_thread"] for m in lines} == {SLACK_THREAD}
+
+
+class TestBulkRestoreRoundTrip:
+    def test_startup_restore_carries_provenance(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """``restore_recent_sessions`` is a second, independent load path."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        path = _write_session(tmp_path, "dashboard_chat1", [_inbound_slack_turn()])
+        path.touch()
+        state = _make_state(tmp_path)
+        assert restore_recent_sessions(state, window_minutes=60) == 1
+        slot = state._slots["chat1"]
+        assert slot.messages[0]["source_thread"] == SLACK_THREAD
+
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+        assert _message_lines(path)[0]["source_thread"] == SLACK_THREAD
+
+
+class TestChannelWindowRoundTrip:
+    """A channel-bound tab loads the CHANNEL's transcript, so nearly every line
+    it reads back arrived from the channel."""
+
+    def test_rebuild_window_carries_provenance(self, tmp_path: Path, monkeypatch: Any) -> None:
+        from kiro_crew.dashboard.channel_slots import _rebuild_window
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("slack_1.1", linked_session_key="slack:1.1")
+        _rebuild_window(slot, [_inbound_slack_turn()])
+
+        assert slot.messages[0]["source_thread"] == SLACK_THREAD
+        assert slot.messages[0]["source_user"] == SLACK_USER
+
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+        lines = _message_lines(tmp_path / "slack_1.1.jsonl")
+        assert lines[0]["source_thread"] == SLACK_THREAD
+        assert lines[0]["source_user"] == SLACK_USER
+
+
+class TestForeignAppendDedup:
+    """Provenance must not perturb the foreign-append scan.
+
+    Identity there is ``(ts, role, content)`` with a ``(role, content)``
+    tiebreak -- never the whole line -- so a window entry that now carries
+    provenance still matches its own on-disk copy rather than being treated as
+    a cross-process append and duplicated.
+    """
+
+    def test_window_entry_is_not_duplicated_as_a_foreign_append(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        _write_session(tmp_path, "dashboard_chat1", [_inbound_slack_turn()])
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        # Force the slow path so the scan actually runs instead of the
+        # mtime/size fast path serving cached bytes.
+        slot._frozen_prefix_cache = None
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+
+        lines = _message_lines(tmp_path / "dashboard_chat1.jsonl")
+        assert len(lines) == 1, "the window's own line came back as a foreign append"
+        assert lines[0]["source_thread"] == SLACK_THREAD
+
+    def test_a_genuine_foreign_append_keeps_its_own_origin(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Foreign lines are merged as raw bytes, so they were always correct --
+        lock that in so the merge is not 'fixed' into a rebuild later."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        path = _write_session(tmp_path, "dashboard_chat1", [_inbound_slack_turn()])
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+
+        # Another process appends while this slot holds its pre-lock snapshot.
+        with path.open("a", encoding="utf-8") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "from a subagent",
+                        "ts": "2026-08-04T16:40:00.000000",
+                        "source_thread": "discord:99",
+                        "source_user": "U9",
+                    }
+                )
+                + "\n"
+            )
+        slot._frozen_prefix_cache = None
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+
+        lines = _message_lines(path)
+        assert [m["source_thread"] for m in lines] == [SLACK_THREAD, "discord:99"]


### PR DESCRIPTION
## Problem

Messages that arrived **from Slack** are persisted claiming they came from the dashboard.

Observed on a live transcript (`slack_1785861252.833429.jsonl`): all six messages carry
`source_thread: "dashboard"` and `source_user: "dashboard"` — including the very first
one, which *was* the inbound Slack DM that created the session.

## Why it matters

This is a data-correctness bug in the audit trail, not a display bug. `source_thread` is
the field that answers "where did this message come from", and three things read it:

- cross-session citation (`get_source_threads`, used to quote one conversation in another)
- SEL attribution
- any per-surface filtering

All of them currently see Slack traffic as dashboard-origin. Nothing surfaces the error to
a user, so it degrades silently.

## Fix (symptom → root cause → change)

**Root cause.** A channel tab and its channel now share **one** transcript. A save
re-serializes the in-memory window through `_build_message_entry`, which hardcoded:

```python
"source_thread": "dashboard",
"source_user": "dashboard",
```

with no reference to what the message actually was. So any Slack-origin message still
inside the window got restamped on the next dashboard flush. Before channel/tab
unification this was impossible — a Slack session and a dashboard tab were separate files,
and the dashboard never re-serialized Slack's lines.

A save composes three regions, which is why the corruption looked selective:

| Region | How it is written | Provenance |
|---|---|---|
| Frozen prefix | on-disk lines older than the window, copied verbatim | survived |
| The window | re-serialized from memory via `_build_message_entry` | **restamped** |
| Foreign lines | another writer's concurrent appends, merged as raw lines | survived |

**Why fixing the write path alone is not enough.** The load path never read
`source_thread`/`source_user` into the in-memory message dict at all — which is why the
whole repo mentioned the field in exactly one place. Preserving `m.get("source_thread")`
would have preserved a key that is never populated, and a test on a freshly-constructed
in-memory message would have passed while every restored message stayed broken.

**Change.** One shared helper, `carry_provenance` in `history.py` (next to the writer that
defines these fields), plus a call at each of the **six** paths that replay persisted lines
into a slot window:

| Path | What it loads |
|---|---|
| `_rehydrate_slot_from_history` | one tab, on demand |
| `_restore_recent_sessions_steps` | every tab, at startup |
| `channel_slots._rebuild_window` | a channel-bound tab's window |
| `channel_slots` incremental refresh | new channel turns since last read |
| `chat_handlers` resume-session | a session reopened from History |
| `chat_fork` | messages copied into a forked session |

`_build_message_entry` then preserves what it finds and falls back to `"dashboard"` only
when there is genuinely no recorded origin — which is the correct answer for a
dashboard-authored turn. No provenance is invented.

Absent stays absent: `ConversationLog.append` writes each field only when truthy and
`get_source_threads` filters on the same truthiness, so an empty string would be a third
state that reads as present-but-unusable. `carry_provenance` treats `""` and non-strings as
absent.

**Foreign-append dedup is unaffected.** That scan keys identity on `(ts, role, content)`
with a `(role, content)` tiebreak — never the whole line — so a window entry that now
carries provenance still matches its own on-disk copy instead of being mistaken for a
cross-process append and duplicated. Locked in by a test.

### Known limitation

Transcripts already flattened to `"dashboard"` are **not** backfilled. The true origin of
those lines is gone, so a backfill would be guessing. New and reloaded traffic is correct
from this change forward.

## Tests

`test/test_message_provenance.py` — 20 tests.

The load→flush round trip is the centerpiece: write a transcript with real Slack
provenance, load it, flush, assert the bytes still name Slack. Coverage:

- `carry_provenance` unit behaviour, including that `""`/`None`/non-strings are absent and
  that a present value is never overwritten by an absent one
- `_build_message_entry` preserves a real origin, keeps `"dashboard"` for a message with
  none, and never writes an empty origin
- round trip through `_rehydrate_slot_from_history`: Slack line keeps its origin while a
  dashboard turn appended alongside it correctly reads `"dashboard"`
- every role in the window (user / assistant / tool), since the restamp flattened all of them
- three consecutive flushes, then a reload of the save's own output and another flush —
  one surviving round trip is not enough if the output cannot be re-read
- frozen prefix and window agree in the same file rather than contradicting each other
- the bulk startup restore path (`restore_recent_sessions`) independently
- the channel-bound window path (`_rebuild_window`)
- a window entry is not duplicated as a foreign append; a genuine foreign append keeps its
  own origin

**Proven non-vacuous:** reverting only the six load-path calls and leaving the write-path
fix in place fails 8 of 20 — every round-trip test. The 12 that still pass are exactly the
pure-unit ones, i.e. the false green this design avoids.

## Manual verification

N/A — unit coverage is sufficient and stronger than a manual check here. The bug is
invisible in the UI (provenance is a stored field, not a rendered one), so the only
observation that proves anything is reading the persisted bytes after a flush, which is
what the round-trip tests do.

Local gates green: `pytest`, `isort`, `flake8`, `mypy` (664 files). Also verified no import
cycle via a fresh interpreter per entry point (`history`, the four dashboard modules,
`mcp_core`) — `channel_slots` gained a `history` import, and pytest's import order would
have hidden an ordering cycle.

## Screenshots

N/A — no user-visible surface changes.
