### PR TITLE
feat(test_brand_name_gate): make brand-gate linearity timing test robust on noisy windows runners

### DIFF
--- a/test/test_brand_name_gate.py
+++ b/test/test_brand_name_gate.py
@@ -172,13 +172,27 @@ class TestUrlBoundary:
         # step that slices the line or rescans its prefix is quadratic here, and a
         # ratio assertion catches that where a wall-clock budget loose enough for a
         # loaded runner would not.
-        def timed(count: int) -> tuple[float, int]:
-            began = time.monotonic()
-            found = len(_hits("!KiroCrew" * count, path="big.md"))
-            return time.monotonic() - began, found
+        #
+        # Each size is measured as the MIN of N repetitions (the first call also
+        # warms up caches). min() is the standard noise-robust estimator: scheduler
+        # preemptions only ever ADD time, so the minimum converges on the true cost
+        # while a genuinely quadratic _hits still blows past the bound on every
+        # repetition. Single-shot timing flaked twice on Windows CI at ~60ms base
+        # durations where one GC pause skewed the ratio past 3.0.
+        _REPS = 3
 
-        base, base_found = timed(20_000)
-        doubled, doubled_found = timed(40_000)
+        def best_of(count: int) -> tuple[float, int]:
+            line = "!KiroCrew" * count
+            times: list[float] = []
+            found = 0
+            for _ in range(_REPS):
+                began = time.monotonic()
+                found = len(_hits(line, path="big.md"))
+                times.append(time.monotonic() - began)
+            return min(times), found
+
+        base, base_found = best_of(20_000)
+        doubled, doubled_found = best_of(40_000)
         assert (base_found, doubled_found) == (20_000, 40_000)
         assert doubled / base < 3.0, f"doubling the input cost {doubled / base:.1f}x, want ~2x"
 


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Make brand-gate linearity timing test robust on noisy Windows runners**

## Changes and rationale

### Make brand-gate linearity timing test robust on noisy Windows runners
**Review focus:** backend

## Review map

| Change | Primary files |
|---|---|
| Make brand-gate linearity timing test robust on noisy Windows runners | `test/test_brand_name_gate.py` |

## Commits
- [`3498c23`](https://github.com/kirodotdev/KiroCrew/pull/1610/commits/3498c23a3fe52ce9deb1806688cec501fb50a745) feat(test_brand_name_gate): make brand-gate linearity timing test rob…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (2 files, +24/-14)</summary>

- `config-baseline.json` (+1/-1)
- `test/test_brand_name_gate.py` (+23/-13)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->