### PR TITLE
docs(remote-crew): EC2 setup guide (SSH + SSM) and cloud launch how-to

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,6 +10,7 @@ system is built, see [../architecture/](../architecture/README.md).
 | [docker.md](docker.md) | Running Kiro Crew as a container. |
 | [remote-and-mobile.md](remote-and-mobile.md) | Running 24/7 on a remote host, keeping it alive as a service, and reaching it from a phone over a tunnel. |
 | [cloud-instance-ssm-vs-ssh.md](cloud-instance-ssm-vs-ssh.md) | How a cloud-launched instance is reached through the Instances hub: the native AWS SSM transport vs the legacy SSH-over-`ProxyCommand` path. |
+| [remote-crew-on-ec2.md](remote-crew-on-ec2.md) | Reaching a Remote Crew gateway on EC2 over SSH or AWS SSM, plus the common EC2 setup gotchas (sandbox backend, linger, port/tunnel matching). |
 | [slack-setup.md](slack-setup.md) | Creating and configuring the Slack app. |
 
 `assets/` holds the copy-pasteable service unit, launchd plist, and setup script

--- a/docs/guides/cloud-instance-ssm-vs-ssh.md
+++ b/docs/guides/cloud-instance-ssm-vs-ssh.md
@@ -78,6 +78,37 @@ machine, not a parallel implementation; the native SSM tunnel even reuses the
 cloud module's own `cloud/ssm.py` primitives (`build_port_forward_argv`,
 `run_command`).
 
+## Launching a box (one command)
+
+The launcher provisions the EC2 box, installs and starts the gateway (bound to
+loopback `:5476`, never public), signs kiro-cli in over SSM, registers the box
+here, and opens the dashboard — all from your laptop.
+
+1. **One-time prep.** Install the AWS CLI and `session-manager-plugin` — on a bare
+   machine the `cloud-install.sh` (macOS/Linux) or `install.ps1` (Windows)
+   bootstrapper does this and hands off to the wizard. Verify prerequisites with
+   `kirocrew cloud doctor`. Attach the least-privilege policy printed by
+   `kirocrew cloud iam-policy` to the AWS profile you'll launch with.
+2. **Launch.** Run `kirocrew cloud launch` — interactive (size picker + confirm),
+   or non-interactive, e.g. `kirocrew cloud launch --size power --region us-west-2
+   --profile dev -y`. Useful flags: `--new` (a separate box instead of resuming
+   your saved one) and `--keep-on-failure` (disable CloudFormation rollback to
+   inspect a failed bootstrap).
+3. **Reach it — and the ports.** Launch ends by opening an SSM port-forward and
+   your browser at `http://localhost:<local>/?token=…`. You never choose the
+   **remote** port: the gateway always listens on loopback `:5476` on the box. The
+   **local** forwarded port defaults to `5599` (deliberately not `5476`, so it
+   won't collide with a local gateway you may run yourself); override it with
+   `--local-port` on the `connect` / `tunnel` verbs, or suppress the browser with
+   `--no-browser`. Because the box is registered here as an SSM crew, the Instances
+   hub afterwards opens its **own** managed SSM tunnel — allocating its own local
+   port, with token refresh and startup auto-reconnect — independent of that
+   one-shot launch tunnel. Re-running `launch` for the same box updates its record
+   in place; `kirocrew cloud destroy` removes both the box and this registration.
+
+For setting up a box you manage yourself (SSH or SSM, and the common EC2 gotchas),
+see [remote-crew-on-ec2.md](remote-crew-on-ec2.md).
+
 ## What you see in Settings → Instances
 
 A launched box appears as a managed instance whose connection line reads, e.g.:

--- a/docs/guides/remote-crew-on-ec2.md
+++ b/docs/guides/remote-crew-on-ec2.md
@@ -1,0 +1,139 @@
+# Setting up Remote Crew on an EC2 instance
+
+You run the Kiro Crew gateway on an EC2 box and drive it from your laptop. The
+gateway always binds **loopback only**, so you reach it through a tunnel — either
+an **SSH tunnel** or an **AWS SSM Session Manager** tunnel. This page covers both,
+plus the EC2-specific gotchas people actually hit (from `kirocrew doctor`).
+
+> Installing the gateway itself (host requirements, packages, running it as a
+> service, moving your state over) is covered in
+> [remote-and-mobile.md](remote-and-mobile.md). This page assumes the gateway is
+> installed and focuses on **reaching** it from EC2 and on troubleshooting.
+
+## Which way should I use?
+
+| | **SSH tunnel** | **AWS SSM Session Manager** |
+|---|---|---|
+| Inbound port on the box | needs inbound SSH (22), or a bastion | **none** |
+| Client secret | an SSH key | none — IAM (`ssm:StartSession`) |
+| Client tooling | `ssh` | `aws` CLI + `session-manager-plugin` |
+| On the box | `sshd` | the SSM agent (preinstalled on Amazon Linux) + an instance role for SSM |
+| Access control | key possession | IAM, centrally grantable/revocable, CloudTrail-audited |
+| Best when | you already SSH to the box | the box has zero SSH ingress (the hardened default) |
+
+Both end at the same loopback gateway and both are managed identically once
+registered in **Settings → Remote Crew**.
+
+## Way 1 — SSH tunnel
+
+1. On your laptop, forward the gateway's port over SSH (use the **real** gateway
+   port — see [the port gotcha](#porttunnel-mismatch-the-common-one)):
+
+   ```bash
+   ssh -N -L 5476:localhost:5476 <user>@<ec2-host>
+   ```
+
+   Then open `http://localhost:5476`. Run `kirocrew token` on the box to mint the
+   sign-in URL. (Full details, including a non-default port, in
+   [remote-and-mobile.md](remote-and-mobile.md#ssh-tunnel-laptop).)
+2. To let the dashboard manage it, add it in **Settings → Remote Crew → Add remote
+   crew → Connection method = SSH tunnel**, giving the **SSH host / alias** and the
+   **remote port**.
+
+## Way 2 — AWS SSM Session Manager (no inbound SSH)
+
+Requires only the SSM agent + an instance role that allows Session Manager on the
+box, and `ssm:StartSession` + `session-manager-plugin` on your laptop. No inbound
+port, no SSH key.
+
+- **Automated (recommended):** the one-command launcher provisions a box, installs
+  the gateway, and registers it over SSM for you — see
+  [cloud-instance-ssm-vs-ssh.md](cloud-instance-ssm-vs-ssh.md).
+- **Manual (a box you already have):** **Settings → Remote Crew → Add remote crew →
+  Connection method = AWS SSM Session Manager**, then fill **SSM target** (the EC2
+  instance id `i-…`, or an SSM managed-instance id `mi-…`), optional **AWS profile**
+  / **AWS region** / **Remote user**, and the **Remote port** (the gateway's real
+  port). Save, then **Connect**.
+
+## EC2 gotchas / troubleshooting
+
+These map to warnings in `kirocrew doctor`.
+
+### MCP tools all fail: "Sandbox backend unavailable … `allow_unsandboxed_exec` is not set"
+
+On Linux, agent subprocesses run inside a **user-namespace sandbox**. Many hardened
+Amazon Linux 2023 / corporate AMIs ship with **unprivileged user namespaces
+disabled**, so no sandbox backend is available and every MCP server — and every
+spawn — fails closed. Pick one:
+
+- **Enable user namespaces on the box (preferred — keeps isolation).** Ensure
+  `user.max_user_namespaces` is non-zero (and on Debian/Ubuntu kernels,
+  `kernel.unprivileged_userns_clone=1`). For example:
+
+  ```bash
+  sudo sysctl -w user.max_user_namespaces=15000
+  # persist across reboots:
+  echo 'user.max_user_namespaces=15000' | sudo tee /etc/sysctl.d/99-userns.conf
+  ```
+
+  Then restart the gateway.
+- **Or opt into unsandboxed execution (trades isolation — only on a box you
+  trust).** Run `kirocrew setup` (it offers this interactively), or set
+  `agent.sandbox_allow_unsandboxed_exec: true` in `~/.kiro/crew/config.json`, then
+  restart the gateway. This lets agent subprocesses run without any sandbox.
+
+### Gateway/pods die on logout: "linger disabled"
+
+A **user**-level systemd unit and any running pods stop when your login session
+ends. Enable linger so they survive logout and reboot:
+
+```bash
+loginctl enable-linger <user>
+```
+
+(A gateway installed as a **system** unit under `/etc/systemd/system` already
+survives logout; linger still matters for pods and for user-level installs.)
+
+### "kiro login: not logged in"
+
+kiro-cli must be authenticated **on the box**. Run `kiro-cli login` there and
+complete the device-code flow. Chat errors like "not logged in" mean this step was
+skipped on the remote.
+
+### Port/tunnel mismatch (the common one)
+
+`kirocrew doctor`'s "Remote access" hint and its `dashboard: http://localhost:5476`
+line show the **defaults**. If your service or shell sets `KIROCREW_PORT` (e.g.
+`7777`), the gateway actually listens **there**, not on 5476 — the doctor line just
+didn't see that env var. Your tunnel, browser, and token must all use the **same,
+real** port:
+
+```bash
+# service has KIROCREW_PORT=7777 → tunnel 7777, not 5476:
+ssh -N -L 7777:localhost:7777 <ec2-host>
+# then open http://localhost:7777
+```
+
+For SSM, set the Instances **Remote port** to that same port. If your browser
+reaches the dashboard on a *different* local port than the remote, opt that local
+port into the CSRF allowlist — see
+[remote-and-mobile.md](remote-and-mobile.md#2-reach-it-from-a-laptop-or-phone).
+
+### Non-fatal warnings you can ignore
+
+- **`ffmpeg: not found`** — only needed for speech-to-text. Drop a static ffmpeg
+  build into `~/.local/bin` (it's not in the AL2023 repos; Kiro Crew auto-detects
+  it).
+- **`Vector Memory … vendored runtime failed to load`** — the in-process embedding
+  runtime couldn't load its shared library on this host; memory falls back
+  gracefully and keeps working. Safe to ignore unless you specifically rely on
+  local vector memory.
+- **`project dir: not set`** — cosmetic. Run `kirocrew setup` from a project root
+  if you want a default project directory.
+
+## Related
+
+- [remote-and-mobile.md](remote-and-mobile.md) — installing the gateway, running
+  it as a service, and reaching it from a phone over an HTTPS tunnel.
+- [cloud-instance-ssm-vs-ssh.md](cloud-instance-ssm-vs-ssh.md) — the two transports
+  in depth and the one-command cloud launcher.


### PR DESCRIPTION
## Problem

Two documentation gaps around running Kiro Crew on EC2:
- The cloud launcher guide (added in #1606) explains the SSM-vs-SSH *transports* but never shows **how to actually launch** a box or what happens to the ports.
- There is no user-facing guide for setting up a Remote Crew on an EC2 box you manage yourself, and several people hit the same EC2 gotchas — a real report showed `kirocrew doctor` with every MCP server failing (no sandbox backend), pods dying on logout (linger), kiro-cli not logged in, and a tunnel pointed at 5476 while the service ran on `KIROCREW_PORT=7777`.

## Why it matters

The launch flow and the EC2 setup path are exactly where new users get stuck, and the failures are non-obvious (a hardened AL2023 AMI silently has no usable sandbox backend, so every agent/MCP spawn fails closed). Documenting the fixes turns a confusing dead-end into a two-line remedy.

## What changed

- **New guide `docs/guides/remote-crew-on-ec2.md`** — reaching a Remote Crew gateway on EC2 over **SSH** or **AWS SSM**, a which-way comparison table, and a **Troubleshooting** section mapped 1:1 to the reported `kirocrew doctor` output:
  - *Sandbox backend unavailable / MCP tools all fail* → enable unprivileged user namespaces (`user.max_user_namespaces`), or opt into `agent.sandbox_allow_unsandboxed_exec` (trades isolation).
  - *Gateway/pods die on logout* → `loginctl enable-linger <user>`.
  - *kiro login: not logged in* → `kiro-cli login` on the box.
  - *Port/tunnel mismatch* → match the tunnel + token to the gateway's real port when `KIROCREW_PORT` overrides the 5476 default.
  - *Non-fatal noise* (ffmpeg, vendored embeddings runtime, project dir) → safe to ignore.
- **Launch how-to** added to `docs/guides/cloud-instance-ssm-vs-ssh.md` — prep (`doctor` / `iam-policy` / bootstrappers), the launch command + flags, and the port model (remote loopback `:5476`, local forward default `5599`, hub allocates its own).
- **Index** row added in `docs/guides/README.md` (satisfies the docs-lint reachability rule).

## Tests

Docs-only — no automated tests. `scripts/docs_lint.py` (links resolve, every doc reachable from its index) and `scripts/check_brand_name.py` (brand-name gate) both pass locally.

## Manual verification

Ran `python3 scripts/docs_lint.py` (all documentation checks passed, 183 files) and `BRAND_BASE_REF=origin/main python3 scripts/check_brand_name.py` (no misspellings in added lines). Cross-doc links to `remote-and-mobile.md` anchors and between the two cloud guides verified.

## Screenshots

N/A — documentation only.
