### PR TITLE
fix(deploy): correct audit LogBucket retention on versioned bucket

### DIFF
--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
@@ -127,19 +127,35 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
       LifecycleConfiguration:
+        # Three coordinated rules give ~365-day retention with tamper-evidence
+        # on a VERSIONED bucket, where a Days expiration inserts a delete marker
+        # rather than erasing data:
+        #  - expire-logs: after 365 days the current log object is replaced by a
+        #    delete marker and its version becomes noncurrent — the declared
+        #    audit-retention window.
+        #  - expire-noncurrent-logs: a noncurrent version (an overwritten/tampered
+        #    object, or one just superseded by its own expiry) is removed 30 days
+        #    later — a short recovery window matching OriginBucket. This bounds the
+        #    retention tail at ~365+30d instead of ~730d (NoncurrentDays counts
+        #    from the moment a version goes noncurrent, not from object creation).
+        #  - expire-delete-markers: reaps the leftover delete marker once nothing
+        #    remains beneath it, so markers do not accumulate unbounded.
+        #    ExpiredObjectDeleteMarker must be its own rule — S3 rejects it in the
+        #    same rule as a Days/Date expiration.
         Rules:
           - Id: expire-logs
             Status: Enabled
             Prefix: ''
             ExpirationInDays: 365
-          # Bound noncurrent versions so tamper-evidence retention does not grow
-          # storage without limit: prior versions of overwritten log objects are
-          # kept for the same 365-day audit window, then expired.
           - Id: expire-noncurrent-logs
             Status: Enabled
             Prefix: ''
             NoncurrentVersionExpiration:
-              NoncurrentDays: 365
+              NoncurrentDays: 30
+          - Id: expire-delete-markers
+            Status: Enabled
+            Prefix: ''
+            ExpiredObjectDeleteMarker: true
           - Id: abort-incomplete-multipart
             Status: Enabled
             Prefix: ''

--- a/test/test_deploy_web_iam.py
+++ b/test/test_deploy_web_iam.py
@@ -98,12 +98,30 @@ def test_audit_log_bucket_has_versioning_enabled():
         assert props.get("VersioningConfiguration", {}).get("Status") == "Enabled", (
             f"{name} must have VersioningConfiguration Status=Enabled"
         )
-    # Versioning must not grow storage unbounded: the log bucket lifecycle must
-    # also expire noncurrent versions.
+    # Retention arithmetic on a versioned bucket must be pinned, not just
+    # "some NoncurrentVersionExpiration exists": a 365-day current-version
+    # expiration inserts a delete marker (the version goes noncurrent), so the
+    # noncurrent rule is a short recovery window (30d, matching OriginBucket) --
+    # NOT another 365d, which would double the effective retention -- and a
+    # dedicated rule must reap the leftover delete markers.
     log_rules = resources["LogBucket"]["Properties"]["LifecycleConfiguration"]["Rules"]
-    assert any("NoncurrentVersionExpiration" in r for r in log_rules), (
-        "LogBucket lifecycle must expire noncurrent versions"
+
+    current = next((r for r in log_rules if r.get("Id") == "expire-logs"), None)
+    assert current and current.get("ExpirationInDays") == 365, (
+        "LogBucket must keep a 365-day current-version expiration window"
     )
+
+    noncurrent = next(
+        (r for r in log_rules if "NoncurrentVersionExpiration" in r), None
+    )
+    assert noncurrent, "LogBucket lifecycle must expire noncurrent versions"
+    assert noncurrent["NoncurrentVersionExpiration"].get("NoncurrentDays") == 30, (
+        "noncurrent recovery window must be 30d (not 365 -- that ~doubles retention)"
+    )
+
+    assert any(
+        r.get("ExpiredObjectDeleteMarker") is True for r in log_rules
+    ), "LogBucket lifecycle must reap expired-object delete markers"
 
 
 def test_policy_covers_engine_bucket_prefix():


### PR DESCRIPTION
## Problem

PR #1460 enabled `VersioningConfiguration` on the deploy-web audit `LogBucket` (CloudTrail S3 data-event + S3 server-access-log target) but kept its pre-existing `ExpirationInDays: 365` and set `NoncurrentVersionExpiration: NoncurrentDays: 365`. On a **versioned** bucket a `Days` expiration does not delete data — S3 writes a delete marker as the new current version and the prior version becomes *noncurrent*, at which point `NoncurrentDays` starts counting.

## Why it matters

- **Retention silently ~doubled** to ~730 days on a bucket that receives all CloudTrail S3 data events plus S3 server access logs — a storage-cost multiplier and a data-minimization / retention-limit drift from the declared 365-day window.
- **Delete markers accumulated unbounded**: once the noncurrent version expired, the leftover expired-object delete marker persisted forever (no `ExpiredObjectDeleteMarker` cleanup existed anywhere in the repo).
- The prior comment claimed it "mirrors OriginBucket", but OriginBucket deliberately has **no** current-version expiration — so copying its noncurrent rule onto a bucket that *does* have one is exactly what produced the doubling.

## Fix (symptom → root cause → change)

- **Symptom:** effective audit-log retention is ~730d and delete markers never get cleaned up.
- **Root cause:** a current-version `Days` expiration + a long `NoncurrentDays` on a versioned bucket stack additively, and nothing reaps expired delete markers.
- **Change:** three coordinated lifecycle rules on `LogBucket`:
  - `expire-logs` — keep `ExpirationInDays: 365` (the declared current-version retention window).
  - `expire-noncurrent-logs` — `NoncurrentVersionExpiration.NoncurrentDays: 30` (a short tamper/recovery window, now actually matching OriginBucket), so the tail is ~365+30d, not ~730d.
  - `expire-delete-markers` — a dedicated rule with `Expiration.ExpiredObjectDeleteMarker: true` (its own rule, since S3 forbids it alongside a `Days`/`Date` expiration), reaping delete markers once nothing remains beneath them.
  - The comment is rewritten to the real semantics.

Tamper-evidence (SAX-05/06/08) is preserved: versioning stays on, and a 30-day noncurrent window is a sane detect/recover window for an overwritten or deleted audit object.

## Tests

`test_audit_log_bucket_has_versioning_enabled` strengthened from "some `NoncurrentVersionExpiration` exists" to pin the arithmetic: `expire-logs` has `ExpirationInDays == 365`, the noncurrent rule has `NoncurrentDays == 30`, and a rule sets `ExpiredObjectDeleteMarker: true`. This locks the retention math and delete-marker cleanup that cfn-lint (schema-only) cannot.

## Manual verification

N/A — CloudFormation template + its regression test; unit coverage is the meaningful evidence. `test_deploy_web_iam.py` passes (22 tests), isort/flake8 clean, YAML parses. `cfn-lint` runs in CI (CloudFormation Lint).

## Screenshots

N/A — no user-visible UI change.
