### PR TITLE
fix(ci): omit every pytest tmp path from coverage, not one fixture name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -239,15 +239,26 @@ looponfailroots = src test
 [coverage:run]
 branch = true
 parallel = true
-# Ephemeral pytest tmp fixtures fabricate a worktree layout at
-# <tmp>/kirocrew-wt-example/src/kiro_crew/agent.py (see
-# test/test_agent_home_isolation.py::_make_linked_worktree). No real file is
-# ever written there, but the phantom path lands in the coverage data and makes
-# `coverage xml`/`coverage report` in the Coverage Combine job abort with
-# "No source for code: .../kirocrew-wt-example/.../agent.py" (the step runs
-# under `bash -e`, so the non-zero exit fails the whole gate — and Coverage Gate
-# then fails closed, blocking PR Readiness on every open PR). Never measure it.
+# Ephemeral pytest tmp fixtures fabricate checkout layouts at
+# <tmp>/<name>/src/kiro_crew/agent.py. No real file is ever written there, but
+# the phantom path lands in the coverage data and makes `coverage xml`/`coverage
+# report` in the Coverage Combine job abort with "No source for code:
+# .../agent.py" (the step runs under `bash -e`, so the non-zero exit fails the
+# whole gate — and Coverage Gate then fails closed, blocking PR Readiness on
+# every open PR). Never measure it.
+#
+# Anchor the pattern on pytest's tmp root, not on each fixture's directory name:
+# test/test_agent_home_isolation.py already builds such a layout under two
+# different names (kirocrew-wt-example/ via _make_linked_worktree, and a plain
+# KiroCrew/ clone dir in test_does_not_decline_from_an_ordinary_clone), so a
+# name-based glob has to be extended for every new fixture — and "*/KiroCrew/*"
+# would be actively unsafe, because CI checks the repo out at
+# /home/runner/work/KiroCrew/KiroCrew and that glob would omit all real source,
+# turning the coverage gate green by measuring nothing. Nothing real is ever
+# measured from a pytest temporary directory. The name-based entry is kept as a
+# backstop for runs that override pytest's basetemp.
 omit =
+    */pytest-of-*/*
     */kirocrew-wt-example/*
 
 [coverage:paths]
@@ -265,6 +276,7 @@ show_missing = true
 # a shard that already recorded the phantom fixture path would still trip
 # `coverage xml`/`coverage report` with "No source for code". Keep both in sync.
 omit =
+    */pytest-of-*/*
     */kirocrew-wt-example/*
 
 [coverage:html]

--- a/test/test_coverage_config.py
+++ b/test/test_coverage_config.py
@@ -1,0 +1,101 @@
+"""The coverage omit globs must swallow phantom fixture paths, not real source.
+
+Several tests in ``test_agent_home_isolation.py`` monkeypatch
+``kiro_crew.agent.__file__`` to a fabricated checkout under pytest's tmp dir.
+Nothing is ever written there, but the phantom path can land in the coverage
+data, and then ``coverage xml`` / ``coverage report`` in the Coverage Combine
+job aborts with ``No source for code: .../agent.py``. That step runs under
+``bash -e``, so it fails the whole gate, Coverage Gate fails closed, and PR
+Readiness is blocked on every open PR.
+
+The omit globs in ``setup.cfg`` are the only thing standing between that
+failure and a red CI, and they are easy to get subtly wrong in both
+directions: too narrow and a new fixture directory name slips through, too
+broad and real source is silently excluded so the coverage gate passes while
+measuring nothing. Pin both directions here, against coverage.py's own
+matcher rather than a hand-rolled fnmatch.
+"""
+
+from configparser import ConfigParser
+from pathlib import Path
+
+import pytest
+
+SETUP_CFG = Path(__file__).resolve().parents[1] / "setup.cfg"
+
+# Phantom paths: what the isolation fixtures fabricate. Both directory names
+# really occur -- kirocrew-wt-example/ via _make_linked_worktree() and a plain
+# KiroCrew/ clone dir in test_does_not_decline_from_an_ordinary_clone.
+PHANTOM_PATHS = [
+    pytest.param(
+        "/tmp/pytest-of-runner/pytest-0/popen-gw0/"
+        "test_does_not_decline_from_an_0/KiroCrew/src/kiro_crew/agent.py",
+        id="ci-ordinary-clone",
+    ),
+    pytest.param(
+        "/tmp/pytest-of-runner/pytest-0/popen-gw0/"
+        "test_declines_0/kirocrew-wt-example/src/kiro_crew/agent.py",
+        id="ci-linked-worktree",
+    ),
+    pytest.param(
+        "/private/var/folders/ab/xyz/T/pytest-of-dev/pytest-3/"
+        "test_does_not_decline_from_an_0/KiroCrew/src/kiro_crew/agent.py",
+        id="macos-local-tmp",
+    ),
+]
+
+# Real source that must stay measured. The CI path is the trap: the repo is
+# checked out at /home/runner/work/KiroCrew/KiroCrew, so a "*/KiroCrew/*" glob
+# would omit the entire package and turn the coverage gate green on nothing.
+REAL_SOURCE_PATHS = [
+    pytest.param(
+        "/home/runner/work/KiroCrew/KiroCrew/src/kiro_crew/agent.py",
+        id="ci-checkout",
+    ),
+    pytest.param("/home/dev/src/KiroCrew/src/kiro_crew/agent.py", id="local-checkout"),
+]
+
+OMIT_SECTIONS = ["coverage:run", "coverage:report"]
+
+
+def _omit_patterns(section: str) -> list[str]:
+    parser = ConfigParser()
+    assert SETUP_CFG.is_file(), f"expected the coverage config at {SETUP_CFG}"
+    parser.read(SETUP_CFG)
+    raw = parser.get(section, "omit")
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def _matcher(section: str):
+    globs = pytest.importorskip("coverage.files")
+    return globs.GlobMatcher(_omit_patterns(section), "omit")
+
+
+def test_run_and_report_omit_lists_stay_in_sync() -> None:
+    """``[coverage:run] omit`` governs collection only; report needs its own.
+
+    Coverage Combine reads shards produced by the test job, so a pattern that
+    exists in one list and not the other still lets the phantom path abort the
+    report.
+    """
+    run_omit, report_omit = (_omit_patterns(s) for s in OMIT_SECTIONS)
+
+    assert run_omit == report_omit
+
+
+@pytest.mark.parametrize("section", OMIT_SECTIONS)
+@pytest.mark.parametrize("phantom", PHANTOM_PATHS)
+def test_phantom_fixture_paths_are_omitted(section: str, phantom: str) -> None:
+    assert _matcher(section).match(phantom), (
+        f"{phantom} would reach `coverage report` and abort the Coverage "
+        f"Combine job; [{section}] omit does not cover it"
+    )
+
+
+@pytest.mark.parametrize("section", OMIT_SECTIONS)
+@pytest.mark.parametrize("real", REAL_SOURCE_PATHS)
+def test_real_source_is_never_omitted(section: str, real: str) -> None:
+    assert not _matcher(section).match(real), (
+        f"[{section}] omit excludes real source at {real}; the coverage gate "
+        f"would pass while measuring nothing"
+    )


### PR DESCRIPTION
## The failure

`Coverage Combine` fails the whole gate when a shard's coverage data contains a
phantom path:

```
Combined data file .coverage.1 ... .coverage.4
No source for code: '/tmp/pytest-of-runner/pytest-0/popen-gw0/
  test_does_not_decline_from_an_0/KiroCrew/src/kiro_crew/agent.py'.
##[error]Process completed with exit code 1.
```

Several tests in `test/test_agent_home_isolation.py` monkeypatch
`kiro_crew.agent.__file__` to a fabricated checkout under pytest's tmp dir.
Nothing is ever written there, so `coverage report` cannot find the source and
exits non-zero. The step runs under `bash -e`, so `Coverage Gate` fails closed
and `PR Readiness` is blocked.

## Why the existing guard missed it

`setup.cfg` already knows about this failure mode and already carries a fix, but
it is keyed on **one fixture's directory name**:

```ini
omit =
    */kirocrew-wt-example/*
```

That is the name `_make_linked_worktree()` uses (about ten tests).
`test_does_not_decline_from_an_ordinary_clone` builds its fabricated checkout
under a plain `KiroCrew/` directory instead — the second and only other name in
that file — and it was never covered. Observed on #1565, where all 42 other
checks were green.

## The fix, and the trap it avoids

Anchor on pytest's tmp root rather than on fixture names: `*/pytest-of-*/*`.
Nothing real is ever measured from a pytest temporary directory, so this covers
both existing fixtures and any future one. The name-based entry stays as a
backstop for runs that override pytest's basetemp. Both omit lists are updated,
as the existing comment asks.

Extending the glob by name is the obvious fix and it is unsafe. Verified against
coverage 7.10.6's own `GlobMatcher` — the version the Coverage Combine job
installs:

| pattern | CI phantom (`KiroCrew/`) | CI phantom (`kirocrew-wt-example/`) | macOS local tmp | **CI real source** |
|---|---|---|---|---|
| `*/pytest-of-*/*` | match | match | match | no |
| `*/kirocrew-wt-example/*` | **no** (the gap) | match | no | no |
| `*/KiroCrew/*` | match | no | match | **match** |

CI checks the repo out at `/home/runner/work/KiroCrew/KiroCrew`, so
`*/KiroCrew/*` would omit the entire package and turn the coverage gate green
while measuring nothing.

## Tests

`test/test_coverage_config.py` is new, and nothing previously guarded these
globs. It parses `setup.cfg` and drives coverage.py's real matcher, pinning
three things:

- every phantom path shape the isolation fixtures fabricate is omitted (both
  directory names, plus the macOS local tmp layout);
- real source is **not** omitted, including the CI checkout path that makes a
  name-based glob dangerous;
- the `[coverage:run]` and `[coverage:report]` omit lists stay identical — the
  existing comment asks for this ("Keep both in sync") and nothing enforced it.

The phantom assertions fail on the pre-fix config, which is what makes them a
regression test rather than a restatement.

## Verification note

`setup.cfg` plus one new test file are the entire change — `git diff main` shows
no change under `src/` or `website/` at all, so mypy and the backend suite cannot
produce a different result on this branch than they do on `main`. Run locally:
isort, flake8, `scrub-lint --no-history`, the brand gate, and the new test
(11 passed). Rebased onto `main` after it advanced past the branch point. CI on
Linux is authoritative for everything else.
