### PR TITLE
fix(ci): resolve fork PR Readiness by matching fork runs on source identity

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -139,7 +139,7 @@ jobs:
           esac
 
           pr_json="$(gh pr view "$PR" --repo "$REPO" \
-            --json number,state,isDraft,isCrossRepository,headRefOid,url)"
+            --json number,state,isDraft,isCrossRepository,headRefOid,headRefName,headRepositoryOwner,headRepository,url)"
           SHA="$(jq -r '.headRefOid' <<<"$pr_json")"
           STATE="$(jq -r '.state' <<<"$pr_json")"
 
@@ -150,6 +150,12 @@ jobs:
             echo "fork=$(jq -r '.isCrossRepository' <<<"$pr_json")"
             echo "draft=$(jq -r '.isDraft' <<<"$pr_json")"
             echo "url=$(jq -r '.url' <<<"$pr_json")"
+            # The head repo full_name ("owner/name") and head branch identify the
+            # SOURCE of the PR's runs. For a fork PR these disambiguate its own
+            # workflow runs from any foreign fork run that happens to share the
+            # head SHA (see the run selector in "Evaluate current revision").
+            echo "head_repo=$(jq -r '.headRepositoryOwner.login + "/" + .headRepository.name' <<<"$pr_json")"
+            echo "head_branch=$(jq -r '.headRefName' <<<"$pr_json")"
           } >> "$GITHUB_OUTPUT"
 
           if [ -n "$EXPECTED_SHA" ] && [ "$EXPECTED_SHA" != "$SHA" ]; then
@@ -189,6 +195,8 @@ jobs:
           SHA: ${{ steps.context.outputs.sha }}
           DRAFT: ${{ steps.context.outputs.draft }}
           FORK: ${{ steps.context.outputs.fork }}
+          HEAD_REPO: ${{ steps.context.outputs.head_repo }}
+          HEAD_BRANCH: ${{ steps.context.outputs.head_branch }}
           TRIGGER_EVENT: ${{ github.event_name }}
           TRIGGER_ACTION: ${{ github.event.action }}
         run: |
@@ -239,9 +247,38 @@ jobs:
             else
               runs="$(gh api --method GET \
                 "repos/$REPO/actions/workflows/$file/runs?event=pull_request&head_sha=$SHA&per_page=20")"
-              run="$(jq -c --argjson pr "$PR" '
+              # Same-repo pull_request runs carry this PR's number in
+              # .pull_requests, so match on it. Fork pull_request runs come back
+              # with an EMPTY .pull_requests[] array (GitHub never populates it
+              # for a head in a different repository), so a number match drops
+              # every fork run and the check is scored "not started" forever --
+              # freezing fork readiness at pending instead of the intended
+              # terminal "maintainer review" verdict.
+              #
+              # For a fork PR ($FORK) we therefore match its runs by SOURCE
+              # IDENTITY -- the head repository full_name and head branch -- not
+              # by .pull_requests. head_sha pins the commit, not the pull request,
+              # and the base repo's run list includes fork runs, so a same-repo PR
+              # #N at SHA S can coexist with a fork PR that pushed the identical
+              # commit S. Matching on (head_repository.full_name, head_branch)
+              # selects exactly this fork PR's own runs: it excludes the same-repo
+              # runs (different head repo) AND any OTHER fork's runs at the same
+              # SHA (different head repo/branch), so neither a same-repo PR nor a
+              # second fork PR can borrow this PR's verdict. A fork PR still
+              # terminates at the RED "maintainer review" verdict; this only fixes
+              # WHICH runs feed CI/Build/Code Review completeness.
+              run="$(jq -c \
+                --argjson pr "$PR" \
+                --arg fork "$FORK" \
+                --arg head_repo "$HEAD_REPO" \
+                --arg head_branch "$HEAD_BRANCH" '
                 [.workflow_runs[]
-                 | select([.pull_requests[]?.number] | index($pr))]
+                 | select(
+                     ($fork != "true" and ([.pull_requests[]?.number] | index($pr)))
+                     or ($fork == "true"
+                         and (.head_repository.full_name == $head_repo)
+                         and (.head_branch == $head_branch))
+                   )]
                 | sort_by(.created_at)
                 | last // empty
               ' <<<"$runs")"

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -221,7 +221,10 @@ class TestPrReadiness:
     def test_readiness_leaves_untriggered_merge_and_review_state_to_live_gates(self) -> None:
         workflow = _workflow("pr-readiness.yml")
 
-        assert "--json number,state,isDraft,isCrossRepository,headRefOid,url)" in workflow
+        assert (
+            "--json number,state,isDraft,isCrossRepository,"
+            "headRefOid,headRefName,headRepositoryOwner,headRepository,url)"
+        ) in workflow
         assert "mergeStateStatus" not in workflow
         assert "reviewDecision" not in workflow
         assert "MERGEABLE:" not in workflow


### PR DESCRIPTION
## Problem

Fork PRs get stuck showing `PR Readiness` = **pending** ("N readiness check(s) still pending") indefinitely, even after all of CI, Build, and Code Review have finished green. The gate never resolves to its intended terminal fork verdict. Observed live on #1500 (`ryancormack/KiroCrew-fork`): the commit status sat at `pending / 3 readiness check(s) still pending` long after every check completed.

## Why it matters

For a fork PR, PR Readiness is supposed to terminate at a dedicated RED `readiness: maintainer review` (`PR Readiness` = failure) — the signal that a maintainer must review manually because the secret-backed AI reviewers/CodeQL structurally cannot run on a fork head. When it instead freezes at `pending`, the merge box shows an indefinite yellow "checking" state instead of the intended RED, and the pending status is misleading. `pr-readiness-sweep.yml` already re-dispatches a recompute for stuck fork PRs, but the recompute re-derived the same wrong pending result — so the freeze persisted.

## Fix (symptom → root cause → change)

- **Symptom:** fork readiness perpetually `pending`; CI/Build/Code Review scored "not started" despite being complete.
- **Root cause:** the "Evaluate current revision" step selects each monitored workflow run for the PR head SHA and then filters candidates by `[.pull_requests[]?.number] | index($pr)`. GitHub leaves `.pull_requests[]` **empty** for a workflow run whose head is in a *different* repository (every fork run). The PR-number filter therefore drops every fork run, so CI/Build/Code Review are all counted as "not started" → the verdict stays `pending`. Confirmed empirically: the `actions/workflows/{ci,build,code-review}.yml/runs` entries for #1500's head SHA all return `pull_requests: []` with `head_repository.full_name = ryancormack/KiroCrew-fork`.
- **Change:** for a fork PR (`$FORK == "true"`), match its runs by **source identity** — `head_repository.full_name == <PR head repo>` and `head_branch == <PR head branch>` — instead of by `.pull_requests`. The context step now resolves `head_repo` (`headRepositoryOwner.login + "/" + headRepository.name`) and `head_branch` from `gh pr view` and passes them to the evaluate step. The **same-repo path is unchanged** (still the PR-number match).
  - Source identity, not "any empty-`.pull_requests` run": `head_sha` pins the commit, not the pull request, and the base repo's run list includes fork runs. A same-repo PR #N at SHA S can coexist with a fork PR that pushed the identical commit S, whose runs carry an empty `.pull_requests[]`. Gating the fork branch on `$FORK` **and** matching (head repo, head branch) selects exactly this fork PR's own runs — it never lets a same-repo PR pick up a foreign fork run, and never lets one fork PR borrow another fork PR's runs.
  - This only fixes *which* runs feed CI/Build/Code Review completeness; a fork PR still terminates at the RED `maintainer review` verdict (that branch is unchanged). The recompute trigger is unchanged too — the existing `pr-readiness-sweep.yml` (and `pull_request_target` on PR edits) re-invoke evaluation; this change makes that recompute resolve correctly instead of re-deriving pending.

## Tests

No automated harness exists for the workflow-embedded bash/jq (there is no workflow-logic test framework in-repo). Verification was done by exercising the exact selector jq against representative fixtures (see Manual verification). This is a CI-workflow-only change; no product code paths are touched.

## Manual verification

- Confirmed the real failure signature on #1500: `actions/workflows/*/runs?head_sha=<S>` returns `pull_requests: []` for all three of CI/Build/Code Review, with `head_repository.full_name = ryancormack/KiroCrew-fork` and `head_branch = feat/instances-ssm`.
- Confirmed `gh pr view 1500 --json headRepositoryOwner,headRepository,headRefName` yields the identical `ryancormack/KiroCrew-fork` / `feat/instances-ssm`, so the source-identity match lines up field-for-field with the runs API.
- Ran the exact selector jq against fixtures:
  - same-repo PR selects its own run; a newer foreign fork run at the same SHA is **not** selected.
  - same-repo PR with only a foreign fork run present → no match ("not started"), never a wrong verdict.
  - fork PR selects its own runs; with a same-repo run and a *second* fork's run also at the same SHA, only this fork PR's own run is selected.
  - fork PR with only another fork's run present → no match.

## Screenshots / video

N/A — no user-visible UI change (CI workflow logic only).
