### PR TITLE
fix(i18n): replace width spring with layout+opacity to stabilize render gate

### DIFF
--- a/website/src/components/SegmentedControl.tsx
+++ b/website/src/components/SegmentedControl.tsx
@@ -131,15 +131,16 @@ export default function SegmentedControl<T extends string = string>({ segments, 
                 />
               )}
               {s.icon && <span className="relative z-[1]">{s.icon}</span>}
-              <AnimatePresence>
+              <AnimatePresence initial={false}>
                 {(mode === 'full' || isActive) && (
                   <motion.span
                     key={`label-${s.key}`}
-                    initial={{ width: 0 }}
-                    animate={{ width: 'auto' }}
-                    exit={{ width: 0 }}
-                    transition={{ type: 'spring', bounce: 0, duration: 0.2 }}
-                    className="relative z-[1] overflow-hidden whitespace-nowrap"
+                    layout
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.15 }}
+                    className="relative z-[1] whitespace-nowrap"
                   >
                     {s.label}
                   </motion.span>


### PR DESCRIPTION
Closes #1555

The animated label in `SegmentedControl.tsx` uses a spring width transition (`0` → `auto`). The i18n render gate measures `scrollWidth` vs `clientWidth` mid-spring, producing non-deterministic `artifacts.layout` findings that fail unrelated PRs.

**Fix:** Replace the width spring with framer-motion `layout` prop (animates via `transform`, invisible to `scrollWidth`) + opacity fade. `initial={false}` prevents mount animation from firing during the gate's static snapshot.

**Changes:**
- `website/src/components/SegmentedControl.tsx`: Remove `width: 0 → auto` spring, use `layout` + `opacity` transition