### PR TITLE
fix(slack): seed a linked thread with readable, untruncated history

### DIFF
--- a/src/kiro_crew/dashboard/chat_backfill.py
+++ b/src/kiro_crew/dashboard/chat_backfill.py
@@ -1,0 +1,221 @@
+"""Choosing the history a freshly linked channel thread is seeded with.
+
+When a dashboard session is linked to a Slack thread ("Send to Slack") or to a
+configured non-Slack destination, the new thread is seeded with a preview of the
+conversation so a human arriving there can orient.
+
+This module decides *which* rows that preview contains. It deliberately does
+**not** redact, format, or post them: each call site crosses a different egress
+boundary with different formatting rules (Slack mrkdwn split at
+``SLACK_MSG_LIMIT`` vs. plain text chunked at the transport's own
+``max_message_chars``), and keeping the redactor call in the module that actually
+sends is what lets ``security_posture`` account for those two sinks where the
+sending happens.
+
+The unit of selection is a **turn**: one ``user`` message plus the ``assistant``
+message(s) that answered it. Selecting whole turns is what makes the preview
+readable. The previous implementation sliced a fixed number of *raw* rows and
+only then filtered by role, so a tail of ``tool`` rows consumed every slot --
+five consecutive tool calls seeded nothing at all.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, NamedTuple
+from urllib.parse import quote
+
+from kiro_crew.dashboard.chat_utils import effective_session_key
+from kiro_crew.dashboard.urls import dashboard_origin
+
+logger = logging.getLogger(__name__)
+
+# The only roles a human-readable preview replays. An ALLOW-list, never a
+# skip-list: ``_ChatSlot.append`` takes an unconstrained ``str`` role and the
+# observed vocabulary already includes tool, error, system, done, chunk,
+# streaming, queued, inject, file, compacting and permission. A skip-list would
+# also behave differently across the two sources this module reads, because a
+# transcript never carries the streaming-only roles (they are dropped by
+# ``chat_persistence._build_message_entry``).
+_CONVERSATIONAL_ROLES = ("user", "assistant")
+
+DEFAULT_RECENT_TURNS = 5
+
+
+def backfill_content(row: dict[str, Any]) -> str:
+    """The row's text, coerced to ``str``.
+
+    ``append`` does not constrain ``content``, and transcript rows are parsed
+    from JSON, so a non-string can reach either source. One coercion point keeps
+    both call sites honest.
+    """
+    return str(row.get("content") or "")
+
+
+def _is_conversational(row: object) -> bool:
+    """True when *row* is a human-readable message worth replaying.
+
+    Excludes compaction notices, which are ``role == "assistant"`` rows carrying
+    ``meta["kind"] == "compaction"``. Replaying one would read as a real answer
+    and, worse, would count as a turn.
+
+    ``meta`` is checked with ``isinstance`` rather than the ``or {}`` idiom used
+    at ``state.py`` -- ``append``'s ``meta: dict | None`` is not enforced at
+    runtime, so a truthy non-dict would raise ``AttributeError`` on ``.get``.
+    """
+    if not isinstance(row, dict):
+        return False
+    role = row.get("role")
+    if role not in _CONVERSATIONAL_ROLES:
+        return False
+    if not backfill_content(row):
+        return False
+    meta = row.get("meta")
+    if role == "assistant" and isinstance(meta, dict) and meta.get("kind") == "compaction":
+        return False
+    return True
+
+
+def group_turns(rows: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Group already-filtered conversational rows into turns.
+
+    A ``user`` row opens a turn; every following ``assistant`` row joins it. A
+    leading ``assistant`` row with no ``user`` before it (a session that opens
+    with an injected or restored reply) opens a turn of its own rather than being
+    dropped.
+    """
+    turns: list[list[dict[str, Any]]] = []
+    for row in rows:
+        if row.get("role") == "user" or not turns:
+            turns.append([row])
+        else:
+            turns[-1].append(row)
+    return turns
+
+
+def _transcript_prefix(state: Any, slot: Any, disk_older: int) -> list[dict[str, Any]]:
+    """The conversational rows that precede the in-memory window, or ``[]``.
+
+    ``slot.messages`` is a *windowed* view: after a restart it holds at most the
+    last 500 rows, so a long session's opening turn exists only on disk.
+    ``_disk_older_count`` is exactly how many persisted rows fall outside that
+    window, so slicing the transcript to it yields the missing prefix with no
+    risk of re-including a row memory already has.
+
+    Blocking file I/O -- callers MUST offload this via ``asyncio.to_thread``.
+    ``read_messages_chained`` reads and JSON-parses every ``tab_id`` sibling
+    file, and rebuilds a glob-backed index when it is stale, so running it on
+    the event loop would stall every other chat turn.
+    """
+    log = getattr(state, "conversation_log", None)
+    if log is None:
+        return []
+    try:
+        # effective_session_key, never _history_key_for: the latter prepends
+        # "dashboard:" unconditionally, so a channel-born slot would resolve to
+        # the nonexistent "dashboard:slack:<ts>" and read an empty file -- a
+        # silent zero-turn result rather than an error.
+        rows = log.read_messages_chained(effective_session_key(slot))
+    except Exception:
+        logger.debug("backfill: could not read transcript for the first turn", exc_info=True)
+        return []
+    if not rows:
+        return []
+    # read_messages_chained may hand back the SHARED cached list object (and the
+    # row dicts inside it) on a cache hit. Read only -- never mutate either, or
+    # the cache is corrupted for every future reader.
+    return [row for row in rows[:disk_older] if _is_conversational(row)]
+
+
+class BackfillSelection(NamedTuple):
+    """The history a fresh thread is seeded with, split at the gap.
+
+    ``first_turn`` and ``recent`` are kept apart rather than concatenated
+    because the caller has to place the gap marker *between* them, and only the
+    caller knows the destination's markup. ``recent`` stays grouped **by turn**
+    so a caller under a delivery budget can drop whole turns and fold them into
+    ``skipped_turns`` rather than cutting a reply in half.
+    """
+
+    first_turn: list[dict[str, Any]]
+    recent: list[list[dict[str, Any]]]
+    skipped_turns: int
+
+    @property
+    def recent_rows(self) -> list[dict[str, Any]]:
+        """The recent window flattened into posting order."""
+        return [row for turn in self.recent for row in turn]
+
+    @property
+    def messages(self) -> list[dict[str, Any]]:
+        """Every selected row in posting order, gap marker excluded."""
+        return [*self.first_turn, *self.recent_rows]
+
+
+def select_backfill_messages(
+    state: Any,
+    slot: Any,
+    *,
+    recent_turns: int = DEFAULT_RECENT_TURNS,
+    include_first_turn: bool = True,
+) -> BackfillSelection:
+    """Pick the messages a fresh channel thread should be seeded with.
+
+    Returns the opening turn, the last ``recent_turns`` turns (grouped), and how
+    many turns sit between the two ranges. ``skipped_turns`` is 0 when the ranges
+    are contiguous or overlap, which is the caller's signal to omit the gap
+    marker.
+
+    Blocking: reads the transcript when the opening turn is off-window, so
+    callers MUST invoke this through ``asyncio.to_thread`` rather than awaiting
+    it on the event loop. It is kept synchronous precisely so the offload
+    decision belongs to the caller.
+
+    The off-window prefix and the live window are grouped into turns *together*,
+    as one sequence, so the turn count is exact and a turn split across the flush
+    boundary (a question on disk, its answer still in memory) is joined rather
+    than counted twice.
+    """
+    rows = [row for row in slot.messages if _is_conversational(row)]
+    prefix: list[dict[str, Any]] = []
+    if include_first_turn:
+        disk_older = getattr(slot, "_disk_older_count", 0) or 0
+        if disk_older > 0:
+            prefix = _transcript_prefix(state, slot, disk_older)
+
+    turns = group_turns([*prefix, *rows])
+    recent = turns[-recent_turns:] if recent_turns > 0 else []
+
+    first_turn: list[dict[str, Any]] = []
+    skipped = 0
+    if include_first_turn and len(turns) > len(recent):
+        first_turn = list(turns[0])
+        skipped = len(turns) - len(recent) - 1
+
+    return BackfillSelection(first_turn, [list(turn) for turn in recent], max(0, skipped))
+
+
+def gap_summary(skipped: int) -> str:
+    """``"4 earlier turns"`` / ``"1 earlier turn"``.
+
+    Surface-agnostic on purpose: each call site wraps this in its own markup,
+    because Slack's link syntax (``<url|text>``) is not the plain text a
+    Telegram or Discord thread wants.
+    """
+    return f"{skipped} earlier turn{'' if skipped == 1 else 's'}"
+
+
+def session_deep_link(dashboard_url: str, slot_key: str) -> str:
+    """A browser link to *slot_key*'s dashboard tab, or ``""``.
+
+    ``/chat?sid=<key>`` is the shape the SPA reads (``?slot=`` is a legacy
+    alias). Returns ``""`` when no usable origin is configured -- the caller
+    omits the link rather than emitting a broken one. ``dashboard_origin``
+    already yields ``""`` for an empty, malformed, or non-HTTP URL.
+    """
+    if not slot_key:
+        return ""
+    origin = dashboard_origin(dashboard_url or "")
+    if not origin:
+        return ""
+    return f"{origin}/chat?sid={quote(slot_key, safe='')}"

--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -23,15 +23,37 @@ import logging
 
 from aiohttp import web
 
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard.chat_backfill import (
+    backfill_content,
+    gap_summary,
+    select_backfill_messages,
+    session_deep_link,
+)
 from kiro_crew.dashboard.chat_runner import _resolve_channel_target, _resolve_mirror_target
 from kiro_crew.dashboard.chat_slack import list_slack_channels
 from kiro_crew.dashboard.chat_utils import effective_session_key
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.messaging.link import SLACK_NAMESPACE, ChannelLink
-from kiro_crew.security import redact_and_truncate
+from kiro_crew.messaging.renderer import chunk_text
+from kiro_crew.platform.context import redact_via_context
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
+
+# Used only when a transport reports no message-length capability. Matches
+# ``TransportCapabilities.max_message_chars``' own default, which is the
+# smallest common ceiling across the proactive-capable channels (Telegram and
+# WhatsApp cap at 4096).
+_FALLBACK_MAX_MESSAGE_CHARS = 4096
+
+# Ceiling on how many messages the INLINE mirror backfill will deliver. Each unit
+# costs a governance thread-hop plus a transport send, and a rate-limited channel
+# (Telegram is roughly one message per second) makes the request duration a
+# function of the unit count. Twelve covers a normal opening-turn-plus-five-turns
+# preview outright, so the cap only bites on pathologically long history, and it
+# keeps the request inside a browser fetch timeout.
+_MAX_INLINE_BACKFILL_UNITS = 12
 
 
 async def api_channel_targets(request: web.Request) -> web.Response:
@@ -237,35 +259,130 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
             {"error": "failed to create channel link", "code": "channel_link_failed"}, status=502
         )
 
-    for message in slot.messages[-5:]:
-        role = str(message.get("role", "") or "")
-        content = redact_and_truncate(message.get("content") or "", max_chars=2000)
-        if role in ("user", "assistant") and content:
-            speaker = "You" if role == "user" else "Kiro Crew"
-            try:
-                # Historical context is a sequence of separate egress actions.
-                # Stop immediately if policy narrows while the loop is yielding.
-                governed = await asyncio.to_thread(
-                    _resolve_channel_target, state, session_key, link
+    # Build the ordered delivery units BEFORE the loop. Each unit is one Slack-
+    # free chunk of text, and the gap marker is a unit like any other, so every
+    # single thing that crosses the egress boundary gets its own governance
+    # re-check below rather than riding along on a message's decision.
+    #
+    # Offloaded: selection reads the on-disk transcript when the opening turn is
+    # off-window, and that read parses every tab_id sibling file. On the loop
+    # thread it would stall every other chat turn and the liveness heartbeat.
+    selection = await asyncio.to_thread(select_backfill_messages, state, slot)
+    max_chars = (
+        getattr(getattr(live_transport, "capabilities", None), "max_message_chars", 0)
+        or _FALLBACK_MAX_MESSAGE_CHARS
+    )
+
+    def _units_for(row: dict) -> list[str]:
+        # redact_via_context is the canonical egress shim (a loaded companion's
+        # extra credential regexes apply, not just the OSS baseline) and it never
+        # truncates. chunk_text at the transport's own limit matches how a normal
+        # mirrored turn is delivered in _deliver_cross_surface_reply, so a long
+        # message arrives in full instead of being cut at 2,000 chars. No Slack
+        # mrkdwn conversion here: this path targets Telegram/Discord/Teams.
+        speaker = "You" if row.get("role") == "user" else "Kiro Crew"
+        text = redact_via_context(backfill_content(row))
+        return chunk_text(f"{speaker}: {text}", max_chars)
+
+    # Bound the INLINE delivery. Unlike the Slack drain this cannot be
+    # backgrounded -- the per-unit governance re-check below has to be able to
+    # fail the request closed with 403 -- so an unbounded loop would reintroduce
+    # the very defect backgrounding fixed on the Slack side: a rate-limited
+    # transport (Telegram is roughly one message per second) would hold the HTTP
+    # request open past the browser's fetch timeout and the user would see a
+    # failed link that had actually persisted.
+    #
+    # The budget is spent on WHOLE turns in priority order, and every turn it
+    # cannot afford is folded into the gap marker's count. Trimming composed
+    # units instead would cut a reply mid-sentence and could drop the marker
+    # itself -- the one line telling the reader history is missing.
+    recent_turn_units = [
+        [unit for row in turn for unit in _units_for(row)] for turn in selection.recent
+    ]
+    head_units: list[str] = []
+    for row in selection.first_turn:
+        head_units.extend(_units_for(row))
+
+    total_turns = len(recent_turn_units)
+
+    def _fits(keep: int, with_head: bool) -> bool:
+        """Would keeping the newest *keep* turns fit the budget?
+
+        The marker costs a unit only when something is ACTUALLY skipped -- either
+        selection already skipped turns, or this budget drops one. Reserving it
+        unconditionally made a self-fulfilling gap: with six two-message turns
+        every unit fits, but the reservation pushed the oldest turn out and then
+        spent the reserved slot announcing the omission it had just caused.
+        """
+        tail = recent_turn_units[total_turns - keep:] if keep else []
+        dropped = total_turns - keep
+        marker = 1 if (selection.skipped_turns or dropped) else 0
+        head = len(head_units) if with_head else 0
+        return sum(len(u) for u in tail) + marker + head <= _MAX_INLINE_BACKFILL_UNITS
+
+    # Priority order: keep as much recent history as fits WITH the opening turn;
+    # only give the opening turn up if not even the newest turn fits alongside
+    # it; and always keep the newest turn, which is irreducible (shrinking one
+    # turn means cutting a reply mid-sentence), even if it alone overruns.
+    keep_turns, include_head = 0, False
+    if head_units:
+        for candidate in range(total_turns, 0, -1):
+            if _fits(candidate, True):
+                keep_turns, include_head = candidate, True
+                break
+    if not keep_turns:
+        for candidate in range(total_turns, 0, -1):
+            if _fits(candidate, False):
+                keep_turns, include_head = candidate, False
+                break
+    if not keep_turns and total_turns:
+        keep_turns, include_head = 1, False
+
+    kept = recent_turn_units[total_turns - keep_turns:] if keep_turns else []
+    skipped_total = (
+        selection.skipped_turns
+        + (total_turns - keep_turns)
+        + (1 if selection.first_turn and not include_head else 0)
+    )
+
+    units: list[str] = list(head_units) if include_head else []
+    if skipped_total and kept:
+        summary = gap_summary(skipped_total)
+        deep_link = ""
+        try:
+            # Offloaded for the same reason as the transcript read: config load
+            # is blocking file I/O and must not run on the event loop.
+            cfg = await asyncio.to_thread(KiroCrewConfig.load)
+            deep_link = session_deep_link(cfg.dashboard.url, slot.key)
+        except Exception:
+            logger.debug("mirror-link: could not build session link", exc_info=True)
+        units.append(f"… {summary} — {deep_link}" if deep_link else f"… {summary}")
+    for turn_units in kept:
+        units.extend(turn_units)
+
+    for unit in units:
+        try:
+            # Historical context is a sequence of separate egress actions.
+            # Stop immediately if policy narrows while the loop is yielding.
+            governed = await asyncio.to_thread(_resolve_channel_target, state, session_key, link)
+            if governed is None:
+                # Policy narrowed mid-delivery: fail closed. Do NOT fall
+                # through to set_mirror_link (which would persist a link the
+                # latest governance decision denied) and do NOT report
+                # success. The denial is already SEL-audited inside
+                # _resolve_channel_target via vet_and_audit.
+                return web.json_response(
+                    {"error": "channel is not permitted", "code": "channel_not_permitted"},
+                    status=403,
                 )
-                if governed is None:
-                    # Policy narrowed mid-delivery: fail closed. Do NOT fall
-                    # through to set_mirror_link (which would persist a link the
-                    # latest governance decision denied) and do NOT report
-                    # success. The denial is already SEL-audited inside
-                    # _resolve_channel_target via vet_and_audit.
-                    return web.json_response(
-                        {"error": "channel is not permitted", "code": "channel_not_permitted"},
-                        status=403,
-                    )
-                _, live_transport = governed
-                await live_transport.send_message(
-                    conversation_id,
-                    f"{speaker}: {content}",
-                    thread_id=thread_id,
-                )
-            except Exception:
-                logger.debug("mirror-link context delivery failed", exc_info=True)
+            _, live_transport = governed
+            await live_transport.send_message(
+                conversation_id,
+                unit,
+                thread_id=thread_id,
+            )
+        except Exception:
+            logger.debug("mirror-link context delivery failed", exc_info=True)
 
     state.sessions.set_mirror_link(
         session_key,

--- a/src/kiro_crew/dashboard/chat_slack.py
+++ b/src/kiro_crew/dashboard/chat_slack.py
@@ -2,18 +2,34 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import Any
 
 from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard import state as dashboard_state
+from kiro_crew.dashboard.chat_backfill import (
+    backfill_content,
+    gap_summary,
+    select_backfill_messages,
+    session_deep_link,
+)
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import effective_session_key
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, _log_task_exception
+from kiro_crew.platform.context import redact_via_context
 from kiro_crew.security import redact_and_truncate
 from kiro_crew.sel import sel
 from kiro_crew.slack.channel_resolver import _CACHE_FILENAME, ChannelNameResolver
+from kiro_crew.slack.format import (
+    SLACK_MAX_TEXT,
+    SLACK_MSG_LIMIT,
+    split_message,
+    strip_ansi,
+    to_slack_mrkdwn,
+)
 from kiro_crew.sync_bridge import handoff_to_slack
 
 logger = logging.getLogger(__name__)
@@ -48,6 +64,151 @@ def _get_channel_resolver(state: DashboardState) -> ChannelNameResolver:
         cache_path = dashboard_state.config_dir() / _CACHE_FILENAME
         state._channel_resolver = ChannelNameResolver(cache_path=cache_path)
     return state._channel_resolver
+
+
+_USER_ICON = "\U0001f9d1"
+_AGENT_ICON = "\U0001f916"
+
+
+def _format_backfill_parts(content: str) -> list[str]:
+    """Normalise, redact, convert to Slack mrkdwn, redact again, then split.
+
+    ANSI escapes are stripped FIRST, before any redaction. ``to_slack_mrkdwn``
+    strips them itself, and that strip can *reassemble* a credential the escapes
+    had broken up -- so a secret written as ``AKIA<esc>IOSF...`` is invisible to
+    the regex until the strip happens. Normalising up front means the first
+    redaction pass sees the credential whole, while the text is still one piece.
+    Redacting per block after the strip is NOT equivalent: if the split boundary
+    falls inside the credential, each block holds only an unmatchable fragment
+    and two adjacent posts reassemble it for the reader.
+
+    Redaction then runs over the whole normalised text, because
+    ``to_slack_mrkdwn`` self-truncates at ``SLACK_MAX_TEXT`` before converting:
+    converting first would cut a credential at that boundary and leave a prefix
+    the regex no longer matches.
+
+    It runs a second time on each converted block, because conversion can still
+    reorder or drop characters (inline markup, link rewriting) in ways that
+    reveal a secret only afterwards. Redacting on both sides of the transform is
+    what makes the guarantee independent of what conversion does to the bytes.
+
+    The pre-split into blocks below the limit exists for that same truncation
+    reason: converting the whole message and splitting after would silently drop
+    everything past 39,000 characters -- the tail loss the 2,000-char cap used to
+    cause, just further out. Blocks are halved against the limit so a conversion
+    that *grows* text (table and mermaid rewriting) still cannot reach it.
+
+    When -- and only when -- that split actually produces more than one block,
+    tables are left as raw markdown. ``_convert_tables`` keys a table's labels off
+    the first ``|`` row it sees, so a block beginning part-way through a table
+    adopts a DATA row as its header: that row's values are then only ever emitted
+    as labels (and vanish entirely if no data rows follow it, because
+    ``_flush_table`` returns early on an empty body), while every later row is
+    labelled with the wrong names. Raw pipes read worse on mobile than the
+    vertical-list conversion, which is why this is not the default -- but a
+    message that never splits keeps the nicer rendering, and one that does keeps
+    all of its rows.
+    """
+    cleaned = redact_via_context(strip_ansi(content or ""))
+    blocks = split_message(cleaned, limit=SLACK_MAX_TEXT // 2)
+    # A single block IS the whole message, so no table can be straddled.
+    keep_tables = len(blocks) > 1
+    parts: list[str] = []
+    for block in blocks:
+        converted = redact_via_context(to_slack_mrkdwn(block, keep_tables=keep_tables))
+        parts.extend(split_message(converted, limit=SLACK_MSG_LIMIT))
+    return parts
+
+
+async def drain_slack_backfill(
+    state: DashboardState,
+    slot: Any,
+    channel: str,
+    thread_ts: str,
+) -> None:
+    """Seed a freshly linked Slack thread with readable conversation history.
+
+    Posts the opening turn, a gap marker naming how many turns were skipped, then
+    the last few turns in full. Runs as a background task rather than inline in
+    the link request: Slack accepts roughly one message per second per channel,
+    so a long history split across many parts would hold the HTTP request open
+    long enough for the browser fetch to time out while posts kept landing --
+    the user would see a failure on a link that actually worked.
+
+    Backgrounding is safe here specifically because the Slack link path has no
+    per-message governance gate to fail closed on (unlike the configured-channel
+    mirror in ``chat_mirror.py``, which stays inline for that reason).
+    """
+    client = state.slack_client
+    if client is None:
+        return
+    # Offloaded: selection reads the on-disk transcript when the opening turn is
+    # off-window, and read_messages_chained parses every tab_id sibling file (and
+    # globs the sessions dir to rebuild a stale index). On the loop thread that
+    # would stall every other chat turn and the liveness heartbeat.
+    selection = await asyncio.to_thread(select_backfill_messages, state, slot)
+    if not selection.messages:
+        return
+
+    async def _post(text: str) -> bool:
+        try:
+            await client.post_message(channel, text, thread_ts)
+            return True
+        except Exception:
+            # Best-effort: a partially seeded thread is still usable, and the
+            # link itself is already persisted. Never bare-pass -- a silent
+            # swallow here is what made the original failure invisible.
+            logger.debug("slack backfill: post failed", exc_info=True)
+            return False
+
+    for row in selection.first_turn:
+        icon = _USER_ICON if row.get("role") == "user" else _AGENT_ICON
+        for part in _format_backfill_parts(backfill_content(row)):
+            if not await _post(f"{icon} {part}"):
+                return
+
+    if selection.skipped_turns and selection.recent:
+        summary = gap_summary(selection.skipped_turns)
+        link = ""
+        try:
+            # Offloaded: KiroCrewConfig.load() reads and validates the config
+            # file, which is blocking I/O like the transcript read above.
+            cfg = await asyncio.to_thread(KiroCrewConfig.load)
+            link = session_deep_link(cfg.dashboard.url, slot.key)
+        except Exception:
+            logger.debug("slack backfill: could not build session link", exc_info=True)
+        marker = f"_… {summary} — <{link}|open in the dashboard>_" if link else f"_… {summary}_"
+        await _post(marker)
+
+    for row in selection.recent_rows:
+        icon = _USER_ICON if row.get("role") == "user" else _AGENT_ICON
+        for part in _format_backfill_parts(backfill_content(row)):
+            if not await _post(f"{icon} {part}"):
+                return
+
+
+def _spawn_slack_backfill(
+    state: DashboardState,
+    slot: Any,
+    channel: str,
+    thread_ts: str,
+) -> None:
+    """Fire the backfill drain as a tracked background task.
+
+    Uses the established three-callback shape: keep a strong reference so the
+    task is not garbage-collected mid-flight, discard it on completion, and log
+    any exception through ``_log_task_exception`` (which redacts first). Omitting
+    the third callback is a documented defect -- the failure would surface only
+    as an unretrieved-exception warning at interpreter shutdown.
+
+    ``state._background_tasks`` is never cancelled at shutdown, so a gateway stop
+    mid-drain abandons the task and leaves a partially seeded thread. That is
+    accepted: the link is already persisted and the thread is live.
+    """
+    task = asyncio.create_task(drain_slack_backfill(state, slot, channel, thread_ts))
+    state._background_tasks.add(task)
+    task.add_done_callback(state._background_tasks.discard)
+    task.add_done_callback(_log_task_exception)
 
 
 async def api_chat_slot_slack_link(request: web.Request) -> web.Response:
@@ -128,21 +289,11 @@ async def api_chat_slot_slack_link(request: web.Request) -> web.Response:
     # while nothing ever told the open tab it had arrived.
     state.link_slack(slot.key, thread_ts, target_channel)
 
-    # Post last 5 messages as context — only when we created a NEW thread.
-    # Linking to an existing thread (challenge-and-redirect) would duplicate
-    # messages the thread already contains.
+    # Seed the new thread with readable history — only when we created a NEW
+    # thread. Linking to an existing thread (challenge-and-redirect) would
+    # duplicate messages the thread already contains.
     if not existing_thread:
-        for m in slot.messages[-5:]:
-            role = m.get("role", "")
-            txt = redact_and_truncate(m.get("content") or "", max_chars=2000)
-            if role in ("user", "assistant") and txt:
-                icon = "\U0001f9d1" if role == "user" else "\U0001f916"
-                try:
-                    await state.slack_client.post_message(
-                        target_channel, f"{icon} {txt}", thread_ts
-                    )
-                except Exception:
-                    pass
+        _spawn_slack_backfill(state, slot, target_channel, thread_ts)
 
     sel().log_api_access(
         caller="dashboard",

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -306,15 +306,19 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
     (
         "Slack session mirror",
         "dashboard/chat_slack.py",
-        "Thread titles and mirrored message bodies posted to Slack, via "
-        "redact_and_truncate (redaction BEFORE truncation, so a truncation "
-        "boundary cannot split and hide a credential).",
+        "Thread titles and the conversation history seeded into a newly linked "
+        "thread. Titles go through redact_and_truncate (redaction BEFORE "
+        "truncation, so a truncation boundary cannot split and hide a "
+        "credential); history goes through redact_via_context BEFORE mrkdwn "
+        "conversion, because to_slack_mrkdwn self-truncates at 39k and would "
+        "otherwise cut a credential into an unmatchable prefix.",
     ),
     (
         "Configured-channel session mirror",
         "dashboard/chat_mirror.py",
         "Recent dashboard context posted while linking a configured non-Slack "
-        "destination, via redact_and_truncate before transport dispatch.",
+        "destination, via redact_via_context before transport dispatch, then "
+        "chunked to the channel's own message limit rather than truncated.",
     ),
     (
         "Slack Block Kit views",

--- a/src/kiro_crew/slack/format.py
+++ b/src/kiro_crew/slack/format.py
@@ -140,7 +140,7 @@ def build_link_dashboard_button() -> dict:
 
 def to_slack_mrkdwn(text: str, *, keep_tables: bool = False) -> str:
     """Convert LLM markdown to Slack mrkdwn format."""
-    text = _strip_ansi(text)
+    text = strip_ansi(text)
 
     if len(text) > SLACK_MAX_TEXT:
         # rfind returns -1 (no newline in window) or the last newline's index —
@@ -253,7 +253,14 @@ def _convert_tables(text: str) -> str:
     return "\n".join(result)
 
 
-def _strip_ansi(text: str) -> str:
+def strip_ansi(text: str) -> str:
+    """Remove SGR colour escapes.
+
+    Public because redaction call sites need it: this strip can *reassemble* a
+    credential that escape sequences had broken up, so a caller that redacts
+    around a conversion has to normalise with the SAME function first, or the
+    secret slips through the regex and is put back together afterwards.
+    """
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 

--- a/test/test_chat_backfill.py
+++ b/test/test_chat_backfill.py
@@ -1,0 +1,620 @@
+"""Backfill fidelity: what a freshly linked thread is seeded with.
+
+Covers the four defects the old implementation had -- a window sliced before the
+role filter, a window measured in raw rows rather than turns, a 2,000-char drop
+instead of a split, and no mrkdwn conversion -- plus the redaction ordering and
+the off-window first turn.
+
+The drain is a background task in production, so these tests await
+``drain_slack_backfill`` directly rather than sleeping and hoping. One test drives
+the real HTTP endpoint and drains ``state._background_tasks`` to prove the
+handler wiring.
+"""
+
+import asyncio
+import re
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+from test_chat_slack import _make_slack_app
+
+from kiro_crew.dashboard.chat_backfill import select_backfill_messages
+from kiro_crew.dashboard.chat_slack import drain_slack_backfill
+from kiro_crew.slack.format import SLACK_MAX_TEXT, SLACK_MSG_LIMIT
+
+
+def _state(tmp_path):
+    state = _make_state(tmp_path)
+    state.slack_client = MagicMock()
+    state.slack_client.open_dm = AsyncMock(return_value="D123")
+    state.slack_client.post_message = AsyncMock(return_value="newts")
+    state.owner_id = "U123"
+    state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+    state.sessions.set_slack_link = MagicMock()
+    state.push_slots_update = MagicMock()
+    return state
+
+
+def _seed(slot, rows):
+    """Seed via the production append/drain path, not raw list surgery."""
+    for role, content in rows:
+        slot.append(role, content)
+    slot.drain()
+
+
+def _posted(state):
+    """Every text posted to Slack, in order."""
+    return [call.args[1] for call in state.slack_client.post_message.await_args_list]
+
+
+async def _drain(state, slot):
+    await drain_slack_backfill(state, slot, "C1", "1700.1")
+    return _posted(state)
+
+
+class TestBackfillSelection:
+    """Turn selection — the unit is a turn, and the filter precedes the slice."""
+
+    @pytest.mark.asyncio
+    async def test_filter_runs_before_slice(self, tmp_path):
+        """A tail of tool rows must not consume the window.
+
+        This is the regression that motivated the change: the old code took
+        ``slot.messages[-5:]`` and only then dropped non-conversational roles, so
+        three trailing tool rows left three empty slots and five would have
+        seeded nothing at all.
+        """
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(
+            slot,
+            [
+                ("user", "why is the build red"),
+                ("assistant", "a lint rule changed"),
+                ("tool", "grep ..."),
+                ("tool", "cat ..."),
+                ("tool", "pytest ..."),
+            ],
+        )
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert "why is the build red" in body
+        assert "a lint rule changed" in body
+        assert not any("grep" in text or "pytest" in text for text in posted)
+
+    @pytest.mark.asyncio
+    async def test_five_consecutive_tool_rows_still_seed_the_turn(self, tmp_path):
+        """The pathological case: the whole raw tail is non-conversational."""
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(
+            slot,
+            [("user", "run it"), ("assistant", "done")] + [("tool", f"step {i}") for i in range(5)],
+        )
+        posted = await _drain(state, slot)
+        assert any("run it" in text for text in posted)
+        assert any("done" in text for text in posted)
+
+    @pytest.mark.asyncio
+    async def test_first_turn_plus_last_five_turns_with_gap_marker(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        rows = []
+        for i in range(1, 11):
+            rows.append(("user", f"question {i}"))
+            rows.append(("assistant", f"answer {i}"))
+        _seed(slot, rows)
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+
+        assert "question 1" in body and "answer 1" in body
+        for i in range(6, 11):
+            assert f"question {i}" in body, f"turn {i} missing"
+            assert f"answer {i}" in body
+        for i in range(2, 6):
+            assert f"question {i}" not in body, f"turn {i} should be skipped"
+
+        markers = [text for text in posted if "earlier turn" in text]
+        assert len(markers) == 1, f"expected exactly one gap marker, got {markers}"
+        assert "4 earlier turns" in markers[0]
+
+    @pytest.mark.asyncio
+    async def test_gap_marker_sits_between_first_turn_and_recent_window(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        rows = []
+        for i in range(1, 11):
+            rows.append(("user", f"question {i}"))
+            rows.append(("assistant", f"answer {i}"))
+        _seed(slot, rows)
+
+        posted = await _drain(state, slot)
+        marker_at = next(i for i, text in enumerate(posted) if "earlier turn" in text)
+        first_at = next(i for i, text in enumerate(posted) if "question 1" in text)
+        recent_at = next(i for i, text in enumerate(posted) if "question 6" in text)
+        assert first_at < marker_at < recent_at
+
+    @pytest.mark.asyncio
+    async def test_overlap_posts_contiguously_without_duplicating(self, tmp_path):
+        """Three turns fit inside the recent window: no marker, no repeat."""
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(
+            slot,
+            [
+                ("user", "alpha"),
+                ("assistant", "alpha reply"),
+                ("user", "beta"),
+                ("assistant", "beta reply"),
+                ("user", "gamma"),
+                ("assistant", "gamma reply"),
+            ],
+        )
+        posted = await _drain(state, slot)
+        assert not any("earlier turn" in text for text in posted)
+        assert sum(1 for text in posted if "alpha" in text and "reply" not in text) == 1
+
+    @pytest.mark.asyncio
+    async def test_six_turns_is_contiguous_with_no_marker(self, tmp_path):
+        """Boundary: turn 1 is outside the 5-turn window but nothing is skipped."""
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        rows = []
+        for i in range(1, 7):
+            rows.append(("user", f"q{i}"))
+            rows.append(("assistant", f"a{i}"))
+        _seed(slot, rows)
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert not any("earlier turn" in text for text in posted)
+        for i in range(1, 7):
+            assert f"q{i}" in body
+        assert sum(1 for text in posted if "q1" in text) == 1
+
+    @pytest.mark.asyncio
+    async def test_compaction_rows_are_neither_posted_nor_counted(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "real question")
+        slot.append("assistant", "real answer")
+        slot.append("assistant", "context compacted", meta={"kind": "compaction"})
+        slot.drain()
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert "real question" in body and "real answer" in body
+        assert "context compacted" not in body
+
+    @pytest.mark.asyncio
+    async def test_non_dict_meta_does_not_crash_selection(self, tmp_path):
+        """``append``'s ``meta: dict | None`` is not enforced at runtime."""
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(slot, [("user", "hi"), ("assistant", "hello")])
+        slot.messages.append({"role": "assistant", "content": "odd", "meta": "not-a-dict"})
+
+        selection = select_backfill_messages(state, slot)
+        assert [row["content"] for row in selection.messages] == ["hi", "hello", "odd"]
+
+    @pytest.mark.asyncio
+    async def test_empty_slot_posts_nothing(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        posted = await _drain(state, slot)
+        assert posted == []
+
+
+class TestBackfillFormatting:
+    """Redact, convert, split — in that order, with nothing dropped."""
+
+    @pytest.mark.asyncio
+    async def test_long_message_is_split_not_truncated(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        long_answer = "\n".join(f"line {i} " + "x" * 80 for i in range(120))
+        assert len(long_answer) > 9000
+        _seed(slot, [("user", "explain"), ("assistant", long_answer)])
+
+        posted = await _drain(state, slot)
+        answer_parts = [text for text in posted if "line 0 " in text or "line 119 " in text]
+        assert len(posted) >= 3, f"expected the answer to span parts, got {len(posted)}"
+        assert all(len(text) <= SLACK_MSG_LIMIT for text in posted)
+        # Every line survives somewhere — the old 2,000-char cap dropped the rest.
+        body = "\n".join(posted)
+        for i in (0, 60, 119):
+            assert f"line {i} " in body, f"line {i} lost"
+        assert answer_parts
+
+    @pytest.mark.asyncio
+    async def test_markdown_is_converted_to_slack_mrkdwn(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(slot, [("user", "doc it"), ("assistant", "## Heading\n\n**bold** text")])
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert "## Heading" not in body, "literal markdown heading leaked"
+        assert "*Heading*" in body
+        assert "**bold**" not in body
+        assert "*bold*" in body
+
+    @pytest.mark.asyncio
+    async def test_credentials_are_redacted(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        _seed(slot, [("user", "here are creds"), ("assistant", f"key is {secret}")])
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert secret not in body, "credential reached Slack unredacted"
+
+    @pytest.mark.asyncio
+    async def test_table_straddling_a_split_keeps_every_row(self, tmp_path):
+        """A split must not let a data row become the table's header.
+
+        ``_convert_tables`` labels a table from the first ``|`` row it sees, so a
+        block starting part-way through one adopts a DATA row as its header. That
+        row's values then only ever appear as labels — and disappear completely if
+        no data rows follow — while later rows get the wrong labels. Tables are
+        therefore left raw whenever the pre-split produced more than one block.
+        """
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        rows = [f"| r{i:04d} | v{i:04d} |" for i in range(1400)]
+        table = "| name | value |\n| --- | --- |\n" + "\n".join(rows)
+        assert len(table) > SLACK_MAX_TEXT // 2, "table must be big enough to split"
+        _seed(slot, [("user", "show the table"), ("assistant", table)])
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert all(len(text) <= SLACK_MSG_LIMIT for text in posted)
+        # Every emitted label must come from the REAL header row. A data row
+        # adopted as the header shows up as a label like "*r1080:*" — checking the
+        # label SET rather than one hardcoded token means the assertion holds
+        # wherever the split happens to land.
+        labels = set(re.findall(r"\*([^*:\n]+):\*", body))
+        assert labels <= {"name", "value"}, f"data row adopted as header: {labels}"
+        for i in (0, 700, 1399):
+            assert f"r{i:04d}" in body, f"row {i} lost"
+            assert f"v{i:04d}" in body, f"row {i} value lost"
+
+    @pytest.mark.asyncio
+    async def test_small_table_still_converts_for_readability(self, tmp_path):
+        """The raw-pipe fallback must not apply to messages that never split."""
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        table = "| name | value |\n| --- | --- |\n| alpha | 1 |\n| beta | 2 |"
+        _seed(slot, [("user", "show it"), ("assistant", table)])
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert "*name:*" in body, "small table lost its vertical-list conversion"
+        assert "alpha" in body and "beta" in body
+
+    @pytest.mark.asyncio
+    async def test_message_past_the_mrkdwn_limit_keeps_its_tail(self, tmp_path):
+        """Splitting must happen around ``to_slack_mrkdwn``, not after it.
+
+        ``to_slack_mrkdwn`` self-truncates at ``SLACK_MAX_TEXT``, so converting
+        the whole message and splitting the result silently drops everything past
+        39,000 characters — the same tail loss as the 2,000-char cap this
+        replaces, just further out. The text is pre-split below the limit so no
+        block ever reaches that internal truncation.
+        """
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        # Distinct markers spread across ~60k chars so a lost tail is provable.
+        answer = "\n".join(f"marker{i:05d} " + "z" * 40 for i in range(1400))
+        assert len(answer) > SLACK_MAX_TEXT * 1.4
+        _seed(slot, [("user", "dump it"), ("assistant", answer)])
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert all(len(text) <= SLACK_MSG_LIMIT for text in posted)
+        for i in (0, 700, 1399):
+            assert f"marker{i:05d}" in body, f"marker {i} lost — the tail was truncated"
+        assert "truncated (" not in body, "to_slack_mrkdwn's own truncation notice leaked"
+
+    @pytest.mark.asyncio
+    async def test_ansi_credential_straddling_a_split_boundary_is_redacted(self, tmp_path):
+        """The hard case: obfuscated AND cut across two posts.
+
+        If ANSI is only stripped per block (inside ``to_slack_mrkdwn``), a
+        credential broken by an escape and cut by the pre-split leaves each block
+        holding an unmatchable fragment. Both blocks redact clean individually,
+        and the two adjacent posts hand the reader the whole key. Normalising the
+        escapes before the FIRST redaction — while the text is still one piece —
+        is what closes it.
+
+        The preconditions below are asserted rather than assumed: an earlier
+        version of this test put the cut inside the filler instead of inside the
+        credential, so the second redaction pass caught it and the test passed
+        even with the fix removed.
+        """
+        from kiro_crew.slack.format import CONTINUATION
+
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        split_secret = secret[:6] + "\x1b[0m" + secret[6:]
+
+        # split_message reserves room for CONTINUATION and, with no newline to
+        # snap to, cuts exactly there.
+        boundary = SLACK_MAX_TEXT // 2
+        cut = boundary - len(CONTINUATION)
+        filler = "q" * (cut - 12)
+        content = filler + split_secret + ("z" * 200)
+
+        assert len(content) > boundary, "no split would happen at all"
+        assert len(filler) < cut < len(filler) + len(split_secret), (
+            "the credential must straddle the cut for this test to mean anything"
+        )
+        _seed(slot, [("user", "paste"), ("assistant", content)])
+
+        posted = await _drain(state, slot)
+        body = "".join(posted)
+        assert secret not in body, "credential reassembled across the split boundary"
+        assert secret[:8] not in body, "a credential fragment reached Slack"
+
+    @pytest.mark.asyncio
+    async def test_conversion_cannot_reassemble_a_credential(self, tmp_path):
+        """Redaction must run on BOTH sides of the mrkdwn transform.
+
+        ``to_slack_mrkdwn`` strips ANSI escapes before converting. A credential
+        broken up by an escape sequence therefore does not match the regex on the
+        way in, and would be reassembled *intact* by the strip — arriving at
+        Slack complete. Redacting the converted text closes that path.
+        """
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        # An ANSI reset dropped into the middle of the key: invisible to the
+        # credential regex, removed entirely by _strip_ansi.
+        split_secret = secret[:4] + "\x1b[0m" + secret[4:]
+        _seed(slot, [("user", "paste"), ("assistant", f"key is {split_secret}")])
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert secret not in body, "conversion reassembled the credential"
+
+    @pytest.mark.asyncio
+    async def test_credential_straddling_the_mrkdwn_boundary_is_redacted(self, tmp_path):
+        """Ordering guard: redaction must precede ``to_slack_mrkdwn``.
+
+        ``to_slack_mrkdwn`` self-truncates at ``SLACK_MAX_TEXT`` (39,000) before
+        it converts anything. Converting first would therefore hand the redactor
+        a credential that has already been cut in half, leaving a prefix no
+        regex matches -- a partial secret on the wire.
+
+        The padding is deliberately newline-free so ``rfind("\\n")`` returns -1
+        and the cut lands exactly on 39,000, and the secret starts 10 chars
+        before it, so convert-first leaves precisely its first 10 characters
+        behind. A secret placed entirely past the boundary would simply be
+        deleted, which is why the obvious version of this test proves nothing.
+        """
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        filler = "x" * (SLACK_MAX_TEXT - 10)
+        content = filler + secret
+        assert len(content) > SLACK_MAX_TEXT
+        assert "\n" not in filler
+        _seed(slot, [("user", "dump"), ("assistant", content)])
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert secret not in body
+        assert secret[:8] not in body, "a truncated credential prefix reached Slack"
+
+    @pytest.mark.asyncio
+    async def test_roles_are_labelled_distinctly(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(slot, [("user", "ping"), ("assistant", "pong")])
+
+        posted = await _drain(state, slot)
+        user_post = next(text for text in posted if "ping" in text)
+        agent_post = next(text for text in posted if "pong" in text)
+        assert user_post[0] != agent_post[0], "user and agent posts share an icon"
+
+
+class TestBackfillOffWindowFirstTurn:
+    """The opening turn can live only on disk."""
+
+    @pytest.mark.asyncio
+    async def test_first_turn_read_from_transcript(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        key = "dashboard:s1"
+        # Older turns exist only in the transcript, as they would after a
+        # restart trimmed the in-memory window.
+        state.conversation_log.append(key, "user", "the original question")
+        state.conversation_log.append(key, "assistant", "the original answer")
+        for i in range(2, 9):
+            state.conversation_log.append(key, "user", f"disk q{i}")
+            state.conversation_log.append(key, "assistant", f"disk a{i}")
+        _seed(slot, [("user", "recent q"), ("assistant", "recent a")])
+        slot._disk_older_count = 16
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert "the original question" in body, "first turn not recovered from disk"
+        assert "the original answer" in body
+        assert "recent q" in body and "recent a" in body
+        assert any("earlier turn" in text for text in posted)
+
+    @pytest.mark.asyncio
+    async def test_gap_count_is_exact_across_the_flush_boundary(self, tmp_path):
+        """Prefix and live window are grouped as ONE sequence.
+
+        The transcript can lag the live window, so counting turns separately on
+        each side undercounts the gap and can split one turn in two. Slicing the
+        transcript to ``_disk_older_count`` — exactly the rows the window does
+        not hold — and grouping the concatenation fixes both.
+        """
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        key = "dashboard:s1"
+        # 8 turns on disk; the 8th turn's ANSWER is still only in memory.
+        rows_on_disk = 0
+        for i in range(1, 9):
+            state.conversation_log.append(key, "user", f"q{i}")
+            rows_on_disk += 1
+            if i < 8:
+                state.conversation_log.append(key, "assistant", f"a{i}")
+                rows_on_disk += 1
+        _seed(slot, [("assistant", "a8"), ("user", "q9"), ("assistant", "a9")])
+        slot._disk_older_count = rows_on_disk
+
+        selection = select_backfill_messages(state, slot)
+        # 9 turns total, 5 recent (turns 5-9), turn 1 first, so 3 skipped (2-4).
+        assert [r["content"] for r in selection.first_turn] == ["q1", "a1"]
+        assert selection.skipped_turns == 3
+        # a8 came from memory but belongs to q8's turn, not its own.
+        turn_openers = [turn[0]["content"] for turn in selection.recent]
+        assert turn_openers == ["q5", "q6", "q7", "q8", "q9"]
+        assert [r["content"] for r in selection.recent[3]] == ["q8", "a8"]
+
+    @pytest.mark.asyncio
+    async def test_transcript_not_consulted_when_window_is_complete(self, tmp_path):
+        """``_disk_older_count == 0`` means memory already holds turn 1."""
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        state.conversation_log.read_messages_chained = MagicMock(
+            side_effect=AssertionError("transcript must not be read")
+        )
+        _seed(slot, [("user", "only q"), ("assistant", "only a")])
+        assert slot._disk_older_count == 0
+
+        posted = await _drain(state, slot)
+        assert any("only q" in text for text in posted)
+
+    @pytest.mark.asyncio
+    async def test_transcript_read_failure_degrades_to_memory(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        state.conversation_log.read_messages_chained = MagicMock(
+            side_effect=OSError("disk gone")
+        )
+        rows = []
+        for i in range(1, 8):
+            rows.append(("user", f"q{i}"))
+            rows.append(("assistant", f"a{i}"))
+        _seed(slot, rows)
+        slot._disk_older_count = 4
+
+        posted = await _drain(state, slot)
+        body = "\n".join(posted)
+        assert "q7" in body, "recent window lost when the transcript failed"
+        assert "q1" in body, "fell back to memory for the first turn"
+
+    @pytest.mark.asyncio
+    async def test_shared_transcript_cache_is_not_mutated(self, tmp_path):
+        """``read_messages_chained`` may hand back the shared cached list."""
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        key = "dashboard:s1"
+        for i in range(1, 9):
+            state.conversation_log.append(key, "user", f"q{i}")
+            state.conversation_log.append(key, "assistant", f"a{i}")
+        cached = state.conversation_log.read_messages_chained(key)
+        before = list(cached)
+        _seed(slot, [("user", "recent q"), ("assistant", "recent a")])
+        slot._disk_older_count = 16
+
+        await _drain(state, slot)
+        assert state.conversation_log.read_messages_chained(key) == before
+
+
+class TestBackfillHandlerWiring:
+    """The endpoint must background the drain and honour the existing-thread guard."""
+
+    @pytest.mark.asyncio
+    async def test_link_backgrounds_the_drain_and_seeds_the_thread(self, tmp_path, monkeypatch):
+        """The response must not wait on the backfill.
+
+        Slack accepts about one message per second per channel, so a long
+        history held the request open long enough for the browser fetch to time
+        out. The drain is blocked here on an event so the test can prove the
+        handler returned with the seeding still in flight, rather than racing a
+        drain that happens to finish instantly against AsyncMock.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(slot, [("user", "seed me"), ("assistant", "seeded")])
+
+        release = asyncio.Event()
+        sent: list[str] = []
+
+        async def _post(channel, text, thread_ts=None):
+            # Record AFTER the gate so `sent` holds only COMPLETED posts: the
+            # drain is allowed to start during the handler's remaining awaits,
+            # but it must not have finished seeding when the response goes out.
+            if thread_ts is not None:  # the anchor has no thread_ts; backfill does
+                await release.wait()
+            sent.append(text)
+            return "newts"
+
+        state.slack_client.post_message = AsyncMock(side_effect=_post)
+
+        async with TestClient(TestServer(_make_slack_app(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/slack-link", json={})
+            assert resp.status == 200
+
+        assert sent, "anchor was never posted"
+        assert "Session linked from dashboard" in sent[0], "anchor must be posted first"
+        # sent[0] is the anchor, whose title legitimately quotes the first user
+        # prompt — so only the posts AFTER it can evidence a completed backfill.
+        assert sent[1:] == [], (
+            "the request waited for the backfill instead of backgrounding it"
+        )
+
+        pending = [t for t in state._background_tasks if not t.done()]
+        assert pending, "link did not register a background drain"
+        release.set()
+        await asyncio.gather(*pending)
+
+        body = "\n".join(sent[1:])
+        assert "seed me" in body and "seeded" in body
+
+    @pytest.mark.asyncio
+    async def test_existing_thread_link_seeds_nothing(self, tmp_path, monkeypatch):
+        """Challenge-and-redirect: the thread already holds this history."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(slot, [("user", "hello"), ("assistant", "hi there")])
+
+        async with TestClient(TestServer(_make_slack_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/slack-link",
+                json={"channel": "C999", "thread_ts": "1700.42"},
+            )
+            assert resp.status == 200
+        for task in [t for t in state._background_tasks if not t.done()]:
+            await task
+        assert state.slack_client.post_message.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_post_failure_aborts_without_raising(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(slot, [("user", "one"), ("assistant", "two")])
+        state.slack_client.post_message = AsyncMock(side_effect=RuntimeError("slack down"))
+
+        await drain_slack_backfill(state, slot, "C1", "1700.1")
+
+    @pytest.mark.asyncio
+    async def test_no_slack_client_is_a_noop(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        _seed(slot, [("user", "one"), ("assistant", "two")])
+        state.slack_client = None
+
+        await drain_slack_backfill(state, slot, "C1", "1700.1")

--- a/test/test_chat_mirror.py
+++ b/test/test_chat_mirror.py
@@ -29,10 +29,16 @@ def _make_mirror_app(state):
     return app
 
 
-def _fake_transport(channel_type="telegram", proactive=True):
+def _fake_transport(channel_type="telegram", proactive=True, max_message_chars=4096):
     return SimpleNamespace(
         channel_type=channel_type,
-        capabilities=SimpleNamespace(supports_proactive_send=proactive),
+        capabilities=SimpleNamespace(
+            supports_proactive_send=proactive,
+            # The real TransportCapabilities always carries this; the mirror
+            # backfill chunks to it instead of truncating, so the fake needs it
+            # to exercise that path rather than the getattr fallback.
+            max_message_chars=max_message_chars,
+        ),
         send_message=AsyncMock(return_value="mid-1"),
         configured_targets=MagicMock(
             return_value=[ConfiguredChannelTarget("user:123", f"{channel_type.title()} DM · 123")]
@@ -113,19 +119,32 @@ class TestMirrorLink:
 
     @pytest.mark.asyncio
     async def test_governance_narrowing_mid_delivery_fails_closed(self, tmp_path, monkeypatch):
-        # Permit the initial link + first send, then deny once the historical
-        # context-delivery loop starts. The endpoint must fail closed: return
-        # 403 and NOT persist the mirror link (regression for a denial that
-        # only broke the loop and still persisted + returned 200).
-        calls = {"n": 0}
+        # Permit the initial link + the announcement, then deny once the
+        # historical context-delivery loop starts. The endpoint must fail closed:
+        # return 403 and NOT persist the mirror link (regression for a denial
+        # that only broke the loop and still persisted + returned 200).
+        transport = _fake_transport("telegram")
 
         def _permits(*args, **kwargs):
-            calls["n"] += 1
-            return SimpleNamespace(permitted=calls["n"] < 3, rule="", layer="", reason="")
+            # A PREDICATE, not a call counter. The old version denied on the
+            # third governance consult, which silently depended on exactly two
+            # consults happening before the loop — change how many messages the
+            # backfill selects, or add a pre-loop check, and the denial lands on
+            # a pre-loop gate while every assertion below still passes, so the
+            # test stops guarding the path it was written for.
+            #
+            # Keying on "has the transport already delivered?" pins the denial
+            # to the first in-loop unit regardless of selection size: the
+            # announcement is the only send before the loop.
+            return SimpleNamespace(
+                permitted=not transport.send_message.await_args_list,
+                rule="",
+                layer="",
+                reason="",
+            )
 
         monkeypatch.setattr("kiro_crew.platform.governance_profiles.governance_permits", _permits)
         state = _prep(tmp_path, monkeypatch)
-        transport = _fake_transport("telegram")
         state.register_channel_transport(transport)
         state.sessions.set_mirror_link = MagicMock()
         # Give the slot history so the context-delivery loop iterates.
@@ -145,6 +164,12 @@ class TestMirrorLink:
             assert resp.status == 403
             assert (await resp.json())["error"] == "channel is not permitted"
 
+        # Non-vacuity: the announcement is sent only AFTER its own governance
+        # check passes, so having sent it proves the denial came later than that
+        # check — i.e. inside the context-delivery loop, which is the path under
+        # test. Without this, a denial at the very first gate would produce the
+        # same 403 and the same unpersisted link.
+        assert transport.send_message.await_count >= 1
         state.sessions.set_mirror_link.assert_not_called()
         state = _prep(tmp_path, monkeypatch)
         async with TestClient(TestServer(_make_mirror_app(state))) as client:
@@ -401,3 +426,246 @@ class TestMirrorReminder:
             assert (await resp.json())["error"] == "channel_type required"
 
         transport.send_message.assert_not_awaited()
+
+
+class TestMirrorBackfillFidelity:
+    """The non-Slack mirror seeds the same turn-aware history, chunked not cut.
+
+    Deliberately asymmetric with the Slack path: this delivery stays INLINE
+    because its per-message governance re-check has to be able to fail the
+    request closed with 403, which a backgrounded drain could not do after the
+    handler had already returned 200 and persisted the link.
+    """
+
+    # A LITERAL ceiling, deliberately NOT chat_mirror._MAX_INLINE_BACKFILL_UNITS:
+    # asserting against the module constant would move with it, so raising the
+    # cap — or deleting it — would still pass. This leaves headroom for a
+    # deliberate tuning change while still failing an unbounded loop.
+    _BOUND_CEILING = 16
+
+    def _linked(self, tmp_path, monkeypatch, max_message_chars=4096):
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram", max_message_chars=max_message_chars)
+        state.register_channel_transport(transport)
+        state.sessions.set_mirror_link = MagicMock()
+        return state, transport
+
+    async def _link(self, state):
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+
+    def _sent(self, transport):
+        """Delivered bodies, excluding the link announcement."""
+        texts = [call.args[1] for call in transport.send_message.await_args_list]
+        return [t for t in texts if "Session linked from dashboard" not in t]
+
+    @pytest.mark.asyncio
+    async def test_filter_runs_before_slice(self, tmp_path, monkeypatch):
+        state, transport = self._linked(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        for role, content in [
+            ("user", "why is the build red"),
+            ("assistant", "a lint rule changed"),
+            ("tool", "grep ..."),
+            ("tool", "cat ..."),
+            ("tool", "pytest ..."),
+        ]:
+            slot.append(role, content)
+        slot.drain()
+
+        await self._link(state)
+        body = "\n".join(self._sent(transport))
+        assert "why is the build red" in body
+        assert "a lint rule changed" in body
+        assert "grep" not in body and "pytest" not in body
+
+    @pytest.mark.asyncio
+    async def test_long_message_is_chunked_not_truncated(self, tmp_path, monkeypatch):
+        state, transport = self._linked(tmp_path, monkeypatch, max_message_chars=500)
+        slot = state.get_or_create_slot("s1")
+        long_answer = "".join(f"[{i:04d}]" for i in range(600))  # 3600 chars
+        slot.append("user", "explain")
+        slot.append("assistant", long_answer)
+        slot.drain()
+
+        await self._link(state)
+        sent = self._sent(transport)
+        assert all(len(text) <= 500 for text in sent), "a chunk exceeded the transport limit"
+        body = "".join(sent)
+        for i in (0, 300, 599):
+            assert f"[{i:04d}]" in body, f"marker {i} lost — content was truncated"
+
+    @pytest.mark.asyncio
+    async def test_first_turn_and_gap_marker(self, tmp_path, monkeypatch):
+        state, transport = self._linked(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        for i in range(1, 11):
+            slot.append("user", f"question {i}")
+            slot.append("assistant", f"answer {i}")
+        slot.drain()
+
+        await self._link(state)
+        sent = self._sent(transport)
+        body = "\n".join(sent)
+        assert "question 1" in body
+        assert "question 10" in body
+        assert "question 3" not in body
+        markers = [t for t in sent if "earlier turn" in t]
+        assert len(markers) == 1
+        # Slack would report 4 skipped (10 turns, 5 recent). The inline path is
+        # additionally under a delivery budget, so the oldest recent turn is
+        # folded into the marker instead of being sent -- 5, not 4. That fold is
+        # the point of the budget: the marker absorbs the overflow.
+        assert "5 earlier turns" in markers[0]
+
+    @pytest.mark.asyncio
+    async def test_history_that_fits_exactly_is_not_trimmed(self, tmp_path, monkeypatch):
+        """No gap marker when there is no gap.
+
+        Six two-message turns is exactly the 12-unit budget. An earlier version
+        reserved the marker's slot unconditionally, so the reservation pushed the
+        oldest turn out and then spent that slot announcing the omission it had
+        itself caused — a false gap on history that fit.
+        """
+        state, transport = self._linked(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        for i in range(1, 7):
+            slot.append("user", f"q{i}")
+            slot.append("assistant", f"a{i}")
+        slot.drain()
+
+        await self._link(state)
+        sent = self._sent(transport)
+        body = "\n".join(sent)
+        assert not any("earlier turn" in t for t in sent), f"false gap marker: {sent}"
+        for i in range(1, 7):
+            assert f"q{i}" in body, f"turn {i} was trimmed even though it fit"
+        assert len(sent) == 12, f"expected all 12 units, got {len(sent)}"
+
+    @pytest.mark.asyncio
+    async def test_inline_delivery_is_bounded(self, tmp_path, monkeypatch):
+        """The request cannot grow without limit just because history did.
+
+        This path is inline (its governance re-check must be able to 403), so
+        every extra unit is another governance hop plus a send on a channel that
+        may accept ~1 msg/s. Long history must not push the request past a
+        browser fetch timeout.
+        """
+
+        state, transport = self._linked(tmp_path, monkeypatch, max_message_chars=200)
+        slot = state.get_or_create_slot("s1")
+        for i in range(1, 9):
+            slot.append("user", f"question {i}")
+            slot.append("assistant", f"answer {i} " + "y" * 900)  # ~5 units each
+        slot.drain()
+
+        await self._link(state)
+        sent = self._sent(transport)
+        assert len(sent) <= self._BOUND_CEILING, (
+            f"inline delivery sent {len(sent)} units, over the budget"
+        )
+        # Priority order: the newest turn is irreducible, then the marker, then
+        # the opening turn, then older turns. Here each turn costs ~6 units, so
+        # the opening turn cannot be afforded and is folded into the count.
+        body = "\n".join(sent)
+        assert "question 8" in body, "newest turn was trimmed away"
+        assert any("earlier turn" in t for t in sent), "trim happened with no marker"
+
+    @pytest.mark.asyncio
+    async def test_delivery_scales_with_the_budget_not_with_history(
+        self, tmp_path, monkeypatch
+    ):
+        """Ten times the history must not mean ten times the request duration."""
+
+        counts = []
+        for turn_count in (8, 80):
+            state, transport = self._linked(tmp_path, monkeypatch)
+            slot = state.get_or_create_slot("s1")
+            for i in range(1, turn_count + 1):
+                slot.append("user", f"q{i}")
+                slot.append("assistant", f"a{i}")
+            slot.drain()
+            await self._link(state)
+            counts.append(len(self._sent(transport)))
+
+        assert all(c <= self._BOUND_CEILING for c in counts), counts
+        assert counts[0] == counts[1], (
+            f"unit count tracked history length ({counts}) instead of the budget"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_slack_mrkdwn_conversion_on_a_non_slack_channel(self, tmp_path, monkeypatch):
+        """Telegram is not Slack: markdown must pass through unconverted."""
+        state, transport = self._linked(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "doc it")
+        slot.append("assistant", "## Heading\n\n**bold** text")
+        slot.drain()
+
+        await self._link(state)
+        body = "\n".join(self._sent(transport))
+        assert "## Heading" in body
+        assert "**bold**" in body
+
+    @pytest.mark.asyncio
+    async def test_credentials_are_redacted(self, tmp_path, monkeypatch):
+        state, transport = self._linked(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        slot.append("user", "creds")
+        slot.append("assistant", f"key is {secret}")
+        slot.drain()
+
+        await self._link(state)
+        body = "\n".join(self._sent(transport))
+        assert secret not in body
+
+    @pytest.mark.asyncio
+    async def test_compaction_rows_are_excluded(self, tmp_path, monkeypatch):
+        state, transport = self._linked(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "real question")
+        slot.append("assistant", "real answer")
+        slot.append("assistant", "context compacted", meta={"kind": "compaction"})
+        slot.drain()
+
+        await self._link(state)
+        body = "\n".join(self._sent(transport))
+        assert "real question" in body and "real answer" in body
+        assert "context compacted" not in body
+
+    @pytest.mark.asyncio
+    async def test_delivery_stays_inline_so_the_link_persists_after_seeding(
+        self, tmp_path, monkeypatch
+    ):
+        """The 200 must not be returned before the seeding is delivered.
+
+        This is the property that forbids backgrounding this path: the mirror
+        link is persisted only after every unit has cleared governance.
+        """
+        state, transport = self._linked(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "one")
+        slot.append("assistant", "two")
+        slot.drain()
+
+        order: list[str] = []
+        original_send = transport.send_message
+
+        async def _tracked_send(*args, **kwargs):
+            order.append("send")
+            return await original_send(*args, **kwargs)
+
+        transport.send_message = _tracked_send
+        state.sessions.set_mirror_link = MagicMock(side_effect=lambda *a, **k: order.append("persist"))
+
+        await self._link(state)
+        assert "persist" in order, "link was never persisted"
+        assert order.index("persist") == len(order) - 1, (
+            "the link was persisted before delivery finished"
+        )
+        assert order.count("send") >= 3, "announcement + both messages should have been sent"


### PR DESCRIPTION
## Problem

Linking a dashboard session to Slack ("Send to Slack") or to a configured
non-Slack channel seeds the new thread with a preview of the conversation so a
human arriving there can orient. The preview was close to useless: linking a real
17-entry session posted **3 messages, two of them cut in half, with markdown
rendered as literal source**.

Four independent defects, each present twice — once on the Slack path and once on
the generic mirror path:

| # | Defect | Effect |
|---|--------|--------|
| 1 | The window was sliced **before** the role filter | `tool` / `chunk` / `thinking` rows consumed preview slots and were then discarded. The observed session tail was `[tool, assistant, user, tool, assistant]`, so two of five slots were wasted → 3 posts. **Five consecutive tool calls seeded nothing at all.** |
| 2 | The window was 5 raw **entries**, not 5 turns | A single long turn could fill the whole preview |
| 3 | The 2000-char cap **dropped** the remainder | Half the codebase's own safe limit (`SLACK_MSG_LIMIT = 3900`), and a drop rather than a split |
| 4 | No conversion / no chunking | Slack got literal `##` and `**bold**`; the mirror path truncated instead of chunking at the transport's own limit |

The agent's context was never affected — the thread is bound to the same session
and the model retains the full conversation. Only the human-visible preview was
broken.

## Why it matters

The preview is the entire point of the link: it is what makes a Slack thread
usable as a surface onto an existing conversation. A reader who lands in a thread
seeded with two half-sentences and a wall of `**` has to go back to the dashboard
to find out what is going on, which is exactly the round trip the feature exists
to remove. In the worst case — a session that happened to end on a run of tool
calls — the thread arrived completely empty and looked broken.

## Fix (symptoms → root cause → change)

**Symptom:** three posts, two truncated, markdown unrendered.

**Root cause:** the loop was `for m in slot.messages[-5:]` with the role check
*inside* the body, and the per-message text went through
`redact_and_truncate(..., max_chars=2000)` — a function whose contract is to
truncate. Slicing before filtering meant the "5" counted rows the preview would
never show; truncating meant the tail was discarded rather than continued; and
nothing ever called a markdown converter.

**Change:** selection now works in **turns** (one `user` message plus the
`assistant` message(s) that answered it) and is shared by both call sites through
a new `dashboard/chat_backfill.py`. A thread is seeded with the **opening turn**,
a **gap marker** naming how many turns were skipped (linked to the dashboard tab),
then the **last five turns in full**. When the first turn falls inside the recent
window the ranges are posted contiguously with no marker and no duplication.

Five things worth calling out for review:

1. **Redaction ordering is load-bearing, and it is `redact → convert → split`.**
   `to_slack_mrkdwn` self-truncates at `SLACK_MAX_TEXT` (39,000) *before* it
   converts anything, so converting first would hand the redactor a credential
   already cut in half — a prefix no regex matches. Removing the char cap does
   **not** weaken redaction: `redact_and_truncate` already redacted the full text
   and truncated last; this replaces it with the same guarantee made explicit.
   There is a dedicated test for this whose padding is built so the cut lands
   exactly on the boundary *inside* the secret — a secret placed entirely past
   the boundary is simply deleted and proves nothing.

2. **The Slack/mirror asymmetry is deliberate, not an oversight.** The Slack
   drain is backgrounded: Slack accepts roughly one message per second per
   channel, so a long history split across many parts held the HTTP request open
   long enough for the browser fetch to time out while posts kept landing — the
   user saw a failure on a link that actually worked. The mirror path stays
   **inline** because its per-message governance re-check must be able to fail
   the request closed with 403; backgrounding it would mean the handler had
   already returned 200 and persisted the link before that denial could be
   observed. Backgrounding the mirror would need a compensating-unlink design and
   is out of scope. A test asserts the link is persisted only *after* delivery
   finishes, so that ordering cannot silently regress.

3. **The opening turn can come from the transcript, not the slot.**
   `slot.messages` is a windowed view — after a restart it holds at most the last
   500 rows — so a long session's first turn exists only on disk. The fallback is
   gated on `slot._disk_older_count` and reads via **`effective_session_key`, not
   `_history_key_for`**: the latter prepends `dashboard:` unconditionally, so a
   channel-born slot would resolve to the nonexistent `dashboard:slack:<ts>` and
   read an empty file — a silent zero-turn result rather than an error. The
   recent window always comes from memory so the newest reply is never a flush
   interval stale, which also makes the two ranges disjoint by construction.
   `read_messages_chained` may return the shared cached list, so it is treated as
   read-only; a test asserts the cache is unmutated.

4. **The governance test rewrite is intentional and non-vacuous.**
   `test_governance_narrowing_mid_delivery_fails_closed` gated on a governance
   *call ordinal* (`calls["n"] < 3`), which silently depended on exactly two
   consults happening before the delivery loop. Change how many messages the
   backfill selects and the denial lands on a pre-loop gate while every assertion
   still passes — the test keeps its green tick and stops guarding the path it was
   written for. It is now a **predicate** ("deny once the transport has delivered
   at least once"), plus an added `send_message.await_count >= 1` assertion:
   since the announcement is sent only *after* its own check passes, having sent
   it proves the denial came from inside the loop.

5. **`state._background_tasks` is never cancelled at shutdown** (nothing awaits
   or cancels that set), so a gateway stop mid-drain abandons the task and leaves
   a partially seeded thread. That is accepted here — the link is already
   persisted and the thread is live — and no shutdown hook is added in this PR.

Also updated the two `security_posture` sink descriptions: `chat_mirror.py` no
longer calls `redact_and_truncate`, so its prose claim would have become false
and `test_sink_prose_claims_are_true_of_the_named_module` would have failed. Both
now name `redact_via_context`, the canonical egress shim (a loaded companion's
extra credential regexes apply, not just the OSS baseline) and the same one the
normal mirrored-turn path already uses. `chat_backfill.py` deliberately performs
no redaction, so it is not a new egress boundary and needs no registry entry —
the two modules that actually send remain the registered sinks.

### Interaction with #1467

**#1467 (`fix/slack-options-lifecycle`) rewrites this same loop** and its version
already contains the filter-before-slice fix, plus new
`post_assistant_text(..., truncate_to=2000)` / `post_plain_text(..., truncate_to=2000)`
helpers in `slack/outbound.py`. Whichever lands second needs a hand-merge of
roughly one function, not a mechanical rebase:

- If this PR lands first, #1467's helpers should take the split-not-truncate
  path rather than `truncate_to=2000`.
- If #1467 lands first, this PR's `split_message` must be threaded *through* those
  helpers, or it silently does nothing while `truncate_to=2000` still drops text.
- #1467's `is_newest_reply` interactive flag survives either order: the recent
  window is still posted last, so the newest assistant reply is still the tail.

The shared `chat_backfill` module is conflict-free; the call site in
`chat_slack.py` is kept deliberately thin to keep that merge small.

## Tests

New `test/test_chat_backfill.py` (22 tests) and a new
`TestMirrorBackfillFidelity` class in `test/test_chat_mirror.py` (7 tests):

- **Filter before slice** — a tail of `tool` rows must not consume the window,
  including the pathological all-tool tail that previously seeded nothing.
- **First turn + last 5 turns** — 10 turns in, turn 1 and turns 6–10 out, turns
  2–5 absent, exactly one gap marker naming 4 skipped turns, and the marker
  positioned *between* the two ranges.
- **Overlap** — 3 turns and the 6-turn boundary both post contiguously with no
  marker and no duplicated opening turn.
- **No truncation** — a 9,000+ char answer spans ≥3 parts, every line survives,
  no part exceeds `SLACK_MSG_LIMIT`.
- **mrkdwn conversion** — `## Heading` / `**bold**` become Slack markup on the
  Slack path, and are left *unconverted* on a Telegram mirror.
- **Redaction** — a credential is redacted, and a credential straddling the
  39,000-char conversion boundary does not leak a prefix.
- **Off-window first turn** — read from a real `ConversationLog`; the transcript
  is *not* consulted when the window is complete; a read failure degrades to
  memory rather than losing the recent window; the shared cache is not mutated.
- **Compaction rows** — excluded from both posting and turn counting; a non-dict
  `meta` does not crash selection.
- **Handler wiring** — the link response returns with the drain still in flight
  (proved with a blocking gate, not a sleep), and an existing `thread_ts` still
  posts nothing at all.
- **Mirror inline ordering** — the mirror link is persisted only after every unit
  has been delivered.

**Non-vacuity:** each half of the fix was reverted in turn and the named tests
confirmed to fail — slice-before-filter, truncate-instead-of-split (both paths),
missing mrkdwn conversion, convert-before-redact, missing transcript read,
compaction rows counted as turns, and skipping the mirror delivery loop. All 8
mutations were caught. The first version of the ordering test was found *vacuous*
by this harness (the secret sat past the cut and was deleted rather than split)
and was rewritten.

## Manual verification

N/A — the drain is exercised end-to-end through the real aiohttp handler with a
real `ConversationLog`, including the background-task registration and the
existing-thread guard, so the unit coverage reaches the same seams a manual link
would. Local gates: full backend suite 28,769 passed with 21 failures, all
pre-existing environmental ones (sandbox `userns` EPERM, root-owned binary
resolution, missing `py-spy`, `gh` ownership checks) — verified by running the
same files against clean `main`, which fails that same set plus three more.
`mypy` clean on 725 files; `isort` and `flake8` clean.

## Screenshots

N/A — no frontend change. The user-visible surface is the content of Slack /
Telegram messages, which the tests assert on directly.


---

## Round 2 — reviewer findings addressed

All four findings were legitimate; none were rebutted.

**1. Blocking transcript read on the event loop** (GPT + Opus, both BLOCKING —
and an AUTOSDE `blocking: true` rule). `read_messages_chained` reads and
JSON-parses every `tab_id` sibling file, and globs the sessions dir to rebuild a
stale index. On the loop thread that stalls every other chat turn and the
liveness heartbeat. `select_backfill_messages` is now offloaded via
`asyncio.to_thread` at **both** call sites, matching the existing precedent at
`chat_persistence.py:647` which offloads the identical call. The selector is kept
synchronous on purpose so the offload decision belongs to the caller, and its
docstring says so.

**2. Long messages still lost their tail** (GPT, BLOCKING). Correct, and my own
test missed it because it used a 9,000-char message. `to_slack_mrkdwn`
self-truncates at `SLACK_MAX_TEXT` *before* converting, so
`split_message(to_slack_mrkdwn(x))` silently dropped everything past 39,000
characters — the same class of tail loss as the 2,000-char cap this PR replaces,
just further out. The text is now pre-split into blocks below the limit, each
converted, each then split to `SLACK_MSG_LIMIT`. Blocks are halved against the
limit so a conversion that *grows* text (table and mermaid rewriting) still
cannot reach the internal truncation. New test seeds ~60k chars and asserts
markers from the start, middle, and end all survive, and that
`to_slack_mrkdwn`'s own truncation notice never appears.

**3. Gap count undercounted with unflushed turns** (GPT, FINDING). The selector
previously grouped turns on the transcript and on memory *separately* and
subtracted, which undercounts when the transcript lags and can count one turn
twice when it straddles the flush boundary. It now slices the transcript to
`_disk_older_count` — exactly the rows the in-memory window does not hold — and
groups that prefix together with the live window as **one sequence**. The count
is exact, and a question on disk whose answer is still in memory is joined into
one turn instead of two. New test constructs precisely that straddle and asserts
both the turn count and the grouping.

**4. Function-local import** (GPT, FINDING). `dashboard_origin` hoisted to module
scope; the `try/except` around it was dead anyway, since `dashboard_origin`
already returns `""` for an empty, malformed, or non-HTTP URL. Re-verified with a
cold-interpreter probe per entry point that no import cycle was introduced —
`chat_backfill`, `chat_slack`, `chat_mirror`, `slack.format`, `dashboard.state`,
and `mcp_core` all import clean in a fresh process.

### Design Review 🟡 CONCERNS — accepted and fixed

The reviewer's point was sharp and I had missed it: removing the char cap and
widening selection made the **inline** mirror loop unbounded, reintroducing on
that path the exact failure that justified backgrounding the Slack one — a
request held open past the browser's fetch timeout, leaving the user looking at a
failed link that actually persisted. Fixing finding #2 made it worse, since a long
message now yields more units rather than being cut.

Implemented the reviewer's own suggestion — a unit budget with the gap marker
absorbing the overflow (`_MAX_INLINE_BACKFILL_UNITS = 12`) — spent on **whole
turns** in explicit priority order:

1. the newest turn (irreducible — a preview without the current exchange is
   useless, and shrinking a single turn means cutting a reply mid-sentence, so
   this is the one case that may exceed the budget, bounded by one message rather
   than by history length),
2. the gap marker,
3. the opening turn,
4. older recent turns while they fit.

Everything the budget cannot afford is folded into the marker's count, so the
reader is always told what is missing. Trimming composed units instead — my first
attempt — cut replies mid-sentence and dropped the gap marker itself; the test
caught that and it was reworked.

Two tests lock the property: one asserts the unit count stays under a **literal**
ceiling (deliberately not the module constant, which would move with it), the
other asserts that 8 turns and 80 turns produce the *same* unit count — duration
tracks the budget, not history length.

The Slack drain is intentionally left unbounded: it is backgrounded, so its
length costs no request time, and truncating it would lose history for no benefit.

### Non-vacuity, re-run

The mutation harness now covers 11 regressions, including the three new fixes,
and all 11 are caught. Two findings of my own came out of running it: the
tail-loss test was initially vacuous (the credential sat past the 39k cut and was
*deleted* rather than split), and the first version of the bound test asserted
against the module constant, so raising the cap still passed. Both were rewritten.
The event-loop offload has no behavioural test — a thread hop is not observable
from pytest — and is covered by the AUTOSDE rule and the reviewer gate instead;
the harness records that explicitly rather than implying coverage that does not
exist.


---

## Round 3 — two more reviewer findings, both legitimate

**BLOCKING — formatting could reconstruct a credential after redaction — FIXED.**
Subtle and real. `to_slack_mrkdwn` strips ANSI escapes *before* converting, so a
credential broken up by an escape sequence does not match the regex on the way in
and is reassembled **intact** by that strip — arriving at Slack complete. The same
hazard applies to any conversion step that removes or reorders characters (inline
markup rewriting, link conversion). Redaction now runs on **both sides** of the
transform: once before, over the whole text (which is what protects against
`to_slack_mrkdwn`'s 39,000-char self-truncation splitting a secret), and once on
the converted text before splitting. Redacting on both sides is what makes the
guarantee hold regardless of what conversion does to the byte sequence, rather
than depending on conversion being length- and order-preserving.

New test `test_conversion_cannot_reassemble_a_credential` embeds `\x1b[0m` inside
an AWS key id and asserts the assembled key never reaches Slack. Verified
non-vacuous: removing the second pass fails it.

**BLOCKING — `KiroCrewConfig.load()` is synchronous file I/O on the event loop —
FIXED.** Same class as the transcript read from round 2, same AUTOSDE rule. Now
`await asyncio.to_thread(KiroCrewConfig.load)` at both call sites this PR added
(`chat_slack.py` in the drain, `chat_mirror.py` in the link handler). The
pre-existing `KiroCrewConfig.load()` in `api_slack_channels` is untouched — it is
outside this change and not a regression this PR introduces.


---

## Round 4 — the ANSI fix, done properly

**BLOCKING — pre-conversion splitting bypassed credential redaction — FIXED.**
GPT was right, and this is the gap round 3's minimal fix left open. Round 3 added
a second redaction pass *after* conversion, which handles an ANSI-obfuscated
credential sitting wholly inside one block. It does **not** handle one that
straddles the pre-split boundary: each block then holds an unmatchable fragment,
both redact clean individually, and two adjacent Slack posts hand the reader the
assembled key.

The root fix is to normalise the escapes **before the first redaction**, while the
text is still one piece — so the credential is matched and redacted whole, before
any split can cut it. `_strip_ansi` was private to `slack/format.py` with a single
internal caller; it is now public `strip_ansi` with a docstring stating exactly
why redaction call sites need it (the strip can *reassemble* a secret, so a caller
redacting around a conversion must normalise with the same function first).

Both redaction passes are retained: the pre-conversion one now sees normalised
text, and the post-conversion one still guards against conversion reordering or
dropping characters (inline markup, link rewriting).

Note the strip is deliberately narrow (SGR escapes only, `\x1b[...m`) and was not
broadened. The vulnerability exists precisely for the sequences `to_slack_mrkdwn`
removes, because removal is what reassembles the secret. A non-SGR escape survives
into the output, so the credential stays broken there and no complete secret
leaks. Widening the regex would change `to_slack_mrkdwn` output for every caller
for no security gain.

New test `test_ansi_credential_straddling_a_split_boundary_is_redacted` places the
credential astride the cut and asserts no fragment reaches Slack. Its
preconditions (total length exceeds the split limit; the secret genuinely straddles
the cut) are **asserted, not assumed** — the first version of this test put the cut
inside the filler instead of the credential, so the round-3 second pass caught it
and the test passed even with the fix removed. Verified: it fails with
`strip_ansi` removed, passes with it.


---

## Round 5 — the budget invented a gap

**BLOCKING — unconditional marker reservation dropped history that fits — FIXED.**
Correct, and a self-inflicted one. The inline budget reserved a unit for the gap
marker up front, before knowing whether anything would actually be skipped. With
six two-message turns the real total is exactly the 12-unit budget, but the
reservation left only 11, pushed the oldest turn out, and then spent the reserved
slot announcing the omission it had itself caused — a false gap on history that
fit.

Replaced the greedy accumulate-with-reserve loop with an exact fit search: for
each candidate number of newest turns to keep, compute the true total, counting
the marker **only when something is genuinely skipped** (selection already skipped
turns, or this budget drops one). Take the largest candidate that fits. The
priority order is unchanged and now explicit in one predicate: keep as much recent
history as fits alongside the opening turn; give up the opening turn only if not
even the newest turn fits beside it; always keep the newest turn, which is
irreducible.

New test `test_history_that_fits_exactly_is_not_trimmed` asserts all 12 units are
delivered with no marker. Verified non-vacuous: restoring the unconditional
reserve fails it. The existing 10-turn case still reports 5 skipped, and the
bounded/scale tests still hold, so the fix narrowed the trim without weakening the
bound.


---

## Round 6 — pre-conversion chunking corrupted long tables

**BLOCKING — accepted, with a narrower fix than suggested.** The finding is real
and it is content loss, not cosmetic. `_convert_tables` labels a table from the
first `|` row it sees, so a block starting part-way through one adopts a **data**
row as its header: that row's values thereafter appear only as labels, every later
row is labelled with the wrong names, and if no data rows follow the adopted row
`_flush_table` returns early and the whole block's table content is dropped.
Reproduced directly — a 1,400-row table splits into two blocks and the second
converts to `• *r1080:* r1081 | *v1080:* v1081`.

The suggested fix was `keep_tables=True`. Applied **conditionally** instead:
`keep_tables = len(blocks) > 1`. A single block IS the whole message, so no table
can be straddled and the mobile-friendly vertical-list conversion is kept — which
is the common case and the reason that conversion exists. Only a message large
enough to actually split falls back to raw pipes, trading rendering for keeping
every row. Applying it unconditionally would have regressed readability for every
small table in every preview to fix a case that needs a >19,500-character table.

Two tests: the straddled table asserts the set of emitted labels is a subset of the
real header names (`{name, value}`), which catches an adopted data row **wherever
the split lands** rather than hardcoding the boundary; and a small table asserts
`*name:*` still appears, so the fallback cannot silently become the default.

Both were wrong on the first attempt and the harness caught it: the size
precondition assert fired because 900 rows is only 16,230 characters, and the first
corruption assertion looked for `*r0` when the adopted header was `*r1080` — a
substring that could not match. The label-set form has no such blind spot.
