### PR TITLE
fix(acp): guard set_mode against unknown modeId + self-heal missing agent config

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -86,6 +86,45 @@ def set_mode_params(session_id: str, agent: str) -> dict[str, Any]:
     return {"sessionId": session_id, "modeId": agent}
 
 
+def parse_session_modes(resp: dict[str, Any]) -> tuple[list[str], str, bool]:
+    """Extract advertised mode ids, current mode id, and whether the backend
+    advertised a modes list at all, from a ``session/new`` / ``session/load``
+    response.
+
+    kiro-cli returns ``modes: {currentModeId, availableModes: [{id, name,
+    description}, ...]}`` (parallel to the ``models`` payload). Returns
+    ``(ids, current_id, advertised)`` where ``advertised`` is True iff the
+    response carried a ``modes`` object with an ``availableModes`` **list**
+    (even an empty one).
+
+    The ``advertised`` flag is load-bearing: an OMITTED modes list (older
+    kiro-cli / offline fake backend → ``advertised=False``) means "unknown,
+    attempt ``set_mode`` for backward compatibility", whereas an ``availableModes:
+    []`` that is *present but empty* (``advertised=True``, ``ids=[]``) means the
+    backend genuinely offers no modes — the caller must fail closed, not attempt
+    a ``set_mode`` that would fault with ``Mode '<agent>' not found``.
+
+    Item id is read from ``id`` first, then ``modeId`` / ``value`` as fallbacks,
+    mirroring the defensive shape-reading in ``_normalize_models``. Never raises.
+    """
+    modes = resp.get("modes")
+    if not isinstance(modes, dict):
+        return [], "", False
+    current = modes.get("currentModeId")
+    current_id = current if isinstance(current, str) else ""
+    advertised_raw = modes.get("availableModes")
+    if not isinstance(advertised_raw, list):
+        return [], current_id, False
+    ids: list[str] = []
+    for m in advertised_raw:
+        if not isinstance(m, dict):
+            continue
+        mode_id = m.get("id") or m.get("modeId") or m.get("value")
+        if mode_id:
+            ids.append(str(mode_id))
+    return ids, current_id, True
+
+
 def set_model_params(session_id: str, model_id: str) -> dict[str, Any]:
     """Params for ``session/set_model`` (override the model on a session)."""
     return {"sessionId": session_id, "modelId": model_id}

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -38,6 +38,7 @@ from kiro_crew.acp._dispatch import (
     _kiro_mcp_server_name,
     _kiro_tool_name,
     extract_tool_purpose,
+    parse_session_modes,
     parse_usage_update,
 )
 from kiro_crew.acp.liveness import VERDICT_UNKNOWN, VERDICT_WORKING, LivenessOracle
@@ -96,6 +97,7 @@ from kiro_crew.acp.types import (
     JsonRpcRequest,
     TurnUsage,
 )
+from kiro_crew.agent import ensure_agent_materialized
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.env import augmented_path, resolve_krb5_ccname
@@ -1411,6 +1413,16 @@ class AcpClient:
         # offers rather than a hardcoded guess. Each entry: {modelId, name,
         # description}.
         self._available_models: list[dict[str, str]] = []
+        # Mode ids the backend advertised at session init (session/new|load
+        # `modes.availableModes`). Empty when the backend omits `modes` (older
+        # kiro-cli / offline fake) — the set_mode guard treats empty as "attempt"
+        # for backward compatibility. Populated by _store_session_config.
+        self._available_mode_ids: list[str] = []
+        # Whether the backend advertised a `modes` list at all (even an empty
+        # one). Distinguishes "unknown, attempt for backward compat" (False)
+        # from "advertised zero/some modes, honor the list" (True) so an
+        # explicitly-empty availableModes fails closed rather than attempting.
+        self._modes_advertised: bool = False
         # Model kiro-cli/claude-agent-acp actually resolved to (may differ
         # from self._model when that's the "auto" sentinel). Used to look up
         # the context window when usage_update isn't sent (see _track_metadata).
@@ -1696,6 +1708,14 @@ class AcpClient:
             self._acp_config_options = config_options
             logger.debug("ACP config options loaded: %d entries", len(config_options))
             self._sync_effort_levels()
+        # Capture advertised mode ids + whether a modes list was advertised at
+        # all, so step 4's set_mode can fail closed against a requested agent the
+        # backend never loaded (would fault with "Mode '<agent>' not found").
+        # Assigned unconditionally so a re-init that omits `modes` clears any
+        # stale state rather than guarding on it.
+        self._available_mode_ids, _current_mode, self._modes_advertised = (
+            parse_session_modes(resp)
+        )
 
     def _handle_config_option_update(self, msg: JsonRpcMessage) -> None:
         """Process a config_option_update session notification.
@@ -1817,6 +1837,14 @@ class AcpClient:
                 raise AcpError(str(exc)) from exc
             if not kiro_bin:
                 raise AcpError(f"{KIRO_CLI_BIN} not found in PATH")
+            # Self-heal (B): ensure the managed default agent file exists before
+            # this --agent spawn, so kiro-cli registers the mode and step 4's
+            # set_mode succeeds instead of faulting "Mode not found". Best-effort,
+            # off the loop; non-managed agents fall through to the step-4 guard.
+            try:
+                await asyncio.to_thread(ensure_agent_materialized, self._agent)
+            except Exception:
+                logger.warning("pre-spawn agent materialization failed", exc_info=True)
             argv = [kiro_bin, KIRO_CLI_SUBCMD, "--agent", self._agent]
 
         # OS-level sandbox: wrap the command to hide sensitive paths.
@@ -2398,12 +2426,29 @@ class AcpClient:
                 self._jsonl_pos = 0
 
         # 4. Activate agent via set_mode (claude-agent-acp does not support set_mode — skip).
+        #    Guard (A): fire only when the backend advertised this agent, or
+        #    advertised no modes at all (older kiro-cli / fake → attempt,
+        #    backward-compatible). If modes ARE advertised but this agent is
+        #    absent, its ~/.kiro/agents/<agent>.json didn't load — FAIL CLOSED
+        #    with an actionable error rather than silently running kiro-cli's
+        #    default (broader) mode, which for a restricted agent is a privilege
+        #    escalation. Self-heal (B, in _spawn) regenerates the managed default
+        #    so the common case never reaches this branch.
         if not self._is_claude:
-            await self._send_request(
-                METHOD_SET_MODE,
-                {"sessionId": self._session_id, "modeId": self._agent},
-            )
-            logger.info("ACP agent activated: %s", self._agent)
+            if not self._modes_advertised or self._agent in self._available_mode_ids:
+                await self._send_request(
+                    METHOD_SET_MODE,
+                    {"sessionId": self._session_id, "modeId": self._agent},
+                )
+                logger.info("ACP agent activated: %s", self._agent)
+            else:
+                raise AcpError(
+                    f"Agent mode {self._agent!r} is not available on this session "
+                    f"(advertised modes: {self._available_mode_ids or 'none'}); its "
+                    f"~/.kiro/agents/{self._agent}.json is likely missing. Refusing "
+                    f"to run the backend default mode in its place. Run "
+                    f"`kirocrew setup --agent-only` to materialize the agent config."
+                )
 
         # 5. Set model — override if KiroCrew config specifies non-default.
         if self._model and self._model != DEFAULT_MODEL:

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -28,6 +28,7 @@ from typing import Any
 from kiro_crew import platform_compat
 from kiro_crew.acp._dispatch import (
     build_session_new_params,
+    parse_session_modes,
     set_mode_params,
 )
 from kiro_crew.acp.client import (
@@ -52,6 +53,7 @@ from kiro_crew.acp.types import (
     JsonRpcMessage,
     JsonRpcRequest,
 )
+from kiro_crew.agent import ensure_agent_materialized
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.env import augmented_path, resolve_krb5_ccname
@@ -567,6 +569,17 @@ class AcpRuntime:
             raise AcpRuntimeError(str(exc)) from exc
         if not kiro_bin:
             raise AcpRuntimeError(f"{KIRO_CLI_BIN} not found in PATH")
+
+        # Self-heal (B): kiro-cli discovers its selectable modes at startup from
+        # ~/.kiro/agents/*.json, so the managed default agent file must exist
+        # BEFORE this --agent spawn or set_mode later fails with
+        # "Mode '<agent>' not found". Regenerate it if missing (best-effort, off
+        # the loop). Non-managed agents can't be materialized here — the
+        # create_session guard fails those closed instead.
+        try:
+            await asyncio.to_thread(ensure_agent_materialized, self._agent)
+        except Exception:
+            logger.warning("pre-spawn agent materialization failed", exc_info=True)
 
         argv: list[str] = [kiro_bin, KIRO_CLI_SUBCMD, "--agent", self._agent]
         if self._model:
@@ -1216,6 +1229,23 @@ class AcpRuntime:
             self._pending_init_notifications.clear()
         return matched
 
+    @staticmethod
+    def _mode_available(agent: str, resp: dict[str, Any]) -> bool:
+        """Whether ``set_mode`` should be attempted for ``agent`` given a
+        ``session/new``|``session/load`` response.
+
+        True when the backend advertised no ``modes`` list at all (older kiro-cli
+        / offline fake backend — attempt for backward compatibility) OR the agent
+        is in the advertised ``availableModes``. False when a modes list WAS
+        advertised (even an empty one) and the agent is absent — the case that
+        would otherwise fault with ``-32603 "Mode '<agent>' not found"``. An
+        explicitly-empty ``availableModes: []`` therefore fails closed, not open.
+        """
+        ids, _current, advertised = parse_session_modes(resp)
+        if not advertised:
+            return True
+        return agent in ids
+
     async def create_session(
         self,
         cwd: str | Path | None = None,
@@ -1272,7 +1302,16 @@ class AcpRuntime:
         # plain local unregister would leak it in the shared process. terminate_
         # session also unregisters the queue. Mirrors the same cleanup in
         # load_session().
-        if agent:
+        #
+        # Guard (A): only activate the mode when the backend advertised it in the
+        # session/new `modes` list, or advertised no modes at all (older kiro-cli
+        # / fake backend → attempt, backward-compatible). If modes ARE advertised
+        # but the requested agent is absent, its ~/.kiro/agents/<agent>.json never
+        # loaded (pre-spawn self-heal covers only the managed default). FAIL CLOSED
+        # rather than silently leaving the session on kiro-cli's default mode: for
+        # a restricted/app agent that would run a BROADER agent than requested (a
+        # privilege escalation), so we terminate and raise an actionable error.
+        if agent and self._mode_available(agent, resp):
             try:
                 await self._send_and_await(
                     METHOD_SET_MODE,
@@ -1281,6 +1320,16 @@ class AcpRuntime:
             except Exception:
                 await self.terminate_session(session_id)
                 raise
+        elif agent:
+            _ids, _current, _adv = parse_session_modes(resp)
+            await self.terminate_session(session_id)
+            raise AcpRuntimeError(
+                f"Agent mode {agent!r} is not available on this session "
+                f"(advertised modes: {_ids or 'none'}); its "
+                f"~/.kiro/agents/{agent}.json is likely missing. Refusing to run "
+                f"the backend default mode {_current or '(unknown)'} in its place. "
+                f"Run `kirocrew setup --agent-only` to materialize the agent config."
+            )
 
         # Drain MCP-server-init / oauth / config notifications before the first
         # prompt so they don't race into the first turn (parity with
@@ -1359,7 +1408,7 @@ class AcpRuntime:
         # succeeded so kiro-cli holds it; a plain local unregister would leak it
         # in the shared process (and leave the reader routing late transcript-
         # replay frames to an abandoned queue). terminate_session unregisters too.
-        if agent:
+        if agent and self._mode_available(agent, resp):
             try:
                 await self._send_and_await(
                     METHOD_SET_MODE,
@@ -1368,6 +1417,20 @@ class AcpRuntime:
             except Exception:
                 await self.terminate_session(resume_sid)
                 raise
+        elif agent:
+            # Guard (A) — see create_session. A resumed session always echoes a
+            # `modes` list (checked above), so an absent agent means its config
+            # isn't loaded. Fail closed rather than silently resuming on a
+            # different (broader) default agent than the one requested.
+            _ids, _current, _adv = parse_session_modes(resp)
+            await self.terminate_session(resume_sid)
+            raise AcpRuntimeError(
+                f"Agent mode {agent!r} is not available for resumed session "
+                f"{resume_sid} (advertised modes: {_ids or 'none'}); its "
+                f"~/.kiro/agents/{agent}.json is likely missing. Refusing to run "
+                f"the backend default mode {_current or '(unknown)'} in its place. "
+                f"Run `kirocrew setup --agent-only` to materialize the agent config."
+            )
 
         # Drain MCP-init / oauth / config notifications before the first prompt
         # (parity with AcpClient). Transcript-replay frames were already dropped

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2673,6 +2673,48 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
 install_agent = rebuild_agent_config
 
 
+def ensure_agent_materialized(agent: str | None) -> bool:
+    """Self-heal: guarantee the managed default agent config exists on disk.
+
+    kiro-cli discovers its selectable *modes* at process startup by scanning
+    ``~/.kiro/agents/*.json``. A session that spawns ``kiro chat --agent <name>``
+    and then issues ``session/set_mode {modeId: <name>}`` therefore needs the
+    backing file present BEFORE spawn, or kiro-cli answers
+    ``-32603 "Mode '<name>' not found"`` on every turn (the crash this closes).
+    Normally ``kirocrew setup --agent-only`` writes it, but a source checkout /
+    dev launch that skips setup leaves it absent — this makes the runtime
+    self-sufficient regardless.
+
+    Only the managed default (``AGENT_FILENAME`` → ``kirocrew.json``) is
+    regenerable here, via :func:`rebuild_agent_config`. App/custom agents are
+    owned by their own subsystems, so a missing one is reported (``False``) and
+    left to the caller's graceful set_mode fallback rather than being guessed at.
+
+    Returns ``True`` when the managed default file is present (already, or after
+    a regenerate); ``False`` when *agent* is non-managed or regeneration failed.
+    Best-effort — never raises, so it can sit on the spawn hot path.
+    """
+    try:
+        managed = Path(AGENT_FILENAME).stem
+        if not agent or agent != managed:
+            return False
+        agent_file = kiro_agents_dir_path() / AGENT_FILENAME
+        if agent_file.exists():
+            return True
+        logger.warning(
+            "Managed agent config %s missing — regenerating before spawn "
+            "(self-heal for kiro-cli 'Mode not found')",
+            agent_file,
+        )
+        rebuild_agent_config()
+        return agent_file.exists()
+    except Exception:
+        logger.warning(
+            "ensure_agent_materialized failed for agent %r", agent, exc_info=True
+        )
+        return False
+
+
 def _install_aim_capabilities() -> None:
     """Write a bare ``kirocrew-lite`` agent config.
 

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -4639,3 +4639,139 @@ class TestToolPurposeExtraction:
         assert (
             extract_tool_purpose({"__tool_use_purpose": "", "__toolUsePurpose": "real"}) == "real"
         )
+
+
+# ── set_mode availableModes guard (regression: "Mode '<agent>' not found") ──
+
+
+def _new_resp(modes: dict | None) -> dict:
+    r: dict = {"sessionId": "s1"}
+    if modes is not None:
+        r["modes"] = modes
+    return r
+
+
+@pytest.mark.asyncio
+async def test_create_session_sets_mode_when_agent_is_advertised():
+    """Happy path: the requested agent is in availableModes → set_mode fires."""
+    rt, _, _ = _make_runtime()
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    resp = _new_resp(
+        {"currentModeId": "kirocrew", "availableModes": [{"id": "kirocrew"}, {"id": "ops"}]}
+    )
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        handle = await rt.create_session(agent="ops", mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert methods == [METHOD_SESSION_NEW, METHOD_SET_MODE]
+    assert rt._send_and_await.call_args_list[1].args[1] == {
+        "sessionId": "s1",
+        "modeId": "ops",
+    }
+    assert handle.session_id == "s1"
+
+
+@pytest.mark.asyncio
+async def test_create_session_fails_closed_when_agent_not_advertised():
+    """Guard (A): modes advertised but the agent is absent → FAIL CLOSED
+    (terminate + raise), never silently run the backend default. Substituting a
+    broader default for a requested restricted agent would be a privilege
+    escalation."""
+    rt, _, _ = _make_runtime()
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    resp = _new_resp({"currentModeId": "default", "availableModes": [{"id": "default"}]})
+    # session/new response, then the terminate roundtrip from the fail-closed path
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        with pytest.raises(AcpRuntimeError, match="not available"):
+            await rt.create_session(agent="kirocrew", mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SET_MODE not in methods  # never activated the wrong mode
+    assert METHOD_SESSION_TERMINATE in methods  # created session cleaned up
+    assert "s1" not in rt._session_queues  # unregistered
+
+
+@pytest.mark.asyncio
+async def test_create_session_fails_closed_when_available_modes_empty():
+    """Regression (GPT round 2): an explicitly-empty `availableModes: []` is
+    ADVERTISED (not absent), so it must fail closed — not be treated as
+    "no modes → attempt" and then fault with "Mode not found"."""
+    rt, _, _ = _make_runtime()
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    resp = _new_resp({"currentModeId": "kirocrew", "availableModes": []})
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        with pytest.raises(AcpRuntimeError, match="not available"):
+            await rt.create_session(agent="kirocrew", mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SET_MODE not in methods
+    assert METHOD_SESSION_TERMINATE in methods
+
+
+@pytest.mark.asyncio
+async def test_create_session_sets_mode_when_no_modes_advertised():
+    """Backward compat: a backend that omits `modes` (older kiro-cli / fake
+    backend) still gets set_mode attempted."""
+    rt, _, _ = _make_runtime()
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    resp = _new_resp(None)
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        await rt.create_session(agent="kirocrew", mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SET_MODE in methods
+
+
+def test_mode_available_helper():
+    """Unit: the guard predicate. Empty modes ⇒ attempt (True); advertised ⇒
+    membership test."""
+    from kiro_crew.acp.runtime import AcpRuntime
+
+    assert AcpRuntime._mode_available("kirocrew", _new_resp(None)) is True
+    assert (
+        AcpRuntime._mode_available(
+            "kirocrew", _new_resp({"availableModes": [{"id": "kirocrew"}]})
+        )
+        is True
+    )
+    assert (
+        AcpRuntime._mode_available(
+            "kirocrew", _new_resp({"availableModes": [{"id": "default"}]})
+        )
+        is False
+    )
+    # Present-but-empty availableModes → advertised, agent absent → fail closed.
+    assert AcpRuntime._mode_available("kirocrew", _new_resp({"availableModes": []})) is False
+    # A modes dict WITHOUT an availableModes list → not advertised → attempt.
+    assert AcpRuntime._mode_available("kirocrew", _new_resp({"currentModeId": "x"})) is True
+
+
+def test_parse_session_modes_shapes():
+    """The shared parser: absent/odd `modes` ⇒ ([], '', False); a present
+    availableModes list ⇒ advertised=True (even when empty); id read from
+    id → modeId → value fallbacks."""
+    from kiro_crew.acp._dispatch import parse_session_modes
+
+    assert parse_session_modes({}) == ([], "", False)
+    assert parse_session_modes({"modes": "nonsense"}) == ([], "", False)
+    # modes dict but no availableModes list → not advertised (attempt path).
+    assert parse_session_modes({"modes": {"currentModeId": "x"}}) == ([], "x", False)
+    # present but empty → advertised True (fail-closed path).
+    assert parse_session_modes({"modes": {"availableModes": []}}) == ([], "", True)
+    ids, current, advertised = parse_session_modes(
+        {
+            "modes": {
+                "currentModeId": "kirocrew",
+                "availableModes": [
+                    {"id": "kirocrew"},
+                    {"modeId": "ops"},
+                    {"value": "code-reviewer"},
+                    {"name": "no-id-dropped"},
+                    "not-a-dict",
+                ],
+            }
+        }
+    )
+    assert ids == ["kirocrew", "ops", "code-reviewer"]
+    assert current == "kirocrew"
+    assert advertised is True

--- a/test/test_acp_set_mode_all_agents.py
+++ b/test/test_acp_set_mode_all_agents.py
@@ -49,3 +49,61 @@ async def test_set_mode_called_for_all_agents(agent, tmp_path):
         f"set_mode not called for agent={agent!r}; calls: {client._send_request.call_args_list}"
     )
     assert set_mode_calls[0].args[1]["modeId"] == agent
+
+
+async def _wait_with_modes(mode_ids):
+    """Init-step response factory that advertises a `modes` payload."""
+
+    async def _fake(rid, timeout=None):
+        return {
+            "protocolVersion": "1.0",
+            "sessionId": "sess-123",
+            "modes": {
+                "currentModeId": "kirocrew",
+                "availableModes": [{"id": m} for m in mode_ids],
+            },
+        }
+
+    return _fake
+
+
+@pytest.mark.asyncio
+async def test_set_mode_fails_closed_when_agent_not_in_advertised_modes(tmp_path):
+    """Guard (A): backend advertises a `modes` list that excludes the agent →
+    FAIL CLOSED (raise), never silently run kiro-cli's default mode in place of
+    the requested (possibly more-restricted) agent."""
+    from kiro_crew.acp.client import AcpError
+
+    client = _make_client("ghost-agent", tmp_path)
+    client._session_id = None  # force the session/new path so modes are captured
+    client._send_request = AsyncMock(return_value=1)
+    client._wait_for_response = AsyncMock(side_effect=await _wait_with_modes(["kirocrew"]))
+    client._drain_notifications = AsyncMock()
+
+    with patch("pathlib.Path.exists", return_value=False), patch("pathlib.Path.stat"):
+        with pytest.raises(AcpError, match="not available"):
+            await client._initialize_session()
+
+    set_mode_calls = [
+        c for c in client._send_request.call_args_list if c.args[0] == METHOD_SET_MODE
+    ]
+    assert set_mode_calls == [], "the wrong agent mode must never be activated"
+
+
+@pytest.mark.asyncio
+async def test_set_mode_sent_when_agent_in_advertised_modes(tmp_path):
+    """When the agent IS advertised, set_mode still fires with its modeId."""
+    client = _make_client("ops", tmp_path)
+    client._session_id = None  # force the session/new path so modes are captured
+    client._send_request = AsyncMock(return_value=1)
+    client._wait_for_response = AsyncMock(side_effect=await _wait_with_modes(["kirocrew", "ops"]))
+    client._drain_notifications = AsyncMock()
+
+    with patch("pathlib.Path.exists", return_value=False), patch("pathlib.Path.stat"):
+        await client._initialize_session()
+
+    set_mode_calls = [
+        c for c in client._send_request.call_args_list if c.args[0] == METHOD_SET_MODE
+    ]
+    assert len(set_mode_calls) == 1
+    assert set_mode_calls[0].args[1]["modeId"] == "ops"

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -3567,3 +3567,66 @@ class TestRefreshDynamicFieldsSyncsConfigModel:
         with patch("kiro_crew.agent._mc_config_path", return_value=mc):
             _refresh_dynamic_fields(config)
         assert config["model"] == "claude-sonnet-4.6"
+
+
+# ── ensure_agent_materialized (self-heal for kiro-cli "Mode not found") ──
+
+
+def test_ensure_agent_materialized_noop_for_non_managed_agent(tmp_path, monkeypatch):
+    """A non-managed (app/custom) agent can't be regenerated here → returns
+    False and never touches rebuild_agent_config."""
+    import kiro_crew.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+    rebuild = unittest.mock.MagicMock()
+    monkeypatch.setattr(agent_mod, "rebuild_agent_config", rebuild)
+
+    assert agent_mod.ensure_agent_materialized("some-app-agent") is False
+    rebuild.assert_not_called()
+
+
+def test_ensure_agent_materialized_present_is_noop(tmp_path, monkeypatch):
+    """Managed default already on disk → True, no regeneration."""
+    import kiro_crew.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+    (tmp_path / agent_mod.AGENT_FILENAME).write_text("{}", encoding="utf-8")
+    rebuild = unittest.mock.MagicMock()
+    monkeypatch.setattr(agent_mod, "rebuild_agent_config", rebuild)
+
+    managed = Path(agent_mod.AGENT_FILENAME).stem
+    assert agent_mod.ensure_agent_materialized(managed) is True
+    rebuild.assert_not_called()
+
+
+def test_ensure_agent_materialized_regenerates_when_missing(tmp_path, monkeypatch):
+    """Managed default missing → rebuild_agent_config is invoked and the file
+    is materialized (the reporter's fresh-checkout case)."""
+    import kiro_crew.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+
+    def _fake_rebuild(*_a, **_k):
+        path = tmp_path / agent_mod.AGENT_FILENAME
+        path.write_text("{}", encoding="utf-8")
+        return path
+
+    rebuild = unittest.mock.MagicMock(side_effect=_fake_rebuild)
+    monkeypatch.setattr(agent_mod, "rebuild_agent_config", rebuild)
+
+    managed = Path(agent_mod.AGENT_FILENAME).stem
+    assert agent_mod.ensure_agent_materialized(managed) is True
+    rebuild.assert_called_once()
+
+
+def test_ensure_agent_materialized_swallows_errors(tmp_path, monkeypatch):
+    """Best-effort: a rebuild failure never propagates (it sits on the spawn
+    hot path) — returns False instead."""
+    import kiro_crew.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+    rebuild = unittest.mock.MagicMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(agent_mod, "rebuild_agent_config", rebuild)
+
+    managed = Path(agent_mod.AGENT_FILENAME).stem
+    assert agent_mod.ensure_agent_materialized(managed) is False


### PR DESCRIPTION
## Problem
On some installs every chat turn fails with:

```
RPC error: {'code': -32603, 'message': 'Internal error', 'data': "Mode 'kirocrew' not found"}
```

(also seen as `Mode 'default' not found`). The session is completely unusable — the same internal error comes back on every prompt.

## Why it matters
kiro-cli rejects `session/set_mode` when the `modeId` (the resolved kiro agent name) has no backing `~/.kiro/agents/<name>.json`. On the shared-runtime path (`AcpRuntime.create_session`) the error is awaited and re-raised, so the session faults on **every** turn with no actionable message. This bites source checkouts / dev launches that never ran `kirocrew setup --agent-only` (so the managed `kirocrew.json` was never materialized).

## Fix (symptom → root cause → change)
- **Symptom:** per-turn `-32603 "Mode '<agent>' not found"`.
- **Root cause:** `set_mode` was issued unconditionally with `modeId=<agent>`; if the backing agent file was absent, kiro-cli never registered that mode, and nothing validated the requested `modeId` against the session's advertised modes.
- **Change — B (self-heal, primary):** `ensure_agent_materialized` regenerates the managed `~/.kiro/agents/kirocrew.json` **before** the `--agent` spawn when it is missing (best-effort, off-loop via `asyncio.to_thread`), so the managed default mode exists for a fresh checkout. This fixes the reported case at the source.
- **Change — A (guard, safety net):** a new shared `parse_session_modes` reads the `session/new`|`session/load` `modes.availableModes`. `set_mode` fires when the agent is advertised, or when the backend advertised **no** modes at all (older kiro-cli / offline fake backend → attempt, backward-compatible). If modes **are** advertised but the requested agent is absent (a non-managed/app agent that self-heal can't regenerate), the code **fails closed**: it terminates the just-created session and raises an actionable error naming the missing agent, the advertised modes, and the `kirocrew setup --agent-only` remedy. It does **not** silently leave the session on kiro-cli's default mode — substituting a broader default for a requested restricted agent would be a privilege escalation. Applied at all three sites: `AcpRuntime.create_session`, `AcpRuntime.load_session`, and `AcpClient._initialize_session` step 4.

## Tests
- `test/test_acp_runtime.py`: `create_session` sends `set_mode` when the agent is advertised; **fails closed** (terminates the session + raises, never sends `set_mode`) when advertised-but-absent; still attempts `set_mode` when no modes are advertised (backward compat); plus `_mode_available` and `parse_session_modes` unit tests.
- `test/test_acp_set_mode_all_agents.py`: the client **raises** (fails closed) when the agent is not in the advertised modes, and **sends** `set_mode` when advertised. The existing "set_mode called for all agents" test stays green (its mocked responses advertise no modes → backward-compat attempt path).
- `test/test_agent.py`: `ensure_agent_materialized` — noop for a non-managed agent, noop when the file is present, regenerates when missing, and swallows errors (returns `False`) so it never breaks the spawn hot path.

## Manual verification
N/A — unit coverage exercises all three `set_mode` sites (advertised / absent-fail-closed / no-modes) and every self-heal branch. Full local run: 775 ACP + agent tests pass; flake8 / isort / mypy clean on all changed source files.

## Screenshots
N/A — no user-visible UI change (backend-only).
