### PR TITLE
docs(readme): document where to find KiroCrew logs for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,28 @@ first MCP startup. For memory search, check that the embedding
 model finished downloading under `~/.kiro/crew/models`. For a stale MCP configuration, run
 `kirocrew setup --agent-only`, or add `--clean` to rebuild it.
 
+**Find the logs.** When you need to debug, the fastest path is
+`kirocrew logs` (tail the most recent gateway output) or `kirocrew logs -f` to
+follow it live; `kirocrew logs -n 200` prints more history. `kirocrew logs`
+reads the right source automatically — the systemd journal when the Linux
+service is installed, the launchd stdout file on macOS, or the foreground
+gateway log otherwise. Raise verbosity with `kirocrew gateway -v` (INFO:
+session lifecycle and context usage) or `-vv` (DEBUG: full ACP events and
+message traces); set the persistent default with
+`kirocrew config set agent.log_level`, or change it at runtime from the
+dashboard **Logs** page. Under `~/.kiro/crew` (or your `KIROCREW_HOME`) you can
+also read the raw files directly:
+
+| File | What it holds |
+|---|---|
+| `~/.kiro/crew/gateway.log` | Main gateway log when running in the foreground. |
+| `~/.kiro/crew/security_events.jsonl` | Append-only security and tool-access events. Inspect with `kirocrew security events`, `audit`, and `verify`. |
+| `~/.kiro/crew/audit.log` | Human-readable audit trail of privileged operations. |
+| `~/.kiro/crew/subagents/<agent_id>/result.txt` | Full transcript of a completed subagent, kept for a grace window after it finishes. |
+
+See the [Troubleshooting guide](src/kiro_crew/docs/troubleshooting.md) for the
+full log-level reference and emergency recovery steps.
+
 ## Anonymous usage telemetry
 
 Kiro Crew sends **one anonymous heartbeat per day** so maintainers can see how


### PR DESCRIPTION
## Problem

The README has no pointer to where KiroCrew writes its logs. When the gateway,
a session, or a subagent misbehaves, a user (or a contributor triaging an issue)
has to already know that `kirocrew logs` exists and that the raw files live under
`~/.kiro/crew` — none of which the README says.

## Why it matters

Log location is the first thing you need when debugging, and the first thing a
maintainer asks a bug reporter for. Leaving it undocumented in the front-door
README slows every debugging session and every issue triage.

## Fix (symptom → root cause → change)

- **Symptom:** README covers install/config/troubleshoot but never says where logs are.
- **Root cause:** the log surface (the `kirocrew logs` command, log-level flags, the
  dashboard Logs page, and the raw files) is only documented in the deeper
  troubleshooting guide, not surfaced in the README.
- **Change:** add a **Find the logs** paragraph to the existing "Install, configure,
  and operate" section, right after "Troubleshoot quickly." It documents:
  - `kirocrew logs` / `kirocrew logs -f` / `kirocrew logs -n 200`, and that the command
    auto-selects the source (systemd journal → launchd stdout → foreground `gateway.log`).
  - Verbosity: `kirocrew gateway -v` / `-vv`, the persistent `agent.log_level` config, and
    the dashboard Logs page.
  - A table of raw files under `~/.kiro/crew` (or `KIROCREW_HOME`): `gateway.log`,
    `security_events.jsonl`, `audit.log`, and `subagents/<agent_id>/result.txt`.
  - A link to the troubleshooting guide for the full reference.

Every command, path, and behavior was verified against the source:
`kirocrew logs` resolution order and the `gateway.log` fallback in `cli_server.py`,
the `security_events.jsonl` store in `sel.py`, and the log-level/Logs-page reference
in `docs/troubleshooting.md`.

## Tests

N/A — documentation-only change (a single Markdown paragraph + table in `README.md`).
No code paths change, so there is nothing to unit-test.

## Manual verification

- Confirmed each documented path/command against the code and shipped docs (see Fix).
- Re-read the rendered Markdown table and section placement for correctness.

## Screenshots

N/A — no user-visible UI change; README prose only.
