### PR TITLE
fix(channels): recover dead Discord WS; surface Weixin poll death

### DIFF
--- a/src/kiro_crew/discord/client.py
+++ b/src/kiro_crew/discord/client.py
@@ -40,6 +40,18 @@ DISCORD_CHUNK_LIMIT = 1900
 _API_BASE = "https://discord.com/api/v10"
 _GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
 
+# Transport-level WS ping interval (seconds). Deliberately a SECOND liveness
+# layer under Discord's op-1 application heartbeat, because the two have
+# different failure domains: op-1 runs in a cancellable user task and proves
+# the Discord session is alive, while the aiohttp ping runs inside the
+# library's read loop and proves the TCP path (host -> NAT -> edge) is alive.
+# Without it, a NAT-evicted half-open connection blocks the dispatch loop
+# forever with no error while outbound REST keeps working. 60s is longer than
+# Discord's ~41s heartbeat so healthy traffic keeps the path warm anyway, and
+# generous enough that a briefly stalled event loop does not flap the
+# connection with false-positive pong timeouts.
+_WS_HEARTBEAT_SECS = 60.0
+
 # Attachment URLs are signed but unauthenticated. Keep the exact CDN host
 # allow-list here at the channel boundary; redirects are disabled during fetch
 # so an allowed URL cannot bounce the downloader to an arbitrary host.
@@ -384,38 +396,63 @@ class DiscordClient:
         """One Gateway connection: hello -> identify/resume -> dispatch loop."""
         session = await self._ensure_session()
         url = self._resume_url if (self._session_id and self._resume_url) else _GATEWAY_URL
-        async with session.ws_connect(url, proxy=self._proxy, heartbeat=None, max_msg_size=0) as ws:
-            self._ws = ws
-            try:
-                async for raw in ws:
-                    if raw.type == aiohttp.WSMsgType.TEXT:
-                        await self._handle_frame(ws, json.loads(raw.data))
-                    elif raw.type in (
-                        aiohttp.WSMsgType.CLOSED,
-                        aiohttp.WSMsgType.CLOSE,
-                        aiohttp.WSMsgType.ERROR,
-                    ):
-                        break
-            finally:
-                self._ws = None
-        # Close code 4004 (auth failed) etc. surfaces via ws.close_code.
-        self.ready.clear()
-        code = ws.close_code or 0
-        if code in (4004, 4010, 4011, 4012, 4013, 4014):
-            # Non-recoverable (bad token / bad intents). Stop rather than
-            # hammering the gateway forever; the failure is already logged.
-            logger.error(
-                "Discord gateway closed with non-recoverable code %s — "
-                "check the bot token and intents. Channel stopped.",
-                code,
-            )
-            self._closed = True
-            self.fatal_error = f"gateway close {code} (check bot token/intents)"
-            self._notify_state(False, self.fatal_error)
-        elif code in (4007, 4009):
-            # Invalid seq / session timed out — must re-identify from scratch.
-            self._session_id = ""
-            self._seq = None
+        ws: Any = None
+        try:
+            async with session.ws_connect(
+                url, proxy=self._proxy, heartbeat=_WS_HEARTBEAT_SECS, max_msg_size=0
+            ) as ws:
+                self._ws = ws
+                try:
+                    async for raw in ws:
+                        if raw.type == aiohttp.WSMsgType.TEXT:
+                            await self._handle_frame(ws, json.loads(raw.data))
+                        elif raw.type in (
+                            aiohttp.WSMsgType.CLOSED,
+                            aiohttp.WSMsgType.CLOSE,
+                            aiohttp.WSMsgType.ERROR,
+                        ):
+                            break
+                finally:
+                    self._ws = None
+            # Clean close only: classify the close code (4004 etc. surfaces
+            # via ws.close_code). An exception path skips this block and gets
+            # its log line from the gateway loop's reconnect handler instead.
+            code = ws.close_code or 0
+            if code in (4004, 4010, 4011, 4012, 4013, 4014):
+                # Non-recoverable (bad token / bad intents). Stop rather than
+                # hammering the gateway forever; the failure is already logged.
+                logger.error(
+                    "Discord gateway closed with non-recoverable code %s — "
+                    "check the bot token and intents. Channel stopped.",
+                    code,
+                )
+                self._closed = True
+                self.fatal_error = f"gateway close {code} (check bot token/intents)"
+                self._notify_state(False, self.fatal_error)
+            elif code in (4007, 4009):
+                # Invalid seq / session timed out — must re-identify from scratch.
+                self._session_id = ""
+                self._seq = None
+            if not self._closed:
+                # Every connection end is WARNING-visible: the default log
+                # level hides INFO, and an unlogged silent reconnect loop is
+                # indistinguishable from a dead channel when diagnosing
+                # "Discord stopped responding".
+                logger.warning(
+                    "Discord gateway connection ended (close code %s) — reconnecting",
+                    code or "none",
+                )
+        finally:
+            # Runs on clean closes AND exception escapes (a send raising
+            # mid-dispatch would otherwise skip this): the READY flag and the
+            # dashboard badge must never keep asserting a connection that no
+            # longer exists. The 4004 branch sets _closed before its own
+            # fatal notify, so this cannot overwrite that reason; deliberate
+            # close() also sets _closed and is skipped the same way.
+            self.ready.clear()
+            if not self._closed:
+                close_code = ws.close_code if ws is not None else None
+                self._notify_state(False, f"reconnecting (close {close_code or 'none'})")
 
     async def _handle_frame(self, ws: Any, frame: dict) -> None:
         op = frame.get("op")
@@ -494,7 +531,17 @@ class DiscordClient:
         except asyncio.CancelledError:
             pass
         except Exception:
-            logger.debug("Discord heartbeat loop error", exc_info=True)
+            # This task is the only sender of Discord's mandatory op-1
+            # heartbeat: if it dies and the connection stays up, the server
+            # eventually drops the session and — behind NAT, where the close
+            # frame can be lost — the dispatch loop blocks on a half-open
+            # socket with heartbeats gone. Close the socket so the gateway
+            # loop reconnects instead of carrying a heartbeat-less connection.
+            logger.warning("Discord heartbeat loop failed — recycling connection", exc_info=True)
+            try:
+                await ws.close()
+            except Exception:
+                logger.debug("Discord heartbeat close failed", exc_info=True)
 
     # ── Dispatch normalization ──
 

--- a/src/kiro_crew/weixin/client.py
+++ b/src/kiro_crew/weixin/client.py
@@ -303,13 +303,20 @@ class WeixinClient:
 
     # -- receive / send --------------------------------------------------------
     async def get_updates(self, sync_buf: str) -> Dict[str, Any]:
-        """Long-poll for new messages; returns {ret, msgs, get_updates_buf}."""
+        """Long-poll for new messages; returns {ret, msgs, get_updates_buf}.
+
+        A client-side deadline expiry is returned as an empty result with
+        ``_timed_out`` set instead of being silently equated with a healthy
+        empty poll: the server normally answers well inside the deadline, so
+        hitting it at all means zero server contact — the poll loop counts
+        consecutive occurrences to make a black-holed network visible.
+        """
         try:
             return await self._post(
                 EP_GET_UPDATES, {"get_updates_buf": sync_buf}, timeout_ms=LONG_POLL_TIMEOUT_MS
             )
         except asyncio.TimeoutError:
-            return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf}
+            return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf, "_timed_out": True}
 
     async def send_message(self, *, to: str, text: str, context_token: Optional[str], client_id: str) -> Dict[str, Any]:
         """Send one text message. Raises :class:`WeixinSendError` if iLink rejects it.

--- a/src/kiro_crew/weixin/gateway.py
+++ b/src/kiro_crew/weixin/gateway.py
@@ -90,8 +90,18 @@ async def maybe_start_weixin(orch: "GatewayOrchestrator") -> "WeixinClient | Non
         if orch.dashboard_state is not None:
             orch.dashboard_state.register_channel_transport(transport)
             # Surface live connection state to GET /api/weixin/config.
-            orch.dashboard_state.weixin_connected = True
-            orch.dashboard_state.weixin_connect_error = ""
+            state = orch.dashboard_state
+            state.weixin_connected = True
+            state.weixin_connect_error = ""
+
+            # Keep the badge truthful across the channel's lifetime: an
+            # unexpected poll-loop death flips it off with the reason instead
+            # of reporting the startup outcome forever.
+            def _on_state(connected: bool, error: str) -> None:
+                state.weixin_connected = connected
+                state.weixin_connect_error = error[:120]
+
+            transport.on_state_change = _on_state
         logger.info("Weixin channel started (transport path, iLink long-polling).")
         return client
     except Exception as exc:

--- a/src/kiro_crew/weixin/transport.py
+++ b/src/kiro_crew/weixin/transport.py
@@ -101,6 +101,10 @@ class WeixinTransport(MessagingTransport):
         self._sync_buf = ""
         self._seen: dict[str, float] = {}
         self._running = False
+        # Optional observer called with (connected, error) when the poll loop
+        # dies without a shutdown — lets the gateway keep the dashboard badge
+        # truthful after boot (mirrors DiscordClient.on_state_change).
+        self.on_state_change: Callable[[bool, str], None] | None = None
 
     @property
     def client(self) -> WeixinClient:
@@ -164,10 +168,52 @@ class WeixinTransport(MessagingTransport):
 
     async def _poll_loop(self) -> None:
         """Long-poll ``getupdates`` and dispatch each inbound message."""
+        cancelled = False
+        try:
+            await self._poll_forever()
+        except asyncio.CancelledError:
+            # Task cancellation IS the production shutdown path: gateway
+            # teardown cancels the poll task without calling ``disconnect()``,
+            # so ``_running`` alone cannot distinguish teardown from death.
+            cancelled = True
+            raise
+        finally:
+            # Reached on a normal return and on a non-cancel escape alike: a
+            # loop that ended any way other than cancellation/shutdown means
+            # inbound is dead. Make that loud (default log level is WARNING)
+            # and flip the dashboard badge, which otherwise reports the
+            # startup outcome forever.
+            if not cancelled and self._running:
+                logger.warning("weixin: inbound poll loop ended unexpectedly — inbound is dead")
+                if self.on_state_change is not None:
+                    try:
+                        self.on_state_change(False, "poll loop ended unexpectedly")
+                    except Exception:
+                        logger.debug("weixin on_state_change observer raised", exc_info=True)
+
+    async def _poll_forever(self) -> None:
         failures = 0
+        timeouts = 0
         while self._running:
             try:
                 resp = await self._client.get_updates(self._sync_buf)
+                if resp.pop("_timed_out", False):
+                    # Zero server contact for a full client-deadline window.
+                    # Warn ONCE per streak, at a threshold well past normal
+                    # long-poll behavior, so this stays quiet whether the
+                    # server answers early when idle or holds requests to the
+                    # deadline — only a sustained black-hole crosses it.
+                    timeouts += 1
+                    if timeouts == 20:
+                        logger.warning(
+                            "weixin: %d consecutive long-poll timeouts (~%d min without "
+                            "a single server response) — either the network path is dead "
+                            "or the server is holding polls past the client deadline",
+                            timeouts,
+                            timeouts * 35 // 60,
+                        )
+                else:
+                    timeouts = 0
                 # iLink reports failure as `errcode` on some endpoints and `ret`
                 # on others (getupdates uses `ret`), both HTTP 200. Read BOTH via
                 # the shared helper: inspecting only `errcode` let a `ret`-keyed
@@ -204,7 +250,10 @@ class WeixinTransport(MessagingTransport):
                     await self.receive(msg)
                 failures = 0
             except asyncio.CancelledError:
-                break
+                # Propagate: cancellation is shutdown, and swallowing it here
+                # would make teardown indistinguishable from loop death in
+                # ``_poll_loop``'s unexpected-end detection.
+                raise
             except Exception as exc:
                 failures += 1
                 delay = 2 if failures < 3 else 30

--- a/test/test_channel_zombie_connections.py
+++ b/test/test_channel_zombie_connections.py
@@ -1,0 +1,295 @@
+"""Regression tests for the silent zombie-connection defect class.
+
+A NAT-evicted half-open TCP connection must never leave a channel's inbound
+path permanently dead while looking healthy: transports need a transport-level
+keepalive (or a per-request deadline), liveness-task death must recycle the
+connection loudly, and connection ends must be visible at WARNING+.
+
+Offline only: no network. The Discord WS and iLink HTTP surfaces are exercised
+through fakes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+
+import pytest
+
+from kiro_crew.discord.client import _WS_HEARTBEAT_SECS, DiscordClient
+from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.weixin.client import ContextTokenStore
+from kiro_crew.weixin.transport import WeixinTransport
+
+# ── Discord: transport keepalive ──────────────────────────────────────────────
+
+
+def test_ws_connect_requests_aiohttp_level_keepalive():
+    """The Gateway WS must be opened with a transport-level ping.
+
+    ``heartbeat=None`` leaves a NAT-evicted half-open socket blocking the
+    dispatch loop forever (the Aug 2026 zombie). The interval must also stay
+    clear of Discord's ~41s op-1 heartbeat so a healthy connection never flaps.
+    """
+    src = inspect.getsource(DiscordClient._run_connection)
+    assert "heartbeat=_WS_HEARTBEAT_SECS" in src
+    assert "heartbeat=None" not in src
+    assert _WS_HEARTBEAT_SECS > 41.25  # aiohttp ping must not race op-1
+
+
+# ── Discord: heartbeat-task death recycles the connection ─────────────────────
+
+
+class _FailingWs:
+    """WS stub whose send always raises, driving the heartbeat error path."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.close_calls = 0
+
+    async def send_json(self, payload) -> None:  # noqa: ANN001
+        raise ConnectionResetError("boom")
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_death_closes_ws_and_warns(caplog):
+    client = DiscordClient(token="test")
+    ws = _FailingWs()
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.discord.client"):
+        # interval=0 removes the pre-send jitter sleep from the timing budget.
+        await client._heartbeat_loop(ws, 0.0)
+    assert ws.close_calls == 1, "a dead heartbeat task must recycle the connection"
+    assert any("heartbeat loop failed" in r.message for r in caplog.records)
+    assert all(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_cancellation_stays_quiet_and_leaves_ws_open():
+    """Shutdown cancellation is not a failure: no close, no warning."""
+    client = DiscordClient(token="test")
+
+    class _IdleWs(_FailingWs):
+        async def send_json(self, payload) -> None:  # noqa: ANN001
+            await asyncio.sleep(3600)
+
+    ws = _IdleWs()
+    task = asyncio.create_task(client._heartbeat_loop(ws, 3600.0))
+    await asyncio.sleep(0)
+    task.cancel()
+    await task
+    assert ws.close_calls == 0
+
+
+# ── Discord: connection end clears READY/badge on EVERY exit path ─────────────
+
+
+class _ExplodingWs:
+    """WS stub whose read loop raises mid-dispatch (socket reset shape)."""
+
+    close_code = None
+    closed = True
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise ConnectionResetError("reset mid-dispatch")
+
+
+class _CleanCloseWs(_ExplodingWs):
+    close_code = 1000
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _FakeWsCtx:
+    def __init__(self, ws) -> None:
+        self._ws = ws
+
+    async def __aenter__(self):
+        return self._ws
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+class _FakeSession:
+    """Just enough of aiohttp.ClientSession for _run_connection."""
+
+    closed = False
+
+    def __init__(self, ws) -> None:
+        self._ws = ws
+
+    def ws_connect(self, *args, **kwargs):
+        return _FakeWsCtx(self._ws)
+
+
+@pytest.mark.asyncio
+async def test_exception_escape_clears_ready_and_flips_the_badge():
+    """A socket reset mid-dispatch exits _run_connection via exception; READY
+    and the dashboard badge must still be cleared (they previously survived
+    only the clean-close path)."""
+    client = DiscordClient(token="test")
+    client._session = _FakeSession(_ExplodingWs())
+    client.ready.set()
+    states: list[tuple[bool, str]] = []
+    client.on_state_change = lambda connected, error: states.append((connected, error))
+    with pytest.raises(ConnectionResetError):
+        await client._run_connection()
+    assert not client.ready.is_set()
+    assert states and states[-1][0] is False
+
+
+@pytest.mark.asyncio
+async def test_clean_close_warns_and_flips_the_badge(caplog):
+    client = DiscordClient(token="test")
+    client._session = _FakeSession(_CleanCloseWs())
+    client.ready.set()
+    states: list[tuple[bool, str]] = []
+    client.on_state_change = lambda connected, error: states.append((connected, error))
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.discord.client"):
+        await client._run_connection()
+    assert not client.ready.is_set()
+    assert any("connection ended" in r.message for r in caplog.records)
+    assert states == [(False, "reconnecting (close 1000)")]
+
+
+@pytest.mark.asyncio
+async def test_deliberate_close_does_not_report_reconnecting():
+    """close() sets _closed before tearing down; the finally must not flip the
+    badge to a 'reconnecting' reason on an intentional shutdown."""
+    client = DiscordClient(token="test")
+    client._session = _FakeSession(_CleanCloseWs())
+    client._closed = True
+    states: list[tuple[bool, str]] = []
+    client.on_state_change = lambda connected, error: states.append((connected, error))
+    await client._run_connection()
+    assert states == []
+
+
+# ── Weixin: timeouts are counted, not laundered ────────────────────────────────
+
+
+class _TimeoutClient:
+    """iLink client stub returning N timed-out polls, then parking forever."""
+
+    def __init__(self, timeouts: int) -> None:
+        self._remaining = timeouts
+
+    async def get_updates(self, sync_buf: str) -> dict:
+        if self._remaining > 0:
+            self._remaining -= 1
+            return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf, "_timed_out": True}
+        await asyncio.sleep(3600)
+        return {}
+
+    async def close(self) -> None:
+        pass
+
+
+def _transport(client, tmp_path) -> WeixinTransport:
+    async def dispatch(msg: InboundMessage) -> None:
+        pass
+
+    return WeixinTransport(
+        client,
+        account_id="acct1",
+        ctx_store=ContextTokenStore(str(tmp_path)),
+        dm_policy="open",
+        dispatch=dispatch,
+    )
+
+
+async def _run_poll_until_parked(t: WeixinTransport) -> None:
+    """Drive the poll loop until the stub client parks, then cancel-shutdown."""
+    t._running = True
+    task = asyncio.create_task(t._poll_loop())
+    for _ in range(400):  # poll until the stub parks (all scripted responses consumed)
+        await asyncio.sleep(0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_a_sustained_timeout_streak_warns_exactly_once(tmp_path, caplog):
+    """45 consecutive timeouts must produce ONE warning (at the 20 threshold),
+    not one every N polls — a long-idle channel must not spam the log even if
+    the server holds every poll to the client deadline."""
+    t = _transport(_TimeoutClient(timeouts=45), tmp_path)
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.weixin.transport"):
+        await _run_poll_until_parked(t)
+    hits = [r for r in caplog.records if "consecutive long-poll timeouts" in r.message]
+    assert len(hits) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_successful_poll_resets_the_timeout_streak(tmp_path, caplog):
+    class _NineteenThenOk(_TimeoutClient):
+        def __init__(self) -> None:
+            super().__init__(timeouts=19)
+            self._served_ok = False
+
+        async def get_updates(self, sync_buf: str) -> dict:
+            if self._remaining > 0:
+                return await super().get_updates(sync_buf)
+            if not self._served_ok:
+                self._served_ok = True
+                return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf}
+            await asyncio.sleep(3600)
+            return {}
+
+    t = _transport(_NineteenThenOk(), tmp_path)
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.weixin.transport"):
+        await _run_poll_until_parked(t)
+    assert not any("consecutive long-poll timeouts" in r.message for r in caplog.records)
+
+
+# ── Weixin: unexpected loop death is loud and flips the badge ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_unexpected_poll_loop_death_warns_and_notifies(tmp_path, caplog):
+    class _ExplodingClient:
+        async def get_updates(self, sync_buf: str) -> dict:
+            raise SystemExit("simulated non-Exception escape")  # bypasses except Exception
+
+        async def close(self) -> None:
+            pass
+
+    t = _transport(_ExplodingClient(), tmp_path)
+    states: list[tuple[bool, str]] = []
+    t.on_state_change = lambda connected, error: states.append((connected, error))
+    t._running = True
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.weixin.transport"):
+        with pytest.raises(SystemExit):
+            await t._poll_loop()
+    assert any("ended unexpectedly" in r.message for r in caplog.records)
+    assert states == [(False, "poll loop ended unexpectedly")]
+
+
+@pytest.mark.asyncio
+async def test_production_shutdown_cancellation_is_not_reported_as_death(tmp_path, caplog):
+    """Gateway teardown cancels the poll task WITHOUT calling disconnect()
+    (so ``_running`` is still True). That is a shutdown, not a death: no
+    warning, no badge flip, and the cancellation propagates."""
+    t = _transport(_TimeoutClient(timeouts=0), tmp_path)
+    states: list[tuple[bool, str]] = []
+    t.on_state_change = lambda connected, error: states.append((connected, error))
+    t._running = True  # deliberately NOT cleared — mirrors production teardown
+    task = asyncio.create_task(t._poll_loop())
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert states == []
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)


### PR DESCRIPTION
## Problem

Discord inbound went permanently dead on a long-running gateway (Aug 2–4) while outbound REST kept working: the WS TCP connection sat ESTABLISHED to Discord's edge, zero MESSAGE_CREATE events arrived, and there was not one log line, SEL event, or dashboard signal for ~2 days. Only a gateway restart recovered it.

## Why it matters

The operator gets no signal at all — logs, dashboard badge, and outbound delivery all look healthy while the channel is deaf. On NATed hosts this recurs on a timescale of days, and every occurrence costs a manual restart plus a forensic dig to distinguish "bot broken" from "model down" from "network".

## Fix (symptoms → root cause → change)

Root-cause chain for the Discord zombie: a NAT-evicted half-open TCP connection cannot be detected because `ws_connect(..., heartbeat=None)` provides no transport-level keepalive; the one liveness mechanism (the op-1 heartbeat task) can die from any transient send error and its death is swallowed at DEBUG with no restart and no close; with heartbeats gone Discord drops the session server-side, the close frame is lost behind NAT, and `async for raw in ws` blocks forever. Three stacked defects, each fixed:

- **`heartbeat=60.0`** on `ws_connect` — an aiohttp-level ping as a second liveness layer with a different failure domain (library read loop vs cancellable user task; proves the host→NAT→edge path, while op-1 proves the Discord session). 60s stays clear of the ~41s op-1 cadence, and aiohttp resets its ping timer on every received frame, so a healthy connection never flaps.
- **Heartbeat-task death recycles the connection**: WARNING (was DEBUG) + best-effort `ws.close()`, so the reconnect loop takes over instead of carrying a heartbeat-less connection.
- **Every connection end is observable**: WARNING log on clean closes, and READY + the dashboard badge are cleared in a `finally` so exception escapes (e.g. a send raising mid-dispatch) can no longer leave stale "connected" state. The 4004-family fatal path and deliberate `close()` keep their existing reasons.

Same-defect-class audit of the other persistent-connection channels:

- **Weixin (iLink long-poll)**: structurally immune to the zombie (35s hard deadline per request) but silently undiagnosable — client-deadline expiries were laundered into synthetic successful polls, and poll-loop death was unlogged with the dashboard badge frozen on the startup value. Now: expiries are marked (`_timed_out`) and counted, warning once per consecutive streak at 20 (~12 min of zero server contact; text does not assert death as fact since a server may legitimately hold polls to the deadline); unexpected loop death (non-cancel escape or return) logs a WARNING and flips the badge via a new `on_state_change` observer, while production teardown — which cancels the poll task without calling `disconnect()` — correctly stays silent (cancellation-aware detection, not flag-only).
- **Slack (Socket Mode)**: audited, no change needed — `slack_sdk` already opens the socket with `ping_interval=10` (websockets applies `ping_timeout=20`) and runs a self-healing session monitor that logs failures at ERROR. Its logger is pinned to WARNING in `events.py`, which hides routine reconnect churn (INFO) but abrupt failures still surface at ERROR; left as-is deliberately since the gateway's root/file handlers sit at WARNING and promoting churn lines would require a log-bridge disproportionate to the value.

## Tests

`test/test_channel_zombie_connections.py` (new, 11 tests) locks in each layer:

- Discord: `ws_connect` requests the aiohttp keepalive and the interval clears op-1's cadence; heartbeat-task death closes the WS + warns; shutdown cancellation stays quiet; an exception escape clears READY and flips the badge; a clean close warns and reports the close code; deliberate `close()` reports nothing.
- Weixin: a 45-poll timeout streak warns exactly once (no log spam under either server-hold behavior); any successful poll resets the streak; non-cancel loop death warns + notifies `(False, ...)`; production-shutdown cancellation (task cancel with `_running` still True) produces no warning, no badge flip, and propagates.

Existing suites: 242 targeted channel/security tests green; full suite 29,721 passed with 45 failures confirmed pre-existing on unmodified `origin/main` via stash round-trip (sandbox userns EPERM + ops_mission_control git-ledger host-env classes); isort / flake8 / mypy (710 files) clean; drift guards (`test_security_posture.py`, `test_spawn_audit.py`) green.

## Manual verification

The defect itself was root-caused on a live gateway (TCP ESTABLISHED to the Discord edge + zero inbound events + zero SEL authorize entries for ~2 days, outbound REST working). Staging a true NAT-eviction repro is impractical; each recovery layer is instead locked by the unit tests above, which exercise the exact failure shapes observed (send raising in the heartbeat task, read loop ending via exception vs clean close vs cancellation).

## Screenshots

N/A — no user-visible UI change (the badge fields written here are already rendered by the existing settings pages).
