### PR TITLE
fix(windows): remove the top causes of Backend Tests (Windows) flakiness

### DIFF
--- a/scripts/check_brand_name.py
+++ b/scripts/check_brand_name.py
@@ -41,6 +41,7 @@ sparingly: it is unscoped and silences the whole line.
 from __future__ import annotations
 
 import bisect
+import math
 import os
 import re
 import subprocess
@@ -50,6 +51,15 @@ from dataclasses import dataclass
 from typing import Iterable, Iterator
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Self-test timing budget for the growth-ratio check. It divides two measured
+# durations, so it is only as trustworthy as the smaller one: pair each baseline
+# with its own doubled sample and keep the least noisy RATIO, then refuse to
+# judge one whose baseline is too small to measure. The floor sits above the
+# ~15.625ms granularity Windows reports process CPU time at, so a coarse clock
+# cannot on its own manufacture a regression.
+_PERF_ATTEMPTS = 5
+_PERF_MIN_BASE_SECS = 0.020
 
 # ---------------------------------------------------------------------------
 # What counts as a misspelling
@@ -608,22 +618,67 @@ def self_test() -> int:
     # prefix. The assertion is on the GROWTH RATIO, not a wall-clock budget: an
     # absolute threshold generous enough for a loaded CI runner is also generous
     # enough to let a quadratic implementation pass at this size.
-    def timed(count: int) -> tuple[float, int]:
-        line = "!KiroCrew" * count
-        began = time.monotonic()
-        found = len(list(scan_line("big.md", 1, line, in_code=False)))
-        return time.monotonic() - began, found
+    #
+    # Measuring a ratio puts the whole burden on the timer, and the original
+    # form (one `time.monotonic()` sample per size) had two independent ways to
+    # report a regression that was not there. It was the single largest source
+    # of Windows CI flakes:
+    #
+    # * WRONG CLOCK. `time.monotonic()` is `GetTickCount64()` on Windows, a
+    #   ~15.625ms tick. The base scan costs ~60ms there, so a sample was only
+    #   ~4 ticks wide and quantisation ALONE moved the ratio ~25%. Every
+    #   observed failure reported times that were exact multiples of 15.625ms
+    #   (0.047/0.062/0.109 -> 0.156/0.188/0.203).
+    # * WALL CLOCK AT ALL. Four xdist workers on a 4-vCPU runner means the
+    #   timed region gets descheduled, and the LONGER scan absorbs more
+    #   preemption than the shorter one -- which inflates the ratio
+    #   systematically rather than symmetrically. Taking the best of several
+    #   wall-clock samples does NOT fix this (measured: it made linear scans
+    #   breach 3.0x MORE often, because the shorter scan cleans up better).
+    #
+    # So measure CPU time, which simply does not advance while the thread is
+    # off-CPU, and pair each baseline with its own doubled sample so the two
+    # halves of a ratio always come from the same conditions. Measured under 2x
+    # CPU oversubscription: a linear scan stays at most 2.02x (never breaching)
+    # while a deliberately quadratic one never drops below 3.88x, so this keeps
+    # every bit of the check's teeth. `process_time` is also coarse on Windows,
+    # so the floor below still applies.
+    def ratio_of(base: int) -> tuple[float, float, int, int]:
+        """Best (least noisy) doubled/base CPU-time ratio over several attempts."""
+        best = math.inf
+        best_pair = (0.0, 0.0)
+        found: tuple[int, int] = (0, 0)
 
-    base_time, base_found = timed(20_000)
-    doubled_time, doubled_found = timed(40_000)
-    ratio = doubled_time / base_time if base_time > 0 else 0.0
+        def once(count: int) -> tuple[float, int]:
+            began = time.process_time()
+            hits = len(list(scan_line("big.md", 1, "!KiroCrew" * count, in_code=False)))
+            return time.process_time() - began, hits
+
+        for _ in range(_PERF_ATTEMPTS):
+            base_time, base_hits = once(base)
+            doubled_time, doubled_hits = once(base * 2)
+            found = (base_hits, doubled_hits)
+            if base_time <= 0.0:
+                continue
+            candidate = doubled_time / base_time
+            if candidate < best:
+                best, best_pair = candidate, (base_time, doubled_time)
+        return (0.0 if best is math.inf else best), best_pair[0], found[0], found[1]
+
+    ratio, base_time, base_found, doubled_found = ratio_of(20_000)
     if (base_found, doubled_found) != (20_000, 40_000):
         print(f"  FAIL repeated-brands: found {base_found}/{doubled_found}, want 20000/40000")
         failures += 1
+    elif base_time < _PERF_MIN_BASE_SECS:
+        # Too small to divide. Quadratic growth at this size costs far more than
+        # the floor, so a baseline under it cannot be hiding a regression --
+        # report the fact rather than dividing noise by noise.
+        print(f"  ok   repeated-brands (baseline {base_time * 1000:.1f}ms below the "
+              f"{_PERF_MIN_BASE_SECS * 1000:.0f}ms measurement floor; ratio not judged)")
     elif ratio > 3.0:
-        print(f"  FAIL repeated-brands: doubling the input cost {ratio:.1f}x "
-              f"({base_time:.3f}s -> {doubled_time:.3f}s); linear is ~2x, so a "
-              f"per-match scan of the line has come back")
+        print(f"  FAIL repeated-brands: doubling the input cost {ratio:.1f}x CPU time "
+              f"(best of {_PERF_ATTEMPTS}, baseline {base_time:.3f}s); linear is ~2x, "
+              f"so a per-match scan of the line has come back")
         failures += 1
     else:
         print(f"  ok   repeated-brands (doubling cost {ratio:.1f}x, linear)")

--- a/src/kiro_crew/computer_use/overlay_proc.py
+++ b/src/kiro_crew/computer_use/overlay_proc.py
@@ -67,6 +67,7 @@ from kiro_crew import platform_compat
 from kiro_crew.computer_use.types import (
     CLICK_PULSE_DEPTH,
     CLICK_PULSE_GAP_MS,
+    CLICK_PULSE_MAX_STEP,
     CLICK_PULSE_MS,
     CURSOR_GLYPH_HEIGHT,
     CURSOR_GLYPH_WIDTH,
@@ -439,9 +440,21 @@ class CursorOverlayWindow:
         duration = CLICK_PULSE_MS / 1000.0
         for pulse in range(pulses):
             started = time.monotonic()
+            progress = 0.0
             while True:
-                elapsed = time.monotonic() - started
-                progress = 1.0 if duration <= 0.0 else min(max(elapsed / duration, 0.0), 1.0)
+                if duration <= 0.0:
+                    target = 1.0
+                else:
+                    target = min(max((time.monotonic() - started) / duration, 0.0), 1.0)
+                # Follow the clock, but never let one frame jump the whole pulse:
+                # alpha is `sin(progress * pi)`, which is 0 at progress 0.0 AND
+                # 1.0, so a stall spanning the pulse would draw alpha 1.0 twice
+                # and the dip that IS the click would never reach the screen.
+                # Capping the advance keeps the peak on screen on a loaded
+                # machine, at a floor of ceil(1 / CLICK_PULSE_MAX_STEP) frames.
+                progress = target if duration <= 0.0 else min(
+                    target, progress + CLICK_PULSE_MAX_STEP
+                )
                 self._set_alpha(1.0 - CLICK_PULSE_DEPTH * math.sin(progress * math.pi))
                 if progress >= 1.0:
                     break

--- a/src/kiro_crew/computer_use/types.py
+++ b/src/kiro_crew/computer_use/types.py
@@ -615,6 +615,14 @@ MAX_CLICK_COUNT = 3
 # Alpha floor at the peak of a click pulse (1.0 - depth). A dip rather than a
 # scale change: scaling the window would re-place the tip anchor every frame.
 CLICK_PULSE_DEPTH = 0.55
+#: Largest share of a pulse one frame may advance. The dip IS the click, and it
+#: is drawn as ``sin(progress * pi)`` -- which is 0 at BOTH progress 0.0 and 1.0.
+#: So a frame gap wide enough to jump the whole pulse (a loaded machine, a GC
+#: pause, a descheduled thread -- routinely a full pulse on a busy CI runner)
+#: renders alpha 1.0 twice and no dip at all: the click silently does not appear.
+#: Capping the per-frame advance guarantees at least one sample near the peak,
+#: i.e. at least ``ceil(1 / step)`` frames per pulse.
+CLICK_PULSE_MAX_STEP = 0.25
 
 # ── Overlay process (``computer_use.overlay`` / ``overlay_proc``) ──
 # The overlay MUST be out of process: AppKit needs a main-thread run loop and the

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -717,6 +717,14 @@ def _redact_at_write_boundary(role: str, content: str) -> str:
 #: while giving the working set a deterministic ceiling.
 _TRANSCRIPT_CACHE_MAX = 256
 
+# Metadata reads retry briefly before reporting "no metadata": on Windows a
+# just-written session file can be transiently unopenable while an indexer or AV
+# scanner holds it (ERROR_SHARING_VIOLATION -> PermissionError). Those holds are
+# measured in milliseconds, and the caller that matters here (the open-tab
+# restore) treats an empty result as "session never existed" and drops the tab.
+_METADATA_READ_ATTEMPTS = 3
+_METADATA_READ_RETRY_SECS = 0.02
+
 
 _V = TypeVar("_V")
 
@@ -2391,38 +2399,82 @@ class ConversationLog:
         """Read the metadata line (first line) from a session JSONL file.
 
         Uses mtime-based caching to avoid re-reading unchanged files.
+
+        Returns ``{}`` for a session that genuinely has no metadata. A caller
+        cannot distinguish that from a transient read failure, and at least one
+        does something destructive with the answer: the open-tab restore treats
+        ``{}`` as "never persisted" and silently drops the tab. So absorb the
+        transient case HERE rather than reporting it as absence -- retry a few
+        times, and if it still fails, say so at warning level instead of
+        returning a confident empty dict. Windows makes this more than
+        theoretical: a freshly written file can be briefly unopenable while an
+        indexer or AV scanner holds it (``ERROR_SHARING_VIOLATION``), which
+        surfaces as ``PermissionError`` -- an ``OSError`` subclass.
         """
         path = self._path(key)
         if not path.exists():
             self._meta_cache.pop(key, None)
             return {}
-        try:
-            mtime = path.stat().st_mtime
-        except OSError:
-            return {}
-        cached = self._meta_cache.get(key)
-        if cached and cached[0] == mtime:
-            return cached[1]
-        # Read ONLY the first line. The previous form slurped the entire file via
-        # read_text() and then threw all but the first line away — on a 26 MB
-        # transcript that is ~10ms and ~26 MB of transient allocation to obtain a
-        # few hundred bytes (measured ~32x slower than readline()). Startup
-        # restore calls this once per tab, so the waste scaled with both tab count
-        # and transcript size, pushing the event loop toward the stall watchdog.
-        try:
-            with open(path, encoding="utf-8") as fh:
-                first = fh.readline().strip()
-        except OSError:
-            return {}
-        if not first:
-            return {}
-        try:
-            data = json.loads(first)
-            meta = data if data.get("_type") == "metadata" else {}
-        except json.JSONDecodeError:
-            meta = {}
-        self._meta_cache[key] = (mtime, meta)
-        return meta
+        for attempt in range(_METADATA_READ_ATTEMPTS):
+            try:
+                mtime = path.stat().st_mtime
+                cached = self._meta_cache.get(key)
+                if cached and cached[0] == mtime:
+                    return cached[1]
+                # Read ONLY the first line. The previous form slurped the entire
+                # file via read_text() and then threw all but the first line away
+                # — on a 26 MB transcript that is ~10ms and ~26 MB of transient
+                # allocation to obtain a few hundred bytes (measured ~32x slower
+                # than readline()). Startup restore calls this once per tab, so
+                # the waste scaled with both tab count and transcript size,
+                # pushing the event loop toward the stall watchdog.
+                with open(path, encoding="utf-8") as fh:
+                    first = fh.readline().strip()
+            except OSError:
+                if attempt + 1 < _METADATA_READ_ATTEMPTS:
+                    # Pause before retrying ONLY off the event loop. This path is
+                    # reached ON it: ``restore_open_slots_async`` keeps the whole
+                    # restore on the loop deliberately (creating a slot broadcasts
+                    # through ``asyncio.Queue.put_nowait`` / ``Event.set``, neither
+                    # thread-safe), and a kernel sleep there stops
+                    # ``_loop_heartbeat`` from petting the LoopStallWatchdog --
+                    # whose ``exit_after`` timer then kills the gateway. That
+                    # crash-loop is the exact thing the async restore exists to
+                    # prevent, so it must not be reintroduced here. Same probe as
+                    # the cross-process lock acquire above.
+                    on_loop = True
+                    try:
+                        asyncio.get_running_loop()
+                    except RuntimeError:
+                        on_loop = False
+                    if not on_loop:
+                        _time.sleep(_METADATA_READ_RETRY_SECS)
+                    # On the loop the retry is immediate instead. It costs a stat
+                    # plus an open, so it is cheap enough to be worth taking, and
+                    # losing it only yields the same ``{}`` this returned before
+                    # any retry existed -- never worse than the old behaviour.
+                    continue
+                # Out of retries. Distinguish this from "no metadata" in the log
+                # so a dropped tab is traceable to its cause instead of looking
+                # like a session that was never written.
+                logger.warning(
+                    "history: could not read metadata for %s after %d attempts; "
+                    "reporting no metadata",
+                    key,
+                    _METADATA_READ_ATTEMPTS,
+                    exc_info=True,
+                )
+                return {}
+            if not first:
+                return {}
+            try:
+                data = json.loads(first)
+                meta = data if data.get("_type") == "metadata" else {}
+            except json.JSONDecodeError:
+                meta = {}
+            self._meta_cache[key] = (mtime, meta)
+            return meta
+        return {}
 
     def sliding_window(self, key: str, keep_recent: int = 5) -> tuple[list[dict], list[dict]]:
         """Split messages into (older, recent) for compaction.

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -3028,11 +3028,43 @@ class TestAcpRuntimePidTracking:
         monkeypatch.setattr(rt_mod, "_untrack_session_pid", lambda p: calls["session"].append(p))
         # os.killpg / getpgid on the fake PID would raise — the kill() body
         # already guards those with OSError/ProcessLookupError, so let them fire.
+        #
+        # kill() only untracks once pid_exists() confirms the process is GONE, so
+        # stub that decision instead of betting the fake PID is absent from the
+        # host's process table. It is not a safe bet: Windows recycles PIDs from a
+        # small space, and on a CI runner spawning subprocesses across xdist
+        # workers 4242 was intermittently a REAL live process -- kill() then took
+        # the survivor branch and this asserted `[] == [4242]`.
+        monkeypatch.setattr(rt_mod.platform_compat, "pid_exists", lambda pid: False)
 
         await rt.kill()
 
         assert calls["pid"] == [4242]
         assert calls["session"] == [4242]
+
+    @pytest.mark.asyncio
+    async def test_kill_keeps_pid_tracked_when_the_process_survives(self, monkeypatch):
+        """A survivor must STAY tracked so the orphan sweeps can still reach it.
+
+        The counterpart to the test above, and the reason that one has to stub
+        `pid_exists` rather than rely on the ambient process table: untracking a
+        process that outlived SIGTERM/SIGKILL escalation would leak it until
+        reboot, because the sweep would no longer have a handle on it.
+        """
+        rt, _, proc = _make_runtime()
+        proc.wait = AsyncMock(return_value=0)
+
+        calls: dict[str, list[int]] = {"pid": [], "session": []}
+        import kiro_crew.acp.runtime as rt_mod
+
+        monkeypatch.setattr(rt_mod, "_untrack_pid", lambda p: calls["pid"].append(p))
+        monkeypatch.setattr(rt_mod, "_untrack_session_pid", lambda p: calls["session"].append(p))
+        monkeypatch.setattr(rt_mod.platform_compat, "pid_exists", lambda pid: True)
+
+        await rt.kill()
+
+        assert calls["pid"] == []
+        assert calls["session"] == []
 
 
 class TestAcpRuntimeLoadSession:

--- a/test/test_computer_use_overlay.py
+++ b/test/test_computer_use_overlay.py
@@ -59,6 +59,8 @@ from kiro_crew.computer_use.overlay import (
     reset_shared_overlay,
 )
 from kiro_crew.computer_use.types import (
+    CLICK_PULSE_DEPTH,
+    CLICK_PULSE_MS,
     CURSOR_GLYPH_HEIGHT,
     CURSOR_GLYPH_WIDTH,
     FALLBACK_SCREEN_HEIGHT,
@@ -974,6 +976,47 @@ class TestAnimation:
 
         assert _dip_runs(one) == 1
         assert _dip_runs(many) == MAX_CLICK_COUNT
+
+    def test_every_pulse_dips_even_when_the_clock_jumps_the_whole_pulse(
+        self, monkeypatch
+    ):
+        """A stall must not swallow the click.
+
+        The dip IS the click, drawn as ``sin(progress * pi)`` -- zero at BOTH
+        progress 0.0 and 1.0. So if the only samples of a pulse are its two
+        endpoints, alpha reads 1.0 twice and nothing appears on screen. That is
+        not hypothetical: a descheduled thread on a loaded machine (four xdist
+        workers on a 4-vCPU Windows runner is where it was caught) skips the
+        whole 160ms in one frame, and the user gets no click feedback at all.
+
+        Simulate the worst case -- a clock that advances a full pulse duration
+        per reading -- and require every requested pulse to still be visible.
+        """
+        ticks = iter(range(0, 10_000))
+        # Each reading jumps a whole pulse (0.16s), so an uncapped progress
+        # would go straight from 0.0 to >=1.0 with nothing in between.
+        monkeypatch.setattr(
+            proc_mod.time, "monotonic", lambda: next(ticks) * (CLICK_PULSE_MS / 1000.0)
+        )
+
+        runtime = _FakeRuntime()
+        proc_mod.CursorOverlayWindow(runtime).pulse_click(400.0, 400.0, MAX_CLICK_COUNT)
+
+        alphas = runtime.alphas()
+        runs, was_dipped = 0, False
+        for value in alphas:
+            dipped = value < 0.999
+            if dipped and not was_dipped:
+                runs += 1
+            was_dipped = dipped
+
+        assert runs == MAX_CLICK_COUNT, (
+            f"a stalled clock lost {MAX_CLICK_COUNT - runs} of {MAX_CLICK_COUNT} "
+            f"click pulses; alphas={alphas}"
+        )
+        # And the dip must be deep enough to actually read as a click, not a
+        # rounding-error wobble just under the 0.999 threshold.
+        assert min(alphas) <= 1.0 - CLICK_PULSE_DEPTH * 0.7
 
     def test_a_failing_pump_still_yields_the_cpu(self, monkeypatch):
         """A broken run loop must not become a busy spin."""

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from windows_sim import builtin_open_sharing_violation
 
 from kiro_crew.history import (
     _CONSOLIDATION_THRESHOLD,
@@ -3487,3 +3489,94 @@ async def test_script_bearing_candidate_stages_even_when_all_scripts_invalid(tmp
     # Not live (would be an auto-publish); staged for review instead.
     assert skills.list_auto_skills() == []
     assert any(s["slug"] == "scripted-skill" for s in skills.list_pending_skills())
+
+
+class TestMetadataReadSurvivesATransientSharingViolation:
+    """A read that FAILED must not be reported as a session with no metadata.
+
+    ``_read_metadata`` returns ``{}`` both for "this session has no metadata line"
+    and (previously) for "I could not open the file". Callers cannot tell those
+    apart and at least one acts destructively on the answer -- the open-tab
+    restore treats ``{}`` as "never persisted" and silently drops the tab. On
+    Windows a just-written file is transiently unopenable while an indexer or AV
+    scanner holds it (``ERROR_SHARING_VIOLATION`` -> ``PermissionError``), which
+    is the shape ``windows_sim.builtin_open_sharing_violation`` reproduces.
+    """
+
+    def test_a_transient_violation_is_retried_not_reported_as_absent(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s1", "user", "hello", agent="my-agent")
+        # Drop the cache so the read genuinely has to touch the file.
+        log._meta_cache.pop("s1", None)
+
+        with builtin_open_sharing_violation(match="s1.jsonl", times=1) as seen:
+            meta = log.get_metadata("s1")
+
+        assert seen["n"] >= 1, "the simulator never intercepted the open"
+        assert meta.get("agent") == "my-agent", (
+            f"a single transient sharing violation was reported as absence: {meta!r}"
+        )
+
+    def test_the_retry_never_sleeps_on_the_event_loop(self, tmp_path):
+        """The retry delay must not run on the loop.
+
+        ``restore_open_slots_async`` keeps the restore ON the event loop on
+        purpose, and reaches here through ``_rehydrate_slot_from_history``. A
+        kernel sleep on that path stops ``_loop_heartbeat`` petting the
+        LoopStallWatchdog, whose ``exit_after`` timer then kills the gateway --
+        the crash-loop the async restore exists to prevent. So on the loop the
+        retry must be immediate, and it must still recover the metadata.
+        """
+        import kiro_crew.history as history_mod
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s1", "user", "hello", agent="my-agent")
+        log._meta_cache.pop("s1", None)
+
+        slept: list[float] = []
+
+        async def _on_loop():
+            with patch.object(history_mod._time, "sleep", lambda s: slept.append(s)):
+                with builtin_open_sharing_violation(match="s1.jsonl", times=1):
+                    return log.get_metadata("s1")
+
+        meta = asyncio.run(_on_loop())
+
+        assert slept == [], f"blocking sleep(s) ran on the event loop: {slept}"
+        # The immediate retry still has to work.
+        assert meta.get("agent") == "my-agent", f"on-loop retry lost the metadata: {meta!r}"
+
+    def test_the_retry_does_sleep_off_the_event_loop(self, tmp_path):
+        """Off the loop the pause is safe and worth taking -- a sharing violation
+        clears in milliseconds, so retrying instantly would usually just fail."""
+        import kiro_crew.history as history_mod
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s1", "user", "hello", agent="my-agent")
+        log._meta_cache.pop("s1", None)
+
+        slept: list[float] = []
+        with patch.object(history_mod._time, "sleep", lambda s: slept.append(s)):
+            with builtin_open_sharing_violation(match="s1.jsonl", times=1):
+                meta = log.get_metadata("s1")
+
+        assert slept, "no retry pause off the event loop"
+        assert meta.get("agent") == "my-agent"
+
+    def test_a_persistent_violation_still_reports_absence_but_warns(
+        self, tmp_path, caplog
+    ):
+        """Fail closed after the retries, but leave a traceable warning rather
+        than a confident empty dict."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s1", "user", "hello", agent="my-agent")
+        log._meta_cache.pop("s1", None)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            with builtin_open_sharing_violation(match="s1.jsonl", times=99):
+                meta = log.get_metadata("s1")
+
+        assert meta == {}
+        assert any(
+            "could not read metadata" in r.getMessage() for r in caplog.records
+        ), f"no warning recorded; got {[r.getMessage() for r in caplog.records]}"

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -31,6 +31,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from chat_test_helpers import _make_state
+from windows_sim import builtin_open_sharing_violation
 
 from kiro_crew.dashboard.chat_persistence import (
     _rehydrate_slot_from_history,
@@ -1022,3 +1023,41 @@ def test_push_slots_update_survives_a_partially_constructed_state():
         assert bare._slots_push_suspend == 1
     assert bare._slots_push_suspend == 0
     assert bare._slots_push_pending is False
+
+
+def test_a_transient_metadata_read_failure_does_not_drop_a_tab(tmp_path, monkeypatch):
+    """A tab must survive a Windows sharing violation on its transcript.
+
+    ``_restore_open_slots_steps`` skips any key whose metadata reads back empty,
+    on the reasoning that the session was never persisted -- and it does so
+    silently (``logger.debug``). But ``_read_metadata`` also returned ``{}`` when
+    it simply could not OPEN the file, which on Windows happens transiently while
+    an indexer or AV scanner holds a just-written transcript
+    (``ERROR_SHARING_VIOLATION`` -> ``PermissionError``). The two were
+    indistinguishable, so one unlucky read silently cost the user a tab and the
+    restore returned one short -- the shape of the intermittent
+    ``assert 5 == 6`` / ``assert 7 == 8`` failures on the Windows CI line.
+
+    Faults the FIRST read of exactly one session's transcript, which is what a
+    scanner holding one file looks like, and requires the full set back.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-transient" for i in range(6)]
+    for k in keys:
+        _seed_session(state, k)
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+    # The transcript filename for the 3rd tab — the one the scanner "holds".
+    victim = state2.conversation_log._path(_history_key_for(keys[2])).name
+
+    with builtin_open_sharing_violation(match=victim, times=1) as seen:
+        restored = restore_open_slots(state2)
+
+    assert seen["n"] >= 1, "the simulator never intercepted the transcript open"
+    assert restored == 6, (
+        f"a single transient sharing violation dropped {6 - restored} tab(s); "
+        f"restored slots: {sorted(state2._slots)}"
+    )
+    assert keys[2] in state2._slots

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -2024,6 +2024,16 @@ def test_trusted_system_bin_rejects_a_name_not_in_system_dirs(tmp_path, monkeypa
     assert platform_compat.trusted_system_bin("ps") is not None
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "asserts the POSIX degradation path: neutering trusted_system_bin only "
+        "disarms _posix_process_parent_map, while process_descendants on Windows "
+        "goes through the Win32 snapshot and still reports this process's real "
+        "live children -- so the == [] assertion depends on whether the xdist "
+        "worker happens to have a subprocess alive at that instant"
+    ),
+)
 def test_parent_map_is_empty_when_no_trusted_ps_exists(monkeypatch):
     """No trusted binary must degrade to best-effort, never fall back to PATH."""
     from kiro_crew import platform_compat

--- a/test/test_windows_sim.py
+++ b/test/test_windows_sim.py
@@ -10,6 +10,7 @@ import os
 
 import pytest
 from windows_sim import (
+    builtin_open_sharing_violation,
     colliding_clock,
     increasing_clock,
     nonatomic_write,
@@ -152,6 +153,45 @@ class TestOpenSharingViolation:
             fd = os.open(str(f), os.O_RDONLY)  # no O_CREAT — not faulted
             os.close(fd)
         assert f.read_bytes() == b"x"
+
+
+class TestBuiltinOpenSharingViolation:
+    def test_first_open_raises_then_succeeds(self, tmp_path):
+        f = tmp_path / "cred"
+        f.write_text("data\n")
+        with builtin_open_sharing_violation(match="cred", times=1) as state:
+            with pytest.raises(PermissionError):
+                open(f).close()
+            with open(f) as fh:  # the retry sees the real content
+                assert fh.readline() == "data\n"
+        assert state["n"] >= 2
+
+    def test_non_matching_path_unaffected(self, tmp_path):
+        other = tmp_path / "other"
+        other.write_text("x")
+        with builtin_open_sharing_violation(match="cred"):
+            with open(other) as fh:
+                assert fh.read() == "x"  # different name — never faults
+
+    def test_times_zero_never_faults(self, tmp_path):
+        f = tmp_path / "cred"
+        f.write_text("data")
+        with builtin_open_sharing_violation(match="cred", times=0):
+            with open(f) as fh:
+                assert fh.read() == "data"
+
+    def test_it_reaches_what_os_open_patching_cannot(self, tmp_path):
+        """Why this simulator exists alongside ``open_sharing_violation``.
+
+        CPython's builtin ``open()`` goes through the C ``_io`` layer and never
+        consults the ``os.open`` Python attribute, so patching ``os.open`` cannot
+        fault a plain read.
+        """
+        f = tmp_path / "cred"
+        f.write_text("data")
+        with open_sharing_violation(match="cred", times=1, create_only=False):
+            with open(f) as fh:  # unaffected: os.open was never consulted
+                assert fh.read() == "data"
 
 
 class TestUnlinkSharingViolation:

--- a/test/windows_sim.py
+++ b/test/windows_sim.py
@@ -49,6 +49,7 @@ __all__ = [
     "colliding_clock",
     "increasing_clock",
     "read_sharing_violation",
+    "builtin_open_sharing_violation",
     "replace_sharing_violation",
     "open_sharing_violation",
     "unlink_sharing_violation",
@@ -196,6 +197,43 @@ def replace_sharing_violation(
 
 
 @contextmanager
+def builtin_open_sharing_violation(
+    *, match: Optional[str] = None, times: int = 1
+) -> Iterator[dict]:
+    """Make the builtin ``open()`` raise a Windows-style sharing violation.
+
+    The counterpart to :func:`read_sharing_violation` (which covers
+    ``Path.read_bytes``) for the very common case of code that reads through
+    ``open(path)`` directly -- e.g. a streaming ``readline()`` that must not slurp
+    a large file. Note that patching ``os.open`` does NOT reach either of those:
+    CPython's ``builtins.open`` and ``pathlib`` read paths go through the C
+    ``_io`` layer and never call the ``os.open`` Python attribute, so
+    :func:`open_sharing_violation` only intercepts explicit ``os.open`` callers.
+
+    Raises ``PermissionError`` for the first *times* matching opens, then
+    delegates to the real call -- so a caller that retries is expected to
+    succeed. *match* filters on the path (basename-equality or substring);
+    ``None`` faults every open. Yields a ``{"n": count}`` dict of how many
+    matching opens were seen, useful for asserting a retry happened.
+    """
+    real_open = open
+    state = {"n": 0}
+
+    def _patched(file, *args, **kwargs):  # type: ignore[no-untyped-def]
+        p = str(file)
+        if match is None or os.path.basename(p) == match or match in p:
+            state["n"] += 1
+            if state["n"] <= times:
+                raise PermissionError(
+                    f"[WinError 32] simulated sharing violation opening {p}"
+                )
+        return real_open(file, *args, **kwargs)
+
+    with mock.patch("builtins.open", _patched):
+        yield state
+
+
+@contextmanager
 def open_sharing_violation(
     *, match: Optional[str] = None, times: int = 1, create_only: bool = True
 ) -> Iterator[dict]:
@@ -209,9 +247,14 @@ def open_sharing_violation(
 
     *match* filters on the path (basename-equality or substring); ``None`` faults
     every ``os.open``. *create_only* (default ``True``) restricts faults to opens
-    that include ``os.O_CREAT`` — so plain reads (``pathlib`` read paths call
-    ``os.open`` with ``O_RDONLY``) are left untouched and only the exclusive
-    create is exercised. Yields a ``{"n": count}`` dict.
+    that include ``os.O_CREAT``, so only the exclusive create is exercised.
+
+    Reaches ONLY code that calls ``os.open`` itself (e.g. ``atomic_write``'s
+    ``O_CREAT | O_EXCL``). It does NOT intercept the builtin ``open()`` or the
+    ``pathlib`` read helpers: those go through the C ``_io`` layer and never
+    consult the ``os.open`` Python attribute. Use
+    :func:`builtin_open_sharing_violation` or :func:`read_sharing_violation` for
+    those. Yields a ``{"n": count}`` dict.
     """
     real_open = os.open
     state = {"n": 0}


### PR DESCRIPTION
# Problem

`Backend Tests (Windows)` fails **~14x more often** than the POSIX line. Over the last 100 `ci.yml` runs:

| line | completed shard attempts | failed | rate |
|---|---|---|---|
| Backend Tests (Windows) | 349 | 15 | **4.3%** |
| Backend Tests (POSIX) | 779 | 2 | 0.3% |

Every one of the 15 failures was a distinct test, so it read as "Windows is just flaky" and got resolved by rerunning. It isn't: each traces to a coarse-clock or ambient-state assumption that POSIX hides, and **two are real product defects** that ship to Windows users.

| count | failure | root cause |
|---|---|---|
| 5x | `check_brand_name --test` `repeated-brands` | 15.6ms clock quantisation + wall-clock ratio |
| 3x | open-tab restore one short (`assert 5 == 6`, `assert 7 == 8`) | transient read error read as "session absent" |
| 2x | `test_kill_untracks_pid` `assert [] == [4242]` | hardcoded PID was intermittently a live process |
| 1x | `test_pulse_click_count_is_clamped` `assert 2 == 3` | animation sampled only its endpoints |
| 1x | `test_parent_map_is_empty_when_no_trusted_ps_exists` | POSIX-only assertion running on Windows |

(2 further failures were in a file not on `main`, and 1 was a genuine ratchet failure on that PR — neither is addressed here.)

# Why it matters

Beyond CI cost and reruns, a flaky required check trains people to rerun instead of read, which is how the two product defects below stayed invisible — both user-visible on every Windows install:

- **Click feedback could be entirely invisible.** Not miscounted — with the fix reverted, the new test shows *all 3 of 3* pulses drawing no dip at all.
- **A restored tab could silently vanish**, logged only at `debug`.

A 6th failure (`test_the_two_rows_carry_distinct_timestamps`, co-stamped rows) was fixed on main by #1690 while this branch was in progress. Its file-authoritative approach — reading the previous row under the cross-process flock — also covers the multi-writer case, so I dropped my own in-process version in favour of it and this PR adds nothing there.

# Fix

## 1. `check_brand_name` self-test — the single largest source (5/15)

The growth-ratio check timed a ~60ms scan with `time.monotonic()`, which on Windows is `GetTickCount64()` — a **15.625ms tick**. The evidence is decisive: every observed failure reported times that are *exact integer multiples* of that tick.

```
0.047s = 3.01 ticks    0.156s =  9.98 ticks
0.062s = 3.97 ticks    0.203s = 12.99 ticks
0.109s = 6.98 ticks    0.329s = 21.06 ticks
```

A 3–7 tick sample means quantisation alone moves the ratio ~25%, against a 3.0x threshold on an expected 2.0x.

**I measured the fix rather than assuming it.** My first attempt — best-of-N wall clock — made things *worse*: under sustained load the longer scan absorbs more preemption than the shorter one, so the ratio inflates systematically rather than symmetrically. Candidate designs under 2x CPU oversubscription:

| design | linear scan breaches >3.0x | injected quadratic caught | verdict |
|---|---|---|---|
| single sample, wall clock (old) | 0/30 (max 2.27) | 10/10 | passes here, fails on Windows |
| best-of-5 times, wall clock | **2/30 (max 4.25)** | 9/10 | unusable |
| best-of-5 ratios, wall clock | 0/30 | **4/10 (min 1.95)** | loses its teeth |
| **best-of-5 ratios, `process_time`** | **0/30 (max 2.02)** | **10/10 (min 3.88)** | **chosen** |

`process_time` is CPU time, which does not advance while the thread is descheduled. Paired samples keep both halves of a ratio under the same conditions, and a measurement floor refuses to judge a baseline too small to divide. Verified 20/20 stable at 2.0x under 64 spinners, and an injected per-match prefix rescan still reports **3.8x / exit 1**.

## 2. Open-tab restore dropped a tab — product defect (3/15)

`_read_metadata` returned `{}` both for *"no metadata line"* and for *"could not open the file"*. `_restore_open_slots_steps` reads `{}` as "never persisted" and skips the tab, silently (`logger.debug`). On Windows a just-written transcript is transiently unopenable while an indexer or AV scanner holds it (`ERROR_SHARING_VIOLATION` → `PermissionError`).

Transient reads are now retried, and a persistent failure is reported at **warning** level instead of as confident absence.

I could not reproduce this on Linux by stress alone (30/30 passed), so I reproduced the *mechanism* deterministically with the simulator below. With the retry reverted, one faulted read drops exactly one tab:

```
AssertionError: a single transient sharing violation dropped 1 tab(s);
restored slots: ['chat-0-transient', 'chat-1-transient', 'chat-3-transient',
                 'chat-4-transient', 'chat-5-transient']
```

`restored == 5`, expected `6` — the exact shape of the CI failure.

## 3. Click pulse could render nothing — product defect (1/15)

Alpha is `sin(progress * pi)`, which is **0 at both `progress` 0.0 and 1.0**. A stall spanning the 160ms pulse sampled only the endpoints, drawing alpha 1.0 twice. Per-frame progress is now capped (`CLICK_PULSE_MAX_STEP`) so the peak is always drawn, at a floor of 4 frames per pulse.

## 4. Tests scoped to the wrong platform (3/15)

- `test_kill_untracks_pid` assumed the hardcoded PID `4242` was dead. Windows recycles PIDs from a small space and it was intermittently **live**, so `kill()` took the survivor branch. Now stubs `pid_exists` — and the previously **uncovered** survivor branch (a live process must *stay* tracked, or it leaks until reboot) gained a test.
- `test_parent_map_is_empty_when_no_trusted_ps_exists` asserts a POSIX degradation path; neutering `trusted_system_bin` does nothing to the Win32 snapshot, so it only passed when the worker happened to have no live children. Skipped on Windows.

I deliberately did **not** use `test/windows-expected-failures.txt` for these: that list applies `pytest.mark.skip`, which is right for deterministic gaps but would throw away real Windows coverage for tests that mostly pass.

## 5. `windows_sim` — added the missing simulator

The repo already has a Windows-condition simulation harness; I reused `colliding_clock` rather than hand-rolling clock patching. It was missing the one I needed, so I added **`builtin_open_sharing_violation`**.

While doing so I found `open_sharing_violation`'s docstring claims it covers plain reads because "pathlib read paths call `os.open` with `O_RDONLY`". **That is not true** — verified empirically:

```
builtins.open  -> os.open intercepted: False
Path.read_bytes -> os.open intercepted: False
```

Both go through the C `_io` layer and never consult the `os.open` Python attribute, so that simulator only reaches explicit `os.open` callers. Docstring corrected, and a self-test now pins the distinction.

# Tests

All new/changed tests were **mutation-checked** — reverting each fix fails the corresponding test.

| test | locks in |
|---|---|
| `test_a_transient_metadata_read_failure_does_not_drop_a_tab` | the full tab set survives a faulted transcript read |
| `TestMetadataReadSurvivesATransientSharingViolation` (2) | transient read retried, not reported as absence; persistent failure warns |
| `test_kill_keeps_pid_tracked_when_the_process_survives` | **new coverage** — a survivor stays tracked so sweeps can reach it |
| `test_every_pulse_dips_even_when_the_clock_jumps_the_whole_pulse` | every pulse visible under a stalled clock, and deep enough to read as a click |
| `TestBuiltinOpenSharingViolation` (4) | the new simulator, incl. why `os.open` patching cannot replace it |

Mutation evidence: `repeated-brands` → `3.8x`/exit 1 · restore → `dropped 1 tab(s)` · pulse → `lost 3 of 3 click pulses`.

# Manual verification

- **Full backend suite: 30936 passed.** The 64 remaining failures are pre-existing and environmental on this host (userns `EPERM`, real `git`/`gh`, optional deps). Pristine `main` scores **62**; the delta is ordering noise in `test_sandbox_*`, confirmed **identical (4 failed, 1 passed)** with my changes reverted. My changes touch no sandbox code.
- `isort`, `flake8`, `mypy` (724 files) clean. `black --check` is deliberately disabled in CI, so not run.
- `test_kill_untracks_pid` was **failing on the baseline run on this host** and now passes — the flake reproduced on Linux and the fix resolves it.
- Load testing used deliberate CPU oversubscription (64 spinners / 32 cores) to approximate 4 xdist workers on a 4-vCPU `windows-latest` runner.

**Not verified:** I have no Windows host, so the Windows-specific paths are exercised through `windows_sim` and by reasoning from the CI logs, not end-to-end on Windows. The real proof is the Windows CI line on this PR.

# Screenshots

N/A — no user-visible UI surface changed. The click-pulse defect is asserted by the tests above; it is a native macOS overlay with no dashboard surface to capture.
