### PR TITLE
fix(palette): make double-Shift trigger opt-in, default to mod-k

### DIFF
--- a/website/src/components/CommandPalette.test.tsx
+++ b/website/src/components/CommandPalette.test.tsx
@@ -10,7 +10,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 
 /**
  * Tests for the Search Everywhere palette:
- *  - {@link useCommandPalette} global trigger (⌘K / Ctrl+K + double-Shift), and
+ *  - {@link useCommandPalette} global trigger (⌘K / Ctrl+K, with opt-in double-Shift), and
  *  - the {@link CommandPalette} modal's open render, Tab tab-scoping, Enter
  *    activation, and close paths (Escape wiring + close button + row click).
  *
@@ -206,6 +206,7 @@ afterEach(() => {
   // localStorage is file-scoped, not per-test: a chat-config write (e.g. the
   // simplifiedToolNames toggle test) would otherwise persist into siblings.
   localStorage.removeItem('mc-chat-config')
+  localStorage.removeItem(QUICK_SEARCH_SHORTCUT_KEY)
   queryClient.clear()
 })
 
@@ -231,7 +232,8 @@ describe('useCommandPalette — global trigger', () => {
     expect(result.current.open).toBe(true)
   })
 
-  it('double-Shift (two bare Shift keydowns) opens the palette', () => {
+  it('double-Shift (two bare Shift keydowns) opens when opted in', () => {
+    localStorage.setItem(QUICK_SEARCH_SHORTCUT_KEY, JSON.stringify({ mode: 'double-shift' }))
     const { result } = renderHook(() => useCommandPalette())
     act(() => {
       fireEvent.keyDown(window, { key: 'Shift' })
@@ -241,6 +243,7 @@ describe('useCommandPalette — global trigger', () => {
   })
 
   it('two Shifts spaced BEYOND the double-tap window do not open (accidental tap)', () => {
+    localStorage.setItem(QUICK_SEARCH_SHORTCUT_KEY, JSON.stringify({ mode: 'double-shift' }))
     const nowSpy = vi.spyOn(Date, 'now')
     try {
       const { result } = renderHook(() => useCommandPalette())
@@ -268,6 +271,7 @@ describe('useCommandPalette — global trigger', () => {
   })
 
   it('a key pressed between the two Shifts cancels the gesture', () => {
+    localStorage.setItem(QUICK_SEARCH_SHORTCUT_KEY, JSON.stringify({ mode: 'double-shift' }))
     const { result } = renderHook(() => useCommandPalette())
     act(() => {
       fireEvent.keyDown(window, { key: 'Shift' })
@@ -292,6 +296,7 @@ describe('useCommandPalette — Enable shortcuts toggle', () => {
   afterEach(() => localStorage.removeItem(SHORTCUTS_ENABLED_KEY))
 
   it('double-Shift does NOT open the palette when shortcuts are disabled', () => {
+    localStorage.setItem(QUICK_SEARCH_SHORTCUT_KEY, JSON.stringify({ mode: 'double-shift' }))
     localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
     const { result } = renderHook(() => useCommandPalette())
     act(() => {
@@ -318,6 +323,7 @@ describe('useCommandPalette — Enable shortcuts toggle', () => {
   })
 
   it('re-enabling restores double-Shift (no stale first tap carries over)', () => {
+    localStorage.setItem(QUICK_SEARCH_SHORTCUT_KEY, JSON.stringify({ mode: 'double-shift' }))
     localStorage.setItem(SHORTCUTS_ENABLED_KEY, '0')
     const { result } = renderHook(() => useCommandPalette())
     // A Shift arrives while disabled (must not seed a pending first tap)…
@@ -343,19 +349,30 @@ describe('useCommandPalette — configurable activation', () => {
     localStorage.removeItem(SHORTCUTS_ENABLED_KEY)
   })
 
-  it('default (unconfigured) preserves BOTH double-Shift and the ⌘K alias', () => {
-    // Backward compatibility: with nothing stored, the shipped behavior stands.
+  it('default (unconfigured) does NOT open on double-Shift but ⌘K works', () => {
+    // Fresh install: default is mod-k, so double-Shift is inactive.
     const a = renderHook(() => useCommandPalette())
     act(() => {
       fireEvent.keyDown(window, { key: 'Shift' })
       fireEvent.keyDown(window, { key: 'Shift' })
     })
-    expect(a.result.current.open).toBe(true)
+    expect(a.result.current.open).toBe(false)
     a.unmount()
 
     const b = renderHook(() => useCommandPalette())
     act(() => { fireEvent.keyDown(window, { key: 'k', metaKey: true }) })
     expect(b.result.current.open).toBe(true)
+  })
+
+  it('explicit double-shift opt-in preserves the gesture for existing users', () => {
+    // An existing user who selected double-shift in Settings has it stored.
+    localStorage.setItem(QUICK_SEARCH_SHORTCUT_KEY, JSON.stringify({ mode: 'double-shift' }))
+    const { result } = renderHook(() => useCommandPalette())
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Shift' })
+      fireEvent.keyDown(window, { key: 'Shift' })
+    })
+    expect(result.current.open).toBe(true)
   })
 
   it('mod-k mode: ⌘K/Ctrl+K toggles, but double-Shift no longer opens', () => {

--- a/website/src/hooks/useCommandPalette.ts
+++ b/website/src/hooks/useCommandPalette.ts
@@ -13,12 +13,15 @@ import {
  * reads the stored {@link QuickSearchConfig} live per keystroke and dispatches
  * accordingly. The three preset modes are:
  *
- *  - **`double-shift`** (default): two bare `Shift` keydowns within
+ *  - **`mod-k`** (default): ⌘K (macOS) / Ctrl+K (Windows/Linux) toggles the
+ *    palette; double-Shift is off.
+ *  - **`double-shift`** (opt-in): two bare `Shift` keydowns within
  *    {@link DOUBLE_SHIFT_WINDOW_MS}. This is the IntelliJ "Search Everywhere"
  *    gesture and is page-safe — a lone Shift has no default browser action, so
- *    nothing needs cancelling and it never collides with a real shortcut.
- *  - **`mod-k`**: ⌘K (macOS) / Ctrl+K (Windows/Linux) toggles the palette;
- *    double-Shift is off.
+ *    nothing needs cancelling and it never collides with a real shortcut. It was
+ *    the shipped default until remote-desktop sessions (RDP/ICA/PCoIP) were found
+ *    to synthesise spurious repeat Shift events and open the palette by
+ *    themselves.
  *  - **`custom`**: a user-recorded chord toggles the palette; double-Shift is
  *    off.
  *
@@ -29,8 +32,9 @@ import {
  * tab switch) which Chrome will NOT let a page cancel. Keeping it live until the
  * user sets their OWN chord guarantees the palette is always reachable from the
  * keyboard — so selecting `custom` before recording never strands the user.
- * This also makes the default (`double-shift` + the ⌘K alias) identical to the
- * previously shipped hard-coded behavior.
+ * Because ⌘K is live in the default (`mod-k`) mode too, a user who relied on the
+ * previously shipped double-Shift default still has a working keyboard route to
+ * the palette after the default moved, even before they visit Settings.
  *
  * All bindings honour the global "Enable shortcuts" toggle
  * ({@link SHORTCUTS_ENABLED_KEY}, shared with useKeyboardShortcuts /

--- a/website/src/lib/quickSearchShortcut.test.ts
+++ b/website/src/lib/quickSearchShortcut.test.ts
@@ -62,9 +62,9 @@ describe('normalizeChord', () => {
 })
 
 describe('load / save round-trip', () => {
-  it('returns the double-shift default when nothing is stored', () => {
+  it('returns the mod-k default when nothing is stored', () => {
     expect(loadQuickSearchConfig()).toEqual(DEFAULT_QUICK_SEARCH_CONFIG)
-    expect(DEFAULT_QUICK_SEARCH_CONFIG).toEqual({ mode: 'double-shift' })
+    expect(DEFAULT_QUICK_SEARCH_CONFIG).toEqual({ mode: 'mod-k' })
   })
 
   it('round-trips the mod-k preset', () => {

--- a/website/src/lib/quickSearchShortcut.ts
+++ b/website/src/lib/quickSearchShortcut.ts
@@ -6,14 +6,15 @@ import { safeGetItem, safeSetItem } from '../utils/safeStorage'
  *
  * Historically the palette was hard-wired to two gestures in `useCommandPalette`:
  * double-Shift (the IntelliJ "Search Everywhere" gesture) and ⌘K / Ctrl+K. This
- * module makes the *primary* gesture user-selectable while keeping the shipped
- * default byte-for-byte, so an existing user who never opens Settings sees no
- * change.
+ * module makes the *primary* gesture user-selectable.
  *
  * Three presets, mutually exclusive:
- *  - **`double-shift`** (default): two bare Shift keydowns open the palette.
- *  - **`mod-k`**: ⌘K (macOS) / Ctrl+K (Windows/Linux) toggles it; double-Shift
- *    is disabled.
+ *  - **`mod-k`** (default): ⌘K (macOS) / Ctrl+K (Windows/Linux) toggles the
+ *    palette; double-Shift is disabled.
+ *  - **`double-shift`** (opt-in): two bare Shift keydowns open the palette. This
+ *    was the shipped default until remote-desktop sessions (RDP/ICA/PCoIP) were
+ *    found to synthesise spurious repeat Shift events and open the palette on
+ *    their own, so it is now opt-in — only users who select it are exposed.
  *  - **`custom`**: a user-recorded chord toggles it; double-Shift is disabled.
  *
  * `⌘K` / `Ctrl+K` stays available as a built-in alias in every mode EXCEPT
@@ -64,8 +65,8 @@ export interface QuickSearchConfig {
   custom?: QuickSearchChord
 }
 
-/** Backward-compatible default: the original double-Shift gesture. */
-export const DEFAULT_QUICK_SEARCH_CONFIG: QuickSearchConfig = { mode: 'double-shift' }
+/** Default for fresh installs: ⌘K/Ctrl+K (mod-k). Double-Shift is opt-in via Settings. */
+export const DEFAULT_QUICK_SEARCH_CONFIG: QuickSearchConfig = { mode: 'mod-k' }
 
 /**
  * A custom chord must carry at least one command/option modifier (`mod` or


### PR DESCRIPTION
## Problem

Remote-desktop environments (RDP, ICA/Citrix, PCoIP) inject synthetic Shift keydown events as part of their input transport layer. These events are indistinguishable from real keystrokes and frequently trigger the double-Shift palette activation gesture on every uppercase letter, effectively rendering the dashboard unusable for affected users.

## Solution

Make the double-Shift gesture **opt-in** rather than the default. Change `DEFAULT_QUICK_SEARCH_CONFIG` from `{ mode: 'double-shift' }` to `{ mode: 'mod-k' }`.

This means:
- **Fresh installs** get `⌘K / Ctrl+K` as the sole keyboard trigger — unambiguous and remote-desktop-safe.
- **The double-Shift preset remains fully selectable** in Settings → Shortcuts for users who prefer the IntelliJ-style gesture on local machines.
- **Existing users who previously selected double-Shift are preserved** (see migration reasoning below).

## Why opt-in, not removal

KiroCrew's `ShortcutsPanel.tsx` exposes double-Shift as a named preset with i18n strings in 10+ locales and a `loadQuickSearchConfig()` preference system. Removing the feature entirely would break the settings surface and lose it for users who genuinely want it on local machines. Making it opt-in fixes the remote-desktop problem for the majority (who never deliberately chose it) while preserving it for the minority who did.

## Migration reasoning

The fix lives entirely in the **config default** — the `loadQuickSearchConfig()` function:

1. If `localStorage` contains `{"mode":"double-shift"}` (user explicitly selected it) → returns that. **No change for these users.**
2. If `localStorage` is empty or malformed → falls through to `DEFAULT_QUICK_SEARCH_CONFIG`. **Previously this was `double-shift`; now it's `mod-k`.**

So users who never opened Settings (the vast majority, including all remote-desktop users hitting this bug) get the fix automatically. Users who deliberately chose the gesture keep it. No data migration, no localStorage rewriting.

## Tests

- **64 tests pass** (26 in `quickSearchShortcut.test.ts` + 38 in `CommandPalette.test.tsx`)
- New test: `'default (unconfigured) does NOT open on double-Shift but ⌘K works'`
- New test: `'explicit double-shift opt-in preserves the gesture for existing users'`
- Existing double-Shift behavior tests updated to opt-in via localStorage before exercising the gesture
- i18n gates (`catalogParity` 64 tests + `deadKeys` 3 tests) pass — no locale changes needed since we're not removing the preset

## Mutation verification

Flipping the default back to `{ mode: 'double-shift' }` causes two specific named assertions to fail:

1. `quickSearchShortcut.test.ts > load / save round-trip > returns the mod-k default when nothing is stored`
   → `expected { mode: 'double-shift' } to deeply equal { mode: 'mod-k' }`
2. `CommandPalette.test.tsx > configurable activation > default (unconfigured) does NOT open on double-Shift but ⌘K works`
   → `expected true to be false`

Both are genuine guards for the default-change behavior.

## Files changed

- `website/src/lib/quickSearchShortcut.ts` — default constant + JSDoc
- `website/src/lib/quickSearchShortcut.test.ts` — assertion for new default
- `website/src/components/CommandPalette.test.tsx` — new fresh-install/opt-in tests, existing tests updated to set localStorage before exercising double-Shift
