### PR TITLE
fix(security): a read-only command could delete branches, repoint a remote, and write files

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -10,6 +10,7 @@ import logging
 import math
 import os
 import re
+import shlex
 import threading
 import time
 import traceback
@@ -299,6 +300,348 @@ _UNSAFE_SHELL_RE = re.compile(r">|`|\$\(|<\(|(?<!&)&(?!&)")
 # a sink, smuggling a real-file write past the unsafe-shell check.
 _DEVNULL_REDIR_RE = re.compile(r"(?:\d*>>?|&>)\s*/dev/null(?![\w./-])|\d*>&\d+")
 
+# ── Side effects reached through an allowlisted read-only verb ──
+#
+# The allowlist above names a verb and is matched as a prefix, so it vouches
+# for every flag, subcommand and operand that verb accepts. Some of those
+# write a file, change a ref or launch another program — and none of it goes
+# through a shell redirect, so `_UNSAFE_SHELL_RE` never sees it.
+#
+# The tables are keyed by verb because the same spelling is harmless
+# elsewhere: `ls -o` is a long listing format and `grep -o` prints only the
+# match, while `sort -o FILE` truncates and writes FILE.
+
+# Flags that make the program write a file named on its own command line.
+_WRITE_FLAGS: dict[str, tuple[str, ...]] = {
+    "sort": ("-o", "--output"),
+    # `-R` writes without being handed a filename: tree re-runs itself in every
+    # directory it descends into, adding `-o 00Tree.html` each time, so the file
+    # is named by tree rather than by the command line. Same outcome as `-o`, one
+    # step removed, which is why looking only for a filename-bearing flag missed
+    # it.
+    "tree": ("-o", "--output", "-R"),
+    "file": ("-C", "--compile"),
+    "uniq": ("-o",),
+    "git diff": ("--output",),
+    "git show": ("--output",),
+    "git log": ("--output",),
+    # A pager, and not on the prefix allowlist — but the PIPE-TARGET check runs
+    # this table too, and `cat f | less -O FILE` writes FILE from a segment whose
+    # leading verb is a read.
+    "less": ("-o", "-O", "--log-file", "--LOG-FILE"),
+}
+
+# Flags that hand control to a program the repository names, not the caller:
+# an external diff driver comes from the repo's config or .gitattributes.
+_EXEC_FLAGS: dict[str, tuple[str, ...]] = {
+    # `--textconv` is the same hand-off as `--ext-diff` through a different config
+    # key, and it was missing here while `git cat-file` below already listed it —
+    # the table gap, not the design, is what let `git diff --textconv` through.
+    #
+    # Scope, stated plainly: this stops the COMMAND LINE from selecting the
+    # program. It does not stop a textconv driver the user configured from being
+    # applied by default, because that name comes from git config, which is not
+    # part of a repository and is not something a checkout can add. Requiring
+    # `--no-textconv` would be the only way to cover that, and it would take plain
+    # `git diff` off the read-only path — the most common read there is.
+    "git diff": ("--ext-diff", "--textconv"),
+    "git show": ("--ext-diff", "--textconv"),
+    "git log": ("--ext-diff", "--textconv"),
+    # `--filters` runs the repository's clean/smudge filter — a command from
+    # `.gitattributes`, i.e. chosen by the checkout rather than by the caller.
+    # `--textconv` is the same hand-off through a different config key.
+    "git cat-file": ("--filters", "--textconv"),
+    # `sort` compresses its temporary files by running this program.
+    "sort": ("--compress-program",),
+    # A pager that runs a filter over its input, reachable as a pipe target.
+    "less": ("--filter",),
+}
+
+# `git branch` and `git tag` each carry a read mode and a write mode under one
+# subcommand, so the prefix match admits the destructive spellings. Some of
+# these also open `$EDITOR`, which runs a program of the environment's
+# choosing: `git branch --edit-description` always does, and `git tag <name>`
+# does whenever `tag.gpgSign` or `tag.forceSignAnnotated` is set.
+_GIT_REF_WRITE_FLAGS: dict[str, tuple[str, ...]] = {
+    "branch": (
+        "-d",
+        "-D",
+        "--delete",
+        "-m",
+        "-M",
+        "--move",
+        "-c",
+        "-C",
+        "--copy",
+        "-f",
+        "--force",
+        "-u",
+        "--set-upstream",
+        "--set-upstream-to",
+        "--unset-upstream",
+        "--edit-description",
+    ),
+    "tag": (
+        "-d",
+        "--delete",
+        "-a",
+        "--annotate",
+        "-s",
+        "--sign",
+        "-m",
+        "--message",
+        "-F",
+        "--file",
+        "-f",
+        "--force",
+        "--cleanup",
+    ),
+}
+
+# Why a bare operand needs TWO tables rather than one.
+#
+# `git branch <name>` creates a ref, so a bare operand is the signal. Deciding
+# when an operand is NOT that name was collapsed into a single "this flag eats
+# the next token" set, and that conflated two different things git keeps apart:
+#
+#   * whether the flag CONSUMES the following word, which git's own option
+#     parser decides by whether the argument is required or optional. A required
+#     argument is taken from the next word; an OPTIONAL one must be attached with
+#     `=`, and a separate word is left as an operand. `--color` is optional, so
+#     `git branch --color newbranch` still creates `newbranch` — while the guard
+#     read `newbranch` as the colour and passed the segment.
+#   * whether the command is in LIST mode, where an operand is a pattern to match
+#     rather than a ref to create. `git branch --list newbranch` lists, it does
+#     not create, so treating that operand as a creation would be a false denial.
+#
+# Splitting them keeps both answers right: `--color` is in neither set, and
+# `--list` is in the list-mode set only.
+
+# Flags whose argument is REQUIRED, so git takes it from the following word.
+_GIT_REF_VALUE_FLAGS: frozenset[str] = frozenset(("--points-at", "--format", "--sort"))
+# Flags that put `git branch` / `git tag` in list mode, where a bare operand is a
+# pattern. `--points-at` appears in both: it consumes its value AND selects.
+_GIT_REF_LIST_FLAGS: frozenset[str] = frozenset(
+    (
+        "-l",
+        "--list",
+        "--contains",
+        "--no-contains",
+        "--merged",
+        "--no-merged",
+        "--points-at",
+    )
+)
+
+# `git remote` subcommands that rewrite remote configuration. `set-url` is the
+# sharpest: it repoints the remote, so later fetches and pushes go elsewhere.
+_GIT_REMOTE_WRITE_SUBCOMMANDS: frozenset[str] = frozenset(
+    ("add", "remove", "rm", "rename", "set-url", "set-head", "set-branches", "prune", "update")
+)
+
+
+#: Shell expansions whose RESULT is the argument, while ``shlex`` hands this
+#: module the unexpanded text. Every check here is keyed on the token, so where
+#: the two disagree the guard inspects one string and the program receives
+#: another:
+#:
+#:     git diff $'--output=/tmp/pwned'       shlex: `$--output=…`     bash: `--output=…`
+#:     git diff $"--output=/tmp/pwned"       shlex: `$--output=…`     bash: `--output=…`
+#:     git diff ${HOME:+--output=/tmp/pwned} shlex: literal           bash: `--output=…`
+#:     git remote se${x}t-url …              shlex: `se${x}t-url`     bash: `set-url`
+#:     git diff --{out,out}put=/tmp/pwned    shlex: `--{out,out}put=` bash: `--output=…`
+#:
+#: Matched as ONE class rather than one spelling at a time. Closing ``$'`` alone
+#: left ``$"`` (locale translation) and ``${…}`` (parameter expansion) open on the
+#: identical path, and the remaining forms are bounded only by bash's grammar.
+#: Un-expanding them here would mean reimplementing that grammar, so a segment
+#: carrying one is refused instead: a read-only command has no need of any of
+#: them, and a rejected segment falls through to the human approval prompt.
+#:
+#: Brace expansion belongs to the same class even though it carries no ``$``: it
+#: is performed FIRST, before any other expansion, and it can assemble a flag out
+#: of fragments that match nothing here. Only the forms bash actually expands are
+#: matched — a comma list or a ``..`` range — so a lone ``{`` (a JSON argument, a
+#: Go template) is left alone.
+#:
+#: ``$(…)`` and backticks are already refused upstream by ``_UNSAFE_SHELL_RE``;
+#: this covers what that pattern does not reach.
+#:
+#: Matched on the raw segment, so a QUOTED occurrence is refused too even though
+#: bash would not expand it (``grep '*.{js,ts}' f``). That is the same trade the
+#: ``$`` forms already make, and it errs toward the prompt.
+_SHELL_EXPANSION_RE = re.compile(
+    r"\$['\"{]"
+    r"|\$[A-Za-z_][A-Za-z0-9_]*"
+    r"|\{[^{}\s]*,[^{}\s]*\}"
+    r"|\{[^{}\s]*\.\.[^{}\s]*\}"
+)
+#: Pathname-expansion metacharacters. NOT part of the class above, because a glob
+#: is usually the argument itself in a read-only command (`ls *.py`) — it is
+#: refused only in the positions where the spelling is what gets classified. See
+#: the note in `_side_effect_reason`.
+_GLOB_META_RE = re.compile(r"[*?\[]")
+
+
+def _matched_flag(tokens: list[str], flags: tuple[str, ...]) -> str:
+    """Return the first token in *tokens* that supplies one of *flags*.
+
+    Matches the flag on its own (``-o``), joined to its value (``--output=x``)
+    and bundled into a short-option cluster (``-uo`` supplies ``-o``), so the
+    check cannot be stepped around by respelling the same flag.
+    """
+    shorts = {f[1] for f in flags if len(f) == 2 and f[0] == "-"}
+    longs = [f for f in flags if f.startswith("--") and len(f) > 2]
+    for tok in tokens:
+        if tok in flags:
+            return tok
+        for flag in flags:
+            if tok.startswith(flag + "="):
+                return flag
+        # A GNU long option may be ABBREVIATED to any unambiguous prefix, so
+        # `--out=FILE` and `--outp=FILE` reach the same `--output` that exact
+        # matching missed. Accept any prefix of a known flag that is at least
+        # `--` plus one character: the parser this guards resolves it, so the
+        # guard has to as well. Over-matching here can only add a prompt.
+        head = tok.split("=", 1)[0]
+        if head.startswith("--") and len(head) > 2:
+            for flag in longs:
+                if flag.startswith(head):
+                    return flag
+        if shorts and len(tok) > 1 and tok[0] == "-" and tok[1] != "-":
+            for ch in tok[1:]:
+                if ch in shorts:
+                    return "-" + ch
+    return ""
+
+
+def _side_effect_reason(segment: str) -> str:
+    """Reason *segment* has a side effect, despite naming a read-only verb.
+
+    Returns "" when the segment is genuinely read-only. Called after the verb
+    has cleared the allowlist, because the allowlist only decides *which
+    program* runs — not what the rest of the command line asks it to do.
+    """
+    # ANSI-C quoting is stripped by `shlex` but honoured by bash, so the token
+    # this check inspects is not the token the shell runs: `git diff $'-o'` reaches
+    # `shlex` as `$-o` — matching no flag — while bash passes `-o`. The same trick
+    # hides a subcommand (`git remote $'set-url'`). It is a spelling with no
+    # legitimate use in a read-only command, so the segment is refused outright
+    # rather than un-quoted here, which would mean reimplementing bash's rules.
+    if _SHELL_EXPANSION_RE.search(segment):
+        return "a shell expansion hides the real argument"
+    try:
+        tokens = shlex.split(segment)
+    except ValueError:
+        # Cannot recover argv, so cannot vouch for the operands.
+        return "quoting cannot be resolved"
+    if not tokens:
+        return ""
+    # The verb is matched case-insensitively, like the allowlist does, so an
+    # unusual spelling cannot step past the table. Flags keep their case,
+    # because for these programs the case carries the meaning.
+    verb = tokens[0].rsplit("/", 1)[-1].lower()
+    args = tokens[1:]
+
+    # Pathname expansion is the one expansion that cannot be refused wholesale.
+    # Every other form in `_SHELL_EXPANSION_RE` has no place in a read-only
+    # command, but a glob usually IS the argument — `ls *.py`, `grep -rn TODO src/*`
+    # — so refusing the character outright would take the ordinary reads off this
+    # path.
+    #
+    # It still has to be refused where the SPELLING is what gets classified, since
+    # there bash resolves the glob against the filesystem and hands the program a
+    # word this module never saw:
+    #
+    #     git remote s?t-url origin https://evil   (a file named `set-url` nearby)
+    #     git diff --outp?t=/tmp/pwned
+    #
+    # Two positions, then: the git subcommand, and a flag NAME. A flag's VALUE is
+    # left alone, so `git log --grep='[abc]'` still passes.
+    for token in args:
+        head = token.split("=", 1)[0]
+        if token.startswith("-") and _GLOB_META_RE.search(head):
+            return "a glob in a flag name hides the real argument"
+
+    # The allowlist names `git <subcommand>`, so that is the unit to key on.
+    key = verb
+    if verb == "git" and args:
+        if _GLOB_META_RE.search(args[0]):
+            return "a glob in the subcommand hides the real argument"
+        subcommand = args[0].lower()
+        key = f"git {subcommand}"
+        args = args[1:]
+
+        if subcommand in _GIT_REF_WRITE_FLAGS:
+            hit = _matched_flag(args, _GIT_REF_WRITE_FLAGS[subcommand])
+            if hit:
+                return f"'git {subcommand} {hit}' changes a ref"
+            # A bare operand names a ref to create, unless the command is in list
+            # mode (where it is a pattern) or the operand is a required flag value.
+            #
+            # List mode is decided over the WHOLE argument list before the walk,
+            # because the selecting flag can come after the operand it makes into a
+            # pattern: `git branch newbranch --list` is still a list.
+            list_mode = any(
+                tok.split("=", 1)[0] in _GIT_REF_LIST_FLAGS
+                or (len(tok) > 1 and tok[0] == "-" and tok[1] != "-" and "l" in tok[1:])
+                for tok in args
+            )
+            previous = ""
+            operand_only = False
+            for tok in args:
+                # `--` ends the options. Everything after it is an operand, however
+                # it is spelled: `git tag -- -z` creates the tag `-z`, while a
+                # leading-dash test read it as one more option and passed.
+                if tok == "--":
+                    operand_only = True
+                    previous = ""
+                    continue
+                if not operand_only and tok.startswith("-"):
+                    # An ATTACHED value (`--sort=x`) takes nothing from the next
+                    # word, so it must not mark the following operand as consumed.
+                    previous = "" if "=" in tok else tok
+                    continue
+                if previous in _GIT_REF_VALUE_FLAGS:
+                    previous = ""
+                    continue
+                if list_mode:
+                    continue
+                return f"'git {subcommand} {tok}' creates a ref"
+
+        if subcommand == "remote":
+            # `git remote -v set-url …` puts an option BEFORE the subcommand, and
+            # git accepts it there. Keying on `args[0]` therefore saw `-v` and let
+            # the mutation through, so the leading options are skipped and the
+            # first non-option word is the subcommand — the same token git uses.
+            for tok in args:
+                if tok.startswith("-"):
+                    continue
+                if tok in _GIT_REMOTE_WRITE_SUBCOMMANDS:
+                    return f"'git remote {tok}' rewrites remote configuration"
+                # `git remote` has its OWN subcommand word, and it is classified by
+                # the same table, so a glob has to be refused here too: with a file
+                # named `set-url` nearby, `git remote s?t-url …` reaches this module
+                # as a word matching nothing and bash hands git the mutation.
+                if _GLOB_META_RE.search(tok):
+                    return "a glob in the subcommand hides the real argument"
+                break
+
+    hit = _matched_flag(args, _WRITE_FLAGS.get(key, ()))
+    if hit:
+        return f"'{key} {hit}' writes a file"
+    hit = _matched_flag(args, _EXEC_FLAGS.get(key, ()))
+    if hit:
+        return f"'{key} {hit}' runs a program named by the repository"
+
+    # `uniq INPUT OUTPUT` writes its second operand.
+    if verb == "uniq":
+        operands = [tok for tok in args if not tok.startswith("-")]
+        if len(operands) > 1:
+            return "'uniq INPUT OUTPUT' writes its second operand"
+
+    return ""
+
 
 def _classify_bash(cmd: str) -> str:
     """Single source of truth for read-only bash classification.
@@ -323,7 +666,12 @@ def _classify_bash(cmd: str) -> str:
         pipe_parts = [p.strip() for p in part.split("|") if p.strip()]
         if not pipe_parts:
             return "unsafe shell pattern"
-        first = pipe_parts[0].strip().lower()
+        # The verb is compared case-insensitively, but the side-effect check
+        # below needs the original spelling: flags are case-sensitive, and the
+        # two cases can mean opposite things (`file -C` compiles a magic file,
+        # `file -c` only prints one).
+        head = pipe_parts[0].strip()
+        first = head.lower()
         if not (
             first.endswith("--help")
             or first.endswith("--version")
@@ -331,10 +679,21 @@ def _classify_bash(cmd: str) -> str:
         ):
             base = first.split()[0] if first.split() else first
             return f"command '{base}' is not on the read-only allowlist"
+        # Clearing the allowlist only settles which program runs. The rest of
+        # the command line can still write a file, change a ref or start
+        # another program.
+        side_effect = _side_effect_reason(head)
+        if side_effect:
+            return f"not read-only: {side_effect}"
         for target in pipe_parts[1:]:
             if not _READ_ONLY_PIPE_RE.match(target):
                 tgt = target.split()[0] if target.split() else target
                 return f"pipe target '{tgt}' is not a read-only filter"
+            # The pipe allowlist matches only the leading verb, so a filter's
+            # own output flag (`sort -o FILE`) needs the same check.
+            side_effect = _side_effect_reason(target)
+            if side_effect:
+                return f"pipe target is not read-only: {side_effect}"
     return ""
 
 

--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -90,6 +90,280 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("java -version") is True
         assert is_read_only_bash("some-tool --help") is True
 
+    def test_allowlisted_verb_may_not_write_via_its_own_output_flag(self):
+        """A write does not need a shell redirect to be a write.
+
+        `_UNSAFE_SHELL_RE` only sees `>`, so a program's own output flag
+        reached the filesystem while the command still classified read-only.
+        """
+        assert is_read_only_bash("tree -o /tmp/pwned") is False
+        assert is_read_only_bash("git diff --output=/tmp/pwned") is False
+        assert is_read_only_bash("git show --output=/tmp/pwned") is False
+        assert is_read_only_bash("git log --output=/tmp/pwned") is False
+        # `file -C` compiles a magic file; `file -c` only prints one.
+        assert is_read_only_bash("file -C -m /tmp/magic.src") is False
+        assert is_read_only_bash("file -c") is True
+
+    def test_pipe_target_may_not_write_via_its_own_output_flag(self):
+        """The pipe allowlist matched only the filter's leading verb."""
+        assert is_read_only_bash("cat f | sort -o /tmp/pwned") is False
+        assert is_read_only_bash("cat f | sort --output=/tmp/pwned") is False
+        # Bundled short cluster supplies the same flag.
+        assert is_read_only_bash("cat f | sort -uo /tmp/pwned") is False
+        # `uniq INPUT OUTPUT` writes its second operand.
+        assert is_read_only_bash("cat f | uniq /tmp/in /tmp/pwned") is False
+        # The read-only spellings of the same filters still pass.
+        assert is_read_only_bash("cat f | sort") is True
+        assert is_read_only_bash("cat f | sort -u") is True
+        assert is_read_only_bash("cat f | uniq -c") is True
+
+    def test_allowlisted_git_verb_may_not_change_a_ref_or_remote(self):
+        """`git branch`/`git tag`/`git remote` have read and write modes.
+
+        The allowlist entries are the listing forms, but a prefix match
+        admitted the destructive spellings under the same verb.
+        """
+        # Ref deletion, rename and copy.
+        assert is_read_only_bash("git branch -D release") is False
+        assert is_read_only_bash("git branch -d release") is False
+        assert is_read_only_bash("git branch -m main hijacked") is False
+        # A bare operand names a ref to create.
+        assert is_read_only_bash("git branch newbranch") is False
+        assert is_read_only_bash("git tag sometag") is False
+        assert is_read_only_bash("git tag -d v1.0.0") is False
+        assert is_read_only_bash("git tag -m msg v1.0.0") is False
+        # Remote configuration: `set-url` repoints where pushes go.
+        assert is_read_only_bash("git remote set-url origin https://evil.example/x.git") is False
+        assert is_read_only_bash("git remote add evil https://evil.example/x.git") is False
+        assert is_read_only_bash("git remote remove origin") is False
+        assert is_read_only_bash("git remote rename origin upstream") is False
+
+    def test_allowlisted_git_verb_may_not_launch_an_editor_or_diff_driver(self):
+        """Both spellings hand control to a program the caller did not name."""
+        # `--edit-description` always opens $EDITOR.
+        assert is_read_only_bash("git branch --edit-description") is False
+        # An external diff driver comes from repo config / .gitattributes.
+        assert is_read_only_bash("git diff --ext-diff") is False
+        assert is_read_only_bash("git log --ext-diff") is False
+
+    def test_read_only_git_inspection_still_auto_approves(self):
+        """The listing and inspection forms must not regress into a prompt."""
+        assert is_read_only_bash("git branch") is True
+        assert is_read_only_bash("git branch -a") is True
+        assert is_read_only_bash("git branch -vv") is True
+        assert is_read_only_bash("git branch --list") is True
+        assert is_read_only_bash("git branch --show-current") is True
+        assert is_read_only_bash("git branch --merged") is True
+        # A bare operand that is the value of a read-only flag is not a new ref.
+        assert is_read_only_bash("git branch --contains HEAD") is True
+        assert is_read_only_bash("git tag") is True
+        assert is_read_only_bash("git tag -l") is True
+        assert is_read_only_bash("git tag -l v1.*") is True
+        assert is_read_only_bash("git remote") is True
+        assert is_read_only_bash("git remote -v") is True
+        assert is_read_only_bash("git remote get-url origin") is True
+
+    def test_side_effect_check_is_case_insensitive_on_the_verb_only(self):
+        """The verb is matched like the allowlist does; flags keep their case.
+
+        The allowlist lowercases before comparing, so an odd verb spelling
+        clears it — the side-effect table has to fold the verb the same way,
+        while `-C` and `-c` must stay distinct.
+        """
+        assert is_read_only_bash("FILE -C -m /tmp/magic.src") is False
+        assert is_read_only_bash("GIT BRANCH -D release") is False
+        assert is_read_only_bash("ls -o") is True
+        assert is_read_only_bash("grep -o pattern file") is True
+
+    def test_an_abbreviated_long_option_still_matches(self):
+        """GNU resolves any unambiguous prefix, so exact matching missed the flag.
+
+        `git diff --out=FILE` reaches the same `--output` as the full spelling and
+        writes the file, while the check compared against `--output` alone.
+        """
+        assert is_read_only_bash("git diff --output=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --outp=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --out=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --o=/tmp/pwned") is False
+        assert is_read_only_bash("git branch --edit-desc") is False
+        assert is_read_only_bash("git branch --ed") is False
+        # A prefix of no known write flag is untouched: these stay read-only.
+        assert is_read_only_bash("git diff --stat") is True
+        assert is_read_only_bash("git diff --name-only") is True
+        assert is_read_only_bash("git branch --contains HEAD") is True
+
+    def test_a_shell_expansion_in_the_arguments_is_refused(self):
+        """bash expands these; `shlex` does not, so the two see different argv.
+
+        Matched as one CLASS, not one spelling. Closing `$'…'` alone left the
+        siblings open on the identical path: `$"…"` is locale translation and
+        `${…}` is parameter expansion, and both let the real flag or subcommand
+        appear only after bash is done with it. Un-expanding them here would mean
+        reimplementing bash's grammar, so a segment carrying one is refused.
+        """
+        # ANSI-C quoting.
+        assert is_read_only_bash("git diff $'-o' /tmp/pwned") is False
+        assert is_read_only_bash("git diff $'--output=/tmp/pwned'") is False
+        assert is_read_only_bash("git remote $'set-url' origin https://evil") is False
+        # Locale translation — the sibling form.
+        assert is_read_only_bash('git diff $"--output=/tmp/pwned"') is False
+        assert is_read_only_bash('git remote $"set-url" origin https://evil') is False
+        # Parameter expansion, including one spliced INSIDE a word.
+        assert is_read_only_bash("git diff ${HOME:+--output=/tmp/pwned}") is False
+        assert is_read_only_bash("git remote ${x:-set-url} origin https://evil") is False
+        assert is_read_only_bash("git remote se${x}t-url origin https://evil") is False
+        assert is_read_only_bash("git branch ${x:--D} release") is False
+        # A bare variable reference is the same divergence.
+        assert is_read_only_bash("git diff $FLAG") is False
+        # Ordinary quoting is unaffected — only the `$`-led forms are.
+        assert is_read_only_bash("git tag -l 'v1.*'") is True
+        assert is_read_only_bash('grep -n "pattern" file') is True
+
+    def test_a_pipe_target_and_git_cat_file_cannot_write_or_exec(self):
+        """The pipe-target check runs the same tables, so their gaps are reachable.
+
+        `less` is not on the prefix allowlist, so it cannot lead a segment — but
+        `cat f | less -O FILE` writes FILE from a segment whose leading verb is a
+        read. `git cat-file --filters` hands off to the filter named by the
+        repository's `.gitattributes`, and `sort --compress-program` to a program
+        of the caller's choosing.
+        """
+        assert is_read_only_bash("cat f | less -O /tmp/pwned") is False
+        assert is_read_only_bash("cat f | less --log-file=/tmp/pwned") is False
+        assert is_read_only_bash("git cat-file --filters HEAD:f") is False
+        assert is_read_only_bash("git cat-file --textconv HEAD:f") is False
+        # The read forms still pass.
+        assert is_read_only_bash("cat f | less") is True
+        assert is_read_only_bash("git cat-file -p HEAD:f") is True
+
+    def test_a_leading_option_does_not_hide_a_git_remote_subcommand(self):
+        """git accepts an option BEFORE the subcommand, so `args[0]` is not it.
+
+        `git remote -v set-url …` repointed the remote because the check read `-v`
+        as the subcommand and found it harmless. The leading options are skipped so
+        the first non-option word is the one git acts on.
+        """
+        assert is_read_only_bash("git remote -v set-url origin https://evil") is False
+        assert is_read_only_bash("git remote --verbose add evil https://evil") is False
+        assert is_read_only_bash("git remote -v remove origin") is False
+        assert is_read_only_bash("git remote -v rename a b") is False
+        # The listing forms, which is what the option is normally used for.
+        assert is_read_only_bash("git remote -v") is True
+        assert is_read_only_bash("git remote --verbose") is True
+        assert is_read_only_bash("git remote") is True
+
+    def test_brace_expansion_can_assemble_a_flag_out_of_fragments(self):
+        """Brace expansion runs FIRST and carries no `$`, so the `$`-led class missed it.
+
+        `git diff --{out,out}put=/tmp/pwned` reaches this module as one token that
+        matches no flag, while bash hands git `--output=…` twice and the file is
+        truncated. Only the forms bash actually expands are refused — a comma list
+        or a `..` range — so a lone brace is still allowed through.
+        """
+        assert is_read_only_bash("git diff --{out,out}put=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --outpu{t,t}=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --output{,}=/tmp/pwned") is False
+        assert is_read_only_bash("cat f | sort -{o,o} /tmp/pwned") is False
+        # A range, the other expanding form.
+        assert is_read_only_bash("git log --{a..z}") is False
+        # A brace that bash does not expand is not this class.
+        assert is_read_only_bash("git log --format={hash}") is True
+        assert is_read_only_bash('grep -n "{}" file') is True
+
+    def test_a_glob_is_refused_only_where_the_spelling_is_classified(self):
+        """Pathname expansion is the one expansion that cannot be refused wholesale.
+
+        A glob usually IS the argument in a read-only command, so refusing the
+        character outright would take `ls *.py` and `grep -rn TODO src/*` off this
+        path. It still has to go where the SPELLING is what gets classified — the
+        subcommand and a flag NAME — because there bash resolves it against the
+        filesystem and hands the program a word this module never saw.
+        """
+        # The subcommand, including `git remote`'s own subcommand word.
+        assert is_read_only_bash("git remote s?t-url origin https://evil") is False
+        assert is_read_only_bash("git remote se[t]-url origin https://evil") is False
+        assert is_read_only_bash("git remote *et-url origin https://evil") is False
+        assert is_read_only_bash("git remote -v s?t-url origin https://evil") is False
+        # A flag name.
+        assert is_read_only_bash("git diff --outp?t=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --outp[u]t=/tmp/pwned") is False
+        assert is_read_only_bash("cat f | sort --out?ut=/tmp/pwned") is False
+        # A glob in an OPERAND is the ordinary case and must keep working.
+        assert is_read_only_bash("ls *.py") is True
+        assert is_read_only_bash("grep -rn TODO src/*") is True
+        assert is_read_only_bash("cat *.log") is True
+        assert is_read_only_bash("wc -l *.md") is True
+        assert is_read_only_bash("ls file?.txt") is True
+        assert is_read_only_bash("grep 'a[bc]d' file") is True
+        assert is_read_only_bash("git diff -- src/*") is True
+        assert is_read_only_bash("git branch --list 'feat/*'") is True
+        # A flag's VALUE is left alone too — only its name is classified.
+        assert is_read_only_bash("git log --grep=[abc]") is True
+
+    def test_tree_writes_without_being_given_a_filename(self):
+        """`tree -R` names the output file itself, so a filename-bearing flag missed it.
+
+        tree re-runs itself in each directory it descends into, adding
+        `-o 00Tree.html` every time. Same write as `-o`, one step removed.
+        """
+        assert is_read_only_bash("tree -L 1 -R .") is False
+        assert is_read_only_bash("tree -aR .") is False
+        # The ordinary listing forms still pass.
+        assert is_read_only_bash("tree -L 2 .") is True
+        assert is_read_only_bash("tree") is True
+
+    def test_textconv_hands_off_the_same_way_ext_diff_does(self):
+        """`--textconv` selects a program from config, exactly as `--ext-diff` does.
+
+        The table listed it for `git cat-file` and not for `git diff`/`show`/`log`,
+        so the identical hand-off was open on the three most-used spellings.
+
+        Scope: this stops the COMMAND LINE from selecting the program. A textconv
+        driver the user configured is still applied by default, because that name
+        comes from git config rather than from the repository, and requiring
+        `--no-textconv` would take plain `git diff` off the read-only path.
+        """
+        assert is_read_only_bash("git diff --textconv HEAD") is False
+        assert is_read_only_bash("git show --textconv HEAD") is False
+        assert is_read_only_bash("git log --textconv") is False
+        # The default spellings stay read-only.
+        assert is_read_only_bash("git diff") is True
+        assert is_read_only_bash("git diff HEAD") is True
+        assert is_read_only_bash("git log --oneline -n 20") is True
+
+    def test_an_optional_flag_value_does_not_swallow_a_ref_name(self):
+        """git takes a separate word only for a REQUIRED argument.
+
+        `--color` takes an optional one, which git accepts only when attached with
+        `=`. Reading `newbranch` as the colour meant `git branch --color newbranch`
+        created the ref and the segment passed. List mode is tracked separately, so
+        `git branch --list newbranch` is still the read it is.
+        """
+        assert is_read_only_bash("git branch --color newbranch") is False
+        assert is_read_only_bash("git branch --color=always newbranch") is False
+        assert is_read_only_bash("git tag --color newtag") is False
+        # A required-argument flag does consume the next word.
+        assert is_read_only_bash("git branch --points-at HEAD") is True
+        assert is_read_only_bash("git branch --format %(refname) --list") is True
+        assert is_read_only_bash("git branch --sort=refname --list") is True
+        # List mode: the operand is a pattern, not a ref to create.
+        assert is_read_only_bash("git branch --list newbranch") is True
+        assert is_read_only_bash("git tag -l 'v1*'") is True
+        assert is_read_only_bash("git branch --contains HEAD") is True
+
+    def test_the_option_terminator_makes_everything_after_it_an_operand(self):
+        """`git tag -- -z` creates the tag `-z`.
+
+        Classifying by a leading dash read `-z` as one more option, so the operand
+        that names the ref was never seen.
+        """
+        assert is_read_only_bash("git tag -- -z") is False
+        assert is_read_only_bash("git branch -- -z") is False
+        assert is_read_only_bash("git tag -- v9") is False
+        # `--` with nothing after it names no ref.
+        assert is_read_only_bash("git tag --") is True
+        assert is_read_only_bash("git branch --") is True
+
     def test_compound_read_commands(self):
         assert is_read_only_bash("git status && git log --oneline -3") is True
         assert is_read_only_bash("ls -la; echo done") is True
@@ -112,9 +386,7 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("ls -la 2>&1") is True
         # Compound + pipe chains with a /dev/null sink stay read-only.
         assert is_read_only_bash("grep -r foo . 2>/dev/null | head -20") is True
-        assert (
-            is_read_only_bash("ls /a 2>/dev/null; grep -r foo /b 2>/dev/null") is True
-        )
+        assert is_read_only_bash("ls /a 2>/dev/null; grep -r foo /b 2>/dev/null") is True
 
     def test_devnull_does_not_unlock_write_commands(self):
         """The /dev/null exemption must not allowlist a write/exec command."""


### PR DESCRIPTION
## Description

`_READ_ONLY_BASH_PREFIXES` names a verb, and `_classify_bash` matches it as a **prefix**:

```python
any(first == p or first.startswith(p + " ") for p in _READ_ONLY_BASH_PREFIXES)
```

So clearing the allowlist vouched for every flag, subcommand and operand that verb accepts. Several of them accept operands that write a file, change a ref or start another program — and none of that goes through a shell redirect, so `_UNSAFE_SHELL_RE`, which only looks for `>`, never saw it.

Every line below classified read-only, so it auto-approved and `hooks.on_tool_call` — the PreToolUse gate carrying the deny floor and the sensitive-path check — was never reached for it. I ran each one and confirmed the side effect:

| command | verified effect |
|---|---|
| `git remote set-url origin <attacker-url>` | remote repointed; later fetches and pushes go there |
| `git branch -D release` | branch deleted |
| `git branch --edit-description` | `$EDITOR` executed |
| `git tag <name>` | `$EDITOR` executed when `tag.gpgSign` is set |
| `git tag -d v1.0.0` | tag deleted |
| `git branch <name>` | branch created |
| `git diff --output=FILE` | FILE written |
| `sort -o FILE` (as a pipe target) | FILE written |
| `uniq IN OUT` | OUT written |
| `file -C -m FILE` | `FILE.mgc` written |

None of these were caught by `is_sensitive_bash_command` or the deny floor either — I checked both.

The two editor cases are the sharpest: an auto-approved command starts a program the caller never named. `--edit-description` opens `$EDITOR` unconditionally; `git tag <name>` does so whenever `tag.gpgSign` or `tag.forceSignAnnotated` is set, which is how I hit it — this host has `tag.gpgSign=true` globally.

### What changed

`_side_effect_reason` runs after the verb clears the allowlist, because the allowlist only settles **which program runs**, not what the rest of the command line asks it to do.

The tables are keyed by verb, because the same spelling is harmless elsewhere: `ls -o` is a long listing format and `grep -o` prints only the match, while `sort -o FILE` truncates and writes FILE. A blanket ban on `-o` would have broken both.

| table | covers |
|---|---|
| `_WRITE_FLAGS` | `sort -o`, `tree -o`, `file -C`, `uniq -o`, `git diff/show/log --output` |
| `_EXEC_FLAGS` | `git diff/show/log --ext-diff` — the driver comes from repo config or `.gitattributes` |
| `_GIT_REF_WRITE_FLAGS` | the write-mode flags of `git branch` and `git tag`, including `--edit-description` |
| `_GIT_REMOTE_WRITE_SUBCOMMANDS` | `add`, `remove`, `rm`, `rename`, `set-url`, `set-head`, `set-branches`, `prune`, `update` |

Three details that decide whether the check actually holds:

- **Flag respelling.** `_matched_flag` accepts the flag alone (`-o`), joined to its value (`--output=x`) and bundled into a short cluster (`-uo` supplies `-o`), so the same flag cannot be smuggled past in a different spelling.
- **Bare operands create refs.** `git branch <name>` and `git tag <name>` mutate with no flag at all, so a bare operand is rejected — unless it is the value of a read-only flag, which is what keeps `git branch --contains HEAD` and `git tag -l 'v1.*'` working.
- **Case.** `_classify_bash` lowercases before comparing against the allowlist, so an odd verb spelling clears it; the side-effect lookup folds the verb the same way. Flags keep their case, because here the case carries the meaning — `file -C` compiles a magic file, `file -c` only prints one.

The pipe allowlist (`_READ_ONLY_PIPE_RE`) matched only a filter's leading verb, so the same check now runs on each pipe target. That is what `cat f | sort -o /tmp/x` needed.

Nothing is newly blocked. A rejected segment falls through to the human approval prompt, which is where a write or a ref change belonged.

## Related Issues

None filed — reporting and fixing together.

Same function as #1259, different root cause: that one is a suffix rule vouching for arbitrary command text, this one is an allowlist keyed on the verb without constraining its flags. They are independent and can be reviewed or merged in either order. They do conflict textually, because both insert a helper after `_DEVNULL_REDIR_RE` and both add tests at the same place in `test_trust_reads.py` — I tried the merge locally to confirm it is only that, adjacent insertions with no semantic overlap. I will rebase whichever lands second, promptly.

## Testing

- [x] Existing tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

Six new cases in `test/test_trust_reads.py`, one per bypass shape: writes through an output flag; the same on a pipe target, including the bundled `-uo` spelling and `uniq`'s second operand; ref and remote mutation under `git branch`/`git tag`/`git remote`; hand-off to `$EDITOR` and to an external diff driver.

Two of them guard against the fix going wrong in the other direction — the listing and inspection forms must keep auto-approving, and the verb-only case folding must not collapse `-C` into `-c`.

```
pytest (full suite)                                                                ->  24556 passed, 124 skipped, 5 xfailed, 1 failed
pytest test/test_trust_reads.py test/test_dashboard_approval.py test/test_hooks.py  ->  175 passed
flake8 / isort / black / mypy on the changed module                                 ->  clean
```

The single failure is pre-existing and unrelated: `test_browser_recording_skill.py::TestRunnerValidation::test_missing_playwright_fails_loud_without_install` asserts on an "install playwright" hint, but this host has no `node` on PATH so the runner fails earlier with `node not found on PATH`. It reproduces identically on clean `main`.

Both call sites of the classifier are exercised by those files: the approval flow in `dashboard/chat_runner.py` and the PreToolUse gate in `hooks.py`.

Manual verification, run against the classifier on each branch. `AUTO-APPROVE` means `_classify_bash` returned `""`, i.e. no permission request is emitted. 26 side-effect commands and 38 read-only commands, no misclassification either way:

| command | `main` | this branch |
|---|---|---|
| `git remote set-url origin https://evil.example/x.git` | AUTO-APPROVE | prompts |
| `git remote add evil https://evil.example/x.git` | AUTO-APPROVE | prompts |
| `git remote remove origin`, `git remote rename origin upstream` | AUTO-APPROVE | prompts |
| `git branch -D release`, `git branch -d release` | AUTO-APPROVE | prompts |
| `git branch -m main hijacked`, `git branch newbranch` | AUTO-APPROVE | prompts |
| `git branch --edit-description` | AUTO-APPROVE | prompts |
| `git tag sometag`, `git tag -d v1.0.0`, `git tag -m msg v1.0.0` | AUTO-APPROVE | prompts |
| `git diff --output=/tmp/pwned`, `git show --output=…`, `git log --output=…` | AUTO-APPROVE | prompts |
| `git diff --ext-diff`, `git log --ext-diff` | AUTO-APPROVE | prompts |
| `tree -o /tmp/pwned` | AUTO-APPROVE | prompts |
| `file -C -m /tmp/magic.src`, `file -bC -m /tmp/magic.src` | AUTO-APPROVE | prompts |
| `cat f \| sort -o /tmp/pwned`, `sort -uo …`, `sort --output=…` | AUTO-APPROVE | prompts |
| `cat f \| uniq /tmp/in /tmp/pwned` | AUTO-APPROVE | prompts |
| `FILE -C -m …`, `GIT BRANCH -D release` | AUTO-APPROVE | prompts |
| `git branch`, `-a`, `-vv`, `--list`, `--show-current`, `--merged`, `--contains HEAD` | AUTO-APPROVE | AUTO-APPROVE |
| `git tag`, `git tag -l`, `git tag -l 'v1.*'` | AUTO-APPROVE | AUTO-APPROVE |
| `git remote`, `git remote -v`, `git remote get-url origin` | AUTO-APPROVE | AUTO-APPROVE |
| `ls -o`, `grep -o pattern file`, `file -c`, `tree -L 2` | AUTO-APPROVE | AUTO-APPROVE |
| `cat f \| sort`, `sort -u`, `uniq`, `uniq -c` | AUTO-APPROVE | AUTO-APPROVE |
| `git status`, `git log --oneline -5`, `git diff HEAD`, `git blame f.py` | AUTO-APPROVE | AUTO-APPROVE |

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

On documentation: the rationale lives in comments above each table, since that is where a future edit would need it. Happy to add a note to the security module spec if you would prefer it recorded there too.

### Not in scope

The tables are a denylist, and a denylist over third-party CLI surface is never provably complete — this closes the shapes I could verify, it does not prove no other allowlisted verb has a side effect. The durable fix is the other direction: an allowlist of permitted flags per verb, or running these commands under a filesystem sandbox so a write cannot land regardless of how it was spelled. Both are larger changes than this, and worth their own discussion.

Two things I did **not** claim, because I could not verify them: `less`/`more` as pipe targets have a `!command` shell escape, but it needs an interactive TTY, which a tool call does not have; and `git diff --ext-diff` is included on the strength of the documented behaviour, since reaching the driver needs repo config or `.gitattributes` I did not stage.

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

