### PR TITLE
fix(security): address 8 CSE scan findings from 2026-08-05

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -369,7 +369,8 @@ async def _handle_repo_prs(request: web.Request) -> web.Response:
     except (adapters.AdapterParseError, adapters.UnsupportedPlatform, ValueError) as e:
         return web.json_response({"error": f"invalid repo url: {e}"}, status=400)
     except Exception as e:  # gh not authed / network / repo not found
-        return web.json_response({"error": str(e)}, status=502)
+        logger.warning("repo PR list failed: %s", e, exc_info=True)
+        return web.json_response({"error": "upstream service error"}, status=502)
     index = await asyncio.to_thread(results.read_reviewed)
     out = []
     for pr in prs:
@@ -415,7 +416,8 @@ async def _handle_review_repo(request: web.Request) -> web.Response:
     except (adapters.AdapterParseError, adapters.UnsupportedPlatform, ValueError) as e:
         return web.json_response({"error": f"invalid repo url: {e}"}, status=400)
     except Exception as e:
-        return web.json_response({"error": str(e)}, status=502)
+        logger.warning("repo review-repo failed: %s", e, exc_info=True)
+        return web.json_response({"error": "upstream service error"}, status=502)
 
     index = await asyncio.to_thread(results.read_reviewed)
     changes: list[str] = []

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -1595,7 +1595,7 @@ async def search_for_context(request: web.Request) -> web.Response:
     max_tokens = cfg.get("knowledge", {}).get("fetch_max_tokens", KNOWLEDGE_FETCH_MAX_TOKENS)
 
     try:
-        limit = int(request.query.get("limit", top_n))
+        limit = min(100, max(1, int(request.query.get("limit", top_n))))
     except ValueError:
         limit = top_n
 

--- a/src/kiro_crew/deploy/engine.py
+++ b/src/kiro_crew/deploy/engine.py
@@ -237,6 +237,15 @@ def create_private_bucket(bucket: str, region: str, profile: str) -> None:
          f"TagSet=[{{Key={TAG_MANAGED},Value=true}}]"],
         profile, action="s3:PutBucketTagging",
     )
+    # SAX-06 / CWE-778: enable S3 server access logging for auditing.
+    # Same-bucket with a prefix is AWS-supported: S3 suppresses access-log records
+    # for log-delivery writes themselves, preventing infinite recursion.
+    _checked(
+        ["s3api", "put-bucket-logging", "--bucket", bucket,
+         "--bucket-logging-status",
+         f'{{"LoggingEnabled":{{"TargetBucket":"{bucket}","TargetPrefix":"s3-access/"}}}}'],
+        profile, action="s3:PutBucketLogging",
+    )
 
 
 def _oac_name_prefix(site_id: str) -> str:

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/base-stack.yaml
@@ -176,6 +176,17 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
+          # Deny non-HTTPS access (SAX-05 / CWE-319).
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !GetAtt LogBucket.Arn
+              - !Sub '${LogBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
           # S3 server access log delivery for OriginBucket (SAX-05).
           - Sid: S3ServerAccessLogsWrite
             Effect: Allow
@@ -315,6 +326,17 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
+          # Deny non-HTTPS access (SAX-05 / CWE-319).
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !GetAtt OriginBucket.Arn
+              - !Sub '${OriginBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
           - Sid: AllowCloudFrontOAC
             Effect: Allow
             Principal:

--- a/src/kiro_crew/deploy/skills/artifact-deploy/templates/reaper.yaml
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/templates/reaper.yaml
@@ -212,6 +212,7 @@ Resources:
     Type: AWS::SNS::Topic
     Condition: HasAlarmEmail
     Properties:
+      KmsMasterKeyId: alias/aws/sns  # wokeignore:rule=master
       Subscription:
         - Endpoint: !Ref AlarmEmail
           Protocol: email

--- a/src/kiro_crew/teams/transport_dispatch.py
+++ b/src/kiro_crew/teams/transport_dispatch.py
@@ -92,7 +92,7 @@ class TeamsDispatcher:
         conversation_id = inbound.conversation_id
         service_url = inbound.service_url
         text = inbound.text
-        logger.info("Teams inbound from %s: %d chars", email, len(text or ""))
+        logger.info("Teams inbound from %s: %d chars", email[:3] + "***" if email else "?", len(text or ""))
 
         # ── Command intercept (no LLM session needed) ──
         cmd = parse_command(text)

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -1876,7 +1876,7 @@ class VectorMemoryStore:
 
         _flush_backfills()
 
-        slug = hashlib.md5(rule.encode()).hexdigest()[:12]
+        slug = hashlib.md5(rule.encode(), usedforsecurity=False).hexdigest()[:12]
         key = f"lesson.{slug}"
         value = rule if not negative else f"{rule} — NOT: {negative}"
         confidence = 1.0 if source == "user_explicit" else 0.9

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -91,7 +91,7 @@ class WebexDispatcher:
         email = inbound.person_email
         room_id = inbound.room_id
         text = inbound.text
-        logger.info("Webex inbound from %s: %d chars", email, len(text or ""))
+        logger.info("Webex inbound from %s: %d chars", email[:3] + "***" if email else "?", len(text or ""))
 
         # ── Command intercept (no LLM session needed) ──
         cmd = parse_command(text)

--- a/test/test_cse_2026_08_05_fixes.py
+++ b/test/test_cse_2026_08_05_fixes.py
@@ -1,0 +1,152 @@
+"""Regression tests for CSE scan findings 2026-08-05.
+
+SEC-3F9C863A: search_for_context limit must be server-clamped
+SEC-8746A074: Teams/Webex must not log raw email addresses
+SEC-7B8BA5B4: sage routes must not leak str(e) in 502 responses
+SEC-EECD3B66: MD5/SHA-1 must use usedforsecurity=False or be replaced
+SEC-48EC51B5: S3 bucket policies must deny non-HTTPS
+SEC-61BB9067: SNS topic must have KMS encryption key configured
+SEC-1A27E6B3: CloudFront distribution must have Logging
+SEC-E9AC8770: engine.py deploy bucket must enable access logging
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "src" / "kiro_crew" / "deploy" / "skills" / "artifact-deploy" / "templates"
+
+
+# ── SEC-3F9C863A: search_for_context limit cap ──
+
+class TestSearchForContextLimitCap:
+    """The limit query param must be clamped to [1, 100]."""
+
+    def _parse_limit_from_source(self):
+        """Extract the limit clamp from knowledge.py source to verify it's bounded."""
+        src = (Path(__file__).resolve().parent.parent
+               / "src" / "kiro_crew" / "dashboard" / "handlers" / "knowledge.py")
+        text = src.read_text(encoding="utf-8")
+        # Find the search_for_context function's limit line
+        match = re.search(r'limit\s*=\s*min\((\d+),\s*max\((\d+),', text)
+        assert match, "limit must use min()/max() clamp in search_for_context"
+        upper = int(match.group(1))
+        lower = int(match.group(2))
+        return lower, upper
+
+    def test_limit_has_server_side_upper_bound(self):
+        lower, upper = self._parse_limit_from_source()
+        assert upper <= 100, f"Upper bound {upper} exceeds 100"
+
+    def test_limit_has_positive_lower_bound(self):
+        lower, upper = self._parse_limit_from_source()
+        assert lower >= 1, f"Lower bound {lower} is not positive"
+
+
+# ── SEC-8746A074: PII email redaction in Teams/Webex logging ──
+
+class TestEmailRedactionInLogs:
+    """Teams and Webex dispatchers must NOT log full email addresses."""
+
+    @pytest.mark.parametrize("module_path", [
+        "src/kiro_crew/teams/transport_dispatch.py",
+        "src/kiro_crew/webex/transport_dispatch.py",
+    ])
+    def test_no_raw_email_in_log_info(self, module_path):
+        src = (Path(__file__).resolve().parent.parent / module_path)
+        text = src.read_text(encoding="utf-8")
+        # The inbound log line must truncate/mask the email, not pass it raw.
+        # Pattern: logger.info("...inbound from %s...", email, ...) is the BAD form.
+        # Good form: logger.info("...inbound from %s...", email[:3] + "***", ...)
+        for line in text.splitlines():
+            if "inbound from %s" in line and "logger.info" in line:
+                # Must NOT be a bare variable without masking
+                assert "***" in line or "[:" in line, \
+                    f"Email logged without redaction: {line.strip()}"
+
+
+# ── SEC-7B8BA5B4: sage routes error info disclosure ──
+
+class TestSageRoutesErrorDisclosure:
+    """The 502 catch-all handlers must not return str(e)."""
+
+    def test_no_raw_exception_in_502_response(self):
+        src = (Path(__file__).resolve().parent.parent
+               / "src" / "kiro_crew" / "apps" / "builtins" / "code_review_sage" / "backend" / "routes.py")
+        text = src.read_text(encoding="utf-8")
+        # Find all lines with status=502 and ensure none pass str(e)
+        lines_502 = [line for line in text.splitlines() if "status=502" in line]
+        for line in lines_502:
+            assert "str(e)" not in line, f"str(e) leaked in 502 response: {line.strip()}"
+
+
+# ── SEC-EECD3B66: weak cryptography ──
+
+class TestWeakCryptography:
+    """MD5 must have usedforsecurity=False; SHA-1 must be replaced."""
+
+    def test_vector_memory_md5_annotated(self):
+        src = (Path(__file__).resolve().parent.parent
+               / "src" / "kiro_crew" / "vector_memory.py")
+        text = src.read_text(encoding="utf-8")
+        md5_calls = [line for line in text.splitlines() if "hashlib.md5(" in line]
+        for line in md5_calls:
+            assert "usedforsecurity=False" in line or "usedforsecurity = False" in line, \
+                f"MD5 call without usedforsecurity=False: {line.strip()}"
+
+    def test_sage_learning_no_sha1(self):
+        src = (Path(__file__).resolve().parent.parent
+               / "src" / "kiro_crew" / "apps" / "builtins" / "code_review_sage" / "sage_lib" / "learning.py")
+        text = src.read_text(encoding="utf-8")
+        assert "hashlib.sha1(" not in text, "SHA-1 must be replaced with SHA-256"
+
+
+# ── SEC-48EC51B5: S3 bucket policy TLS enforcement ──
+
+class TestS3BucketPolicyTLS:
+    """Both S3 bucket policies must deny non-HTTPS access."""
+
+    def test_base_stack_has_secure_transport_deny(self):
+        src = TEMPLATES_DIR / "base-stack.yaml"
+        text = src.read_text(encoding="utf-8")
+        assert "aws:SecureTransport" in text, "Missing aws:SecureTransport condition"
+        assert "DenyInsecureTransport" in text, "Missing DenyInsecureTransport statement"
+        # Must appear for BOTH buckets — check at least 2 occurrences
+        assert text.count("DenyInsecureTransport") >= 2, \
+            "DenyInsecureTransport must appear in both LogBucketPolicy and BucketPolicy"
+
+
+# ── SEC-61BB9067: SNS topic encryption ──
+
+class TestSNSEncryption:
+    """The AlarmTopic must have KMS key configured for encryption at rest."""
+
+    def test_reaper_alarm_topic_has_kms(self):
+        src = TEMPLATES_DIR / "reaper.yaml"
+        text = src.read_text(encoding="utf-8")
+        # AWS property name -- wokeignore applied inline in the source
+        assert "KmsMasterKeyId" in text, "AlarmTopic missing KMS encryption key"  # wokeignore:rule=master
+
+
+# ── SEC-1A27E6B3: CloudFront access logging ──
+# REVERTED: Legacy CloudFront standard logging (DistributionConfig.Logging)
+# requires ACL-enabled target buckets, incompatible with BucketOwnerEnforced.
+# The Medium observability finding is accepted rather than breaking stack creation.
+# CloudFront real-time logs (a newer mechanism) would be the proper fix but is
+# out of scope for this security-fix PR.
+
+
+# ── SEC-E9AC8770: engine.py deploy bucket logging ──
+
+class TestEngineDeployBucketLogging:
+    """The CLI deploy path must enable S3 server access logging."""
+
+    def test_create_private_bucket_enables_logging(self):
+        src = (Path(__file__).resolve().parent.parent
+               / "src" / "kiro_crew" / "deploy" / "engine.py")
+        text = src.read_text(encoding="utf-8")
+        assert "put-bucket-logging" in text, \
+            "create_private_bucket must call put-bucket-logging"


### PR DESCRIPTION
## Problem

CSE scan 2026-08-05 21:34 UTC (session 16d7cee8, mirror commit f792ec8) detected 9 open findings. 7 are genuine and fixable; 1 (api_reveal_path) is risk-accepted; 1 (CloudFront logging) is accepted-and-deferred because the correct fix (legacy `DistributionConfig.Logging`) is incompatible with `BucketOwnerEnforced` on the target bucket.

## Why it matters

- Unbounded `limit` allows a single request to exhaust memory/CPU by dumping the entire knowledge store (DoS)
- Raw exception messages leak internal paths, binary args, and host details to browser callers
- Full email addresses in application logs violate CWE-532 (PII in logs)
- MD5 without `usedforsecurity=False` annotation flags in security audits
- S3 buckets reachable over plaintext HTTP without a Deny policy
- SNS topic stores alarm messages without encryption at rest
- CLI-created deploy buckets lack server access logging

## Fix (symptoms → root cause → change)

| Finding | Root cause | Fix |
|---|---|---|
| SEC-3F9C863A (High) | `search_for_context` passes caller limit straight through | `min(100, max(1, ...))` clamp |
| SEC-8746A074 (High) | Teams/Webex log raw `email` | Truncate to `email[:3] + '***'` |
| SEC-7B8BA5B4 (Medium) | Sage routes return `str(e)` in 502 | Generic message + server-side log |
| SEC-EECD3B66 (High) | MD5 unannotated | `usedforsecurity=False` |
| SEC-48EC51B5 (High) | No `aws:SecureTransport` Deny | Add DenyInsecureTransport to both bucket policies |
| SEC-61BB9067 (High) | SNS topic missing encryption | `KmsMasterKeyId: alias/aws/sns` |
| SEC-E9AC8770 (Medium) | engine.py skips `put-bucket-logging` | Add the call after tagging |

**Accepted / deferred:**
- SEC-BEFEB5CF (High) — `api_reveal_path` — risk-accepted: the feature IS 'open/reveal a file in the user's OS', gated by dashboard token auth + `is_sensitive_path()`.
- SEC-1A27E6B3 (Medium) — CloudFront access logging — accepted-and-deferred: legacy `DistributionConfig.Logging` requires ACL-writable target bucket, incompatible with `BucketOwnerEnforced` on LogBucket. Would need CloudFront real-time logs (a separate CFN resource) or a dedicated ACL-enabled log bucket. Out of scope for this security-fix PR.

## Tests

`test/test_cse_2026_08_05_fixes.py` — 10 assertions pinning each fix:
- Limit has [1, 100] server-side clamp
- No raw email in Teams/Webex log lines
- No `str(e)` in 502 responses
- MD5 annotated `usedforsecurity=False`
- Both S3 policies have DenyInsecureTransport
- SNS topic has KmsMasterKeyId
- engine.py calls put-bucket-logging

## Manual verification

N/A — unit coverage sufficient. All fixes are mechanical substitutions verified by source-level assertions. CloudFormation template changes validated by cfn-lint (CloudFormation Lint CI check).