### PR TITLE
fix(security): resolve OS-introspection spawns from trusted system dirs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,7 @@ Kiro Crew runs on macOS, Linux (x86_64 and ARM), and Windows (native). `fcntl`,
 | Process RSS / CPU | `proc_rss_bytes()` / `proc_cpu_seconds()` | `resource.getrusage` |
 | FD soft limit | `raise_nofile_soft_limit(n)` | `resource.setrlimit` |
 | Port to PID | `find_listening_pids(port)` / `listening_pid_tool_available()` | `lsof` directly |
+| Spawn a system tool (`ps`, `lsof`, `netstat`, `taskkill`) | `trusted_system_bin(name)`, treating `None` as "unavailable" | a bare argv name (resolved through a `PATH` that can lead with same-uid-writable dirs) |
 | strftime no-pad | `strftime(dt, "%-I")` | bare `dt.strftime("%-I")` (`ValueError` on Windows) |
 
 Verify process, signal, file-lock, and metrics changes on macOS + Linux. Frontend:

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -607,8 +607,20 @@ that must not change, because the SPA's per-origin `localStorage` is keyed on it
    target a non-default dev gateway): `platform_compat.find_listening_pids(port)`
    to find PIDs — `lsof -ti TCP:{port} -sTCP:LISTEN` on POSIX, `netstat -ano`
    parsing on Windows (there is no `lsof` there; this previously made
-   `kirocrew stop` a no-op on Windows). `listening_pid_tool_available()`
-   distinguishes "no listener" from "lookup tool missing".
+   `kirocrew stop` a no-op on Windows). Both binaries are resolved through
+   `platform_compat.trusted_system_bin()` — the fixed system directories, never
+   `PATH`, which on a gateway can lead with same-uid-writable dirs — and a name
+   that does not resolve there counts as absent rather than falling back.
+   `listening_pid_tool_available()` performs the same pinned resolution, so it
+   distinguishes "no listener" from "lookup tool missing" without disagreeing
+   with the lookup it describes. A host that installs the tool outside those
+   directories (NixOS, a Homebrew or conda prefix) therefore reads as not having
+   it; `trusted_system_bin()` logs a warning once per name when the tool is on
+   `PATH` but not resolvable under the pin, and `tool_outside_trusted_dirs()`
+   lets `stop` name where the tool actually is rather than tell an operator who
+   already has it to install it. That case carries SEL
+   `reason=<tool>_outside_trusted_dirs`, distinct from `<tool>_not_found`, so
+   the two are separable in the audit log.
 3. `platform_compat.process_command_line(pid)` to verify it's a KiroCrew process —
    `/proc/<pid>/cmdline` (Linux), `ps -o command=` (macOS), `Win32_Process.CommandLine`
    via WMI (Windows). The Windows venv `kirocrew.exe` re-execs `python.exe`, so the

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1399,8 +1399,11 @@ def _get_start_time(pid: int) -> int | None:
             fields = stat.rsplit(")", 1)[1].split()
             return int(fields[19])  # field 22 = starttime
         # macOS: use ps -o lstart= (absolute start timestamp, constant for process lifetime)
+        ps_bin = platform_compat.trusted_system_bin("ps")
+        if ps_bin is None:
+            return None
         out = subprocess_mod.check_output(
-            ["ps", "-o", "lstart=", "-p", str(pid)], stderr=subprocess_mod.DEVNULL, timeout=2
+            [ps_bin, "-o", "lstart=", "-p", str(pid)], stderr=subprocess_mod.DEVNULL, timeout=2
         )
         return hash(out.strip())  # stable per-process, changes on recycle
     except Exception:
@@ -1426,8 +1429,11 @@ def _read_basename(pid: int) -> bytes | None:
                 return None
             return cmdline.split(b"\x00", 1)[0].rsplit(b"/", 1)[-1]
         else:
+            ps_bin = platform_compat.trusted_system_bin("ps")
+            if ps_bin is None:
+                return None
             out = subprocess_mod.check_output(
-                ["ps", "-o", "comm=", "-p", str(pid)], stderr=subprocess_mod.DEVNULL, timeout=2
+                [ps_bin, "-o", "comm=", "-p", str(pid)], stderr=subprocess_mod.DEVNULL, timeout=2
             )
             name = out.strip()
             if not name:

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -244,9 +244,12 @@ def _get_rss_mb(pid: int) -> float | None:
 
     # macOS / other: no /proc, fall back to ps (mirrors the sysctl/ps pattern
     # used elsewhere in this codebase for darwin system info).
+    ps_bin = platform_compat.trusted_system_bin("ps")
+    if ps_bin is None:
+        return None
     try:
         out = (
-            subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)], timeout=2)
+            subprocess.check_output([ps_bin, "-o", "rss=", "-p", str(pid)], timeout=2)
             .decode()
             .strip()
         )
@@ -342,8 +345,13 @@ def _get_rss_tree_mb(pid: int) -> float | None:
 
     # macOS / other: build a ppid map from a single ps snapshot, then sum the
     # descendant subtree rooted at pid (ps reports RSS in KiB).
+    ps_bin = platform_compat.trusted_system_bin("ps")
+    if ps_bin is None:
+        return _get_rss_mb(pid)
     try:
-        out = subprocess.check_output(["ps", "-Ao", "pid=,ppid=,rss="], timeout=2).decode().strip()
+        out = (
+            subprocess.check_output([ps_bin, "-Ao", "pid=,ppid=,rss="], timeout=2).decode().strip()
+        )
     except (OSError, subprocess.SubprocessError):
         return _get_rss_mb(pid)
     children: dict[int, list[int]] = {}

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -413,17 +413,32 @@ def _stop(cli_port: int | None = None) -> None:
         # would then double-spawn).
         if not platform_compat.listening_pid_tool_available():
             _tool = platform_compat.listening_pid_tool()
+            # A host that keeps its binaries outside the system directories
+            # (NixOS, a Homebrew or conda prefix) has the tool and still lands
+            # here, because the lookup is pinned to those directories. Telling
+            # that operator to install what they already have sends them in
+            # circles, so name where it actually is instead.
+            _unpinned = platform_compat.tool_outside_trusted_dirs(_tool)
+            _reason = f"{_tool}_outside_trusted_dirs" if _unpinned else f"{_tool}_not_found"
             sel().log_api_access(
                 caller="cli",
                 operation="gateway_stop",
                 outcome="no_target",
                 source="cli",
-                resources=f"port={port} reason={_tool}_not_found",
+                resources=f"port={port} reason={_reason}",
             )
-            print(
-                f"`{_tool}` not found — cannot look up the gateway process on "
-                f"port {port}. Install {_tool} and retry."
-            )
+            if _unpinned:
+                print(
+                    f"`{_tool}` is installed at {_unpinned}, outside the system directories "
+                    f"Kiro Crew resolves it from, so it cannot look up the gateway process "
+                    f"on port {port}. Falling back to PATH is deliberately refused: a "
+                    f"gateway's PATH can lead with writable directories."
+                )
+            else:
+                print(
+                    f"`{_tool}` not found — cannot look up the gateway process on "
+                    f"port {port}. Install {_tool} and retry."
+                )
             sys.exit(1)
         sel().log_api_access(
             caller="cli",

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -645,6 +645,83 @@ def _descendants_from_parent_map(root_pid: int, parent_map: dict[int, int]) -> l
 
 _TRUSTED_SYSTEM_BIN_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin")
 
+# Windows argv carries a bare name (``taskkill``) while the file on disk carries
+# an extension (``taskkill.exe``), so a trusted lookup must try the suffixes the
+# loader would rather than requiring callers to spell them.
+_WINDOWS_BIN_SUFFIXES = ("", ".exe", ".com")
+
+
+def _windows_system_dirs() -> tuple[str, ...]:
+    """Return the Windows directories a system binary may be resolved from.
+
+    ``GetSystemDirectoryW`` is the authoritative source and, unlike
+    ``%SystemRoot%``, is not read from the process environment — which is
+    precisely the input this module declines to trust. The environment variable
+    and the conventional install path follow only as fallbacks for the
+    unexpected case where the API call fails. PowerShell ships in a versioned
+    directory beside the system binaries, not inside it, so it is appended per
+    root rather than assumed to sit alongside ``taskkill``.
+    """
+
+    dirs: list[str] = []
+    try:
+        buf = ctypes.create_unicode_buffer(wintypes.MAX_PATH)
+        written = ctypes.windll.kernel32.GetSystemDirectoryW(  # type: ignore[attr-defined]
+            buf, len(buf)
+        )
+        if 0 < written < len(buf):
+            dirs.append(buf.value)
+    except Exception:
+        pass
+    root = os.environ.get("SystemRoot") or r"C:\Windows"
+    # Case-insensitive dedupe: GetSystemDirectoryW reports the on-disk casing
+    # ("C:\Windows\system32"), which names the same directory as the
+    # conventionally-cased fallback and must not be probed twice.
+    seen = {d.casefold() for d in dirs}
+    for fallback in (os.path.join(root, "System32"), r"C:\Windows\System32"):
+        if fallback.casefold() not in seen:
+            seen.add(fallback.casefold())
+            dirs.append(fallback)
+    return tuple(dirs) + tuple(os.path.join(d, "WindowsPowerShell", "v1.0") for d in dirs)
+
+
+# Names already probed for the diagnostic below, so the message costs one PATH
+# scan per name per process. Only the *message* is one-shot; resolution itself
+# stays uncached, so a tool that lands in a trusted directory later is still
+# found on the next call.
+_UNPINNED_TOOL_PROBED: set[str] = set()
+
+
+def _log_tool_outside_trusted_dirs(name: str, directories: tuple[str, ...]) -> None:
+    """Log once per *name* when the pin is what made a present tool unavailable.
+
+    A host that keeps its binaries outside the FHS system directories (NixOS's
+    ``/run/current-system/sw/bin``, a Homebrew or conda prefix) has a working
+    ``lsof`` that this lookup still declines, and the caller's degradation is
+    otherwise indistinguishable from the tool not being installed:
+    ``listening_pid_tool_available()`` would tell such an operator to install a
+    tool they already have, and ``kirocrew stop`` would quietly no-op. The
+    ``PATH`` result is read to write the message and is never spawned, so
+    reporting it does not widen what may run.
+    """
+
+    if name in _UNPINNED_TOOL_PROBED:
+        return
+    # Concurrent first probes of one name can duplicate the line. That is
+    # cheaper than serializing a filesystem scan behind a lock for a message.
+    _UNPINNED_TOOL_PROBED.add(name)
+    on_path = shutil.which(name)
+    if not on_path:
+        return
+    logger.warning(
+        "%s is on PATH at %s but does not resolve under the trusted system "
+        "directories (%s), so it is treated as unavailable; OS introspection "
+        "that needs it degrades instead of running a PATH-chosen binary",
+        name,
+        on_path,
+        ", ".join(directories),
+    )
+
 
 def trusted_system_bin(name: str) -> str | None:
     """Resolve *name* from fixed system directories, ignoring ``PATH``.
@@ -653,13 +730,46 @@ def trusted_system_bin(name: str) -> str | None:
     (a worktree venv's ``bin``, ``~/.local/bin``), so a bare argv name lets a
     planted shim run with the gateway's environment. Callers that shell out for
     OS introspection resolve through here and treat ``None`` as "unavailable".
+
+    A miss on a host whose tools live elsewhere is a real functional
+    degradation, so it is logged once per name rather than left silent. The pin
+    still decides; the log only makes the decision diagnosable.
+
+    Deliberately uncached. The lookup is a handful of ``stat`` calls on
+    teardown and introspection paths, and caching the *miss* would pin "tool
+    absent" for the lifetime of a long-lived gateway, so an ``lsof`` installed
+    after boot would never be picked up.
     """
 
-    for directory in _TRUSTED_SYSTEM_BIN_DIRS:
-        candidate = os.path.join(directory, name)
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
+    if IS_WINDOWS:
+        directories: tuple[str, ...] = _windows_system_dirs()
+        suffixes: tuple[str, ...] = _WINDOWS_BIN_SUFFIXES
+    else:
+        directories = _TRUSTED_SYSTEM_BIN_DIRS
+        suffixes = ("",)
+    for directory in directories:
+        for suffix in suffixes:
+            candidate = os.path.join(directory, name + suffix)
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+    _log_tool_outside_trusted_dirs(name, directories)
     return None
+
+
+def tool_outside_trusted_dirs(name: str) -> str | None:
+    """Where ``PATH`` finds *name* when :func:`trusted_system_bin` declined it.
+
+    ``None`` means the pin is not the reason the tool is unavailable: either it
+    resolved normally, or it is not installed anywhere ``PATH`` can see. Callers
+    use this to word a diagnostic — an operator on a host that keeps its
+    binaries elsewhere needs to be told where theirs actually is, not to install
+    a tool they already have. The path is reported and never spawned, so asking
+    does not widen what may run.
+    """
+
+    if trusted_system_bin(name) is not None:
+        return None
+    return shutil.which(name)
 
 
 def _posix_process_parent_map() -> dict[int, int]:
@@ -1148,8 +1258,11 @@ def process_matches(pid: int, needles: tuple[str, ...]) -> bool:
             cmdline = Path(f"/proc/{pid}/cmdline").read_bytes()
             return any(n.encode() in cmdline for n in needles)
         if sys.platform == "darwin":
+            ps_bin = trusted_system_bin("ps")
+            if ps_bin is None:
+                return False
             out = subprocess.check_output(
-                ["ps", "-o", "command=", "-p", str(pid)],
+                [ps_bin, "-o", "command=", "-p", str(pid)],
                 stderr=subprocess.DEVNULL,
                 timeout=2,
             )
@@ -1221,11 +1334,19 @@ def listening_pid_tool() -> str:
 
 def listening_pid_tool_available() -> bool:
     """Whether the port->PID lookup tool (lsof on POSIX / netstat on Windows) is
-    on PATH. Lets callers distinguish "tool absent" from "no listener found",
+    resolvable. Lets callers distinguish "tool absent" from "no listener found",
     which find_listening_pids() alone collapses into an empty list — without that
     a genuinely-running gateway reads as stopped when lsof is missing.
+
+    Resolves through :func:`trusted_system_bin`, the same lookup
+    :func:`find_listening_pids` performs. Probing ``PATH`` here instead would
+    let the two disagree: a shim on ``PATH`` would answer "available" for a tool
+    the pinned lookup refuses to run, turning a live gateway into one that reads
+    as stopped — the exact failure this probe exists to prevent. A tool that is
+    installed but outside those directories therefore reads as absent, which
+    :func:`trusted_system_bin` logs so the answer can be explained.
     """
-    return shutil.which(listening_pid_tool()) is not None
+    return trusted_system_bin(listening_pid_tool()) is not None
 
 
 def find_listening_pids(port: int) -> list[int]:
@@ -1239,9 +1360,12 @@ def find_listening_pids(port: int) -> list[int]:
     to tell a genuine empty result apart from the tool being absent).
     """
     if IS_POSIX:
+        lsof_bin = trusted_system_bin("lsof")
+        if lsof_bin is None:
+            return []
         try:
             out = subprocess.check_output(
-                ["lsof", "-ti", f"TCP:{port}", "-sTCP:LISTEN"],
+                [lsof_bin, "-ti", f"TCP:{port}", "-sTCP:LISTEN"],
                 text=True,
                 stderr=subprocess.DEVNULL,
             )
@@ -1258,9 +1382,12 @@ def find_listening_pids(port: int) -> list[int]:
     # "TCP" too — the bracketed address form is what distinguishes v4 vs
     # v6, not the proto token — so once `-p tcp` is dropped the existing
     # port suffix match already handles both families uniformly.
+    netstat_bin = trusted_system_bin("netstat")
+    if netstat_bin is None:
+        return []
     try:
         out = subprocess.check_output(
-            ["netstat", "-ano"],
+            [netstat_bin, "-ano"],
             # encoding="oem" (Windows-only pseudo-codec): netstat emits the
             # console OEM codepage when piped; text=True would decode with the
             # ANSI codepage and can raise UnicodeDecodeError on non-Western
@@ -1327,8 +1454,11 @@ def process_command_line(pid: int) -> str:
             raw = Path(f"/proc/{pid}/cmdline").read_bytes()
             return raw.replace(b"\x00", b" ").decode(errors="replace").strip()
         if sys.platform == "darwin":
+            ps_bin = trusted_system_bin("ps")
+            if ps_bin is None:
+                return ""
             out = subprocess.check_output(
-                ["ps", "-o", "command=", "-p", str(pid)],
+                [ps_bin, "-o", "command=", "-p", str(pid)],
                 text=True,
                 stderr=subprocess.DEVNULL,
                 timeout=2,
@@ -1337,9 +1467,12 @@ def process_command_line(pid: int) -> str:
         if IS_WINDOWS:
             # Query WMI for the exact PID's command line. PowerShell is always
             # present on supported Windows; -NoProfile keeps it fast.
+            powershell_bin = trusted_system_bin("powershell")
+            if powershell_bin is None:
+                return ""
             out = subprocess.check_output(
                 [
-                    "powershell",
+                    powershell_bin,
                     "-NoProfile",
                     "-NonInteractive",
                     "-Command",
@@ -1374,8 +1507,14 @@ def process_owner_uid(pid: int) -> int | None:
         if sys.platform == "linux":
             return os.stat(f"/proc/{int(pid)}").st_uid
         if sys.platform == "darwin":
+            # An unresolvable ``ps`` yields None, which ``_gateway_owns_port``
+            # treats as "ownership unproven" and denies on — the same direction
+            # as every other failure in that gate.
+            ps_bin = trusted_system_bin("ps")
+            if ps_bin is None:
+                return None
             out = subprocess.check_output(
-                ["ps", "-o", "uid=", "-p", str(int(pid))],
+                [ps_bin, "-o", "uid=", "-p", str(int(pid))],
                 text=True,
                 stderr=subprocess.DEVNULL,
                 timeout=2,
@@ -1657,9 +1796,12 @@ def kill_pid(pid: int, sig: int = SIGTERM) -> bool:
     if IS_POSIX:
         os.kill(pid, sig)
         return True
+    taskkill_bin = trusted_system_bin("taskkill")
+    if taskkill_bin is None:
+        raise OSError("taskkill not found in the trusted system directories")
     try:
         r = subprocess.run(
-            ["taskkill", "/F", "/PID", str(pid)],
+            [taskkill_bin, "/F", "/PID", str(pid)],
             check=False,
             capture_output=True,
             timeout=5,
@@ -1708,9 +1850,12 @@ def kill_process_tree(pid: int, sig: int = SIGTERM) -> bool:
             return True
         os.killpg(pgid, sig)
         return True
+    taskkill_bin = trusted_system_bin("taskkill")
+    if taskkill_bin is None:
+        raise OSError("taskkill not found in the trusted system directories")
     try:
         r = subprocess.run(
-            ["taskkill", "/T", "/F", "/PID", str(pid)],
+            [taskkill_bin, "/T", "/F", "/PID", str(pid)],
             check=False,
             capture_output=True,
             timeout=5,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1830,6 +1830,70 @@ class TestStop:
             assert exc.value.code == 1
         assert "No Kiro Crew gateway" in capsys.readouterr().out
 
+    def _tool_absent(self, unpinned_at):
+        # The lookup tool reads as unavailable; ``unpinned_at`` is where PATH
+        # finds it anyway (None when it is genuinely not installed).
+        return (
+            patch(
+                "kiro_crew.cli_server.platform_compat.listening_pid_tool_available",
+                return_value=False,
+            ),
+            patch("kiro_crew.cli_server.platform_compat.listening_pid_tool", return_value="lsof"),
+            patch(
+                "kiro_crew.cli_server.platform_compat.tool_outside_trusted_dirs",
+                return_value=unpinned_at,
+            ),
+        )
+
+    def test_a_tool_outside_the_pin_is_not_reported_as_missing(self, capsys):
+        """A host that keeps binaries elsewhere has the tool; the pin declined it.
+
+        NixOS and Homebrew/conda prefixes are the real population here. Telling
+        that operator to install an ``lsof`` they already have sends them in
+        circles, so name the path and say the pin is deliberate.
+        """
+        from kiro_crew.cli_server import _stop
+
+        mock_sel = MagicMock()
+        available, tool, unpinned = self._tool_absent("/run/current-system/sw/bin/lsof")
+        with (
+            patch("kiro_crew.cli_server.sel", return_value=mock_sel),
+            self._ports([]),
+            available,
+            tool,
+            unpinned,
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _stop(5476)
+            assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "/run/current-system/sw/bin/lsof" in out, "must name where the tool actually is"
+        assert "Install lsof" not in out
+        # The audit log has to separate the two causes, not just the outcome.
+        resources = mock_sel.log_api_access.call_args.kwargs["resources"]
+        assert "reason=lsof_outside_trusted_dirs" in resources
+
+    def test_a_genuinely_missing_tool_still_says_to_install_it(self, capsys):
+        """Nothing on PATH means the install advice is the correct advice."""
+        from kiro_crew.cli_server import _stop
+
+        mock_sel = MagicMock()
+        available, tool, unpinned = self._tool_absent(None)
+        with (
+            patch("kiro_crew.cli_server.sel", return_value=mock_sel),
+            self._ports([]),
+            available,
+            tool,
+            unpinned,
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _stop(5476)
+            assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Install lsof and retry." in out
+        resources = mock_sel.log_api_access.call_args.kwargs["resources"]
+        assert "reason=lsof_not_found" in resources
+
     def test_no_kirocrew_process(self, capsys):
         # A listener exists but its cmdline isn't a kirocrew gateway → refuse to kill.
         from kiro_crew.cli_server import _stop

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -12,6 +12,7 @@ output we can assert directly), and the process-helper return contracts.
 from __future__ import annotations
 
 import errno
+import logging
 import os
 import stat
 import subprocess
@@ -23,6 +24,19 @@ import types
 import pytest
 
 from kiro_crew import platform_compat as pc
+
+
+def _fake_windows_bins(monkeypatch):
+    """Resolve Windows system binaries while ``IS_WINDOWS`` is faked on POSIX.
+
+    The Windows branches are deliberately exercised on the Linux CI fleet by
+    flipping ``IS_WINDOWS``. Those branches resolve their binary from the
+    trusted system directories before spawning, which a Linux host cannot
+    satisfy, so the lookup is faked alongside the platform flag — otherwise the
+    spawn reports the tool missing before the branch under test is reached.
+    """
+
+    monkeypatch.setattr(pc, "trusted_system_bin", lambda name: rf"C:\Windows\System32\{name}.exe")
 
 
 class TestPlatformFlags:
@@ -1049,6 +1063,7 @@ class TestTaskkillErrorMapping:
     def test_taskkill_rc128_maps_to_process_lookup(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "run",
                             self._fake_run(128, b"process not found"))
         with pytest.raises(ProcessLookupError):
@@ -1059,6 +1074,7 @@ class TestTaskkillErrorMapping:
     def test_taskkill_rc5_maps_to_permission_error(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "run",
                             self._fake_run(5, b"access denied"))
         with pytest.raises(PermissionError):
@@ -1069,6 +1085,7 @@ class TestTaskkillErrorMapping:
     def test_taskkill_generic_rc_maps_to_oserror(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "run",
                             self._fake_run(42, b"weird error"))
         with pytest.raises(OSError) as ei:
@@ -1079,6 +1096,7 @@ class TestTaskkillErrorMapping:
     def test_taskkill_success_returns_true_on_windows(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "run", self._fake_run(0))
         assert pc.kill_pid(99999, pc.SIGKILL) is True
         assert pc.kill_process_tree(99999, pc.SIGKILL) is True
@@ -1086,6 +1104,7 @@ class TestTaskkillErrorMapping:
     def test_taskkill_subprocess_error_wraps_as_oserror(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
 
         def _boom(*_a, **_kw):
             raise FileNotFoundError(2, "taskkill.exe not found")
@@ -1467,6 +1486,7 @@ class TestFindListeningPidsErrors:
         )
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "check_output", self._fake_netstat(blob))
         assert pc.find_listening_pids(7777) == [12345]
 
@@ -1481,6 +1501,7 @@ class TestFindListeningPidsErrors:
         )
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "check_output", self._fake_netstat(blob))
         assert pc.find_listening_pids(7777) == [99]
 
@@ -1495,6 +1516,7 @@ class TestFindListeningPidsErrors:
         )
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "check_output", self._fake_netstat(blob))
         assert pc.find_listening_pids(7777) == [77]
 
@@ -1508,6 +1530,7 @@ class TestFindListeningPidsErrors:
         )
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "check_output", self._fake_netstat(blob))
         assert pc.find_listening_pids(7777) == [88]
 
@@ -1526,6 +1549,7 @@ class TestFindListeningPidsErrors:
         )
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(pc.subprocess, "check_output", self._fake_netstat(blob))
         assert pc.find_listening_pids(7777) == [44]
 
@@ -1628,6 +1652,7 @@ class TestKillAsyncVariants:
         """
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
 
         # Fake subprocess_executor sentinel — anything hashable-and-truthy.
         sentinel = object()
@@ -1682,6 +1707,7 @@ class TestKillAsyncVariants:
         """Same offload contract as kill_pid_async but for the /T variant."""
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
 
         sentinel = object()
         seen_executors: list[object] = []
@@ -1721,6 +1747,7 @@ class TestKillAsyncVariants:
         """
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
         monkeypatch.setattr(
             pc.subprocess,
             "run",
@@ -2041,3 +2068,271 @@ def test_parent_map_is_empty_when_no_trusted_ps_exists(monkeypatch):
     monkeypatch.setattr(platform_compat, "trusted_system_bin", lambda name: None)
     assert platform_compat._posix_process_parent_map() == {}
     assert platform_compat.process_descendants(os.getpid()) == []
+
+
+def _listening_port(sock):
+    """Bind and listen on an ephemeral loopback port, returning it."""
+
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    return sock.getsockname()[1]
+
+
+def test_listening_pid_lookup_ignores_a_planted_tool_on_path(tmp_path, monkeypatch):
+    """A PATH-planted lsof must never answer the port->PID lookup.
+
+    This lookup feeds ``cli_server._gateway_owns_port``, so a shim that names an
+    attacker-chosen PID as the port holder subverts an ownership gate rather
+    than merely returning bad diagnostics.
+
+    POSIX-only by necessity: a faithful Windows shim would have to be a real
+    ``.exe``, because ``CreateProcess`` appends only that extension when it
+    resolves a bare argv name and so never reaches a planted ``.bat``. The
+    Windows guarantee is covered at the resolution level instead, by
+    ``test_trusted_system_bin_resolves_system32_and_rejects_path_on_windows``.
+    """
+
+    import socket
+
+    if pc.IS_WINDOWS:  # pragma: no cover - POSIX binary resolution
+        pytest.skip("POSIX binary resolution")
+
+    bogus = 999_999
+    tool = pc.listening_pid_tool()
+    shim = tmp_path / tool
+    shim.write_text(f"#!/bin/sh\necho {bogus}\n")
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        pids = pc.find_listening_pids(_listening_port(sock))
+
+    assert bogus not in pids, "planted PATH shim was executed"
+    if pc.trusted_system_bin(tool) is not None:
+        # A trusted tool exists on this host, so an empty list would not be a
+        # real answer — the lookup must still see this process holding the port.
+        # Without this the test could pass simply by returning nothing.
+        assert os.getpid() in pids
+
+
+def test_listening_pid_lookup_still_resolves_the_pinned_tool(tmp_path, monkeypatch):
+    """Pinning must not cost the lookup its real answer, PATH notwithstanding.
+
+    Guards the other direction from the shim test: a pin that resolved nothing
+    would make every port read as unheld, which is silent and fails open into
+    "no gateway is running".
+    """
+
+    import socket
+
+    tool = pc.listening_pid_tool()
+    if pc.trusted_system_bin(tool) is None:  # pragma: no cover - host lacks the tool
+        pytest.skip(f"no trusted {tool} on this host")
+
+    # An empty PATH proves the resolution owes nothing to it.
+    monkeypatch.setenv("PATH", str(tmp_path))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        pids = pc.find_listening_pids(_listening_port(sock))
+
+    assert os.getpid() in pids
+
+
+def test_listening_pid_tool_available_ignores_a_planted_tool_on_path(tmp_path, monkeypatch):
+    """The availability probe must agree with the lookup it describes.
+
+    Probing PATH here while the lookup resolves from the trusted directories
+    would let the two disagree: a shim would answer "available" for a tool the
+    lookup refuses to run, and a live gateway would read as stopped.
+    """
+
+    tool = pc.listening_pid_tool()
+    planted = tmp_path / (f"{tool}.exe" if pc.IS_WINDOWS else tool)
+    planted.write_text("")
+    if not pc.IS_WINDOWS:
+        planted.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    # Empty the trusted directories so the only resolvable copy of the tool is
+    # the planted one. A host that genuinely ships the tool would otherwise
+    # answer True for both the pinned and the PATH lookup, and the test could
+    # not tell them apart.
+    monkeypatch.setattr(pc, "_TRUSTED_SYSTEM_BIN_DIRS", ())
+    monkeypatch.setattr(pc, "_windows_system_dirs", lambda: ())
+
+    assert pc.trusted_system_bin(tool) is None
+    assert pc.listening_pid_tool_available() is False
+
+
+def test_listening_pid_lookup_degrades_when_no_trusted_tool_exists(monkeypatch):
+    """No trusted tool must read as "absent", never as a silent empty answer."""
+
+    monkeypatch.setattr(pc, "trusted_system_bin", lambda name: None)
+    assert pc.find_listening_pids(8000) == []
+    assert pc.listening_pid_tool_available() is False
+
+
+def test_process_owner_uid_ignores_a_planted_ps_on_path(tmp_path, monkeypatch):
+    """The uid backing the port-trust gate must not come from a PATH shim.
+
+    ``process_owner_uid`` reads ``/proc`` on Linux and shells out to ``ps`` only
+    on macOS, so the darwin branch is selected explicitly to exercise the spawn
+    on any POSIX host rather than leaving it covered on macOS CI alone.
+    """
+
+    if pc.IS_WINDOWS:  # pragma: no cover - POSIX binary resolution
+        pytest.skip("POSIX binary resolution")
+
+    shim = tmp_path / "ps"
+    shim.write_text("#!/bin/sh\necho 999999\n")
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    assert pc.process_owner_uid(os.getpid()) == os.getuid()
+
+
+def test_process_owner_uid_denies_when_no_trusted_ps_exists(monkeypatch):
+    """An unresolvable ``ps`` must report "unknown owner", which the gate denies on."""
+
+    if pc.IS_WINDOWS:  # pragma: no cover - POSIX binary resolution
+        pytest.skip("POSIX binary resolution")
+
+    monkeypatch.setattr(pc, "trusted_system_bin", lambda name: None)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert pc.process_owner_uid(os.getpid()) is None
+
+
+def test_trusted_system_bin_resolves_system32_and_rejects_path_on_windows(tmp_path, monkeypatch):
+    """Windows argv names must resolve from the real system directory only."""
+
+    if not pc.IS_WINDOWS:  # pragma: no cover - Windows binary resolution
+        pytest.skip("Windows binary resolution")
+
+    planted = tmp_path / "definitely-not-a-system-tool.exe"
+    planted.write_text("")
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert pc.trusted_system_bin("definitely-not-a-system-tool") is None
+    # A bare argv name still resolves, extension supplied by the lookup.
+    resolved = pc.trusted_system_bin("taskkill")
+    assert resolved is not None and resolved.lower().endswith("taskkill.exe")
+    assert os.path.isfile(resolved)
+
+
+def test_kill_helpers_fail_loud_when_taskkill_is_unresolvable(monkeypatch):
+    """Windows kills must raise, not silently report success, with no taskkill.
+
+    Callers branch on the exception to escalate; a quiet ``True`` would strand a
+    live process while reporting it terminated.
+    """
+
+    if not pc.IS_WINDOWS:  # pragma: no cover - Windows kill path
+        pytest.skip("Windows kill path")
+
+    # A PID that does not exist, so a regression that reaches the real taskkill
+    # cannot terminate the test runner; ``match`` pins the failure to the
+    # resolution step rather than to taskkill rejecting an unknown PID.
+    monkeypatch.setattr(pc, "trusted_system_bin", lambda name: None)
+    with pytest.raises(OSError, match="trusted system directories"):
+        pc.kill_pid(999_999)
+    with pytest.raises(OSError, match="trusted system directories"):
+        pc.kill_process_tree(999_999)
+
+
+def _plant_on_path(tmp_path, monkeypatch, name):
+    """Make *name* the only thing PATH can resolve, and return its path."""
+
+    planted = tmp_path / (f"{name}.exe" if pc.IS_WINDOWS else name)
+    planted.write_text("")
+    if not pc.IS_WINDOWS:
+        planted.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    return planted
+
+
+def _pin_warnings(caplog):
+    """Only this module's records, so an unrelated warning cannot skew the count."""
+
+    return [r for r in caplog.records if r.name == "kiro_crew.platform_compat"]
+
+
+def test_a_tool_installed_outside_the_trusted_dirs_is_diagnosable(tmp_path, monkeypatch, caplog):
+    """A non-FHS host must learn the pin is why its tool reads as unavailable.
+
+    NixOS and Homebrew/conda prefixes keep a perfectly good ``lsof`` outside the
+    system directories. The pin still refuses it, but without this line the
+    operator sees only ``kirocrew stop`` no-opping and a prompt to install a
+    tool they already have.
+    """
+
+    monkeypatch.setattr(pc, "_UNPINNED_TOOL_PROBED", set())
+    planted = _plant_on_path(tmp_path, monkeypatch, "definitely-not-a-system-tool")
+
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.platform_compat"):
+        assert pc.trusted_system_bin("definitely-not-a-system-tool") is None
+
+    records = _pin_warnings(caplog)
+    assert len(records) == 1
+    message = records[0].getMessage()
+    # Case-insensitive: Windows resolution reports the PATHEXT entry's own
+    # casing (".EXE"), not the casing the file was created with.
+    assert str(planted).casefold() in message.casefold(), "must name where the tool actually is"
+    assert "unavailable" in message
+
+
+def test_the_unpinned_tool_diagnostic_does_not_repeat(tmp_path, monkeypatch, caplog):
+    """One line per name: these lookups run on every teardown and gate check."""
+
+    monkeypatch.setattr(pc, "_UNPINNED_TOOL_PROBED", set())
+    _plant_on_path(tmp_path, monkeypatch, "definitely-not-a-system-tool")
+
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.platform_compat"):
+        for _ in range(3):
+            assert pc.trusted_system_bin("definitely-not-a-system-tool") is None
+
+    assert len(_pin_warnings(caplog)) == 1
+
+
+def test_a_genuinely_absent_tool_is_not_reported_as_misplaced(tmp_path, monkeypatch, caplog):
+    """Nothing on PATH means nothing to explain, so the line must stay quiet.
+
+    Claiming a tool sits outside the trusted directories when it is simply not
+    installed would send the operator hunting for a path that does not exist.
+    """
+
+    monkeypatch.setattr(pc, "_UNPINNED_TOOL_PROBED", set())
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.platform_compat"):
+        assert pc.trusted_system_bin("definitely-not-a-system-tool") is None
+
+    assert _pin_warnings(caplog) == []
+
+
+def test_a_resolvable_tool_is_never_reported_as_sitting_outside_the_pin(monkeypatch):
+    """Nothing to explain when the pinned lookup succeeded."""
+
+    monkeypatch.setattr(pc, "trusted_system_bin", lambda name: os.path.join("/usr/bin", name))
+    assert pc.tool_outside_trusted_dirs("lsof") is None
+
+
+def test_the_unpinned_path_is_reported_so_stop_can_name_it(tmp_path, monkeypatch):
+    """``stop`` needs the real location to tell a NixOS operator what happened."""
+
+    monkeypatch.setattr(pc, "trusted_system_bin", lambda name: None)
+    planted = _plant_on_path(tmp_path, monkeypatch, "definitely-not-a-system-tool")
+
+    found = pc.tool_outside_trusted_dirs("definitely-not-a-system-tool")
+
+    assert found is not None
+    assert found.casefold() == str(planted).casefold()
+
+
+def test_an_absent_tool_reports_no_unpinned_path(tmp_path, monkeypatch):
+    """Absent everywhere must stay ``None``, or ``stop`` would claim a path that
+    does not exist instead of saying the tool is missing."""
+
+    monkeypatch.setattr(pc, "trusted_system_bin", lambda name: None)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert pc.tool_outside_trusted_dirs("definitely-not-a-system-tool") is None


### PR DESCRIPTION
## Problem / Motivation

Eleven OS-introspection spawns passed a **bare binary name** as `argv[0]`, so `ps`, `lsof`, `netstat`, `taskkill` and `powershell` were resolved through the running process's `PATH`.

That `PATH` is not neutral in the gateway. `env.augmented_path` places `~/.local/bin`, `~/.toolbox/bin`, `~/.local/share/mise/shims` and `~/.volta/bin` **ahead** of the base path, and `activate_mise()` writes the result straight into `os.environ`:

```python
# env.py — extra dirs are prepended, base_path follows
parts = extra + ([base_path] if base_path else [])
...
target = os.environ if env is None else target   # activate_mise mutates in place
```

An executable dropped into any of those same-uid-writable directories therefore ran with the long-lived gateway's full, unscrubbed environment.

## Why it matters

Most of these sites return diagnostics. One does not.

`process_owner_uid` shells out to `ps -o uid=`, and its answer is the ownership half of the CLI's port-trust gate:

```python
# cli_server._gateway_owns_port
owner = platform_compat.process_owner_uid(recorded)
if owner is None or owner != os.getuid():
    return False
```

The existing test file already states the stakes plainly — *"`process_owner_uid` backs the ownership half of the CLI's port-trust gate"*. A shim there influences an authorization decision rather than merely returning bad output. `find_listening_pids`, which feeds step 2 of the same gate, had the same exposure.

This is a same-uid trust boundary, not a cross-user one, and I want to be accurate about that: a different local user cannot write those directories. What it closes is repo- or agent-controlled code planting a name that the gateway later executes with its own environment — the exposure `_run_cmd`'s `_TRUSTED_PATH` pinning and `sandboxed_spawn_argv`'s env scrubbing already exist to prevent elsewhere.

## What changed (motivation → approach → change)

The primitive already existed — PR #1432 added `trusted_system_bin()` and `_posix_process_parent_map` already uses it. The convention was established, just not applied uniformly. So this is a sweep onto an existing seam rather than a new mechanism.

Every site now resolves through `platform_compat.trusted_system_bin()` and treats an unresolvable name as "tool unavailable" instead of falling back to `PATH`. Each degradation follows the documented contract of its own caller rather than a blanket default:

| Site | Unresolvable behaviour |
|---|---|
| `process_owner_uid` | `None` — "owner unknown", which the port-trust gate already denies on |
| `find_listening_pids` | `[]` — the documented "no listener found" result |
| `process_matches` | `False` — its existing failure return |
| `process_command_line` | `""` — its existing failure return |
| `_get_rss_mb` / `_get_rss_tree_mb` | `None` / falls back to the single-process reading |
| `kill_pid` / `kill_process_tree` | raises `OSError`, so a caller's escalation branch runs instead of a silent success |

**Two decisions the issue deliberately left open:**

1. **The availability probe is pinned too.** `listening_pid_tool_available()` used `shutil.which`. Leaving it on `PATH` while the lookup resolves from trusted directories would let the two disagree — a shim would answer "available" for a tool the pinned lookup refuses to run, and a live gateway would read as stopped. That is the exact failure the probe exists to prevent, so pinning it is a correctness fix as much as a hardening one.

2. **Resolution stays uncached.** It is a handful of `stat` calls on teardown and introspection paths. Caching the *miss* would pin "tool absent" for the lifetime of a long-lived gateway, so an `lsof` installed after boot would never be picked up. Happy to add a positive-only cache if you would rather have it.

**Windows.** `trusted_system_bin` was POSIX-only, so `taskkill`/`netstat`/`powershell` needed it extended. It resolves against the real system directory from `GetSystemDirectoryW` rather than the environment-supplied `%SystemRoot%` — the environment being the input this module declines to trust — and tries the executable suffixes the loader would, since argv carries `taskkill` while the file on disk is `taskkill.exe`.

**One site beyond the issue's table:** `process_command_line` also spawned bare `powershell` on Windows. It is the same bug class in the same function family, and that function verifies a listener is really a KiroCrew gateway, so I pinned it rather than leave the sweep half-applied.

## Degradation that names its cause

Failing closed is the right direction, but on a host that keeps its binaries elsewhere (NixOS's `/run/current-system/sw/bin`, a Homebrew or conda prefix) the result is indistinguishable from the tool not being installed. `kirocrew stop` prints "install lsof" at an operator who already has lsof, and the port-trust gate quietly reads a live gateway as not-owned.

`trusted_system_bin` now logs once per name when the miss is the pin's doing — that is, when the name resolves on `PATH` but not under the pinned directories — and `tool_outside_trusted_dirs()` gives callers the same answer. `cli_server._stop` uses it to say where the tool actually is rather than advise an install that would change nothing, and that case carries SEL `reason=<tool>_outside_trusted_dirs`, so the two causes stay separable in the audit log.

The `PATH` result is read only to write those messages and is never spawned, so the pin still decides what runs and nothing new can run. A tool that is absent everywhere stays silent and keeps the install advice, which is the right advice in that case — reporting it as misplaced would send an operator hunting for a path that does not exist.

Once per name rather than once per miss, because these lookups run on every teardown and every gate check. Only the message is one-shot; resolution itself stays uncached, so a tool that lands in a trusted directory later is still picked up.

I did not add an operator override for the pinned directory list. An environment variable is exactly the input this module declines to trust, and a keystone-config knob is a wider change than a security fix should carry without a maintainer's call. Tell me which way you want it and I will follow.

## Tests

Added to `test/test_platform_compat.py`, mirroring the three shapes #1432 established:

- `test_listening_pid_lookup_ignores_a_planted_tool_on_path` — plants an executable `lsof` first on `PATH` that reports a bogus PID, binds a real loopback listener, and asserts the bogus PID never appears **and** that the real PID still does, so it cannot pass by returning empty.
- `test_process_owner_uid_ignores_a_planted_ps_on_path` — plants a `ps` shim reporting uid 999999 and asserts the real uid comes back. The darwin branch is selected explicitly so this spawn is covered on the Linux fleet rather than on macOS CI alone.
- `test_listening_pid_tool_available_ignores_a_planted_tool_on_path` — empties the trusted directories so the planted copy is the *only* resolvable one, which is what makes the probe's answer discriminating.
- `test_listening_pid_lookup_still_resolves_the_pinned_tool` — the other direction: a pin that resolved nothing would make every port read as unheld, silently.
- Degradation guards for the ownership probe and the listener lookup, plus Windows coverage for `System32` resolution and for the kill helpers failing loud.

**Mutation-checked**, as the issue asked. Reverting each pin to the bare argv name fails the corresponding test:

| Mutation | Result |
|---|---|
| `process_owner_uid` → bare `ps` | `test_process_owner_uid_ignores_a_planted_ps_on_path` **FAILED** |
| `find_listening_pids` → bare `lsof` | `test_listening_pid_lookup_ignores_a_planted_tool_on_path` **FAILED** |
| availability probe → `shutil.which` | both probe tests **FAILED** |

The third mutation initially passed, because on a host that ships `lsof` the pinned and `PATH` lookups agree; the test was strengthened to empty the trusted directories so it actually discriminates.

I also had to update 13 existing tests. `TestTaskkillErrorMapping`, the Windows `TestFindListeningPidsErrors` cases and `TestKillAsyncVariants` deliberately exercise the Windows branches on the Linux fleet by flipping `IS_WINDOWS`; now that those branches resolve a binary first, the simulation has to fake the lookup too (a Linux host has no `taskkill` to find). They share one helper, `_fake_windows_bins`. Two of them were passing for the wrong reason before that — my `OSError` satisfied a generic-`OSError` assertion — so they are also more honest now.

## Manual verification

- **Linux** (container, Python 3.12, non-root, with `procps` and `lsof`): full `pytest test` run diffed against a pristine baseline of the same tree.

  | | failed | passed | skipped |
  |---|---|---|---|
  | with this change | 85 | 28753 | 193 |
  | pristine baseline | 85 | 28748 | 190 |

  The failing sets are **identical in both directions** — no test fails with the change that does not fail without it. The 85 are pre-existing in this environment. The delta is the 8 tests this PR adds. (The baseline is taken by checking the four files out at `HEAD~1` and asserting the revert actually landed before the second run, because an earlier attempt of mine silently compared the branch against itself.)
- **Windows 11** (native, Python 3.12): `test/test_platform_compat.py` green. Verified `trusted_system_bin` resolves `taskkill`/`netstat`/`powershell` out of `System32` and returns `None` for an unknown name, and that the pinned `netstat` lookup still reports this process holding a bound port.
- **Gates**: `mypy src/kiro_crew` clean (721 files), `flake8 src/kiro_crew test` clean, `isort` clean, `scripts/docs-lint.sh` passes, `BRAND_BASE_REF` brand gate passes.
- **macOS**: not run locally. The darwin `ps` branches are covered on Linux by selecting the branch explicitly, so they are not left to macOS CI alone.

One note on `black`: it reports these files as needing reformatting, but it does so on the **unmodified** files at `HEAD` too (it wants to reformat pre-existing lines in `runtime.py`, `client.py` and the test file that this PR does not touch). I checked every requested hunk against my diff — none fall inside it — so I have not reformatted anything, to keep the diff to the change itself. The one line my edit did push over 100 chars is wrapped.

## Related Issues

Fixes #1503

## Adjacent, deliberately not in this PR

`_current_user_sid` and `restrict_to_owner` use `shutil.which("whoami") or r"C:\Windows\System32\whoami.exe"` and the same pattern for `icacls` — PATH first, hardcoded path only as fallback. That is the same resolution-order weakness, and `restrict_to_owner` is a security-enforcement path, so it may be worth its own issue. I left it out because it is a different function family from the introspection sweep this issue scopes. Happy to fold it in if you would prefer one pass.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated — `docs/system-specs/modules/cli.md` (the lookup's documented resolution source changed) and a `platform_compat` shim-table row in `AGENTS.md`, so the next bare-name spawn has a rule to trip over
- [x] No secrets, credentials, or internal references in the diff

