### PR TITLE
fix(a11y): add focus-visible outline to ApprovalModePicker trigger

### DIFF
--- a/website/src/components/ApprovalModePicker.tsx
+++ b/website/src/components/ApprovalModePicker.tsx
@@ -109,7 +109,7 @@ export default function ApprovalModePicker({ mode, slotKey, compact }: { mode: s
         {/* Chrome type ("Normal" / "Reads" / "Trust" / "YOLO" are labels), so no
             `font-mono` — that pinned `var(--mono)`, which the Font Family
             setting never writes. */}
-        <button className="h-7 px-2 rounded-lg text-[12px] text-muted hover:text-text hover:bg-bg-hover flex items-center gap-1 cursor-pointer transition-all bg-transparent border-none shrink-0 whitespace-nowrap" title={i18nT('components.approvalModePicker.approval_mode')} aria-label={i18nT('components.approvalModePicker.approval_mode_aria', { mode: displayText.label })}>
+        <button className="h-7 px-2 rounded-lg text-[12px] text-muted hover:text-text hover:bg-bg-hover flex items-center gap-1 cursor-pointer transition-all bg-transparent border-none shrink-0 whitespace-nowrap outline-none focus-visible:outline-2 focus-visible:outline-accent/50 focus-visible:-outline-offset-2" title={i18nT('components.approvalModePicker.approval_mode')} aria-label={i18nT('components.approvalModePicker.approval_mode_aria', { mode: displayText.label })}>
           <span className={`shrink-0 ${display.color}`}>{display.icon}</span>
           {!compact && displayText.label}
         </button>


### PR DESCRIPTION
## Summary

Add a keyboard focus indicator to the approval-mode picker button (Normal / Reads / Trust / YOLO) in the chat composer toolbar.

## Problem

The button had no visible focus ring when navigated via Tab. The previous attempt using Tailwind `ring-*` utilities was clipped by a parent `overflow:hidden` container.

## Solution

Switched to CSS `outline` which is not affected by overflow clipping:

- `outline-none` — suppress default browser outline
- `focus-visible:outline-2` — 2px outline on keyboard focus only
- `focus-visible:outline-accent/50` — theme accent color at 50% opacity
- `focus-visible:-outline-offset-2` — negative offset draws inside the element

## Testing

- Verified on localhost dev server: Tab to button shows complete rounded outline

Before:

<img width="102" height="41" alt="before" src="https://github.com/user-attachments/assets/ca87975b-8f20-4574-a1aa-b00beda5800a" />


After:
<img width="89" height="48" alt="after" src="https://github.com/user-attachments/assets/8e4fba6c-e77b-44fe-b92a-a9f8621346c2" />


- Tested all 4 modes (Normal, Reads, Trust, YOLO) — no clipping on any
- Click does not show the ring (focus-visible only triggers on keyboard nav)