### PR TITLE
fix(settings): remember the tab you opened across navigation

### DIFF
--- a/website/src/components/SidePanelLayout.tsx
+++ b/website/src/components/SidePanelLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { safeGetSessionItem, safeSetSessionItem } from '../utils/safeStorage'
 
 import { i18nT } from '../i18n/t'
 export interface SidePanelTab {
@@ -22,6 +23,11 @@ interface SidePanelLayoutProps {
   title: string
   tabs: readonly SidePanelTab[]
   defaultTab?: string
+  /** Stable id under which this page's last visited tab is remembered for the
+   *  rest of the browser session, so navigating away and back returns to it
+   *  instead of snapping to the first tab. Omit to disable remembering.
+   *  Must NOT be localized — it is a storage key, not a label. */
+  rememberKey?: string
   footer?: React.ReactNode
   headerRight?: React.ReactNode
   /** When true, content area uses overflow-hidden + flex layout for Virtuoso/fixed-height children */
@@ -29,19 +35,86 @@ interface SidePanelLayoutProps {
   children: (activeTab: string) => React.ReactNode
 }
 
-export default function SidePanelLayout({ title, tabs, defaultTab, footer, headerRight, fixedContent, children }: SidePanelLayoutProps) {
+/** sessionStorage namespace for the per-page remembered tab. Session-scoped on
+ *  purpose: returning to a page inside one sitting should resume where you
+ *  left off, but a fresh launch should open on the page's own first tab rather
+ *  than somewhere you were days ago. */
+const TAB_MEMORY_PREFIX = 'kirocrew:sidepanel-tab:'
+
+export default function SidePanelLayout({ title, tabs, defaultTab, rememberKey, footer, headerRight, fixedContent, children }: SidePanelLayoutProps) {
   const [params, setParams] = useSearchParams()
   const isMobile = useIsMobile()
   const rawTab = params.get('tab')
   const first = defaultTab || tabs[0]?.key || ''
-  const tab = rawTab && tabs.some(t => t.key === rawTab) ? rawTab : first
-  const setTab = (t: string) => setParams(prev => {
-    const next = new URLSearchParams(prev)
-    if (t === first) next.delete('tab')
-    else next.set('tab', t)
-    return next
-  }, { replace: true })
+
+  // Read the remembered tab ONCE, before any effect can overwrite it. Reading
+  // it lazily inside an effect instead would race the persist effect below,
+  // which fires on the same mount with the not-yet-restored tab.
+  const [remembered] = React.useState(() => (rememberKey ? safeGetSessionItem(TAB_MEMORY_PREFIX + rememberKey) : null))
+
+  // The tab to show whenever the URL carries no `?tab=`. Seeded from the
+  // remembered tab DURING THE FIRST RENDER, so the remembered pane is what
+  // actually paints — restoring from an effect instead would mount the first
+  // tab's pane for a frame (a visible flash, and real wasted work when that
+  // pane fetches: Overview loads memory + usage metrics).
+  //
+  // It stays in step with whatever is shown, rather than being a one-shot,
+  // because the param can vanish while this component is still MOUNTED: ⌘+,
+  // runs `navigate('/settings')` and the sidebar entry is that same route, so
+  // an already-open page keeps its layout alive and simply loses its param. A
+  // one-shot restore fell back to the first tab there — snapping the pane to
+  // Overview and letting the persist effect below overwrite the stored tab
+  // with `overview`, destroying the very preference this exists to keep.
+  const [fallbackTab, setFallbackTab] = React.useState<string | null>(() =>
+    rememberKey && !rawTab && remembered && tabs.some(t => t.key === remembered) ? remembered : null,
+  )
+
+  const tab = rawTab && tabs.some(t => t.key === rawTab) ? rawTab : (fallbackTab || first)
+  const setTab = (t: string) => {
+    // Synchronously, in the same batched update as the param write: picking the
+    // FIRST tab deletes the param, so a fallback still holding the previous tab
+    // would render it for a frame AND get re-written into the URL by the sync
+    // effect below — silently undoing the click.
+    if (rememberKey) setFallbackTab(t)
+    setParams(prev => {
+      const next = new URLSearchParams(prev)
+      if (t === first) next.delete('tab')
+      else next.set('tab', t)
+      return next
+    }, { replace: true })
+  }
   const meta = tabs.find(t => t.key === tab)
+
+  // Keep the URL in step with the shown tab, so the address bar stays
+  // copy-pasteable — including after an in-place param drop. Keyed on the
+  // resolved tab rather than mount-only, and it cannot loop: writing the param
+  // makes `rawTab` truthy, which short-circuits the next run. `tab === first`
+  // writes nothing, matching `setTab`'s convention that the first tab is the
+  // param-less state.
+  //
+  // Deliberately a passive effect, NOT useLayoutEffect: react-router 7 drops
+  // navigations fired from a layout effect during the initial mount (its ready
+  // flag is set in a passive effect) — see the same note on SettingsPage's
+  // legacy tab remap.
+  React.useEffect(() => {
+    if (!rememberKey || rawTab || !tab || tab === first) return
+    setParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.set('tab', tab)
+      return next
+    }, { replace: true })
+  }, [rememberKey, rawTab, tab, first, setParams])
+
+  // Remember the tab that is effectively shown — in component state, so an
+  // in-place param drop has something to fall back to, and in sessionStorage,
+  // so a later visit restores it. Keying off the shown tab (not just an
+  // explicit click) means a deep link (command palette, docs link) is
+  // remembered too.
+  React.useEffect(() => {
+    if (!rememberKey || !tab) return
+    setFallbackTab(tab)
+    safeSetSessionItem(TAB_MEMORY_PREFIX + rememberKey, tab)
+  }, [rememberKey, tab])
 
   return (
     <div className={`flex-1 min-h-0 flex overflow-hidden ${isMobile ? 'flex-col' : ''}`}>

--- a/website/src/pages/CapabilitiesPage.tsx
+++ b/website/src/pages/CapabilitiesPage.tsx
@@ -60,7 +60,7 @@ export default function CapabilitiesPage() {
   }, [provider])
 
   return (
-    <SidePanelLayout title={i18nT('pages.capabilitiesPage.agent_capabilities')} tabs={tabs} headerRight={<RestartButton />}>
+    <SidePanelLayout title={i18nT('pages.capabilitiesPage.agent_capabilities')} tabs={tabs} rememberKey="capabilities" headerRight={<RestartButton />}>
       {tab => <>
         {tab === 'crews' && <KiroCrewAgentsPage embedded />}
         {tab === 'templates' && <AgentsPage embedded />}

--- a/website/src/pages/DeveloperPage.tsx
+++ b/website/src/pages/DeveloperPage.tsx
@@ -45,7 +45,7 @@ function buildTabs() {
 export default function DeveloperPage() {
   const tabs = buildTabs()
   return (
-    <SidePanelLayout title={i18nT('pages.developerPage.developer')} tabs={tabs}>
+    <SidePanelLayout title={i18nT('pages.developerPage.developer')} tabs={tabs} rememberKey="developer">
       {tab => <>
         {tab === 'logs' && <div className="h-[calc(100vh-160px)] min-h-[300px] flex flex-col overflow-hidden"><LogViewer compact /></div>}
         {tab === 'system' && <SystemPage embedded />}

--- a/website/src/pages/SettingsPage.tsx
+++ b/website/src/pages/SettingsPage.tsx
@@ -100,6 +100,9 @@ export default function SettingsPage() {
     <SidePanelLayout
       title={i18nT('pages.settingsPage.settings')}
       tabs={tabs}
+      // Keyed apart from the main window: an embedded pane has a different tab
+      // roster (no Instances), so the two must not restore each other's tab.
+      rememberKey={embedded ? 'settings-embedded' : 'settings'}
       footer={<span className="text-[12px] text-muted">{i18nT('pages.settingsPage.kirocrew_v')}{version}</span>}
     >
       {tab => <>

--- a/website/src/test/safeStorage.test.ts
+++ b/website/src/test/safeStorage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { safeSetItem, safeSetSessionItem, isQuotaExceededError } from '../utils/safeStorage'
+import { safeGetItem, safeSetItem, safeGetSessionItem, safeSetSessionItem, isQuotaExceededError } from '../utils/safeStorage'
 
 /** Build a DOMException that looks like a browser quota error. */
 function quotaError(name = 'QuotaExceededError', code = 22): DOMException {
@@ -242,5 +242,71 @@ describe('safeSetSessionItem', () => {
     expect(() => safeSetSessionItem('k', 'v')).not.toThrow()
     expect(safeSetSessionItem('k', 'v')).toBe(false)
     spy.mockRestore()
+  })
+})
+
+/**
+ * The storage-DENIED platform, which is different from the storage-rejects-a-write
+ * platform above. Chrome with cookies blocked (and a sandboxed iframe) makes the
+ * global `sessionStorage` / `localStorage` accessor itself throw SecurityError.
+ * `typeof` does NOT suppress that: it only suppresses ReferenceError for an
+ * undeclared identifier, so a `typeof x === 'undefined'` availability probe
+ * sitting outside the try/catch throws on exactly the platform it exists to
+ * survive — taking the calling component's render down with it.
+ */
+describe('storage-denied platform (global accessor throws)', () => {
+  /** Replace a storage global with a throwing accessor for one test. */
+  function denyStorage(name: 'localStorage' | 'sessionStorage'): () => void {
+    const original = Object.getOwnPropertyDescriptor(window, name)
+    Object.defineProperty(window, name, {
+      configurable: true,
+      get() {
+        throw new DOMException('access denied', 'SecurityError')
+      },
+    })
+    return () => {
+      if (original) Object.defineProperty(window, name, original)
+      else delete (window as unknown as Record<string, unknown>)[name]
+    }
+  }
+
+  it('safeGetSessionItem returns null instead of throwing', () => {
+    const restore = denyStorage('sessionStorage')
+    try {
+      expect(() => safeGetSessionItem('k')).not.toThrow()
+      expect(safeGetSessionItem('k')).toBeNull()
+    } finally {
+      restore()
+    }
+  })
+
+  it('safeSetSessionItem returns false instead of throwing', () => {
+    const restore = denyStorage('sessionStorage')
+    try {
+      expect(() => safeSetSessionItem('k', 'v')).not.toThrow()
+      expect(safeSetSessionItem('k', 'v')).toBe(false)
+    } finally {
+      restore()
+    }
+  })
+
+  it('safeGetItem returns null instead of throwing', () => {
+    const restore = denyStorage('localStorage')
+    try {
+      expect(() => safeGetItem('k')).not.toThrow()
+      expect(safeGetItem('k')).toBeNull()
+    } finally {
+      restore()
+    }
+  })
+
+  it('safeSetItem returns false instead of throwing', () => {
+    const restore = denyStorage('localStorage')
+    try {
+      expect(() => safeSetItem('k', 'v')).not.toThrow()
+      expect(safeSetItem('k', 'v')).toBe(false)
+    } finally {
+      restore()
+    }
   })
 })

--- a/website/src/test/sidePanelTabMemory.test.tsx
+++ b/website/src/test/sidePanelTabMemory.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Tab memory for SidePanelLayout-backed pages.
+ *
+ * The tab lives in `?tab=`, and every plain entry point (sidebar link, the
+ * ⌘-shortcut, `navigate('/settings')`) drops that param — which used to snap
+ * the page back to its first tab on every return visit. These tests pin the
+ * memory that fixes it, and the three ways it must NOT fire:
+ *   - an explicit `?tab=` (deep link / command palette) always wins,
+ *   - deliberately picking the first tab is remembered as the first tab,
+ *   - a remembered tab that no longer exists in the roster is ignored.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom'
+import SidePanelLayout, { type SidePanelTab } from '../components/SidePanelLayout'
+
+// SidePanelLayout → useIsMobile reads window.matchMedia at module load.
+if (!window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}
+
+const TABS: SidePanelTab[] = [
+  { key: 'overview', label: 'Overview', icon: null },
+  { key: 'security', label: 'Security', icon: null },
+  { key: 'about', label: 'About', icon: null },
+]
+
+const KEY = 'kirocrew:sidepanel-tab:test-page'
+
+/** Surfaces the live query string so a test can assert URL/pane agreement. */
+function UrlProbe() {
+  const { search } = useLocation()
+  return <div data-testid="search">{search}</div>
+}
+
+/** Re-navigates to the SAME route with no query — what ⌘+, and the sidebar
+ *  entry both do — without unmounting the layout. */
+function ReNavigate({ to }: { to: string }) {
+  const navigate = useNavigate()
+  return <button onClick={() => navigate(to)}>re-navigate</button>
+}
+
+function renderPage(opts: { url?: string; rememberKey?: string; tabs?: SidePanelTab[]; seen?: string[] } = {}) {
+  return render(
+    <MemoryRouter initialEntries={[opts.url ?? '/page']}>
+      <SidePanelLayout
+        title="Test"
+        tabs={opts.tabs ?? TABS}
+        rememberKey={'rememberKey' in opts ? opts.rememberKey : 'test-page'}
+      >
+        {tab => {
+          opts.seen?.push(tab)
+          return <div data-testid="active">{tab}</div>
+        }}
+      </SidePanelLayout>
+    </MemoryRouter>,
+  )
+}
+
+describe('SidePanelLayout tab memory', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('remembers the tab you clicked and restores it on a param-less return', () => {
+    const { unmount } = renderPage()
+    fireEvent.click(screen.getByText('Security'))
+    expect(screen.getByTestId('active')).toHaveTextContent('security')
+    unmount()
+
+    // Navigating back via the sidebar / shortcut — no ?tab= in the URL.
+    renderPage()
+    expect(screen.getByTestId('active')).toHaveTextContent('security')
+  })
+
+  it('remembers a tab reached by deep link, not just by click', () => {
+    const { unmount } = renderPage({ url: '/page?tab=about' })
+    expect(screen.getByTestId('active')).toHaveTextContent('about')
+    unmount()
+
+    renderPage()
+    expect(screen.getByTestId('active')).toHaveTextContent('about')
+  })
+
+  it('paints the remembered pane on the FIRST render, never flashing the first tab', () => {
+    // Restoring from an effect would render `overview` for a frame before
+    // swapping to `security` — a visible flash, and a wasted mount of a pane
+    // that fetches. The restore is seeded during the first render instead, so
+    // the first-tab pane must never be handed to the children callback at all.
+    sessionStorage.setItem(KEY, 'security')
+    const seen: string[] = []
+    renderPage({ seen })
+    expect(seen[0]).toBe('security')
+    expect(seen).not.toContain('overview')
+    expect(screen.getByTestId('active')).toHaveTextContent('security')
+  })
+
+  it('keeps an explicitly-picked tab through an in-place re-navigation, and does not clobber the memory', () => {
+    // The destructive sequence: pick a tab in-session, then hit ⌘+, while still
+    // on the page. The param drops with the layout alive, so a one-shot restore
+    // fell through to the first tab AND the persist effect then overwrote the
+    // stored tab with `overview` — losing the preference this feature exists to
+    // keep.
+    sessionStorage.setItem(KEY, 'security')
+    render(
+      <MemoryRouter initialEntries={['/page']}>
+        <SidePanelLayout title="Test" tabs={TABS} rememberKey="test-page">
+          {tab => (
+            <div>
+              <div data-testid="active">{tab}</div>
+              <UrlProbe />
+              <ReNavigate to="/page" />
+            </div>
+          )}
+        </SidePanelLayout>
+      </MemoryRouter>,
+    )
+    // An explicit pick clears any one-shot restore state.
+    fireEvent.click(screen.getByText('About'))
+    expect(screen.getByTestId('active')).toHaveTextContent('about')
+    expect(sessionStorage.getItem(KEY)).toBe('about')
+
+    fireEvent.click(screen.getByText('re-navigate'))
+
+    expect(screen.getByTestId('active')).toHaveTextContent('about')
+    expect(screen.getByTestId('search')).toHaveTextContent('?tab=about')
+    expect(sessionStorage.getItem(KEY)).toBe('about')
+  })
+
+  it('keeps a deep-linked tab through an in-place re-navigation', () => {
+    // Same defect reached the other way: arriving via ?tab= leaves no restore
+    // state at all, so a later param drop had nothing to fall back to.
+    render(
+      <MemoryRouter initialEntries={['/page?tab=about']}>
+        <SidePanelLayout title="Test" tabs={TABS} rememberKey="test-page">
+          {tab => (
+            <div>
+              <div data-testid="active">{tab}</div>
+              <UrlProbe />
+              <ReNavigate to="/page" />
+            </div>
+          )}
+        </SidePanelLayout>
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('active')).toHaveTextContent('about')
+
+    fireEvent.click(screen.getByText('re-navigate'))
+
+    expect(screen.getByTestId('active')).toHaveTextContent('about')
+    expect(sessionStorage.getItem(KEY)).toBe('about')
+  })
+
+  it('re-syncs the URL when the same route is re-navigated without a param', () => {
+    // ⌘+, runs navigate('/settings') and the sidebar entry is the same route,
+    // so the layout does NOT unmount — the param just disappears underneath it.
+    // A mount-only sync effect could never re-add it, leaving the URL and the
+    // shown pane persistently divergent.
+    sessionStorage.setItem(KEY, 'security')
+    render(
+      <MemoryRouter initialEntries={['/page']}>
+        <SidePanelLayout title="Test" tabs={TABS} rememberKey="test-page">
+          {tab => (
+            <div>
+              <div data-testid="active">{tab}</div>
+              <UrlProbe />
+              <ReNavigate to="/page" />
+            </div>
+          )}
+        </SidePanelLayout>
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('active')).toHaveTextContent('security')
+    expect(screen.getByTestId('search')).toHaveTextContent('?tab=security')
+
+    fireEvent.click(screen.getByText('re-navigate'))
+
+    expect(screen.getByTestId('active')).toHaveTextContent('security')
+    expect(screen.getByTestId('search')).toHaveTextContent('?tab=security')
+  })
+
+  it('lets an explicit ?tab= win over the remembered tab', () => {
+    sessionStorage.setItem(KEY, 'security')
+    renderPage({ url: '/page?tab=about' })
+    expect(screen.getByTestId('active')).toHaveTextContent('about')
+  })
+
+  it('honours deliberately returning to the first tab', () => {
+    const { unmount } = renderPage()
+    fireEvent.click(screen.getByText('Security'))
+    // Picking the first tab deletes the param — the memory must record the
+    // first tab, not bounce back to Security on the next visit.
+    fireEvent.click(screen.getByText('Overview'))
+    expect(screen.getByTestId('active')).toHaveTextContent('overview')
+    unmount()
+
+    renderPage()
+    expect(screen.getByTestId('active')).toHaveTextContent('overview')
+  })
+
+  it('does not bounce away when the user picks the first tab in-session', () => {
+    sessionStorage.setItem(KEY, 'security')
+    renderPage()
+    expect(screen.getByTestId('active')).toHaveTextContent('security')
+    fireEvent.click(screen.getByText('Overview'))
+    expect(screen.getByTestId('active')).toHaveTextContent('overview')
+  })
+
+  it('ignores a remembered tab missing from this roster', () => {
+    // e.g. the embedded pane hides Instances, or a tab was removed by an update.
+    sessionStorage.setItem(KEY, 'instances')
+    renderPage()
+    expect(screen.getByTestId('active')).toHaveTextContent('overview')
+  })
+
+  it('stays stateless without a rememberKey', () => {
+    const { unmount } = renderPage({ rememberKey: undefined })
+    fireEvent.click(screen.getByText('Security'))
+    expect(sessionStorage.length).toBe(0)
+    unmount()
+
+    renderPage({ rememberKey: undefined })
+    expect(screen.getByTestId('active')).toHaveTextContent('overview')
+  })
+
+  it('survives sessionStorage access throwing', () => {
+    // safeStorage warns in dev on a failed write — expected here, keep it quiet.
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+    renderPage()
+    expect(screen.getByTestId('active')).toHaveTextContent('overview')
+    fireEvent.click(screen.getByText('Security'))
+    expect(screen.getByTestId('active')).toHaveTextContent('security')
+    getItem.mockRestore()
+    setItem.mockRestore()
+  })
+})

--- a/website/src/utils/safeStorage.ts
+++ b/website/src/utils/safeStorage.ts
@@ -143,8 +143,8 @@ function warnDev(key: string, err: unknown): void {
  * the caller.
  */
 export function safeGetItem(key: string): string | null {
-  if (typeof localStorage === 'undefined') return null
   try {
+    if (typeof localStorage === 'undefined') return null
     return localStorage.getItem(key)
   } catch {
     return null
@@ -152,8 +152,8 @@ export function safeGetItem(key: string): string | null {
 }
 
 export function safeSetItem(key: string, value: string): boolean {
-  if (typeof localStorage === 'undefined') return false
   try {
+    if (typeof localStorage === 'undefined') return false
     localStorage.setItem(key, value)
     return true
   } catch (err) {
@@ -186,13 +186,34 @@ export function safeSetItem(key: string, value: string): boolean {
 }
 
 /**
+ * Non-throwing sessionStorage read — the per-tab mirror of `safeGetItem`.
+ * Returns null when storage access is denied (SecurityError in locked-down
+ * embedding contexts / browser policies) or unavailable.
+ *
+ * The `typeof` availability probe is INSIDE the try on purpose: `typeof` only
+ * suppresses ReferenceError for an undeclared identifier, it does not suppress
+ * an exception thrown by a property getter. `sessionStorage` is an accessor on
+ * the global, and browsers that deny storage (Chrome with cookies blocked, a
+ * sandboxed iframe) throw SecurityError from that getter — so probing outside
+ * the try would throw on the very platform the probe exists to survive.
+ */
+export function safeGetSessionItem(key: string): string | null {
+  try {
+    if (typeof sessionStorage === 'undefined') return null
+    return sessionStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+/**
  * Write to sessionStorage without ever throwing. sessionStorage is per-tab and
  * far less prone to filling up, so there is nothing useful to reclaim — we just
  * swallow failures so a full/disabled store can't crash the app.
  */
 export function safeSetSessionItem(key: string, value: string): boolean {
-  if (typeof sessionStorage === 'undefined') return false
   try {
+    if (typeof sessionStorage === 'undefined') return false
     sessionStorage.setItem(key, value)
     return true
   } catch (err) {


### PR DESCRIPTION
## Problem

Open Settings, go to a tab that is not the first one — say **Security** — then
navigate away to a chat and come back to Settings. You land on **Overview**
again, not Security. The same happens on **Capabilities** and **Developer**.
Anyone doing repeated work in one settings area re-navigates to it every single
time they leave the page.

## Why it matters

Settings is where a user goes to *change something and check the result*, which
is inherently a back-and-forth loop: flip a toggle → go look at the effect →
come back. Losing the tab on every return taxes exactly the workflow the page
exists to serve, and it reads as the app forgetting what you were doing.

## Fix (symptom → root cause → change)

**Symptom:** returning to a tabbed settings page snaps to its first tab.

**Root cause:** the active tab lives *only* in the `?tab=` search param
(`SidePanelLayout`), and every plain entry point drops that param — the sidebar
entry (`surfaces/builtins.tsx` route `/settings`) and the keyboard shortcut
(`useKeyboardShortcuts.ts`) both navigate to a bare `/settings`. With no param,
the component falls back to `tabs[0]`. Nothing was ever persisted, so there was
nothing to fall back *to*.

**Change:** `SidePanelLayout` gains an optional `rememberKey`. The effectively
shown tab is written to `sessionStorage`, and when the caller arrives with **no
explicit `?tab=`** that remembered tab is what renders. Three details make it
behave rather than fight the user:

- **An explicit `?tab=` always wins.** Deep links, the command palette, and
  docs links are unaffected — the memory only fills the gap when the URL says
  nothing.
- **The restore is seeded during the first render**, not from an effect, so the
  remembered pane is what paints (see below).
- **The fallback stays in step with what is shown**, so the param vanishing
  while the component is still mounted cannot collapse the page to its first
  tab (see below).

Rosters are re-validated on restore (`tabs.some(...)`), so a tab that no longer
exists — or one hidden in the embedded pane, which drops Instances — is ignored
rather than restored into nothing.

**Session-scoped on purpose, and consistent with the repo:** `AppsPage` already
persists its own tab to `sessionStorage` under `appstore-tab`. Resuming inside
one sitting is the actual ask; a fresh launch should still open on the page's own
first tab rather than wherever you happened to be days ago.

Storage goes through `safeGetSessionItem` / `safeSetSessionItem`, so a denied or
disabled store degrades to "no memory" instead of throwing — this PR adds the
`safeGetSessionItem` read helper to mirror the existing `safeGetItem`.

### Also in this PR (all three found by review, none by me)

**1. A storage-denied browser could take the page down.** All four helpers in
`safeStorage.ts` probed availability with `typeof localStorage === 'undefined'`
*outside* their try/catch. `typeof` only suppresses ReferenceError for an
undeclared identifier — it does **not** suppress an exception thrown by a
property getter, and `sessionStorage` / `localStorage` are accessors on the
global that throw `SecurityError` when a browser denies storage (Chrome with
cookies blocked, a sandboxed iframe). So the probe threw on exactly the platform
it existed to survive. The probe now sits inside the try in all four functions.
Only the two session functions are reached by this PR's new code; the two
localStorage twins carried the identical latent hole and were fixed in the same
pass rather than left as a trap.

**2. The restored pane flashed the first tab.** Restoring from a post-mount
effect meant the first tab's pane mounted and painted for a frame before
swapping — visible, and real wasted work when that pane fetches (Overview loads
memory + usage metrics). The restore is seeded during the first render instead.
`useLayoutEffect` was *not* used for the URL write: react-router 7 drops
navigations fired from a layout effect during the initial mount, which
`SettingsPage` already documents at its own legacy tab-remap effect.

**3. An in-place re-navigation wiped the memory — the worst of the three.** The
layout does **not** unmount when an already-open page is re-navigated to its own
bare route: ⌘+, runs `navigate('/settings')`, and the sidebar entry is that same
route. The param simply disappears underneath a live component. With a *one-shot*
restore, that fell through to the first tab — so after picking a tab in-session
(or arriving by deep link), pressing ⌘+, snapped the pane to Overview **and the
persist effect then overwrote the stored tab with `overview`**, destroying the
preference this PR exists to keep.

The one-shot is now a sticky fallback that tracks whatever is shown, so a param
drop while mounted resolves to the current tab instead of collapsing to the
first. `setTab` updates it synchronously in the same batched update as the param
write, which is what keeps a deliberate click on the *first* tab (encoded as
deleting the param) from being re-expanded by the URL-sync effect.

## Tests

New `website/src/test/sidePanelTabMemory.test.tsx` — 12 cases, weighted toward the
ways this could misfire rather than the happy path:

| Test | Locks in |
|---|---|
| remembers a clicked tab across a param-less return | the reported bug is fixed |
| remembers a tab reached by deep link | persistence keys off the shown tab, not just clicks |
| paints the remembered pane on the FIRST render | no first-tab flash; asserts the first-tab pane is never handed to the render callback at all |
| keeps an explicitly-picked tab through an in-place re-navigation | defect 3, click path — asserts the *stored* value too, not just the pane |
| keeps a deep-linked tab through an in-place re-navigation | defect 3, deep-link path (no restore state was ever armed) |
| re-syncs the URL on a same-route param-less re-navigation | URL and pane cannot drift apart |
| explicit `?tab=` beats the remembered tab | deep links / command palette stay authoritative |
| deliberately returning to the first tab is remembered | the param-deletion encoding is not misread as "no preference" |
| picking the first tab in-session does not bounce back | the restore cannot re-apply over an explicit pick |
| a remembered tab missing from the roster is ignored | embedded pane + removed-tab safety |
| no `rememberKey` ⇒ nothing written, no restore | opt-in; other consumers behave exactly as before |
| `sessionStorage` throwing ⇒ page still works | locked-down / private-mode browsers |

Extended `website/src/test/safeStorage.test.ts` with 4 storage-**denied** cases
(the global accessor itself throwing, which is a different platform from the
existing storage-rejects-a-write cases).

Every one of these was verified **non-vacuous** by running it against the
pre-fix implementation and confirming it fails there — including checking out
the previous `SidePanelLayout.tsx` to prove the two in-place-re-navigation tests
fail on the one-shot version. `safeSetSessionItem` returning `false` is likewise
only reachable if the storage accessor actually throws; against a working store
it returns `true`.

Full suite: 9224 passed. `tsc -b`, `eslint`, `jscpd` clean; i18n 13/13 PASS
(no new strings — `rememberKey` values are storage keys, explicitly documented
as non-localizable). The one suite failure is `src/i18n/format.test.ts`, which is
timezone-dependent and pre-existing — it passes under `TZ=UTC` as CI runs it.

## Manual verification

**Not performed live — and worth being explicit about why.** Starting an
isolated dev gateway to click through this failed in my environment: dashboard
init needs `~/.kiro/crew-auth-staging`, which the agent sandbox denies
(`PermissionError: Operation not permitted`), so `dev-backend.sh` exits before
serving. The behavior is fully covered by the unit tests above, which assert the
exact mount → click → unmount → remount state sequence a manual pass would walk.

Worth a human doing once: open Settings → Security, navigate to a chat, come
back, and confirm you land on Security; then click Overview, leave, and come
back, and confirm you land on Overview (not Security).

## Screenshots

**N/A — no visual change.** Every panel, tab strip, and layout renders exactly as
on `main`; the only difference is *which* existing tab is selected when you
return to the page. A still frame of the Security tab would be pixel-identical
before and after this change, so it would be evidence of nothing.
