### PR TITLE
chore(version): bump dev base to 0.2.0 after v0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.1.2"
+version = "0.2.0"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, Slack, or desktop app"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kirocrew-electron-mac",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kirocrew-electron-mac",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.9"

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-electron-mac",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## What

Bumps the in-code base version from `0.1.2` to `0.2.0` across the three manifests plus the Electron lockfile. No tag is created.

| File | 0.1.2 -> 0.2.0 |
|---|---|
| `pyproject.toml` | `version` |
| `src/kiro_crew/__init__.py` | `__version__` |
| `website/electron/package.json` | `version` |
| `website/electron/package-lock.json` | root + `packages[""]` |

## Why

`__version__` is the base the nightly lane stamps onto. `nightly.yml` reads it and emits two strings:

- `<base>-nightly.<YYYYMMDD>t<HHMMSS>` — semver, for the Electron app and the S3 build path
- `<base>.dev<stamp>` — PEP 440, for the pip wheel

The base was left at `0.1.2` while **v0.1.3 shipped to stable today**. So a nightly cut from `main` right now stamps `0.1.2-nightly.<...>` / `0.1.2.dev<...>`, both of which sort **below** the released `0.1.3` — the nightly feed would be offering stable users a downgrade.

`0.2.0` fixes the ordering: a prerelease is only demoted below *its own* release, so `0.2.0-nightly.<...>` > `0.1.3`, and `0.2.0.dev<...>` > `0.1.3` under PEP 440 as well. Nightlies read as previews of the next minor.

This is the same correction PR #687 made after v0.1.1 shipped against a `0.1.0` base.

## Notes

- Kept as a bare `X.Y.Z` rather than `0.2.0.dev0` — `nightly.yml` needs a bare base to build valid semver and PEP 440 strings from it.
- Tagged releases override all three manifests at build time (`sed` in the build lane), so this value governs only **untagged** builds: nightly and local/source installs.
- The three third-party deps in the lockfile that coincidentally sit at `0.1.2` (`universalify`, `compare-version`) are untouched — only the two fields describing this package changed.

## Testing

- `pytest test/test_api_health.py test/test_beacon.py test/test_dashboard_branding.py test/test_pip_deps_consistency.py` — 196 passed
- `isort --check-only src/kiro_crew test` — clean
- `flake8 src/kiro_crew test` — clean
- Verified nothing pins the literal `"0.1.2"`: tests reach `__version__` by import or `monkeypatch`, and the `test_beacon.py` occurrences are input fixtures for the version-normalization function, not assertions about the live value.
