### PR TITLE
fix(cron): add timeout to post-kill proc.communicate() to prevent executor pool deadlock

### DIFF
--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -654,7 +654,7 @@ def run_script_sandboxed(
                 # Popen.communicate does not kill the child on timeout
                 # (unlike subprocess.run) — clean up before re-raising.
                 _kill_proc_group(proc)
-                proc.communicate()
+                proc.communicate(timeout=5)
                 raise
         finally:
             cancelled = _unregister_proc(job_id, proc)
@@ -851,7 +851,7 @@ def run_command_sandboxed(command: str, timeout: int = 300, job_id: str | None =
                 output, stderr_out = proc.communicate(timeout=timeout)
             except subprocess.TimeoutExpired:
                 _kill_proc_group(proc)
-                proc.communicate()
+                proc.communicate(timeout=5)
                 return {"status": "error", "output": f"❌ Command timed out after {timeout}s", "exit_code": -1}
         finally:
             if job_id:


### PR DESCRIPTION
## Summary

- Add `timeout=5` to both bare `proc.communicate()` calls that follow `_kill_proc_group(proc)` in `run_script_sandboxed()` and `run_command_sandboxed()`

## Problem

After SIGKILL, `proc.communicate()` reads until EOF on the subprocess pipe. If any other process (e.g., a forked gateway child) holds the pipe FD open, this blocks forever — permanently consuming a cron executor thread. With a 4-thread pool, a single FD leak cascades into a full deadlock of all script crons while agent crons remain unaffected (different execution path).

**Observed in production:** A forked gateway child (3.1 GB RSS) inherited pipe FDs, blocking all 4 executor threads within one tick. 10 script crons failed; 5 auto-paused. Only fix was killing the orphan process.

## Fix

5 seconds is generous — after SIGKILL the pipe should close instantly. If it doesn't, something else holds the FD and waiting longer won't help. The thread recovers and the pool stays healthy.

## Test plan

- [ ] Verify existing cron tests pass with the timeout addition
- [ ] Manually test: start a script cron, let it timeout, confirm the executor thread returns within ~5s even if a subprocess holds the pipe FD
- [ ] Confirm no regression in normal (non-timeout) script execution