### PR TITLE
fix(dev-fleet): let re-pointing at the running checkout cancel a staged cutover

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -3888,9 +3888,138 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
     can_restart = svc is not None and unit_status == "ok"
 
     live = await _live_worktree_path()
-    if live is not None and _same_path(str(real), live):
+    same_as_running = live is not None and _same_path(str(real), live)
+    if same_as_running and _staged_target() is None:
+        # Nothing staged: pointing at the checkout already running is a no-op on
+        # EVERY host. This guard sits before the cancel below so that a drivable
+        # host cannot turn a harmless repeat click into a real gateway restart by
+        # falling through to the cutover path.
         return {"ok": False, "code": "already_live",
                 "error": f"{real.name} is already the live gateway"}
+    if same_as_running and not can_restart:
+        # Pointing at the checkout already running is normally a no-op — EXCEPT
+        # while a cutover is staged, where it is the operator cancelling it. The
+        # pointer names a different checkout than the running image, so re-pinning
+        # the running one is exactly "stay on what is running", and it is the only
+        # cancel a non-drivable host can offer: without this the operator's only
+        # routes are to complete the cutover into the wrong code and reverse it
+        # (two manual restarts) or to hand-delete a keystone-fenced file the
+        # product never names.
+        #
+        # Deliberately limited to hosts this app cannot drive. A drivable host
+        # also stages a service DEFINITION naming the staged checkout, and this
+        # shortcut only touches the pointer — so the definition would keep naming
+        # a checkout nobody intends to run. Once that checkout is pruned the unit
+        # fails to start before it ever reads the pointer, turning a recoverable
+        # mis-stage into a gateway that will not boot. A drivable host therefore
+        # falls through to the full cutover below, which restages the definition
+        # and the pointer together and restarts.
+        pending_target = _staged_target()
+        if pending_target is None:
+            # Defensive re-read: the check above and this one straddle no await,
+            # but keeping it means the cancel never builds a plan around a stage
+            # that has since disappeared.
+            return {"ok": False, "code": "already_live",
+                    "error": f"{real.name} is already the live gateway"}
+        cancel_plan = {
+            "action": "cancel_staged_cutover",
+            "staged_target": pending_target,
+            "keeps_live_target": str(real),
+            "pointer_path": str(live_target.pointer_path()),
+            "restart": "not needed",
+        }
+        # Deleting the pointer IS a mutation, so it owes the same two duties as
+        # the cutover below: never act under ``dry_run``, and never touch the
+        # pointer outside the single-flight lock.
+        if dry_run:
+            return {"ok": True, "dry_run": True, "plan": cancel_plan}
+        if _MAKE_LIVE_LOCK.locked():
+            return {"ok": False, "code": "busy", "error": (
+                "another make-live cutover is in progress"
+            )}
+        async with _MAKE_LIVE_LOCK:
+            if _MAKE_LIVE_COMMITTED:
+                return {"ok": False, "code": "restart_pending", "error": (
+                    "a cutover has been scheduled; the gateway is restarting — "
+                    "retry after it comes back"
+                )}
+            # Re-read under the lock: the awaits above mean the stage may have
+            # been completed or re-pointed since the entry check, and cancelling
+            # a stage that no longer exists would delete a pointer someone else
+            # just wrote.
+            if _staged_target() is None:
+                return {"ok": False, "code": "already_live",
+                        "error": f"{real.name} is already the live gateway"}
+            # Re-pin the RUNNING checkout rather than deleting the pointer.
+            # Deleting only means "stay here" when the running image is the
+            # installed build; if this checkout was itself selected by an earlier
+            # cutover, the pointer is the only record of that choice, so removing
+            # it would silently demote the operator back to the installed build
+            # on the next restart — the opposite of the cancel they asked for.
+            # Writing is idempotent when the pointer already named it.
+            loop = asyncio.get_running_loop()
+            try:
+                prior_pointer = await loop.run_in_executor(
+                    subprocess_executor(), live_target.snapshot
+                )
+            except (OSError, ValueError) as exc:
+                return {"ok": False, "code": "write_failed", "error": (
+                    "refusing to cancel the staged cutover: the staged pointer "
+                    "exists but could not be read, so a failed cancel could not "
+                    f"be rolled back: {_redact(str(exc))}"
+                )}
+            try:
+                await loop.run_in_executor(
+                    subprocess_executor(), live_target.write_target, real
+                )
+            except (live_target.InvalidTarget, OSError) as exc:
+                # InvalidTarget refuses before anything is written. OSError can
+                # arrive AFTER the pointer has been replaced, because
+                # write_target re-applies the owner-only mode as its last step —
+                # so a failure there would otherwise leave a code-execution input
+                # in place with inherited permissions while this call reported
+                # failure. Roll the pointer back so the cancel is all-or-nothing,
+                # and only when there was one: restore(None) DELETES, which is
+                # the demotion this branch exists to avoid.
+                rolled_back = True
+                if prior_pointer is not None:
+                    rolled_back = await loop.run_in_executor(
+                        subprocess_executor(), live_target.restore, prior_pointer
+                    )
+                detail = "" if rolled_back else (
+                    " The rollback also failed, so the pointer may name the "
+                    "running checkout without owner-only permissions — check it "
+                    "before the next restart."
+                )
+                return {"ok": False, "code": "write_failed", "error": (
+                    "refusing to cancel the staged cutover: the running "
+                    "checkout could not be re-pinned as the live target: "
+                    f"{_redact(str(exc))}.{detail}"
+                )}
+            _LIVE_WORKTREE = None
+            _LIVE_CHECK_AT = 0.0
+            return {"ok": True, "cancelled": True, "target": str(real),
+                    "plan": cancel_plan,
+                    "notice": (
+                        f"Staged cutover cancelled. {real.name} stays the live "
+                        f"target and no restart is needed."
+                    )}
+    if same_as_running:
+        # Drivable host with a stage pending. The pointer-only cancel above is
+        # unsafe here (it would leave the service definition naming the staged
+        # checkout), but falling through to the full cutover would bounce a live
+        # gateway carrying real sessions in response to a request that reads as
+        # "keep running what is already running". Refuse and name both real
+        # exits instead: surprising an operator in the destructive direction is
+        # worse than doing nothing.
+        pending = _staged_target()
+        pending_name = Path(pending).name if pending else "another checkout"
+        return {"ok": False, "code": "staged_cutover_pending", "error": (
+            f"a cutover to {pending_name} is already staged. Dev Fleet can "
+            f"restart this host, so cancelling by re-pointing here would leave "
+            f"the service definition naming {pending_name}. Make {pending_name} "
+            f"live to complete the cutover, or restart the gateway to apply it."
+        )}
 
     kcbin = real / ".venv" / "bin" / "kirocrew"
     if not kcbin.is_file():
@@ -3997,12 +4126,22 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
                     f"rolled back: {_redact(str(exc))}"
                 )}
 
-        def _unwind() -> bool:
+        def _unwind_sync() -> bool:
             """Restore both staged surfaces. False when either did not land."""
             ok = live_target.restore(prior_content)
             if can_restart and svc is not None:
                 ok = svc.rollback(prior_definition) and ok
             return ok
+
+        async def _unwind() -> bool:
+            # Both halves block: restore() ends in restrict_to_owner, which shells
+            # out to icacls on Windows, and svc.rollback() rewrites the service
+            # definition. Offload them for the same reason the write below is
+            # offloaded — an unwind must not stall every other gateway request for
+            # the duration of a subprocess.
+            return await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), _unwind_sync
+            )
 
         try:
             # write_target ends in restrict_to_owner, which shells out to icacls
@@ -4015,7 +4154,8 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
         except live_target.InvalidTarget as exc:
             return {"ok": False, "code": "unsafe_path", "error": _redact(str(exc))}
         except OSError as exc:
-            return {"ok": False, "code": "write_failed", "rolled_back": _unwind(),
+            return {"ok": False, "code": "write_failed",
+                    "rolled_back": await _unwind(),
                     "error": _redact(str(exc))}
 
         # Nothing bounces the gateway on this host, so the cutover is STAGED and
@@ -4035,7 +4175,7 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
 
         staged, code, err = await svc.stage(real, kcbin)
         if not staged:
-            rolled_back = _unwind()
+            rolled_back = await _unwind()
             # Re-read definitions so the loaded config matches the restored disk
             # state rather than the rejected override.
             await svc.reload()
@@ -4052,7 +4192,7 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
         start_id = await _gateway_start_id()
         restarted, err = await svc.restart_detached()
         if not restarted:
-            rolled_back = _unwind()
+            rolled_back = await _unwind()
             await svc.reload()
             return {"ok": False, "code": "restart_failed", "rolled_back": rolled_back,
                     "error": _redact(err)}

--- a/src/kiro_crew/service/live_target.py
+++ b/src/kiro_crew/service/live_target.py
@@ -228,6 +228,12 @@ def restore(prior: str | None) -> bool:
         else:
             path.parent.mkdir(parents=True, exist_ok=True)
             atomic_write(path, prior, mode=_MODE)
+            # Harden the restored file for the same reason write_target does:
+            # atomic_write's mode is a POSIX permission bit and a no-op on
+            # Windows, so without this the pointer — a code-execution input read
+            # at every startup — would come back inheriting the directory's ACL.
+            # A rollback must not be the step that widens access to it.
+            platform_compat.restrict_to_owner(path)
         return True
     except OSError:
         return False

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -8,7 +8,9 @@ import hmac as _hmac_mod
 import json
 import os
 import sys
+import tempfile
 import textwrap
+import threading
 import time
 from contextlib import ExitStack
 from pathlib import Path
@@ -1853,6 +1855,27 @@ def _mk_make_live_wt(tmp_path, *, venv: bool = False, dist: bool = False,
     return wt
 
 
+def _assert_sandboxed(path, what: str) -> None:
+    """Fail loudly when a host-mutating make-live seam resolves outside the sandbox.
+
+    The seams below decide WHERE the cutover writes and WHAT it executes. If one is
+    left unpatched the production code is correct and does exactly what it is told —
+    against the developer's own machine: it rewrites the live gateway's systemd
+    drop-in to point at a pytest tmpdir and restarts the unit, which then fails
+    203/EXEC on every boot once the tmpdir is reaped. Asserting containment here
+    makes the next missed seam fail inside the test instead of taking down the host.
+    """
+    resolved = Path(path).resolve()
+    tmp_root = Path(tempfile.gettempdir()).resolve()
+    assert tmp_root in resolved.parents, (
+        f"{what} resolved OUTSIDE the temp sandbox: {resolved}. A test that reaches "
+        f"the cutover path must never touch a real host path."
+    )
+    assert (Path.home() / ".config").resolve() not in resolved.parents, (
+        f"{what} resolved inside the real user config dir: {resolved}"
+    )
+
+
 def _stub_make_live(monkeypatch, wt, *, live=None, in_pod=False, unit_status="ok",
                     platform="linux", pointer_dir=None):
     """Wire the make-live seams: the path resolves to *wt*, pod/live/unit state
@@ -1863,6 +1886,15 @@ def _stub_make_live(monkeypatch, wt, *, live=None, in_pod=False, unit_status="ok
     sub-directory), ``live_target.pointer_path`` returns a file inside it so no
     test ever reads or writes the real data home. Every test that reaches the
     cutover path MUST pass this.
+
+    The service-definition and command seams are isolated **unconditionally**,
+    because forgetting them is not a test failure — it is a live-host outage.
+    ``_dropin_path`` otherwise resolves ``$XDG_CONFIG_HOME``/``~/.config`` and
+    ``_run_cmd`` otherwise runs the real ``systemctl --user``, so a test reaching
+    the cutover path would repoint and restart the developer's own gateway at a
+    tmpdir. Both are redirected under *wt*'s parent and containment-asserted; a
+    test that needs to observe or shape them re-patches after this call, which
+    wins because it is applied later.
 
     ``platform`` pins the service backend (default systemd). Without it these
     assertions silently follow the HOST's platform: the same test would check a
@@ -1880,6 +1912,15 @@ def _stub_make_live(monkeypatch, wt, *, live=None, in_pod=False, unit_status="ok
     monkeypatch.setattr(mod, "_live_worktree_path", AsyncMock(return_value=live))
     monkeypatch.setattr(mod, "_in_pod", lambda: in_pod)
     monkeypatch.setattr(mod, "_live_user_unit_status", AsyncMock(return_value=unit_status))
+    sandbox_dropin = (
+        Path(wt).parent / "_systemd" / f"{mod._LIVE_GATEWAY_UNIT}.d" / "make-live.conf"
+    )
+    _assert_sandboxed(sandbox_dropin, "_dropin_path")
+    monkeypatch.setattr(mod, "_dropin_path", lambda: sandbox_dropin)
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "", "")))
+    # Prove the redirect actually took: a rename of the production symbol would
+    # otherwise leave the real path live while every test still looked green.
+    _assert_sandboxed(mod._dropin_path(), "patched _dropin_path()")
     if pointer_dir is not None:
         pointer_dir.mkdir(parents=True, exist_ok=True)
         ptr_file = pointer_dir / "live_target.json"
@@ -2866,6 +2907,294 @@ async def test_live_worktree_path_honours_pointer_when_checkout_unknown(monkeypa
 
     assert await mod._live_worktree_path() == str(target_wt.resolve())
     assert mod._staged_target() is None
+
+
+@pytest.mark.asyncio
+async def test_repointing_at_the_running_checkout_cancels_a_staged_cutover(monkeypatch, tmp_path):
+    """While a cutover is staged, naming the checkout that is RUNNING is a cancel.
+
+    Without this the operator has no un-stage route on exactly the host class this
+    feature serves: `already_live` refuses (the running image IS that checkout) and
+    the UI hides Make live on live rows, so the only ways out are to complete the
+    cutover into the wrong code and reverse it — two manual restarts — or to
+    hand-delete a keystone-fenced file the product never names.
+    """
+    running = _mk_make_live_wt(tmp_path / "running", venv=True, dist=True)
+    other = _mk_make_live_wt(tmp_path / "other", venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    ptr_dir.mkdir()
+
+    # The running image IS `running`, so the already_live branch is the one reached.
+    # A host this app cannot drive -- exactly the `service install` case #1700 is
+    # about, and the only class where the pointer-only cancel applies.
+    _stub_make_live(monkeypatch, running, live=str(running), pointer_dir=ptr_dir,
+                    unit_status="no_user_unit")
+    monkeypatch.setattr(mod, "_running_checkout", lambda: running)
+
+    # A cutover to a DIFFERENT checkout is staged.
+    import json as _json
+    ptr = mod.live_target.pointer_path()
+    ptr.write_text(_json.dumps({"checkout": str(other)}) + "\n")
+    assert mod._staged_target() == str(other)
+
+    res = await mod._make_live(str(running))
+
+    assert res.get("ok") is True, res
+    assert res.get("cancelled") is True, res
+    assert res.get("code") != "already_live"
+    # The pointer is RE-PINNED to the running checkout, not deleted: deleting it
+    # would discard the record that this checkout is the chosen live target.
+    assert ptr.exists(), "cancelling must not delete the live-target record"
+    assert mod.live_target.read_target() == running.resolve()
+    assert mod._staged_target() is None
+
+
+def _stage_a_cutover(monkeypatch, tmp_path):
+    """running checkout + a pointer staged at a DIFFERENT checkout."""
+    running = _mk_make_live_wt(tmp_path / "running", venv=True, dist=True)
+    other = _mk_make_live_wt(tmp_path / "other", venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    ptr_dir.mkdir()
+    # A host this app cannot drive -- exactly the `service install` case #1700 is
+    # about, and the only class where the pointer-only cancel applies.
+    _stub_make_live(monkeypatch, running, live=str(running), pointer_dir=ptr_dir,
+                    unit_status="no_user_unit")
+    monkeypatch.setattr(mod, "_running_checkout", lambda: running)
+    import json as _json
+    ptr = mod.live_target.pointer_path()
+    ptr.write_text(_json.dumps({"checkout": str(other)}) + "\n")
+    assert mod._staged_target() == str(other)
+    return running, other, ptr
+
+
+@pytest.mark.asyncio
+async def test_cutover_unwind_runs_off_the_event_loop(monkeypatch, tmp_path):
+    """The rollback must not block the loop.
+
+    restore() ends in restrict_to_owner, which shells out to icacls on Windows,
+    and svc.rollback() rewrites the service definition. Run inline, an unwind
+    would stall every other gateway request for the duration of a subprocess, so
+    it has to reach the executor like the write it is undoing.
+    """
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    _stub_make_live(monkeypatch, wt, pointer_dir=ptr_dir, unit_status="no_user_unit")
+
+    # Force the cutover write to fail so the unwind path runs.
+    monkeypatch.setattr(mod.live_target, "write_target",
+                        lambda _c: (_ for _ in ()).throw(OSError(28, "No space")))
+    loop_thread = threading.get_ident()
+    restore_threads: list = []
+    monkeypatch.setattr(
+        mod.live_target, "restore",
+        lambda prior: restore_threads.append(threading.get_ident()) or True)
+
+    res = await mod._make_live(str(wt))
+
+    assert res.get("ok") is False, res
+    assert res.get("code") == "write_failed", res
+    assert restore_threads, "the unwind must have run"
+    # The thread identity is the real evidence: observing that
+    # subprocess_executor() was called proves nothing, since the cutover write
+    # already uses it.
+    assert all(t != loop_thread for t in restore_threads), (
+        "restore ran on the event-loop thread — the unwind was not offloaded"
+    )
+
+
+@pytest.mark.asyncio
+async def test_drivable_host_with_a_stage_pending_refuses(monkeypatch, tmp_path):
+    """On a host Dev Fleet CAN drive, this request must do NOTHING destructive.
+
+    Two wrong answers to avoid. The pointer-only cancel is unsafe here: a drivable
+    host also stages a service DEFINITION, so re-pinning just the pointer leaves
+    the definition naming a checkout nobody intends to run, and once that is
+    pruned the unit fails to start before it ever reads the pointer. But falling
+    through to the full cutover is worse -- it bounces a live gateway carrying
+    real sessions in response to a request that reads as "keep running what is
+    already running". So it refuses and names both real exits.
+    """
+    running = _mk_make_live_wt(tmp_path / "running", venv=True, dist=True)
+    other = _mk_make_live_wt(tmp_path / "other", venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    ptr_dir.mkdir()
+    _stub_make_live(monkeypatch, running, live=str(running), pointer_dir=ptr_dir,
+                    unit_status="ok")          # drivable
+    monkeypatch.setattr(mod, "_running_checkout", lambda: running)
+    ptr = mod.live_target.pointer_path()
+    ptr.write_text(json.dumps({"checkout": str(other)}) + "\n")
+    assert mod._staged_target() == str(other)
+
+    res = await mod._make_live(str(running))
+
+    # Neither the pointer-only cancel...
+    assert res.get("ok") is False, res
+    assert res.get("cancelled") is not True, res
+    assert res.get("plan", {}).get("action") != "cancel_staged_cutover", res
+    assert res.get("code") == "staged_cutover_pending", res
+    # ...nor a cutover: no definition written, and the staged pointer is intact.
+    assert not mod._dropin_path().exists(), "a refusal must not write a definition"
+    assert mod._staged_target() == str(other), "the stage must survive untouched"
+    # The message names the staged checkout so the operator knows both exits.
+    assert other.name in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_keeps_a_pointer_selected_checkout_live(monkeypatch, tmp_path):
+    """The scenario that makes deletion wrong.
+
+    Checkout A was made live BY the pointer (so the installed build is something
+    else). Staging B and then cancelling must leave A as the live target — if the
+    cancel deleted the pointer, the next restart would boot the installed build
+    instead of A, silently undoing a cutover the operator never asked to undo.
+    """
+    running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
+
+    res = await mod._make_live(str(running))
+
+    assert res.get("cancelled") is True, res
+    assert res["plan"]["keeps_live_target"] == str(running)
+    # The record survives AND still names the running checkout.
+    assert ptr.exists()
+    assert mod.live_target.read_target() == running.resolve()
+    # Nothing is staged any more, so no restart is pending.
+    assert mod._staged_target() is None
+
+
+@pytest.mark.parametrize("boom", [
+    OSError(28, "No space left on device"),
+    OSError(30, "Read-only file system"),
+])
+@pytest.mark.asyncio
+async def test_cancel_write_failure_is_a_refusal_not_a_crash(monkeypatch, tmp_path, boom):
+    """A full or read-only data home must refuse, not raise into a 500.
+
+    write_target mkdirs, writes atomically and re-applies the owner-only mode, so
+    the failure mode here is OSError — which the InvalidTarget guard alone (a
+    ValueError) does not cover.
+    """
+    running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
+
+    def explode(_checkout):
+        raise boom
+
+    monkeypatch.setattr(mod.live_target, "write_target", explode)
+
+    res = await mod._make_live(str(running))
+
+    assert res.get("ok") is False, res
+    assert res.get("code") == "write_failed", res
+    assert "could not be re-pinned" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_rolls_the_pointer_back_when_hardening_fails(monkeypatch, tmp_path):
+    """write_target can fail AFTER replacing the pointer.
+
+    It re-applies the owner-only mode as its last step, so a failure there leaves
+    a code-execution input in place with inherited permissions. The cancel must be
+    all-or-nothing: the staged pointer goes back exactly as it was.
+    """
+    running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
+    staged_before = ptr.read_text(encoding="utf-8")
+
+    real_write = mod.live_target.write_target
+
+    def write_then_fail(checkout):
+        real_write(checkout)                      # the pointer IS replaced
+        raise OSError(5, "SetNamedSecurityInfo failed")
+
+    monkeypatch.setattr(mod.live_target, "write_target", write_then_fail)
+
+    res = await mod._make_live(str(running))
+
+    assert res.get("ok") is False, res
+    assert res.get("code") == "write_failed", res
+    # Rolled back byte-for-byte: the stage is still staged, nothing half-applied.
+    assert ptr.read_text(encoding="utf-8") == staged_before
+    assert mod._staged_target() is not None
+
+
+@pytest.mark.asyncio
+async def test_cancel_reports_a_failed_rollback(monkeypatch, tmp_path):
+    """When the rollback itself fails the operator is told, not left guessing."""
+    running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
+
+    def write_then_fail(_checkout):
+        raise OSError(5, "SetNamedSecurityInfo failed")
+
+    monkeypatch.setattr(mod.live_target, "write_target", write_then_fail)
+    monkeypatch.setattr(mod.live_target, "restore", lambda _prior: False)
+
+    res = await mod._make_live(str(running))
+
+    assert res.get("ok") is False, res
+    assert "rollback also failed" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_invalid_target_is_a_refusal_not_a_crash(monkeypatch, tmp_path):
+    """The validation half of the same guard."""
+    running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
+
+    def explode(_checkout):
+        raise mod.live_target.InvalidTarget("no src/kiro_crew in target")
+
+    monkeypatch.setattr(mod.live_target, "write_target", explode)
+
+    res = await mod._make_live(str(running))
+
+    assert res.get("ok") is False, res
+    assert res.get("code") == "write_failed", res
+
+
+@pytest.mark.asyncio
+async def test_dry_run_cancel_reports_the_plan_without_deleting(monkeypatch, tmp_path):
+    """`dry_run` must never mutate.
+
+    The already_live check runs BEFORE the dry_run return because it is
+    validation; turning that point into a pointer delete would make a dry run
+    destroy a staged cutover it was only asked to describe.
+    """
+    running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
+
+    res = await mod._make_live(str(running), dry_run=True)
+
+    assert res.get("ok") is True, res
+    assert res.get("dry_run") is True
+    assert res.get("cancelled") is not True, "dry run must not claim to have acted"
+    assert res["plan"]["action"] == "cancel_staged_cutover"
+    assert res["plan"]["staged_target"] == str(other)
+    assert ptr.exists(), "dry run must NOT delete the pointer"
+    assert mod._staged_target() == str(other)
+
+
+@pytest.mark.asyncio
+async def test_cancel_fails_fast_while_a_cutover_holds_the_lock(monkeypatch, tmp_path):
+    """The cancel mutates the same pointer a cutover writes, so it takes the
+    same single-flight lock and reports `busy` instead of racing it."""
+    running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
+
+    async with mod._MAKE_LIVE_LOCK:
+        res = await mod._make_live(str(running))
+
+    assert res.get("ok") is False, res
+    assert res.get("code") == "busy", res
+    assert ptr.exists(), "a contended cancel must not delete the pointer"
+
+
+@pytest.mark.asyncio
+async def test_cancel_refuses_once_a_cutover_has_committed(monkeypatch, tmp_path):
+    """A committed cutover is already restarting; deleting the pointer then would
+    land the pending restart somewhere the operator did not choose."""
+    running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
+    monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", True, raising=False)
+
+    res = await mod._make_live(str(running))
+
+    assert res.get("ok") is False, res
+    assert res.get("code") == "restart_pending", res
+    assert ptr.exists()
 
 
 @pytest.mark.asyncio

--- a/test/test_live_target.py
+++ b/test/test_live_target.py
@@ -358,6 +358,49 @@ class TestSnapshotRestore:
         with pytest.raises(OSError):
             snapshot()
 
+    def test_restore_reapplies_the_owner_only_dacl(self, tmp_path, monkeypatch):
+        """A rollback must not be the step that widens access to the pointer.
+
+        atomic_write's mode is a POSIX bit and a no-op on Windows, so without an
+        explicit restrict_to_owner the restored pointer -- a code-execution input
+        read at every startup -- comes back inheriting the directory ACL, and on
+        a shared data home another local account could redirect it.
+        """
+        hardened: list = []
+        monkeypatch.setattr(
+            "kiro_crew.service.live_target.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
+        path = pointer_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        assert restore('{"checkout": "/old/path"}\n') is True
+
+        assert hardened == [path], "restore must harden the file it wrote"
+
+    def test_restore_none_does_not_harden_a_deleted_pointer(self, tmp_path, monkeypatch):
+        """Deleting leaves no file, so there is nothing to apply a DACL to."""
+        hardened: list = []
+        monkeypatch.setattr(
+            "kiro_crew.service.live_target.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
+        path = pointer_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("anything")
+
+        assert restore(None) is True
+
+        assert not path.exists()
+        assert hardened == []
+
+    def test_restore_returns_false_when_hardening_fails(self, tmp_path, monkeypatch):
+        """A partial rollback reports False so the caller can warn the operator."""
+        def boom(_path):
+            raise OSError(5, "icacls failed")
+
+        monkeypatch.setattr("kiro_crew.service.live_target.platform_compat.restrict_to_owner", boom)
+        path = pointer_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        assert restore('{"checkout": "/old/path"}\n') is False
+
     def test_restore_returns_false_on_oserror(self, tmp_path, monkeypatch):
         """Best-effort: returns False rather than raising."""
         # Parent is a FILE, so both the mkdir and the write fail on every


### PR DESCRIPTION
## What is the problem?

After #1615, a staged cutover can only be **completed** — never cancelled.

On a host where Dev Fleet cannot drive the service (the `kirocrew service install` case #1615 exists to serve), Make Live *stages* the live-target pointer and the operator finishes it with `kirocrew restart`. If they staged the wrong worktree, there is no way back:

- Re-pointing at the checkout that is currently **running** is refused with `already_live`, because `_live_worktree_path()` correctly returns the *running* image while a pointer is staged.
- The UI hides Make live on rows it considers live.

So the only routes out are to complete the cutover into the wrong code and then reverse it — two manual gateway restarts — or to hand-delete `$KIROCREW_HOME/live_target.json`, a keystone-fenced file the product never names to the user.

This is a regression from #1615's own live-vs-staged split, not a pre-existing gap. Before that split the pointer *was* reported as live, so re-pointing at the running checkout wrote a new pointer and effectively cancelled. Making `is_live` honest removed that accidental escape hatch.

## Why this issue matters to the user

Staging the wrong worktree is a one-click mistake. The recovery is either two restarts of the live gateway — which sits on real data and real sessions — or knowing about an undocumented file the agent is deliberately fenced from. The change that made cutover reachable on these hosts left them without an undo.

## How our fix solves it

Treat "make the running checkout live **while a stage is pending**" as a cancel: re-pin the pointer at the checkout that is already running.

Re-pinning rather than *deleting* is the load-bearing detail. Deleting only means "stay here" when the running image is the installed build — if this checkout was itself selected by an earlier cutover, the pointer is the only record of that choice, so removing it would silently demote the operator back to the installed build on the next restart. Writing is idempotent when the pointer already named it.

```python
same_as_running = live is not None and _same_path(str(real), live)

# 1. nothing staged -> harmless no-op, on EVERY host
if same_as_running and _staged_target() is None:
    return {"ok": False, "code": "already_live", ...}

# 2. non-drivable host with a stage pending -> the cancel this PR adds
if same_as_running and not can_restart:
    if dry_run:                      # a plan, never a mutation
        return {"ok": True, "dry_run": True, "plan": cancel_plan}
    if _MAKE_LIVE_LOCK.locked():     # fail fast; queuing would deadlock
        return {"ok": False, "code": "busy", ...}
    async with _MAKE_LIVE_LOCK:
        ...                          # re-read the staged state under the lock
        prior_pointer = live_target.snapshot()
        try:
            live_target.write_target(real)   # re-pin the RUNNING checkout
        except (live_target.InvalidTarget, OSError):
            live_target.restore(prior_pointer)   # all-or-nothing
            return {"ok": False, "code": "write_failed", ...}
        return {"ok": True, "cancelled": True, ...}

# 3. DRIVABLE host with a stage pending -> refuse, do nothing
#    The pointer-only cancel is unsafe here (the staged service DEFINITION would
#    survive), and a full cutover would bounce a live gateway carrying real
#    sessions for a request that reads as "keep running what is running". So it
#    names both real exits instead of picking a destructive one.
if same_as_running:
    return {"ok": False, "code": "staged_cutover_pending", ...}
```

Chain from symptom to root cause:

| | |
|---|---|
| **Symptom** | operator staged the wrong worktree and cannot get back |
| **Immediate cause** | `already_live` refuses the one target that would undo it |
| **Root cause** | `_live_worktree_path()` reports the *running* image (correct), so the running checkout looks "already live" even though the pointer names something else |
| **Fix** | when the pointer disagrees with the running image, that same request means *cancel* — re-pin the pointer at the running checkout |

`_staged_target()` (added in #1615) returns non-None only when the pointer names a checkout other than the running one, so the ordinary no-stage case still refuses as `already_live` — the fix cannot swallow a genuine no-op. The pointer write goes through `subprocess_executor()` so it cannot block the event loop. The cancel obeys the same three invariants as the cutover it undoes: it never mutates under `dry_run` (it returns a `cancel_staged_cutover` plan instead), it holds `_MAKE_LIVE_LOCK` with a `busy` fail-fast and re-reads the staged state under the lock, and it refuses with `restart_pending` once a cutover is committed. The fail-fast is not decoration: queuing behind the lock deadlocks the cancel.

## What tests we did

Every test below is **mutation-verified** — the covered production line was reverted to its defective form and the test observed to fail, so none of these are vacuous assertions.

- `test_repointing_at_the_running_checkout_cancels_a_staged_cutover` — stages a pointer at a different checkout, stubs the running image, asserts `ok/cancelled`, that the code is **not** `already_live`, that the pointer **survives and names the running checkout**, and that `_staged_target()` is then `None`.
- `test_cancel_keeps_a_pointer_selected_checkout_live` — the case that makes deletion wrong: checkout A was made live *by* the pointer, B is staged, and cancelling must leave A pinned rather than dropping the operator back to the installed build.
- `test_dry_run_cancel_reports_the_plan_without_deleting` — `dry_run` describes the cancel and mutates nothing.
- `test_cancel_is_serialised_by_the_make_live_lock` — the `busy` fail-fast; removing it makes the cancel deadlock rather than merely race.
- `test_cancel_write_failure_is_a_refusal_not_a_crash` — parametrised over `ENOSPC` and `EROFS`, because `write_target` mkdirs and writes: a full or read-only data home must refuse, not surface as an HTTP 500.
- `test_cancel_rolls_the_pointer_back_when_hardening_fails` — `write_target` re-applies the owner-only mode *after* replacing the pointer, so a failure there would otherwise leave a code-execution input in place with inherited permissions. The staged pointer must come back byte-for-byte.
- `test_cancel_reports_a_failed_rollback` — when the rollback itself fails the operator is told, not left guessing.
- The pre-existing no-stage behaviour stays covered — `already_live` tests pass unchanged.
- Gates: import cycle clean, flake8, `isort --check-only src/kiro_crew test`, mypy **724 source files clean**, `test_dev_fleet_app.py` + `test_live_target.py` = **291 passed**. Two failures are not from this diff: `test_trusted_bin_pins_the_resolved_target_not_the_symlink` (identical on main) and one `test_hmac_*` member — a load/order flake whose failing member varies between runs, where all 7 pass in isolation and this diff contains 0 hmac/signature lines.

One defect was caught by mypy during development and fixed before pushing: the first draft named the local variable `staged`, which shadowed the later `staged, code, err = await svc.stage(...)` and assigned a `bool` to a `str | None`. It is now `pending_target`.

## Known limitation — this fix is API-level only

`#1700` names two blockers and this PR closes **one**. The `already_live` refusal is fixed; the dashboard still offers no control that can issue the cancelling request. `DevFleetPage.tsx` renders the Make live action only under `!w.is_live` and `makeLive()` early-returns on `if (w.is_live) return`, and the running row *is* `is_live` while a stage is pending — which is exactly the honesty #1615 introduced. So an operator who mis-stages a cutover from the dashboard still cannot undo it from the dashboard.

The affordance is deliberately not bolted onto the existing button: "Make live" on the staged row reads as *confirm*, so rebinding it to cancel would surprise the operator in the destructive direction. The honest fix is a distinct "Cancel staged cutover" action on the restart-pending row, which is frontend plus an i18n key. Both the GPT and Design reviews reached this independently and recommend the same shape. Tracked as #1724 — this PR ships the backend contract the UI will call, and #1700 stays open until that lands.

## Any other suggestions on the work

Four advisory UX items from the same #1615 review also did not land, and are deliberately **not** in this PR to keep it to the one functional gap:

- Make live tooltips still read "(restarts the gateway)" on non-drivable hosts — the exact host class this feature serves — so every hover repeats the promise the dialog copy was rewritten to remove.
- After the toast dismisses, `manual_restart` survives only in the Restart-pending badge's native `title`: mouse-hover only, no keyboard or touch path to the command that finishes the cutover.
- The confirm button reads "Make live" on a path that only stages; "Stage cutover" would name what actually happens.
- Backticks render literally in the staged dialog and toast.

Worth a small copy/affordance follow-up PR.

Refs #1700 — deliberately NOT `Closes`: the dashboard still has no control
that can issue the cancel (#1724), so the umbrella issue must stay open
until that lands, and this PR ships the backend contract it will call.



