### PR TITLE
docs: align PR template with prepare-pr contract + screenshot/video guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,65 @@
-## Description
+<!-- Fill in each section below. Omit a section only when it is genuinely not
+     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
+     description in sync: every claim here must be supported by the diff. -->
 
-<!-- What does this PR do? Why is it needed? -->
+## Problem / Motivation
+
+<!-- Bug fix: the concrete symptom — what is broken or missing, ideally what the
+     user observes.
+     New feature / enhancement: the gap, use case, or opportunity this addresses
+     — what a user cannot do (or does awkwardly) today. -->
+
+## Why it matters
+
+<!-- Impact if this is left undone: for a fix, who is hit by the bug and how
+     badly; for a feature, the user/business value it unlocks. -->
+
+## What changed (motivation → approach → change)
+
+<!-- A short chain of thought so the reader sees *why this is the right change*,
+     not just what changed:
+     - Bug fix: observed symptom → underlying root cause → the specific change
+       that addresses that cause.
+     - New feature / enhancement: goal → the approach/design you chose (and why,
+       over the alternatives you considered) → what you actually built. -->
+
+## Tests
+
+<!-- Automated tests added/updated and the behavior each one locks in. -->
+
+## Manual verification
+
+<!-- Manual steps performed or still required where unit tests fall short
+     (integration paths, UI, external services). State "N/A — unit coverage
+     sufficient" only when genuinely true, with a one-line why. -->
+
+## Screenshots / video
+
+<!-- MANDATORY for any user-visible UI change (new/changed panels, components,
+     layouts, themes); delete this section otherwise.
+
+     - Show each affected surface in its meaningful variants (e.g. desktop vs
+       browser, empty vs populated, light vs dark).
+     - Prefer a short video/GIF when the change involves motion or a multi-step
+       flow (animations, transitions, interactions) — a still image cannot
+       prove those.
+     - Commit media to the PR branch under a top-level, ephemeral, never-packaged
+       dir `temp-screenshots/<feature>/` (never under docs/ or src/kiro_crew/**)
+       and embed with commit-SHA-pinned URLs so they survive branch deletion on
+       merge and periodic cleanup:
+       ![alt](https://github.com/<owner>/<repo>/raw/<sha>/temp-screenshots/<feature>/<name>.png)
+     - Put the two or three most telling shots inline; fold full-page context
+       into a <details> block. -->
 
 ## Related Issues
 
 <!-- Link to relevant issues, e.g. Fixes #123 -->
 
-## Testing
-
-- [ ] Existing tests pass (`make test`)
-- [ ] New tests added for new functionality
-- [ ] Manual verification performed (describe below if applicable)
-
 ## Checklist
 
-- [ ] Code follows the project style guidelines
-- [ ] Self-review completed
+- [ ] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
+- [ ] Existing tests pass and new tests added for new functionality
+- [ ] Self-review completed; code follows project style guidelines
 - [ ] Documentation updated (if applicable)
 - [ ] No secrets, credentials, or internal references in the diff
 


### PR DESCRIPTION
## Problem / Motivation

The repo's `PULL_REQUEST_TEMPLATE.md` asks only for a freeform "Description" plus a testing/style checklist. It does not line up with the structure the `prepare-pr` skill requires of every PR body (motivation → why it matters → chain-of-thought change → Tests → Manual verification → Screenshots), and it gives no guidance on attaching visual evidence. Contributors (and the automation) therefore produce descriptions that omit the rationale and skip screenshots/video for UI changes.

## Why it matters

The PR body is the primary review artifact. A template that mirrors the review contract means reviewers consistently get the reasoning behind a change and the visual evidence needed to judge UI work, instead of a one-line "Description". It also makes the human-authored path match what `prepare-pr` already fills in, so PRs look the same whether opened by hand or by the skill.

## What changed (motivation → approach → change)

Motivation: template sections don't match the required PR body contract and never prompt for images/video. Approach: rewrite `.github/PULL_REQUEST_TEMPLATE.md` to the contract sections, each with an HTML-comment prompt so a small change isn't forced to pad every section — and frame the narrative sections to cover **both bug fixes and new features/enhancements** rather than assuming every PR fixes a bug. Change:

- `## Problem / Motivation`, `## Why it matters`, and `## What changed (motivation → approach → change)` each carry dual guidance: bug fix (symptom → root cause → change) *and* feature (gap/use case → chosen approach → what was built).
- Added a `## Screenshots / video` section that (a) is marked mandatory for user-visible UI changes, (b) suggests a short video/GIF when the change involves motion or a multi-step flow, and (c) documents the SHA-pinned `temp-screenshots/<feature>/` embedding recipe.
- Kept the repo-specific `## Related Issues` and `## Contribution License Agreement` (OSPO placeholder) sections, and tightened the checklist (single commit + Conventional Commits title, tests, self-review, docs, no secrets/internal references).

## Tests

N/A — documentation-only change to a single markdown template; no code paths affected.

## Manual verification

Rendered the template as Markdown; all headings and HTML comments are well-formed, the embedded example image URL is a same-origin `github.com/.../raw/...` link, and no Amazon-internal references are present (public-repo rule). Confirmed the diff touches only `.github/PULL_REQUEST_TEMPLATE.md`.

## Screenshots / video

N/A — the change is to the PR template markdown itself, no application UI surface.

## Related Issues

N/A — no tracking issue.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — docs only)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (this IS the doc change)
- [x] No secrets, credentials, or internal references in the diff
