### PR TITLE
fix(md_notebook): env-overridable git timeouts; widen budget on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,11 @@ jobs:
         group: [1, 2, 3, 4]
     env:
       SHARD_COUNT: 4
+      # windows-latest subprocess spawn + filesystem latency is slow and
+      # highly variable; the md_notebook git-ops default (30s) intermittently
+      # times out on plain `git add` here (#1673). Give git invocations a
+      # wider budget on this job only.
+      MDNB_GIT_TIMEOUT_SEC: 120
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
@@ -57,9 +57,12 @@ def in_trash(path: str) -> bool:
 
 
 # Seconds before a git invocation is abandoned. Network operations (clone,
-# fetch, push) get the longer budget.
-GIT_TIMEOUT_SEC = 30
-GIT_NETWORK_TIMEOUT_SEC = 180
+# fetch, push) get the longer budget. Overridable via environment for hosts
+# where subprocess spawn and filesystem latency are slow or highly variable
+# (e.g. shared Windows CI runners) — mirrors FE_GIT_TIMEOUT_SEC in the
+# file_explorer app.
+GIT_TIMEOUT_SEC = int(os.environ.get("MDNB_GIT_TIMEOUT_SEC", 30))
+GIT_NETWORK_TIMEOUT_SEC = int(os.environ.get("MDNB_GIT_NETWORK_TIMEOUT_SEC", 180))
 
 
 class GitError(RuntimeError):


### PR DESCRIPTION
## What

Fixes #1673 (the `git add timed out after 30s` Windows shard flake).

- `md_notebook/git_ops.py`: `GIT_TIMEOUT_SEC` and `GIT_NETWORK_TIMEOUT_SEC` become environment-overridable (`MDNB_GIT_TIMEOUT_SEC` / `MDNB_GIT_NETWORK_TIMEOUT_SEC`), defaults unchanged (30s / 180s). Mirrors the existing `FE_GIT_TIMEOUT_SEC` pattern in `file_explorer/server.py`.
- `ci.yml`: the `backend-test-windows` job sets `MDNB_GIT_TIMEOUT_SEC: 120` — windows-latest subprocess spawn + filesystem latency is slow and variable enough that plain `git add` intermittently exceeds 30s there (see the run linked in #1673, which flaked on a PR that doesn't touch md_notebook). Scoped to that job only; POSIX shards and local dev keep the tight default.

## Why not just bump the constant

The 30s default is a reasonable guard for interactive use — the failure mode is specific to shared Windows runners, so the widening is scoped to exactly that environment rather than loosening everyone's budget.

## Testing

- `MDNB_GIT_TIMEOUT_SEC=99` → module reports 99; unset → 30 (verified by import)
- `test/test_md_notebook.py`: 154/154 pass
- `actionlint` clean on the workflow change (only the pre-existing SC2129 style note in an untouched script); YAML validated
- flake8 + docs-lint clean
