### PR TITLE
fix(config): read back two dropped config fields on load

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -6046,6 +6046,7 @@ class KiroCrewConfig:
                 subagent_spawn_stagger_secs=_safe_float(
                     agent_data.get("subagent_spawn_stagger_secs", 2.0), 2.0
                 ),
+                spawn_min_memory_gb=_safe_float(agent_data.get("spawn_min_memory_gb", 4.0), 4.0),
                 resource_pressure_gb=_safe_float(agent_data.get("resource_pressure_gb", 4.0), 4.0),
                 resource_critical_gb=_safe_float(agent_data.get("resource_critical_gb", 2.0), 2.0),
                 admission_gate=_safe_bool(agent_data.get("admission_gate"), True),
@@ -6344,6 +6345,9 @@ class KiroCrewConfig:
                 reactions_enabled=bool(slack_data.get("reactions_enabled", True)),
                 use_tunnel_url=bool(slack_data.get("use_tunnel_url", False)),
                 show_thinking=bool(slack_data.get("show_thinking", True)),
+                home_tab_sessions_per_kind=_safe_int(
+                    slack_data.get("home_tab_sessions_per_kind", 5), 5
+                ),
             ),
             publish=PublishConfig(
                 allowed_destinations=[

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -273,6 +273,30 @@ def test_publish_relocate_roots_parsed_and_round_trips():
     assert reloaded.publish.relocate_roots == ["/srv/shared"]
 
 
+def test_agent_spawn_min_memory_gb_parsed_and_round_trips():
+    # Regression: agent.spawn_min_memory_gb was declared + consumed (the
+    # subagent admission gate) and emitted by to_dict(), but NOT parsed in
+    # load(), so an operator value was silently ignored (stuck at the 4.0
+    # default) and overwritten on the next save().
+    loaded = _load_from_dict({"agent": {"spawn_min_memory_gb": 9.5}})
+    assert loaded.agent.spawn_min_memory_gb == 9.5
+    # Survives a to_dict() -> load() round-trip.
+    reloaded = _load_from_dict(loaded.to_dict())
+    assert reloaded.agent.spawn_min_memory_gb == 9.5
+
+
+def test_slack_home_tab_sessions_per_kind_parsed_and_round_trips():
+    # Regression: slack.home_tab_sessions_per_kind was declared + consumed (the
+    # Slack Home Tab per-category cap) and emitted by to_dict(), but NOT parsed
+    # in load(), so an operator value was silently ignored (stuck at 5) and
+    # overwritten on the next save().
+    loaded = _load_from_dict({"slack": {"home_tab_sessions_per_kind": 42}})
+    assert loaded.slack.home_tab_sessions_per_kind == 42
+    # Survives a to_dict() -> load() round-trip.
+    reloaded = _load_from_dict(loaded.to_dict())
+    assert reloaded.slack.home_tab_sessions_per_kind == 42
+
+
 class TestMalformedConfigValuesNeverCrashLoad:
     """Round-2 hardening: several config parse sites coerced values with a bare
     .upper()/int()/list()/set()/.items() and no guard. jsonschema is optional


### PR DESCRIPTION
## Problem / Motivation

Two config fields are declared on their dataclasses, consumed at runtime, and emitted by `to_dict()` (via `asdict()`), but `KiroCrewConfig.load()` never passed them to their config constructors. The result is silent data loss: an operator-set value is ignored on load (the dataclass default wins), and then overwritten with that default on the next `save()`.

- `agent.spawn_min_memory_gb` — gates subagent admission (`subagent.py`). A tuned value (or `0` to disable the memory gate) silently reverted to `4.0`.
- `slack.home_tab_sessions_per_kind` — caps sessions shown per category in the Slack Home Tab (`slack/events.py`). The runtime consumer's defensive fallback masked the loss, so it always used `5`.

## Why it matters

Operators who tune either field lose the setting on the next config round-trip with no error or warning — the same drop-on-read class as the previously-fixed `secretary` and `publish.relocate_roots` regressions. A disabled memory gate (`spawn_min_memory_gb: 0`) silently re-enabling at `4.0` changes subagent admission behavior behind the operator's back.

## What changed (motivation → approach → change)

Symptom: operator values for the two fields revert to defaults after a load/save cycle. Root cause: `load()` constructs `AgentConfig(...)` / `SlackConfig(...)` without passing these keys, so the dataclass defaults always win. Change: add the two missing parse lines to `load()` using the existing `_safe_float` / `_safe_int` coercion helpers with fallbacks matching the field defaults (4.0, 5) — the same pattern every neighboring field already uses. No behavior change for configs that never set these keys.

## Tests

Two round-trip regression tests in `test/test_config_loader.py`, one per field: each loads a non-default value, asserts it survives `load()`, then asserts it survives a full `to_dict()` → `load()` round-trip. Both fail without the parse lines.

## Manual verification

N/A — unit coverage sufficient: the round-trip tests exercise the exact load/save cycle the bug corrupts.

## Related Issues

no linked issue: config-load regression found by direct code inspection; no tracking issue was filed for it.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface for these keys
- [x] No secrets, credentials, or internal references in the diff
