### PR TITLE
fix(packaging): ship the vendored libllama.so in the sdist

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -74,6 +74,24 @@ jobs:
           pip install --upgrade build
           python -m build
 
+      # Guard against MANIFEST.in regressions (e.g. a global-exclude silently
+      # stripping a vendored runtime from the sdist, and therefore from the
+      # wheel built from it — see #1507): every file in the repo's vendored
+      # llama.cpp tree must be present in the built wheel.
+      - name: Verify vendored native libs survived into the wheel
+        run: |
+          python - <<'PY'
+          import pathlib, sys, zipfile
+          root = pathlib.Path("src/kiro_crew/_vendor/llama_cpp_libs")
+          names = set(zipfile.ZipFile(next(pathlib.Path("dist").glob("*.whl"))).namelist())
+          missing = [
+              p for p in sorted(root.rglob("*")) if p.is_file()
+              and f"kiro_crew/_vendor/llama_cpp_libs/{p.relative_to(root).as_posix()}" not in names
+          ]
+          if missing:
+              sys.exit("missing from wheel: " + ", ".join(str(p) for p in missing))
+          PY
+
       - name: Upload wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -53,3 +53,10 @@ global-exclude *.py[cod]
 global-exclude *.so
 global-exclude .DS_Store
 recursive-include src/kiro_crew/deploy/skills *
+# Re-include the vendored llama.cpp runtime AFTER the excludes: the
+# `global-exclude *.so` above strips exactly `libllama.so` (the Linux libs whose
+# names end in `.so.0` and the macOS/Windows libs escape the glob), and
+# `python -m build` builds the wheel FROM the sdist, so without this line every
+# published Linux wheel ships a vendored llama_cpp that cannot load its own
+# shared library and in-process embeddings fail at gateway startup.
+recursive-include src/kiro_crew/_vendor/llama_cpp_libs *


### PR DESCRIPTION
## Description

On Linux, a wheel install has no `libllama.so`, so the vendored llama-cpp-python fails to import and in-process embeddings die at gateway startup with `FileNotFoundError: Shared library with base name 'llama' not found` — vector memory is unavailable on every default Linux install.

Root cause: `MANIFEST.in` ends with `global-exclude *.so`, which strips **exactly** `libllama.so` from the sdist — and nothing else:

- the other Linux vendored libs are versioned (`libggml.so.0`, `libgomp-*.so.1.0.0`), so the `*.so` glob doesn't match them;
- the macOS (`.dylib`) and Windows (`.dll`) libs escape it entirely.

That's why the bug is Linux-only and why the rest of the `llama_cpp_libs` tree looks intact. `build-wheel.yml` runs `python -m build`, which builds the wheel **from the sdist**, so the published wheel inherits the gap even though `setup.cfg`'s `[options.package_data]` lists `_vendor/llama_cpp_libs/linux_*/*` correctly — those globs can only package files that survived into the sdist.

Fix: re-include `src/kiro_crew/_vendor/llama_cpp_libs` **after** the exclude rules (later `MANIFEST.in` rules win), mirroring how `deploy/skills` is already re-included after the `prune` rules at the end of the file. The `global-exclude *.so` stays in place for its original purpose (build cruft / compiled extensions).

Per review feedback, `build-wheel.yml` now also verifies — right after `python -m build` — that every file under the vendored `llama_cpp_libs` tree made it into the built wheel, so a future `MANIFEST.in` regression fails the build instead of shipping silently. (This makes the PR touch `.github/workflows/`, so the fork workflow-change guard needs the `allow-fork-workflow-change` label from a maintainer.)

## Related Issues

Fixes #1507

## Testing

- [x] Existing tests pass (`make test`) — N/A: packaging-manifest-only change, no Python code touched
- [x] New tests added for new functionality — CI wheel-content verification step in `build-wheel.yml` (fails on the pre-fix MANIFEST.in, passes on the fixed one; both directions verified locally)
- [x] Manual verification performed (describe below if applicable)

Reproduced the exact CI build flow (`python -m build`: sdist → wheel-from-sdist) before and after:

**Before** — sdist contains only 3 of 5 `libllama*` runtimes; both Linux `libllama.so` files missing:
```
macos_arm64/libllama.dylib
macos_x86_64/libllama.dylib
win_amd64/llama.dll
```

**After** — all 26 files under `llama_cpp_libs/` present in the sdist, and the wheel built from that sdist contains:
```
kiro_crew/_vendor/llama_cpp_libs/linux_aarch64/libllama.so   (3.4 MB)
kiro_crew/_vendor/llama_cpp_libs/linux_x86_64/libllama.so    (3.6 MB)
```

Also verified `tar tzf … | grep '\.so' | grep -v llama_cpp_libs` returns nothing — the re-include does not resurrect any other `.so` into the sdist.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — the new MANIFEST.in rule carries a comment explaining the exclude-glob interaction
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

