### PR TITLE
fix(channels): !unlink frees the conversation's location, not just its key spelling

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -502,6 +502,12 @@ only when a `mirror` `ChannelLink` exists on the dashboard-side key:
 - `SessionManager.set_mirror_link(key, link)` / `clear_mirror_link(key)` /
   `get_mirror_link(key)` — persist/read the outbound `ChannelLink` (Slack routes
   to `set_slack_link` so its reverse index stays intact).
+- `SessionManager.clear_mirror_links_at(link)` — value-keyed sweep: clears
+  EVERY session whose mirror targets that exact non-Slack location and returns
+  the cleared keys. The write counterpart of `find_mirror_sessions`, and the
+  only clear that reaches a binding stranded under a key spelling the
+  conversation no longer derives (a rotated DM generation, a pre-unification
+  `dashboard:` row).
 - `POST /api/chat/slots/{name}/mirror-link` | `mirror-unlink` — dashboard-side
   endpoints (auth posture matches `slack-link`: under the `/api/chat`
   `mixed_internal_paths` prefix, never the strict `internal_paths` set).
@@ -516,10 +522,17 @@ only when a `mirror` `ChannelLink` exists on the dashboard-side key:
   silently omitted (Teams before first inbound; WeCom proactive send); the menu
   keeps those rows keyboard-focusable, shows the reason inline, and announces
   the same reason instead of presenting an unexplained disabled action.
-- In-channel `/link` / `/unlink` — write/clear the link on the current
-  conversation's `dashboard_mirror_key`. `/link` does not control display,
-  history, or the inbound direction — only the outbound echo; `/unlink` changes
-  nothing else, since the two sids already exist independently.
+- In-channel `/link` / `/unlink` — `/link` writes the link on the current
+  conversation's `dashboard_mirror_key`; it does not control display, history,
+  or the inbound direction — only the outbound echo. `/unlink` frees the
+  LOCATION via the shared `messaging.link.release_conversation_location`
+  helper (one implementation for every DM dispatcher): after the key-addressed
+  clears it sweeps every binding whose mirror targets this conversation
+  (`clear_mirror_links_at`), including a binding stranded under a rotated DM
+  generation and another dashboard session's outbound mirror into the
+  conversation — the same occupant set the Discord resume conflict check
+  refuses on, so its "Run `!unlink` first" guidance is always followable. The
+  reply reports the count when more than one binding was cleared.
 
 **Delivery** (`chat_runner._deliver_cross_surface_reply` /
 `_deliver_cross_surface_user_message`, via the shared `_resolve_mirror_target`

--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -147,7 +147,19 @@ class DiscordSessionResume:
     def leave_resumed_session(self, channel_id: str) -> str | None:
         key = self.resumed_session(channel_id)
         if key is not None:
-            self.sessions.clear_mirror_link(key)
+            # Free the LOCATION, not just the resume binding: the dashboard's
+            # mirror-link endpoint performs no occupancy check, so an outbound
+            # mirror can be laid onto a conversation a resumed session already
+            # holds. This early path bypasses the dispatcher's own sweep —
+            # clearing only *key* here would leave that mirror occupying the
+            # location and reproduce the "already attached" refusal after an
+            # apparently successful unlink.
+            cleared = self.sessions.clear_mirror_links_at(self.link_for(channel_id))
+            logger.info(
+                "discord: released resumed session %s (cleared bindings: %s)",
+                key,
+                ", ".join(cleared) or "none",
+            )
             self._push_slots()
         return key
 
@@ -344,14 +356,12 @@ class DiscordSessionResume:
             if candidate != key
         ]
         if occupants:
-            guidance = (
-                "Run `!unlink` first."
-                if any(candidate in inbound for candidate in occupants)
-                else "Unlink the existing dashboard mirror first."
-            )
+            # `!unlink` clears every binding at this location by value —
+            # resumed sessions and outbound dashboard mirrors alike — so one
+            # instruction is always followable from inside the conversation.
             return (
                 "⚠️ This Discord conversation is already attached to another "
-                f"session. {guidance}"
+                "session. Run `!unlink` first."
             )
         return None
 

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -51,6 +51,7 @@ from kiro_crew.messaging.link import (
     ChannelLink,
     build_dm_session_key,
     legacy_dashboard_mirror_key,
+    release_conversation_location,
     seed_generation,
 )
 from kiro_crew.messaging.transport import InboundMessage
@@ -975,14 +976,18 @@ class DiscordDispatcher:
             )
             return
         key = self._session_key(user_id, thread_id)
-        was_linked = self.sessions.clear_mirror_link(key)
-        was_linked = (
-            self.sessions.clear_mirror_link(legacy_dashboard_mirror_key(key)) or was_linked
+        reply, swept = release_conversation_location(
+            self.sessions,
+            key=key,
+            location=ChannelLink("discord", channel_id=channel_id),
+            channel="discord",
         )
-        await self.client.send_message(
-            channel_id,
-            "✅ Unlinked." if was_linked else "This conversation wasn't linked.",
-        )
+        if swept:
+            # A swept binding can belong to a dashboard slot whose link chip is
+            # projected at push time — nudge the dashboard like every other
+            # binding mutation does.
+            self._session_resume._push_slots()
+        await self.client.send_message(channel_id, reply)
 
     def _live_dashboard_slot(self, session_key: str) -> Any | None:
         """The OPEN dashboard slot for *session_key*, or ``None``.

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -10,10 +10,13 @@ Stdlib-only; imported by ``session_map`` (no import cycle).
 
 from __future__ import annotations
 
+import logging
 import re
 import time
 from dataclasses import dataclass
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 #: Slack ts format: ``"{epoch_seconds}.{microseconds}"`` -- pure digits + one dot.
 #: Both runs are BOUNDED. Unbounded ``\d+`` on either side of the dot makes
@@ -287,6 +290,51 @@ def legacy_dashboard_mirror_key(channel_session_key: str) -> str:
     from kiro_crew.history import _safe_key
 
     return "dashboard:" + _safe_key(channel_session_key)
+
+
+def release_conversation_location(
+    sessions: Any,
+    *,
+    key: str,
+    location: ChannelLink,
+    channel: str,
+) -> tuple[str, list[str]]:
+    """Free a conversation's mirror LOCATION and shape the unlink reply.
+
+    The in-channel unlink shared by the DM dispatchers. Key-addressed clears
+    only reach rows spelled with the CURRENT session key, but the bindings
+    that block a session resume at this conversation are matched by location
+    value — a mirror row stranded under a rotated DM generation, or a
+    dashboard session mirroring into the conversation, occupies the location
+    while being unreachable by any spelling of *key*. Unlink means "nothing
+    mirrors into this conversation": clear the conversation's own binding
+    (current + legacy spelling), then sweep every binding targeting the exact
+    *location*, so ✅ is only reported when the conversation is actually free.
+
+    A swept key can belong to ANOTHER (dashboard) session — a cross-session
+    write triggered by a one-word channel command — so the sweep is INFO-logged
+    and the reply reports the count when more than one binding fell, rather
+    than a bare ✅ that reads as "just yours".
+
+    Returns ``(reply_text, swept_keys)``. A non-empty sweep is the caller's
+    cue to refresh any dashboard projection of the cleared bindings.
+    """
+    cleared = int(sessions.clear_mirror_link(key))
+    cleared += int(sessions.clear_mirror_link(legacy_dashboard_mirror_key(key)))
+    swept = sessions.clear_mirror_links_at(location)
+    if swept:
+        logger.info(
+            "%s: unlink swept %d mirror binding(s) at this conversation: %s",
+            channel,
+            len(swept),
+            ", ".join(swept),
+        )
+    cleared += len(swept)
+    if cleared > 1:
+        return f"✅ Unlinked ({cleared} bindings).", swept
+    if cleared == 1:
+        return "✅ Unlinked.", swept
+    return "This conversation wasn't linked.", swept
 
 
 def seed_generation(

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -3626,6 +3626,10 @@ class SessionManager:
         """Remove a session's outbound mirror binding. Returns True iff present."""
         return self._session_map.clear_mirror_link(key)
 
+    def clear_mirror_links_at(self, link: ChannelLink) -> list[str]:
+        """Clear every session mirroring to an exact location; return cleared keys."""
+        return self._session_map.clear_mirror_links_at(link)
+
     # Backward-compat aliases used by callers not yet migrated
     async def set_channel(self, key: str, channel_id: str) -> None:
         """Set channel for a session. Prefer set_slack_link for new code."""

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -489,6 +489,35 @@ class SessionMap:
                 matches.append(key)
         return matches
 
+    def clear_mirror_links_at(self, link: ChannelLink) -> list[str]:
+        """Clear EVERY session whose mirror targets an exact non-Slack location.
+
+        The write counterpart of :meth:`find_mirror_sessions`. An in-channel
+        unlink means "nothing mirrors into this conversation anymore", and the
+        bindings that occupy a location are matched by VALUE there — so a row
+        stranded under a key spelling the conversation no longer uses (a rotated
+        DM generation, a pre-unification ``dashboard:`` row) or a dashboard
+        session mirroring into the conversation still blocks it while being
+        unreachable by any key-addressed :meth:`clear_mirror_link`. Clearing by
+        location closes that gap and doubles as the repair path for duplicate
+        bindings, which the inbound resolver deliberately refuses to pick from.
+
+        Returns the cleared session keys (empty when the location was free).
+        Slack mirrors live in their own reverse index and are out of scope,
+        exactly as in :meth:`find_mirror_sessions`.
+        """
+        cleared: list[str] = []
+        for key in self.find_mirror_sessions(link):
+            entry = self._data.get(key)
+            if entry is None:  # pragma: no cover - keys come from _data itself
+                continue
+            entry.pop("mirror", None)
+            entry.pop("mirror_accepts_inbound", None)
+            cleared.append(key)
+        if cleared:
+            self._save()
+        return cleared
+
     def clear_mirror_link(self, key: str) -> bool:
         """Remove a session's outbound mirror binding; return True iff one existed.
 

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -39,6 +39,7 @@ from kiro_crew.messaging.link import (
     ChannelLink,
     build_dm_session_key,
     legacy_dashboard_mirror_key,
+    release_conversation_location,
     seed_generation,
 )
 from kiro_crew.messaging.transport import InboundMessage
@@ -938,15 +939,21 @@ class TelegramDispatcher:
     async def _handle_unlink(self, route: tuple[str, str], chat_id: int) -> None:
         assert self.client is not None
         key = self._session_key(route)
-        was_linked = self.sessions.clear_mirror_link(key)
-        was_linked = (
-            self.sessions.clear_mirror_link(legacy_dashboard_mirror_key(key)) or was_linked
+        # Match the location exactly as _handle_link writes it (forum Topic
+        # included). No dashboard nudge here: a swept slot's link chip is
+        # refreshed by the periodic channel_slot_reconciler push.
+        topic = self._route_thread(route)
+        reply, _swept = release_conversation_location(
+            self.sessions,
+            key=key,
+            location=ChannelLink(
+                "telegram",
+                channel_id=str(chat_id),
+                thread_id=(str(topic) if topic is not None else None),
+            ),
+            channel="telegram",
         )
-        await self._reply(
-            chat_id,
-            "✅ Unlinked." if was_linked else "This conversation wasn't linked.",
-            thread=self._route_thread(route),
-        )
+        await self._reply(chat_id, reply, thread=self._route_thread(route))
 
     def _persist_turn(
         self, session_key: str, user_text: str, reply_text: str, is_new: bool

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -57,7 +57,7 @@ from kiro_crew.discord.transport_dispatch import (
     _receipt_text,
 )
 from kiro_crew.messaging.attachments import cleanup
-from kiro_crew.messaging.link import legacy_dashboard_mirror_key
+from kiro_crew.messaging.link import ChannelLink, legacy_dashboard_mirror_key
 from kiro_crew.messaging.transport import InboundMessage
 
 _PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
@@ -272,6 +272,13 @@ class FakeSessions:
     def clear_mirror_link(self, key: str) -> bool:
         self.inbound_mirror_keys.discard(key)
         return self.mirror_links.pop(key, None) is not None
+
+    def clear_mirror_links_at(self, link: Any) -> list[str]:
+        cleared = self.find_mirror_sessions(link)
+        for key in cleared:
+            self.inbound_mirror_keys.discard(key)
+            self.mirror_links.pop(key, None)
+        return cleared
 
     def enqueue(self, key: str, ts: str, text: str, *, force: bool = False, **kw: Any) -> bool:
         if force or self._busy:
@@ -1551,6 +1558,90 @@ class TestDispatcher:
         assert sess.mirror_links[key].channel_id == "c1"
         await d.handle_message(self._msg("!unlink"))
         assert key not in sess.mirror_links
+
+    @pytest.mark.asyncio
+    async def test_unlink_clears_binding_stranded_by_generation_rotation(self) -> None:
+        # THE stale-mirror regression: a binding written at one DM generation,
+        # then the conversation rotates (!new / idle / daily reset). The row's
+        # key spelling no longer derives from the current session key, so the
+        # key-addressed clears cannot reach it — yet it still occupies the
+        # location and blocks `!session` resume. Unlink must free it by value.
+        d, cli, sess = _dispatcher({"u1"})
+        await d.handle_message(self._msg("!link"))
+        stale_key = d._session_key("u1")
+        await d.handle_message(self._msg("!new"))  # rotate the generation
+        key = d._session_key("u1")
+        assert stale_key != key  # binding is now stranded under the old spelling
+        assert stale_key not in (key, legacy_dashboard_mirror_key(key))
+        await d.handle_message(self._msg("!unlink"))
+        assert sess.mirror_links == {}
+        assert any("Unlinked" in t for t, _ in cli.sent)
+
+    @pytest.mark.asyncio
+    async def test_unlink_clears_dashboard_mirror_into_this_channel(self) -> None:
+        # A dashboard session mirroring outbound into this conversation is the
+        # exact occupant `!session`'s conflict check refuses on ("attached to
+        # another session") — `!unlink` in the conversation must clear it.
+        d, cli, sess = _dispatcher({"u1"})
+        sess.mirror_links["dashboard:chat-9"] = ChannelLink("discord", channel_id="c1")
+        await d.handle_message(self._msg("!unlink"))
+        assert sess.mirror_links == {}
+        assert any("Unlinked" in t for t, _ in cli.sent)
+
+    @pytest.mark.asyncio
+    async def test_unlink_leaves_other_locations_alone(self) -> None:
+        # The value sweep is exact-match: a mirror into a DIFFERENT Discord
+        # channel must survive an unlink here, and with nothing pointing at
+        # this conversation the reply stays truthful ("wasn't linked").
+        d, cli, sess = _dispatcher({"u1"})
+        other = ChannelLink("discord", channel_id="c2")
+        sess.mirror_links["dashboard:chat-9"] = other
+        await d.handle_message(self._msg("!unlink"))
+        assert sess.mirror_links == {"dashboard:chat-9": other}
+        assert any("wasn't linked" in t for t, _ in cli.sent)
+
+    @pytest.mark.asyncio
+    async def test_unlink_frees_location_in_one_shot_with_resumed_session(self) -> None:
+        # A resumed session AND an outbound dashboard mirror can co-occupy a
+        # location (the dashboard mirror-link endpoint performs no occupancy
+        # check). The resumed-session early path must still free the WHOLE
+        # location — one `!unlink`, not two.
+        d, cli, sess = _dispatcher({"u1"})
+        loc = ChannelLink("discord", channel_id="c1")
+        sess.set_mirror_link("dashboard:resumed", loc, accepts_inbound=True)
+        sess.set_mirror_link("dashboard:chat-9", loc)
+        await d.handle_message(self._msg("!unlink"))
+        assert sess.mirror_links == {}
+        assert any("Left the resumed session" in t for t, _ in cli.sent)
+        await d.handle_message(self._msg("!unlink"))
+        assert any("wasn't linked" in t for t, _ in cli.sent)
+
+    @pytest.mark.asyncio
+    async def test_unlink_repairs_duplicate_inbound_bindings(self) -> None:
+        # Duplicate inbound bindings make the resume resolver fail closed
+        # (routing denied), so the resumed-session path cannot release them —
+        # the dispatcher sweep is the repair, and the reply says how much it
+        # cleared instead of a bare ✅ that reads as "just yours".
+        d, cli, sess = _dispatcher({"u1"})
+        loc = ChannelLink("discord", channel_id="c1")
+        sess.set_mirror_link("dashboard:wedged-a", loc, accepts_inbound=True)
+        sess.set_mirror_link("dashboard:wedged-b", loc, accepts_inbound=True)
+        await d.handle_message(self._msg("!unlink"))
+        assert sess.mirror_links == {}
+        assert any("Unlinked (2 bindings)" in t for t, _ in cli.sent)
+
+    @pytest.mark.asyncio
+    async def test_new_frees_whole_location_when_leaving_resumed_session(self) -> None:
+        # `!new` releases a resumed session through the same whole-location
+        # sweep as `!unlink`: a co-located outbound mirror must not leak into
+        # the fresh conversation the command starts.
+        d, cli, sess = _dispatcher({"u1"})
+        loc = ChannelLink("discord", channel_id="c1")
+        sess.set_mirror_link("dashboard:resumed", loc, accepts_inbound=True)
+        sess.set_mirror_link("dashboard:bystander", loc)
+        await d.handle_message(self._msg("!new"))
+        assert sess.mirror_links == {}
+        assert any("left the resumed session" in t for t, _ in cli.sent)
 
     @pytest.mark.asyncio
     async def test_default_agent_fallback(self) -> None:

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -133,6 +133,13 @@ class _Sessions:
         self.inbound_keys.discard(key)
         return self.mirror_links.pop(key, None) is not None
 
+    def clear_mirror_links_at(self, link: ChannelLink) -> list[str]:
+        cleared = self.find_mirror_sessions(link)
+        for key in cleared:
+            self.inbound_keys.discard(key)
+            self.mirror_links.pop(key, None)
+        return cleared
+
     def max_generation(self, bucket: str) -> int:
         return -1
 
@@ -1000,6 +1007,51 @@ async def test_choice_refuses_occupied_discord_conversation() -> None:
 
     assert "dashboard:chat-1" not in sessions.mirror_links
     assert any("!unlink" in text for _, text, _ in client.edits)
+
+
+@pytest.mark.asyncio
+async def test_choice_refusal_for_outbound_mirror_names_unlink() -> None:
+    # The outbound-only occupant used to get "Unlink the existing dashboard
+    # mirror first" — an instruction with no in-channel action. `!unlink` now
+    # clears outbound mirrors by location, so the guidance is unified and must
+    # name the command for BOTH occupant kinds.
+    dispatcher, client, sessions = _dispatcher({"u1"}, _log())
+    sessions.set_mirror_link(
+        "dashboard:other",
+        ChannelLink(channel_type="discord", channel_id="c1"),
+    )
+    await dispatcher.handle_message(_message("!sessions"))
+    custom_id, message_id = _picker_button(client)
+
+    await dispatcher.on_interaction(_interaction(custom_id, message_id))
+
+    assert "dashboard:chat-1" not in sessions.mirror_links
+    assert any("Run `!unlink` first" in text for _, text, _ in client.edits)
+    # And the instruction is followable: the sweep frees the location, after
+    # which the conflict check no longer refuses.
+    sessions.clear_mirror_links_at(ChannelLink(channel_type="discord", channel_id="c1"))
+    conflict = dispatcher._session_resume._binding_conflict(
+        "dashboard:chat-1",
+        "chat one",
+        ChannelLink(channel_type="discord", channel_id="c1"),
+    )
+    assert conflict is None
+
+
+@pytest.mark.asyncio
+async def test_leave_resumed_session_frees_whole_location() -> None:
+    # The resumed-session release must clear co-located occupants too: the
+    # dashboard mirror-link endpoint performs no occupancy check, so an
+    # outbound mirror can share the location with the resume binding.
+    dispatcher, client, sessions = _dispatcher({"u1"}, _log())
+    loc = ChannelLink(channel_type="discord", channel_id="c1")
+    sessions.set_mirror_link("dashboard:resumed", loc, accepts_inbound=True)
+    sessions.set_mirror_link("dashboard:bystander", loc)
+
+    released = dispatcher._session_resume.leave_resumed_session("c1")
+
+    assert released == "dashboard:resumed"
+    assert sessions.mirror_links == {}
 
 
 @pytest.mark.asyncio

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -13,7 +13,11 @@ from unittest.mock import patch
 
 import pytest
 
-from kiro_crew.messaging.link import ChannelLink
+from kiro_crew.messaging.link import (
+    ChannelLink,
+    legacy_dashboard_mirror_key,
+    release_conversation_location,
+)
 from kiro_crew.session_map import SessionMap
 
 
@@ -185,6 +189,123 @@ class TestClearMirrorLink:
         )
         session_map.set_mirror_link("dashboard:chat-1", None)
         assert session_map.get_mirror_link("dashboard:chat-1") is None
+
+
+class TestClearMirrorLinksAt:
+    LINK = ChannelLink(channel_type="discord", channel_id="chan-1")
+
+    def test_clears_every_spelling_at_the_location(self, session_map):
+        # The stale-mirror shape: rows under key spellings the conversation no
+        # longer derives (rotated generation, pre-unification dashboard row)
+        # plus a dashboard session mirroring in — all at one location.
+        session_map.set_mirror_link("discord:agent:direct:u1", self.LINK)
+        session_map.set_mirror_link("dashboard:discord_agent_direct_u1", self.LINK)
+        session_map.set_mirror_link("dashboard:chat-3", self.LINK)
+        cleared = session_map.clear_mirror_links_at(self.LINK)
+        assert sorted(cleared) == [
+            "dashboard:chat-3",
+            "dashboard:discord_agent_direct_u1",
+            "discord:agent:direct:u1",
+        ]
+        assert session_map.find_mirror_sessions(self.LINK) == []
+
+    def test_returns_empty_when_location_free(self, session_map):
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK)
+        other = ChannelLink(channel_type="discord", channel_id="chan-2")
+        assert session_map.clear_mirror_links_at(other) == []
+        assert session_map.get_mirror_link("dashboard:chat-1") == self.LINK
+
+    def test_no_save_when_location_free(self, session_map):
+        # An empty sweep must not touch disk — the common case is `!unlink`
+        # on an unlinked conversation.
+        with patch.object(session_map, "_save") as save:
+            assert session_map.clear_mirror_links_at(self.LINK) == []
+        save.assert_not_called()
+
+    def test_exact_location_match_includes_thread(self, session_map):
+        topic = ChannelLink(channel_type="telegram", channel_id="7", thread_id="42")
+        general = ChannelLink(channel_type="telegram", channel_id="7", thread_id=None)
+        session_map.set_mirror_link("dashboard:chat-1", topic)
+        assert session_map.clear_mirror_links_at(general) == []
+        assert session_map.clear_mirror_links_at(topic) == ["dashboard:chat-1"]
+
+    def test_clears_inbound_resume_binding_and_marker(self, session_map):
+        # Duplicate/corrupt inbound bindings are exactly what the inbound
+        # resolver refuses to pick from — the location sweep is the repair.
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK, accepts_inbound=True)
+        assert session_map.clear_mirror_links_at(self.LINK) == ["dashboard:chat-1"]
+        assert session_map.mirror_accepts_inbound("dashboard:chat-1") is False
+        assert session_map.get_mirror_link("dashboard:chat-1") is None
+
+    def test_slack_bindings_are_out_of_scope(self, session_map):
+        session_map.set(
+            "dashboard:chat-1", "sid-abc"
+        )  # Slack link needs an entry to attach to
+        session_map.set_mirror_link(
+            "dashboard:chat-1",
+            ChannelLink(channel_type="slack", channel_id="C1", thread_id="ts-1"),
+        )
+        slack = ChannelLink(channel_type="slack", channel_id="C1", thread_id="ts-1")
+        assert session_map.clear_mirror_links_at(slack) == []
+        assert session_map.get_session_for_thread("ts-1") == "dashboard:chat-1"
+
+    def test_cleared_rows_survive_reload(self, session_map, tmp_path):
+        # The sweep must persist: a clear that only mutates memory would
+        # resurrect the stale binding on the next gateway start.
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK)
+        session_map.clear_mirror_links_at(self.LINK)
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+        assert reloaded.find_mirror_sessions(self.LINK) == []
+
+
+class TestReleaseConversationLocation:
+    """The shared in-channel unlink, composed against the REAL SessionMap."""
+
+    KEY = "discord:agent:direct:u1"
+    LINK = ChannelLink(channel_type="discord", channel_id="chan-1")
+
+    def test_free_location_reports_not_linked(self, session_map):
+        reply, swept = release_conversation_location(
+            session_map, key=self.KEY, location=self.LINK, channel="discord"
+        )
+        assert reply == "This conversation wasn't linked."
+        assert swept == []
+
+    def test_own_binding_reports_plain_success(self, session_map):
+        session_map.set_mirror_link(self.KEY, self.LINK)
+        reply, swept = release_conversation_location(
+            session_map, key=self.KEY, location=self.LINK, channel="discord"
+        )
+        # The conversation's own row falls to the key-addressed clear BEFORE
+        # the sweep runs, so one binding is never double-counted.
+        assert reply == "✅ Unlinked."
+        assert swept == []
+        assert session_map.find_mirror_sessions(self.LINK) == []
+
+    def test_stranded_and_foreign_rows_are_counted(self, session_map):
+        # Own binding + a row stranded under a rotated-generation spelling +
+        # a dashboard session mirroring in: one call frees the location and
+        # the reply owns up to the full count.
+        session_map.set_mirror_link(self.KEY, self.LINK)
+        session_map.set_mirror_link(f"{self.KEY}:gen1", self.LINK)
+        session_map.set_mirror_link("dashboard:chat-9", self.LINK)
+        reply, swept = release_conversation_location(
+            session_map, key=self.KEY, location=self.LINK, channel="discord"
+        )
+        assert reply == "✅ Unlinked (3 bindings)."
+        assert sorted(swept) == ["dashboard:chat-9", f"{self.KEY}:gen1"]
+        assert session_map.find_mirror_sessions(self.LINK) == []
+
+    def test_legacy_spelling_row_counted_once(self, session_map):
+        # A pre-unification row is reachable by the legacy key clear; the
+        # sweep must not see it again.
+        session_map.set_mirror_link(legacy_dashboard_mirror_key(self.KEY), self.LINK)
+        reply, swept = release_conversation_location(
+            session_map, key=self.KEY, location=self.LINK, channel="discord"
+        )
+        assert reply == "✅ Unlinked."
+        assert swept == []
 
 
 class TestPrunePreservesMirror:

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -256,6 +256,12 @@ class FakeSessions:
     def clear_mirror_link(self, key: str) -> bool:
         return self.mirror_links.pop(key, None) is not None
 
+    def clear_mirror_links_at(self, link: Any) -> list[str]:
+        cleared = [key for key, candidate in self.mirror_links.items() if candidate == link]
+        for key in cleared:
+            self.mirror_links.pop(key, None)
+        return cleared
+
     def enqueue(self, key: str, ts: str, text: str, *, force: bool = False, **kw: Any) -> bool:
         if force or self._busy:
             self.queued.append((ts, text, kw))
@@ -2215,6 +2221,19 @@ class TestLinkCommand:
         assert sess.mirror_links == {}
         assert any("Unlinked" in t for t, _ in cli.sent)
 
+    def test_forum_unlink_sweeps_the_topic_scoped_location(self) -> None:
+        # /link and /unlink must construct the SAME topic-scoped location, and
+        # the sweep must not leak across Topics: a General-scoped (threadless)
+        # binding in the same supergroup survives an unlink inside a Topic.
+        d, cli, sess = _dispatcher({7}, allow_forum=True, allowed_forum_chat_ids=[-1001234567890])
+        route = ("forum", "-1001234567890:5")
+        asyncio.run(d._handle_link(route, -1001234567890))
+        general = ChannelLink("telegram", channel_id="-1001234567890", thread_id=None)
+        sess.mirror_links["dashboard:chat-9"] = general
+        asyncio.run(d._handle_unlink(route, -1001234567890))
+        assert sess.mirror_links == {"dashboard:chat-9": general}
+        assert any("Unlinked" in t for t, _ in cli.sent)
+
     def test_unlink_clears_existing(self) -> None:
         d, cli, sess = _dispatcher({7})
         asyncio.run(d._handle_link(("direct", "7"), 7))
@@ -2225,6 +2244,27 @@ class TestLinkCommand:
     def test_unlink_when_not_linked(self) -> None:
         d, cli, sess = _dispatcher({7})
         asyncio.run(d._handle_unlink(("direct", "7"), 7))
+        assert any("wasn't linked" in t for t, _ in cli.sent)
+
+    def test_unlink_clears_binding_stranded_under_foreign_spelling(self) -> None:
+        # The stale-mirror regression: a binding whose key spelling no longer
+        # derives from the current session key (rotated DM generation, or a
+        # dashboard session mirroring into this chat) still occupies the
+        # location. Unlink must clear it by location value.
+        d, cli, sess = _dispatcher({7})
+        sess.mirror_links["dashboard:chat-9"] = ChannelLink("telegram", channel_id="7")
+        asyncio.run(d._handle_unlink(("direct", "7"), 7))
+        assert sess.mirror_links == {}
+        assert any("Unlinked" in t for t, _ in cli.sent)
+
+    def test_unlink_leaves_other_locations_alone(self) -> None:
+        # Exact-match sweep: a mirror into a DIFFERENT chat survives, and the
+        # reply stays truthful when nothing points at this conversation.
+        d, cli, sess = _dispatcher({7})
+        other = ChannelLink("telegram", channel_id="8")
+        sess.mirror_links["dashboard:chat-9"] = other
+        asyncio.run(d._handle_unlink(("direct", "7"), 7))
+        assert sess.mirror_links == {"dashboard:chat-9": other}
         assert any("wasn't linked" in t for t, _ in cli.sent)
 
 


### PR DESCRIPTION
## Symptom (live incident, 2026-08-04)

A Discord DM was permanently locked out of `!session`:

- `!session` → "⚠️ This Discord conversation is already attached to another session. Unlink the existing dashboard mirror first."
- `!unlink` → "This conversation wasn't linked." (and later a false "✅ Unlinked." that cleared an unrelated row while the blocker survived)

The blocking row in `session_map.json` was a dashboard→Discord mirror written while the conversation was at DM generation 0 (`dashboard:discord_<agent>_direct_<user>`). After the conversation rotated to gen 1, no spelling of the current session key could reach it — but the resume conflict check matches occupants by **location value**, so it kept refusing. Manual state surgery was the only way out.

## Root cause

Write/clear and occupancy-check disagree on the index:

- `!unlink` cleared **by key spelling**: current session key + its legacy `dashboard:` spelling.
- `_binding_conflict` refuses **by location value**: `find_mirror_sessions(ChannelLink(...))` scans every row's mirror target.

Any row whose key spelling detaches from the conversation (generation rotation via `!new`/idle/daily reset, pre-unification rows, another dashboard session mirroring into the channel) is unclearable in-channel yet still occupies the location.

## Fix

- **`SessionMap.clear_mirror_links_at(link)`** — value-keyed sweep, the write counterpart of `find_mirror_sessions`: clears every session mirroring to that exact non-Slack location, persists once, returns the cleared keys. Slack stays in its dedicated reverse index, exactly like the read side.
- **Discord + Telegram `!unlink`** run the sweep after the existing key-addressed clears (Telegram matches the forum Topic exactly as its `!link` writes it), INFO-log the swept keys, and reply `✅ Unlinked (N bindings).` when more than one row fell — the ✅ is now only reported when the conversation is actually free.
- **Discord resumed-session release frees the whole location** (`leave_resumed_session` → sweep): the dashboard `mirror-link` endpoint performs no occupancy check, so an outbound mirror can co-occupy a location with a resume binding; without this, that state needed `!unlink` twice.
- **Dashboard stays truthful**: both Discord paths push a slots update when the sweep clears anything, so a cleared slot's link chip can't go stale. (Telegram's dispatcher holds no dashboard state; noted in-code, chip refreshes on the next push.)
- **Refusal guidance unified** to "Run `!unlink` first" — followable for both occupant kinds now.
- **One shared implementation** (review feedback): the key-addressed clears + location sweep + INFO log + counted reply live in `messaging.link.release_conversation_location()` — the module that owns `ChannelLink` and the key-spelling helpers, following the `seed_generation` precedent (there is no dispatcher base class; `messaging/` helpers are the codebase's cross-channel abstraction). Discord keeps only its resume early-return + slots push; Telegram only its forum-topic location. Four direct tests compose the helper against the real `SessionMap`, including the legacy-fallback double-count trap; forum-topic and `!new`-path dispatcher tests pin the wiring.
- Spec updated: `docs/system-specs/modules/session.md` (§ mirror API, § in-channel link/unlink).

## Review rounds (local mirrors before push)

GPT + Opus mirrors both flagged the same two blockers, fixed in-branch: (1) the resumed-session early return skipped the sweep (mixed-occupant location needed two `!unlink`s — now one); (2) the sweep could clear a dashboard slot's binding without a slots push (stale UI chip). Also taken: INFO-logging for the cross-session write, honest reply counts, spec drift, five test gaps. A focused verifier confirmed all fixes closed with nothing new.

Deliberately deferred (pre-existing/latent, flagged in review): `ChannelLink.from_dict` not coercing numeric ids to `str`; the legacy `slack_channel_id="discord:<id>"` corruption scrub only covering `dashboard:` keys; a shared helper for the two identical dispatcher blocks if a third channel grows `!unlink`.

## Verification

- 16 new tests: `SessionMap` sweep unit tests (exact-location match incl. thread, inbound-marker cleanup, Slack exclusion, empty-sweep no-save, persistence across reload), Discord end-to-end regression (`!link` → `!new` rotation → `!unlink` frees the stranded row), dashboard-mirror occupant cleared in-channel, exact-match non-interference, one-shot mixed-occupant release, duplicate-inbound repair with counted reply, outbound-occupant refusal text pinned + conflict-clears-after-sweep, whole-location resume release
- 427 targeted tests green (discord, telegram, sessions, session_map, chat_mirror + both drift guards); isort / flake8 / mypy (CI-parity venv, 710 files) clean
- Full 29.8k suite: failures confirmed pre-existing via stash round-trip on the unmodified base (env-only families: gh binary, sandbox userns EPERM, systemd)
