### PR TITLE
perf(security): cache sensitive-path targets; raise skills scan TTL

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -15,6 +15,7 @@ import shlex
 import socket
 import string
 import sys
+import time
 import uuid
 from collections import Counter
 from dataclasses import dataclass
@@ -4516,9 +4517,20 @@ def _candidate_forms(path_str: str, base_dir: str | None = None) -> set[str]:
     return candidates
 
 
-def _home_dir_targets(home_dirs: list[str]) -> set[str]:
+def _home_dir_targets_uncached(
+    home_dirs: list[str],
+    roots: tuple[str, str | None] | None = None,
+) -> set[str]:
     """Anchor the ``$HOME``-relative *home_dirs* entries into absolute, casefolded
     on-disk targets.
+
+    *roots* optionally supplies the ``(home, crew_home)`` anchors already
+    resolved by the caller. The TTL cache in :func:`_home_dir_targets` MUST pass
+    it: resolving the roots here as well would read the filesystem a second
+    time, and a root symlink repointed between the two reads would file this
+    set under a key naming the OTHER root — caching one root's targets against
+    another root's key, which fails OPEN. ``None`` (direct callers and tests)
+    resolves them here as before.
 
     Anchors against BOTH the logical home and its realpath.  On macOS the
     per-user temp/home prefix can itself be reached via OS symlinks (``/var`` →
@@ -4534,10 +4546,10 @@ def _home_dir_targets(home_dirs: list[str]) -> set[str]:
     secrets. On POSIX a single-segment entry splits to a 1-element list, so
     this is a no-op there.
     """
-    try:
-        home = str(Path.home().resolve())
-    except (OSError, ValueError):
-        home = str(Path.home())
+    if roots is not None:
+        home, crew_home = roots
+    else:
+        home, crew_home = _resolved_root_key()
 
     def _anchor(root: str, d: str) -> str:
         return os.path.join(root, *d.split("/")).casefold()
@@ -4556,12 +4568,8 @@ def _home_dir_targets(home_dirs: list[str]) -> set[str]:
     # prefix an entry carries and re-anchor the leaf under the env-override
     # root ADDITIONALLY (the ~/-rooted default forms stay, so every location is
     # always covered).
-    kiro_home_env = os.environ.get("KIROCREW_HOME")
-    if kiro_home_env:
-        try:
-            kiro_home = str(Path(kiro_home_env).expanduser().resolve())
-        except (OSError, ValueError):
-            kiro_home = os.path.abspath(os.path.expanduser(kiro_home_env))
+    if crew_home:
+        kiro_home = crew_home
         for d in home_dirs:
             for _prefix in _CREW_HOME_PREFIXES:
                 # Compare with POSIX separators (home_dirs entries are authored
@@ -4578,6 +4586,103 @@ def _home_dir_targets(home_dirs: list[str]) -> set[str]:
                         pass
                     break
     return sensitive_targets
+
+
+# How long a built target set stays reusable. ``_home_dir_targets_uncached``
+# rebuilds a ~75-entry set on EVERY ``is_sensitive_path`` call and measured at
+# 1.14ms of that call's 1.25ms (91%) on a dev desktop, because it realpath()s
+# ``$HOME`` and each KIROCREW_HOME-anchored leaf. Callers hit it per FILE — one
+# skills-tree walk made thousands of identical calls and took 4.2s, of which
+# 3.5s was this rebuild.
+#
+# Deliberately TTL-bounded rather than a plain ``lru_cache``: part of the set is
+# derived from FILESYSTEM state, so an unbounded cache would keep matching a
+# stale target if a symlink were repointed after the cache warmed — a gate that
+# fails OPEN. A few seconds bounds that window.
+#
+# The key is built from the RESOLVED roots (``Path.home().resolve()`` and the
+# resolved ``KIROCREW_HOME``), NOT from the raw env vars, because those two
+# values are exactly what the builder anchors its targets on. Keying on the raw
+# ``$HOME`` string was wrong twice over:
+#   1. Repointing a symlink AT ``$HOME`` leaves ``$HOME`` unchanged while every
+#      target moves, so the gate returned False for a credential path the
+#      uncached code blocked (a real, reproduced bypass — see the regression
+#      test ``test_repointed_home_symlink_is_not_served_from_cache``).
+#   2. ``Path.home()`` reads ``USERPROFILE`` on Windows and never ``HOME``, so on
+#      that platform the key omitted the one variable that decides the anchor.
+# Resolving the roots costs ~2 realpath calls (~0.06ms) against the ~1.14ms
+# rebuild it replaces, so the win survives.
+#
+# Residual, accepted: a symlink swapped DEEPER inside the crew home (an
+# individual keystone leaf, or an intermediate directory on the way to one) can
+# still be served stale for up to the TTL. Detecting that needs the per-leaf
+# realpath calls that ARE the expense — measured 45 realpath calls per build,
+# 94% of its 1.39ms — so there is no cheap way to keep the cache and revalidate
+# them.
+#
+# The TTL is therefore sized as small as it can be while still doing its job.
+# The value is 0.1s, NOT a "few seconds", because a skills walk issues thousands
+# of calls in a burst and one build serves the whole burst either way. Measured
+# cold-walk cost against this constant:
+#     5.0s -> 0.95s    1.0s -> 0.93s    0.1s -> 0.95s    0.0s -> 4.66s
+# So 0.1s keeps the entire win while cutting the stale window 50x versus 5.0s.
+# Only 0.0 (no cache) closes the window completely, and that reverts to the 4.7s
+# scan whose GIL-held cost wedges the event loop — the defect this exists to fix.
+_HOME_TARGETS_TTL_SECS = 0.1
+# key -> (expiry_monotonic, targets)
+_home_targets_cache: dict[tuple[object, ...], tuple[float, set[str]]] = {}
+
+
+def _resolved_root_key() -> tuple[str, str | None]:
+    """Return the (home, crew_home) roots the target set is anchored on.
+
+    Mirrors how :func:`_home_dir_targets_uncached` derives its anchors, so the
+    cache key changes exactly when the anchors would. Falls back to the
+    unresolved form on OSError/ValueError the same way the builder does.
+    """
+    try:
+        home = str(Path.home().resolve())
+    except (OSError, ValueError):
+        home = str(Path.home())
+    crew_env = os.environ.get("KIROCREW_HOME")
+    if not crew_env:
+        return home, None
+    try:
+        crew = str(Path(crew_env).expanduser().resolve())
+    except (OSError, ValueError):
+        crew = os.path.abspath(os.path.expanduser(crew_env))
+    return home, crew
+
+
+def _home_dir_targets(home_dirs: list[str]) -> set[str]:
+    """TTL-cached :func:`_home_dir_targets_uncached`.
+
+    Keyed on the *home_dirs* list plus the RESOLVED home and crew-home roots
+    (see the note above the constant for why the raw env vars are not enough).
+
+    ponytail: the returned set is the cached instance, not a copy — both
+    callers only iterate it. A future caller that MUTATES the result would
+    poison the cache for every other caller; copy here if that ever happens.
+    """
+    # Resolve the roots ONCE and use the same tuple for both the key and the
+    # build. Resolving separately let a root symlink repointed between the two
+    # reads file one root's targets under the other root's key — a fail-OPEN
+    # TOCTOU. Local review caught this; see the regression test
+    # test_roots_are_resolved_once_for_key_and_build.
+    roots = _resolved_root_key()
+    key = (tuple(home_dirs),) + roots
+    now = time.monotonic()
+    cached = _home_targets_cache.get(key)
+    if cached is not None and now < cached[0]:
+        return cached[1]
+    targets = _home_dir_targets_uncached(home_dirs, roots)
+    # Bound the dict: the key space is tiny (two constant home_dirs lists ×
+    # roots), but a test or embedder that churns KIROCREW_HOME must not grow it
+    # without limit.
+    if len(_home_targets_cache) > 32:
+        _home_targets_cache.clear()
+    _home_targets_cache[key] = (now + _HOME_TARGETS_TTL_SECS, targets)
+    return targets
 
 
 def _path_in_home_dirs(path_str: str, home_dirs: list[str], base_dir: str | None = None) -> bool:

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -86,10 +86,19 @@ _DOLLAR_SKILL_PATTERN = re.compile(r"(?<![\w$])\$([a-z0-9][a-z0-9/_-]*)")
 _MAX_DOLLAR_SKILLS = 5
 # Cache the discovered skill-file list for this long. get_triggered_skills runs
 # on EVERY message; without this it os.walk()s the skills dir + every extra
-# path per message. Skills change rarely (add/remove via setup or sync), so a
-# short TTL keeps trigger matching off the per-message filesystem hot path
-# while still picking up new skills within a few seconds.
-_ITER_CACHE_TTL_SECS = 5.0
+# path per message.
+#
+# This was 5.0s, which did not achieve that: a walk of a real skills tree (645
+# files across 21 roots on a dev desktop, incl. AIM-installed package roots)
+# takes ~0.7s, and chat messages arrive MINUTES apart — so every message missed
+# the cache and paid the full walk, and the 5s only ever deduped the several
+# _iter() calls WITHIN one message. At 60s the walk is amortized ~12x with a
+# worst-case staleness of one minute.
+#
+# Staleness only affects skills added OUT OF BAND (AIM sync, a manual cp):
+# the app's own create/update/delete/refresh all call _invalidate_iter_cache(),
+# so a skill written through the app is visible immediately regardless of TTL.
+_ITER_CACHE_TTL_SECS = 60.0
 
 # ── Auto skill creation ──
 

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -2304,6 +2304,186 @@ class TestIsSensitivePath:
         assert is_sensitive_path("") is False
 
 
+class TestHomeDirTargetsCache:
+    """Tests for the TTL cache in front of ``_home_dir_targets_uncached``.
+
+    The cache exists because rebuilding the target set was 91% of every
+    ``is_sensitive_path`` call (it realpath()s ``$HOME`` and each crew-home
+    leaf), and callers hit it per FILE. These tests pin the two properties that
+    make caching a security gate's inputs acceptable: the cached set is
+    equivalent to an uncached build, and an env change is reflected AT ONCE
+    rather than after the TTL.
+    """
+
+    @staticmethod
+    def _clear() -> None:
+        from kiro_crew import security
+
+        security._home_targets_cache.clear()
+
+    def test_cached_result_matches_uncached(self, monkeypatch, tmp_path) -> None:
+        """Caching must not change WHAT is considered sensitive."""
+        from kiro_crew.security import (
+            _SENSITIVE_HOME_DIRS,
+            _home_dir_targets,
+            _home_dir_targets_uncached,
+        )
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._clear()
+        assert _home_dir_targets(_SENSITIVE_HOME_DIRS) == _home_dir_targets_uncached(
+            _SENSITIVE_HOME_DIRS
+        )
+
+    def test_second_call_does_not_rebuild(self, monkeypatch, tmp_path) -> None:
+        """Within the TTL the expensive builder runs once, not per call."""
+        from kiro_crew import security
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._clear()
+        calls: list[int] = []
+        real = security._home_dir_targets_uncached
+
+        def counting(home_dirs, roots=None):
+            calls.append(1)
+            return real(home_dirs, roots)
+
+        monkeypatch.setattr(security, "_home_dir_targets_uncached", counting)
+        for _ in range(50):
+            security._home_dir_targets(security._SENSITIVE_HOME_DIRS)
+        assert len(calls) == 1
+
+    def test_kirocrew_home_change_is_not_deferred_by_ttl(self, monkeypatch, tmp_path) -> None:
+        """A changed KIROCREW_HOME must re-key immediately, not after the TTL.
+
+        This is the security-relevant property: the keystone secrets live under
+        KIROCREW_HOME, so a stale target set built for the OLD home would stop
+        gating them. The resolved roots are part of the cache key precisely so
+        this cannot wait out ``_HOME_TARGETS_TTL_SECS``.
+        """
+        from kiro_crew import security
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        home_a = tmp_path / "crew-a"
+        home_b = tmp_path / "crew-b"
+        home_a.mkdir()
+        home_b.mkdir()
+        self._clear()
+
+        monkeypatch.setenv("KIROCREW_HOME", str(home_a))
+        targets_a = set(security._home_dir_targets(security._SENSITIVE_HOME_DIRS))
+        monkeypatch.setenv("KIROCREW_HOME", str(home_b))
+        targets_b = set(security._home_dir_targets(security._SENSITIVE_HOME_DIRS))
+
+        # No sleep: the switch is visible on the very next call.
+        assert targets_a != targets_b
+        assert any(str(home_b).casefold() in t for t in targets_b)
+        # And the new home's secrets are actually gated through the public API.
+        assert is_sensitive_path(str(home_b / "token_signing.key")) is True
+
+    def test_repointed_home_symlink_is_not_served_from_cache(self, monkeypatch, tmp_path) -> None:
+        """Repointing a symlink AT $HOME must invalidate the cached target set.
+
+        Regression test for a real, reproduced fail-open: the builder anchors on
+        ``Path.home().resolve()``, so when ``$HOME`` is itself a symlink every
+        target moves while the ``$HOME`` string stays identical. Keying the cache
+        on the raw env var therefore served a stale set and is_sensitive_path()
+        returned False for a credential path the uncached code blocked. The key
+        uses the RESOLVED root so the repoint re-keys.
+        """
+        real_a = tmp_path / "vol1" / "u"
+        real_b = tmp_path / "vol2" / "u"
+        real_a.mkdir(parents=True)
+        real_b.mkdir(parents=True)
+        link = tmp_path / "home"
+        try:
+            link.symlink_to(real_a)
+        except (OSError, NotImplementedError):  # pragma: no cover — Windows w/o privilege
+            pytest.skip("symlink creation not permitted on this platform")
+        # Path.home() reads HOME on POSIX and USERPROFILE on Windows; set both so
+        # the test pins the behavior on every supported platform.
+        monkeypatch.setenv("HOME", str(link))
+        monkeypatch.setenv("USERPROFILE", str(link))
+        self._clear()
+
+        probe = str(link / ".aws" / "credentials")
+        assert is_sensitive_path(probe) is True  # warms the cache
+
+        link.unlink()
+        link.symlink_to(real_b)  # repoint INSIDE the TTL window
+        assert is_sensitive_path(probe) is True, "cached target set served a fail-open verdict"
+
+    def test_roots_are_resolved_once_for_key_and_build(self, monkeypatch, tmp_path) -> None:
+        """The key and the target set must come from ONE root resolution.
+
+        Regression test for a fail-open TOCTOU: when the key resolved the roots
+        and the builder resolved them again, a root symlink repointed between
+        the two reads filed root B's targets under root A's key, so later
+        requests under A got a false-negative verdict for up to the TTL.
+
+        Rather than racing a real symlink, this asserts the structural property
+        that makes the race impossible: exactly one resolution per cache fill,
+        and the builder receives those captured roots.
+        """
+        from kiro_crew import security
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._clear()
+        calls: list[tuple[str, str | None]] = []
+        real_key = security._resolved_root_key
+
+        def counting_key():
+            r = real_key()
+            calls.append(r)
+            return r
+
+        seen_roots: list[object] = []
+        real_build = security._home_dir_targets_uncached
+
+        def spy_build(home_dirs, roots=None):
+            seen_roots.append(roots)
+            return real_build(home_dirs, roots)
+
+        monkeypatch.setattr(security, "_resolved_root_key", counting_key)
+        monkeypatch.setattr(security, "_home_dir_targets_uncached", spy_build)
+        security._home_dir_targets(security._SENSITIVE_HOME_DIRS)
+
+        assert len(calls) == 1, f"roots resolved {len(calls)}x for one fill; must be 1"
+        assert seen_roots == [calls[0]], "builder did not receive the captured roots"
+
+    def test_expired_entry_is_rebuilt(self, monkeypatch, tmp_path) -> None:
+        """Past the TTL the set is rebuilt, so filesystem changes are picked up."""
+        from kiro_crew import security
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._clear()
+        calls: list[int] = []
+        real = security._home_dir_targets_uncached
+
+        def counting(home_dirs, roots=None):
+            calls.append(1)
+            return real(home_dirs, roots)
+
+        monkeypatch.setattr(security, "_home_dir_targets_uncached", counting)
+        security._home_dir_targets(security._SENSITIVE_HOME_DIRS)
+        # Expire the entry rather than sleeping the real TTL.
+        for key, (_expiry, targets) in list(security._home_targets_cache.items()):
+            security._home_targets_cache[key] = (0.0, targets)
+        security._home_dir_targets(security._SENSITIVE_HOME_DIRS)
+        assert len(calls) == 2
+
+    def test_cache_dict_is_bounded(self, monkeypatch, tmp_path) -> None:
+        """Churning the env key must not grow the cache without limit."""
+        from kiro_crew import security
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._clear()
+        for i in range(200):
+            monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / f"h{i}"))
+            security._home_dir_targets(security._SENSITIVE_HOME_DIRS)
+        assert len(security._home_targets_cache) <= 33
+
+
 class TestIsSensitiveBashCommand:
     """Tests for is_sensitive_bash_command()."""
 


### PR DESCRIPTION
## Problem

The dashboard gateway's asyncio event loop wedges and its loop-stall watchdog
kills the process; systemd's `Restart=always` revives it seconds later. Every
occurrence drops in-flight turns — a user watching a session sees it stop dead,
and any running sub-agent dies with the process.

On the affected desktop this fired **three times in ninety minutes**
(05:58:50, 06:26:43, 07:23:54 UTC).

## Why it matters

Each stall is an unplanned restart of the whole gateway. Turns in flight are
lost, sub-agents are killed mid-task, and the user has no signal beyond the
session going quiet. It is self-inflicted work loss on a completely healthy
host — memory was 43 GB free of 186 GB with zero swap activity, and systemd
recorded `Result=success`, so nothing was OOM-killed.

## Fix (symptom → root cause → change)

**Symptom.** The faulthandler dump written at the stall shows **3 of 47 threads
simultaneously inside a cold skills-tree scan**, 2 of them inside the
sensitive-path target rebuild, one sitting on `posixpath.realpath`:

```
context.py:2145 build_message → skills.py:2226 get_triggered_skills
  → skills.py:562 _iter → skills.py:571 _iter_uncached
  → skills.py:374 _iter_skill_files → security.py:2921 is_sensitive_path
  → security.py:2853 _home_dir_targets → posixpath:427 realpath
```

**Root cause.** Two independent multipliers, both on the per-message path:

1. `_home_dir_targets()` rebuilt a ~75-entry sensitive-target set on **every**
   `is_sensitive_path()` call, `realpath()`-ing `$HOME` and each
   `KIROCREW_HOME`-anchored leaf. Measured at **1.14 ms of that call's
   1.25 ms — 91%**. Callers hit it once per *file*.
2. `_ITER_CACHE_TTL_SECS` was **5.0s** while the walk it caches takes ~0.9s
   (645 skill files across 21 roots, including AIM-installed package roots).
   Chat messages arrive minutes apart, so **every** message missed the cache and
   paid the full walk. The 5s only ever deduplicated the several `_iter()` calls
   *within* one message.

Together: a ~4s, mostly GIL-held scan on essentially every message. Because the
walk holds the GIL, three concurrent context builds do not overlap — they
serialize and starve the loop, which is how a 4s scan reaches the watchdog's
25s threshold.

**Change.**
- `security.py`: split the builder out as `_home_dir_targets_uncached()` and
  front it with a TTL cache.
- `skills.py`: `_ITER_CACHE_TTL_SECS` 5.0 → 60.0.

**Why a TTL and not `lru_cache`.** Part of the target set is derived from
filesystem state, so an unbounded cache could keep matching a stale target after
a symlink was repointed. The TTL bounds that. The *input* side
(`_candidate_forms`) is still recomputed per call, so the symlink-bypass
hardening (AWS-345 / AWS-62) is untouched.

**On the remaining leaf-symlink staleness — measured, not assumed.** Only the
`realpath(<crew_home>/<leaf>)` entries can go stale, and changing one requires
controlling a symlink at or under that leaf. That precondition already defeats the
UNCACHED gate, by a simpler route than any race: the builder anchors the target on
wherever the symlink currently points, so an actor who repoints it *away* from a
secret removes that secret from a freshly-built target set too. Reproduced with
the cache cleared before every call (i.e. uncached behaviour), on
`.kiro/crew/.env`:

```
1. leaf -> secretA, UNCACHED gate on secretA : True
2. leaf -> decoy,   UNCACHED gate on secretA : False
```

So the cache grants no capability the uncached gate withheld; the permeability is
a pre-existing property of anchoring through a mutable symlink. `TTL = 0.0` would
cost ~3.5s per walk and close nothing. The TTL is therefore sized for freshness,
not as a security control: 0.1s, which measures identical to 5.0s on the walk
(0.95s both) because a walk issues thousands of calls in a burst that one build
serves either way.

**Two fail-open defects found in local review and fixed, not rebutted:**

1. Keying on the raw `$HOME` string was wrong twice over. The builder anchors on
   `Path.home().resolve()`, so repointing a symlink **at** `$HOME` moves every
   target while the `$HOME` string is unchanged — `is_sensitive_path()` returned
   `False` for a credential path the uncached code blocked (reproduced end to
   end). Separately, `Path.home()` reads `USERPROFILE` on Windows and never
   `HOME`, so the key omitted the variable that decides the anchor there. The key
   is now built from the **resolved** roots via `_resolved_root_key()`.
2. Resolving those roots for the key and again inside the builder was a TOCTOU: a
   root symlink repointed between the two reads filed root B's targets under root
   A's key. The roots are now resolved **once** and the captured tuple is passed
   to the builder, which no longer reads `$HOME` or `KIROCREW_HOME` at all.

**Accepted residual, documented in the code:** a symlink swapped *deeper* inside
the crew home can still be served stale for up to the TTL. Catching that needs
the per-leaf `realpath` calls that are the actual expense.

**Measured** (same host, warm page cache):

| | before | after |
|---|---|---|
| cold skills walk | 4.06s | **0.97s** (4.2×) |
| `is_sensitive_path` | 1.397 ms | **0.212 ms** (6.6×) |
| skills discovered | 539 | **539** — unchanged |

Per-message scan cost drops roughly **50×**: 4.2× cheaper, run 12× less often.
The `is_sensitive_path` win applies to every caller of that gate, not just the
skills scan.

60s for the skills TTL is the knee of the curve — at ~0.9s per walk it already
amortizes to about a 1.5% duty cycle, and 300s would buy roughly a point more
while making worst-case staleness 5× worse. Staleness only affects skills added
**out of band** (AIM sync, a manual `cp`); `create`/`update`/`delete`/`refresh`
all call `_invalidate_iter_cache()`, so an in-app edit is visible immediately.

## Tests

`test_security.py::TestHomeDirTargetsCache` — 7 tests:

| Test | Locks in |
|---|---|
| `test_cached_result_matches_uncached` | caching does not change *what* is sensitive |
| `test_second_call_does_not_rebuild` | builder runs once per TTL window, not per call |
| `test_kirocrew_home_change_is_not_deferred_by_ttl` | a crew-home switch re-keys with no sleep |
| `test_repointed_home_symlink_is_not_served_from_cache` | **regression for defect 1** — repoints a `$HOME` symlink inside the TTL and asserts the gate still blocks |
| `test_roots_are_resolved_once_for_key_and_build` | **regression for defect 2** — exactly one root resolution per fill, and the builder receives it |
| `test_expired_entry_is_rebuilt` | expiry rebuilds, so filesystem changes land |
| `test_cache_dict_is_bounded` | env churn cannot grow the cache without limit |

Both regression tests are **mutation-proven**: reverting the respective fix makes
that test fail (the second reports `roots resolved 2x for one fill; must be 1`),
and restoring it makes it pass.

## Manual verification

Beyond unit coverage, because the defects are timing- and filesystem-shaped:

1. **Reproduced defect 1 end to end** — `$HOME` as a symlink, warm the cache,
   repoint within the TTL: cached gate returned `False` where the uncached gate
   returned `True`. After the fix, `True`.
2. **Reproduced defect 2** by forcing the interleaving (repoint between key
   derivation and target construction, then restore). Before: B's targets cached
   under A's key with a false-negative verdict. After: targets contain A, not B,
   and the gate blocks.
3. **Measured the numbers above** against the shipped baseline via `PYTHONPATH`
   shadowing, confirming 539 skills discovered both before and after.

Gates: isort, flake8, mypy (721 files), and 606 tests across `test_security`,
`test_skills`, `test_config_validation`, `test_file_raw`,
`test_computer_use_api`, `test_security_posture`.

## Screenshots

N/A — backend only, no user-visible UI surface changed.
