### PR TITLE
fix(ci): restore the readable YYYYMMDD nightly desktop stamp

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,22 +46,18 @@ jobs:
           # PEP 440 integer ordering stays monotonic across days. Seconds close the
           # same-minute double-dispatch window; publish-cli.yml additionally enforces
           # never-republish with an S3 conditional write (If-None-Match).
-          # ONE clock read, everything sliced from it. The format appends
-          # %y%j (2-digit year + zero-padded day-of-year) to the full
-          # timestamp so BOTH the wheel's YYYYMMDDHHMMSS and the desktop's
-          # compact YYDDD can come from a single `date` — three separate
+          # ONE clock read, everything sliced from it. Three separate
           # `date -u` calls can straddle UTC midnight, pairing an old-day date
           # with a new-day time (version goes backward -> the feed offers
           # clients a downgrade) and can also make the desktop and wheel stamps
           # disagree for the SAME run.
-          STAMP=$(date -u +%Y%m%d%H%M%S%y%j)
-          STAMP_DATE="${STAMP:0:8}"       # YYYYMMDD (wheel)
+          STAMP=$(date -u +%Y%m%d%H%M%S)
+          STAMP_DATE="${STAMP:0:8}"       # YYYYMMDD (desktop)
           STAMP_TIME="${STAMP:8:6}"       # HHMMSS   (both)
           STAMP_FULL="${STAMP:0:14}"      # YYYYMMDDHHMMSS (wheel .dev<N>)
-          STAMP_YYDOY="${STAMP:14:5}"     # YYDDD    (desktop, compact date)
           BASE=$(grep -m1 '__version__' src/kiro_crew/__init__.py | sed -E 's/.*= *"([^"]+)".*/\1/')
           # Desktop/Squirrel needs semver; the pip wheel needs PEP 440. Emit both:
-          #   nightly_version (semver):  <base>-nightly.<YYDDD>t<HHMMSS> -> Electron app + S3 build path
+          #   nightly_version (semver):  <base>-nightly.<YYYYMMDD>t<HHMMSS> -> Electron app + S3 build path
           #   wheel_version   (PEP 440): <base>.dev<YYYYMMDDHHMMSS>      -> pip wheel, unique per RUN
           # The desktop stamp carries the same seconds precision as the wheel:
           # a date-only stamp meant two nightlies on one UTC date overwrote the
@@ -72,48 +68,53 @@ jobs:
           # every nightly wheel down to the base version (all became 0.1.0). ".dev<date>"
           # is valid PEP 440 and keeps nightly wheels uniquely versioned.
           #
-          # DATE AND TIME ARE ONE ALPHANUMERIC IDENTIFIER SEPARATED BY "t", using
-          # the COMPACT date <YYDDD> (2-digit year + zero-padded day-of-year),
+          # DATE AND TIME ARE ONE ALPHANUMERIC IDENTIFIER SEPARATED BY "t",
           # never a bare number and never two dot-separated numeric identifiers.
-          # Three independent constraints force this exact shape:
+          # ONE live constraint forces this shape, and two retired ones explain
+          # why it is not just a bare timestamp:
           #
-          # 1. NuGet / Squirrel 20-char "special version" cap. The Squirrel
-          #    target bundled with electron-builder-squirrel-windows 26.x rejects
-          #    a prerelease part over 20 chars ("The special version part cannot
-          #    exceed 20 characters."), which killed every Windows nightly on the
-          #    old "nightly.<YYYYMMDD>t<HHMMSS>" (23 chars). "nightly." (8) + a
-          #    mandatory letter separator leaves room for 11 stamp digits, so the
-          #    date is compacted to YYDDD: "nightly.<YYDDD>t<HHMMSS>" is exactly
-          #    20 chars and keeps full seconds precision.
-          # 2. Squirrel.Windows Int32 overflow. Squirrel derives each release
-          #    entry's version from the nupkg FILENAME
-          #    (ReleaseEntry.Version -> Filename.ToSemanticVersion()) and sorts
-          #    entries in WriteReleaseFile; that comparison Int32-parses digit
-          #    runs, so a run above 2147483647 makes `Update.com --releasify`
-          #    die with System.OverflowException. Proven: `-nightly.20260727152449`
-          #    (2.0e13) FAILS, `-nightly.20260727t184500` PASSES. The compact
-          #    runs here (YYDDD <= 99366, HHMMSS <= 235959) are far under Int32
-          #    and, unlike an epoch, never cross it (no 2038 cliff). Dot-splitting
-          #    does NOT help: electron-builder concatenates the identifiers into
-          #    the nupkg filename, so a LETTER between the digit runs is required.
-          # 3. SemVer forbids leading zeros in a purely NUMERIC prerelease
-          #    identifier. The 06:00 cron yields HHMMSS=060000, so a bare
-          #    `.${STAMP_TIME}` identifier would be invalid and electron-builder
-          #    would reject it. Inside an alphanumeric identifier (the "t" makes
-          #    it alphanumeric) leading zeros are legal.
+          # 1. LIVE -- SemVer forbids leading zeros in a purely NUMERIC
+          #    prerelease identifier. The 06:00 cron yields HHMMSS=060000, so a
+          #    bare `.${STAMP_TIME}` identifier would be invalid and
+          #    electron-builder would reject it. Inside an alphanumeric
+          #    identifier (the "t" makes it alphanumeric) leading zeros are legal.
+          # 2. RETIRED with Squirrel.Windows -- Int32 overflow. Squirrel derived
+          #    each release entry's version from the nupkg FILENAME
+          #    (ReleaseEntry.Version -> Filename.ToSemanticVersion()) and sorted
+          #    entries in WriteReleaseFile; that comparison Int32-parsed digit
+          #    runs, so a run above 2147483647 made `Update.com --releasify` die
+          #    with System.OverflowException. Proven: `-nightly.20260727152449`
+          #    (2.0e13) FAILED, `-nightly.20260727t184500` PASSED. Dot-splitting
+          #    did NOT help: electron-builder concatenates the identifiers into
+          #    the package filename, so a LETTER between the digit runs was
+          #    required. Both runs here (YYYYMMDD ~2.0e7, HHMMSS <= 235959) stay
+          #    far under Int32 anyway.
+          # 3. RETIRED with Squirrel.Windows -- NuGet's 20-char "special version"
+          #    cap. It rejected a prerelease part over 20 chars ("The special
+          #    version part cannot exceed 20 characters."), which killed every
+          #    Windows nightly on this 23-char shape and forced a temporary
+          #    compact date (YYDDD, exactly 20). The Windows target is NSIS as of
+          #    #1428 and electron-updater's win32 path has no NuGet in it, so the
+          #    cap is gone and the readable YYYYMMDD is back.
+          #
+          # 2 and 3 are kept written down because the shape still satisfies 2
+          # (both digit runs stay far under Int32) and DELIBERATELY violates 3
+          # (23 chars against a 20-char cap) -- exceeding that cap is the point
+          # of the readable date. A future NuGet-based Windows target (msi, appx)
+          # would re-impose the cap and require re-compacting the date; this
+          # comment is the only place that records why, and what it would cost.
           #
           # Ordering still works: the identifier is fixed-width, and semver
           # compares alphanumeric identifiers lexically -- which for a
-          # zero-padded YYDDDtHHMMSS is chronological (YYDDD sorts as the date
-          # does within this century).
+          # zero-padded YYYYMMDDtHHMMSS is chronological.
           #
           # The "-nightly." prefix is load-bearing and preserved: auto-update.js
           # channelForVersion, instance-guard identityFamily, and
           # packaging/build-desktop.sh's *-nightly.* glob all match on it.
           # test/test_nightly_version_contract.py pins every property above.
-          echo "version=${BASE}-nightly.${STAMP_YYDOY}t${STAMP_TIME}" >> "$GITHUB_OUTPUT"
+          echo "version=${BASE}-nightly.${STAMP_DATE}t${STAMP_TIME}" >> "$GITHUB_OUTPUT"
           echo "wheel_version=${BASE}.dev${STAMP_FULL}" >> "$GITHUB_OUTPUT"
-          echo "Nightly (semver): ${BASE}-nightly.${STAMP_YYDOY}t${STAMP_TIME}"
+          echo "Nightly (semver): ${BASE}-nightly.${STAMP_DATE}t${STAMP_TIME}"
           echo "Wheel (PEP 440):  ${BASE}.dev${STAMP_FULL}"
 
   dependency-vulnerability-gate:

--- a/test/test_nightly_version_contract.py
+++ b/test/test_nightly_version_contract.py
@@ -45,15 +45,9 @@ INT32_MAX = 2_147_483_647
 
 # Worst-case stamp components. The TIME is deliberately the 06:00 cron's value:
 # HHMMSS=060000 is the case that makes a bare numeric identifier invalid SemVer
-# (leading zero), which electron-builder rejects outright. The desktop stamp
-# uses the COMPACT date (YYDDD, 2-digit year + zero-padded day-of-year); its
-# worst case is the widest value (year 99, day 366).
+# (leading zero), which electron-builder rejects outright.
 _WORST_CASE_DATE = "29991231"
 _WORST_CASE_TIME = "060000"
-_WORST_CASE_YYDOY = "99366"
-# NuGet / Squirrel reject a prerelease ("special version") part over this many
-# characters, which is what broke the old 23-char "nightly.<YYYYMMDD>t<HHMMSS>".
-NUGET_SPECIAL_VERSION_MAX = 20
 
 
 def _workflow_text() -> str:
@@ -71,36 +65,13 @@ def _rendered_nightly_version() -> str:
     assert match, "nightly.yml no longer emits a version= output in the expected shape"
     suffix = match.group(1)
     rendered = (
-        suffix.replace("${STAMP_YYDOY}", _WORST_CASE_YYDOY)
-        .replace("${STAMP_DATE}", _WORST_CASE_DATE)
+        suffix.replace("${STAMP_DATE}", _WORST_CASE_DATE)
         .replace("${STAMP_TIME}", _WORST_CASE_TIME)
         .replace("${STAMP_FULL}", _WORST_CASE_DATE + _WORST_CASE_TIME)
         .replace("${STAMP}", _WORST_CASE_DATE + _WORST_CASE_TIME)
     )
     assert "$" not in rendered, f"unresolved shell variable in rendered stamp: {rendered!r}"
     return "0.1.0" + rendered
-
-
-def test_prerelease_fits_nuget_special_version_cap() -> None:
-    """NuGet rejects a prerelease part longer than 20 characters.
-
-    HISTORICAL, still enforced. The Squirrel.Windows target bundled with
-    electron-builder-squirrel-windows 26.x failed releasify with "The special
-    version part cannot exceed 20 characters": the old
-    "nightly.<YYYYMMDD>t<HHMMSS>" was 23 chars and broke every Windows nightly,
-    and the compact "nightly.<YYDDD>t<HHMMSS>" is exactly 20. The target is now
-    NSIS, which imposes no such cap, so the bound is no longer live -- but the
-    assertion is kept as a regression guard: lengthening the stamp buys nothing,
-    and a future NuGet-based target (msi, appx) would re-impose it silently."""
-    version = _rendered_nightly_version()
-    _, _, prerelease = version.partition("-")
-    assert prerelease, f"nightly version carries no prerelease part: {version!r}"
-    assert len(prerelease) <= NUGET_SPECIAL_VERSION_MAX, (
-        f"prerelease part {prerelease!r} is {len(prerelease)} chars, over the "
-        f"NuGet/Squirrel {NUGET_SPECIAL_VERSION_MAX}-char cap; `Update.com "
-        "--releasify` fails with 'The special version part cannot exceed 20 "
-        "characters.' and the Windows desktop leg dies."
-    )
 
 
 def test_digit_runs_fit_int32_after_identifier_concatenation() -> None:
@@ -158,15 +129,30 @@ def test_nightly_channel_prefix_is_preserved() -> None:
 
 
 def test_stamp_keeps_seconds_precision() -> None:
-    """Two nightlies in the same minute must not collide on immutable keys.
+    """Same-minute re-dispatch must not collide, and the date stays 8 digits.
 
-    The compact desktop stamp is <date>t<HHMMSS>: a unique date identifier plus
-    six digits of time. What matters is that the time component carries full
-    SECONDS (HHMMSS, 6 digits), so a same-minute re-dispatch differs; the date
-    half no longer needs to be the full 8-digit YYYYMMDD (it is YYDDD, 5 digits)
-    to keep that guarantee."""
+    Two separate properties, deliberately not conflated:
+
+    * UNIQUENESS is carried by the SECONDS component alone. sign-and-notarize.yml
+      keys pre-signed/signed/notarized/desktop objects on ${VERSION} with an
+      If-None-Match never-republish check, so what stops a same-minute
+      re-dispatch reusing a key is HHMMSS being full seconds -- and that held
+      for the 11-digit YYDDD form too.
+    * The 14-digit total pins the DATE WIDTH: the desktop stamp keeps the full
+      8-digit YYYYMMDD so it stays legible and matches the digits the wheel's
+      .dev<YYYYMMDDHHMMSS> carries for the same run. That is a shape pin, not a
+      uniqueness guard -- a future target that re-imposed a length cap could
+      shorten the date without breaking uniqueness."""
     version = _rendered_nightly_version()
     _, _, prerelease = version.partition("-")
+    digits = "".join(re.findall(r"\d", prerelease))
+    assert len(digits) >= 14, (
+        f"{version!r} carries {len(digits)} stamp digits; the desktop stamp is "
+        "pinned to the full 8-digit YYYYMMDD + HHMMSS (14) so it stays legible "
+        "and shares its digits with the wheel's .dev<N>. Shortening the DATE "
+        "does not break uniqueness (the seconds assertion below owns that), so "
+        "if a Windows target re-imposes a length cap, change this pin knowingly"
+    )
     # The time is the last digit run after the "t" separator.
     time_part = prerelease.rsplit("t", 1)[-1]
     time_digits = "".join(re.findall(r"\d", time_part))
@@ -184,16 +170,9 @@ def test_stamp_orders_chronologically() -> None:
     assert match
     suffix = match.group(1)
 
-    from datetime import datetime
-
     def render(date: str, time: str) -> str:
-        # Derive the compact YYDDD the workflow computes with `date -u +%y%j`,
-        # so the ordering assertion tracks the real stamp shape.
-        dt = datetime.strptime(date, "%Y%m%d")
-        yydoy = dt.strftime("%y%j")
         return (
-            suffix.replace("${STAMP_YYDOY}", yydoy)
-            .replace("${STAMP_DATE}", date)
+            suffix.replace("${STAMP_DATE}", date)
             .replace("${STAMP_TIME}", time)
             .replace("${STAMP_FULL}", date + time)
             .replace("${STAMP}", date + time)


### PR DESCRIPTION
## Problem

The nightly desktop version stamp is unreadable. #1409 compressed its date to
`YYDDD` (2-digit year + zero-padded day-of-year):

```
0.1.2-nightly.26216t075917
```

`26216` is day-of-year 216, not a truncated date. Reading it against a build log,
an S3 key, or a feed entry means converting by hand — and the desktop and wheel
stamps for the SAME run no longer share a legible date, because the wheel kept
`.dev<YYYYMMDDHHMMSS>`.

## Why it matters

That compression bought exactly one thing: fitting NuGet's 20-character
prerelease cap, at `20/20` with zero headroom. The cap was **Squirrel.Windows's**,
via the NuGet its releasify step used. #1428 switched the Windows target to NSIS,
and electron-updater's win32 path constructs `NsisUpdater` unconditionally with no
NuGet anywhere in it — so the constraint that forced the compression is gone, and
the only thing still paying for it is whoever has to read a version string.

## Fix (symptoms → root cause → change)

The unreadable stamp is a symptom of a constraint that no longer exists. So this
restores the readable form rather than working around the compact one:

```
0.1.2-nightly.20260804t075917   <- 23 chars, unbounded under NSIS
```

- `.github/workflows/nightly.yml` — `${STAMP_YYDOY}` → `${STAMP_DATE}` in the
  `version=` output. `STAMP_DATE` was already computed and had gone completely
  unused (one occurrence in the base workflow: its own definition, mislabelled
  `# YYYYMMDD (wheel)` when the wheel actually uses `STAMP_FULL`).
- Drop the `%y%j` suffix from the single `date -u` read and delete `STAMP_YYDOY`.
  The one-clock-read invariant is unchanged and still pinned by
  `test_stamp_components_come_from_a_single_clock_read` — three separate `date`
  calls can straddle UTC midnight and pair an old-day date with a new-day time,
  walking the version backwards and offering clients a downgrade.
- **Rewrite the constraint comment, which was overstating things.** It claimed
  "three independent constraints force this exact shape". Two of the three died
  with Squirrel. Only the SemVer leading-zero rule is still LIVE: the `0 6 * * *`
  cron yields `HHMMSS=060000`, so a bare `.${STAMP_TIME}` identifier would be
  purely numeric with a leading zero and invalid — the `t` separator is
  load-bearing. The Int32-overflow and 20-char constraints are marked RETIRED
  with their evidence kept, because the shape still satisfies the Int32 bound and
  **deliberately violates** the 20-char cap, and a future NuGet-based target
  (msi, appx) would re-impose it and force re-compacting the date.

## Tests

- **Deleted** `test_prerelease_fits_nuget_special_version_cap`. #1428 had kept
  this same assertion and relabelled it "HISTORICAL, still enforced ... a future
  NuGet-based target would re-impose it silently". Lengthening the stamp is now
  the point, so the guard became *wrong* rather than merely stale: asserting
  `<= 20` against a deliberate 23 fails, and asserting "no cap" tests nothing.
  The property that relabel actually wanted guarded — that no NuGet-based Windows
  target exists — was never what the test measured; it would need a new assertion
  against `website/electron/package.json`, i.e. a new mechanism on untouched
  code. The retired constraint is recorded in the workflow comment instead.
- **Restored** the `>= 14` stamp-digit assertion #1409 had to remove (YYDDD +
  HHMMSS is only 11 digits) — but pinned to what it actually guards. It is a
  **date-width** pin: the desktop stamp keeps the full 8-digit YYYYMMDD so it
  stays legible and shares digits with the wheel's `.dev<N>`. It is **not** the
  uniqueness guard. The 11-digit form also carried a distinct date and full
  seconds, so what stops a same-minute re-dispatch reusing an immutable
  `signed/`/`notarized/` key is the seconds assertion (`HHMMSS >= 6`), which was
  already present. Both assertions now say which property they own, so a future
  editor re-fitting a length cap is not misdirected into thinking uniqueness
  breaks.
- Dropped the dead `${STAMP_YYDOY}` substitutions and the `datetime`-based YYDDD
  derivation in the ordering test's render helper.
- The Int32 assertion is unchanged and still passes: worst case `29991231` is
  ~3.0e7, far under `2147483647`.

Local: 10/10 version-contract tests, 1056 tests across the 47 test files that
read workflow config, isort + flake8 clean, `scrub-lint.sh` clean, `nightly.yml`
parses.

## Manual verification

The stamp shell was executed directly to confirm the rendered output rather than
inferred from the template: `STAMP=$(date -u +%Y%m%d%H%M%S)` then
`${STAMP:0:8}t${STAMP:8:6}` yields `0.1.2-nightly.20260804t224510`. `STAMP` is
exactly 14 chars, so `${STAMP:0:8}` / `${STAMP:8:6}` / `${STAMP:0:14}` all sit in
range with no residue — desktop and wheel now carry byte-identical digits from
one clock read, which is strictly tighter than before.

Ordering was re-checked across a year boundary (`20260728...` < `20270101...`);
zero-padded `YYYYMMDDtHHMMSS` sorts lexically as it sorts in time, which is what
semver compares alphanumeric identifiers by.

Not verifiable locally: the actual nightly run. The stamp only materialises on a
scheduled/dispatched `nightly.yml` run, so the first nightly after merge is the
real confirmation.

## Screenshots

N/A — no user-visible UI surface. The only visible change is the version string
in build logs, feed entries, and S3 keys.
