### PR TITLE
fix(test): eliminate process_matches timing flake with readiness pipe

### DIFF
--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -598,19 +598,26 @@ class TestProcessIdentityPosix:
         # "Python". Production needles ("kiro-cli", "claude") appear verbatim in
         # the argv they guard, so only the test's choice of needle was fragile.
         token = "kirocrew-procmatch-probe"
+        # Use a readiness pipe: the child signals after exec completes, so we
+        # never race /proc/<pid>/cmdline population on a loaded runner.
         child = subprocess.Popen(
-            [sys.executable, "-c", f"import time; time.sleep(30)  # {token}"],
+            [
+                sys.executable, "-c",
+                f"import sys, time; sys.stdout.write('R'); sys.stdout.flush(); "
+                f"time.sleep(30)  # {token}",
+            ],
             start_new_session=True,
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
         )
         try:
-            assert child.poll() is None  # alive
-            # Poll: a just-spawned child's /proc/<pid>/cmdline (or ps output) is
-            # not populated until it finishes exec'ing, so an immediate single
-            # check races the scheduler on a loaded runner. Wait for the match
-            # with a generous deadline rather than asserting once.
+            # Wait for the readiness byte (generous timeout for slow CI).
+            ready = child.stdout.read(1)
+            assert ready == b"R", f"child did not signal readiness: {ready!r}"
+            assert child.poll() is None  # still alive after signalling
             if pc.IS_POSIX:
+                # /proc/<pid>/cmdline is guaranteed populated after exec, but
+                # keep a short retry for edge cases on exotic kernels.
                 deadline = time.monotonic() + 10.0
                 result = pc.process_matches(child.pid, (token,))
                 while not result and time.monotonic() < deadline:


### PR DESCRIPTION
## Problem

`TestProcessIdentityPosix::test_process_matches_true_for_a_child_with_a_known_token` intermittently fails on loaded CI runners. The test spawns a child process and immediately polls `/proc/<pid>/cmdline` for a known token, but on heavily-loaded GitHub Actions runners the child's cmdline is not populated within the 10-second deadline.

## Why it matters

This flake causes spurious CI failures on any open PR, wasting developer time triaging false reds and requiring re-runs.

## Fix (symptoms → root cause → change)

**Symptom:** `assert result is True` fails after the 10s deadline expires.

**Root cause:** The test races the child's exec — `/proc/<pid>/cmdline` is only populated after the kernel completes the `execve()` syscall, but the parent starts polling immediately after `Popen()` returns (which only means `fork()` completed). On a loaded runner, the child may not finish exec within 10 seconds.

**Change:** Add a readiness pipe: the child writes a single byte (`'R'`) to stdout after exec completes (proving its Python code is running), and the parent blocks on `child.stdout.read(1)` before asserting. This eliminates the race entirely — by the time the parent proceeds, the child's cmdline is guaranteed populated. The existing retry loop is preserved as a defensive fallback for exotic kernels.

## Tests

The fix modifies the test itself. The readiness-byte assertion (`assert ready == b"R"`) verifies the child actually exec'd and signalled. The existing `assert result is True` validates `process_matches` correctness.

## Manual verification

N/A — the change is to a unit test. The fix is structural (pipe synchronization eliminates the race) rather than heuristic (longer timeout).
