### PR TITLE
fix(models): never send a model the account cannot use

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -684,6 +684,32 @@ class AcpAuthRequired(AcpError):  # noqa: N818
     """
 
 
+class AcpModelUnavailable(AcpError):  # noqa: N818
+    """An explicitly requested model is not available to this account.
+
+    A DISTINCT type because the semantics differ from every other ``set_model``
+    failure. The generic ones ("the call didn't land") are legitimately handled
+    by tearing the session down and cold-starting. This one means "the request
+    itself is invalid, and no amount of restarting changes that" — falling back
+    to a reset would destroy a live conversation and then quietly land on a
+    different model, reporting success. Callers must surface it (4xx / user
+    error), not recover from it.
+
+    Non-retryable: ``transient`` is fixed False, since no retry earns an
+    entitlement.
+    """
+
+    def __init__(self, model_id: str, advertised: Sequence[str] | None = None) -> None:
+        self.model_id = model_id
+        self.advertised = list(advertised or [])
+        usable = ", ".join(self.advertised) if self.advertised else "none advertised"
+        super().__init__(
+            f"The model {model_id!r} is not available on your account. "
+            f"Available models: {usable}.",
+            transient=False,
+        )
+
+
 class AcpPromptBusy(AcpError):  # noqa: N818
     """A prompt is already in progress on this session.
 
@@ -821,6 +847,59 @@ def _is_transient_raw_error(
         or _RE_5XX_HINT.search(haystack)
         or _RE_GENERATE_FAILED.search(data)
     )
+
+
+def advertised_model_ids(entries: object) -> list[str]:
+    """Model ids out of an ``availableModels``-shaped list, defensively.
+
+    The advertised list is remote input reshaped by several backends, so this
+    tolerates anything that is not a list of ``{"modelId": ...}`` dicts and
+    returns what it can. Shared by the three call sites that pre-flight a model
+    so none of them re-derives the shape — and so a surprising payload degrades
+    to "entitlement unknown" (empty list -> :func:`model_is_unusable` allows the
+    send) instead of raising inside session startup.
+    """
+    if not isinstance(entries, (list, tuple)):
+        return []
+    ids: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        model_id = entry.get("modelId") or entry.get("value") or ""
+        if isinstance(model_id, str) and model_id.strip():
+            ids.append(model_id)
+    return ids
+
+
+def model_is_unusable(model_id: str, advertised: Sequence[str] | None) -> bool:
+    """True when *advertised* is known and excludes *model_id*.
+
+    The counterpart to :func:`_model_is_unentitled`, moved BEFORE the wire: that
+    one explains a rejection after the fact, this one declines to send a model
+    the backend already told us the account cannot run. Deliberately ONE shared
+    predicate rather than a copy per call site — the same reason #1550 made the
+    formatter and the retry classifier share a discriminator: two spellings of
+    "can this account use it" would eventually disagree.
+
+    Returns False — allow the send — whenever entitlement is unknowable: an
+    empty/None advertised set (no session yet, or a backend that omits
+    ``models``) must not be read as "nothing is allowed", which would withhold
+    every model on a backend that simply does not advertise.
+
+    Only meaningful where the advertised ids share a namespace with *model_id*,
+    and callers gate on that. kiro-cli's advertised ids are exactly the ids
+    ``session/set_model`` accepts, so an id absent from the list is genuinely
+    unusable. The claude backend advertises BARE ids (``claude-opus-4-8[1m]``)
+    while the configured model is the prefixed provider id
+    (``global.anthropic.claude-opus-4-8[1m]``), so comparing those two
+    namespaces would call every legitimate model unusable; that backend
+    announces its own substitutions through the ``session/new`` advisory
+    instead (see ``_new_session_following_substitution``).
+    """
+    if not advertised:
+        return False
+    wanted = model_id.strip().lower()
+    return wanted not in {m.strip().lower() for m in advertised if m and m.strip()}
 
 
 def _format_acp_error(error: object, available_models: Sequence[str] | None = None) -> str:
@@ -1593,6 +1672,23 @@ class AcpClient:
         """Switch model on a running session (used by warm pool post-claim)."""
         if not self._session_id:
             raise AcpError("Cannot set model before session is initialized")
+        # Unlike the spawn path, this is an explicit request for THIS model, so
+        # a silent downgrade would report success while running something else.
+        # Refuse before the wire and name what the account can use.
+        # AcpModelUnavailable (not a bare AcpError) so callers can tell "invalid
+        # request" from "the call didn't land": the generic failure is recovered
+        # by resetting the session, which for THIS case would destroy a live
+        # conversation and then land on a different model anyway.
+        #
+        # Callers passing an INHERITED value (warm-pool post-claim re-apply of a
+        # persisted slot model) must pre-check with model_is_unusable and skip
+        # instead of calling into here — otherwise the same stale setting that is
+        # quietly withheld on a cold start would raise and kill a warm claim,
+        # making the outcome depend on whether a pooled process happened to exist.
+        if not self._is_claude and self._model_is_unusable(model_id):
+            _rejected_log, _ = redact_exfiltration_urls(str(model_id))
+            _rejected_log, _ = redact_credentials(_rejected_log)
+            raise AcpModelUnavailable(_rejected_log, self._advertised_model_ids())
         if self._is_claude:
             await self.set_config_option("model", model_id)
         else:
@@ -1669,6 +1765,65 @@ class AcpClient:
             if isinstance(model_id, str) and model_id.strip():
                 ids.append(model_id)
         return ids
+
+    def _model_is_unusable(self, model_id: str) -> bool:
+        """Whether this session's advertised set excludes *model_id*.
+
+        Thin bind of :func:`model_is_unusable` to the set captured at
+        ``session/new`` / ``session/load``, so this client and the
+        ``providers.acp`` live path share one definition of entitlement.
+        """
+        return model_is_unusable(model_id, self._advertised_model_ids())
+
+    async def _apply_startup_model(self) -> None:
+        """Apply the configured model to a freshly initialized session.
+
+        Split out of ``_init_session`` step 5 so the withhold decision is
+        reachable without standing up a whole session.
+
+        The model here was NOT chosen for this turn: it arrives from the agent
+        spec, the config default, or a slot value persisted before the account's
+        entitlements were known. So when the backend has already told us the
+        account cannot run it, withholding beats failing — the user did not pick
+        this model and cannot be expected to know why every turn dies. The
+        session simply stays on the backend's own default, which ``session/new``
+        already applied and reported as ``currentModelId``.
+
+        Note this fixes the WIRE, not the stored setting: the persisted config /
+        slot value is untouched, so a picker reading it still shows the model
+        that was withheld. Healing the stored value is a separate change.
+
+        An EXPLICIT switch is handled the opposite way in :meth:`set_model`:
+        there the user asked for that exact model, and quietly running another
+        one would be a lie.
+        """
+        if not self._model or self._model == DEFAULT_MODEL:
+            logger.info("ACP model: %s (from agent config)", self._model or "auto")
+            return
+        if not self._is_claude and self._model_is_unusable(self._model):
+            _withheld_log, _ = redact_exfiltration_urls(str(self._model))
+            _withheld_log, _ = redact_credentials(_withheld_log)
+            logger.warning(
+                "ACP model %s is not available to this account; staying on the "
+                "backend default %s (advertised: %s)",
+                _withheld_log,
+                self._resolved_model_id or DEFAULT_MODEL,
+                ", ".join(self._advertised_model_ids()),
+            )
+            # Record the session as running the default rather than the value we
+            # declined: the "!= DEFAULT_MODEL" test above is also what the
+            # warm-pool re-apply path reads (session_provider), so leaving the
+            # unusable id here would re-offer it on every claim.
+            self._model = DEFAULT_MODEL
+            return
+        if self._is_claude:
+            await self.set_config_option("model", self._model)
+        else:
+            await self._send_request(
+                METHOD_SET_MODEL,
+                {"sessionId": self._session_id, "modelId": self._model},
+            )
+        logger.info("ACP model: %s", self._model)
 
     async def set_config_option(self, config_id: str, value: str) -> None:
         """Set a session config option (e.g. effort level) via session/set_config_option."""
@@ -2406,17 +2561,7 @@ class AcpClient:
             logger.info("ACP agent activated: %s", self._agent)
 
         # 5. Set model — override if KiroCrew config specifies non-default.
-        if self._model and self._model != DEFAULT_MODEL:
-            if self._is_claude:
-                await self.set_config_option("model", self._model)
-            else:
-                await self._send_request(
-                    METHOD_SET_MODEL,
-                    {"sessionId": self._session_id, "modelId": self._model},
-                )
-            logger.info("ACP model: %s", self._model)
-        else:
-            logger.info("ACP model: %s (from agent config)", self._model or "auto")
+        await self._apply_startup_model()
 
         # Drain MCP server init notifications
         await self._drain_notifications()

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -26,7 +26,10 @@ from kiro_crew.acp.client import (
     DEFAULT_MODEL,
     AcpAuthRequired,
     AcpError,
+    AcpModelUnavailable,
     AcpProcessDied,
+    advertised_model_ids,
+    model_is_unusable,
 )
 from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeDead, AcpRuntimeError, AcpSessionHandle
 from kiro_crew.acp.types import STOP_REASON_END_TURN
@@ -477,7 +480,19 @@ class AcpSessionProvider(LLMProvider):
     # ── Model & Effort ──
 
     async def set_model(self, model_id: str) -> None:
-        """Switch the active model."""
+        """Switch the active model.
+
+        An explicit pick the account cannot run is REFUSED here rather than
+        silently downgraded (the opposite of the spawn path in ``providers.acp``,
+        which withholds an inherited default): the user asked for this exact
+        model, so reporting success while running another one would be a lie.
+        Raises :class:`AcpModelUnavailable` so the caller surfaces it as a user
+        error instead of recovering with a session reset — a reset here would
+        destroy the live conversation and still land on a different model.
+        """
+        advertised = advertised_model_ids(self._handle.available_models)
+        if model_is_unusable(model_id, advertised):
+            raise AcpModelUnavailable(model_id, advertised)
         await self._guarded(self._handle.set_model(model_id))
 
     async def set_mode(self, agent_name: str) -> None:

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -20,6 +20,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 
 from kiro_crew import model_registry
+from kiro_crew.acp.client import AcpModelUnavailable
 from kiro_crew.config.loader import (
     KiroCrewConfig,
     _workspace_name_for_dir,
@@ -1994,6 +1995,12 @@ async def _try_live_model_switch(
         return False
     try:
         await provider.client.set_model(wire)
+    except AcpModelUnavailable:
+        # NOT a "the call didn't land" failure, so the reset fallback below is
+        # the wrong recovery: it would tear down the live conversation and then
+        # cold-start on a DIFFERENT model while the caller reported success.
+        # Propagate so the handler answers 4xx and the slot keeps its old model.
+        raise
     except Exception as exc:
         logger.warning(
             "Live set_model(%s) failed for slot %s: %s: %s — falling back to reset",
@@ -2056,10 +2063,25 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
         return web.json_response({"error": reason}, status=400)
     if slot.model == model_name:
         return web.json_response({"ok": True, "model": model_name})
-    slot.model = model_name
     session_key = _history_key_for(name)
     provider = state.sessions.get_provider(session_key)
-    if await _try_live_model_switch(name, slot, provider, model_name):
+    prior_model = slot.model
+    slot.model = model_name
+    try:
+        went_live = await _try_live_model_switch(name, slot, provider, model_name)
+    except AcpModelUnavailable as exc:
+        # The live session refused the pick as unavailable to this account. Roll
+        # the slot back so the picker keeps showing what is actually running, and
+        # answer 4xx — deliberately NOT the reset fallback below, which would
+        # destroy the conversation and cold-start on a different model while
+        # reporting success. Only the session that owns the advertised list gets
+        # to make this call, so there is no pre-emptive gate here to go stale.
+        slot.model = prior_model
+        logger.warning("Slot %s model rejected: %s", name, exc)
+        return web.json_response(
+            {"error": str(exc), "code": "model_unavailable"}, status=400
+        )
+    if went_live:
         _broadcast_context_reset(state, slot.key, provider)
     else:
         logger.info("Slot %s model switched to %r, resetting session", name, model_name or "auto")

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -16,6 +16,8 @@ from kiro_crew.acp.client import (
     AcpAuthRequired,
     AcpClient,
     AcpError,
+    advertised_model_ids,
+    model_is_unusable,
 )
 from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeError
 from kiro_crew.acp.session_handle import AcpSessionHandle
@@ -658,18 +660,37 @@ class AcpProvider(LLMProvider):
             # Apply the configured model override (mirrors AcpClient handshake).
             # DEFAULT_MODEL ("auto") means "let kiro-cli pick per agent config".
             if configured_model and configured_model != DEFAULT_MODEL:
-                _t_model = time.monotonic()
-                try:
-                    await handle.set_model(configured_model)
-                    logger.info("Kiro runtime model set: %s", configured_model)
-                except Exception:
+                # Withhold a model this account cannot run rather than sending
+                # it. session/new has already reported what is on offer, and
+                # this model was NOT picked for this turn — it comes from the
+                # agent spec, the config default, or a slot value persisted
+                # before entitlements were known. Sending it anyway is what put
+                # a raw "-32603 ... model is not available" in the transcript on
+                # every turn: kiro-cli ACCEPTS the id here (so the except below
+                # never fires) and only the service rejects it, mid-prompt.
+                # Leaving it unset keeps the session on the backend's own
+                # default, so the turn succeeds.
+                _advertised = advertised_model_ids(handle.available_models)
+                if model_is_unusable(configured_model, _advertised):
                     logger.warning(
-                        "Failed to set model %s on kiro runtime session",
+                        "Configured model %s is not available to this account; "
+                        "leaving the session on the backend default (advertised: %s)",
                         configured_model,
-                        exc_info=True,
+                        ", ".join(_advertised),
                     )
-                finally:
-                    phases["set_model"] = (time.monotonic() - _t_model) * 1000.0
+                else:
+                    _t_model = time.monotonic()
+                    try:
+                        await handle.set_model(configured_model)
+                        logger.info("Kiro runtime model set: %s", configured_model)
+                    except Exception:
+                        logger.warning(
+                            "Failed to set model %s on kiro runtime session",
+                            configured_model,
+                            exc_info=True,
+                        )
+                    finally:
+                        phases["set_model"] = (time.monotonic() - _t_model) * 1000.0
 
             # Replace the placeholder AcpClient with the real AcpSessionProvider
             provider = AcpSessionProvider(handle, runtime, owns_runtime=True)

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -92,6 +92,7 @@ if TYPE_CHECKING:
     from kiro_crew.acp.types import AcpEvent
 
 from kiro_crew import model_registry, platform_compat, shutdown_event
+from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     POOL_SIZE_MAX,
@@ -2266,8 +2267,30 @@ class SessionManager:
                                 model_registry.to_acp_id(_pool_model) if _pool_model else _pool_model
                             )
                         if _pool_model and _switch_model != _cmp_pool:
-                            await provider.client.set_model(_switch_model)
-                            logger.info("Pool post-claim: switched model to %s", _switch_model)
+                            # This is an INHERITED value (the slot's persisted
+                            # model), not a pick made for this turn, so it gets
+                            # the same withhold treatment as a cold start. Left
+                            # to raise, AcpModelUnavailable would land in the
+                            # except below and kill the claimed provider — the
+                            # identical stale setting would then fail or not
+                            # purely on whether a pooled process happened to
+                            # exist, which is the worst kind of intermittent.
+                            try:
+                                _advertised = advertised_model_ids(provider.available_models())
+                            except Exception:  # pragma: no cover - defensive
+                                _advertised = []
+                            if _advertised and model_is_unusable(_switch_model, _advertised):
+                                logger.warning(
+                                    "Pool post-claim: model %s is not available to this "
+                                    "account; leaving the claimed process on %s",
+                                    _switch_model,
+                                    _pool_model,
+                                )
+                            else:
+                                await provider.client.set_model(_switch_model)
+                                logger.info(
+                                    "Pool post-claim: switched model to %s", _switch_model
+                                )
                 logger.info(
                     "Claimed warm-pool process for %s (agent=%s)", key, agent or self._pool_agent
                 )

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -8843,3 +8843,144 @@ class TestCompactionResetsContextStats:
         assert stats.context_pct == 0.0
         assert stats.context_used_tokens == 0
         assert stats.context_window_tokens == 200_000
+
+
+class TestModelEntitlementPreflight:
+    """An unusable model is stopped BEFORE the wire, not explained afterwards.
+
+    PR #1550 made a post-hoc rejection readable and terminal. These cover the
+    turn never failing in the first place: the advertised set is known at
+    session/new, so a model the account cannot run has no business being sent.
+    """
+
+    @staticmethod
+    def _client(advertised, model, is_claude=False):
+        from kiro_crew.acp.client import ACP_BACKEND_CLAUDE, AcpClient
+
+        client = AcpClient()
+        client._session_id = "sess-1"
+        client._model = model
+        # _is_claude is derived from the backend seam, not settable directly.
+        client._acp_backend = ACP_BACKEND_CLAUDE if is_claude else ""
+        client._available_models = [{"modelId": m, "name": m} for m in advertised]
+        return client
+
+    def test_unadvertised_model_is_unusable(self):
+        client = self._client(["claude-sonnet-4.6"], "claude-opus-4.8")
+        assert client._model_is_unusable("claude-opus-4.8") is True
+
+    def test_advertised_model_is_usable(self):
+        client = self._client(["claude-sonnet-4.6", "claude-opus-4.8"], "claude-opus-4.8")
+        assert client._model_is_unusable("claude-opus-4.8") is False
+
+    def test_unknown_entitlement_allows_the_send(self):
+        """Empty advertised set means "unknowable", never "nothing is allowed".
+
+        A backend that omits ``models`` must not have every model withheld.
+        """
+        client = self._client([], "claude-opus-4.8")
+        assert client._model_is_unusable("claude-opus-4.8") is False
+
+    def test_match_is_case_and_space_insensitive(self):
+        client = self._client(["Claude-Opus-4.8"], "claude-opus-4.8")
+        assert client._model_is_unusable("  claude-opus-4.8 ") is False
+
+    @pytest.mark.asyncio
+    async def test_startup_withholds_unusable_model(self):
+        """The screenshot case: a stale default the account cannot run.
+
+        Nothing goes on the wire and the session is recorded as running the
+        backend default, so the turn proceeds instead of dying three retries in.
+        """
+        from kiro_crew.acp.client import DEFAULT_MODEL
+
+        client = self._client(["claude-sonnet-4.6"], "claude-opus-4.8")
+        client._resolved_model_id = "claude-sonnet-4.6"
+        sent = []
+        client._send_request = _record(sent)
+
+        await client._apply_startup_model()
+
+        assert sent == []
+        # Not left holding the id we declined -- the warm-pool re-apply path
+        # reads this and would re-offer it on every claim.
+        assert client._model == DEFAULT_MODEL
+
+    @pytest.mark.asyncio
+    async def test_startup_still_applies_a_usable_model(self):
+        client = self._client(["claude-sonnet-4.6", "claude-opus-4.8"], "claude-opus-4.8")
+        sent = []
+        client._send_request = _record(sent)
+
+        await client._apply_startup_model()
+
+        assert len(sent) == 1
+        assert sent[0][1]["modelId"] == "claude-opus-4.8"
+        assert client._model == "claude-opus-4.8"
+
+    @pytest.mark.asyncio
+    async def test_startup_leaves_claude_backend_alone(self):
+        """The claude backend advertises BARE ids while _model is prefixed.
+
+        Comparing the two namespaces would call every legitimate model unusable,
+        so that backend keeps its own session/new substitution advisory.
+        """
+        client = self._client(
+            ["claude-opus-4-8[1m]"],
+            "global.anthropic.claude-opus-4-8[1m]",
+            is_claude=True,
+        )
+        applied = []
+
+        async def _set_config_option(config_id, value):
+            applied.append((config_id, value))
+
+        client.set_config_option = _set_config_option
+
+        await client._apply_startup_model()
+
+        assert applied == [("model", "global.anthropic.claude-opus-4-8[1m]")]
+
+    @pytest.mark.asyncio
+    async def test_explicit_switch_is_refused_not_downgraded(self):
+        """An explicit pick gets an error, because silence would misreport it."""
+        from kiro_crew.acp.client import AcpModelUnavailable
+
+        client = self._client(["claude-sonnet-4.6", "claude-haiku-4.5"], "claude-sonnet-4.6")
+        sent = []
+        client._send_request = _record(sent)
+
+        with pytest.raises(AcpModelUnavailable) as excinfo:
+            await client.set_model("claude-opus-4.8")
+
+        assert sent == []
+        msg = str(excinfo.value)
+        assert "claude-opus-4.8" in msg
+        assert "not available on your account" in msg
+        # The actionable part: what they CAN pick.
+        assert "claude-sonnet-4.6" in msg
+        assert "claude-haiku-4.5" in msg
+        # Terminal, and EXPLICITLY so -- None would send the retry layer back to
+        # string-matching, which is what produced the retry rows.
+        assert excinfo.value.transient is False
+
+    @pytest.mark.asyncio
+    async def test_explicit_switch_to_advertised_model_works(self):
+        client = self._client(["claude-sonnet-4.6", "claude-opus-4.8"], "claude-sonnet-4.6")
+        sent = []
+        client._send_request = _record(sent)
+
+        await client.set_model("claude-opus-4.8")
+
+        assert len(sent) == 1
+        assert client._model == "claude-opus-4.8"
+
+
+def _record(sink):
+    """An async _send_request stub that records calls and returns a request id."""
+
+    async def _send_request(method, params=None):
+        sink.append((method, params or {}))
+        return 1
+
+    return _send_request

--- a/test/test_acp_provider.py
+++ b/test/test_acp_provider.py
@@ -957,3 +957,70 @@ class TestLoadSessionWithRetry:
         assert got is None
         assert rt.load_session.await_count == 1  # bail as soon as the runtime is dead
         assert sleep_mock.await_count == 0
+
+
+class TestStartKiroRuntimeModelEntitlement:
+    """_start_kiro_runtime withholds a configured model the account cannot run.
+
+    This is the path real dashboard sessions take. Sending an unusable model
+    here is what produced a failed turn every time: kiro-cli ACCEPTS the id at
+    session/set_model, so nothing fails locally, and only the service rejects
+    it mid-prompt as "-32603 ... model is not available".
+    """
+
+    def _kiro_provider(self, model):
+        provider = _build_provider(backend="")  # kiro backend
+        provider._client._work_dir = "/tmp/ws"
+        provider._client._agent = "kirocrew"
+        provider._client._sandbox_mode = "auto"
+        provider._client._extra_env = {}
+        provider._client._mcp_gateway_overlay = None
+        provider._client._mcp_gateway_settings_mcp_json = None
+        provider._client._mcp_gateway_socket = None
+        provider._client._model = model
+        provider._client._resume_session_id = ""  # straight to create_session
+        return provider
+
+    async def _run(self, model, advertised):
+        provider = self._kiro_provider(model)
+        handle = MagicMock()
+        handle.session_id = "kiro-sess-1"
+        handle.store_session_config = MagicMock()
+        handle.set_model = AsyncMock()
+        handle.available_models = [{"modelId": m, "name": m} for m in advertised]
+        runtime = MagicMock()
+        runtime.pid = 4321
+        runtime.spawn = AsyncMock()
+        runtime.create_session = AsyncMock(return_value=handle)
+
+        with (
+            patch("kiro_crew.providers.acp.AcpRuntime", return_value=runtime),
+            patch(
+                "kiro_crew.providers.acp.AcpSessionProvider",
+                side_effect=lambda h, r, **kw: MagicMock(_handle=h, _runtime=r, resumed=False),
+            ),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            await provider._start_kiro_runtime()
+        return handle
+
+    @pytest.mark.asyncio
+    async def test_unusable_configured_model_is_never_sent(self):
+        handle = await self._run("claude-opus-4.8", ["claude-sonnet-4.6"])
+        handle.set_model.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_usable_configured_model_is_applied(self):
+        handle = await self._run("claude-opus-4.8", ["claude-sonnet-4.6", "claude-opus-4.8"])
+        handle.set_model.assert_awaited_once_with("claude-opus-4.8")
+
+    @pytest.mark.asyncio
+    async def test_unknown_entitlement_still_applies(self):
+        """No advertised list means unknowable, so behaviour is unchanged."""
+        handle = await self._run("claude-opus-4.8", [])
+        handle.set_model.assert_awaited_once_with("claude-opus-4.8")
+
+    @pytest.mark.asyncio
+    async def test_auto_sentinel_never_reaches_the_check(self):
+        handle = await self._run("auto", ["claude-sonnet-4.6"])
+        handle.set_model.assert_not_awaited()

--- a/test/test_acp_session_provider.py
+++ b/test/test_acp_session_provider.py
@@ -1008,3 +1008,77 @@ class TestNewConversation:
         # destroyed and stays the provider's handle for the hard-reset fallback.
         new_handle.destroy.assert_awaited_once()
         assert provider._handle is old
+
+
+class TestLivePathModelEntitlement:
+    """The guard has to sit on the path real sessions actually take.
+
+    Dashboard sessions do NOT go through AcpClient's handshake — providers.acp
+    spawns an AcpRuntime and applies the configured model with
+    ``handle.set_model``. A guard in AcpClient alone would be inert here, which
+    is exactly how the unusable model kept reaching the wire.
+    """
+
+    @staticmethod
+    def _provider(advertised):
+        from kiro_crew.acp.session_provider import AcpSessionProvider
+
+        handle = _make_handle()
+        handle.available_models = [{"modelId": m, "name": m} for m in advertised]
+        handle.set_model = AsyncMock()
+        return AcpSessionProvider(handle, MagicMock()), handle
+
+    @pytest.mark.asyncio
+    async def test_explicit_switch_refused_on_live_path(self):
+        from kiro_crew.acp.client import AcpModelUnavailable
+
+        provider, handle = self._provider(["claude-sonnet-4.6", "claude-haiku-4.5"])
+
+        with pytest.raises(AcpModelUnavailable) as excinfo:
+            await provider.set_model("claude-opus-4.8")
+
+        handle.set_model.assert_not_awaited()
+        msg = str(excinfo.value)
+        assert "not available on your account" in msg
+        assert "claude-sonnet-4.6" in msg
+        # Terminal, so the retry ladder does not reproduce the same rejection.
+        assert excinfo.value.transient is False
+
+    @pytest.mark.asyncio
+    async def test_advertised_switch_still_applied_on_live_path(self):
+        provider, handle = self._provider(["claude-sonnet-4.6", "claude-opus-4.8"])
+
+        await provider.set_model("claude-opus-4.8")
+
+        handle.set_model.assert_awaited_once_with("claude-opus-4.8")
+
+    @pytest.mark.asyncio
+    async def test_unknown_advertised_set_still_applied(self):
+        """A backend that advertises nothing must not have every switch refused."""
+        provider, handle = self._provider([])
+
+        await provider.set_model("claude-opus-4.8")
+
+        handle.set_model.assert_awaited_once_with("claude-opus-4.8")
+
+    @pytest.mark.asyncio
+    async def test_malformed_advertised_payload_does_not_raise(self):
+        """Remote-shaped input degrades to "unknown", never an exception."""
+        provider, handle = self._provider([])
+        handle.available_models = "not-a-list"
+
+        await provider.set_model("claude-opus-4.8")
+
+        handle.set_model.assert_awaited_once_with("claude-opus-4.8")
+
+
+class TestAdvertisedModelIds:
+    def test_extracts_ids_and_tolerates_junk(self):
+        from kiro_crew.acp.client import advertised_model_ids
+
+        assert advertised_model_ids([{"modelId": "a"}, {"value": "b"}]) == ["a", "b"]
+        # Non-list, non-dict members, and blank ids are all dropped rather than
+        # raising inside session startup.
+        assert advertised_model_ids(None) == []
+        assert advertised_model_ids("nope") == []
+        assert advertised_model_ids([{"modelId": "  "}, "x", 7]) == []

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -11731,6 +11731,44 @@ class TestSlotModelLiveSwitch:
         provider.change_effort.assert_not_awaited()
         state.sessions.reset.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_unavailable_model_is_4xx_and_keeps_the_session(self, tmp_path):
+        """An entitlement refusal must NOT take the reset fallback.
+
+        Design Review on #1596: the generic ``except Exception`` here treats
+        every set_model failure as "the call didn't land" and recovers with a
+        reset. For a model the account cannot use that recovery is wrong twice
+        over — it destroys the live conversation AND cold-starts on a different
+        model, while the handler still answers ok:True. The slot must also keep
+        its previous model, or the picker asserts a model that was refused.
+        """
+        from kiro_crew.acp.client import AcpModelUnavailable
+
+        state = _make_state(tmp_path)
+        state.sessions.reset = AsyncMock()
+        provider = self._provider()
+        provider.client.set_model = AsyncMock(
+            side_effect=AcpModelUnavailable("claude-opus-4.8", ["gpt-5.6-sol"])
+        )
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        state.get_or_create_slot("a", model="gpt-5.6-sol")
+        state.push_slots_update = MagicMock()
+
+        async with TestClient(TestServer(self._app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "not available on your account" in body["error"]
+        # Names what the account CAN use.
+        assert "gpt-5.6-sol" in body["error"]
+        # The conversation survives — no reset fallback.
+        state.sessions.reset.assert_not_awaited()
+        # And the slot still reports the model that is actually running.
+        assert state._slots["a"].model == "gpt-5.6-sol"
+
 
 class TestSlotModelSwitchContextBroadcast:
     """POST /api/chat/slots/{slot}/model — one ``context_usage`` event per

--- a/test/test_session_pool.py
+++ b/test/test_session_pool.py
@@ -639,6 +639,38 @@ class TestModelMatchesPoolDefault:
         # (pool process already has whatever model kiro-cli defaults to)
         pooled.client.set_model.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_unusable_model_is_withheld_not_raised_on_claim(self):
+        """A stale slot model must behave the SAME warm as cold.
+
+        Design Review on #1596: the post-claim re-apply carries an INHERITED
+        value, so letting AcpModelUnavailable escape here would kill the claimed
+        provider — while an identical cold start quietly withholds. That makes
+        the outcome depend on whether a pooled process happened to exist.
+        """
+        from kiro_crew.providers.acp import AcpProvider
+
+        mgr, factory = _make_manager(pool_agent="kirocrew")
+        pooled = _make_provider()
+        pooled.__class__ = AcpProvider
+        pooled.client = MagicMock()
+        pooled.client.set_model = AsyncMock()
+        pooled.client.resumed = False
+        pooled.client._session_id = "fake-sid"
+        # The account can only run sonnet; the slot still asks for opus.
+        pooled.available_models = MagicMock(return_value=[{"modelId": "claude-sonnet-4.6"}])
+        mgr._drain_and_claim = AsyncMock(return_value=pooled)
+        mgr._schedule_replenish = MagicMock()
+
+        with patch.object(type(mgr), "_resolve_agent_model", return_value="claude-sonnet-4.6"):
+            provider, _is_new, _resumed = await mgr.get_or_create(
+                "test-key", agent="kirocrew", model="claude-opus-4.8"
+            )
+
+        # Withheld, not sent — and the claim survives.
+        pooled.client.set_model.assert_not_awaited()
+        assert provider is pooled
+
 
 # ---------------------------------------------------------------------------
 # Stateless sessions must not claim from pool


### PR DESCRIPTION
## The problem

A model the account cannot use was being **sent** at session startup, and only rejected mid-prompt. Every turn died like this:

```
Backend hiccup — retrying...
Backend hiccup — retrying...
Backend hiccup — retrying...
ACP error: {'code': -32603, 'message': 'Internal error', 'data': "Encountered an
error in the response stream: The model 'claude-opus-4.8' is not available. ..."}
```

The model is rarely one the user picked. It arrives from the agent spec, the config default, or a slot value persisted before the account's entitlements were known — the reporting user's own configured default was Opus 5, which never went on the wire at all.

`#1550` made that rejection readable and terminal. This stops it happening: `session/new` already reports what the account can run, so the check belongs **ahead of the wire**.

## What changed

Two deliberately opposite behaviours, because the two cases mean different things:

| Case | Behaviour | Why |
|---|---|---|
| Startup, inherited default | Withhold it; session stays on the backend's own default | The user never picked this model. Failing the turn punishes them for a stale setting. |
| Explicit switch | Refuse with an error naming the usable models | They asked for *that* model; silently running another would misreport it. |

The refusal passes `transient=False` **explicitly**. Leaving it as the default `None` means "unclassified" and sends the retry layer back to string-matching the message — which is what earned those three retry rows.

## The guard is on the path that actually runs

`AcpClient` is not how dashboard sessions start. `providers/acp.py` spawns an `AcpRuntime`, creates an `AcpSessionHandle`, and applies the model with `handle.set_model`. **A guard in `AcpClient` alone would have been inert for the reported failure** — so it sits on all three call sites, sharing one predicate for the same reason #1550 made the formatter and the retry classifier share a discriminator.

Note the pre-existing `except Exception` around `handle.set_model` never fired here: kiro-cli *accepts* the id locally, and only the service rejects it once the prompt streams.

## Fails safe

- **Unknown or malformed advertised set** → "entitlement unknowable", allow the send. An empty list must never read as "nothing is allowed", or a backend that omits `models` would have every model withheld. `advertised_model_ids` tolerates non-list payloads rather than raising inside session startup.
- **Claude backend excluded.** It advertises bare ids (`claude-opus-4-8[1m]`) while the configured model is the prefixed provider id (`global.anthropic.claude-opus-4-8[1m]`); comparing those namespaces would reject every legitimate model. That backend keeps its own `session/new` substitution advisory.

## Scope limit

This fixes the **wire**, not the stored setting. The persisted config / slot value is untouched, so a picker reading it still displays the model that was withheld. Healing the stored value is a follow-up — worth doing, since `#1549` filters the picker but never clears an already-persisted selection, which is why an existing install stayed broken.

## Verification

- 18 new tests across the three paths; **revert-verified** (reverting the source drops the withhold and refusal tests to failing, leaving the no-regression guards passing).
- `2120 passed` across the acp / provider / session / dashboard-chat / cc-models suites.
- `isort` + `flake8` clean on CI scope (`src/kiro_crew test`); `mypy src/kiro_crew/` clean apart from a pre-existing `vector_memory.py` faiss overload that reproduces on `origin/main`.
