### PR TITLE
fix(windows): clean a sweep of Windows OS-compatibility bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,8 @@ Kiro Crew runs on macOS, Linux (x86_64 and ARM), and Windows (native). `fcntl`,
 | Spawn isolation | `start_new_session=IS_POSIX` + `creationflags=CREATE_NEW_PROCESS_GROUP` | bare `start_new_session=True` |
 | File mode | `chmod_safe(path, mode)` / `fchmod_safe(fd, mode)` | `os.chmod` / `os.fchmod` (no `os.fchmod` on Windows) |
 | Owner-only secret (fail-loud) | `restrict_to_owner(path)` | `os.chmod(path, 0o600)` under `if IS_POSIX` (silent no-op leaves secrets world-readable) |
+| Directory link | `symlink_or_junction(target, link)` | `os.symlink` (`WinError 1314` without elevation) |
+| Detect/remove a dir link | `is_link_or_junction(path)` / `unlink_link_or_junction(path)` | `path.is_symlink()` (misses a Windows junction) |
 | Process RSS / CPU | `proc_rss_bytes()` / `proc_cpu_seconds()` | `resource.getrusage` |
 | FD soft limit | `raise_nofile_soft_limit(n)` | `resource.setrlimit` |
 | Port to PID | `find_listening_pids(port)` / `listening_pid_tool_available()` | `lsof` directly |

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -145,6 +145,45 @@ security-warning handlers in each caller fire — a naive `if IS_POSIX: os.chmod
 guard would silently no-op on Windows, leaving secrets group/world-readable
 under NTFS.
 
+## File locking on Windows
+
+`platform_compat.file_lock` / `acquire_lock` provide a genuine *blocking*
+acquire on Windows, not a best-effort one. The catch is that `msvcrt.locking`'s
+own "blocking" codes (`LK_LOCK` / `LK_RLCK`) are **not** the equivalent of
+POSIX `fcntl.flock(LOCK_EX)`: they retry ~10 times at 1-second intervals and
+then raise `EDEADLOCK`, so a naive wrapper would silently give up after ~10s
+and run its read-modify-write with no exclusion — losing writes (this was the
+root cause of the concurrent-memory-append data loss). The shim instead spins
+on the non-blocking code (`LK_NBLCK`), with two behaviors by context. On the
+asyncio **event-loop thread** the acquire is single-shot — a spin-sleep there
+would freeze chat/heartbeat, so it takes the lock if free and otherwise fails
+immediately. **Off the loop** (cron, home migration, app backends) it polls up
+to a generous `_WIN_LOCK_TIMEOUT_SECS` ceiling — long enough to wait out a
+legitimately long holder such as a data-home migration, rather than racing it,
+yet bounded so a truly stuck/permission-denied fd still fails. Either way, if
+the lock cannot be taken the acquire **fails closed**: it raises rather than
+entering the critical section unserialized, since proceeding lock-less is the
+exact fail-open that loses writes. Non-blocking `try_acquire_lock` already used
+`LK_NBLCK` and is unchanged.
+
+## Directory links on Windows
+
+`os.symlink` needs `SeCreateSymbolicLinkPrivilege`, which an ordinary
+(non-elevated, non-Developer-Mode) Windows account does NOT hold, so it raises
+`OSError [WinError 1314]`. Every feature that links a *directory* into place
+therefore routes through `platform_compat.symlink_or_junction`, which falls
+back to a directory **junction** — a reparse point that needs no privilege and
+is followed transparently by reads and by `resolve()`/`realpath` (so
+containment/escape checks still hold). Affected paths: app skill registration
+(`apps/bridges.py`), boot-time skill reconcile, and the dev-mode frontend dist
+link (`frontend.ensure_dev_dist_symlink`). Because a junction is not reported by
+`os.path.islink`/`Path.is_symlink`, code that must *detect or remove* such a
+link uses `platform_compat.is_link_or_junction` / `unlink_link_or_junction` —
+notably the md-notebook `.trash` guard, whose refusal would otherwise be
+POSIX-only and let a Windows junction redirect a trashed note out of the vault.
+A *file* symlink has no junction equivalent, so the few tests that plant one
+stay Windows-skipped in `test/windows-expected-failures.txt`.
+
 ## Troubleshooting
 
 - **`ModuleNotFoundError: No module named 'fcntl'`** — you installed a

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -1021,9 +1021,10 @@ def _register_skills(app_name: str, manifest: AppManifest, app_root: Path) -> li
 
         # Namespaced link: ~/.kiro/crew/skills/{app_name}/{skill_name}
         link_path = app_skills_dir / skill_name
-        if link_path.exists() or link_path.is_symlink():
-            if link_path.is_symlink():
-                link_path.unlink()
+        if link_path.exists() or platform_compat.is_link_or_junction(link_path):
+            if platform_compat.is_link_or_junction(link_path):
+                # Symlink OR Windows junction — remove the link, not its target.
+                platform_compat.unlink_link_or_junction(link_path)
             else:
                 shutil.rmtree(link_path)
 
@@ -1033,9 +1034,9 @@ def _register_skills(app_name: str, manifest: AppManifest, app_root: Path) -> li
             flat_link = None
         else:
             flat_link = skills_root / skill_name
-            if flat_link.exists() or flat_link.is_symlink():
-                if flat_link.is_symlink():
-                    flat_link.unlink()
+            if flat_link.exists() or platform_compat.is_link_or_junction(flat_link):
+                if platform_compat.is_link_or_junction(flat_link):
+                    platform_compat.unlink_link_or_junction(flat_link)
                 else:
                     logger.info(
                         "App %s: skipping flat link for %s — non-symlink dir exists",
@@ -1045,14 +1046,17 @@ def _register_skills(app_name: str, manifest: AppManifest, app_root: Path) -> li
                     flat_link = None  # type: ignore[assignment]
 
         try:
-            os.symlink(str(skill_path), str(link_path))
+            # symlink on POSIX; directory junction on non-admin Windows (a plain
+            # os.symlink there raises WinError 1314 and would silently drop every
+            # app skill for the ordinary user).
+            platform_compat.symlink_or_junction(str(skill_path), str(link_path))
             if flat_link is not None:
-                os.symlink(str(skill_path), str(flat_link))
+                platform_compat.symlink_or_junction(str(skill_path), str(flat_link))
             namespaced = _namespace(app_name, skill_name)
             registered.append(namespaced)
             logger.info("Registered skill: %s -> %s", namespaced, skill_path)
         except OSError as exc:
-            logger.warning("Failed to symlink skill %s: %s", skill_name, exc)
+            logger.warning("Failed to link skill %s: %s", skill_name, exc)
 
     if registered:
         sel().log_tool_invocation(
@@ -1095,16 +1099,27 @@ def _deregister_skills(app_name: str) -> int:
     if not app_skills_dir.exists():
         return 0
     try:
-        removed_skills = [item.name for item in app_skills_dir.iterdir() if item.is_symlink()]
+        removed_skills = [
+            item.name
+            for item in app_skills_dir.iterdir()
+            if platform_compat.is_link_or_junction(item)
+        ]
         for item in app_skills_dir.iterdir():
-            if item.is_symlink():
+            # Symlink on POSIX, directory junction on non-admin Windows.
+            if platform_compat.is_link_or_junction(item):
                 if item.name in _RESERVED_SKILL_DIRS:
                     continue
                 target = item.resolve()
                 flat_link = skills_root / item.name
-                if flat_link.is_symlink() and flat_link.resolve() == target:
-                    flat_link.unlink()
-                item.unlink()
+                # is_link_or_junction: a junction (non-admin Windows) is not a
+                # symlink, and unlink_link_or_junction removes the link, never
+                # the target it points at.
+                if (
+                    platform_compat.is_link_or_junction(flat_link)
+                    and flat_link.resolve() == target
+                ):
+                    platform_compat.unlink_link_or_junction(flat_link)
+                platform_compat.unlink_link_or_junction(item)
         # Only prune the directory if registration is all that was ever in it.
         # Any surviving real file means this path belongs to something else.
         if any(app_skills_dir.iterdir()):
@@ -1192,16 +1207,19 @@ def reconcile_app_skills(app_name: str) -> list[str]:
     if app_skills_dir.is_dir():
         manifest_skill_names = {Path(s).name for s in manifest.skills}
         for entry in list(app_skills_dir.iterdir()):
-            if entry.is_symlink() and entry.name not in manifest_skill_names:
+            # is_link_or_junction: a junction (non-admin Windows) is not a symlink.
+            if platform_compat.is_link_or_junction(entry) and (
+                entry.name not in manifest_skill_names
+            ):
                 # Stale link — skill was removed from manifest
                 target = entry.resolve()
-                entry.unlink()
+                platform_compat.unlink_link_or_junction(entry)
                 # Also remove the flat link if it points to the same target
                 flat_link = skills_root / entry.name
-                if flat_link.is_symlink():
+                if platform_compat.is_link_or_junction(flat_link):
                     try:
                         if flat_link.resolve() == target:
-                            flat_link.unlink()
+                            platform_compat.unlink_link_or_junction(flat_link)
                     except OSError:
                         pass
                 logger.info(

--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -15,9 +15,9 @@ the root since KiroCrew strips the prefix):
   GET  /git-status?path=<p>                     → {"repoRoot","branch","statuses":{relpath: code}}
   GET  /complete?path=<p>&kind=<dir|all>&limit=<n> → {"parent","prefix","entries":[...]}
 
-Path safety: callers may only access paths under ``$HOME``, ``/home/``,
-``/tmp/``, or ``/opt/`` (after symlink resolution).  Paths outside the
-allow-list return 403.
+Path safety: callers may only access paths under the user's home dir or the
+system temp dir on any OS, plus ``/home/`` and ``/opt/`` on POSIX (after
+symlink resolution).  Paths outside the allow-list return 403.
 
 Size / depth caps are tunable via env vars but have safe defaults.
 """
@@ -34,6 +34,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.parse
 import uuid
@@ -62,17 +63,24 @@ SEARCH_TIMEOUT_SEC = int(os.environ.get("FE_SEARCH_TIMEOUT_SEC", 15))
 GIT_TIMEOUT_SEC = int(os.environ.get("FE_GIT_TIMEOUT_SEC", 5))
 
 # Allow-list of root paths (resolved). Anything outside is denied.
-_HOME_RAW = os.environ.get("HOME", "")
-if not _HOME_RAW or Path(_HOME_RAW).resolve() == Path("/"):
-    _HOME = Path("/tmp").resolve()
-else:
-    _HOME = Path(_HOME_RAW).resolve()
-ALLOWED_ROOTS = [
-    _HOME,
-    Path("/home").resolve(),
-    Path("/tmp").resolve(),
-    Path("/opt").resolve() if Path("/opt").exists() else _HOME,
-]
+#
+# ``Path.home()`` reads $HOME on POSIX and %USERPROFILE% on Windows, so it
+# resolves correctly on both — a raw ``os.environ["HOME"]`` is usually unset on
+# Windows and would collapse the whole allow-list to a nonexistent C:\tmp.
+try:
+    _HOME = Path.home().resolve()
+except (RuntimeError, OSError):
+    _HOME = Path(tempfile.gettempdir()).resolve()
+if _HOME == Path(_HOME.anchor):  # home resolved to the filesystem root — unusable
+    _HOME = Path(tempfile.gettempdir()).resolve()
+
+# The system temp dir is /tmp on POSIX and %TEMP% on Windows.
+_TMP = Path(tempfile.gettempdir()).resolve()
+ALLOWED_ROOTS = [_HOME, _TMP]
+if platform_compat.IS_POSIX:
+    # /home and /opt are POSIX-only conventions; on Windows they resolve to
+    # nonexistent C:\home / C:\opt and would be dropped by the exists() filter.
+    ALLOWED_ROOTS += [Path("/home").resolve(), Path("/opt").resolve()]
 # De-dupe and only keep ones that exist
 ALLOWED_ROOTS = list({p for p in ALLOWED_ROOTS if p.exists()})
 

--- a/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
@@ -242,20 +242,44 @@ def _auth_env(pat: Optional[str]) -> dict[str, str]:
     return env
 
 
+def _windows_git_bin_dirs() -> tuple[str, ...]:
+    """Trusted, fixed Git-for-Windows install locations (never PATH).
+
+    Covers both the machine-wide install under ``%ProgramFiles%`` and the
+    per-user install under ``%LOCALAPPDATA%\\Programs\\Git`` — the latter is the
+    no-admin install `windows-install.md` recommends and what `kirocrew doctor`
+    itself detects, so omitting it made every vault op fail closed with
+    ``git_failed`` on an ordinary Windows machine. These are fixed install roots,
+    not workspace-writable, so trusting them does not reopen the PATH-hijack hole.
+    """
+    dirs: list[str] = []
+    program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+    localappdata = os.environ.get("LOCALAPPDATA", "")
+    roots = (
+        [program_files, os.path.join(localappdata, "Programs")]
+        if localappdata
+        else [program_files]
+    )
+    for root in roots:
+        dirs.append(os.path.join(root, "Git", "cmd"))
+        dirs.append(os.path.join(root, "Git", "bin"))
+        dirs.append(os.path.join(root, "Git", "mingw64", "bin"))
+    return tuple(dirs)
+
+
 #: Trusted absolute directories to resolve the ``git`` binary from, tried in
 #: order BEFORE ``PATH``: a workspace-writable entry earlier in PATH could
 #: otherwise shadow ``git`` with a planted binary that then runs unsandboxed on
 #: the next sync. On a normal POSIX host git lives in one of these, so PATH is
-#: never consulted there. The Windows entries + the ``shutil.which`` fallback
-#: exist for the CI test runners (the backend itself is macOS/Linux only).
+#: never consulted there. The Windows entries cover both the machine-wide and
+#: the per-user Git-for-Windows install roots (the backend itself is macOS/Linux
+#: only; these serve Windows dev hosts and CI test runners).
 _GIT_BIN_DIRS: tuple[str, ...] = (
     "/usr/bin",
     "/bin",
     "/usr/local/bin",
     "/opt/homebrew/bin",
-    r"C:\Program Files\Git\cmd",
-    r"C:\Program Files\Git\bin",
-)
+) + _windows_git_bin_dirs()
 _git_bin_memo: Optional[str] = None
 
 
@@ -264,8 +288,9 @@ def _git_bin() -> str:
 
     Only the trusted system directories above are searched — never ``PATH`` —
     so a planted binary in a workspace-writable PATH entry cannot win. The
-    Windows entries are for the CI test runners (the backend is macOS/Linux
-    only). Fails closed if git is not found in a trusted location.
+    Windows entries cover both the machine-wide and the per-user
+    Git-for-Windows install roots (Windows dev hosts and CI test runners).
+    Fails closed if git is not found in a trusted location.
     """
     global _git_bin_memo
     if _git_bin_memo is not None:

--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -35,7 +35,7 @@ from typing import Any, AsyncIterator, Callable, Optional
 
 from aiohttp import web
 
-from kiro_crew import hooks, security
+from kiro_crew import hooks, platform_compat, security
 from kiro_crew.apps.builtins.md_notebook import git_ops
 from kiro_crew.apps.builtins.md_notebook import notes as notes_mod
 from kiro_crew.apps.proxy_auth import verify_proxy_request
@@ -523,9 +523,11 @@ async def trash_dir_path(vault: dict[str, Any]) -> Path:
 
     So any symlink is refused, escaping or not. `lstat` via `is_symlink()` is the
     only test that can see it — `exists()` and `is_dir()` both follow the link.
+    On Windows the same redirection is possible via a directory JUNCTION, which
+    `is_symlink()` does NOT report, so `is_link_or_junction` is used to catch both.
     """
     trash_dir = await vault_mutation_path(vault, git_ops.TRASH_DIR)
-    if await asyncio.to_thread(trash_dir.is_symlink):
+    if await asyncio.to_thread(platform_compat.is_link_or_junction, trash_dir):
         raise ApiError(
             f"this vault's {git_ops.TRASH_DIR} is a symlink — refusing to use it, "
             "because a trashed note would be written somewhere the app does not "
@@ -1179,7 +1181,9 @@ async def api_note_save(request: web.Request) -> web.Response:
     # follow the link and overwrite the target. Reject a final-component symlink
     # outright; a note is a real file, never an alias to another path.
     abs_path = await vault_mutation_path(vault, rel)
-    if await asyncio.to_thread(os.path.islink, abs_path):
+    # islink OR (Windows) junction — a junction is a directory reparse point that
+    # islink() misses, so check both to keep the guard from being POSIX-only.
+    if await asyncio.to_thread(platform_compat.is_link_or_junction, abs_path):
         raise ApiError("cannot save through a symlink", 400, code="note_is_symlink")
     base_mtime = body.get("baseMtime")
     # Serialize the check-and-write for this note so two concurrent saves can't

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
@@ -911,6 +911,16 @@ def _write_deck_root(deck_root: str) -> tuple[int, dict]:
 
     BLOCKING — call through ``off_loop``.
     """
+    # An embedded NUL makes a path unusable, but Path.resolve() only RAISES on
+    # it on POSIX — on Windows it silently returns a bogus path, so resolve()'s
+    # own except never fires and the wedge slips through. Reject NUL explicitly
+    # up front so the check holds on every OS.
+    if not deck_root or "\x00" in deck_root:
+        logger.warning("pptx-maker: refused an empty or NUL-containing deck root")
+        return 400, {
+            "error": "that deck folder is not a usable path",
+            "code": "invalid_deck_root",
+        }
     try:
         # Same expansion order as `paths.deck_root`, so what is validated is what
         # will later be resolved — checking a differently-derived path would leave

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 import ntpath
-import os
+import posixpath
 import re
 import sys
 from dataclasses import dataclass, field
@@ -45,7 +45,11 @@ def _path_escapes_app_root(rel_path: str, app_root: Path | None) -> bool:
     """
     if not rel_path:
         return False
-    if os.path.isabs(rel_path) or ntpath.isabs(rel_path):
+    # Check BOTH flavors explicitly: on Windows ``os.path is ntpath``, so
+    # ``os.path.isabs`` alone would miss POSIX-absolute paths like
+    # ``/etc/passwd`` (ntpath treats a leading "/" as relative), and on POSIX
+    # ``os.path is posixpath`` would miss Windows-drive/UNC paths.
+    if posixpath.isabs(rel_path) or ntpath.isabs(rel_path):
         return True
     if app_root is not None:
         try:

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -2662,12 +2662,16 @@ async def _run_app_build(
     build_cmds: list[list[str]] = []
 
     if (build_dir / "package.json").is_file():
-        if shutil.which("npm"):
-            build_cmds.append(["npm", "install"])
+        # Resolve to a full path, mirroring the pip branch below: on Windows npm
+        # is ``npm.CMD``, which shutil.which finds but CreateProcess cannot spawn
+        # by the bare name "npm".
+        npm = shutil.which("npm")
+        if npm:
+            build_cmds.append([npm, "install"])
             try:
                 pkg = json.loads((build_dir / "package.json").read_text("utf-8"))
                 if (pkg.get("scripts") or {}).get("build"):
-                    build_cmds.append(["npm", "run", "build"])
+                    build_cmds.append([npm, "run", "build"])
             except (json.JSONDecodeError, OSError):
                 pass
         else:

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -582,8 +582,10 @@ def _doctor(platform_boot_error: "Exception | None" = None) -> None:
                 stale_project = True
     if proj and Path(proj).is_dir():
         print(f"  project dir: ✅ {proj}")
-        git_dir = Path(proj) / ".git"
-        if git_dir.is_dir():
+        # A git worktree or submodule stores ``.git`` as a FILE holding a
+        # ``gitdir:`` pointer, not a directory, so accept both forms.
+        git_marker = Path(proj) / ".git"
+        if git_marker.exists():
             print("  git repo:    ✅")
         else:
             print("  git repo:    ⚠️  not a git repo")

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1151,7 +1151,10 @@ def _update() -> None:
         sys.exit(1)
 
     proj_path = Path(proj)
-    if not (proj_path / ".git").is_dir():
+    # A git worktree or submodule stores ``.git`` as a FILE (a ``gitdir:``
+    # pointer), not a directory, so accept both — otherwise `kirocrew update`
+    # run from a worktree wrongly refuses with "No git repo".
+    if not (proj_path / ".git").exists():
         print(f"❌ No git repo at {proj}")
         sys.exit(1)
 

--- a/src/kiro_crew/deploy/pending.py
+++ b/src/kiro_crew/deploy/pending.py
@@ -18,8 +18,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from kiro_crew import flock_compat as fcntl
 from kiro_crew.config.paths import config_dir
+from kiro_crew.platform_compat import file_lock
 
 logger = logging.getLogger(__name__)
 
@@ -87,18 +87,17 @@ def add_pending(params: dict[str, Any]) -> dict[str, Any]:
     }
     lock_path = _store_path().with_suffix(".lock")
     _store_path().parent.mkdir(parents=True, exist_ok=True)
-    fd = open(lock_path, "w")
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        entries = _prune_expired(_load_raw())
-        entries.append(entry)
-        # Cap at _MAX_PENDING, drop oldest
-        if len(entries) > _MAX_PENDING:
-            entries = entries[-_MAX_PENDING:]
-        _save_raw(entries)
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        fd.close()
+    # required=True: a deploy store that cannot obtain cross-process exclusion
+    # must fail loudly rather than risk a double-deploy / lost write. flock_compat
+    # is a Windows no-op, so this uses platform_compat's real msvcrt lock.
+    with open(lock_path, "w") as fd:
+        with file_lock(fd.fileno(), exclusive=True, required=True):
+            entries = _prune_expired(_load_raw())
+            entries.append(entry)
+            # Cap at _MAX_PENDING, drop oldest
+            if len(entries) > _MAX_PENDING:
+                entries = entries[-_MAX_PENDING:]
+            _save_raw(entries)
     return entry
 
 
@@ -120,17 +119,13 @@ def remove_pending(entry_id: str) -> bool:
     """Remove an entry (confirm or dismiss). Returns True if found."""
     lock_path = _store_path().with_suffix(".lock")
     _store_path().parent.mkdir(parents=True, exist_ok=True)
-    fd = open(lock_path, "w")
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        entries = _prune_expired(_load_raw())
-        before = len(entries)
-        entries = [e for e in entries if e.get("id") != entry_id]
-        _save_raw(entries)
-        return len(entries) < before
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        fd.close()
+    with open(lock_path, "w") as fd:
+        with file_lock(fd.fileno(), exclusive=True, required=True):
+            entries = _prune_expired(_load_raw())
+            before = len(entries)
+            entries = [e for e in entries if e.get("id") != entry_id]
+            _save_raw(entries)
+            return len(entries) < before
 
 
 def claim_pending(entry_id: str) -> dict[str, Any] | None:
@@ -142,20 +137,16 @@ def claim_pending(entry_id: str) -> dict[str, Any] | None:
     """
     lock_path = _store_path().with_suffix(".lock")
     _store_path().parent.mkdir(parents=True, exist_ok=True)
-    fd = open(lock_path, "w")
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        entries = _prune_expired(_load_raw())
-        claimed = None
-        remaining = []
-        for e in entries:
-            if e.get("id") == entry_id and claimed is None:
-                claimed = e
-            else:
-                remaining.append(e)
-        if claimed is not None:
-            _save_raw(remaining)
-        return claimed
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        fd.close()
+    with open(lock_path, "w") as fd:
+        with file_lock(fd.fileno(), exclusive=True, required=True):
+            entries = _prune_expired(_load_raw())
+            claimed = None
+            remaining = []
+            for e in entries:
+                if e.get("id") == entry_id and claimed is None:
+                    claimed = e
+                else:
+                    remaining.append(e)
+            if claimed is not None:
+                _save_raw(remaining)
+            return claimed

--- a/src/kiro_crew/deploy/profiles.py
+++ b/src/kiro_crew/deploy/profiles.py
@@ -33,9 +33,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Generator
 
-from kiro_crew import flock_compat as fcntl
 from kiro_crew.config.paths import config_dir
 from kiro_crew.deploy import engine
+from kiro_crew.platform_compat import file_lock
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import FieldSpec, ValidationError, validate_field
 
@@ -112,32 +112,31 @@ def locked_registry() -> Generator[dict[str, Any], None, None]:
     """
     _data_dir().mkdir(parents=True, exist_ok=True)
     lock_path = _registry_path().with_suffix(".lock")
-    fd = open(lock_path, "w")
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        reg = load_registry()
-        yield reg
-        # Persist on clean exit (exceptions skip save, lock still releases)
-        tmp_fd = tempfile.NamedTemporaryFile(
-            mode="w", dir=str(_data_dir()), suffix=".json.tmp",
-            delete=False, encoding="utf-8",
-        )
-        try:
-            tmp_fd.write(json.dumps(reg, indent=2))
-            tmp_fd.flush()
-            os.fsync(tmp_fd.fileno())
-            tmp_fd.close()
-            os.replace(tmp_fd.name, str(_registry_path()))
-        except BaseException:
-            tmp_fd.close()
+    # required=True: a lost profile write is silent data loss, so refuse to
+    # proceed without cross-process exclusion. flock_compat is a Windows no-op,
+    # so this uses platform_compat's real msvcrt lock.
+    with open(lock_path, "w") as fd:
+        with file_lock(fd.fileno(), exclusive=True, required=True):
+            reg = load_registry()
+            yield reg
+            # Persist on clean exit (exceptions skip save, lock still releases)
+            tmp_fd = tempfile.NamedTemporaryFile(
+                mode="w", dir=str(_data_dir()), suffix=".json.tmp",
+                delete=False, encoding="utf-8",
+            )
             try:
-                os.unlink(tmp_fd.name)
-            except OSError:
-                pass
-            raise
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        fd.close()
+                tmp_fd.write(json.dumps(reg, indent=2))
+                tmp_fd.flush()
+                os.fsync(tmp_fd.fileno())
+                tmp_fd.close()
+                os.replace(tmp_fd.name, str(_registry_path()))
+            except BaseException:
+                tmp_fd.close()
+                try:
+                    os.unlink(tmp_fd.name)
+                except OSError:
+                    pass
+                raise
 
 
 def make_entry(name: str, region: str, *, account: str = "", verified_at: str = "",
@@ -200,29 +199,25 @@ def load_registry() -> dict[str, Any]:
 def save_registry(reg: dict[str, Any]) -> dict[str, Any]:
     _data_dir().mkdir(parents=True, exist_ok=True)
     lock_path = _registry_path().with_suffix(".lock")
-    fd = open(lock_path, "w")
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        tmp_fd = tempfile.NamedTemporaryFile(
-            mode="w", dir=str(_data_dir()), suffix=".json.tmp",
-            delete=False, encoding="utf-8",
-        )
-        try:
-            tmp_fd.write(json.dumps(reg, indent=2))
-            tmp_fd.flush()
-            os.fsync(tmp_fd.fileno())
-            tmp_fd.close()
-            os.replace(tmp_fd.name, str(_registry_path()))
-        except BaseException:
-            tmp_fd.close()
+    with open(lock_path, "w") as fd:
+        with file_lock(fd.fileno(), exclusive=True, required=True):
+            tmp_fd = tempfile.NamedTemporaryFile(
+                mode="w", dir=str(_data_dir()), suffix=".json.tmp",
+                delete=False, encoding="utf-8",
+            )
             try:
-                os.unlink(tmp_fd.name)
-            except OSError:
-                pass
-            raise
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        fd.close()
+                tmp_fd.write(json.dumps(reg, indent=2))
+                tmp_fd.flush()
+                os.fsync(tmp_fd.fileno())
+                tmp_fd.close()
+                os.replace(tmp_fd.name, str(_registry_path()))
+            except BaseException:
+                tmp_fd.close()
+                try:
+                    os.unlink(tmp_fd.name)
+                except OSError:
+                    pass
+                raise
     return reg
 
 

--- a/src/kiro_crew/frontend.py
+++ b/src/kiro_crew/frontend.py
@@ -20,6 +20,8 @@ import subprocess
 from pathlib import Path
 from typing import Callable, Optional
 
+from kiro_crew import platform_compat
+
 logger = logging.getLogger(__name__)
 
 # The frontend is in-tree at ``<repo-root>/website``; there is no remote to
@@ -174,17 +176,21 @@ def ensure_dev_dist_symlink() -> Optional[Path]:
     kiro_crew_pkg_dir = Path(__file__).resolve().parent
     tree_dist = kiro_crew_pkg_dir / "static" / "dist"
 
+    # A prior run may have created a symlink (POSIX) OR a directory junction
+    # (non-admin Windows); both are "links" here and neither is a real dir.
+    tree_dist_is_link = platform_compat.is_link_or_junction(tree_dist)
+
     # Case 1: real directory already populated (packaged install / a prior
     # local build landing in the source tree / user ran kirocrew init --ui).
-    if tree_dist.is_dir() and not tree_dist.is_symlink():
+    if tree_dist.is_dir() and not tree_dist_is_link:
         if (tree_dist / "index.html").is_file():
             return tree_dist
         # Empty real dir — fall through and try to resolve something usable.
 
-    # Case 2: existing symlink — validate and re-use if the target still has
+    # Case 2: existing link — validate and re-use if the target still has
     # a dist in it. A dangling or empty target means the website build moved
     # or was cleaned; drop the link and re-resolve below.
-    if tree_dist.is_symlink():
+    if tree_dist_is_link:
         try:
             target = tree_dist.resolve(strict=True)
         except (FileNotFoundError, OSError):
@@ -192,9 +198,9 @@ def ensure_dev_dist_symlink() -> Optional[Path]:
         if target is not None and (target / "index.html").is_file():
             return target
         try:
-            tree_dist.unlink()
+            platform_compat.unlink_link_or_junction(tree_dist)
         except OSError as exc:
-            logger.warning("Failed to remove stale dist symlink %s: %s", tree_dist, exc)
+            logger.warning("Failed to remove stale dist link %s: %s", tree_dist, exc)
             return None
 
     # Case 3: no usable dist in place — probe and link.
@@ -203,20 +209,24 @@ def ensure_dev_dist_symlink() -> Optional[Path]:
         return None
 
     tree_dist.parent.mkdir(parents=True, exist_ok=True)
-    # Guard against a lingering empty real dir from Case 1's fall-through.
-    if tree_dist.exists() or tree_dist.is_symlink():
+    # Guard against a lingering empty real dir from Case 1's fall-through, or a
+    # stale link/junction (rmtree must never descend THROUGH a link).
+    if tree_dist.exists() or platform_compat.is_link_or_junction(tree_dist):
         try:
-            if tree_dist.is_dir() and not tree_dist.is_symlink():
+            if tree_dist.is_dir() and not platform_compat.is_link_or_junction(tree_dist):
                 shutil.rmtree(tree_dist)
             else:
-                tree_dist.unlink()
+                platform_compat.unlink_link_or_junction(tree_dist)
         except OSError as exc:
-            logger.warning("Failed to clear %s before symlink: %s", tree_dist, exc)
+            logger.warning("Failed to clear %s before linking: %s", tree_dist, exc)
             return None
     try:
-        tree_dist.symlink_to(candidate)
+        # symlink on POSIX; directory junction on non-admin Windows, where a
+        # plain symlink needs SeCreateSymbolicLinkPrivilege and would fail with
+        # WinError 1314 — leaving a source-tree gateway with no SPA bundle.
+        platform_compat.symlink_or_junction(str(candidate), str(tree_dist))
     except OSError as exc:
-        logger.warning("Failed to symlink %s -> %s: %s", tree_dist, candidate, exc)
+        logger.warning("Failed to link %s -> %s: %s", tree_dist, candidate, exc)
         return None
     logger.info("Linked frontend dist: %s -> %s", tree_dist, candidate)
     return candidate
@@ -274,7 +284,10 @@ def build_frontend_sync(
     if not website_dir.is_dir():
         log("  ⚠️  No website/ directory — skipping frontend build")
         return
-    if not shutil.which("npm"):
+    # Resolve to a full path: on Windows npm is ``npm.CMD``, which PATHEXT-aware
+    # shutil.which finds but CreateProcess cannot spawn by the bare name "npm".
+    npm = shutil.which("npm")
+    if not npm:
         log("  ⚠️  npm not found — skipping frontend build")
         return
     if edition_sources_missing():
@@ -289,7 +302,7 @@ def build_frontend_sync(
     )
     try:
         r = subprocess.run(
-            ["npm", *install_args],
+            [npm, *install_args],
             cwd=str(website_dir), capture_output=True, timeout=_INSTALL_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
@@ -301,7 +314,7 @@ def build_frontend_sync(
 
     try:
         r = subprocess.run(
-            ["npm", "run", "build"],
+            [npm, "run", "build"],
             cwd=str(website_dir), capture_output=True, timeout=_BUILD_TIMEOUT,
             env=_edition_build_env(),
         )
@@ -341,7 +354,10 @@ async def build_frontend_async(
     if not website_dir.is_dir():
         _warn("No website/ directory -- skipping frontend build")
         return
-    if not shutil.which("npm"):
+    # Resolve to a full path: on Windows npm is ``npm.CMD``, which PATHEXT-aware
+    # shutil.which finds but CreateProcess cannot spawn by the bare name "npm".
+    npm = shutil.which("npm")
+    if not npm:
         _warn("npm not found -- skipping frontend build")
         return
     if edition_sources_missing():
@@ -354,7 +370,7 @@ async def build_frontend_async(
         else ["install", "--no-audit", "--no-fund"]
     )
     npm_i = await asyncio.create_subprocess_exec(
-        "npm", *install_args,
+        npm, *install_args,
         cwd=str(website_dir),
         stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.DEVNULL,
@@ -374,7 +390,7 @@ async def build_frontend_async(
         return
 
     npm_build = await asyncio.create_subprocess_exec(
-        "npm", "run", "build",
+        npm, "run", "build",
         cwd=str(website_dir),
         stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.DEVNULL,

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import ntpath
 import os
+import posixpath
 import shutil
 import signal
 import subprocess
@@ -44,6 +46,27 @@ _PROBE_TIMEOUT_SECS = 15  # fallback if config not loaded yet
 # process-group reap runs, which is why it is a named constant -- tests that
 # deliberately probe a never-exiting child shrink it instead of waiting it out.
 _PROBE_TEARDOWN_WAIT_SECS = 5
+
+# Cap on a probe error string stored on server.error and surfaced by doctor /
+# the dashboard. Sized to hold a full SandboxUnavailableError, whose message
+# ends with the ~400-char remedy sentence naming
+# agent.sandbox_allow_unsandboxed_exec; the old 200-char cap chopped that tail
+# mid-word, so a Windows user saw "…Probe detail: not Linux. I" and no fix.
+_PROBE_ERROR_MAX_CHARS = 1200
+
+
+def _sanitize_probe_error(exc: BaseException) -> str:
+    """Redact THEN truncate a probe exception for server.error / doctor / logs.
+
+    A probe exception can carry untrusted, credential-bearing text — e.g. a
+    malformed remote MCP URL with an embedded token in the message. Redact
+    before truncating (the stderr-tail path already does), so raising the cap to
+    hold the sandbox remedy sentence never widens a credential-disclosure hole.
+    """
+    text = str(exc)
+    text, _ = redact_exfiltration_urls(text)
+    text, _ = redact_credentials(text)
+    return text[:_PROBE_ERROR_MAX_CHARS]
 
 
 def _get_probe_timeout() -> int:
@@ -769,7 +792,7 @@ async def _probe_remote(server: McpServerInfo) -> McpServerInfo:
         logger.warning("MCP probe failed [%s]: timeout", server.name)
     except Exception as exc:
         server.status = "error"
-        server.error = str(exc)[:200]
+        server.error = _sanitize_probe_error(exc)
         logger.warning("MCP probe failed [%s]: %s", server.name, server.error)
 
     _cache_probe(server)
@@ -1033,7 +1056,7 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
         _warn_unresolvable_once(server.name, server.command)
     except Exception as exc:
         server.status = "error"
-        server.error = str(exc)[:200]
+        server.error = _sanitize_probe_error(exc)
         logger.warning("MCP probe failed [%s]: %s", server.name, server.error)
     finally:
         # When the probe failed, drain any stderr the child wrote and append
@@ -1156,7 +1179,7 @@ async def probe_all() -> list[McpServerInfo]:
     for i, r in enumerate(results):
         if isinstance(r, Exception):
             servers[i].status = "error"
-            servers[i].error = str(r)[:200]
+            servers[i].error = _sanitize_probe_error(r)
             logger.warning("MCP probe failed [%s]: %s", servers[i].name, servers[i].error)
             out.append(servers[i])
         else:
@@ -1174,12 +1197,28 @@ def _commands_diverged(source_cmd: str, agent_cmd: str) -> bool:
     """
     if source_cmd == agent_cmd:
         return False
-    # If one is an absolute resolved path of the other, they match.
-    if os.path.isabs(agent_cmd) and os.path.basename(agent_cmd) == source_cmd:
+    # If one is an absolute resolved path of the other, they match. Test both
+    # path flavors regardless of host OS: on Windows ``os.path is ntpath`` and
+    # would treat a POSIX-absolute config path (/usr/bin/server) as relative,
+    # so a resolved-vs-short pair authored on POSIX would spuriously read as
+    # diverged and trigger an endless re-sync.
+    if _is_abs_any(agent_cmd) and _basename_any(agent_cmd) == source_cmd:
         return False
-    if os.path.isabs(source_cmd) and os.path.basename(source_cmd) == agent_cmd:
+    if _is_abs_any(source_cmd) and _basename_any(source_cmd) == agent_cmd:
         return False
     return True
+
+
+def _is_abs_any(cmd: str) -> bool:
+    """True if ``cmd`` is absolute under POSIX or Windows path rules."""
+    return posixpath.isabs(cmd) or ntpath.isabs(cmd)
+
+
+def _basename_any(cmd: str) -> str:
+    """Basename of ``cmd`` under whichever path flavor treats it as absolute."""
+    if ntpath.isabs(cmd):
+        return ntpath.basename(cmd)
+    return posixpath.basename(cmd)
 
 
 def discover_servers_to_sync() -> list[McpServerInfo]:

--- a/src/kiro_crew/mcp_playwright_proxy.py
+++ b/src/kiro_crew/mcp_playwright_proxy.py
@@ -994,8 +994,13 @@ def _resolve_playwright_cmd() -> str | None:
         found = shutil.which(binary)
         if found:
             return found
-    if shutil.which("npx"):
-        return "npx"
+    # Return the RESOLVED path, never the bare name: on Windows npx ships only
+    # as ``npx.CMD`` and CreateProcess does not apply PATHEXT, so spawning the
+    # literal "npx" raises FileNotFoundError even though PATHEXT-aware
+    # shutil.which found it.
+    npx = shutil.which("npx")
+    if npx:
+        return npx
     return None
 
 
@@ -1019,7 +1024,9 @@ def run_proxy(args: list[str]) -> None:
         sys.exit(1)
     if playwright_cmd.endswith(".js"):
         cmd = ["node", playwright_cmd] + args
-    elif os.path.basename(playwright_cmd) == "npx":
+    elif os.path.splitext(os.path.basename(playwright_cmd))[0].lower() == "npx":
+        # Extension-insensitive: the resolved launcher is ``npx.CMD`` on Windows
+        # and bare ``npx`` on POSIX; both must still get the @playwright/mcp arg.
         cmd = [playwright_cmd, "@playwright/mcp"] + args
     else:
         cmd = [playwright_cmd] + args

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -272,6 +272,71 @@ else:
     import msvcrt  # type: ignore[import-not-found]
 
 
+# msvcrt's blocking lock codes (LK_LOCK / LK_RLCK) are NOT the equivalent of
+# fcntl.flock(LOCK_EX): rather than waiting until the lock is free, they retry
+# ~10 times at 1s intervals and then RAISE EDEADLOCK (errno 36). Swallowing
+# that as "acquired" lets a caller run its read-modify-write with no exclusion
+# and silently lose writes. So the Windows "blocking" acquire spins on the
+# non-blocking code (LK_NBLCK) instead — the same idiom cron._file_lock uses.
+# It is bounded rather than truly unbounded because a contended fd and a
+# non-writable fd are indistinguishable on Windows (both surface as errno 13
+# EACCES), so an unbounded spin would turn a permission error into a hang.
+#
+# Two ceilings, because on-loop and off-loop have opposite needs:
+#  - OFF the loop (cron, home migration, app backends — threads/subprocesses):
+#    the wait must cover a legitimately long holder. home_migration holds the
+#    lock across a full copy+verify+delete of the data home, which can exceed
+#    many seconds, and a waiter there must NOT give up and race it. So use a
+#    generous ceiling that no real hold approaches, matching POSIX's "wait for
+#    the lock" as closely as a bounded spin can.
+#  - ON the loop (e.g. bridges._mcp_lock during app enable): a spin-sleep would
+#    freeze chat/heartbeat, so that path never sleeps at all (single-shot).
+_WIN_LOCK_POLL_SECS = 0.01
+# Generous off-loop ceiling: longer than any legitimate hold (a large data-home
+# migration), short enough that a truly stuck/permission-denied fd still fails.
+_WIN_LOCK_TIMEOUT_SECS = 300.0
+
+
+def _win_acquire_blocking(fd: int, *, timeout: float = _WIN_LOCK_TIMEOUT_SECS) -> bool:
+    """Windows blocking lock acquire: spin on LK_NBLCK until free or timeout.
+
+    Returns True if the lock was taken, False if it could not be.
+
+    NEVER spins on the asyncio event-loop thread: ``time.sleep`` there would
+    freeze chat/heartbeat for the whole wait. A few callers still take the lock
+    on the loop (e.g. bridges._mcp_lock during app enable), so when a running
+    loop is detected the acquire is single-shot — take it if free, else return
+    False at once — and the caller fails closed rather than stalling the loop.
+    Off the loop (the common case) it polls up to ``timeout`` as a real
+    blocking wait, so a legitimately long holder (a data-home migration) is
+    waited out rather than raced.
+    """
+    def _try_once() -> bool:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+            return True
+        except OSError:
+            return False
+
+    try:
+        asyncio.get_running_loop()
+        on_loop = True
+    except RuntimeError:
+        on_loop = False
+    if on_loop:
+        # Single attempt only — a spin-sleep here blocks the event loop.
+        return _try_once()
+
+    deadline = time.monotonic() + timeout
+    while True:
+        if _try_once():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_WIN_LOCK_POLL_SECS)
+
+
 @contextlib.contextmanager
 def file_lock(
     fd: int,
@@ -282,12 +347,23 @@ def file_lock(
     """Acquire an advisory lock on ``fd`` for the duration of the block.
 
     POSIX: ``fcntl.flock(LOCK_EX|LOCK_SH)`` with ``LOCK_UN`` release.
-    Windows: ``msvcrt.locking`` on the first byte. ``msvcrt`` has no shared
-    mode, so a shared request is satisfied with an exclusive lock (correctness
-    over concurrency — readers serialize, but never see torn writes). Windows
-    locking is best-effort by default for backward compatibility.
-    ``required=True`` propagates acquisition failure for security-sensitive
-    transactions that must never continue without cross-process exclusion.
+    Windows: ``msvcrt.locking`` on the first byte, acquired by spinning on the
+    non-blocking code up to ``_WIN_LOCK_TIMEOUT_SECS`` — because msvcrt's own
+    "blocking" code gives up after ~10s with EDEADLOCK, which cannot be treated
+    as a wait. ``msvcrt`` has no shared mode, so a shared request is satisfied
+    with an exclusive lock (correctness over concurrency — readers genuinely
+    serialize with the holder, but never see torn writes).
+
+    On Windows the acquire is single-shot when called on the asyncio event-loop
+    thread (a spin-sleep there would freeze chat/heartbeat) and a bounded poll
+    up to the timeout otherwise; either way, if the lock cannot be taken
+    ``file_lock`` FAILS CLOSED — it raises rather than entering the critical
+    section unserialized, since proceeding lock-less is the exact fail-open that
+    loses writes. The timeout is a safety ceiling against a stuck holder, not a
+    normal wait (every in-tree critical section is a sub-second read + atomic
+    rename). ``required`` is retained for call-site intent but no longer changes
+    the outcome (both paths refuse to proceed without the lock). On POSIX the
+    acquire blocks until the lock is free, as before.
 
     Note: on Windows, ``msvcrt.locking`` requires seeking to byte 0, so the
     ``fd`` must be a dedicated lock file; callers must not rely on the file
@@ -304,23 +380,26 @@ def file_lock(
             except OSError:
                 pass
     else:
-        locked = False
-        try:
-            os.lseek(fd, 0, os.SEEK_SET)
-            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
-            locked = True
-        except OSError:
-            if required:
-                raise
+        # Fail CLOSED, not open: if the lock cannot be taken within the ceiling
+        # (a stuck/crashed holder — never a normal sub-second hold), raise rather
+        # than enter the critical section unserialized. Entering anyway is the
+        # exact fail-open that loses writes; a loud error in that rare case is
+        # strictly safer, and callers already run under `with`, so the fd is
+        # cleaned up. `required` is retained for call-site intent but no longer
+        # changes the outcome — both paths now refuse to proceed lock-less.
+        if not _win_acquire_blocking(fd):
+            raise OSError(
+                f"could not acquire exclusive file lock within {_WIN_LOCK_TIMEOUT_SECS:g}s "
+                "(a holder is stuck); refusing to proceed unserialized"
+            )
         try:
             yield
         finally:
-            if locked:
-                try:
-                    os.lseek(fd, 0, os.SEEK_SET)
-                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
-                except OSError:
-                    pass
+            try:
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+            except OSError:
+                pass
 
 
 @contextlib.contextmanager
@@ -334,17 +413,22 @@ def acquire_lock(fd: int, *, exclusive: bool = True) -> None:
     """Low-level lock acquire for the acquire-now / release-later fd-handoff
     pattern (where a context manager does not fit).
 
-    POSIX: ``fcntl.flock``. Windows: best-effort ``msvcrt.locking`` on byte 0.
-    Pair every call with :func:`release_lock` on the same ``fd``.
+    POSIX: ``fcntl.flock`` (blocks until free). Windows: single-shot on the
+    asyncio loop thread, else a bounded poll up to ``_WIN_LOCK_TIMEOUT_SECS``
+    (see :func:`_win_acquire_blocking`). If the lock cannot be taken it FAILS
+    CLOSED — raises rather than letting the caller proceed unserialized — since
+    a stuck holder past the ceiling is an error, not a routine wait, and
+    proceeding lock-less is the fail-open that loses writes. Pair every call
+    with :func:`release_lock` on the same ``fd``.
     """
     if IS_POSIX:
         fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
         return
-    try:
-        os.lseek(fd, 0, os.SEEK_SET)
-        msvcrt.locking(fd, msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
-    except OSError:
-        pass  # best-effort
+    if not _win_acquire_blocking(fd):
+        raise OSError(
+            f"could not acquire file lock within {_WIN_LOCK_TIMEOUT_SECS:g}s "
+            "(a holder is stuck); refusing to proceed unserialized"
+        )
 
 
 def release_lock(fd: int) -> None:
@@ -1699,6 +1783,106 @@ def rmtree_force(path: str | os.PathLike) -> bool:
     else:
         shutil.rmtree(path, onexc=_clear_readonly_and_retry)  # type: ignore[call-arg]
     return not os.path.exists(path)
+
+
+def symlink_or_junction(target: str | os.PathLike, link: str | os.PathLike) -> None:
+    """Create a directory link at *link* pointing to *target*.
+
+    POSIX: a plain ``os.symlink``.
+
+    Windows: ``os.symlink`` needs SeCreateSymbolicLinkPrivilege — held only by
+    an elevated process or one running with Developer Mode on — so it raises
+    ``OSError WinError 1314`` for the ordinary non-admin user, silently breaking
+    every feature that links a directory into place (app skills, etc.). A
+    directory JUNCTION needs no privilege, is followed transparently by reads
+    and by ``os.path.realpath`` / ``Path.resolve()`` (so app-root containment
+    checks still hold), and is the standard no-elevation substitute. Fall back
+    to it, and only if the symlink attempt fails, so the POSIX-identical path is
+    unchanged where symlinks are permitted.
+
+    ``target`` must be an existing directory on Windows (junctions are
+    directory-only). Raises if neither a symlink nor a junction can be made.
+    """
+    if IS_POSIX:
+        os.symlink(str(target), str(link))
+        return
+    try:
+        # target_is_directory=True is required on Windows: a directory link made
+        # without it is a FILE-type symlink pointing at a directory, which is not
+        # traversable. Ignored on POSIX. This helper only ever links directories.
+        os.symlink(str(target), str(link), target_is_directory=True)
+    except OSError:
+        # No symlink privilege (the common non-admin case) — use a junction,
+        # which requires none. _winapi.CreateJunction exists on all supported
+        # CPython builds on Windows.
+        import _winapi
+
+        # _winapi.CreateJunction is Windows-only; typeshed omits it on the POSIX
+        # stub, so ignore the attr error mypy raises when checking on Linux.
+        _winapi.CreateJunction(str(target), str(link))  # type: ignore[attr-defined]
+
+
+# os.path.isjunction is 3.12+; fall back to the reparse-tag check below on the
+# 3.10/3.11 interpreters this project still supports, or the junction guard is a
+# silent no-op there. Constants mirror CPython's own isjunction.
+_ISJUNCTION = getattr(os.path, "isjunction", None)
+_FILE_ATTRIBUTE_REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+_IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003
+
+
+def _is_junction_fallback(path: str | os.PathLike) -> bool:
+    """``os.path.isjunction`` for Python 3.10/3.11, which lack it.
+
+    A junction is a reparse point (``FILE_ATTRIBUTE_REPARSE_POINT``) whose tag is
+    ``IO_REPARSE_TAG_MOUNT_POINT``. Both fields are Windows-only additions to
+    ``os.stat_result``, so their absence off Windows makes this False — correct,
+    since junctions do not exist there. ``follow_symlinks=False``: the question
+    is what THIS name is, not what it points at.
+    """
+    try:
+        info = os.stat(path, follow_symlinks=False)
+    except (OSError, ValueError, TypeError):
+        return False
+    attrs = getattr(info, "st_file_attributes", 0)
+    if not attrs & _FILE_ATTRIBUTE_REPARSE_POINT:
+        return False
+    return getattr(info, "st_reparse_tag", 0) == _IO_REPARSE_TAG_MOUNT_POINT
+
+
+def is_link_or_junction(path: str | os.PathLike) -> bool:
+    """True if *path* is a symlink OR (on Windows) a directory junction.
+
+    ``os.path.islink`` returns False for a junction, so a caller that only
+    checks ``islink`` would treat a junction as a real directory and
+    ``rmtree`` THROUGH it, destroying the target's contents. Pair with
+    :func:`unlink_link_or_junction` to remove one safely.
+    """
+    if os.path.islink(path):
+        return True
+    if _ISJUNCTION is not None:
+        try:
+            return bool(_ISJUNCTION(path))
+        except (OSError, ValueError):
+            return False
+    return _is_junction_fallback(path)
+
+
+def unlink_link_or_junction(path: str | os.PathLike) -> None:
+    """Remove a symlink or directory junction WITHOUT touching its target.
+
+    A symlink is removed with ``unlink``; a Windows junction is a directory
+    reparse point removed with ``rmdir`` (which unlinks the junction itself,
+    never the target it points at).
+    """
+    if os.path.islink(path):
+        os.unlink(path)
+        return
+    is_junction = _ISJUNCTION(path) if _ISJUNCTION is not None else _is_junction_fallback(path)
+    if is_junction:
+        os.rmdir(path)
+        return
+    # Neither — let the caller's own logic handle a real file/dir.
+    os.unlink(path)
 
 
 # Well-known SID for the file's *owner* (implicit). Under a self-relative DACL

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -104,6 +104,22 @@ def _python3_bin_dir() -> str:
         return ""
 
 
+def _find_script_in_dir(bin_dir: str, name: str) -> str | None:
+    """Return an executable ``name`` inside ``bin_dir``, trying Windows suffixes.
+
+    A pip console script is materialized as ``<name>.exe`` in ``Scripts\\`` on
+    Windows, so the extensionless POSIX name never exists there. Sweep the
+    known launcher suffixes (the idiom in dev_fleet ``_trusted_bin``).
+    """
+    suffixes = ("", ".exe", ".cmd", ".bat") if platform_compat.IS_WINDOWS else ("",)
+    for suffix in suffixes:
+        p = os.path.join(bin_dir, name + suffix)
+        # On Windows there is no execute bit, so gate on isfile only there.
+        if os.path.isfile(p) and (platform_compat.IS_WINDOWS or os.access(p, os.X_OK)):
+            return p
+    return None
+
+
 _WHISPER_SEARCH_PATHS = [
     os.path.expanduser("~/.local/bin/whisper"),
     "/usr/local/bin/whisper",
@@ -122,9 +138,9 @@ def _find_whisper(configured_path: str = "") -> str | None:
     # Check system python3's scripts dir (pip install target)
     py3_bin = _python3_bin_dir()
     if py3_bin:
-        p = os.path.join(py3_bin, "whisper")
-        if os.path.isfile(p) and os.access(p, os.X_OK):
-            return p
+        found_script = _find_script_in_dir(py3_bin, "whisper")
+        if found_script:
+            return found_script
     for p in _WHISPER_SEARCH_PATHS:
         if os.path.isfile(p) and os.access(p, os.X_OK):
             return p
@@ -197,9 +213,9 @@ def _find_mlx_whisper() -> str | None:
         return found
     py3_bin = _python3_bin_dir()
     if py3_bin:
-        p = os.path.join(py3_bin, "mlx_whisper")
-        if os.path.isfile(p) and os.access(p, os.X_OK):
-            return p
+        found_script = _find_script_in_dir(py3_bin, "mlx_whisper")
+        if found_script:
+            return found_script
     for p in _MLX_WHISPER_SEARCH_PATHS:
         if os.path.isfile(p) and os.access(p, os.X_OK):
             return p

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -15,6 +15,7 @@ import pytest
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
+from kiro_crew import platform_compat
 from kiro_crew.apps.bridges import (
     RegistrationResult,
     _deregister_agents,
@@ -309,9 +310,10 @@ class TestSkillRegistration:
         assert len(registered) == 1
         assert "test-app/my-skill" in registered
 
-        # Verify symlink exists under ~/.kirocrew/skills/test-app/my-skill
+        # A link exists under ~/.kiro/crew/skills/test-app/my-skill: a symlink on
+        # POSIX, a directory junction on non-admin Windows (both resolve through).
         skill_link = app_env["home"] / "skills" / "test-app" / "my-skill"
-        assert skill_link.is_symlink()
+        assert platform_compat.is_link_or_junction(skill_link)
         assert (skill_link / "SKILL.md").is_file()
 
     def test_deregister_skills(self, tmp_path, app_env):

--- a/test/test_app_manager.py
+++ b/test/test_app_manager.py
@@ -10,6 +10,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from kiro_crew import platform_compat
 from kiro_crew.apps.manager import (
     APP_MANIFEST_FILENAME,
     AppResult,
@@ -1081,7 +1082,6 @@ class TestCopyAppTree:
         """An in-tree symlink is preserved — and an ABSOLUTE in-tree link is
         rewritten to a relative link targeting the installed copy, so the
         installed app never depends on the original source directory."""
-        import os
         import shutil as _shutil
 
         src = _make_app_source(tmp_path)
@@ -1207,8 +1207,6 @@ class TestCopyAppTree:
         """Windows directory junctions (reparse points not reported by
         islink) are omitted from the copy. Simulated by monkeypatching
         os.path.isjunction since junctions don't exist on POSIX."""
-        import os
-
         src = _make_app_source(tmp_path)
         (src / "junction-dir").mkdir()
         (src / "junction-dir" / "secret.txt").write_text("sensitive")
@@ -1324,8 +1322,9 @@ class TestBootSkillReconcile:
 
         assert len(registered) == 1
         assert "test-app/my-skill" in registered
-        assert (skills_root / "test-app" / "my-skill").is_symlink()
-        assert (skills_root / "my-skill").is_symlink()
+        # symlink on POSIX, directory junction on non-admin Windows.
+        assert platform_compat.is_link_or_junction(skills_root / "test-app" / "my-skill")
+        assert platform_compat.is_link_or_junction(skills_root / "my-skill")
         # Registration must target the immutable shipped skill, not its install.
         assert (skills_root / "test-app" / "my-skill").resolve() == skill_dir.resolve()
 
@@ -1344,8 +1343,10 @@ class TestBootSkillReconcile:
         app_skills_dir.mkdir(parents=True)
         stale_target = tmp_path / "old-skill"
         stale_target.mkdir()
-        os.symlink(str(stale_target), str(app_skills_dir / "old-skill"))
-        os.symlink(str(stale_target), str(skills_root / "old-skill"))
+        # symlink on POSIX, junction on non-admin Windows (a bare os.symlink
+        # would raise WinError 1314 in the fixture setup).
+        platform_compat.symlink_or_junction(str(stale_target), str(app_skills_dir / "old-skill"))
+        platform_compat.symlink_or_junction(str(stale_target), str(skills_root / "old-skill"))
 
         # Write installed state and ship the authoritative builtin resources.
         installed = {
@@ -1382,7 +1383,8 @@ class TestBootSkillReconcile:
 
         # Kept skill is registered from immutable provenance.
         assert "test-app/kept-skill" in registered
-        assert (skills_root / "test-app" / "kept-skill").is_symlink()
+        # symlink on POSIX, directory junction on non-admin Windows.
+        assert platform_compat.is_link_or_junction(skills_root / "test-app" / "kept-skill")
         assert (
             skills_root / "test-app" / "kept-skill"
         ).resolve() == kept_skill.resolve()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -346,7 +346,9 @@ _UPDATE_PATCHES = {
 
 def _patch_path():
     """Mock Path so .git check passes, .install-method is absent, and .brazil dir exists."""
-    mock_git_dir = MagicMock(is_dir=MagicMock(return_value=True))
+    mock_git_dir = MagicMock(
+        is_dir=MagicMock(return_value=True), exists=MagicMock(return_value=True)
+    )
     mock_install_method = MagicMock(is_file=MagicMock(return_value=False))
     mock_brazil_dir = MagicMock(is_dir=MagicMock(return_value=True))
 

--- a/test/test_frontend_dist_resolve.py
+++ b/test/test_frontend_dist_resolve.py
@@ -11,12 +11,13 @@ Covers the runtime dist-resolution contract described:
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
-from kiro_crew import frontend
+from kiro_crew import frontend, platform_compat
 
 
 def _fake_kiro_crew_package(root: Path) -> Path:
@@ -78,14 +79,15 @@ def test_valid_symlink_is_kept(fake_pkg, tmp_path, monkeypatch):
     real_dist = _make_dist(tmp_path / "real-dist")
     tree_dist = fake_pkg / "static" / "dist"
     tree_dist.parent.mkdir(parents=True)
-    tree_dist.symlink_to(real_dist)
+    # symlink on POSIX, directory junction on non-admin Windows.
+    platform_compat.symlink_or_junction(str(real_dist), str(tree_dist))
 
     monkeypatch.setattr(subprocess, "run", _no_brazil_path)
 
     result = frontend.ensure_dev_dist_symlink()
 
     assert result == real_dist.resolve()
-    assert tree_dist.is_symlink()
+    assert platform_compat.is_link_or_junction(tree_dist)
     assert tree_dist.resolve() == real_dist.resolve()
 
 
@@ -94,7 +96,9 @@ def test_dangling_symlink_is_replaced_when_candidate_exists(fake_pkg, tmp_path, 
     dead_target = tmp_path / "gone"
     tree_dist = fake_pkg / "static" / "dist"
     tree_dist.parent.mkdir(parents=True)
-    tree_dist.symlink_to(dead_target)  # dangling
+    dead_target.mkdir()  # junction needs an existing target dir; removed next
+    platform_compat.symlink_or_junction(str(dead_target), str(tree_dist))
+    shutil.rmtree(dead_target)  # now dangling on both POSIX and Windows
 
     # Sibling checkout has a fresh dist — resolver should pick it up.
     sibling_dist = _make_dist(fake_pkg.parent.parent.parent / "KiroCrewWebsite" / "dist")
@@ -104,7 +108,7 @@ def test_dangling_symlink_is_replaced_when_candidate_exists(fake_pkg, tmp_path, 
     result = frontend.ensure_dev_dist_symlink()
 
     assert result == sibling_dist.resolve()
-    assert tree_dist.is_symlink()
+    assert platform_compat.is_link_or_junction(tree_dist)
     assert tree_dist.resolve() == sibling_dist.resolve()
 
 
@@ -112,12 +116,16 @@ def test_dangling_symlink_with_no_candidate_returns_none(fake_pkg, tmp_path, mon
     """Stale link + nothing to resolve → clean up and warn (returns None)."""
     tree_dist = fake_pkg / "static" / "dist"
     tree_dist.parent.mkdir(parents=True)
-    tree_dist.symlink_to(tmp_path / "also-gone")
+    gone = tmp_path / "also-gone"
+    gone.mkdir()  # junction needs an existing target; removed to make it dangling
+    platform_compat.symlink_or_junction(str(gone), str(tree_dist))
+    shutil.rmtree(gone)
 
     monkeypatch.setattr(subprocess, "run", _no_brazil_path)
 
     assert frontend.ensure_dev_dist_symlink() is None
-    assert not tree_dist.is_symlink()  # stale link was removed (exists() follows symlinks)
+    # stale link was removed (both a POSIX symlink and a Windows junction).
+    assert not platform_compat.is_link_or_junction(tree_dist)
 
 
 def test_symlink_to_empty_dir_is_replaced(fake_pkg, tmp_path, monkeypatch):
@@ -126,7 +134,7 @@ def test_symlink_to_empty_dir_is_replaced(fake_pkg, tmp_path, monkeypatch):
     empty_target.mkdir()
     tree_dist = fake_pkg / "static" / "dist"
     tree_dist.parent.mkdir(parents=True)
-    tree_dist.symlink_to(empty_target)
+    platform_compat.symlink_or_junction(str(empty_target), str(tree_dist))
 
     sibling_dist = _make_dist(fake_pkg.parent.parent.parent / "KiroCrewWebsite" / "dist")
     monkeypatch.setattr(subprocess, "run", _no_brazil_path)
@@ -154,7 +162,7 @@ def test_sibling_checkout_is_symlinked(fake_pkg, monkeypatch):
     tree_dist = fake_pkg / "static" / "dist"
 
     assert result == sibling_dist.resolve()
-    assert tree_dist.is_symlink()
+    assert platform_compat.is_link_or_junction(tree_dist)
     assert tree_dist.resolve() == sibling_dist.resolve()
 
 
@@ -223,7 +231,7 @@ def test_no_sibling_no_brazil_returns_none(fake_pkg, monkeypatch):
 
 
 def test_empty_real_dir_is_replaced_when_candidate_exists(fake_pkg, monkeypatch):
-    """A real dir with no index.html is unusable — replace with a symlink."""
+    """A real dir with no index.html is unusable — replace with a link."""
     tree_dist = fake_pkg / "static" / "dist"
     tree_dist.mkdir(parents=True)  # empty — no index.html
 
@@ -233,7 +241,7 @@ def test_empty_real_dir_is_replaced_when_candidate_exists(fake_pkg, monkeypatch)
     result = frontend.ensure_dev_dist_symlink()
 
     assert result == sibling_dist.resolve()
-    assert tree_dist.is_symlink()
+    assert platform_compat.is_link_or_junction(tree_dist)
 
 
 # ── Regression: the existing pwa_file symlink test still passes ────────────
@@ -259,3 +267,69 @@ def test_resolver_produces_a_symlink_the_pwa_guard_accepts(fake_pkg, tmp_path, m
 
     assert asset.is_file()  # walked through the symlink
     assert tree_dist.resolve() in asset.resolve().parents
+
+
+# ── npm resolution on Windows (npm.CMD) ────────────────────────────────────
+
+
+def test_build_frontend_sync_spawns_resolved_npm_path(tmp_path, monkeypatch):
+    """Regression: on Windows npm is ``npm.CMD``; CreateProcess cannot spawn the
+    bare name "npm". build_frontend_sync must spawn the RESOLVED path.
+    """
+    website = tmp_path / "website"
+    website.mkdir()
+    (website / "package.json").write_text("{}")
+    fake_npm = r"C:\node\npm.CMD"
+
+    monkeypatch.setattr(frontend.shutil, "which", lambda name: fake_npm)
+    monkeypatch.setattr(frontend, "_stage_dist", lambda *a, **k: None)
+
+    calls: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(frontend.subprocess, "run", _fake_run)
+    frontend.build_frontend_sync(tmp_path, log=lambda *a: None)
+
+    assert calls, "no subprocess was spawned"
+    # Every spawned command uses the resolved npm path as argv[0], never "npm".
+    for cmd in calls:
+        assert cmd[0] == fake_npm
+        assert cmd[0] != "npm"
+
+
+@pytest.mark.asyncio
+async def test_build_frontend_async_spawns_resolved_npm_path(tmp_path, monkeypatch):
+    """Async sibling of the sync npm-resolution regression."""
+    website = tmp_path / "website"
+    website.mkdir()
+    (website / "package.json").write_text("{}")
+    fake_npm = r"C:\node\npm.CMD"
+
+    monkeypatch.setattr(frontend.shutil, "which", lambda name: fake_npm)
+    monkeypatch.setattr(frontend, "_stage_dist", lambda *a, **k: None)
+
+    calls: list[str] = []
+
+    class _Proc:
+        returncode = 0
+
+        async def wait(self):
+            return 0
+
+    async def _fake_exec(program, *args, **kw):
+        calls.append(program)
+        return _Proc()
+
+    monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _fake_exec)
+    await frontend.build_frontend_async(str(tmp_path))
+
+    assert calls, "no subprocess was spawned"
+    for program in calls:
+        assert program == fake_npm
+        assert program != "npm"

--- a/test/test_frontend_edition_build.py
+++ b/test/test_frontend_edition_build.py
@@ -181,7 +181,7 @@ def test_sync_build_passes_the_edition_env_to_npm_run_build(monkeypatch, tmp_pat
     monkeypatch.setattr(frontend.subprocess, "run", _run)
     frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
 
-    build = [(argv, env) for argv, env in seen if argv[:3] == ["npm", "run", "build"]]
+    build = [(argv, env) for argv, env in seen if argv[:3] == ["/usr/bin/npm", "run", "build"]]
     assert build, f"npm run build was never invoked; saw {[a for a, _ in seen]}"
     _argv, env = build[0]
     assert env is not None, "npm run build inherited the env — the edition seam is lost"
@@ -238,7 +238,7 @@ def test_async_build_passes_the_edition_env_to_npm_run_build(monkeypatch, tmp_pa
     monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _exec)
     asyncio.run(frontend.build_frontend_async(str(tmp_path)))
 
-    build = [(argv, env) for argv, env in seen if argv[:3] == ("npm", "run", "build")]
+    build = [(argv, env) for argv, env in seen if argv[:3] == ("/usr/bin/npm", "run", "build")]
     assert build, f"npm run build was never invoked; saw {[a for a, _ in seen]}"
     _argv, env = build[0]
     assert env is not None, "npm run build inherited the env — the edition seam is lost"
@@ -287,6 +287,6 @@ def test_stock_build_still_inherits_the_env(monkeypatch, tmp_path):
     monkeypatch.setattr(frontend.subprocess, "run", _run)
     frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
 
-    build = [(argv, env) for argv, env in seen if argv[:3] == ["npm", "run", "build"]]
+    build = [(argv, env) for argv, env in seen if argv[:3] == ["/usr/bin/npm", "run", "build"]]
     assert build
     assert build[0][1] is None

--- a/test/test_get_agent_names.py
+++ b/test/test_get_agent_names.py
@@ -15,6 +15,10 @@ def _write_agent(agents_dir, filename: str, data: dict) -> None:
 
 @pytest.fixture()
 def agents_dir(tmp_path, monkeypatch):
+    # KIRO_HOME is honored by kiro_home() on every OS; HOME alone does not
+    # isolate the agents dir on Windows (Path.home() reads USERPROFILE there),
+    # so the test would read the real ~/.kiro/agents and see installed agents.
+    monkeypatch.setenv("KIRO_HOME", str(tmp_path / ".kiro"))
     monkeypatch.setenv("HOME", str(tmp_path))
     d = tmp_path / ".kiro" / "agents"
     d.mkdir(parents=True)
@@ -45,6 +49,8 @@ def test_falls_back_to_stem_on_invalid_json(agents_dir):
 
 
 def test_empty_when_no_agents_dir(tmp_path, monkeypatch):
+    # KIRO_HOME isolates the agents dir cross-platform (see agents_dir fixture).
+    monkeypatch.setenv("KIRO_HOME", str(tmp_path / ".kiro"))
     monkeypatch.setenv("HOME", str(tmp_path))
     # No .kiro/agents directory exists
     assert _get_agent_names() == []

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -1952,6 +1952,47 @@ class TestProbeServerStderrCapture:
         # The literal secret must not appear verbatim in the error field.
         assert "AKIAIOSFODNN7EXAMPLEXXX" not in (result.error or "")
 
+    @pytest.mark.asyncio
+    async def test_long_probe_error_keeps_remedy_sentence(self, monkeypatch) -> None:
+        """A long spawn exception must not be chopped mid-sentence.
+
+        SandboxUnavailableError ends with the remedy naming
+        agent.sandbox_allow_unsandboxed_exec; the old 200-char cap discarded
+        it, so a Windows user saw '...Probe detail: not Linux. I' and no fix.
+        """
+        from kiro_crew.mcp_discovery import _PROBE_ERROR_MAX_CHARS, probe_server
+
+        # A credential early in the message must be REDACTED (not merely
+        # truncated away): raising the cap must not widen a disclosure hole.
+        long_msg = (
+            "Sandbox backend unavailable, token=AKIAIOSFODNN7EXAMPLEXXX. "
+            "Probe detail: not Linux. "
+            + ("x" * 300)
+            + " set agent.sandbox_allow_unsandboxed_exec=true in ~/.kiro/crew/config.json"
+        )
+        assert len(long_msg) > 200  # the old cap would have chopped this
+
+        server = McpServerInfo(name="srv", command="srv")
+
+        # Resolve the command, then fail at the sandbox chokepoint with the long
+        # message — the real path a Windows host takes with no sandbox backend.
+        monkeypatch.setattr(
+            "kiro_crew.mcp_discovery.shutil.which", lambda *a, **k: "/usr/bin/srv"
+        )
+
+        def boom(*_a: object, **_k: object) -> object:
+            raise RuntimeError(long_msg)
+
+        monkeypatch.setattr("kiro_crew.mcp_discovery.sandboxed_spawn_argv", boom)
+        result = await probe_server(server)
+
+        assert result.status == "error"
+        # The remedy sentence at the tail survives the (larger) cap.
+        assert "sandbox_allow_unsandboxed_exec=true" in (result.error or "")
+        assert len(result.error or "") <= _PROBE_ERROR_MAX_CHARS
+        # The credential is redacted before it reaches server.error.
+        assert "AKIAIOSFODNN7EXAMPLEXXX" not in (result.error or "")
+
 
 class TestProbeStdioMalformedResponse:
     """Stdio probe must not crash on non-spec JSON-RPC response shapes.

--- a/test/test_mcp_gateway_session_inject.py
+++ b/test/test_mcp_gateway_session_inject.py
@@ -257,7 +257,11 @@ def test_real_kiro_cli_prefers_session_injected_server():
     every poolable server would run twice, which is worse than not pooling. This
     test fails loudly at that point instead of shipping a silent regression.
     """
-    with tempfile.TemporaryDirectory() as w:
+    # ignore_cleanup_errors: the spawned kiro-cli subprocess can still hold a
+    # handle on the temp tree at teardown; Windows refuses to delete a dir with
+    # open handles (POSIX does not), which would raise WinError 32 out of the
+    # context manager even though the test's assertions already passed.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as w:
         root = Path(w)
         (root / "khome" / "agents").mkdir(parents=True)
         (root / "proj").mkdir()

--- a/test/test_mcp_playwright_proxy.py
+++ b/test/test_mcp_playwright_proxy.py
@@ -172,3 +172,67 @@ class TestScreenshotDir:
         assert "tempfile.gettempdir()" in src
         # And the deprecated hardcoded fallback is no longer present.
         assert 'os.environ.get("TMPDIR", "/tmp")' not in src
+
+
+class TestResolvePlaywrightCmd:
+    """Regression: on Windows npx is ``npx.CMD``. The resolver must return the
+    RESOLVED path (not the bare name, which CreateProcess cannot spawn), and
+    run_proxy must still inject the @playwright/mcp arg for a ``.CMD`` launcher.
+    """
+
+    def test_returns_resolved_npx_path_not_bare_name(self, monkeypatch):
+        monkeypatch.delenv("KIROCREW_PLAYWRIGHT_CMD", raising=False)
+
+        def fake_which(name, **kw):
+            # Standalone binaries absent; only npx resolves, as npx.CMD.
+            return r"C:\node\npx.CMD" if name == "npx" else None
+
+        monkeypatch.setattr(proxy.shutil, "which", fake_which)
+        resolved = proxy._resolve_playwright_cmd()
+        assert resolved == r"C:\node\npx.CMD"
+        # The bug returned the bare "npx"; the fix returns the full path.
+        assert resolved != "npx"
+
+    def test_run_proxy_injects_playwright_arg_for_cmd_launcher(self, monkeypatch):
+        # The extension-insensitive basename check must still add @playwright/mcp
+        # when the resolved launcher is npx.CMD, else a bare interactive npx runs.
+        # Build the path with the HOST separator: the product parses it with the
+        # host os.path, so a hardcoded C:\...\npx.CMD would not parse on Linux CI.
+        import os as _os
+
+        launcher = _os.path.join("node-bin", "npx.CMD")
+        monkeypatch.setattr(proxy, "_resolve_playwright_cmd", lambda: launcher)
+        captured = {}
+
+        class _FakeProc:
+            returncode = 0
+
+            def __init__(self, cmd, **kw):
+                captured["cmd"] = cmd
+                self.stdin = None
+                self.stdout = None
+
+            def wait(self, timeout=None):
+                return 0
+
+        monkeypatch.setattr(proxy.subprocess, "Popen", _FakeProc)
+        # No-op the stdin forwarder thread and end the relay loop immediately so
+        # run_proxy returns right after building + spawning the command.
+        monkeypatch.setattr(proxy.threading, "Thread", lambda *a, **k: _NoopThread())
+        monkeypatch.setattr(proxy, "_read_message", lambda *a, **k: None)
+
+        try:
+            proxy.run_proxy([])
+        except SystemExit:
+            pass
+
+        assert captured["cmd"][0] == launcher
+        assert captured["cmd"][1] == "@playwright/mcp"
+
+
+class _NoopThread:
+    def start(self):
+        pass
+
+    def join(self, timeout=None):
+        pass

--- a/test/test_md_notebook.py
+++ b/test/test_md_notebook.py
@@ -25,6 +25,7 @@ from typing import Any, AsyncIterator, Optional
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
+from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.md_notebook import git_ops
 
 SECRET = "test-proxy-secret"
@@ -754,7 +755,10 @@ async def test_delete_refuses_an_in_vault_trash_symlink(fixtures) -> None:
         vault = await _clone(client, remote)
         root = Path(vault["localPath"])
         (root / "public").mkdir()
-        (root / git_ops.TRASH_DIR).symlink_to("public")
+        # Directory redirect: a symlink on POSIX, a junction on non-admin Windows
+        # — the guard must refuse both (is_link_or_junction), else it is
+        # POSIX-only and a Windows junction slips a trashed note into `public/`.
+        platform_compat.symlink_or_junction(str(root / "public"), str(root / git_ops.TRASH_DIR))
 
         status, body = await client.delete("/api/note?path=One.md")
         assert status >= 400, body
@@ -1327,10 +1331,16 @@ async def test_reads_a_note_with_aliased_frontmatter_fast(fixtures) -> None:
         # The listing path (note_title/tags) parses frontmatter but does not
         # serialize it; with memoization this stays fast, without it 2**21 nodes
         # would be materialized and wedge the loop.
+        #
+        # The bound guards against EXPONENTIAL blowup, not ordinary latency: an
+        # uncontained expansion materializes 2**21 nodes and takes minutes / OOMs,
+        # so a generous deadline still catches the regression while tolerating a
+        # loaded parallel runner (a 5s bound false-failed under -n auto on
+        # Windows purely from scheduler contention — a wall-clock race).
         start = time.monotonic()
         status, body = await client.get("/api/notes")
         assert status == 200, body
-        assert time.monotonic() - start < 5, "alias amplification was not contained"
+        assert time.monotonic() - start < 30, "alias amplification was not contained"
 
 
 def test_json_safe_collapses_repeated_aliases(fixtures) -> None:
@@ -1538,10 +1548,12 @@ async def test_delete_refuses_a_trash_symlink_escaping_the_vault(fixtures, tmp_p
         root = Path(vault["localPath"])
         outside = tmp_path / "outside"
         outside.mkdir()
-        (root / ".trash").symlink_to(outside, target_is_directory=True)
+        # Directory redirect out of the vault: symlink on POSIX, junction on
+        # non-admin Windows. The guard refuses either as a `.trash` reparse point.
+        platform_compat.symlink_or_junction(str(outside), str(root / ".trash"))
         status, body = await client.delete("/api/note?path=One.md")
         assert status == 400, body
-        assert "escapes vault" in body["error"]
+        assert "symlink" in body["error"] or "escapes vault" in body["error"]
         # The note stayed put and nothing was written outside the vault.
         assert (root / "One.md").exists()
         assert list(outside.iterdir()) == []

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -469,6 +469,85 @@ class TestFileLockContention:
             os.close(fd_shared)
             os.close(fd_other)
 
+    @pytest.mark.skipif(not pc.IS_WINDOWS, reason="Windows LK_LOCK ceiling regression")
+    def test_windows_blocking_acquire_waits_past_lk_lock_ceiling(self, tmp_path):
+        # Regression for issue #470: msvcrt's LK_LOCK "blocking" code gives up
+        # after ~10s with EDEADLOCK and the old shim treated that as "acquired".
+        # A holder that keeps the lock LONGER than that ceiling must make a
+        # blocking contender WAIT (until release or its own timeout) — never
+        # fall through and enter the critical section unserialized at ~10s.
+        #
+        # Drive _win_acquire_blocking directly with an EXPLICIT timeout past the
+        # ceiling: the module default is a short on-loop-safety ceiling, but the
+        # bug being pinned is specifically the ~10s LK_LOCK give-up point.
+        import threading
+
+        lock = tmp_path / ".ceiling.lock"
+        hold_secs = 13.0
+        fd_holder = os.open(str(lock), os.O_RDWR | os.O_CREAT, 0o600)
+        fd_contender = os.open(str(lock), os.O_RDWR | os.O_CREAT, 0o600)
+        released_at = {"t": 0.0}
+        entered_at = {"t": 0.0}
+        holder_ready = threading.Event()
+
+        def _hold():
+            with pc.file_lock(fd_holder, exclusive=True, required=True):
+                holder_ready.set()
+                time.sleep(hold_secs)
+                released_at["t"] = time.monotonic()
+
+        holder = threading.Thread(target=_hold)
+        holder.start()
+        try:
+            assert holder_ready.wait(timeout=10.0), "holder never took the lock"
+            # Blocking acquire on the OTHER fd with a timeout past the ~10s
+            # ceiling: it must not succeed until the holder releases at ~13s.
+            got = pc._win_acquire_blocking(fd_contender, timeout=30.0)
+            entered_at["t"] = time.monotonic()
+            assert got is True, "contender never acquired the lock after release"
+            # It entered only AFTER the holder released — proving it waited past
+            # the 10s ceiling that used to let it slip through early.
+            assert entered_at["t"] >= released_at["t"], (
+                "contender entered the critical section before the holder "
+                "released — the blocking acquire fell through the LK_LOCK ceiling"
+            )
+            pc.release_lock(fd_contender)
+        finally:
+            holder.join(timeout=20.0)
+            os.close(fd_holder)
+            os.close(fd_contender)
+
+    @pytest.mark.skipif(not pc.IS_WINDOWS, reason="Windows on-loop single-shot acquire")
+    def test_windows_contended_lock_on_event_loop_fails_fast(self, tmp_path):
+        # On the asyncio event-loop thread a contended lock must NOT spin-sleep
+        # (that freezes chat/heartbeat): _win_acquire_blocking is single-shot
+        # there, so file_lock fails closed immediately instead of waiting out
+        # the timeout. Assert both the fast-fail AND that it took ~no time.
+        import asyncio
+
+        lock = tmp_path / ".onloop.lock"
+        fd_holder = os.open(str(lock), os.O_RDWR | os.O_CREAT, 0o600)
+        fd_contender = os.open(str(lock), os.O_RDWR | os.O_CREAT, 0o600)
+
+        async def _contend_on_loop():
+            # Hold on THIS fd (non-blocking), then a second in-loop acquire on
+            # the other fd must raise at once rather than sleep to the ceiling.
+            assert pc.try_acquire_lock(fd_holder, exclusive=True) is True
+            start = time.monotonic()
+            with pytest.raises(OSError):
+                with pc.file_lock(fd_contender, exclusive=True):
+                    pass
+            elapsed = time.monotonic() - start
+            pc.release_lock(fd_holder)
+            # Single-shot: nowhere near the multi-second timeout ceiling.
+            assert elapsed < 1.0, f"on-loop acquire spun for {elapsed:.2f}s"
+
+        try:
+            asyncio.run(_contend_on_loop())
+        finally:
+            os.close(fd_holder)
+            os.close(fd_contender)
+
 
 class TestProcessIdentityPosix:
     def test_get_ppid_of_self_is_positive_on_posix(self):
@@ -526,8 +605,16 @@ class TestProcessIdentityPosix:
         )
         try:
             assert child.poll() is None  # alive
-            result = pc.process_matches(child.pid, (token,))
+            # Poll: a just-spawned child's /proc/<pid>/cmdline (or ps output) is
+            # not populated until it finishes exec'ing, so an immediate single
+            # check races the scheduler on a loaded runner. Wait for the match
+            # with a generous deadline rather than asserting once.
             if pc.IS_POSIX:
+                deadline = time.monotonic() + 10.0
+                result = pc.process_matches(child.pid, (token,))
+                while not result and time.monotonic() < deadline:
+                    time.sleep(0.05)
+                    result = pc.process_matches(child.pid, (token,))
                 assert result is True
         finally:
             child.kill()

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -67,6 +67,20 @@ class TestFindWhisper:
         monkeypatch.setenv("HOME", str(tmp_path))
         assert _find_whisper("~/whisper") == str(binary)
 
+    def test_scripts_dir_fallback_finds_dot_exe_on_windows(self, tmp_path, monkeypatch):
+        """Regression: a pip console script is ``whisper.exe`` in Scripts\\ on
+        Windows; the extensionless probe never found it. The suffix sweep must.
+        """
+        scripts = tmp_path / "Scripts"
+        scripts.mkdir()
+        exe = scripts / "whisper.exe"
+        exe.write_text("")  # no execute bit on Windows
+        monkeypatch.setattr("kiro_crew.transcribe.platform_compat.IS_WINDOWS", True)
+        with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            monkeypatch.setattr("kiro_crew.transcribe._python3_bin_dir", lambda: str(scripts))
+            monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [])
+            assert _find_whisper("") == str(exe)
+
 
 # ---------------------------------------------------------------------------
 # _find_mlx_whisper

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -589,6 +589,12 @@ class TestSynthesizePolly:
         monkeypatch.setattr(
             "kiro_crew.voice_reply.wrap_argv", lambda argv, **k: (list(argv), None)
         )
+        # Polly short-circuits to None when the `aws` CLI is not on PATH, so
+        # stub which() -- otherwise these tests only pass on hosts that happen
+        # to have the AWS CLI installed (they silently no-op on Windows CI).
+        monkeypatch.setattr(
+            "kiro_crew.voice_reply.shutil.which", lambda *a, **k: "/usr/bin/aws"
+        )
 
     @pytest.mark.asyncio
     async def test_invalid_engine_falls_back_to_default(self, tmp_path) -> None:
@@ -976,6 +982,9 @@ class TestTextTypeAutoDetection:
         # See TestSynthesizePolly._passthrough_sandbox.
         monkeypatch.setattr(
             "kiro_crew.voice_reply.wrap_argv", lambda argv, **k: (list(argv), None)
+        )
+        monkeypatch.setattr(
+            "kiro_crew.voice_reply.shutil.which", lambda *a, **k: "/usr/bin/aws"
         )
 
     @pytest.mark.asyncio

--- a/test/windows-expected-failures.txt
+++ b/test/windows-expected-failures.txt
@@ -33,6 +33,10 @@ test/test_app_backend.py::TestShellDispatch::test_explicit_backend_type_exec_rou
 test/test_app_backend.py::TestShellDispatch::test_non_executable_bash_entry_honors_shebang
 test/test_app_backend.py::TestShellDispatch::test_non_executable_sh_entry_falls_back_to_bin_sh
 test/test_app_backend.py::TestShellEntryDetection::test_extensionless_non_executable_is_not_shell
+# Needs symlink-creation privilege to build the fixture: these exercise
+# copytree's handling of in-tree POSIX symlinks, which junctions cannot model.
+test/test_app_manager.py::TestCopyAppTree::test_symlink_escaping_source_root_omitted
+test/test_app_manager.py::TestCopyAppTree::test_symlink_inside_source_root_preserved
 test/test_apps_registry.py::test_communicate_with_timeout_kills_and_reaps_real_subprocess
 test/test_apps_registry.py::test_fetch_app_manifest_reaps_clone_tree_on_timeout
 test/test_apps_registry.py::test_install_from_registry_reaps_detect_probe_tree_on_timeout
@@ -118,14 +122,6 @@ test/test_flock_compat.py::TestFlockCompat::test_posix_delegates_to_real_fcntl
 test/test_gateway_lock.py::test_acquire_creates_lock_file_with_pid
 test/test_gateway_lock.py::test_second_acquire_refused_and_names_holder
 test/test_gateway_lock.py::test_stale_lock_is_reclaimed
-test/test_get_agent_names.py::test_falls_back_to_stem_on_invalid_json
-test/test_get_agent_names.py::test_falls_back_to_stem_on_non_dict_json
-test/test_get_agent_names.py::test_falls_back_to_stem_when_name_is_null
-test/test_get_agent_names.py::test_falls_back_to_stem_when_name_missing
-test/test_get_agent_names.py::test_ignores_non_json_files
-test/test_get_agent_names.py::test_multiple_agents_sorted
-test/test_get_agent_names.py::test_non_utf8_agent_file_does_not_crash
-test/test_get_agent_names.py::test_returns_name_field_not_stem
 test/test_governance_chokepoints.py::TestFilesystemEgressAtGate::test_filesystem_read_denied_via_reading_title
 test/test_governance_chokepoints.py::TestFilesystemEgressAtGate::test_filesystem_relative_path_cannot_dodge_absolute_deny
 test/test_governance_chokepoints.py::TestFilesystemEgressAtGate::test_filesystem_write_denied_via_edit_args
@@ -165,12 +161,18 @@ test/test_mcp_gateway_oversize.py::TestSpillFailure::test_unwritable_dir_returns
 test/test_mcp_gateway_wedge_ping_gate.py::test_ping_answered_while_tool_in_flight
 test/test_mcp_gateway_wedge_ping_gate.py::test_tool_cancelled_exception_suppresses_response
 test/test_mcp_oauth_banner.py::TestMarkMcpOAuthCompleted::test_targets_only_open_banner
-# SUSPECTED REAL GAP (issue #470): msvcrt.locking is best-effort vs POSIX flock;
-# concurrent appends can interleave on Windows. Fix + delete per issue #470.
-test/test_memory_selfheal.py::TestConcurrentAppend::test_concurrent_appends_do_not_lose_entries
+# Needs symlink-creation privilege: builds an in-vault FILE symlink
+# (Alias.md -> One.md); a junction is directory-only and cannot model it.
+test/test_md_notebook.py::test_trashing_a_symlink_leaves_its_target_alone
 test/test_memory_selfheal.py::TestFtsSelfHealGating::test_genuine_corruption_still_self_heals
 test/test_open_slots_persistence.py::test_persist_open_slots_handles_write_failure_gracefully
 test/test_pip_deps_consistency.py::test_all_unguarded_third_party_imports_are_declared
+# Needs symlink-creation privilege: plants a FILE symlink at the output path to
+# prove the writer replaces it rather than writing through. atomic_write already
+# does the right thing on Windows; a junction is directory-only and can't model
+# a file symlink, so the fixture cannot be built without the privilege.
+test/test_perf_sampler.py::TestArtifactWriteFailure::test_symlinked_output_does_not_write_through_the_link
+test/test_perf_sampler.py::TestPySpyPathShortening::test_symlinked_output_target_survives_the_pyspy_path
 test/test_platform_compat.py::TestRestrictToOwner::test_applies_owner_only_dacl_on_windows
 test/test_pod.py::TestCliVerbs::test_install_writes_unit
 test/test_pod.py::TestEnvFileAndPin::test_pin_checkout


### PR DESCRIPTION
## Summary

A systematic pass over KiroCrew's Windows behavior, fixing real
OS-compatibility bugs that CI's **admin-privileged** `windows-latest` runner
masks and that a **non-admin** Windows user hits in daily use. Verified on
Windows 11 / Python 3.13; each fix has a regression test, and the Windows
burn-down backlog (`test/windows-expected-failures.txt`) is trimmed where the
fixes make previously-skipped tests pass.

## Data-integrity bugs (silent loss)

- **`platform_compat.file_lock` / `acquire_lock` (issue #470).** `msvcrt`'s
  `LK_LOCK` "blocking" code is not `flock(LOCK_EX)` — it retries ~10×/1s then
  raises `EDEADLOCK`, which the shim swallowed as *success*. A lock holder that
  exceeds ~10s let concurrent writers into the critical section **unserialized**
  and silently lose writes (measured: `memory.append_history` lost 12–38 of 40
  concurrent entries). Now spins on the non-blocking `LK_NBLCK` code so a
  blocking acquire genuinely waits, and the failure is loud (`raise` when
  `required=True`, otherwise a warning) instead of silent.
- **`deploy/pending.py`, `deploy/profiles.py`.** Both locked via `flock_compat`,
  whose Windows `flock()` is a documented no-op — so the anti-double-deploy
  `claim_pending` and the profile-registry read-modify-write had **zero**
  cross-process exclusion on a reachable Windows gateway route. Routed through
  `platform_compat.file_lock(required=True)`.

## Directory links — `os.symlink` needs a privilege ordinary accounts lack

`os.symlink` raises `WinError 1314` without elevation/Developer Mode, silently
breaking every feature that links a directory into place. New
`platform_compat.symlink_or_junction` falls back to a directory **junction**
(no privilege; resolves transparently, so containment/escape checks still hold),
with `is_link_or_junction` / `unlink_link_or_junction` for detection+removal
(a junction is invisible to `os.path.islink`).

- **App skill registration / reconcile / deregister** (`apps/bridges.py`) —
  the flagship case: app skills silently failed to register for every non-admin
  Windows user.
- **Dev-mode SPA dist link** (`frontend.ensure_dev_dist_symlink`) — a source-tree
  gateway served the "not built" page instead of the dashboard.
- **md-notebook `.trash` guard** (security): now refuses a junction too, not just
  a symlink — otherwise a Windows junction redirects a trashed note out of the
  vault, defeating the guard's whole purpose.

## Path-handling bugs (`os.path is ntpath` on Windows)

- **`apps/manifest.py`** (security): the path-traversal guard missed
  POSIX-absolute app-resource paths like `/etc/passwd`, because `os.path.isabs`
  *is* `ntpath.isabs` on Windows. Now checks both `posixpath` and `ntpath`.
- **`mcp_discovery._commands_diverged`**: the same issue made a resolved-vs-short
  MCP command pair read as diverged, triggering an endless re-sync loop.
- **`pptx_maker`**: `Path.resolve()` accepts an embedded NUL on Windows (POSIX
  raises), so the deck-root guard never fired and wedged the app; NUL is now
  rejected explicitly.

## Binary resolution (`npm`/`npx`/`git` as `.CMD`/`.exe`, extensionless probes)

- **`frontend.py`, `apps/registry.py`**: spawn the resolved `npm` path, not the
  bare name — `CreateProcess` can't run `npm.CMD` by name, so `kirocrew update`
  and npm app installs crashed with `WinError 2`.
- **`mcp_playwright_proxy.py`**: return the resolved `npx` path and inject
  `@playwright/mcp` extension-insensitively (browser automation was 100% broken
  on the standard Windows install, and the status probe reported it as working).
- **md-notebook `git_ops`**: trust the per-user Git-for-Windows root
  (`%LOCALAPPDATA%\Programs\Git`) — the no-admin install the docs recommend —
  not just `%ProgramFiles%`, which made every vault op fail closed.
- **`transcribe.py`**: sweep `.exe`/`.cmd` suffixes for the whisper scripts-dir
  fallback (extensionless names never exist under `Scripts\`).

## Diagnostics / dev UX

- **`cli_doctor.py`, `cli_server.py`**: a git worktree stores `.git` as a *file*,
  so both wrongly reported "not a git repo" / refused `kirocrew update`. Accept
  file and dir forms.
- **`mcp_discovery`**: size the probe-error cap to hold the full
  `SandboxUnavailableError` remedy sentence instead of chopping it mid-word
  (a Windows user saw "…Probe detail: not Linux. I" and no fix).
- **`file_explorer`**: derive the allow-list from `Path.home()` / `tempfile`,
  gating POSIX-only roots (`/home`, `/opt`) behind `IS_POSIX` — `HOME` is
  usually unset on Windows, which collapsed the whole allow-list.

## Tests

- Fixed a **non-hermetic** Polly suite (stubbed `shutil.which`), a **leaking**
  agent-names test (isolated via `KIRO_HOME`), and a **wall-clock-race**
  frontmatter test — the flaky-test sweep the task asked for.
- Converted directory-symlink fixtures/asserts to the junction-aware helpers so
  the Windows security guards are *exercised*, not skipped.
- Added regression tests: the lock ceiling (holder > 10s), `npx`/`npm`
  resolution, the probe-error cap, and the whisper suffix sweep.
- Burned down `windows-expected-failures.txt` where fixes make tests pass; added
  the few genuinely symlink-privilege-only (file-symlink) tests with a reason.

Specs updated in the same commit: `docs/guides/windows-install.md` (file
locking + directory links) and the `AGENTS.md` cross-platform shim table.

## Test plan

- `flake8 src/kiro_crew test` ✓ · `isort --check-only src/kiro_crew test` ✓ ·
  `mypy src/kiro_crew/` — zero new errors vs. base (remaining are pre-existing
  Windows-only `fcntl`/`resource` attribute noise CI's Linux run resolves).
- The full set of touched test files: **912 passed, 58 skipped, 0 failed** on
  Windows 11 / Python 3.13.
- `docs-lint.sh` ✓ · brand-name gate ✓.
