### PR TITLE
fix(acp): tell users an unavailable model is an access problem, not capacity

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -31,7 +31,7 @@ import time
 from collections import deque
 from contextlib import aclosing
 from pathlib import Path
-from typing import Any, AsyncGenerator, AsyncIterator
+from typing import Any, AsyncGenerator, AsyncIterator, Sequence
 
 from kiro_crew import model_registry, platform_compat
 from kiro_crew.acp._dispatch import (
@@ -744,7 +744,44 @@ _RE_5XX_HINT = re.compile(r"(please try again|response stream)", re.IGNORECASE)
 _RE_GENERATE_FAILED = re.compile(r"failed to generate a response", re.IGNORECASE)
 
 
-def _is_transient_raw_error(error: object) -> bool:
+def _model_is_unentitled(data: str, available_models: Sequence[str] | None) -> str | None:
+    """Return the rejected model name iff the account is not entitled to it.
+
+    Upstream reports entitlement failures and transient capacity failures with
+    the SAME string ("The model 'X' is not available"), so the string alone
+    cannot tell them apart. The advertised model list can: it is captured at
+    session init from what this account is actually served, so a rejected model
+    that is absent from it was never on offer -- an entitlement problem no retry
+    can fix. A rejected model that IS advertised really is a transient
+    capacity/rollout blip.
+
+    Returns None when the model is advertised, when nothing was rejected, or
+    when *available_models* is None/empty (entitlement unknowable -- treat as
+    transient rather than telling a user their plan lacks a model on no
+    evidence).
+
+    Both :func:`_format_acp_error` and :func:`_is_transient_raw_error` route
+    through this single helper so the user-facing wording and the retry verdict
+    cannot drift apart -- see the drift warning above.
+    """
+    match = _RE_MODEL_UNAVAILABLE.search(data)
+    if not match:
+        return None
+    if not available_models:
+        return None
+    rejected = match.group(1)
+    # Compare case-insensitively on the bare id: the rejection echoes back the
+    # id that was sent, but casing has no meaning in these ids and an
+    # entitled-but-differently-cased match must not be reported as unentitled.
+    advertised = {m.strip().lower() for m in available_models if m and m.strip()}
+    if rejected.strip().lower() in advertised:
+        return None
+    return rejected
+
+
+def _is_transient_raw_error(
+    error: object, available_models: Sequence[str] | None = None
+) -> bool:
     """True iff a raw ACP JSON-RPC ``error`` is a retryable transient backend
     failure (Bedrock 5xx / throttle / model-unavailable rollout) rather than an
     auth/validation/unknown error that a retry cannot fix.
@@ -753,13 +790,24 @@ def _is_transient_raw_error(error: object) -> bool:
     user-facing string — so the retry decision is independent of message
     wording. :class:`AcpError` carries this verdict (``.transient``) to the
     retry layer (``llm_helpers``, ``chat_runner``). Precedence mirrors
-    :func:`_format_acp_error`: model-unavailable → throttle → auth(terminal) →
-    generic 5xx / pre-stream generation failure → unknown(terminal)."""
+    :func:`_format_acp_error`: unentitled-model(terminal) → model-unavailable →
+    throttle → auth(terminal) → generic 5xx / pre-stream generation failure →
+    unknown(terminal).
+
+    *available_models* is this account's advertised set when the caller knows
+    it. It only ever makes the verdict MORE conservative: a model the account
+    was never offered is terminal instead of being retried to no purpose. Omit
+    it and behaviour is unchanged from before this parameter existed.
+    """
     if not isinstance(error, dict):
         return False
     data = str(error.get("data", "") or "")
     message = str(error.get("message", "") or "")
     haystack = f"{data} {message}"
+    if _model_is_unentitled(data, available_models):
+        # Terminal: the account is not entitled to this model, so every retry
+        # spends latency to reproduce the same rejection.
+        return False
     if _RE_MODEL_UNAVAILABLE.search(data):
         return True
     if _RE_THROTTLE_NAMED.search(haystack) or _RE_THROTTLE_GENERIC.search(haystack):
@@ -775,7 +823,7 @@ def _is_transient_raw_error(error: object) -> bool:
     )
 
 
-def _format_acp_error(error: object) -> str:
+def _format_acp_error(error: object, available_models: Sequence[str] | None = None) -> str:
     """Format a JSON-RPC error from the ACP backend into actionable user text.
 
     The ACP backend (kiro-cli or claude-agent-acp) surfaces upstream Bedrock
@@ -805,18 +853,35 @@ def _format_acp_error(error: object) -> str:
         req_id_match = re.search(r"request_id:\s*([0-9a-fA-F-]+)", data)
         req_id_suffix = f" (request_id: {req_id_match.group(1)})" if req_id_match else ""
 
+        # Entitlement failure: this account was never offered the model, so the
+        # capacity/rollout advice below would be actively misleading (there is
+        # nothing to wait for). Checked FIRST because upstream uses the same
+        # string for both cases.
+        unentitled = _model_is_unentitled(data, available_models)
+        if unentitled:
+            usable = [m.strip() for m in (available_models or []) if m and m.strip()]
+            # Cap the list: an account with many models would otherwise bury the
+            # message, and the picker shows the full set anyway.
+            shown = ", ".join(usable[:8])
+            more = f" (+{len(usable) - 8} more)" if len(usable) > 8 else ""
+            formatted = (
+                f"Your account does not have access to model '{unentitled}'. "
+                f"Available to you: {shown}{more}. Pick one in the model picker, "
+                f"or set agent.model to 'auto' to let the backend choose a model "
+                f"your plan includes. Retrying will not help."
+                f"{req_id_suffix}"
+            )
         # Bedrock model alias resolved to a version that is currently
         # unavailable (capacity throttle, region rollout in progress,
         # deprecated, etc.).
-        model_match = _RE_MODEL_UNAVAILABLE.search(data)
-        if model_match:
-            model = model_match.group(1)
+        elif _RE_MODEL_UNAVAILABLE.search(data):
+            model = str(_RE_MODEL_UNAVAILABLE.search(data).group(1))  # type: ignore[union-attr]
             formatted = (
-                f"Model '{model}' is unavailable on Bedrock right now (capacity "
-                f"throttle or region rollout). Try: (1) pick a different alias in "
-                f"the model picker, (2) edit ~/.claude/settings.json 'model' field "
-                f"to a different version (e.g. claude-opus-4-6-v1), or (3) wait a "
-                f"minute and retry."
+                f"Model '{model}' is unavailable on the backend right now "
+                f"(capacity throttle or region rollout). Try: (1) pick a "
+                f"different model in the model picker, (2) set agent.model to "
+                f"'auto' in ~/.kiro/crew/config.json, or (3) wait a minute and "
+                f"retry."
                 f"{req_id_suffix}"
             )
         elif _RE_THROTTLE_NAMED.search(haystack) or _RE_THROTTLE_GENERIC.search(haystack):
@@ -920,21 +985,25 @@ def _format_acp_error(error: object) -> str:
 _PROMPT_BUSY_RE = re.compile(r"already in progress", re.IGNORECASE)
 
 
-def _raise_acp_error(error: object) -> None:
+def _raise_acp_error(error: object, available_models: Sequence[str] | None = None) -> None:
     """Format and raise the appropriate AcpError subclass for *error*.
 
     Delegates formatting to ``_format_acp_error`` and raises either
     ``AcpPromptBusy`` (when the backend reports a concurrent in-flight prompt)
     or the generic ``AcpError`` for all other cases.
+
+    *available_models* is passed to BOTH the formatter and the transient
+    classifier so a model-rejection's wording and its retry verdict are decided
+    from the same evidence.
     """
-    formatted = _format_acp_error(error)
+    formatted = _format_acp_error(error, available_models)
     # Detect prompt-busy from the raw error (before formatting rewrites it)
     raw_data = ""
     if isinstance(error, dict):
         raw_data = f"{error.get('data', '')} {error.get('message', '')}"
     if _PROMPT_BUSY_RE.search(raw_data):
         raise AcpPromptBusy(formatted)
-    raise AcpError(formatted, transient=_is_transient_raw_error(error))
+    raise AcpError(formatted, transient=_is_transient_raw_error(error, available_models))
 
 
 # Matches claude-agent-acp policy-substitution advisories:
@@ -1586,6 +1655,20 @@ class AcpClient:
     def available_models(self) -> list[dict[str, str]]:
         """Models advertised by the backend at session init (may be empty)."""
         return list(self._available_models)
+
+    def _advertised_model_ids(self) -> list[str]:
+        """Advertised model ids, for the model-rejection error path.
+
+        Empty when the backend advertised nothing (no session yet, or a backend
+        that omits ``models``), which the error path reads as "entitlement
+        unknown" and leaves the existing transient/capacity handling alone.
+        """
+        ids = []
+        for entry in self._available_models:
+            model_id = entry.get("modelId") if isinstance(entry, dict) else None
+            if isinstance(model_id, str) and model_id.strip():
+                ids.append(model_id)
+        return ids
 
     async def set_config_option(self, config_id: str, value: str) -> None:
         """Set a session config option (e.g. effort level) via session/set_config_option."""
@@ -3056,7 +3139,7 @@ class AcpClient:
                     self._turn_done.set()
                     return
                 if action == "error":
-                    _raise_acp_error(msg.error)
+                    _raise_acp_error(msg.error, self._advertised_model_ids())
                 if action == "permission":
                     await self._handle_permission(msg)
                 elif action == "server_request_unknown":
@@ -3183,7 +3266,7 @@ class AcpClient:
                 )
                 return
             if action == "error":
-                _raise_acp_error(msg.error)
+                _raise_acp_error(msg.error, self._advertised_model_ids())
             if action == "permission":
                 yield self._build_permission_event(msg)
             elif action == "server_request_unknown":
@@ -3687,7 +3770,7 @@ class AcpClient:
                 self._turn_done.set()
                 return "".join(output)
             if action == "error":
-                _raise_acp_error(msg.error)
+                _raise_acp_error(msg.error, self._advertised_model_ids())
             if action == "permission":
                 await self._handle_permission(msg)
             elif action == "server_request_unknown":

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -6436,6 +6436,8 @@ class TestFormatAcpError:
         assert "weird" in out
 
     def test_model_not_available_rewrite(self):
+        # With NO advertised list the caller cannot know whether this is an
+        # entitlement or a capacity failure, so it keeps the capacity wording.
         err = {
             "code": -32603,
             "message": "Internal error",
@@ -6446,14 +6448,76 @@ class TestFormatAcpError:
             ),
         }
         out = _format_acp_error(err)
-        assert "unavailable on Bedrock" in out
+        assert "unavailable on the backend" in out
         assert "'opus'" in out
         assert "model picker" in out
-        assert "settings.json" in out
+        # Must NOT point at ~/.claude/settings.json — KiroCrew never reads it;
+        # the model lives in config.json / the agent spec.
+        assert "settings.json" not in out
+        assert "config.json" in out
         # Request id is preserved for support correlation.
         assert "3ce0318a-24d6-4b1a-a4a7-ee81f1a3991e" in out
         # Should not leak the raw dict prefix when we have a real rewrite.
         assert "Prompt error: {" not in out
+
+    def test_unentitled_model_names_what_the_account_can_use(self):
+        """The free-tier case: say it is an access problem and list the options.
+
+        Upstream sends the SAME string for entitlement and capacity failures,
+        so the advertised list is the only thing that distinguishes them.
+        """
+        err = {
+            "code": -32603,
+            "message": "Internal error",
+            "data": "The model 'opus-4.8-1m' is not available. (request_id: abc-123)",
+        }
+        out = _format_acp_error(err, ["claude-sonnet-4-6", "claude-haiku-4-5"])
+        assert "does not have access" in out
+        assert "'opus-4.8-1m'" in out
+        # The actionable part: what they CAN pick.
+        assert "claude-sonnet-4-6" in out
+        assert "claude-haiku-4-5" in out
+        # Must NOT blame capacity or tell them to wait — no retry will help.
+        assert "capacity" not in out
+        assert "wait a minute" not in out
+        assert "abc-123" in out
+
+    def test_advertised_model_still_reads_as_capacity(self):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        # The model IS on offer, so a rejection really is a transient blip and
+        # must keep the capacity wording (and stay retryable).
+        err = {"code": -32603, "message": "x", "data": "The model 'opus' is not available."}
+        out = _format_acp_error(err, ["opus", "sonnet"])
+        assert "unavailable on the backend" in out
+        assert "does not have access" not in out
+        assert _is_transient_raw_error(err, ["opus", "sonnet"]) is True
+
+    def test_unentitled_model_is_terminal_not_retried(self):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        # The retry verdict must move with the wording -- retrying a model the
+        # account was never offered just reproduces the same rejection.
+        err = {"code": -32603, "message": "x", "data": "The model 'opus' is not available."}
+        assert _is_transient_raw_error(err, ["sonnet", "haiku"]) is False
+        # Unknown entitlement -> unchanged (transient), never a false accusation.
+        assert _is_transient_raw_error(err, None) is True
+        assert _is_transient_raw_error(err, []) is True
+
+    def test_unentitled_match_is_case_insensitive(self):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        # An entitled-but-differently-cased model must not be called unentitled.
+        err = {"code": -32603, "message": "x", "data": "The model 'Opus' is not available."}
+        assert _is_transient_raw_error(err, ["opus"]) is True
+        assert "does not have access" not in _format_acp_error(err, ["opus"])
+
+    def test_long_available_list_is_capped(self):
+        err = {"code": -32603, "message": "x", "data": "The model 'nope' is not available."}
+        out = _format_acp_error(err, [f"model-{i}" for i in range(12)])
+        assert "+4 more" in out
+        assert "model-7" in out
+        assert "model-8" not in out
 
     def test_throttling_exception_rewrite(self):
         err = {


### PR DESCRIPTION
## Problem

When a user's plan does not include the selected model, the backend rejects the
prompt and KiroCrew tells them this:

> Model 'opus' is unavailable on Bedrock right now (capacity throttle or region
> rollout). Try: (1) pick a different alias in the model picker, (2) edit
> ~/.claude/settings.json 'model' field to a different version (e.g.
> claude-opus-4-6-v1), or (3) wait a minute and retry.

Every substantive claim in that message is wrong for the entitlement case. Here
is the actual upstream error (captured verbatim in `test_acp_client.py`):

> Encountered an error in the response stream: The model 'opus' is not
> available. **Please use '/model' to select a different model and try again.**

Upstream says *pick a different model*. KiroCrew rewrote that into a capacity
story.

## Why it matters

Four separate failures, and only the first is cosmetic:

1. **Wrong cause.** A free-tier user is told to wait for a rollout that will
   never grant them access.
2. **Retried when it cannot succeed.** `_is_transient_raw_error` returned `True`
   for this error, so the retry layer (`llm_helpers`, `chat_runner`) spent
   attempts reproducing the same rejection — the user waits through them to
   reach misleading advice.
3. **Points at a file this repo never reads.** Before this change, the only
   occurrence of `~/.claude/settings.json` anywhere in `src/kiro_crew/` was that
   error string itself. KiroCrew's model lives in `config.agent.model` and the
   agent spec.
4. **Never named the models the account can use**, despite the entitled set
   being known at session init.

#1549 narrowed the window by scoping the picker to entitled models, but it
cannot close it: a config-pinned model, a stale advertised set, or an
already-open session can all still reach this path. When it is reached, the
error should be legible.

## Fix (symptom -> root cause -> change)

The root cause is that **upstream uses one string for two different failures**,
so the message text alone cannot tell entitlement from capacity — and the old
code assumed capacity unconditionally.

The advertised model list resolves the ambiguity. It is captured at session init
from what this account is actually served, so a rejected model that is *absent*
from it was never on offer — an entitlement problem no retry can fix. A rejected
model that *is* advertised really is a transient capacity/rollout blip.

`_model_is_unentitled(data, available_models)` applies exactly that test, and
**both** `_format_acp_error` and `_is_transient_raw_error` route through it. That
is deliberate: the code above those functions already warns that the formatter
and the retry classifier must not drift, or "the formatter could rewrite a
generic 5xx into a friendly string the marker-based retry classifier does not
recognise, silently preventing the retry from firing." One shared discriminator
means the wording and the retry verdict move together by construction.

Resulting behaviour:

| Advertised set | Rejected model | Message | Retried |
|---|---|---|---|
| known | **not** in it | access problem, lists usable models | **no** (terminal) |
| known | in it | capacity/rollout (as before) | yes |
| unknown / empty | any | capacity/rollout (as before) | yes |

The third row is the conservative default: with no advertised list we cannot
prove entitlement, so the change never accuses a plan of lacking a model on no
evidence. `available_models` is an optional parameter defaulting to `None`, so
any caller that cannot supply it behaves exactly as before.

Threaded through `_raise_acp_error` -> the three `_raise_acp_error(msg.error)`
sites via a new `_advertised_model_ids()` accessor on the client.

The capacity message is also corrected to point at `~/.kiro/crew/config.json`
and to say "the backend" rather than "Bedrock" (the ACP backend is not
necessarily Bedrock).

## Tests

`test/test_acp_client.py` — 505 pass in that file plus `test_llm_helpers.py`;
1109 pass across `-k "acp or cron_gateway or session_handle"`. Six tests
added/updated:

- `test_unentitled_model_names_what_the_account_can_use` — asserts the access
  wording, that the usable models are named, and that "capacity" / "wait a
  minute" are **absent**.
- `test_unentitled_model_is_terminal_not_retried` — the retry verdict moves with
  the wording; `None` and `[]` advertised lists stay transient.
- `test_advertised_model_still_reads_as_capacity` — an advertised model keeps the
  capacity wording *and* stays retryable.
- `test_unentitled_match_is_case_insensitive` — an entitled-but-differently-cased
  model is not reported as unentitled.
- `test_long_available_list_is_capped` — 12 models render as 8 + "+4 more".
- `test_model_not_available_rewrite` — updated: now asserts `settings.json` is
  **not** present and `config.json` is.

**Revert-verified.** Neutering `_model_is_unentitled` to always return `None`
fails exactly the three tests that assert entitlement behaviour, while the two
asserting the advertised/capacity path correctly stay green — they cover the
branch the sabotage does not affect.

## Manual verification

N/A — unit coverage is sufficient and more faithful here than a manual attempt.
These are pure functions over the raw JSON-RPC error dict, and the decisive input
is a real upstream payload already captured verbatim in the test file. I do not
have a free-tier account to trigger a live rejection, so an end-to-end
reproduction was not possible; that is the one gap in this change's evidence.

## Screenshots

N/A — no UI change. The text is raised as an `AcpError` and rendered by existing
surfaces.
