### PR TITLE
fix(dev-fleet): find node where version managers install it

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -52,6 +52,7 @@ from aiohttp import web
 
 from kiro_crew import frontend, hooks, platform_compat
 from kiro_crew.apps.builtins.dev_fleet import gateway_service
+from kiro_crew.env import find_node_tool, node_bin_dirs
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_BUILD,
@@ -599,6 +600,58 @@ else:
     )
 _TRUSTED_PATH = os.pathsep.join(_TRUSTED_BIN_DIRS)
 _TRUSTED_BIN_CACHE: dict[str, str | None] = {}
+_BUILD_PATH_CACHE: str | None = None
+
+
+def _build_path() -> str:
+    """``_TRUSTED_PATH`` with the node toolchain dirs prepended.
+
+    BLOCKING: ``node_bin_dirs()`` walks the filesystem (globs + stats + one
+    small read). On an NFS-backed ``$HOME`` those are not microseconds, so this
+    must never be first-called on the event loop — it would stall every backend
+    request and health check behind one directory scan.
+
+    Callers on an async path therefore await :func:`_warm_build_path` first,
+    which resolves it on ``subprocess_executor()``. After that the underlying
+    resolver is ``lru_cache``d and this is a pure in-memory read, which is why
+    :func:`_build_env` can stay synchronous.
+    """
+    global _BUILD_PATH_CACHE
+    if _BUILD_PATH_CACHE is None:
+        _BUILD_PATH_CACHE = os.pathsep.join([*node_bin_dirs(), _TRUSTED_PATH])
+    return _BUILD_PATH_CACHE
+
+
+async def _warm_build_path() -> None:
+    """Resolve the node toolchain off the event loop, once per process.
+
+    Idempotent and cheap after the first call (a ``None`` check). Called from
+    ``dev_fleet_startup`` so the common case is warm before any request, and
+    again at the top of every async handler that constructs a build env — a
+    handler must not depend on startup having run (tests, and any future entry
+    point that skips it).
+    """
+    if _BUILD_PATH_CACHE is not None:
+        return
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(subprocess_executor(), _build_path)
+
+
+def _invalidate_toolchain_cache() -> None:
+    """Forget the memoized node-toolchain resolution.
+
+    Both layers are memoized for the process lifetime: ``node_bin_dirs()`` is
+    ``lru_cache``d and ``_BUILD_PATH_CACHE`` is filled once. That is right for a
+    hot path but wrong for a REMEDY: the "npm not found" banner tells the user to
+    run ``ensure-node.sh``, which writes the marker file this resolver reads — so
+    without dropping both caches a long-lived gateway would keep serving the same
+    error after the user had already fixed the host. Called only from the
+    not-found path, so a working resolution is never discarded.
+    """
+    global _BUILD_PATH_CACHE
+    _BUILD_PATH_CACHE = None
+    node_bin_dirs.cache_clear()
+
 
 # Upper bound on a propagated "sandbox unavailable" message. Wide enough to
 # carry the sandbox layer's remedy sentence (the actionable half, appended after
@@ -664,6 +717,32 @@ def _trusted_bin(name: str) -> str | None:
             break
     _TRUSTED_BIN_CACHE[name] = resolved
     return resolved
+
+
+def _toolchain_bin(name: str) -> str | None:
+    """Resolve a NODE-TOOLCHAIN executable (``npm``/``node``/``npx``).
+
+    Deliberately NOT ``_trusted_bin``. That function fails closed on anything
+    under ``$HOME`` or writable by us, because it resolves ``git``/``gh`` -- the
+    binaries that run in the CREDENTIAL-BEARING standard tier, where a planted
+    shim would exfiltrate the operator's token. npm is a different case in both
+    directions:
+
+    * It is only ever spawned in the ``strict`` tier under
+      :func:`_build_env` (no credential helpers), and it already executes
+      worktree-controlled ``package.json`` scripts -- arbitrary code, by design.
+      Requiring a system-owned npm buys nothing there.
+    * Kiro Crew's own supported installer (``install.sh --mise`` /
+      ``ensure-node.sh``) puts node under ``$HOME``, so ``_trusted_bin`` returned
+      ``None`` for npm on exactly the hosts Kiro Crew set up itself, and Pull+Build
+      failed with "no trusted executable for 'npm'".
+
+    Managed toolchain first, system npm second: a distribution's node can be
+    older than ``website/package.json``'s ``engines`` (Amazon Linux 2023 ships
+    node 18 against ``20 || >=22``), while ``ensure-node.sh`` installs a version
+    chosen to satisfy the build.
+    """
+    return find_node_tool(name, _TRUSTED_PATH) or _trusted_bin(name)
 
 
 async def _run_cmd(
@@ -1798,14 +1877,38 @@ def _build_env(*, with_credentials: bool = False) -> dict:
     helper/sshCommand) for the sync ``git pull`` and any git a build step
     runs. Harmless for pip/npm.
 
-    Operator credential helpers are injected ONLY when ``with_credentials``
-    is set — reserved for the network fetch step. Build steps (pip/npm) run
+    Operator credential helpers are injected ONLY when ``with_credentials`` is
+    set — reserved for the network fetch step. Build steps (pip/npm) run
     worktree-controlled code and must never see a configured helper: a
     malicious install script could otherwise mint the operator's token via
     ``git credential fill``.
+
+    ``with_credentials`` ALSO selects the PATH, and that is a security boundary,
+    not a convenience:
+
+    * credential-free (default) — the node toolchain dirs are PREPENDED to the
+      trusted path. npm's own run-scripts (``tsc``, ``vite``) are
+      ``#!/usr/bin/env node``, so ``node`` has to resolve by NAME inside the
+      child; resolving only the ``npm`` argv would still fail at the first
+      script. Those dirs live under ``$HOME`` because that is where
+      ``ensure-node.sh`` installs node.
+    * with credentials — the pinned ``_TRUSTED_PATH`` only. The fetch step's
+      argv is an already-vetted absolute ``git``, but git looks its OWN helpers
+      up (``git-remote-https``, credential helpers) on PATH, so a
+      same-user-writable directory there would be a path to intercepting a
+      credential-bearing fetch. Never widen this side.
+
+    Scope of that guarantee, precisely: this ternary is what enforces it for the
+    callers that spawn DIRECTLY (the ``raw_steps`` list, ``_pod_provision``,
+    ``_start_run``). Callers that route through :func:`_run_cmd` are covered by
+    a second, independent mechanism — ``_run_cmd`` overwrites PATH with
+    ``_TRUSTED_PATH`` unconditionally, BEFORE it injects any credential helper —
+    so on that path a node-augmented PATH from :func:`_pod_env` is discarded and
+    never coexists with credentials. Both mechanisms must keep holding; do not
+    remove one on the assumption that the other covers it.
     """
     out = {k: v for k, v in os.environ.items() if k in _SAFE_ENV_KEYS}
-    out["PATH"] = _TRUSTED_PATH
+    out["PATH"] = _TRUSTED_PATH if with_credentials else _build_path()
     out.update(_GIT_ENV_NEUTRALIZERS)
     if with_credentials and _GIT_TRUSTED_HELPERS:
         out.update(_GIT_TRUSTED_HELPERS)
@@ -1921,6 +2024,9 @@ async def _pod_up(name: str) -> dict:
     guard = await _pod_checkout_guard(name)
     if guard:
         return {"ok": False, "error": guard}
+    # Resolve the node toolchain off the loop before building the pod env:
+    # `pod up` runs the provision chain (npm ci + vite) when asked to.
+    await _warm_build_path()
     cmd = _find_cli() + ["pod", "up", name, "--json"]
     rc, stdout, stderr = await _run_cmd(cmd, cwd=MAIN_REPO, env=_pod_env(), timeout=180)
     if rc != 0:
@@ -1953,6 +2059,7 @@ async def _pod_down(name: str) -> dict:
     guard = await _pod_checkout_guard(name)
     if guard:
         return {"ok": False, "error": guard}
+    await _warm_build_path()
     cmd = _find_cli() + ["pod", "down", name]
     rc, stdout, stderr = await _run_cmd(cmd, cwd=MAIN_REPO, env=_pod_env(), timeout=30)
     if rc != 0:
@@ -2040,6 +2147,7 @@ async def _pod_provision(name: str) -> dict:
                 running = _RUNS.get(prev, {}).get("status") == "running"
             if running:
                 return {"ok": False, "error": "provision already running", "run_id": prev}
+        await _warm_build_path()
         loop = asyncio.get_running_loop()
         p_argv, p_env, p_cleanup = await loop.run_in_executor(
             subprocess_executor(),
@@ -2303,6 +2411,7 @@ async def _sync_start_locked() -> dict:
     """Start the sync run. Caller holds _SYNC_LOCK."""
     global _SYNC_RID  # noqa: F824 (assigned below after await)
 
+    await _warm_build_path()
     head = await _git(MAIN_REPO, "symbolic-ref", "--short", "HEAD")
     if head is None:
         return {"ok": False, "error": "cannot determine checked-out branch (git failed)"}
@@ -2324,12 +2433,38 @@ async def _sync_start_locked() -> dict:
             "main checkout has no .venv — provision it first "
             f"(expected under {Path(MAIN_REPO) / '.venv'})"
         )}
-    git_bin = _trusted_bin("git")
-    npm_bin = _trusted_bin("npm")
-    if git_bin is None or npm_bin is None:
-        missing = "git" if git_bin is None else "npm"
+    # Both binary lookups stat the filesystem (`_trusted_bin` walks the trusted
+    # dirs; `_toolchain_bin` adds a `shutil.which` over the node bin dirs, which
+    # may be NFS-backed). Resolve them together on the executor so /api/sync
+    # cannot stall the gateway's requests and liveness behind a directory scan.
+    loop = asyncio.get_running_loop()
+    git_bin, npm_bin = await loop.run_in_executor(
+        subprocess_executor(),
+        lambda: (_trusted_bin("git"), _toolchain_bin("npm")),
+    )
+    if git_bin is None:
         return {"ok": False, "error": (
-            f"no trusted executable for {missing!r} in {_TRUSTED_PATH}"
+            f"no trusted executable for 'git' in {_TRUSTED_PATH}"
+        )}
+    if npm_bin is None:
+        # Drop the memoized resolution so the remedy this message advertises
+        # actually works. `node_bin_dirs()` is lru_cached and `_BUILD_PATH_CACHE`
+        # is set once per process, so in a long-lived gateway a user who ran
+        # ensure-node.sh and hit Pull+build again would get this SAME error --
+        # the marker file is never re-read. Invalidating on the failure path
+        # makes the retry fresh. Only on failure: a successful resolution is
+        # worth keeping cached, and this path is user-initiated, not a loop.
+        _invalidate_toolchain_cache()
+        return {"ok": False, "error": (
+            "npm not found. Kiro Crew looks for a Node toolchain in "
+            "<data-home>/node-bin-dir (written by ensure-node.sh), then in "
+            "mise / asdf / nvm / fnm / volta install dirs, then in "
+            f"{_TRUSTED_PATH}. Fix: run `bash ensure-node.sh` in the main "
+            "checkout and press Pull + build again — no restart needed. To point "
+            "at a toolchain by hand instead, set "
+            "KIROCREW_NODE_BIN_DIR=/abs/path/to/node/bin in the gateway's "
+            "service environment; that one does need a restart, because a "
+            "running process cannot see a new environment variable."
         )}
     raw_steps: list[tuple[list[str], str, dict, str]] = [
         ([git_bin, "fetch", remote, BASE_BRANCH], "standard",
@@ -3021,6 +3156,9 @@ async def dev_fleet_startup(app: web.Application) -> None:
     await _load_trusted_credential_helpers()
     await _load_fallback_repos()
     await _upstream_remote()
+    # Resolve the node build toolchain here, on the executor, so no request
+    # handler ever pays for the filesystem scan (NFS homes make it slow).
+    await _warm_build_path()
     if _refresher_task is None or _refresher_task.done():
         _refresher_task = asyncio.create_task(_status_refresher())
     if _reaper_task is None or _reaper_task.done():

--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -15,6 +15,7 @@ from collections.abc import MutableMapping
 from pathlib import Path
 
 from kiro_crew import platform_compat
+from kiro_crew.config.paths import data_home
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,224 @@ def _node_version_manager_bins(home: str) -> list[str]:
             if bin_dir.is_dir():
                 bins.append(str(bin_dir))
     return bins
+
+
+# --- node build toolchain -----------------------------------------------------
+#
+# Directories a Node VERSION MANAGER installs a real ``node``/``npm`` into.
+# Deliberately NARROW and separate from ``_EXTRA_PATH_DIRS``: that list is a
+# broad "where might an MCP binary live" search path (it includes
+# ``~/.local/bin`` and, via :func:`augmented_path`, the running interpreter's
+# own ``bin``). Build callers prepend these entries to a PINNED PATH, so
+# reusing the broad list would defeat the pinning.
+#
+# Candidates are generous on purpose -- each is validated by probing for an
+# executable ``node`` inside it, so a layout guess that does not exist on this
+# host simply drops out instead of polluting PATH.
+_NODE_MANAGER_GLOBS = (
+    # mise -- the manager ``install.sh --mise`` and ``ensure-node.sh`` use.
+    "{mise_data}/installs/node/*/bin",
+    # asdf's nodejs plugin.
+    "{home}/.asdf/installs/nodejs/*/bin",
+    # nvm.
+    "{home}/.nvm/versions/node/*/bin",
+    # fnm, both layouts: XDG default and legacy ``~/.fnm``.
+    "{home}/.local/share/fnm/node-versions/*/installation/bin",
+    "{home}/.fnm/node-versions/*/installation/bin",
+)
+# Shim / single-dir managers, which have no per-version path to glob.
+# Two of these (mise shims, volta) also appear in ``_EXTRA_PATH_DIRS`` above.
+# The repetition is deliberate, not an oversight: that list is the broad
+# MCP-binary search path and this one is the narrow build toolchain, and entries
+# here are additionally gated on actually containing an executable ``node``. If
+# a manager moves its shim dir, BOTH lists need editing.
+_NODE_MANAGER_DIRS = (
+    "{mise_data}/shims",
+    "{home}/.volta/bin",
+    "{home}/n/bin",
+)
+# Marker file written by ``ensure-node.sh`` recording the node bin dir it
+# resolved. The Makefile already consumes it; this keeps Python callers on the
+# same answer instead of re-deriving one.
+_NODE_BIN_DIR_MARKER = "node-bin-dir"
+# Operator escape hatch: an explicit absolute node bin dir, for hosts whose
+# toolchain lives somewhere none of the layouts above cover.
+_NODE_BIN_DIR_ENV = "KIROCREW_NODE_BIN_DIR"
+
+
+def _mise_data_dir(home: str) -> str:
+    """mise's data dir, honouring ``MISE_DATA_DIR`` then ``XDG_DATA_HOME``."""
+    explicit = os.environ.get("MISE_DATA_DIR")
+    if explicit:
+        return explicit
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = xdg if xdg else os.path.join(home, ".local", "share")
+    return os.path.join(base, "mise")
+
+
+def _has_node(d: Path) -> bool:
+    """True when *d* holds an executable ``node``.
+
+    This is the definition of "a node bin dir", and it is what lets the
+    candidate lists above stay generous: a directory that does not actually
+    provide node is not one.
+    """
+    names = ("node.exe", "node") if platform_compat.IS_WINDOWS else ("node",)
+    return any(platform_compat.is_executable_file(d / n) for n in names)
+
+
+def _node_version_key(name: str) -> tuple[int, tuple[int, ...], str]:
+    """Sort key ranking a manager's version directory, highest/most-specific first.
+
+    Version managers create ALIAS directories beside the real installs (mise
+    alone has ``lts``, ``latest``, ``lts-jod``, plus truncations like ``22`` next
+    to ``22.22.2``). Plain reverse-lexicographic order puts ``lts-krypton`` above
+    ``24.16.0``, so the "newest" pick would be an arbitrary alias name. Rank
+    parseable versions above unparseable aliases and compare them numerically.
+    """
+    stripped = name[1:] if name[:1] in ("v", "V") else name
+    parts = stripped.split(".")
+    if parts and all(p.isdigit() for p in parts):
+        return (1, tuple(int(p) for p in parts), name)
+    return (0, (), name)
+
+
+def _validated_bin_dir(val: str) -> str | None:
+    """Accept *val* as a single absolute bin directory, else ``None``.
+
+    Used by BOTH untrusted-ish sources of a bin dir -- the
+    ``KIROCREW_NODE_BIN_DIR`` override and the ``ensure-node.sh`` marker file --
+    so they cannot drift apart. Each names ONE directory; a value carrying a path
+    separator would smuggle extra entries into every PATH built from it, so it is
+    rejected rather than split. (``os.path.isabs("/a:/b")`` is True on POSIX, so
+    the absolute check alone does not catch that.)
+    """
+    val = val.strip()
+    if not val or os.pathsep in val or "\0" in val or not os.path.isabs(val):
+        return None
+    return val
+
+
+def _marker_node_bin_dir() -> str | None:
+    """Read the node bin dir recorded by ``ensure-node.sh``, or ``None``."""
+    try:
+        raw = (data_home() / _NODE_BIN_DIR_MARKER).read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    return _validated_bin_dir(raw.strip().splitlines()[0] if raw.strip() else "")
+
+
+@functools.lru_cache(maxsize=1)
+def node_bin_dirs() -> tuple[str, ...]:
+    """Directories holding a version-manager-installed node, best first.
+
+    Resolution order, most specific first:
+
+    1. ``KIROCREW_NODE_BIN_DIR`` -- explicit operator override.
+    2. ``<data-home>/node-bin-dir`` -- the marker ``ensure-node.sh`` writes
+       after installing/locating node. Preferred over a bare filesystem scan
+       because it names the version that script decided on.
+    3. The highest version found under each per-version manager root
+       (mise / asdf / nvm / fnm).
+    4. Shim dirs (mise shims, volta, n).
+
+    Every entry is verified to contain an executable ``node``, so the result is
+    only ever real toolchain directories. Only the BEST version per manager root
+    is returned: these entries go on the PATH of build subprocesses, and mise
+    alone can contribute ~18 install and alias directories on a developer box --
+    a PATH that long slows every exec lookup and buries the intended toolchain
+    behind stale majors (node 16/18 against a ``20 || >=22`` engines field).
+
+    Why this exists: ``install.sh --mise`` and ``ensure-node.sh`` -- the
+    supported install path -- put node under ``$HOME``. A non-login gateway
+    (systemd / launchd) does not inherit those on ``$PATH``, and build callers
+    additionally pin PATH to system dirs, so without this the build cannot see
+    the very node Kiro Crew installed for it.
+
+    Cached for the process lifetime: the globs must run once, matching
+    :func:`_node_version_manager_bins`. A node installed while a long-lived
+    gateway is running is not seen until restart; call ``cache_clear()`` if it
+    ever needs re-discovery without one.
+    """
+    home = os.path.expanduser("~")
+    mise_data = _mise_data_dir(home)
+    ordered: list[str] = []
+
+    override = _validated_bin_dir(os.environ.get(_NODE_BIN_DIR_ENV, ""))
+    if override:
+        ordered.append(override)
+    marker = _marker_node_bin_dir()
+    if marker:
+        ordered.append(marker)
+
+    for pattern in _NODE_MANAGER_GLOBS:
+        root, _, leaf = pattern.format(home=home, mise_data=mise_data).partition("/*")
+        try:
+            matches = sorted(
+                (p for p in Path(root).glob("*" + leaf) if _has_node(p)),
+                # The version dir is the child of `root`; with a deeper leaf
+                # (fnm's `<ver>/installation/bin`) that is not p.parent, so
+                # index it off the root instead of walking up a fixed count.
+                key=lambda p: _node_version_key(p.relative_to(root).parts[0]),
+                reverse=True,
+            )
+        except (OSError, ValueError):
+            continue
+        if matches:
+            ordered.append(str(matches[0]))
+
+    ordered.extend(d.format(home=home, mise_data=mise_data) for d in _NODE_MANAGER_DIRS)
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for d in ordered:
+        # Normalize BEFORE the dedup check and before emitting. The glob branch
+        # yields `str(Path(...))` while the template branch yields the format
+        # string verbatim, so without this one function emits two spellings of
+        # the same directory -- on Windows "C:\home/.volta/bin" alongside
+        # "C:\home\.volta\bin". Windows tolerates forward slashes for filesystem
+        # calls (so the dir is still FOUND), but these strings are joined onto
+        # PATH and compared, and two spellings would also slip past `seen`.
+        d = os.path.normpath(d)
+        if d in seen:
+            continue
+        seen.add(d)
+        try:
+            if _has_node(Path(d)):
+                out.append(d)
+        except OSError:
+            continue
+    return tuple(out)
+
+
+def node_augmented_path(base_path: str = "") -> str:
+    """Return *base_path* with :func:`node_bin_dirs` PREPENDED.
+
+    Prepended, not appended: a distribution's system ``node`` can be older than
+    what ``website/package.json`` declares in ``engines`` (Amazon Linux 2023
+    ships node 18 against a ``20 || >=22`` requirement), whereas
+    ``ensure-node.sh`` installs a version chosen to satisfy the build. Where
+    both exist the managed toolchain is the one that works.
+    """
+    parts = [*node_bin_dirs()]
+    if base_path:
+        parts.append(base_path)
+    return os.pathsep.join(parts)
+
+
+def find_node_tool(name: str, base_path: str | None = None) -> str | None:
+    """Resolve a node-toolchain executable (``npm``, ``node``, ``npx``) absolutely.
+
+    Searches :func:`node_bin_dirs` first, then *base_path* (default: the
+    inherited ``PATH``). Returns ``None`` when the tool is nowhere -- callers
+    must surface an actionable message rather than spawning a bare name and
+    letting the OS raise ``FileNotFoundError``.
+
+    Absolute by design: on Windows npm is ``npm.CMD``, which PATHEXT-aware
+    ``shutil.which`` finds but ``CreateProcess`` cannot spawn by bare name.
+    """
+    base = os.environ.get("PATH", "") if base_path is None else base_path
+    return shutil.which(name, path=node_augmented_path(base))
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/kiro_crew/pod/provision.py
+++ b/src/kiro_crew/pod/provision.py
@@ -23,6 +23,7 @@ import sys
 from pathlib import Path
 
 from kiro_crew import platform_compat
+from kiro_crew.env import find_node_tool, node_augmented_path
 
 
 def _say(msg: str) -> None:
@@ -77,14 +78,48 @@ def has_dist(checkout: Path) -> bool:
     return dist_dir(checkout).is_dir()
 
 
-def _run(cmd: list[str], cwd: Path) -> int:
+def _run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> int:
     """Run a provisioning step, streaming its output to STDERR (so a concurrent
     ``pod up --json`` keeps a clean stdout). Returns the exit code."""
     _say(f"  $ {' '.join(cmd)}  (cwd={cwd})")
     # Redirect the child's stdout to our stderr so its chatter never lands on our
     # stdout; its own stderr passes through to stderr too.
-    cp = subprocess.run(cmd, cwd=str(cwd), stdout=sys.stderr)
+    cp = subprocess.run(cmd, cwd=str(cwd), stdout=sys.stderr, env=env)
     return cp.returncode
+
+
+def _npm_env() -> dict[str, str]:
+    """Environment for an npm step, with the node toolchain on ``PATH``.
+
+    Resolving the ``npm`` executable is not enough: npm spawns its own
+    run-scripts (``tsc``, ``vite``) whose shebang is ``#!/usr/bin/env node``, so
+    ``node`` must be findable by NAME inside the child too.
+    """
+    env = dict(os.environ)
+    env["PATH"] = node_augmented_path(env.get("PATH", ""))
+    return env
+
+
+def _npm_bin() -> str | None:
+    """Absolute path to ``npm``, or ``None`` with an actionable message emitted.
+
+    ``pod provision`` runs from whatever spawned it. A login shell has the user's
+    version manager active, but the Dev Fleet backend pins ``PATH`` to system bin
+    dirs, and a systemd/launchd gateway inherits no version manager at all --
+    so a bare ``["npm", ...]`` raised ``FileNotFoundError`` as an unhandled
+    traceback. Resolve explicitly and fail with a remedy instead.
+    """
+    npm = find_node_tool("npm")
+    if npm:
+        return npm
+    _say(
+        "FATAL: npm not found. Kiro Crew looks for a Node toolchain in "
+        "<data-home>/node-bin-dir (written by ensure-node.sh), then in "
+        "mise / asdf / nvm / fnm / volta install dirs, then on PATH.\n"
+        "  Fix: run `bash ensure-node.sh` in the main checkout to install "
+        "Node, or set KIROCREW_NODE_BIN_DIR=/abs/path/to/node/bin."
+    )
+    return None
 
 
 def ensure_venv(checkout: Path) -> bool:
@@ -144,15 +179,19 @@ def ensure_node_modules(website: Path) -> bool:
     re-provisioning stays fast. Returns True when deps are ready."""
     if _has_node_modules(website):
         return True
+    npm = _npm_bin()
+    if npm is None:
+        return False
+    env = _npm_env()
     _say("[provision] installing website npm deps (node_modules missing)…")
-    if _run(["npm", "ci"], website) == 0:
+    if _run([npm, "ci"], website, env) == 0:
         return True
     _say(
         "[provision] `npm ci` failed (lockfile drift?) — falling back to "
         "`npm install --no-package-lock` (non-mutating: won't rewrite the "
         "tracked package-lock.json)"
     )
-    return _run(["npm", "install", "--no-package-lock"], website) == 0
+    return _run([npm, "install", "--no-package-lock"], website, env) == 0
 
 
 def build_dist(checkout: Path) -> bool:
@@ -174,7 +213,10 @@ def build_dist(checkout: Path) -> bool:
     if not ensure_node_modules(website):
         _say("FATAL: failed to install website npm deps")
         return False
-    if _run(["npm", "run", "build"], website) != 0:
+    npm = _npm_bin()
+    if npm is None:
+        return False
+    if _run([npm, "run", "build"], website, _npm_env()) != 0:
         _say("FATAL: npm run build failed")
         return False
     src_dist = website / "dist"

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -897,7 +897,13 @@ def test_build_env_excludes_credentials(monkeypatch):
     monkeypatch.setenv("HOME", "/home/u")
 
     env = mod._pod_env()
-    assert env["PATH"] == mod._TRUSTED_PATH  # pinned, never inherited
+    # Pinned, never inherited. The pin is _TRUSTED_PATH plus (in the
+    # credential-FREE tier only) the node toolchain dirs prepended, so that
+    # npm's `#!/usr/bin/env node` run-scripts resolve — see
+    # test_dev_fleet_node_toolchain.py for that boundary.
+    assert env["PATH"] != "/usr/bin"
+    assert mod._TRUSTED_PATH in env["PATH"]
+    assert env["PATH"].endswith(mod._TRUSTED_PATH)
     assert "SLACK_BOT_TOKEN" not in env
     assert "AWS_SECRET_ACCESS_KEY" not in env
 
@@ -907,6 +913,10 @@ def test_build_env_excludes_credentials(monkeypatch):
     benv = mod._build_env()
     assert "SLACK_BOT_TOKEN" not in benv
     assert "KIROCREW_POD_REPO" not in benv
+
+    # The credential-bearing tier keeps the bare pinned path — git resolves its
+    # own helpers (git-remote-https, credential helpers) through PATH.
+    assert mod._build_env(with_credentials=True)["PATH"] == mod._TRUSTED_PATH
 
 
 def test_read_pin_strict_rejects_symlinked_env(tmp_path):

--- a/test/test_dev_fleet_node_toolchain.py
+++ b/test/test_dev_fleet_node_toolchain.py
@@ -1,0 +1,327 @@
+"""Dev Fleet + pod provisioning must find a version-manager node toolchain.
+
+Two symptoms, one cause. ``_trusted_bin`` fails closed on anything under
+``$HOME`` — correct for ``git``/``gh``, which run in the credential-bearing
+tier — but Kiro Crew's own installer puts node under ``$HOME``, so:
+
+* Dev Fleet "Pull + build main" answered ``no trusted executable for 'npm'``;
+* ``kirocrew pod provision`` raised an unhandled ``FileNotFoundError: 'npm'``.
+
+The fix gives the node toolchain its own resolution tier. These tests pin the
+security boundary that makes that safe: the toolchain dirs reach the
+credential-FREE build environment only, never the credential-bearing one.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import kiro_crew.apps.builtins.dev_fleet.server as mod
+from kiro_crew.pod import provision as prov
+
+
+def _fake_node_bin(d: Path) -> Path:
+    d.mkdir(parents=True, exist_ok=True)
+    for name in ("node", "npm"):
+        f = d / name
+        f.write_text("#!/bin/sh\nexit 0\n")
+        f.chmod(0o755)
+    return d
+
+
+@pytest.fixture
+def node_dir(tmp_path, monkeypatch):
+    """A resolvable node bin dir, with the module's PATH memo reset."""
+    d = _fake_node_bin(tmp_path / "home" / ".local/share/mise/installs/node/22.0.0/bin")
+    monkeypatch.setattr(mod, "_BUILD_PATH_CACHE", None, raising=False)
+    monkeypatch.setattr(mod, "node_bin_dirs", lambda: (str(d),), raising=True)
+    yield d
+    monkeypatch.setattr(mod, "_BUILD_PATH_CACHE", None, raising=False)
+
+
+# --- the security boundary ---
+def test_credential_free_build_env_gets_the_node_toolchain(node_dir):
+    """npm run-scripts are `#!/usr/bin/env node`, so node must resolve by NAME."""
+    path = mod._build_env()["PATH"]
+    assert path.split(os.pathsep)[0] == str(node_dir)
+
+
+def test_credential_bearing_env_keeps_the_pinned_trusted_path(node_dir):
+    """git looks its OWN helpers up on PATH (git-remote-https, credential
+    helpers). A same-user-writable dir there is a route to intercepting a
+    credential-bearing fetch, so this side must never be widened."""
+    assert mod._build_env(with_credentials=True)["PATH"] == mod._TRUSTED_PATH
+    assert str(node_dir) not in mod._build_env(with_credentials=True)["PATH"]
+
+
+def test_the_two_environments_actually_differ(node_dir):
+    """Non-vacuity: if these ever collapse to the same string, the test above
+    passes for the wrong reason."""
+    assert mod._build_env()["PATH"] != mod._build_env(with_credentials=True)["PATH"]
+
+
+def test_credential_helpers_are_still_withheld_from_the_build_tier(node_dir):
+    """The PATH change must not have disturbed the pre-existing helper split."""
+    with patch.object(mod, "_GIT_TRUSTED_HELPERS", {"GIT_CONFIG_KEY_9": "credential.helper"}):
+        assert "GIT_CONFIG_KEY_9" not in mod._build_env()
+        assert "GIT_CONFIG_KEY_9" in mod._build_env(with_credentials=True)
+
+
+def test_build_path_still_contains_the_trusted_dirs(node_dir):
+    """Prepend, not replace: system git/coreutils a build step shells out to
+    must stay reachable."""
+    assert mod._TRUSTED_PATH in mod._build_path()
+
+
+def test_build_path_is_memoized(node_dir):
+    calls = []
+
+    def counting():
+        calls.append(1)
+        return (str(node_dir),)
+
+    with patch.object(mod, "node_bin_dirs", counting):
+        mod._BUILD_PATH_CACHE = None
+        mod._build_path()
+        mod._build_path()
+    assert len(calls) == 1
+
+
+def test_no_toolchain_leaves_the_build_path_unchanged(monkeypatch):
+    """A host with a system-only node must behave exactly as before."""
+    monkeypatch.setattr(mod, "_BUILD_PATH_CACHE", None, raising=False)
+    monkeypatch.setattr(mod, "node_bin_dirs", lambda: (), raising=True)
+    assert mod._build_path() == mod._TRUSTED_PATH
+    monkeypatch.setattr(mod, "_BUILD_PATH_CACHE", None, raising=False)
+
+
+# --- the filesystem scan must not run on the event loop ---
+def test_warm_build_path_resolves_off_the_event_loop(node_dir):
+    """node_bin_dirs() globs and stats. On an NFS-backed $HOME that is slow
+    enough to stall every backend request, so it must be resolved on the
+    executor, never inline on the loop."""
+    ran_on: list[str] = []
+
+    def tracking_dirs():
+        ran_on.append(threading.current_thread().name)
+        return (str(node_dir),)
+
+    async def go():
+        loop_thread = threading.current_thread().name
+        with patch.object(mod, "node_bin_dirs", tracking_dirs):
+            mod._BUILD_PATH_CACHE = None
+            await mod._warm_build_path()
+        return loop_thread
+
+    loop_thread = asyncio.run(go())
+    assert ran_on, "node_bin_dirs was never called — the warm did nothing"
+    assert ran_on[0] != loop_thread, (
+        f"the scan ran on the event-loop thread ({loop_thread})"
+    )
+    mod._BUILD_PATH_CACHE = None
+
+
+def test_warm_build_path_is_idempotent(node_dir):
+    """Called at the top of every async handler, so the warm-path check must be
+    free once resolved."""
+    calls = []
+
+    async def go():
+        with patch.object(mod, "node_bin_dirs", lambda: calls.append(1) or (str(node_dir),)):
+            mod._BUILD_PATH_CACHE = None
+            await mod._warm_build_path()
+            await mod._warm_build_path()
+
+    asyncio.run(go())
+    assert len(calls) == 1
+    mod._BUILD_PATH_CACHE = None
+
+
+@pytest.mark.parametrize("fn", [
+    "_pod_up", "_pod_down", "_pod_provision", "_sync_start_locked",
+])
+def test_every_async_build_env_caller_warms_first(fn):
+    """A handler must not depend on dev_fleet_startup having run — tests and any
+    future entry point that skips startup would otherwise scan on the loop."""
+    src = inspect.getsource(getattr(mod, fn))
+    assert "_warm_build_path()" in src, f"{fn} builds a build env without warming"
+
+
+def test_startup_warms_the_build_path():
+    assert "_warm_build_path()" in inspect.getsource(mod.dev_fleet_startup)
+
+
+# --- the advertised remedy must actually work on retry ---
+def test_invalidate_drops_both_cache_layers(node_dir):
+    """The banner says "run ensure-node.sh and press Pull + build again".
+
+    That is only true if BOTH memo layers are dropped: `_BUILD_PATH_CACHE` and
+    `node_bin_dirs`'s lru_cache. Leaving either one makes the remedy inert for
+    the long-lived gateway that printed it.
+    """
+    cleared: list[str] = []
+
+    class _Resolver:
+        def __call__(self):
+            return (str(node_dir),)
+
+        def cache_clear(self):
+            cleared.append("lru")
+
+    with patch.object(mod, "node_bin_dirs", _Resolver()):
+        mod._BUILD_PATH_CACHE = None
+        mod._build_path()
+        assert mod._BUILD_PATH_CACHE is not None
+        mod._invalidate_toolchain_cache()
+        assert mod._BUILD_PATH_CACHE is None, "_BUILD_PATH_CACHE not dropped"
+    assert cleared == ["lru"], "node_bin_dirs.cache_clear() was not called"
+
+
+def test_npm_not_found_path_invalidates_so_a_retry_rescans():
+    """Non-vacuity: the not-found branch must call the invalidator, and the
+    success branch must NOT (a working resolution is worth keeping)."""
+    src = inspect.getsource(mod._sync_start_locked)
+    head, _, tail = src.partition("if npm_bin is None:")
+    assert tail, "npm-not-found branch not found — test is stale"
+    assert "_invalidate_toolchain_cache()" in tail.split("raw_steps")[0]
+    assert "_invalidate_toolchain_cache()" not in head
+
+
+def test_npm_not_found_message_separates_the_two_remedies():
+    """ensure-node.sh works on retry; an env var needs a restart. Saying both
+    need a restart, or neither, is what made the original message wrong."""
+    src = inspect.getsource(mod._sync_start_locked)
+    assert "no restart needed" in src
+    assert "does need a restart" in src
+
+
+# --- npm resolution for Pull + build ---
+def test_toolchain_bin_finds_a_home_resident_npm(node_dir):
+    """The exact case _trusted_bin rejects, and the one Kiro Crew's own
+    installer creates."""
+    with patch.object(mod, "find_node_tool", return_value=str(node_dir / "npm")), \
+            patch.object(mod, "_trusted_bin", return_value=None):
+        assert mod._toolchain_bin("npm") == str(node_dir / "npm")
+
+
+def test_toolchain_bin_prefers_the_managed_toolchain_over_system_npm(node_dir):
+    """A distro node can be older than website/package.json's engines field
+    (AL2023 ships node 18 against `20 || >=22`); ensure-node.sh installs one
+    chosen to satisfy the build."""
+    with patch.object(mod, "find_node_tool", return_value=str(node_dir / "npm")), \
+            patch.object(mod, "_trusted_bin", return_value="/usr/bin/npm"):
+        assert mod._toolchain_bin("npm") == str(node_dir / "npm")
+
+
+def test_toolchain_bin_falls_back_to_the_trusted_system_binary():
+    with patch.object(mod, "find_node_tool", return_value=None), \
+            patch.object(mod, "_trusted_bin", return_value="/usr/bin/npm"):
+        assert mod._toolchain_bin("npm") == "/usr/bin/npm"
+
+
+def test_toolchain_bin_returns_none_when_nothing_resolves():
+    with patch.object(mod, "find_node_tool", return_value=None), \
+            patch.object(mod, "_trusted_bin", return_value=None):
+        assert mod._toolchain_bin("does-not-exist-anywhere") is None
+
+
+def test_toolchain_bin_searches_the_trusted_path_as_its_base():
+    """find_node_tool must not be handed the inherited service PATH, whose
+    leading entries are agent-writable."""
+    with patch.object(mod, "find_node_tool", return_value=None) as fnt, \
+            patch.object(mod, "_trusted_bin", return_value=None):
+        mod._toolchain_bin("npm")
+    assert fnt.call_args.args == ("npm", mod._TRUSTED_PATH)
+
+
+def test_git_resolution_is_untouched_by_the_toolchain_tier():
+    """The credential-bearing binaries keep the strict rule. Guards against a
+    later refactor routing git through _toolchain_bin."""
+    src = Path(mod.__file__).read_text()
+    assert '_toolchain_bin("git")' not in src
+    assert "_toolchain_bin('git')" not in src
+    assert '_toolchain_bin("gh")' not in src
+    assert "_toolchain_bin('gh')" not in src
+
+
+# --- pod provision ---
+def test_provision_passes_an_absolute_npm_and_a_node_path(tmp_path, monkeypatch):
+    website = tmp_path / "website"
+    website.mkdir()
+    node_bin = _fake_node_bin(tmp_path / "nb")
+    seen: list[tuple[list[str], dict | None]] = []
+
+    def fake_run(cmd, cwd, env=None):
+        seen.append((cmd, env))
+        return 0
+
+    monkeypatch.setattr(prov, "_has_node_modules", lambda w: False)
+    monkeypatch.setattr(prov, "find_node_tool", lambda n: str(node_bin / n))
+    monkeypatch.setattr(
+        prov, "node_augmented_path", lambda base: f"{node_bin}{os.pathsep}{base}"
+    )
+    monkeypatch.setattr(prov, "_run", fake_run)
+
+    assert prov.ensure_node_modules(website) is True
+    argv, env = seen[0]
+    assert argv[0] == str(node_bin / "npm")
+    assert os.path.isabs(argv[0])
+    assert env is not None
+    assert env["PATH"].split(os.pathsep)[0] == str(node_bin)
+
+
+def test_provision_reports_a_remedy_instead_of_raising(tmp_path, monkeypatch, capsys):
+    """Before the fix this surfaced as a raw FileNotFoundError traceback from
+    subprocess.Popen — no message, no remedy."""
+    website = tmp_path / "website"
+    website.mkdir()
+    monkeypatch.setattr(prov, "_has_node_modules", lambda w: False)
+    monkeypatch.setattr(prov, "find_node_tool", lambda n: None)
+
+    def exploding_run(cmd, cwd, env=None):  # pragma: no cover - must not run
+        raise AssertionError(f"must not spawn a bare name: {cmd}")
+
+    monkeypatch.setattr(prov, "_run", exploding_run)
+
+    assert prov.ensure_node_modules(website) is False
+    err = capsys.readouterr().err
+    assert "npm not found" in err
+    assert "ensure-node.sh" in err
+    assert "KIROCREW_NODE_BIN_DIR" in err
+
+
+def test_build_dist_bails_out_when_npm_is_unresolvable(tmp_path, monkeypatch):
+    checkout = tmp_path / "wt"
+    (checkout / "website").mkdir(parents=True)
+    monkeypatch.setattr(prov, "has_dist", lambda c: False)
+    monkeypatch.setattr(prov, "ensure_node_modules", lambda w: True)
+    monkeypatch.setattr(prov, "find_node_tool", lambda n: None)
+
+    def exploding_run(cmd, cwd, env=None):  # pragma: no cover - must not run
+        raise AssertionError(f"must not spawn a bare name: {cmd}")
+
+    monkeypatch.setattr(prov, "_run", exploding_run)
+    assert prov.build_dist(checkout) is False
+
+
+def test_run_without_env_still_inherits(tmp_path, monkeypatch):
+    """The new `env` parameter defaults to None so existing callers (venv/pip
+    steps) keep inheriting the parent environment unchanged."""
+    captured: dict = {}
+
+    class _CP:
+        returncode = 0
+
+    def fake_subprocess_run(cmd, cwd=None, stdout=None, env=None):
+        captured["env"] = env
+        return _CP()
+
+    monkeypatch.setattr(prov.subprocess, "run", fake_subprocess_run)
+    assert prov._run(["true"], tmp_path) == 0
+    assert captured["env"] is None

--- a/test/test_node_toolchain_resolution.py
+++ b/test/test_node_toolchain_resolution.py
@@ -1,0 +1,305 @@
+"""Node build-toolchain resolution.
+
+Kiro Crew's supported installer (``install.sh --mise`` / ``ensure-node.sh``)
+installs node under ``$HOME``. Callers that build the SPA pin ``PATH`` to system
+bin dirs for credential safety, so before this resolution existed they could not
+see the very node Kiro Crew installed for them: ``kirocrew pod provision`` died
+with an unhandled ``FileNotFoundError: 'npm'`` and Dev Fleet's Pull+Build
+reported "no trusted executable for 'npm'".
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import env as env_mod
+from kiro_crew import platform_compat
+
+
+def _fake_node_bin(d: Path) -> Path:
+    """Create *d* containing an executable ``node`` (and ``npm``).
+
+    Platform-faithful naming matters: on Windows a bare extensionless ``node``
+    is not an executable file, and real Windows toolchains ship ``node.exe`` /
+    ``npm.cmd`` — which is exactly what ``_has_node`` and ``shutil.which``
+    (via PATHEXT) look for. A POSIX-only fixture made every layout test here
+    report an empty result on Windows CI.
+    """
+    d.mkdir(parents=True, exist_ok=True)
+    names = ("node.exe", "npm.cmd") if platform_compat.IS_WINDOWS else ("node", "npm")
+    for name in names:
+        f = d / name
+        f.write_text("@echo off\n" if name.endswith(".cmd") else "#!/bin/sh\nexit 0\n")
+        f.chmod(0o755)
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """``node_bin_dirs`` is lru_cached for the process lifetime — reset per test."""
+    env_mod.node_bin_dirs.cache_clear()
+    yield
+    env_mod.node_bin_dirs.cache_clear()
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """A HOME with no version manager and no ensure-node.sh marker.
+
+    Sets USERPROFILE as well as HOME, and clears HOMEDRIVE/HOMEPATH: the
+    resolver calls ``os.path.expanduser("~")``, and on Windows that reads
+    USERPROFILE (then HOMEDRIVE+HOMEPATH) and **never HOME**. Patching only HOME
+    left the resolver scanning the runner's real profile — which has no version
+    managers — so every layout assertion below saw an empty result on Windows CI
+    while passing on POSIX.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
+    monkeypatch.delenv("KIROCREW_NODE_BIN_DIR", raising=False)
+    monkeypatch.delenv("MISE_DATA_DIR", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    # No marker file: point data_home at an empty dir.
+    monkeypatch.setattr(
+        env_mod, "_marker_node_bin_dir", lambda: None, raising=True
+    )
+    return home
+
+
+def test_isolated_home_actually_redirects_expanduser(isolated_home):
+    """Non-vacuity guard for the fixture itself: if expanduser stops following
+    it, every layout test silently degrades to scanning the real home."""
+    assert os.path.expanduser("~") == str(isolated_home)
+
+
+# --- the marker file ensure-node.sh writes ---
+def test_marker_dir_is_preferred_over_a_filesystem_scan(isolated_home, tmp_path, monkeypatch):
+    """ensure-node.sh records the version it decided on; that answer wins."""
+    mise_node = isolated_home / ".local/share/mise/installs/node"
+    _fake_node_bin(mise_node / "24.0.0" / "bin")
+    marker_dir = _fake_node_bin(tmp_path / "chosen" / "bin")
+    monkeypatch.setattr(
+        env_mod, "_marker_node_bin_dir", lambda: str(marker_dir), raising=True
+    )
+
+    dirs = env_mod.node_bin_dirs()
+    assert dirs[0] == str(marker_dir)
+    # The scan still contributes, so a stale marker is not the only chance.
+    assert str(mise_node / "24.0.0" / "bin") in dirs
+
+
+def test_marker_carrying_a_path_separator_is_rejected(tmp_path, monkeypatch):
+    """A multi-entry value would smuggle extra dirs into every PATH built from it."""
+    home = tmp_path / "dh"
+    home.mkdir()
+    (home / "node-bin-dir").write_text(f"/opt/a/bin{os.pathsep}/tmp/evil/bin\n")
+    monkeypatch.setattr(env_mod, "data_home", lambda: home, raising=True)
+    assert env_mod._marker_node_bin_dir() is None
+
+
+def test_relative_marker_is_rejected(tmp_path, monkeypatch):
+    home = tmp_path / "dh"
+    home.mkdir()
+    (home / "node-bin-dir").write_text("relative/bin\n")
+    monkeypatch.setattr(env_mod, "data_home", lambda: home, raising=True)
+    assert env_mod._marker_node_bin_dir() is None
+
+
+def test_absolute_marker_first_line_is_taken(tmp_path, monkeypatch):
+    home = tmp_path / "dh"
+    home.mkdir()
+    (home / "node-bin-dir").write_text("/opt/node/bin\ntrailing junk\n")
+    monkeypatch.setattr(env_mod, "data_home", lambda: home, raising=True)
+    assert env_mod._marker_node_bin_dir() == "/opt/node/bin"
+
+
+def test_missing_marker_is_not_an_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(env_mod, "data_home", lambda: tmp_path / "nope", raising=True)
+    assert env_mod._marker_node_bin_dir() is None
+
+
+# --- operator override ---
+def test_env_override_wins(isolated_home, tmp_path, monkeypatch):
+    override = _fake_node_bin(tmp_path / "operator" / "bin")
+    monkeypatch.setenv("KIROCREW_NODE_BIN_DIR", str(override))
+    assert env_mod.node_bin_dirs()[0] == str(override)
+
+
+def test_relative_env_override_is_ignored(isolated_home, monkeypatch):
+    monkeypatch.setenv("KIROCREW_NODE_BIN_DIR", "some/relative/bin")
+    assert "some/relative/bin" not in env_mod.node_bin_dirs()
+
+
+def test_env_override_carrying_a_path_separator_is_rejected(isolated_home, monkeypatch):
+    """The override and the marker must validate IDENTICALLY.
+
+    `os.path.isabs("/a:/b")` is True on POSIX, so an absolute-only check would
+    let the override contribute two PATH entries where the marker refuses one.
+    """
+    monkeypatch.setenv("KIROCREW_NODE_BIN_DIR", f"/opt/a/bin{os.pathsep}/tmp/evil/bin")
+    assert env_mod.node_bin_dirs() == ()
+
+
+@pytest.mark.parametrize("bad", [
+    "",
+    "   ",
+    "relative/bin",
+    "/opt/a/bin:/tmp/evil/bin" if os.pathsep == ":" else "/opt/a/bin;/tmp/evil",
+    "/opt/\0/bin",
+])
+def test_validated_bin_dir_rejects(bad):
+    assert env_mod._validated_bin_dir(bad) is None
+
+
+def test_validated_bin_dir_accepts_and_strips():
+    assert env_mod._validated_bin_dir("  /opt/node/bin  ") == "/opt/node/bin"
+
+
+def test_data_home_is_imported_at_module_scope():
+    """The marker read uses a top-level import (AUTOSDE `top-level-imports`).
+
+    Proven by attribute presence rather than by reading the source: a reverted
+    lazy import would leave `env.data_home` undefined.
+    """
+    assert callable(env_mod.data_home)
+
+
+# --- version selection ---
+def test_only_the_best_version_per_root_is_returned(isolated_home):
+    """~18 mise install+alias dirs on a real box would bury the right toolchain."""
+    root = isolated_home / ".local/share/mise/installs/node"
+    for name in ("16.20.2", "18", "22.22.2", "24.16.0", "lts", "lts-krypton", "latest"):
+        _fake_node_bin(root / name / "bin")
+
+    dirs = env_mod.node_bin_dirs()
+    mise_entries = [d for d in dirs if str(root) in d]
+    assert mise_entries == [str(root / "24.16.0" / "bin")]
+
+
+def test_numeric_versions_outrank_alias_names(isolated_home):
+    """Reverse-lexicographic order would pick 'lts-krypton' over '24.16.0'."""
+    root = isolated_home / ".local/share/mise/installs/node"
+    _fake_node_bin(root / "lts-krypton" / "bin")
+    _fake_node_bin(root / "24.16.0" / "bin")
+    assert env_mod.node_bin_dirs()[0] == str(root / "24.16.0" / "bin")
+
+
+def test_version_key_orders_numerically_not_lexicographically():
+    assert env_mod._node_version_key("22.0.0") > env_mod._node_version_key("9.9.9")
+    assert env_mod._node_version_key("20.1.0") > env_mod._node_version_key("lts")
+    assert env_mod._node_version_key("v18.1.0") > env_mod._node_version_key("v9.1.0")
+
+
+# --- validation: a dir is a node bin dir only if it provides node ---
+def test_dir_without_node_is_dropped(isolated_home):
+    root = isolated_home / ".local/share/mise/installs/node"
+    (root / "22.0.0" / "bin").mkdir(parents=True)  # empty: no node
+    assert env_mod.node_bin_dirs() == ()
+
+
+@pytest.mark.skipif(
+    platform_compat.IS_WINDOWS,
+    reason="asserts POSIX execute-bit semantics; Windows has no x bit, so an "
+           "existing .exe is executable regardless of mode",
+)
+def test_non_executable_node_is_dropped(isolated_home):
+    d = isolated_home / ".local/share/mise/installs/node/22.0.0/bin"
+    d.mkdir(parents=True)
+    (d / "node").write_text("not executable")
+    (d / "node").chmod(0o644)
+    assert env_mod.node_bin_dirs() == ()
+
+
+def test_no_toolchain_anywhere_returns_empty(isolated_home):
+    assert env_mod.node_bin_dirs() == ()
+
+
+# --- other managers ---
+@pytest.mark.parametrize("layout", [
+    ".asdf/installs/nodejs/{v}/bin",
+    ".nvm/versions/node/{v}/bin",
+    ".local/share/fnm/node-versions/{v}/installation/bin",
+    ".fnm/node-versions/{v}/installation/bin",
+])
+def test_each_version_manager_layout_is_found(isolated_home, layout):
+    d = _fake_node_bin(isolated_home / layout.format(v="v20.1.0"))
+    assert str(d) in env_mod.node_bin_dirs()
+
+
+@pytest.mark.parametrize("layout", [
+    ".local/share/mise/shims",
+    ".volta/bin",
+    "n/bin",
+])
+def test_shim_dirs_are_found(isolated_home, layout):
+    d = _fake_node_bin(isolated_home / layout)
+    assert str(d) in env_mod.node_bin_dirs()
+
+
+def test_returned_paths_are_os_normalized(isolated_home):
+    """Every entry must use the platform's own separator.
+
+    The static-dir templates are written with forward slashes, so without
+    normalization Windows emitted "C:\\home/.volta/bin" while the glob branch
+    emitted "C:\\home\\.volta\\bin" — two spellings of one directory from one
+    function. They land on PATH and are compared, so this is not cosmetic.
+    """
+    _fake_node_bin(isolated_home / ".volta" / "bin")
+    _fake_node_bin(isolated_home / ".local/share/mise/installs/node/22.0.0/bin")
+    dirs = env_mod.node_bin_dirs()
+    assert dirs
+    for d in dirs:
+        assert d == os.path.normpath(d), f"not normalized: {d!r}"
+    if os.sep == "\\":
+        assert not any("/" in d for d in dirs)
+
+
+def test_duplicate_spellings_collapse(isolated_home, monkeypatch):
+    """Normalizing before the dedup check is what makes `seen` effective."""
+    d = _fake_node_bin(isolated_home / ".volta" / "bin")
+    monkeypatch.setenv("KIROCREW_NODE_BIN_DIR", str(d) + os.sep + ".")
+    dirs = env_mod.node_bin_dirs()
+    assert dirs.count(os.path.normpath(str(d))) == 1
+
+
+def test_mise_data_dir_env_is_honoured(isolated_home, tmp_path, monkeypatch):
+    monkeypatch.setenv("MISE_DATA_DIR", str(tmp_path / "custom-mise"))
+    d = _fake_node_bin(tmp_path / "custom-mise" / "installs/node/22.0.0/bin")
+    assert str(d) in env_mod.node_bin_dirs()
+
+
+def test_xdg_data_home_is_honoured(isolated_home, tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    d = _fake_node_bin(tmp_path / "xdg" / "mise" / "installs/node/22.0.0/bin")
+    assert str(d) in env_mod.node_bin_dirs()
+
+
+# --- PATH composition ---
+def test_node_augmented_path_prepends(isolated_home):
+    """Prepended, not appended: a distro's node 18 must not shadow a managed 22."""
+    d = _fake_node_bin(isolated_home / ".volta" / "bin")
+    out = env_mod.node_augmented_path("/usr/bin:/bin")
+    assert out.split(os.pathsep)[0] == str(d)
+    assert out.endswith("/usr/bin:/bin")
+
+
+def test_node_augmented_path_with_empty_base_has_no_empty_entry(isolated_home):
+    _fake_node_bin(isolated_home / ".volta" / "bin")
+    assert "" not in env_mod.node_augmented_path("").split(os.pathsep)
+
+
+def test_find_node_tool_returns_absolute_path(isolated_home):
+    d = _fake_node_bin(isolated_home / ".volta" / "bin")
+    found = env_mod.find_node_tool("npm", "")
+    assert found is not None
+    assert os.path.isabs(found)
+    assert Path(found).parent == d
+
+
+def test_find_node_tool_returns_none_when_absent(isolated_home):
+    assert env_mod.find_node_tool("npm", "") is None

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -24,6 +24,30 @@ from kiro_crew.pod.config import (
     PodConfig,
 )
 
+# Stand-in for a version-manager node bin dir (mise/nvm/fnm/volta/asdf install
+# under $HOME). Provisioning resolves ``npm`` to an absolute path there.
+NODE_BIN = "/fake/node/bin"
+
+
+def _npm(*args: str) -> list[str]:
+    """The argv provisioning is expected to spawn for an npm step."""
+    return [f"{NODE_BIN}/npm", *args]
+
+
+@pytest.fixture(autouse=True)
+def _fake_node_toolchain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin node-toolchain resolution so provisioning tests are host-independent.
+
+    ``provision`` now resolves ``npm`` to an absolute path and hands the child a
+    PATH carrying the node bin dir (npm run-scripts are ``#!/usr/bin/env node``).
+    Without this fixture the tests below would pass or fail according to whether
+    the host running them happens to have a version manager installed.
+    """
+    monkeypatch.setattr(prov, "find_node_tool", lambda name: f"{NODE_BIN}/{name}")
+    monkeypatch.setattr(
+        prov, "node_augmented_path", lambda base="": f"{NODE_BIN}{os.pathsep}{base}"
+    )
+
 
 @pytest.fixture(autouse=True)
 def _systemd_backend(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -350,7 +374,7 @@ class TestProvisionBuildPaths:
         co.mkdir()
         monkeypatch.setattr(prov, "_find_python", lambda version="3.12": "/usr/bin/python3.12")
 
-        def fake_run(cmd: list[str], cwd: Path) -> int:
+        def fake_run(cmd: list[str], cwd: Path, env: dict | None = None) -> int:
             if cmd[1:3] == ["-m", "venv"]:
                 b = prov.venv_bin(co)
                 b.parent.mkdir(parents=True, exist_ok=True)
@@ -371,7 +395,7 @@ class TestProvisionBuildPaths:
         co = tmp_path / "wt"
         (co / "website").mkdir(parents=True)
 
-        def fake_run(cmd: list[str], cwd: Path) -> int:
+        def fake_run(cmd: list[str], cwd: Path, env: dict | None = None) -> int:
             (co / "website" / "dist").mkdir(parents=True, exist_ok=True)
             (co / "website" / "dist" / "index.html").write_text("<html>")
             return 0
@@ -390,7 +414,7 @@ class TestProvisionBuildPaths:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         co = _ready_worktree(tmp_path, "wt", venv=False, dist=True)
-        monkeypatch.setattr(prov, "_run", lambda cmd, cwd: 99)  # must not be called
+        monkeypatch.setattr(prov, "_run", lambda cmd, cwd, env=None: 99)  # must not be called
         assert prov.build_dist(co) is True
 
     def test_provision_full_chain(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -414,7 +438,7 @@ class TestProvisionDependencyInstall:
         """Return a fake _run that records calls and materializes the venv bin on
         `python -m venv`, so has_venv() passes. Optionally fail `--group` cmds."""
 
-        def fake_run(cmd: list[str], cwd: Path) -> int:
+        def fake_run(cmd: list[str], cwd: Path, env: dict | None = None) -> int:
             calls.append(cmd)
             if cmd[1:3] == ["-m", "venv"]:
                 # Materialize the venv entry point at the layout THIS platform
@@ -437,11 +461,11 @@ class TestProvisionDependencyInstall:
         website = tmp_path / "wt" / "website"
         website.mkdir(parents=True)
         calls: list[list[str]] = []
-        monkeypatch.setattr(prov, "_run", lambda cmd, cwd: calls.append(cmd) or 0)
+        monkeypatch.setattr(prov, "_run", lambda cmd, cwd, env=None: calls.append(cmd) or 0)
         assert prov.ensure_node_modules(website) is True
-        assert ["npm", "ci"] in calls
+        assert _npm("ci") in calls
         # ci succeeded → no fallback (non-mutating install never runs)
-        assert ["npm", "install", "--no-package-lock"] not in calls
+        assert _npm("install", "--no-package-lock") not in calls
 
     def test_node_modules_skipped_when_present(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -450,7 +474,7 @@ class TestProvisionDependencyInstall:
         (website / "node_modules" / ".bin").mkdir(parents=True)
         (website / "node_modules" / ".bin" / "tsc").write_text("#!/bin/sh\n")
 
-        def boom(cmd: list[str], cwd: Path) -> int:
+        def boom(cmd: list[str], cwd: Path, env: dict | None = None) -> int:
             raise AssertionError(f"must not run npm when node_modules present: {cmd}")
 
         monkeypatch.setattr(prov, "_run", boom)
@@ -463,17 +487,17 @@ class TestProvisionDependencyInstall:
         website.mkdir(parents=True)
         calls: list[list[str]] = []
 
-        def fake_run(cmd: list[str], cwd: Path) -> int:
+        def fake_run(cmd: list[str], cwd: Path, env: dict | None = None) -> int:
             calls.append(cmd)
-            return 1 if cmd == ["npm", "ci"] else 0  # ci fails, install succeeds
+            return 1 if cmd == _npm("ci") else 0  # ci fails, install succeeds
 
         monkeypatch.setattr(prov, "_run", fake_run)
         assert prov.ensure_node_modules(website) is True
         # Fallback must be NON-MUTATING: --no-package-lock so the tracked
         # website/package-lock.json is never rewritten (would dirty the worktree).
-        assert ["npm", "ci"] in calls
-        assert ["npm", "install", "--no-package-lock"] in calls
-        assert ["npm", "install"] not in calls  # plain (mutating) install never runs
+        assert _npm("ci") in calls
+        assert _npm("install", "--no-package-lock") in calls
+        assert _npm("install") not in calls  # plain (mutating) install never runs
 
     def test_build_dist_installs_node_modules_before_build(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -483,16 +507,16 @@ class TestProvisionDependencyInstall:
         website.mkdir(parents=True)
         calls: list[list[str]] = []
 
-        def fake_run(cmd: list[str], cwd: Path) -> int:
+        def fake_run(cmd: list[str], cwd: Path, env: dict | None = None) -> int:
             calls.append(cmd)
-            if cmd == ["npm", "run", "build"]:
+            if cmd == _npm("run", "build"):
                 (website / "dist").mkdir(parents=True, exist_ok=True)
                 (website / "dist" / "index.html").write_text("<html>")
             return 0
 
         monkeypatch.setattr(prov, "_run", fake_run)
         assert prov.build_dist(co) is True
-        assert calls.index(["npm", "ci"]) < calls.index(["npm", "run", "build"])
+        assert calls.index(_npm("ci")) < calls.index(_npm("run", "build"))
 
     # ---- #230: venv dev extras ----
 


### PR DESCRIPTION
## Problem

On a machine where Node was installed by a version manager — mise, nvm, fnm,
volta, asdf — two Dev Fleet actions fail:

**Provision a worktree** dies with an unhandled traceback:

```
[provision] installing website npm deps (node_modules missing)...
  $ npm ci  (cwd=/workplace/nrb/kirocrew-wt-live-sync/website)
Traceback (most recent call last):
  ...
  File ".../kiro_crew/pod/provision.py", line 148, in ensure_node_modules
    if _run(["npm", "ci"], website) == 0:
  ...
FileNotFoundError: [Errno 2] No such file or directory: 'npm'
```

**Pull + build main** fails with `no trusted executable for 'npm' in
/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin`.

Same cause. Dev Fleet never lets a build subprocess inherit the gateway's PATH:
`_build_env()` replaces it with a fixed allowlist of system bin dirs, and
`_trusted_bin()` additionally rejects any binary whose resolved target sits
under `$HOME` or is writable by the running user. Both rules exist to keep a
planted `git`/`gh` shim out of the credential-bearing tier, and for `git`/`gh`
they are right.

But npm is not git. A version manager installs Node **under `$HOME`** — and
that is where Kiro Crew's own installer puts it: `install.sh --mise` and
`ensure-node.sh` install Node via mise into
`~/.local/share/mise/installs/node/<ver>/bin`. So the supported install path
produces a Node toolchain that Dev Fleet is structurally unable to see. On the
reporting host none of the five allowlisted directories contained `node` or
`npm` at all.

## Why it matters

Provisioning a worktree and pulling+building main are the two things Dev Fleet
exists to do, and on a mise/nvm/fnm/volta/asdf host both are dead on arrival.
It is self-inflicted: the more closely a user follows Kiro Crew's documented
install, the more certainly they hit it. The provision path also had no error
handling on that call, so the user got a raw Python traceback with no statement
of what was missing and no remedy.

## Fix (symptoms → root cause → change)

Root cause: **one trust rule was serving two unrelated purposes.**
`_trusted_bin` answers "may this binary run with the operator's credentials?"
Resolving npm asks a different question — "where is the build toolchain?" — and
inherited the credential rule's `$HOME` exclusion for free.

So give the node toolchain its own resolution tier, and leave the `git`/`gh`
rule untouched.

**1. `src/kiro_crew/env.py` — one shared resolver.**
`node_bin_dirs()` returns real node bin dirs, best first:

1. `KIROCREW_NODE_BIN_DIR` — operator override.
2. `<data-home>/node-bin-dir` — the marker **`ensure-node.sh` already writes**
   recording the version it resolved. The `Makefile` already consumes it; this
   puts Python callers on the same answer instead of deriving a second one.
3. The highest version under each per-version manager root (mise / asdf / nvm /
   fnm).
4. Shim dirs (mise shims, volta, n).

Every entry is verified to contain an executable `node`, so a layout that does
not exist on the host drops out rather than polluting PATH. Only the *best*
version per root is returned: mise alone contributes ~18 install and alias
directories on a developer box, and returning them all would bury the intended
toolchain behind stale majors (node 16/18 against `website/package.json`'s
`engines: 20 || >=22`). Alias directories (`lts`, `latest`, `lts-krypton`) are
ranked below parsed versions — plain reverse-lexicographic order picks
`lts-krypton` over `24.16.0`.

Companions: `node_augmented_path()` (prepends — a distro node can be older than
`engines` requires) and `find_node_tool()` (absolute path, or `None` so callers
can say something useful).

Both untrusted-ish sources of a bin dir — the env override and the marker file —
go through one `_validated_bin_dir()` so they cannot drift apart: each names
*one* directory, and a value carrying a path separator is rejected rather than
split. `os.path.isabs("/a:/b")` is True on POSIX, so an absolute-only check does
not catch that.

**2. `src/kiro_crew/pod/provision.py` — resolve npm instead of spawning a bare
name.** `pod provision` and `pod up` now find `npm` themselves and hand the
child a PATH carrying the node bin dir. Resolving the `npm` argv alone is not
enough: npm spawns its own run-scripts (`tsc`, `vite`) whose shebang is
`#!/usr/bin/env node`, so `node` must resolve by *name* inside the child. When
nothing resolves, the step now reports where it looked and how to fix it instead
of raising `FileNotFoundError` out of `subprocess.Popen`. This also makes the
pod CLI correct for *any* caller — previously it only worked when the invoking
shell happened to have a version manager active.

**3. `src/kiro_crew/apps/builtins/dev_fleet/server.py` — Pull + build.**
`_toolchain_bin()` resolves npm from the toolchain tier, falling back to
`_trusted_bin`. Managed toolchain first, system npm second: Amazon Linux 2023
ships node 18 against an `engines: 20 || >=22` requirement, while
`ensure-node.sh` installs a version chosen to satisfy the build.

`_build_env()` prepends the toolchain dirs to PATH — **and only in the
credential-free tier.** This is the security boundary of the change:

| tier | PATH | why |
|---|---|---|
| `_build_env()` (default, `strict` steps: pip / `npm ci` / `npm run build`) | toolchain dirs + `_TRUSTED_PATH` | already executes worktree-controlled `package.json` scripts with no credential helpers; `node` must resolve by name |
| `_build_env(with_credentials=True)` (the network fetch) | `_TRUSTED_PATH` only | the argv is a vetted absolute `git`, but git resolves its **own** helpers (`git-remote-https`, credential helpers) through PATH, so a same-user-writable dir there is a route to intercepting a credential-bearing fetch |

`_trusted_bin`, `_TRUSTED_BIN_DIRS` and `_run_cmd`'s pinning are unchanged;
`git` and `gh` keep the strict rule. A test asserts no `_toolchain_bin("git")`
/ `("gh")` call site can appear later.

Two independent mechanisms enforce that boundary, and the docstring now says so
explicitly rather than implying the ternary is the only one. The ternary covers
callers that spawn **directly** (`raw_steps`, `_pod_provision`, `_start_run`);
callers routing through `_run_cmd` are covered by `_run_cmd` overwriting PATH
with `_TRUSTED_PATH` unconditionally *before* it injects any credential helper,
so a node-augmented PATH from `_pod_env()` is discarded there and never coexists
with credentials. Both must keep holding.

**The toolchain scan never runs on the event loop.** `node_bin_dirs()` globs and
stats the filesystem, and `find_node_tool()` adds a `shutil.which` over those
dirs — on an NFS-backed `$HOME` either is slow enough to stall every backend
request and health check behind one directory walk. Both are therefore resolved
on `subprocess_executor()`:

- `async def _warm_build_path()` resolves the PATH, awaited in
  `dev_fleet_startup` so the common case is warm before any request arrives, and
  again at the top of each of the four async handlers that construct a build env
  (`_pod_up`, `_pod_down`, `_pod_provision`, `_sync_start_locked`) so a handler
  never depends on startup having run. After the first resolve the resolver is
  `lru_cache`d and `_build_path()` is a pure in-memory read, which is what lets
  `_build_env()` stay synchronous.
- `/api/sync` resolves `git` and `npm` together in one `run_in_executor` call
  rather than calling `_trusted_bin` / `_toolchain_bin` inline.

**Deliberately out of scope, worth a follow-up:** `node_bin_dirs()` strictly
supersedes the older `env._node_version_manager_bins()` — it adds mise installs,
asdf, fnm's XDG layout, `_has_node` validation, and version-aware ranking in
place of reverse-lexicographic (which is the `lts-krypton` > `24.16.0` bug).
Consolidating them would change `augmented_path()`'s shape for MCP-binary
discovery (fewer entries, best-version-only), editing untouched code and risking
an MCP-resolution regression. Separately, `acp/client.py`'s
`_mise_node_installs_dir()` hardcodes `~/.local/share/mise/installs/node` and
honours neither `MISE_DATA_DIR` nor `XDG_DATA_HOME` — the bug `_mise_data_dir()`
fixes here. Both are pre-existing in untouched code, and both are now filed as
https://github.com/kirodotdev/KiroCrew/issues/1605 so they cannot quietly drift.

**The advertised remedy works on retry.** Both resolution layers are memoized for
the process lifetime (`node_bin_dirs()` is `lru_cache`d, `_BUILD_PATH_CACHE` is
filled once), which is right for a hot path and wrong for an error message: the
"npm not found" banner tells the user to run `ensure-node.sh`, which writes the
very marker file the resolver reads. Without dropping both caches, a long-lived
gateway would keep serving the same error after the host was already fixed. The
not-found path now invalidates both, so pressing Pull + build again re-scans —
and the message distinguishes the two remedies honestly, since pointing at a
toolchain via `KIROCREW_NODE_BIN_DIR` genuinely does need a restart (a running
process cannot see a new environment variable).

**Deliberately out of scope:** `frontend.build_frontend_sync()` (the
`kirocrew update` / auto-apply rebuild) resolves npm off the inherited PATH and
has the same blind spot, but it degrades to a logged warning rather than
failing, and fixing it means threading a PATH through `_edition_build_env()` —
which returns `None` specifically to keep the stock path byte-identical to
inheriting `os.environ`. That is its own design question, not this fix.

## Tests

`test/test_node_toolchain_resolution.py` (new) — the resolver:
marker file preferred over a filesystem scan; marker **and** env override
rejected identically when relative or carrying a path separator (a multi-entry
value would smuggle extra dirs into every PATH built from it); only the best
version per root returned; numeric versions outrank alias names; a dir with no
executable `node` is dropped; each of the five manager layouts and three shim
dirs found; `MISE_DATA_DIR` / `XDG_DATA_HOME` honoured; prepend order;
`find_node_tool` absolute-or-`None`. Plus every returned entry asserted
OS-normalized, and duplicate spellings asserted to collapse — the static-dir
templates are written with forward slashes, so before normalization Windows
emitted `C:\home/.volta/bin` from one branch and `C:\home\.volta\bin` from the
other. Windows still *found* those dirs, but the strings are joined onto PATH
and compared, and two spellings also slipped past the dedup guard.

`test/test_dev_fleet_node_toolchain.py` (new) — the boundary:
credential-free `_build_env()` gets the toolchain, credential-bearing does not,
**and the two are asserted to actually differ** so the second cannot pass
vacuously; the pre-existing credential-helper split still holds; `_TRUSTED_PATH`
is still present (prepend, not replace); a host with no toolchain produces a
byte-identical PATH to before; `_build_path()` memoized; `_toolchain_bin`
prefers managed over system, falls back, and returns `None`; `git`/`gh` never
routed through it; provision spawns an absolute npm with a node PATH, and
reports a remedy instead of raising. Plus the event-loop guarantee: the scan is
asserted to run on a **different thread** than the loop, the warm is idempotent,
and all four async handlers plus `dev_fleet_startup` are asserted to warm — so
adding a fifth handler that forgets fails the suite.

The Windows fixture creates `node.exe` / `npm.cmd` rather than extensionless
files. A bare `node` is not an executable file on Windows, and real toolchains
there ship the suffixed names that `_has_node` and PATHEXT-aware
`shutil.which` actually look for — the POSIX-only fixture made every layout
test report empty on Windows CI. The one test asserting POSIX execute-bit
semantics is skipped there, with the reason stated.

`test/test_dev_fleet_app.py` — `test_build_env_excludes_credentials` asserted
`PATH == _TRUSTED_PATH`, which is the behaviour this changes. Rewritten to the
invariant it was actually protecting (never inherited, still ends with the
trusted dirs) plus the credential-bearing pin.

`test/test_pod.py` — provisioning stubs updated for `_run`'s new `env`
parameter and the absolute npm argv, with an autouse fixture pinning toolchain
resolution so these tests no longer depend on whether the host running them has
a version manager.

Full suite: **30179 passed, 44 failed**, all 44 pre-existing and unrelated
(sandbox backend unavailable on this host + host-state-dependent
`gh`/provider-executable trust tests). Verified by running the same files
against `origin/main` at the same commit: they fail there too, same assertions.
Zero failures in any file this PR touches. `isort` / `flake8` / `mypy` clean on
every changed file.

The `data_home` import is at module scope, and a cold-interpreter probe
(`python -c "import <mod>"` per entry point, which is the only thing that
catches an ordering cycle — pytest's discovery order can break one incidentally)
confirms `kiro_crew.env`, `config.paths`, `pod.provision`,
`dev_fleet.server` and `cli` all import clean from a fresh process.

## Manual verification

Resolver run on the reporting host, where `_trusted_bin("npm")` returns `None`:

```
resolved node bin dirs:
    /home/nrb/.local/share/mise/installs/node/22/bin      <- ensure-node.sh marker
    /home/nrb/.local/share/mise/installs/node/24.16.0/bin <- highest mise install
    /home/nrb/.local/share/mise/shims
npm  -> /home/nrb/.local/share/mise/installs/node/22/bin/npm
node  -> /home/nrb/.local/share/mise/installs/node/22/bin/node
```

Before the version-ranking change the same host produced 19 entries led by
`lts-krypton`, with node 16 and 18 dirs on the build PATH.

## Screenshots

N/A — no user-visible UI change. The change is subprocess environment
construction plus one error string; the only user-facing difference is that
Pull + build's failure banner now names a remedy instead of reporting a pinned
PATH.
