### PR TITLE
fix(slack): show a Slack turn in its dashboard tab as it happens

### DIFF
--- a/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
@@ -4277,6 +4277,24 @@ def test_state_guard_watches_the_whole_directory():
     assert "_REAL_STATE_DIR" in inspect.getsource(_live_state_snapshot)
 
 
+def test_state_guard_compares_the_real_dir_not_the_redirect():
+    """The captured dir must survive the autouse redirect active right now.
+
+    _REAL_STATE_DIR is captured on first use rather than at import (banned by
+    issue #874). The property that makes the guard work is that it holds the
+    un-redirected dir even while routes._STATE_DIR points at a tmp dir -- the
+    guard re-reads it AFTER its yield, with the redirect still applied. If the
+    memoization were ever dropped so it re-resolved live, before == after would
+    compare tmp-to-tmp and this app's tests could rewrite real user specs
+    undetected, which has already happened twice.
+    """
+    assert _REAL_STATE_DIR is not None, "the first-use capture did not run"
+    assert _REAL_STATE_DIR != routes._STATE_DIR, (
+        "the live-state guard is pointed at the redirected tmp dir, so it can no "
+        "longer detect a test writing to the user's real state"
+    )
+
+
 # ── GPT round-46 findings (#518) ───────────────────────────────────────────────
 
 
@@ -6696,7 +6714,10 @@ def test_prepare_handoff_unpinned_call_keeps_working(tmp_path, monkeypatch):
 
 #: Roles _ChatSlot.append suppresses the global SSE push for. Everything else is
 #: broadcast to every connected dashboard client, so its content leaves the
-#: process and must be redacted first.
+#: process and must be redacted first. "chunk"/"done" are skipped
+#: unconditionally; "user" is skipped only because this app never passes the
+#: host's ``broadcast_user=True`` opt-in (guarded by
+#: test_the_host_still_exempts_only_these_roles_from_broadcast).
 _NON_BROADCAST_ROLES = ("chunk", "done", "user")
 
 
@@ -6723,14 +6744,31 @@ class _NoopState:
 def test_the_host_still_exempts_only_these_roles_from_broadcast():
     """Fixture guard. The rule below is derived from _ChatSlot.append's skip set;
     if the host changes it, the derivation is stale and must be revisited rather
-    than silently protecting the wrong roles."""
+    than silently protecting the wrong roles.
+
+    The host skips "chunk"/"done" unconditionally, and skips "user" unless the
+    caller opts in via ``broadcast_user=True`` (added so a message typed in a
+    CHANNEL renders in its dashboard tab -- nothing rendered it optimistically
+    there). This app never passes that opt-in, so all three roles are still
+    non-broadcast HERE; the third assertion is what keeps that true.
+    """
     import inspect
 
     from kiro_crew.dashboard.state import _ChatSlot
 
     src = inspect.getsource(_ChatSlot.append)
-    assert 'role not in ("chunk", "done", "user")' in src, (
-        "the host's broadcast skip set changed; _NON_BROADCAST_ROLES is now stale"
+    assert 'role not in ("chunk", "done")' in src, (
+        "the host's unconditional broadcast skip set changed; "
+        "_NON_BROADCAST_ROLES is now stale"
+    )
+    assert '(role != "user" or broadcast_user)' in src, (
+        "the host no longer skips user rows by default; _NON_BROADCAST_ROLES is "
+        "now stale"
+    )
+    assert "broadcast_user" not in inspect.getsource(routes._dispatch_turn), (
+        "this app now opts into broadcasting user rows, so 'user' is broadcast "
+        "and must be REMOVED from _NON_BROADCAST_ROLES (its content would reach "
+        "every dashboard client unredacted)"
     )
 
 

--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -431,6 +431,11 @@ def refresh_channel_window(
             content,
             cls,
             ts=msg.get("ts", ""),
+            # These lines came from the channel, not from this dashboard's
+            # composer, so nothing has rendered them optimistically -- ask for
+            # the user rows to be broadcast or the tab shows the reply without
+            # the message that prompted it.
+            broadcast_user=True,
             meta=(msg["meta"] if isinstance(msg.get("meta"), dict) else None),
         )
         # See the equivalent call in _rebuild_window.
@@ -770,18 +775,32 @@ async def _reconcile_channel_slots_locked(state: "DashboardState", window_minute
     return surfaced
 
 
+async def surface_channel_state(state: object | None, dashboard_cfg: object) -> None:
+    """Surface/refresh channel-session slots against an explicit state + config.
+
+    The dispatcher-free entry point. Most transports own a dispatcher object and
+    call :func:`surface_dispatcher_session`, but Slack drives its turns through
+    ``handle_message_transport`` with no dispatcher to hand over -- which is why
+    it was the only transport with no dashboard hook at all, leaving the
+    30-second reconciler as the sole path by which a Slack turn reached an open
+    tab.
+    """
+    if state is None:
+        return
+    if dashboard_cfg is None or not getattr(dashboard_cfg, "surface_channel_sessions", True):
+        return
+    await reconcile_channel_slots(
+        state,  # type: ignore[arg-type]
+        int(getattr(dashboard_cfg, "restore_window_minutes", 30)),
+    )
+
+
 async def surface_dispatcher_session(dispatcher: object) -> None:
     """Surface a channel dispatcher's just-persisted session immediately."""
     cfg = getattr(dispatcher, "cfg", None)
-    dashboard_cfg = getattr(cfg, "dashboard", None)
-    if dashboard_cfg is None or not getattr(dashboard_cfg, "surface_channel_sessions", True):
-        return
-    state = getattr(dispatcher, "dashboard_state", None)
-    if state is None:
-        return
-    await reconcile_channel_slots(
-        state,
-        int(getattr(dashboard_cfg, "restore_window_minutes", 30)),
+    await surface_channel_state(
+        getattr(dispatcher, "dashboard_state", None),
+        getattr(cfg, "dashboard", None),
     )
 
 

--- a/src/kiro_crew/dashboard/chat_slack.py
+++ b/src/kiro_crew/dashboard/chat_slack.py
@@ -119,10 +119,14 @@ async def api_chat_slot_slack_link(request: web.Request) -> web.Response:
         if not thread_ts:
             return web.json_response({"error": "failed to create thread"}, status=500)
 
-    state.sessions.set_slack_link(session_key, thread_ts, target_channel)
-    slot._slack_linked = True
-    slot._slack_channel = target_channel
-    slot._slack_thread_ts = thread_ts
+    # Route through the ONE canonical link writer. ``link_slack`` sets the same
+    # three slot fields and persists via ``set_slack_link``, but it ALSO
+    # registers the thread -> slot reverse index that inbound Slack replies
+    # resolve through, and releases the thread from any slot that held it
+    # before. Hand-assigning the fields here duplicated everything except that
+    # index, so a reply in the mirrored thread routed and persisted correctly
+    # while nothing ever told the open tab it had arrived.
+    state.link_slack(slot.key, thread_ts, target_channel)
 
     # Post last 5 messages as context — only when we created a NEW thread.
     # Linking to an existing thread (challenge-and-redirect) would duplicate

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1205,6 +1205,7 @@ class _ChatSlot:
         ts: str = "",
         *,
         broadcast: bool = True,
+        broadcast_user: bool = False,
         meta: dict | None = None,
     ) -> None:
         msg: dict[str, Any] = {
@@ -1222,11 +1223,18 @@ class _ChatSlot:
         self._pending.append(msg)
         self.event.set()
         # Broadcast via global SSE when no HTTP stream reader is active
-        # Skip: chunk (too noisy), done (internal), user (frontend adds optimistically)
+        # Skip: chunk (too noisy), done (internal). A "user" row is skipped by
+        # DEFAULT because the composer that submitted it already rendered it
+        # optimistically -- but that is only true of a message typed in this
+        # dashboard. A row replayed from a CHANNEL transcript was typed in
+        # Slack, so nothing rendered it here; those callers pass
+        # ``broadcast_user=True`` or the message stays invisible until a full
+        # transcript reload, arriving AFTER the reply it came before.
         if (
             broadcast
             and self._on_message
-            and role not in ("chunk", "done", "user")
+            and role not in ("chunk", "done")
+            and (role != "user" or broadcast_user)
             and not self._has_reader
         ):
             self._on_message(self.key, msg)  # type: ignore[operator]
@@ -2947,6 +2955,36 @@ class DashboardState:
                     namespaced = _split_namespaced_channel_id(_ch)
                     slot._slack_channel = namespaced[1] if namespaced else (_ch or "")
                     slot._slack_thread_ts = _ts or ""
+                    # Rebuild the thread -> slot index too, not just the fields:
+                    # inbound replies resolve through the index, so restoring
+                    # the fields alone leaves a mirrored session delivering to
+                    # Slack but not back to its tab after a restart.
+                    #
+                    # Index ONLY a genuine mirror-OUT. A channel-born session's
+                    # ``slack_thread_ts`` is a SELF-reference -- the thread the
+                    # session lives IN, not one it mirrors TO -- and indexing
+                    # that would make every inbound Slack message resolve to a
+                    # "linked" slot and run through the dashboard chat runner
+                    # instead of the Slack transport, silently changing the
+                    # execution engine and approval semantics of all Slack
+                    # traffic.
+                    #
+                    # Both tests are load-bearing and neither is a name
+                    # heuristic. A channel slot whose stem RESOLVED is caught by
+                    # ``linked_session_key``; one whose stem did NOT resolve
+                    # (leaving that field empty) is caught by comparing the link
+                    # against the slot's own filename stem, because a channel
+                    # slot is named for the very thread it lives in. A dashboard
+                    # slot that merely happens to be named ``slack_...`` matches
+                    # neither test and is still indexed.
+                    from kiro_crew.history import _safe_key
+                    from kiro_crew.messaging.link import canonical_key
+
+                    _self_ref = False
+                    if _ts:
+                        _self_ref = _safe_key(canonical_key(_ts)) == name
+                    if _ts and not slot.linked_session_key and not _self_ref:
+                        self._slack_to_slot[_ts] = name
         except Exception:
             pass
         self._slots[name] = slot
@@ -3021,11 +3059,19 @@ class DashboardState:
         #    other way would be a cycle.
         #
         # What makes that safe: live tool meta is redacted at source (_tool_meta),
-        # and no DISK-LOADED message is ever appended with broadcast=True — both
-        # restore loops pass broadcast=False. That invariant is what lets the load
-        # path skip meta redaction, and it is pinned by
+        # and a DISK-LOADED message reaches this path only when the caller opts
+        # in per-role. Both restore loops pass broadcast=False, and the ONE
+        # exception is refresh_channel_window, which replays a channel
+        # transcript's tail and passes broadcast_user=True so a message typed in
+        # Slack renders at all (nothing rendered it optimistically here). That
+        # exception cannot carry unredacted meta: ConversationLog.append writes
+        # only role/content/ts/source_thread/source_user for such a row -- no
+        # meta dict -- so the arm below never fires for it, and the row's
+        # content is human-typed, which is deliberately raw at every other
+        # boundary too. The invariant is pinned by
         # test_rehydrate_does_not_broadcast_replayed_messages and
-        # test_restore_recent_sessions_does_not_broadcast_either. Do not relax it.
+        # test_restore_recent_sessions_does_not_broadcast_either. Do not relax
+        # it further without re-checking that meta is still absent.
         direct_meta = msg.get("meta")
         if direct_meta and isinstance(direct_meta, dict):
             payload["meta"] = {**(payload.get("meta") or {}), **direct_meta}

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -1244,6 +1244,24 @@ def set_dashboard_state(state: object) -> None:
     _dashboard_state = state
 
 
+def get_dashboard_state() -> object | None:
+    """The live dashboard state, or None when running without a dashboard.
+
+    An accessor rather than a direct read of the global: the gateway installs
+    the state AFTER import, so a caller that imported the name would capture
+    None forever.
+    """
+    return _dashboard_state
+
+
+def get_orch_cfg() -> "KiroCrewConfig | None":
+    """The orchestrator's live config, or None before the gateway installs it.
+
+    Same reason as :func:`get_dashboard_state` -- the value is set post-import.
+    """
+    return _orch_cfg
+
+
 def _reload_orch_cfg() -> None:
     """Reload in-memory config after !channel writes so changes take effect immediately."""
     if _orch_cfg is not None:

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -16,6 +16,7 @@ unaffected (they don't go through events.py Slack dispatch).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import time
@@ -36,6 +37,8 @@ from kiro_crew.slack.handler import (
     _is_slack_restricted,
     _should_auto_approve_spawn,
     _thread_agents,
+    get_dashboard_state,
+    get_orch_cfg,
     is_slack_session_trusted,
     maybe_apply_privacy_modifiers,
     maybe_handle_keyword_command,
@@ -64,6 +67,39 @@ logger = logging.getLogger(__name__)
 #: Mirrors the native path's fallback (``handler.py``: ``_get_default_agent()
 #: or "kirocrew"``) and the many ``agent="kirocrew"`` call sites.
 _DEFAULT_KIROCREW_AGENT = "kirocrew"
+
+
+async def _refresh_dashboard_tab(session_key: str) -> None:
+    """Push freshly-written transcript lines into an open dashboard tab.
+
+    The Slack transport persists a turn but owns no dashboard slot, so without
+    this an open tab learned about a Slack turn only when the background
+    reconciler next ran -- up to 30 seconds later, and later still while a turn
+    was in flight. Called after each transcript write so the tab tracks the
+    conversation as it happens.
+
+    Best-effort by design: this is presentation bookkeeping, and a dashboard
+    that is absent (Slack-only gateway) or erroring must never fail the turn.
+    """
+    try:
+        # Kept function-local ON PURPOSE, unlike the handler accessors above:
+        # the gateway supports running Slack-only with no dashboard at all
+        # (``--slack-only``), and the dashboard is already optional at runtime
+        # here (see the None check below). A module-level import would pull the
+        # whole dashboard module graph into the Slack inbound path's import
+        # time and make it a hard dependency of a mode that does not use it.
+        from kiro_crew.dashboard.channel_slots import surface_channel_state
+
+        state = get_dashboard_state()
+        if state is None:
+            return
+        await surface_channel_state(state, getattr(get_orch_cfg(), "dashboard", None))
+    except Exception:
+        logger.debug(
+            "transport_dispatch: dashboard refresh failed session=%s",
+            session_key,
+            exc_info=True,
+        )
 
 
 async def handle_message_transport(
@@ -349,6 +385,56 @@ async def handle_message_transport(
         # X-Session-Key; one shared writer lives in messaging.identity.
         await publish_turn_identity(sessions, session_key)
 
+        # ── Conversation log: the user's turn, at RECEIPT ──
+        # Recorded BEFORE the turn runs rather than alongside the reply
+        # afterwards. Writing both rows at the end meant the message did not
+        # exist anywhere for the whole duration of the turn, so a dashboard tab
+        # had nothing to show until the reply was already finished -- and both
+        # rows then carried effectively the same timestamp, losing how long the
+        # turn actually took. ``session_key`` is final by this point: the
+        # thread-owner re-resolution and session acquisition above are done, so
+        # this cannot write under a key the turn later abandons.
+        #
+        # Slack-restricted (incognito / temporary) sessions are skipped at BOTH
+        # write points, so a restricted session still persists nothing. Note
+        # this is a skip-at-each-write guarantee, not parity with the old
+        # single write: because Slack events dispatch concurrently, an
+        # `!incognito` that lands mid-turn used to suppress the whole turn
+        # (both rows were still unwritten), and can now only suppress the
+        # reply -- the question is already durable.
+        _logged_user_turn = False
+        if conversation_log and not _is_slack_restricted(session_key):
+            try:
+                # Off the loop deliberately. ``ConversationLog.append`` takes a
+                # cross-process flock, and ON the event loop that primitive
+                # makes a single NON-BLOCKING acquire and raises on any
+                # concurrent holder -- so calling it inline would both write to
+                # disk on the loop and silently drop this row whenever another
+                # writer happens to hold the lock.
+                #
+                # Awaited via to_thread rather than routed through
+                # ``append_off_loop`` because that helper is fire-and-forget:
+                # the tab refresh below must not run until the row is actually
+                # on disk (it reads the file), and a failure here has to be
+                # visible so the post-turn fallback can cover the whole turn.
+                await asyncio.to_thread(
+                    conversation_log.append,
+                    session_key,
+                    "user",
+                    text,
+                    source_thread=session_key,
+                    source_user=user_id,
+                )
+                _logged_user_turn = True
+            except Exception:
+                logger.warning(
+                    "transport_dispatch: user-turn log failed session=%s",
+                    session_key,
+                    exc_info=True,
+                )
+            if _logged_user_turn:
+                await _refresh_dashboard_tab(session_key)
+
         # ── Build message with context ──
         if context_builder:
             # Off-loop: build_message embeds the episodic query (blocking urllib).
@@ -444,17 +530,34 @@ async def handle_message_transport(
                 exc_info=True,
             )
 
-        # ── Conversation log ──
+        # ── Conversation log: the reply ──
+        # The user's row already landed at receipt, so only the reply is added
+        # here. If that receipt write failed we fall back to the combined write
+        # so a turn is never persisted reply-only.
         try:
             if conversation_log and not _is_slack_restricted(session_key):
-                save_conversation_turn(
-                    conversation_log,
-                    session_key,
-                    text,
-                    accumulated,
-                    source_thread=session_key,
-                    source_user=user_id,
-                )
+                if _logged_user_turn:
+                    if accumulated:
+                        # Same off-loop reasoning as the receipt write above.
+                        await asyncio.to_thread(
+                            conversation_log.append,
+                            session_key,
+                            "assistant",
+                            accumulated,
+                            source_thread=session_key,
+                            source_user=user_id,
+                        )
+                else:
+                    await asyncio.to_thread(
+                        save_conversation_turn,
+                        conversation_log,
+                        session_key,
+                        text,
+                        accumulated,
+                        source_thread=session_key,
+                        source_user=user_id,
+                    )
+                await _refresh_dashboard_tab(session_key)
         except Exception:
             logger.warning(
                 "transport_dispatch: save_conversation_turn failed session=%s",

--- a/test/test_slack_dashboard_live_sync.py
+++ b/test/test_slack_dashboard_live_sync.py
@@ -1,0 +1,351 @@
+"""A Slack turn must reach its dashboard tab as it happens, both directions.
+
+Two symptoms motivated these tests, and both were delivery bugs rather than
+persistence bugs -- in each case the transcript on disk was already correct:
+
+* A Slack-born conversation's tab showed nothing while the agent worked, then
+  the reply, then (only after a reload) the message that had prompted it.
+* A dashboard session mirrored out to Slack answered in Slack but never updated
+  the tab at all.
+
+Every test here fails before the change.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+
+from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, STOP_REASON_END_TURN
+from kiro_crew.dashboard.channel_slots import refresh_channel_window, surface_channel_session
+from kiro_crew.history import ConversationLog
+from kiro_crew.messaging.link import canonical_key
+from kiro_crew.slack import transport_dispatch
+
+_test_dir = Path(__file__).parent
+if str(_test_dir) not in sys.path:  # pragma: no cover
+    sys.path.insert(0, str(_test_dir))
+_golden = importlib.import_module("test_slack_golden_transcript")
+
+FakeSessions = _golden.FakeSessions
+RecordingSlackClient = _golden.RecordingSlackClient
+ScriptedProvider = _golden.ScriptedProvider
+make_event = _golden.make_event
+
+_MSG_TS = "1700000000.000100"
+_SESSION_KEY = canonical_key(_MSG_TS)
+
+SLACK_KEY = "slack:1785370133.085469"
+SLACK_STEM = "slack_1785370133.085469"
+
+
+def _recorder(slot):
+    """Capture what the slot would push to an open tab over the websocket."""
+    seen: list[dict] = []
+    slot._on_message = lambda key, msg: seen.append(msg)
+    slot._has_reader = False
+    return seen
+
+
+class TestAUserRowReachesTheTab:
+    """The message a person typed in Slack must render, not just the reply."""
+
+    def test_a_locally_typed_user_row_is_still_not_broadcast(self, tmp_path, monkeypatch):
+        # The default must not change: the dashboard composer already rendered
+        # its own message optimistically, so broadcasting it would double it.
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        seen = _recorder(slot)
+
+        slot.append("user", "typed here")
+
+        assert [m["role"] for m in seen] == []
+
+    def test_a_channel_user_row_is_broadcast_when_requested(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        seen = _recorder(slot)
+
+        slot.append("user", "from slack", broadcast_user=True)
+
+        assert [(m["role"], m["content"]) for m in seen] == [("user", "from slack")]
+
+    def test_assistant_rows_are_unaffected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        seen = _recorder(slot)
+
+        slot.append("assistant", "reply")
+
+        assert [m["role"] for m in seen] == ["assistant"]
+
+
+class TestBTheWindowRefreshDeliversBothRoles:
+    """The refresh that catches a tab up must not drop the user's message."""
+
+    @pytest.fixture
+    def log(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.history.config_dir", lambda: tmp_path)
+        return ConversationLog()
+
+    def _surfaced_slot(self, tmp_path, monkeypatch, log):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.sessions.channel_key_for_stem = lambda stem: (
+            SLACK_KEY if stem == SLACK_STEM else ""
+        )
+        state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+        path = Path(log._dir)
+        path.mkdir(parents=True, exist_ok=True)
+        (path / f"{SLACK_STEM}.jsonl").write_text(
+            json.dumps({"_type": "metadata", "created_at": "2026-08-01T10:00:00"}) + "\n",
+            encoding="utf-8",
+        )
+        log.append(SLACK_KEY, "user", "first")
+        log.append(SLACK_KEY, "assistant", "first reply")
+        slot = surface_channel_session(
+            state,
+            {"key": SLACK_STEM, "modified": 100.0},
+            {},
+            log.read_messages(SLACK_KEY),
+            session_key=SLACK_KEY,
+        )
+        assert slot is not None
+        return slot
+
+    def test_a_later_slack_turn_broadcasts_the_user_row_too(self, tmp_path, monkeypatch, log):
+        slot = self._surfaced_slot(tmp_path, monkeypatch, log)
+        seen = _recorder(slot)
+
+        # The Slack transport writes the next turn straight to the shared file.
+        log.append(SLACK_KEY, "user", "second question")
+        log.append(SLACK_KEY, "assistant", "second reply")
+        added = refresh_channel_window(slot, log.read_messages(SLACK_KEY), 200.0)
+
+        assert added == 2
+        # Before the fix only the assistant row was pushed, so the tab showed a
+        # reply to a question that was not on screen.
+        assert [(m["role"], m["content"]) for m in seen] == [
+            ("user", "second question"),
+            ("assistant", "second reply"),
+        ]
+
+
+class TestCTheMirrorIsResolvableInbound:
+    """Sending a session to Slack must make replies findable again."""
+
+    def _app(self, state):
+        from kiro_crew.dashboard.chat_slack import api_chat_slot_slack_link
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/slack-link", api_chat_slot_slack_link)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_link_registers_the_inbound_reverse_index(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "hello")
+        slot.drain()
+        state.slack_client = MagicMock()
+        state.slack_client.open_dm = AsyncMock(return_value="C123")
+        state.slack_client.post_message = AsyncMock(return_value="ts123")
+        state.owner_id = "U123"
+        state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+        state.sessions.set_slack_link = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/slack-link", json={})
+            assert resp.status == 200
+
+        # The inbound Slack path resolves a thread through get_linked_slot. The
+        # old hand-assignment left this index empty, so a reply in the mirrored
+        # thread ran the turn but never told the tab.
+        assert state.get_linked_slot("ts123") is slot
+        # The persisted half must still happen (it survives a restart).
+        assert state.sessions.set_slack_link.called
+
+    def test_a_restart_restores_the_index_for_a_mirrored_session(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.sessions.get_slack_link = MagicMock(return_value=("ts777", "C777"))
+
+        slot = state.get_or_create_slot("chat-9-1700000000")
+
+        assert state.get_linked_slot("ts777") is slot
+
+    def test_a_restart_does_not_index_a_channel_born_self_link(self, tmp_path, monkeypatch):
+        # A channel-born session's slack_thread_ts points at the thread it LIVES
+        # in, not one it mirrors to. Indexing that would route every inbound
+        # Slack message into the dashboard chat runner, changing the execution
+        # engine and approval semantics of all Slack traffic.
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.sessions.get_slack_link = MagicMock(return_value=("1785370133.085469", "C777"))
+        state.sessions.channel_key_for_stem = lambda stem: (
+            SLACK_KEY if stem == SLACK_STEM else ""
+        )
+
+        state.get_or_create_slot(SLACK_STEM, linked_session_key=SLACK_KEY)
+
+        assert state._slack_to_slot == {}
+        assert state.get_linked_slot("1785370133.085469") is None
+
+    def test_an_unresolved_channel_stem_is_still_not_indexed(self, tmp_path, monkeypatch):
+        # Same danger, harder case: the stem did NOT resolve, so
+        # linked_session_key is empty and cannot be the discriminator. The slot
+        # is still named for the thread it lives in, which is what catches it.
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.sessions.get_slack_link = MagicMock(return_value=("1785370133.085469", "C777"))
+        state.sessions.channel_key_for_stem = lambda stem: ""
+
+        state.get_or_create_slot(SLACK_STEM)
+
+        assert state._slack_to_slot == {}
+
+    def test_a_dashboard_slot_named_like_a_channel_is_still_indexed(self, tmp_path, monkeypatch):
+        # The guard must not be a name heuristic: a dashboard slot a caller
+        # happened to name "slack_notes" is a genuine mirror-out and must still
+        # deliver inbound replies to its tab.
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.sessions.get_slack_link = MagicMock(return_value=("ts777", "C777"))
+        state.sessions.channel_key_for_stem = lambda stem: ""
+
+        slot = state.get_or_create_slot("slack_notes")
+
+        assert state.get_linked_slot("ts777") is slot
+
+
+def _drive_transport(log, *, driver_cls=None):
+    """Run one full Slack transport turn against *log*."""
+    slack = RecordingSlackClient()
+    provider = ScriptedProvider(
+        [
+            make_event(EVENT_TEXT_CHUNK, text="the reply"),
+            make_event(EVENT_COMPLETE, stop_reason=STOP_REASON_END_TURN),
+        ]
+    )
+    sessions = FakeSessions(provider)
+    asyncio.run(
+        transport_dispatch.handle_message_transport(
+            slack=slack,
+            sessions=sessions,
+            channel="C1",
+            text="the question",
+            thread_ts=None,
+            msg_ts=_MSG_TS,
+            user_id="U_OWNER",
+            context_builder=None,
+            conversation_log=log,
+        )
+    )
+
+
+class TestDTheQuestionIsRecordedBeforeTheAnswer:
+    """The inbound message must exist while the turn runs, not only after."""
+
+    @pytest.fixture(autouse=True)
+    def _quiet_agents(self, monkeypatch):
+        monkeypatch.setattr(transport_dispatch, "_get_default_agent", lambda: "")
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_thread_agents", {})
+
+    def test_the_user_row_is_on_disk_when_the_turn_starts(self, tmp_path, monkeypatch):
+        log = ConversationLog(base_dir=tmp_path)
+        seen_at_turn_start: list[list[dict]] = []
+
+        real_driver = transport_dispatch.TurnDriver
+
+        class _Snapshotting(real_driver):  # type: ignore[misc, valid-type]
+            async def run(self, message):  # type: ignore[override]
+                seen_at_turn_start.append(log.read_messages(_SESSION_KEY))
+                return await super().run(message)
+
+        monkeypatch.setattr(transport_dispatch, "TurnDriver", _Snapshotting)
+        _drive_transport(log)
+
+        assert seen_at_turn_start, "the turn never ran"
+        # Before the fix both rows were written together AFTER the turn, so the
+        # transcript was empty at this point and the tab had nothing to show.
+        assert [(m["role"], m["content"]) for m in seen_at_turn_start[0]] == [
+            ("user", "the question")
+        ]
+
+    def test_the_finished_turn_has_exactly_one_of_each_row(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+
+        _drive_transport(log)
+
+        rows = [(m["role"], m["content"]) for m in log.read_messages(_SESSION_KEY)]
+        # Splitting the write must not double the question.
+        assert rows == [("user", "the question"), ("assistant", "the reply")]
+
+    def test_the_two_rows_carry_distinct_timestamps(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+
+        _drive_transport(log)
+
+        rows = log.read_messages(_SESSION_KEY)
+        # Co-stamping them microseconds apart lost how long the turn took and
+        # made the pair sort unstably at the millisecond precision JS carries.
+        assert rows[0]["ts"] != rows[1]["ts"]
+
+    def test_a_failed_receipt_write_still_records_the_whole_turn(self, tmp_path):
+        class _FailsFirstAppend(ConversationLog):
+            def __init__(self, *a, **k):
+                super().__init__(*a, **k)
+                self.fail_next = True
+
+            def append(self, *a, **k):
+                if self.fail_next:
+                    self.fail_next = False
+                    raise RuntimeError("disk full")
+                return super().append(*a, **k)
+
+        log = _FailsFirstAppend(base_dir=tmp_path)
+
+        _drive_transport(log)
+
+        rows = [(m["role"], m["content"]) for m in log.read_messages(_SESSION_KEY)]
+        # The fallback exists so a turn is never persisted reply-only.
+        assert rows == [("user", "the question"), ("assistant", "the reply")]
+
+    def test_no_transcript_write_happens_on_the_event_loop_thread(self, tmp_path):
+        # ConversationLog.append takes a cross-process flock, and on the event
+        # loop that primitive makes ONE non-blocking acquire and raises on any
+        # concurrent holder -- so an on-loop append both writes to disk on the
+        # loop and drops the row under benign contention.
+        idents: list[int] = []
+
+        class _ThreadRecordingLog(ConversationLog):
+            def append(self, *a, **k):
+                idents.append(threading.get_ident())
+                return super().append(*a, **k)
+
+        log = _ThreadRecordingLog(base_dir=tmp_path)
+        main_ident = threading.get_ident()
+
+        _drive_transport(log)
+
+        assert idents, "no transcript write happened"
+        assert main_ident not in idents, (
+            "a transcript write ran on the event loop thread: " f"{idents} includes {main_ident}"
+        )


### PR DESCRIPTION
## Problem

Two reported symptoms, both with a Slack thread bound to a dashboard tab:

**A Slack-born session rendered its own conversation out of order.** Replying from Slack showed nothing in the tab at first, then the agent's reply appeared, and only later did the message that prompted it show up — in the correct position above the reply.

**A dashboard session sent to Slack never updated at all.** Replying in the mirrored Slack thread got an answer in Slack, but the dashboard tab never moved. Typing in the dashboard still worked in both places; only the Slack-inbound direction was invisible.

Neither is a persistence bug. In both cases the transcript on disk was already correct, with correct provenance and no forked session — the messages were written and then simply never delivered to the open tab.

## Why it matters

The dashboard tab is supposed to *be* the conversation, not a delayed copy of it. Today, answering from your phone leaves the tab showing a reply to a question that isn't on screen, which reads as data loss even though nothing was lost. In the mirrored direction the tab silently stops tracking the conversation entirely, so the surface you'd reach for to catch up is the one place the conversation isn't.

## Fix

**Symptom → root cause.** A conversation has two stores: the in-memory `_ChatSlot` window a tab renders from (appending to it broadcasts a `chat_message` frame), and the on-disk transcript (read only on a full reload). A dashboard-typed turn writes both. The Slack inbound transport wrote **only** disk — it contained no reference to `slot.append`, `broadcast_ws`, or `push_slots_update`, making it the only transport with no dashboard hook at all. It also wrote both rows *after* the turn, so for the entire duration of a turn the message did not exist anywhere. The tab's only path to a Slack turn was a 30-second background reconciler whose own docstring says it exists to bound how stale the **sidebar** can be. When it did run, it dropped the user row at a broadcast gate that skips every `user` message — correct for a message this dashboard's composer already rendered optimistically, wrong for one typed in Slack.

The mirrored direction failed for an independent reason: there are two reverse indexes, and the send-to-Slack endpoint populated only one. `link_slack` is the canonical writer — it sets the slot fields, persists the link, registers `thread_ts → slot`, and releases the thread from any previous owner. The endpoint hand-assigned three of those fields and skipped the index. The inbound intercept — the one piece of Slack code that appends to a slot and broadcasts — resolves through exactly that index, so it declined every time and the tab was never told.

**Change.**
- Persist the inbound user row at **receipt** and refresh the tab, then append only the reply afterwards, with a fallback to the combined write if the receipt write failed so a turn is never recorded reply-only. This also restores meaningful timestamps: the two rows were previously stamped microseconds apart.
- Give the Slack transport a dashboard hook. `surface_channel_state` is the dispatcher-free entry point; `surface_dispatcher_session` now delegates to it, so the six transports that already had a hook are unchanged.
- Let a caller opt a user row into the broadcast (`broadcast_user`), and have the window refresh do so for rows replayed from a channel. The default is unchanged, so a locally-typed message is still not double-rendered.
- Route the mirror link through `link_slack`, and rebuild the reverse index on slot rehydration so the mirror survives a gateway restart.

**One trap, deliberately avoided.** `_is_genuine_slack_link` does not exclude self-references, so a Slack-*born* session also looks "linked" — its `slack_thread_ts` is the thread it lives *in*, not one it mirrors *to*. Indexing that would make every inbound Slack message resolve to a "linked" slot and run through the dashboard's chat runner instead of the Slack transport, silently changing the execution engine and approval semantics of all Slack traffic. Index registration is therefore restricted to genuine mirror-outs, using the session's own binding rather than a slot-name heuristic: a channel slot whose stem resolved is caught by `linked_session_key`, and one whose stem did not resolve is caught by comparing the link against the slot's own filename stem. A dashboard slot that merely happens to be named `slack_…` matches neither and still works.

Transcript writes moved off the event loop. `ConversationLog.append` takes a cross-process flock, and on the loop that primitive makes a single non-blocking acquire and **raises on any concurrent holder** — so an on-loop append both wrote to disk on the loop and dropped the row under benign contention. They are awaited via `to_thread` rather than routed through `append_off_loop` because the tab refresh must not run until the row is actually on disk, and a failure has to be visible enough to trip the fallback.

Scoped out on purpose: widening the reconciler's eligibility to dashboard-born keys. Once the live intercept works it buys nothing — if the tab isn't open there is nothing to refresh, and on open it loads from disk.

**One cross-module guard needed updating.** The Spec Builder builtin mirrors the host's broadcast skip set as `_NON_BROADCAST_ROLES` and guards the copy with a test that asserts the host's literal is unchanged — so relaxing the gate correctly failed it. The mirror is still accurate for that app (it never passes `broadcast_user`), so the guard was re-pointed at the two new literals and strengthened with a third assertion: if Spec Builder ever *does* opt in, the test now fails and tells you to drop `"user"` from its list, because those rows would then reach every dashboard client unredacted.

While in that file, one adjacent gap got a test: nothing asserted that the live-state guard compares against the *un-redirected* dir. That guard has already caught two real leaks into a user's own Spec Builder data, and if its capture ever re-resolved live it would compare tmp-against-tmp and silently stop guarding. `test_state_guard_compares_the_real_dir_not_the_redirect` pins it.

## Tests

14 tests in `test/test_slack_dashboard_live_sync.py`, grouped by the guarantee each holds:

- A locally-typed user row is still **not** broadcast; a channel one is when requested; assistant rows are unaffected.
- The window refresh delivers **both** roles, so a tab never shows a reply without its question.
- Linking a session to Slack makes the thread resolvable inbound, and the mirror survives a restart.
- A channel-born self-link is **not** indexed — including the harder case where the stem did not resolve — while a dashboard slot named like a channel still is.
- The user row is on disk when the turn starts; a finished turn has exactly one of each row; the two rows carry distinct timestamps; a failed receipt write still records the whole turn; no transcript write runs on the event loop thread.

Every test was proven non-vacuous: each half of the change was reverted independently and the matching test failed each time (8 reverts, 8 caught). The two guard conditions catch *different* tests, confirming both are load-bearing.

## Manual verification

Reproduced from the reported sessions before fixing: the on-disk transcripts for both a Slack-born session and a dashboard-born mirrored session already contained every message with correct provenance and no forked session, which is what localized this to delivery rather than persistence. The Slack-inbound rows were stamped microseconds apart while dashboard rows in the same file were seconds apart — the signature of the post-turn combined write.

End-to-end confirmation needs a live Slack round trip: reply from Slack in a session surfaced as a tab and confirm the message appears immediately and above the reply, then reply in a thread created by "send to Slack" and confirm the tab tracks it.

## Screenshots

N/A — no new or restyled surface. The change alters *when* an existing message reaches the tab, not how anything renders; there is no new component, layout, or style, and no static frame distinguishes the fixed behavior from the broken one (the difference is ordering and latency in a live message stream).
