### PR TITLE
fix(security): any local web page could open a shell through the terminal WebSocket

### DIFF
--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -19,6 +19,7 @@ from aiohttp import web
 
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_path
+from kiro_crew.dashboard.origin import check_origin
 from kiro_crew.executors import discovery_executor, subprocess_executor
 from kiro_crew.hooks import validate_file_path
 from kiro_crew.security import (
@@ -396,6 +397,21 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
         - Client→Server: {"type":"ping"}
         - Server→Client: {"type":"pong"}
     """
+    # A WebSocket upgrade is a GET, and `csrf_middleware` validates the origin
+    # only for unsafe methods, so the handshake would otherwise arrive
+    # unchecked. The session cookie is attached automatically and SameSite=Lax
+    # does not distinguish ports, so any other loopback origin could open a PTY
+    # under the operator's own session. The other two WebSocket routes check in
+    # their own handlers for the same reason (`ws.py`, `stt_stream.py`).
+    if not check_origin(request, require=True):
+        _sel().log_api_access(
+            caller=request.get("user") or "unknown",
+            operation="terminal.ws.open",
+            outcome="denied",
+            source="dashboard",
+            resources=f"origin_not_allowed={request.headers.get('Origin', '')[:80]!r}",
+        )
+        raise web.HTTPForbidden(text="WebSocket origin not allowed")
     caller = request.get("user")
     if not caller:
         _sel().log_api_access(

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -30,17 +30,30 @@ def _clear_enabled_cache(monkeypatch):
 # ── Helpers ──
 
 
-def _make_request(user="testuser", session_id="abc123", registry=None, cfg=None):
-    """Build a mock aiohttp request with state and match_info."""
+def _make_request(
+    user="testuser",
+    session_id="abc123",
+    registry=None,
+    cfg=None,
+    origin=None,
+    remote="127.0.0.1",
+):
+    """Build a mock aiohttp request with state and match_info.
+
+    ``origin`` is the Origin header the handshake carries. Left unset it is
+    absent, which ``check_origin`` trusts from loopback — a browser always
+    sends one, so its absence means a local process rather than a page.
+    """
     state = MagicMock()
     state._terminal_sessions = registry if registry is not None else {}
-    app = {"state": state}
+    app = {"state": state, "allowed_origins": {"http://localhost:5476"}}
     request = MagicMock()
     request.app = app
     request.get = lambda k, default=None: user if k == "user" else default
     request.match_info = MagicMock()
     request.match_info.get = lambda k, default="": session_id if k == "session_id" else default
-    request.remote = "127.0.0.1"
+    request.remote = remote
+    request.headers = {} if origin is None else {"Origin": origin}
     return request
 
 
@@ -1213,6 +1226,79 @@ class TestApiTerminalList:
 # ── api_terminal_ws ──
 
 
+class TestApiTerminalWsOrigin:
+    """The handshake must validate its Origin before anything else.
+
+    A WebSocket upgrade is a GET, and ``csrf_middleware`` checks the origin only
+    for unsafe methods, so without an in-handler check the handshake arrives
+    unvalidated. The cookie rides along automatically and SameSite=Lax does not
+    distinguish ports, so another loopback origin could otherwise drive a PTY
+    under the operator's own session.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rejects_a_cross_origin_handshake(self):
+        req = _make_request(origin="http://127.0.0.1:9999")
+        with patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            with pytest.raises(web.HTTPForbidden):
+                await terminal.api_terminal_ws(req)
+
+    @pytest.mark.asyncio
+    async def test_rejects_a_remote_origin(self):
+        req = _make_request(origin="https://evil.example")
+        with patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            with pytest.raises(web.HTTPForbidden):
+                await terminal.api_terminal_ws(req)
+
+    @pytest.mark.asyncio
+    async def test_origin_is_checked_before_authentication(self):
+        """A cross-origin handshake is refused whether or not it is authorised.
+
+        Ordering matters for the audit trail: the rejection has to name the
+        origin rather than report an unauthenticated caller, or a CSWSH attempt
+        is indistinguishable from someone opening the panel while logged out.
+        """
+        req = _make_request(user=None, origin="http://127.0.0.1:9999")
+        with patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            with pytest.raises(web.HTTPForbidden):
+                await terminal.api_terminal_ws(req)
+
+    @pytest.mark.asyncio
+    async def test_allows_the_dashboard_origin(self):
+        """An allowed Origin passes the check and reaches the later gates."""
+        req = _make_request(user=None, origin="http://localhost:5476")
+        with patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            resp = await terminal.api_terminal_ws(req)
+        # Past the origin gate, so it fails on authentication instead.
+        assert isinstance(resp, web.Response)
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_allows_a_loopback_client_with_no_origin(self):
+        """No Origin from loopback is a local process, not a browser page.
+
+        ``check_origin`` trusts this case and local callers depend on it.
+        """
+        req = _make_request(user=None, origin=None, remote="127.0.0.1")
+        with patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            resp = await terminal.api_terminal_ws(req)
+        assert isinstance(resp, web.Response)
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_rejects_a_non_loopback_client_with_no_origin(self):
+        req = _make_request(user=None, origin=None, remote="10.0.0.5")
+        with patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            with pytest.raises(web.HTTPForbidden):
+                await terminal.api_terminal_ws(req)
+
+
 class TestApiTerminalWs:
     @pytest.mark.asyncio
     async def test_rejects_unauthenticated(self):
@@ -1498,6 +1584,9 @@ def _make_app(registry=None, cfg=None, user="testuser"):
 
     app = web.Application(middlewares=[fake_auth])
     app["state"] = state
+    # The handshake validates its Origin in the handler, so the app needs the
+    # same allowlist the real gateway builds.
+    app["allowed_origins"] = {"http://localhost:5476"}
     app.router.add_get("/api/ws/terminal/{session_id}", terminal.api_terminal_ws)
     app.router.add_post("/api/terminal/sessions", terminal.api_terminal_create)
     app.router.add_get("/api/terminal/sessions", terminal.api_terminal_list)


### PR DESCRIPTION
## Description

`api_terminal_ws` accepted a handshake from any origin.

A WebSocket upgrade is a GET, and `csrf_middleware` validates the origin only for unsafe methods:

```python
_safe_methods = {"GET", "HEAD", "OPTIONS"}
...
if request.method not in _safe_methods:
    if not check_origin(request, require=True, fallback_header="Referer"):
```

So the handshake reached the handler unvalidated. The two other WebSocket routes each compensate inside their own handler for exactly this reason — `ws.py:108` and `stt_stream.py:321` — while `terminal.py` had zero calls to `check_origin`.

The result is a cross-site WebSocket hijack:

- the browser attaches `mc_token_<port>` automatically, and SameSite=Lax does not distinguish ports, so **any other loopback origin** counts as same-site — a dev server, an app preview, an artifact preview
- `session_id` comes from the path and is attacker-chosen, so the connection gets a **fresh PTY** rather than joining one the operator is watching
- `?cwd=` accepts any existing directory (`_resolve_cwd` documents that there is no root restriction beyond `isdir`)

What comes back is a full bidirectional interactive shell as the gateway user, with the gateway's own environment.

```html
<script>
const ws = new WebSocket('ws://127.0.0.1:<port>/api/ws/terminal/attacker1?cwd=/tmp');
ws.binaryType = 'arraybuffer';
ws.onopen = () => ws.send(new TextEncoder().encode("id > /tmp/PROOF\n"));
ws.onmessage = e => console.log(new TextDecoder().decode(e.data));
</script>
```

### What changed

`check_origin(request, require=True)` now runs first — before the authentication check and before `ws.prepare` — and the refusal is audited with the offending origin.

The ordering is deliberate. A cross-origin attempt has to be recorded as one, not as an unauthenticated caller: an attacker page carries the operator's cookie, so it *is* authenticated, and if the origin check sat after the auth check the audit trail for a CSWSH attempt would be indistinguishable from someone opening the panel while logged out.

Loopback callers that send no Origin header stay trusted. That is `check_origin`'s existing contract and a browser always sends one, so its absence means a local process rather than a page.

Two lines of behaviour change, and nothing that worked before stops working: the dashboard's own origin is on the allowlist, and local processes without an Origin header are unaffected.

### The other terminal routes

| route | method | covered by |
|---|---|---|
| `/api/ws/terminal/{session_id}` | GET (upgrade) | this change |
| `/api/terminal/sessions` | POST | `csrf_middleware` |
| `/api/terminal/redact` | POST | `csrf_middleware` |
| `/api/terminal/complete` | POST | `csrf_middleware` |
| `/api/terminal/sessions/{id}` | DELETE | `csrf_middleware` |
| `/api/terminal/sessions` | GET | JSON with no CORS header — a cross-origin page cannot read the response |

WebSocket is the one shape where the browser lets a cross-origin caller both connect and read, which is why it needs the in-handler check that the unsafe methods get from the middleware.

## Related Issues

None filed — reporting and fixing together.

Independent of #1259, #1263 (both `dashboard/state.py`) and #1269 (`security.py`). No overlap, no conflict, any merge order.

## Testing

- [x] Existing tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Manual verification performed (describe below if applicable)

Six new cases in `TestApiTerminalWsOrigin`: the cross-origin and remote-origin refusals; that the check precedes authentication; that an allowed origin still reaches the later gates; and both no-Origin cases — trusted from loopback, refused from anywhere else.

The two request builders (`_make_request`, `_make_app`) now supply `allowed_origins` the way the real gateway does, which is what lets the handler's check run under test at all.

```
pytest test/test_terminal_handler.py test/test_dashboard_origin.py test/test_dashboard_security_headers.py
  -> 290 passed, 1 skipped
flake8 / isort / mypy on the changed module  -> clean
```

Manual verification over real HTTP, driving the handshake through `TestServer` against the actual route:

| Origin | before | after |
|---|---|---|
| `http://127.0.0.1:9999` (another loopback port) | **101 — PTY opened** | 403 |
| `https://evil.example` | **101 — PTY opened** | 403 |
| `http://localhost:5476` (the dashboard) | 101 | 101 |
| absent, from `127.0.0.1` | 101 | 101 |
| absent, from `10.0.0.5` | 101 | 403 |

`black` was deliberately not run: `ci.yml` keeps `black --check` disabled pending a bulk format pass, and running it here rewrites unrelated regions of both files. The diff is 2 hunks in `terminal.py` — the import and the check.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

On documentation: the reasoning sits in the comment above the check, next to the code a future edit would touch. Happy to add a note to the security module spec if you would rather have it recorded there.

### Not in scope

`_resolve_cwd` still accepts any existing directory, by design — its docstring says so, since this is the operator's own interactive shell. With the origin gate closed the caller is the operator, so the open `?cwd=` is no longer reachable cross-origin. Whether the panel should confine itself to project roots anyway is a separate product question.

Also unchanged: the PTY inherits the gateway's environment and has no rlimits of its own. That is the same posture as before this change and belongs with the sandbox work rather than here.

A middleware that refused any `Upgrade: websocket` request failing the origin check would make this structural, so a fourth WebSocket route cannot be added unprotected. I kept the fix in the handler to match how `ws.py` and `stt_stream.py` already do it; happy to move it if you would prefer the middleware.

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
