### PR TITLE
fix(webpreview): canonicalize IPv6 loopback preview host to IPv4

### DIFF
--- a/website/src/components/WebPreviewPanel.tsx
+++ b/website/src/components/WebPreviewPanel.tsx
@@ -199,30 +199,50 @@ function isLoopbackHost(h: string): boolean {
 }
 
 /**
- * Isolate a loopback preview URL onto a hostname DISTINCT from the dashboard's.
+ * Normalize a loopback preview URL's host so it is both reachable under the
+ * dashboard CSP and cookie-isolated from the dashboard. Two rewrites, in order:
  *
- * Cookies are scoped by host but NOT by port, so an iframe pointed at
- * `http://localhost:5173` while the dashboard is served from the same host
- * (`localhost`, `127.0.0.1`, or a `*.localhost` alias like `kirocrew.localhost`)
- * would send the dashboard's host-scoped auth cookie to the previewed dev server
- * (which could read/replay it). When the preview host matches the dashboard host
- * and both are loopback, swap it to a guaranteed-distinct loopback host
- * (`127.0.0.1`, or `localhost` when the dashboard already IS `127.0.0.1`) — a
- * different host string, so no dashboard cookie is ever sent to the framed
- * server. Non-loopback hosts and already-distinct hosts are returned unchanged.
+ * 1. **IPv6 loopback → IPv4.** The dashboard CSP admits loopback preview origins
+ *    (see `server.py` `_LOOPBACK_FRAME_SRC`), but a bracketed IPv6 literal with a
+ *    wildcard port — `http://[::1]:*` — is INVALID CSP grammar, so Chromium drops
+ *    the whole source and can never admit it. The panel's no-cors liveness probe
+ *    to `[::1]` is therefore refused and a perfectly healthy dev server shows as
+ *    "Preview server not reachable" (while it opens fine in the OS browser, whose
+ *    top-level navigation is not bound by the dashboard CSP). `127.0.0.1` is the
+ *    same loopback and IS admitted, so canonicalize `[::1]`/`::1` to it. This runs
+ *    independent of the dashboard host — even when it is unknown — because the CSP
+ *    gap has nothing to do with cookie isolation.
+ *
+ * 2. **Cookie isolation.** Cookies are scoped by host but NOT by port, so an
+ *    iframe pointed at `http://localhost:5173` while the dashboard is served from
+ *    the same host (`localhost`, `127.0.0.1`, or a `*.localhost` alias like
+ *    `kirocrew.localhost`) would send the dashboard's host-scoped auth cookie to
+ *    the previewed dev server (which could read/replay it). When the preview host
+ *    matches the dashboard host and both are loopback, swap it to a
+ *    guaranteed-distinct loopback host (`127.0.0.1`, or `localhost` when the
+ *    dashboard already IS `127.0.0.1`) — a different host string, so no dashboard
+ *    cookie is ever sent to the framed server.
+ *
+ * Non-loopback hosts and already-distinct hosts skip the isolation swap.
  * `dashboardHost` defaults to the current document host (overridable for tests).
  */
 export function isolatePreviewHost(url: string, dashboardHost?: string): string {
+  let u: URL
+  try { u = new URL(url) } catch { return url }
+  // (1) IPv6 loopback canonicalization — unconditional (the CSP gap is
+  // orthogonal to the dashboard host, so it must fire even when host is unknown).
+  // A parsed URL exposes an IPv6 host in bracketed form (`[::1]`); guard the bare
+  // form too, defensively.
+  if (u.hostname === '[::1]' || u.hostname === '::1') u.hostname = '127.0.0.1'
+  // (2) Cookie isolation — needs to know the dashboard host to compare against.
   let host = dashboardHost
   if (host == null) {
     try { host = typeof window !== 'undefined' ? window.location.hostname : '' } catch { host = '' }
   }
-  if (!host) return url
-  let u: URL
-  try { u = new URL(url) } catch { return url }
+  if (!host) return u.toString()
   const h = u.hostname
-  if (!isLoopbackHost(h)) return url        // real host / tunnel — leave it
-  if (h !== host) return url                // already a distinct host → isolated
+  if (!isLoopbackHost(h)) return u.toString()  // real host / tunnel — leave it
+  if (h !== host) return u.toString()          // already a distinct host → isolated
   u.hostname = h === '127.0.0.1' ? 'localhost' : '127.0.0.1'
   return u.toString()
 }

--- a/website/src/test/WebPreviewPanel.test.tsx
+++ b/website/src/test/WebPreviewPanel.test.tsx
@@ -60,6 +60,20 @@ describe('isolatePreviewHost', () => {
   it('is a no-op when the dashboard host is unknown', () => {
     expect(isolatePreviewHost('http://localhost:5173/', '')).toBe('http://localhost:5173/')
   })
+  it('canonicalizes an IPv6 loopback ([::1]) preview host to 127.0.0.1 (CSP cannot admit [::1]:*)', () => {
+    // The dashboard CSP structurally cannot admit `http://[::1]:*`, so the
+    // liveness probe to [::1] is refused and a healthy server shows unreachable.
+    expect(isolatePreviewHost('http://[::1]:8765/', 'localhost')).toBe('http://127.0.0.1:8765/')
+    expect(isolatePreviewHost('http://[::1]:8765/app?x=1#h', 'localhost'))
+      .toBe('http://127.0.0.1:8765/app?x=1#h')
+  })
+  it('canonicalizes [::1] even when the dashboard host is unknown (CSP gap is host-independent)', () => {
+    expect(isolatePreviewHost('http://[::1]:8765/', '')).toBe('http://127.0.0.1:8765/')
+  })
+  it('canonicalizes [::1] then still cookie-isolates against a 127.0.0.1 dashboard', () => {
+    // [::1] → 127.0.0.1, which now equals the dashboard host → isolate to localhost.
+    expect(isolatePreviewHost('http://[::1]:8765/', '127.0.0.1')).toBe('http://localhost:8765/')
+  })
 })
 
 


### PR DESCRIPTION
## Problem
The Web Preview panel (right-side **Browser** tab) shows **"Preview server not reachable"** for a healthy local dev server addressed via IPv6 loopback (`http://[::1]:PORT`) — even though the exact same URL opens fine in the OS browser.

## Why it matters
A user previewing a dev server that is addressed as IPv6 loopback sees a broken panel (the iframe is unmounted ~10s after it loads) with no hint of the real cause. The failure is silent and misattributed to a dead server, when the server is actually up and serving 200.

## Fix (symptoms → root cause → change)
- **Symptom:** panel says unreachable; the OS browser loads the same URL fine.
- **Root cause:** the panel can't tell from a cross-origin iframe that its server died, so it polls the URL every 5s with a `no-cors fetch` liveness probe. That probe is governed by the dashboard's CSP `connect-src`. The CSP admits loopback preview origins, but a bracketed IPv6 literal with a wildcard port — `http://[::1]:*` — is **invalid CSP grammar**, so Chromium drops the whole source and can never admit it. The probe (and the iframe `frame-src`) to `[::1]` is refused; two consecutive probe failures flip the panel to "stopped responding" and unmount the iframe. A top-level OS-browser navigation is **not** bound by the dashboard CSP, which is exactly why it works there but not in the panel.
- **Change:** canonicalize an IPv6 loopback host (`[::1]`/`::1`) to `127.0.0.1` in `isolatePreviewHost`, **before** the cookie-isolation step and **independent of the dashboard host** (the CSP gap is orthogonal to cookie isolation, so it must fire even when the host is unknown). `127.0.0.1` is the same loopback and **is** admitted by the CSP. `isolatePreviewHost` is the single chokepoint every iframe-path URL flows through (`commit`, the chat feed, and mount-restore), so a legacy-persisted `[::1]` value is fixed on restore too — one edit, no second call site. Cookie isolation is preserved: the rewrite runs first, and a canonicalized `127.0.0.1` is still swapped to `localhost` when it equals a `127.0.0.1` dashboard host.

## Tests
`website/src/test/WebPreviewPanel.test.tsx` — 3 new `isolatePreviewHost` cases:
- `[::1]` → `127.0.0.1`, with path/query/fragment preserved;
- canonicalization when the dashboard host is unknown (host-independent);
- canonicalization followed by cookie-isolation against a `127.0.0.1` dashboard (→ `localhost`).

45/45 `WebPreviewPanel` tests pass.

## Manual verification
Reproduced the mechanism in headless Chromium against a live `127.0.0.1:8765` static server: under the current dashboard CSP a `no-cors` probe to `http://[::1]:8765` throws with an explicit `connect-src` violation (a healthy server reported unreachable), while `http://127.0.0.1:8765` succeeds — so the canonicalization resolves it. Frontend build (`tsc` + vite) and eslint are clean.

## Screenshots
N/A — no visual/layout change; the panel renders identically. This is host-canonicalization logic affecting reachability, verified by the unit tests and the headless-Chromium probe reproduction above.

### Known limitation (deliberate)
A dev server bound **exclusively** to IPv6 (`::1` only, never `127.0.0.1`) cannot be previewed in-panel either way: the CSP cannot express `[::1]` for `frame-src`/`connect-src`, so before this change the iframe **and** probe were already refused. After this change the "Open in browser" link is also rewritten to `127.0.0.1`, so it no longer reaches such a server — the one behavior that regresses, only for this rare exclusively-IPv6-bound case. Removing the rewrite (as a reviewer suggested) would reinstate the original bug for the common IPv6-loopback case and is therefore not the right trade.
