### PR TITLE
docs(telemetry): state what attribute redaction actually guarantees

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -80,10 +80,11 @@ second `PeriodicExportingMetricReader` alongside the local JSONL sink
 `pip install "kirocrew[otlp]"`. If the endpoint is set but the package extra is
 not installed, telemetry
 degrades to local-only with a warning instead of crashing. The OTLP exporter
-only ever sees the same redacted, low-cardinality data points as the local sink
-(the `MetricsRecorder` facade sanitises attributes before they reach ANY
-reader), so opting in cannot leak prompts, content, tokens, paths, user ids, or
-secrets.
+sees the same data points as the local sink: the `MetricsRecorder` facade
+sanitises attributes before they reach ANY reader, and call sites are required
+to pass low-cardinality constants rather than prompts, content, tokens, paths or
+user ids. That sanitisation is defence in depth over the requirement, not a
+substitute for it, so egress is only as safe as the call sites feeding it.
 
 **Bounded local retention (rec #14, explicit opt-in):** both destructive caps
 default to `0`, so upgrading cannot delete existing telemetry history. Operators
@@ -118,13 +119,19 @@ can opt in independently to age and/or size bounds:
   dates, symlinks, and the lock sidecar are excluded. It is fully best-effort —
   a rotation/prune failure is logged and swallowed, never breaking export.
 
-**Never recorded:** prompts, message/tool content, token counts, filesystem
-paths, user ids, and secrets. `telemetry.otlp_endpoint` is schema-sensitive so
-credential-bearing collector URLs are masked by config API/UI consumers as well
-as omitted from logs. Enforced structurally at the `MetricsRecorder`
-facade via the `schema.py` guardrails (see below) — call sites emit only
-low-cardinality enum-like attribute values, and any string that looks like a
-credential/PII is redacted to `"[REDACTED]"` before it reaches an instrument.
+**Must never be recorded:** prompts, message/tool content, token counts,
+filesystem paths, user ids, and secrets. `telemetry.otlp_endpoint` is
+schema-sensitive so credential-bearing collector URLs are masked by config
+API/UI consumers as well as omitted from logs.
+
+That is a contract on call sites — they emit only low-cardinality enum-like
+attribute values — backed at the `MetricsRecorder` facade by the `schema.py`
+guardrails (see below), which redact a string matching a known credential shape,
+or clearing the entropy backstop, to `"[REDACTED]"` before it reaches an
+instrument. Namespace validation is exhaustive; attribute redaction is defence
+in depth with a bounded reach (`schema.py` documents where the entropy backstop
+can and cannot fire), so it narrows the blast radius of a call site that breaks
+the contract rather than making one impossible.
 
 Tests: `test/metrics/test_local_exporter.py` (retention: direct age cap,
 oldest-first size cap, live-writer protection, live-shard rotation, non-blocking

--- a/src/kiro_crew/metrics/local_exporter.py
+++ b/src/kiro_crew/metrics/local_exporter.py
@@ -13,9 +13,11 @@ rotation stay lock-free on their per-PID shards; pruning protects canonical
 writers owned by live PIDs (and recently modified canonical shards), so it
 never unlinks another process's active write.
 
-PRIVACY: attribute values are redacted at the ``MetricsRecorder``
-facade before they reach the SDK, so the serialized data points carry no secrets
-or PII. The directory (0o700) and shards (0o600) are created private -- matching
+PRIVACY: attribute values are redacted at the ``MetricsRecorder`` facade before
+they reach the SDK. That is defence in depth over the call-site requirement to
+pass only low-cardinality constants, not a guarantee that a serialized data
+point carries no secret or PII -- see ``schema.py`` for where redaction reaches.
+The directory (0o700) and shards (0o600) are created private -- matching
 the ``~/.kiro/crew`` file-permission convention -- so no other local user on a
 shared host can read another user's metrics.
 

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -328,9 +328,12 @@ def _build_otlp_reader(cfg: object) -> Optional["_ReaderT"]:
     in the separate ``kirocrew[otlp]`` package extra (install with
     ``pip install "kirocrew[otlp]"``), not the hard dependency set. If a host
     opts in without installing it, we log a warning and degrade to local-only
-    rather than crashing telemetry init. The exporter only ever sees redacted, low-cardinality data points (the MetricsRecorder
-    facade sanitises attributes before they reach any reader), so opting in
-    cannot leak prompts, content, tokens, paths, user ids, or secrets.
+    rather than crashing telemetry init. The exporter sees only what the
+    MetricsRecorder facade lets through: attributes are sanitised before they
+    reach any reader, and call sites are required to pass low-cardinality
+    constants rather than prompts, content, tokens, paths or user ids. That
+    sanitisation is defence in depth over that requirement, not a substitute
+    for it, so egress is only as safe as the call sites feeding it.
     """
     endpoint = str(getattr(cfg, "otlp_endpoint", "") or "").strip()
     if not endpoint:

--- a/src/kiro_crew/metrics/recorder.py
+++ b/src/kiro_crew/metrics/recorder.py
@@ -3,9 +3,15 @@
 Every core or app metric flows through this facade so KiroCrew's namespace and
 privacy guardrails (``validate_name`` / ``validate_attrs`` / ``redact`` from
 ``kiro_crew.metrics.schema``) run *before* the value reaches an OTEL instrument.
-That makes it structurally impossible for a call site to emit an out-of-namespace
-metric or to leak a secret / PII into an attribute (security event logging:
-never log secrets or user PII).
+Namespace validation is exhaustive: ``validate_name`` rejects anything outside
+the caller's namespace, so an out-of-namespace metric cannot be emitted.
+
+Attribute redaction is defence in depth, not a guarantee. ``redact`` matches
+known credential shapes and falls back to a Shannon-entropy heuristic whose
+reach is bounded (see ``schema.py``), so a call site remains responsible for
+passing only the declared low-cardinality constants the CARDINALITY note in
+``schema.py`` requires. Do not treat this facade as a licence to hand it raw
+values (security event logging: never log secrets or user PII).
 
 Design:
   * OTEL instrument objects are created once per metric name and cached under a

--- a/src/kiro_crew/metrics/schema.py
+++ b/src/kiro_crew/metrics/schema.py
@@ -83,7 +83,18 @@ def _is_high_entropy(value: str) -> bool:
             for pat in _HIGH_ENTROPY_PATTERNS:
                 if pat.search(decoded):
                     return True
-    # Shannon entropy heuristic for strings > 16 chars.
+    # Shannon entropy backstop, for values no pattern above matched.
+    #
+    # Reach: entropy over a string's own character frequencies is bounded by
+    # log2(distinct characters), so the 4.5 threshold below is only attainable
+    # once a value has at least 23 distinct characters — the length guard lets
+    # shorter values in, but they can never cross it. It is also unattainable
+    # for any alphabet of fewer than 23 symbols at any length -- hex has 16, so
+    # only the 40-or-more pattern above covers it, and shorter hex is
+    # deliberately left visible to keep trace ids and UUIDs readable. Keep that
+    # in mind before treating this as a general secret detector: it is a
+    # last-resort net under the patterns, not a replacement for passing the
+    # declared low-cardinality values the CARDINALITY note requires.
     if len(value) >= 16:
         freq: dict[str, int] = {}
         for ch in value:

--- a/test/metrics/test_schema.py
+++ b/test/metrics/test_schema.py
@@ -185,3 +185,45 @@ class TestRedact:
         TLD-based, so use a long-query exfil shape it flags.
         """
         assert redact("https://attacker.example/c?x=" + "q" * 300) == "[REDACTED]"
+
+
+# ---------------------------------------------------------------------------
+# Reach of the entropy backstop — characterisation, not a target
+# ---------------------------------------------------------------------------
+
+
+class TestEntropyBackstopReach:
+    """Pin where the entropy backstop can and cannot fire.
+
+    These record CURRENT behaviour so the boundary is visible to the next
+    reader, not a statement that the boundary is where it should be. Entropy
+    over a value's own character frequencies is bounded by
+    ``log2(distinct characters)``, so the 4.5 threshold needs >= 23 distinct
+    characters before it is attainable at all. Anything that widens the
+    backstop should update these, deliberately.
+
+    Short hex staying visible is a separate, deliberate choice — see
+    ``TestRedact.test_short_hex_32_chars_not_redacted`` and the 40-char pattern
+    bound that spares trace ids.
+    """
+
+    def test_22_distinct_characters_cannot_reach_the_threshold(self):
+        # log2(22) = 4.459 < 4.5: maximal entropy for this length, still under.
+        value = "abcdefghijklmnopqrstuv"
+        assert len(set(value)) == 22
+        assert redact(value) == value
+
+    def test_23_distinct_characters_is_the_first_reachable_length(self):
+        # log2(23) = 4.524 > 4.5.
+        value = "abcdefghijklmnopqrstuvw"
+        assert len(set(value)) == 23
+        assert redact(value) == "[REDACTED]"
+
+    def test_a_small_alphabet_never_reaches_the_threshold(self):
+        # 16 symbols cap entropy at log2(16) = 4.0 whatever the length, so the
+        # backstop alone cannot fire on one. Deliberately not hex: hex of this
+        # length is caught by the explicit pattern, which would hide the effect
+        # being pinned here.
+        value = ("qwertyuiopasdfgh" * 4)[:62]  # 62 chars, 16 distinct, non-hex
+        assert len(set(value)) == 16
+        assert redact(value) == value


### PR DESCRIPTION
## Summary
Refs #1609.
`metrics/recorder.py` told readers the facade makes it "structurally impossible
for a call site to ... leak a secret / PII into an attribute", and
`metrics/provider.py` told them opting into OTLP egress "cannot leak prompts,
content, tokens, paths, user ids, or secrets".
Redaction is a list of credential patterns plus a Shannon-entropy backstop. That
is defence in depth over the CARDINALITY requirement `schema.py` already states —
attribute values MUST be low-cardinality enum-like constants — not a replacement
for it. A reader who takes the absolute at face value has no reason to keep
honouring the requirement that actually does the work.
## What changed
- `recorder.py`: separate the two claims. Namespace validation *is* exhaustive
  and keeps its wording; attribute redaction is restated as defence in depth,
  with the call-site requirement named.
- `provider.py`: the OTLP paragraph now says egress is only as safe as the call
  sites feeding it.
- `schema.py`: the entropy comment read "Shannon entropy heuristic for strings >
  16 chars", which mis-states its own reach. Entropy over a value's character
  frequencies is bounded by `log2(distinct characters)`, so the 4.5 threshold is
  unattainable below 23 distinct characters — the length guard admits shorter
  values, but they can never cross it. The comment now says so.
- `docs/system-specs/modules/metrics.md`: the spec carried the same absolute
  twice — "opting in cannot leak ..." and "**Never recorded:** ... Enforced
  structurally". Both are restated as a call-site contract that redaction
  backs rather than replaces. Updated in this commit so the spec and the code
  do not disagree.
- `local_exporter.py`: same correction to its PRIVACY note, which concluded
  that serialized data points "carry no secrets or PII".
- `test/metrics/test_schema.py`: three characterisation tests pinning that
  boundary.
## What this does not do
**No detection behaviour changes.** Same patterns, same 4.5 threshold, same
verdict on every value. The existing suite is untouched and green.
**It does not treat short hex as a defect.** `test_long_hex_40_plus_redacted`
("raised from 20 to spare trace ids") and `test_short_hex_32_chars_not_redacted`
("32-char hex (trace IDs, UUIDs) should NOT be redacted") record a deliberate
trade-off, and this PR leaves it alone. #1609 framed that gap as a defect; that
framing was too broad, and I'd rather correct it here than argue it. What is
genuinely inaccurate is the pair of absolute claims and the comment about the
backstop's own reach, which is what this changes.
**It does not propose a new detector.** Where the backstop should sit, and
whether an attribute-value allowlist should replace guessing at free-form
strings, are calls with real false-positive cost and they are yours. One
direction worth a look, if you want it explored: `http_metrics.py` already
bounds `route_template`, `method` and `status_class` to declared value sets
captured at build time, and generalising that to attributes would close both
this and the cardinality note `schema.py` flags as unimplemented. That is an
RFC rather than a PR, so I have not written one — say the word and I will.
## Tests
New `TestEntropyBackstopReach` in `test/metrics/test_schema.py`:
- 22 distinct characters cannot reach the threshold (`log2(22) = 4.459`)
- 23 distinct characters is the first reachable length (`log2(23) = 4.524`)
- a 16-symbol non-hex alphabet never reaches it at any length — deliberately
  not hex, since the explicit pattern would mask the effect being pinned
Their docstring says they record current behaviour rather than desired
behaviour, so widening the backstop later means updating them on purpose.
`test/metrics/`: **323 passed, 1 skipped**. `flake8`, `isort`, `mypy` clean on
`src/kiro_crew/metrics/`. `docs_lint.py` and the brand gate pass.
`black`: my added lines follow the 100-col style, but a repo-wide run in my
environment reports "Python 3.10 cannot parse code formatted for Python 3.14"
and wants to reformat unrelated pre-existing lines — it reports the same on
pristine `origin/main`, so it is an environment skew rather than anything this
branch introduced.