### PR TITLE
fix(dev-fleet): stop Pull+Build needing host workarounds on stock macOS

### DIFF
--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -724,6 +724,19 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         # checkout. minimal_env() strips it; backends need it to locate the
         # gateway's source checkout (e.g. dev-fleet worktree discovery).
         _platform_extra["KIROCREW_PROJECT_DIR"] = os.environ["KIROCREW_PROJECT_DIR"]
+    if os.environ.get("KIROCREW_EDITION_DIR"):
+        # Platform var, same class as the above: whether this gateway is an
+        # EDITION composition root. A backend that stages frontend build output
+        # into the served static/dist must know, because a rebuild it drives
+        # cannot recompose the edition (the build env deliberately withholds the
+        # edition opt-in) and staging a stock SPA would silently replace the
+        # edition dashboard with upstream's. minimal_env() strips it, so without
+        # this the backend cannot tell an edition install from a stock one and
+        # any such guard reads as "stock" everywhere. A path, not a secret; the
+        # opt-in (KIROCREW_ALLOW_EDITION) is deliberately NOT propagated, so a
+        # backend can detect an edition but never manufacture consent to compile
+        # one.
+        _platform_extra["KIROCREW_EDITION_DIR"] = os.environ["KIROCREW_EDITION_DIR"]
     for _k, _v in os.environ.items():
         # Operator-declared trusted-binary overrides (unit-file owned):
         # backends resolve credential-bearing tools through these instead of

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -50,7 +50,7 @@ from typing import Any, Callable
 
 from aiohttp import web
 
-from kiro_crew import hooks, platform_compat
+from kiro_crew import frontend, hooks, platform_compat
 from kiro_crew.apps.builtins.dev_fleet import gateway_service
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.sandbox import (
@@ -475,14 +475,33 @@ async def _load_fallback_repos() -> None:
 
 async def _load_trusted_credential_helpers() -> None:
     global _GIT_TRUSTED_HELPERS
-    rc, out, _err = await _run_cmd(
-        ["git", "config", "--global", "--get-regexp", r"^credential(\..+)?\.helper$"],
-        timeout=5,
-    )
     extra: dict[str, str] = {}
-    if rc == 0 and out:
-        base = int(_GIT_ENV_NEUTRALIZERS["GIT_CONFIG_COUNT"])
-        idx = base
+    base = int(_GIT_ENV_NEUTRALIZERS["GIT_CONFIG_COUNT"])
+    idx = base
+    # SYSTEM scope first, then GLOBAL, mirroring git's own precedence: for a
+    # multi-valued key like credential.helper the later entry wins, so the
+    # operator's own global setting still overrides a machine-wide default.
+    #
+    # System scope is read at all because that is where macOS puts the operator's
+    # helper: Xcode's Command Line Tools ship
+    # `credential.helper = osxkeychain` in
+    # /Library/Developer/CommandLineTools/usr/share/git-core/gitconfig, and a
+    # stock install has NOTHING in global. Scanning only --global therefore left
+    # the neutralizer's reset unrepaired on every stock macOS host, and `git
+    # fetch` died with "could not read Username" — no tty to prompt on.
+    #
+    # Repo-LOCAL scope stays excluded. That is the attack surface the reset
+    # exists for: a checkout Dev Fleet builds can write .git/config, and a helper
+    # from there would run in the credential-bearing standard tier.
+    for scope in ("--system", "--global"):
+        rc, out, _err = await _run_cmd(
+            ["git", "config", scope, "--get-regexp", r"^credential(\..+)?\.helper$"],
+            timeout=5,
+        )
+        # A missing system gitconfig is rc != 0 with no output — normal, not an
+        # error worth surfacing.
+        if rc != 0 or not out:
+            continue
         for line in out.splitlines():
             key, _, val = line.partition(" ")
             if not key.endswith(".helper"):
@@ -494,7 +513,7 @@ async def _load_trusted_credential_helpers() -> None:
                 # withheld; only the config KEY name is recorded.
                 logger.warning(
                     "dev-fleet: skipping helper with unverifiable provenance"
-                    " for config key %s", key,
+                    " for config key %s (%s scope)", key, scope.lstrip("-"),
                 )
                 continue
             extra[f"GIT_CONFIG_KEY_{idx}"] = key
@@ -502,8 +521,10 @@ async def _load_trusted_credential_helpers() -> None:
             idx += 1
             if idx - base >= 9:
                 break
-        if idx > base:
-            extra["GIT_CONFIG_COUNT"] = str(idx)
+        if idx - base >= 9:
+            break
+    if idx > base:
+        extra["GIT_CONFIG_COUNT"] = str(idx)
     _GIT_TRUSTED_HELPERS = extra
 
 
@@ -2288,9 +2309,54 @@ async def _sync_start_locked() -> dict:
          _build_env(with_credentials=True), "Pull"),
         ([git_bin, "merge", "--ff-only", f"{remote}/{BASE_BRANCH}"], "strict", _build_env(), "Pull"),
         ([str(target_py), "-m", "pip", "install", "-e", "."], "strict", _build_env(), "pip install"),
-        ([npm_bin, "ci", "--prefix", "website"], "strict", _build_env(), "npm ci"),
-        ([npm_bin, "run", "build", "--prefix", "website"], "strict", _build_env(), "npm build"),
     ]
+    # The whole FRONTEND half of the sync is skipped on an edition checkout.
+    #
+    # The build runs under _build_env(), whose allowlist (_SAFE_ENV_KEYS) drops
+    # KIROCREW_EDITION_DIR and KIROCREW_ALLOW_EDITION, so on an edition
+    # composition root `npm run build` can only compile the STOCK SPA -- and vite
+    # builds with emptyOutDir, so it OVERWRITES website/dist. On a source-tree
+    # install frontend.ensure_dev_dist_symlink() has pointed static/dist at
+    # website/dist, which means the build alone replaces the served edition
+    # dashboard with upstream's, with or without a staging step. Skipping the
+    # build is therefore the only way to make this safe, and it costs an edition
+    # nothing: the only artifact this path could produce for it is a stock SPA it
+    # must never serve. It is the same call frontend's own
+    # edition_sources_missing() guard already makes -- leave the shipped bundle
+    # alone rather than degrade it.
+    #
+    # This backend is a SEPARATE process started with apps.registry.minimal_env(),
+    # which strips KIROCREW_EDITION_DIR, so the guard would read "stock" on every
+    # install and never fire. apps/backend.py therefore propagates that one var
+    # explicitly, the same way it already propagates KIROCREW_PROJECT_DIR.
+    if frontend.edition_configured():
+        logger.info(
+            "dev-fleet: skipping the frontend build and dist staging -- this is "
+            "an edition checkout and the sync build cannot recompose the "
+            "edition; the shipped bundle is left in place"
+        )
+    else:
+        raw_steps += [
+            ([npm_bin, "ci", "--prefix", "website"], "strict", _build_env(), "npm ci"),
+            ([npm_bin, "run", "build", "--prefix", "website"], "strict", _build_env(), "npm build"),
+            # `npm run build` writes website/dist; the dashboard SERVES
+            # src/kiro_crew/static/dist. Without a staging step the rebuild never
+            # reaches the served path and Pull+Build reports success while the
+            # gateway keeps serving the previous bundle. On a source-tree gateway
+            # start the gap is masked by the dev symlink; a packaged install has
+            # no such link, so nothing takes effect.
+            #
+            # Run with THIS backend's interpreter, not the target checkout's.
+            # Staging is a pure file copy between two paths inside MAIN_REPO, so
+            # the logic is revision-independent -- while resolving it from the
+            # target would make the step's very EXISTENCE contingent on the
+            # pulled revision already carrying stage_built_dist, turning an older
+            # target into an ImportError that fails the whole Pull+Build.
+            ([sys.executable, "-c",
+              "import sys;from kiro_crew.frontend import stage_built_dist;"
+              "stage_built_dist(sys.argv[1])", MAIN_REPO],
+             "strict", _build_env(), "stage dist"),
+        ]
     cleanups: list[str] = []
     wrapped_steps: list[dict] = []
     loop = asyncio.get_running_loop()

--- a/src/kiro_crew/frontend.py
+++ b/src/kiro_crew/frontend.py
@@ -226,33 +226,102 @@ def _stage_dist(
     built_dist: Path,
     proj_path: Path,
     log: Callable[[str], None] = print,
-) -> None:
+) -> bool:
     """Copy the freshly built ``website/dist`` into ``static/dist``.
 
-    Removes any stale destination (real dir or symlink) first, then copies the
-    build output so the dashboard serves the latest frontend assets without a
-    manual step. A copy (rather than a symlink) is used here so the served
-    bundle is a self-contained snapshot independent of later ``website/``
-    rebuilds — important for packaged/installed layouts.
+    A copy (rather than a symlink) is used here so the served bundle is a
+    self-contained snapshot independent of later ``website/`` rebuilds —
+    important for packaged/installed layouts.
+
+    The copy lands in a temporary sibling and only REPLACES ``static/dist`` once
+    it is complete. Removing the destination first (as this did originally) meant
+    any copy error left the dashboard with no bundle at all — a failed rebuild
+    would take the working UI down with it. The unavailable window is now a
+    rename rather than a whole ``copytree``.
+
+    Returns ``True`` when ``static/dist`` now holds the new bundle. Callers that
+    treat staging as best-effort can keep ignoring the result — the failure is
+    still logged — but a caller whose own success depends on staging (Dev Fleet's
+    Pull+Build) must check it, because a preserved older bundle is no longer
+    evidence that anything was staged.
     """
     static_dist = proj_path / "src" / "kiro_crew" / "static" / "dist"
     if not built_dist.is_dir():
         log(f"  ⚠️  Built dist not found at {built_dist} — dashboard may be stale")
-        return
+        return False
+    staging = static_dist.parent / f".dist.staging.{os.getpid()}"
+    try:
+        static_dist.parent.mkdir(parents=True, exist_ok=True)
+        if staging.is_symlink() or staging.is_file():
+            staging.unlink()
+        elif staging.is_dir():
+            shutil.rmtree(staging)
+        shutil.copytree(built_dist, staging)
+    except OSError as exc:
+        shutil.rmtree(staging, ignore_errors=True)
+        log(f"  ⚠️  Could not copy static/dist: {exc}")
+        return False
     try:
         if static_dist.is_symlink() or static_dist.is_file():
             static_dist.unlink()
         elif static_dist.is_dir():
             shutil.rmtree(static_dist)
+        staging.replace(static_dist)
     except OSError as exc:
-        log(f"  ⚠️  Could not remove stale static/dist: {exc}")
-        return
-    try:
-        static_dist.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(built_dist, static_dist)
-        log(f"  📦 Staged static/dist ← {built_dist}")
-    except OSError as exc:
-        log(f"  ⚠️  Could not copy static/dist: {exc}")
+        shutil.rmtree(staging, ignore_errors=True)
+        log(f"  ⚠️  Could not replace static/dist: {exc}")
+        return False
+    log(f"  📦 Staged static/dist ← {built_dist}")
+    return True
+
+
+def edition_configured() -> bool:
+    """True when an edition composition root is configured for this process.
+
+    A rebuild that cannot pass the edition seam through to vite can only produce
+    a STOCK SPA (see :func:`_edition_build_env`), so a caller that STAGES build
+    output must skip rather than replace an edition dashboard with upstream's.
+    Distinct from :func:`edition_sources_missing`, which answers whether the
+    sources are present; this answers whether an edition is in play at all.
+    """
+    return bool(os.environ.get(_EDITION_DIR_ENV))
+
+
+def stage_built_dist(
+    proj_path: "str | Path",
+    log: Callable[[str], None] = print,
+) -> None:
+    """Stage an ALREADY-built ``website/dist`` into the served ``static/dist``.
+
+    The public seam for callers that run the npm build themselves and only need
+    the staging half — Dev Fleet's Pull+Build, which drives each build step as
+    its own audited subprocess and so cannot call
+    :func:`build_frontend_sync`'s all-in-one path.
+
+    Without this step a Pull+Build leaves the new bundle in ``website/dist``
+    while the gateway keeps serving the old ``static/dist``. On a source-tree
+    gateway start that goes unnoticed because :func:`ensure_dev_dist_symlink`
+    has already linked the two; with a packaged install there is no link, so the
+    rebuild silently never takes effect.
+
+    Raises ``RuntimeError`` when staging did not happen.
+    :func:`_stage_dist` logs and returns ``False`` on failure because its other
+    callers treat staging as best-effort; here it is a SYNC STEP whose exit
+    status decides whether Pull+Build reports success. Note that a surviving
+    older bundle is NOT evidence of success -- `_stage_dist` now preserves it on
+    failure -- so this checks the returned flag rather than merely asserting that
+    something is present at the destination.
+
+    The caller is responsible for not invoking this after a build that could not
+    recompose an edition — see :func:`edition_configured`.
+    """
+    proj = Path(proj_path)
+    built = proj / "website" / "dist"
+    if not _stage_dist(built, proj, log):
+        raise RuntimeError(
+            f"dist staging failed; the dashboard still serves the previous "
+            f"bundle (built dist: {built})"
+        )
 
 
 def build_frontend_sync(

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -7,6 +7,7 @@ import hmac as _hmac  # noqa: F401
 import hmac as _hmac_mod
 import json
 import os
+import sys
 import textwrap
 import time
 from contextlib import ExitStack
@@ -2795,8 +2796,14 @@ async def test_trusted_helpers_loaded_from_global_config(monkeypatch):
     monkeypatch.setattr(mod, "_GIT_TRUSTED_HELPERS", None)
     monkeypatch.setattr(mod, "_trusted_bin", lambda n: f"/usr/bin/{n}")
 
+    scopes: list = []
+
     async def fake_run_cmd(cmd, **kw):
-        assert cmd[:4] == ["git", "config", "--global", "--get-regexp"]
+        assert cmd[:2] == ["git", "config"]
+        assert cmd[3] == "--get-regexp"
+        scopes.append(cmd[2])
+        if cmd[2] != "--global":
+            return 1, "", ""  # nothing machine-wide
         return 0, (
             "credential.https://github.com.helper !gh auth git-credential\n"
             "credential.helper store\n"
@@ -2811,6 +2818,79 @@ async def test_trusted_helpers_loaded_from_global_config(monkeypatch):
     assert h[f"GIT_CONFIG_VALUE_{base}"] == "!/usr/bin/gh auth git-credential"
     assert f"GIT_CONFIG_KEY_{base + 1}" not in h
     assert h["GIT_CONFIG_COUNT"] == str(base + 1)
+    # Both operator-owned scopes are probed, and repo-LOCAL never is: a checkout
+    # Dev Fleet builds can write .git/config, and a helper from there would run
+    # in the credential-bearing standard tier.
+    assert scopes == ["--system", "--global"]
+
+
+@pytest.mark.asyncio
+async def test_trusted_helpers_loaded_from_system_config(monkeypatch):
+    """A SYSTEM-scope helper is re-pinned — the stock-macOS case.
+
+    Xcode's Command Line Tools ship `credential.helper = osxkeychain` in the
+    system gitconfig and a stock install has nothing in global, so scanning only
+    --global left the neutralizer's reset unrepaired and `git fetch` died with
+    "could not read Username" (no tty to prompt on).
+    """
+    monkeypatch.setattr(mod, "_GIT_TRUSTED_HELPERS", None)
+
+    async def fake_run_cmd(cmd, **kw):
+        if cmd[2] == "--system":
+            return 0, "credential.helper osxkeychain\n", ""
+        return 1, "", ""  # nothing in global, as on a stock macOS host
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    await mod._load_trusted_credential_helpers()
+    h = mod._GIT_TRUSTED_HELPERS or {}
+    base = int(mod._GIT_ENV_NEUTRALIZERS["GIT_CONFIG_COUNT"])
+    assert h[f"GIT_CONFIG_KEY_{base}"] == "credential.helper"
+    assert h[f"GIT_CONFIG_VALUE_{base}"] == "osxkeychain"
+    assert h["GIT_CONFIG_COUNT"] == str(base + 1)
+
+
+@pytest.mark.asyncio
+async def test_trusted_helpers_global_is_pinned_after_system(monkeypatch):
+    """Ordering mirrors git's own precedence: system first, then global.
+
+    credential.helper is multi-valued and the LAST entry wins, so an operator's
+    own global setting must still override a machine-wide default.
+    """
+    monkeypatch.setattr(mod, "_GIT_TRUSTED_HELPERS", None)
+
+    async def fake_run_cmd(cmd, **kw):
+        if cmd[2] == "--system":
+            return 0, "credential.helper osxkeychain\n", ""
+        return 0, "credential.helper manager\n", ""
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    await mod._load_trusted_credential_helpers()
+    h = mod._GIT_TRUSTED_HELPERS or {}
+    base = int(mod._GIT_ENV_NEUTRALIZERS["GIT_CONFIG_COUNT"])
+    assert h[f"GIT_CONFIG_VALUE_{base}"] == "osxkeychain"      # system
+    assert h[f"GIT_CONFIG_VALUE_{base + 1}"] == "manager"      # global wins
+    assert h["GIT_CONFIG_COUNT"] == str(base + 2)
+
+
+@pytest.mark.asyncio
+async def test_trusted_helpers_never_read_repo_local_scope(monkeypatch):
+    """--local is never probed.
+
+    Repo-local config is the attack surface the neutralizer's reset exists for:
+    a checkout Dev Fleet builds can write .git/config, and a helper from there
+    would run in the credential-bearing standard tier.
+    """
+    monkeypatch.setattr(mod, "_GIT_TRUSTED_HELPERS", None)
+    scopes: list = []
+
+    async def fake_run_cmd(cmd, **kw):
+        scopes.append(cmd[2])
+        return 1, "", ""
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    await mod._load_trusted_credential_helpers()
+    assert "--local" not in scopes
+    assert set(scopes) == {"--system", "--global"}
 
 
 @pytest.mark.asyncio
@@ -2849,6 +2929,77 @@ def test_build_env_credentials_only_when_requested(monkeypatch):
     assert plain["GIT_CONFIG_COUNT"] == str(base)
 
 
+async def _sync_step_argvs(monkeypatch) -> list:
+    """Run _sync with every spawn stubbed; return each step's argv, in order."""
+    captured: list = []
+
+    def fake_sandbox(argv, mode, *, env=None, **kw):
+        captured.append(list(argv))
+        return list(argv), dict(env or {}), None
+
+    with patch.object(mod, "_git", new_callable=AsyncMock,
+                      return_value=mod.BASE_BRANCH), \
+         patch.object(mod, "_venv_python", return_value=Path("/fake/.venv/bin/python")), \
+         patch.object(mod, "_trusted_bin", side_effect=lambda n: f"/usr/bin/{n}"), \
+         patch.object(mod, "sandboxed_spawn_argv", fake_sandbox), \
+         patch.object(mod, "_start_run", new_callable=AsyncMock,
+                      return_value="rid-steps"):
+        mod._SYNC_RID = None
+        res = await mod._sync()
+    assert res["ok"] is True
+    return captured
+
+
+def _is_stage_step(argv: list) -> bool:
+    return any("stage_built_dist" in str(part) for part in argv)
+
+
+@pytest.mark.asyncio
+async def test_sync_stages_dist_on_a_stock_checkout(monkeypatch):
+    """The staging step is part of the sync on a stock checkout.
+
+    `npm run build` writes website/dist while the dashboard serves
+    src/kiro_crew/static/dist; without this step Pull+Build reports success and
+    the gateway keeps serving the previous bundle.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    argvs = await _sync_step_argvs(monkeypatch)
+    stage_at = [i for i, a in enumerate(argvs) if _is_stage_step(a)]
+    build_at = [i for i, a in enumerate(argvs)
+                if Path(a[0]).name == "npm" and "build" in a]
+    assert stage_at, f"no staging step in {argvs}"
+    assert build_at and stage_at[0] > build_at[0], \
+        "staging must run AFTER the build that produces the bundle"
+    # THIS backend's interpreter, not the target checkout's: resolving the
+    # helper from the pulled revision would make the step's existence contingent
+    # on that revision already carrying it, so an older target would turn the
+    # whole Pull+Build into an ImportError.
+    assert argvs[stage_at[0]][0] == sys.executable
+
+
+@pytest.mark.asyncio
+async def test_sync_never_stages_dist_on_an_edition_checkout(monkeypatch):
+    """An edition checkout must NOT have its dashboard rebuilt or staged over.
+
+    The sync build runs under _build_env(), whose allowlist drops
+    KIROCREW_EDITION_DIR / KIROCREW_ALLOW_EDITION, so on an edition composition
+    root `npm run build` compiles the STOCK SPA. Staging that would silently
+    replace the edition dashboard with upstream's; leaving the shipped bundle in
+    place is what frontend's own edition guards already do.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: True)
+    argvs = await _sync_step_argvs(monkeypatch)
+    assert not any(_is_stage_step(a) for a in argvs)
+    # The BUILD is skipped too. vite builds with emptyOutDir, so on a source-tree
+    # install -- where static/dist is a symlink to website/dist -- the stock build
+    # alone would replace the served edition dashboard, staging step or not.
+    assert not any(Path(a[0]).name == "npm" for a in argvs)
+    # The backend half of the sync is untouched: an edition still gets the pull
+    # and the editable reinstall.
+    assert any(Path(a[0]).name == "git" and "fetch" in a for a in argvs)
+    assert any("pip" in a for a in argvs)
+
+
 @pytest.mark.asyncio
 async def test_sync_build_steps_never_see_credential_helpers(monkeypatch):
     """Only the network fetch step carries operator credential helpers;
@@ -2881,9 +3032,12 @@ async def test_sync_build_steps_never_see_credential_helpers(monkeypatch):
     build_envs = [
         e for a, e in captured
         if _base(a) == ["git", "merge"] or "pip" in a or Path(a[0]).name == "npm"
+        # The dist-staging step is a build step too and must not be exempt from
+        # the credential-absence invariant just because it runs via `python -c`.
+        or any("stage_built_dist" in str(x) for x in a)
     ]
     assert fetch_envs and all(key in e for e in fetch_envs)
-    assert len(build_envs) == 4  # merge + pip + npm ci + npm build
+    assert len(build_envs) == 5  # merge + pip + npm ci + npm build + stage dist
     assert all(key not in e for e in build_envs)
 
 
@@ -3064,6 +3218,8 @@ async def test_load_helpers_skips_untrusted(monkeypatch):
     """Untrusted helper lines are dropped; trusted ones survive with a
     correct GIT_CONFIG_COUNT."""
     async def fake_run(cmd, **kw):
+        if cmd[2] != "--global":
+            return 1, "", ""
         return 0, (
             "credential.helper !evil-shim\n"
             "credential.https://github.com.helper !gh auth git-credential\n"

--- a/test/test_frontend_edition_build.py
+++ b/test/test_frontend_edition_build.py
@@ -290,3 +290,151 @@ def test_stock_build_still_inherits_the_env(monkeypatch, tmp_path):
     build = [(argv, env) for argv, env in seen if argv[:3] == ["npm", "run", "build"]]
     assert build
     assert build[0][1] is None
+
+
+def test_stage_built_dist_copies_website_dist_into_static_dist(tmp_path):
+    """The staging-only seam Dev Fleet's Pull+Build calls.
+
+    Pull+Build drives each build step as its own audited subprocess, so it cannot
+    use build_frontend_sync's all-in-one path; before this seam existed it ran
+    `npm run build` and never staged, leaving the gateway serving the previous
+    bundle while reporting success.
+    """
+    built = tmp_path / "website" / "dist"
+    built.mkdir(parents=True)
+    (built / "index.html").write_text("<html>fresh</html>")
+    frontend.stage_built_dist(tmp_path, log=lambda _m: None)
+    staged = tmp_path / "src" / "kiro_crew" / "static" / "dist" / "index.html"
+    assert staged.read_text() == "<html>fresh</html>"
+
+
+def test_stage_built_dist_replaces_a_stale_symlink(tmp_path):
+    """A source-tree gateway leaves static/dist as a SYMLINK to website/dist.
+
+    Staging must replace it with a real snapshot rather than fail or write
+    through it, so a packaged layout gets a self-contained bundle.
+    """
+    built = tmp_path / "website" / "dist"
+    built.mkdir(parents=True)
+    (built / "index.html").write_text("<html>fresh</html>")
+    static_parent = tmp_path / "src" / "kiro_crew" / "static"
+    static_parent.mkdir(parents=True)
+    (static_parent / "dist").symlink_to(built)
+    frontend.stage_built_dist(tmp_path, log=lambda _m: None)
+    staged = static_parent / "dist"
+    assert not staged.is_symlink(), "a stale symlink must be replaced by a copy"
+    assert (staged / "index.html").read_text() == "<html>fresh</html>"
+
+
+def test_stage_built_dist_fails_loudly_without_a_build(tmp_path):
+    """No website/dist -> raise, and leave the served bundle alone.
+
+    Two separate requirements. Deleting a working static/dist because the build
+    step failed would take the dashboard down harder than the failed build
+    already did -- so the previous bundle survives. But this runs as a sync step
+    right after `npm run build` reported success, so a MISSING build output means
+    something is genuinely wrong and must not be reported as a successful sync.
+    """
+    static_dist = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    static_dist.mkdir(parents=True)
+    (static_dist / "index.html").write_text("<html>previous</html>")
+    messages: list = []
+    with pytest.raises(RuntimeError, match="staging failed"):
+        frontend.stage_built_dist(tmp_path, log=messages.append)
+    assert (static_dist / "index.html").read_text() == "<html>previous</html>"
+    assert any("not found" in m for m in messages)
+
+
+def test_stage_built_dist_raises_when_staging_did_not_happen(tmp_path, monkeypatch):
+    """A staging failure must FAIL the caller, not report success.
+
+    Dev Fleet's Pull+Build runs this as a sync step whose exit status decides
+    whether the sync reports success. A surviving older bundle is deliberately
+    NOT treated as evidence of success: _stage_dist now preserves it on failure,
+    so only its returned flag can distinguish "staged" from "kept the old one".
+    """
+    built = tmp_path / "website" / "dist"
+    built.mkdir(parents=True)
+    (built / "index.html").write_text("<html>fresh</html>")
+    served = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    served.mkdir(parents=True)
+    (served / "index.html").write_text("<html>previous</html>")
+    monkeypatch.setattr(frontend, "_stage_dist", lambda *_a, **_k: False)
+    with pytest.raises(RuntimeError, match="staging failed"):
+        frontend.stage_built_dist(tmp_path, log=lambda _m: None)
+
+
+def test_stage_dist_keeps_the_served_bundle_when_the_copy_fails(tmp_path, monkeypatch):
+    """A failed rebuild must not take the working dashboard down with it.
+
+    The original order removed the destination and THEN copied, so any copy error
+    left static/dist missing entirely. Staging into a temp sibling and swapping
+    means a failure costs the update, not the UI.
+    """
+    built = tmp_path / "website" / "dist"
+    built.mkdir(parents=True)
+    (built / "index.html").write_text("<html>fresh</html>")
+    served = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    served.mkdir(parents=True)
+    (served / "index.html").write_text("<html>previous</html>")
+
+    def boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(frontend.shutil, "copytree", boom)
+    assert frontend._stage_dist(built, tmp_path, log=lambda _m: None) is False
+    # The previously served bundle is untouched.
+    assert (served / "index.html").read_text() == "<html>previous</html>"
+    # No staging leftovers.
+    assert not list(served.parent.glob(".dist.staging.*"))
+
+
+def test_stage_dist_replaces_the_served_bundle_on_success(tmp_path):
+    """The happy path still swaps the new bundle in and reports True."""
+    built = tmp_path / "website" / "dist"
+    built.mkdir(parents=True)
+    (built / "index.html").write_text("<html>fresh</html>")
+    served = tmp_path / "src" / "kiro_crew" / "static" / "dist"
+    served.mkdir(parents=True)
+    (served / "index.html").write_text("<html>previous</html>")
+    (served / "stale-asset.js").write_text("old")
+
+    assert frontend._stage_dist(built, tmp_path, log=lambda _m: None) is True
+    assert (served / "index.html").read_text() == "<html>fresh</html>"
+    # A replace, not a merge -- stale files from the old bundle are gone.
+    assert not (served / "stale-asset.js").exists()
+    assert not list(served.parent.glob(".dist.staging.*"))
+
+
+def test_edition_configured_tracks_the_env_var(monkeypatch):
+    """The predicate callers use to decide whether staging is safe at all."""
+    monkeypatch.delenv("KIROCREW_EDITION_DIR", raising=False)
+    assert frontend.edition_configured() is False
+    monkeypatch.setenv("KIROCREW_EDITION_DIR", "/opt/edition")
+    assert frontend.edition_configured() is True
+
+
+def test_edition_dir_survives_the_app_backend_env_allowlist(monkeypatch):
+    """An app backend must be ABLE to tell an edition install from a stock one.
+
+    The backend runs as a separate process started with
+    ``apps.registry.minimal_env()``, which passes only a fixed safe-key set --
+    so an edition guard inside a backend reads "stock" on every install unless
+    the var is propagated explicitly. Dev Fleet's dist-staging guard depends on
+    this: without it the guard can never fire and a stock SPA would be staged
+    over an edition dashboard.
+    """
+    from kiro_crew.apps.registry import minimal_env
+
+    monkeypatch.setenv("KIROCREW_EDITION_DIR", "/opt/edition")
+    # The generic allowlist does NOT carry it -- that is the trap this guards.
+    assert "KIROCREW_EDITION_DIR" not in minimal_env()
+
+    # apps/backend.py must therefore add it to the explicit platform extras.
+    src = Path(frontend.__file__).parent / "apps" / "backend.py"
+    body = src.read_text()
+    assert '_platform_extra["KIROCREW_EDITION_DIR"]' in body, \
+        "app backends can no longer detect an edition install"
+    # The opt-in must NOT be propagated: a backend may detect an edition but
+    # never manufacture consent to compile edition sources into a package.
+    assert '_platform_extra["KIROCREW_ALLOW_EDITION"]' not in body


### PR DESCRIPTION
Two independent root causes made Dev Fleet's Pull+Build unusable on a stock
macOS host until the operator patched their own machine. Both are fixed here so
the workarounds are no longer needed.

## 1. The credential helper was killed and never restored

`_GIT_ENV_NEUTRALIZERS` resets `credential.helper` for every git call, so a
repo-injected helper cannot run in the credential-bearing standard tier. Its own
comment says the operator's helper is re-pinned afterwards -- but
`_load_trusted_credential_helpers` only read `git config --global`.

Stock macOS puts the operator's helper in the SYSTEM gitconfig: Xcode's Command
Line Tools ship `credential.helper = osxkeychain` in
`/Library/Developer/CommandLineTools/usr/share/git-core/gitconfig`, and a stock
install has nothing in global. So the reset was never repaired and step 1 of the
sync died with `could not read Username for 'https://github.com'` -- no tty to
prompt on. Linux rarely hits it because helpers there are usually in global, or
the remote is ssh and needs no helper at all.

Now both operator-owned scopes are scanned, system first then global, mirroring
git's own precedence: `credential.helper` is multi-valued and the last entry
wins, so an operator's global setting still overrides a machine-wide default.

Repo-LOCAL scope stays excluded, deliberately -- that is the attack surface the
reset exists for, since a checkout Dev Fleet builds can write `.git/config`.

## 2. The frontend rebuild never reached the served path

`npm run build` writes `website/dist`; the dashboard serves
`src/kiro_crew/static/dist`. `_sync` ran the build and stopped there, so
Pull+Build reported success while the gateway kept serving the previous bundle.

On a source-tree gateway start the gap is invisible because
`frontend.ensure_dev_dist_symlink()` has already linked the two paths. A packaged
install has no such link, so the rebuild silently never took effect -- and
`_build_pending()` then had nothing new to report either.

`updates.py` already routes through `frontend.build_frontend_async`, whose
docstring says it exists so the build/stage logic is not duplicated across
paths; `_sync` is a fourth path that duplicated it and dropped the staging half.
Since `_sync` drives each step as its own audited subprocess it cannot call the
all-in-one helper, so this adds the staging-only public seam
`frontend.stage_built_dist()` and a sync step that invokes it through the TARGET
checkout's interpreter -- so the staging logic comes from the revision just
pulled and installed, not from whatever version the backend happens to be.

Two constraints the staging step has to respect:

- **The whole frontend half must be skipped on an edition checkout.** The build
  runs under `_build_env()`, whose allowlist (`_SAFE_ENV_KEYS`) drops
  `KIROCREW_EDITION_DIR` / `KIROCREW_ALLOW_EDITION`, so on an edition
  composition root `npm run build` can only compile the STOCK SPA -- and vite
  builds with `emptyOutDir`, so it overwrites `website/dist`. On a source-tree
  install `ensure_dev_dist_symlink()` has pointed `static/dist` AT
  `website/dist`, so the build alone replaces the served edition dashboard with
  upstream's, with or without a staging step. `npm ci`, `npm build` and staging
  are therefore all skipped for an edition, which costs it nothing -- the only
  artifact this path could produce for it is a stock SPA it must never serve --
  and mirrors what `frontend`'s existing `edition_sources_missing()` guard
  already does. The backend half (pull, editable reinstall) is untouched.

  For that guard to be able to fire at all, the app backend has to KNOW it is an
  edition install. It runs as a separate process started with
  `apps.registry.minimal_env()`, which passes a fixed safe-key set and strips
  `KIROCREW_EDITION_DIR` -- so `apps/backend.py` now propagates that one var
  explicitly, exactly as it already propagates `KIROCREW_PROJECT_DIR`. The
  opt-in `KIROCREW_ALLOW_EDITION` is deliberately NOT propagated: a backend may
  detect an edition but must never be able to manufacture consent to compile
  edition sources into a package.

- **It must not depend on the pulled revision.** Staging runs with THIS
  backend's interpreter, not the target checkout's. The operation is a pure file
  copy between two paths inside the target, so the logic is
  revision-independent, while resolving it from the target would make the step's
  very existence contingent on that revision already carrying
  `stage_built_dist` -- turning an older target into an ImportError that fails
  the whole Pull+Build.
- **A failed staging must cost the update, not the UI -- and must still fail the
  sync.** `_stage_dist` removed the destination and THEN copied, so any copy
  error left `static/dist` missing entirely: a failed rebuild took the working
  dashboard down with it. It now copies into a temporary sibling and replaces
  `static/dist` only once the copy is complete, so the unavailable window is a
  rename rather than a whole `copytree`. That preservation makes "something is
  present at the destination" useless as a success signal, so `_stage_dist` now
  returns a bool and `stage_built_dist` raises on `False` -- its other callers
  keep treating staging as best-effort and ignore the result unchanged.

## Tests

- `stage_built_dist`: stages a fresh build; REPLACES a stale symlink with a real
  copy (the shape a source-tree gateway leaves behind); is a no-op that warns
  when there is no build, rather than deleting a working bundle because the
  build step failed.
- Credential helpers: a system-scope helper is re-pinned (the stock-macOS case);
  global is pinned after system so it still wins; `--local` is never probed.
- Two existing helper tests updated to the two-scope contract -- they asserted a
  single `--global` invocation.
- The "no build step receives credentials" invariant now covers the new staging
  step, which would otherwise have escaped it by running via `python -c`.

## Not in this PR

`_trusted_bin`'s trust check is the third root cause (it rejects the only
legitimate npm on an Apple Silicon Homebrew host, which is why that workaround
was a `chmod`). Fixing it means changing what the check treats as a security
boundary, so it goes in its own PR rather than riding along with two mechanical
fixes.

Aligning `_sync`'s `pip install -e .` with `provision.ensure_venv`'s
`--group dev` is also left out: it needs the same pip-version fallback
`provision` carries, and that is a separate concern from these two.
