### PR TITLE
test(code-review-sage): pin pattern_id away from broken digests

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_learning.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_learning.py
@@ -1,5 +1,6 @@
 """Unit tests for the V2 file-centric learning system (stage -> candidate ->
 AI-merge consolidate -> learned-patterns.md)."""
+import hashlib
 import os
 import shutil
 import tempfile
@@ -407,3 +408,50 @@ class TestCandidateLockPortability:
         assert raised, "a symlinked lock path must be refused"
         # The point of the refusal: the pointed-at file is untouched.
         assert victim.read_text(encoding="utf-8") == "precious"
+
+
+class TestPatternId(unittest.TestCase):
+    """`pattern_id` is a content-derived identifier, not a security digest.
+
+    It must stay deterministic and content-addressed, and it must not reach for a
+    broken hash: SHA-1 here made a scanner read an identifier as a cryptographic
+    use and report a high-severity alert on every PR touching this file.
+    """
+
+    def test_is_deterministic_and_content_addressed(self):
+        a = L.pattern_id("Reset guard flags on all paths", "common")
+        self.assertEqual(a, L.pattern_id("Reset guard flags on all paths", "common"))
+        # Normalisation is part of the contract: case and surrounding whitespace
+        # must not produce a second id for the same pattern.
+        self.assertEqual(a, L.pattern_id("  reset GUARD flags on all paths  ", "common"))
+        # Title and scope are both part of the identity.
+        self.assertNotEqual(a, L.pattern_id("Reset guard flags on all paths", "repo"))
+        self.assertNotEqual(a, L.pattern_id("Something else entirely", "common"))
+
+    def test_is_a_16_char_hex_handle(self):
+        pid = L.pattern_id("Reset guard flags on all paths", "common")
+        self.assertEqual(len(pid), 16)
+        self.assertTrue(all(c in "0123456789abcdef" for c in pid), pid)
+
+    def test_does_not_use_a_broken_hash(self):
+        """Pin the digest away from SHA-1/MD5 so the scanner finding cannot return."""
+        payload = "reset guard flags on all paths|common".encode()
+        self.assertEqual(L.pattern_id("Reset guard flags on all paths", "common"),
+                         hashlib.sha256(payload).hexdigest()[:16])
+        for broken in ("sha1", "md5"):
+            self.assertNotEqual(
+                L.pattern_id("Reset guard flags on all paths", "common"),
+                hashlib.new(broken, payload).hexdigest()[:16],
+                f"pattern_id must not be a truncated {broken} digest")
+
+    def test_parsed_patterns_get_ids_recomputed(self):
+        """Ids are derived on parse, never read back from the file.
+
+        This is what makes changing the digest safe without a migration.
+        """
+        p = _pattern("Reset guard flags on all paths", repo=None,
+                     added_at="2026-06-11T00:00:00Z")
+        parsed = L.parse_patterns(L.render_pattern(p))[0]
+        self.assertEqual(parsed["id"], L.pattern_id(p["title"], p["scope"]))
+        # The rendered markdown carries no id of its own to go stale.
+        self.assertNotIn(parsed["id"], L.render_pattern(p))


### PR DESCRIPTION
## Problem

`pattern_id` in Code Review Sage hashes `title|scope` into a 16-character handle used to dedupe learned patterns. It used **SHA-1**, which CodeQL reads as a cryptographic use rather than an identifier and reports as `py/weak-sensitive-data-hashing` at **high severity** — on every PR that touched the file, not just this one.

## Why it matters

The alert was noise on unrelated PRs, and the usual way that noise gets silenced is a suppression comment, which hides the intent instead of stating it.

While this branch sat, **main moved the digest to SHA-256 independently** — but added no test for it. So the code is correct today and nothing prevents a future edit from reintroducing a broken digest and the alert along with it.

## Fix (symptom → root cause → change)

The symptom was a recurring scanner alert; the root cause was an identifier built with a digest a scanner cannot distinguish from a security control; main fixed the digest. What is still missing is the guard that keeps it fixed.

**This PR is now tests only — no production code change.** It adds a `TestPatternId` ratchet covering the properties the identifier has to hold:

- **deterministic and content-addressed** — including the normalisation contract (case and surrounding whitespace must not mint a second id for one pattern) and that title *and* scope are both part of the identity;
- **a 16-character lowercase hex handle**;
- **equal to a truncated SHA-256** of the payload and **not equal to a truncated SHA-1 or MD5** — the assertion that fails if the digest regresses;
- **ids are recomputed on parse**, never read back from the rendered markdown, which is what makes changing the digest safe without a migration.

## What this PR dropped, and why

It originally carried two more things. Both are superseded, and keeping either would have added a second mechanism for a job main already does:

- **The SHA-256 change itself** — already on main (`learning.py`), under its own comment. Resolved by taking main's version.
- **A module-scoped autouse fixture containing `macos.LIVE_PROGRAM` during `test_service.py`** — superseded by the root `conftest.py` fixture `_isolate_launchd_paths`, which pins `LIVE_PROGRAM` **suite-wide** and also patches the sibling bindings this branch's fixture missed (`service.common.launchd_live_program`, `dev_fleet.gateway_service`). That fixture's own docstring names this exact reachable case: `macos.install()` calls `write_live_program(...)` with no path argument, so the launcher lands on the real path even in a test that pinned every `PLIST_*` constant.

Verified empirically rather than assumed: running the four install/uninstall tests against main leaves nothing under `~/Library/Application Support/KiroCrew/`.

## Tests

Four new tests in `src/kiro_crew/apps/builtins/code_review_sage/tests/test_learning.py`. Main had **zero** pattern_id or digest coverage before this.

**Revert-verified:** flipping `pattern_id` back to `hashlib.sha1` fails `test_does_not_use_a_broken_hash` and leaves the other three passing; restoring SHA-256 returns all four to green.

## Manual verification

N/A — unit coverage is the whole change, and the regression it guards is exercised directly by the revert-verification above.

Gates: 939 passing across the Code Review Sage suite plus `test/test_service.py`; isort and flake8 clean. Rebased onto current main, one commit, 0 behind.
