### PR TITLE
fix(spec-builder): capture the guarded state dir on first use, not at import

### DIFF
--- a/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
@@ -57,7 +57,19 @@ def _redirect_state(monkeypatch, tmp_path):
 
 
 def _live_state_snapshot() -> dict[str, int]:
-    """Names + mtimes of the USER's real state dir, or {} when there is none."""
+    """Names + mtimes of the guarded live state dir, or {} when there is none.
+
+    The guarded dir is captured on FIRST call and memoized: the capture must
+    happen before any test's ``_redirect_state`` patches the ``routes``
+    attributes (the autouse guard calls this before redirecting, so first use
+    is always un-redirected), but it must NOT happen at import time -- a
+    module-level ``routes._state_dir()`` freezes whichever ``KIROCREW_HOME``
+    is active at collection, defeating pod isolation and the per-test home
+    isolation (the issue #874 class the lazy-paths ratchet enforces).
+    """
+    global _REAL_STATE_DIR
+    if _REAL_STATE_DIR is None:
+        _REAL_STATE_DIR = routes._state_dir()
     try:
         return {p.name: p.stat().st_mtime_ns for p in _REAL_STATE_DIR.iterdir()}
     except OSError:
@@ -84,8 +96,10 @@ def _never_touch_the_real_state(monkeypatch, tmp_path):
     )
 
 
-#: Captured at import, before any test can monkeypatch the module attributes.
-_REAL_STATE_DIR = routes._state_dir()
+#: The un-redirected state dir the autouse guard watches. ``None`` until
+#: :func:`_live_state_snapshot`'s first call fills it (see its docstring for
+#: why capture is first-use, not import-time).
+_REAL_STATE_DIR: Path | None = None
 
 
 @web.middleware


### PR DESCRIPTION
## Problem

Main is red repo-wide since #518 (Spec Builder, af8774b8b): `test/test_lazy_data_home_paths.py::TestNoImportTimePathResolution::test_no_module_level_path_constants` fails on every PR's Backend Tests shard 2 (3.10, 3.12, Windows) with:

```
Data-home path resolved at import time (issue #874):
  apps/builtins/spec_builder/tests/test_routes.py:88  [module] _REAL_STATE_DIR = ..._state_dir()
```

## Why it matters

Every open PR fails CI regardless of its content (e.g. #1536 hit exactly this), and the frozen-at-import path is the real #874 hazard: it resolves the collection-time `KIROCREW_HOME`, defeating pod isolation and the per-test home isolation, and iterdirs the operator's real data home during collection.

## Fix (symptom → root cause → change)

The constant exists to capture the state dir **before any test's `_redirect_state` monkeypatches the `routes` attributes** — the autouse live-state guard compares against it. Import-time capture achieved that but violates the ratchet. First-use memoization inside `_live_state_snapshot` preserves the capture-before-redirect property (the autouse fixture snapshots *before* redirecting, so first use is always un-redirected) with no import-time resolution. The module-level name stays (`Path | None = None`), so the meta-test `test_state_guard_watches_the_whole_directory` (which pins `_REAL_STATE_DIR` inside the snapshot source) still passes, and the guard's semantics under per-test home isolation are unchanged: a test that forgets `_redirect_state` still trips the assert.

## Tests

The ratchet itself is the regression test (now green), plus the full spec_builder suite: 284 passed locally (`test_lazy_data_home_paths.py` + `spec_builder/tests/test_routes.py`), including both guard meta-tests. isort/flake8/mypy clean.

## Manual verification

N/A — unit coverage sufficient: the failing check is itself the deterministic reproducer.
