### PR TITLE
feat(pr-maintenance): pr 918 follow-up: branch-aware manifest fast path (round-8 admission desync)

### DIFF
--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -732,11 +732,12 @@ async def _fetch_app_manifest(
             local_manifest is not None
             and local_manifest.is_file()
             and await _clone_origin_matches(clone_dir, git_url)
+            and await _clone_branch_matches(clone_dir, branch)
         ):
             try:
                 content = await asyncio.to_thread(local_manifest.read_text, "utf-8")
                 return json.loads(content)
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 pass
 
     if not _looks_like_git_url(git_url):
@@ -810,7 +811,7 @@ async def _fetch_app_manifest(
             return None
         content = await asyncio.to_thread(manifest_path.read_text, "utf-8")
         return json.loads(content)
-    except (asyncio.TimeoutError, OSError, json.JSONDecodeError) as exc:
+    except (asyncio.TimeoutError, OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         logger.debug("Failed to fetch app.json from %s: %s", git_url, exc)
         return None
     finally:
@@ -1236,7 +1237,7 @@ async def _fetch_external_registry_index(
                     # item (e.g. a bare string) must never reach normalization.
                     _sel_outcome("success")
                     return [item for item in data if isinstance(item, dict)]
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 pass
 
         # Fallback: scan for apps/*/app.json
@@ -1785,7 +1786,7 @@ def _resolved_clone_commit(clone_root: Path) -> str:
     git_dir = clone_root / ".git"
     try:
         head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return ""
     if not head.startswith("ref:"):
         # Detached HEAD holds the SHA directly.
@@ -1799,7 +1800,7 @@ def _resolved_clone_commit(clone_root: Path) -> str:
         loose = (git_dir / ref).read_text(encoding="utf-8").strip()
         if _COMMIT_SHA_RE.match(loose):
             return loose
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         pass
     # A repacked clone keeps no loose ref file.
     try:
@@ -1807,7 +1808,7 @@ def _resolved_clone_commit(clone_root: Path) -> str:
             parts = line.split()
             if len(parts) == 2 and parts[1] == ref and _COMMIT_SHA_RE.match(parts[0]):
                 return parts[0]
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         pass
     return ""
 
@@ -2008,6 +2009,47 @@ async def _clone_origin_matches(dest: Path, git_url: str) -> bool:
     if not git_url:
         return False
     return await _clone_origin_url(dest) == git_url
+
+
+def _read_clone_branch(clone_dir: Path) -> str | None:
+    """Read the current branch of an existing git clone.
+
+    Returns the branch name (e.g. ``"main"``), or None if the clone does not
+    exist, is in detached HEAD state, or the branch cannot be determined.
+    Reads ``.git/HEAD`` directly (stdlib-only, no subprocess spawn) — mirrors
+    the fail-closed posture of :func:`_clone_origin_matches`.
+
+    A ``.git`` that is a *file* (worktree / submodule gitfile) rather than a
+    directory also fails closed (``is_file()`` on the nested path returns
+    False), so no fast path is attempted for those layouts.
+    """
+    head_file = clone_dir / ".git" / "HEAD"
+    if not head_file.is_file():
+        return None
+    try:
+        head_content = head_file.read_text("utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    # A normal branch checkout has HEAD = "ref: refs/heads/<branch>"
+    _REF_PREFIX = "ref: refs/heads/"
+    if head_content.startswith(_REF_PREFIX):
+        return head_content[len(_REF_PREFIX) :]
+    # Detached HEAD (raw SHA) or unexpected format — fail closed.
+    return None
+
+
+async def _clone_branch_matches(dest: Path, branch: str) -> bool:
+    """Whether *dest* has *branch* checked out (exact string equality).
+
+    Fails closed: an unreadable or detached HEAD, a missing ``.git/HEAD``,
+    or an empty *branch* to compare against all return False — the caller
+    must fall through to the throwaway clone so admission sees the correct
+    branch's manifest.
+    """
+    if not branch:
+        return False
+    clone_branch = await asyncio.to_thread(_read_clone_branch, dest)
+    return clone_branch == branch
 
 
 # ---------------------------------------------------------------------------
@@ -2433,16 +2475,10 @@ async def _unpoison_rejected_checkout(
         # (HEAD never moved), and app.json is the poison vector the next
         # prefetch reads.
         if manifest_snapshot is not None:
-            await asyncio.to_thread(
-                (pkg_dir / manifest_relpath).write_bytes, manifest_snapshot
-            )
-            log_lines.append(
-                f"Restored {manifest_relpath} to its exact pre-update contents"
-            )
+            await asyncio.to_thread((pkg_dir / manifest_relpath).write_bytes, manifest_snapshot)
+            log_lines.append(f"Restored {manifest_relpath} to its exact pre-update contents")
         else:
-            rc = await _run_git(
-                ["git", "--literal-pathspecs", "checkout", "--", manifest_relpath]
-            )
+            rc = await _run_git(["git", "--literal-pathspecs", "checkout", "--", manifest_relpath])
             if rc != 0:
                 log_lines.append(
                     f"WARNING: could not restore {manifest_relpath}; "
@@ -2480,9 +2516,7 @@ async def _clone_build_app_locked(
     # checkout left sitting at a policy-rejected commit would make every retry
     # reject at prefetch before the pull could ever fetch a fixed remote.
     pre_pull_commit = (
-        await asyncio.to_thread(_resolved_clone_commit, pkg_dir)
-        if checkout_preexisted
-        else ""
+        await asyncio.to_thread(_resolved_clone_commit, pkg_dir) if checkout_preexisted else ""
     )
     # And the manifest's exact pre-update WORKING-TREE bytes (which may carry
     # the user's uncommitted local edits): a rejection restores THIS snapshot,
@@ -2492,9 +2526,7 @@ async def _clone_build_app_locked(
     pre_update_manifest: bytes | None = None
     if checkout_preexisted:
         try:
-            pre_update_manifest = await asyncio.to_thread(
-                (pkg_dir / manifest_rel).read_bytes
-            )
+            pre_update_manifest = await asyncio.to_thread((pkg_dir / manifest_rel).read_bytes)
         except OSError:
             pre_update_manifest = None
     clone_err = await _git_clone_or_pull(
@@ -2537,12 +2569,10 @@ async def _clone_build_app_locked(
         app_source = contained
     cloned_manifest: dict[str, Any] | None = None
     try:
-        parsed = json.loads(
-            await asyncio.to_thread((app_source / "app.json").read_text, "utf-8")
-        )
+        parsed = json.loads(await asyncio.to_thread((app_source / "app.json").read_text, "utf-8"))
         if isinstance(parsed, dict):
             cloned_manifest = parsed
-    except (json.JSONDecodeError, OSError) as exc:
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
         logger.debug("cloned app.json for %s is unreadable pre-build: %s", app_name, exc)
     cloned_name = str((cloned_manifest or {}).get("name", "") or "")
     if cloned_manifest is None or cloned_name != app_name:
@@ -2672,7 +2702,7 @@ async def _run_app_build(
                 pkg = json.loads((build_dir / "package.json").read_text("utf-8"))
                 if (pkg.get("scripts") or {}).get("build"):
                     build_cmds.append([npm, "run", "build"])
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 pass
         else:
             log_lines.append("npm not found on PATH — skipping JavaScript build step")
@@ -3012,7 +3042,7 @@ async def install_from_registry(
             parsed = json.loads(manifest_raw)
             if isinstance(parsed, dict):
                 manifest_data = parsed
-        except (json.JSONDecodeError, OSError) as exc:
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
             logger.debug("cloned app.json for %s is unreadable: %s", name, exc)
 
         # IDENTITY GATE, second pass: the primary gate already ran inside
@@ -3033,9 +3063,7 @@ async def install_from_registry(
                 pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
                 manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
                 manifest_snapshot=build_result.get("_pre_update_manifest"),
-                restore_from=next(
-                    iter(build_result.get("_pending_stale_cleanup") or []), None
-                ),
+                restore_from=next(iter(build_result.get("_pending_stale_cleanup") or []), None),
             )
 
         # ADMISSION GATE, third pass — the post-build manifest is what
@@ -3070,9 +3098,7 @@ async def install_from_registry(
                 pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
                 manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
                 manifest_snapshot=build_result.get("_pre_update_manifest"),
-                restore_from=next(
-                    iter(build_result.get("_pending_stale_cleanup") or []), None
-                ),
+                restore_from=next(iter(build_result.get("_pending_stale_cleanup") or []), None),
             )
             return {
                 "ok": False,
@@ -3173,13 +3199,9 @@ async def install_from_registry(
             try:
                 if platform_compat.IS_POSIX:
                     if type(proc.pid) is int and proc.pid > 1:
-                        await asyncio.to_thread(
-                            os.killpg, proc.pid, platform_compat.SIGKILL
-                        )
+                        await asyncio.to_thread(os.killpg, proc.pid, platform_compat.SIGKILL)
                 else:
-                    await platform_compat.kill_process_tree_async(
-                        proc.pid, platform_compat.SIGKILL
-                    )
+                    await platform_compat.kill_process_tree_async(proc.pid, platform_compat.SIGKILL)
             except OSError:
                 # Empty group (no stragglers) — the common case.
                 pass
@@ -3196,7 +3218,7 @@ async def install_from_registry(
                 )
                 if isinstance(parsed, dict):
                     manifest_data = parsed
-            except (json.JSONDecodeError, OSError) as exc:
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
                 logger.debug("post-script app.json for %s is unreadable: %s", name, exc)
             if manifest_data is None or str(manifest_data.get("name", "") or "") != name:
                 return await _refuse_identity_mismatch(
@@ -3209,9 +3231,7 @@ async def install_from_registry(
                     pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
                     manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
                     manifest_snapshot=build_result.get("_pre_update_manifest"),
-                    restore_from=next(
-                        iter(build_result.get("_pending_stale_cleanup") or []), None
-                    ),
+                    restore_from=next(iter(build_result.get("_pending_stale_cleanup") or []), None),
                 )
             denied = app_admission_denied(
                 name,
@@ -3242,9 +3262,7 @@ async def install_from_registry(
                     pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
                     manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
                     manifest_snapshot=build_result.get("_pre_update_manifest"),
-                    restore_from=next(
-                        iter(build_result.get("_pending_stale_cleanup") or []), None
-                    ),
+                    restore_from=next(iter(build_result.get("_pending_stale_cleanup") or []), None),
                 )
                 return {
                     "ok": False,
@@ -3322,9 +3340,7 @@ async def install_from_registry(
                     name,
                     official=True,
                     kind=(
-                        install_receipt.KIND_UPDATE
-                        if was_installed
-                        else install_receipt.KIND_FRESH
+                        install_receipt.KIND_UPDATE if was_installed else install_receipt.KIND_FRESH
                     ),
                 )
             return {
@@ -3374,9 +3390,7 @@ async def install_from_registry(
                     name,
                     official=True,
                     kind=(
-                        install_receipt.KIND_UPDATE
-                        if was_installed
-                        else install_receipt.KIND_FRESH
+                        install_receipt.KIND_UPDATE if was_installed else install_receipt.KIND_FRESH
                     ),
                 )
 

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -2091,6 +2091,7 @@ class TestManifestOriginGate:
     def _seed_stale_clone(self, tmp_path, marker):
         clone_dir = tmp_path / "app-sources" / "myapp"
         (clone_dir / ".git").mkdir(parents=True)
+        (clone_dir / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
         (clone_dir / "app.json").write_text(
             json.dumps({"name": "myapp", "version": marker}), encoding="utf-8"
         )
@@ -3593,11 +3594,391 @@ class TestStaleCheckoutSweep:
         removed = _sweep_stale_checkouts_sync(sources, time.time())
 
         # The refreshed dir must survive — its mtime is now < retention.
-        assert moved.exists(), (
-            "Move-aside dir with refreshed mtime should NOT be swept"
-        )
+        assert moved.exists(), "Move-aside dir with refreshed mtime should NOT be swept"
         assert "myapp.stale-aabb0011" not in removed
 
         # The genuinely old one must still be swept.
         assert not genuinely_old.exists()
         assert "other.stale-cc001122" in removed
+
+
+# ---------------------------------------------------------------------------
+# Branch-aware manifest fast path: persistent clone on branch A + entry
+# branch B must NOT serve the stale (branch-A) manifest through the fast path.
+# (registry-admission-branch-consistency)
+# ---------------------------------------------------------------------------
+
+
+class TestManifestBranchGate:
+    """Regression: the fast path must require BOTH origin AND branch to match.
+
+    The pre-fix chain:
+      1. _fetch_app_manifest served app.json from persistent clone (branch A)
+      2. Admission gated on branch-A's manifest
+      3. _git_clone_or_pull fast-forwarded onto branch B
+      4. Branch-B code ran with admission decided on branch-A's manifest
+
+    Post-fix: the fast path also checks ``_clone_branch_matches`` — it only
+    serves the local manifest when clone branch == requested branch. Mismatch
+    falls through to the throwaway clone that fetches the correct branch.
+    """
+
+    @pytest.mark.asyncio
+    async def test_branch_mismatch_skips_fast_path(self, tmp_path):
+        """Persistent clone on branch A must NOT supply its manifest when
+        the entry requests branch B."""
+        from kiro_crew.apps import registry as reg
+
+        clone_url = "https://example.com/target-app.git"
+
+        # Set up a fake persistent clone on "old-branch" with a stale manifest.
+        clone_dir = tmp_path / "app-sources" / "target-app"
+        clone_dir.mkdir(parents=True)
+        git_dir = clone_dir / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text(
+            f'[remote "origin"]\n\turl = {clone_url}\n',
+            encoding="utf-8",
+        )
+        (git_dir / "HEAD").write_text(
+            "ref: refs/heads/old-branch\n",
+            encoding="utf-8",
+        )
+        (clone_dir / "app.json").write_text(
+            '{"name": "target-app", "version": "1.0.0", "stale": true}',
+            encoding="utf-8",
+        )
+
+        # The throwaway clone (new branch) returns a different manifest.
+        new_manifest = {"name": "target-app", "version": "2.0.0", "stale": False}
+
+        async def _fake_exec(*args, **kwargs):
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            return mock_proc
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.app_source_dir",
+                return_value=clone_dir,
+            ),
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch(
+                "kiro_crew.apps.registry.wrap_argv",
+                lambda argv, **k: (list(argv), None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.cgroup_scope_argv",
+                side_effect=lambda a: a,
+            ),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_exec,
+            ),
+            patch("tempfile.mkdtemp", return_value=str(tmp_path / "throwaway")),
+        ):
+            # Ensure the throwaway dir has app.json from the new branch.
+            throwaway = tmp_path / "throwaway"
+            throwaway.mkdir(parents=True, exist_ok=True)
+            (throwaway / "app.json").write_text(json.dumps(new_manifest), encoding="utf-8")
+
+            result = await reg._fetch_app_manifest(
+                clone_url,
+                "new-branch",  # entry wants branch B
+                "",
+                app_name="target-app",
+                git_url=clone_url,
+                owner_designated=False,
+            )
+
+        # The stale manifest (branch-A, version 1.0.0) must NOT be returned.
+        assert result is not None
+        assert result.get("stale") is not True
+        assert result.get("version") == "2.0.0"
+
+    @pytest.mark.asyncio
+    async def test_same_branch_serves_fast_path(self, tmp_path):
+        """Persistent clone with matching origin AND branch still serves its
+        local manifest (fast path preserved)."""
+        from kiro_crew.apps import registry as reg
+
+        matching_url = "https://example.com/matching-app.git"
+
+        clone_dir = tmp_path / "app-sources" / "matching-app"
+        clone_dir.mkdir(parents=True)
+        git_dir = clone_dir / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text(
+            f'[remote "origin"]\n\turl = {matching_url}\n',
+            encoding="utf-8",
+        )
+        (git_dir / "HEAD").write_text(
+            "ref: refs/heads/main\n",
+            encoding="utf-8",
+        )
+        (clone_dir / "app.json").write_text(
+            '{"name": "matching-app", "version": "3.0.0"}',
+            encoding="utf-8",
+        )
+
+        captured: dict = {}
+
+        async def _fake_exec(*args, **kwargs):
+            captured.setdefault("calls", []).append(list(args))
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(matching_url.encode() + b"\n", b""))
+            mock_proc.returncode = 0
+            return mock_proc
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.app_source_dir",
+                return_value=clone_dir,
+            ),
+            patch(
+                "kiro_crew.apps.registry.wrap_argv",
+                side_effect=lambda a, mode="standard": (a, None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.cgroup_scope_argv",
+                side_effect=lambda a: a,
+            ),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_exec,
+            ),
+        ):
+            result = await reg._fetch_app_manifest(
+                matching_url,
+                "main",
+                "",
+                app_name="matching-app",
+                git_url=matching_url,
+                owner_designated=False,
+            )
+
+        # Origin + branch match → persistent clone manifest served directly.
+        assert result is not None
+        assert result["version"] == "3.0.0"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_branch_fails_closed(self, tmp_path):
+        """If .git/HEAD is missing (detached or corrupt), the fast path is NOT
+        used — fail closed to throwaway clone."""
+        from kiro_crew.apps import registry as reg
+
+        matching_url = "https://example.com/target-app.git"
+
+        # Set up persistent clone with matching origin but NO .git/HEAD.
+        clone_dir = tmp_path / "app-sources" / "target-app"
+        clone_dir.mkdir(parents=True)
+        git_dir = clone_dir / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text(
+            f'[remote "origin"]\n\turl = {matching_url}\n',
+            encoding="utf-8",
+        )
+        # No HEAD file — _read_clone_branch returns None.
+        (clone_dir / "app.json").write_text(
+            '{"name": "target-app", "version": "1.0.0", "should-not-serve": true}',
+            encoding="utf-8",
+        )
+
+        new_manifest = {"name": "target-app", "version": "2.0.0"}
+
+        async def _fake_exec(*args, **kwargs):
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            return mock_proc
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.app_source_dir",
+                return_value=clone_dir,
+            ),
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch(
+                "kiro_crew.apps.registry.wrap_argv",
+                lambda argv, **k: (list(argv), None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.cgroup_scope_argv",
+                side_effect=lambda a: a,
+            ),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_exec,
+            ),
+            patch("tempfile.mkdtemp", return_value=str(tmp_path / "throwaway")),
+        ):
+            throwaway = tmp_path / "throwaway"
+            throwaway.mkdir(parents=True, exist_ok=True)
+            (throwaway / "app.json").write_text(json.dumps(new_manifest), encoding="utf-8")
+
+            result = await reg._fetch_app_manifest(
+                matching_url,
+                "main",
+                "",
+                app_name="target-app",
+                git_url=matching_url,
+                owner_designated=False,
+            )
+
+        # Unreadable branch → fail closed → throwaway clone manifest served.
+        assert result is not None
+        assert result.get("should-not-serve") is not True
+        assert result.get("version") == "2.0.0"
+
+    @pytest.mark.asyncio
+    async def test_detached_head_fails_closed(self, tmp_path):
+        """Detached HEAD (raw SHA in .git/HEAD) → fail closed, throwaway clone
+        used even though origin matches."""
+        from kiro_crew.apps import registry as reg
+
+        matching_url = "https://example.com/target-app.git"
+
+        clone_dir = tmp_path / "app-sources" / "target-app"
+        clone_dir.mkdir(parents=True)
+        git_dir = clone_dir / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text(
+            f'[remote "origin"]\n\turl = {matching_url}\n',
+            encoding="utf-8",
+        )
+        # Detached HEAD — raw SHA, not a branch ref.
+        (git_dir / "HEAD").write_text(
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\n",
+            encoding="utf-8",
+        )
+        (clone_dir / "app.json").write_text(
+            '{"name": "target-app", "version": "1.0.0", "stale": true}',
+            encoding="utf-8",
+        )
+
+        new_manifest = {"name": "target-app", "version": "2.0.0"}
+
+        async def _fake_exec(*args, **kwargs):
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            return mock_proc
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.app_source_dir",
+                return_value=clone_dir,
+            ),
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch(
+                "kiro_crew.apps.registry.wrap_argv",
+                lambda argv, **k: (list(argv), None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.cgroup_scope_argv",
+                side_effect=lambda a: a,
+            ),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_exec,
+            ),
+            patch("tempfile.mkdtemp", return_value=str(tmp_path / "throwaway")),
+        ):
+            throwaway = tmp_path / "throwaway"
+            throwaway.mkdir(parents=True, exist_ok=True)
+            (throwaway / "app.json").write_text(json.dumps(new_manifest), encoding="utf-8")
+
+            result = await reg._fetch_app_manifest(
+                matching_url,
+                "main",
+                "",
+                app_name="target-app",
+                git_url=matching_url,
+                owner_designated=False,
+            )
+
+        # Detached HEAD → _read_clone_branch returns None → fail closed.
+        assert result is not None
+        assert result.get("stale") is not True
+        assert result.get("version") == "2.0.0"
+
+    @pytest.mark.asyncio
+    async def test_non_utf8_head_fails_closed(self, tmp_path):
+        """Non-UTF-8 bytes in .git/HEAD → _read_clone_branch returns None,
+        _clone_branch_matches returns False, no UnicodeDecodeError propagates.
+
+        Regression: before the fix, read_text("utf-8") raised
+        UnicodeDecodeError which was not caught by the except-OSError handler.
+        """
+        from kiro_crew.apps import registry as reg
+
+        matching_url = "https://example.com/target-app.git"
+
+        clone_dir = tmp_path / "app-sources" / "target-app"
+        clone_dir.mkdir(parents=True)
+        git_dir = clone_dir / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text(
+            f'[remote "origin"]\n\turl = {matching_url}\n',
+            encoding="utf-8",
+        )
+        # Write non-UTF-8 bytes into HEAD — triggers UnicodeDecodeError on read.
+        (git_dir / "HEAD").write_bytes(b"ref: refs/heads/\xff\xfe\n")
+        (clone_dir / "app.json").write_text(
+            '{"name": "target-app", "version": "1.0.0", "stale": true}',
+            encoding="utf-8",
+        )
+
+        # Unit-level: _read_clone_branch must return None, no exception.
+        assert reg._read_clone_branch(clone_dir) is None
+
+        # Unit-level: _clone_branch_matches must return False, no exception.
+        assert await reg._clone_branch_matches(clone_dir, "main") is False
+
+        # Integration: fetch_app_manifest fails closed → throwaway clone used.
+        new_manifest = {"name": "target-app", "version": "2.0.0"}
+
+        async def _fake_exec(*args, **kwargs):
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            return mock_proc
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.app_source_dir",
+                return_value=clone_dir,
+            ),
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch(
+                "kiro_crew.apps.registry.wrap_argv",
+                lambda argv, **k: (list(argv), None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.cgroup_scope_argv",
+                side_effect=lambda a: a,
+            ),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_exec,
+            ),
+            patch("tempfile.mkdtemp", return_value=str(tmp_path / "throwaway")),
+        ):
+            throwaway = tmp_path / "throwaway"
+            throwaway.mkdir(parents=True, exist_ok=True)
+            (throwaway / "app.json").write_text(json.dumps(new_manifest), encoding="utf-8")
+
+            result = await reg._fetch_app_manifest(
+                matching_url,
+                "main",
+                "",
+                app_name="target-app",
+                git_url=matching_url,
+                owner_designated=False,
+            )
+
+        # Non-UTF-8 HEAD → fail closed → throwaway clone manifest served.
+        assert result is not None
+        assert result.get("stale") is not True
+        assert result.get("version") == "2.0.0"


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **PR 918 follow-up: branch-aware manifest fast path (round-8 admission desync)**

## Changes and rationale

### PR 918 follow-up: branch-aware manifest fast path (round-8 admission desync)
**Tests:** Regression pinning round 8: persistent clone on branch A + entry branch B -> fast path NOT used (admission sees B's manifest); same-branch case still serves the fast path; unreadable branch -> fail closed (throwaway clone). Keep the full existing suite green (incl. TestStaleCheckoutSweep as it exists at the merged/PR head — do NOT change sweep behavior).…
**Review focus:** pr-maintenance, security boundaries, regression coverage

## Review map

| Change | Primary files |
|---|---|
| PR 918 follow-up: branch-aware manifest fast path (round-8 admission desync) | — |

## Commits
- [`9a0e026`](https://github.com/kirodotdev/KiroCrew/pull/1489/commits/9a0e026d3422d4eaf35cfe0352049e59cfb95a03) feat(pr-maintenance): pr 918 follow-up: branch-aware manifest fast pa…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (4 files, +361/-9)</summary>

- `src/kiro_crew/apps/registry.py` (+38/-0)
- `test/test_external_registry.py` (+313/-0)
- `website/src/i18n/format.test.ts` (+8/-8)
- `website/src/test/fileExplorer.test.tsx` (+2/-1)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->