### PR TITLE
fix(website): render the real brand mark in screenshot harnesses

### DIFF
--- a/website/scripts/lib/serve-dist.mjs
+++ b/website/scripts/lib/serve-dist.mjs
@@ -15,6 +15,20 @@ import { fileURLToPath } from 'node:url'
 // join() then turns into an invalid "\C:\…" and every read fails with ENOENT.
 export const DEFAULT_DIST = fileURLToPath(new URL('../../dist/', import.meta.url))
 
+/**
+ * Assets the REAL dashboard serves from its own routes rather than from the
+ * SPA bundle, mapped to the file on disk.
+ *
+ * `/logo.png` is an aiohttp route (`server.py`: `add_get("/logo.png",
+ * handlers.logo)`) reading the packaged PNG — it is NOT in `website/dist`, so a
+ * plain static server 404s it and the brand mark renders as a broken-image
+ * placeholder in EVERY harness screenshot. That was silently wrong in every
+ * capture script in this folder until it was noticed in a review.
+ */
+const SERVER_ROUTED = {
+  '/logo.png': fileURLToPath(new URL('../../../src/kiro_crew/static/kirocrew-logo.png', import.meta.url)),
+}
+
 export const MIME = {
   '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css',
   '.json': 'application/json', '.svg': 'image/svg+xml', '.png': 'image/png',
@@ -43,6 +57,15 @@ export function serveDist(dist = DEFAULT_DIST) {
         // Malformed percent-escapes throw; treat as a bad request rather than
         // crashing the harness mid-capture.
         res.writeHead(400); res.end('bad request'); return
+      }
+      // Server-routed assets first, keyed on the decoded path. Checked before
+      // the dist lookup so a same-named file in dist could not shadow the real
+      // route, and skipped silently when the file is absent (a source checkout
+      // without the Python package still captures, just without the mark).
+      const routed = SERVER_ROUTED['/' + rel]
+      if (routed && existsSync(routed)) {
+        res.writeHead(200, { 'Content-Type': MIME[extname(routed)] || 'application/octet-stream' })
+        res.end(readFileSync(routed)); return
       }
       let file = resolve(root, rel)
       if (file !== root && !file.startsWith(root + sep)) {

--- a/website/scripts/lib/stub-dashboard-api.mjs
+++ b/website/scripts/lib/stub-dashboard-api.mjs
@@ -36,7 +36,12 @@ export async function stubDashboardApi(page, opts = {}) {
     folders = [],
     slots = [],
     theme = 'dark',
-    botName = 'Kiro',
+    // The backend's own default (`api_branding`: `cfg.dashboard.bot_name or
+    // "Kiro Crew"`). It must stay TWO WORDS: the nav brand row accents the last
+    // word only, and the composer placeholder interpolates the whole name — so
+    // a single-word "Kiro" here silently produced screenshots with no "CREW"
+    // and a "Message Kiro…" composer, in every harness in this folder.
+    botName = 'Kiro Crew',
     extra = null,
   } = opts
 
@@ -66,7 +71,10 @@ export async function stubDashboardApi(page, opts = {}) {
     if (path === '/api/auth/me') return json(route, { user: 'owner', app: '' })
     if (path === '/api/themes') return json(route, { themes: [], installed: [] })
     if (path === '/api/theme/boot') return json(route, { mode: theme, theme: '' })
-    if (path === '/api/dashboard/branding') return json(route, { bot_name: botName, avatar: '' })
+    // Mirrors `api_branding` exactly, avatar included. Returning '' let the
+    // frontend fall back to its own '/logo.png' default, which is the same URL —
+    // but being explicit keeps the fixture readable as "what the server sends".
+    if (path === '/api/dashboard/branding') return json(route, { bot_name: botName, avatar: '/logo.png' })
     if (path === '/api/recent-projects') return json(route, { dirs: [] })
     if (path === '/api/dashboard/config') {
       return json(route, {

--- a/website/src/test/serveDist.routes.test.ts
+++ b/website/src/test/serveDist.routes.test.ts
@@ -1,0 +1,141 @@
+/**
+ * `scripts/lib/serve-dist.mjs` — the static server every screenshot harness in
+ * `website/scripts/` runs the built SPA behind.
+ *
+ * The bug this locks: `/logo.png` is not in `website/dist`. It is an aiohttp
+ * route in the real dashboard (`server.py`: `add_get("/logo.png",
+ * handlers.logo)`) reading the packaged PNG. A plain static server therefore
+ * 404s it and falls through to the SPA `index.html`, so the brand mark rendered
+ * as a broken-image placeholder in EVERY harness frame — for a long time, in
+ * every capture script, unnoticed because reviewers were looking at whatever
+ * else each frame was capturing.
+ *
+ * Locks the contract:
+ *  (1) `/logo.png` is served as the packaged PNG, byte for byte — not the
+ *      index.html fallback wearing a .png name.
+ *  (2) The SPA fallback and ordinary asset serving still work.
+ *  (3) The path-traversal guard is intact. This matters: the server-routed
+ *      lookup was added BEFORE the containment check, so it is the one change
+ *      here that could have widened the attack surface.
+ *
+ * Driven through a real `node` child process, not an import: this is a plain
+ * `.mjs` harness module that resolves its own paths from `import.meta.url`, and
+ * the test runner's transform rewrites that to a non-`file:` URL, which
+ * `fileURLToPath` rejects. Spawning node also exercises the module exactly as
+ * every capture script uses it — including the path resolution that finds the
+ * packaged PNG, which an import-based test would have stubbed away.
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// `__dirname`, not `import.meta.url`: the runner's transform rewrites the latter
+// to a non-`file:` URL, which `fileURLToPath` rejects. Every other path-reading
+// test in this folder resolves the same way.
+const WEBSITE = resolve(__dirname, '..', '..')
+const LOGO = resolve(WEBSITE, '..', 'src', 'kiro_crew', 'static', 'kirocrew-logo.png')
+
+interface Probe {
+  status: number
+  type: string | null
+  len: number
+  sha: string
+  head: string
+}
+
+/** Boot serveDist in a child node process, probe the given paths, return JSON. */
+function probe(paths: string[], root: string): Record<string, Probe> {
+  const dir = mkdtempSync(join(tmpdir(), 'serve-dist-probe-'))
+  const script = join(dir, 'probe.mjs')
+  // `pathToFileURL(...).href`, NOT the raw path: on Windows the absolute path is
+  // `C:\…`, and a JSON-stringified `"C:\\…"` is not a valid ESM specifier —
+  // Node reads `C:` as a URL scheme and refuses with
+  // ERR_UNSUPPORTED_ESM_URL_SCHEME before the child probes anything, failing the
+  // Windows suite. A file:// URL is the portable form.
+  const moduleUrl = pathToFileURL(join(WEBSITE, 'scripts/lib/serve-dist.mjs')).href
+  writeFileSync(script, `
+import { createHash } from 'node:crypto'
+import { serveDist } from ${JSON.stringify(moduleUrl)}
+const { srv, base } = await serveDist(${JSON.stringify(root)})
+const out = {}
+for (const p of ${JSON.stringify(paths)}) {
+  const res = await fetch(base + p)
+  const buf = Buffer.from(await res.arrayBuffer())
+  out[p] = {
+    status: res.status,
+    type: res.headers.get('content-type'),
+    len: buf.length,
+    sha: createHash('sha256').update(buf).digest('hex'),
+    head: buf.subarray(0, 16).toString('latin1'),
+  }
+}
+srv.close()
+process.stdout.write(JSON.stringify(out))
+`)
+  try {
+    return JSON.parse(execFileSync(process.execPath, [script], { encoding: 'utf8', timeout: 30_000 }))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const sha256 = async (buf: Buffer) => {
+  const { createHash } = await import('node:crypto')
+  return createHash('sha256').update(buf).digest('hex')
+}
+
+// Serve website/ itself rather than dist/: dist only exists after a build, and
+// nothing asserted here depends on the bundle's contents.
+const RESULTS = probe(
+  // Only ENCODED traversal is worth probing: a literal "/../x" is normalised
+  // away by the client's URL parser and never reaches the server, so asserting
+  // on it would test `fetch`, not `serveDist`. `pyproject.toml` sits one level
+  // ABOVE the served root, so a 200 there would be an unambiguous escape.
+  ['/logo.png', '/settings', '/package.json', '/%2e%2e%2fpyproject.toml',
+    '/%2e%2e%2f%2e%2e%2fREADME.md', '/%ZZ'],
+  WEBSITE,
+)
+
+describe('serveDist server-routed assets', () => {
+  it('serves /logo.png as the packaged PNG, byte for byte', async () => {
+    const r = RESULTS['/logo.png']
+    expect(r.status).toBe(200)
+    expect(r.type).toBe('image/png')
+    expect(r.sha).toBe(await sha256(readFileSync(LOGO)))
+  })
+
+  it('is a decodable PNG, not index.html under a .png name', () => {
+    // The exact failure mode being locked out: an <img> pointing at HTML renders
+    // as a broken-image placeholder, which is what every frame showed.
+    const { head } = RESULTS['/logo.png']
+    expect([...Buffer.from(head, 'latin1').subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47])
+    expect(head.toLowerCase()).not.toContain('<!')
+  })
+
+  it('still falls back to index.html for SPA deep links', () => {
+    const r = RESULTS['/settings']
+    expect(r.status).toBe(200)
+    expect(r.head.toLowerCase()).toContain('<!doctype')
+  })
+
+  it('still serves ordinary files from the root', () => {
+    expect(RESULTS['/package.json'].status).toBe(200)
+  })
+
+  it('keeps the traversal guard — the routed lookup runs before it', () => {
+    // The routed map is an exact-key match against one hardcoded key, so no
+    // user-controlled path can reach the filesystem through it. These prove the
+    // ordinary path is still contained: percent-encoded "../" survives URL
+    // normalisation and only becomes a traversal at decode time, which is why
+    // normalising alone was never the defence.
+    expect(RESULTS['/%2e%2e%2fpyproject.toml'].status).toBe(403)
+    expect(RESULTS['/%2e%2e%2f%2e%2e%2fREADME.md'].status).toBe(403)
+  })
+
+  it('rejects malformed percent-escapes instead of crashing', () => {
+    expect(RESULTS['/%ZZ'].status).toBe(400)
+  })
+})


### PR DESCRIPTION
## Problem

Every screenshot harness under `website/scripts/` has been producing frames with a **broken-image placeholder where the brand logo belongs**, a wordmark reading `KIRO` instead of `KIRO CREW`, and a composer placeholder reading `Message Kiro…` instead of `Message Kiro Crew…`.

It went unnoticed for a long time because each harness is reviewed for whatever *else* it was capturing — a scrollbar, a nav active state, a card layout — and nobody was looking at the chrome in the corner of the frame.

## Why it matters

These frames are the evidence attached to PRs for user-visible UI changes. Reviewers have been approving changes against screenshots that misrepresent the product's own name and show a broken asset, and any frame reused in docs or an issue carries the same defect. It also actively wastes time: it invites reviewers to report a product bug that does not exist outside the harness.

## Fix (symptoms → root cause → change)

Three symptoms, two root causes, both in the **shared** fixtures — which is why every harness in the folder was affected rather than one.

**Symptom 1 — broken logo.** `/logo.png` is not in `website/dist`. The real dashboard serves it from an aiohttp route:

```python
# src/kiro_crew/dashboard/server.py
app.router.add_get("/logo.png", handlers.logo)
```

…which reads the packaged PNG (`src/kiro_crew/static/kirocrew-logo.png`). The harnesses run the built SPA behind `serve-dist.mjs`, a plain static server over `website/dist` — so `/logo.png` 404'd, hit the SPA `index.html` fallback, and the `<img>` ended up pointing at HTML. An `<img>` pointing at HTML *is* a broken-image placeholder.

`serve-dist.mjs` now maps that one path to the packaged file. Three deliberate details:
- checked **before** the dist lookup, so a same-named bundle file cannot shadow the real route;
- skipped when the file is absent, so a frontend-only checkout still captures (just without the mark) instead of erroring;
- the lookup is an exact match against a one-key map, so no user-controlled path reaches the filesystem through it — the existing containment check still governs every real path.

**Symptoms 2 and 3 — missing `CREW`, short composer placeholder.** Both come from one line: `stub-dashboard-api.mjs` hardcoded `botName = 'Kiro'`. The backend's own default is `'Kiro Crew'` (`api_branding`: `cfg.dashboard.bot_name or "Kiro Crew"`), and the name must stay **two words** because two consumers split it:

- the nav brand row accents the **last word only** (`App.tsx`: muted brand + accent product), so a single-word name renders all-muted with no accent segment;
- the composer placeholder **interpolates the whole name** (`ChatInput.tsx`: `i18nT('components.chatInput.message_placeholder', { bot: botName })`).

The fixture now mirrors `api_branding` exactly, avatar included.

## Tests

New `website/src/test/serveDist.routes.test.ts` (6 cases) locks:

- `/logo.png` is served as the packaged PNG, **byte-identical** (sha256 against the file the aiohttp handler reads) — not merely "some 200";
- it starts with the PNG signature and contains no `<!`, which is the exact failure mode being locked out (index.html under a `.png` name);
- the SPA `index.html` deep-link fallback and ordinary root-file serving still work;
- **the path-traversal guard still holds.** This is the security-relevant assertion: the new lookup runs *before* the containment check. Percent-encoded `../` (which survives URL normalisation and only becomes a traversal at decode time) still returns 403 for targets above the served root.
- malformed percent-escapes still return 400 rather than crashing the harness.

Bidirectionally proven: reverting the route lookup turns 2 of the 6 red.

The test drives the module through a real `node` child process rather than importing it — it is a plain `.mjs` that resolves its own paths from `import.meta.url`, which the test runner rewrites to a non-`file:` URL that `fileURLToPath` rejects. Spawning node also covers the path resolution an import-based test would have stubbed away.

## Manual verification

Verified against a harness **other than** the one this was found in, so the claim "every harness benefits" is measured rather than assumed:

```
GET /logo.png -> 200 image/png 82941 bytes
logo decodes at 512px natural width
wordmark  "Kiro Crew"
composer  "Message Kiro Crew… (/command · @file · $skill)"
```

Also probed the routed lookup for collisions and escapes — `/LOGO.PNG`, `/logo.png/`, `/logo.png?x=1`, `//logo.png`, `/%6cogo.png` (single-encoded), `/%256cogo.png` (double-encoded), `/foo/../logo.png` — only the intended forms select the PNG, and encoded traversal stays 403.

Local gates: `tsc -b`, eslint (0 errors), the 13 i18n checks, jscpd (0 clones), the product-name gate, and the full frontend suite (9256 passing) all green.

## Risk / rollback

Confined to `website/scripts/` fixtures plus one new test — no product code, and the capture harnesses are not run in CI. Reverting the two hunks restores the previous behaviour exactly.
