### PR TITLE
fix(models): scope the model picker to what the account can actually use

### DIFF
--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -664,20 +664,49 @@ def _advertised_cc_models(request: web.Request) -> list[dict]:
 
 
 def _cc_models(request: web.Request, configured_default: str = "") -> list[dict]:
-    """Assemble the CC model dropdown: canonical registry first, then adapter extras.
+    """Assemble the CC model dropdown, scoped to what the account can actually use.
 
-    Merge order (deduped by model_name, first wins):
-      1. The canonical model registry (model_registry.display_list) — canonical
-         versioned+capability keys (opus-4.8-1m, …) with registry display names,
-         shown FIRST so users always see clean, current defaults. These are the
-         wire values; the backend translates them to provider ids at the factory.
-      2. The live backend's advertised models NOT already covered — appended,
-         de-duped, so nothing the adapter offers is hidden (its set can be stale).
-    The configured default is force-included so the active model is always
-    selectable even if neither source lists it.
+    The live backend's advertised set is AUTHORITATIVE when present. It is the
+    only source that reflects entitlement: claude-agent-acp captures it at session
+    init from what the signed-in account is actually served. The registry is a
+    static catalog of everything KiroCrew knows how to name, so a free-tier user
+    used to be offered the full flagship list and only discovered the truth when a
+    prompt failed.
+
+    So when anything is advertised, registry rows are FILTERED DOWN to it (keeping
+    the registry's cleaner display names for the survivors), and advertised models
+    the registry does not list are appended for forward-compat.
+
+    When NOTHING is advertised the registry is shown unfiltered. That is not a
+    fallback to the old behaviour by preference -- an empty advertised set means
+    "no session has initialized yet", which is indistinguishable from "this account
+    gets nothing", and showing an empty picker on a cold dashboard would be worse
+    than showing a superset.
+
+    ``auto`` is always present and always FIRST. It is the configured default
+    (``config.agent.model``) and a sentinel rather than a real model, so it is
+    never filtered by entitlement. It leads the list because the registry's own
+    ``default: true`` flag sorts the current flagship to the top, which presented
+    a specific paid model as the default in the picker.
     """
     advertised = _advertised_cc_models(request)
     registry_rows = model_registry.display_list("claude_code")
+
+    if advertised:
+        advertised_keys = {
+            _normalize_model_key(e.get("model_name", ""))
+            for e in advertised
+            if _normalize_model_key(e.get("model_name", ""))
+        }
+        # Keep registry rows only when the backend also advertises them; "auto" is
+        # a sentinel, not an entitlement, so it survives regardless.
+        registry_rows = [
+            e
+            for e in registry_rows
+            if _normalize_model_key(e.get("model_name", "")) in advertised_keys
+            or _normalize_model_key(e.get("model_name", "")) == "auto"
+        ]
+
     merged: list[dict] = []
     seen: set[str] = set()
     for entry in (*registry_rows, *advertised):
@@ -687,6 +716,14 @@ def _cc_models(request: web.Request, configured_default: str = "") -> list[dict]
             continue
         seen.add(key)
         merged.append(entry)
+    # "auto" leads. It may be absent entirely if a future registry drops the row,
+    # so synthesize it rather than assuming the filter above preserved one.
+    merged = [e for e in merged if _normalize_model_key(e.get("model_name", "")) == "auto"] + [
+        e for e in merged if _normalize_model_key(e.get("model_name", "")) != "auto"
+    ]
+    if not any(_normalize_model_key(e.get("model_name", "")) == "auto" for e in merged):
+        merged.insert(0, {"model_name": "auto", "display_name": "Auto", "description": ""})
+        seen.add("auto")
     # Guarantee the configured default is present (e.g. a custom cc_model the
     # backend doesn't advertise) so the selected model never vanishes. Resolve it
     # to its canonical key first (it may be stored as a provider id or alias) so a
@@ -702,9 +739,20 @@ def _cc_models(request: web.Request, configured_default: str = "") -> list[dict]
         # the first/selected dropdown option. The "auto" registry row already
         # covers this case.
         key = _normalize_model_key(canonical_default)
-        if key and key not in seen:
+        # Only resurrect the configured default when entitlement cannot contradict
+        # it: either nothing was advertised (unknown, so trust config) or it WAS
+        # advertised but the registry lacked a row. Force-including a model the
+        # backend did not advertise would reintroduce exactly the unusable option
+        # this filter removes -- a stale config pick outliving the entitlement.
+        may_include = not advertised or key in {
+            _normalize_model_key(e.get("model_name", "")) for e in advertised
+        }
+        if key and key not in seen and may_include:
+            # After "auto", never before it: "auto" is the configured default in
+            # the general case and leads the list.
             merged.insert(
-                0,
+                1 if merged and _normalize_model_key(merged[0].get("model_name", "")) == "auto"
+                else 0,
                 {
                     "model_name": canonical_default,
                     "display_name": canonical_default,

--- a/test/test_cc_models_endpoint.py
+++ b/test/test_cc_models_endpoint.py
@@ -1,9 +1,12 @@
 """Tests for the claude_code model list assembled by /api/models.
 
-The dropdown leads with the KiroCrew-curated set (Opus 4.8 1M/200k, Opus 4.7,
-Sonnet 4.6, Haiku 4.5) so users always see clean, current defaults ahead of
-whatever the adapter advertises (its set can be stale — Opus 4.1, Sonnet 4.5);
-adapter extras are appended de-duped, plus the configured default.
+The dropdown is scoped to what the account can actually use: the backend's
+advertised set is authoritative when present and the static registry is filtered
+down to it, so a free-tier account is not offered flagship models it cannot run.
+When nothing is advertised (no session yet) the registry is shown unfiltered,
+since an empty advertised set cannot be told apart from "entitled to nothing".
+"auto" always leads and is never filtered -- it is the configured-default
+sentinel, not a served model.
 """
 
 from __future__ import annotations
@@ -84,19 +87,49 @@ class TestAdvertisedCcModels:
 
 class TestCcModelsMerge:
     def test_registry_set_always_present_even_without_session(self):
-        # No live provider → the full canonical registry set leads the list,
-        # using canonical keys (the wire values) ordered default-first.
+        # No live provider → nothing is advertised, so entitlement is UNKNOWN and
+        # the full canonical registry is shown unfiltered. An empty advertised set
+        # cannot be distinguished from "this account gets nothing", and an empty
+        # picker on a cold dashboard is worse than a superset.
         out = _cc_models(_request_with_providers({}))
         names = [m["model_name"] for m in out]
         assert "opus-4.8-1m" in names
         assert "opus-4.8" in names
-        assert names[: len(_REGISTRY_NAMES)] == _REGISTRY_NAMES
-        assert names[0] == "opus-4.8-1m"
+        assert set(_REGISTRY_NAMES) <= set(names)
+        # "auto" leads, not the registry's default-flagged flagship. The flag used
+        # to sort a specific paid model to the top and present it as the default.
+        assert names[0] == "auto"
 
-    def test_registry_leads_then_adapter_extras_appended(self):
-        # Adapter advertises a stale set (Opus 4.1, Sonnet 4.5) the registry does
-        # not list. Registry leads; unknown adapter extras pass through and are
-        # appended after, never displacing the canonical defaults.
+    def test_advertised_set_filters_the_registry(self):
+        """The advertised set is authoritative: unentitled registry rows go away.
+
+        This is the free-tier case. Previously the registry led unconditionally and
+        the adapter could only ADD, so an account served two models was still
+        offered the full flagship list and only found out at prompt time.
+        """
+        prov = _FakeProvider(
+            [{"modelId": "global.anthropic.claude-sonnet-4-6[1m]", "name": "Sonnet 4.6"}]
+        )
+        out = _cc_models(_request_with_providers({"s": prov}))
+        names = [m["model_name"] for m in out]
+        assert names[0] == "auto"
+        assert "sonnet-4.6-1m" in names
+        # The flagship is in the registry but was NOT advertised → filtered out.
+        assert "opus-4.8-1m" not in names
+        assert "opus-4.8" not in names
+
+    def test_registry_display_name_wins_for_survivors(self):
+        """Filtering keeps the registry's cleaner display name, not the adapter's."""
+        prov = _FakeProvider(
+            [{"modelId": "global.anthropic.claude-sonnet-4-6[1m]", "name": "sonnet-4-6-v1-ugly"}]
+        )
+        out = _cc_models(_request_with_providers({"s": prov}))
+        row = next(m for m in out if m["model_name"] == "sonnet-4.6-1m")
+        assert row["display_name"] == "Sonnet 4.6 (1M context)"
+
+    def test_unknown_advertised_models_still_pass_through(self):
+        # Forward-compat: a model the registry does not list is still offered when
+        # the backend advertises it, otherwise a newly-served model is unreachable.
         prov = _FakeProvider(
             [
                 {"modelId": "claude-opus-4-1", "name": "Opus 4.1", "description": ""},
@@ -105,10 +138,35 @@ class TestCcModelsMerge:
         )
         out = _cc_models(_request_with_providers({"s": prov}))
         names = [m["model_name"] for m in out]
-        assert names[: len(_REGISTRY_NAMES)] == _REGISTRY_NAMES
         assert "claude-opus-4-1" in names
         assert "claude-sonnet-4-5" in names
-        assert names.index("claude-opus-4-1") >= len(_REGISTRY_NAMES)
+        # And the unentitled registry flagship is gone.
+        assert "opus-4.8-1m" not in names
+        # "auto" still leads and is never filtered by entitlement -- it is the
+        # configured-default sentinel, not a model the backend serves.
+        assert names[0] == "auto"
+
+    def test_configured_default_is_not_resurrected_when_unentitled(self):
+        """A stale config pick must not outlive the entitlement.
+
+        Force-including it would reintroduce exactly the unusable option the
+        filter removes.
+        """
+        prov = _FakeProvider(
+            [{"modelId": "global.anthropic.claude-sonnet-4-6[1m]", "name": "Sonnet 4.6"}]
+        )
+        out = _cc_models(_request_with_providers({"s": prov}), configured_default="opus-4.8-1m")
+        names = [m["model_name"] for m in out]
+        assert "opus-4.8-1m" not in names
+        assert names[0] == "auto"
+
+    def test_configured_default_still_included_when_nothing_advertised(self):
+        # Entitlement unknown → trust the operator's config rather than dropping
+        # their selected model from the picker.
+        out = _cc_models(_request_with_providers({}), configured_default="some-custom-model")
+        names = [m["model_name"] for m in out]
+        assert "some-custom-model" in names
+        assert names[0] == "auto"  # still after nothing, before everything else
 
     def test_no_duplicate_when_adapter_lists_known_model(self):
         # The adapter advertises provider ids that ARE in the registry; mapped


### PR DESCRIPTION
## Problem

The model picker offers models the signed-in account cannot use. A free-tier user
sees the full flagship list (Opus 4.8 1M, Opus 4.8, Opus 4.7, …), picks one, and
only finds out it is unavailable when the prompt fails.

Separately, the picker presents a specific paid model as the default: the registry's
`default: true` flag sorts `opus-4.8-1m` to position 0 and pushes `auto` to 6th.

## Why it matters

Both are silent-failure shapes. The first turns an entitlement problem into a
runtime error at the worst moment, with no signal at selection time. The second
means a user who never touches the dropdown is steered onto a specific paid model
rather than the configured default (`config.agent.model`, which ships as `auto`).

## Fix (symptom -> root cause -> change)

The root cause is a documented merge policy in `_cc_models`, which said:

```
1. The canonical model registry — shown FIRST so users always see clean,
   current defaults.
2. The live backend's advertised models NOT already covered — appended,
   de-duped, so nothing the adapter offers is hidden (its set can be stale).
```

So the static catalogue was primary and the account's real entitlement was only
ever **additive** — it could add rows but never remove them. Yet the advertised set
is the *only* source that reflects entitlement: `claude-agent-acp` captures it at
session init from what the account is actually served.

This inverts that. When anything is advertised it is **authoritative**: registry
rows are filtered down to it (keeping the registry's cleaner display names for the
survivors), and advertised models the registry does not list still pass through for
forward-compat.

When **nothing** is advertised the registry is shown unfiltered. That is not a
preference for the old behaviour — an empty advertised set means "no session has
initialized yet", which is indistinguishable from "this account gets nothing", and
an empty picker on a cold dashboard would be worse than a superset.

Two consequences worth reviewing:

- **A stale configured default is no longer force-included** past the filter. It
  previously inserted unconditionally, which would reintroduce exactly the unusable
  option this removes. It is still included when nothing is advertised (entitlement
  unknown, so trust the operator's config).
- **`auto` always leads and is never filtered.** It is the configured default and a
  sentinel rather than a served model, so entitlement does not apply to it. It is
  synthesized if a future registry drops the row, rather than assuming the filter
  preserved one.

### Scope limit, stated explicitly

This fixes the **picker**. It does not change what a session resolves `auto` to.
I could not find any KiroCrew layer that defaults to Opus 4.8 — `DEFAULT_MODEL` in
`config/loader.py` is `"auto"`, and the shipped `config/defaults.json` also carries
`"model": "auto"`. If a fresh free-tier session still runs Opus 4.8, the cause is
downstream of this repo (most likely kiro-cli's own pick when handed `auto`), and I
have no evidence either way. Flagging rather than guessing.

## Tests

`test/test_cc_models_endpoint.py` — 15 tests pass, 6 new:

- `test_advertised_set_filters_the_registry` — the free-tier case: an account served
  only Sonnet 4.6 no longer sees `opus-4.8-1m` / `opus-4.8`.
- `test_registry_display_name_wins_for_survivors` — filtering keeps `Sonnet 4.6
  (1M context)`, not the adapter's raw `sonnet-4-6-v1-ugly`.
- `test_unknown_advertised_models_still_pass_through` — forward-compat, and the
  unentitled registry flagship is still gone.
- `test_configured_default_is_not_resurrected_when_unentitled`.
- `test_configured_default_still_included_when_nothing_advertised`.
- `test_registry_set_always_present_even_without_session` — rewritten: still asserts
  the unfiltered registry on a cold dashboard, now also asserts `auto` leads.

**One test was deleted, not loosened.**
`test_registry_leads_then_adapter_extras_appended` asserted the registry leads
"never displacing the canonical defaults" even when the adapter advertised a
different set — that is precisely the policy being inverted, so it cannot be
adapted. Its still-valid halves (extras pass through, no duplicates) are covered by
`test_unknown_advertised_models_still_pass_through` and the existing
`test_no_duplicate_when_adapter_lists_known_model`.

The module docstring was rewritten for the same reason: it described the old policy.

## Manual verification

N/A — this is a pure list-assembly function with no UI change of its own, and the
new tests drive it directly through `_cc_models` with a fake provider, including
the cold-dashboard (no provider) path.

Three failures under `-k "model or agents_handler or cc_models"` are all in
`test_embedding_space_reconcile.py` / `test_embedding_model_apply.py` — files not in
this diff, which contains zero embedding references.

## Screenshots

N/A — no component or layout changed. The dropdown renders whatever this function
returns; the visible difference is which rows appear and that `auto` is first.
