### PR TITLE
fix(telemetry): warn when a non-finite usage value is zeroed

### DIFF
--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -870,6 +870,26 @@ def _write_token_record(record: dict[str, Any], now: datetime) -> None:
     try:
         line = json.dumps(record, allow_nan=False)
     except ValueError:
+        # Name the fields before sanitizing. Without this the fallback rewrites
+        # a provider's measurement to 0.0 and the turn is persisted as free,
+        # with nothing on record that it happened. Field NAMES only: the values
+        # are the corrupt measurement and the rest of the record is per-turn
+        # telemetry, neither of which belongs in a log line.
+        #
+        # Re-raise when nothing non-finite is present: allow_nan=False is not
+        # the only way json.dumps raises ValueError, and sanitizing cannot fix
+        # the others. Swallowing them here would emit a warning naming no field
+        # and blame corruption that did not occur.
+        non_finite = sorted(
+            k for k, v in record.items() if isinstance(v, float) and not math.isfinite(v)
+        )
+        if not non_finite:
+            raise
+        logger.warning(
+            "token usage: replaced non-finite value(s) with 0.0 before persisting; "
+            "fields=%s",
+            ",".join(non_finite),
+        )
         line = json.dumps(_finite_only(record), allow_nan=False)
     with open(shard_path, "a", encoding="utf-8") as f:
         f.write(line + "\n")

--- a/test/metrics/test_cost_breakdown.py
+++ b/test/metrics/test_cost_breakdown.py
@@ -8,6 +8,7 @@ dashboard spend.
 from __future__ import annotations
 
 import json
+import logging
 import math
 from datetime import datetime, timedelta, timezone
 
@@ -245,6 +246,53 @@ class TestNonFiniteCredits:
         assert d["turns"] == 1
         assert d["credits"] == 5.0
         assert math.isfinite(d["credits"])
+
+    def test_the_substitution_is_reported(self, tmp_path, monkeypatch, caplog):
+        """Zeroing a provider's measurement books the turn as free.
+
+        Silently, before this: the row is valid JSON and reads as a real turn
+        that cost nothing, so nobody has a reason to look at the provider.
+        """
+        monkeypatch.setattr(usage_mod, "_token_usage_dir", lambda: tmp_path)
+        with caplog.at_level(logging.WARNING, logger=usage_mod.__name__):
+            usage_mod._write_token_record(
+                {"_type": "tokens", "credits": float("nan")}, datetime.now(timezone.utc)
+            )
+        assert "credits" in caplog.text
+        assert "non-finite" in caplog.text
+
+    def test_every_affected_field_is_named(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr(usage_mod, "_token_usage_dir", lambda: tmp_path)
+        with caplog.at_level(logging.WARNING, logger=usage_mod.__name__):
+            usage_mod._write_token_record(
+                {"_type": "tokens", "credits": float("nan"), "cost": float("inf")},
+                datetime.now(timezone.utc),
+            )
+        assert "credits" in caplog.text and "cost" in caplog.text
+
+    def test_a_clean_record_is_written_quietly(self, tmp_path, monkeypatch, caplog):
+        # The warning has to mean something when it appears, so the ordinary
+        # path must not emit one.
+        monkeypatch.setattr(usage_mod, "_token_usage_dir", lambda: tmp_path)
+        with caplog.at_level(logging.WARNING, logger=usage_mod.__name__):
+            usage_mod._write_token_record(
+                {"_type": "tokens", "credits": 12.5}, datetime.now(timezone.utc)
+            )
+        assert caplog.records == []
+
+    def test_a_serialization_failure_that_is_not_a_non_finite_float_still_raises(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # `allow_nan=False` is not the only way json.dumps raises ValueError.
+        # Sanitizing cannot fix the others, so they must surface rather than be
+        # absorbed into a warning that names no field.
+        monkeypatch.setattr(usage_mod, "_token_usage_dir", lambda: tmp_path)
+        cyclic: dict = {"_type": "tokens"}
+        cyclic["self"] = cyclic
+        with caplog.at_level(logging.WARNING, logger=usage_mod.__name__):
+            with pytest.raises(ValueError):
+                usage_mod._write_token_record(cyclic, datetime.now(timezone.utc))
+        assert caplog.records == []
 
 
 class TestDegenerateInputs:


### PR DESCRIPTION
## Summary

Refs #1564, item 2 — the observability half only.

`_write_token_record` falls back to `_finite_only` when `json.dumps(...,
allow_nan=False)` rejects a non-finite provider float. That keeps the shard
valid, but it rewrites the measurement to `0.0` and writes the row anyway. The
turn is then persisted as free, and nothing on record says a substitution
happened — so a provider emitting `NaN` costs nothing on the cost page and
nobody has a reason to look at it.

## Fix

Emit a warning naming the affected fields when the fallback fires.

- **Field names only.** The values are the corrupt measurement and the rest of
  the record is per-turn telemetry; neither belongs in a log line. `credits` or
  `cost` is enough to say which provider measurement broke.
- **Re-raise when no non-finite float is present.** `allow_nan=False` is not the
  only way `json.dumps` raises `ValueError`, sanitizing cannot fix the others,
  and absorbing them here would emit a warning that names no field and blames
  corruption that did not occur.
- **No rate limiting.** Every warning corresponds to one measurement that was
  rewritten, so the count is the signal. If this turns out to be noisy in
  practice, throttling is easy to add and better decided against real volume.

## What this deliberately does not change

Write-side and legacy read-side behaviour are untouched: the value is still
zeroed on write, and `cost_breakdown` still skips a legacy row whose `credits`
is non-finite.

Item 2 also asks for one consistent semantics across those two paths. I have not
picked one. `TestNonFiniteCredits` currently holds both behaviours in place —
one case asserts the row is written with `credits == 0.0`, another asserts a
legacy non-finite row is skipped rather than summed — so either choice changes
an existing test, and which way to go is a policy call about corrupt rows rather
than a bug fix. Happy to implement whichever you prefer, in a follow-up.

## Tests

Four cases added to `TestNonFiniteCredits` in
`test/metrics/test_cost_breakdown.py`:

- the substitution is reported (warning names `credits`)
- every affected field is named (`credits` and `cost` together)
- a clean record is written quietly — so the warning means something when it
  does appear
- a serialization failure that is not a non-finite float still raises

**Fail-before / pass-after:** with the source change reverted, the first two fail
(no warning to find). The last two pass either way by design — they are
regression guards on the quiet path and the re-raise, not evidence of the fix.

`test/metrics/`: **324 passed, 1 skipped**. `flake8`, `isort`, `mypy` clean on
the changed files; docs-lint and the brand gate pass.

`black`: my added lines follow the 100-col style, but a repo-wide run in my
environment reports "Python 3.10 cannot parse code formatted for Python 3.14"
and wants to reformat unrelated pre-existing lines — it reports the same on
pristine `origin/main`, so it is an environment skew rather than anything this
branch introduced.