### PR TITLE
fix(prepare-pr): terminal-state and superseded-run defects; babysit docs

### DIFF
--- a/skills/kirocrew-dev/babysit/SKILL.md
+++ b/skills/kirocrew-dev/babysit/SKILL.md
@@ -104,6 +104,136 @@ bypasses the LLM approval layer entirely, at roughly a 5-minute interval. An
 hourly job loses the race: one observed merge-to-teardown window was 17
 minutes.
 
+## Reading PR/MR state — ask the host for its verdict, don't hand-roll a filter
+
+Whatever you are babysitting, the read step is **not** yours to invent. These
+five rules hold on GitHub, GitLab and Bitbucket alike; only the command changes.
+
+1. **Ask the host for its own aggregate verdict.** Do not reduce a list of
+   individual checks into a pass/fail yourself. Every host computes a merge
+   verdict and exposes it; a filter you write over the raw list is a second,
+   worse implementation of it that silently disagrees.
+2. **Classify every state you see, and fail closed on the ones you don't.** An
+   unrecognized or unmapped status must count as *not passing*, never as
+   passing. Collapse superseded runs to the newest attempt per check identity
+   before counting failures, or a stale cancelled run reads as a live failure.
+3. **"Checks are green" is not "nothing is outstanding."** Unresolved review
+   threads and *advisory* (non-blocking) results are separate axes that the
+   aggregate verdict does not cover, by design. Read them separately, every
+   cycle, or the loop will declare readiness over an open thread.
+4. **Lifecycle state is terminal — read it every cycle.** Merged, closed, or
+   declined means stop, report the real outcome, and call `autonudge_stop`.
+   Do not infer this from the checks; ask for the state field.
+5. **Mergeability is computed asynchronously.** "Unknown", "checking" or
+   "unchecked" means **wait**, not pass — and on a non-open object it may never
+   resolve at all (see the GitHub limits below).
+
+### Where each host keeps those answers
+
+| host | one-shot verdict | unresolved-thread axis | the local trap |
+|---|---|---|---|
+| **GitHub** | `pr_status.py` (below); optionally an aggregate status context | review threads via GraphQL (`pr_status.py` prints the count) | `statusCheckRollup` is a `CheckRun \| StatusContext` union — `.conclusion` vs `.state` |
+| **GitLab** | `detailed_merge_status` on the MR (`glab mr view <iid>`, or `glab api projects/:id/merge_requests/:iid`) | `glab mr view <iid> --unresolved`, or the Discussions API | a pipeline reports `success` while its `allow_failure: true` jobs failed |
+| **Bitbucket Cloud** | none — combine PR `state` with the commit's build statuses (`/2.0/repositories/{ws}/{repo}/commit/{sha}/statuses`) | PR comments/tasks on the PR resource | below Premium, unresolved merge checks only **warn**; the host still allows the merge |
+
+GitLab specifics worth knowing: use `detailed_merge_status`, not `merge_status`
+(deprecated since 15.6 and it does not account for every state). Its values are
+themselves the loop's decision — `ci_still_running` / `checking` / `preparing` /
+`unchecked` are *wait*; `mergeable` is clean; `conflict`, `need_rebase`,
+`not_approved`, `draft_status`, `discussions_not_resolved`,
+`status_checks_must_pass` and `requested_changes` are each a distinct blocked
+reason worth reporting as itself. Note that `blocking_discussions_resolved` is
+**not** an unresolved-thread count: it only tells you whether resolution is
+required *and* satisfied, so on a project that does not require resolution it can
+be `true` with threads still open. Count threads from the discussions, and treat
+external status checks as their own axis, separate from the pipeline.
+
+Bitbucket specifics: there is no single "can this merge" field to poll, so rule 1
+becomes "combine the two sources the host does give you" — the PR's `state`
+(non-`OPEN` is terminal) and the head commit's build statuses. And because merge
+checks are advisory below Premium, a Bitbucket "green" is weaker evidence than
+elsewhere: rule 3 is not optional there.
+
+Provenance: the GitHub path below is exercised (including against an unrelated
+public repo); the GitLab and Bitbucket rows come from those vendors' API docs and
+are **not** something this skill has run. Verify the exact flag or field against
+your host before trusting a value you have not seen come back.
+
+### On GitHub: use `pr_status.py`
+
+The `prepare-pr` skill owns the tool, and it is project-agnostic — stdlib Python
+over `gh`, no repo-specific assumptions baked in. Call it by path from the target
+repo (do **not** `cd` into the skill folder; the scripts read which repo they are
+talking about from your cwd):
+
+```bash
+SKILL_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/prepare-pr"
+python3 "$SKILL_DIR/scripts/pr_status.py" <pr#>     # exit 0 clean / 10 running / 20 blocked / 2 env
+python3 "$SKILL_DIR/scripts/pr_findings.py" <pr#>   # only after 20: failed steps, log tails, threads
+```
+
+Drive the cycle off the **exit code**, not off prose: `10` → report nothing and
+wait for the next cycle; `20` → drill in with `pr_findings.py` and act; `2` →
+environment problem, escalate rather than loop on it.
+
+**Exit `0` is necessary but not sufficient — do not stop on it alone** (rule 3).
+The script's decision is fail-closed about *checks*, but the unresolved-thread
+count it prints is **advisory: it is not part of the exit code**, so a PR with
+open review threads still exits `0`. Before you declare review-ready and call
+`autonudge_stop`, confirm all three:
+
+1. `pr_status.py` exits `0`;
+2. its `unresolved threads (advisory)` line reads `0` — a `?` means the count
+   could not be retrieved, which is not a zero, so treat it as unresolved and
+   check the threads yourself with `pr_findings.py`;
+3. every reviewer that raised something has an answer from you on the PR. An
+   **advisory** reviewer posts its concerns *and* passes its own check, so its
+   verdict appears in neither the exit code nor the aggregate. In this repo that
+   is `Design Review` / `UX Review` reporting `🟡 CONCERNS` while green; in
+   another repo it is whatever non-blocking bots and human reviewers comment
+   there. See `prepare-pr`'s "Answer every concern".
+
+If any of the three is unmet, the loop has not reached its exit condition —
+keep cycling (or escalate), and do not report the PR as review-ready.
+
+Two GitHub-shaped traps this closes, both of which produce a confidently wrong
+reading:
+
+- **`.conclusion` is not universal — this is a GitHub API shape, not a
+  per-repo quirk.** `statusCheckRollup` is a union: **CheckRun** entries carry
+  `.conclusion`, while **StatusContext** entries (the legacy commit-status API,
+  still how many third-party integrations and any home-grown aggregate report)
+  carry `.state` instead. So
+  `gh pr view --jq '.statusCheckRollup[] | select(.conclusion==...)'` silently
+  drops every status context in any repo that has one, and the PR reads cleaner
+  than it is. `pr_status.py` classifies both shapes, and treats an aggregate
+  status as authoritative over the individual rollup when one is published —
+  naming it with `--readiness-context NAME` (or `PREPARE_PR_READINESS_CONTEXT`;
+  the default is this repo's `PR Readiness`, and `resolve_profile.py` reports
+  the right name for another project, which you then pass in). With no aggregate
+  published it falls back to the full rollup, so it still works on a repo that
+  publishes none.
+- **The failing count is fail-closed, not a bug count** (rule 2). Any
+  unrecognized COMPLETED conclusion counts as a failure, and superseded re-run
+  attempts are collapsed to the newest run per check identity before counting —
+  so every remaining `[fail]` line is live. Read the per-check lines before
+  naming causes to the user.
+
+Two limits worth knowing before you trust it on an arbitrary PR:
+
+- **Run it from a checkout of the target repo.** A bare PR number resolves
+  against your cwd's repo. A full PR URL works for any repo, but the
+  unresolved-thread count re-resolves the repo from cwd (`gh repo view`), so a
+  URL from a foreign checkout mixes two repos: usually that prints `?` (the
+  number does not exist there), but if the cwd repo happens to have a PR with
+  the same number you get a thread count for the *wrong* PR with nothing marking
+  it as such.
+- **A merged, closed or declined PR exits `20`** with `PR state is ... (not
+  OPEN; terminal)` — that satisfies rule 4, so on that message report the real
+  outcome and stop the loop rather than triaging it as a failure.
+- **`?` is not `0`.** It means the count could not be established (auth, page
+  cap, wrong repo). Treat it as unresolved.
+
 ## Workflow
 
 1. **Write the message as instructions to your future self.** Include:
@@ -131,15 +261,23 @@ User: "babysit PR #247 until it's review-ready"
 
 ```
 monitor_start(
-  message="Check PR #247: CI checks and review-bot comments. Fix legitimate
-           High/Medium findings and push (single commit, force-with-lease).
-           Rebut false positives. When all checks are green and every thread
-           is resolved, tell the user the PR is review-ready and call
-           autonudge_stop.",
+  message="Check PR #247 with
+           python3 \"${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/prepare-pr/scripts/pr_status.py\" 247
+           and act on its exit code (10 = still running, report nothing;
+           20 = drill in with pr_findings.py, or stop if the reason is a
+           terminal PR state). Fix legitimate High/Medium findings and push,
+           following this repo's history convention. Rebut false positives.
+           Stop ONLY when exit 0 AND the unresolved-thread count is 0 AND
+           every reviewer that raised something has a reply: then tell the
+           user the PR is review-ready and call autonudge_stop.",
   interval_secs=300,
   max_cycles=20,
 )
 ```
+
+On GitLab or Bitbucket the shape is identical — only the first line changes (the
+host's own verdict call from the table above), plus its own thread axis and its
+own "green is weaker than it looks" caveat.
 
 ## Rules & gotchas
 

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
@@ -16,8 +16,9 @@ Exit codes:
                   aggregate PR Readiness (or the legacy full rollup) passed
   10  RUNNING   - a required check is still queued/in-progress, or mergeability
                   has not been computed yet
-  20  BLOCKED   - failing readiness, merge conflict, draft,
-                  CHANGES_REQUESTED, or anything that cannot be confirmed
+  20  BLOCKED   - failing readiness, merge conflict, draft, CHANGES_REQUESTED,
+                  a terminal PR state (MERGED/CLOSED), or anything that cannot
+                  be confirmed
    2  ENV ERROR - gh missing or not authenticated, or PR not found
 """
 import json
@@ -114,6 +115,40 @@ def classify_check(entry):
     return "fail"  # unknown shape -> fail closed
 
 
+def collapse_superseded(rollup):
+    """Collapse re-run check attempts to the newest run per check identity.
+
+    GitHub keeps superseded attempts (typically CANCELLED) in the rollup next
+    to the run that replaced them; counting them inflates the failure count
+    with entries that are no longer live. Identity is the workflow-qualified
+    check name for CheckRuns and the context name for StatusContexts; newest
+    is decided by startedAt (ISO-8601, so string comparison orders correctly).
+    Entries that cannot be strictly ordered against the current winner are all
+    kept -- when in doubt, over-report rather than hide a live failure.
+    """
+    winners = {}
+    order = []
+    undecidable = []
+    for e in rollup:
+        context = e.get("context")
+        if context:
+            key = ("ctx", context, "")
+        else:
+            key = ("run", e.get("workflowName") or "", e.get("name") or "")
+        started = e.get("startedAt") or ""
+        if key not in winners:
+            winners[key] = (started, e)
+            order.append(key)
+            continue
+        prev_started, prev = winners[key]
+        if started and prev_started:
+            if started > prev_started:
+                winners[key] = (started, e)
+        else:
+            undecidable.append(e)  # no ordering evidence -> keep both
+    return [winners[k][1] for k in order] + undecidable
+
+
 def unresolved_thread_count(number):
     """Count unresolved review threads across all pages for advisory output."""
     rc, repo, _ = run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
@@ -187,7 +222,7 @@ def main(argv):
     mergeable = (d.get("mergeable") or "").upper()
     merge_state = (d.get("mergeStateStatus") or "").upper()
     decision = (d.get("reviewDecision") or "NONE").upper()
-    rollup = d.get("statusCheckRollup") or []
+    rollup = collapse_superseded(d.get("statusCheckRollup") or [])
 
     print("=" * 54)
     print("PR #{}  [{}{}]".format(d.get("number"), state, " draft" if draft else ""))
@@ -228,6 +263,12 @@ def main(argv):
     print("=" * 54)
 
     # ---- Decision (fail-closed) --------------------------------------------
+    # A non-open PR is terminal, and must be decided BEFORE the mergeability
+    # wait: GitHub reports mergeable=UNKNOWN for merged/closed PRs forever, so
+    # waiting on it would return 10 on every poll and a loop would never stop.
+    if state != "OPEN":
+        print("STATUS: BLOCKED - PR state is {} (not OPEN; terminal)".format(state or "?"))
+        return 20
     # Once published, the aggregate is authoritative over stale duplicate
     # checks in the rollup. Legacy PRs without it still use the full rollup.
     if readiness_kind == "running" or (readiness_kind is None and n_running > 0):
@@ -245,8 +286,6 @@ def main(argv):
         reasons.append("{} check(s) failed".format(n_fail))
     if len(rollup) == 0:
         reasons.append("no CI checks reported - cannot confirm CI (fail-closed)")
-    if state != "OPEN":
-        reasons.append("PR state is {} (not OPEN)".format(state or "?"))
     if draft:
         reasons.append("PR is a draft")
     if mergeable == "CONFLICTING" or merge_state in ("DIRTY", "CONFLICTING"):

--- a/test/test_prepare_pr_status.py
+++ b/test/test_prepare_pr_status.py
@@ -20,21 +20,21 @@ def _load_script() -> ModuleType:
     return module
 
 
-def _pr_payload(checks: list[dict[str, str]]) -> str:
-    return json.dumps(
-        {
-            "number": 42,
-            "title": "fix: keep the change focused",
-            "state": "OPEN",
-            "isDraft": False,
-            "mergeable": "MERGEABLE",
-            "mergeStateStatus": "CLEAN",
-            "reviewDecision": "REVIEW_REQUIRED",
-            "url": "https://github.com/example/repo/pull/42",
-            "headRefName": "fix/focused",
-            "statusCheckRollup": checks,
-        }
-    )
+def _pr_payload(checks: list[dict[str, str]], **overrides: object) -> str:
+    payload: dict[str, object] = {
+        "number": 42,
+        "title": "fix: keep the change focused",
+        "state": "OPEN",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "reviewDecision": "REVIEW_REQUIRED",
+        "url": "https://github.com/example/repo/pull/42",
+        "headRefName": "fix/focused",
+        "statusCheckRollup": checks,
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
 
 
 def _install_fake_gh(module: ModuleType, payload: str) -> None:
@@ -96,3 +96,150 @@ def test_check_run_named_pr_readiness_cannot_mask_a_failure() -> None:
     _install_fake_gh(module, payload)
 
     assert module.main(["pr_status.py", "42"]) == 20
+
+
+def test_merged_pull_request_is_terminal_not_running() -> None:
+    """A non-open PR must exit 20, not wait on mergeability GitHub never computes."""
+    module = _load_script()
+    payload = _pr_payload([], state="MERGED", mergeable="UNKNOWN", mergeStateStatus="UNKNOWN")
+    _install_fake_gh(module, payload)
+
+    assert module.main(["pr_status.py", "42"]) == 20
+
+
+def test_closed_pull_request_is_terminal_not_running() -> None:
+    module = _load_script()
+    payload = _pr_payload([], state="CLOSED", mergeable="UNKNOWN", mergeStateStatus="UNKNOWN")
+    _install_fake_gh(module, payload)
+
+    assert module.main(["pr_status.py", "42"]) == 20
+
+
+def test_open_pull_request_with_unknown_mergeability_still_waits() -> None:
+    """The terminal-state check must not swallow the legitimate async wait."""
+    module = _load_script()
+    payload = _pr_payload(
+        [{"name": "Backend Tests", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+        mergeable="UNKNOWN",
+    )
+    _install_fake_gh(module, payload)
+
+    assert module.main(["pr_status.py", "42"]) == 10
+
+
+def test_superseded_cancelled_run_does_not_count_as_a_failure() -> None:
+    """A re-run leaves the CANCELLED attempt in the rollup; newest run wins."""
+    module = _load_script()
+    payload = _pr_payload(
+        [
+            {
+                "name": "GPT Review",
+                "workflowName": "review.yml",
+                "status": "COMPLETED",
+                "conclusion": "CANCELLED",
+                "startedAt": "2026-08-06T01:00:00Z",
+            },
+            {
+                "name": "GPT Review",
+                "workflowName": "review.yml",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-08-06T02:00:00Z",
+            },
+        ]
+    )
+    _install_fake_gh(module, payload)
+
+    assert module.main(["pr_status.py", "42"]) == 0
+
+
+def test_superseded_success_does_not_mask_a_newer_failure() -> None:
+    """Newest-wins must work in both directions: a fresh failure stays red."""
+    module = _load_script()
+    payload = _pr_payload(
+        [
+            {
+                "name": "Backend Tests",
+                "workflowName": "ci.yml",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-08-06T01:00:00Z",
+            },
+            {
+                "name": "Backend Tests",
+                "workflowName": "ci.yml",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "startedAt": "2026-08-06T02:00:00Z",
+            },
+        ]
+    )
+    _install_fake_gh(module, payload)
+
+    assert module.main(["pr_status.py", "42"]) == 20
+
+
+def test_same_check_name_in_different_workflows_stays_distinct() -> None:
+    """Identity is workflow-qualified: two workflows may share a job name."""
+    module = _load_script()
+    payload = _pr_payload(
+        [
+            {
+                "name": "build",
+                "workflowName": "linux.yml",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-08-06T02:00:00Z",
+            },
+            {
+                "name": "build",
+                "workflowName": "windows.yml",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "startedAt": "2026-08-06T01:00:00Z",
+            },
+        ]
+    )
+    _install_fake_gh(module, payload)
+
+    assert module.main(["pr_status.py", "42"]) == 20
+
+
+def test_unordered_duplicates_are_all_kept_fail_closed() -> None:
+    """Without startedAt on both entries there is no ordering evidence, so
+    neither may silently supersede the other -- the failure must survive."""
+    module = _load_script()
+    payload = _pr_payload(
+        [
+            {
+                "name": "Backend Tests",
+                "workflowName": "ci.yml",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+            },
+            {
+                "name": "Backend Tests",
+                "workflowName": "ci.yml",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-08-06T02:00:00Z",
+            },
+        ]
+    )
+    _install_fake_gh(module, payload)
+
+    assert module.main(["pr_status.py", "42"]) == 20
+
+
+def test_status_contexts_collapse_by_context_name() -> None:
+    """StatusContexts share the identity axis via their context string."""
+    module = _load_script()
+    payload = _pr_payload(
+        [
+            {"context": "PR Readiness", "state": "FAILURE", "startedAt": "2026-08-06T01:00:00Z"},
+            {"context": "PR Readiness", "state": "SUCCESS", "startedAt": "2026-08-06T02:00:00Z"},
+        ]
+    )
+    _install_fake_gh(module, payload)
+
+    assert module.main(["pr_status.py", "42"]) == 0


### PR DESCRIPTION
## Problem

The `babysit` skill documents how to **arm** and **exit** a monitoring loop, but
never how to **read the state of the thing being watched**. For its single most
common target -- a PR or MR -- it prescribed no polling command at all.

An agent babysitting one therefore improvises, and the obvious improvisation is
wrong. On GitHub:

```
gh pr view <n> --json statusCheckRollup \
  --jq '.statusCheckRollup[] | select(.conclusion=="FAILURE")'
```

`statusCheckRollup` is a union type. **CheckRun** entries carry `.conclusion`;
**StatusContext** entries -- the legacy commit-status API, still how many
third-party integrations and any home-grown aggregate report -- carry `.state`.
The filter silently drops every one of them, with no error to notice. `prepare-pr`
already owns a tool that classifies both shapes; `babysit` did not mention it
exists.

The same class of error exists on the other hosts, with different surface detail:
on GitLab a pipeline reports `success` while its `allow_failure: true` jobs
failed, and `blocking_discussions_resolved` is not an unresolved-thread count; on
Bitbucket Cloud there is no single merge verdict to poll at all, and below Premium
unresolved merge checks only *warn*.

And the correct tool itself had two defects that made a naive loop wrong:

- **A merged or closed PR reported `10` (running) forever** (#1755): GitHub
  returns `mergeable=UNKNOWN` for a non-open PR, and the mergeability wait ran
  before the state check, so a loop watching a PR merged out from under it
  cycled to its cap instead of reporting the merge.
- **Superseded re-run attempts counted as live failures** (#1749): a `CANCELLED`
  run beside the newer SUCCESS that replaced it inflated `failing=N`, and on a
  legacy PR with no aggregate published the count *is* the decision.

## Why it matters

A babysit loop's whole job is to decide "is this done yet?" on every cycle. A
reading method that omits the authoritative verdict makes the loop confidently
wrong in the dangerous direction (looks green, is not); a loop that cannot see
"merged" never terminates; a fail-closed count that includes dead runs
over-reports causes; and guidance with no host-neutral rules only works on the
host whose quirks its author happened to know.

## Fix (symptom -> root cause -> change)

**Docs.** New **"Reading PR/MR state -- ask the host for its verdict, don't
hand-roll a filter"** section, led by five host-independent rules: ask the host
for its own aggregate verdict instead of reducing a check list yourself; classify
every state and fail closed on unrecognized ones (collapsing superseded runs
first); green checks are not the same as nothing outstanding, because unresolved
threads and advisory results are separate axes the verdict does not cover;
lifecycle state (merged / closed / declined) is terminal and must end the loop;
and mergeability is computed asynchronously, so "unknown" means wait, not pass.
A per-host table maps those rules onto concrete calls -- `pr_status.py` on
GitHub, `detailed_merge_status` on GitLab (`merge_status` is deprecated;
`blocking_discussions_resolved` is not an unresolved count), PR `state` plus the
head commit's build statuses on Bitbucket Cloud (no single merge verdict; merge
checks advisory below Premium) -- each row naming the trap that makes a naive
read wrong there. Provenance is stated in the skill: the GitHub path is
exercised; the GitLab and Bitbucket rows come from vendor API docs and have not
been run from here. The GitHub subsection keeps the exit-code contract and
documents **exit `0` as necessary but not sufficient** (exit 0 **and** zero
unresolved threads **and** a reply to every reviewer that raised something).

**Script.** Fixes the two `pr_status.py` defects the section would otherwise
have had to document around (per review feedback that a doc compensating for
fixable bugs is prose that must be un-written later):

- **Fixes #1755 -- terminal state.** Non-OPEN now returns `20` with `PR state is
  MERGED/CLOSED (not OPEN; terminal)`, checked *before* the mergeability wait.
  The legitimate async wait for OPEN PRs is unchanged.
- **Fixes #1749 -- superseded runs.** `collapse_superseded()` keeps the newest
  run per check identity (workflow-qualified name for CheckRuns, context for
  StatusContexts, ordered by `startedAt`); entries that cannot be strictly
  ordered are all kept, so a live failure can never be silently superseded.

With both fixed, the skill's corresponding caveats are deleted rather than
maintained -- the remaining text documents current behavior only.

## Tests

Eight new tests in `test/test_prepare_pr_status.py`, each revert-verified
(restoring the pre-fix script fails exactly the three lock tests; the fixed
script passes all 12 in the file):

- merged and closed PRs are terminal (`20`), and open + `mergeable=UNKNOWN`
  still waits (`10`) -- the terminal check must not swallow the async wait;
- a superseded `CANCELLED` run no longer counts as a failure; newest-wins works
  in both directions (a fresh failure is not masked by an older success);
  same-named checks in different workflows stay distinct; unordered duplicates
  are all kept (fail-closed); StatusContexts collapse by context name.

Doc gates: `scripts/docs-lint.sh` passes; the brand-name gate reports no
findings in the changed files. Lint: isort/flake8 clean; mypy on
`src/kiro_crew/` reports only the known faiss-venv artifact in
`vector_memory.py` (absent under CI's faiss-less environment).

## Manual verification

- **Ran the GitHub path against an unrelated repo.** From a checkout of a
  different project, `pr_status.py https://github.com/cli/cli/pull/14083` read
  the PR, classified all 7 checks, printed `aggregate readiness: not published`
  (the full-rollup fallback engaging where no aggregate exists), and correctly
  blocked on `PR is a draft`. This is the evidence for the project-agnostic
  claim.
- **Reproduced the merged-PR defect, then verified the fix live.** Pre-fix,
  `cli/cli#1700` printed `PR #1700 [MERGED]` then `STATUS: RUNNING (mergeability
  not yet computed: UNKNOWN)`. Post-fix it prints `STATUS: BLOCKED - PR state is
  MERGED (not OPEN; terminal)` and exits 20. The fixed script also read this
  PR's own live rollup correctly (exit 10 while checks run).
- **Confirmed the cwd/URL split.** A bare number from a foreign checkout fails
  to resolve; a URL resolves the PR but the thread count re-resolves the repo
  from cwd and degraded to `?`. The same-number collision case is a code-read
  claim, not reproduced.
- GitLab and Bitbucket claims are sourced from `docs.gitlab.com` (merge requests
  API: `detailed_merge_status` values, `merge_status` deprecated in 15.6,
  `blocking_discussions_resolved` semantics, async mergeability) and Atlassian's
  Bitbucket Cloud docs (commit statuses API; merge checks warn-only below
  Premium). Not exercised -- stated as such in the skill.

## Screenshots

N/A -- no user-visible UI change.

Fixes #1749
Fixes #1755
