### PR TITLE
fix(build): make build fails for anyone whose python comes from uv or mise

### DIFF
--- a/ensure-python.sh
+++ b/ensure-python.sh
@@ -11,9 +11,10 @@
 # to resolve modern deps (AL2/3.7) or the install "succeeds" and then crashes at
 # import (AL2023/3.9). Prefer any already-usable system Python >= 3.10;
 # otherwise install one via mise, whose python-build-standalone binaries run on
-# AL2's glibc 2.26. On success the chosen interpreter path is recorded in
-# "<data-home>/python-bin" so non-interactive callers (make) can use it without
-# re-running a version manager. The data home is "$KIROCREW_HOME" when set, else
+# AL2's glibc 2.26. On success the chosen interpreter's real path — symlinks
+# resolved, see _resolve — is recorded in "<data-home>/python-bin" so
+# non-interactive callers (make) can use it without re-running a version
+# manager. The data home is "$KIROCREW_HOME" when set, else
 # "$HOME/.kiro/crew" (the current default) — NOT the pre-move "$HOME/.kirocrew",
 # which the one-time data-home migration deletes, so writing there would
 # resurrect the legacy dir on every build.
@@ -55,6 +56,30 @@ _mise_bin() {
     fi
 }
 
+# Resolve a python path through any symlinks. Every candidate is passed through
+# this before being reported or recorded, because the recorded path is what
+# `make backend` runs `-m venv` with, and python-build-standalone interpreters —
+# what uv, mise and pyenv install — locate their stdlib relative to the
+# *invoked* path's dirname instead of following the symlink first. Creating a
+# venv from a symlink such as "$HOME/.local/bin/python3.13" (how uv and mise
+# expose an interpreter on PATH) therefore writes `home = $HOME/.local/bin` into
+# pyvenv.cfg, so the venv looks for the stdlib under
+# "$HOME/.local/lib/python3.13" and aborts with "ModuleNotFoundError: No module
+# named 'encodings'", failing ensurepip and the build. That is fatal wherever
+# venv copies the interpreter instead of symlinking it, which is the default for
+# framework builds on macOS. Resolve with Python rather than realpath(1) or
+# `readlink -f`, whose presence and flags differ across the macOS and Amazon
+# Linux targets above; the interpreter is already known to run by this point.
+_resolve() {
+    local real
+    real="$("$1" -c 'import os, sys; print(os.path.realpath(sys.executable))' 2>/dev/null)"
+    if [ -n "$real" ] && [ -x "$real" ]; then
+        printf '%s\n' "$real"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
 _record() {
     home="${KIROCREW_HOME:-$HOME/.kiro/crew}"
     mkdir -p "$home"
@@ -64,6 +89,7 @@ _record() {
 # 1. Existing usable system python.
 PY="$(_find_system_python)"
 if [ -n "$PY" ]; then
+    PY="$(_resolve "$PY")"
     echo "  ✅ python $(_pyver "$PY") ($PY)"
     _record "$PY"
     exit 0
@@ -76,6 +102,7 @@ MISE="$(_mise_bin)"
 if [ -n "$MISE" ]; then
     CAND="$("$MISE" which python 2>/dev/null)"
     if _py_ok "$CAND"; then
+        CAND="$(_resolve "$CAND")"
         echo "  ✅ python $(_pyver "$CAND") (mise: $CAND)"
         _record "$CAND"
         exit 0
@@ -97,6 +124,7 @@ fi
 "$MISE" use -g "python@$TARGET_PY" 2>/dev/null
 CAND="$("$MISE" which python 2>/dev/null)"
 if _py_ok "$CAND"; then
+    CAND="$(_resolve "$CAND")"
     echo "  ✅ python $(_pyver "$CAND") installed ($CAND)"
     _record "$CAND"
 else

--- a/test/test_ensure_python_symlink.py
+++ b/test/test_ensure_python_symlink.py
@@ -1,0 +1,111 @@
+"""``ensure-python.sh`` must record a real interpreter path, not a symlink.
+
+uv and mise expose the interpreter they manage as a symlink on PATH (typically
+``~/.local/bin/python3.13``). python-build-standalone builds — what both of them
+install — locate their stdlib relative to the *invoked* path's dirname instead of
+following the symlink first, so a venv created from that symlink is written with
+``home = ~/.local/bin`` in ``pyvenv.cfg``, looks for the stdlib under
+``~/.local/lib/python3.13``, and aborts with "ModuleNotFoundError: No module
+named 'encodings'" — which fails ensurepip and so ``make build``.
+
+``make backend`` feeds the recorded path straight to ``python -m venv``, so
+resolving symlinks before recording is what keeps that working.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="ensure-python.sh is a bash script; Windows uses a different bootstrap",
+)
+
+SCRIPT = Path(__file__).parent.parent / "ensure-python.sh"
+
+# The interpreter names ensure-python.sh probes, in its own preference order.
+# Symlinking all of them makes the test independent of which one it settles on.
+_PROBED_NAMES = (
+    "python3.13",
+    "python3.12",
+    "python3.11",
+    "python3.10",
+    "python3",
+    "python",
+)
+
+
+def _record_via_symlinked_python(tmp_path: Path) -> str:
+    """Run the script with every probed name symlinked; return the recorded path.
+
+    Reproduces the uv/mise layout: the only pythons on PATH are symlinks, the
+    shape that made the script record a path a venv cannot be built from.
+    """
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for name in _PROBED_NAMES:
+        (fake_bin / name).symlink_to(sys.executable)
+
+    home = tmp_path / "home"
+    env = dict(os.environ)
+    env["KIROCREW_HOME"] = str(home)
+    # The symlinks must win the PATH search, but the script also shells out to
+    # `mkdir`, so keep coreutils reachable.
+    env["PATH"] = os.pathsep.join([str(fake_bin), "/usr/bin", "/bin"])
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    recorded = (home / "python-bin").read_text().strip()
+    assert recorded, f"nothing recorded; script said: {proc.stdout}{proc.stderr}"
+    return recorded
+
+
+def test_records_the_resolved_path_when_python_on_path_is_a_symlink(tmp_path):
+    recorded = _record_via_symlinked_python(tmp_path)
+
+    assert not Path(recorded).is_symlink(), (
+        f"recorded a symlink ({recorded}) — a venv built from it gets "
+        "`home = <the symlink's dirname>` in pyvenv.cfg and cannot find its stdlib"
+    )
+    assert Path(recorded).exists(), recorded
+
+
+def test_a_venv_built_from_the_recorded_path_can_import_the_stdlib(tmp_path):
+    """The reported symptom: ``make build`` died inside ensurepip.
+
+    ``--copies`` is what makes this bite. macOS copies the interpreter into the
+    venv by default for framework builds, leaving ``pyvenv.cfg``'s ``home`` as
+    the only thing that says where the stdlib lives. Linux symlinks instead and
+    so happens to survive a wrong ``home`` — without ``--copies`` this test
+    would pass even with the bug present.
+    """
+    recorded = _record_via_symlinked_python(tmp_path)
+
+    venv = tmp_path / "venv"
+    subprocess.run(
+        [recorded, "-m", "venv", "--copies", "--without-pip", str(venv)],
+        check=True,
+        capture_output=True,
+        timeout=60,
+    )
+
+    proc = subprocess.run(
+        [str(venv / "bin" / "python"), "-c", "import encodings; print('ok')"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "ok" in proc.stdout


### PR DESCRIPTION
## Problem / Motivation

`make build` fails while creating the venv on any machine where the Python it finds on PATH is a symlink — which is exactly how uv and mise expose the interpreter they manage:

```
ModuleNotFoundError: No module named 'encodings'
```

ensurepip then fails and the build stops. `rm -rf .venv` and rebuilding reproduces it every time, because the symlink path is written back on each run.

## Why it matters

uv and mise both put their shim in `~/.local/bin`, so anyone relying on either to provide Python hits this on the first `make build`. The error points at the venv rather than at the recorded path, so it is not obvious where to look.

## What changed (motivation → approach → change)

**Symptom** → `python -m venv` produced a venv whose interpreter cannot find its stdlib.

**Root cause** → `ensure-python.sh:59` records the discovered path without resolving it, and `Makefile:46` feeds that path straight to `python -m venv`. python-build-standalone builds — what uv, mise and pyenv install — locate their stdlib relative to the dirname of the path they were *invoked* through, rather than following the symlink first. A venv created from `~/.local/bin/python3.13` is therefore written with

```
home = /Users/me/.local/bin        # the symlink's dirname
```

and then looks for the stdlib under `~/.local/lib/python3.13/`, which does not exist.

Whether that is fatal depends on how venv materialises the interpreter. macOS **copies** it for framework builds, leaving `home` as the only thing that says where the stdlib is → hard failure. Linux **symlinks** it, and that symlink resolves to the real interpreter, so the wrong `home` goes unnoticed. Hence macOS in practice.

**Change** → resolve each candidate through its symlinks before reporting or recording it (`_resolve`), applied at the three points where a candidate is confirmed. The path printed on success is then the same one recorded — the original bug was precisely a silent divergence between those two.

`realpath(1)` would be the shorter one-liner, but this script also targets macOS and Amazon Linux 2, where `realpath` availability and `readlink -f` support are not consistent. The interpreter is already known to run at that point, so `os.path.realpath(sys.executable)` is used instead: one mechanism, identical behaviour everywhere, no new dependency. It falls back to the original path if resolution yields nothing executable.

One deliberate side effect: a *venv* interpreter on PATH now resolves to its base interpreter, which is what you want when the recorded path is about to be used to create a fresh venv.

## Tests

`test/test_ensure_python_symlink.py` runs the real script with every probed interpreter name symlinked, reproducing the uv/mise layout. Both tests fail on current `main`:

- the recorded path is not a symlink
- a venv built from the recorded path can import the stdlib — created with `--copies` on purpose, since the Linux default of symlinking masks the bug

## Manual verification

Reproduced and confirmed fixed on Linux against a uv-managed interpreter:

```bash
REAL=~/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/bin/python3.12
mkdir -p /tmp/fakebin && ln -s "$REAL" /tmp/fakebin/python3.12
/tmp/fakebin/python3.12 -m venv --copies /tmp/v   # --copies = what macOS does by default
```

- Before: `home = /tmp/fakebin`, exit 1, `ModuleNotFoundError: No module named 'encodings'`
- After: `home = <real uv path>/bin`, exit 0, interpreter runs

Also confirmed a non-symlink path is recorded unchanged, and that the two mise branches resolve as well.

Note on scope: I reproduced this on Linux using `--copies` to force the layout macOS uses. I have not run the build on macOS myself — the original report came from a macOS build, where it fails with the default (non-`--copies`) invocation.

## Screenshots / video

N/A — build script change, no user-visible UI.

## Related Issues

None filed; found while building from source.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the script's header comment now states that the recorded path is symlink-resolved
- [x] No secrets, credentials, or internal references in the diff
