### PR TITLE
docs(temp-screenshots): add the README that CI already references

### DIFF
--- a/temp-screenshots/README.md
+++ b/temp-screenshots/README.md
@@ -1,0 +1,133 @@
+# `temp-screenshots/`
+
+Review evidence for pull requests: the screenshots, GIFs and short videos that
+show a reviewer what a user-visible change actually looks like. Nothing here is a
+product asset, and no application code imports or reads these files. `MANIFEST.in`
+prunes the whole directory, so none of it reaches a distribution.
+
+The path itself is referenced, though — by the cleanup workflow, the PR template,
+and three shipped skill files under `src/kiro_crew/` that tell an agent how to
+attach media (see **See also**). So treat the directory as contractual: agents and
+CI expect this layout.
+
+The directory is **ephemeral by design and permanent in history**, which sounds
+contradictory and is the single thing worth understanding before you add to it or
+ask someone to remove something from it. A weekly job deletes files from `main`'s
+tip; the blobs stay reachable in history, and the URLs in merged PR bodies keep
+resolving because they are pinned to the commit that introduced them.
+
+## Why the files are committed rather than attached
+
+GitHub lets you drag an image into a PR description, which uploads it to
+`user-attachments` and needs no commit. This repository commits instead, for two
+reasons that survive scrutiny better than convenience does.
+
+**Automated UX review is gated on these paths — and reads the files in one of its
+two lanes.** `UX Review` runs only when a PR touches `website/`,
+`temp-screenshots/**` or `.github/screenshots/**`, and skips with no model call
+otherwise. Putting a screenshot here is therefore what brings a PR into scope at
+all, which an attachment cannot do, because an attachment is not a file in the
+repository.
+
+Whether the reviewer can then *look* at the image depends on the lane:
+
+- **Same-repo PRs** (`ux-review.yml`): it reads each image the diff adds or
+  changes under those paths and grounds its visual findings in them.
+- **Fork PRs** (`fork-ux-review.yml`): it runs on `pull_request_target` against
+  the **base** tree, so it can open screenshots already committed on `main` but
+  **not** ones the PR itself adds — those appear in the diff as binary markers and
+  the review is made from code. The workflow says so at `fork-ux-review.yml:236`.
+
+So for a fork PR the trigger still works and the images are still the durable
+record for human reviewers; only the automated visual read is unavailable.
+
+**Pinned URLs outlive the cleanup.** Embed with the commit SHA, not a branch name:
+
+```markdown
+![alt](https://github.com/kirodotdev/KiroCrew/raw/<sha>/temp-screenshots/<feature>/<name>.png)
+```
+
+A `main`-relative URL breaks the moment the weekly prune removes the file, and a
+branch-relative one breaks when the branch is deleted on merge. A SHA-pinned URL
+keeps resolving from the historical commit either way. That property is what the
+prune relies on, and it is why the blobs entering history is the mechanism rather
+than an accident.
+
+## Naming and re-pinning
+
+```
+temp-screenshots/<feature>/<name>.png
+```
+
+`<feature>` is a short slug for the change, not a PR number or a date — several
+subdirectories here pair `before.png` with `after.png`, which reads well in a
+diff. Show each affected surface in the variants that matter: light and dark,
+empty and populated, desktop app and browser. Prefer a short video or GIF when the
+change involves motion or a multi-step flow, because a still cannot evidence
+those.
+
+**Re-pin after every amend or rebase.** This repository requires a single squashed
+commit per PR, so the SHA changes on essentially every revision, and every URL in
+the body silently stops resolving when it does. This is routine here, not an edge
+case: if you amended, assume your links are stale and update them.
+
+## Lifecycle
+
+`.github/workflows/cleanup-temp-screenshots.yml` runs on a schedule — `cron: "0 8
+* * 1"`, Mondays 08:00 UTC — and prunes tracked files under this directory older
+than `RETENTION_DAYS`, default **14**. It is a timer, not a per-PR job, and the
+retention window is overridable per run through `workflow_dispatch`. Because
+`main` is protected, it opens a pull request with the deletions instead of pushing
+them.
+
+This file is exempt by name:
+
+```bash
+[ "$f" = "temp-screenshots/README.md" ] && continue
+```
+
+so it needs no allowlist entry and no workflow change to stay put.
+
+For scale: this directory currently holds around 300 files across roughly 85
+feature subdirectories, and the oldest of them is about a week old — so that count
+is one week of review evidence on this project, not a full retention window. Note
+also that the prune has not yet removed anything: the convention landed on 24 July,
+so the first files only reach the 14-day cutoff in early August, and both scheduled
+runs so far have exited with nothing to do.
+
+## Do not delete your own screenshots before merge
+
+**Authors: leave them in the PR.** **Reviewers, human or model: do not ask for
+them to be removed.**
+
+This is the part that costs review rounds when it is not written down. Committed
+PNGs in a source tree look like debris to a reviewer seeing the diff cold, and an
+AI reviewer has flagged exactly that as blocking — on #1216, the Arbiter objected
+to `temp-screenshots/library-hero/*.png` being "baked into `main`'s history". The
+finding was resolved with a scoped `/ai-review override arbiter`, on the grounds
+that committing review screenshots here is the documented convention and that the
+blobs staying in history is precisely what keeps SHA-pinned URLs resolving after
+the tip is pruned.
+
+That override cost a round trip on a PR whose actual change was three files. The
+purpose of this README is to make the next one unnecessary: the convention is
+deliberate, the cleanup is automated, and deleting files pre-merge would break
+the URLs in the very PR body a reviewer is reading.
+
+## See also
+
+The files that actually drive this directory, roughly in the order an author or
+agent meets them:
+
+- `src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md` and its
+  `assets/pr-body-template.md` — what an agent reads before it writes here.
+- `src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md` — the full
+  operational recipe: copy the approved media in, amend into the PR's single
+  commit, force-push with lease, re-pin every URL after any later amend, and
+  verify the body update landed. It also notes that a force-push resets PR
+  approvals, which is worth knowing before you attach anything.
+- `.github/PULL_REQUEST_TEMPLATE.md` — when screenshots are mandatory, and the
+  exact URL form to embed.
+- `docs/ci/ci-and-reviews.md` — the cleanup job among the other scheduled
+  maintenance workflows, and `UX Review`'s early-skip behaviour.
+- `.github/workflows/cleanup-temp-screenshots.yml` — the prune itself.


### PR DESCRIPTION
## Problem / Motivation

`temp-screenshots/README.md` does not exist on `main`, yet CI already treats it as if it does.
`.github/workflows/cleanup-temp-screenshots.yml` names it twice: once in its header comment (*"commits PR review images (see temp-screenshots/README.md)"*) and once in the prune loop, which skips it explicitly:

```bash
[ "$f" = "temp-screenshots/README.md" ] && continue
```

So the weekly cleanup carves out a file that was never written.

Meanwhile the directory holds **306 tracked files across 85 feature subdirectories** with nothing next to them explaining what they are. A reviewer opening a PR that adds PNGs to a source tree has no in-repo answer to "why is this committed?", and the conventions that make it work — SHA-pinned URLs, the 14-day prune, don't-delete-before-merge — live only in the PR template's HTML comments and a workflow file.

## Why it matters

The absence has already cost review time, which is the strongest argument for fixing it.

On **#1216** (`fix(apps): render app hero art in Library rows`, merged, 3 files added under `temp-screenshots/library-hero/`), the **Arbiter** raised a *blocking* finding against `temp-screenshots/library-hero/*.png` being "baked into `main`'s history". @chenmingwei23 had to argue it down and resolve it with a scoped `/ai-review override arbiter`, on the grounds that this is the documented convention and that the blobs remaining in history is exactly what keeps SHA-pinned URLs resolving after the tip is pruned.

That was a round trip on a PR whose real change was three files, and nothing prevents the next reviewer — human or model — from reaching the same conclusion from the same evidence. A README in the directory is what makes the convention discoverable at the point of confusion.

There is a second, quieter cost: an author who pins a URL to a branch instead of a commit, or forgets to re-pin after an amend, ships a PR body full of links that break on merge. With a mandatory single squashed commit, amending is routine here, so this is not a rare mistake.

## What changed (motivation → approach → change)

One new file, `temp-screenshots/README.md`. No code, no workflow edit.

**On the workflow edit — verified, since it is the first thing a reviewer will ask.** The prune loop already exempts this exact path by name at `cleanup-temp-screenshots.yml:53`, so the file it now protects finally exists and needs no allowlist entry and no change to the workflow.

**I rebuilt the rationale instead of transcribing the issue, because two of its load-bearing claims no longer hold.** Both are verified against `main` as of this PR:

| Issue says | Actually |
|---|---|
| "the repo is private, so `raw.githubusercontent.com` 404s for everyone" — the basis of its whole "committed rather than attached" argument | The repo is **public** (`private: false`), and `https://raw.githubusercontent.com/kirodotdev/KiroCrew/main/CONTRIBUTING.md` returns **HTTP 200, 21,687 bytes** |
| cross-reference `docs/app-store-guidelines.md`'s screenshot section | That file is **absent from `main`**. Links `docs/ci/ci-and-reviews.md` and `.github/PULL_REQUEST_TEMPLATE.md` instead — the two places that do document this |
| 182 files under `temp-screenshots/` | **306**, across 85 subdirectories. (182 was accurate when @chenmingwei23 wrote it in the #1216 override; it has grown since) |

The convention itself is real and worth documenting — none of it depended on the repo being private. So the README grounds "commit, don't attach" on two things that are true:

1. **SHA-pinned URLs outlive the prune**, because the blob stays reachable in history after the file leaves `main`'s tip. This is not my inference: `docs/ci/ci-and-reviews.md` says the cleanup is *"safe because PR bodies embed commit-SHA-pinned raw URLs that keep resolving"*, and the workflow's own generated PR body says the same.

2. **`UX Review` reads files, not attachments** — a reason the issue does not mention and which I think is the more decisive one. `ux-review.yml` and `fork-ux-review.yml` run only when the diff touches `website/`, `temp-screenshots/**` or `.github/screenshots/**`, and when they run they read each image *from those paths*. An attachment uploaded through the web UI is not a file in the repository, so it can be neither read as evidence nor used to trigger the review at all. Committing the screenshot is what makes the automated visual review happen.

I deliberately did **not** claim that `user-attachments` assets are unusable by CI in general. What I could verify is narrower and I stuck to it: `codex-review.yml` strips *all* embedded media from the PR body before the code reviewer sees it — markdown images, `<img>`, `<video>` and bare `user-attachments` URLs alike — because they burn the context budget. That is a budget measure, not an attachments-specific one, so it does not belong in the argument.

Content covered, kept factual: what lives here and that `MANIFEST.in` prunes it from distributions; why committed rather than attached; naming (`temp-screenshots/<feature>/<name>.png`) with the exact SHA-pinned URL form and the re-pin-after-amend warning; the lifecycle (weekly `cron: "0 8 * * 1"`, `RETENTION_DAYS` default 14, `workflow_dispatch` override, opens a PR because `main` is protected); and an explicit section stating that authors must not delete their own screenshots pre-merge and reviewers must not ask them to, with the #1216 precedent named so the next Arbiter finding has a documented answer.

## Tests

N/A — this adds a single markdown file with no code path to exercise, and I would rather say that than invent a test that asserts a file exists.

What I did verify mechanically:

| Check | Result |
|---|---|
`scripts/docs_lint.py` | **pass**, exit 0, 181 files, "All documentation checks passed". Worth noting it scans `docs/`, `src/kiro_crew/docs/` and `website/docs/` only, so it does not actually lint this path — I am not claiming coverage it does not give. |
`test/test_brand_name_gate.py` | **84 passed** |
`scripts/check_brand_name.py` | exit 0 |
`scrub-lint.sh --no-history` | Fails on clean `main` too, identically (`SECURITY.md`, CloudWatch console URLs). **Zero hits name `temp-screenshots/README.md`.** |
Prune exemption | Confirmed present at `cleanup-temp-screenshots.yml:53`; no workflow change needed |
Blob count | `git ls-tree -r origin/main -- temp-screenshots` → 306 files, 85 subdirs |

## Manual verification

Read the workflow, the PR template, `docs/ci/ci-and-reviews.md`, both UX-review workflows and the #1216 thread to source every factual claim in the file, and re-checked the two stale claims live (repo visibility, the raw fetch, and the absence of `docs/app-store-guidelines.md`). Every number and quotation in the README comes from one of those, not from the issue body.

## Screenshots / video

N/A — no user-visible UI change; the diff is one markdown file. (Fittingly, a PR about screenshot conventions needs none.)

## Related Issues

Fixes #1256

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

---

*Written with agentic AI assistance (Kiro), per `CONTRIBUTING.md`'s "Using AI Tools". The corrections to the issue's premises are mine to defend: each one is checkable in a couple of commands, and I have listed what I checked rather than asking anyone to take it on trust.*
