### PR TITLE
ci: bind readiness runs by head ref, not the fork-empty pull_requests

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -71,18 +71,24 @@ concurrency:
   # conclusion (success / failure / skipped), never cancelled. The evaluate and
   # publish steps are idempotent and stale-SHA guarded, so un-collapsed PT runs
   # on superseded revisions simply no-op green. workflow_run / workflow_dispatch
-  # runs do NOT appear in the rollup, so they keep the cheap per-(pr, sha)
-  # burst collapse via cancel-in-progress.
+  # runs do NOT appear in the rollup, so they keep the cheap per-revision burst
+  # collapse via cancel-in-progress. A workflow_run burst collapses on
+  # (head repository, head branch, head SHA) and NOT on the PR number, because
+  # `workflow_run.pull_requests` is empty whenever the head repository is a
+  # fork -- keying on it degraded every fork burst to one group per run. That
+  # triple identifies the same PR, since only one open PR can exist per source
+  # repository + branch.
   group: >-
     ${{
       github.event_name == 'pull_request_target'
       && format('pr-readiness-pt-{0}', github.run_id)
-      || format('pr-readiness-wr-{0}-{1}',
-           inputs.pr
-             || github.event.workflow_run.pull_requests[0].number
+      || github.event_name == 'workflow_dispatch'
+      && format('pr-readiness-wd-{0}-{1}', inputs.pr, inputs.sha)
+      || format('pr-readiness-wr-{0}-{1}-{2}',
+           github.event.workflow_run.head_repository.full_name
              || github.run_id,
-           inputs.sha
-             || github.event.workflow_run.head_sha
+           github.event.workflow_run.head_branch || '',
+           github.event.workflow_run.head_sha
              || github.run_id)
     }}
   cancel-in-progress: true
@@ -90,10 +96,18 @@ concurrency:
 jobs:
   readiness:
     name: Publish readiness signal
+    # This gate MUST NOT consult `workflow_run.pull_requests`: that array is
+    # empty whenever the head repository is a fork, so requiring a number in it
+    # skipped every fork PR's re-evaluation. A fork PR's verdict was then only
+    # ever computed by the pull_request_target run -- which fires BEFORE the
+    # monitored workflows exist -- and the commit status stayed pending forever
+    # with no later event able to recompute it. The head SHA is the fork-safe
+    # key, and the step below resolves it to a PR (skipping cleanly when no
+    # open PR owns it), so admitting every pull_request run is correct and the
+    # non-PR events are already excluded by the event check.
     if: >-
       github.event_name != 'workflow_run'
-      || (github.event.workflow_run.event == 'pull_request'
-          && github.event.workflow_run.pull_requests[0].number != null)
+      || github.event.workflow_run.event == 'pull_request'
       || github.event.workflow_run.event == 'dynamic'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -110,7 +124,6 @@ jobs:
           EVENT_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
           RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-          RUN_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           set -euo pipefail
           case "$EVENT" in
@@ -118,7 +131,10 @@ jobs:
             workflow_run)
               PR="$RUN_PR"
               EXPECTED_SHA="$RUN_SHA"
-              if [ -z "$PR" ] && [ "$RUN_EVENT" = "dynamic" ]; then
+              # `workflow_run.pull_requests` is empty for a fork head AND for
+              # the managed `dynamic` CodeQL runs, so it can never be the only
+              # way in. Resolve the PR from the immutable head SHA instead.
+              if [ -z "$PR" ]; then
                 associated="$(gh api "repos/$REPO/commits/$RUN_SHA/pulls")"
                 PR="$(jq -r --arg sha "$RUN_SHA" '
                   [.[] | select(.state == "open" and .head.sha == $sha)]
@@ -139,7 +155,7 @@ jobs:
           esac
 
           pr_json="$(gh pr view "$PR" --repo "$REPO" \
-            --json number,state,isDraft,isCrossRepository,headRefOid,url)"
+            --json number,state,isDraft,isCrossRepository,headRefName,headRefOid,headRepository,headRepositoryOwner,url)"
           SHA="$(jq -r '.headRefOid' <<<"$pr_json")"
           STATE="$(jq -r '.state' <<<"$pr_json")"
 
@@ -150,6 +166,13 @@ jobs:
             echo "fork=$(jq -r '.isCrossRepository' <<<"$pr_json")"
             echo "draft=$(jq -r '.isDraft' <<<"$pr_json")"
             echo "url=$(jq -r '.url' <<<"$pr_json")"
+            # (head repository, head branch) is how a monitored workflow run is
+            # bound back to this PR below. Both fields are populated on a fork
+            # run, unlike `pull_requests`.
+            echo "head_repo=$(jq -r '
+              "\(.headRepositoryOwner.login)/\(.headRepository.name)"
+            ' <<<"$pr_json")"
+            echo "head_ref=$(jq -r '.headRefName' <<<"$pr_json")"
           } >> "$GITHUB_OUTPUT"
 
           if [ -n "$EXPECTED_SHA" ] && [ "$EXPECTED_SHA" != "$SHA" ]; then
@@ -187,6 +210,8 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ steps.context.outputs.pr }}
           SHA: ${{ steps.context.outputs.sha }}
+          HEAD_REPO: ${{ steps.context.outputs.head_repo }}
+          HEAD_REF: ${{ steps.context.outputs.head_ref }}
           DRAFT: ${{ steps.context.outputs.draft }}
           FORK: ${{ steps.context.outputs.fork }}
           TRIGGER_EVENT: ${{ github.event_name }}
@@ -239,9 +264,16 @@ jobs:
             else
               runs="$(gh api --method GET \
                 "repos/$REPO/actions/workflows/$file/runs?event=pull_request&head_sha=$SHA&per_page=20")"
-              run="$(jq -c --argjson pr "$PR" '
+              # Bind the run to this PR by (head repository, head branch), NOT
+              # by `.pull_requests`: that array is empty on every fork run, so
+              # filtering on it matched nothing and reported each already-green
+              # workflow as "(not started)" -- a permanent pending verdict. The
+              # query is already pinned to this exact head SHA, and only one
+              # open PR can exist per source repository + branch.
+              run="$(jq -c --arg head_repo "$HEAD_REPO" --arg head_ref "$HEAD_REF" '
                 [.workflow_runs[]
-                 | select([.pull_requests[]?.number] | index($pr))]
+                 | select(.head_repository.full_name == $head_repo
+                          and .head_branch == $head_ref)]
                 | sort_by(.created_at)
                 | last // empty
               ' <<<"$runs")"

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -384,6 +384,17 @@ Two subtleties:
   recompute it on an unchanged commit, freezing the status at pending indefinitely.
   So it is added only when the live evaluation still found something genuinely
   incomplete.
+- **Nothing keys off `workflow_run.pull_requests`.** That array is empty whenever the
+  head repository is a fork, the same GitHub behaviour the `fork-*` workflows already
+  work around. The job gate admits every `pull_request` and `dynamic` run and lets the
+  head SHA resolve to a PR via `repos/:repo/commits/:sha/pulls`, and a monitored run is
+  bound back to the PR by `(head_repository.full_name, head_branch)` on top of the
+  `head_sha=` query — a pair that is populated on a fork run, and unique because only
+  one open PR can exist per source repository + branch. Keying either place on the PR
+  number froze a fork PR at pending forever: the gate skipped every re-evaluation, so
+  the verdict was whatever the `pull_request_target` run saw *before* the monitored
+  workflows existed, and the lookup independently reported already-green workflows as
+  `(not started)`.
 
 ## Fork PRs
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -221,11 +221,31 @@ class TestPrReadiness:
     def test_readiness_leaves_untriggered_merge_and_review_state_to_live_gates(self) -> None:
         workflow = _workflow("pr-readiness.yml")
 
-        assert "--json number,state,isDraft,isCrossRepository,headRefOid,url)" in workflow
+        assert (
+            "--json number,state,isDraft,isCrossRepository,headRefName,"
+            "headRefOid,headRepository,headRepositoryOwner,url)"
+        ) in workflow
         assert "mergeStateStatus" not in workflow
         assert "reviewDecision" not in workflow
         assert "MERGEABLE:" not in workflow
         assert "MERGE_STATE:" not in workflow
+
+    def test_readiness_never_keys_a_fork_pr_off_the_empty_pull_requests_array(self) -> None:
+        # `workflow_run.pull_requests` is empty whenever the head repository is
+        # a fork. Keying the job gate or the run lookup on it froze every fork
+        # PR's commit status at pending: the gate skipped each re-evaluation,
+        # and the lookup reported already-green workflows as "(not started)".
+        # Both must key on the head SHA / (head repository, head branch).
+        workflow = _workflow("pr-readiness.yml")
+
+        assert "pull_requests[0].number != null" not in workflow
+        assert "select([.pull_requests[]?.number] | index($pr))" not in workflow
+        assert "github.event.workflow_run.event == 'pull_request'" in workflow
+        assert ".head_repository.full_name == $head_repo" in workflow
+        assert "and .head_branch == $head_ref" in workflow
+        # The SHA -> PR fallback must not be gated on the `dynamic` CodeQL
+        # event; a fork `pull_request` run needs it too.
+        assert '[ -z "$PR" ] && [ "$RUN_EVENT" = "dynamic" ]' not in workflow
 
     def test_readiness_aggregates_all_review_and_build_lanes(self) -> None:
         workflow = _workflow("pr-readiness.yml")


### PR DESCRIPTION
## Problem / Motivation

The required `PR Readiness` commit status freezes at `pending` on fork PRs and never
recovers, so the PR can never merge even when every check is green.

Observed on #1526: CI, Build and Code Review all `success` at 15:38, all four fork AI
reviews returning "no blocking findings", a code-owner approval in place — and the status
still reading `pending / "3 readiness check(s) still pending"` hours later, written once at
05:32 before CI had results and never rewritten.

## Why it matters

This is not a rare flake. Measured against the current open PR list:

```
open PRs                96   (44 forks)
stale-pending >15min    43   ->  42 forks, 1 same-repo
oldest                  PR 816, pending 160h; PR 896, 135h; PR 1197, 52h
```

**42 of 44 open fork PRs are stuck**, i.e. no external contribution can reach a terminal
readiness verdict. It also saturates `pr-readiness-sweep.yml` (#1510): the sweep nudges at
most `MAX_DISPATCH=10` per 15 minutes, newest-first, against a backlog of ~43 — and because
a nudge re-runs the same broken lookup and republishes `pending`, no fork ever leaves the
queue. Its own logs: `Re-fired 10 recompute(s); 37 stale PR(s) deferred`. The single
genuinely-stuck same-repo PR — the case the sweep was built for — is queued behind 42 forks
that can never clear, and older entries are starved indefinitely.

Worth noting for #1510's rationale: **PR #1461, cited there as the evidence for dropped
`workflow_run` events, was itself a fork PR** (`qh2244`, `isCrossRepository: true`). Nothing
was dropped — the events fired and the job gate skipped them. "Zero workflow_run readiness
runs fired afterward" is what a run list looks like when every run is `skipped`. The sweep is
a valid backstop for real dropped events, but it was aimed at a deterministic bug that a
retry loop cannot converge on.

## What changed (motivation → approach → change)

**Root cause, one GitHub behaviour:** `workflow_run.pull_requests` is `[]` whenever the head
repository is a fork. The four `fork-*` workflows already carry this exact comment;
`pr-readiness.yml` keyed on it anyway, in two independent places.

1. **The job gate never let the job run.** `pull_requests[0].number != null` is false for a
   fork, so every `workflow_run` re-evaluation was `skipped` — visible at 15:38:50 and
   15:39:00 on #1526, exactly as its CI finished. The only run that ever did work was the
   `pull_request_target` one at PR-open time, before results existed. `pull_request_target`
   does not re-fire on an unchanged commit, so `pending` became permanent.
2. **The run lookup discarded the results.** `select([.pull_requests[]?.number] | index($pr))`
   matches nothing on a fork, leaving `$run` empty, which the next line reads as
   `pending+=("$label (not started)")`. Three green workflows, reported as never started —
   literally the `3 readiness check(s) still pending` on #1526.

**Approach:** stop asking "which PR?" via `pull_requests`; key on the head SHA and head ref,
which forks do populate.

- The gate now admits every `pull_request` / `dynamic` run and lets the following step
  resolve the PR from the head SHA via `repos/:repo/commits/:sha/pulls` — the fallback that
  already existed for CodeQL, no longer fenced behind `dynamic`. Nothing extra is scored: the
  pre-existing `No open pull request…` branch still exits cleanly.
- A monitored run binds to the PR by `(head_repository.full_name, head_branch)` on top of the
  existing `head_sha=` query. Both fields are populated on a fork run, and the pair is unique
  because only one open PR can exist per source repository + branch.
- The `workflow_run` concurrency key moves to the same triple, restoring burst collapse that
  had silently degraded to one group per run on forks. `workflow_dispatch` gets its own `-wd-`
  key, so a sweep nudge no longer shares a `cancel-in-progress` group with the event path.

**Result:** a fork PR reaches its intended terminal verdict — `readiness: maintainer review`
with `PR Readiness = failure` — instead of freezing yellow. That verdict is unchanged policy;
this PR only makes it reachable. Yellow says "still working, wait"; red says "automation is
done and cannot clear this, a human decides". Forks also stop being `pending`, so they leave
the sweep's scan permanently and it can do the job it was written for.

## Tests

- `test_readiness_never_keys_a_fork_pr_off_the_empty_pull_requests_array` (new) pins both
  directions: neither the gate nor the lookup may key on `pull_requests`, the fork-safe
  `(head_repository.full_name, head_branch)` match must be present, and the SHA→PR fallback
  must not be re-fenced behind `dynamic`. Added because this bug produced **no failing
  signal** — nothing went red, a status just sat yellow while the PR quietly could not merge,
  and a reviewer re-introducing either key would see fully green CI.
- `test_readiness_leaves_untriggered_merge_and_review_state_to_live_gates` updated for the
  three added `gh pr view --json` fields. Its intent is unchanged — readiness still reads
  neither `mergeStateStatus` nor `reviewDecision`.

## Manual verification

Replayed both filters against the live API rather than reasoning about them.

Fork PR #1526, head `bf1e791` — before: 0 matches, three `(not started)`. After:

```
CI          -> completed / success  30978336991
Build       -> completed / success  30978336992
Code Review -> completed / success  30978388743
```

Same-repo regression check — on #1635 and #1615 the old and new filters select **identical
run ids** across all monitored lanes, so non-fork behaviour is untouched.

Also: YAML parses, all four `run` blocks pass `bash -n`, `scripts/docs-lint.sh` passes, and
`test/test_ai_review_workflows.py` + `test/test_workflow_permissions.py` pass (43 tests).

Not verifiable pre-merge: `pull_request_target` and `workflow_run` always load the workflow
from the default branch, so the real trigger paths can only be exercised once this lands.
First check after merge should be a `workflow_dispatch` refresh of #1526 — expected to flip
it from yellow `checking` to red `maintainer review`.

## Related Issues

Fixes the freeze that motivated #1510 (`pr-readiness-sweep.yml`) at its actual root cause;
the sweep remains valuable for genuinely dropped events. Unblocks the readiness signal on
#1526 and the other 41 stuck fork PRs.

Two follow-ups deliberately **not** included here:

1. `pr-readiness-sweep.yml` orders candidates newest-first with strict priority, so any
   backlog over `MAX_DISPATCH` starves the oldest entries — how PR 816 reached 160h. Sorting
   by staleness descending would fix it independently of this change.
2. The fork verdict's `description` says "AI reviews could not run", which is now stale: the
   `fork-*` pipeline does run all four and posted "no blocking findings" on #1526. CodeQL is
   the one genuinely absent lane. Correcting the text, or letting readiness count those
   check-runs, changes gate semantics and deserves its own discussion.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/ci/ci-and-reviews.md` § `pr-readiness.yml`
- [x] No secrets, credentials, or internal references in the diff
