### PR TITLE
fix(gatewayd): provide fd_count/rss_kb on macOS+Windows, add pid field

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -2614,20 +2614,63 @@ def _zombie_diagnostic_path() -> Path:
 
 
 def _count_open_fds() -> int:
-    """Return the number of open file descriptors for this process.
+    """Return the number of open file descriptors (or handles on Windows).
 
     FD exhaustion is one of the four hypothesised zombie causes; tracking
     the count per snapshot lets us confirm or eliminate that path without
     deploying a separate tracer.
+
+    Platform implementations:
+    - Linux: ``/proc/self/fd``
+    - macOS/BSD: ``/dev/fd``
+    - Windows: ``GetProcessHandleCount`` via ctypes (handle count, not
+      fd count — the field documents this as platform-dependent)
+
+    Returns ``-1`` when the platform cannot provide the value.
     """
+    # Linux — preferred, most precise.
     try:
         return len(os.listdir("/proc/self/fd"))
     except OSError:
-        return -1
+        pass
+
+    # macOS / BSD — /dev/fd is a per-process virtual directory.
+    try:
+        return len(os.listdir("/dev/fd"))
+    except OSError:
+        pass
+
+    # Windows — count kernel handles for the current process.
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+            handle_count = wintypes.DWORD()
+            current_process = kernel32.GetCurrentProcess()
+            if kernel32.GetProcessHandleCount(current_process, ctypes.byref(handle_count)):
+                return handle_count.value
+        except (OSError, AttributeError, ValueError):
+            pass
+
+    return -1
 
 
 def _read_rss_kb() -> int:
-    """Return RSS in kilobytes from ``/proc/self/status`` or ``-1``."""
+    """Return current RSS in kilobytes, or ``-1`` if unavailable.
+
+    Platform implementations:
+    - Linux: ``/proc/self/status`` VmRSS field (already in KB).
+    - macOS: ``resource.getrusage`` (``ru_maxrss`` is in bytes on macOS).
+    - Other POSIX: ``resource.getrusage`` (``ru_maxrss`` is in KB on Linux,
+      but this branch only runs on non-Linux where it is bytes; if neither
+      applies we fall through to ``-1``).
+    - Windows: ``GetProcessMemoryInfo`` via ctypes (WorkingSetSize in bytes).
+
+    Returns ``-1`` when the platform cannot provide the value.
+    """
+    # Linux — parse VmRSS from /proc/self/status (current RSS, not peak).
     try:
         with open("/proc/self/status", "r", encoding="ascii") as fh:
             for line in fh:
@@ -2635,6 +2678,54 @@ def _read_rss_kb() -> int:
                     return int(line.split()[1])
     except (OSError, ValueError, IndexError):
         pass
+
+    # macOS / other POSIX — resource.getrusage gives ru_maxrss.
+    # On macOS ru_maxrss is in bytes; on other BSDs it is in KB.
+    if sys.platform != "win32":
+        try:
+            import resource
+
+            ru = resource.getrusage(resource.RUSAGE_SELF)
+            maxrss = ru.ru_maxrss
+            if maxrss > 0:
+                if sys.platform == "darwin":
+                    return maxrss // 1024  # bytes → KB
+                return maxrss  # already in KB on most other POSIX
+        except (OSError, ValueError, AttributeError, ImportError):
+            pass
+
+    # Windows — GetProcessMemoryInfo returns WorkingSetSize in bytes.
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            import ctypes.wintypes as wintypes
+
+            SIZE_T = ctypes.c_size_t
+
+            class PROCESS_MEMORY_COUNTERS(ctypes.Structure):
+                _fields_ = [
+                    ("cb", wintypes.DWORD),
+                    ("PageFaultCount", wintypes.DWORD),
+                    ("PeakWorkingSetSize", SIZE_T),
+                    ("WorkingSetSize", SIZE_T),
+                    ("QuotaPeakPagedPoolUsage", SIZE_T),
+                    ("QuotaPagedPoolUsage", SIZE_T),
+                    ("QuotaPeakNonPagedPoolUsage", SIZE_T),
+                    ("QuotaNonPagedPoolUsage", SIZE_T),
+                    ("PagefileUsage", SIZE_T),
+                    ("PeakPagefileUsage", SIZE_T),
+                ]
+
+            psapi = ctypes.WinDLL("psapi", use_last_error=True)  # type: ignore[attr-defined]
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+            pmc = PROCESS_MEMORY_COUNTERS()
+            pmc.cb = ctypes.sizeof(pmc)
+            handle = kernel32.GetCurrentProcess()
+            if psapi.GetProcessMemoryInfo(handle, ctypes.byref(pmc), pmc.cb):
+                return pmc.WorkingSetSize // 1024  # bytes → KB
+        except (OSError, AttributeError, ValueError):
+            pass
+
     return -1
 
 
@@ -2687,6 +2778,7 @@ def _snapshot_state(
     return {
         "ts_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "ts_epoch": time.time(),
+        "pid": os.getpid(),
         "is_serving": is_serving,
         "task_count": task_count,
         "fd_count": _count_open_fds(),

--- a/tests/test_gatewayd_diag.py
+++ b/tests/test_gatewayd_diag.py
@@ -1,0 +1,146 @@
+"""Tests for gatewayd diagnostic helpers (_count_open_fds, _read_rss_kb, _snapshot_state)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.mcp_gateway.gatewayd import (
+    _count_open_fds,
+    _read_rss_kb,
+    _snapshot_state,
+)
+
+
+class TestCountOpenFds:
+    """Verify _count_open_fds returns a positive int on supported platforms."""
+
+    def test_returns_positive_on_current_platform(self) -> None:
+        """We're running on Linux CI — expect a real fd count."""
+        result = _count_open_fds()
+        # On Linux (and macOS with /dev/fd), this should be > 0.
+        if sys.platform in ("linux", "darwin"):
+            assert result > 0
+        else:
+            # On truly unsupported platforms, -1 is acceptable.
+            assert result == -1 or result > 0
+
+    def test_returns_minus_one_when_all_sources_fail(self) -> None:
+        """If /proc/self/fd, /dev/fd, and Win32 all fail, return -1."""
+        with patch("os.listdir", side_effect=OSError("mocked")):
+            with patch.object(sys, "platform", "linux"):
+                result = _count_open_fds()
+        assert result == -1
+
+    def test_proc_self_fd_preferred_on_linux(self) -> None:
+        """On Linux, /proc/self/fd is used and returns a sane count."""
+        if sys.platform != "linux":
+            pytest.skip("Linux-only test")
+        result = _count_open_fds()
+        # The interpreter itself holds at least stdin/stdout/stderr.
+        assert result >= 3
+
+
+class TestReadRssKb:
+    """Verify _read_rss_kb returns a positive int on supported platforms."""
+
+    def test_returns_positive_on_current_platform(self) -> None:
+        """We're running on Linux — expect a real RSS value."""
+        result = _read_rss_kb()
+        if sys.platform in ("linux", "darwin"):
+            assert result > 0
+        else:
+            assert result == -1 or result > 0
+
+    def test_returns_minus_one_when_all_sources_fail(self) -> None:
+        """If /proc/self/status and resource both fail, return -1."""
+        with patch("builtins.open", side_effect=OSError("mocked")):
+            with patch.dict("sys.modules", {"resource": None}):
+                with patch.object(sys, "platform", "linux"):
+                    result = _read_rss_kb()
+        assert result == -1
+
+    def test_rss_is_in_kilobytes(self) -> None:
+        """RSS should be in a plausible range for a Python process (> 1MB)."""
+        result = _read_rss_kb()
+        if result == -1:
+            pytest.skip("Not available on this platform")
+        # A Python process should use at least ~1MB = 1024 KB.
+        assert result > 1024
+
+
+class TestSnapshotState:
+    """Verify _snapshot_state includes all expected fields including pid."""
+
+    def test_snapshot_has_pid_field(self) -> None:
+        """The snapshot dict must include a pid field matching os.getpid()."""
+        server = MagicMock()
+        server.is_serving.return_value = True
+        pool = MagicMock()
+        pool._backends = {}
+        connections: set = set()
+
+        result = _snapshot_state(
+            server=server,
+            pool=pool,
+            connections=connections,
+            task_count=5,
+        )
+
+        assert "pid" in result
+        assert result["pid"] == os.getpid()
+
+    def test_snapshot_has_all_fields(self) -> None:
+        """The snapshot dict must contain the expected diagnostic fields."""
+        server = MagicMock()
+        server.is_serving.return_value = True
+        pool = MagicMock()
+        pool._backends = {"k": "v"}
+        connections: set = set()
+
+        result = _snapshot_state(
+            server=server,
+            pool=pool,
+            connections=connections,
+            task_count=10,
+        )
+
+        expected_keys = {
+            "ts_iso",
+            "ts_epoch",
+            "pid",
+            "is_serving",
+            "task_count",
+            "fd_count",
+            "rss_kb",
+            "pool_size",
+            "connections_in_flight",
+        }
+        assert set(result.keys()) == expected_keys
+        assert result["task_count"] == 10
+        assert result["pool_size"] == 1
+        assert result["connections_in_flight"] == 0
+        assert result["is_serving"] is True
+
+    def test_snapshot_fd_and_rss_are_populated(self) -> None:
+        """On Linux, fd_count and rss_kb should be real values, not -1."""
+        if sys.platform != "linux":
+            pytest.skip("Linux-only test")
+        server = MagicMock()
+        server.is_serving.return_value = True
+        pool = MagicMock()
+        pool._backends = {}
+        connections: set = set()
+
+        result = _snapshot_state(
+            server=server,
+            pool=pool,
+            connections=connections,
+            task_count=0,
+        )
+
+        assert result["fd_count"] > 0
+        assert result["rss_kb"] > 0


### PR DESCRIPTION
## What is the problem?

The gatewayd zombie diagnostic snapshot (`gatewayd_zombie_diagnostic.jsonl`) reports `fd_count` and `rss_kb` as `-1` on macOS and Windows because both `_count_open_fds()` and `_read_rss_kb()` have only a `/proc`-based implementation. Additionally, the snapshot lacks a `pid` field, making it impossible to distinguish daemon generations within the append-only log file without out-of-band process inspection.

## Why this issue matters to the user

During a live incident on Windows, all 238 rows in the diagnostic file carried `fd_count: -1` and `rss_kb: -1`. Without those values and without a pid field, the natural way to tell whether a wedge belongs to an old or new process—a discontinuity in resource metrics—was unavailable, requiring a manual `Get-CimInstance` + `py-spy` walk. FD leaks and memory-growth wedges are also invisible to this instrument on non-Linux hosts, which is a significant fraction of what the snapshot exists to catch.

## How our fix solves it (symptom → root cause → change)

**Symptom:** `fd_count` and `rss_kb` are always `-1` on non-Linux hosts.

**Root cause:** Both accessors (`gatewayd.py:2616`, `gatewayd.py:2629`) have a single `/proc`-based implementation with no platform fallback.

**Change:**

1. `_count_open_fds()` now chains: `/proc/self/fd` → `/dev/fd` (macOS/BSD) → `GetProcessHandleCount` (Windows ctypes). Returns `-1` only when no source succeeds.

2. `_read_rss_kb()` now chains: `/proc/self/status` VmRSS → `resource.getrusage` (macOS/POSIX, handling the bytes-vs-KB difference) → `GetProcessMemoryInfo` WorkingSetSize (Windows ctypes). Returns `-1` only when no source succeeds.

3. Added `"pid": os.getpid()` to the `_snapshot_state()` dict so daemon restarts are directly identifiable without resource-value discontinuities.

The Windows handle count is documented in the docstring as "descriptors or handles, platform-dependent" per the issue's guidance.

## What tests we did

- **New test suite** `tests/test_gatewayd_diag.py` (9 tests) covering:
  - Real values on Linux (fd_count > 0, rss_kb > 1024 KB)
  - Fallback to `-1` when all sources are mocked out
  - `_snapshot_state` includes `pid == os.getpid()` and all expected keys
- **Real output on Linux:**
  ```json
  {"pid": 772321, "fd_count": 6, "rss_kb": 33776, "platform": "linux"}
  ```
- **Simulated all-sources-fail:**
  ```json
  {"fd_count": -1, "rss_kb": -1, "note": "all sources blocked → -1 returned"}
  ```
- isort ✅, flake8 ✅, mypy ✅ (0 issues in both changed files)
- Brand gate: 0 `KiroCrew` occurrences in added lines

**Not verified:** actual Windows/macOS execution (no access to those hosts in this environment). The ctypes paths are guarded by `sys.platform == "win32"` / `sys.platform == "darwin"` and wrapped in defensive try/except, so they cannot regress Linux behavior.

## Any other suggestions on the work

The Windows ctypes path uses `GetProcessHandleCount` which counts kernel handles, not POSIX file descriptors. The docstring documents this difference. A future pass could split `fd_count` into `fd_count` + `handle_count` if consumers need to threshold them differently, but the issue explicitly accepts documenting it as platform-dependent.

Closes #1576
