### PR TITLE
fix(dev-fleet): refuse force-remove on dirty+unmerged worktrees, restrict branch ref deletion to merged PRs

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -2847,6 +2847,7 @@ async def _worktree_remove(
 
     pr = (await _pr_status_cached(branch)) if branch else None
     own = await _own_commits_count(path)
+
     if not force and not _is_pr_merged(pr):
         if own is None or own > 0:
             return {
@@ -3189,7 +3190,14 @@ async def _worktree_remove(
                 )
             return {"ok": False, "error": _redact((stderr or stdout).strip()[:300])}
 
-        # Delete branch if shipped/empty — atomically against the pinned OID.
+        # Delete branch ref only when the PR is MERGED — atomically against
+        # the pinned OID. Unmerged branch refs are always retained, even when
+        # own == 0 (every commit already reachable from the upstream base, so
+        # no unique commits exist): keying deletion to PR state alone is a
+        # deliberately simpler, fail-closed policy (recoverable > irrecoverable).
+        # Known cost: removing an unmerged empty worktree leaves refs/heads/
+        # <branch> behind, which blocks re-creating a worktree under the same
+        # branch name until the ref is deleted manually.
         # Fail-closed ancestry gate: even when the cached PR status says MERGED,
         # verify the branch OID is actually contained in the base branch. A stale
         # or wrong merged verdict cannot delete the only local pointer to unmerged
@@ -3200,7 +3208,7 @@ async def _worktree_remove(
         # using the pr_head_oid already fetched above (or fresh if needed).
         if branch and branch != BASE_BRANCH and verdict_oid:
             should_delete = False
-            if _is_pr_merged(pr) or own == 0:
+            if _is_pr_merged(pr):
                 remote = await _upstream_remote()
                 rc_anc, _, _ = await _run_cmd(
                     [
@@ -3212,7 +3220,7 @@ async def _worktree_remove(
                 should_delete = rc_anc == 0
                 # Squash-safe fallback: ancestry fails for squash/rebase merges.
                 # Use the containment check (branch OID is ancestor of PR head).
-                if not should_delete and _is_pr_merged(pr):
+                if not should_delete:
                     head_oid = pr_head_oid or await _fetch_pr_head_oid(
                         branch, repo=(pr or {}).get("_repo")
                     )

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -7278,9 +7278,11 @@ async def test_ancestry_gate_allows_ref_delete_when_ancestor():
 
 
 @pytest.mark.asyncio
-async def test_empty_branch_still_deletes_ref():
-    """own==0 (empty branch) still results in ref deletion because an empty
-    branch is trivially an ancestor of the base (merge-base succeeds)."""
+async def test_empty_branch_ref_survives_when_pr_not_merged():
+    """own==0 (empty branch) must NOT delete the branch ref when no PR is
+    merged: an empty branch may simply not have been pushed yet, and the ref
+    is the only local pointer to those commits (recoverable > irrecoverable).
+    Regression test for kirodotdev#1554."""
     import kiro_crew.apps.builtins.dev_fleet.server as mod
 
     deleted_refs: list[str] = []
@@ -7321,7 +7323,7 @@ async def test_empty_branch_still_deletes_ref():
         result = await mod._worktree_remove("empty-br", force=False)
 
     assert result["ok"] is True
-    assert "refs/heads/empty-br" in deleted_refs
+    assert deleted_refs == [], f"unmerged empty-branch ref must survive: {deleted_refs}"
 
 
 @pytest.mark.asyncio
@@ -7724,61 +7726,6 @@ async def test_squash_merge_ref_deletion():
     assert (
         "refs/heads/feat-x" in deleted_refs
     ), "ref should be deleted via squash-safe containment fallback"
-
-
-@pytest.mark.asyncio
-async def test_ref_delete_fails_closed_both_ancestry_and_containment_fail():
-    """Fail-closed control: ancestry fails AND containment fails → ref
-    survives (no deletion). Uses own==0 (empty branch) with an OPEN PR so
-    that ref deletion is attempted via the own==0 path without triggering
-    the non-forced squash-safe race guard (which only fires for merged PRs)."""
-    import kiro_crew.apps.builtins.dev_fleet.server as mod
-
-    git_calls: list[tuple] = []
-
-    async def _fake_run_cmd(cmd, **kwargs):
-        git_calls.append(tuple(cmd))
-        if "worktree" in cmd and "remove" in cmd:
-            return (0, "", "")
-        if "merge-base" in cmd and "--is-ancestor" in cmd:
-            return (1, "", "")
-        return (0, "", "")
-
-    with (
-        patch.object(
-            mod,
-            "_find_worktree",
-            new_callable=AsyncMock,
-            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
-        ),
-        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
-        patch.object(mod, "_own_checkout_path", return_value=None),
-        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
-        patch.object(
-            mod,
-            "_pr_status_cached",
-            new_callable=AsyncMock,
-            return_value={"state": "OPEN"},
-        ),
-        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
-        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
-        patch.object(
-            mod,
-            "_fetch_pr_head_oid",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=False),
-        patch.object(mod, "_load_cfg", return_value=None),
-        patch.object(mod, "_POD_AVAILABLE", False),
-        patch.object(mod, "_run_cmd", new_callable=AsyncMock, side_effect=_fake_run_cmd),
-        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
-    ):
-        result = await mod._worktree_remove("feat-x", force=False)
-
-    assert result["ok"] is True
-    update_ref_calls = [c for c in git_calls if "update-ref" in c]
-    assert update_ref_calls == [], f"ref should NOT be deleted: {update_ref_calls}"
 
 
 # --- Regression tests for PR 1840 round-3: TOCTOU + containment fixes ---


### PR DESCRIPTION
## Problem

`_worktree_remove(force=True)` destroyed uncommitted work when the PR was unmerged (original incident: a worktree with 15 modified files and an open PR was force-removed, branch ref deleted, work unrecoverable). Additionally, branch ref deletion triggered on `_is_pr_merged(pr) or own == 0`, so unmerged branches' refs could be deleted via the empty-branch path.

## Why it matters

Data loss with no recovery path (the original incident), and a ref-deletion policy that keys off anything other than merge state.

## Status after rebasing onto current main

**The headline fix (refuse force-removal of dirty+unmerged worktrees) is already shipped by main** — the teardown guard in `_worktree_remove` refuses forced removal of a dirty or unverifiable unmerged tree, with audit logging and a TOCTOU mitigation. This PR no longer changes that path; the originally-described changes 1–2 are intentionally absent from this diff.

## What this PR still changes (the whole diff)

Branch ref deletion (`update-ref -d`) now fires **only** for merged PRs — the `or own == 0` trigger is removed. Main's fail-closed ancestry gate and squash-safe containment checks are retained unchanged.

Honest framing of this change (per review): `own == 0` means every commit is already reachable from the upstream base, and the old path was additionally ancestry-gated against a pinned OID — so the removed path was provably lossless. What this change buys is a **simpler, merge-state-only deletion policy**; what it costs is **stale-ref debris**: removing an unmerged empty worktree now leaves `refs/heads/<branch>` behind, which blocks re-creating a worktree under the same branch name (create uses compare-and-create requiring ref absence) until the ref is deleted manually. The in-code comment and commit message document this tradeoff. The author previously dispositioned this concern as accepted-and-deferred with a follow-up plan (periodic ref-prune that checks for associated worktrees).

## Tests

- `test_empty_branch_still_deletes_ref` inverted into `test_empty_branch_ref_survives_when_pr_not_merged` — locks the new merged-only behavior.
- `test_ref_delete_fails_closed_both_ancestry_and_containment_fail` **deleted** (declared here explicitly): under the merged-only rule its OPEN-PR setup never reaches the ancestry/containment gate, making it an exact duplicate of the inverted test. The fail-closed ancestry/containment gate remains covered by `test_ancestry_gate_skips_ref_delete_when_not_ancestor` (MERGED + ancestry fail + containment fail → ref survives) and `test_squash_merge_ref_deletion`.
- Full dev-fleet suites pass locally (610 tests); isort/flake8/mypy clean.

## Manual verification

N/A — pure backend logic change; unit coverage exercises the changed gate directly.
