### PR TITLE
feat(pod): let a pod choose its approval mode and cron scheduler

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1201,6 +1201,29 @@ Examples:
     )
     pod_up.add_argument("--ttl", default="2h", help="Token TTL (default: 2h)")
     pod_up.add_argument("--seed", default="", help="Seed config dir (tunnel is forced off)")
+    pod_up.add_argument(
+        "--approval",
+        # Literal mirrors kiro_crew.pod.runtime.APPROVAL_MODES, which is the
+        # enforcement point; this parser imports no pod module at startup.
+        choices=["reads", "yolo", "interactive"],
+        help=(
+            "Approval mode the pod's gateway boots with, forwarded to "
+            "`kirocrew gateway --approval`. Persisted per pod so it survives a "
+            "service-manager restart. Omit to leave the gateway's own default in "
+            "force, which resolves from config agent.approval_mode (default: "
+            "auto). Applies at boot, so re-up a stopped pod to change it."
+        ),
+    )
+    pod_up.add_argument(
+        "--crons",
+        action="store_true",
+        help=(
+            "Run the pod's cron scheduler. Pods boot with --no-crons by default. A "
+            "pod's HOME starts with no cron definitions (only a sanitized config is "
+            "seeded), so this enables an empty scheduler for testing cron behavior "
+            "inside the pod. Persisted per pod; applies at boot."
+        ),
+    )
     pod_down = pod_sub.add_parser("down", help="Evict a pod (zero residue)")
     pod_down.add_argument("name", help="Worktree name")
     pod_ls = pod_sub.add_parser("ls", help="List running pods")

--- a/src/kiro_crew/pod/README.md
+++ b/src/kiro_crew/pod/README.md
@@ -2,7 +2,8 @@
 
 Spin up a **throwaway, full-stack KiroCrew gateway** for any feature worktree —
 its own port, its own `KIROCREW_HOME` (own DB / sessions / memory), no Slack
-tunnel, `--no-crons`, resource-capped, and `rm -rf`'d on stop. Test a branch's
+tunnel, `--no-crons` (unless you pass `--crons`), resource-capped, and `rm -rf`'d
+on stop. Test a branch's
 backend `/api/*` **and** the SPA bundle it serves, all **without touching your
 live gateway or your shared `~/.kiro/crew` data**.
 
@@ -17,6 +18,8 @@ kirocrew pod install              # lay down the systemd --user template unit (o
 kirocrew pod provision <wt>       # build the worktree's venv + SPA dist (the on-ramp)
 kirocrew pod up   <wt> [--json]   # bring up an isolated pod → {base_url, token, port}
 kirocrew pod up   <wt> --provision# provision (if needed) then bring it up
+kirocrew pod up   <wt> --approval reads  # boot its gateway in an approval mode
+kirocrew pod up   <wt> --crons          # boot its gateway with the cron scheduler on
 kirocrew pod ls                   # what's running (≈ kubectl get pods)
 kirocrew pod status <wt>          # up/down + health
 kirocrew pod token  <wt> [--ttl]  # (re)mint a dashboard token for a running pod

--- a/src/kiro_crew/pod/cli.py
+++ b/src/kiro_crew/pod/cli.py
@@ -115,17 +115,55 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
     # would delete the pin we just wrote and this pod would crash-loop on boot.
     with rt.pod_name_mutex(cfg, name):
         rt.pin_checkout(cfg, name, checkout)
+        # Boot-time settings, merged into a single env-file write. ``boot`` reads
+        # them once at start, so recording one against a live pod would look
+        # applied and change nothing until a restart -- hence the note below.
+        # Read defensively, as ``provision`` above is: hand-built Namespaces in
+        # tests (and older callers) may not carry every key.
+        env_updates: dict[str, str] = {}
+        boot_flags: list[str] = []
         if args.seed:
-            rt.write_env_file(cfg, name, {"SEED": args.seed})
+            env_updates["SEED"] = args.seed
+        approval = getattr(args, "approval", None)
+        if approval:
+            env_updates["APPROVAL"] = approval
+            boot_flags.append(f"--approval {approval}")
+        crons = bool(getattr(args, "crons", False))
+        if crons:
+            env_updates["CRONS"] = "1"
+            boot_flags.append("--crons")
+        if env_updates:
+            rt.write_env_file(cfg, name, env_updates)
 
-        if not rt.is_active(cfg, name):
+        was_active = rt.is_active(cfg, name)
+        if not was_active:
             cp = rt.start_pod(cfg, name)
             if cp.returncode != 0:
                 _audit(
                     "pod.up", "failure", f"name={name} port={port}", error="backend start failed"
                 )
                 _die(f"starting pod {name} failed: {(cp.stderr or '').strip()}")
-        _audit("pod.up", "allowed", f"name={name} port={port}")
+        elif boot_flags:
+            joined = " ".join(boot_flags)
+            print(
+                f"pod: note: {joined} recorded for {name!r}, but that pod is already "
+                f"running, so it applies on the next boot "
+                f"(kirocrew pod down {name} && kirocrew pod up {name} {joined}).",
+                file=sys.stderr,
+            )
+        # Record boot-time settings: a pod in `yolo` auto-approves every tool and
+        # one with the scheduler on runs work unattended, so the audit trail must
+        # say so rather than recording only that a pod came up. Mark the
+        # requested-but-not-yet-effective case: `boot` reads these once at start,
+        # so a setting recorded against a live pod has not applied yet.
+        resources = f"name={name} port={port}"
+        if approval:
+            resources += f" approval={approval}"
+        if crons:
+            resources += " crons=on"
+        if boot_flags and was_active:
+            resources += " applied=next_boot"
+        _audit("pod.up", "allowed", resources)
 
         code = _wait_healthy(cfg, name, port)
         if code not in (200, 401, 403):

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -44,9 +44,26 @@ def validate_name(name: str) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Per-pod env file (pinned CHECKOUT= / PORT= / SEED=). Values are single-quoted
-# on write and unquoted on read; unknown keys are preserved on merge.
+# Per-pod env file (pinned CHECKOUT= / PORT= / SEED= / APPROVAL=). Values are
+# single-quoted on write and unquoted on read; unknown keys are preserved on
+# merge.
 # --------------------------------------------------------------------------- #
+
+# Approval modes a pod's gateway may boot with, mirroring the choices on
+# ``kirocrew gateway --approval``. This tuple is the ENFORCEMENT point: the env
+# file is hand-editable, so ``boot`` re-validates against it instead of trusting
+# whatever ``pod up`` wrote. The top-level ``cli.py`` repeats the literal for its
+# argparse ``choices`` because that parser deliberately imports no pod module at
+# startup; argparse is the UX layer, this tuple is the invariant.
+APPROVAL_MODES: tuple[str, ...] = ("reads", "yolo", "interactive")
+
+# Truthy spellings accepted for the boolean ``CRONS=`` key. ``pod up --crons``
+# writes ``"1"``; the others are accepted because the env file is hand-editable
+# and these are the obvious alternatives. Anything else is treated as OFF, which
+# is the pre-existing ``--no-crons`` behavior and the safer of the two.
+CRONS_TRUE: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+
 def read_env_file(cfg: PodConfig, name: str) -> dict[str, str]:
     out: dict[str, str] = {}
     f = cfg.env_file(name)
@@ -1003,6 +1020,32 @@ def boot(cfg: PodConfig, name: str) -> int:
         return 70
 
     seed = env_data.get("SEED", "")
+    approval = env_data.get("APPROVAL", "")
+    if approval and approval not in APPROVAL_MODES:
+        # `pod up` constrains the flag, but this file is hand-editable, so an
+        # unknown value can still reach here. Do NOT merely drop it: omitting
+        # --approval does not mean "interactive". The gateway leaves
+        # ``approval_mode`` unset, and slack/events.py falls through to
+        # ``cfg.agent.approval_mode``, which config/loader.py defaults to
+        # "auto" -- auto-approve every tool. Dropping would therefore be the
+        # LEAST restrictive outcome. Pin interactive explicitly instead.
+        print(
+            f"kirocrew-pod: ignoring unknown APPROVAL={approval!r} "
+            f"(expected one of: {', '.join(APPROVAL_MODES)}); "
+            f"forcing --approval interactive"
+        )
+        approval = "interactive"
+
+    crons_raw = env_data.get("CRONS", "")
+    crons = crons_raw.strip().lower() in CRONS_TRUE
+    if crons_raw and not crons:
+        # Same reasoning as APPROVAL above: hand-editable file, so an
+        # unrecognised value falls back to the safer setting (scheduler off)
+        # instead of guessing, and the pod still boots.
+        print(
+            f"kirocrew-pod: ignoring unrecognised CRONS={crons_raw!r} "
+            f"(expected one of: {', '.join(sorted(CRONS_TRUE))}); scheduler stays off"
+        )
 
     # Write the pod's isolated, tunnel-disabled config with owner-only perms.
     # Creates the HOME (0o700) too. Never copies DB/sessions/crons.
@@ -1011,5 +1054,10 @@ def boot(cfg: PodConfig, name: str) -> int:
     print(f"kirocrew-pod: name={name} port={port} home={home_dir} checkout={checkout}")
 
     pod_env = build_pod_env(cfg, home_dir, port, checkout)
-    os.execve(str(bin_path), [str(bin_path), "gateway", "--no-crons"], pod_env)
+    argv = ["gateway"]
+    if not crons:
+        argv.append("--no-crons")
+    if approval:
+        argv += ["--approval", approval]
+    os.execve(str(bin_path), [str(bin_path), *argv], pod_env)
     return 0  # unreachable on success

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import os
 import stat
@@ -1261,3 +1262,304 @@ class TestSessionBus:
             for n in ast.walk(chokepoint)
             if isinstance(n, ast.Call)
         ), "_run no longer passes env=_systemctl_env()"
+
+
+class TestBootTimeSettings:
+    """``pod up --approval`` / ``--crons`` are persisted per pod and applied at boot.
+
+    Neither can ride the unit file: both backends re-enter the pod as
+    ``kirocrew pod _run <name>`` with no flags. On systemd one template unit is
+    shared by every instance, so it cannot carry per-pod flags; launchd writes a
+    per-pod plist but still execs that same flagless argv. So they travel through
+    the per-pod env file, exactly as ``SEED`` does.
+    """
+
+    def _booted_argv(
+        self, root: Path, monkeypatch: pytest.MonkeyPatch, env: dict[str, str]
+    ) -> list[str]:
+        """Boot a ready pod with *env* merged into its env file; return the exec argv."""
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(root / "env"))
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(root / "pods"))
+        c = PodConfig.load()
+        rt.pin_checkout(c, "x", _ready_worktree(root, "x"))
+        if env:
+            rt.write_env_file(c, "x", env)
+        seen: list[list[str]] = []
+        monkeypatch.setattr(rt, "derive_port", lambda cfg, n: 7811)
+        monkeypatch.setattr(os, "execve", lambda path, argv, e: seen.append(argv))
+        rt.boot(c, "x")
+        assert len(seen) == 1, "boot did not exec exactly once"
+        return seen[0][1:]  # drop argv[0], the venv binary path
+
+    def test_boot_forwards_the_recorded_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        argv = self._booted_argv(tmp_path, monkeypatch, {"APPROVAL": "reads"})
+        assert argv == ["gateway", "--no-crons", "--approval", "reads"]
+
+    def test_boot_argv_unchanged_when_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The no-regression pin: a pod created before this flag existed, or
+        # created without it, must boot byte-identically to before.
+        argv = self._booted_argv(tmp_path, monkeypatch, {})
+        assert argv == ["gateway", "--no-crons"]
+
+    def test_boot_forces_interactive_on_an_unknown_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        # The env file is hand-editable, so boot re-validates. It must NOT merely
+        # drop the value: omitting --approval leaves approval_mode unset, and the
+        # gateway then falls through to cfg.agent.approval_mode, which
+        # config/loader.py defaults to "auto" -- auto-approve every tool.
+        # Dropping would be the LEAST restrictive outcome, so boot pins
+        # interactive explicitly.
+        argv = self._booted_argv(tmp_path, monkeypatch, {"APPROVAL": "--not-a-mode"})
+        assert argv == ["gateway", "--no-crons", "--approval", "interactive"]
+        assert "ignoring unknown APPROVAL" in capsys.readouterr().out
+
+    def test_every_declared_mode_survives_boot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Behavioural pin only: each mode in the enforcement tuple round-trips
+        # through the env file into argv. This does NOT guard parser drift --
+        # a mode present in cli.py but absent from APPROVAL_MODES is never
+        # iterated here. test_cli_approval_choices_match_the_enforcement_tuple
+        # covers that.
+        for mode in rt.APPROVAL_MODES:
+            argv = self._booted_argv(tmp_path / mode, monkeypatch, {"APPROVAL": mode})
+            assert argv[-2:] == ["--approval", mode]
+
+    @staticmethod
+    def _top_level_cli_ast() -> ast.Module:
+        # rt.__file__ is pod/runtime.py, so parent.parent is the package root.
+        # encoding is explicit: cli.py contains non-ASCII (emoji in guard
+        # messages), and read_text() defaults to the platform locale codec,
+        # which is cp1252 on Windows CI and raises UnicodeDecodeError there.
+        src = (Path(rt.__file__).parent.parent / "cli.py").read_text(encoding="utf-8")
+        return ast.parse(src)
+
+    def test_cli_approval_choices_match_the_enforcement_tuple(self) -> None:
+        # cli.py repeats the choices literal instead of importing pod.runtime
+        # (the top-level parser must not import pod modules at startup), so the
+        # duplication is real. Read the literal argparse actually registers, so a
+        # mode added on one side only fails HERE rather than being accepted by
+        # argparse and then dropped at boot. Iterating APPROVAL_MODES alone
+        # cannot catch that, because the missing mode is not in it.
+        choices: list[list[str]] = []
+        for node in ast.walk(self._top_level_cli_ast()):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            if not (isinstance(fn, ast.Attribute) and fn.attr == "add_argument"):
+                continue
+            if not (isinstance(fn.value, ast.Name) and fn.value.id == "pod_up"):
+                continue
+            if not any(isinstance(a, ast.Constant) and a.value == "--approval" for a in node.args):
+                continue
+            for kw in node.keywords:
+                if kw.arg == "choices" and isinstance(kw.value, ast.List):
+                    choices.append([e.value for e in kw.value.elts if isinstance(e, ast.Constant)])
+        assert choices == [list(rt.APPROVAL_MODES)], (
+            "pod up --approval choices must match runtime.APPROVAL_MODES exactly; parser "
+            f"declares {choices}, enforcement tuple is {list(rt.APPROVAL_MODES)}"
+        )
+
+    def test_every_pod_subparser_name_is_assigned(self) -> None:
+        # A `--crons` edit deleted `pod_down = pod_sub.add_parser(...)`, leaving
+        # pod_down undefined: a NameError at parser build. That is invisible to
+        # py_compile AND to every test in this file, which imports pod.cli and
+        # never the top-level parser. Pin the structure so it cannot recur.
+        tree = self._top_level_cli_ast()
+        assigned = {
+            t.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            for t in node.targets
+            if isinstance(t, ast.Name) and t.id.startswith("pod_")
+        }
+        used = {
+            n.value.id
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Attribute)
+            and isinstance(n.value, ast.Name)
+            and n.value.id.startswith("pod_")
+        }
+        assert used <= assigned, f"pod_* names used but never assigned: {sorted(used - assigned)}"
+
+    def _prep_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, active: bool
+    ) -> PodConfig:
+        monkeypatch.setenv("KIROCREW_POD_WORKTREES_ROOT", str(tmp_path / "wts"))
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
+        monkeypatch.setattr(rt, "_git_worktrees", lambda ref: {})
+        _ready_worktree(tmp_path / "wts", "demo")
+        monkeypatch.setattr(rt, "derive_port", lambda cfg, n: 7811)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: active)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        return PodConfig.load()
+
+    def test_up_records_the_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        c = self._prep_up(tmp_path, monkeypatch, active=False)
+        pod_cli._up(
+            c,
+            argparse.Namespace(
+                name="demo", json=False, seed="", ttl="2h", provision=False, approval="yolo"
+            ),
+        )
+        assert rt.read_env_file(c, "demo").get("APPROVAL") == "yolo"
+
+    def test_up_on_a_running_pod_notes_the_restart(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        c = self._prep_up(tmp_path, monkeypatch, active=True)
+        pod_cli._up(
+            c,
+            argparse.Namespace(
+                name="demo", json=False, seed="", ttl="2h", provision=False, approval="reads"
+            ),
+        )
+        err = capsys.readouterr().err
+        assert "already running" in err and "pod down demo" in err
+        # Recorded either way, so the next boot picks it up.
+        assert rt.read_env_file(c, "demo").get("APPROVAL") == "reads"
+
+    def test_up_tolerates_a_namespace_without_the_flag(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``provision`` is read the same defensive way, and hand-built Namespaces
+        # (here and in TestUpVerb) must not have to carry every optional key.
+        c = self._prep_up(tmp_path, monkeypatch, active=False)
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=False, seed="", ttl="2h", provision=False)
+        )
+        assert "APPROVAL" not in rt.read_env_file(c, "demo")
+
+    def test_up_audits_the_mode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # `yolo` auto-approves every tool, so the SEL trail must name the mode
+        # rather than recording only that a pod came up.
+        c = self._prep_up(tmp_path, monkeypatch, active=False)
+        seen: list[tuple] = []
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: seen.append(a))
+        pod_cli._up(
+            c,
+            argparse.Namespace(
+                name="demo", json=False, seed="", ttl="2h", provision=False, approval="yolo"
+            ),
+        )
+        allowed = [a for a in seen if a[:2] == ("pod.up", "allowed")]
+        assert allowed, "pod.up allowed was never audited"
+        assert "approval=yolo" in allowed[0][2]
+
+    # --- crons -------------------------------------------------------------
+
+    def test_boot_enables_the_scheduler(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # --no-crons is dropped, which is how the gateway turns the scheduler on.
+        argv = self._booted_argv(tmp_path, monkeypatch, {"CRONS": "1"})
+        assert argv == ["gateway"]
+
+    def test_boot_accepts_alternative_truthy_spellings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The env file is hand-editable, so the obvious spellings are honoured.
+        for i, raw in enumerate(("true", "YES", " on ")):
+            argv = self._booted_argv(tmp_path / f"t{i}", monkeypatch, {"CRONS": raw})
+            assert argv == ["gateway"], raw
+
+    def test_boot_ignores_an_unrecognised_crons_value(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        # Falls back to the safer setting (scheduler off, the pre-existing
+        # behavior) rather than guessing, and the pod still boots.
+        argv = self._booted_argv(tmp_path, monkeypatch, {"CRONS": "maybe"})
+        assert argv == ["gateway", "--no-crons"]
+        assert "ignoring unrecognised CRONS" in capsys.readouterr().out
+
+    def test_boot_combines_crons_and_approval(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        argv = self._booted_argv(
+            tmp_path, monkeypatch, {"CRONS": "1", "APPROVAL": "reads"}
+        )
+        assert argv == ["gateway", "--approval", "reads"]
+
+    def test_up_records_crons(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        c = self._prep_up(tmp_path, monkeypatch, active=False)
+        pod_cli._up(
+            c,
+            argparse.Namespace(
+                name="demo", json=False, seed="", ttl="2h", provision=False, crons=True
+            ),
+        )
+        assert rt.read_env_file(c, "demo").get("CRONS") == "1"
+
+    def test_up_audits_crons(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A pod with the scheduler on runs work unattended; the trail must say so.
+        c = self._prep_up(tmp_path, monkeypatch, active=False)
+        seen: list[tuple] = []
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: seen.append(a))
+        pod_cli._up(
+            c,
+            argparse.Namespace(
+                name="demo", json=False, seed="", ttl="2h", provision=False, crons=True
+            ),
+        )
+        allowed = [a for a in seen if a[:2] == ("pod.up", "allowed")]
+        assert allowed, "pod.up allowed was never audited"
+        assert "crons=on" in allowed[0][2]
+
+    def test_up_notes_every_deferred_flag_on_a_running_pod(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        # One note covers both settings; a per-flag note would be two messages
+        # and the repeated `pod down` instruction would read as two restarts.
+        c = self._prep_up(tmp_path, monkeypatch, active=True)
+        pod_cli._up(
+            c,
+            argparse.Namespace(
+                name="demo",
+                json=False,
+                seed="",
+                ttl="2h",
+                provision=False,
+                approval="yolo",
+                crons=True,
+            ),
+        )
+        err = capsys.readouterr().err
+        assert err.count("pod: note:") == 1
+        assert "--approval yolo --crons" in err
+
+    def test_up_merges_all_boot_settings_into_one_env_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # SEED / APPROVAL / CRONS share one write; the pinned CHECKOUT survives it.
+        c = self._prep_up(tmp_path, monkeypatch, active=False)
+        pod_cli._up(
+            c,
+            argparse.Namespace(
+                name="demo",
+                json=False,
+                seed="/tmp/fixture",
+                ttl="2h",
+                provision=False,
+                approval="reads",
+                crons=True,
+            ),
+        )
+        env = rt.read_env_file(c, "demo")
+        assert env.get("SEED") == "/tmp/fixture"
+        assert env.get("APPROVAL") == "reads"
+        assert env.get("CRONS") == "1"
+        # Compare path components, not a "/"-joined suffix: str(Path) uses "\"
+        # on Windows, so endswith("wts/demo") fails there.
+        checkout = Path(env.get("CHECKOUT", ""))
+        assert (checkout.parent.name, checkout.name) == ("wts", "demo")


### PR DESCRIPTION

## Problem / Motivation

A pod boots its gateway with a fixed argument list. `pod/runtime.py` execs
`["gateway", "--no-crons"]`, so two boot-time settings are unreachable:

1. No approval mode. A pod has no human attached to answer a prompt, so an
   agent turn started inside a pod, through `pod exec` or the `pod-e2e` skill,
   stalls on the first tool call that is not read-only.
2. The scheduler is hardcoded off, so cron behavior cannot be exercised in a pod
   at all.

## Why it matters

Pods exist to run unattended verification, and the `pod-e2e` skill drives agent
turns against a pod. An operator cannot select either setting today. The only
workaround for the approval gap is to restrict a pod to tool calls that never
need approval, which removes most of the value of running an agent in a pod.

## What changed (motivation to approach to change)

Goal: let `pod up` select the approval mode and the scheduler state its gateway
boots with.

Approach: persist both choices in the per-pod env file, then read them at boot.

Why this approach. The service manager re-enters the pod as
`kirocrew pod _run <name>`, and that re-entry carries no flags, so `up` cannot
pass a value directly to `boot`. The env file is the existing channel for
per-pod state, already carrying `CHECKOUT`, `PORT` and `SEED`. `--seed` uses
exactly this path: `_up` writes it, `boot` reads it. This change follows that
precedent instead of inventing a second channel.

Rejected alternative: bake the settings into the unit file. On systemd
`pod install` writes one template unit per machine and every instance shares it,
so a per-pod value cannot live there. launchd does write a per-pod plist, but it
execs the same flagless `pod _run <name>` argv, so the unit file is not a
transport on either backend. Revisit only if pods need per-instance unit
properties for an unrelated reason.

The change:

1. Add `--approval {reads,yolo,interactive}` and `--crons` to the `pod up`
   subparser. The approval choices mirror the gateway flag exactly.
2. `_up` merges `APPROVAL` and `CRONS` into the pod env file through a single
   `write_env_file` call, next to the existing `SEED` write and inside the same
   `pod_name_mutex`.
3. `boot` reads both back and builds the argv accordingly.
4. Omitting both flags leaves the argv byte-identical to today.
5. `runtime.APPROVAL_MODES` and `runtime.CRONS_TRUE` are the enforcement points,
   not argparse, because the env file is hand-editable. `boot` re-validates both.
6. An unrecognised `APPROVAL` value is NOT dropped. Omitting `--approval` leaves
   `approval_mode` unset, and the gateway then falls through to
   `cfg.agent.approval_mode`, which `config/loader.py` defaults to `auto`, so
   every tool is auto-approved. Dropping would be the least restrictive outcome,
   so `boot` pins `interactive` explicitly. An unrecognised `CRONS` value leaves
   the scheduler off, which is the pre-existing behavior.
7. `pod up` against an already-running pod records the values and prints one note
   that they apply on the next boot. Without the note a flag would look applied
   and change nothing.
8. The `pod.up` SEL audit line carries `approval=<mode>` and `crons=on` when set,
   plus `applied=next_boot` when they have not taken effect yet. Booting in
   `yolo` auto-approves every tool and an enabled scheduler runs work unattended,
   so the trail must say so, and must not imply a setting is live when it is not.

Items 5 to 8 came from review, not the original scope.

### `--crons` cannot replay your host jobs

A pod's HOME never receives cron definitions. `write_pod_config` copies only a
sanitized `config.json` and never the DB, sessions or crons. `--crons` therefore
starts an empty scheduler, which is what makes it useful for testing cron
behavior rather than replaying the host's jobs. One caveat: a pod HOME that
already exists is preserved across a restart, so jobs created inside a pod can
replay on that pod's next boot. Host jobs still cannot cross over.

### Safety note on `yolo`

The gateway refuses `--approval yolo` unless `KIROCREW_HOME` is explicitly set to
a non-default location, and `build_pod_env` always sets it to the pod's isolated
home. A pod is therefore the case the rail was written to permit. This PR does
not touch the rail.

Reviewer caveat, stated plainly: that rail checks the data home only. It rejects
an exact protected `KIROCREW_HOME`. It is not a sandbox. A pod still points at
the host worktree and deliberately retains `AWS_*` credentials, so `yolo` in a
pod auto-approves every tool against real credentials. Treat a `yolo` pod as
trusted-operator territory, not as containment.

## Tests

`test/test_pod.py`, class `TestBootTimeSettings`:

| Test | Behavior locked in |
|---|---|
| `test_boot_forwards_the_recorded_mode` | argv becomes `gateway --no-crons --approval reads` |
| `test_boot_argv_unchanged_when_unset` | argv stays `gateway --no-crons`, pinning today's contract |
| `test_boot_forces_interactive_on_an_unknown_mode` | A hand-edited `APPROVAL` yields `--approval interactive`, not a dropped flag |
| `test_every_declared_mode_survives_boot` | Each mode in `APPROVAL_MODES` round-trips through boot |
| `test_cli_approval_choices_match_the_enforcement_tuple` | AST check: `pod up --approval` choices equal `APPROVAL_MODES` |
| `test_every_pod_subparser_name_is_assigned` | AST check: no `pod_*` name is used without being assigned |
| `test_boot_enables_the_scheduler` | `CRONS=1` drops `--no-crons` from the argv |
| `test_boot_accepts_alternative_truthy_spellings` | `true`, `yes`, `on` all enable the scheduler |
| `test_boot_ignores_an_unrecognised_crons_value` | `CRONS=maybe` leaves the scheduler off, with a warning |
| `test_boot_combines_crons_and_approval` | Both settings compose in one argv |
| `test_up_records_the_mode` | `pod up --approval yolo` persists to the env file |
| `test_up_records_crons` | `pod up --crons` persists to the env file |
| `test_up_merges_all_boot_settings_into_one_env_file` | One `write_env_file` call, `SEED` preserved |
| `test_up_on_a_running_pod_notes_the_restart` | The note fires and the value is still recorded |
| `test_up_notes_every_deferred_flag_on_a_running_pod` | The note names both flags, not just one |
| `test_up_tolerates_a_namespace_without_the_flag` | No keys written when the flags are absent |
| `test_up_audits_the_mode` | The `pod.up` audit line carries `approval=yolo` |
| `test_up_audits_crons` | The `pod.up` audit line carries `crons=on` |

Two of these exist because of mistakes made while writing this PR, and they are
worth calling out:

- `test_cli_approval_choices_match_the_enforcement_tuple` reads the choices
  literal out of `cli.py` via AST. An earlier version of this test iterated
  `APPROVAL_MODES` and claimed to guard parser drift, which it cannot do: a mode
  present in `cli.py` but absent from `APPROVAL_MODES` is never iterated, so the
  test passes and the drift ships.
- `test_every_pod_subparser_name_is_assigned` exists because a `--crons` edit
  deleted `pod_down = pod_sub.add_parser(...)`, leaving `pod_down` undefined and
  the parser raising `NameError` at build time. That damage is invisible to
  `py_compile` and to every test in this file, because they import `pod/cli.py`
  and never the top-level parser.

Evidence run, 2026-08-06, after the final code change:

- 248 passed across `test_pod.py`, `test_pod_launchd.py`,
  `test_pod_self_contained.py`, `test_pod_e2e_harness_paths.py`,
  `test_pod_e2e_video_guard.py`. No failures.
- `isort --check-only src/kiro_crew test`: clean.
- `flake8 src/kiro_crew test`: clean.
- `mypy src/kiro_crew/`: no issues in 724 source files.

These are the three gates CI actually runs. `black` is disabled in CI and `ruff`
is not a gate, so neither was used as evidence.

## Manual verification

Not performed, and the reviewer should know why. The authoring host has no usable
KiroCrew venv and no `pip` in the one venv available, so the top-level CLI cannot
be executed here. `test/test_cli.py` also fails to collect on that host for the
same missing dependency, unmodified.

The `cli.py` argparse edits are therefore verified statically, not by execution.
Both AST assertions listed above are committed as tests rather than run as
one-off checks, so CI enforces them. CI is still the first place
`kirocrew pod up --help` actually runs.

Still required on a machine with a built worktree:

1. `kirocrew pod provision <wt>`
2. `kirocrew pod up <wt> --approval reads`
3. `kirocrew pod logs <wt>`, and confirm the gateway line carries the flag.
4. `kirocrew pod exec <wt> -- <a turn that calls a non-read-only tool>`, and
   confirm it completes without waiting on an approval prompt.
5. `kirocrew pod up <wt> --crons`, and confirm the scheduler starts empty.
6. `kirocrew pod up <wt>` with no flags, and confirm behavior is unchanged.

## Screenshots / video

N/A. No user-visible UI surface changes.

## Related Issues

None yet. Two candidates worth filing:

1. The unattended-approval gap this PR closes.
2. An upstream defect this PR surfaced but does not fix: the `gateway --approval`
   help text says "When omitted, current interactive behavior is preserved". That
   is false. Omitting it resolves through `cfg.agent.approval_mode`, which
   defaults to `auto`. That help text is what led to the bug fixed in item 6, so
   it will mislead the next reader too.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added
- [x] Self-review completed
- [x] Documentation updated: flag added to the `pod` README Interface block
- [x] No secrets, credentials, or internal references in the diff

---

# Appendix A: withdrawn scope, and why

The original ask paired this flag with "pod adopts `testing/harness.py`". That
half is withdrawn. Verification against `origin/main` shows no primitive fits.

`testing/harness.py` exposes three things. Each fails for a different reason:

1. `terminate_pgid`. Pod has no process-lifecycle code to replace. A grep of
   `pod/runtime.py` for `SIGTERM`, `SIGKILL`, `killpg`, `os.kill` and `Popen`
   returns zero matches. systemd and launchd own the lifecycle, and teardown
   runs through `ExecStopPost` into `pod _cleanup`. There is nothing to dedupe.
2. `parse_ready_line`. Pod reads readiness over HTTP from `/api/health` and
   derives its port deterministically before boot, because it needs the port to
   mint the token and URL. The READY line is a stdout contract for a foreground
   parent holding a `Popen`. A pod's parent is the service manager and its stdout
   goes to the journal. Adopting the line would mean tailing the journal to learn
   a port pod already computed.
3. `spawn_feature_gateway`. It is a context manager that owns a `Popen` and tears
   down on exit. A supervised unit cannot use it.

The env-builder overlap assumed in the earlier draft is also absent. The harness
sets three env keys and scrubs nothing, because it is a foreground developer tool
that inherits the developer's environment on purpose. `build_pod_env` scrubs
`SLACK_*`, `WECOM_*` and non-AWS `*_TOKEN`, keeps `AWS_*` deliberately so
`AWS_SESSION_TOKEN` survives, and adds `KIROCREW_POD` and `KIRO_HOME`. These are
opposite requirements, not duplicated code.

Revisit condition: if a second out-of-process supervisor appears that drives a
detached gateway and needs the READY line, then `parse_ready_line` gains a real
second consumer and extraction becomes worth discussing. Pod alone is not that
consumer.

# Appendix B: gaps that remain, deliberately out of this PR

- `--crons` has no inverse. It is `store_true`, and `write_env_file` merges
  rather than removes, so a pod whose env file already carries `CRONS=1` cannot
  have the scheduler turned off by a later `pod up` alone. `pod down` clears the
  env file, so evict-then-up is the reset. `--approval` escapes this because
  `interactive` is itself a valid choice. Worth an explicit reset flag if anyone
  hits it.
- `--fixture`. `--seed <dir>` already takes a path. Named presets are sugar over
  it, not new capability.
- Source-backed fast iteration and Vite hot reload. Already covered outside pod
  by `dev-backend.sh` and the full-stack dev setup in `CONTRIBUTING.md`. Pod is
  dist-backed by design.
- `--root`. Obsolete. Pod resolves a worktree git-natively by basename, branch or
  exact path, per the `pod` README.
- Centralising the approval-mode literal. `cli.py` repeats it rather than
  importing `pod.runtime`, because the top-level parser must not import pod
  modules at startup. The AST parity test pins the duplication instead. A shared
  constants module would remove it if the duplication grows past one site.

# Appendix C: review round

A four-seat cross-vendor adversarial council reviewed the rebased diff
(`gpt-5.6-sol`, `deepseek-3.2`, `glm-5`, `qwen3-coder-next`). Recording the
outcome because it changed the design, and because the vote was the wrong signal.

One seat found the item-6 defect, by tracing the approval resolution out of
`pod/runtime.py` into `config/loader.py` and `slack/events.py`. The other three
each asserted that omitting `--approval` leaves the gateway interactive, without
opening either file. A majority vote would have shipped the bug.

Fixes applied from that round: item 6 (fail safe to `interactive`), the AST parity
test replacing an inert one, the `applied=next_boot` audit marker, and the launchd
correction to the transport rationale. Findings refuted against source and
deliberately not applied: that the env-file write happens after the running-pod
check, that the audit omits the flags for a running pod, that a warning should
fire when the pod is not yet running, and that the default argv changed. One
finding was applied and then reverted: a seat reported no test for a truthy but
invalid `CRONS` value, and `test_boot_ignores_an_unrecognised_crons_value` already
covers exactly that with `CRONS=maybe`, so the test added for it was redundant and
was removed.

---

Disclosure, per Simon's standing convention rather than the repo template: this
PR description was drafted by an AI agent and reviewed by the author.
