### PR TITLE
fix(service): stop the installed service opening a browser, and let it carry the port

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -716,14 +716,26 @@ def main() -> None:
     os.environ.pop("KIROCREW_SANDBOX_ACTIVE", None)
 
     # Validate KIROCREW_PORT early — fail fast before anything else loads.
+    # Range as well as type: an in-range check that lives only in the binder
+    # would let `KIROCREW_PORT=70000 kirocrew service install` bake an
+    # unbindable port into a service definition and report success, leaving a
+    # gateway that dies on every start. Rejecting here keeps ONE policy for
+    # every entry point rather than a second one per consumer.
     _raw_port = os.environ.get("KIROCREW_PORT")
     if _raw_port is not None:
         try:
-            int(_raw_port)
+            _port_val = int(_raw_port)
         except ValueError:
             print(
                 f"❌ KIROCREW_PORT={_raw_port!r} is not a valid integer.\n"
                 f"   Unset it or provide a numeric port (e.g. KIROCREW_PORT=6777).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not 1 <= _port_val <= 65535:
+            print(
+                f"❌ KIROCREW_PORT={_raw_port!r} is outside the valid port range 1-65535.\n"
+                f"   Unset it or provide a bindable port (e.g. KIROCREW_PORT=6777).",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/src/kiro_crew/service/common.py
+++ b/src/kiro_crew/service/common.py
@@ -124,6 +124,23 @@ def service_environment(home: str) -> "dict[str, str]":
     kiro_bin = os.environ.get("KIROCREW_KIRO_BIN", "").strip()
     if kiro_bin:
         env["KIROCREW_KIRO_BIN"] = os.path.abspath(kiro_bin)
+    # KIROCREW_PORT is the ONLY input DASHBOARD_PORT reads, so a service that
+    # cannot carry it can only ever bind the default 5476 — broken by
+    # construction on a host where that port is already taken, which includes
+    # every host running Kiro Crew's own instance tunnel (it pins
+    # local_port == remote_port). Propagated the same way KIROCREW_KIRO_BIN is:
+    # captured from the installer's environment, so
+    # `KIROCREW_PORT=5477 kirocrew service install` bakes 5477 into the unit.
+    #
+    # No validation here on purpose. `cli.py`'s main() already rejects a
+    # KIROCREW_PORT that is not an integer in 1-65535 before any subcommand
+    # runs, install included, so a check here could only become a second policy
+    # that drifts from the first. It must reject rather than silently drop an
+    # out-of-range value: dropping would install the DEFAULT port while the
+    # operator believes they set theirs.
+    port = os.environ.get("KIROCREW_PORT", "").strip()
+    if port:
+        env["KIROCREW_PORT"] = port
     return env
 
 

--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -132,7 +132,10 @@ def render_unit(apparmor_profile: str = "") -> str:
     user = _current_user()
     group = _current_group(user) if user else ""
     home = str(Path.home())
-    exec_start = f"{_sd_quote(bin_path)} gateway"
+    # `--no-open` for the same reason as the launchd plist: a service starts on
+    # boot and on every restart, and auto-opening a browser there is wrong. It is
+    # simply less visible on a headless Linux box than on a desktop.
+    exec_start = f"{_sd_quote(bin_path)} gateway --no-open"
     env_lines = f"Environment={_sd_quote(f'USER={user}')}\n" + "".join(
         f"Environment={_sd_quote(f'{key}={value}')}\n"
         for key, value in service_environment(home).items()

--- a/src/kiro_crew/service/macos.py
+++ b/src/kiro_crew/service/macos.py
@@ -70,6 +70,12 @@ def render_plist() -> str:
         "    <array>\n"
         f"        <string>{bin_path}</string>\n"
         "        <string>gateway</string>\n"
+        # A background service must never open a browser. launchd starts this on
+        # login, on every KeepAlive respawn, and on every `kickstart` — which is
+        # what Dev Fleet's Restart button runs — so without this the user gets a
+        # new dashboard tab each time. The surface they are already using (a
+        # browser tab or the Electron window) reconnects on its own.
+        "        <string>--no-open</string>\n"
         "    </array>\n"
         "    <key>RunAtLoad</key>\n"
         "    <true/>\n"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1042,6 +1042,50 @@ class TestCronCli:
             assert ns.agent is None
 
 
+class TestPortEnvValidatedAtEntry:
+    """`main()` rejects an unusable KIROCREW_PORT before any subcommand runs.
+
+    Type alone is not enough. 70000 parses as an int, so a type-only check let
+    `KIROCREW_PORT=70000 kirocrew service install` bake an unbindable port into
+    a service definition and report success -- leaving a gateway that dies on
+    every start, with the failure surfacing far from its cause.
+
+    Rejecting here rather than in the consumer keeps ONE policy for every entry
+    point. It must reject rather than silently drop: dropping would install the
+    DEFAULT port while the operator believes they set theirs.
+    """
+
+    def test_out_of_range_port_exits_before_dispatch(self, monkeypatch, capsys):
+        import sys
+
+        for bad in ("70000", "0", "-1"):
+            monkeypatch.setenv("KIROCREW_PORT", bad)
+            dispatched = []
+            with patch.object(sys, "argv", ["kirocrew", "cron", "list"]), patch(
+                "kiro_crew.cli._cron", lambda _ns: dispatched.append(True)
+            ):
+                from kiro_crew.cli import main
+
+                with pytest.raises(SystemExit) as exc:
+                    main()
+            assert exc.value.code == 1, bad
+            assert not dispatched, f"{bad} reached the subcommand"
+            assert "1-65535" in capsys.readouterr().err
+
+    def test_in_range_port_is_accepted(self, monkeypatch):
+        import sys
+
+        monkeypatch.setenv("KIROCREW_PORT", "5477")
+        dispatched = []
+        with patch.object(sys, "argv", ["kirocrew", "cron", "list"]), patch(
+            "kiro_crew.cli._cron", lambda _ns: dispatched.append(True)
+        ):
+            from kiro_crew.cli import main
+
+            main()
+        assert dispatched == [True]
+
+
 class TestSandboxActiveMarkerCleared:
     """cli.main() must drop an INHERITED KIROCREW_SANDBOX_ACTIVE marker.
 

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -82,8 +82,11 @@ class TestLinuxUnitRendering:
         ):
             unit = svc_linux.render_unit()
         # ExecStart executable is double-quoted (systemd tokenizes on
-        # whitespace; a spaced path would otherwise break the exec).
-        assert 'ExecStart="/home/u/.toolbox/bin/kirocrew" gateway' in unit
+        # whitespace; a spaced path would otherwise break the exec). `--no-open`
+        # is asserted as part of the SAME string rather than separately: a bare
+        # `in unit` check for the prefix passes even if the flag is dropped,
+        # because the prefix is still a substring of the shorter line.
+        assert 'ExecStart="/home/u/.toolbox/bin/kirocrew" gateway --no-open' in unit
         assert "Restart=on-failure" in unit
         assert "RestartSec=10" in unit
         # System-level unit must run as the invoking user with the user's
@@ -284,6 +287,40 @@ class TestLinuxUnitRendering:
 
 
 class TestMacOSPlistRendering:
+    def test_plist_and_unit_never_auto_open_a_browser(self, monkeypatch, tmp_path):
+        """Both installers pass `--no-open`.
+
+        A service starts at login, on every KeepAlive respawn, and on every
+        `launchctl kickstart` — which is what Dev Fleet's Restart button runs. Without
+        the flag each of those opens a new dashboard tab in the default browser. The
+        surface the user already has (browser tab or Electron window) reconnects on
+        its own, so there is nothing for the service to open.
+
+        Asserted on the plist AND the unit in one test because the flag was missing
+        from both: on a headless Linux box the auto-open has nothing to reach, which
+        is why the gap survived there unnoticed.
+        """
+        from kiro_crew.service import linux as svc_linux
+        from kiro_crew.service import macos as svc_macos
+
+        monkeypatch.setattr(svc_macos, "LIVE_PROGRAM", tmp_path / "live-gateway")
+        with patch(
+            "kiro_crew.service.common.shutil.which", return_value="/opt/homebrew/bin/kirocrew"
+        ):
+            plist = svc_macos.render_plist()
+        args = plist.split("<key>ProgramArguments</key>", 1)[1].split("</array>", 1)[0]
+        assert "<string>--no-open</string>" in args, (
+            "--no-open must be inside ProgramArguments, not merely somewhere in the plist"
+        )
+
+        monkeypatch.setenv("USER", "tester")
+        gid = MagicMock(returncode=0, stdout="staff\n", stderr="")
+        with patch(
+            "kiro_crew.service.common.shutil.which", return_value="/usr/local/bin/kirocrew"
+        ), patch("kiro_crew.service.linux.subprocess.run", return_value=gid):
+            unit = svc_linux.render_unit()
+        assert 'ExecStart="/usr/local/bin/kirocrew" gateway --no-open' in unit
+
     def test_render_plist_runs_the_live_program_not_the_resolved_bin(self, monkeypatch, tmp_path):
         """ProgramArguments[0] is the live-gateway launcher.
 
@@ -1264,6 +1301,47 @@ class TestServiceEnvironment:
         else:
             assert env["LANG"] == "C.UTF-8"
             assert env["LC_ALL"] == "C.UTF-8"
+
+    def test_propagates_port_only_when_set(self, monkeypatch):
+        """KIROCREW_PORT reaches the installed service.
+
+        It is the ONLY input DASHBOARD_PORT reads, so a service definition that
+        cannot carry it can only ever bind the default 5476 — broken by
+        construction on any host where that port is taken, which includes every
+        host running Kiro Crew's own instance tunnel (it pins
+        local_port == remote_port).
+        """
+        monkeypatch.delenv("KIROCREW_PORT", raising=False)
+        assert "KIROCREW_PORT" not in service_environment("/home/tester")
+        monkeypatch.setenv("KIROCREW_PORT", "5477")
+        assert service_environment("/home/tester")["KIROCREW_PORT"] == "5477"
+
+    def test_port_reaches_both_rendered_service_definitions(self, monkeypatch, tmp_path):
+        """End-to-end, not just present in the dict.
+
+        `service_environment()` feeds the launchd plist's EnvironmentVariables and
+        the systemd unit's Environment= lines. Asserting only the dict would pass
+        even if a renderer dropped the key on the way out.
+        """
+        from kiro_crew.service import linux as svc_linux
+        from kiro_crew.service import macos as svc_macos
+
+        monkeypatch.setenv("KIROCREW_PORT", "5477")
+        monkeypatch.setattr(svc_macos, "LIVE_PROGRAM", tmp_path / "live-gateway")
+        with patch(
+            "kiro_crew.service.common.shutil.which", return_value="/opt/homebrew/bin/kirocrew"
+        ):
+            plist = svc_macos.render_plist()
+        envs = plist.split("<key>EnvironmentVariables</key>", 1)[1].split("</dict>", 1)[0]
+        assert "<key>KIROCREW_PORT</key>" in envs and "<string>5477</string>" in envs
+
+        monkeypatch.setenv("USER", "tester")
+        gid = MagicMock(returncode=0, stdout="staff\n", stderr="")
+        with patch(
+            "kiro_crew.service.common.shutil.which", return_value="/usr/local/bin/kirocrew"
+        ), patch("kiro_crew.service.linux.subprocess.run", return_value=gid):
+            unit = svc_linux.render_unit()
+        assert "KIROCREW_PORT=5477" in unit
 
     def test_propagates_kiro_bin_pin_only_when_set(self, monkeypatch):
         monkeypatch.delenv("KIROCREW_KIRO_BIN", raising=False)


### PR DESCRIPTION
`kirocrew service install` rendered a service definition that is wrong for two
kinds of host, on both platforms.

**It opened a browser on every start.** Both renderers ran a bare `gateway`, so
the service auto-opened the dashboard URL at login, on every KeepAlive respawn,
and on every `launchctl kickstart` -- which is what Dev Fleet's Restart button
runs. One tab per click. The surface the user already has (a browser tab or the
Electron window) reconnects on its own, so there is nothing for a background
service to open. Both now pass `--no-open`.

The gap existed on Linux too and is simply less visible there: a headless box has
no browser for the auto-open to reach. The new test asserts the flag on the plist
AND the unit in one place for exactly that reason.

**It could not set the port.** `service_environment()` is the single source of
truth for the launchd plist's `EnvironmentVariables` and the systemd unit's
`Environment=` lines, and it baked only HOME, PATH, LANG/LC_ALL and an optional
`KIROCREW_KIRO_BIN`. Since `KIROCREW_PORT` is the only input `DASHBOARD_PORT`
reads, the installed service could only ever bind the default 5476 -- broken by
construction on any host where that port is taken, which includes every host
running KiroCrew's own instance tunnel, since it pins
`local_port == remote_port`.

Observed on a real macOS host: 5476 held by the tunnel to a remote instance, so
the LaunchAgent had to be hand-edited to inject `KIROCREW_PORT=5477` before the
gateway could bind at all. Without that edit the agent starts, fails to bind,
exits, and -- with `KeepAlive.SuccessfulExit=false` -- launchd does not retry,
leaving no gateway and no visible reason why.

`KIROCREW_PORT` is now propagated the same way `KIROCREW_KIRO_BIN` already is:
captured from the installer's environment, so
`KIROCREW_PORT=5477 kirocrew service install` bakes 5477 into the unit. No
parsing is added here on purpose -- `cli.py`'s `main()` already rejects a
non-integer `KIROCREW_PORT` before any subcommand runs, install included, so a
second check could only drift from the first.

Deliberately NOT changed, flagged for the reviewer:

- `_spawn_detached_gateway()` in `cli_server.py` (used by `kirocrew restart`) is a
  third site that starts a gateway without `--no-open`. Whether a user typing
  `kirocrew restart` wants a browser is a different question from what a service
  definition should do, so it is left alone rather than folded in.
- A `service install --port` flag would be more discoverable than the env var.
  That is a CLI-surface change (the `install()` functions currently take no
  arguments) and is left for a follow-up.

The existing ExecStart assertion was tightened rather than added to: it checked
`'ExecStart="..." gateway' in unit`, which still passes when the flag is dropped,
because the prefix is a substring of the shorter line. It now asserts the whole
string.

Fixes #1561
