### PR TITLE
test: stop tests from reconfiguring or restarting the host's real service

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,404 @@
+"""Repo-root pytest configuration: the host-mutation floor.
+
+``test/conftest.py`` holds the bulk of the suite's isolation, but it only applies
+to ``test/``. ``[tool:pytest] testpaths`` also collects ``transfer`` and
+``src/kiro_crew/apps/builtins`` (42 test modules that ship inside the package,
+next to the code they cover), and those get no ``test/conftest.py`` fixtures at
+all. Anything that must hold for EVERY test therefore has to live here, at the
+rootdir, which is the one conftest pytest applies to all three testpaths.
+
+Only the host-mutation floor belongs in this file. It is deliberately narrow: a
+guard that makes it impossible for a test to reconfigure or restart the
+developer's real Kiro Crew service. Everything else stays in ``test/conftest.py``.
+
+One consequence of living at the rootdir: the module name ``conftest`` is now
+resolvable from the repository root as well as from ``test/``, and 11 test modules
+import helpers by bare name (``from conftest import requires_git``). Under pytest's
+default ``prepend`` import mode each test module's own directory goes on
+``sys.path`` first, so those imports still bind to ``test/conftest.py`` -- but the
+name IS shadowed, so switching to ``--import-mode=importlib`` would need those
+imports made explicit first. The visible effect today is that isort now classifies
+``conftest`` as first-party (a root-level module is inside its default
+``src_paths``), which is why this change also reorders that import in the modules
+that use it.
+
+Why this floor exists (issue #1722): a test asserting that a staged cutover can
+be *cancelled* rewrote the operator's real ``kirocrew-gateway.service`` drop-in
+to point at its own pytest temp dir. pytest deleted the temp dir at the end of
+the run; the drop-in survived, so systemd looped on ``203/EXEC`` — 548 failed
+starts over 25 minutes. The test never intended to touch the host: it called the
+real ``_make_live()`` because that function was the subject under test, and two
+of that function's seams (the drop-in path and the subprocess layer) were left
+for each test to remember to stub.
+
+The two fixtures below remove that "remember to" from the contract. Neither
+changes the behaviour of a test that already isolates itself correctly.
+
+Imports are stdlib + pytest only, on purpose: a rootdir conftest is imported
+before every collection, so pulling ``kiro_crew`` in here would make the whole
+suite depend on import-time side effects of the package under test.
+"""
+
+from __future__ import annotations
+
+import asyncio.base_events
+import importlib
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+#: Service managers whose *mutating* subcommands reconfigure, start, or stop a
+#: real service. Matched on BASENAME against every token of the argv, not just
+#: ``argv[0]``, because in this codebase the interesting name is usually not
+#: first: ``dev_fleet._run_cmd`` rewrites ``argv[0]`` to a trusted absolute path
+#: and then routes the spawn through ``sandboxed_spawn_argv``, and
+#: ``SystemdBackend.restart_detached`` invokes through ``systemd-run``, so the
+#: real program ends up in the middle of the final argv behind a wrapper.
+#:
+#: Deliberately NOT here:
+#:
+#: * ``systemd-run`` — in this codebase it is not a service-control tool at all.
+#:   ``sandbox`` wraps essentially EVERY subprocess in
+#:   ``systemd-run --user --scope --slice=kirocrew-agents.slice -p MemoryMax=…``
+#:   to apply cgroup resource limits, so denying it would refuse an ordinary
+#:   ``git config`` spawn. Its one service-control use (``restart_detached``)
+#:   passes ``systemctl restart`` as the wrapped command, which this guard
+#:   catches on the inner token instead.
+#: * ``sudo`` — a privilege prefix, not an action. Whether the spawn mutates
+#:   anything is decided by the command it wraps, and ``sudo systemctl restart``
+#:   is already caught on ``systemctl``.
+_SERVICE_MANAGERS = frozenset({"systemctl", "launchctl"})
+
+#: Subcommands of the managers above that CHANGE host service state.
+#:
+#: The verb matters as much as the binary. ``systemctl show``, ``systemctl cat``
+#: and ``systemctl is-active`` are read-only queries, and tests legitimately run
+#: them through the sandbox to inspect the environment they are running in — a
+#: guard keyed on the binary alone would fail those for no safety gain. Only the
+#: verbs below actually write.
+_MUTATING_VERBS = frozenset(
+    {
+        # systemctl
+        "start",
+        "stop",
+        "restart",
+        "try-restart",
+        "reload",
+        "reload-or-restart",
+        "try-reload-or-restart",
+        "daemon-reload",
+        "daemon-reexec",
+        "enable",
+        "disable",
+        "reenable",
+        "mask",
+        "unmask",
+        "preset",
+        "revert",
+        "set-property",
+        "set-environment",
+        "unset-environment",
+        "import-environment",
+        "edit",
+        "link",
+        "isolate",
+        "kill",
+        # launchctl
+        "load",
+        "unload",
+        "bootstrap",
+        "bootout",
+        "kickstart",
+        "remove",
+        "submit",
+        "setenv",
+        "unsetenv",
+        "attach",
+    }
+)
+
+#: Programs that have no read-only mode worth allowing in a test: any invocation
+#: rewrites host policy.
+_ALWAYS_REFUSED = frozenset({"apparmor_parser"})
+
+#: Test modules permitted to really mutate host service state.
+#:
+#: EMPTY, and it should stay that way. Every suite that exercises these paths
+#: today already stubs them — ``test_service.py`` patches
+#: ``service.linux.subprocess.run`` / ``service.macos.subprocess.run``,
+#: ``test_pod.py`` and ``test_pod_launchd.py`` stub at the module boundary, and
+#: the ``dev_fleet`` make-live tests stub ``_run_cmd``. So this guard breaks no
+#: existing test, and an addition here means a test is about to restart a real
+#: service on whoever runs the suite. Same shape as ``_ALLOWED`` in
+#: ``test/test_spawn_preexec_guard.py``: an entry needs a comment saying why the
+#: host mutation is acceptable.
+_HOST_SERVICE_EXEC_ALLOWED_MODULES: frozenset[str] = frozenset()
+
+
+def _tokens(argv: object, *, shell: bool = False) -> list[str]:
+    """Normalise every spawn-API argv shape into a list of string tokens.
+
+    Accepts a string (shell form, or a lone program), a ``PathLike``, or a
+    sequence of either. Anything uninterpretable yields no tokens: this guard
+    refuses on a POSITIVE match only, so an exotic argv shape can never turn into
+    a spurious failure in an unrelated suite.
+    """
+    if isinstance(argv, (str, bytes, os.PathLike)):
+        raw = os.fsdecode(argv)
+        return raw.split() if shell else [raw]
+    if isinstance(argv, (list, tuple)):
+        out = []
+        for item in argv:
+            if isinstance(item, (str, bytes, os.PathLike)):
+                out.append(os.fsdecode(item))
+        return out
+    return []
+
+
+def _basename(token: str) -> str:
+    # PurePath handles both separators, so a Windows C:\...\sc.exe form and a
+    # POSIX /usr/bin/systemctl normalise the same way.
+    return pathlib.PurePath(token.replace("\\", "/")).name
+
+
+def _refusal_reason(argv: object, *, shell: bool = False) -> str | None:
+    """Describe why *argv* mutates host service state, or ``None`` if it does not.
+
+    A service manager alone is not enough — the argv must also carry a mutating
+    verb AFTER the manager token. Scanning only the tail keeps a unit named after
+    a verb, or a wrapper flag, from being read as the action.
+    """
+    tokens = _tokens(argv, shell=shell)
+    for index, token in enumerate(tokens):
+        name = _basename(token)
+        if name in _ALWAYS_REFUSED:
+            return f"{name!r} rewrites host security policy"
+        if name not in _SERVICE_MANAGERS:
+            continue
+        for candidate in tokens[index + 1:]:
+            if _basename(candidate) in _MUTATING_VERBS:
+                return f"{name} {candidate!r} changes host service state"
+    return None
+
+
+def _refuse(reason: str, argv: object) -> None:
+    """Fail the test with the stub it is missing, not just 'permission denied'."""
+    raise AssertionError(
+        f"Test tried to run a command that mutates host service state: {reason} "
+        f"(see issue #1722).\n"
+        f"  argv: {argv!r}\n"
+        f"This spawn must be stubbed. Depending on the code under test:\n"
+        f"  - dev_fleet make-live: stub BOTH `_run_cmd` and `_dropin_path`\n"
+        f"  - kiro_crew.service.*: patch `service.<platform>.subprocess.run`\n"
+        f"  - pod runtime: stub the runtime's `systemctl` / `launchctl` helper\n"
+        f"Read-only queries (`systemctl show`, `cat`, `is-active`) are allowed and "
+        f"need no stub.\n"
+        f"If this test genuinely must drive a real service, add its module to "
+        f"_HOST_SERVICE_EXEC_ALLOWED_MODULES in the root conftest.py with a "
+        f"comment explaining why."
+    )
+
+
+@pytest.fixture(scope="session")
+def _xdg_config_root(tmp_path_factory):
+    """One tmp dir per session (per xdist worker) to stand in for ``~/.config``.
+
+    Session-scoped so the redirect below costs one ``mkdir`` for the whole run
+    rather than one per test: nothing here is written by a passing test — the
+    point of the guard is that these writes should not happen at all — so a
+    per-test directory would isolate nothing and add a syscall to every test.
+    """
+    return tmp_path_factory.mktemp("xdg")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_xdg_config_home(_xdg_config_root, monkeypatch):
+    """Point ``$XDG_CONFIG_HOME`` at a tmp dir so no test writes a real unit file.
+
+    ``dev_fleet._dropin_path()`` resolves the make-live systemd drop-in as
+    ``$XDG_CONFIG_HOME/systemd/user/kirocrew-gateway.service.d/make-live.conf``,
+    falling back to ``~/.config`` when the variable is unset — which is the
+    default on most developer machines and in CI. So a test that reaches the
+    cutover path without stubbing ``_dropin_path`` writes the operator's real
+    drop-in. That is what took the gateway down in #1722.
+
+    Redirecting the variable fixes the whole class rather than one call site,
+    because the production code already honours it (its docstring notes a literal
+    ``~/.config`` would be the wrong directory on a host that sets XDG). It is
+    also not dev-fleet-specific: ``pptx_maker/backend/paths.py`` resolves against
+    the same variable, so its tests stop touching the real config dir too.
+
+    A test that wants its own value still wins — it sets XDG later, and reverts
+    independently.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(_xdg_config_root))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_launchd_paths(_xdg_config_root, monkeypatch):
+    """Pin the launchd install paths, which ``$XDG_CONFIG_HOME`` cannot reach.
+
+    The macOS half of Make Live does not resolve through XDG at all. Its paths are
+    module globals bound at IMPORT time from ``Path.home()``::
+
+        PLIST_DIR    = ~/Library/LaunchAgents
+        PLIST_PATH   = PLIST_DIR / "dev.kirocrew.gateway.plist"
+        LOG_DIR      = ~/Library/Logs/...        (+ STDOUT_LOG, STDERR_LOG)
+        LIVE_PROGRAM = launchd_live_program()    (under ~/Library/Application Support)
+
+    That is the same import-time-binding class the suite already documents (#874):
+    an env var read *after* the module captured the path changes nothing, so the
+    redirect above leaves the launchd side wide open.
+
+    It is reachable today, not hypothetically. ``macos.install()`` calls
+    ``write_live_program(render_live_program(kirocrew_bin()))`` with no path
+    argument, so the launcher lands on the real ``LIVE_PROGRAM`` even in a test that
+    carefully pinned every ``PLIST_*`` constant — which
+    ``test_install_writes_plist_and_loads`` does. Raised in review of #1722.
+
+    Every binding is patched rather than just the canonical one, because both
+    consumers import by value: ``dev_fleet.gateway_service`` holds its own
+    ``PLIST_PATH`` and its own ``launchd_live_program`` reference, and
+    ``LaunchdBackend.live_program()`` calls that function fresh on each use instead
+    of reading the constant.
+
+    ``gateway_service`` is patched only when it is already imported. It is a heavy
+    module and forcing it in for all ~31k tests would cost more than it protects; a
+    test that imports it later binds from the already-patched ``service.macos``, so
+    it inherits the tmp paths anyway.
+
+    Tolerant by design: an unimportable module is skipped rather than failing
+    collection, and every attribute uses ``raising=False`` so a renamed constant
+    does not become a suite-wide error.
+    """
+    root = pathlib.Path(_xdg_config_root) / "launchd"
+    launcher = root / "live-gateway"
+    plist_dir = root / "LaunchAgents"
+    plist_path = plist_dir / "dev.kirocrew.gateway.plist"
+    log_dir = root / "Logs"
+
+    eager: dict[str, dict[str, object]] = {
+        "kiro_crew.service.macos": {
+            "PLIST_DIR": plist_dir,
+            "PLIST_PATH": plist_path,
+            "LOG_DIR": log_dir,
+            "STDOUT_LOG": log_dir / "gateway.log",
+            "STDERR_LOG": log_dir / "gateway.err",
+            "LIVE_PROGRAM": launcher,
+        },
+        "kiro_crew.service.common": {"launchd_live_program": lambda: launcher},
+    }
+    lazy: dict[str, dict[str, object]] = {
+        "kiro_crew.apps.builtins.dev_fleet.gateway_service": {
+            "PLIST_PATH": plist_path,
+            "launchd_live_program": lambda: launcher,
+        },
+    }
+
+    for name, attrs in eager.items():
+        try:
+            imported = importlib.import_module(name)
+        except Exception:  # pragma: no cover - a partial checkout must not break collection
+            continue
+        for attr, value in attrs.items():
+            monkeypatch.setattr(imported, attr, value, raising=False)
+
+    for name, attrs in lazy.items():
+        already = sys.modules.get(name)
+        if already is None:
+            continue
+        for attr, value in attrs.items():
+            monkeypatch.setattr(already, attr, value, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _block_host_service_mutation(request, monkeypatch):
+    """Fail loudly if a test really starts, stops, or reconfigures a service.
+
+    Redirecting ``$XDG_CONFIG_HOME`` above stops a test from *writing* a real
+    unit file, but not from *running* ``systemctl --user daemon-reload`` or
+    ``systemctl --user restart kirocrew-gateway.service``. Those restart the
+    developer's live gateway even when the drop-in they read is pristine, so the
+    second half of the floor has to be an execution guard.
+
+    Patched at the deepest stdlib funnels rather than at the names call sites
+    happen to use, so the guard cannot be bypassed by import style:
+
+    * ``subprocess.Popen.__init__`` — every sync spawn funnels here, including
+      ``run``, ``check_call`` and ``check_output``, and including a module that
+      did ``from subprocess import run`` (that ``run`` still resolves ``Popen``
+      through its own module globals).
+    * ``BaseEventLoop.subprocess_exec`` / ``subprocess_shell`` — every
+      ``asyncio.create_subprocess_*`` funnels here, so patching these also covers
+      ``from asyncio import create_subprocess_exec``.
+    * ``os.execve`` — ``live_target.maybe_reexec()`` execs into another checkout,
+      which would REPLACE the pytest process with a real gateway. Guarded
+      unconditionally: no argv inspection makes that sane in a test.
+
+      ``os.execv`` is deliberately NOT guarded. The two exec paths in this
+      codebase use different funnels, and the difference is load-bearing:
+      ``maybe_reexec`` needs ``execve`` because it hands the gateway a modified
+      environment across the exec, while ``spawn/exec_shim`` uses ``execv``
+      precisely because it passes its inherited environment through untouched
+      ("execv, not execve: the environment this process was given IS the
+      environment the caller built"). The shim's exec also happens in a CHILD
+      process (it is spawned as ``python -c <shim source>``), so trapping
+      ``execv`` here protects nothing and only breaks the shim's in-process unit
+      tests of its own 127-on-exec-failure contract.
+      ``test_host_service_guard.py`` ratchets the assumption that
+      ``live_target`` still execs through ``execve``.
+
+    The mechanism follows ``test/test_update_git_guard.py``, which already
+    monkeypatches ``create_subprocess_exec`` to raise on an unwanted spawn. The
+    difference is scope: this one is autouse, so it holds for tests nobody
+    thought to write a guard for.
+
+    Everything else is delegated to the real implementation untouched — which
+    matters more than it sounds, because ``sandbox`` wraps nearly every spawn in
+    this codebase in ``systemd-run --scope`` for cgroup limits. A guard keyed on
+    binaries rather than verbs refused ``git config``.
+    """
+    if request.module is not None and request.module.__name__ in _HOST_SERVICE_EXEC_ALLOWED_MODULES:
+        return
+
+    real_popen_init = subprocess.Popen.__init__
+    real_exec = asyncio.base_events.BaseEventLoop.subprocess_exec
+    real_shell = asyncio.base_events.BaseEventLoop.subprocess_shell
+
+    def guarded_popen_init(self, args=(), *rest, **kwargs):
+        reason = _refusal_reason(args, shell=bool(kwargs.get("shell")))
+        if reason:
+            _refuse(reason, args)
+        return real_popen_init(self, args, *rest, **kwargs)
+
+    def guarded_subprocess_exec(self, protocol_factory, program=None, *args, **kwargs):
+        argv = [program, *args]
+        reason = _refusal_reason(argv)
+        if reason:
+            _refuse(reason, argv)
+        return real_exec(self, protocol_factory, program, *args, **kwargs)
+
+    def guarded_subprocess_shell(self, protocol_factory, cmd=None, **kwargs):
+        reason = _refusal_reason(cmd, shell=True)
+        if reason:
+            _refuse(reason, cmd)
+        return real_shell(self, protocol_factory, cmd, **kwargs)
+
+    def guarded_exec(*argv, **kwargs):
+        raise AssertionError(
+            "Test called os.execve, which would REPLACE the pytest process with "
+            f"another checkout's gateway (see issue #1722). argv: {argv!r}\n"
+            "Stub the re-exec seam instead (e.g. live_target.maybe_reexec)."
+        )
+
+    monkeypatch.setattr(subprocess.Popen, "__init__", guarded_popen_init)
+    monkeypatch.setattr(
+        asyncio.base_events.BaseEventLoop, "subprocess_exec", guarded_subprocess_exec
+    )
+    monkeypatch.setattr(
+        asyncio.base_events.BaseEventLoop, "subprocess_shell", guarded_subprocess_shell
+    )
+    monkeypatch.setattr(os, "execve", guarded_exec)

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -100,6 +100,27 @@ test). The sweep's own behavior belongs in its own module's tests.
   subagents or persists agent folders without isolating the import-time global
   leaks stub folders into `~/.kiro/crew/subagents/`, which a running gateway then
   sweeps as orphans on its next restart.
+- Tests MUST NOT reconfigure or restart a real host service. This is enforced,
+  not just asked for: the **rootdir** `conftest.py` (distinct from
+  `test/conftest.py`, which only applies to `test/` — `testpaths` also collects
+  `transfer` and `src/kiro_crew/apps/builtins`) pins `$XDG_CONFIG_HOME` to a tmp
+  dir so `dev_fleet._dropin_path()` cannot name the operator's real
+  `~/.config/systemd/user/kirocrew-gateway.service.d/`, and traps every stdlib
+  spawn funnel (`subprocess.Popen.__init__`,
+  `BaseEventLoop.subprocess_exec`/`subprocess_shell`, `os.execve`) to
+  refuse a `systemctl`/`launchctl` invocation carrying a **mutating verb**
+  (`restart`, `daemon-reload`, `stop`, `enable`, `load`, `bootout`, …). Read-only
+  queries (`systemctl show`, `cat`, `is-active`) are allowed and need no stub,
+  and `systemd-run` is deliberately NOT guarded because `sandbox` wraps nearly
+  every subprocess in `systemd-run --scope` for cgroup limits — the guard keys on
+  the verb, so it still catches `systemd-run … -- systemctl restart …` on the
+  inner token. A test that reaches the make-live cutover path must stub BOTH
+  `_run_cmd` and `_dropin_path`. Issue #1722: a test asserting that a staged
+  cutover could be *cancelled* rewrote the developer's real unit to point into
+  its own pytest temp dir, and systemd then looped on `203/EXEC` for 25 minutes
+  after that dir was deleted. `test/test_host_service_guard.py` ratchets the
+  guarded set against the service tools `src/` actually names, so a new
+  host-mutating call site cannot land outside the floor.
 - Tests SHOULD be fast (< 1s each)
 - Async tests MUST use `@pytest.mark.asyncio`
 

--- a/test/test_channel_activation.py
+++ b/test/test_channel_activation.py
@@ -296,7 +296,6 @@ class TestHandlerChannelAgent:
     async def test_channel_agent_passed_to_session(self):
         """channel_agent parameter is used for session agent selection."""
         from conftest import MockSlackClient
-
         from kiro_crew.slack.handler import handle_message
 
         class FakeProvider:

--- a/test/test_host_service_guard.py
+++ b/test/test_host_service_guard.py
@@ -1,0 +1,460 @@
+"""The host-mutation floor guards itself (issue #1722).
+
+Two jobs:
+
+* **Behaviour** — prove the root ``conftest.py`` fixtures are actually armed, that
+  they catch the argv shapes this codebase really produces, and that they do NOT
+  interfere with an ordinary spawn. A guard nobody exercises is a guard that
+  silently stops working after a refactor.
+* **Ratchet** — pin the guarded set against the service managers production
+  actually shells out to, so a NEW host-mutating call site in ``src/`` cannot land
+  outside the guard's coverage. Same shape as ``test_spawn_preexec_guard.py``'s
+  ``_ALLOWED``.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import functools
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_ROOT_CONFTEST = _REPO_ROOT / "conftest.py"
+_SRC = _REPO_ROOT / "src" / "kiro_crew"
+
+
+def _load_root_conftest():
+    """Import the rootdir conftest under its own module name.
+
+    pytest already loads it as a plugin, but reaching it through the plugin
+    manager depends on the name pytest happened to register. Loading it by path
+    is deterministic, and the fixtures it defines are inert in this namespace
+    (a ``@pytest.fixture`` decorator only marks a function; nothing collects
+    them from here).
+    """
+    spec = importlib.util.spec_from_file_location("_kirocrew_root_conftest", _ROOT_CONFTEST)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_root = _load_root_conftest()
+
+#: Every program that could plausibly control a host service, across the init
+#: systems this product might ever run under. Deliberately WIDER than what the
+#: guard acts on, so that adding e.g. an ``initctl`` call site to production fails
+#: the ratchet below until someone decides guard-or-exclude.
+#:
+#: Generic words are excluded on purpose. ``"service"`` as a bare literal is
+#: almost always a dict key or a log message, and ``"systemd"`` / ``"launchd"`` in
+#: this codebase are manager LABELS (``gateway_service.py`` ``kind = "launchd"``,
+#: ``service/common.py`` ``LAUNCHD = "launchd"``), never ``argv[0]``.
+_SERVICE_TOOL_VOCABULARY = frozenset(
+    {
+        "systemctl",
+        "systemd-run",
+        "launchctl",
+        "apparmor_parser",
+        "sudo",
+        "pkexec",
+        "doas",
+        "initctl",
+        "telinit",
+        "rc-service",
+        "update-rc.d",
+        "chkconfig",
+        "svcadm",
+        "rcctl",
+        "sc.exe",
+    }
+)
+
+#: Tools present in ``src/`` that the guard intentionally lets through, with the
+#: reason. Reviewed as part of this test rather than buried in a comment.
+_DELIBERATELY_UNGUARDED = {
+    # sandbox wraps nearly EVERY subprocess in `systemd-run --user --scope
+    # --slice=kirocrew-agents.slice -p MemoryMax=...` to apply cgroup limits.
+    # Refusing it refuses an ordinary `git config` spawn. Its one service-control
+    # use passes `systemctl restart` as the wrapped command, caught on the inner
+    # token instead -- pinned by test_wrapped_service_restart_is_refused below.
+    "systemd-run": "cgroup scope wrapper, not a service-control verb",
+    # A privilege prefix, not an action. `sudo systemctl restart` is caught on
+    # `systemctl`; `sudo` alone says nothing about whether state changes.
+    "sudo": "privilege prefix; the wrapped command carries the action",
+}
+
+
+def _docstring_nodes(tree: ast.AST) -> set[int]:
+    """ids() of string-literal nodes that are docstrings, so prose is skipped."""
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+            if isinstance(first.value.value, str):
+                out.add(id(first.value))
+    return out
+
+
+@functools.lru_cache(maxsize=1)
+def _service_tools_referenced_in_src() -> dict[str, tuple[str, ...]]:
+    """Map each vocabulary program name -> where ``src/`` names it as a literal.
+
+    Whitespace-bearing literals are skipped: a rendered unit file or a sentence
+    mentioning ``systemctl --user`` is documentation or file content, not an argv
+    token. An argv token never contains a space, so this keeps prose out without
+    needing to model every call shape -- the codebase spawns through several
+    wrappers (``_run_cmd``, ``_systemctl``, ``sandboxed_spawn_argv``), so a scan
+    anchored on stdlib call sites alone would miss most of them.
+    """
+    found: dict[str, list[str]] = {}
+    for path in sorted(_SRC.rglob("*.py")):
+        if "_vendor" in path.parts:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        skip = _docstring_nodes(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if id(node) in skip:
+                continue
+            token = node.value
+            if not token or any(c.isspace() for c in token):
+                continue
+            name = pathlib.PurePath(token.replace("\\", "/")).name
+            if name in _SERVICE_TOOL_VOCABULARY:
+                found.setdefault(name, []).append(f"{path.relative_to(_REPO_ROOT)}:{node.lineno}")
+    # Frozen on the way out: the result is cached and shared by every caller.
+    return {name: tuple(sites) for name, sites in found.items()}
+
+
+class TestRatchet:
+    def test_every_service_tool_in_src_is_guarded_or_explicitly_excluded(self) -> None:
+        """A new service-control tool in production must be a conscious decision.
+
+        Without this, someone adding an ``initctl`` or ``pkexec`` call site would
+        land a spawn the floor does not recognise, and the next #1722 would look
+        exactly like the first one.
+        """
+        accounted = (
+            _root._SERVICE_MANAGERS
+            | _root._ALWAYS_REFUSED
+            | frozenset(_DELIBERATELY_UNGUARDED)
+        )
+        unaccounted = {
+            name: sites
+            for name, sites in _service_tools_referenced_in_src().items()
+            if name not in accounted
+        }
+        assert not unaccounted, (
+            "src/ names service-control tools the host-mutation guard neither "
+            "covers nor explicitly excludes. Either add each to _SERVICE_MANAGERS "
+            "(with its mutating verbs in _MUTATING_VERBS) / _ALWAYS_REFUSED in the "
+            "root conftest.py, or add it to _DELIBERATELY_UNGUARDED here with a "
+            f"reason:\n{unaccounted}"
+        )
+
+    def test_exclusions_are_still_real(self) -> None:
+        """Drop an exclusion once production stops using the tool.
+
+        Keeps ``_DELIBERATELY_UNGUARDED`` from accumulating stale entries that
+        quietly widen the hole for a tool nobody calls any more.
+        """
+        referenced = _service_tools_referenced_in_src()
+        stale = [name for name in _DELIBERATELY_UNGUARDED if name not in referenced]
+        assert not stale, f"src/ no longer uses these, so stop excluding them: {stale}"
+
+    def test_scan_actually_finds_something(self) -> None:
+        """Guards the ratchet against silently scanning nothing.
+
+        If ``_SRC`` moved or the AST walk broke, the assertions above would pass
+        vacuously on an empty result. Production is known to invoke systemctl and
+        launchctl, so an empty scan means the detector is broken, not that the
+        codebase got clean.
+        """
+        referenced = _service_tools_referenced_in_src()
+        assert "systemctl" in referenced
+        assert "launchctl" in referenced
+
+    def test_exec_allowlist_is_empty(self) -> None:
+        """No test may drive a real service today, and adding one needs review."""
+        assert _root._HOST_SERVICE_EXEC_ALLOWED_MODULES == frozenset()
+
+    def test_live_target_reexecs_through_the_guarded_funnel(self) -> None:
+        """The guard traps ``execve`` only; pin that this is still the funnel used.
+
+        ``maybe_reexec`` replacing the pytest process with a real gateway is the
+        thing worth blocking, and it is reachable only through ``os.execve``.
+        ``os.execv`` is left unguarded so the exec shim's own contract stays
+        testable. If ``live_target`` ever switches funnel, that reasoning breaks
+        silently and the re-exec becomes unguarded -- so fail here instead.
+        """
+        source = (_SRC / "service" / "live_target.py").read_text(encoding="utf-8")
+        used = set()
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr.startswith("exec"):
+                used.add(func.attr)
+        assert used, "no os.exec* call found in live_target.py -- has it moved?"
+        assert used <= {"execve"}, (
+            "live_target now execs through a funnel the root conftest does not trap: "
+            f"{sorted(used)}. Either guard it there, or update this test's reasoning."
+        )
+
+
+class TestRefusalReason:
+    """``_refusal_reason`` decides what counts as host service mutation."""
+
+    def test_a_mutating_verb_is_refused(self) -> None:
+        assert _root._refusal_reason(["systemctl", "--user", "restart", "x"])
+
+    def test_daemon_reload_is_refused(self) -> None:
+        assert _root._refusal_reason(["systemctl", "--user", "daemon-reload"])
+
+    def test_an_absolute_path_is_matched(self) -> None:
+        """``dev_fleet._run_cmd`` rewrites argv[0] to a trusted absolute path."""
+        assert _root._refusal_reason(["/usr/bin/systemctl", "--user", "stop", "x"])
+
+    def test_a_read_only_query_is_allowed(self) -> None:
+        """The verb matters, not just the binary.
+
+        Tests legitimately run these through the sandbox to inspect the
+        environment they are running in, and they change nothing.
+        """
+        assert _root._refusal_reason(["systemctl", "--user", "show", "x", "--value"]) is None
+        assert _root._refusal_reason(["systemctl", "--user", "cat", "x"]) is None
+        assert _root._refusal_reason(["systemctl", "is-active", "x"]) is None
+        assert _root._refusal_reason(["launchctl", "list"]) is None
+
+    def test_a_cgroup_scope_wrapper_is_allowed(self) -> None:
+        """The regression that keying on binaries alone caused.
+
+        ``sandbox`` wraps nearly every spawn in ``systemd-run --scope`` for cgroup
+        limits, so a binary-keyed guard refused an ordinary ``git config``. This is
+        the exact argv shape that failed 27 tests before the guard learned verbs.
+        """
+        argv = [
+            "/usr/bin/systemd-run", "--user", "--scope", "-q",
+            "--slice=kirocrew-agents.slice", "-p", "MemoryMax=82386M",
+            "--", "/usr/bin/git", "config", "branch.main.remote",
+        ]
+        assert _root._refusal_reason(argv) is None
+
+    def test_wrapped_service_restart_is_refused(self) -> None:
+        """...but the real cutover, wrapped the same way, must still be caught.
+
+        ``SystemdBackend.restart_detached`` invokes through ``systemd-run``, so the
+        dangerous verb is nested two wrappers deep. This is the pair that makes
+        the exclusion of ``systemd-run`` safe.
+        """
+        argv = [
+            "/usr/bin/systemd-run", "--user", "--scope", "-q",
+            "--", "/usr/bin/systemctl", "--user", "restart", "kirocrew-gateway.service",
+        ]
+        assert _root._refusal_reason(argv)
+
+    def test_sudo_wrapped_mutation_is_refused(self) -> None:
+        assert _root._refusal_reason(["sudo", "systemctl", "stop", "kirocrew.service"])
+
+    def test_sudo_alone_is_allowed(self) -> None:
+        """A privilege prefix is not an action."""
+        assert _root._refusal_reason(["sudo", "cat", "/etc/hosts"]) is None
+
+    def test_apparmor_parser_is_always_refused(self) -> None:
+        """No read-only mode worth allowing: any invocation rewrites policy."""
+        assert _root._refusal_reason(["apparmor_parser", "-r", "/etc/apparmor.d/x"])
+
+    def test_a_shell_string_is_matched(self) -> None:
+        assert _root._refusal_reason("systemctl --user daemon-reload", shell=True)
+
+    def test_a_lookalike_token_is_ignored(self) -> None:
+        """A flag or message that merely CONTAINS a name is not a spawn."""
+        assert _root._refusal_reason(["git", "log", "--grep=systemctl"]) is None
+        assert _root._refusal_reason(["echo", "restart the service"]) is None
+
+    def test_a_unit_filename_is_ignored(self) -> None:
+        assert _root._refusal_reason(["cat", "kirocrew-gateway.service"]) is None
+
+    def test_a_verb_before_the_manager_is_ignored(self) -> None:
+        """Only the tail is scanned, so a wrapper's own flags cannot be the action."""
+        assert _root._refusal_reason(["restart-helper", "--", "systemctl", "show", "x"]) is None
+
+    def test_an_ordinary_spawn_is_allowed(self) -> None:
+        assert _root._refusal_reason(["git", "status", "--porcelain"]) is None
+
+    def test_an_unrecognised_argv_shape_is_tolerated(self) -> None:
+        """Positive matches only -- an exotic argv can never fail a random test."""
+        assert _root._refusal_reason(None) is None
+        assert _root._refusal_reason(12345) is None
+        assert _root._refusal_reason([None, 7]) is None
+
+    def test_a_pathlike_is_matched(self) -> None:
+        assert _root._refusal_reason([pathlib.Path("/bin/launchctl"), "unload", "x"])
+
+
+class TestGuardIsArmed:
+    """End-to-end: the autouse fixture is live during this very test.
+
+    These do not patch anything -- they call the real stdlib APIs and rely on the
+    root conftest's autouse fixture being in effect. That makes them a mutation
+    test of the fixture itself: disarm it and every assertion here fails.
+    """
+
+    def test_sync_spawn_is_refused(self) -> None:
+        with pytest.raises(AssertionError, match="mutates host service state"):
+            subprocess.run(["systemctl", "--user", "restart", "x"], capture_output=True)
+
+    def test_popen_is_refused(self) -> None:
+        with pytest.raises(AssertionError, match="mutates host service state"):
+            subprocess.Popen(["/usr/bin/launchctl", "unload", "x"])
+
+    def test_check_output_is_refused(self) -> None:
+        """``check_output`` never touches ``subprocess.run``; it funnels via Popen."""
+        with pytest.raises(AssertionError, match="mutates host service state"):
+            subprocess.check_output(["systemctl", "--user", "daemon-reload"])
+
+    def test_async_spawn_is_refused(self) -> None:
+        async def go():
+            await asyncio.create_subprocess_exec(
+                "/usr/bin/systemctl", "--user", "daemon-reload",
+                stdout=asyncio.subprocess.PIPE,
+            )
+
+        with pytest.raises(AssertionError, match="mutates host service state"):
+            asyncio.run(go())
+
+    def test_async_shell_spawn_is_refused(self) -> None:
+        async def go():
+            await asyncio.create_subprocess_shell("systemctl --user restart x")
+
+        with pytest.raises(AssertionError, match="mutates host service state"):
+            asyncio.run(go())
+
+    def test_os_execve_is_refused(self) -> None:
+        """``live_target.maybe_reexec`` would replace the pytest process."""
+        with pytest.raises(AssertionError, match="REPLACE the pytest process"):
+            os.execve("/bin/true", ["/bin/true"], {})
+
+    def test_os_execv_is_left_alone(self) -> None:
+        """The exec shim's own 127-on-failure contract must still be testable.
+
+        ``spawn/exec_shim`` uses ``execv`` deliberately (it passes its inherited
+        env through untouched) and its real exec happens in a child process, so
+        trapping ``execv`` in the pytest process protects nothing and breaks the
+        shim's unit tests. A nonexistent path must still surface as ``OSError``,
+        which is what the shim catches to return 127.
+        """
+        with pytest.raises(OSError):
+            os.execv("/nonexistent/binary/for/this/test", ["x"])
+
+    def test_an_ordinary_spawn_still_works(self) -> None:
+        """Delegation is intact: the guard must not break git/npm/python spawns.
+
+        Without this the whole fixture could be a blanket refusal and the suite
+        above would still pass.
+        """
+        res = subprocess.run([sys.executable, "-c", "print('ok')"], capture_output=True, text=True)
+        assert res.returncode == 0
+        assert res.stdout.strip() == "ok"
+
+    def test_an_ordinary_async_spawn_still_works(self) -> None:
+        async def go():
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, "-c", "print('ok')", stdout=asyncio.subprocess.PIPE,
+            )
+            out, _ = await proc.communicate()
+            return out
+
+        assert asyncio.run(go()).strip() == b"ok"
+
+
+class TestLaunchdRedirect:
+    """The macOS half does not resolve through XDG, so it needs its own pins."""
+
+    def _assert_under(self, value, root) -> None:
+        """Assert *value* lives inside the session tmp root.
+
+        Containment in the tmp root, NOT "outside ``Path.home()``": on Windows the
+        pytest temp dir is ``C:\\Users\\<user>\\AppData\\Local\\Temp\\pytest-of-...``,
+        which is legitimately *inside* the home directory, so an "outside home"
+        assertion encodes a POSIX-only assumption. Asserting the redirect target
+        directly is both platform-correct and a stronger claim.
+        """
+        resolved = pathlib.Path(value).resolve()
+        root = pathlib.Path(root).resolve()
+        assert root == resolved or root in resolved.parents, f"{resolved} is not under {root}"
+
+    def test_every_macos_install_path_is_redirected(self, _xdg_config_root) -> None:
+        from kiro_crew.service import macos
+
+        for attr in ("PLIST_DIR", "PLIST_PATH", "LOG_DIR", "STDOUT_LOG", "STDERR_LOG",
+                     "LIVE_PROGRAM"):
+            self._assert_under(getattr(macos, attr), _xdg_config_root)
+
+    def test_the_launcher_path_helper_is_redirected(self, _xdg_config_root) -> None:
+        """``LaunchdBackend.live_program()`` calls the function, not the constant."""
+        from kiro_crew.service.common import launchd_live_program
+
+        self._assert_under(launchd_live_program(), _xdg_config_root)
+
+    def test_install_writes_the_launcher_into_tmp_not_the_real_home(
+        self, _xdg_config_root
+    ) -> None:
+        """The exact leak raised in review: install() ignores the PLIST_* pins.
+
+        ``macos.install()`` calls ``write_live_program(render_live_program(...))``
+        with no path argument, so before this fixture existed the launcher landed on
+        the real ``LIVE_PROGRAM`` even when a test had pinned every ``PLIST_*``
+        constant. Subprocess is stubbed here because ``launchctl load`` is a
+        mutating verb the execution guard would (correctly) refuse.
+        """
+        from kiro_crew.service import macos
+
+        with mock.patch.object(macos, "_launchctl", return_value=SimpleNamespace(
+            returncode=0, stdout="", stderr=""
+        )), mock.patch.object(macos, "kirocrew_bin", return_value="/usr/bin/true"):
+            macos.install()
+
+        self._assert_under(macos.LIVE_PROGRAM, _xdg_config_root)
+        assert macos.LIVE_PROGRAM.exists(), "install() should have written the tmp launcher"
+        assert macos.PLIST_PATH.exists(), "install() should have written the tmp plist"
+
+
+class TestXdgRedirect:
+    def test_xdg_config_home_is_set_and_not_the_real_home(self) -> None:
+        """The systemd drop-in path resolves from this variable."""
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        assert xdg, "XDG_CONFIG_HOME must be pinned so no test writes a real unit file"
+        assert pathlib.Path(xdg).resolve() != (pathlib.Path.home() / ".config").resolve()
+
+    def test_the_dropin_path_lands_outside_the_real_config_dir(self) -> None:
+        """The exact call that caused #1722, now provably harmless.
+
+        ``_dropin_path()`` is unstubbed here on purpose -- that is the whole point.
+        A test that forgets to stub it must no longer be able to name the
+        operator's real unit directory.
+        """
+        from kiro_crew.apps.builtins.dev_fleet import server as mod
+
+        dropin = mod._dropin_path().resolve()
+        real = (pathlib.Path.home() / ".config" / "systemd" / "user").resolve()
+        assert real not in dropin.parents, f"{dropin} is inside the operator's real config dir"

--- a/test/test_interaction_telemetry.py
+++ b/test/test_interaction_telemetry.py
@@ -13,8 +13,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from chat_test_helpers import _make_state
-from conftest import MockSlackClient
 
+from conftest import MockSlackClient
 from kiro_crew.acp.types import STOP_REASON_CANCELLED
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.platform import build_default_context

--- a/test/test_scenarios_v2.py
+++ b/test/test_scenarios_v2.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import requires_git
 
+from conftest import requires_git
 from kiro_crew import git_coord
 from kiro_crew.taskrunner import (
     Step,

--- a/test/test_slack_client.py
+++ b/test/test_slack_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from conftest import MockSlackClient
 
 

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from conftest import MockSlackClient
 
+from conftest import MockSlackClient
 from kiro_crew.context import ContextBuilder
 from kiro_crew.hooks import AutoReplyHook, HookManager, HooksConfig
 from kiro_crew.providers.base import LLMEvent

--- a/test/test_slack_sessions_view.py
+++ b/test/test_slack_sessions_view.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from conftest import MockSlackClient
 
+from conftest import MockSlackClient
 from kiro_crew.slack.handler import _handle_sessions_command
 from kiro_crew.slack.sessions_view import (
     _SESSION_KIND_DASHBOARD,

--- a/test/test_sync_bridge.py
+++ b/test/test_sync_bridge.py
@@ -7,8 +7,8 @@ import time
 from unittest.mock import patch
 
 import pytest
-from conftest import MockSlackClient
 
+from conftest import MockSlackClient
 from kiro_crew.history import ConversationLog
 from kiro_crew.sync_bridge import (
     _PENDING_RESUME_TTL,

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from conftest import requires_git
 
+from conftest import requires_git
 from kiro_crew.task_models import PROGRESS_FILE
 from kiro_crew.taskrunner import (
     _STALL_CANCEL_TIMEOUT,

--- a/test/test_taskrunner_v2_scenarios.py
+++ b/test/test_taskrunner_v2_scenarios.py
@@ -15,8 +15,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from conftest import requires_git
 
+from conftest import requires_git
 from kiro_crew.taskrunner import (
     MAX_TOTAL_TASKS,
     Step,

--- a/test/test_thread_override_persistence.py
+++ b/test/test_thread_override_persistence.py
@@ -6,8 +6,8 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from conftest import MockSlackClient
 
+from conftest import MockSlackClient
 from kiro_crew.slack.handler import (
     _discover_project_agents,
     _hydrate_thread_overrides,

--- a/test/test_thread_parent_context.py
+++ b/test/test_thread_parent_context.py
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from conftest import MockSlackClient
 
+from conftest import MockSlackClient
 from kiro_crew.context import ContextBuilder
 from kiro_crew.memory import MemoryStore
 from kiro_crew.providers.base import LLMEvent

--- a/test/test_xdist_host_budget.py
+++ b/test/test_xdist_host_budget.py
@@ -19,8 +19,9 @@ import subprocess
 import sys
 import textwrap
 
-import conftest as ct
 import pytest
+
+import conftest as ct
 
 needs_symlinks = pytest.mark.skipif(
     os.name != "posix", reason="symlink creation needs privileges on Windows"


### PR DESCRIPTION
## 1. What is the problem?

A unit test rewrote the developer's **real** systemd user unit and took the live gateway down for 25 minutes.

`test_cancel_keeps_a_pointer_selected_checkout_live` (added in #1701) asserts that re-pointing at the already-running checkout **cancels** a staged cutover. To assert that, it has to call the real `_make_live()` — that function is the subject under test. Two of that function's seams were not isolated:

- **`_dropin_path()`** (`dev_fleet/server.py`) resolves `$XDG_CONFIG_HOME/systemd/user/kirocrew-gateway.service.d/make-live.conf`, falling back to `~/.config` — the default on every developer box and in CI. Nothing redirected it.
- **`_run_cmd`** was unstubbed in the whole cancel block (unlike `test_make_live_dry_run_plan`, which installs its own `fake_run_cmd`), so the real `systemctl --user daemon-reload` and detached restart ran.

`_mk_make_live_wt` builds a fake worktree convincing enough to pass every production check — `.venv/bin/kirocrew` written and `chmod 0o755` (its docstring calls this "the realistic provisioned state that passes the make-live exec-bit gate") plus `src/kiro_crew/static/dist/index.html`. Production correctly concluded "valid target, cut over" and pointed `ExecStart` at the pytest temp dir. pytest deleted that dir at teardown; the drop-in survived:

```
kirocrew-gateway.service: Failed to locate executable
  /tmp/pytest-of-.../test_cancel_keeps_a_pointer_se0/running/kirocrew-wt-feat/.venv/bin/kirocrew
Failed at step EXEC ... status=203/EXEC
```

**548 failed starts, restart counter 281**, from 00:55:45 until 01:20:39.

## 2. Why this issue matters to the user

This is a missing floor, not one careless test. Three properties make it a class:

1. **The blast radius is the tool the developer is working in.** The symptom is not a red test — it is the gateway entering a restart loop, with the cause (a stale drop-in) *outliving the process that created it*. Recovery requires knowing to read `journalctl` for a systemd unit, which is nowhere near the test output.
2. **Test doubles are built to be convincing enough to defeat validation.** The more faithful the fake worktree, the more completely production accepts it. That is the fixture doing its job, and it is exactly what made the damage total.
3. **Correct isolation was opt-in, per-test, and unenforced.** `_stub_make_live` isolates seven seams and its docstring even mandates one ("Every test that reaches the cutover path MUST pass this") — but the drop-in path and the subprocess layer were left to memory. Existing tests remembered. A new one did not, and nothing failed until the host did.

The macOS half is currently *less* protected, not more: CI runs the Linux matrix, so a launchd-side equivalent would only ever reproduce on someone's laptop.

## 3. How our fix solves it

The chain is symptom → stale drop-in → unredirected `_dropin_path()` + unstubbed `_run_cmd` → *isolation being a convention rather than a floor*. The fix attacks that last link.

**Why the rootdir `conftest.py` and not `test/conftest.py`:** `test/conftest.py` only applies to `test/`. `[tool:pytest] testpaths` also collects `transfer` and `src/kiro_crew/apps/builtins` — 42 test modules that ship inside the package and get **none** of its fixtures, including the existing `KIROCREW_HOME` safety net. A floor placed in `test/conftest.py` would have been partial. There was no rootdir conftest before this PR.

**Layer 1 — redirect `$XDG_CONFIG_HOME`** to a session-scoped tmp dir. This kills the entire class of unit-file writes rather than one call site, because production already honours the variable (its own docstring notes a literal `~/.config` would be wrong on a host that sets XDG). Not dev-fleet-specific either: `pptx_maker/backend/paths.py` resolves against the same variable, so its tests stop touching the real config dir too. Session-scoped because nothing here is written by a passing test — a per-test dir would add a `mkdir` to ~31k tests to isolate nothing. A test that sets its own value still wins.

**Layer 2 — a fail-closed execution guard.** Layer 1 stops a test *writing* a unit file but not *running* `systemctl --user daemon-reload`, which restarts the live gateway even from a pristine drop-in. Patched at the deepest stdlib funnels so import style cannot bypass it: `subprocess.Popen.__init__` (covers `run`/`check_call`/`check_output`, and `from subprocess import run`, since that `run` still resolves `Popen` through its module globals), `BaseEventLoop.subprocess_exec`/`subprocess_shell` (covers `from asyncio import create_subprocess_exec`), and `os.execve`. Mechanism follows `test_update_git_guard.py`, which already traps `create_subprocess_exec`; the difference is that this one is autouse, so it covers tests nobody thought to guard.

**The guard keys on the VERB, not the binary — this was the important correction.** A binary-keyed first draft **failed 27 tests**, because `sandbox` wraps nearly every subprocess in `systemd-run --user --scope --slice=kirocrew-agents.slice -p MemoryMax=…` for cgroup limits, so it refused an ordinary `git config`. It also refused `systemctl show` / `cat` / `is-active`, which tests legitimately run to inspect their own environment and which change nothing. So:

- `systemctl` / `launchctl` are refused only when a mutating verb (`restart`, `daemon-reload`, `stop`, `enable`, `load`, `bootout`, …) appears **after** the manager token.
- `systemd-run` is not guarded — it is a cgroup wrapper here, not a service verb. Its one service-control use passes `systemctl restart` as the wrapped command, still caught on the inner token (pinned by `test_wrapped_service_restart_is_refused`).
- `sudo` is not guarded — a privilege prefix is not an action, and `sudo systemctl restart` is caught on `systemctl`.
- `apparmor_parser` is refused unconditionally: no read-only mode worth allowing.

`os.execv` is deliberately left alone. The two exec paths use different funnels and the difference is load-bearing: `maybe_reexec` needs `execve` because it hands the gateway a modified environment, while `spawn/exec_shim` uses `execv` precisely because it passes its inherited env through untouched — and the shim's real exec happens in a *child* process. Guarding `execv` protected nothing and broke the shim's own "127 on exec failure" contract test (caught by the paired full-suite comparison below). A ratchet pins that `live_target` still execs through `execve`, so this reasoning cannot rot silently.

**Layer 3 — a ratchet** (`test/test_host_service_guard.py`). AST-scans `src/` for service-control tool names and asserts each is either guarded, always-refused, or in an explicitly reasoned `_DELIBERATELY_UNGUARDED` map. Adding an `initctl` or `pkexec` call site to production now fails until someone decides guard-or-exclude. A companion test asserts the exclusions are still real, and another asserts the scan finds something, so the ratchet cannot pass vacuously on a broken detector.

The exec-allowlist (`_HOST_SERVICE_EXEC_ALLOWED_MODULES`) is **empty** and pinned empty by a test.

## 4. What tests we did

**`test/test_host_service_guard.py` — 28 tests, all mutation-verified.** The `TestGuardIsArmed` class patches nothing: it calls the real stdlib APIs and relies on the autouse fixture being live, so disarming the fixture fails every assertion. It also asserts an ordinary spawn (`sys.executable -c print('ok')`, sync and async) still works — without that, a blanket refusal would pass everything else. `test_the_dropin_path_lands_outside_the_real_config_dir` calls the *unstubbed* `_dropin_path()` — the exact #1722 call — and asserts it can no longer name the operator's real unit dir.

**Paired full-suite comparison, guarded worktree vs pristine `main`, isolated `--basetemp` each.** This is how the blast radius was measured rather than asserted:

| Run | Baseline | Guarded | Delta |
|---|---|---|---|
| First paired run | 53 failed / 30828 passed | 51 failed / 30904 passed | **1 real regression** |
| After the `execve` narrowing | 50 failed / 30831 passed | 51 failed / 30905 passed | 1 candidate, disproved |

The first run's regression was real — `test_spawn_exec_shim.py::test_exec_failure_reports_127_not_a_traceback` — and produced the `execv`/`execve` distinction above. The second run's lone difference (`test_sandbox_no_isolation`) was disproved by running that trio head-to-head: **16 failed / 143 passed on both** the guarded worktree and pristine `main`, byte-identical. Those sandbox tests share a warn-once global and are order-dependent under `xdist` (flake class 4 in `testing-conventions.md`), so which member of the cluster lands in the failing set varies per run.

Also verified: the seven suites that touch these paths (`test_service`, `test_pod`, `test_pod_launchd`, `test_live_target`, `test_dev_fleet_app`, `test_sandbox_argv`, `test_update_git_guard`) produce **identical failure sets** with and without the guard — 11 pre-existing failures both ways.

Gates: `isort --check-only`, `flake8`, `mypy` all clean on both new files.

**Caveat, stated plainly:** this machine's full-suite baseline carries ~50 pre-existing failures because the agent sandbox cannot `unshare(CLONE_NEWUSER)` (`EPERM`), so the sandbox and root-owned-binary suites fail environmentally. Those are identical on both sides and CI is the real arbiter for absolute green.

## 5. Any other suggestions on the work

Three things found while verifying this, all out of scope here:

- **The per-test fix for #1701's own cancel tests is deliberately not in this PR**, to keep that PR's review surface intact. It is being handled there.
- **`test/test_config_baseline.py:123` writes `config-baseline.json` into `_REPO_ROOT`**, not `tmp_path`, so running the suite dirties the working tree. Reproduced on a pristine `main` checkout too, so it is pre-existing — but it is the same shape of bug as #1722 (a test mutating something outside its sandbox) and would be a natural next target for this floor.
- **`/tmp` tmpfs inode exhaustion.** Verifying this PR hit `100% IUse` (1048576/1048576) with `/tmp/pytest-of-<user>` holding 860k inodes across 15 stale basetemps, which manifests as `OSError: could not create numbered dir` and collapsed one baseline run into 917 failures / 7408 errors before I noticed. Bytes were fine (54G free), so `df -h` looks healthy and `df -i` is the one that tells you. Worth a periodic sweep or an explicit `--basetemp` in the documented full-suite invocation.

Closes #1722
