### PR TITLE
fix(sandbox): wait for the boot probe instead of racing it

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -56,6 +56,7 @@ from kiro_crew.platform import (
     safe_context_call,
 )
 from kiro_crew.platform.governance import CU_MCP_SERVER, may_skip_gate_now
+from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import sel
 from kiro_crew.transcribe import _find_whisper, ensure_ffmpeg_in_path
 
@@ -215,6 +216,32 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
 
     if not probe_targets:
         return
+
+    # Every probe below spawns its server through the sandbox chokepoint, and
+    # asyncio.gather releases them together. On a cold cache the first arrivals
+    # therefore land on the on-loop deferral path simultaneously and each logs a
+    # transient probe failure — noise that reads as a real sandbox fault during a
+    # health check whose subject is MCP, not the sandbox. Warm the cache here,
+    # off any loop, so the probes see a settled verdict.
+    #
+    # The chokepoint helper is deliberately NOT named here: test_spawn_audit
+    # classifies a spawn as sandbox-routed by substring-scanning the enclosing
+    # function's source, so spelling that identifier even in a comment flips this
+    # function's classification and then demands a resource-limit preexec_fn it
+    # does not own. The routing genuinely happens inside
+    # mcp_discovery.probe_server, not here.
+    #
+    # Failing to warm is non-fatal BY DESIGN (the cache stays cold and the
+    # self-healing transient path applies), so it must not be able to abort the
+    # command. `warm_backend` starts a thread, and `Thread.start()` raises when
+    # the process is out of threads — precisely the degraded state someone runs
+    # `doctor` to diagnose, which is the worst moment for the diagnostic itself
+    # to die. Swallow it here rather than inside the probe `try` below, so a warm
+    # failure is never misreported as an MCP probe failure.
+    try:
+        warm_backend()
+    except Exception:
+        logger.debug("sandbox probe warm failed; probes will re-probe", exc_info=True)
 
     try:
 

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -74,7 +74,7 @@ from kiro_crew.mcp_gateway.rewriter import (
 from kiro_crew.mcp_gateway.shutdown_budget import DRAIN_SECS, POOL_SHUTDOWN_SECS
 from kiro_crew.mcp_gateway.spill import cleanup_old_spill_files
 from kiro_crew.metrics.provider import get_recorder
-from kiro_crew.sandbox import prewarm_backend
+from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import SecurityEventLog
 from kiro_crew.session_pid_sig import read_session_pid_txt
 
@@ -2868,8 +2868,14 @@ async def _amain(argv: Optional[list[str]] = None) -> int:
 
     hb_task = asyncio.create_task(_heartbeat(), name="mcp-gateway-heartbeat")
 
-    # Prewarm sandbox probe cache so backends spawned on-loop never hit cold path
-    prewarm_backend()
+    # Fill the sandbox probe cache BEFORE any backend is spawned on-loop. See the
+    # matching site in slack/gateway.py: the wait is what makes the guarantee
+    # hold, since a fire-and-forget prewarm leaves the first spawn racing the
+    # warm thread and reading a cold-cache transient as "no sandbox backend".
+    try:
+        await asyncio.to_thread(warm_backend)
+    except RuntimeError:
+        logger.warning("sandbox warm_backend skipped (thread exhaustion); cache stays cold")
 
     for sig in (signal.SIGTERM, signal.SIGINT):
         try:

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -218,6 +218,14 @@ _TRANSIENT_PROBE_ERRNOS = frozenset(
 # Delay before the single in-probe retry on a transient failure.
 _PROBE_TRANSIENT_RETRY_DELAY_SECS = 0.05
 
+# Ceiling on how long a blocking ``warm_backend`` waits for the probe to land.
+# The probe itself is a fork + unshare (sub-millisecond) and the warm thread
+# makes at most two attempts separated by one _PROBE_TRANSIENT_RETRY_DELAY_SECS
+# sleep, so this is orders of magnitude of slack rather than a tuned value — it
+# exists so a wedged probe cannot stall boot indefinitely. Exceeding it is not
+# an error: the cache stays cold and the self-healing transient path applies.
+_WARM_JOIN_TIMEOUT_SECS = 2.0
+
 # Steps of the launcher's namespace handshake, named in probe failure reasons so
 # a caller can tell the host mechanisms apart instead of seeing a bare errno: a
 # NEWNS denial is Ubuntu's AppArmor userns restriction, while NEWUSER with
@@ -562,12 +570,22 @@ def _background_warm() -> None:
 
 
 def _kick_background_warm() -> None:
-    """Start the background warm thread if not already running."""
+    """Start the background warm thread if not already running.
+
+    Thread-start failure (RuntimeError under thread exhaustion) is swallowed:
+    the cache stays cold and the pre-existing self-healing transient path
+    applies on the next spawn.  This keeps gateway boot stable even when the
+    host is resource-constrained.
+    """
     global _warm_thread
     if _warm_thread is not None and _warm_thread.is_alive():
         return  # dedupe: warm already in progress
     _warm_thread = threading.Thread(target=_background_warm, name="sandbox-probe-warm", daemon=True)
-    _warm_thread.start()
+    try:
+        _warm_thread.start()
+    except RuntimeError:
+        _warm_thread = None
+        logger.debug("sandbox warm thread start failed; cache stays cold")
 
 
 def prewarm_backend() -> None:
@@ -579,6 +597,34 @@ def prewarm_backend() -> None:
     if sys.platform != "linux":
         return  # probes are Linux-only
     _kick_background_warm()
+
+
+def warm_backend(timeout: float = _WARM_JOIN_TIMEOUT_SECS) -> None:
+    """Blocking boot hook: fill the probe cache BEFORE returning.
+
+    ``prewarm_backend`` only *starts* the probe, so a caller that reaches
+    ``detect_backend`` in the same tick still races the warm thread and gets the
+    synthetic-transient answer — a cold-cache false negative that reads exactly
+    like "this host has no sandbox backend". This variant waits for the probe to
+    land, so the next ``detect_backend`` sees a warm cache and the transient path
+    is not reachable from a warmed boot.
+
+    The wait is bounded: ``_background_warm`` makes at most two attempts with a
+    single short delay between them, and a join timeout caps the total. A timeout
+    is not an error — the cache simply stays cold and the pre-existing
+    self-healing transient path applies, exactly as with ``prewarm_backend``.
+
+    **Never-block-on-loop invariant**: this blocks on a thread join, so it MUST
+    NOT be called from a running event loop. On-loop callers use
+    ``await asyncio.to_thread(warm_backend)``; synchronous callers (CLI paths)
+    may call it directly.
+    """
+    if sys.platform != "linux":
+        return  # probes are Linux-only
+    _kick_background_warm()
+    thread = _warm_thread
+    if thread is not None and thread.is_alive():
+        thread.join(timeout)
 
 
 def _probe_unshare() -> bool:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -159,7 +159,7 @@ from kiro_crew.platform.governance_profiles import (
 )
 from kiro_crew.providers.base import LLMEvent
 from kiro_crew.safety_override import safety_override
-from kiro_crew.sandbox import prewarm_backend
+from kiro_crew.sandbox import warm_backend
 from kiro_crew.security import redact, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.service.common import restart_command_hint
@@ -5550,8 +5550,15 @@ class GatewayOrchestrator:
 
         cleanup_orphaned_sessions()
 
-        # Prewarm sandbox probe cache so on-loop spawns never hit cold-cache path
-        prewarm_backend()
+        # Fill the sandbox probe cache BEFORE any on-loop spawn path can reach
+        # detect_backend(). Waiting (off-loop) rather than firing-and-forgetting
+        # is what makes that guarantee hold: a fire-and-forget prewarm leaves the
+        # very next caller racing the warm thread and reading a cold-cache
+        # transient as "no sandbox backend on this host".
+        try:
+            await asyncio.to_thread(warm_backend)
+        except RuntimeError:
+            logger.warning("sandbox warm_backend skipped (thread exhaustion); cache stays cold")
 
         # ── Initialise all services ──
         from kiro_crew.slack.events import SeenCache, init_socket_mode

--- a/test/test_sandbox_backend_cache.py
+++ b/test/test_sandbox_backend_cache.py
@@ -351,6 +351,120 @@ def test_prewarm_backend_populates_cache(monkeypatch):
     assert sb._backend == "namespace"
 
 
+# ── Blocking boot warm (warm_backend) ──
+
+
+def test_warm_backend_returns_with_cache_already_populated(monkeypatch):
+    """warm_backend() must not return until the probe has landed.
+
+    This is the whole difference from ``prewarm_backend``: the caller is entitled
+    to assume a settled verdict on return. The probe is made observably slow so a
+    non-joining implementation loses the race and leaves the cache cold — the
+    assertions below then fail rather than passing by luck.
+    """
+    monkeypatch.setattr(sb, "sys", types.SimpleNamespace(platform="linux"))
+
+    def slow_probe():
+        # Independent of sb.time.sleep (patched by the autouse fixture) so the
+        # delay is real for this thread.
+        threading.Event().wait(0.05)
+        return (True, False, "ok")
+
+    monkeypatch.setattr(sb, "_probe_unshare_once", slow_probe)
+
+    sb.warm_backend()
+
+    assert sb._backend == "namespace"
+    # The join is what produced the guarantee — prove it happened rather than
+    # inferring it from the cache alone.
+    assert sb._warm_thread is not None
+    assert not sb._warm_thread.is_alive()
+
+
+def test_warm_backend_makes_on_loop_transient_path_unreachable(monkeypatch):
+    """After a warmed boot, an on-loop caller sees the verdict, not a deferral.
+
+    The user-visible symptom being fixed: an on-loop ``detect_backend`` racing a
+    fire-and-forget prewarm logs a transient probe failure that reads as "this
+    host has no sandbox backend".
+    """
+    monkeypatch.setattr(sb, "sys", types.SimpleNamespace(platform="linux"))
+    probe_calls: list[str] = []
+
+    def counting_probe():
+        # Slow, for the same reason as the test above: with an instant probe this
+        # assertion would hold even without the join, by winning the race rather
+        # than by the guarantee under test.
+        threading.Event().wait(0.05)
+        probe_calls.append(threading.current_thread().name)
+        return (True, False, "ok")
+
+    monkeypatch.setattr(sb, "_probe_unshare_once", counting_probe)
+
+    sb.warm_backend()
+    assert len(probe_calls) == 1
+
+    async def _on_loop() -> str:
+        return sb.detect_backend()
+
+    assert asyncio.run(_on_loop()) == "namespace"
+    # No re-probe and no synthetic transient: the warm cache answered.
+    assert len(probe_calls) == 1
+    assert sb._last_unshare_failure is None
+
+
+def test_warm_backend_permanent_failure_caches_none(monkeypatch):
+    """A permanent denial is a real verdict and must be cached, not retried."""
+    monkeypatch.setattr(sb, "sys", types.SimpleNamespace(platform="linux"))
+    monkeypatch.setattr(sb, "_probe_unshare_once", lambda: (False, False, _EPERM_REASON))
+
+    sb.warm_backend()
+
+    assert sb._backend == "none"
+
+
+def test_warm_backend_wait_is_bounded_and_leaves_cache_cold(monkeypatch):
+    """A wedged probe must not stall boot; the cold cache then self-heals.
+
+    Exceeding the join timeout is explicitly not an error — it degrades to the
+    pre-existing ``prewarm_backend`` behaviour (cache uncached, next caller
+    re-probes) rather than failing startup.
+    """
+    monkeypatch.setattr(sb, "sys", types.SimpleNamespace(platform="linux"))
+    release = threading.Event()
+
+    def wedged_probe():
+        release.wait(10.0)
+        return (True, False, "ok")
+
+    monkeypatch.setattr(sb, "_probe_unshare_once", wedged_probe)
+
+    try:
+        sb.warm_backend(timeout=0.05)
+        # Returned while the probe is still in flight, so no verdict is cached.
+        assert sb._backend is None
+        assert sb._warm_thread is not None and sb._warm_thread.is_alive()
+    finally:
+        release.set()
+        if sb._warm_thread is not None:
+            sb._warm_thread.join(timeout=5.0)
+
+
+def test_warm_backend_is_a_noop_off_linux(monkeypatch):
+    """Probes are Linux-only — no thread, no cache write, no wait."""
+    monkeypatch.setattr(sb, "sys", types.SimpleNamespace(platform="darwin"))
+
+    def unexpected_probe():  # pragma: no cover - must never run
+        raise AssertionError("probe must not run off Linux")
+
+    monkeypatch.setattr(sb, "_probe_unshare_once", unexpected_probe)
+
+    sb.warm_backend()
+
+    assert sb._warm_thread is None
+    assert sb._backend is None
+
+
 # ── Off-loop behaviour preserved ──
 
 


### PR DESCRIPTION
## The problem

`prewarm_backend()` only **starts** the sandbox capability probe. Both gateway boot sites called it fire-and-forget, so the first caller to reach `detect_backend()` in the same tick raced the warm thread, took the on-loop cold-cache branch, and got the synthetic-transient answer — which logs and reads as *"this host has no sandbox backend"* before the probe has actually finished.

The docstring already claimed the guarantee this PR implements:

> Boot sites call `prewarm_backend()` to fill the cache before any on-loop caller ever reaches `detect_backend()`, so the transient path is typically never hit in production.

"Typically" was doing real work in that sentence — nothing enforced the ordering.

**Reproduced on a real host.** Two `kirocrew doctor` runs, two warnings each, every time:

```
Sandbox backend probe failed transiently (probe deferred to background thread
(cold cache on event loop); cache warms in ms — retry); result NOT cached
Sandbox backend probe failed transiently (...)          <- same second
Background warm: probe permanent failure: unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)
```

The third line is the *real* verdict; the first two are the race. The path is `_doctor_mcp_tools` → `asyncio.gather(probe_server(...))` → `sandboxed_spawn_argv` → `detect_backend()`: `gather` releases the probes together, so the first arrivals all land on the cold cache simultaneously and each logs. Net effect — `kirocrew doctor` prints sandbox faults during a health check whose subject is MCP.

On a host where user namespaces *do* work, the same race is worse than noise: it is a false negative at the exact moment an isolation decision is made.

## How the fix works

Adds a blocking `warm_backend()` beside the existing `prewarm_backend()`, used at the three sites that need a settled verdict:

| site | before | after |
|---|---|---|
| `slack/gateway.py` boot | `prewarm_backend()` | `await asyncio.to_thread(warm_backend)` |
| `mcp_gateway/gatewayd.py` boot | `prewarm_backend()` | `await asyncio.to_thread(warm_backend)` |
| `cli_doctor.py` before the probe gather | *(nothing)* | `warm_backend()` (already off-loop) |

`to_thread` keeps the **never-block-on-loop** invariant intact — the loop still never runs or waits on a fork — while making the ordering the docstring promised actually hold.

The wait is bounded by `_WARM_JOIN_TIMEOUT_SECS` (2.0s against a sub-millisecond fork+unshare, so slack rather than a tuned value). **A timeout is explicitly not an error**: the cache stays cold and the pre-existing self-healing transient path applies, i.e. it degrades to exactly today's behaviour rather than failing startup.

Doctor is fixed at the source rather than by muting the logger — the warning is correct when the cache really is cold; the bug was letting a health check create that condition itself.

## Why `prewarm_backend()` stays

It now has no production callers, which usually invites deletion. Keeping it is deliberate:

- it is the right primitive for any future caller that must **not** block, and
- the macOS notes in `apps/builtins/papyrus/backend/gitops.py` and `latex.py` reference it **by name** when explaining why their cache is cold off Linux (`prewarm_backend()` returns early on non-Linux).

Removing it would mean rewriting those explanations to describe a function that no longer exists.

## Tests

5 added to `test/test_sandbox_backend_cache.py` (**26 pass** in that file):

- returns with the cache already populated, **and** the thread is no longer alive (proves the join happened rather than inferring it from the cache)
- after a warmed boot an on-loop `detect_backend()` gets the verdict with **no re-probe and no transient** — the user-visible guarantee
- a permanent denial is cached as a real verdict
- a wedged probe returns within the timeout and leaves the cache cold (self-healing preserved)
- no-op off Linux (a probe stub that raises if called)

**Mutation-verified.** Deleting only the `thread.join(timeout)` line fails `test_warm_backend_returns_with_cache_already_populated` on the specific assertion `assert sb._backend == "namespace"` (reads `None`), and also fails the on-loop test.

Both use a deliberately slow probe so they discriminate the join rather than winning the race by luck. Worth flagging: an earlier draft of the on-loop test used an instant probe and **passed under mutation** — it was rewritten for that reason. The remaining three tests pass under mutation by construction (they assert on cold-cache or non-Linux states), so they are characterization, not guards.

Gate: `isort` clean, `flake8` clean, `mypy` clean on the changed files.
