### PR TITLE
fix(session): recycle under the held semaphore after a failed compact

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -755,7 +755,15 @@ In-place compaction (both backends) keeps the `_sessions` entry healthy:
 a concurrent `get_or_create()` reuses it, queueing on the session
 semaphore behind the compact, then continues on the compacted session.
 
-Only the kiro-cli recycle fallback tears the entry down. It records the
+Only the kiro-cli failure recycle tears the entry down, and it runs inside
+`_compact_in_place` under the turn semaphore that the compact attempt
+already holds — never after releasing it. That is load-bearing: releasing
+first and re-acquiring for the recycle leaves a gap a queued turn wins, and
+that turn is then dispatched into a kiro-cli still finishing its compaction,
+receives the late `completed` status instead of an `end_turn`, and hangs
+holding the semaphore until the prompt timeout.
+
+The recycle records the
 exact session object under teardown in `_recycling` (distinct from
 `_compacting`, which is just the trigger dedup gate): `get_or_create()`
 skips reuse only when the map still holds that exact object, then

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -2041,7 +2041,7 @@ class SessionManager:
                         "SessionManager is closing (gateway restart/shutdown in "
                         "progress); refusing to start or resume a turn"
                     )
-                # Skip the live-session branch only while the recycle FALLBACK
+                # Skip the live-session branch only while the failure recycle
                 # is tearing down the EXACT session object still in the map.
                 # In-place compaction — both the kiro-cli and claude paths —
                 # keeps the entry healthy, so concurrent get_or_create must
@@ -2367,7 +2367,7 @@ class SessionManager:
                 # were starting the provider (race on same key). In-place
                 # compaction (kiro-cli and claude) leaves the existing entry
                 # healthy, so reuse it even when _compacting is set; only an
-                # entry that IS the exact object the recycle FALLBACK is
+                # entry that IS the exact object the failure recycle is
                 # tearing down should fall through to register us — a healthy
                 # replacement under the same key must be reused, never
                 # overwritten. The recycle path also pops by object identity,
@@ -2619,7 +2619,7 @@ class SessionManager:
         key = self._fold_key(key)
         pct = provider.context_usage_pct()
 
-        # Track prompts for background session recycle fallback
+        # Track prompts for background session recycle
         session = self._sessions.get(key)
         if session:
             session.prompt_count += 1
@@ -2703,13 +2703,15 @@ class SessionManager:
         claude SDK session) survives and any queued or agentic work continues
         automatically — the fix for "session stops after auto-compaction".
 
-        kiro-cli only: if the in-place ``/compact`` fails or times out, fall
-        back to the legacy recycle — kill the session and let the next user
-        message re-seed context via build_session_context(). The session_map
-        entry is dropped so we don't false-resume from stale state. A recycle
-        is never forced through a live turn: if the turn semaphore cannot be
-        acquired within the budget, the attempt is skipped and the next
-        turn-end ``check_context_usage`` re-triggers it.
+        kiro-cli only: if the in-place ``/compact`` fails or times out, the
+        session is recycled — killed so the next user message re-seeds context
+        via build_session_context(). The session_map entry is dropped so we
+        don't false-resume from stale state. That recycle happens inside
+        ``_compact_in_place``, under the turn semaphore it already holds, so no
+        queued turn can slip in between the failed compact and the kill. A
+        recycle is never forced through a live turn: if the turn semaphore
+        cannot be acquired within the budget, the attempt is skipped and the
+        next turn-end ``check_context_usage`` re-triggers it.
         """
         try:
             session = self._sessions.get(key)
@@ -2747,72 +2749,65 @@ class SessionManager:
                 await self._fire_compact_callback(key, pct, success=True)
                 return
 
-            # ── kiro-cli: in-place /compact first ──
-            if session is not None:
-                outcome = await self._compact_in_place(key, session, pct)
-                if outcome == "ok":
-                    return
-                if outcome == "busy":
-                    # A turn is still running. NEVER kill a live turn for
-                    # compaction — the old force-recycle here SIGKILLed
-                    # kiro-cli mid-turn, losing all in-flight work. The next
-                    # turn-end check_context_usage re-triggers compaction
-                    # when the semaphore is free. No cooldown / no failure
-                    # callback: this is a deferral, not a failure.
-                    logger.warning(
-                        "Session %s compaction deferred — turn still active after %.0fs",
-                        key,
-                        _COMPACT_TIMEOUT_SECS,
-                    )
-                    return
-                # outcome == "failed" → fall through to the recycle fallback.
-
-            # ── kiro-cli recycle fallback ──
-            # SIGKILLs the provider; drain the in-flight turn via the session
-            # semaphore first so we don't kill mid-turn. Operates strictly on
-            # the *session object captured above*: pop-by-identity means a
-            # fresh session registered by a racing cold-start is never popped
-            # or killed by mistake.
+            # ── kiro-cli: in-place /compact, recycling on failure ──
+            # Every outcome is terminal. _compact_in_place owns the turn
+            # semaphore for the whole critical section — including the failure
+            # recycle — so there is no window here in which a queued turn can
+            # be dispatched into a session that is mid-compaction or mid-kill.
             if session is None:
                 return
-            sem = session.semaphore
-            try:
-                await asyncio.wait_for(sem.acquire(), timeout=_COMPACT_TIMEOUT_SECS)
-            except asyncio.TimeoutError:
+            outcome = await self._compact_in_place(key, session, pct)
+            if outcome == "busy":
+                # A turn is still running. NEVER kill a live turn for
+                # compaction — the old force-recycle here SIGKILLed
+                # kiro-cli mid-turn, losing all in-flight work. The next
+                # turn-end check_context_usage re-triggers compaction
+                # when the semaphore is free. No cooldown / no failure
+                # callback: this is a deferral, not a failure.
                 logger.warning(
-                    "Session %s recycle skipped — turn still active after %.0fs",
+                    "Session %s compaction deferred — turn still active after %.0fs",
                     key,
                     _COMPACT_TIMEOUT_SECS,
                 )
-                return
-            self._recycling[key] = session
-            try:
-                async with self._lock:
-                    popped = None
-                    if self._sessions.get(key) is session:
-                        popped = self._sessions.pop(key, None)
-                if popped is None:
-                    # A racing cold-start already replaced the entry — the map
-                    # now points at a fresh, healthy session. Reap OUR old
-                    # provider (its process would otherwise leak) but leave the
-                    # replacement and its session_map entry untouched.
-                    await session.provider.shutdown()
-                    logger.info(
-                        "Recycled session %s (context overflow; entry already replaced)", key
-                    )
-                else:
-                    self._session_map.delete(key)
-                    await popped.provider.shutdown()
-                    logger.info("Recycled session %s (context overflow)", key)
-                await self._fire_compact_callback(key, pct, success=True)
-            finally:
-                if self._recycling.get(key) is session:
-                    self._recycling.pop(key, None)
-                sem.release()
         except Exception:
-            logger.exception("Session recycle failed for %s", key)
+            logger.exception("Session compaction/recycle failed for %s", key)
         finally:
             self._compacting.discard(key)
+
+    async def _recycle_held(self, key: str, session: "_Session", pct: float) -> None:
+        """Recycle *session* — SIGKILL the provider and drop the map entry.
+
+        The caller MUST already hold ``session.semaphore`` and is responsible
+        for releasing it: this method neither acquires nor releases it, so the
+        recycle runs inside the caller's turn-exclusion window. That is what
+        lets ``_compact_in_place`` recycle without ever dropping the semaphore
+        (see the race documented there).
+
+        Operates strictly on the *session object passed in*: pop-by-identity
+        means a fresh session registered by a racing cold-start is never
+        popped or killed by mistake.
+        """
+        self._recycling[key] = session
+        try:
+            async with self._lock:
+                popped = None
+                if self._sessions.get(key) is session:
+                    popped = self._sessions.pop(key, None)
+            if popped is None:
+                # A racing cold-start already replaced the entry — the map
+                # now points at a fresh, healthy session. Reap OUR old
+                # provider (its process would otherwise leak) but leave the
+                # replacement and its session_map entry untouched.
+                await session.provider.shutdown()
+                logger.info("Recycled session %s (context overflow; entry already replaced)", key)
+            else:
+                self._session_map.delete(key)
+                await popped.provider.shutdown()
+                logger.info("Recycled session %s (context overflow)", key)
+            await self._fire_compact_callback(key, pct, success=True)
+        finally:
+            if self._recycling.get(key) is session:
+                self._recycling.pop(key, None)
 
     async def _compact_in_place(self, key: str, session: "_Session", pct: float) -> str:
         """Attempt a native in-place ``/compact`` on a kiro-cli session.
@@ -2823,18 +2818,33 @@ class SessionManager:
         - ``"busy"``: the turn semaphore could not be acquired within
           ``_COMPACT_TIMEOUT_SECS`` — a turn is still running. Nothing was
           attempted; the caller must NOT recycle (no mid-turn kill).
-        - ``"failed"``: the compact was attempted but failed, timed out, or
-          the provider does not support it (base ``wait_for_compaction``
-          returns ``{"type": "timeout"}``). The caller falls back to recycle.
+        - ``"recycled"``: the compact was attempted and failed (or timed out,
+          or the provider has no native compaction — base
+          ``wait_for_compaction`` returns ``{"type": "timeout"}``), so the
+          session was recycled HERE, before the turn semaphore was released.
+
+        Every outcome is terminal: the caller never recycles.
 
         Holds the session semaphore for the duration so a queued turn waits
         behind the compaction (and then continues on the compacted session)
         instead of interleaving with it.
+
+        The semaphore is held across the failure recycle too, and that is
+        load-bearing. Releasing it first and letting the caller re-acquire
+        leaves a gap a queued turn wins: the turn is then dispatched into a
+        kiro-cli that is still compacting, its late ``completed`` status lands
+        in that turn's stream, and no ``end_turn`` ever follows — the turn
+        hangs holding the semaphore until the 2h prompt timeout, and the
+        recycle that would have rescued it gives up at its own acquire
+        timeout. Observed in production 2026-08-05: a ``/compact`` reported
+        ``completed`` 161s in, 41s after the 120s async wait had already
+        declared timeout.
         """
         try:
             await asyncio.wait_for(session.semaphore.acquire(), timeout=_COMPACT_TIMEOUT_SECS)
         except asyncio.TimeoutError:
             return "busy"
+        started = time.monotonic()
         try:
 
             async def _run() -> None:
@@ -2871,11 +2881,18 @@ class SessionManager:
             await asyncio.wait_for(_run(), timeout=_COMPACT_TIMEOUT_SECS)
         except (Exception, asyncio.TimeoutError):
             logger.warning(
-                "Session %s in-place /compact failed — falling back to recycle",
+                "Session %s in-place /compact failed after %.0fs — recycling "
+                "(semaphore held; async wait budget %.0fs)",
                 key,
+                time.monotonic() - started,
+                _COMPACT_RESULT_WAIT_SECS,
                 exc_info=True,
             )
-            return "failed"
+            # Recycle NOW, still holding the semaphore — see the docstring.
+            # A failure here is logged by the caller's outer handler; the
+            # finally below still releases the semaphore either way.
+            await self._recycle_held(key, session, pct)
+            return "recycled"
         finally:
             session.semaphore.release()
         self._compact_cooldown_until.pop(key, None)

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -2451,7 +2451,7 @@ class TestClaudeBackendCompaction:
 
     @pytest.mark.asyncio
     async def test_get_or_create_during_recycle_teardown_cold_starts(self, cfg):
-        """While the recycle fallback is tearing the entry down (_recycling
+        """While the failure recycle is tearing the entry down (_recycling
         holds the exact object still in the map), get_or_create must not
         reuse the doomed entry — fall through to cold-start."""
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
@@ -2735,20 +2735,110 @@ class TestKiroInPlaceCompaction:
         await mgr.close_all()
 
     @pytest.mark.asyncio
+    async def test_failure_recycle_never_yields_semaphore_to_queued_turn(self, cfg):
+        """Regression (production 2026-08-05): the failure recycle must not
+        open a window in which a queued turn is dispatched into a session that
+        is still compacting.
+
+        The old code released the turn semaphore as soon as the in-place
+        compact reported failure and let the CALLER re-acquire it for the
+        recycle. A queued turn won that gap: it was sent to a kiro-cli that was
+        still finishing its ``/compact``, its stream received the late
+        ``completed`` status instead of an ``end_turn``, and the turn hung
+        holding the semaphore until the 2h prompt timeout — while the recycle
+        that would have rescued it gave up at its own acquire timeout. The kill
+        must therefore land BEFORE any queued turn can run.
+        """
+        order: list[str] = []
+        gate = asyncio.Event()
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            m = AsyncMock()
+            m.start = AsyncMock()
+            m.context_usage_pct = lambda: 0.0
+
+            async def _stream(_cmd):
+                if False:  # pragma: no cover - empty async generator
+                    yield
+
+            m.stream_command = MagicMock(side_effect=_stream)
+
+            async def _shutdown() -> None:
+                order.append("shutdown")
+
+            m.shutdown = AsyncMock(side_effect=_shutdown)
+
+            async def _wait(timeout=120.0):
+                # Mirrors production: the async wait gives up while the
+                # compaction is in fact still running on the backend.
+                await gate.wait()
+                return {"type": "timeout"}
+
+            m.wait_for_compaction = _wait
+            return m
+
+        mgr = SessionManager(cfg, provider_factory=factory)
+        await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        sess = mgr._sessions["dashboard:chat-1"]
+
+        compact = asyncio.create_task(mgr._compact_session("dashboard:chat-1", 92.0))
+        await asyncio.sleep(0.05)
+        assert sess.semaphore.locked()
+
+        # A queued turn parks on the turn semaphore, exactly as a real
+        # dispatch does while a compaction holds it.
+        async def _queued_turn() -> None:
+            async with sess.semaphore:
+                order.append("turn")
+
+        turn = asyncio.create_task(_queued_turn())
+        await asyncio.sleep(0.05)
+        assert not turn.done()
+
+        gate.set()  # compact reports timeout -> recycle, semaphore still held
+        await asyncio.wait_for(compact, timeout=2)
+        await asyncio.wait_for(turn, timeout=2)
+
+        # Kill first, queued turn second: the semaphore was never handed back
+        # while the backend could still have been compacting.
+        assert order == ["shutdown", "turn"]
+        assert "dashboard:chat-1" not in mgr._sessions
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
     async def test_recycle_pop_by_identity_spares_replacement(self, cfg):
-        """If a racing cold-start replaced the entry while the recycle
-        fallback waited on the old turn semaphore, only the OLD session is
-        killed; the fresh replacement (and its session_map entry) survives."""
+        """If a racing cold-start replaced the entry while the in-place
+        compact was still running, the failure recycle kills only the OLD
+        session; the fresh replacement (and its session_map entry) survives."""
         from kiro_crew.session import _Session
 
-        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        gate = asyncio.Event()
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            m = AsyncMock()
+            m.start = AsyncMock()
+            m.shutdown = AsyncMock()
+            m.context_usage_pct = lambda: 0.0
+
+            async def _stream(_cmd):
+                if False:  # pragma: no cover - empty async generator
+                    yield
+
+            m.stream_command = MagicMock(side_effect=_stream)
+
+            async def _wait(timeout=120.0):
+                await gate.wait()
+                return {"type": "failed"}
+
+            m.wait_for_compaction = _wait
+            return m
+
+        mgr = SessionManager(cfg, provider_factory=factory)
         old_provider, _, _ = await mgr.get_or_create("k1")
-        old_sess = mgr._sessions["k1"]
-        # Keep the old turn semaphore held so the recycle blocks on acquire.
+        mgr.release("k1")
         cb = AsyncMock()
         mgr.set_compact_callback(cb)
-        # Skip the in-place attempt: force the fallback path directly.
-        mgr._compact_in_place = AsyncMock(return_value="failed")  # type: ignore[method-assign]
 
         task = asyncio.create_task(mgr._compact_session("k1", 92.0))
         await asyncio.sleep(0.05)
@@ -2759,8 +2849,7 @@ class TestKiroInPlaceCompaction:
         new_provider.shutdown = AsyncMock()
         mgr._sessions["k1"] = _Session(provider=new_provider, is_new=False)
 
-        # Old turn ends -> recycle proceeds, pops by identity.
-        old_sess.semaphore.release()
+        gate.set()  # compact fails -> recycle pops by identity
         await asyncio.wait_for(task, timeout=2)
 
         # Replacement untouched; old provider reaped.


### PR DESCRIPTION
# Problem

A dashboard session can hang **indefinitely** after auto-compaction. The user
sees the compaction summary render in chat, and then nothing — the session
never answers again and never errors.

Observed in production on 2026-08-05 (session `chat-79`, a long-running
analysis thread). Timeline from `gateway.log`:

| Time | Event |
|---|---|
| 01:48:11 | Auto-compaction fires at 80% context. Takes the turn semaphore, sends `/compact` as a prompt. |
| 01:49:17 | User sends a new message. It queues behind the semaphore. |
| 01:50:11 | `wait_for_compaction` hits `_COMPACT_RESULT_WAIT_SECS` (120s) and returns `{"type":"timeout"}` → `RuntimeError: compaction reported timeout` → gives up, **releases the semaphore**. |
| 01:50:11 | The queued turn immediately wins the semaphore and is dispatched into a kiro-cli that is **still compacting**. |
| 01:50:52 | kiro-cli emits compaction `completed` — 161s in, 41s *after* we gave up. It lands in the queued turn's stream and renders as the summary the user sees. |
| 01:55:11 | The recycle fallback, blocked on `sem.acquire()` behind the live turn, expires at 300s: `recycle skipped — turn still active`. It abandons the attempt. |
| after | Zero stream events. The turn never ends. |

# Why it matters

The turn holds the session semaphore, so **every subsequent message queues
behind a turn that will never complete**. The session is unusable and the
user has no signal as to why.

Nothing reaps it. The 90s stale-turn detector in `acp/client.py` only arms
after a *text* chunk streams (`_stale_eligible`, set in `_dispatch_events`);
this turn streamed only a compaction-status event, so the detector stayed
disarmed and the turn fell through to `_DEFAULT_PROMPT_TIMEOUT` — **2 hours**.
The one mechanism that would have rescued it, the recycle, had already given
up at its own acquire timeout. Recovery requires the user to notice and press
Stop.

# Fix (symptom → root cause → change)

**Symptom:** session silent after compaction; semaphore held by a turn with no
`end_turn`.

**Root cause:** the failure path released the turn semaphore and let the
*caller* re-acquire it. `_compact_in_place` returned `"failed"` (releasing in
its `finally`), and `_compact_session` then did
`await asyncio.wait_for(sem.acquire(), ...)` to recycle. Between those two
points the semaphore is free, and a queued turn wins it. The compaction was
still in flight — it had not failed, it was merely *slower than the 120s wait
window* — so the turn was dispatched into a runtime mid-compaction and
received the late `completed` status instead of a turn response.

Note the two distinct failure modes the old code conflated: `failed` (the
backend genuinely finished and failed) and `timeout` (we do **not know** — it
may still be running). Both released the semaphore into a possibly-live
compaction.

**Change:** extract the recycle body into `_recycle_held(key, session, pct)`,
which assumes the caller holds `session.semaphore` and neither acquires nor
releases it, and call it from inside `_compact_in_place`'s `except` block —
*before* the `finally` releases. The kill now lands while the semaphore is
still held, so no queued turn can be dispatched between the failed compact and
the teardown. The window is closed by construction rather than narrowed.

Two consequences, both intentional:

- The `"failed"` outcome became **unreachable**, so the caller's recycle
  fallback is deleted rather than left as a dead branch. `_compact_in_place`
  now returns `ok` / `busy` / `recycled`, all terminal.
- That also removes the `recycle skipped — turn still active after 300s` path,
  which is now *structurally impossible*: the recycle can never fail to
  acquire a semaphore it already holds. This is the exact log line the
  production incident emitted. A repo-wide grep confirms no consumer of the
  removed string.

The failure log line now records elapsed time and the async-wait budget, so
the 120s window can be tuned from data instead of guesswork. **I deliberately
did not change `_COMPACT_RESULT_WAIT_SECS` in this PR** — I have exactly one
measurement (161s) and did not want to pick a constant from n=1. Raising it
would avoid the (now-safe) recycle and keep the healthy compacted session;
that is a reasonable follow-up once the new log line has produced a
distribution.

Also updated the three in-code comments and the `session.md`
"Compaction Race Handling" spec section that still described a caller-side
"recycle fallback". These are prose-only, but load-bearing prose: they sit
next to the `_recycling` guard logic, and a maintainer tracing them would hunt
for a fallback that no longer exists and could plausibly reintroduce the gap.

# Tests

`test/test_session.py`:

- **`test_failure_recycle_never_yields_semaphore_to_queued_turn`** (new) — the
  regression lock. Drives a compact whose `wait_for_compaction` returns
  `{"type":"timeout"}` (mirroring production: the async wait gives up while
  the backend is still working), parks a *real* waiter on the session
  semaphore exactly as a dispatched turn would, and asserts the ordering
  `order == ["shutdown", "turn"]` — the kill lands before the queued turn can
  run.

  **Mutation-proven, not tautological.** I reintroduced the old
  release-then-reacquire ordering and the test failed; restored the fix and it
  passes. The Opus reviewer independently derived the mechanism: under the old
  code the `finally` release wakes the parked waiter via `call_soon` before the
  caller's next await, so the fallback's `sem.acquire()` yields and the queued
  turn wins, inverting `order` to `["turn", "shutdown"]` — on both 3.10 and
  3.12.

- **`test_recycle_pop_by_identity_spares_replacement`** (retargeted) — it
  previously mocked `_compact_in_place` to return `"failed"`, exercising the
  branch this PR deletes. It now lets a racing cold-start replace the entry
  *during* a real in-place compact, so the same assertions exercise the real
  `_recycle_held` identity check instead of a mock's return value. The
  `popped is None` branch is genuinely reached, so the `_session_map.delete`
  skip is covered.

All 224 tests in `test/test_session.py` pass, including the 46 existing
compaction/recycle tests.

# Manual verification

Not applicable — this is a concurrency-ordering fix with no user-visible
surface, and the ordering invariant is exactly what the new test asserts. A
live reproduction would require driving a session to 80% context and inducing
a >120s compaction, which the unit test models deterministically.

**Gaps I want to be explicit about:**

- **The full backend suite was not run locally.** `isort`, `flake8`,
  `mypy` (716 files) and the full `test/test_session.py` module are green, but
  the whole-suite run did not complete in this environment (a runner attempt
  timed out at 30 min). I am relying on CI for it. The change is confined to
  `SessionManager` compaction internals, but that is an expectation, not a
  measurement.
- The worktree venv was built with `--only-binary :all:` because numpy 2.5.1
  has no wheel for this host and its GCC (<10.3) cannot build it, so local
  dependency *versions* may sit slightly below CI's.

# Screenshots

N/A — no user-visible UI change. Backend session-lifecycle logic, one spec
doc, and tests only.
