### PR TITLE
docs(temp-screenshots): correct the attachment rationale and add the skill cross-refs

### DIFF
--- a/temp-screenshots/README.md
+++ b/temp-screenshots/README.md
@@ -6,19 +6,30 @@ package, a wheel, or the desktop app.
 
 ## Why these are committed rather than attached
 
-This repository is private, so GitHub's `raw.githubusercontent.com` host
-returns 404 for everyone and cannot serve an image embedded in a PR
-description. The `user-attachments` mechanism (drag-and-drop upload in the
-GitHub web UI) works, but nothing in an automated PR workflow, CI or CLI,
-can produce an attachment that way.
-
-Committing the file into the PR branch and linking it with a commit-SHA-pinned
-URL sidesteps both problems, because the URL is served from the repository
-itself:
+The `user-attachments` mechanism (drag-and-drop upload in the GitHub web UI)
+renders fine in a PR description, but nothing in an automated PR workflow, CI
+or CLI, can produce an attachment that way. Committing the file and linking it
+with a commit-SHA-pinned URL is reachable from a script:
 
 ```
 https://github.com/<owner>/<repo>/raw/<sha>/temp-screenshots/<feature>/<name>.png
 ```
+
+Committing also puts the PR in scope for automated UX review, which an
+attachment cannot do because an attachment is not a file in the repository.
+Both `ux-review.yml` (:70) and `fork-ux-review.yml` (:205) gate on the changed
+paths:
+
+```bash
+grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)'
+```
+
+Whether the reviewer can then *see* the image depends on the lane. A same-repo
+PR's reviewer reads the files the diff adds. A fork PR's reviewer runs against
+the base tree, so it can open screenshots already on `main` but not ones the PR
+itself adds — those are judged from the diff and surrounding code, as
+`fork-ux-review.yml:236` and `:275` note. The trigger works either way, so the
+images remain the durable record for human reviewers.
 
 ## Naming
 
@@ -40,3 +51,15 @@ pruning the tip never breaks a past PR's images.
 **Authors should not delete their own files before merge, and reviewers
 should not ask them to.** The scheduled cleanup job is the only thing that
 removes files here.
+
+## See also
+
+No application code imports these files, but the path itself is referenced by
+three shipped skills under `src/kiro_crew/`, which are what tell an author or
+agent to write here in the first place:
+
+- `builtin_skills/kirocrew-dev/prepare-pr/SKILL.md` and its
+  `assets/pr-body-template.md` — read before a PR body is written.
+- `apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md` — the operational recipe:
+  copy the media in, amend into the PR's single commit, force-push, then verify
+  the body update landed.


### PR DESCRIPTION
﻿
## Problem / Motivation

#1613 landed `temp-screenshots/README.md`, and its "why these are committed rather
than attached" section rests on a premise that isn't true:

> This repository is private, so GitHub's `raw.githubusercontent.com` host returns
> 404 for everyone and cannot serve an image embedded in a PR description.

The repository is public. `raw.githubusercontent.com` serves the merged README
itself today:

```
GET https://raw.githubusercontent.com/kirodotdev/KiroCrew/main/temp-screenshots/README.md
  -> HTTP 200, 1690 bytes
```

The premise comes from #1256's issue body, which was written when it was accurate.

## Why it matters

This file exists to be cited back at reviewers â€” #1256 was filed because an AI
reviewer raised a blocking finding on #1216 that a README would have pre-empted. A
doc used that way is only worth its weakest sentence, and the stated reason for the
whole convention is currently one a reviewer can disprove in one request. The
convention is right; the justification needs to be one that holds.

## What changed

**Motivation â†’ approach â†’ change.**

The convention doesn't actually depend on repo visibility, so I replaced the
visibility argument with two reasons that hold either way:

1. **`user-attachments` is unreachable from automation.** Attachments can only be
   produced by drag-and-drop in the GitHub web UI, so no CI or CLI path can create
   one. This half of #1613's reasoning was already correct and is kept.
2. **Committing under this path is what puts a PR in scope for automated UX
   review** â€” which an attachment cannot do, because an attachment is not a file in
   the repository. Both lanes gate on the changed paths:

   ```bash
   # ux-review.yml:70 and fork-ux-review.yml:205
   grep -qE '^(website/|temp-screenshots/|\.github/screenshots/)'
   ```

I scoped the image-*reading* half to the lane it applies to. A same-repo PR's
reviewer reads the files the diff adds; a fork PR's reviewer runs against the base
tree and cannot see screenshots the PR itself adds â€” those are judged from the diff
and surrounding code, per `fork-ux-review.yml:236` and `:275`:

> screenshots the PR ADDS are not materialized here (they appear in the diff as
> binary markers) and are judged from code.

The trigger works in both lanes, so the images remain the durable record for human
reviewers regardless.

Finally, added a **See also** for the three shipped skills under `src/kiro_crew/`
that tell an author or agent to write here in the first place â€” `prepare-pr/SKILL.md`,
its `assets/pr-body-template.md`, and `pod-e2e/SKILL.md` (the operational recipe).
That also qualifies the "nothing here is referenced" framing: no application code
imports these files, but the path is contractual and those skills ship inside
`src/kiro_crew/`.

+32/âˆ’9 on one file. Nothing else touched.

## Tests

None â€” documentation-only change, no code paths affected.

## Manual verification

| Check | Result |
|---|---|
| `raw.githubusercontent.com` on the merged file | **HTTP 200, 1690 bytes** â€” the claim being corrected |
| `gh api repos/kirodotdev/KiroCrew` | `private=false`, `visibility=public` |
| UX-review path gate | Regex verified verbatim at `ux-review.yml:70` and `fork-ux-review.yml:205` |
| Fork-lane base-tree behaviour | `fork-ux-review.yml:236` and `:275`; workflow runs `on: pull_request_target` with `ref: base_sha` |
| All three skill paths exist on `main` | Confirmed in a fresh checkout of `09e717f` |
| `scripts/docs_lint.py` | **passes** â€” 183 markdown files |
| Brand Name Gate (diff-scoped, as CI runs it) | **passes** â€” `brand gate: no misspellings of 'Kiro Crew' in the lines added since 09e717f` |

**Limitation, stated rather than glossed:** `docs_lint.py` scans only `docs/`,
`src/kiro_crew/docs/` and `website/docs/`, so it never lints `temp-screenshots/`.
Its pass is not evidence about this file. I checked the file by hand against the
workflows it cites.

## Screenshots / video

N/A â€” no user-visible UI change. This PR adds no images; it edits a markdown file
already on `main`.

Note this PR does touch `temp-screenshots/`, so the UX Review workflow will trigger
on it by design (per the path gate documented above). It's advisory and does not
block merge.

## Related Issues

Follow-up to #1613, which closed #1256. Supersedes #1568, which I've closed â€” it
predated #1613 and would have conflicted on the whole file.

## Checklist

- [x] Single commit, Conventional Commits title
- [x] Self-reviewed the diff
- [x] Docs updated (this *is* the docs change)
- [x] No secrets or credentials
- [ ] Tests added â€” N/A, documentation-only

---

Written with agentic AI assistance, per `CONTRIBUTING.md`'s "Using AI Tools". Every
factual claim above was verified against a fresh checkout of `main` rather than
carried over from the issue or the prior PR â€” which is the specific failure being
corrected here.

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text â€” it will be added here once Legal provides it. -->
