### PR TITLE
fix(spec-builder): resolve the guard's live state dir per test, not at import

### DIFF
--- a/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
@@ -56,10 +56,10 @@ def _redirect_state(monkeypatch, tmp_path):
     return state_dir
 
 
-def _live_state_snapshot() -> dict[str, int]:
+def _live_state_snapshot(state_dir: Path) -> dict[str, int]:
     """Names + mtimes of the USER's real state dir, or {} when there is none."""
     try:
-        return {p.name: p.stat().st_mtime_ns for p in _REAL_STATE_DIR.iterdir()}
+        return {p.name: p.stat().st_mtime_ns for p in state_dir.iterdir()}
     except OSError:
         return {}
 
@@ -75,17 +75,21 @@ def _never_touch_the_real_state(monkeypatch, tmp_path):
     tests rewrote the real deleted.json. The guard therefore compares the WHOLE
     directory (names + mtimes) rather than one known filename, so the next file
     this app learns to write is covered without anyone remembering to list it.
+
+    The live dir is resolved HERE, per test, and deliberately not at import:
+    _state_dir() reads the data home on every call, so a module-level capture
+    would freeze whichever KIROCREW_HOME was active when collection imported
+    this file -- the exact class of bug this app's own override hooks exist to
+    avoid (see test/test_lazy_data_home_paths.py and #874). Resolving it before
+    _redirect_state runs still gives the unpatched value the guard needs.
     """
-    before = _live_state_snapshot()
+    real_state_dir = routes._state_dir()
+    before = _live_state_snapshot(real_state_dir)
     _redirect_state(monkeypatch, tmp_path / "_autouse_state")
     yield
-    assert _live_state_snapshot() == before, (
-        f"a test wrote to the live state dir: {_REAL_STATE_DIR}"
+    assert _live_state_snapshot(real_state_dir) == before, (
+        f"a test wrote to the live state dir: {real_state_dir}"
     )
-
-
-#: Captured at import, before any test can monkeypatch the module attributes.
-_REAL_STATE_DIR = routes._state_dir()
 
 
 @web.middleware
@@ -4257,10 +4261,19 @@ def test_redirect_state_covers_every_path_the_app_writes():
 
 def test_state_guard_watches_the_whole_directory():
     """The guard used to assert one known filename, which is why the second leak
-    got through. It now compares the directory listing."""
+    got through. It now compares the directory listing.
+
+    Also pins that the live dir is resolved inside the fixture rather than at
+    import: a module-level capture freezes the data home for the whole session
+    and trips the #874 ratchet.
+    """
     src = inspect.getsource(_never_touch_the_real_state)
-    assert "_live_state_snapshot()" in src
-    assert "_REAL_STATE_DIR" in inspect.getsource(_live_state_snapshot)
+    assert "_live_state_snapshot(real_state_dir)" in src
+    assert "routes._state_dir()" in src
+    snap = inspect.getsource(_live_state_snapshot)
+    assert "state_dir.iterdir()" in snap
+    module_src = inspect.getsource(sys.modules[__name__])
+    assert not re.search(r"(?m)^_REAL_STATE_DIR\s*=", module_src)
 
 
 # ── GPT round-46 findings (#518) ───────────────────────────────────────────────


### PR DESCRIPTION
## What is the problem?

`main` is red. `test/test_lazy_data_home_paths.py::TestNoImportTimePathResolution::test_no_module_level_path_constants` — the #874 ratchet — fails on `Backend Tests (3.10, 2)`, `(3.12, 2)` and `(Windows) (2)`, with `Coverage Gate` cascading (Coverage Combine is skipped when a shard fails) and `PR Readiness` red on top:

```
AssertionError: Data-home path resolved at import time (issue #874). Convert each to an
override hook + accessor -- see the module docstring of this file for the pattern:
    apps/builtins/spec_builder/tests/test_routes.py:88  [module] _REAL_STATE_DIR = ..._state_dir()
```

The offending line is one module-level capture in the Spec Builder test file, landed by #518 (`af8774b8b`):

```python
#: Captured at import, before any test can monkeypatch the module attributes.
_REAL_STATE_DIR = routes._state_dir()
```

## Why this issue matters to the user

Because the red is on `main`, **every** open PR inherits it through its merge commit and cannot reach `readiness: passed` — including PRs that touch no Python at all. It was first observed on #1530, a docs-only PR whose branch does not even contain the offending file. Two PRs (#1492, #1509) have since merged through the red, so the queue is now landing changes with a red aggregate gate, which is exactly the state the readiness signal exists to prevent.

The ratchet itself is not noise. `_state_dir()` reads the data home on every call, so freezing its result at import pins whichever `KIROCREW_HOME` was active when collection imported the module. That is the #874 class of bug — a pod writes into the real data home instead of its isolated one — and this repository has already paid for it with real state pollution.

## How our fix solves it

Symptom: three shards plus two aggregate gates red on `main`. → Root cause: the guard fixture needs the **unpatched** state dir, and the author got it by resolving at import, because `_redirect_state` monkeypatches `routes._STATE_DIR` before each test body runs. Import time is the only moment that is obviously "before the patch" — but it is also the one moment the data home may not be final yet. → Change: resolve it **inside the fixture, before it installs the redirect**. That is still unpatched, and it is now per-test and live.

`src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py`:

- Deleted the module-level `_REAL_STATE_DIR`.
- `_live_state_snapshot()` now takes the directory as a parameter instead of reading a module global.
- `_never_touch_the_real_state` resolves `routes._state_dir()` as its first statement — before `_redirect_state` runs — and passes that value to the before/after snapshots and the failure message.

The guard keeps its original semantics (whole-directory names + mtimes, compared across the test) and gains one property: under a `KIROCREW_HOME` override it now watches the **sandbox's** state dir rather than a path frozen from the ambient home, so it protects the directory the test could actually pollute.

No production code changed. `routes.py` was already compliant — its `_STATE_DIR` / `_INDEX_PATH` / `_DELETED_PATH` / `_SETTINGS_PATH` are `None`-defaulted override hooks with per-call accessors; only the test file froze a path.

## What tests we did

- `test/test_lazy_data_home_paths.py` — **16 passed**, including the ratchet that was red. This is the check that unblocks `main`.
- `src/kiro_crew/apps/builtins/spec_builder/tests/` — **268 passed** (whole Spec Builder suite, `-n auto --dist loadgroup`). Combined run of both: **284 passed**.
- Updated `test_state_guard_watches_the_whole_directory`, the drift test that pins the guard's shape. It previously asserted on the identifiers this PR removes, so leaving it alone would have made it pass vacuously. It now pins the invariants that matter: the snapshot is taken against the fixture-resolved dir, the dir is resolved via `routes._state_dir()` inside the fixture, the snapshot iterates the whole directory, and no module-level `_REAL_STATE_DIR =` reappears.
- `isort --check-only`, `flake8`, and `mypy` on the changed file / its package: clean.

## Manual verification

**Mutation-tested the guard, because a "fix" that quietly disarms a safety net is worse than the red it removes.** Appended a throwaway test to `test_routes.py` that writes `leak.json` directly into `config_dir()/workspace/spec-builder` (bypassing the redirect), ran it under `KIROCREW_HOME=$(mktemp -d)`, and confirmed the fixture still fails the run:

```
E  AssertionError: a test wrote to the live state dir: /tmp/tmp.73UZ6TyCqJ/workspace/spec-builder
```

Note the reported path is the sandbox home, which is the behaviour improvement described above. The probe was removed afterwards; `git status --porcelain` shows only the one intended file.

Two earlier mutation attempts did **not** trip the guard, and are worth recording because they look like gaps and are not: dropping the `_DELETED_PATH` redirect, and dropping the `_STATE_DIR` redirect. Neither leaks, because `_deleted_path()` derives from `_state_dir()` and the remaining explicit `*_PATH` redirects still point at the tmp dir. Only a write that bypasses every hook reaches the live directory — which is what the final probe does.

## Any other suggestions on the work

The three-shard fan-out plus `Coverage Gate` plus `PR Readiness` makes one line of test code look like five independent failures, and the `--log-failed` archive was empty for these jobs so the real assertion was only reachable by pulling the raw job log. Surfacing the first failing test name in the readiness summary would have cut the triage on this from ~20 minutes to seconds. Filing separately rather than widening this fix.

Fixes #1537
