### PR TITLE
fix(dev-fleet): make launchd restarts graceful

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -406,9 +406,10 @@ On Linux this writes a **system-level** systemd unit at
 `/etc/systemd/system/kirocrew.service` and enables it, so the gateway survives
 SSH disconnects, restarts on failure, and starts on boot
 (`WantedBy=multi-user.target`). On macOS it writes a launchd LaunchAgent at
-`~/Library/LaunchAgents/dev.kirocrew.gateway.plist` with `RunAtLoad` and
-`KeepAlive`/`SuccessfulExit=false`, so it starts at user login and relaunches on
-a non-zero exit but stays down after a clean stop.
+`~/Library/LaunchAgents/dev.kirocrew.gateway.plist` with `RunAtLoad`,
+`KeepAlive=true`, and a finite `ExitTimeOut`, so it starts at login, relaunches
+after exit, and force-kills only after the graceful stop deadline. An explicit
+`kirocrew stop` unloads the agent so it stays down for the current login session.
 
 ```bash
 kirocrew service status      # service state

--- a/docs/system-specs/common/code-style.md
+++ b/docs/system-specs/common/code-style.md
@@ -35,6 +35,7 @@ Paths below are relative to `src/kiro_crew/`.
 | Embed cache | `embeddings.py` | `_EMBED_CACHE_MAX` (128 entries, keyed by text plus model id; the comment there carries the memory arithmetic). |
 | Slack UX strings and pacing | `slack/handler.py` | `_THINKING`, `_CURSOR`, `_NO_RESPONSE`, `_STATUS_WORKING`, `_TRUNCATION_MARKER`, plus `_EDIT_INTERVAL`, `_APPROVAL_TIMEOUT`, `_SLACK_SECTION_TEXT_LIMIT`, the stall thresholds and the phase debounce. |
 | Cross-cutting shared constants | `constants.py` | `KIROCREW_SPAWNED_ENV`, `ENV_TRUTHY`, `CHAT_TURN_TIMEOUT`, the `[OPTIONS:]` parse regexes, `DATA_WARNING`, `BANNER`. |
+| Gateway shutdown budget | `gateway_shutdown_budget.py` | Gateway cooperative timeout, service-manager signal margin, and the derived systemd/launchd stop deadline. |
 | Process-wide shutdown signal | `__init__.py` | `shutdown_event`. Background loops `await shutdown_event.wait()` with a timeout instead of a plain `asyncio.sleep`, so they wake instantly on Ctrl-C. |
 | Base agent config | `config/defaults.json` | `tools`, `allowedTools`, `resources`, `hooks`, model. Packaged as package data, so editing it needs no code change. |
 | Managed MCP server specs | `agent.py` | `_MANAGED_MCP_SERVERS`: which servers are auto-registered and refreshed while preserving user customizations. |

--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -56,7 +56,7 @@ verification. Route names below are relative to that prefix.
 | `/apps/dev-fleet/api/pod/token` | `{name}` | Mint a dashboard token for the pod |
 | `/apps/dev-fleet/api/pod/provision` | `{name}` | Start async venv+dist build (returns `{run_id}`) |
 | `/apps/dev-fleet/api/rebase` | `{name}` | Rebase worktree onto origin/main |
-| `/apps/dev-fleet/api/restart-gateway` | — | Restart the live gateway in place (detached `systemd-run`); returns the pre-restart `start_id` for the restart handshake |
+| `/apps/dev-fleet/api/restart-gateway` | — | Restart the live gateway through its service-manager backend; returns the pre-restart `start_id` for the restart handshake |
 | `/apps/dev-fleet/api/make-live` | `{path, dry_run?}` | Repoint the live gateway at another worktree (see Make Live); a real cutover returns `start_id` for the restart handshake |
 
 ## Authorization
@@ -297,21 +297,17 @@ duplicate Restart Gateway causes a second real ~10s gateway outage
 ### Restart identity handshake
 
 `POST /apps/dev-fleet/api/restart-gateway` returns `{"ok": true, "start_id": …}`
-the instant `systemd-run --collect systemctl --user restart <unit>` has
-**scheduled** the restart — the bounce happens after the response and takes ~10s
-because graceful shutdown times out. "The request succeeded" therefore says
-nothing about whether the gateway is back.
+after the platform manager accepts the restart. Linux schedules detached
+`systemd-run`; macOS submits `launchctl stop` under the loaded contract described
+below. The bounce happens after the response, so success does not mean the new
+gateway is serving yet.
 
 To close that gap the backend captures the unit's **start identity** BEFORE
 scheduling the restart and hands it to the frontend:
 
-- **Identity = `ExecMainStartTimestampMonotonic`** — the CLOCK_MONOTONIC
-  microsecond stamp of the unit's ExecStart *main* PID (`_gateway_start_id`).
-  Chosen because it is (a) monotonic, so it can only increase and never repeats
-  or goes backwards across a restart even if the wall clock is stepped by NTP,
-  and (b) tied to the actual main-process spawn, so it changes the instant the
-  NEW process starts (a unit can enter `active` before its replacement main PID
-  exists, so `ActiveEnterTimestampMonotonic` is a weaker signal).
+- **Identity is manager-specific.** systemd uses
+  `ExecMainStartTimestampMonotonic`; launchd uses the loaded job PID. Both change
+  when the replacement main process starts.
 - The current identity is reported by extending the existing **`/health`**
   surface (`{status, start_id}`). Because the gateway proxies only
   `/apps/dev-fleet/api/*` to the backend, the same handler is registered at
@@ -321,10 +317,9 @@ scheduling the restart and hands it to the frontend:
   DIFFERS from the one captured before the restart. A 200 from the old process
   still winding down returns the SAME identity and is correctly NOT counted as
   recovered.
-- **None-safe degrade.** On a platform that cannot report identity (non-Linux,
-  no `systemctl`, or a `0`/absent stamp) `start_id` is `null`; the frontend then
-  degrades to the legacy "reload on the first reachable response" instead of
-  hanging forever in the restarting overlay.
+- **None-safe degrade.** An absent/zero systemd stamp or absent launchd PID
+  yields `start_id: null`; the frontend then reloads on the first reachable
+  response instead of waiting forever.
 - **A reachable 404 counts as recovery.** Cutting over to a worktree whose
   dev-fleet backend predates `/api/health` leaves that route answering 404
   permanently, so its `start_id` can never appear and waiting for one would burn
@@ -499,15 +494,16 @@ content, or absence) was successfully restored on disk.
 The cutover writes the pointer on every platform. What differs is whether Dev
 Fleet can also bounce the gateway:
 
-- **Automatic restart** (`can_restart = True`): the gateway runs as a systemd
-  `--user` unit that Dev Fleet can drive. After writing the pointer, Dev Fleet
-  issues a detached `systemd-run` restart (survives its own death), sets the
-  `_MAKE_LIVE_COMMITTED` latch, and returns `start_id` for the restart
-  handshake. The next gateway process reads the pointer and execs into the
-  target checkout.
+- **Automatic restart** (`can_restart = True`): the gateway runs as an active
+  systemd `--user` unit or a current macOS LaunchAgent that Dev Fleet can drive.
+  After writing the pointer, Dev Fleet asks the manager to restart it (`systemd-run`
+  on Linux, bounded graceful `launchctl stop` on macOS), sets the
+  `_MAKE_LIVE_COMMITTED` latch, and returns `start_id` for the restart handshake.
+  The next gateway process reads the pointer and execs into the target checkout.
 - **Staged only** (`can_restart = False`): no drivable service manager is
   available (system unit via `kirocrew service install`, macOS without a launchd
-  agent, terminal-launched gateway, or non-Linux host). The pointer is still
+  agent or with a legacy restart contract, terminal-launched gateway, or another
+  unsupported manager). The pointer is still
   written and the cutover is reported as a success carrying `staged_only: true`,
   plus `manual_restart` (the shell command that finishes it) and a human-readable
   `notice`. The latch is deliberately NOT set — no restart is pending, so a
@@ -572,9 +568,18 @@ when there was none. The refusal response carries `rolled_back: true|false`.
 ### Platform scope
 
 Staging (writing the pointer) works on every platform — Linux, macOS, and
-Windows. Only the automatic restart still requires a drivable service manager
-(a loaded systemd `--user` unit). Cutover from inside a pod is always refused
-(`pod` / `pod_indeterminate`).
+Windows. Automatic restart requires a drivable manager: an active systemd
+`--user` unit or an active macOS per-user LaunchAgent with the current restart
+contract. Without one, the cutover succeeds as `staged_only` and the operator
+restarts manually. Cutover from inside a pod is always refused (`pod` /
+`pod_indeterminate`).
+
+On macOS, Restart and automatic Make Live submit `launchctl stop <label>`.
+Disk and loaded launchd definitions must both report `KeepAlive=true` and
+`ExitTimeOut=TOTAL_SHUTDOWN_BUDGET_SECS` (20s). The Gateway's cooperative cap is
+`GRACEFUL_SHUTDOWN_SECS` (10s), leaving the remaining budget for cleanup and
+exit before launchd escalates to SIGKILL. An agent with a legacy contract falls
+back to staged-only Make Live and names `kirocrew service install` as the repair.
 
 ## Output Redaction
 
@@ -641,8 +646,9 @@ Per-platform behavior:
   worktree's venv + dist works anywhere; Make Live stages the pointer on any
   platform and reports `staged_only` when it cannot bounce the gateway itself.
 - **Make Live** — staging (pointer write) works on every platform. Automatic
-  restart requires a loaded systemd `--user` unit; without one the cutover
-  succeeds with `staged_only: true` and the operator restarts manually.
+  restart requires an active systemd `--user` unit or a current macOS
+  LaunchAgent; without one the cutover succeeds with `staged_only: true` and
+  the operator restarts manually.
 - **git** and **gh** CLI required for full functionality; missing binaries produce
   graceful degradation via OSError catch in `_run_cmd`.
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
@@ -22,9 +22,9 @@ concern              systemd                                     launchd
 ===================  ==========================================  ==================================================
 manageable           ``systemctl --user cat <unit>`` rc == 0      ``launchctl print gui/<uid>/<label>`` rc == 0
 start identity       ``ExecMainStartTimestampMonotonic``          the job's PID (launchd exposes no monotonic stamp)
-detached restart     ``systemd-run --user --collect systemctl     ``launchctl kickstart -k`` (launchd performs the
-                     --user restart <unit>``                      kill+respawn itself, so nothing is left for our
-                                                                  dying process to run)
+detached restart     ``systemd-run --user --collect systemctl     ``launchctl stop <label>`` returns immediately;
+                     --user restart <unit>``                      ``KeepAlive`` respawns after graceful SIGTERM,
+                                                                  with ``ExitTimeOut`` as the SIGKILL ceiling
 stage a new target   a drop-in overriding ExecStart,             atomically rewrite the ``live-gateway`` launcher
                      WorkingDirectory and PATH, then             script the agent's ProgramArguments executes
                      ``daemon-reload``
@@ -38,9 +38,9 @@ definition and never re-reads the file). ``bootout`` kills us, so the
 ``bootstrap`` half would never run: the gateway would stop and never come back.
 
 So the plist never changes. It points permanently at a generated launcher script
-and staging is an atomic rewrite of that script plus a ``kickstart -k``, which
-launchd executes on our behalf. Nothing is left for a dying process to do, and
-rollback restores the previous script text.
+and staging is an atomic rewrite of that script plus ``launchctl stop``.
+launchd owns the stop and respawn; rollback restores the previous script if the
+restart request is rejected.
 
 The launcher is a script rather than a symlink to the binary because a cutover
 must also move the working directory and put the target checkout's venv first on
@@ -53,8 +53,9 @@ The consequence is that make-live on macOS requires an agent installed WITH
 that indirection (``kirocrew service install`` from a build that has it).
 An older, directly-pointed agent is reported as ``agent_not_indirected`` — the
 launchd analogue of systemd's ``no_user_unit``: installed, but not controllable
-this way, and actionable rather than a silent false success. A loaded agent whose
-launcher has been deleted is reported as ``live_program_missing``.
+this way, and actionable rather than a silent false success. An indirected agent
+with the legacy restart contract reports ``agent_restart_contract_outdated``. A
+loaded agent whose launcher has been deleted is reported as ``live_program_missing``.
 """
 
 from __future__ import annotations
@@ -70,7 +71,9 @@ from typing import Awaitable, Callable, Protocol
 from kiro_crew.service.common import launchd_live_program
 from kiro_crew.service.macos import (
     PLIST_PATH,
+    loaded_restart_contract_current,
     render_live_program,
+    restart_contract_current,
     write_live_program,
 )
 
@@ -100,6 +103,9 @@ Which = Callable[[str], "str | None"]
 #   agent_not_indirected   the agent is loaded but its ProgramArguments does not
 #               (launchd)  go through the live-gateway symlink, so staging would
 #                          be a silent no-op. Remedy: `kirocrew service install`
+#   agent_restart_contract_outdated
+#               (launchd)  the plist lacks KeepAlive=true or the expected
+#                          ExitTimeOut value for detached graceful restart
 STATUS_OK = "ok"
 
 
@@ -328,11 +334,9 @@ class SystemdBackend:
 class LaunchdBackend:
     """``launchctl`` backend for the per-user gateway LaunchAgent.
 
-    Uses the modern ``print`` / ``kickstart`` verbs (the same dialect
-    :mod:`kiro_crew.pod.launchd` uses) rather than the legacy
-    ``load``/``unload`` pair: legacy ``unload`` + ``load`` cannot restart the
-    gateway from inside the gateway, because the ``unload`` half kills the
-    process that would have run the ``load``.
+    Uses ``print`` for state and launchd's non-blocking ``stop`` transaction for
+    restart. ``unload`` + ``load`` is unsafe because unload can terminate the
+    process that would issue load.
     """
 
     kind = "launchd"
@@ -405,6 +409,11 @@ class LaunchdBackend:
         # repair rather than reporting a healthy service.
         if not self.live_program().exists():
             return "live_program_missing"
+        if (
+            not restart_contract_current(self.plist_path())
+            or not loaded_restart_contract_current(_out)
+        ):
+            return "agent_restart_contract_outdated"
         return "ok"
 
     async def active(self) -> bool:
@@ -442,16 +451,24 @@ class LaunchdBackend:
         return None if rc != 0 else self._parse_pid(out)
 
     async def restart_detached(self) -> tuple[bool, str]:
-        """``kickstart -k`` — launchd performs the kill and the respawn itself.
-
-        This is what makes it safe to call from the process being killed: unlike
-        ``unload`` + ``load``, there is no second command left for us to run
-        after we are gone.
-        """
+        """Schedule a bounded graceful restart through launchd."""
+        if not restart_contract_current(self.plist_path()):
+            return False, (
+                "launchd agent restart contract is outdated; re-run "
+                "`kirocrew service install`"
+            )
+        rc, printed = await self._print()
+        if rc != 0:
+            return False, "launchd agent is not loaded"
+        if not loaded_restart_contract_current(printed):
+            return False, (
+                "loaded launchd restart contract is outdated; re-run "
+                "`kirocrew service install`"
+            )
         rc, _out, stderr = await self._run(
-            ["launchctl", "kickstart", "-k", self.target()], timeout=10
+            ["launchctl", "stop", self._label()], timeout=10
         )
-        return (rc == 0, "" if rc == 0 else (stderr.strip()[:200] or "kickstart failed"))
+        return (rc == 0, "" if rc == 0 else (stderr.strip()[:200] or "launchctl stop failed"))
 
     # -- staging --
     def plan(self, worktree: Path, kcbin: Path) -> dict:

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -3706,8 +3706,9 @@ async def _live_user_unit_status() -> str:
                            the process serving this request: restarting it would
                            bounce an idle unit while the real gateway (foreground,
                            or a system unit) keeps serving the old code;
-      ``"no_launchd"`` / ``"no_agent"`` / ``"agent_not_indirected"`` — the launchd
-                           counterparts (see ``gateway_service``);
+      ``"no_launchd"`` / ``"no_agent"`` / ``"agent_not_indirected"`` /
+      ``"agent_restart_contract_outdated"`` — the launchd counterparts (see
+                           ``gateway_service``);
       ``"ok"``           — the live service is known to the manager AND running,
                            so a restart actually replaces the gateway we are in.
     """
@@ -3779,6 +3780,11 @@ def _make_live_status_error(code: str) -> str:
             "live-gateway launcher, so Dev Fleet does not treat it as one it "
             "can safely bounce. Re-run `kirocrew service install` to refresh "
             "the agent definition"
+        ),
+        "agent_restart_contract_outdated": (
+            f"the launchd agent {_LIVE_GATEWAY_LABEL} lacks the bounded graceful "
+            "restart contract required by Dev Fleet. Re-run "
+            "`kirocrew service install` to refresh the agent definition"
         ),
         "live_program_missing": (
             f"the launchd agent {_LIVE_GATEWAY_LABEL} is loaded but its "
@@ -4043,8 +4049,8 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
                     "error": _redact(err)}
 
         # The restart tears down THIS backend with the gateway, so it is handed
-        # to the service manager to perform (systemd-run on Linux, launchd's own
-        # kickstart on macOS) so it survives our own death. Capture the
+        # to the service manager to perform (systemd-run on Linux, launchd's
+        # stop/relaunch transaction on macOS) so it survives our own death. Capture the
         # pre-restart identity FIRST so the dashboard reuses the same handshake
         # it uses for restart-gateway (wait for a DIFFERENT start id, not "a 200
         # came back") -- a cutover is just a restart into different code, so it

--- a/src/kiro_crew/gateway_shutdown_budget.py
+++ b/src/kiro_crew/gateway_shutdown_budget.py
@@ -1,0 +1,14 @@
+"""Shared shutdown budgets for the Gateway and its service managers."""
+
+from __future__ import annotations
+
+#: Maximum time allowed for the Gateway's cooperative shutdown.
+GRACEFUL_SHUTDOWN_SECS = 10
+
+#: Headroom for signal delivery, event-loop wakeup, cleanup, and exit.
+SIGNAL_MARGIN_SECS = 10
+
+#: SIGTERM-to-SIGKILL deadline shared by systemd and launchd.
+TOTAL_SHUTDOWN_BUDGET_SECS = (
+    GRACEFUL_SHUTDOWN_SECS + SIGNAL_MARGIN_SECS
+)

--- a/src/kiro_crew/service/common.py
+++ b/src/kiro_crew/service/common.py
@@ -23,7 +23,7 @@ def launchd_live_program() -> "os.PathLike[str]":
     only re-reads a plist on ``bootout`` + ``bootstrap`` (``kickstart`` restarts
     the in-memory job definition), and ``bootout`` kills the very process that
     would have to run the ``bootstrap``. The gateway would stop and never come
-    back. Rewriting THIS file plus ``kickstart -k`` leaves nothing for a dying
+    back. Rewriting THIS file plus ``launchctl stop`` leaves nothing for a dying
     process to do.
 
     It is a generated launcher SCRIPT rather than a symlink to the binary

--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -25,6 +25,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from kiro_crew.gateway_shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
 from kiro_crew.service import apparmor
 from kiro_crew.service.common import (
     SERVICE_NAME,
@@ -187,7 +188,7 @@ def render_unit(apparmor_profile: str = "") -> str:
         f"ExecStart={exec_start}\n"
         "Restart=on-failure\n"
         "RestartSec=10\n"
-        "TimeoutStopSec=20\n"
+        f"TimeoutStopSec={TOTAL_SHUTDOWN_BUDGET_SECS}\n"
         # Pin a high open-file limit rather than inheriting the host's
         # ambient DefaultLimitNOFILE. Stock systemd defaults to 1024 — and
         # the frontend production build (vite/rollup) opens ~1000

--- a/src/kiro_crew/service/macos.py
+++ b/src/kiro_crew/service/macos.py
@@ -1,18 +1,22 @@
 """launchd LaunchAgent generation and control for macOS.
 
 The plist lives at ``~/Library/LaunchAgents/dev.kirocrew.gateway.plist``
-and is loaded via ``launchctl load -w``. The service starts on user login
-and is restarted on crash by ``KeepAlive``.
+and is loaded via ``launchctl load -w``. It keeps the gateway continuously
+running. Dev Fleet's ``launchctl stop`` restart is launchd-owned: SIGTERM first,
+then SIGKILL only after the finite ``ExitTimeOut`` if cooperative shutdown does
+not finish.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import plistlib
 import subprocess
 import tempfile
 from pathlib import Path
 
+from kiro_crew.gateway_shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
 from kiro_crew.service.common import (
     LAUNCHD_LABEL,
     kirocrew_bin,
@@ -80,10 +84,9 @@ def render_plist() -> str:
         "    <key>RunAtLoad</key>\n"
         "    <true/>\n"
         "    <key>KeepAlive</key>\n"
-        "    <dict>\n"
-        "        <key>SuccessfulExit</key>\n"
-        "        <false/>\n"
-        "    </dict>\n"
+        "    <true/>\n"
+        "    <key>ExitTimeOut</key>\n"
+        f"    <integer>{TOTAL_SHUTDOWN_BUDGET_SECS}</integer>\n"
         "    <key>EnvironmentVariables</key>\n"
         "    <dict>\n"
         f"{env_entries}"
@@ -94,6 +97,60 @@ def render_plist() -> str:
         f"    <string>{err_log}</string>\n"
         "</dict>\n"
         "</plist>\n"
+    )
+
+
+def _plist_payload(path: Path) -> dict[str, object] | None:
+    try:
+        payload = plistlib.loads(path.read_bytes())
+    except (OSError, ValueError, plistlib.InvalidFileException):
+        return None
+    except Exception as exc:
+        # plistlib's XML parser exposes ExpatError without re-exporting its type.
+        # Avoid importing the unsafe low-level XML module; malformed local plist
+        # input fails closed, while an unrelated parser failure still surfaces.
+        if (type(exc).__module__, type(exc).__name__) == (
+            "xml.parsers.expat",
+            "ExpatError",
+        ):
+            return None
+        raise
+    return payload if isinstance(payload, dict) else None
+
+
+def _launchctl_print_value(printed: str, key: str) -> str | None:
+    prefix = f"{key} = "
+    for line in printed.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            return stripped[len(prefix):].strip()
+    return None
+
+
+def loaded_restart_contract_current(printed: str) -> bool:
+    """Return whether the loaded launchd job has the expected restart contract."""
+    timeout = _launchctl_print_value(printed, "exit timeout")
+    properties = _launchctl_print_value(printed, "properties")
+    if timeout is None or properties is None:
+        return False
+    try:
+        parsed_timeout = int(timeout)
+    except ValueError:
+        return False
+    flags = {part.strip().lower() for part in properties.split("|")}
+    return "keepalive" in flags and parsed_timeout == TOTAL_SHUTDOWN_BUDGET_SECS
+
+
+def restart_contract_current(path: Path | None = None) -> bool:
+    """Return whether *path* has the expected ``launchctl stop`` contract."""
+    payload = _plist_payload(path or PLIST_PATH)
+    if payload is None:
+        return False
+    timeout = payload.get("ExitTimeOut")
+    return (
+        payload.get("KeepAlive") is True
+        and type(timeout) is int
+        and timeout == TOTAL_SHUTDOWN_BUDGET_SECS
     )
 
 
@@ -263,14 +320,10 @@ def is_active() -> bool:
 
 
 def stop() -> None:
-    """Stop the running agent.
+    """Stop the agent without triggering its ``KeepAlive`` restart.
 
-    ``launchctl stop`` only sends SIGTERM, which the plist's
-    ``KeepAlive={SuccessfulExit: false}`` treats as an unsuccessful exit
-    and immediately restarts — so a plain ``stop`` is effectively a
-    no-op. Use ``unload`` (without ``-w``) so the agent stops and stays
-    stopped for the current session, but reloads automatically on next
-    login. This mirrors ``systemctl stop`` semantics on Linux.
+    Dev Fleet restarts with ``launchctl stop``; operator stop unloads the job
+    from the current domain while leaving it enabled for the next login.
     """
     if PLIST_PATH.exists():
         _launchctl("unload", str(PLIST_PATH))
@@ -287,9 +340,8 @@ def restart() -> bool:
     from the gateway, the ``unload`` half SIGTERMs the caller, so the ``load``
     half never executes and the agent stays down — the exact failure mode that
     made Dev Fleet's Restart unimplementable on macOS. ``launchctl restart`` is
-    deprecated and behaves like ``stop``, which ``KeepAlive`` treats as an
-    unsuccessful exit and respawns immediately, so it re-runs the OLD job
-    definition rather than re-reading anything.
+    deprecated and behaves like ``stop``; ``KeepAlive`` immediately respawns the
+    loaded job definition rather than re-reading anything.
 
     Returns False when the plist is absent or launchd rejects the kickstart, so
     callers never report a restart that never happened.

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -119,6 +119,7 @@ from kiro_crew.executors import (
     subprocess_executor,
 )
 from kiro_crew.frontend import build_frontend_async
+from kiro_crew.gateway_shutdown_budget import GRACEFUL_SHUTDOWN_SECS
 from kiro_crew.heartbeat import (
     HEARTBEAT_TASK_TIMEOUT_SECS,
     HeartbeatService,
@@ -5906,7 +5907,9 @@ class GatewayOrchestrator:
             logger.debug("Gateway run-marker clear skipped", exc_info=True)
 
         try:
-            await asyncio.wait_for(self._shutdown(), timeout=10.0)
+            await asyncio.wait_for(
+                self._shutdown(), timeout=GRACEFUL_SHUTDOWN_SECS
+            )
         except (asyncio.TimeoutError, Exception):
             logger.warning("Graceful shutdown timed out — force exiting")
 

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1884,6 +1884,13 @@ def _stub_make_live(monkeypatch, wt, *, live=None, in_pod=False, unit_status="ok
         pointer_dir.mkdir(parents=True, exist_ok=True)
         ptr_file = pointer_dir / "live_target.json"
         monkeypatch.setattr(mod.live_target, "pointer_path", lambda: ptr_file)
+    if platform == "darwin":
+        monkeypatch.setattr(
+            mod.gateway_service, "restart_contract_current", lambda _path: True
+        )
+        monkeypatch.setattr(
+            mod.gateway_service, "loaded_restart_contract_current", lambda _out: True
+        )
 
 
 @pytest.mark.asyncio
@@ -2337,7 +2344,42 @@ async def test_live_user_unit_status_darwin_ok(monkeypatch, tmp_path):
     monkeypatch.setattr(
         mod.gateway_service.LaunchdBackend, "live_program", staticmethod(lambda: link)
     )
+    monkeypatch.setattr(
+        mod.gateway_service, "restart_contract_current", lambda _path: True
+    )
+    monkeypatch.setattr(
+        mod.gateway_service, "loaded_restart_contract_current", lambda _out: True
+    )
     assert await mod._live_user_unit_status() == "ok"
+
+
+@pytest.mark.asyncio
+async def test_live_user_unit_status_darwin_loaded_contract_outdated(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="darwin"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/bin/launchctl"))
+    )
+    link = tmp_path / "live-gateway"
+    link.write_text("#!/bin/sh\n")
+    plist = tmp_path / "agent.plist"
+    plist.write_text(f"<string>{link}</string>")
+    monkeypatch.setattr(
+        mod.gateway_service.LaunchdBackend, "plist_path", staticmethod(lambda: plist)
+    )
+    monkeypatch.setattr(
+        mod.gateway_service.LaunchdBackend, "live_program", staticmethod(lambda: link)
+    )
+    monkeypatch.setattr(
+        mod.gateway_service, "restart_contract_current", lambda _path: True
+    )
+    monkeypatch.setattr(
+        mod.gateway_service, "loaded_restart_contract_current", lambda _out: False
+    )
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "pid = 7\n", "")))
+
+    assert await mod._live_user_unit_status() == "agent_restart_contract_outdated"
 
 
 @pytest.mark.asyncio
@@ -2450,19 +2492,20 @@ async def test_make_live_unsafe_path_returns_code(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_restart_gateway_darwin_kickstarts_the_agent(monkeypatch):
-    """macOS restart is ONE `launchctl kickstart -k`, performed by launchd.
-
-    It has to be a single call: `unload` + `load` cannot be issued from inside
-    the gateway, because the unload SIGTERMs the caller before the load can run.
-    That is precisely why Restart was unimplementable on macOS before this.
-    """
+async def test_restart_gateway_darwin_requests_graceful_stop(monkeypatch):
+    """macOS restart asks launchd for a bounded SIGTERM-first stop."""
     monkeypatch.setattr(mod, "sys", MagicMock(platform="darwin"))
     monkeypatch.setattr(
         mod, "shutil", MagicMock(which=MagicMock(return_value="/bin/launchctl"))
     )
     monkeypatch.setattr(mod, "_GATEWAY_SERVICE_ACTIVE", None, raising=False)
     monkeypatch.setattr(mod, "_GATEWAY_SERVICE_CHECK_AT", 0.0, raising=False)
+    monkeypatch.setattr(
+        mod.gateway_service, "restart_contract_current", lambda _path: True
+    )
+    monkeypatch.setattr(
+        mod.gateway_service, "loaded_restart_contract_current", lambda _out: True
+    )
     calls: list = []
 
     async def fake_run_cmd(cmd, **kw):
@@ -2477,10 +2520,33 @@ async def test_restart_gateway_darwin_kickstarts_the_agent(monkeypatch):
     # The PID stands in for systemd's monotonic start stamp: it changes on every
     # respawn, which is the edge the frontend handshake waits for.
     assert res["start_id"] == "4242"
-    kick = [c for c in calls if c[:2] == ["launchctl", "kickstart"]]
-    assert len(kick) == 1, f"expected exactly one kickstart, got {calls}"
-    assert kick[0][2] == "-k" and kick[0][3].startswith("gui/")
-    assert not any(c[:2] == ["launchctl", "unload"] for c in calls)
+    assert ["launchctl", "stop", mod._gateway_label()] in calls
+    assert not any(c[:2] == ["launchctl", "kickstart"] for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_darwin_refuses_stale_loaded_contract(monkeypatch):
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="darwin"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/bin/launchctl"))
+    )
+    monkeypatch.setattr(
+        mod.gateway_service, "restart_contract_current", lambda _path: True
+    )
+    monkeypatch.setattr(
+        mod.gateway_service, "loaded_restart_contract_current", lambda _out: False
+    )
+    calls = []
+
+    async def fake_run_cmd(cmd, **_kw):
+        calls.append(cmd)
+        return (0, "pid = 4242\n", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    res = await mod._restart_gateway()
+    assert res["ok"] is False
+    assert "loaded launchd restart contract is outdated" in res["error"]
+    assert not any(c[:2] == ["launchctl", "stop"] for c in calls)
 
 
 @pytest.mark.asyncio
@@ -2517,12 +2583,8 @@ _posix_symlink_only = pytest.mark.skipif(
 
 @pytest.mark.asyncio
 @_posix_symlink_only
-async def test_make_live_darwin_writes_pointer_and_kickstarts(monkeypatch, tmp_path):
-    """A macOS cutover writes the pointer file, then kickstarts the agent.
-
-    The mechanism is identical to linux (pointer file) — the only difference is
-    HOW the restart is issued (kickstart vs systemd-run).
-    """
+async def test_make_live_darwin_writes_pointer_and_stops_agent(monkeypatch, tmp_path):
+    """A macOS cutover writes the pointer, then asks launchd to stop the agent."""
     wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
     ptr_dir = tmp_path / "ptr"
     _stub_make_live(monkeypatch, wt, platform="darwin", pointer_dir=ptr_dir)
@@ -2544,9 +2606,8 @@ async def test_make_live_darwin_writes_pointer_and_kickstarts(monkeypatch, tmp_p
     import json as _json
     data = _json.loads(ptr_file.read_text())
     assert Path(data["checkout"]).resolve() == wt.resolve()
-    # Kickstart issued (the launchd restart mechanism).
-    assert any(c[:3] == ["launchctl", "kickstart", "-k"] for c in calls)
-    # No bootout/bootstrap: kickstart is the single-call restart.
+    assert any(c[:2] == ["launchctl", "stop"] for c in calls)
+    assert not any(c[:2] == ["launchctl", "kickstart"] for c in calls)
     assert not any("bootout" in c or "bootstrap" in c for c in calls)
 
 
@@ -2555,7 +2616,7 @@ async def test_make_live_darwin_writes_pointer_and_kickstarts(monkeypatch, tmp_p
 async def test_make_live_darwin_rolls_back_pointer_on_restart_failure(
     monkeypatch, tmp_path
 ):
-    """A failed kickstart restores the prior pointer state.
+    """A rejected launchd stop restores the prior pointer state.
 
     Leaving the new pointer in place would silently activate the new checkout
     on the NEXT unrelated restart.
@@ -2568,8 +2629,8 @@ async def test_make_live_darwin_rolls_back_pointer_on_restart_failure(
     async def fake_run_cmd(cmd, **kw):
         if cmd[:2] == ["launchctl", "print"]:
             return (0, "  pid = 99\n", "")
-        if cmd[:2] == ["launchctl", "kickstart"]:
-            return (1, "", "kickstart refused")
+        if cmd[:2] == ["launchctl", "stop"]:
+            return (1, "", "stop refused")
         return (0, "", "")
 
     monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -15,6 +15,7 @@ subprocess calls in :mod:`kiro_crew.service.linux` and
 from __future__ import annotations
 
 import os
+import plistlib
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -62,6 +63,20 @@ class TestPlatformDetection:
         ):
             mock_sys.platform = "win32"
             assert current_platform() == Platform.UNSUPPORTED
+
+
+class TestShutdownBudget:
+    def test_service_deadline_covers_gateway_grace(self):
+        from kiro_crew.gateway_shutdown_budget import (
+            GRACEFUL_SHUTDOWN_SECS,
+            SIGNAL_MARGIN_SECS,
+            TOTAL_SHUTDOWN_BUDGET_SECS,
+        )
+
+        assert TOTAL_SHUTDOWN_BUDGET_SECS == (
+            GRACEFUL_SHUTDOWN_SECS + SIGNAL_MARGIN_SECS
+        )
+        assert (GRACEFUL_SHUTDOWN_SECS, TOTAL_SHUTDOWN_BUDGET_SECS) == (10, 20)
 
 
 class TestLinuxUnitRendering:
@@ -344,6 +359,43 @@ class TestMacOSPlistRendering:
         assert "<string>gateway</string>" in plist
         assert "<key>RunAtLoad</key>" in plist
         assert "<key>KeepAlive</key>" in plist
+
+    def test_render_plist_pins_bounded_graceful_restart_contract(self, tmp_path):
+        from kiro_crew.gateway_shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
+        from kiro_crew.service import macos as svc_macos
+
+        rendered = svc_macos.render_plist()
+        payload = plistlib.loads(rendered.encode())
+        assert payload["KeepAlive"] is True
+        assert payload["ExitTimeOut"] == TOTAL_SHUTDOWN_BUDGET_SECS
+        plist = tmp_path / "agent.plist"
+        plist.write_text(rendered)
+        assert svc_macos.restart_contract_current(plist) is True
+
+    def test_restart_contract_rejects_legacy_and_unbounded_definitions(self, tmp_path):
+        from kiro_crew.gateway_shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
+        from kiro_crew.service import macos as svc_macos
+
+        plist = tmp_path / "agent.plist"
+        for payload in (
+            {"KeepAlive": {"SuccessfulExit": False}},
+            {"KeepAlive": True},
+            {"KeepAlive": True, "ExitTimeOut": 0},
+        ):
+            plist.write_bytes(plistlib.dumps(payload))
+            assert svc_macos.restart_contract_current(plist) is False
+
+        current = (
+            f"exit timeout = {TOTAL_SHUTDOWN_BUDGET_SECS}\n"
+            "properties = keepalive | runatload\n"
+        )
+        assert svc_macos.loaded_restart_contract_current(current) is True
+        assert svc_macos.loaded_restart_contract_current(
+            current.replace("keepalive | ", "")
+        ) is False
+        assert svc_macos.loaded_restart_contract_current(
+            current.replace(str(TOTAL_SHUTDOWN_BUDGET_SECS), "5")
+        ) is False
 
     def test_render_plist_xml_escapes_special_chars(self, monkeypatch, tmp_path):
         """The Program path is XML-escaped.


### PR DESCRIPTION
## Problem / Motivation

Dev Fleet used `launchctl kickstart -k` for Restart and Make Live on macOS. The gateway could exit with SIGKILL instead of completing its shutdown path, unlike the existing SIGTERM-first systemd restart.

## Why it matters

A hard stop can interrupt an active agent turn, leave session state unflushed, and prevent SQLite handles and child processes from closing cleanly.

## What changed (motivation → approach → change)

- Replaced the macOS Dev Fleet restart with a launchd-owned `stop` transaction.
- Added a shared shutdown budget: 10 seconds for cooperative Gateway shutdown plus 10 seconds of signal/exit margin; Linux `TimeoutStopSec` remains 20 seconds and macOS uses `ExitTimeOut=20`.
- Made generated live and pod LaunchAgents use `KeepAlive=true`, while explicit `kirocrew stop` still unloads the agent.
- Validate both the on-disk plist and launchd's loaded program/restart contract before stopping; legacy definitions fail closed with `kirocrew service install` as the repair.
- Made service installation unload the prior job before changing its definition and verify the loaded contract afterward.
- Preserved the existing PID start-identity handshake and the Linux restart behavior.

## Tests

- `python -m pytest test/test_service.py test/test_dev_fleet_app.py -n0 -q`: all passed
- `python -m pytest test/test_pod_launchd.py test/test_slack_gateway.py -n0 -q -k 'launchd or shutdown'`: all passed

## Manual verification

- Confirmed `launchctl print` exposes the loaded program, keepalive property, and exit timeout used by the new preflight.
- Reproduced disk/current vs loaded/legacy drift and verified the new checks reject it before stop.
- Confirmed aiohttp `AppRunner.cleanup()` drains an in-flight restart JSON response before shutdown completes.
- Did not restart the operator's live Gateway during verification.

## Related Issues

Fixes #1562

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff