### PR TITLE
fix(browser): downscale screenshots on longest edge, not just width

### DIFF
--- a/src/kiro_crew/mcp_playwright_proxy.py
+++ b/src/kiro_crew/mcp_playwright_proxy.py
@@ -95,13 +95,29 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-# Max width (px) for relayed/saved frames — 1920 so a resized mirror panel
+# Max edge (px) for relayed/saved frames — 1920 so a resized mirror panel
 # shows real pixels instead of an upscaled blur; set KIROCREW_BROWSE_MAX_WIDTH=0
-# to disable downscaling entirely (send native resolution). JPEG quality is
-# likewise tunable. Both apply to the on-disk screenshot and the live mirror
-# frame, which share one encode.
-_MAX_FRAME_WIDTH = _env_int("KIROCREW_BROWSE_MAX_WIDTH", 1920)
+# to disable *cosmetic* downscaling (send native resolution up to the hard
+# ceiling). JPEG quality is likewise tunable. Both apply to the on-disk
+# screenshot and the live mirror frame, which share one encode.
+_MAX_FRAME_EDGE = _env_int("KIROCREW_BROWSE_MAX_WIDTH", 1920)
 _FRAME_JPEG_QUALITY = _env_int("KIROCREW_BROWSE_JPEG_QUALITY", 70)
+
+# Hard ceiling: the model gateway rejects any image dimension > 2000px in
+# multi-image requests. This limit is applied regardless of MAX_WIDTH — even
+# when the cosmetic downscale is disabled (MAX_WIDTH=0) — to prevent
+# irreversible session corruption from oversized screenshots poisoning
+# conversation history. It requires PIL; without PIL, native bytes are
+# forwarded unresized.
+_HARD_MAX_EDGE = 2000
+
+# Pixel ceiling for a frame decode. Pillow's stock decompression-bomb guard
+# (~178M pixels) is cleared by a legitimate fullPage capture of a long page
+# (3000x60000 is 180M) — exactly the frames the hard ceiling must downscale.
+# Raising it is safe for this input class (our own browser's capture, not an
+# untrusted upload) and bounded, not disabled. Mirrors web-verify's
+# downscale_image.py, which uses the same value for the same reason.
+_MAX_DECODE_PIXELS = 512_000_000
 
 # The browse session this proxy serves. kiro-cli freezes KIROCREW_SESSION_KEY in
 # the MCP subprocess env at spawn, so it identifies the session whose browse is
@@ -113,23 +129,62 @@ _SESSION_KEY = os.environ.get("KIROCREW_SESSION_KEY", "")
 def _encode_frame(data: str, media_type: str) -> tuple[bytes, str]:
     """Decode a base64 image; downscale + JPEG-encode if PIL is available.
 
+    Downscales the **longest edge** (not just width) to ``_MAX_FRAME_EDGE``,
+    matching the computer-use capture path. A hard ceiling of
+    ``_HARD_MAX_EDGE`` (2000px) is applied regardless of ``MAX_WIDTH`` to
+    prevent the model gateway from rejecting the image and permanently breaking
+    the session (requires PIL; without it, native bytes pass through unresized).
+
     Returns ``(bytes, ext)``. Shared by the on-disk save and the live-frame POST
     so the (relatively expensive) decode/resize/encode runs once per screenshot.
     """
     img_bytes = base64.b64decode(data)
     ext = "jpeg" if ("jpeg" in media_type or "jpg" in media_type) else "png"
     if _HAS_PIL:
+        # Raised only for this decode and then put back: the ceiling is a
+        # MODULE-LEVEL global in Pillow, so leaving it changed would silently
+        # relax the guard for every later decode in the process.
+        previous_ceiling = Image.MAX_IMAGE_PIXELS
+        Image.MAX_IMAGE_PIXELS = _MAX_DECODE_PIXELS
         try:
             img: Image.Image = Image.open(io.BytesIO(img_bytes))
-            if _MAX_FRAME_WIDTH and img.width > _MAX_FRAME_WIDTH:
-                ratio = _MAX_FRAME_WIDTH / img.width
+            longest = max(img.width, img.height)
+            # Apply cosmetic downscale (user-configurable, 0 = disabled).
+            max_edge = _MAX_FRAME_EDGE
+            # Always enforce the hard ceiling, even when cosmetic is disabled.
+            if not max_edge or max_edge > _HARD_MAX_EDGE:
+                max_edge = _HARD_MAX_EDGE
+            if longest > max_edge:
+                ratio = max_edge / longest
                 resample = getattr(Image, "LANCZOS", getattr(Image, "ANTIALIAS", None))
-                img = img.resize((_MAX_FRAME_WIDTH, int(img.height * ratio)), resample)
+                img = img.resize(
+                    (
+                        max(1, round(img.width * ratio)),
+                        max(1, round(img.height * ratio)),
+                    ),
+                    resample,
+                )
             buf = io.BytesIO()
             img.save(buf, format="JPEG", quality=_FRAME_JPEG_QUALITY)
             return buf.getvalue(), "jpeg"
         except Exception:
-            pass
+            # Never forward a frame we KNOW is oversized: the gateway rejects
+            # any dimension > _HARD_MAX_EDGE and the rejection permanently
+            # wedges the session. Probe the header only (``Image.open`` is
+            # lazy — no pixel decode happens, so lifting the bomb guard for
+            # the probe is safe) and substitute a placeholder if oversized.
+            try:
+                Image.MAX_IMAGE_PIXELS = None
+                with Image.open(io.BytesIO(img_bytes)) as probe:
+                    oversized = max(probe.size) > _HARD_MAX_EDGE
+                if oversized:
+                    buf = io.BytesIO()
+                    Image.new("RGB", (1, 1)).save(buf, format="JPEG")
+                    return buf.getvalue(), "jpeg"
+            except Exception:
+                pass
+        finally:
+            Image.MAX_IMAGE_PIXELS = previous_ceiling
     return img_bytes, ext
 
 

--- a/test/test_browser_screencast.py
+++ b/test/test_browser_screencast.py
@@ -9,6 +9,7 @@ client with the loopback gate patched.
 from __future__ import annotations
 
 import base64
+import io
 import os
 from unittest.mock import MagicMock, patch
 
@@ -146,6 +147,206 @@ class TestProxyFrameHelpers:
         assert ext in ("jpeg", "png")
         # Round-trips as valid base64 input.
         assert base64.b64decode(png_b64)
+
+    def test_encode_frame_downscales_tall_image(self, monkeypatch):
+        """A fullPage screenshot taller than the max edge is downscaled (#1273)."""
+        from PIL import Image as PILImage
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        monkeypatch.setattr(proxy, "_MAX_FRAME_EDGE", 1920)
+        monkeypatch.setattr(proxy, "_HARD_MAX_EDGE", 2000)
+
+        # Simulate a fullPage screenshot: 1440x5200 (width under limit, height way over).
+        img = PILImage.new("RGB", (1440, 5200), color=(255, 0, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        result_bytes, ext = proxy._encode_frame(png_b64, "image/png")
+        result_img = PILImage.open(io.BytesIO(result_bytes))
+        # Longest edge (5200) should be clamped to 1920.
+        assert max(result_img.width, result_img.height) <= 1920
+        # Aspect ratio preserved.
+        assert abs(result_img.width / result_img.height - 1440 / 5200) < 0.01
+
+    def test_encode_frame_tiny_limit_never_yields_zero_dimension(self, monkeypatch):
+        """A tiny cosmetic limit still downscales instead of forwarding oversized.
+
+        With MAX_WIDTH=1 and a 1440x3000 frame, the width would round to 0 and
+        PIL would raise -- the except fallback then forwarded the >2000px
+        original, wedging the session the ceiling exists to prevent. Both
+        dimensions are clamped to >= 1px so the resize always succeeds.
+        """
+        from PIL import Image as PILImage
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        monkeypatch.setattr(proxy, "_MAX_FRAME_EDGE", 1)
+        monkeypatch.setattr(proxy, "_HARD_MAX_EDGE", 2000)
+
+        img = PILImage.new("RGB", (1440, 3000), color=(255, 0, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        result_bytes, ext = proxy._encode_frame(png_b64, "image/png")
+        result_img = PILImage.open(io.BytesIO(result_bytes))
+        # The oversized original must NOT pass through: encoded as JPEG and
+        # both dimensions valid (>=1) and within the requested edge.
+        assert ext == "jpeg"
+        assert result_img.width >= 1 and result_img.height >= 1
+        assert max(result_img.width, result_img.height) <= 1
+
+    def test_encode_frame_downscales_wide_image(self, monkeypatch):
+        """A wide image exceeding the max edge is downscaled (existing behavior)."""
+        from PIL import Image as PILImage
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        monkeypatch.setattr(proxy, "_MAX_FRAME_EDGE", 1920)
+        monkeypatch.setattr(proxy, "_HARD_MAX_EDGE", 2000)
+
+        # 2800x900 — width is the longest edge.
+        img = PILImage.new("RGB", (2800, 900), color=(0, 255, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        result_bytes, _ = proxy._encode_frame(png_b64, "image/png")
+        result_img = PILImage.open(io.BytesIO(result_bytes))
+        assert result_img.width <= 1920
+        assert result_img.height <= 1920
+
+    def test_encode_frame_hard_ceiling_when_cosmetic_disabled(self, monkeypatch):
+        """Setting MAX_WIDTH=0 disables cosmetic downscale but respects hard ceiling (#1273)."""
+        from PIL import Image as PILImage
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        monkeypatch.setattr(proxy, "_MAX_FRAME_EDGE", 0)  # cosmetic disabled
+        monkeypatch.setattr(proxy, "_HARD_MAX_EDGE", 2000)
+
+        # 1440x3000 — both dimensions under 2000 in width but height exceeds.
+        img = PILImage.new("RGB", (1440, 3000), color=(0, 0, 255))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        result_bytes, _ = proxy._encode_frame(png_b64, "image/png")
+        result_img = PILImage.open(io.BytesIO(result_bytes))
+        # Hard ceiling enforced: no dimension exceeds 2000.
+        assert max(result_img.width, result_img.height) <= 2000
+
+    def test_encode_frame_no_downscale_when_within_limits(self, monkeypatch):
+        """Images within limits are not resized."""
+        from PIL import Image as PILImage
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        monkeypatch.setattr(proxy, "_MAX_FRAME_EDGE", 1920)
+        monkeypatch.setattr(proxy, "_HARD_MAX_EDGE", 2000)
+
+        # 1400x900 — both well within limits.
+        img = PILImage.new("RGB", (1400, 900), color=(128, 128, 128))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        result_bytes, _ = proxy._encode_frame(png_b64, "image/png")
+        result_img = PILImage.open(io.BytesIO(result_bytes))
+        # No downscale — dimensions preserved (JPEG re-encode may shift by 1px).
+        assert abs(result_img.width - 1400) <= 1
+        assert abs(result_img.height - 900) <= 1
+
+    def test_encode_frame_hard_ceiling_caps_large_cosmetic_value(self, monkeypatch):
+        """A cosmetic limit above the hard ceiling is clamped to the hard ceiling."""
+        from PIL import Image as PILImage
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        monkeypatch.setattr(proxy, "_MAX_FRAME_EDGE", 4000)  # above hard max
+        monkeypatch.setattr(proxy, "_HARD_MAX_EDGE", 2000)
+
+        # 1920x2500 — height exceeds hard max but not cosmetic.
+        img = PILImage.new("RGB", (1920, 2500), color=(255, 255, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        result_bytes, _ = proxy._encode_frame(png_b64, "image/png")
+        result_img = PILImage.open(io.BytesIO(result_bytes))
+        assert max(result_img.width, result_img.height) <= 2000
+
+    def test_encode_frame_decodes_under_raised_bounded_ceiling(self, monkeypatch):
+        """The decode runs under _MAX_DECODE_PIXELS, then restores the guard.
+
+        Pillow's stock bomb guard (~178M pixels) rejects a legitimate fullPage
+        capture of a long page (3000x60000 = 180M); the swallowed error then
+        forwarded the oversized original -- the exact wedge the hard ceiling
+        exists to prevent. The decode must run under the raised, still-bounded
+        ceiling and put the process-wide guard back afterwards.
+        """
+        from PIL import Image as PILImage
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        monkeypatch.setattr(proxy, "_MAX_FRAME_EDGE", 1920)
+        monkeypatch.setattr(proxy, "_HARD_MAX_EDGE", 2000)
+
+        img = PILImage.new("RGB", (1440, 3000), color=(0, 255, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        seen: dict = {}
+        real_open = proxy.Image.open
+
+        def spying_open(*a, **kw):
+            seen.setdefault("limit", proxy.Image.MAX_IMAGE_PIXELS)
+            return real_open(*a, **kw)
+
+        stock_ceiling = PILImage.MAX_IMAGE_PIXELS
+        monkeypatch.setattr(proxy.Image, "open", spying_open)
+        result_bytes, ext = proxy._encode_frame(png_b64, "image/png")
+        # Decode ran under the raised, bounded ceiling (not stock, not None),
+        # the frame downscaled, and the process-wide guard was restored.
+        assert seen["limit"] == proxy._MAX_DECODE_PIXELS
+        assert PILImage.MAX_IMAGE_PIXELS == stock_ceiling
+        result_img = real_open(io.BytesIO(result_bytes))
+        assert max(result_img.width, result_img.height) <= 1920
+        assert ext == "jpeg"
+
+    def test_encode_frame_never_forwards_known_oversized_on_decode_failure(
+        self, monkeypatch
+    ):
+        """A frame that fails decode but is provably oversized is not forwarded.
+
+        Beyond even _MAX_DECODE_PIXELS the decode raises; forwarding the
+        original would wedge the session (gateway rejects any dimension >
+        _HARD_MAX_EDGE). The header probe substitutes a placeholder instead.
+        """
+        from PIL import Image as PILImage
+
+        import kiro_crew.mcp_playwright_proxy as proxy
+
+        monkeypatch.setattr(proxy, "_MAX_FRAME_EDGE", 1920)
+        monkeypatch.setattr(proxy, "_HARD_MAX_EDGE", 2000)
+        # Force the primary decode down the failure path regardless of size.
+        monkeypatch.setattr(proxy, "_MAX_DECODE_PIXELS", 1)
+
+        img = PILImage.new("RGB", (30, 3000), color=(0, 0, 255))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        result_bytes, ext = proxy._encode_frame(png_b64, "image/png")
+        result_img = PILImage.open(io.BytesIO(result_bytes))
+        # The 3000px original must NOT pass through; a placeholder does.
+        assert max(result_img.width, result_img.height) <= 2000
+        assert ext == "jpeg"
+        # And the module-level Pillow ceiling was restored afterwards.
+        assert PILImage.MAX_IMAGE_PIXELS not in (1, None)
 
     def test_internal_secret_read_from_kirocrew_home(self, monkeypatch, tmp_path):
         import kiro_crew.mcp_playwright_proxy as proxy


### PR DESCRIPTION
## Description

`_encode_frame` capped width only — a `fullPage: true` screenshot taller than
2000px passed through at full height, hit the model gateway's per-dimension
limit, and permanently broke the session (every subsequent turn re-sent the
oversized image from history and failed).

Changes:
- Downscale the **longest edge** (not just width), matching the computer-use
  capture path (`computer_use/macos_ffi.py` uses `kCGImageDestinationImageMaxPixelSize`)
- Add a hard ceiling of 2000px applied unconditionally — `KIROCREW_BROWSE_MAX_WIDTH=0`
  now means "no cosmetic downscale" rather than "exceed the protocol limit"
- Env var name kept for backward compat; internal constant renamed to `_MAX_FRAME_EDGE`

## Related Issues

Fixes #1273

## Testing

- [x] Existing tests pass (`make test`) — all 50 tests in test_browser_screencast.py pass
- [x] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

Verified with standalone PIL script exercising all edge cases:
- Tall image (1440×5200) → clamped to 532×1920 ✅
- Wide image (2800×900) → clamped to 1920×617 ✅
- Normal image (1400×900) → no resize ✅
- Cosmetic disabled (MAX_WIDTH=0) + tall image → hard ceiling enforced at 2000px ✅
- Cosmetic set above hard ceiling (4000) → clamped to 2000 ✅

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — docstring updated; no subsystem doc change needed
- [x] No secrets, credentials, or internal references in the diff