### PR TITLE
fix(dev-fleet): refuse force-remove on dirty+unmerged worktrees, never delete unmerged branch ref

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -2119,6 +2119,19 @@ async def _worktree_remove(
 
     pr = (await _pr_status_cached(branch)) if branch else None
     own = await _own_commits_count(path)
+
+    if force and not _is_pr_merged(pr):
+        dirty = await _real_dirty(path)
+        if dirty:
+            return {
+                "ok": False,
+                "error": (
+                    "refusing forced removal: worktree is dirty AND PR is not merged — "
+                    "commit or stash changes first, or merge the PR"
+                ),
+                "pr": _redact_pr(pr),
+            }
+
     if not force and not _is_pr_merged(pr):
         if own is None or own > 0:
             return {
@@ -2232,9 +2245,8 @@ async def _worktree_remove(
         if rc != 0:
             return {"ok": False, "error": _redact((stderr or stdout).strip()[:300])}
 
-        # delete branch if shipped/empty — atomically against the pinned OID
         if branch and branch != BASE_BRANCH and verdict_oid:
-            if _is_pr_merged(pr) or own == 0:
+            if _is_pr_merged(pr):
                 await _git(
                     MAIN_REPO, "update-ref", "-d",
                     f"refs/heads/{branch}", verdict_oid.strip(), timeout=10,


### PR DESCRIPTION
Closes #1554

Two safety failures fixed:

1. **Force + dirty + unmerged = refuse.** `_worktree_remove(force=True)` now checks: if the PR is not merged AND the worktree is dirty, return an error instead of proceeding. This prevents the exact data-loss scenario in the issue (uncommitted changes destroyed with no recovery path).

2. **Branch ref deletion restricted to merged PRs.** `update-ref -d` previously ran when `_is_pr_merged(pr) or own == 0`. The `own == 0` path deleted unmerged branch refs for empty branches — but an empty branch may simply not have been pushed yet. Now only merged PRs trigger ref deletion; an unmerged branch is always retained (recoverable > irrecoverable).

**Changes:**
- `src/kiro_crew/apps/builtins/dev_fleet/server.py`:
  - Add force+dirty+unmerged guard (lines 2122-2133)
  - Remove `or own == 0` from branch deletion condition (line 2248)