### PR TITLE
fix(acp): stop dumping the raw JSON-RPC error dict into chat

### DIFF
--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -39,12 +39,11 @@ from kiro_crew.acp._dispatch import (
     set_model_params,
 )
 from kiro_crew.acp.client import (
-    AcpError,
     AcpProcessDied,
     AcpTimeoutError,
     _is_safe_oauth_url,
     _is_tool_interrupted_marker,
-    _is_transient_raw_error,
+    _raise_acp_error,
 )
 from kiro_crew.acp.liveness import (
     EVIDENCE_ESTABLISHED_FLAT,
@@ -844,6 +843,25 @@ class AcpSessionHandle:
         """Models advertised by the backend at session init."""
         return list(self._available_models)
 
+    def _advertised_model_ids(self) -> list[str]:
+        """Advertised model ids, for the model-rejection error path.
+
+        Parity with ``AcpClient._advertised_model_ids``. Empty when the backend
+        advertised nothing (no session yet, or a backend that omits ``models``),
+        which the error path reads as "entitlement unknown" and leaves the
+        transient/capacity handling alone.
+
+        This handle is the shared-runtime path every dashboard chat takes, so
+        without it the entitlement discrimination in ``_model_is_unentitled``
+        would only ever fire for direct-spawn ``AcpClient`` sessions.
+        """
+        ids = []
+        for entry in self._available_models:
+            model_id = entry.get("modelId") if isinstance(entry, dict) else None
+            if isinstance(model_id, str) and model_id.strip():
+                ids.append(model_id)
+        return ids
+
     def supports_config_option(self, config_id: str) -> bool:
         """Whether the session advertised a config option with this id.
 
@@ -1011,17 +1029,18 @@ class AcpSessionHandle:
                     raise AcpProcessDied("Runtime process died while waiting for response")
                 if msg.is_response_for(req_id):
                     if msg.error:
-                        # Classify the raw JSON-RPC error so the chat_runner /
-                        # llm_helpers retry ladder recognizes transient backend 5xx
-                        # (e.g. a mid-stream InternalServerError surfaced as -32603)
-                        # instead of surfacing a bare error card. The transient=
-                        # flag is set explicitly because the string fallback
-                        # classifier misses the raw "InternalServerError" dict.
-                        # Mirrors client._raise_acp_error.
-                        raise AcpError(
-                            f"ACP error: {msg.error}",
-                            transient=_is_transient_raw_error(msg.error),
-                        )
+                        # Delegate to the shared raise helper so this path gets
+                        # the SAME treatment as AcpClient: actionable prose from
+                        # _format_acp_error (model-unavailable / throttle / auth /
+                        # 5xx), credential+URL redaction, the transient= verdict
+                        # for the chat_runner / llm_helpers retry ladder, and the
+                        # AcpPromptBusy subclass for a concurrent in-flight
+                        # prompt. Raising a bare f"ACP error: {msg.error}" here
+                        # put the raw JSON-RPC dict in front of the user.
+                        # The advertised ids let the shared entitlement
+                        # discriminator tell "your plan lacks this model"
+                        # (terminal) from a capacity blip (retryable).
+                        _raise_acp_error(msg.error, self._advertised_model_ids())
                     return msg
                 # Not our response — buffer (do not drop) for re-injection.
                 buffered.append(msg)
@@ -1178,17 +1197,14 @@ class AcpSessionHandle:
                 # Turn-complete response
                 if msg.is_response_for(req_id):
                     if msg.error:
-                        # Classify the raw JSON-RPC error so the chat_runner /
-                        # llm_helpers retry ladder recognizes transient backend 5xx
-                        # (e.g. a mid-stream InternalServerError surfaced as -32603)
-                        # instead of surfacing a bare error card. The transient=
-                        # flag is set explicitly because the string fallback
-                        # classifier misses the raw "InternalServerError" dict.
-                        # Mirrors client._raise_acp_error.
-                        raise AcpError(
-                            f"ACP error: {msg.error}",
-                            transient=_is_transient_raw_error(msg.error),
-                        )
+                        # Same as _wait_for_response: route through the shared
+                        # raise helper so a mid-turn failure surfaces actionable
+                        # prose instead of the raw JSON-RPC dict, keeps its
+                        # transient verdict for the retry ladder, and raises
+                        # AcpPromptBusy when the backend reports a concurrent
+                        # in-flight prompt. Advertised ids feed the entitlement
+                        # discriminator (see _wait_for_response).
+                        _raise_acp_error(msg.error, self._advertised_model_ids())
                     result = msg.result or {}
                     reason = ""
                     if isinstance(result, dict):

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -14,7 +14,13 @@ from typing import Any
 from urllib.parse import parse_qsl, urlparse
 
 from kiro_crew import mcp_apps_render, model_registry, session_directive
-from kiro_crew.acp.client import AcpAuthRequired, AcpError, AcpProcessDied, _is_safe_oauth_url
+from kiro_crew.acp.client import (
+    AcpAuthRequired,
+    AcpError,
+    AcpProcessDied,
+    AcpPromptBusy,
+    _is_safe_oauth_url,
+)
 from kiro_crew.acp.types import (
     EVENT_AGENT_SWITCHED,
     EVENT_CLEAR_STATUS,
@@ -5326,7 +5332,14 @@ async def _run_chat(
             # but still surface feedback so the nested turn doesn't fail silently.
             slot.append("error", "⟳ Session busy — please retry.", "msg msg-err")
     except AcpError as exc:
-        logger.warning("ACP error in slot %s: %s", slot.key, exc)
+        # The exception CLASS is logged alongside the message because the
+        # session-health scanner keys its prompt_stuck signal off this line, and
+        # the message text is no longer a reliable carrier: _format_acp_error
+        # rewrites the backend's "prompt already in progress" into user-facing
+        # prose. The class name is the structural classification rendered into
+        # text, so a scanner never has to pattern-match wording that a copy
+        # edit (or translation) can move. See session_health._PATTERNS.
+        logger.warning("ACP error in slot %s: [%s] %s", slot.key, type(exc).__name__, exc)
         _msg = str(exc)
         # Retry-eligible transients:
         #   - "already in progress": prompt busy (kiro-cli side)
@@ -5334,8 +5347,17 @@ async def _run_chat(
         # For both: reset the session and re-queue the message so auto-nudges
         # (and dashboard messages) get executed on a fresh provider instead of
         # surfacing a bare ❌ error card with no work done.
+        # Prompt-busy is matched STRUCTURALLY (the AcpPromptBusy subclass) with
+        # the string as a fallback. _format_acp_error rewrites the backend's
+        # "prompt already in progress" into friendly prose that no longer
+        # contains the marker, so a string-only check silently loses the
+        # reset-and-requeue path for every producer that formats before raising.
+        # The fallback still covers history-restored / unformatted messages.
         _retry_eligible = (
-            "already in progress" in _msg or "process exited" in _msg or "not running" in _msg
+            isinstance(exc, AcpPromptBusy)
+            or "already in progress" in _msg
+            or "process exited" in _msg
+            or "not running" in _msg
         )
         if _retry_eligible:
             logger.info(

--- a/src/kiro_crew/dashboard/session_health.py
+++ b/src/kiro_crew/dashboard/session_health.py
@@ -4,7 +4,15 @@ A slot is "stalled" when the UI would show it as working but the underlying agen
 already failed silently. Detected patterns:
 
 * ``subagent_timeout``  — ``Injected timeout error for subagent ... into slot KEY``
-* ``prompt_stuck``      — ``ACP error in slot KEY: ... 'Prompt already in progress'``
+* ``prompt_stuck``      — ``ACP error in slot KEY: [AcpPromptBusy] ...``, or the
+  legacy shape ``ACP error in slot KEY: ... 'Prompt already in progress'``
+
+Two ``prompt_stuck`` patterns exist on purpose. The current one keys off the
+exception class that ``chat_runner`` logs, which is the structural
+classification and cannot drift when user-facing wording changes; the legacy one
+keys off the raw backend text and is retained so log tails written by earlier
+gateways (before the message was formatted) still resolve. Either match is the
+same signal.
 
 Note: ``Session KEY has dead provider — removing stale entry`` is NOT a stall signal.
 It's emitted during healthy self-cleanup: the session manager detected a dead provider
@@ -29,6 +37,10 @@ _LOG_TAIL_BYTES = 256 * 1024  # scan last 256 KB of gateway.log — cheap
 
 _PATTERNS: List[Tuple[str, re.Pattern[str]]] = [
     ("subagent_timeout", re.compile(r"Injected timeout error for subagent \S+ into slot (\S+)")),
+    # Current shape: chat_runner logs the exception class, so this matches the
+    # structural verdict rather than any wording the formatter produces.
+    ("prompt_stuck", re.compile(r"ACP error in slot (\S+): \[AcpPromptBusy\]")),
+    # Legacy shape: raw backend text, for log tails written by earlier gateways.
     ("prompt_stuck", re.compile(r"ACP error in slot (\S+):.*Prompt already in progress")),
 ]
 

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -14,7 +14,7 @@ from collections.abc import Awaitable, Callable
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.acp.client import AcpError
+from kiro_crew.acp.client import AcpError, AcpPromptBusy
 from kiro_crew.acp.types import TurnUsage
 from kiro_crew.hooks import fire_tool_hooks, get_global_hook_store
 from kiro_crew.providers.base import (
@@ -65,7 +65,17 @@ _TRANSIENT_MARKERS = (
     "connectionreset",
     "dispatch failure",  # AWS SDK connector-level I/O failure (conn/DNS/TLS drop)
     "dispatchfailure",  # Rust DispatchFailure variant (unspaced)
-    "is unavailable on bedrock",  # capacity/region rollout (formatted message)
+    # Model-unavailable capacity/rollout, matched against _format_acp_error's
+    # wording. Two phrasings are listed: the current "on the backend" text
+    # (#1550) and the pre-2026-08 "on Bedrock" one, so a transcript or log line
+    # written by an older gateway still classifies. Any future rewording of
+    # that branch must add its marker here.
+    #
+    # Deliberately does NOT cover the sibling unentitled-model branch: that one
+    # is terminal by design (_model_is_unentitled), so a marker matching it
+    # would resurrect the pointless retry loop #1550 removed.
+    "is unavailable on the backend",
+    "is unavailable on bedrock",
     "transient error (http 5xx)",  # _format_acp_error's generic-5xx message
 )
 
@@ -435,7 +445,18 @@ async def stream_and_collect(
             return result_text
         except AcpError as exc:
             msg = str(exc)
-            busy = "already in progress" in msg
+            # Prompt-busy is matched STRUCTURALLY first, with the substring kept
+            # as a fallback. _format_acp_error rewrites the backend's "prompt
+            # already in progress" into friendly prose that no longer carries
+            # the marker, so a string-only check silently loses BOTH arms below
+            # (cancel+retry and PromptBusyExhaustedError) for any producer that
+            # formats before raising — which the shared-runtime AcpSessionHandle
+            # now does. Unattended callers (workflows/agent_pool, handlers/side,
+            # the subagent-completion injector) depend on those arms to reset a
+            # wedged parent session, so losing them surfaces a generic failure
+            # and leaves the session stuck. The fallback still covers
+            # unformatted / history-restored messages.
+            busy = isinstance(exc, AcpPromptBusy) or "already in progress" in msg
 
             # ── Case 1: prompt-busy (provider mid-turn) — cancel + retry. ──
             if busy:

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -6455,6 +6455,9 @@ class TestFormatAcpError:
         # the model lives in config.json / the agent spec.
         assert "settings.json" not in out
         assert "config.json" in out
+        # Nor echo the provider's own "use '/model'" advice: that is a kiro-cli
+        # TUI command, inert in the dashboard, Slack, and cron.
+        assert "/model" not in out
         # Request id is preserved for support correlation.
         assert "3ce0318a-24d6-4b1a-a4a7-ee81f1a3991e" in out
         # Should not leak the raw dict prefix when we have a real rewrite.

--- a/test/test_acp_error_surface.py
+++ b/test/test_acp_error_surface.py
@@ -1,0 +1,256 @@
+"""Tests for how a JSON-RPC error frame reaches the user.
+
+``AcpSessionHandle`` (the shared-runtime path every dashboard chat takes) used
+to raise ``AcpError(f"ACP error: {msg.error}")`` — a ``repr`` of the raw
+``{code, message, data}`` dict — so a routine model-unavailable failure landed
+in the transcript as an unreadable red wall:
+
+    ACP error: {'code': -32603, 'message': 'Internal error', 'data':
+    "Encountered an error in the response stream: The model 'claude-opus-4.8'
+    is not available. Please use '/model' to select a different model and try
+    again. (request_id: ...)"}
+
+Meanwhile ``AcpClient`` — the other producer of the identical frame — routed
+through ``_raise_acp_error``, which rewrites known failure modes into recovery
+steps, redacts credentials, and raises ``AcpPromptBusy`` for a concurrent
+prompt. Both handle sites now delegate to that helper, so the two producers
+cannot drift.
+
+The raw dump was quietly LOAD-BEARING: ``chat_runner`` decided prompt-busy
+retry eligibility by searching the message for "already in progress", which
+only ever matched because the dict was echoed verbatim. Formatting rewrites
+that marker away, so the runner's check is now structural
+(``isinstance(exc, AcpPromptBusy)``) with the string kept as a fallback. The
+coupling guard below fails if a future reformat re-breaks it.
+
+Both handle sites also pass the session's advertised model ids, so the
+entitlement discriminator added by #1550 (``_model_is_unentitled``) actually
+fires on this path. #1550 wired only the ``AcpClient`` sites, and this handle
+is the path every dashboard chat takes.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.acp.client import AcpError, AcpPromptBusy
+from kiro_crew.acp.session_handle import AcpSessionHandle
+from kiro_crew.acp.types import JsonRpcMessage
+
+# The exact frame from the reported transcript, minus the request id value.
+_MODEL_UNAVAILABLE = {
+    "code": -32603,
+    "message": "Internal error",
+    "data": (
+        "Encountered an error in the response stream: The model "
+        "'claude-opus-4.8' is not available. Please use '/model' to select a "
+        "different model and try again. (request_id: "
+        "863ae6fe-de1d-4149-b3ff-6ee02d8d58a2)"
+    ),
+}
+
+_PROMPT_BUSY = {
+    "code": -32603,
+    "message": "Internal error",
+    "data": "Prompt already in progress",
+}
+
+
+def _handle() -> AcpSessionHandle:
+    rt = MagicMock()
+    rt.pid = None
+    rt.is_alive = MagicMock(return_value=True)
+    rt.send_notification = AsyncMock()
+    h = AcpSessionHandle("sErr", asyncio.Queue(), rt)
+    h._turn_done.clear()
+    return h
+
+
+async def _raise_via_wait(error: dict, models: list[dict] | None = None) -> BaseException:
+    """Drive ``_wait_for_response`` to the error branch and return the raised exc."""
+    h = _handle()
+    if models is not None:
+        h._available_models = models
+    h._queue.put_nowait(JsonRpcMessage(id=7, error=error))
+    with pytest.raises(AcpError) as ei:
+        await h._wait_for_response(7, timeout=5.0)
+    return ei.value
+
+
+async def _raise_via_dispatch(error: dict, models: list[dict] | None = None) -> BaseException:
+    """Drive ``_dispatch_events`` to the error branch and return the raised exc."""
+    h = _handle()
+    if models is not None:
+        h._available_models = models
+    h._queue.put_nowait(JsonRpcMessage(id=7, error=error))
+    with pytest.raises(AcpError) as ei:
+        async for _ev in h._dispatch_events(7, timeout=5.0):
+            pass
+    return ei.value
+
+
+class TestNoRawDictInUserFacingError:
+    """Both handle raise sites must format, never dump the JSON-RPC dict."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_model_unavailable_is_actionable(self, driver):
+        msg = str(await driver(_MODEL_UNAVAILABLE))
+
+        # The dict repr and the JSON-RPC boilerplate are gone.
+        assert "'code': -32603" not in msg
+        assert "ACP error: {" not in msg
+        assert "Internal error" not in msg
+        # The failing model and the recovery step are present.
+        assert "claude-opus-4.8" in msg
+        assert "model picker" in msg
+        # The provider's own advice names a kiro-cli TUI command that does
+        # nothing in the dashboard, Slack, or a cron — it must not be echoed.
+        assert "/model" not in msg
+        # request_id survives for support correlation.
+        assert "863ae6fe-de1d-4149-b3ff-6ee02d8d58a2" in msg
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_transient_verdict_still_carried(self, driver):
+        """Formatting must not cost the retry ladder its structured verdict."""
+        assert (await driver(_MODEL_UNAVAILABLE)).transient is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_prompt_busy_raises_subclass(self, driver):
+        """A concurrent in-flight prompt gets the typed exception, not bare AcpError."""
+        exc = await driver(_PROMPT_BUSY)
+        assert isinstance(exc, AcpPromptBusy)
+        assert "still processing a previous request" in str(exc)
+
+    @pytest.mark.asyncio
+    async def test_unknown_shape_still_preserved(self):
+        """An unrecognised frame must not be swallowed — the raw shape is kept."""
+        msg = str(await _raise_via_wait({"code": -32602, "message": "Invalid params"}))
+        assert "Invalid params" in msg
+
+
+class TestEntitlementReachesTheHandlePath:
+    """The shared-runtime path must feed the entitlement discriminator too.
+
+    #1550 added ``_model_is_unentitled`` and wired it into the three
+    ``AcpClient`` raise sites. ``AcpSessionHandle`` is the path every dashboard
+    chat actually takes, so without passing its advertised ids the entitlement
+    split stays inert exactly where users hit it: a free-tier rejection would
+    still read as a capacity blip and still burn the retry ladder.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_unentitled_model_is_terminal_and_names_alternatives(self, driver):
+        exc = await driver(
+            _MODEL_UNAVAILABLE,
+            [
+                {"modelId": "claude-sonnet-4-5", "name": "Sonnet", "description": ""},
+                {"modelId": "auto", "name": "Auto", "description": ""},
+            ],
+        )
+        msg = str(exc)
+        # Access problem, not capacity — and retrying is called out as futile.
+        assert "does not have access" in msg
+        assert "claude-sonnet-4-5" in msg
+        assert "Retrying will not help" in msg
+        # Terminal: the retry ladder must not spend attempts reproducing this.
+        assert exc.transient is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_advertised_model_stays_a_retryable_capacity_blip(self, driver):
+        """A rejected model the account WAS offered is a genuine transient."""
+        exc = await driver(
+            _MODEL_UNAVAILABLE,
+            [{"modelId": "claude-opus-4.8", "name": "Opus", "description": ""}],
+        )
+        assert "does not have access" not in str(exc)
+        assert exc.transient is True
+
+    @pytest.mark.asyncio
+    async def test_empty_advertised_list_leaves_behaviour_unchanged(self):
+        """No advertised set means entitlement is unknowable — stay transient."""
+        exc = await _raise_via_wait(_MODEL_UNAVAILABLE, [])
+        assert "does not have access" not in str(exc)
+        assert exc.transient is True
+
+
+class TestRunnerPromptBusyIsStructural:
+    """The runner's retry gate must not depend on error-message wording."""
+
+    def test_formatted_prompt_busy_has_no_string_marker(self):
+        """Coupling guard: proves the string check ALONE would now miss.
+
+        If a future edit reintroduces "already in progress" into the formatted
+        text this assertion fails — which is the signal to re-check that the
+        structural isinstance branch (not the resurrected substring) is what
+        keeps the reset-and-requeue path alive.
+        """
+        from kiro_crew.acp.client import _format_acp_error
+
+        assert "already in progress" not in _format_acp_error(_PROMPT_BUSY)
+
+    def test_runner_gate_matches_typed_exception(self):
+        """The runner's own predicate, evaluated on a formatted AcpPromptBusy."""
+        from kiro_crew.acp.client import _format_acp_error
+
+        exc = AcpPromptBusy(_format_acp_error(_PROMPT_BUSY))
+        _msg = str(exc)
+        # Mirrors chat_runner's `_retry_eligible` expression.
+        eligible = (
+            isinstance(exc, AcpPromptBusy)
+            or "already in progress" in _msg
+            or "process exited" in _msg
+            or "not running" in _msg
+        )
+        assert eligible
+
+
+class TestTransientMarkerCoupling:
+    """``llm_helpers`` string fallback must recognise the formatted wording.
+
+    ``acp_error_is_transient`` prefers the structured ``.transient`` flag, but
+    unattended callers (``stream_and_collect``) and history-restored messages
+    still fall back to substring matching against ``_TRANSIENT_MARKERS``, whose
+    entries quote ``_format_acp_error``'s prose verbatim. Rewording a branch
+    without updating that tuple makes a retryable failure look terminal — which
+    is exactly what #1550 did when it changed "on Bedrock" to "on the backend"
+    and left the marker behind.
+
+    Scope note: this pins the OUTCOME (formatted transients classify), not any
+    single marker. The capacity branch is matched twice over — by
+    "is unavailable on the backend" and incidentally by "throttl" in its own
+    "capacity throttle" clause — so dropping either one alone does not fail
+    here. That redundancy is deliberate belt-and-braces.
+    """
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            _MODEL_UNAVAILABLE,
+            {"code": -32603, "message": "Internal error", "data": "ThrottlingException"},
+            {"code": -32603, "message": "Internal error", "data": "InternalServerError"},
+        ],
+    )
+    def test_formatted_transient_still_classifies(self, error):
+        from kiro_crew.acp.client import _format_acp_error
+        from kiro_crew.llm_helpers import is_transient_backend_error
+
+        assert is_transient_backend_error(_format_acp_error(error))
+
+    def test_unentitled_wording_is_not_marked_transient(self):
+        """The terminal sibling branch must NOT match a retry marker.
+
+        A marker that caught the unentitled text would resurrect the pointless
+        retry loop #1550 removed, via the string-fallback path.
+        """
+        from kiro_crew.acp.client import _format_acp_error
+        from kiro_crew.llm_helpers import is_transient_backend_error
+
+        formatted = _format_acp_error(_MODEL_UNAVAILABLE, ["claude-sonnet-4-5"])
+        assert "does not have access" in formatted
+        assert not is_transient_backend_error(formatted)

--- a/test/test_llm_helpers.py
+++ b/test/test_llm_helpers.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kiro_crew.acp.client import AcpError
+from kiro_crew.acp.client import AcpError, AcpPromptBusy
 from kiro_crew.llm_helpers import (
     PromptBusyExhaustedError,
     ToolApprovalPolicy,
@@ -208,6 +208,67 @@ class TestStreamAndCollectPromptBusy:
     async def test_shuts_down_provider_after_retries_exhausted(self) -> None:
         """After all retries fail, provider.shutdown() is called."""
         provider = _make_provider(error=AcpError("already in progress"))
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(PromptBusyExhaustedError),
+        ):
+            await stream_and_collect(provider, "test")
+
+        provider.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_formatted_prompt_busy_still_retries(self) -> None:
+        """A FORMATTED prompt-busy must take the busy arm, not fall through.
+
+        Regression guard. The shared-runtime raise path routes through
+        _format_acp_error, which rewrites the backend's "prompt already in
+        progress" into user-facing prose carrying none of that substring. When
+        this check was string-only, such an error skipped BOTH busy arms
+        (cancel+retry and PromptBusyExhaustedError) and surfaced as a generic
+        failure — leaving the wedged parent session un-reset for every
+        unattended caller (workflows/agent_pool, handlers/side, the
+        subagent-completion injector).
+        """
+        from kiro_crew.acp.client import _format_acp_error
+
+        formatted = _format_acp_error(
+            {"code": -32603, "message": "Internal error", "data": "Prompt already in progress"}
+        )
+        # Precondition: the marker the old check relied on really is gone.
+        assert "already in progress" not in formatted
+
+        call_count = 0
+
+        async def _stream(msg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise AcpPromptBusy(formatted)
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="ok")
+            yield LLMEvent(kind=EVENT_COMPLETE)
+
+        provider = AsyncMock()
+        provider.cancel = AsyncMock()
+        provider.shutdown = AsyncMock()
+        provider.stream = _stream
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await stream_and_collect(provider, "test")
+
+        assert result == "ok"
+        assert call_count == 2
+        provider.cancel.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_formatted_prompt_busy_exhaustion_still_raises_typed(self) -> None:
+        """The exhaustion arm must also fire for a formatted prompt-busy."""
+        from kiro_crew.acp.client import _format_acp_error
+
+        formatted = _format_acp_error(
+            {"code": -32603, "message": "Internal error", "data": "Prompt already in progress"}
+        )
+        provider = _make_provider(error=AcpPromptBusy(formatted))
 
         with (
             patch("asyncio.sleep", new_callable=AsyncMock),

--- a/test/test_session_health.py
+++ b/test/test_session_health.py
@@ -46,6 +46,40 @@ def test_detects_prompt_stuck(tmp_path: Path) -> None:
     assert result["chat-9-1776732990"]["reason"] == "prompt_stuck"
 
 
+def test_detects_prompt_stuck_from_formatted_message(tmp_path: Path) -> None:
+    """The current log shape: class name present, backend text absent.
+
+    Regression guard. chat_runner's message now comes from _format_acp_error,
+    which rewrites "prompt already in progress" into user-facing prose. With
+    only the legacy text pattern this line matched nothing and the stall went
+    undetected, so the UI kept showing the slot as working. The class-name
+    pattern is what carries the signal, and it cannot drift when the copy does.
+    """
+    log = tmp_path / "gateway.log"
+    _write_log(log, [""])  # touch to get mtime
+    ts = _ts_from_file(log)
+    _write_log(log, [
+        f"{ts} WARNING kiro_crew.dashboard.chat: ACP error in slot chat-7-1776999111: "
+        "[AcpPromptBusy] I'm still processing a previous request. Please wait a "
+        "moment and try again.",
+    ])
+    result = session_health.compute_session_health(log_path=log, now=log.stat().st_mtime)
+    assert result["chat-7-1776999111"]["reason"] == "prompt_stuck"
+
+
+def test_other_acp_error_classes_are_not_prompt_stuck(tmp_path: Path) -> None:
+    """The class-name pattern must not over-match sibling AcpError subclasses."""
+    log = tmp_path / "gateway.log"
+    _write_log(log, [""])  # touch to get mtime
+    ts = _ts_from_file(log)
+    _write_log(log, [
+        f"{ts} WARNING kiro_crew.dashboard.chat: ACP error in slot chat-8-1776999222: "
+        "[AcpError] Bedrock is throttling requests.",
+    ])
+    result = session_health.compute_session_health(log_path=log, now=log.stat().st_mtime)
+    assert result == {}
+
+
 def test_ignores_internal_background_sessions(tmp_path: Path) -> None:
     log = tmp_path / "gateway.log"
     _write_log(log, [""])  # touch to get mtime


### PR DESCRIPTION
## What the user saw

```
ACP error: {'code': -32603, 'message': 'Internal error', 'data': "Encountered an
error in the response stream: The model 'claude-opus-4.8' is not available. Please
use '/model' to select a different model and try again. (request_id: 863ae6fe-...)"}
```

A `repr()` of a JSON-RPC dict, in a red bubble, offering a slash command that does
not exist in the dashboard.

## Root cause

Two producers raise the same JSON-RPC error frame:

| Producer | Path | Behaviour |
|---|---|---|
| `AcpClient` | direct-spawn | `_raise_acp_error` → formatted, redacted, typed |
| `AcpSessionHandle` | **shared runtime — every dashboard chat** | `raise AcpError(f"ACP error: {msg.error}")` |

The handle bypassed the formatter at both of its error-frame sites
(`_wait_for_response`, `_dispatch_events`). Both now delegate to
`_raise_acp_error`, so the two producers cannot drift again.

## Rebase note: converged with #1550

#1550 landed while this was open and independently rewrote the same
model-unavailable copy — better than this PR did, by splitting *entitlement*
(terminal, names your available models) from *capacity* (retryable) via a shared
`_model_is_unentitled` discriminator.

**This PR's copy change is dropped entirely in favour of main's.** `client.py` is now
byte-identical to main. What survives is the routing fix, plus two things the
convergence surfaced:

**1. #1550's entitlement fix was inert on the path users actually hit.** It wired
`available_models` into the three `AcpClient` raise sites only. `AcpSessionHandle` is
the shared-runtime path every dashboard chat takes, so a free-tier rejection there
still read as a capacity blip and still burned the retry ladder. This PR adds
`AcpSessionHandle._advertised_model_ids()` (parity with the `AcpClient` helper) and
passes it at both sites. Revert-verified: dropping the argument fails 2 tests.

**2. `_TRANSIENT_MARKERS` was left stale by #1550.** It still carried
`"is unavailable on bedrock"` after the formatter changed to *"on the backend"*.
Latent rather than live — the branch's own "capacity throttle" clause still matches
`"throttl"` — but the marker no longer matched its producer. Updated to the current
wording, keeping the old one for log lines written by earlier gateways, with an
explicit note that the terminal unentitled branch must **not** gain a marker (that
would resurrect the retry loop #1550 removed).

## The trap this had to clear

The raw dump was quietly **load-bearing**. `chat_runner` decided prompt-busy retry
eligibility by searching the message for `"already in progress"` — which only ever
matched because the dict was echoed verbatim. `_format_acp_error` rewrites that phrase
into *"I'm still processing a previous request"*, so formatting alone would have
silently killed the reset-and-requeue path for every prompt-busy error.

The runner's gate is now structural (`isinstance(exc, AcpPromptBusy)`) with the
substring kept as a fallback for unformatted / history-restored messages.
`TestRunnerPromptBusyIsStructural` asserts the formatted text *no longer contains* the
marker, so if a future reformat reintroduces it the test fires as a prompt to re-check
which branch is carrying the path.

## Tests

18 tests in `test/test_acp_error_surface.py`, parametrized over both handle raise sites.

Revert-verified:
- restoring either bare `raise AcpError(f"ACP error: ...")` → **6 fail**
- dropping `self._advertised_model_ids()` from the raise calls → **2 fail**
- reintroducing `"already in progress"` into the formatted text → coupling guard fails

Honest scope note in `TestTransientMarkerCoupling`: it pins the *outcome* (formatted
transients classify as retryable), not any single marker. The capacity branch is
matched twice over — by `"is unavailable on the backend"` and incidentally by
`"throttl"` — so dropping either alone does not fail the test. The redundancy is
deliberate.

## Gates

- pytest `28541 passed`. 11 failures, all inherited — verified by running the same
  files on this branch's exact parent commit. Ten reproduce on unmodified main
  (`test_dashboard_origin` picks up the live `KIROCREW_PORT`, plus embedding /
  app_manager / platform_compat). The eleventh,
  `test_mcp_gateway_wedge_ping_gate::test_unknown_notification_silently_ignored`, is a
  pre-existing load flake: 2/8 failures on the unmodified parent vs 1/6 here.
- isort, flake8 clean
- mypy 717 files: 1 error in `vector_memory.py`, also on base
- No frontend change, so no tsc / vitest / i18n surface

## Not in scope

Two adjacent findings from the same screenshot, deliberately left out because they
change retry semantics and transcript shape rather than error text:

1. **Three red "Backend hiccup — retrying…" rows for one incident.** Each retry
   appends its own persisted `danger`-styled row. `RecoveryCard` already establishes
   that routine self-healing should get neutral styling; this path never got it.
2. **The user's message re-appears per retry.** `queue_insert(0, message)` re-queues
   the original, and the dequeue path unconditionally does
   `slot.append("user", next_msg, ...)` — so one "hi" rendered as four user bubbles,
   persisted to history.
