### PR TITLE
docs(readme): say what the missing Windows sandbox layer actually costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,10 @@ the runtime boundary instead of relying only on prompt instructions.
   the underlying deny and sensitive-path controls.
 - **OS sandbox.** On Linux and macOS, `kiro-cli` can run inside namespace or
   Seatbelt isolation. Standard, strict, and off modes make the tradeoff
-  explicit. Windows does not currently provide this OS-level layer.
+  explicit. Windows offers no equivalent OS-level layer, so Kiro Crew fails
+  closed there: agent subprocesses are refused rather than run unconfined, until
+  you declare the
+  [`sandbox_allow_unsandboxed_exec` opt-in](docs/guides/windows-install.md#the-unsandboxed-exec-opt-in).
 - **Sensitive data guards.** Kiro Crew blocks direct access to protected paths,
   strips sensitive environment variables, and redacts credential patterns from
   output before it reaches a chat surface.


### PR DESCRIPTION
## What is the problem?

The README's security section described the Windows sandbox situation and stopped one sentence short:

> **OS sandbox.** On Linux and macOS, `kiro-cli` can run inside namespace or Seatbelt isolation. Standard, strict, and off modes make the tradeoff explicit. **Windows does not currently provide this OS-level layer.**

That sentence is true, but it omits the consequence — which is the only part a Windows reader actually needs. Because no backend exists, `detect_backend()` returns `"none"` and `wrap_argv()` fails **closed**: agent subprocesses are *refused outright*, not run with weaker isolation, until the operator declares `agent.sandbox_allow_unsandboxed_exec`.

## Why this issue matters to the user

The README is where a Windows evaluator lands first, and the natural reading of "does not provide this OS-level layer" is "less isolation on Windows" — not "nothing spawns until you flip a config key". So the refusal arrives later, unexplained, as `{"error": "app 'dev-fleet' has no reachable backend"}` and three red `kirocrew doctor` probes. That was exactly the shape of https://github.com/kirodotdev/KiroCrew/issues/1525.

The remedy is documented in `docs/guides/windows-install.md`, but nothing in the README pointed a reader there from the place the question arises.

## How our fix solves it (symptom → root cause → change)

**Symptom:** a Windows user reads the README, expects degraded isolation, and later meets a hard refusal with no obvious cause.

**Root cause:** the bullet describes the *absence of a mechanism* without describing the *behaviour that absence produces*, and does not link the section that carries the remedy.

**Change:** one bullet, extended to state the fail-closed behaviour and link the opt-in section of the Windows guide (which holds the config snippet and the per-feature status table).

Wording is deliberately independent of https://github.com/kirodotdev/KiroCrew/pull/1527 — it describes the fail-closed posture and the config key, not the setup-wizard prompt that #1527 adds — so it is accurate whether or not #1527 has landed, and the two can merge in either order. Once #1527 is in, the linked guide section already documents the wizard.

## What tests we did

Docs-only, no code paths touched.

- `./scripts/docs-lint.sh` — 181 files, all checks pass
- `python3 scripts/docs_lint.py --test` — self-test passes
- `./scripts/scrub-lint.sh --no-history` — all checks pass
- Link target verified by hand: `docs/guides/windows-install.md` line 104 is `## The unsandboxed-exec opt-in`, so the `#the-unsandboxed-exec-opt-in` anchor resolves. (Worth noting `docs-lint.sh` scans `docs/`, `src/kiro_crew/docs/` and `website/docs/` — not root-level `README.md` — so its pass does **not** by itself validate this link.)
- Product name check: no added line uses the joined spelling; the bullet says "Kiro Crew"

## Any other suggestions on the work

- **Deliberately left alone:** the `- **Windows**: no desktop build yet …` line. `website/electron/package.json` does declare a `win` target with `nsis`, but no CI job builds Windows desktop and no download link ships it, so the README claim is still accurate. Changing it would be wrong today.
- **Considered and skipped:** "macOS and Linux require Python 3.10+, Node.js 18+, npm, and `kiro-cli`" could be read as those prerequisites not applying to Windows. The very next sentence redirects Windows readers to the platform guide, so the ambiguity is bounded — folding a second rewording into a one-bullet correction seemed worse than leaving it.
- The remaining Windows-specific defects found while investigating #1525 (MCP stub bridge liveness, the wedge-recycler's reachability, `_terminate_process` targeting the venv launcher, empty loopstall dumps, `/proc`-only diagnostics) are code issues, not doc issues, and are being tracked separately.
