### PR TITLE
fix(dev-fleet): recover and reveal macOS launchd gateway ownership

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1672,6 +1672,99 @@ async def _fleet_cached() -> dict:
     return data
 
 
+#: Memoized ``(key, reason)``. The comparison needs real path resolution —
+#: a symlinked checkout otherwise reads as a mismatch — and that is filesystem
+#: IO, which on a network-backed checkout can stall. So it runs on the executor,
+#: once per distinct key, rather than on the event loop for every ``/fleet`` poll.
+_SERVING_REASON: "tuple[tuple[str, tuple[str, ...]], str | None] | None" = None
+
+
+def _is_checkout(path: str) -> bool:
+    """Whether *path* is a real git checkout. Blocking — executor only.
+
+    ``.git`` is tested rather than mere existence, and as a path rather than a
+    directory, because a linked worktree's ``.git`` is a FILE. An empty or absent
+    directory is not something Dev Fleet can be said to manage.
+    """
+    if not path:
+        return False
+    try:
+        return (Path(path) / ".git").exists()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _serving_install_reason_sync(
+    main_repo: str, managed: "tuple[str, ...]"
+) -> str | None:
+    """Why the install serving this dashboard is not one Dev Fleet manages.
+
+    Blocking — resolves paths. Call it through an executor, never on the loop.
+
+    Dev Fleet drives a set of checkouts, but the backend answering these routes
+    can be a different install altogether — a published desktop bundle, say,
+    whose own Pull+Build predates the dist-staging step. Every control then keeps
+    reporting success while doing an incomplete job: the checkout fast-forwards,
+    the bundle it serves does not, and a Restart button whose eligibility that
+    older backend computes never appears at all. Saying nothing is what turns a
+    one-line diagnosis into a long session chasing the downstream symptoms.
+
+    Every discovered worktree counts as managed, not just the primary checkout:
+    Make live deliberately points the gateway at a linked worktree that lives
+    outside it, and warning about a state this app just created would train the
+    user to dismiss the one signal built for the takeover case.
+    """
+    # __file__ is the strongest available evidence of which install is RUNNING:
+    # it is this very module, so it cannot disagree with the process the way a
+    # PATH-resolved binary can.
+    pkg = Path(__file__).resolve().parents[3]
+    for candidate in (main_repo, *managed):
+        if not candidate:
+            continue
+        try:
+            root = Path(candidate).resolve()
+        except (OSError, RuntimeError, ValueError):
+            # An unusable entry is skipped, not raised: /fleet is a read and every
+            # other field still describes the fleet correctly. RuntimeError is in
+            # the tuple because a symlink cycle surfaces as one rather than as an
+            # OSError — the same reason beacon.is_default_home() catches it.
+            continue
+        if pkg == root or root in pkg.parents:
+            return None
+    if not _is_checkout(main_repo):
+        # Nothing is actually being managed. MAIN_REPO defaults to ~/kirocrew
+        # whether or not it exists, so a desktop-bundle or pip install with no
+        # source checkout — the out-of-the-box case — would otherwise get a
+        # permanent warning whose remedy ("start the gateway from <path>") names
+        # a directory that is not there. A dead-end instruction on every visit is
+        # how a signal gets trained away.
+        return None
+    return (
+        "This dashboard is served by a different install than the checkout you are "
+        "managing, so Pull+Build here does not change the code that runs. "
+        f"Start the gateway from {_redact(main_repo)}, or Make live onto it. "
+        f"Serving now: {_redact(str(pkg))} — an install older than the pulled "
+        "revision may not refresh the dashboard bundle."
+    )
+
+
+async def _serving_install_reason(worktrees: "list[dict]") -> str | None:
+    global _SERVING_REASON
+    managed = tuple(sorted(
+        str(wt["path"]) for wt in worktrees if wt.get("path")
+    ))
+    key = (MAIN_REPO, managed)
+    if _SERVING_REASON is not None and _SERVING_REASON[0] == key:
+        return _SERVING_REASON[1]
+    loop = asyncio.get_running_loop()
+    reason = await loop.run_in_executor(
+        subprocess_executor(),
+        functools.partial(_serving_install_reason_sync, MAIN_REPO, managed),
+    )
+    _SERVING_REASON = (key, reason)
+    return reason
+
+
 async def _build_fleet() -> dict:
     live_path = await _live_worktree_path()
     staged_path = _staged_target()
@@ -1783,6 +1876,11 @@ async def _build_fleet() -> dict:
         # macOS user saw a Pull+Build succeed with no way to apply it and
         # nothing on screen saying why. ``None`` when the service is drivable.
         "gateway_service_reason": await _gateway_service_reason(),
+        # Non-null when the backend answering this request is NOT the checkout
+        # below. Reported for the same reason as gateway_service_reason: the
+        # controls stay clickable and keep succeeding, so nothing else on screen
+        # would ever reveal that the managed code is not the running code.
+        "serving_install_reason": await _serving_install_reason(worktrees),
         # Whether pods can run on THIS host, and if not, why. Previously
         # _POD_ERROR was computed and then never read by anything, so a
         # non-Linux user saw pod controls that silently failed with no
@@ -3789,8 +3887,11 @@ def _make_live_status_error(code: str) -> str:
         "live_program_missing": (
             f"the launchd agent {_LIVE_GATEWAY_LABEL} is loaded but its "
             "live-gateway launcher is missing (deleted application-support "
-            "directory?), so it has nothing to execute. Re-run "
-            "`kirocrew service install` to restore it"
+            "directory?), so it has nothing to execute. Make live onto a "
+            "worktree to rewrite it, or start a gateway from your source "
+            "checkout — either restores the launcher without touching the "
+            "agent definition, whereas kirocrew service install would rewrite "
+            "the whole plist and discard any environment you added to it"
         ),
     }.get(code, f"the live gateway cannot be repointed ({code})")
 

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -19,6 +19,7 @@ import urllib.request
 from pathlib import Path
 
 from kiro_crew import __version__, platform_compat
+from kiro_crew.beacon import is_default_home
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     _DEFAULT_PORT,
@@ -1317,6 +1318,35 @@ def _status(args: argparse.Namespace) -> None:
     print(f"  Lessons:     {data.get('lessons', 0)}")
 
 
+def _should_reconcile_launchd_launcher() -> bool:
+    """Whether this gateway may repair the shared launchd launcher.
+
+    Only a non-frozen production instance may.
+
+    ``LIVE_PROGRAM`` is a per-user path under Application Support that
+    ``KIROCREW_HOME`` does not scope, so a dev, pod, or worktree gateway
+    repairing it would repoint the user's REAL agent at its own venv —
+    recreating the serving-vs-managed mismatch the reconcile exists to prevent,
+    and doing it without the operator ever acting on the production instance.
+    ``is_default_home`` is reused rather than re-derived so the two cannot drift
+    on what counts as the real home.
+
+    A frozen build is excluded for a different reason: the launchd agent is a
+    ``service install`` artifact belonging to a source or pip install, while a
+    packaged app manages its own backend lifecycle and supplies environment its
+    interpreter needs — notably ``PYTHONPYCACHEPREFIX``, which keeps bytecode out
+    of the signed bundle. A launcher naming the bundled executable would be run by
+    launchd WITHOUT that environment, so the interpreter would write
+    ``__pycache__`` inside the app and invalidate its signature. The packaged app
+    has no business owning this artifact at all.
+    """
+    return (
+        sys.platform == "darwin"
+        and not getattr(sys, "frozen", False)
+        and is_default_home()
+    )
+
+
 async def _gateway(
     *,
     no_dashboard: bool = False,
@@ -1356,6 +1386,19 @@ async def _gateway(
             "Run `npm ci && npm run build` in the website/ directory to build "
             "the full dashboard."
         )
+
+    # Reconcile the other derived artifact that lives outside the install: the
+    # launchd agent's launcher script. It sits under Application Support, so a
+    # "reset the app" gesture that clears that directory leaves the agent loaded
+    # with nothing to execute and no in-product way back. Self-healing here
+    # rather than in the service installer keeps a hand-customized plist intact.
+    if _should_reconcile_launchd_launcher():
+        try:
+            svc_macos.ensure_live_program()
+        except OSError as exc:
+            logging.getLogger(__name__).warning(
+                "Could not restore the launchd live-gateway launcher: %s", exc
+            )
 
     if not config_path().exists():
         cfg = KiroCrewConfig()

--- a/src/kiro_crew/service/macos.py
+++ b/src/kiro_crew/service/macos.py
@@ -13,6 +13,7 @@ import logging
 import os
 import plistlib
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -257,6 +258,106 @@ def write_live_program(contents: str, path: Path | None = None) -> None:
         except FileNotFoundError:
             pass
         raise
+
+
+def _repairer_bin() -> str:
+    """The executable of the install performing the repair.
+
+    Resolution is deliberately narrow: an explicit ``KIROCREW_SERVICE_BIN``, else
+    the ``kirocrew`` console script sitting beside the running interpreter. There
+    is no ``PATH`` fallback, because ``PATH`` cannot answer the question being
+    asked — "which install is running" — and an unrelated or older ``kirocrew``
+    earlier on the inherited PATH would be baked into the agent, so the gateway
+    would come back as a DIFFERENT install than the one that repaired it. That is
+    a quieter form of the very mismatch this repair exists to end.
+
+    Raises ``OSError`` when neither resolves, or when what resolves is not an
+    executable file. Refusing beats guessing: nothing is written, so the launcher
+    stays absent and a later run can still fix it, whereas a wrong or
+    unexecutable target would leave launchd unable to spawn the agent AND — since
+    the file would now exist — suppress every later repair, cementing the
+    failure. The caller logs the reason.
+    """
+    override = os.environ.get("KIROCREW_SERVICE_BIN", "").strip()
+    if override:
+        resolved = kirocrew_bin()
+        if not _is_executable_file(Path(resolved)):
+            raise OSError(
+                f"refusing to restore the launchd launcher: KIROCREW_SERVICE_BIN "
+                f"resolves to {resolved!r}, which is not an executable file."
+            )
+        return resolved
+    sibling = Path(sys.executable).parent / (
+        "kirocrew.exe" if os.name == "nt" else "kirocrew"
+    )
+    if _is_executable_file(sibling):
+        return str(sibling)
+    raise OSError(
+        "refusing to restore the launchd launcher: no kirocrew console script "
+        f"beside the running interpreter ({sys.executable}). PATH is not "
+        "consulted, because an unrelated kirocrew ahead of this install on PATH "
+        "would be persisted into the agent. Set KIROCREW_SERVICE_BIN to the "
+        "intended executable, or install so the console script sits beside the "
+        "interpreter."
+    )
+
+
+def _is_executable_file(path: Path) -> bool:
+    try:
+        return path.is_file() and os.access(path, os.X_OK)
+    except OSError:
+        return False
+
+
+def ensure_live_program() -> bool:
+    """Restore a missing launcher without touching the plist. True if written.
+
+    The launcher is a derived artifact that lives OUTSIDE the install, under
+    Application Support, and the plist's ``ProgramArguments[0]`` executes it. If
+    it goes missing the agent stays loaded with nothing to run: launchd exits it
+    ``EX_CONFIG``, stops retrying, and nothing on screen explains why the
+    gateway never comes up. ``install`` repairs it only as a side effect of
+    rewriting the whole plist, which discards operator-added
+    ``EnvironmentVariables`` (a non-default ``KIROCREW_PORT``, for instance), so
+    reconciling this half alone is what keeps a customized agent intact.
+
+    Deliberately narrow: it acts only when an agent is installed AND indirected
+    through the launcher. Writing the file where no plist exists, or where the
+    plist executes a binary directly, would leave a script nothing ever runs.
+
+    The restored launcher targets the install running right now. A previous
+    Dev Fleet cutover recorded its worktree and venv-first PATH inside the very
+    file that was lost, so that pointer cannot be recovered here -- but the
+    caller performing the repair is itself a working install, and Make live can
+    re-target the agent afterwards. A dead agent has no such recovery.
+
+    Callers are responsible for the platform check, matching every other
+    function in this module.
+    """
+    if LIVE_PROGRAM.exists():
+        return False
+    # Reuses the module's own payload reader rather than parsing again: it already
+    # fails closed on the cases that matter here — unreadable, not a plist, a
+    # malformed-XML plist (an unescaped `&` in a hand-added value is the usual
+    # way), and a non-dict root. That matters because this runs on the gateway
+    # startup path, where anything escaping a check that only decides whether to
+    # rewrite a launcher becomes a crash loop under KeepAlive.
+    payload = _plist_payload(PLIST_PATH)
+    if payload is None:
+        return False
+    # ProgramArguments carries no type guarantee either, so validate before indexing.
+    argv = payload.get("ProgramArguments")
+    if not isinstance(argv, list) or not argv or str(argv[0]) != str(LIVE_PROGRAM):
+        # No agent, or one that execs something else — not a launcher of ours.
+        return False
+    write_live_program(render_live_program(_repairer_bin()))
+    log.warning(
+        "Restored the missing launchd launcher at %s -- the agent %s was loaded "
+        "with nothing to execute. It now targets this install; use Dev Fleet's "
+        "Make live to point it at a different checkout.",
+        LIVE_PROGRAM, LAUNCHD_LABEL,
+    )
+    return True
 
 
 def install() -> None:

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -5627,3 +5627,165 @@ def test_kill_tree_survives_an_already_dead_descendant():
 
     # 333 is still attempted after 222's ProcessLookupError.
     assert [c.args[0] for c in km.call_args_list] == [111, 222, 333]
+
+
+def test_live_program_missing_reason_names_the_non_destructive_repairs():
+    """`service install` rewrites the whole plist, discarding operator env.
+
+    Naming it as THE repair would contradict the reason this reconcile exists, so
+    the guidance points at the two routes that leave the agent definition alone.
+    """
+    reason = mod._make_live_status_error("live_program_missing")
+
+    assert "Make live" in reason
+    assert "source checkout" in reason
+    # The destructive route may be mentioned as a contrast, never as the remedy.
+    assert "discard" in reason
+
+
+# --- serving install vs managed checkout --------------------------------------
+
+def test_serving_install_reason_is_silent_for_a_source_install():
+    """The normal case: the package answering these routes lives in the checkout.
+
+    Asserted against the REAL package location rather than a fixture, so the
+    check cannot pass by accident on a layout that does not exist.
+    """
+    pkg = Path(mod.__file__).resolve().parents[3]
+
+    assert mod._serving_install_reason_sync(str(pkg.parents[1]), ()) is None
+
+
+def test_serving_install_reason_is_silent_when_the_checkout_is_the_package_dir():
+    """A managed path that IS the serving package is not a mismatch either."""
+    pkg = Path(mod.__file__).resolve().parents[3]
+
+    assert mod._serving_install_reason_sync(str(pkg), ()) is None
+
+
+def test_serving_install_reason_is_silent_after_make_live_onto_a_worktree(tmp_path):
+    """Make live points the gateway at a LINKED worktree, outside the primary
+    checkout. Warning about a state this app just created — and already labels
+    via `is_live` — would train the user to dismiss the takeover signal.
+    """
+    pkg = Path(mod.__file__).resolve().parents[3]
+    serving_checkout = str(pkg.parents[1])
+
+    reason = mod._serving_install_reason_sync(
+        str(tmp_path),                      # primary checkout: somewhere else
+        (str(tmp_path / "other-wt"), serving_checkout),
+    )
+
+    assert reason is None
+
+
+def test_serving_install_reason_names_both_installs_and_a_remedy(tmp_path):
+    """The silent-wrong-answer case: managing checkouts, running none of them.
+
+    Every Dev Fleet control keeps reporting success here, so this string is the
+    only thing that can tell the user the pulled code is not the running code —
+    which makes naming a next step part of the contract, not decoration.
+    """
+    (tmp_path / ".git").mkdir()
+
+    reason = mod._serving_install_reason_sync(
+        str(tmp_path), (str(tmp_path / "wt-a"), str(tmp_path / "wt-b"))
+    )
+
+    assert reason is not None
+    # Both sides must be named — one path alone does not identify the mismatch.
+    assert tmp_path.name in reason
+    assert "kiro_crew" in reason
+    assert "Make live" in reason
+    # Problem first, action before the paths: a warn banner that leads with two
+    # absolute paths and buries the remedy at the end gets skimmed.
+    assert reason.startswith("This dashboard is served by a different install")
+    assert reason.index("Make live") < reason.index("Serving now:")
+
+
+def test_serving_install_reason_is_silent_with_no_checkout_to_manage(tmp_path):
+    """MAIN_REPO defaults to ~/kirocrew whether or not it exists.
+
+    A desktop-bundle or pip install with no source checkout is the out-of-the-box
+    case; warning it to "start the gateway from <path>" names a directory that is
+    not there, and a dead-end instruction on every visit trains the signal away.
+    """
+    assert mod._serving_install_reason_sync(str(tmp_path / "absent"), ()) is None
+    # Present but not a checkout is equally unmanageable.
+    (tmp_path / "empty").mkdir()
+    assert mod._serving_install_reason_sync(str(tmp_path / "empty"), ()) is None
+
+
+def test_serving_install_reason_accepts_a_linked_worktree_dot_git_file(tmp_path):
+    """A linked worktree's `.git` is a FILE, so existence is the right test."""
+    (tmp_path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n")
+
+    assert mod._serving_install_reason_sync(str(tmp_path), ()) is not None
+
+
+def test_serving_install_reason_skips_unresolvable_entries(tmp_path):
+    """A bad path must be skipped, not abort the scan or crash the payload."""
+    pkg = Path(mod.__file__).resolve().parents[3]
+
+    # The poison entry comes FIRST; the healthy one after it must still be seen.
+    assert mod._serving_install_reason_sync(
+        "\x00not-a-path", (str(pkg.parents[1]),)
+    ) is None
+    # And with nothing healthy anywhere, it still returns without raising.
+    (tmp_path / ".git").mkdir()
+    assert mod._serving_install_reason_sync(str(tmp_path), ()) is not None
+
+
+@pytest.mark.asyncio
+async def test_serving_install_reason_resolves_paths_off_the_event_loop(monkeypatch):
+    """The resolution is filesystem IO, so it must not run on the loop.
+
+    Memoized on the checkout set as well: /fleet is polled, and repeating the
+    walk on every poll is what would make a network-backed checkout stall the
+    gateway.
+    """
+    monkeypatch.setattr(mod, "_SERVING_REASON", None)
+    monkeypatch.setattr(mod, "MAIN_REPO", "/nowhere/at/all")
+    calls: list[tuple] = []
+
+    def _spy(main_repo: str, managed: tuple) -> str | None:
+        calls.append((main_repo, managed))
+        return "mismatch"
+
+    monkeypatch.setattr(mod, "_serving_install_reason_sync", _spy)
+    loop = asyncio.get_running_loop()
+    offloaded: list[bool] = []
+    real_executor = loop.run_in_executor
+
+    def _tracking_executor(executor, func, *args):
+        offloaded.append(True)
+        return real_executor(executor, func, *args)
+
+    monkeypatch.setattr(loop, "run_in_executor", _tracking_executor)
+    wts = [{"path": "/wt/a"}, {"path": "/wt/b"}, {"no_path": 1}]
+
+    assert await mod._serving_install_reason(wts) == "mismatch"
+    assert await mod._serving_install_reason(wts) == "mismatch"
+
+    assert calls == [("/nowhere/at/all", ("/wt/a", "/wt/b"))], "second call must be memoized"
+    assert offloaded == [True], "the blocking work must go through an executor"
+
+
+@pytest.mark.asyncio
+async def test_serving_install_reason_recomputes_when_the_checkout_set_changes(
+    monkeypatch
+):
+    """A new worktree can make a previously-foreign serving install managed, so
+    the memo must be keyed on the set, not just on MAIN_REPO."""
+    monkeypatch.setattr(mod, "_SERVING_REASON", None)
+    monkeypatch.setattr(mod, "MAIN_REPO", "/nowhere")
+    seen: list[tuple] = []
+    monkeypatch.setattr(
+        mod, "_serving_install_reason_sync",
+        lambda repo, managed: seen.append(managed) or "r",
+    )
+
+    await mod._serving_install_reason([{"path": "/wt/a"}])
+    await mod._serving_install_reason([{"path": "/wt/a"}, {"path": "/wt/b"}])
+
+    assert seen == [("/wt/a",), ("/wt/a", "/wt/b")]

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1571,6 +1571,285 @@ class TestServiceEnvironment:
         assert [p.name for p in tmp_path.iterdir()] == ["live-gateway"]
 
 
+class TestEnsureLiveProgram:
+    """Self-heal for a deleted launchd launcher.
+
+    The repair has to be surgical: re-running `service install` also restores the
+    launcher, but it rewrites the plist and so throws away operator-added
+    EnvironmentVariables. These lock in that only the launcher half moves, and
+    that the helper stays quiet where there is no agent to repair.
+    """
+
+    def _agent(self, monkeypatch, tmp_path, *, indirected=True, fmt=None):
+        from kiro_crew.service import macos as svc_macos
+
+        launcher = tmp_path / "live-gateway"
+        plist = tmp_path / "dev.kirocrew.gateway.plist"
+        target = str(launcher) if indirected else "/usr/local/bin/kirocrew"
+        # A REAL plist, in either wire format: launchd accepts XML and binary
+        # alike, and the reconcile must not care which one it is handed.
+        plist.write_bytes(plistlib.dumps(
+            {
+                "Label": "dev.kirocrew.gateway",
+                "EnvironmentVariables": {"KIROCREW_PORT": "5477"},
+                "ProgramArguments": [target, "gateway", "--no-open"],
+            },
+            fmt=fmt or plistlib.FMT_XML,
+        ))
+        monkeypatch.setattr(svc_macos, "LIVE_PROGRAM", launcher)
+        monkeypatch.setattr(svc_macos, "PLIST_PATH", plist)
+        return svc_macos, launcher, plist
+
+    def test_reads_a_binary_plist_rather_than_assuming_utf8_text(
+        self, monkeypatch, tmp_path
+    ):
+        """launchd plists are legitimately binary or UTF-16.
+
+        This runs during gateway startup, so decoding one as UTF-8 text would
+        raise UnicodeDecodeError and take the whole gateway down over a check
+        that only decides whether to rewrite a launcher.
+        """
+        svc, launcher, _plist = self._agent(
+            monkeypatch, tmp_path, fmt=plistlib.FMT_BINARY
+        )
+        monkeypatch.setenv(
+            "KIROCREW_SERVICE_BIN", str(self._exe(tmp_path / "bin" / "kirocrew"))
+        )
+
+        assert svc.ensure_live_program() is True
+        assert launcher.exists()
+
+    def test_writes_nothing_when_the_plist_is_not_a_plist(self, monkeypatch, tmp_path):
+        """Garbage at the plist path must be declined, not raised through."""
+        svc, launcher, plist = self._agent(monkeypatch, tmp_path)
+        plist.write_bytes(b"\x00\x01 not a plist at all")
+
+        assert svc.ensure_live_program() is False
+        assert not launcher.exists()
+
+    def test_a_malformed_xml_plist_cannot_take_the_gateway_down(
+        self, monkeypatch, tmp_path
+    ):
+        """An unescaped `&` in a hand-added value is the ordinary way to get one.
+
+        plistlib surfaces that as xml.parsers.expat.ExpatError, whose base is
+        Exception — and this runs at gateway startup, so anything escaping here is
+        a crash loop under launchd KeepAlive rather than a skipped check.
+        """
+        svc, launcher, plist = self._agent(monkeypatch, tmp_path)
+        plist.write_bytes(
+            b'<?xml version="1.0"?><plist version="1.0"><dict>'
+            b"<key>Label</key><string>a & b</string></dict></plist>"
+        )
+
+        assert svc.ensure_live_program() is False
+        assert not launcher.exists()
+
+    def test_a_plist_whose_root_is_an_array_is_declined(self, monkeypatch, tmp_path):
+        """A plist root may legally be an array, which has no .get()."""
+        svc, launcher, plist = self._agent(monkeypatch, tmp_path)
+        plist.write_bytes(plistlib.dumps(["not", "a", "dict"]))
+
+        assert svc.ensure_live_program() is False
+        assert not launcher.exists()
+
+    def test_a_non_list_program_arguments_is_declined(self, monkeypatch, tmp_path):
+        """ProgramArguments carries no type guarantee either."""
+        svc, launcher, plist = self._agent(monkeypatch, tmp_path)
+        plist.write_bytes(plistlib.dumps({"ProgramArguments": "just a string"}))
+
+        assert svc.ensure_live_program() is False
+        assert not launcher.exists()
+
+    @staticmethod
+    def _exe(path: Path) -> Path:
+        """An executable stub — the repair now refuses a non-executable target."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/bin/sh\nexit 0\n")
+        path.chmod(0o755)  # fmt: skip
+        return path
+
+    def test_restores_a_deleted_launcher_and_leaves_the_plist_untouched(
+        self, monkeypatch, tmp_path
+    ):
+        svc, launcher, plist = self._agent(monkeypatch, tmp_path)
+        pinned = self._exe(tmp_path / "opt" / "kirocrew")
+        monkeypatch.setenv("KIROCREW_SERVICE_BIN", str(pinned))
+        # Read the target back off the resolver rather than restating a literal:
+        # kirocrew_bin() absolutizes, so the path SHAPE differs per platform
+        # (Windows resolves a rooted POSIX path to a drive-qualified one).
+        resolved = svc.kirocrew_bin()
+        before = plist.read_bytes()
+
+        assert svc.ensure_live_program() is True
+
+        assert f"exec '{resolved}' \"$@\"" in launcher.read_text()
+        assert os.access(launcher, os.X_OK), "launchd must be able to exec it"
+        # The whole reason this exists rather than deferring to `service install`.
+        assert plist.read_bytes() == before
+        assert b"5477" in plist.read_bytes()
+
+    @pytest.mark.skipif(
+        os.name != "posix",
+        reason="os.access(X_OK) has no permission meaning for a .py file on "
+               "Windows, and this reconcile only ever runs on darwin",
+    )
+    def test_refuses_to_write_a_launcher_that_execs_a_non_executable(
+        self, monkeypatch, tmp_path
+    ):
+        """`python -m kiro_crew` with no console script resolves to `__main__.py`.
+
+        Writing that would leave launchd unable to spawn the agent AND suppress
+        every later repair, since the launcher would then exist — the self-heal
+        would cement the broken state. Refusing keeps the next run able to fix it.
+        """
+        svc, launcher, _plist = self._agent(monkeypatch, tmp_path)
+        not_exec = tmp_path / "pkg" / "__main__.py"
+        not_exec.parent.mkdir()
+        not_exec.write_text("# a module, not a program\n")
+        monkeypatch.setenv("KIROCREW_SERVICE_BIN", str(not_exec))
+
+        with pytest.raises(OSError, match="not an executable file"):
+            svc.ensure_live_program()
+
+        assert not launcher.exists(), "a later repair must still be possible"
+
+    def test_refuses_rather_than_falling_back_to_path(self, monkeypatch, tmp_path):
+        """No sibling script and no override: refuse, never resolve through PATH.
+
+        PATH cannot answer "which install is running", so an unrelated or older
+        `kirocrew` ahead of this one would be persisted into the agent — the
+        mismatch this repair exists to end, recreated by the repair.
+        """
+        svc, launcher, _plist = self._agent(monkeypatch, tmp_path)
+        monkeypatch.delenv("KIROCREW_SERVICE_BIN", raising=False)
+        stray = self._exe(tmp_path / "stray" / "kirocrew")
+        from kiro_crew.service import common as svc_common
+        monkeypatch.setattr(svc_common.shutil, "which", lambda _n: str(stray))
+        # An interpreter directory with NO kirocrew beside it.
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        monkeypatch.setattr(svc.sys, "executable", str(bare / "python"))
+
+        with pytest.raises(OSError, match="no kirocrew console script"):
+            svc.ensure_live_program()
+
+        assert not launcher.exists()
+
+    def test_targets_the_repairing_install_not_whatever_path_finds(
+        self, monkeypatch, tmp_path
+    ):
+        """A stray `kirocrew` earlier on PATH must not be baked into the launcher.
+
+        Restoring the agent onto some OTHER install is a quieter version of the
+        mismatch this repair exists to end, so the target comes from the running
+        interpreter rather than from PATH resolution.
+        """
+        svc, launcher, _plist = self._agent(monkeypatch, tmp_path)
+        monkeypatch.delenv("KIROCREW_SERVICE_BIN", raising=False)
+        stray = self._exe(tmp_path / "stray" / "kirocrew")
+        # kirocrew_bin() lives in service.common and resolves through ITS shutil.
+        from kiro_crew.service import common as svc_common
+        monkeypatch.setattr(svc_common.shutil, "which", lambda _n: str(stray))
+        # The console script that ships beside the running interpreter.
+        mine = self._exe(
+            tmp_path / "mine" / ("kirocrew.exe" if os.name == "nt" else "kirocrew")
+        )
+        monkeypatch.setattr(svc.sys, "executable", str(mine.parent / "python"))
+
+        assert svc.ensure_live_program() is True
+
+        script = launcher.read_text()
+        assert str(mine) in script
+        assert str(stray) not in script
+
+    def test_an_explicit_service_bin_override_still_wins(self, monkeypatch, tmp_path):
+        """Pinning the service Program is operator intent, not PATH shadowing."""
+        svc, launcher, _plist = self._agent(monkeypatch, tmp_path)
+        pinned = self._exe(tmp_path / "pinned" / "kirocrew")
+        monkeypatch.setenv("KIROCREW_SERVICE_BIN", str(pinned))
+        resolved = svc.kirocrew_bin()
+
+        assert svc.ensure_live_program() is True
+
+        assert f"exec '{resolved}' \"$@\"" in launcher.read_text()
+
+    def test_is_a_noop_when_the_launcher_is_already_there(self, monkeypatch, tmp_path):
+        """An existing launcher may carry a Dev Fleet cutover — never clobber it."""
+        svc, launcher, _plist = self._agent(monkeypatch, tmp_path)
+        launcher.write_text("#!/bin/sh\ncd '/wt/live' || exit 1\nexec '/wt/live/.venv/bin/kirocrew' \"$@\"\n")
+
+        assert svc.ensure_live_program() is False
+        assert "/wt/live" in launcher.read_text()
+
+    def test_writes_nothing_when_no_agent_is_installed(self, monkeypatch, tmp_path):
+        """No plist means no job whose launcher this would be — writing it is litter."""
+        svc, launcher, plist = self._agent(monkeypatch, tmp_path)
+        plist.unlink()
+
+        assert svc.ensure_live_program() is False
+        assert not launcher.exists()
+
+    def test_writes_nothing_when_the_agent_bypasses_the_launcher(
+        self, monkeypatch, tmp_path
+    ):
+        """An older agent execs the binary directly; a launcher it never runs is litter."""
+        svc, launcher, _plist = self._agent(monkeypatch, tmp_path, indirected=False)
+
+        assert svc.ensure_live_program() is False
+        assert not launcher.exists()
+
+
+class TestLauncherReconcileIsProductionOnly:
+    """Only the real instance may repair the shared launchd launcher.
+
+    LIVE_PROGRAM is a per-user path that KIROCREW_HOME does not scope, so a dev,
+    pod, or worktree gateway "repairing" it would repoint the user's REAL agent
+    at its own venv — the serving-vs-managed mismatch the reconcile exists to
+    prevent, authored by the reconcile itself.
+    """
+
+    def test_the_default_home_on_darwin_reconciles(self, monkeypatch):
+        from kiro_crew import cli_server
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(cli_server.sys, "platform", "darwin")
+
+        assert cli_server._should_reconcile_launchd_launcher() is True
+
+    def test_an_isolated_home_does_not_reconcile(self, monkeypatch, tmp_path):
+        from kiro_crew import cli_server
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / ".kirocrew-dev"))
+        monkeypatch.setattr(cli_server.sys, "platform", "darwin")
+
+        assert cli_server._should_reconcile_launchd_launcher() is False
+
+    def test_non_darwin_never_reconciles(self, monkeypatch):
+        from kiro_crew import cli_server
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(cli_server.sys, "platform", "linux")
+
+        assert cli_server._should_reconcile_launchd_launcher() is False
+
+    def test_a_frozen_build_never_reconciles(self, monkeypatch):
+        """The packaged app must not own this artifact.
+
+        launchd would run the bundled interpreter WITHOUT the environment the app
+        supplies it — notably PYTHONPYCACHEPREFIX — so bytecode would land inside
+        the signed bundle and invalidate its signature. The launchd agent belongs
+        to a `service install`, not to an app that manages its own backend.
+        """
+        from kiro_crew import cli_server
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(cli_server.sys, "platform", "darwin")
+        monkeypatch.setattr(cli_server.sys, "frozen", True, raising=False)
+
+        assert cli_server._should_reconcile_launchd_launcher() is False
+
+
 class TestAppArmorGate:
     """The profile must install ONLY where that mechanism is the one in play.
 

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -16,7 +16,7 @@ import { setPendingInput } from '../store/chatSlice'
 import {
   Server, RefreshCw, Play, Square, ExternalLink, ChevronRight, Trash2,
   LoaderCircle, Check, Video, X,
-  Ellipsis, RotateCw, FileText, GitCommit, Rocket, Info,
+  Ellipsis, RotateCw, FileText, GitCommit, Rocket, Info, AlertTriangle,
 } from 'lucide-react'
 import * as api from './devFleetApi'
 
@@ -376,7 +376,7 @@ interface Worktree {
   own_commits?: number; real_dirty?: boolean; is_live?: boolean; is_staged?: boolean; legacy?: boolean
   path?: string
 }
-interface FleetData { worktrees: Worktree[]; error?: string; sync_run_id?: string; build_pending?: boolean; gateway_service_active?: boolean; gateway_service_reason?: string | null; pods_available?: boolean; pods_unavailable_reason?: string | null; staged_target?: string | null; manual_restart?: string }
+interface FleetData { worktrees: Worktree[]; error?: string; sync_run_id?: string; build_pending?: boolean; gateway_service_active?: boolean; gateway_service_reason?: string | null; pods_available?: boolean; pods_unavailable_reason?: string | null; serving_install_reason?: string | null; staged_target?: string | null; manual_restart?: string }
 interface SyncRun { rid: string; status: 'running' | 'done' | 'error'; phase: number; phaseAt?: number; lines: string[]; startedAt: number; exit?: number | null; last?: string; stepLabel?: string }
 // Provision run state: the FULL output is kept (not just the last
 // line) so the expandable log panel can show everything, and a failed run
@@ -549,6 +549,11 @@ export default function DevFleetPage() {
   const [provLogOpen, setProvLogOpen] = useState<Record<string, boolean>>({})
   const provDoneTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
   const [rebaseResult, setRebaseResult] = useState<Record<string, RebaseResult>>({})
+  // A failed restart is the one error on this page that carries an instruction
+  // rather than just a symptom. Toasts are pointer-events:none and self-dismiss,
+  // so they cannot be selected or copied and a long message vanishes mid-read —
+  // keep the text on the page until it is dealt with.
+  const [gatewayError, setGatewayError] = useState<string | null>(null)
   const [podLogs, setPodLogs] = useState<Record<string, string>>({})
   const [podLogsLoading, setPodLogsLoading] = useState<Record<string, boolean>>({})
   const rebaseTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
@@ -944,20 +949,34 @@ export default function DevFleetPage() {
       await sleep(2000)
     }
     setRestarting(false)
-    notify(i18nT('pages.devFleetPage.gateway_did_not_come_back_within_60s_reload_the'), { type: 'error' })
+    // Same treatment as a failed restart: the user may have walked away during
+    // the 60s overlay, and a self-dismissing toast leaves a stale page with no
+    // explanation for why it never came back.
+    const timedOut = i18nT('pages.devFleetPage.gateway_did_not_come_back_within_60s_reload_the')
+    notify(timedOut, { type: 'error' })
+    setGatewayError(timedOut)
   }
 
   async function restartGateway() {
     const ok = await askConfirm(i18nT('pages.devFleetPage.restart_gateway_2'), i18nT('pages.devFleetPage.applies_the_last_pull_build_the_dashboard_will_b'), { confirmLabel: i18nT('pages.devFleetPage.restart') })
     if (!ok) return
     setRestarting(true)
+    setGatewayError(null)
     try {
       const r = await api.post<{ ok?: boolean; error?: string; start_id?: string | null }>('/restart-gateway', {})
-      if (!r?.ok) { notify(r?.error || i18nT('pages.devFleetPage.restart_failed'), { type: 'error' }); setRestarting(false); return }
+      if (!r?.ok) {
+        const msg = r?.error || i18nT('pages.devFleetPage.restart_failed')
+        notify(msg, { type: 'error' }); setGatewayError(msg); setRestarting(false); return
+      }
       // Wait for the NEW process (a different start identity), not "a 200 came
       // back" — see gatewayRecovered.
       await awaitGatewayBack(r.start_id ?? null)
-    } catch (e: unknown) { notify((e as Error)?.message || String(e), { type: 'error' }); setRestarting(false) }
+    } catch (e: unknown) {
+      // Bare transport text ("Failed to fetch") says nothing on its own, and this
+      // lands in a persistent banner — lead with what failed.
+      const msg = `${i18nT('pages.devFleetPage.restart_failed')}: ${(e as Error)?.message || String(e)}`
+      notify(msg, { type: 'error' }); setGatewayError(msg); setRestarting(false)
+    }
   }
 
   async function makeLive(w: Worktree) {
@@ -982,7 +1001,13 @@ export default function DevFleetPage() {
         ok?: boolean; error?: string; start_id?: string | null
         staged_only?: boolean; notice?: string
       }>('/make-live', { path: w.path })
-      if (!r?.ok) { notify(r?.error || i18nT('pages.devFleetPage.make_live_failed'), { type: 'error' }); setFlag(w.name + ':makelive', false); return }
+      if (!r?.ok) {
+        // Same treatment as a failed restart: this branch surfaces
+        // restart_detached's message, which names a remedy the operator has to
+        // act on — useless in a 7s toast.
+        const msg = r?.error || i18nT('pages.devFleetPage.make_live_failed')
+        notify(msg, { type: 'error' }); setGatewayError(msg); setFlag(w.name + ':makelive', false); return
+      }
       // Staged, not bounced: this gateway is not a service Dev Fleet can
       // restart, so the operator finishes the cutover with the command the
       // backend names in `notice`. There is no replacement process coming, so
@@ -1002,7 +1027,10 @@ export default function DevFleetPage() {
       setRestarting(true)
       await awaitGatewayBack(r.start_id ?? null)
       setFlag(w.name + ':makelive', false)
-    } catch (e: unknown) { notify((e as Error)?.message || String(e), { type: 'error' }); setRestarting(false); setFlag(w.name + ':makelive', false) }
+    } catch (e: unknown) {
+      const msg = `${i18nT('pages.devFleetPage.make_live_failed')}: ${(e as Error)?.message || String(e)}`
+      notify(msg, { type: 'error' }); setGatewayError(msg); setRestarting(false); setFlag(w.name + ':makelive', false)
+    }
   }
 
   async function loadPodLogs(name: string) {
@@ -1031,6 +1059,11 @@ export default function DevFleetPage() {
   const gatewayReason = fleet?.gateway_service_active === false
     ? (fleet?.gateway_service_reason || null)
     : null
+  // Why the code being managed is not the code being run, when they differ.
+  // Rendered ABOVE the other two notices because it explains them: an older
+  // serving install is also what makes the Restart eligibility and the staged
+  // bundle wrong, so reading those first sends you down the wrong trail.
+  const servingReason = fleet?.serving_install_reason || null
   const isDiscoveryError = !fleetError && !!fleet?.error
   const ql = q.trim().toLowerCase()
   const matchesRow = (w: Worktree) => !ql || (w.name + ' ' + (w.branch || '')).toLowerCase().includes(ql)
@@ -1400,6 +1433,40 @@ export default function DevFleetPage() {
               <span className="text-text-strong">{i18nT('pages.devFleetPage.rebase')}</span> {i18nT('pages.devFleetPage.moves_a_feature_branch_onto_the_latest_main_and')}{' '}
               <span className="text-text-strong">{i18nT('pages.devFleetPage.prune')}</span> {i18nT('pages.devFleetPage.safely_removes_worktrees_whose_pr_has_already_me')}
             </p>
+            {gatewayError && (
+              <div
+                role="alert"
+                data-testid="gateway-restart-error"
+                className="flex items-start gap-2 rounded-md border border-danger/40 bg-danger-subtle px-3 py-2.5 mt-3 max-w-[860px] text-[12.5px] leading-relaxed text-danger"
+              >
+                <AlertTriangle size={14} className="lucide-inline shrink-0 mt-0.5" />
+                {/* select-text + break-words: the message can be a pair of
+                    commands with absolute paths that the operator has to run. */}
+                <span className="min-w-0 flex-1 break-words select-text">{gatewayError}</span>
+                <Btn
+                  onClick={() => setGatewayError(null)}
+                  aria-label={i18nT('app.dismiss')}
+                  title={i18nT('app.dismiss')}
+                  className="shrink-0"
+                >
+                  <X size={13} className="lucide-inline" />
+                </Btn>
+              </div>
+            )}
+            {servingReason && (
+              <div
+                role="alert"
+                data-testid="serving-install-warning"
+                className="flex items-start gap-2 rounded-md border border-warn/40 bg-warn-subtle px-3 py-2.5 mt-3 max-w-[860px] text-[12.5px] leading-relaxed text-warn"
+              >
+                <AlertTriangle size={14} className="lucide-inline shrink-0 mt-0.5" />
+                <div className="min-w-0">
+                  {/* break-words: the two embedded install paths are unbroken
+                      tokens and CSS does not wrap at '/'. */}
+                  <span className="break-words">{servingReason}</span>
+                </div>
+              </div>
+            )}
             {!podsAvailable && (
               <div
                 role="note"

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -374,6 +374,34 @@ describe('DevFleetPage', () => {
     })
   }
 
+  // --- serving install differs from the managed checkout ---
+  // The silent-wrong-answer case: Pull+Build fast-forwards the checkout and
+  // reports success while an older install keeps serving, so no other control
+  // on this page reveals that the managed code is not the running code.
+  it('warns when the install serving the dashboard is not the managed checkout', async () => {
+    mockFleet({
+      serving_install_reason: 'this dashboard is served by the install at /Applications/KiroCrew.app/Contents/Resources/backend-dist/kirocrew-backend-arm64/lib/python3.12/site-packages/kiro_crew, which is not inside the checkout Dev Fleet manages (/Users/dev/kirocrew).',
+      worktrees: [{ name: 'main', is_main: true, running: false, has_dist: true, behind: 0 }],
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('serving-install-warning')).toBeInTheDocument())
+    // Surfaced verbatim, both installs named.
+    expect(screen.getByText(/not inside the checkout Dev Fleet manages/)).toBeInTheDocument()
+    expect(screen.getByText(/backend-dist/)).toBeInTheDocument()
+  })
+
+  it('shows no serving-install warning for a matching install', async () => {
+    mockFleet({
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0 },
+        { name: 'feature-x', is_main: false, running: false, has_dist: true, behind: 0, path: '/wt/feature-x' },
+      ],
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    expect(screen.queryByTestId('serving-install-warning')).toBeNull()
+  })
+
   it('explains WHY pods are unavailable instead of failing silently', async () => {
     mockFleet(FLEET_NO_PODS)
     renderPage()
@@ -1034,6 +1062,44 @@ describe('DevFleetPage restart handshake', () => {
       releaseMakeLive?.()
     }
   }, 15000)
+
+  it('keeps a failed restart on the page instead of only in a toast', async () => {
+    // The wedge message is a pair of commands with absolute paths that the
+    // operator has to run. Toasts are pointer-events:none and self-dismiss, so
+    // the one actionable failure this page can produce must also land somewhere
+    // selectable that outlives the 7s window.
+    // The message restart_detached returns when the loaded agent predates the
+    // graceful-restart contract: an instruction the operator has to act on, so it
+    // must survive long enough to be read and copied.
+    const RESTART_ERR = "loaded launchd restart contract is outdated; re-run `kirocrew service install`"
+    const FLEET_LIVE = {
+      gateway_service_active: true,
+      worktrees: [
+        { name: 'main', is_main: true, running: false, has_dist: true, behind: 0, is_live: true, path: '/wt/main' },
+      ],
+    }
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_LIVE), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 1024 }), { status: 200 }))
+      if (u.includes('/restart-gateway')) return Promise.resolve(new Response(JSON.stringify({ ok: false, error: RESTART_ERR }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+    await waitFor(() => expect(screen.getAllByText('main').length).toBeGreaterThan(0))
+
+    fireEvent.click(screen.getByLabelText('Restart gateway'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }))
+
+    const banner = await screen.findByTestId('gateway-restart-error')
+    // The remedy survives in full, not truncated or summarised away.
+    expect(banner.textContent).toContain('restart contract is outdated')
+    expect(banner.textContent).toContain('kirocrew service install')
+    // Dismissable, so it does not become permanent furniture.
+    fireEvent.click(within(banner).getByLabelText('Dismiss'))
+    await waitFor(() => expect(screen.queryByTestId('gateway-restart-error')).toBeNull())
+  })
 
   it('reports a staged-only cutover without entering the restart handshake', async () => {
     // A host whose gateway Dev Fleet cannot bounce gets ok:true + staged_only:


### PR DESCRIPTION
Fixes #1696, #1697, #1698.

## Problem

Three defects on the macOS launchd gateway path that compound into one long
debugging session. Observed end to end on a real machine this week:

1. The launchd agent's launcher script vanished from Application Support. The
   agent stayed loaded with nothing to execute, launchd exited it `EX_CONFIG`
   (78), and `runs` froze — no in-product path put it back. `Restart` and
   `Make live` both refuse in that state, and `kirocrew service install` repairs
   it only by rewriting the whole plist, discarding operator-added
   `EnvironmentVariables` such as a non-default `KIROCREW_PORT`.
2. With no launchd gateway holding the port, the desktop app filled the vacuum
   with its own bundled backend — and Dev Fleet said nothing. Pull+Build reported
   success (it did fast-forward the checkout and rebuild `website/dist`), but the
   serving backend predated the dist-staging step, so the SPA it served stayed
   frozen while `website/dist` advanced on every pull. That same older backend
   computes `_gateway_service_active()` as `False` on non-Linux, so the Restart
   button silently never rendered either.
3. Reaching for the restart hit the third: `launchctl kickstart -k` blocks
   indefinitely against a job parked in `spawn scheduled` (7 minutes, `runs`
   never incremented — the kickstart was never delivered). The product already
   bounds that call, but the failure it produces is the bare string
   `timeout (10s)`, which reads like a slow machine and invites a retry that
   wedges identically.

## Why it matters

This is a silent-wrong-answer class of bug, not a missing feature. Every control
keeps working and keeps reporting success while doing an incomplete job, so
there is no reason to suspect the backend's identity — the user sees "I pulled
successfully but the Restart button is gone and the frontend never refreshes"
and spends the session on the downstream symptoms. It is also the state a Mac
user lands in out of the box: a published bundle is by definition older than the
checkout it is asked to manage.

## Fix (symptoms → root cause → change)

**Launcher self-heal — `ensure_live_program()`.** Symptom: a loaded agent that
cannot spawn, forever. Root cause: the launcher is a *derived* artifact stored
outside the install, and nothing reconciled it; the only repair also rewrote the
plist. Change: reconcile that half alone at gateway start, and only for an agent
that is genuinely installed AND indirected through the launcher — writing the
file where no plist exists, or where the plist execs a binary directly, would
leave a script nothing ever runs. The restored launcher targets the install
performing the repair; a prior Make live recorded its worktree and PATH inside
the very file that was lost, so that pointer is unrecoverable here, and Make live
can re-target afterwards. A dead agent has no such recovery.

**Serving-install warning — `serving_install_reason`.** Symptom: Pull+Build
succeeds, nothing changes. Root cause: the code being managed is not the code
being run, and nothing compared them. Change: compare the serving package root
(derived from this module's own `__file__`, which cannot disagree with the
running process the way a PATH-resolved binary can) against `MAIN_REPO`, and
name both installs. Rendered *above* the pods and gateway notices on purpose:
an older serving install is also what makes those two wrong, so reading them
first sends you down the wrong trail.

**Actionable wedge diagnosis.** Symptom: `timeout (10s)`. Root cause: only a
reload clears the parking, and nothing said so. Change: on a kickstart timeout,
report the wedge and name `launchctl bootout` + `launchctl load -w`. A genuine
launchctl rejection and a non-timeout spawn failure (`rc == -1` also covers
sandbox and spawn refusals) keep their own messages, so a healthy job is never
mislabelled as wedged. The 10s bound moves to a documented constant.

### Scope note

All three fixes take effect from this commit forward — they cannot help a
*currently* running older backend, which by definition does not contain them.
The value is that the next published bundle carries the warning, so the mismatch
announces itself instead of being diagnosed from scratch. The other half of
#1697 (having Pull+Build itself report that it could not stage) is deliberately
not included: the only builds that skip staging are older than this commit, so
the check would live in code the affected case never runs. #1697 stays open for
that half.

## Tests

- `TestEnsureLiveProgram` (`test/test_service.py`) — restores a deleted launcher
  and asserts the plist is **byte-identical** afterwards (the whole reason this
  is not just `service install`); no-op when the launcher exists (it may carry a
  Make live cutover); writes nothing when no plist exists or when the agent execs
  the binary directly.
- `test_launchd_restart_names_the_reload_when_kickstart_times_out` — asserts both
  recovery verbs and that the bound is ours, read off the constant.
- `test_launchd_restart_does_not_relabel_a_real_kickstart_error` /
  `..._reports_a_non_timeout_spawn_failure_verbatim` — a healthy job is never
  reported as wedged.
- `test_serving_install_reason_*` — silent for a source install (asserted against
  the **real** package location, so it cannot pass on a layout that does not
  exist), silent when the managed path IS the package dir, names both installs
  when they differ, and survives an unresolvable `MAIN_REPO` rather than taking
  the payload down.
- `DevFleetPage.test.tsx` — banner renders with the backend prose verbatim, and
  is absent when the payload omits the field. No new i18n keys: the reason is
  server-provided prose, same as `pods_unavailable_reason`.

Local gates green: pytest (385 tests across both touched modules), isort,
flake8, mypy, `tsc -b`, vitest (58 in `DevFleetPage.test.tsx`).

## Manual verification

The launcher self-heal and the wedge message were both reproduced by hand on the
machine that hit them, which is where the repro in #1696 / #1698 comes from.

**Screenshots: not captured — declaring the gap rather than papering over it.**
The warning banner is a user-visible change, so this PR should carry a shot of
it. Reaching that state needs a running instance whose serving install differs
from its managed checkout, and the authoring session's security policy blocked
minting a dashboard token for the isolated dev instance, so the capture could
not be completed. What was verified instead: the production bundle was built and
the banner's `data-testid` confirmed present in the emitted chunk, and
`DevFleetPage.test.tsx` asserts the banner renders the backend prose verbatim and
is absent when the field is omitted. A reviewer wanting the visual can reach the
state from a worktree with:

```
KIROCREW_DEVFLEET_REPO=/path/to/a/different/checkout ./dev-backend.sh
```

## Pre-existing failure found, not fixed here

`test_gateway_service_active_non_linux` fails on any Mac with the LaunchAgent
installed — it asserts pre-#1434 behaviour and reads real `launchctl` state.
Confirmed failing on a clean `main` (3a372b72) with no local changes, so it is
not a regression from this branch; it passes in CI only because the macos-14
runners have no agent loaded. Filed separately as #1702 rather than widened into
this PR.

