### PR TITLE
fix(scripts): install the demo app from website/, not frontend/

### DIFF
--- a/scripts/install-demo-app.sh
+++ b/scripts/install-demo-app.sh
@@ -4,7 +4,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-APP_SOURCE="$SCRIPT_DIR/../frontend/public/apps/demo-app"
+APP_SOURCE="$SCRIPT_DIR/../website/public/apps/demo-app"
 APP_DEST="${KIROCREW_HOME:-$HOME/.kiro/crew}/apps/demo-app"
 
 if [ -d "$APP_DEST" ]; then


### PR DESCRIPTION
## Problem / Motivation

`scripts/install-demo-app.sh` set `APP_SOURCE` to
`$SCRIPT_DIR/../frontend/public/apps/demo-app`. No `frontend/` directory exists
in the repo — the SPA is `website/`, and the demo app is at
`website/public/apps/demo-app`. The first `cp` therefore failed:

    cp: .../frontend/public/apps/demo-app/app.json: No such file or directory

Under `set -e` the script aborted there and installed nothing.

## Why it matters

The script is the one-step path to get the demo app into the data home, so
anyone exercising the App Kit pipeline end-to-end is blocked at step one, by a
failure that reads like a broken checkout rather than a stale path.

The abort also leaves the destination half-written: on the already-installed
path, `rm -rf "$APP_DEST/ui"` and `mkdir -p "$APP_DEST/ui"` both run *before*
the failing `cp`, so a re-run empties `ui/` and then exits non-zero.

## What changed (motivation → approach → change)

- **Symptom:** script exits non-zero on the first `cp`; no app installed.
- **Root cause:** the frontend directory is `website/`, and this script's
  `APP_SOURCE` was never moved with it. It is the last stale reference —
  `grep -rn '\.\./frontend/'` over the repo returns only this line.
- **Change:** point `APP_SOURCE` at `$SCRIPT_DIR/../website/public/apps/demo-app`.

One line. Nothing else needed to change: the layout under the app directory is
identical at the new location (`app.json` plus `ui/index.mjs`), so both `cp`
invocations and the `installed.json` heredoc work unmodified.

## Tests

N/A — no automated test added. This is a developer-only bash helper and the repo
has no shell-test harness (`pytest` covers the Python package only). Adding one
for a one-line path fix would mean introducing a shell test framework, which is
out of scope.

## Manual verification

Ran against a throwaway data home so nothing touched `~/.kiro/crew`:

```bash
export KIROCREW_HOME="$(mktemp -d)"
./scripts/install-demo-app.sh; echo "exit=$?"
find "$KIROCREW_HOME/apps/demo-app" -type f
