### PR TITLE
fix(acp): show the provider's real error instead of a fake 5xx

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -758,7 +758,27 @@ _RE_5XX_NAMED = re.compile(
     r"|DispatchFailure|ConnectionReset(?:Error)?)\b"
 )
 _RE_5XX_STATUS = re.compile(r"(?:HTTP|status)\s*(?:code\s*)?(?:50[0234]|529)\b", re.IGNORECASE)
-_RE_5XX_HINT = re.compile(r"(please try again|response stream)", re.IGNORECASE)
+# Genuine retry hint only. "response stream" USED TO BE matched here, which made
+# this branch a catch-all: kiro-cli wraps EVERY mid-stream provider failure as
+# "Encountered an error in the response stream: <real cause>", so the wrapper
+# prefix alone — present on quota exhaustion, validation errors, anything —
+# classified the error as a momentary 5xx, told the user to retry, and DISCARDED
+# the real cause. A monthly-usage-limit rejection surfaced as "The model backend
+# hit a transient error (HTTP 5xx)" and burned the retry ladder. The wrapper is
+# a transport envelope, not a signal about the failure inside it; classification
+# now reads the inner detail (see _provider_detail).
+_RE_5XX_HINT = re.compile(r"(please try again)", re.IGNORECASE)
+# Account/plan capacity is EXHAUSTED — terminal. Distinct from a throttle: a
+# throttle clears in seconds and a retry is the right move, whereas a spent
+# monthly allowance does not come back until it resets, so retrying only adds
+# latency before the same rejection. Checked BEFORE the throttle branch because
+# some limit messages also carry rate-limit-ish wording.
+_RE_USAGE_LIMIT = re.compile(
+    r"\b(?:monthly|daily|weekly)\s+(?:usage\s+)?limit\b"
+    r"|\busage\s+limit\s+has\s+been\s+reached\b"
+    r"|\b(?:MonthlyLimitError|FreeTierLimitExceeded)\b",
+    re.IGNORECASE,
+)
 # kiro-cli's generic wrapper for a backend generation failure that died BEFORE
 # the response stream was established (so no request_id, no error class, and
 # none of the tokens above). Observed a case where data was exactly "Kiro
@@ -770,6 +790,29 @@ _RE_5XX_HINT = re.compile(r"(please try again|response stream)", re.IGNORECASE)
 # boilerplate, and scoping to `data` keeps a stray echo in `message` from
 # flipping an otherwise-terminal error.
 _RE_GENERATE_FAILED = re.compile(r"failed to generate a response", re.IGNORECASE)
+
+# kiro-cli's envelope for a failure that happened mid-stream. The text after the
+# colon is the provider's own message — the same words the CLI prints in a
+# terminal — so it is what a user needs to see.
+_RE_STREAM_ENVELOPE = re.compile(
+    r"^\s*Encountered an error in the response stream:\s*", re.IGNORECASE
+)
+# Trailing "(request_id: ...)" is stripped from the detail because every branch
+# re-appends it via req_id_suffix; leaving it would print the id twice.
+_RE_TRAILING_REQ_ID = re.compile(r"\s*\(request_id:\s*[0-9a-fA-F-]+\)\s*$")
+
+
+def _provider_detail(data: str) -> str:
+    """The provider's own error text, unwrapped from kiro-cli's stream envelope.
+
+    Returns "" when *data* carries nothing worth showing. Used by the
+    unknown-shape fallback so an unrecognised provider failure surfaces its real
+    message (CLI parity) instead of a ``repr`` of the JSON-RPC dict. Recognised
+    failure modes keep their curated guidance and do not call this.
+    """
+    detail = _RE_STREAM_ENVELOPE.sub("", str(data or "")).strip()
+    detail = _RE_TRAILING_REQ_ID.sub("", detail).strip()
+    return detail
 
 
 def _model_is_unentitled(data: str, available_models: Sequence[str] | None) -> str | None:
@@ -818,9 +861,9 @@ def _is_transient_raw_error(
     user-facing string — so the retry decision is independent of message
     wording. :class:`AcpError` carries this verdict (``.transient``) to the
     retry layer (``llm_helpers``, ``chat_runner``). Precedence mirrors
-    :func:`_format_acp_error`: unentitled-model(terminal) → model-unavailable →
-    throttle → auth(terminal) → generic 5xx / pre-stream generation failure →
-    unknown(terminal).
+    :func:`_format_acp_error`: unentitled-model(terminal) →
+    usage-limit(terminal) → model-unavailable → throttle → auth(terminal) →
+    generic 5xx / pre-stream generation failure → unknown(terminal).
 
     *available_models* is this account's advertised set when the caller knows
     it. It only ever makes the verdict MORE conservative: a model the account
@@ -835,6 +878,10 @@ def _is_transient_raw_error(
     if _model_is_unentitled(data, available_models):
         # Terminal: the account is not entitled to this model, so every retry
         # spends latency to reproduce the same rejection.
+        return False
+    if _RE_USAGE_LIMIT.search(haystack):
+        # Terminal: the allowance is spent until it resets. Ahead of the throttle
+        # check so limit wording that also reads as rate-limiting stays terminal.
         return False
     if _RE_MODEL_UNAVAILABLE.search(data):
         return True
@@ -955,6 +1002,22 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
         # Bedrock model alias resolved to a version that is currently
         # unavailable (capacity throttle, region rollout in progress,
         # deprecated, etc.).
+        elif _RE_USAGE_LIMIT.search(haystack):
+            # Plan allowance exhausted. Quote the provider's own sentence rather
+            # than paraphrasing it: it is the authoritative statement of WHICH
+            # limit was hit, and the CLI shows exactly this, so the dashboard
+            # matching it means the two surfaces cannot tell different stories.
+            _limit_detail = _provider_detail(data)
+            # The provider sentence has no trailing period, so add one before
+            # appending guidance or the two run together as one sentence.
+            if _limit_detail and _limit_detail[-1] not in ".!?":
+                _limit_detail += "."
+            formatted = (
+                f"{_limit_detail} Retrying will not help until the limit resets. "
+                f"Check your plan's usage allowance, or switch to a model or "
+                f"account tier with remaining capacity."
+                f"{req_id_suffix}"
+            )
         elif _RE_MODEL_UNAVAILABLE.search(data):
             model = str(_RE_MODEL_UNAVAILABLE.search(data).group(1))  # type: ignore[union-attr]
             formatted = (
@@ -1037,9 +1100,30 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
                 "and try again — if it persists, send `!restart` to reset the session."
             )
         else:
-            # Unknown shape — preserve the raw dict so we don't lose
-            # information.  Redaction below scrubs any embedded secrets.
-            formatted = f"Prompt error: {error}"
+            # Unrecognised failure mode. Show the PROVIDER'S OWN message when
+            # there is one — it is the true error, and the same words the CLI
+            # prints, so the two surfaces agree. This is the path every provider
+            # failure without a curated branch above now takes; previously such
+            # errors were swallowed by an over-broad 5xx match and reported as a
+            # momentary blip, so the real cause never reached the user at all.
+            #
+            # Falls back to the raw dict only when there is no usable detail
+            # (empty/odd data), so a genuinely opaque shape still loses nothing.
+            # Redaction below scrubs any embedded secrets either way.
+            _detail = _provider_detail(data)
+            if _detail:
+                # Keep the JSON-RPC `message` too when it carries signal. For
+                # -32603 it is the fixed boilerplate "Internal error" (pure
+                # noise next to the provider text), but other codes use it as
+                # the actual summary, and dropping it there would lose the only
+                # description the error has.
+                _summary = "" if message.strip().lower() == "internal error" else message.strip()
+                if _summary and _summary.lower() not in _detail.lower():
+                    formatted = f"{_summary}: {_detail}{req_id_suffix}"
+                else:
+                    formatted = f"{_detail}{req_id_suffix}"
+            else:
+                formatted = f"Prompt error: {error}"
     else:
         formatted = f"Prompt error: {error}"
 

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -6429,11 +6429,19 @@ class TestFormatAcpError:
         assert _format_acp_error("boom") == "Prompt error: boom"
 
     def test_unknown_dict_preserves_raw(self):
+        """An unrecognised shape must lose no information.
+
+        The fallback now leads with the provider's own text rather than a repr
+        of the JSON-RPC dict, but both fields still have to survive: the
+        provider detail AND the non-boilerplate JSON-RPC message, which for
+        codes other than -32603 is the only summary the error carries.
+        """
         err = {"code": -32000, "message": "Something else", "data": "weird"}
         out = _format_acp_error(err)
-        assert out.startswith("Prompt error: ")
         assert "Something else" in out
         assert "weird" in out
+        # No dict repr: punctuation soup is not a user-facing error message.
+        assert "Prompt error: {" not in out
 
     def test_model_not_available_rewrite(self):
         # With NO advertised list the caller cannot know whether this is an
@@ -6598,8 +6606,10 @@ class TestFormatAcpError:
         }
         out = _format_acp_error(err)
         assert "AKIAIOSFODNN7EXAMPLE" not in out
-        # Fallback prefix is preserved so operators can recognize the shape.
-        assert "Prompt error:" in out
+        # The scrubbed placeholder proves redaction ran on this path.
+        assert "REDACTED" in out
+        # The surrounding provider text still reaches the user.
+        assert "leak:" in out
 
     def test_exfiltration_url_in_unknown_dict_fallback_is_redacted(self):
         """The fallback path echoes raw dict — exfil URLs must also be scrubbed.
@@ -6735,7 +6745,7 @@ class TestFormatAcpError:
         canonical JSON-RPC message 'Internal error' must NOT be misclassified
         as transient. The transient branch keys off the provider `data` field
         only (never the generic `message`), so a deterministic failure like a
-        ValidationException preserves the raw dict and the real cause survives.
+        ValidationException surfaces its real cause instead.
         """
         err = {
             "code": -32603,
@@ -6744,8 +6754,11 @@ class TestFormatAcpError:
         }
         out = _format_acp_error(err)
         assert "transient error" not in out.lower()
-        # Unknown-shape fallback preserved for the most common error code.
-        assert "Prompt error: {" in out
+        # The real cause is shown verbatim — stronger than the old assertion,
+        # which only required a dict repr containing it somewhere.
+        assert "ValidationException: input contains an unsupported field 'foo'" in out
+        # The -32603 boilerplate message is dropped as noise next to that.
+        assert "Internal error" not in out
 
     def test_bare_500_token_is_not_treated_as_5xx(self):
         """A standalone numeric (e.g. a token-limit value) must not match the
@@ -6760,7 +6773,7 @@ class TestFormatAcpError:
         }
         out = _format_acp_error(err)
         assert "transient error" not in out.lower()
-        assert "Prompt error: {" in out
+        assert "max_tokens 500 exceeds the model limit of 200000" in out
 
     def test_http_500_status_context_still_classifies_transient(self):
         """An HTTP/status-anchored 50x token IS a genuine transient signal."""
@@ -6798,7 +6811,7 @@ class TestFormatAcpError:
         }
         out = _format_acp_error(err)
         assert "transient error" not in out.lower()
-        assert "Prompt error: {" in out
+        assert "ValidationException: input contains an unsupported field 'foo'" in out
 
 
 class TestIsTransientRawError:

--- a/test/test_acp_true_provider_error.py
+++ b/test/test_acp_true_provider_error.py
@@ -1,0 +1,147 @@
+"""Tests for surfacing the provider's TRUE error text.
+
+kiro-cli wraps every mid-stream provider failure in one envelope::
+
+    Encountered an error in the response stream: <the real cause>
+
+``_RE_5XX_HINT`` used to match the literal ``response stream``, i.e. the
+ENVELOPE rather than anything about the failure inside it. Because the 5xx
+branch sits near the end of the if/elif chain, that made it a catch-all: every
+provider failure without an earlier curated branch was rewritten to "The model
+backend hit a transient error (HTTP 5xx) ... retry in a moment", the real cause
+was discarded, and ``_is_transient_raw_error`` agreed it was retryable so the
+turn burned the whole retry ladder first.
+
+Reported case: a monthly-usage-limit rejection. The terminal CLI printed "The
+monthly usage limit has been reached" while the dashboard, for the same class of
+error, claimed a momentary 5xx and told the user to retry — which can never
+succeed until the allowance resets.
+
+Two changes are pinned here:
+
+1. The envelope is no longer a transient token, and unrecognised failures show
+   the provider's own text (CLI parity) instead of a ``repr`` of the JSON-RPC
+   dict.
+2. Usage-limit exhaustion is a first-class TERMINAL branch, so it is never
+   retried and says so.
+"""
+
+import pytest
+
+from kiro_crew.acp.client import (
+    _format_acp_error,
+    _is_transient_raw_error,
+    _provider_detail,
+)
+
+_ENVELOPE = "Encountered an error in the response stream: "
+_REQ = "8182dc3a-700a-4832-bd91-563bf5875626"
+
+
+def _err(data: str, message: str = "Internal error") -> dict:
+    return {"code": -32603, "message": message, "data": data}
+
+
+# The exact reported shape, request id included.
+_MONTHLY_LIMIT = _err(
+    f"{_ENVELOPE}The monthly usage limit has been reached (request_id: {_REQ})"
+)
+
+
+class TestUsageLimitIsTerminalAndTruthful:
+    def test_shows_the_providers_own_sentence(self):
+        """The dashboard must say what the CLI says, not invent a 5xx."""
+        out = _format_acp_error(_MONTHLY_LIMIT)
+        assert "The monthly usage limit has been reached" in out
+        # The wrong old message must be gone.
+        assert "transient error" not in out.lower()
+        assert "5xx" not in out
+        # The envelope is transport noise, not part of the message.
+        assert "response stream" not in out
+        # request_id survives for support correlation, and exactly once.
+        assert out.count(_REQ) == 1
+
+    def test_says_retrying_will_not_help(self):
+        out = _format_acp_error(_MONTHLY_LIMIT)
+        assert "Retrying will not help" in out
+
+    def test_is_not_retried(self):
+        """The retry ladder must not spend attempts on a spent allowance."""
+        assert _is_transient_raw_error(_MONTHLY_LIMIT) is False
+
+    def test_provider_sentence_is_punctuated_before_guidance(self):
+        """Provider text has no trailing period; guidance must not run into it."""
+        out = _format_acp_error(_MONTHLY_LIMIT)
+        assert "reached. Retrying" in out
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            "The monthly usage limit has been reached",
+            "You have reached your daily limit for this model",
+            "weekly limit exceeded for your plan",
+            "MonthlyLimitError: allowance consumed",
+            "FreeTierLimitExceeded",
+        ],
+    )
+    def test_limit_wording_variants_are_terminal(self, data):
+        assert _is_transient_raw_error(_err(data)) is False
+
+    def test_limit_outranks_throttle_wording(self):
+        """A limit message that also reads as rate-limiting stays terminal.
+
+        Ordering matters: the throttle branch returns transient, so if it were
+        checked first a quota rejection would be retried on a backoff curve that
+        can never clear it.
+        """
+        err = _err("The monthly usage limit has been reached: rate limit for your plan")
+        assert _is_transient_raw_error(err) is False
+        assert "Retrying will not help" in _format_acp_error(err)
+
+
+class TestEnvelopeIsNotATransientSignal:
+    def test_envelope_alone_is_not_transient(self):
+        """The regression: the wrapper by itself must decide nothing."""
+        assert _is_transient_raw_error(_err(f"{_ENVELOPE}Input is too long")) is False
+
+    def test_unrecognised_failure_shows_real_text(self):
+        out = _format_acp_error(
+            _err(f"{_ENVELOPE}Input is too long for the requested model (request_id: {_REQ})")
+        )
+        assert out == f"Input is too long for the requested model (request_id: {_REQ})"
+
+    def test_genuine_5xx_inside_envelope_still_transient(self):
+        """Removing the envelope token must not cost us real 5xx detection.
+
+        A real backend blip carries its own token (a named exception, an
+        HTTP status, or an explicit retry hint) inside the envelope, and that
+        is what the classifier keys on now.
+        """
+        err = _err(f"{_ENVELOPE}InternalServerError ... please try again.")
+        assert _is_transient_raw_error(err) is True
+        assert "transient error" in _format_acp_error(err).lower()
+
+    def test_bare_retry_hint_still_transient(self):
+        assert _is_transient_raw_error(_err("Service hiccup, please try again.")) is True
+
+
+class TestProviderDetail:
+    def test_strips_envelope_and_trailing_request_id(self):
+        assert (
+            _provider_detail(f"{_ENVELOPE}Something broke (request_id: {_REQ})")
+            == "Something broke"
+        )
+
+    def test_passes_through_unwrapped_text(self):
+        assert _provider_detail("ValidationException: bad field") == (
+            "ValidationException: bad field"
+        )
+
+    def test_empty_for_no_detail(self):
+        assert _provider_detail("") == ""
+        assert _provider_detail(_ENVELOPE) == ""
+
+    def test_opaque_shape_keeps_the_raw_dict(self):
+        """With no usable detail the dict is still better than nothing."""
+        out = _format_acp_error({"code": -32603, "message": "Internal error", "data": ""})
+        assert "Prompt error: {" in out


### PR DESCRIPTION
## Problem

The terminal and the dashboard told different stories about the same failure.

kiro-cli:
```
The monthly usage limit has been reached (request_id: 8182dc3a-700a-4832-bd91-563bf5875626)
```

The dashboard, for that same class of error:
```
The model backend hit a transient error (HTTP 5xx). This is usually momentary — retry
in a moment. If it keeps happening, switch to a different model in the picker.
(request_id: 20a426aa-a09a-4942-b5c3-21156261eb5d)
```

Wrong cause, wrong advice, and the true message never reached the user.

## Why it matters

Three compounding costs:

- **The user is misinformed.** "Momentary, retry in a moment" is the opposite of the truth — a spent monthly allowance does not come back until it resets.
- **The turn burns the retry ladder.** `_is_transient_raw_error` agreed it was retryable, so every attempt reproduced the same rejection, each behind a backoff sleep, before finally surfacing an error.
- **It was not limited to usage limits.** This masked *every* provider error we had no curated branch for.

## Fix: symptom → root cause → change

`_RE_5XX_HINT` matched the literal `response stream`. That is not a signal about the failure — it is kiro-cli's **envelope**, present on every mid-stream provider error:

```
Encountered an error in the response stream: <the real cause>
```

Because the 5xx branch sits near the end of the `if/elif` chain, matching the envelope turned it into a **catch-all**. Anything without an earlier curated branch was rewritten as a momentary 5xx and its real text discarded. The model-unavailable case only ever escaped because `_RE_MODEL_UNAVAILABLE` is checked *earlier* — same envelope, different outcome purely from ordering.

The branch's own comment asserted it "require[s] a real transient *token* ... so a bare uncaught -32603 still falls through". The envelope was never such a token, so that guarantee did not hold.

**1. Drop `response stream` from `_RE_5XX_HINT`.** Classification now reads the failure *inside* the envelope. `please try again` stays — that IS a genuine retry hint. Real 5xx detection is unaffected: a genuine blip carries its own token inside the envelope, and every pre-existing test already carried `InternalServerError`, `dispatch failure`, or `please try again` alongside it, so none of them depended on the envelope.

**2. Unrecognised failures show the provider's own text.** New `_provider_detail()` strips the envelope and the duplicate trailing `request_id`. This is the general fix — CLI parity for every provider error, including ones not yet seen. The non-boilerplate JSON-RPC `message` is kept as a prefix when it adds signal (for codes other than `-32603` it is the only summary the error carries), and the raw dict remains the fallback when there is no usable detail.

**3. A terminal usage-limit branch.** A spent monthly/daily/weekly allowance is not a throttle — it does not clear in seconds. It quotes the provider's sentence and states plainly that retrying will not help. Ordered ahead of the throttle check so limit wording that also reads as rate-limiting stays terminal.

### Result

| Case | Before | After |
|---|---|---|
| Monthly usage limit | "transient error (HTTP 5xx) … retry" + **retried** | "The monthly usage limit has been reached. Retrying will not help until the limit resets. …" + **terminal** |
| Novel provider error | "transient error (HTTP 5xx) … retry" + retried | `Input is too long for the requested model (request_id: …)` |
| Genuine `InternalServerError` | transient | transient (unchanged) |
| `ThrottlingException` | transient | transient (unchanged) |
| Opaque shape (no detail) | raw dict | raw dict (unchanged) |

### Honest scope note

The classifier arm in (3) is **largely redundant** with (1): once the envelope is no longer a transient token, plain limit wording is already terminal because it matches nothing. Reverting that arm alone fails only **1** test — the throttle-overlap case. It is kept because that case is real and because the formatter and classifier are deliberately keyed to the same predicate so they cannot drift. The terminal behaviour you actually get for a plain monthly limit comes from (1), not (3).

## Tests

18 new in `test/test_acp_true_provider_error.py`, covering the exact reported payload (request id included), limit-wording variants, the throttle-overlap ordering, envelope stripping, and that genuine 5xx / throttle classification is untouched.

Revert-verified independently:

| Reverted | Result |
|---|---|
| `response stream` back in `_RE_5XX_HINT` | **2 fail** |
| usage-limit branch disabled | **1 fail** |
| fallback dumps raw dict again | **3 fail** |

Five existing tests asserted the old raw-dict fallback and were updated to the new shape. Each keeps its original intent, and three get **stronger** — they now assert the real cause appears verbatim rather than merely appearing somewhere inside a dict repr. `test_unknown_dict_preserves_raw` caught a genuine gap in my first attempt: the fallback initially dropped the JSON-RPC `message` field, which is why (2) preserves it.

## Manual verification

Reproduced all five shapes above against the patched formatter and classifier directly, asserting both the rendered text and the `.transient` verdict. N/A for UI work — this is a backend string/classification change with no visual surface; the transcript row rendering is unchanged.

## Gates

- pytest `28959 passed`. 10 failures inherited, verified identical on a clean `origin/main` worktree at the same SHA (`test_dashboard_origin` picks up the live `KIROCREW_PORT`, plus embedding / app_manager / platform_compat).
- isort, flake8 clean
- mypy 723 files: 1 pre-existing `vector_memory.py` error, also on base
- No frontend change, so no tsc / vitest / i18n surface
