### PR TITLE
fix(chat): pin the latest prompt by default

### DIFF
--- a/website/src/pages/chat/ChatSettings.tsx
+++ b/website/src/pages/chat/ChatSettings.tsx
@@ -48,7 +48,7 @@ export type FollowUpLayout = 'multiline' | 'scroll'
 export type StreamMode = 'immediate' | 'smooth'
 
 const LS_KEY = 'mc-chat-config'
-const DEFAULTS: ChatConfig = { historyExpanded: true, showTimestamps: true, showTurnStats: true, sendOnEnter: 'enter', collapseAllSteps: true, confirmCloseSession: false, simplifiedToolNames: true, contentWidth: 'compact', tagColumnsEnabled: true, fileChipStyle: 'expanded', followUpLayout: 'scroll', streamMode: 'smooth', showContextPct: false, defaultAutopilot: false, pinLastPrompt: false }
+const DEFAULTS: ChatConfig = { historyExpanded: true, showTimestamps: true, showTurnStats: true, sendOnEnter: 'enter', collapseAllSteps: true, confirmCloseSession: false, simplifiedToolNames: true, contentWidth: 'compact', tagColumnsEnabled: true, fileChipStyle: 'expanded', followUpLayout: 'scroll', streamMode: 'smooth', showContextPct: false, defaultAutopilot: false, pinLastPrompt: true }
 
 const VALID_FILE_CHIP_STYLES: ReadonlySet<FileChipStyle> = new Set(['expanded', 'minimal'])
 const VALID_FOLLOW_UP_LAYOUTS: ReadonlySet<FollowUpLayout> = new Set(['multiline', 'scroll'])
@@ -80,7 +80,7 @@ export function loadChatConfig(): ChatConfig {
     if (!VALID_STREAM_MODES.has(cfg.streamMode)) cfg.streamMode = 'smooth'
     if (typeof cfg.showContextPct !== 'boolean') cfg.showContextPct = false
     if (typeof cfg.showTurnStats !== 'boolean') cfg.showTurnStats = true
-    if (typeof cfg.pinLastPrompt !== 'boolean') cfg.pinLastPrompt = false
+    if (typeof cfg.pinLastPrompt !== 'boolean') cfg.pinLastPrompt = true
     return cfg
   }
   catch { return { ...DEFAULTS } }

--- a/website/src/test/ChatSettings.test.tsx
+++ b/website/src/test/ChatSettings.test.tsx
@@ -44,6 +44,29 @@ describe('loadChatConfig', () => {
     localStorage.setItem('mc-chat-config', JSON.stringify({ showTurnStats: 'no' }))
     expect(loadChatConfig().showTurnStats).toBe(true)
   })
+
+  it('pins the latest prompt by default', () => {
+    expect(loadChatConfig().pinLastPrompt).toBe(true)
+  })
+
+  it('adopts the new default for a stored config that predates the setting', () => {
+    // Configs written before the sticky-banner setting existed carry no
+    // pinLastPrompt key, so the DEFAULTS spread is what upgrades them.
+    localStorage.setItem('mc-chat-config', JSON.stringify({ showTimestamps: false }))
+    const cfg = loadChatConfig()
+    expect(cfg.pinLastPrompt).toBe(true)
+    expect(cfg.showTimestamps).toBe(false)
+  })
+
+  it('respects stored pinLastPrompt=false', () => {
+    localStorage.setItem('mc-chat-config', JSON.stringify({ pinLastPrompt: false }))
+    expect(loadChatConfig().pinLastPrompt).toBe(false)
+  })
+
+  it('repairs a non-boolean pinLastPrompt value to the enabled default', () => {
+    localStorage.setItem('mc-chat-config', JSON.stringify({ pinLastPrompt: 'yes' }))
+    expect(loadChatConfig().pinLastPrompt).toBe(true)
+  })
 })
 
 describe('ChatSettings – session restore UI', () => {


### PR DESCRIPTION
## Problem

The sticky prompt banner — the band that keeps your most recent prompt readable at the top of the chat once it scrolls above the fold — shipped in #950 behind a `Settings → Chat → Pin the latest prompt` toggle that defaults to **off**. So for practically everyone the surface does not exist: you only get it if you went hunting through chat settings and happened to guess what that row does.

## Why it matters

On a long streaming answer the prompt you are waiting on scrolls out of view within a few seconds, and there is then nothing on screen that says what was asked. Re-anchoring means scrolling back up and losing your place in the output. That is the default experience today, and the fix for it is already written and shipped — just switched off.

## Fix (symptoms → root cause → change)

- **Symptom:** users report the pinned prompt "isn't there" / "disappeared".
- **Root cause:** not a rendering bug. `DEFAULTS.pinLastPrompt` is `false`, and `ChatPage` clears the band outright when the flag is off (`setPinned(null)`), so an untouched install renders nothing.
- **Change:** flip the `DEFAULTS` entry to `true`, and flip the matching non-boolean repair branch so a corrupted stored value lands on the same enabled default the neighbouring repaired keys already use (`showTurnStats` does exactly this).

Two literal values in `website/src/pages/chat/ChatSettings.tsx`. No component, layout, or consumer code is touched.

**No migration, deliberately.** `loadChatConfig` merges `{...DEFAULTS, ...stored}`, so any stored config written before #950 carries no `pinLastPrompt` key at all and picks the new default up on its own. Only a config **saved since 2026-07-31** has `false` written into it explicitly — `saveChatConfig` persists the whole object, so changing any unrelated chat setting bakes the then-current default in — and that is a four-day window. Those users keep their stored value, which is also the correct outcome for anyone who turned it off on purpose. A migration would have to override that group to reach a handful of installs, so there isn't one.

## Tests

Four cases added to `website/src/test/ChatSettings.test.tsx`, following the existing `showTurnStats` pattern in the same `describe`:

- `pins the latest prompt by default` — the new baseline.
- `adopts the new default for a stored config that predates the setting` — a stored config with no `pinLastPrompt` key gets `true` **while an unrelated stored `showTimestamps: false` survives**. This is the test that actually locks in the no-migration claim above, through the `{...DEFAULTS, ...stored}` spread.
- `respects stored pinLastPrompt=false` — a deliberate opt-out is not overridden.
- `repairs a non-boolean pinLastPrompt value to the enabled default` — pins the repair branch.

## Manual verification

N/A — unit coverage is the right level here. The behaviour being changed is one boolean read out of `localStorage`; the tests exercise all four stored-config shapes (absent key, explicit `false`, non-boolean, empty store) directly against `loadChatConfig`, which is the whole surface of the change.

Local gates, run with CI's own commands from `.github/workflows/ci.yml`:

| Gate | Result |
|---|---|
| `npx tsc -b` | clean |
| `npx vitest run` | 8919 tests, 1 pre-existing local failure (`src/i18n/format.test.ts`, host TZ); `TZ=UTC npx vitest run src/i18n/format.test.ts` → 49/49, which is how CI runs it |
| `npx eslint src/ --max-warnings 1116` | clean (0 errors, 504 warnings, unchanged) |
| `npm run i18n:check` | clean |
| `npm run i18n:render` | clean |

Backend gates not run locally: zero `.py` files changed.

## Screenshots

N/A — no UI is added or restyled. `PinnedPrompt.tsx` and its `ChatPage` driver are untouched; this only changes which value the banner's existing gate reads on a fresh install. The rendered banner is the one reviewed and shipped in #950.

I did check the two things a default-visible surface could newly expose, since the component was effectively unreviewed *as a default*: `PinnedPrompt.tsx` has no hardcoded user-visible strings (its labels all route through `i18nT`, and `pin_last_prompt` / `pin_last_prompt_desc` are already present in all 11 shipped locales plus `en-XA`), and `npm run i18n:render` — which builds the SPA and measures untranslated runtime surfaces — is clean.
