### PR TITLE
fix(installer): prefer supported Python 3.12 over untested 3.13

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -125,10 +125,11 @@ command -v curl    >/dev/null 2>&1 || err "curl is required"
 command -v openssl >/dev/null 2>&1 || err "openssl is required to verify the signed manifest"
 # KiroCrew needs Python >=3.10 at runtime (contextlib.aclosing, etc.) even
 # though older published wheels' METADATA claimed >=3.9 -- pip would install
-# fine on 3.9 and then crash on first run. Pick the best interpreter, newest
-# first; plain python3 only counts if it is itself >=3.10.
+# fine on 3.9 and then crash on first run. Prefer the newest interpreter the
+# project builds and tests on (3.12 is the CI target); 3.13 is untested and
+# only a last resort before bare python3, which itself only counts if >=3.10.
 PY=""
-for c in python3.13 python3.12 python3.11 python3.10 python3; do
+for c in python3.12 python3.11 python3.10 python3.13 python3; do
   command -v "$c" >/dev/null 2>&1 || continue
   if "$c" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
     PY="$c"; break

--- a/ensure-python.sh
+++ b/ensure-python.sh
@@ -32,10 +32,12 @@ _pyver() {
     "$1" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null
 }
 
-# First usable system python >= 3.9, preferring newer explicit minors.
+# First usable system python, preferring the newest SUPPORTED minor (3.12 is
+# the CI/build target, matching TARGET_PY above); untested 3.13 and bare
+# python3/python are last resorts so a bleeding-edge install still succeeds.
 _find_system_python() {
     local c resolved
-    for c in python3.13 python3.12 python3.11 python3.10 python3 python; do
+    for c in python3.12 python3.11 python3.10 python3.13 python3 python; do
         resolved="$(command -v "$c" 2>/dev/null)" || continue
         if _py_ok "$resolved"; then
             echo "$resolved"


### PR DESCRIPTION
## Description

`cli.sh` and `ensure-python.sh` selected the newest available Python interpreter first (`python3.13`), but the project is built and tested on 3.12 — the CI matrix (`.github/workflows/ci.yml`), the release workflows, and `ensure-python.sh`'s own `TARGET_PY="${KIROCREW_PYTHON_VERSION:-3.12}"` all target it. On a host with Python 3.13 installed (common via Homebrew), the managed venv landed on an untested interpreter, forcing source builds for dependencies without cp313 wheels and producing noisy resolver conflicts.

This reorders both interpreter-selection loops to prefer 3.12, then 3.11, 3.10, and only fall back to 3.13 as a last resort before bare `python3` — the same order already used by `minimal_install.sh` and `cloud-install.sh` (which omit 3.13 entirely). Keeping 3.13 in the list (rather than dropping it) means hosts with *only* 3.13 still install instead of being hard-blocked, addressing the follow-up comment on the issue about up-to-date distros where bare `python3` is 3.14.

No changes to `requires-python` — an upper bound would hard-block users already running on 3.13, which is more disruptive than a preference-order change.

## Related Issues

Fixes #86

## Testing

- [x] Existing tests pass (`make test`) — N/A: shell-only change, no Python/JS code touched; verified with `sh -n cli.sh` and `bash -n ensure-python.sh`
- [ ] New tests added for new functionality — no test harness exists for installer shell scripts
- [x] Manual verification performed (describe below if applicable)

Verified the selection loop with fake interpreter shims on an isolated `PATH`:

```
3.11 + 3.12 + 3.13 present -> python3.12   (previously python3.13)
only 3.13 present          -> python3.13   (fallback still works)
```

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — comments above both loops updated to state the preference rationale
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
