### PR TITLE
chore(i18n): stop reporting parser-facing literals as untranslated copy

### DIFF
--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -99,6 +99,30 @@ export default [
       // false positive it fixes. A path this narrow cannot exempt a future file
       // that does hold copy.
       'src/apps/meetings/lib/sketchSrcdoc.ts',
+      // The widget and MCP-app srcdoc builders — the same category as
+      // `sketchSrcdoc.ts` directly above, and listed by the same exact-path rule
+      // rather than a shared `*Srcdoc.ts` glob. Every literal in both is handed to
+      // a PARSER: CSP directives, a DOCTYPE, `<meta>`/`<style>`/`<script>` markup,
+      // the frame's own reset CSS, and two fixed JS bootstraps (the height reporter
+      // and the nav beacon). Translating any of them would not change a word anyone
+      // reads — it would break the policy or blank the frame.
+      //
+      // Verified copy-free rather than assumed: neither module imports `i18nT` /
+      // `useTranslation`, neither renders a text node, and their exports are pure
+      // builders. The consumers that DO show copy (`WidgetFrame.tsx`, the MCP app
+      // host) stay fully gated.
+      //
+      // Two exact paths, not a content regex. The `^(default|script|img|…)-src\b`
+      // exclusion that the `sketchSrcdoc.ts` note above records as tried-and-rejected
+      // is exactly what would cover these, and it leaked into unrelated files; a
+      // measured `^rgba?\(` variant leaked into `apps/issue-radar/lib/format.ts`.
+      // A path this narrow cannot leak.
+      //
+      // Stated as a false-negative class, per this file's convention: any
+      // user-visible copy ever added to these two paths will not be reported —
+      // keep both modules parser-facing only.
+      'src/lib/widgetSrcdoc.ts',
+      'src/lib/mcpAppSrcdoc.ts',
       // The PPTX Maker board-preview builder — the same category as
       // `sketchSrcdoc.ts` directly above, and listed by the same exact-path rule
       // rather than a shared glob. Every literal in it is handed to a PARSER: the
@@ -139,6 +163,35 @@ export default [
       'src/apps/mochi/src/shared/shortcut.ts',
       // CSS text injected through <style>; a stylesheet is not translatable copy.
       'src/apps/spec-builder/inlineStyles.ts',
+      // The theme stylesheet builders, extracted out of `hooks/useTheme.tsx` so
+      // they COULD be exempted by path. Every literal in the module is handed to
+      // the CSS parser: the `--*` custom-property allowlist, the
+      // `[data-theme="custom-<slug>-<mode>"]` selectors, the static font/radius/
+      // color-scheme defaults, `@font-face` blocks, and the `url()` values the
+      // overrides-pipeline rewrites to pack asset routes. Translating any of them
+      // would not change a word anyone reads — it would unstyle the theme or
+      // silently weaken the §4.2/§5.1 selector scoper.
+      //
+      // Verified copy-free rather than assumed, and by a MECHANICAL boundary
+      // rather than a reading: the module imports no `i18nT` / `useTranslation`,
+      // and it does not touch the DOM at all — every export is data in, CSS
+      // `string` out. The `<style>` tags, `document.head` writes and
+      // `style.setProperty` calls all stayed in `useTheme.tsx`, so nothing here
+      // has a path to the screen.
+      //
+      // This split is the whole reason a path exemption is admissible here.
+      // `useTheme.tsx` also declares `THEMES` — 19 theme-picker display names —
+      // so exempting THAT file would hand back real copy, which is what the
+      // `object-properties: next` note above refuses. Extracting the CSS leaves
+      // the 19 names in a still-gated file. Measured: `useTheme.tsx` 34 -> 17
+      // (exactly the 17 CSS findings), the new module contributes 0, and no other
+      // file's count moves.
+      //
+      // Stated as a false-negative class, per this file's convention: any
+      // user-visible copy ever added to THIS path will not be reported — keep the
+      // module parser-facing only, and keep it DOM-free, which is the property
+      // that makes that easy to check.
+      'src/hooks/themeCss.ts',
     ],
     linterOptions: {
       // Every `eslint-disable` comment in this codebase targets the MAIN config's
@@ -411,6 +464,21 @@ export default [
             exclude: [
               // Diagnostics and dev-only output.
               '^console\\.\\w+$', '^(Type)?Error$', '^URL(SearchParams)?$',
+              // `popoutController.ts`'s two console shims: `logDebug` is
+              // `console.debug` and `logWarn` is `console.warn`, both behind a debug
+              // flag. Identical class to `^console\.\w+$` one line up — the argument
+              // is operator diagnostics ("direct focus of … vetoed"), never a string
+              // the UI renders.
+              //
+              // A CALLEE exemption and deliberately NOT a whole-file one: the module
+              // also raises a `window.alert(i18nT(…))`, so releasing the file would
+              // release a module that does render copy — it would fail the
+              // "verified copy-free" standard the exact-path precedents above meet.
+              //
+              // Known false negative, stated: a future `logDebug`/`logWarn` defined
+              // in another module inherits this. Both names exist in exactly one
+              // module today (`src/utils/popoutController.ts`).
+              '^log(Debug|Warn)$',
               // Validator diagnostics, for parity with `Error` above. A rejected input's
               // reason names the FIELD that failed (`Missing or invalid "meta" field`,
               // `Invalid meta.format: "…" (expected "svg", "lottie", or "sprite")`) and

--- a/website/src/components/themeEditor.tsx
+++ b/website/src/components/themeEditor.tsx
@@ -21,7 +21,7 @@ import ErrorNotice from './ErrorNotice'
  *
  * The CSS custom-property names themselves (`--bg`, `--accent-hover`) are NOT in
  * here: they are the identifiers the theme JSON, the stylesheet and
- * `ALLOWED_CSS_VARS` in `hooks/useTheme.tsx` agree on, so they are data. Only
+ * `ALLOWED_CSS_VARS` in `hooks/themeCss.ts` agree on, so they are data. Only
  * the human labels beside them are copy.
  */
 const VAR_GROUP_LABEL_KEY: Record<string, string> = {

--- a/website/src/hooks/themeCss.ts
+++ b/website/src/hooks/themeCss.ts
@@ -1,0 +1,384 @@
+/**
+ * Theme CSS text: every builder, sanitizer and filter that produces the
+ * stylesheet text `useTheme.tsx` injects.
+ *
+ * Split out of `useTheme.tsx` so the i18n lint does not read stylesheet text as
+ * user-visible copy — the same named-boundary idiom as
+ * `apps/md-notebook/styles.ts` and `apps/spec-builder/inlineStyles.ts`, and this
+ * module is ignored by path in `website/eslint.i18n.config.js`. The rest of
+ * `useTheme.tsx` stays fully gated, which is the point of the split: the theme
+ * picker's 19 display names live there and must keep being reported.
+ *
+ * The boundary is mechanical, not a judgement call: **nothing here touches the
+ * DOM.** Every export is `string`/data in, `string` out. The `<style>` tags,
+ * `document.head` writes and `style.setProperty` calls stay in `useTheme.tsx`,
+ * so this module has no path to the screen at all — a literal added here can
+ * only ever reach a CSS parser.
+ *
+ * Keep it that way. Any copy added to this file will NOT be reported by the
+ * i18n gate; copy belongs in the catalog and its render site belongs in a
+ * gated module.
+ */
+
+import { sanitizeCssValue } from '../lib/cssSanitize'
+import type { CustomThemeData } from './useTheme'
+
+// Allowlist of allowed CSS custom property names for themes.
+// Only these variables will be injected — unknown keys are silently dropped.
+const ALLOWED_CSS_VARS = new Set([
+  '--bg', '--bg-accent', '--bg-elevated', '--bg-hover',
+  '--card', '--card-fg', '--card-hl',
+  '--panel', '--panel-strong', '--chrome',
+  '--text', '--text-strong', '--muted', '--muted-strong',
+  '--border', '--border-strong', '--border-hover',
+  '--accent', '--accent-hover', '--accent-subtle',
+  '--accent-glow', '--ring',
+  '--ok', '--ok-subtle', '--warn', '--warn-subtle',
+  '--danger', '--danger-subtle', '--info',
+  '--aim', '--aim-subtle',
+  '--clarify', '--clarify-subtle',
+  '--diff-add', '--diff-add-text',
+  '--diff-del', '--diff-del-text',
+  '--diff-hunk', '--diff-hunk-text', '--diff-meta-text',
+  '--shadow-sm', '--shadow-md', '--shadow-lg',
+])
+
+/**
+ * Positive-allowlist CSS value sanitizer lives in src/lib/cssSanitize.ts so
+ * WidgetFrame and any other surface that serializes theme vars uses the same
+ * filter. See that file for the security rationale.
+ */
+const escapeCssValue = sanitizeCssValue
+
+/**
+ * Build a custom theme's dark + light CSS variable blocks.
+ *
+ * `slug` must ALREADY be sanitized — `safeSlug` is the one sanitization site, so
+ * the `[data-theme]` selector here and the `<style>` element id the caller
+ * derives can never disagree. Returns '' for an empty slug (nothing to paint).
+ */
+export function buildCustomThemeCss(slug: string, theme: CustomThemeData): string {
+  if (!slug) return ''
+
+  const buildVars = (vars: Record<string, string>) =>
+    Object.entries(vars)
+      .filter(([k]) => ALLOWED_CSS_VARS.has(k))
+      .map(([k, v]): [string, string] => [k, escapeCssValue(v)])
+      .filter(([, v]) => v !== '')  // drop entries with empty/rejected values
+      .map(([k, v]) => `${k}:${v}`)
+      .join(';')
+
+  // Static defaults (not user-controlled)
+  const darkDefaults =
+    '--font-body:var(--script-fallbacks),\'Space Grotesk\',-apple-system,BlinkMacSystemFont,sans-serif;' +
+    '--mono:var(--script-fallbacks-mono),\'JetBrains Mono\',ui-monospace,SFMono-Regular,monospace;' +
+    '--radius-sm:6px;--radius-md:8px;--radius-lg:12px;--radius-xl:16px;' +
+    'color-scheme:dark;'
+  const lightDefaults =
+    '--font-body:var(--script-fallbacks),\'Space Grotesk\',-apple-system,BlinkMacSystemFont,sans-serif;' +
+    '--mono:var(--script-fallbacks-mono),\'JetBrains Mono\',ui-monospace,SFMono-Regular,monospace;' +
+    '--radius-sm:6px;--radius-md:8px;--radius-lg:12px;--radius-xl:16px;' +
+    'color-scheme:light;'
+
+  const darkCss = buildVars(theme.dark)
+  const lightCss = buildVars(theme.light)
+
+  return (
+    `[data-theme="custom-${slug}-dark"]{${darkCss};${darkDefaults}}\n` +
+    `[data-theme="custom-${slug}-light"]{${lightCss};${lightDefaults}}`
+  )
+}
+
+// ── Level 1 (branded) asset paths ──
+
+/** The backend asset route for one installed theme pack. */
+export const assetBase = (slug: string) => `/api/theme/${encodeURIComponent(slug)}/assets`
+/** Reduce a theme slug to the chars that are safe in a CSS selector and an element id. */
+export const safeSlug = (slug: string) => slug.replace(/[^a-z0-9-]/g, '')
+const _safeFamily = (f: string) => f.replace(/[^A-Za-z0-9 _-]/g, '')
+// Sanitize a branding asset relative path (e.g. "branding/logo.svg"): allow only
+// safe chars, reject traversal/absolute. Defense-in-depth on top of the backend
+// asset route's own path-containment; returns '' when unusable.
+export const safeAssetPath = (p: string): string => {
+  const cleaned = (p || '').replace(/[^a-z0-9./_-]/gi, '')
+  if (!cleaned || cleaned.startsWith('/') || cleaned.split('/').includes('..')) return ''
+  return cleaned
+}
+
+/** A `url()` CSS VALUE addressing one asset in an installed pack, for a custom property. */
+export const assetUrlValue = (slug: string, rel: string) => `url('${assetBase(slug)}/${rel}')`
+
+/**
+ * Build @font-face rules + a --font-body override for an installed theme,
+ * scoped to that theme's data-theme selectors. Returns '' when no declared face
+ * is usable, so the caller injects no stylesheet at all.
+ *
+ * `slug` must already be sanitized (see `buildCustomThemeCss`).
+ */
+export function buildThemeFontCss(slug: string, theme: CustomThemeData): string {
+  const fonts = theme.assets?.fonts || []
+  const faces: string[] = []
+  // Track the family of the FIRST face that actually made it into the stylesheet
+  // — fonts[0] may have been skipped (bad family/src/format), in which case
+  // keying --font-body off it would name a family with no @font-face behind it.
+  let firstEmittedFamily = ''
+  for (const f of fonts) {
+    const fam = _safeFamily(f.family || '')
+    const file = (f.src || '').replace(/[^a-z0-9./_-]/gi, '')
+    if (!fam || !file.startsWith('styles/fonts/')) continue
+    const fmt = file.endsWith('.woff2') ? 'woff2' : file.endsWith('.ttf') ? 'truetype' : ''
+    if (!fmt) continue
+    const weight = typeof f.weight === 'number' && f.weight >= 100 && f.weight <= 900 ? f.weight : 400
+    const style = f.style === 'italic' ? 'italic' : 'normal'
+    faces.push(
+      `@font-face{font-family:'${fam}';` +
+        `src:url('${assetBase(slug)}/${file}') format('${fmt}');` +
+        `font-weight:${weight};font-style:${style};font-display:swap;}`
+    )
+    if (!firstEmittedFamily) firstEmittedFamily = fam
+  }
+  if (!faces.length) return ''
+  const primary = firstEmittedFamily
+  return (
+    faces.join('\n') +
+    `\n[data-theme="custom-${slug}-dark"],[data-theme="custom-${slug}-light"]{` +
+    `--font-body:'${primary}',var(--script-fallbacks),'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;}`
+  )
+}
+
+// ── §4.2/§5.1 runtime positive-selector scoper ──
+// A selector group from overrides.css is kept only if EVERY selector, after
+// stripping one optional leading [data-theme="…"] / html[data-theme…] scoping
+// prefix, targets one of the 10 allowlisted surfaces (optionally with extra
+// chained classes/pseudo-classes on the SAME base — no descendant/child/sibling
+// combinators, no ids/attribute selectors, never the forbidden set).
+const _ALLOWED_ELEMENTS = new Set(['', 'body', 'button']) // blocks iframe/script/div/…
+const _ALLOWED_CLASSES = new Set([
+  'topbar',
+  'chat-container',
+  'sidebar',
+  'message-bubble',
+  'input-area',
+  'code-block',
+])
+const _FORBIDDEN_CLASSES = new Set(['token', 'credential'])
+
+/** True if a single selector targets an allowlisted surface. */
+function _selectorAllowed(sel: string): boolean {
+  let s = sel.trim()
+  if (!s) return false
+  // Strip one optional leading scoping prefix: [data-theme…] or html[data-theme…].
+  s = s.replace(/^(?:html)?\s*\[data-theme[^\]]*\]\s*/i, '').trim()
+  if (!s) return false
+  // No descendant/child/sibling combinators may remain in the compound.
+  if (/[\s>+~]/.test(s)) return false
+  // No ids or (remaining) attribute selectors — blocks #app-root and [data-auth].
+  if (s.includes('#') || s.includes('[')) return false
+  // Leading element (optional) followed by chained .class / :pseudo / ::pseudo.
+  const m = /^([a-zA-Z][\w-]*)?((?:\.[\w-]+|::?[\w-]+(?:\([^)]*\))?)*)$/.exec(s)
+  if (!m) return false
+  const element = (m[1] || '').toLowerCase()
+  if (!_ALLOWED_ELEMENTS.has(element)) return false
+  const classes = new Set<string>()
+  const pseudoEls = new Set<string>()
+  const tokRe = /(\.[\w-]+)|(::?[\w-]+(?:\([^)]*\))?)/g
+  let t: RegExpExecArray | null
+  while ((t = tokRe.exec(m[2] || '')) !== null) {
+    if (t[1]) {
+      classes.add(t[1].slice(1).toLowerCase())
+    } else if (t[2]) {
+      const dbl = t[2].startsWith('::')
+      const name = t[2].replace(/^::?/, '').replace(/\(.*$/, '').toLowerCase()
+      if (dbl || name === 'before' || name === 'after') pseudoEls.add(name)
+      // single-colon pseudo-classes (:hover, :focus, …) are tolerated / ignored
+    }
+  }
+  for (const c of classes) if (_FORBIDDEN_CLASSES.has(c)) return false
+  if (element === 'body') {
+    // Only bare body / body::before / body::after (single-colon tolerated).
+    if (classes.size) return false
+    for (const p of pseudoEls) if (p !== 'before' && p !== 'after') return false
+    return true
+  }
+  if (element === 'button') return classes.has('primary')
+  // Class-based surfaces (element === ''): allowed if any base class is present.
+  for (const c of classes) if (_ALLOWED_CLASSES.has(c)) return true
+  return false
+}
+
+/** True if a comma selector group is kept (every selector must pass). */
+function _groupAllowed(group: string): boolean {
+  const parts = group.split(',')
+  return parts.length > 0 && parts.every((p) => _selectorAllowed(p))
+}
+
+/**
+ * Filter an overrides.css string to allowlisted rules only. Top-level rules
+ * whose selector group passes are emitted verbatim; @media blocks are recursed
+ * into (wrapper preserved, inner filtered); every other at-rule is dropped.
+ */
+// Declaration-body denylist — mirrors the backend `_THEME_CSS_DENY_RE`
+// (theme_validate.py). Non-global (no /g) so repeated `.test()` is stateless.
+// Applied to KEPT rules' bodies so the runtime boundary is fail-closed for
+// declarations, not just selectors.
+const _DECL_DENY_RE =
+  /@import|expression\s*\(|javascript:|-moz-binding|url\s*\(\s*['"]?\s*(?:https?:)?\/\//i
+
+// Evasion normalization: a browser decodes CSS
+// `\`-escapes during tokenization, so `\75 rl(` becomes `url(`. Comments are
+// already stripped globally below. Decode escapes and run the denylist on the
+// decoded text too, so an escaped forbidden token can't hide from the scoper.
+// Mirrors backend `_decode_css_escapes` / `_css_denylist_normalize`. Not a full
+// CSS parse (that is #316) — just the minimal decode the known evasions exploit.
+const _CSS_ESCAPE_RE = /\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g
+function _decodeCssEscapes(s: string): string {
+  return s.replace(_CSS_ESCAPE_RE, (_m, hex: string | undefined, ch: string | undefined) => {
+    if (hex !== undefined) {
+      try {
+        return String.fromCodePoint(parseInt(hex, 16))
+      } catch {
+        return ''
+      }
+    }
+    return ch ?? ''
+  })
+}
+/** True if a declaration body hits the denylist raw OR after escape-decoding. */
+function _declDenied(block: string): boolean {
+  return _DECL_DENY_RE.test(block) || _DECL_DENY_RE.test(_decodeCssEscapes(block))
+}
+
+export function scopeOverridesCss(css: string): { css: string; kept: number; dropped: number } {
+  const src = css.replace(/\/\*[\s\S]*?\*\//g, '') // strip comments
+  let kept = 0
+  let dropped = 0
+
+  const walk = (input: string): string => {
+    const out: string[] = []
+    let i = 0
+    let buf = ''
+    while (i < input.length) {
+      const ch = input[i]
+      // Skip quoted strings verbatim so braces/quotes inside them (e.g.
+      // `content:"}"`) can't desync the brace walker. Mirrors the backend
+      // `_css_skip_string`. (Comments are already stripped above.)
+      if (ch === '"' || ch === "'") {
+        buf += ch
+        i++
+        while (i < input.length) {
+          const c = input[i]
+          buf += c
+          i++
+          if (c === '\\') {
+            if (i < input.length) {
+              buf += input[i]
+              i++
+            }
+            continue
+          }
+          if (c === ch) break
+        }
+        continue
+      }
+      if (ch === '{') {
+        const prelude = buf.trim()
+        buf = ''
+        let depth = 1
+        i++
+        const start = i
+        while (i < input.length && depth > 0) {
+          const c = input[i]
+          if (c === '"' || c === "'") {
+            // Skip string literal so braces inside it don't affect depth.
+            i++
+            while (i < input.length) {
+              const cc = input[i]
+              i++
+              if (cc === '\\') {
+                if (i < input.length) i++
+                continue
+              }
+              if (cc === c) break
+            }
+            continue
+          }
+          if (c === '{') depth++
+          else if (c === '}') depth--
+          if (depth > 0) i++
+        }
+        const block = input.slice(start, i)
+        i++ // skip closing }
+        if (prelude.startsWith('@')) {
+          if (/^@media\b/i.test(prelude)) {
+            const inner = walk(block)
+            if (inner.trim()) out.push(`${prelude}{${inner}}`)
+          }
+          // all other at-rules (@import, @font-face, @supports, …) are dropped
+        } else if (_groupAllowed(prelude)) {
+          // Fail-closed on declaration BODIES too, not just selectors:
+          // mirror the backend install denylist at runtime so a declaration that
+          // EVADES install-time validation (encoding drift, future CSS features)
+          // is still dropped before it reaches the main document. Legit packs are
+          // unaffected — their declarations already passed the identical check at
+          // install. Closes the selector-allowlist / declaration-fail-open
+          // asymmetry pending the #316 CSSOM consolidation.
+          if (_declDenied(block)) {
+            dropped++
+          } else {
+            kept++
+            out.push(`${prelude}{${block}}`)
+          }
+        } else {
+          dropped++
+        }
+      } else {
+        buf += ch
+        i++
+      }
+    }
+    return out.join('\n')
+  }
+
+  return { css: walk(src), kept, dropped }
+}
+
+// ── §4.2 pack-relative url() rewriting ──
+// overrides.css is injected as an inline <style>, so a relative url() would
+// resolve against the *document* base (→ 404), not the pack. Rewrite relative
+// refs in KEPT rules to absolute asset-route URLs, resolving against the
+// stylesheet's virtual location `styles/overrides.css` (so `../branding/x.png`
+// → `<assetBase>/branding/x.png`, `fonts/x.ttf` → `<assetBase>/styles/fonts/x.ttf`).
+// data:, absolute (`/…`, incl. already-rewritten `/api/theme/…`) and schemed
+// (http:, blob:, …) urls are left untouched — external refs are install-blocked;
+// this is defense-in-depth. Traversal escaping the pack root is neutralized.
+
+/** Resolve a relative overrides.css url() ref to a sanitized pack-relative path
+ *  (rooted at the pack), or '' if it escapes the pack root / is otherwise unsafe. */
+function _resolveOverrideAsset(rel: string): string {
+  const stack = ['styles'] // stylesheet dir = styles/ (styles/overrides.css)
+  for (const seg of rel.split('/')) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      if (!stack.length) return '' // escaped the pack root
+      stack.pop()
+      continue
+    }
+    stack.push(seg)
+  }
+  return safeAssetPath(stack.join('/'))
+}
+
+/** Rewrite relative url() refs in scoped overrides.css to absolute asset URLs. */
+export function rewriteOverridesUrls(css: string, slug: string): string {
+  const base = assetBase(slug)
+  return css.replace(/url\(\s*(['"]?)([^'")]*)\1\s*\)/gi, (whole, _q, raw) => {
+    const u = (raw || '').trim()
+    if (!u) return whole
+    if (/^data:/i.test(u)) return whole // inline data URI — leave as-is
+    if (u.startsWith('/')) return whole // absolute same-origin (incl. /api/theme/…)
+    if (/^[a-z][a-z0-9+.-]*:/i.test(u)) return whole // schemed (http:, blob:, …) — install-blocked
+    const safe = _resolveOverrideAsset(u)
+    if (!safe) return "url('')" // traversal / unsafe → neutralized, no raw ../ leaks
+    return `url('${base}/${safe}')`
+  })
+}

--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -10,8 +10,21 @@ import {
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { api } from '../api/client'
 import { reportSeamCollision } from '../apps/seamCollision'
-import { sanitizeCssValue } from '../lib/cssSanitize'
 import { safeSetItem } from '../utils/safeStorage'
+// Every stylesheet TEXT this hook injects is built there, so the i18n gate does
+// not read CSS as user-visible copy. The DOM side (which <style> tag, when, and
+// when to revert it) stays here, as does every string this file SHOWS a user —
+// `THEMES` below is still fully gated.
+import {
+  assetBase,
+  assetUrlValue,
+  buildCustomThemeCss,
+  buildThemeFontCss,
+  rewriteOverridesUrls,
+  safeAssetPath,
+  safeSlug,
+  scopeOverridesCss,
+} from './themeCss'
 
 import { i18nT } from '../i18n/t'
 
@@ -161,37 +174,10 @@ function applyTheme(colorTheme: ColorTheme, mode: ResolvedMode, pref: ModePrefer
   el.dataset.modePref = pref
 }
 
-// Allowlist of allowed CSS custom property names for themes.
-// Only these variables will be injected — unknown keys are silently dropped.
-const ALLOWED_CSS_VARS = new Set([
-  '--bg', '--bg-accent', '--bg-elevated', '--bg-hover',
-  '--card', '--card-fg', '--card-hl',
-  '--panel', '--panel-strong', '--chrome',
-  '--text', '--text-strong', '--muted', '--muted-strong',
-  '--border', '--border-strong', '--border-hover',
-  '--accent', '--accent-hover', '--accent-subtle',
-  '--accent-glow', '--ring',
-  '--ok', '--ok-subtle', '--warn', '--warn-subtle',
-  '--danger', '--danger-subtle', '--info',
-  '--aim', '--aim-subtle',
-  '--clarify', '--clarify-subtle',
-  '--diff-add', '--diff-add-text',
-  '--diff-del', '--diff-del-text',
-  '--diff-hunk', '--diff-hunk-text', '--diff-meta-text',
-  '--shadow-sm', '--shadow-md', '--shadow-lg',
-])
-
-/**
- * Positive-allowlist CSS value sanitizer lives in src/lib/cssSanitize.ts so
- * WidgetFrame and any other surface that serializes theme vars uses the same
- * filter. See that file for the security rationale.
- */
-const escapeCssValue = sanitizeCssValue
-
 /** Inject a custom theme's CSS variables as a <style> tag in the document head. */
 function injectCustomThemeCSS(theme: CustomThemeData) {
   // Validate slug is safe for use in CSS selector
-  const slug = theme.slug.replace(/[^a-z0-9-]/g, '')
+  const slug = safeSlug(theme.slug)
   if (!slug) return
 
   const id = `mc-custom-theme-${slug}`
@@ -199,40 +185,13 @@ function injectCustomThemeCSS(theme: CustomThemeData) {
 
   const style = document.createElement('style')
   style.id = id
-
-  const buildVars = (vars: Record<string, string>) =>
-    Object.entries(vars)
-      .filter(([k]) => ALLOWED_CSS_VARS.has(k))
-      .map(([k, v]): [string, string] => [k, escapeCssValue(v)])
-      .filter(([, v]) => v !== '')  // drop entries with empty/rejected values
-      .map(([k, v]) => `${k}:${v}`)
-      .join(';')
-
-  // Static defaults (not user-controlled)
-  const darkDefaults =
-    '--font-body:var(--script-fallbacks),\'Space Grotesk\',-apple-system,BlinkMacSystemFont,sans-serif;' +
-    '--mono:var(--script-fallbacks-mono),\'JetBrains Mono\',ui-monospace,SFMono-Regular,monospace;' +
-    '--radius-sm:6px;--radius-md:8px;--radius-lg:12px;--radius-xl:16px;' +
-    'color-scheme:dark;'
-  const lightDefaults =
-    '--font-body:var(--script-fallbacks),\'Space Grotesk\',-apple-system,BlinkMacSystemFont,sans-serif;' +
-    '--mono:var(--script-fallbacks-mono),\'JetBrains Mono\',ui-monospace,SFMono-Regular,monospace;' +
-    '--radius-sm:6px;--radius-md:8px;--radius-lg:12px;--radius-xl:16px;' +
-    'color-scheme:light;'
-
-  const darkCss = buildVars(theme.dark)
-  const lightCss = buildVars(theme.light)
-
-  style.textContent =
-    `[data-theme="custom-${slug}-dark"]{${darkCss};${darkDefaults}}\n` +
-    `[data-theme="custom-${slug}-light"]{${lightCss};${lightDefaults}}`
-
+  style.textContent = buildCustomThemeCss(slug, theme)
   document.head.appendChild(style)
 }
 
 /** Remove injected CSS for a custom theme. */
 function removeCustomThemeCSS(slug: string) {
-  const safe = _safeSlug(slug)
+  const safe = safeSlug(slug)
   document.getElementById(`mc-custom-theme-${safe}`)?.remove()
   document.getElementById(`mc-theme-fonts-${safe}`)?.remove()
 }
@@ -246,296 +205,27 @@ function removeCustomThemeCSS(slug: string) {
 // scoped: applied only while the theme is the active selection and reverted on
 // switch-away. On top of the install-time denylist, overrides.css is also
 // fetched, parsed, and run through the §4.2/§5.1 positive-selector allowlist at
-// runtime (see _scopeOverridesCss) before injection — defense-in-depth so a
+// runtime (see `scopeOverridesCss`) before injection — defense-in-depth so a
 // rule can only reach one of the 10 allowlisted surfaces.
-
-const _assetBase = (slug: string) => `/api/theme/${encodeURIComponent(slug)}/assets`
-const _safeSlug = (slug: string) => slug.replace(/[^a-z0-9-]/g, '')
-const _safeFamily = (f: string) => f.replace(/[^A-Za-z0-9 _-]/g, '')
-// Sanitize a branding asset relative path (e.g. "branding/logo.svg"): allow only
-// safe chars, reject traversal/absolute. Defense-in-depth on top of the backend
-// asset route's own path-containment; returns '' when unusable.
-const _safeAssetPath = (p: string): string => {
-  const cleaned = (p || '').replace(/[^a-z0-9./_-]/gi, '')
-  if (!cleaned || cleaned.startsWith('/') || cleaned.split('/').includes('..')) return ''
-  return cleaned
-}
+//
+// The stylesheet TEXT every step below injects is built in `./themeCss`; this
+// file keeps the DOM side (which tag, when, and when to revert it).
 
 /** Inject @font-face rules + a --font-body override for an installed theme. */
 function injectThemeFonts(theme: CustomThemeData) {
-  const slug = _safeSlug(theme.slug)
+  const slug = safeSlug(theme.slug)
   if (!slug) return
   const id = `mc-theme-fonts-${slug}`
   document.getElementById(id)?.remove()
-  const fonts = theme.assets?.fonts || []
-  const faces: string[] = []
-  // Track the family of the FIRST face that actually made it into the stylesheet
-  // — fonts[0] may have been skipped (bad family/src/format), in which case
-  // keying --font-body off it would name a family with no @font-face behind it.
-  let firstEmittedFamily = ''
-  for (const f of fonts) {
-    const fam = _safeFamily(f.family || '')
-    const file = (f.src || '').replace(/[^a-z0-9./_-]/gi, '')
-    if (!fam || !file.startsWith('styles/fonts/')) continue
-    const fmt = file.endsWith('.woff2') ? 'woff2' : file.endsWith('.ttf') ? 'truetype' : ''
-    if (!fmt) continue
-    const weight = typeof f.weight === 'number' && f.weight >= 100 && f.weight <= 900 ? f.weight : 400
-    const style = f.style === 'italic' ? 'italic' : 'normal'
-    faces.push(
-      `@font-face{font-family:'${fam}';` +
-        `src:url('${_assetBase(slug)}/${file}') format('${fmt}');` +
-        `font-weight:${weight};font-style:${style};font-display:swap;}`
-    )
-    if (!firstEmittedFamily) firstEmittedFamily = fam
-  }
-  if (!faces.length) return
-  const primary = firstEmittedFamily
+  const css = buildThemeFontCss(slug, theme)
+  if (!css) return
   const style = document.createElement('style')
   style.id = id
-  style.textContent =
-    faces.join('\n') +
-    `\n[data-theme="custom-${slug}-dark"],[data-theme="custom-${slug}-light"]{` +
-    `--font-body:'${primary}',var(--script-fallbacks),'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif;}`
+  style.textContent = css
   document.head.appendChild(style)
 }
 
-// ── §4.2/§5.1 runtime positive-selector scoper ──
-// A selector group from overrides.css is kept only if EVERY selector, after
-// stripping one optional leading [data-theme="…"] / html[data-theme…] scoping
-// prefix, targets one of the 10 allowlisted surfaces (optionally with extra
-// chained classes/pseudo-classes on the SAME base — no descendant/child/sibling
-// combinators, no ids/attribute selectors, never the forbidden set).
 const _OVERRIDES_ID = 'mc-theme-overrides'
-const _ALLOWED_ELEMENTS = new Set(['', 'body', 'button']) // blocks iframe/script/div/…
-const _ALLOWED_CLASSES = new Set([
-  'topbar',
-  'chat-container',
-  'sidebar',
-  'message-bubble',
-  'input-area',
-  'code-block',
-])
-const _FORBIDDEN_CLASSES = new Set(['token', 'credential'])
-
-/** True if a single selector targets an allowlisted surface. */
-function _selectorAllowed(sel: string): boolean {
-  let s = sel.trim()
-  if (!s) return false
-  // Strip one optional leading scoping prefix: [data-theme…] or html[data-theme…].
-  s = s.replace(/^(?:html)?\s*\[data-theme[^\]]*\]\s*/i, '').trim()
-  if (!s) return false
-  // No descendant/child/sibling combinators may remain in the compound.
-  if (/[\s>+~]/.test(s)) return false
-  // No ids or (remaining) attribute selectors — blocks #app-root and [data-auth].
-  if (s.includes('#') || s.includes('[')) return false
-  // Leading element (optional) followed by chained .class / :pseudo / ::pseudo.
-  const m = /^([a-zA-Z][\w-]*)?((?:\.[\w-]+|::?[\w-]+(?:\([^)]*\))?)*)$/.exec(s)
-  if (!m) return false
-  const element = (m[1] || '').toLowerCase()
-  if (!_ALLOWED_ELEMENTS.has(element)) return false
-  const classes = new Set<string>()
-  const pseudoEls = new Set<string>()
-  const tokRe = /(\.[\w-]+)|(::?[\w-]+(?:\([^)]*\))?)/g
-  let t: RegExpExecArray | null
-  while ((t = tokRe.exec(m[2] || '')) !== null) {
-    if (t[1]) {
-      classes.add(t[1].slice(1).toLowerCase())
-    } else if (t[2]) {
-      const dbl = t[2].startsWith('::')
-      const name = t[2].replace(/^::?/, '').replace(/\(.*$/, '').toLowerCase()
-      if (dbl || name === 'before' || name === 'after') pseudoEls.add(name)
-      // single-colon pseudo-classes (:hover, :focus, …) are tolerated / ignored
-    }
-  }
-  for (const c of classes) if (_FORBIDDEN_CLASSES.has(c)) return false
-  if (element === 'body') {
-    // Only bare body / body::before / body::after (single-colon tolerated).
-    if (classes.size) return false
-    for (const p of pseudoEls) if (p !== 'before' && p !== 'after') return false
-    return true
-  }
-  if (element === 'button') return classes.has('primary')
-  // Class-based surfaces (element === ''): allowed if any base class is present.
-  for (const c of classes) if (_ALLOWED_CLASSES.has(c)) return true
-  return false
-}
-
-/** True if a comma selector group is kept (every selector must pass). */
-function _groupAllowed(group: string): boolean {
-  const parts = group.split(',')
-  return parts.length > 0 && parts.every((p) => _selectorAllowed(p))
-}
-
-/**
- * Filter an overrides.css string to allowlisted rules only. Top-level rules
- * whose selector group passes are emitted verbatim; @media blocks are recursed
- * into (wrapper preserved, inner filtered); every other at-rule is dropped.
- */
-// Declaration-body denylist — mirrors the backend `_THEME_CSS_DENY_RE`
-// (theme_validate.py). Non-global (no /g) so repeated `.test()` is stateless.
-// Applied to KEPT rules' bodies so the runtime boundary is fail-closed for
-// declarations, not just selectors.
-const _DECL_DENY_RE =
-  /@import|expression\s*\(|javascript:|-moz-binding|url\s*\(\s*['"]?\s*(?:https?:)?\/\//i
-
-// Evasion normalization: a browser decodes CSS
-// `\`-escapes during tokenization, so `\75 rl(` becomes `url(`. Comments are
-// already stripped globally below. Decode escapes and run the denylist on the
-// decoded text too, so an escaped forbidden token can't hide from the scoper.
-// Mirrors backend `_decode_css_escapes` / `_css_denylist_normalize`. Not a full
-// CSS parse (that is #316) — just the minimal decode the known evasions exploit.
-const _CSS_ESCAPE_RE = /\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g
-function _decodeCssEscapes(s: string): string {
-  return s.replace(_CSS_ESCAPE_RE, (_m, hex: string | undefined, ch: string | undefined) => {
-    if (hex !== undefined) {
-      try {
-        return String.fromCodePoint(parseInt(hex, 16))
-      } catch {
-        return ''
-      }
-    }
-    return ch ?? ''
-  })
-}
-/** True if a declaration body hits the denylist raw OR after escape-decoding. */
-function _declDenied(block: string): boolean {
-  return _DECL_DENY_RE.test(block) || _DECL_DENY_RE.test(_decodeCssEscapes(block))
-}
-
-function _scopeOverridesCss(css: string): { css: string; kept: number; dropped: number } {
-  const src = css.replace(/\/\*[\s\S]*?\*\//g, '') // strip comments
-  let kept = 0
-  let dropped = 0
-
-  const walk = (input: string): string => {
-    const out: string[] = []
-    let i = 0
-    let buf = ''
-    while (i < input.length) {
-      const ch = input[i]
-      // Skip quoted strings verbatim so braces/quotes inside them (e.g.
-      // `content:"}"`) can't desync the brace walker. Mirrors the backend
-      // `_css_skip_string`. (Comments are already stripped above.)
-      if (ch === '"' || ch === "'") {
-        buf += ch
-        i++
-        while (i < input.length) {
-          const c = input[i]
-          buf += c
-          i++
-          if (c === '\\') {
-            if (i < input.length) {
-              buf += input[i]
-              i++
-            }
-            continue
-          }
-          if (c === ch) break
-        }
-        continue
-      }
-      if (ch === '{') {
-        const prelude = buf.trim()
-        buf = ''
-        let depth = 1
-        i++
-        const start = i
-        while (i < input.length && depth > 0) {
-          const c = input[i]
-          if (c === '"' || c === "'") {
-            // Skip string literal so braces inside it don't affect depth.
-            i++
-            while (i < input.length) {
-              const cc = input[i]
-              i++
-              if (cc === '\\') {
-                if (i < input.length) i++
-                continue
-              }
-              if (cc === c) break
-            }
-            continue
-          }
-          if (c === '{') depth++
-          else if (c === '}') depth--
-          if (depth > 0) i++
-        }
-        const block = input.slice(start, i)
-        i++ // skip closing }
-        if (prelude.startsWith('@')) {
-          if (/^@media\b/i.test(prelude)) {
-            const inner = walk(block)
-            if (inner.trim()) out.push(`${prelude}{${inner}}`)
-          }
-          // all other at-rules (@import, @font-face, @supports, …) are dropped
-        } else if (_groupAllowed(prelude)) {
-          // Fail-closed on declaration BODIES too, not just selectors:
-          // mirror the backend install denylist at runtime so a declaration that
-          // EVADES install-time validation (encoding drift, future CSS features)
-          // is still dropped before it reaches the main document. Legit packs are
-          // unaffected — their declarations already passed the identical check at
-          // install. Closes the selector-allowlist / declaration-fail-open
-          // asymmetry pending the #316 CSSOM consolidation.
-          if (_declDenied(block)) {
-            dropped++
-          } else {
-            kept++
-            out.push(`${prelude}{${block}}`)
-          }
-        } else {
-          dropped++
-        }
-      } else {
-        buf += ch
-        i++
-      }
-    }
-    return out.join('\n')
-  }
-
-  return { css: walk(src), kept, dropped }
-}
-
-// ── §4.2 pack-relative url() rewriting ──
-// overrides.css is injected as an inline <style>, so a relative url() would
-// resolve against the *document* base (→ 404), not the pack. Rewrite relative
-// refs in KEPT rules to absolute asset-route URLs, resolving against the
-// stylesheet's virtual location `styles/overrides.css` (so `../branding/x.png`
-// → `<assetBase>/branding/x.png`, `fonts/x.ttf` → `<assetBase>/styles/fonts/x.ttf`).
-// data:, absolute (`/…`, incl. already-rewritten `/api/theme/…`) and schemed
-// (http:, blob:, …) urls are left untouched — external refs are install-blocked;
-// this is defense-in-depth. Traversal escaping the pack root is neutralized.
-
-/** Resolve a relative overrides.css url() ref to a sanitized pack-relative path
- *  (rooted at the pack), or '' if it escapes the pack root / is otherwise unsafe. */
-function _resolveOverrideAsset(rel: string): string {
-  const stack = ['styles'] // stylesheet dir = styles/ (styles/overrides.css)
-  for (const seg of rel.split('/')) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (!stack.length) return '' // escaped the pack root
-      stack.pop()
-      continue
-    }
-    stack.push(seg)
-  }
-  return _safeAssetPath(stack.join('/'))
-}
-
-/** Rewrite relative url() refs in scoped overrides.css to absolute asset URLs. */
-function _rewriteOverridesUrls(css: string, slug: string): string {
-  const base = _assetBase(slug)
-  return css.replace(/url\(\s*(['"]?)([^'")]*)\1\s*\)/gi, (whole, _q, raw) => {
-    const u = (raw || '').trim()
-    if (!u) return whole
-    if (/^data:/i.test(u)) return whole // inline data URI — leave as-is
-    if (u.startsWith('/')) return whole // absolute same-origin (incl. /api/theme/…)
-    if (/^[a-z][a-z0-9+.-]*:/i.test(u)) return whole // schemed (http:, blob:, …) — install-blocked
-    const safe = _resolveOverrideAsset(u)
-    if (!safe) return "url('')" // traversal / unsafe → neutralized, no raw ../ leaks
-    return `url('${base}/${safe}')`
-  })
-}
 
 // Monotonic token so an in-flight fetch can't re-inject after a switch-away.
 let _overridesToken = 0
@@ -549,14 +239,14 @@ let _overridesToken = 0
 function applyThemeOverrides(theme: CustomThemeData | undefined): Promise<void> {
   const myToken = ++_overridesToken
   document.getElementById(_OVERRIDES_ID)?.remove()
-  const slug = theme ? _safeSlug(theme.slug) : ''
+  const slug = theme ? safeSlug(theme.slug) : ''
   if (!theme?.assets?.hasOverrides || !slug) return Promise.resolve()
   if (typeof fetch !== 'function') return Promise.resolve()
-  return fetch(`${_assetBase(slug)}/styles/overrides.css`)
+  return fetch(`${assetBase(slug)}/styles/overrides.css`)
     .then((r) => (r.ok ? r.text() : ''))
     .then((raw) => {
       if (myToken !== _overridesToken || !raw) return // superseded or empty
-      const { css, dropped } = _scopeOverridesCss(raw)
+      const { css, dropped } = scopeOverridesCss(raw)
       if (dropped) {
         // eslint-disable-next-line no-console -- intentional theme-scoper diagnostic
         console.debug(`[theme] overrides.css: dropped ${dropped} disallowed rule(s)`)
@@ -564,7 +254,7 @@ function applyThemeOverrides(theme: CustomThemeData | undefined): Promise<void> 
       if (!css.trim()) return
       // Rewrite pack-relative url() refs → absolute asset-route URLs (the inline
       // <style> injection point means relative refs would 404 against the doc base).
-      const scoped = _rewriteOverridesUrls(css, slug)
+      const scoped = rewriteOverridesUrls(css, slug)
       document.getElementById(_OVERRIDES_ID)?.remove()
       const style = document.createElement('style')
       style.id = _OVERRIDES_ID
@@ -582,19 +272,19 @@ function applyThemeBranding(theme: CustomThemeData | undefined) {
   document.getElementById('mc-theme-favicon')?.remove()
   root.style.removeProperty('--theme-logo')
   const b = theme?.assets?.branding
-  const slug = theme ? _safeSlug(theme.slug) : ''
+  const slug = theme ? safeSlug(theme.slug) : ''
   if (!b || !slug) return
-  const fav = b.favicon ? _safeAssetPath(b.favicon) : ''
+  const fav = b.favicon ? safeAssetPath(b.favicon) : ''
   if (fav) {
     const link = document.createElement('link')
     link.id = 'mc-theme-favicon'
     link.rel = 'icon'
-    link.href = `${_assetBase(slug)}/${fav}`
+    link.href = `${assetBase(slug)}/${fav}`
     document.head.appendChild(link)
   }
-  const logo = b.logo ? _safeAssetPath(b.logo) : ''
+  const logo = b.logo ? safeAssetPath(b.logo) : ''
   if (logo) {
-    root.style.setProperty('--theme-logo', `url('${_assetBase(slug)}/${logo}')`)
+    root.style.setProperty('--theme-logo', assetUrlValue(slug, logo))
   }
 }
 


### PR DESCRIPTION
## Problem

The i18n gate reports 76 template literals that are handed to a **parser**, never to
a person: Content-Security-Policy directives, a `DOCTYPE`, `<meta>`/`<style>`/
`<script>` markup, an iframe's own reset CSS, two fixed JS bootstraps, `@font-face`
blocks, and CSS `url()` asset rewrites.

They inflate the untranslated ledger, which is also the Phase 1 worklist. Worse, the
gate's suggested remedy for a finding is to give it a catalog key — so the gate
actively pushes a contributor toward translating a CSP directive, which would
silently weaken the policy rather than change a word anyone reads.

## Why it matters

`eslint.i18n.config.js` states the governing doctrine: an exemption must not
*"silently hand back other files' debt"*, and must be declared **by WHERE the string
lives** rather than by a content regex. That makes this not a config-tweak but a
measurement problem — and one file could not be exempted at all without first
changing code.

## Fix (symptom → root cause → change)

Three exemptions, each declared by location and each measured:

| mechanism | target | why not something broader |
|---|---|---|
| exact-path `ignores` | `src/lib/widgetSrcdoc.ts`, `src/lib/mcpAppSrcdoc.ts` | verified copy-free: neither imports `i18nT`, neither renders a text node, exports are pure builders |
| `callees.exclude` `^log(Debug\|Warn)$` | `popoutController.ts`'s two `console` shims | a whole-file release would free a module that also raises a **translated** `window.alert` |
| exact-path `ignores` + extraction | **new** `src/hooks/themeCss.ts` | see below |

`useTheme.tsx` could not be exempted in place. Its 9 CSS builders sit in the same
file that declares `THEMES` — **19 user-visible theme picker labels**. A whole-file
exemption would hand those 19 back, which the doctrine forbids. So the CSS moved out
to a parser-facing-only module, making the boundary a path again. **`THEMES` stays in
`useTheme.tsx` and stays gated** (it is the 17 findings that remain there).

## Result — measured, not asserted

**1408 → 1332 findings (−76)**, and **only the four target files move**:

| file | before | after |
|---|---:|---:|
| `src/lib/widgetSrcdoc.ts` | 39 | 0 |
| `src/lib/mcpAppSrcdoc.ts` | 16 | 0 |
| `src/utils/popoutController.ts` | 5 | 1 |
| `src/hooks/useTheme.tsx` | 34 | 17 |

No unrelated file changes count. That property — not the −76 — is what the doctrine
actually requires, and it is why each candidate was applied and re-scanned per file
rather than reasoned about.

## Two candidates rejected under the same rule

Recorded because "we tried the obvious thing and it leaked" is the useful part:

- **`'^rgba?\('` content regex.** Would have retired 14 scene colour literals, but
  leaked into `apps/issue-radar/lib/format.ts` — a file outside the target set. This
  is the same failure the existing `sketchSrcdoc.ts` comment already records for a
  CSP-shaped regex.
- **Whole-file release of `popoutController.ts`.** Clears 5 instead of 4, but the
  module renders a translated `window.alert`, so it fails the "verified copy-free"
  standard the accepted exact-path precedents meet. The callee exemption gets 4 of
  the 5 with no such class; the remaining one (a `window.open` features string) stays
  in the ledger as honest debt.

## Left deliberately in the ledger

The 14 scene `rgba` literals and ~41 prompt-text / ~25 wire-value rows are **not**
exempted here. The scenes hold ~100 real copy strings alongside their colours, so no
path exemption is legitimate; retiring those needs a source change (an `rgba()`
helper), and the prompt/wire populations need a mechanism decision that is not this
PR's to make. Reporting them as debt is more honest than a regex that leaks.

## Tests

No new tests. This PR changes which strings a **lint gate** reports, so its own
verification is the per-file measurement above, reproduced against the base ref. The
extraction is behaviour-preserving and covered by existing theme tests.

## Manual verification

- `npx tsc -b` — exit 0 (note: `npm run typecheck` checks **zero** files in this repo)
- Full gate re-scan per file against the base, confirming only the four targets move
- `themeCss.ts` confirmed copy-free — no `i18nT` import, no text node
- `THEMES` confirmed still in `useTheme.tsx` (0 occurrences in the new module)

## Screenshots

N/A — no user-visible change. `useTheme.tsx` paints themes and the extraction is a
pure code move with no behaviour change; a rendering regression would be visible in
the existing theme tests.

## Progress map

Tracks #1004. This PR is **Phase 6 groundwork** — it does not close a numbered item;
it makes item 5's target honest before anyone ratchets against it.

| Phase | Goal | State |
|---|---|---|
| 0 — Guards + writing | CI gates, zero UI change | ✅ complete |
| 0.5 — i18next 26 | unblock 3/4/6 | ✅ complete |
| 1 — Remove visible English | mechanically fixable half of D4 | 🔄 batches merged, #1040 open |
| 2a — Script fonts | CJK/Devanagari/Bengali glyphs | 🔄 item 1 merged |
| 2b — Bidi + expansion | `<bdi>`, line-height, fixed heights | 🔄 local, not submitted |
| 3 — De-fragment | make Chinese read like Chinese | 🔄 14 slices local, no PR |
| 4 — Locale-aware formatting | dates/numbers/sorting | 🔄 seam landed, 97 sites left |
| 5 — Render-time gate | automate pseudolocale assertions | 🔄 #1107 open |
| **6 — Structural cleanup** | **D4 remainder, D6, D7, D13, D14-a** | 🔄 **groundwork here; #1750 starts item 2** |
| 7 — Contributor machinery | terminology CI, guide, `<Dnt>` | ⬜ not started |
| Track B — Backend boundary | `{code, params, message?}` at the JSON edge | ⬜ not started |
| Track C — RTL | `ar`/`ur`/`he`/`fa` | ⬜ not funded |
| D5 — Payload splitting | ship one language, lazy-load rest | 🚫 out of scope |

### Phase 6 items

| # | Item | This PR |
|---|---|---|
| 1 | Object-literal label tables (155) + array literals (110) | ⬜ not started |
| 2 | Template literals → catalog key + `{{vars}}` | 🔄 in #1750 |
| 3 | D13 value/label split | ⬜ not started |
| 4 | D14-a manifest execution | ⬜ not started |
| **5** | **Ratchet `--max-warnings` down directory by directory** | 🔄 **prerequisite: −76 false positives removed from the target** |
| 6 | Type safety — `CustomTypeOptions`, `strictKeyChecks` | ⬜ not started |
| 7 | Key-scheme migration via `rename-map.json` | ⬜ not started |

Item 5 ratchets a warning budget toward zero. That budget currently counts CSP
directives, `@font-face` blocks and iframe bootstraps as untranslated copy, so
ratcheting against it today would either stall at an unreachable floor or push a
contributor to translate a security policy. Removing the false positives first is
what makes the ratchet meaningful.

### Corrections to the plan

| Plan assumption | Measured | Note |
|---|---|---|
| the untranslated ledger measures translatable copy | **~133 of 500** interpolated findings are not copy at all | 41 prompt text, 25 wire values, 67 parser-facing. 76 retired here; the rest need source changes or a mechanism decision |
| a content regex can separate machine strings from copy | **falsified again** | A `'^rgba?\('` exclusion leaked into `apps/issue-radar/lib/format.ts`. This is the second recorded instance — the `sketchSrcdoc.ts` comment already records a CSP-shaped regex failing the same way. Shape cannot express "CSS, but only in this module"; only a path can |
