### PR TITLE
fix(test): resolve spec_builder real state dir lazily, not at import — unbreak main CI

### DIFF
--- a/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
@@ -56,10 +56,25 @@ def _redirect_state(monkeypatch, tmp_path):
     return state_dir
 
 
+#: Real state dir, captured on FIRST USE -- which is fixture setup, before
+#: _redirect_state monkeypatches the module attributes, so it still snapshots
+#: the USER's live dir. Resolved lazily rather than at module level because
+#: binding a data-home path at import time freezes whichever KIROCREW_HOME was
+#: active at collection (test_lazy_data_home_paths enforces this repo-wide).
+_REAL_STATE_DIR: Path | None = None
+
+
+def _real_state_dir() -> Path:
+    global _REAL_STATE_DIR
+    if _REAL_STATE_DIR is None:
+        _REAL_STATE_DIR = routes._state_dir()
+    return _REAL_STATE_DIR
+
+
 def _live_state_snapshot() -> dict[str, int]:
     """Names + mtimes of the USER's real state dir, or {} when there is none."""
     try:
-        return {p.name: p.stat().st_mtime_ns for p in _REAL_STATE_DIR.iterdir()}
+        return {p.name: p.stat().st_mtime_ns for p in _real_state_dir().iterdir()}
     except OSError:
         return {}
 
@@ -80,12 +95,8 @@ def _never_touch_the_real_state(monkeypatch, tmp_path):
     _redirect_state(monkeypatch, tmp_path / "_autouse_state")
     yield
     assert _live_state_snapshot() == before, (
-        f"a test wrote to the live state dir: {_REAL_STATE_DIR}"
+        f"a test wrote to the live state dir: {_real_state_dir()}"
     )
-
-
-#: Captured at import, before any test can monkeypatch the module attributes.
-_REAL_STATE_DIR = routes._state_dir()
 
 
 @web.middleware
@@ -4260,7 +4271,7 @@ def test_state_guard_watches_the_whole_directory():
     got through. It now compares the directory listing."""
     src = inspect.getsource(_never_touch_the_real_state)
     assert "_live_state_snapshot()" in src
-    assert "_REAL_STATE_DIR" in inspect.getsource(_live_state_snapshot)
+    assert "_real_state_dir()" in inspect.getsource(_live_state_snapshot)
 
 
 # ── GPT round-46 findings (#518) ───────────────────────────────────────────────


### PR DESCRIPTION
## Description

**Main CI is currently red** (runs on `af8774b8` and `794aeed7` both failed), and every open PR inherits the failure: `Backend Tests (3.10, 2)`, `(3.12, 2)`, `(Windows) (2)` and therefore `Coverage Gate` fail with:

```
FAILED test/test_lazy_data_home_paths.py::TestNoImportTimePathResolution::test_no_module_level_path_constants
assert not ['apps/builtins/spec_builder/tests/test_routes.py:88  [module] _REAL_STATE_DIR = ..._state_dir()']
```

The Spec Builder builtin (#518, merged as `af8774b8`) added a test harness that binds `_REAL_STATE_DIR = routes._state_dir()` at module level. `_state_dir()` resolves through `config_dir()`, so this is exactly the import-time data-home freeze the repo-wide guard from issue #874 forbids — the transitive-factory detector added in #1059/#1451 catches it.

Fix: replace the module-level constant with the sanctioned override-hook pattern (per the guard's own docstring): a lazy `_real_state_dir()` accessor that resolves on first use and caches. **The harness's safety-net semantics are preserved**: first use is the autouse fixture's *setup* (`_live_state_snapshot()` before `_redirect_state(...)` runs), so it still captures the USER's real live state dir before any monkeypatching — the property the original comment ("Captured at import, before any test can monkeypatch") was protecting. The meta-test `test_state_guard_watches_the_whole_directory` is updated to assert the snapshot helper uses the accessor.

## Related Issues

Unbreaks CI broken by #518 (`af8774b8`). Guard context: #874, #1059.

## Testing

- [x] Existing tests pass — ran both affected files locally on Python 3.12:
  ```
  pytest src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py test/test_lazy_data_home_paths.py
  284 passed
  ```
  Before the fix: `test_no_module_level_path_constants` fails exactly as on main CI; after: passes, and all 268 spec_builder tests still pass (including the autouse leak-guard meta-test).
- [ ] New tests added for new functionality — n/a, this fixes a guard violation; the guard is the test
- [x] Manual verification performed (describe above)

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable) — the accessor carries a comment explaining the lazy resolution and where first-use happens
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
