### PR TITLE
test(credwatch): make the windows-skipped credwatch tests deterministic

### DIFF
--- a/src/kiro_crew/mcp_gateway/credwatch.py
+++ b/src/kiro_crew/mcp_gateway/credwatch.py
@@ -141,6 +141,7 @@ async def watch_credential(
     stop_event: asyncio.Event,
     on_change: OnChange,
     logger: logging.Logger,
+    on_probe_complete: Optional[Callable[[], None]] = None,
 ) -> None:
     """Poll ``cred_path`` and fire ``on_change`` whenever its content
     changes.
@@ -156,6 +157,13 @@ async def watch_credential(
             not on an mtime-only no-op rewrite).
         logger: ``logging.Logger`` used for state-change INFO and
             handler-error WARNING messages.
+        on_probe_complete: Test seam, ``None`` in production. Optional
+            no-arg callable invoked after every probe cycle finishes,
+            including cycles that fire nothing. It lets a caller await
+            "one poll has happened" instead of sleeping a wall-clock
+            guess. The sleep-based tests were flaky on Windows runners,
+            whose coarser timer resolution let a write land outside the
+            intended window (issue #1105).
     """
     baseline_mtime: Optional[float] = None
     baseline_digest: Optional[str] = None
@@ -183,83 +191,117 @@ async def watch_credential(
                 except asyncio.TimeoutError:
                     pass
             first_probe = False
-
-            # Offload the blocking stat + content hash to a worker thread so
-            # the event loop never stalls on credential IO — the file may live
-            # on a network-mounted home directory. The content is hashed every
-            # poll (no mtime cheap-gate) so a coarse-mtime in-place rotation is
-            # never permanently missed — see the module docstring.
             try:
-                mtime, digest = await asyncio.to_thread(_probe_credential, cred_path)
-            except OSError as exc:
-                # stat() or read() failed transiently — log and skip without
-                # advancing the baseline.
-                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a path + exception, never credential bytes
-                logger.warning("credential watcher: probe(%s) failed: %s", cred_path, exc)
-                continue
-            if digest is None:
-                # Genuinely absent (``_probe_credential`` returns None ONLY on
-                # FileNotFoundError; a transient OSError propagated and was caught
-                # above without advancing the baseline).
+
+                # Offload the blocking stat + content hash to a worker thread so
+                # the event loop never stalls on credential IO — the file may live
+                # on a network-mounted home directory. The content is hashed every
+                # poll (no mtime cheap-gate) so a coarse-mtime in-place rotation is
+                # never permanently missed — see the module docstring.
+                try:
+                    mtime, digest = await asyncio.to_thread(_probe_credential, cred_path)
+                except OSError as exc:
+                    # stat() or read() failed transiently — log and skip without
+                    # advancing the baseline.
+                    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a path + exception, never credential bytes
+                    logger.warning("credential watcher: probe(%s) failed: %s", cred_path, exc)
+                    continue
+                if digest is None:
+                    # Genuinely absent (``_probe_credential`` returns None ONLY on
+                    # FileNotFoundError; a transient OSError propagated and was caught
+                    # above without advancing the baseline).
+                    if not baseline_established:
+                        # FIRST observation is absent — record it as the absent
+                        # baseline so a later appearance is treated as a change (not
+                        # silently adopted as a no-fire baseline).
+                        baseline_established = True
+                        logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a path only, never credential bytes
+                            "credential watcher: baseline is ABSENT (no file yet) for %s",
+                            cred_path,
+                        )
+                        continue
+                    if baseline_digest is not None:
+                        # PRESENT -> ABSENT: the credential was deleted/revoked. This
+                        # is a real transition and MUST fire on_change — otherwise
+                        # pooled/pinned backends keep the revoked credential and stay
+                        # authenticated until deadline/restart, defeating revocation.
+                        # Move the baseline to absent so a later re-appearance fires
+                        # again (absent -> present) rather than silently rebaselining.
+                        logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a truncated content hash + path, never credential bytes
+                            "credential watcher: file removed (was digest=%s) for %s "
+                            "— firing (credential revoked)",
+                            baseline_digest[:12],
+                            cred_path,
+                        )
+                        baseline_mtime = None
+                        baseline_digest = None
+                        try:
+                            result = on_change()
+                            if inspect.isawaitable(result):
+                                await result
+                        except Exception:
+                            logger.exception(
+                                "credential watcher: on_change handler failed; continuing"
+                            )
+                    # Already absent (baseline_digest is None) — nothing to compare;
+                    # wait for it to (re)appear.
+                    continue
+
                 if not baseline_established:
-                    # FIRST observation is absent — record it as the absent
-                    # baseline so a later appearance is treated as a change (not
-                    # silently adopted as a no-fire baseline).
+                    # First observation and the file is PRESENT — no-fire baseline.
                     baseline_established = True
-                    logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a path only, never credential bytes
-                        "credential watcher: baseline is ABSENT (no file yet) for %s",
+                    baseline_mtime = mtime
+                    baseline_digest = digest
+                    logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a truncated content hash + path, never credential bytes
+                        "credential watcher: baseline mtime=%.3f digest=%s for %s",
+                        mtime,
+                        digest[:12],
                         cred_path,
                     )
                     continue
-                if baseline_digest is not None:
-                    # PRESENT -> ABSENT: the credential was deleted/revoked. This
-                    # is a real transition and MUST fire on_change — otherwise
-                    # pooled/pinned backends keep the revoked credential and stay
-                    # authenticated until deadline/restart, defeating revocation.
-                    # Move the baseline to absent so a later re-appearance fires
-                    # again (absent -> present) rather than silently rebaselining.
+
+                if baseline_digest is None:
+                    # Baseline was ABSENT and the file has now APPEARED — a real
+                    # "no credential -> credential" transition. Fire on_change so any
+                    # backend prewarmed during the absent window is drained and
+                    # respawned against the now-present credential, then adopt it as
+                    # the new baseline.
                     logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a truncated content hash + path, never credential bytes
-                        "credential watcher: file removed (was digest=%s) for %s "
-                        "— firing (credential revoked)",
-                        baseline_digest[:12],
+                        "credential watcher: file appeared (digest=%s) after absent "
+                        "baseline for %s — firing",
+                        digest[:12],
                         cred_path,
                     )
-                    baseline_mtime = None
-                    baseline_digest = None
+                    baseline_mtime = mtime
+                    baseline_digest = digest
                     try:
                         result = on_change()
                         if inspect.isawaitable(result):
                             await result
                     except Exception:
-                        logger.exception(
-                            "credential watcher: on_change handler failed; continuing"
+                        logger.exception("credential watcher: on_change handler failed; continuing")
+                    continue
+
+                if digest == baseline_digest:
+                    # mtime moved but the bytes are identical — a no-op rewrite
+                    # by a credential refresh daemon. Advance the mtime gate so we
+                    # do not re-hash next poll, but do NOT fire on_change.
+                    if mtime != baseline_mtime:
+                        logger.debug(
+                            "credential watcher: mtime moved %.3f -> %.3f, content "
+                            "unchanged (digest=%s); not firing for %s",
+                            baseline_mtime,
+                            mtime,
+                            digest[:12],
+                            cred_path,
                         )
-                # Already absent (baseline_digest is None) — nothing to compare;
-                # wait for it to (re)appear.
-                continue
+                    baseline_mtime = mtime
+                    continue
 
-            if not baseline_established:
-                # First observation and the file is PRESENT — no-fire baseline.
-                baseline_established = True
-                baseline_mtime = mtime
-                baseline_digest = digest
-                logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a truncated content hash + path, never credential bytes
-                    "credential watcher: baseline mtime=%.3f digest=%s for %s",
-                    mtime,
-                    digest[:12],
-                    cred_path,
-                )
-                continue
-
-            if baseline_digest is None:
-                # Baseline was ABSENT and the file has now APPEARED — a real
-                # "no credential -> credential" transition. Fire on_change so any
-                # backend prewarmed during the absent window is drained and
-                # respawned against the now-present credential, then adopt it as
-                # the new baseline.
-                logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a truncated content hash + path, never credential bytes
-                    "credential watcher: file appeared (digest=%s) after absent "
-                    "baseline for %s — firing",
+                # Real content change — credential rotation.
+                logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs truncated content hashes + path, never credential bytes
+                    "credential watcher: content changed digest %s -> %s for %s",
+                    baseline_digest[:12],
                     digest[:12],
                     cred_path,
                 )
@@ -271,38 +313,12 @@ async def watch_credential(
                         await result
                 except Exception:
                     logger.exception("credential watcher: on_change handler failed; continuing")
-                continue
-
-            if digest == baseline_digest:
-                # mtime moved but the bytes are identical — a no-op rewrite
-                # by a credential refresh daemon. Advance the mtime gate so we
-                # do not re-hash next poll, but do NOT fire on_change.
-                if mtime != baseline_mtime:
-                    logger.debug(
-                        "credential watcher: mtime moved %.3f -> %.3f, content "
-                        "unchanged (digest=%s); not firing for %s",
-                        baseline_mtime,
-                        mtime,
-                        digest[:12],
-                        cred_path,
-                    )
-                baseline_mtime = mtime
-                continue
-
-            # Real content change — credential rotation.
-            logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs truncated content hashes + path, never credential bytes
-                "credential watcher: content changed digest %s -> %s for %s",
-                baseline_digest[:12],
-                digest[:12],
-                cred_path,
-            )
-            baseline_mtime = mtime
-            baseline_digest = digest
-            try:
-                result = on_change()
-                if inspect.isawaitable(result):
-                    await result
-            except Exception:
-                logger.exception("credential watcher: on_change handler failed; continuing")
+            finally:
+                # Fire on EVERY path out of the body, including the six
+                # ``continue`` branches. A caller that awaits this seam to
+                # mean "one poll has happened" would deadlock if a branch
+                # skipped the notify.
+                if on_probe_complete is not None:
+                    on_probe_complete()
     except asyncio.CancelledError:
         pass

--- a/test/test_mcp_gateway_bluegreen.py
+++ b/test/test_mcp_gateway_bluegreen.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
-import sys
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -543,16 +542,46 @@ def _resilient_cred_unlink(cred: Path) -> None:
             time.sleep(0.01)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
+class _ProbeBarrier:
+    """Counts ``watch_credential`` probe cycles so a test can await "N polls
+    have completed" instead of sleeping a wall-clock guess.
+
+    Sleeping was the root of the Windows flake in issue #1105. A test slept
+    50ms hoping the baseline probe had run, then wrote the rotation. On a runner
+    with ~15.6ms timer granularity and slower file IO the write could land
+    BEFORE the baseline probe, so the baseline captured the rotated bytes and no
+    change was ever detected.
+
+    Pass an instance as ``on_probe_complete``. The watcher invokes it once per
+    cycle, on every branch.
+    """
+
+    def __init__(self) -> None:
+        self.count = 0
+        self._bumped = asyncio.Event()
+
+    def __call__(self) -> None:
+        self.count += 1
+        self._bumped.set()
+
+    async def wait_for(self, n: int, timeout: float = 5.0) -> None:
+        """Return once at least ``n`` probe cycles have completed.
+
+        Clear-then-wait is safe because ``__call__`` is synchronous and runs on
+        this same loop, so it cannot interleave between the count check and the
+        ``wait()``. The post-clear re-check is belt and braces.
+        """
+
+        async def _spin() -> None:
+            while self.count < n:
+                self._bumped.clear()
+                if self.count >= n:
+                    return
+                await self._bumped.wait()
+
+        await asyncio.wait_for(_spin(), timeout)
+
+
 @pytest.mark.asyncio
 async def test_credwatch_first_observation_is_baseline_no_fire(tmp_path: Path) -> None:
     """The first observation of the credential file establishes the baseline
@@ -563,27 +592,25 @@ async def test_credwatch_first_observation_is_baseline_no_fire(tmp_path: Path) -
     cred.write_bytes(b"secret-v1")
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
 
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.1)  # several polls on the unchanged baseline
+    await barrier.wait_for(3)  # 3 polls: baseline + 2 unchanged confirms no fire
     stop.set()
     await task
 
     assert fired == []
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_baseline_established_immediately(tmp_path: Path) -> None:
     """The baseline is captured on the FIRST probe (at startup), not one full
@@ -597,33 +624,31 @@ async def test_credwatch_baseline_established_immediately(tmp_path: Path) -> Non
     cred.write_bytes(b"secret-v1")
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
 
     # interval 0.1s: immediate probe at t≈0 sets baseline=v1; v2 written at
     # t≈0.05 (after baseline, before the next poll); poll at t≈0.1 detects the
     # change and fires. A wait-first loop would first probe at t≈0.1, see v2,
     # and make it the baseline → no fire.
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.1, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.1,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.05)  # baseline (v1) captured by the immediate probe
+    await barrier.wait_for(1)  # baseline (v1) captured by the immediate probe
     _atomic_cred_write(cred, b"secret-v2-rotated")
-    await asyncio.sleep(0.25)  # let the next poll(s) detect the rotation
+    await barrier.wait_for(barrier.count + 2)  # 2 more polls to detect the rotation
     stop.set()
     await task
 
     assert fired == [True]  # rotation within the first interval was detected
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_no_fire_on_byte_identical_rewrite(tmp_path: Path) -> None:
     """An mtime bump with byte-identical content (a no-op rewrite by a
@@ -634,11 +659,19 @@ async def test_credwatch_no_fire_on_byte_identical_rewrite(tmp_path: Path) -> No
     cred.write_bytes(b"secret-v1")
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
 
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.05)  # let the baseline establish
+    await barrier.wait_for(1)  # baseline established
     # Simulate a no-op refresh (byte-identical content, moved mtime) by touching
     # ONLY the mtime — do NOT physically rewrite. The watcher's identity is
     # (mtime, content-hash), so re-writing the SAME bytes is indistinguishable
@@ -653,23 +686,13 @@ async def test_credwatch_no_fire_on_byte_identical_rewrite(tmp_path: Path) -> No
 
     st = cred.stat()
     os.utime(cred, (st.st_atime, st.st_mtime + 10.0))
-    await asyncio.sleep(0.1)
+    await barrier.wait_for(barrier.count + 2)  # 2 more polls confirm no fire
     stop.set()
     await task
 
     assert fired == []
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_fires_on_content_change(tmp_path: Path) -> None:
     """A real content change past the baseline fires on_change (async
@@ -680,12 +703,22 @@ async def test_credwatch_fires_on_content_change(tmp_path: Path) -> None:
     cred.write_bytes(b"secret-v1")
     stop = asyncio.Event()
     fired = asyncio.Event()
+    barrier = _ProbeBarrier()
 
     async def _on_change() -> None:
         fired.set()
 
-    task = asyncio.create_task(credwatch.watch_credential(cred, 0.01, stop, _on_change, logger))
-    await asyncio.sleep(0.05)  # let the baseline establish
+    task = asyncio.create_task(
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            _on_change,
+            logger,
+            on_probe_complete=barrier,
+        )
+    )
+    await barrier.wait_for(1)  # baseline established
     import os
 
     cred.write_bytes(b"secret-v2")
@@ -696,16 +729,6 @@ async def test_credwatch_fires_on_content_change(tmp_path: Path) -> None:
     await task
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_fires_on_content_change_with_unchanged_mtime(tmp_path: Path) -> None:
     """A rotation that rewrites the file in-place with NEW content but leaves
@@ -720,12 +743,22 @@ async def test_credwatch_fires_on_content_change_with_unchanged_mtime(tmp_path: 
     baseline_mtime = cred.stat().st_mtime
     stop = asyncio.Event()
     fired = asyncio.Event()
+    barrier = _ProbeBarrier()
 
     async def _on_change() -> None:
         fired.set()
 
-    task = asyncio.create_task(credwatch.watch_credential(cred, 0.01, stop, _on_change, logger))
-    await asyncio.sleep(0.05)  # let the baseline establish
+    task = asyncio.create_task(
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            _on_change,
+            logger,
+            on_probe_complete=barrier,
+        )
+    )
+    await barrier.wait_for(1)  # baseline established
 
     # Rewrite with new content, then FORCE mtime back to the baseline value —
     # simulating a coarse-mtime filesystem where the rotation shares a tick.
@@ -737,16 +770,6 @@ async def test_credwatch_fires_on_content_change_with_unchanged_mtime(tmp_path: 
     await task
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_absent_then_appearing_fires(tmp_path: Path) -> None:
     """When the file is ABSENT at the first probe, its later appearance is a
@@ -758,29 +781,27 @@ async def test_credwatch_absent_then_appearing_fires(tmp_path: Path) -> None:
     cred = tmp_path / "cred"  # does not exist yet
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
 
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.05)  # polls against the missing file (absent baseline)
+    await barrier.wait_for(1)  # absent baseline captured
     _atomic_cred_write(cred, b"secret-v1")  # appearance after an absent baseline → fires
-    await asyncio.sleep(0.1)
+    await barrier.wait_for(barrier.count + 2)  # 2 polls: detect appearance + confirm
     stop.set()
     await task
 
     assert fired == [True]
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_never_appearing_file_never_fires(tmp_path: Path) -> None:
     """A file that stays ABSENT for the watcher's whole life never fires — the
@@ -790,27 +811,25 @@ async def test_credwatch_never_appearing_file_never_fires(tmp_path: Path) -> Non
     cred = tmp_path / "cred"  # never created
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
 
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.1)  # many polls, file never appears
+    await barrier.wait_for(3)  # 3 polls on absent file: confirms no spurious fire
     stop.set()
     await task
 
     assert fired == []
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_present_then_deleted_fires_revocation(tmp_path: Path) -> None:
     """Deleting a PRESENT credential (present -> absent) is a revocation and
@@ -822,13 +841,21 @@ async def test_credwatch_present_then_deleted_fires_revocation(tmp_path: Path) -
     cred.write_bytes(b"secret-v1")
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
 
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.05)  # present baseline captured
+    await barrier.wait_for(1)  # present baseline captured
     _resilient_cred_unlink(cred)  # revocation
-    await asyncio.sleep(0.1)  # several absent polls
+    await barrier.wait_for(barrier.count + 3)  # 3 absent polls: detect + confirm no re-fire
     stop.set()
     await task
 
@@ -836,16 +863,6 @@ async def test_credwatch_present_then_deleted_fires_revocation(tmp_path: Path) -
     assert fired == [True]
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_delete_then_reappear_fires_twice(tmp_path: Path) -> None:
     """present -> absent -> present: the delete fires (revocation) AND the later
@@ -857,15 +874,23 @@ async def test_credwatch_delete_then_reappear_fires_twice(tmp_path: Path) -> Non
     cred.write_bytes(b"secret-v1")
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
 
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.05)  # present baseline
+    await barrier.wait_for(1)  # present baseline
     _resilient_cred_unlink(cred)  # -> absent (fire #1: revocation)
-    await asyncio.sleep(0.05)
+    await barrier.wait_for(barrier.count + 2)  # 2 polls: detect deletion + stabilize
     _atomic_cred_write(cred, b"secret-v2")  # -> present (fire #2: new credential)
-    await asyncio.sleep(0.1)
+    await barrier.wait_for(barrier.count + 2)  # 2 polls: detect reappearance + confirm
     stop.set()
     await task
 
@@ -879,16 +904,6 @@ async def test_credwatch_delete_then_reappear_fires_twice(tmp_path: Path) -> Non
 # fix (the _atomic_cred_write / _resilient_cred_unlink helpers surviving it).
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_nonatomic_appearance_double_fires_but_atomic_single(
     tmp_path: Path,
@@ -904,13 +919,21 @@ async def test_credwatch_nonatomic_appearance_double_fires_but_atomic_single(
     cred = tmp_path / "cred"
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.05)  # absent baseline
+    await barrier.wait_for(1)  # absent baseline
     with nonatomic_write(cred, b"secret-v1"):
-        await asyncio.sleep(0.05)  # poller observes the EMPTY truncate window
-    await asyncio.sleep(0.05)  # poller observes the full payload
+        await barrier.wait_for(barrier.count + 1)  # poller observes the EMPTY truncate window
+    await barrier.wait_for(barrier.count + 1)  # poller observes the full payload
     stop.set()
     await task
     assert fired == [True, True]  # empty→fire, then full→fire: the spurious extra
@@ -919,27 +942,25 @@ async def test_credwatch_nonatomic_appearance_double_fires_but_atomic_single(
     cred2 = tmp_path / "cred2"
     stop2 = asyncio.Event()
     fired2: list[bool] = []
+    barrier2 = _ProbeBarrier()
     task2 = asyncio.create_task(
-        credwatch.watch_credential(cred2, 0.01, stop2, lambda: fired2.append(True), logger)
+        credwatch.watch_credential(
+            cred2,
+            0.01,
+            stop2,
+            lambda: fired2.append(True),
+            logger,
+            on_probe_complete=barrier2,
+        )
     )
-    await asyncio.sleep(0.05)  # absent baseline
+    await barrier2.wait_for(1)  # absent baseline
     _atomic_cred_write(cred2, b"secret-v1")
-    await asyncio.sleep(0.1)
+    await barrier2.wait_for(barrier2.count + 2)  # 2 polls: detect appearance + confirm
     stop2.set()
     await task2
     assert fired2 == [True]
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "Timing-flaky on Windows CI: these sequence a 0.1s credential poller with "
-        "50-250ms asyncio.sleep windows, and the runners' coarse timer resolution "
-        "and slower file IO push the write outside the intended window "
-        "(intermittent `fired == []`). The watcher logic itself is "
-        "platform-independent and stays covered on POSIX. See issue #1105."
-    ),
-)
 @pytest.mark.asyncio
 async def test_credwatch_resilient_unlink_survives_sharing_violation(
     tmp_path: Path,
@@ -963,14 +984,22 @@ async def test_credwatch_resilient_unlink_survives_sharing_violation(
     cred.write_bytes(b"secret-v1")
     stop = asyncio.Event()
     fired: list[bool] = []
+    barrier = _ProbeBarrier()
     task = asyncio.create_task(
-        credwatch.watch_credential(cred, 0.01, stop, lambda: fired.append(True), logger)
+        credwatch.watch_credential(
+            cred,
+            0.01,
+            stop,
+            lambda: fired.append(True),
+            logger,
+            on_probe_complete=barrier,
+        )
     )
-    await asyncio.sleep(0.05)  # present baseline
+    await barrier.wait_for(1)  # present baseline
     with unlink_sharing_violation(match="cred", times=1):
         _resilient_cred_unlink(cred)  # first delete faults, retry lands
     assert not cred.exists()
-    await asyncio.sleep(0.1)  # several absent polls
+    await barrier.wait_for(barrier.count + 3)  # 3 absent polls: detect + confirm no re-fire
     stop.set()
     await task
     assert fired == [True]  # exactly one revocation fire, no spurious extras


### PR DESCRIPTION
## Problem / Motivation

Eleven credential-watcher tests in `test/test_mcp_gateway_bluegreen.py` are skipped on
Windows. Each carries a `skipif(sys.platform == "win32")` marker citing #1105. The
marker states the symptom:

> Timing-flaky on Windows CI: these sequence a 0.1s credential poller with 50-250ms
> `asyncio.sleep` windows, and the runners' coarse timer resolution and slower file IO
> push the write outside the intended window (intermittent `fired == []`).

The tests start `watch_credential` at a 0.01-0.1s poll interval. They then sleep a fixed
wall-clock guess, mutate the credential file, and sleep again. The sleep is a bet that a
poll cycle lands in the window. Windows timer granularity is about 15.6ms. When the bet
loses, the mutation lands outside the intended window and the poller legitimately
observes nothing.

## Why it matters

The credential watcher is unverified on Windows today. `pytest` scores a skip as a pass,
so a real Windows regression in `credwatch.py` produces a green run.

The failure mode is also silent in the other direction. A baseline sleep that runs late
lets the mutation land before the baseline probe. The baseline then captures the
post-mutation content, no change is ever detected, and the test times out.

## What changed (motivation to approach to change)

The tests cannot sequence a poller they cannot observe. So the change gives them an
observation point instead of a better guess.

`watch_credential` takes a new optional `on_probe_complete: Optional[Callable[[], None]]`
parameter. Production passes nothing, so the parameter is inert on the production path.
Tests pass a `_ProbeBarrier` that counts probe cycles and exposes
`await barrier.wait_for(n)`. Every `asyncio.sleep` in the credwatch tests becomes an await
on a probe count.

Issue #1105 suggests awaiting an event the watcher sets after each probe. This follows
that suggestion.

One design point drove the diff. The notify call sits in a `finally` block placed inside
the poll-loop body, not at the end of it. The body has six `continue` branches, covering
transient `OSError` and an absent baseline. A seam at the end of the body would not fire
on those branches. A test awaiting "N probes have completed" would then hang rather than
fail, which is the worst failure shape for a CI gate.

Rejected alternative: extract the per-cycle body into a function so tests drive cycles
directly and need no sleeps or seam at all. That removes the test-only parameter from the
production signature, but it restructures production control flow further than the issue
asks. Revisit this if a reviewer objects to a test seam living in production code.

The 11 `skipif` markers are deleted, and the now-unused `import sys` with them.

Read `credwatch.py` with `git diff -w`. Its diff reads 204 changed lines for four real
changes, because wrapping the loop body in `try`/`finally` re-indents 90 unmodified lines.

## Tests

No new test cases are added. The existing 12 credwatch tests are converted from
wall-clock sleeps to probe-count awaits, and then run on Windows for the first time.

Conversion is one-for-one and was checked per test, not in aggregate:

- 24 `await asyncio.sleep(` calls at base become 2. Both survivors are in pool and
  backend tests unrelated to credwatch.
- The 22 credwatch sleeps become 22 `barrier.wait_for(...)` awaits, mapping 1:1.
- 12 watcher starts, 12 `_ProbeBarrier()` constructions, 12 `on_probe_complete=`
  arguments. No test starts the watcher without the seam.

Each sleep carried a comment naming its intent, such as `baseline`, `several polls on the
unchanged baseline`, or `let the next poll(s) detect the rotation`. Those map to different
probe counts, so each site was converted individually.

Assertions are unchanged, which was verified against the base file rather than assumed:

- `assert` statements: 75 at base, 75 now.
- `assert fired == []` negative assertions: 3 at base, 3 now, at the same three tests.
- `asyncio.wait_for` timeouts: unchanged at `timeout=2.0`, none raised.

The negative assertions are what the seam earns. A negative cannot be proven by sleeping.
It can only be proven by "K probe cycles have definitely completed and nothing fired".

The clearest gain is in
`test_credwatch_nonatomic_appearance_double_fires_but_atomic_single`. It now awaits one
probe inside the `with nonatomic_write(...)` block. The poller is therefore guaranteed to
observe the transient empty-truncate window the test asserts on. Previously the test slept
50ms and hoped a poll landed inside that window.

Local results on Linux:

```
pytest test/test_mcp_gateway_bluegreen.py         -> 34 passed
pytest -k credwatch                               -> 12 passed
```

Runtime for the credwatch selection fell from 2.33s to 0.76s, which follows from deleting
fixed sleeps.

Blocking gates, exactly as `ci.yml` runs them:

```
isort --check-only src/kiro_crew test  -> exit 0
flake8 src/kiro_crew test              -> exit 0
mypy src/kiro_crew/                    -> Success: no issues found in 724 source files
```

`black --check` is commented out in `ci.yml` and is not a gate. Both changed files are
black-clean under the repo's `line-length = 100` regardless.

## Manual verification

The Windows shards on this PR are the verification that matters. A Linux run proves the
barrier is wired correctly and that the conversion preserves behaviour. It cannot prove
the un-skip, because the markers gated Windows only and every one of these tests already
ran on POSIX.

The specific claim under test: with sequencing driven by probe counts rather than
wall-clock sleeps, timer granularity no longer decides the outcome, so these 12 tests hold
on the Windows shards.

## Related Issues

Refs #1105

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
