### PR TITLE
fix(gateway): spawn the real interpreter, not the Windows venv launcher

### DIFF
--- a/src/kiro_crew/mcp_gateway/manager.py
+++ b/src/kiro_crew/mcp_gateway/manager.py
@@ -23,7 +23,6 @@ import json
 import logging
 import os
 import signal
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -301,7 +300,7 @@ class GatewayManager:
         if extra_dirs:
             env["PATH"] = os.pathsep.join([*extra_dirs, existing_path]) if existing_path else os.pathsep.join(extra_dirs)
         argv = [
-            sys.executable,
+            platform_compat.daemon_executable(),
             "-m", _GATEWAYD_MODULE,
             "--socket", str(self._spec.socket_path),
             "--idle-timeout-secs", str(self._spec.idle_timeout_secs),

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -2362,6 +2362,24 @@ def _is_windows_store_python_stub(path: str) -> bool:
     return "\\microsoft\\windowsapps\\" in norm
 
 
+def daemon_executable() -> str:
+    """Return the real Python interpreter path for spawning long-lived daemons.
+
+    On Windows a virtualenv's ``Scripts/python.exe`` is a **launcher stub** that
+    starts the base interpreter as a child process. If we spawn that stub as the
+    gateway daemon, our process handle points at the launcher — not the
+    interpreter actually running ``gatewayd.main()`` — so signals and
+    ``proc.wait()`` miss the real daemon entirely (see issue #1575).
+
+    ``sys._base_executable`` resolves straight to the underlying interpreter on
+    every platform. On POSIX (where the venv ``bin/python`` IS the interpreter
+    via symlink) it equals ``sys.executable``; on Windows it skips the launcher
+    shim. Falls back to ``sys.executable`` if the private attribute is absent
+    (should never happen on CPython ≥ 3.3, but defensive).
+    """
+    return getattr(sys, "_base_executable", sys.executable)
+
+
 def find_python_interpreter(reject: Optional[Callable[[str], bool]] = None) -> str | None:
     """Resolve a real CPython >= 3.10 interpreter, or None.
 

--- a/test/test_mcp_gateway_daemon_executable.py
+++ b/test/test_mcp_gateway_daemon_executable.py
@@ -1,0 +1,167 @@
+"""Tests for the Windows venv-launcher fix (issue #1575).
+
+The gateway manager must spawn the *real* interpreter, not the Windows venv
+launcher stub. ``platform_compat.daemon_executable()`` resolves straight to
+``sys._base_executable``, which on Windows skips the launcher shim and on
+POSIX equals ``sys.executable`` (no behavioral change).
+
+These tests verify:
+1. ``daemon_executable()`` returns the base interpreter on every platform.
+2. ``GatewayManager._spawn_once`` passes the resolved interpreter into the
+   subprocess argv, not raw ``sys.executable``.
+3. On Linux, the spawned process IS the real interpreter (no launcher parent)
+   and ``terminate`` reaps the daemon directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.mcp_gateway import manager as mgr
+
+# ─── daemon_executable() unit tests ──────────────────────────────────────────
+
+
+class TestDaemonExecutable:
+    """Verify daemon_executable() resolves the real interpreter."""
+
+    def test_returns_base_executable(self) -> None:
+        """Must match sys._base_executable (the real interpreter)."""
+        expected = getattr(sys, "_base_executable", sys.executable)
+        assert platform_compat.daemon_executable() == expected
+
+    def test_is_a_real_file(self) -> None:
+        """The resolved path must be an existing file."""
+        exe = platform_compat.daemon_executable()
+        assert os.path.isfile(exe), f"daemon_executable() -> {exe!r} is not a file"
+
+    def test_fallback_when_base_executable_absent(self) -> None:
+        """If _base_executable is somehow missing, falls back to sys.executable."""
+        with patch.object(sys, "_base_executable", new=None, create=False):
+            # Simulate absence by deleting the attribute
+            saved = sys._base_executable
+            try:
+                del sys._base_executable  # type: ignore[attr-defined]
+                result = platform_compat.daemon_executable()
+                assert result == sys.executable
+            finally:
+                sys._base_executable = saved  # type: ignore[attr-defined]
+
+    def test_on_posix_equals_or_resolves_same_binary(self) -> None:
+        """On Linux/macOS the base executable resolves the same interpreter."""
+        if platform_compat.IS_WINDOWS:
+            pytest.skip("POSIX-only assertion")
+        exe = platform_compat.daemon_executable()
+        # On POSIX, _base_executable and executable point at the same
+        # interpreter (possibly through a symlink chain).
+        assert os.path.realpath(exe) == os.path.realpath(sys.executable)
+
+
+# ─── Manager spawn integration ───────────────────────────────────────────────
+
+
+class TestManagerUsesRealInterpreter:
+    """Verify _spawn_once passes daemon_executable(), not sys.executable."""
+
+    @pytest.mark.asyncio
+    async def test_spawn_argv_uses_daemon_executable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The first element of the spawn argv must be daemon_executable()."""
+        captured_argv: list[str] = []
+
+        async def fake_create_subprocess_exec(
+            *args: Any, **kwargs: Any
+        ) -> MagicMock:
+            captured_argv.extend(args)
+            proc = MagicMock()
+            proc.pid = 12345
+            proc.returncode = None
+            proc.wait = AsyncMock(return_value=0)
+            return proc
+
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+        )
+        # Stub restrict_to_owner so it doesn't touch the filesystem
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", lambda p: None)
+
+        spec = MagicMock()
+        spec.socket_path = tmp_path / "gateway.sock"
+        spec.idle_timeout_secs = 60
+        spec.max_backends = 4
+        spec.prewarm_count = 0
+        spec.mcp_target_env = {}
+        manager = mgr.GatewayManager(spec)
+        # Stub credential watch paths
+        monkeypatch.setattr(manager, "_credential_watch_paths", lambda: [])
+
+        await manager._spawn_once()
+
+        expected_exe = platform_compat.daemon_executable()
+        assert captured_argv[0] == expected_exe
+        # Must NOT be the raw sys.executable if they differ (Windows venv case)
+        assert captured_argv[0] == getattr(sys, "_base_executable", sys.executable)
+
+
+# ─── Live process test: spawned daemon IS the real interpreter ────────────────
+
+
+class TestSpawnedProcessIsRealInterpreter:
+    """On Linux, verify a process spawned with daemon_executable() has no
+    launcher parent and can be terminated directly."""
+
+    @pytest.mark.asyncio
+    async def test_spawned_process_no_launcher_parent(self) -> None:
+        """Spawn a trivial script with daemon_executable(). The process
+        should be directly reachable — its parent is us, not a launcher."""
+        if platform_compat.IS_WINDOWS:
+            pytest.skip("Windows has no reliable ppid check from Python")
+
+        exe = platform_compat.daemon_executable()
+        # Spawn a process that just sleeps briefly
+        proc = await asyncio.create_subprocess_exec(
+            exe, "-c", "import time; time.sleep(30)",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            # The process should be alive and its parent should be us
+            assert proc.pid is not None
+            assert proc.returncode is None
+
+            # Verify our pid is the parent (no intermediate launcher)
+            ppid_path = Path(f"/proc/{proc.pid}/stat")
+            if ppid_path.exists():
+                stat_fields = ppid_path.read_text().split()
+                # Field index 3 is ppid in /proc/[pid]/stat
+                ppid = int(stat_fields[3])
+                assert ppid == os.getpid(), (
+                    f"Spawned process ppid={ppid} != our pid={os.getpid()}; "
+                    f"a launcher shim is sitting in between"
+                )
+
+            # Verify terminate() actually reaches the process
+            proc.terminate()
+            try:
+                rc = await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                pytest.fail("terminate() did not reach the daemon process")
+            # SIGTERM -> negative return code on POSIX
+            assert rc == -signal.SIGTERM
+        finally:
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()


### PR DESCRIPTION
## What is the problem?

On Windows, `GatewayManager._spawn_once()` spawns gatewayd using `sys.executable` (`manager.py:304`). Inside a virtualenv on Windows, `sys.executable` resolves to `.venv\Scripts\python.exe` — a **launcher stub** that starts the real interpreter as a child process. The manager's `self._process` handle therefore points at the launcher shim, not the interpreter actually running `gatewayd.main()`.

This means `_terminate_process()` sends SIGTERM to the launcher (not the daemon), and `proc.wait()` monitors the launcher (not the daemon). The real daemon process is unreachable.

## Why this issue matters to the user

Two failure modes:

1. **Stopping the daemon does not stop it.** Killing the launcher orphans the real daemon, which keeps holding the singleton lock and named pipe. The manager believes shutdown succeeded.
2. **The watchdog watches the wrong process.** If the launcher exits while the real daemon survives, the manager misreads this as "daemon exited" and respawns — producing duplicate daemons on one socket path, causing intermittent "transport closed" errors for kiro-cli sessions.

## How our fix solves it (symptom → root cause → change)

**Symptom:** orphaned gatewayd survives shutdown on Windows; watchdog misreads launcher exit as daemon exit.

**Root cause:** `sys.executable` on Windows in a venv is a launcher stub, not the interpreter. The manager holds a handle to the wrong process.

**Change:** Introduce `platform_compat.daemon_executable()` which returns `sys._base_executable` — the real interpreter path on every platform. On POSIX this is a no-op (venv `bin/python` is the interpreter itself via symlink, so `_base_executable == executable`). On Windows it skips the launcher shim entirely: one process per daemon, `self._process` IS the daemon, signals and `proc.wait()` reach it directly.

- `src/kiro_crew/platform_compat.py:2365`: new `daemon_executable()` helper
- `src/kiro_crew/mcp_gateway/manager.py:304`: `sys.executable` → `platform_compat.daemon_executable()`

## What tests we did

1. **Unit tests** (`test/test_mcp_gateway_daemon_executable.py`):
   - `daemon_executable()` returns `sys._base_executable` (the real interpreter)
   - The resolved path is an existing file
   - Fallback to `sys.executable` if `_base_executable` is absent
   - On POSIX, both resolve to the same binary (no behavioral change)

2. **Manager spawn argv test**: mocks `create_subprocess_exec` and verifies the first argv element is `daemon_executable()`, not raw `sys.executable`.

3. **Live process test (Linux)**: spawns a process with `daemon_executable()`, verifies:
   - Parent PID is us (no intermediate launcher in between)
   - `proc.terminate()` directly reaps the process (returns `-SIGTERM`)

4. **Existing gateway tests pass** (transport, bluegreen, cluster, control_plane, stop_kill_cancel — 132 tests, 0 new failures).

5. **Lint/type checks**: isort, flake8, mypy all pass on changed files.

**Not verified:** actual Windows behavior (this environment is Linux). The fix is derived from CPython's documented behavior of `sys._base_executable` and the issue's live diagnosis on a Windows host.

## Any other suggestions on the work

The same `sys.executable` pattern in `rewriter.py:271` (MCP stub overlay) is intentionally different — that path is launched by kiro-cli (which strips env), and the stub needs to resolve imports from the gateway's venv, so using the venv interpreter there is correct. No change needed.

The issue also suggests a defence-in-depth pid-sidecar approach. That would protect against future launcher-like indirections but is a larger change best tracked separately.

Closes #1575
