### PR TITLE
test(instances): stub _is_port_free in SSM transport-selection tests

### DIFF
--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -3046,6 +3046,20 @@ class TestSsmTunnelProcessGroup:
 class TestSsmTransportSelection:
     """The manager must drive the transport each instance is configured for."""
 
+    @pytest.fixture(autouse=True)
+    def _free_ports(self, monkeypatch):
+        # These tests assert which TRANSPORT the manager selects (ssh vs ssm) via
+        # _FakeTunnel; they are not about real local-port availability. connect()
+        # probes the real _is_port_free (CSE SEC-016 mirror-conflict check), and
+        # on a busy CI shard the fixed ports below (53510-53513) can already be
+        # bound -- connect() then returns an error status WITHOUT registering the
+        # tunnel, so `mgr._tunnels[id]` raises KeyError and the test flakes. Stub
+        # the probe to always-free, exactly as the other SshTunnelManager test
+        # classes do, so transport selection is tested deterministically.
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+
+        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+
     def _mgr(self, tmp_path, *, mint=None):
         from kiro_crew.instances.registry import InstancesRegistry
         from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager


### PR DESCRIPTION
## Problem

`test/test_instances.py::TestSsmTransportSelection` fails intermittently in CI with `KeyError: 'dev'` (and the same for the SSM cases), blocking the whole PR queue — the failures land in `Backend Tests` shard 1 across Python 3.10 / 3.12 / Windows. The tests pass locally and in isolation, so it looks like a flake, but it is deterministic given the right condition.

## Why it matters

`Backend Tests` feeds the `PR Readiness` aggregate, so this flake turns PR Readiness `action required` on **every** open PR whose CI runs against the current `main` (GitHub tests the merge-with-base). It is a false red that costs re-runs and masks real failures across the queue.

## Fix (symptom → root cause → change)

- **Symptom:** `mgr._tunnels["dev"]` → `KeyError: 'dev'` after `await mgr.connect("dev")` in `TestSsmTransportSelection`.
- **Root cause:** `TestSsmTransportSelection` (added in #1500) is the **only** `SshTunnelManager` test class that does not stub `_is_port_free`. `connect()` runs a real port-conflict probe (`_is_port_free(local_port)`, the CSE SEC-016 mirror-conflict check) against the class's fixed ports 53510–53513. On a busy CI shard (many test files, other services/leftovers holding ports) that probe returns `False`; `connect()` then correctly returns an ERROR status **without registering the tunnel** in `_tunnels`, so the test's `mgr._tunnels[id]` lookup raises `KeyError`. Locally the ports happen to be free, so it passes — which is why it slipped through.
- **Change:** add an autouse `_free_ports` fixture to `TestSsmTransportSelection` that monkeypatches `kiro_crew.instances.ssh_tunnel_manager._is_port_free` to always-True — the **identical pattern already used by every other `SshTunnelManager` test class** in this file (e.g. `TestSshTunnelArgvCompression`, and the classes around lines 954/1841/2378/2480/2554). These tests assert *which transport the manager selects* (ssh vs ssm) via `_FakeTunnel`; real local-port availability is not their subject, so removing that real-host dependency is the correct isolation fix, not a workaround. The genuine port-conflict behavior of `connect()` remains covered by its dedicated test (around line 2296).

No product/source code changes — test-only.

## Tests

- Existing `test/test_instances.py::TestSsmTransportSelection` (4 tests) now deterministic.
- **Reproduced the failure and proved the fix:** with ports 53510/53511 bound in-process (simulating a busy shard), the pre-fix tests fail with exactly the CI signature (`local port 53511 is already in use` → `KeyError`); with the fixture, all 4 pass with the same ports bound.
- Full `test/test_instances.py` passes under `pytest -n4` (172 passed). `isort` / `black` / `flake8` clean on the changed file.

## Manual verification

N/A — unit coverage is the evidence here; the reproduction above exercises the exact failing path deterministically.

## Screenshots / video

N/A — test-only change, no user-visible surface.
