### PR TITLE
fix(dashboard): reset context meter when post-compact usage lacks counts

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2153,12 +2153,12 @@ def _broadcast_context_reset(state: "DashboardState", slot_key: str, provider: A
     Without this the frontend keeps the previous model's stored ``{used,
     window}`` until the next turn emits an event. ``reset: true`` tells the
     ``sseContextUsage`` reducer it may REPLACE or DELETE the stored token entry
-    (per-turn events deliberately never delete, so a pct-only event cannot wipe
-    good counts). With a live provider the payload carries the freshly rebased
-    stats from ``set_model``; without one (the session-reset path) it carries no
-    tokens, so the reducer deletes the entry and the UI falls back to its own
-    model-derived window for the slot's new model. Best-effort: a broadcast
-    failure must not fail the switch.
+    (a frame WITHOUT ``reset`` never deletes, so the backend sets ``reset``
+    whenever it has no real counts to send). With a live provider the payload
+    carries the freshly rebased stats from ``set_model``; without one (the
+    session-reset path) it carries no tokens, so the reducer deletes the entry
+    and the UI falls back to its own model-derived window for the slot's new
+    model. Best-effort: a broadcast failure must not fail the switch.
     """
     try:
         if provider is not None:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -372,8 +372,20 @@ def _context_usage_payload(slot_key: str, client: Any) -> dict[str, Any]:
 
     The token counts let the frontend ring tooltip show "used / window" in
     absolute tokens (sourced from the adapter's usage_update), so a 44%-of-200k
-    reading is not misread as 44%-of-1M. Token fields are omitted (0) when the
-    provider doesn't report them.
+    reading is not misread as 44%-of-1M.
+
+    When real per-turn token counts are unavailable the payload carries
+    ``reset: True`` instead of the ``used_tokens``/``window_tokens`` pair. This
+    is load-bearing, not cosmetic: the frontend keeps the percentage and the
+    token counts in two independent slices (``slotContextPct`` vs
+    ``slotContextTokens``), so a bare ``{slot, pct}`` frame updates the
+    percentage while leaving whatever token counts the ring last stored in
+    place — a headline that disagrees with the count beside it. Emitting
+    ``reset`` whenever ``used`` is unknown — a fresh session before the first
+    ``usage_update``, or the post-compaction / post-model-switch state where the
+    provider zeroes ``used`` but keeps the window — moves the two fields
+    together: the ring drops its stored counts and the meter self-corrects on
+    the next turn's telemetry. Harmless when nothing is stored.
     """
     pct = client.context_usage_pct()
     payload: dict[str, Any] = {"slot": slot_key, "pct": round(pct, 1)}
@@ -381,16 +393,19 @@ def _context_usage_payload(slot_key: str, client: Any) -> dict[str, Any]:
     # inner AcpClient, not on the provider, so reaching for it on `client`
     # (the AcpProvider returned by get_or_create) would always miss.
     window = client.context_window_tokens() if hasattr(client, "context_window_tokens") else 0
-    if window:
-        used = client.context_used_tokens() if hasattr(client, "context_used_tokens") else 0
-        # used == 0 means "not measured yet", not "empty context" — it is the
-        # post-compaction state (AcpPromptStats.reset_after_compaction keeps
-        # the window but zeroes the counts until the next turn's telemetry).
-        # Shipping {used: 0, window: W} would overwrite the compaction reset
-        # with a false "0 / W tokens" claim in the ring tooltip.
-        if used:
-            payload["used_tokens"] = used
-            payload["window_tokens"] = window
+    # used == 0 means "not measured yet", not "empty context" — it is the
+    # post-compaction / post-model-switch state (AcpPromptStats zeroes the
+    # counts but keeps the window until the next turn's telemetry). Shipping
+    # {used: 0, window: W} would assert a false "0 / W tokens", so we omit the
+    # pair and signal a reset instead.
+    used = 0
+    if window and hasattr(client, "context_used_tokens"):
+        used = client.context_used_tokens()
+    if window and used:
+        payload["used_tokens"] = used
+        payload["window_tokens"] = window
+    else:
+        payload["reset"] = True
     return payload
 
 
@@ -4931,30 +4946,21 @@ async def _run_chat(
                 else:
                     msg = "⚠️ Compaction timed out."
                 _append_compaction_notice(state, slot, msg)
-                # Update context usage after compaction. On success the
-                # provider dropped its stale counts when the completed status
-                # arrived (AcpPromptStats.reset_after_compaction), then
-                # wait_for_compaction grace-drained for kiro's fresh
+                # Update the context meter from the provider's post-compaction
+                # state. On success the provider has dropped its stale counts by
+                # the time the completed status arrives (reset_after_compaction),
+                # and wait_for_compaction grace-drains for kiro's fresh
                 # post-compaction metadata (~1s after the status), which
-                # re-derives REAL numbers against the kept served window. If
-                # that metadata arrived, broadcast the accurate payload; if
-                # not, fall back to the `reset` form so the frontend drops its
-                # stale counts (same contract as the threshold auto-compact
-                # path) and the meter self-corrects on the next turn. On
-                # failure/timeout the counts are unchanged and still valid, so
-                # re-send them as-is.
-                if compaction_result["type"] == "completed":
-                    _payload = _context_usage_payload(slot.key, client)
-                    if _payload.get("used_tokens"):
-                        state.broadcast_context_usage(slot.key, _payload)
-                    else:
-                        state.broadcast_context_usage(
-                            slot.key, {"slot": slot.key, "pct": 0.0, "reset": True}
-                        )
-                else:
-                    state.broadcast_context_usage(
-                        slot.key, _context_usage_payload(slot.key, client)
-                    )
+                # re-derives REAL numbers against the kept served window.
+                # _context_usage_payload ships those accurate counts when the
+                # metadata has landed, and otherwise a `reset` frame (used == 0)
+                # carrying whatever pct the provider currently reports, so the
+                # frontend drops its stale counts and the meter self-corrects on
+                # the next turn. On failure/timeout `used` is unchanged and still
+                # valid, so the same call re-sends the real counts as-is.
+                state.broadcast_context_usage(
+                    slot.key, _context_usage_payload(slot.key, client)
+                )
 
         if assistant_text:
             # ── Plan format validation (planning turn only) ─────

--- a/test/test_context_usage_payload.py
+++ b/test/test_context_usage_payload.py
@@ -4,6 +4,13 @@ Regression guard: the payload must include absolute used/window token counts
 when the provider reports a window. The bug this catches shipped green because
 nothing exercised the helper — it read last_prompt_stats off the AcpProvider
 (where it does not exist) instead of via the provider's public accessors.
+
+Second regression guard (#1645): when real token counts are unavailable the
+payload must carry ``reset: True`` rather than a bare ``{slot, pct}`` frame.
+A pct-only frame updates the frontend's percentage slice while stranding the
+token-count slice, which surfaced as the "225K used / 0%" disagreement right
+after ``/compact`` — the reset percentage sitting next to a stale
+pre-compaction token count.
 """
 
 from __future__ import annotations
@@ -35,33 +42,39 @@ def test_payload_includes_tokens_when_window_known():
     assert payload["pct"] == 44.0
     assert payload["used_tokens"] == 88000
     assert payload["window_tokens"] == 200000
+    # A frame carrying real counts is not a reset.
+    assert "reset" not in payload
 
 
-def test_payload_omits_tokens_when_window_unknown():
-    # Before the first usage_update, window is 0 → token fields omitted, pct only.
+def test_payload_resets_when_window_unknown():
+    # Before the first usage_update, window is 0 → no token counts to ship, so
+    # the frame must reset the frontend's stored counts rather than update the
+    # percentage alone and leave stale tokens behind.
     provider = _provider_with_stats(used=0, window=0, pct=0.0)
     payload = _context_usage_payload("dashboard:1", provider)
-    assert payload == {"slot": "dashboard:1", "pct": 0.0}
+    assert payload == {"slot": "dashboard:1", "pct": 0.0, "reset": True}
     assert "used_tokens" not in payload
     assert "window_tokens" not in payload
 
 
-def test_payload_pct_only_for_provider_without_token_accessors():
+def test_payload_resets_for_provider_without_token_accessors():
     # A provider lacking the token accessors (e.g. a bare stub) must not crash;
-    # it simply yields pct only.
+    # it yields pct plus a reset so the meter cannot strand stale counts.
     stub = MagicMock(spec=["context_usage_pct"])
     stub.context_usage_pct.return_value = 12.3
     payload = _context_usage_payload("dashboard:1", stub)
-    assert payload == {"slot": "dashboard:1", "pct": 12.3}
+    assert payload == {"slot": "dashboard:1", "pct": 12.3, "reset": True}
 
 
-def test_payload_omits_tokens_when_used_unmeasured():
-    # Post-compaction state: reset_after_compaction keeps the window but
+def test_payload_resets_when_used_unmeasured():
+    # Post-compaction state (#1645): reset_after_compaction keeps the window but
     # zeroes the counts. used == 0 means "not measured yet", not "empty
-    # context" — shipping {used: 0, window: W} would overwrite the compaction
-    # reset with a false "0 / W tokens" tooltip claim.
+    # context" — shipping {used: 0, window: W} would assert a false "0 / W
+    # tokens", and a bare pct-only frame would strand the pre-compaction token
+    # count beside the freshly-reset 0%. The frame must carry `reset: True` so
+    # the frontend drops its stored counts.
     provider = _provider_with_stats(used=0, window=200000, pct=0.0)
     payload = _context_usage_payload("dashboard:1", provider)
-    assert payload == {"slot": "dashboard:1", "pct": 0.0}
+    assert payload == {"slot": "dashboard:1", "pct": 0.0, "reset": True}
     assert "used_tokens" not in payload
     assert "window_tokens" not in payload

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1256,8 +1256,9 @@ const chatSlice = createSlice({
         // Model switch / compaction / session reset: the stored counts belong
         // to a window that no longer describes the session. Deleting re-enables
         // the model-derived fallback (provider.getContextWindow(slot.model)).
-        // Per-turn events without `reset` deliberately never delete, so a
-        // pct-only event cannot wipe good token counts.
+        // A frame WITHOUT `reset` never deletes — it only fills or replaces — so
+        // the backend sets `reset` whenever it has no real counts to send,
+        // clearing stale counts instead of leaving them beside a fresh pct.
         delete state.slotContextTokens[safeKey(slot)]
       }
     },

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -1556,7 +1556,12 @@ describe('sseContextUsage reducer', () => {
   it('reset without a window deletes the stored entry (session reset / compaction)', () => {
     // Deleting re-enables the model-derived fallback for the slot's NEW model;
     // without reset the stale old-model entry short-circuits it until the next turn.
-    const seeded = reducer(initial, sseContextUsage({ slot: 's1', pct: 10, used_tokens: 100000, window_tokens: 1000000 }))
+    //
+    // #1645: this is the frontend half of the "225K used / 0%" bug. After
+    // /compact the backend zeroes `used` but keeps the window, so it emits a
+    // reset frame here. Honouring it deletes the pre-compaction token entry so
+    // the ring can never show a stale count beside the freshly-reset 0%.
+    const seeded = reducer(initial, sseContextUsage({ slot: 's1', pct: 10, used_tokens: 225000, window_tokens: 1000000 }))
     const state = reducer(seeded, sseContextUsage({ slot: 's1', pct: 0, reset: true }))
     expect(state.slotContextTokens['s1']).toBeUndefined()
     expect(state.slotContextPct['s1']).toBe(0)


### PR DESCRIPTION
## Problem

After running `/compact`, the context-window readout (composer popover percentage
and the expanded Used/Remaining/Total panel) does not reflect the newly compacted
size. Immediately after the compact the token count is **stale** (still the
pre-compaction figure, e.g. 225K) while the **percentage resets to 0%** — so the
two fields disagree and both are wrong. It only reconverges to the true value
(e.g. 66K / 7%) after several further turns. Reported in #1645.

## Why it matters

`/compact` is exactly the moment a user checks the readout — to confirm the
compaction freed headroom. A stale, internally contradictory "225K / 0%" is
misleading precisely when it matters most: the user can't tell whether the
compact worked or how much room they actually have.

## Fix (symptoms → root cause → change)

**Symptom:** the percentage snaps to 0 while the token count keeps its
pre-compaction value.

**Root cause:** the frontend stores the two fields in *independent* Redux slices
(`slotContextPct` vs `slotContextTokens`), read separately in `ChatPage.tsx`. The
`sseContextUsage` reducer updates `slotContextPct` on every frame but only touches
`slotContextTokens` when a frame carries `window_tokens` or `reset`. Backend
`_context_usage_payload` returned a bare `{slot, pct}` frame whenever the provider
reported a percentage but `used == 0` — exactly the post-`/compact` state, since
`AcpPromptStats.reset_after_compaction()` zeroes `used`/`pct` but **keeps** the
window. The unconditional turn-end broadcast then shipped that pct-only frame,
updating the percentage while stranding the stale token count.

**Change:** `_context_usage_payload` now emits `reset: True` whenever it can't
ship real token counts (window unknown, or `used == 0`), so a pct-only frame
clears stale counts instead of stranding them. A positive `used` remains the
"I have real counts" signal — it is carried across turns — so steady-state frames
still carry the real `used`/`window` pair unchanged. The deferred `/compact`
handler's hand-rolled reset branch is collapsed into the single builder call; as
a side effect its no-counts case now emits the provider's current pct alongside
`reset` (e.g. a real 7% once kiro's post-compaction metadata drains a percentage
before absolute counts) rather than a hardcoded 0% — strictly more accurate. Two
now-stale comments that asserted the retired "per-turn events never delete"
contract are re-synced to the new rule.

## Tests

- `test/test_context_usage_payload.py` — updated the three tests that encoded the
  old pct-only contract to assert `reset: True` for the window-unknown,
  no-accessors, and post-compaction (`used == 0`) cases; added a "not a reset when
  real counts are present" assertion for the happy path.
- `website/src/test/chatSlice.test.ts` — the `sseContextUsage` reducer test now
  seeds a 225K token entry and asserts the compaction `reset` frame deletes it
  (the frontend half of the 225K/0% bug), leaving pct/tokens consistent.
- Full backend `test_dashboard_chat.py` (492) and the frontend `chatSlice`
  reducer suites (197) pass unchanged.

## Manual verification

N/A — unit coverage is sufficient. The change is confined to the shape of the
`context_usage` WS frame (a data-consistency fix); there is no DOM/layout change,
and the frontend reducer's handling of `{pct, reset}` is covered directly by the
reducer test. The live behavior (real percentage + dropped stale counts after
`/compact`, self-correcting on the next turn) follows deterministically from the
frame contract the tests pin.

Note: the full backend lint gate (black/isort/flake8/mypy) was not run — those
tools were unavailable in the environment; line length was checked by hand and the
change is confined to a dict-construction branch plus comment/docstring edits.
