### PR TITLE
fix(ci): require anonymous GHCR pull in both publish callers

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -213,8 +213,9 @@ jobs:
       channel: nightly
       version: ${{ needs.version.outputs.nightly_version }}
       publish: true
-      # The GHCR package intentionally remains private for now.
-      require_public_access: false
+      # The GHCR package is public. Nightly is the earliest signal that the
+      # package's visibility regressed, so assert anonymous pull here too.
+      require_public_access: true
       wheel_artifact: cli-wheel
     # No `secrets: inherit`: the lane authenticates with GITHUB_TOKEN only
     # (implicitly available to reusable workflows). Inheriting would expose

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -311,12 +311,13 @@ jobs:
           fi
           echo "::notice::Version tag already existed — channel alias NOT moved (re-runs must never roll a channel backward). If this re-run was repairing an interrupted first publish and the alias is stale, move it manually: docker buildx imagetools create -t ${IMAGE}:${CHANNEL} ${IMAGE}@${DIGEST}"
 
-      # Public distribution is an explicit release-policy switch. GHCR
-      # creates packages private, which is the required posture for now.
-      # When public distribution is approved, callers flip
-      # require_public_access and this gate prevents a release from
-      # advertising an image that anonymous users cannot pull.
-      # Canonical repo only: forks legitimately keep private packages.
+      # Public distribution is an explicit release-policy switch. GHCR creates
+      # every new package PRIVATE and never inherits visibility from the linked
+      # repository, so a public repo does not imply a pullable image. Both
+      # canonical callers set require_public_access, which makes this gate the
+      # thing that stops a release from advertising an image anonymous users
+      # cannot pull. The input still defaults to false so forks — which
+      # legitimately keep private packages — are unaffected.
       - name: Verify anonymous pull (package visibility)
         if: github.repository_owner == 'kirodotdev' && inputs.require_public_access
         run: |
@@ -324,7 +325,7 @@ jobs:
           IMAGE="${{ steps.image.outputs.name }}"
           docker logout ghcr.io
           if ! docker buildx imagetools inspect "${IMAGE}:${VERSION}" > /dev/null 2>&1; then
-            echo "::error::Anonymous pull of ${IMAGE}:${VERSION} FAILED. On the first-ever publish GHCR creates the package PRIVATE — a repo admin must open ghcr.io package settings for 'kirocrew', change visibility to Public (one-time). No rebuild is needed: the image and alias are already published; visibility is the only gate."
+            echo "::error::Anonymous pull of ${IMAGE}:${VERSION} FAILED — the GHCR package is not public. Open the package settings for 'kirocrew' (Danger Zone → Change visibility → Public); GHCR creates packages private and does NOT inherit visibility from the repo, so this is expected on a first-ever publish and otherwise means visibility regressed. No rebuild is needed: the image and alias are already published; visibility is the only gate. Note the flip is one-way — a package made public cannot be made private again."
             exit 1
           fi
           echo "Anonymous pull OK — package is public."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,8 +166,10 @@ jobs:
       channel: ${{ needs.version.outputs.channel }}
       version: ${{ needs.version.outputs.version }}
       publish: true
-      # The GHCR package intentionally remains private for now.
-      require_public_access: false
+      # The GHCR package is public: README tells users to `docker pull` it
+      # anonymously, so a release that lands behind a private package is a
+      # broken release. Fail the lane rather than advertise an unpullable tag.
+      require_public_access: true
       wheel_artifact: cli-wheel
     # No `secrets: inherit`: the lane authenticates with GITHUB_TOKEN only
     # (implicitly available to reusable workflows). Inheriting would expose

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -139,11 +139,16 @@ stable) moves only after the version tag and its attestation exist. GHCR needs
 no AWS credentials: the push authenticates with the workflow's own
 `GITHUB_TOKEN`, so this lane also works on forks.
 
-The GHCR package is intentionally private for now. Both canonical callers pass
-`require_public_access: false`; authorized consumers authenticate with a token
-carrying `read:packages`. Going public is a release-policy change: setting
-`require_public_access: true` enables the logged-out-pull gate that proves
-anonymous consumers can resolve the image.
+The GHCR package is public, so `docker pull ghcr.io/kirodotdev/kirocrew:stable`
+works with no login. That is not automatic: GHCR creates every package private
+and inherits only *access permissions* from the linked repository, never
+visibility — a public repo does not imply a pullable image, and the flip is
+one-way (a public package cannot be made private again). Both canonical callers
+pass `require_public_access: true`, which arms the logged-out-pull gate proving
+anonymous consumers can resolve the image; a visibility regression fails the
+lane instead of shipping an unpullable tag. The input itself still defaults to
+`false` and the step is scoped to `kirodotdev`, so forks keep private packages
+and authenticate with a token carrying `read:packages`.
 
 ### GitHub Releases
 

--- a/test/test_publish_docker_contract.py
+++ b/test/test_publish_docker_contract.py
@@ -11,8 +11,9 @@ The lane's documented guarantees:
 * A VERSION tag, once published, is never rebuilt or repointed — and a
   transient registry failure must never be misread as "tag absent" (that
   would rebuild different bytes under a published version).
-* The package remains private unless callers explicitly opt into the
-  anonymous-pull release gate.
+* Every canonical caller requires the anonymous-pull gate, so a GHCR
+  visibility regression fails the lane instead of shipping an image the
+  documented ``docker pull`` cannot reach.
 * The lane needs no repository secrets beyond the implicit GITHUB_TOKEN —
   callers must not ``secrets: inherit`` into it.
 
@@ -184,18 +185,27 @@ def test_existing_tag_check_distinguishes_not_found_from_transport_failure() -> 
     )
 
 
-def test_public_access_gate_is_opt_in_and_callers_keep_package_private() -> None:
-    """Anonymous pulls are a release-policy choice, not a publish invariant.
+def test_public_access_gate_is_required_by_every_canonical_caller() -> None:
+    """Anonymous pullability is a release invariant for the canonical repo.
 
-    GHCR packages default to private and KiroCrew intentionally retains that
-    posture for now. Public distribution must be enabled explicitly in both
-    the reusable workflow contract and each canonical caller.
+    GHCR creates packages private and never inherits visibility from the
+    linked repository, so a public repo does not imply a pullable image. The
+    README tells users to ``docker pull`` anonymously, so every canonical
+    caller must arm the gate — otherwise a visibility regression ships
+    silently and the step merely reports ``skipped``.
+
+    The reusable workflow's input still DEFAULTS to false: forks legitimately
+    keep private packages, and the gate is additionally scoped to the
+    canonical owner.
     """
     import yaml
 
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     inputs = workflow[True]["workflow_call"]["inputs"]
-    assert inputs["require_public_access"]["default"] is False
+    assert inputs["require_public_access"]["default"] is False, (
+        "the input must stay opt-in so forks with private packages are "
+        "unaffected; canonical callers opt in explicitly"
+    )
 
     lines = _lines()
     public_gate = _step_index(lines, "Verify anonymous pull")
@@ -215,9 +225,10 @@ def test_public_access_gate_is_opt_in_and_callers_keep_package_private() -> None
         }
         assert docker_jobs, f"{caller.name}: publish-docker call site not found"
         for name, job in docker_jobs.items():
-            assert job["with"]["require_public_access"] is False, (
-                f"{caller.name}: job {name!r} must keep GHCR private until "
-                "public distribution is explicitly approved"
+            assert job["with"]["require_public_access"] is True, (
+                f"{caller.name}: job {name!r} must require anonymous pull — "
+                "the published image is documented as publicly pullable, so a "
+                "private package is a broken release, not a valid posture"
             )
 
 


### PR DESCRIPTION
## Problem

`publish-docker.yml` has a step whose whole job is to prove the published image
is anonymously pullable:

```yaml
- name: Verify anonymous pull (package visibility)
  if: github.repository_owner == 'kirodotdev' && inputs.require_public_access
```

`require_public_access` defaults to `false` and **both** canonical callers
passed `false`, so the step never ran. The latest nightly
([run 30926602096](https://github.com/kirodotdev/KiroCrew/actions/runs/30926602096))
reports it as `skipped` inside a green job:

```
job:  Publish Docker Image (nightly)                    → success
step: Verify anonymous pull (package visibility)        → skipped
```

That was correct while the GHCR package was deliberately private. It isn't
anymore: the package is public and the README tells users to run
`docker pull ghcr.io/kirodotdev/kirocrew:stable` with no login. With the gate
disarmed, nothing in CI asserts that instruction still works.

This is not hypothetical. The package sat `private` for the whole of launch day
even though the repo was public — GHCR creates every package private and
inherits only *access permissions* from the linked repository, never
visibility. Anonymous pulls returned `unauthorized` until the visibility was
flipped by hand, and no lane complained.

## Change

Flip both callers to `require_public_access: true`:

| Caller | Rationale |
| --- | --- |
| `release.yml` | A release that lands behind a private package is a broken release — fail rather than advertise an unpullable tag. |
| `nightly.yml` | Earliest signal that visibility regressed, ~24h ahead of a release. |

The reusable workflow's input still defaults to `false`, and the step remains
scoped to `github.repository_owner == 'kirodotdev'`. **Forks are unaffected** —
they legitimately keep private packages and authenticate with a
`read:packages` token.

`test_publish_docker_contract.py` pinned the *old* policy (asserting every
caller keeps `false`), so leaving it alone would have failed the build. It now
pins the new invariant instead: canonical callers must arm the gate, while the
input default stays opt-in for forks.

Also refreshed, since all three described a posture that no longer holds:

- the step's comment block
- the failure message, which framed a private package as only a first-publish
  condition — it is now equally a regression signal, and it gains the
  one-way-flip warning
- `docs/build/release.md`

## Verification

- `test/test_publish_docker_contract.py` + `test/test_workflow_permissions.py`
  — **19 passed**, including the rewritten gate test
- `isort --check-only src/kiro_crew test` — clean
- `flake8 src/kiro_crew test` — clean
- All three workflow YAMLs parse (the contract test loads each one structurally)
- Added lines scanned for non-inclusive terms — clean

Current registry state was verified anonymously before writing this, all with
`docker logout` in effect:

| Check | Result |
| --- | --- |
| package visibility | `public` |
| anonymous registry token | issued |
| `manifests/stable` | `200`, OCI image index |
| platforms | `linux/amd64`, `linux/arm64` |
| layer blob | `206`, 1 MB pulled, gzip magic `1f 8b` |

So the gate this PR arms should pass on the next nightly rather than turn it
red.

## Note for reviewers

No behaviour change to what gets built, pushed, or attested — this only decides
whether one verification step runs. The blast radius is that a future GHCR
visibility regression now fails `release.yml` instead of shipping quietly.
