### PR TITLE
fix(tips): drop the Getting Started overview from the tip pool

### DIFF
--- a/src/kiro_crew/data/tips_catalog.json
+++ b/src/kiro_crew/data/tips_catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-04T17:06:03.571642+00:00",
+  "generated_at": "2026-08-04T21:49:53.608854+00:00",
   "entries": [
     {
       "feature": "Agents & Configuration",
@@ -41,7 +41,7 @@
       "title": "Discord Integration",
       "summary": "Talk to your agent from Discord DMs and explicitly approved server threads. The channel connects outbound over Discord's Gateway WebSocket, so it works behind NAT and firewalls with no webhook, public address, or inbound port.",
       "doc": "discord-integration.md",
-      "mtime": 1785702592.0
+      "mtime": 1785474761.0
     },
     {
       "feature": "Dynamic Sub-Agent Max Count",
@@ -58,13 +58,6 @@
       "mtime": 1785856770.0
     },
     {
-      "feature": "Getting Started with Kiro Crew",
-      "title": "Getting Started with Kiro Crew",
-      "summary": "Kiro Crew is an autonomous AI agent layer that runs on your own machine on top of the kiro-cli (KiroACP) backend.",
-      "doc": "getting-started.md",
-      "mtime": 1785861404.0
-    },
-    {
       "feature": "Knowledge Library \u2014 How the Graph Works",
       "title": "Knowledge Library \u2014 How the Graph Works",
       "summary": "The Knowledge Library builds a graph from documents without embeddings. It uses LLM extraction to identify entities and their relationships, then connects them through shared entity names across chunks.",
@@ -76,7 +69,7 @@
       "title": "MCP Apps",
       "summary": "Kiro Crew renders **MCP Apps** natively: when an MCP tool returns a `ui://` resource alongside its text, the dashboard mounts that resource as a live, interactive component in the chat instead of showing you a wall of JSON.",
       "doc": "mcp-apps.md",
-      "mtime": 1785863161.0
+      "mtime": 1785871324.0
     },
     {
       "feature": "Memory & Learning",
@@ -90,7 +83,7 @@
       "title": "Research Lab",
       "summary": "Research Lab (the `auto-research` builtin app) runs autonomous, multi-cycle campaigns: you define a research question, a **grill tree** interactively clarifies scope and sub-questions, then the system investigates cycle-by-cycle until it satisfies a success criterion or exhausts its cycle budget.",
       "doc": "research-lab.md",
-      "mtime": 1785702592.0
+      "mtime": 1785365928.0
     },
     {
       "feature": "Skills",
@@ -125,7 +118,7 @@
       "title": "Task Runner",
       "summary": "The task runner executes multi-step autonomous tasks from spec files. It's useful for complex workflows that need structured execution with progress tracking.",
       "doc": "task-runner.md",
-      "mtime": 1785702592.0
+      "mtime": 1785365928.0
     },
     {
       "feature": "Microsoft Teams Integration",

--- a/src/kiro_crew/tips_allowlist.py
+++ b/src/kiro_crew/tips_allowlist.py
@@ -9,6 +9,13 @@ incident write-ups, and design documents must NOT be listed — the exploration
 blend picks uniformly from the catalog, so anything listed can surface as a
 user-facing tip.
 
+Onboarding docs do not belong here either. Tips are feature DISCOVERY —
+"a feature you have not used yet" (see feature-tips.md and the generation
+prompt in tips.py) — and they render above the chat composer of a running
+dashboard session. Anyone who can see a tip has already installed, started,
+and opened Kiro Crew, so a product-overview tip like "Getting Started" can
+only ever be redundant there.
+
 Deliberately dependency-free so the maintainer script can import it without
 pulling in the full kiro_crew runtime.
 """
@@ -25,7 +32,6 @@ TIP_DOC_ALLOWLIST: frozenset[str] = frozenset(
         "discord-integration.md",
         "dynamic-subagent-sizing.md",
         "feature-tips.md",
-        "getting-started.md",
         "knowledge-library-how-it-works.md",
         "mcp-apps.md",
         "memory-and-learning.md",


### PR DESCRIPTION
Fixes #1498.

## Problem

The tip strip above the chat composer can serve the **"Getting Started with Kiro Crew"** product overview to a user mid-conversation in the dashboard. Tips are contractually feature *discovery* — `feature-tips.md` promises "a feature you have not used yet" and the generation prompt asks for "features the user would benefit from but may not know about". Every reader of a tip has already installed, started, and opened Kiro Crew, so a Getting Started overview can only ever be redundant there.

## Root cause

`getting-started.md` sits in `TIP_DOC_ALLOWLIST`, which feeds the bundled catalog, the LLM prompt, the catalog fallback pool, and the exploration blend (uniform pick over the catalog — anything listed will eventually surface).

## Change

- Remove `getting-started.md` from `TIP_DOC_ALLOWLIST`; document the onboarding exclusion in the module docstring beside the existing internal-docs rule.
- Regenerate `src/kiro_crew/data/tips_catalog.json` via `scripts/generate_tips_catalog.py` (`test_bundled_catalog_only_contains_allowlisted_docs` pins catalog ⊆ allowlist, so the two must land together). The mtime drift in the regenerated artifact is squash-merge commit timestamps having moved since the last generation; the generator is documented as idempotent and the brand gate already classes this file as a regenerable artifact.

## Deliberately retained

`dashboard.md` and `feature-tips.md` are superficially similar ("you are looking at the dashboard / at a tip") but both document sub-features and controls the reader may not know (memory pages, cron UI, tip cadence/opt-out), so they still fit the discovery contract. `getting-started.md` is the only pure-onboarding entry.

## Testing

- `pytest test/test_tips.py` — 119 passed
- `black`/`isort`/`flake8`/`mypy` clean on the touched module
- `scripts/docs_lint.py` — same 78 pre-existing findings as clean main (none introduced)
- `BRAND_BASE_REF=upstream/main scripts/check_brand_name.py` — clean
