### PR TITLE
fix(models): resolve background model selection to a served model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,10 +124,33 @@ Never hardcode a model id (`claude-*`, `opus*`, `sonnet*`, `haiku*`, `gpt-*`,
 specific model — fails at runtime for anyone not entitled to it, with a
 silent-until-first-prompt shape.
 
-- The entitlement-safe default is the `"auto"` sentinel: the provider resolves it
-  server-side against what the account is actually served. `agent.model` and
+- The default is the `"auto"` sentinel: the provider resolves it server-side
+  against what the account is actually served. `agent.model` and
   `config/defaults.json` ship `"auto"` for exactly this reason — do not replace it
-  with a concrete model.
+  with a concrete model. But `"auto"` is NOT universally available: some
+  partitions (e.g. PDT, OSU) do not serve it, and sending it there fails with
+  `Invalid model ID: auto`. So `"auto"` is validated against the advertised list
+  like any other id — never assume it is usable.
+- Model resolution is UNIFIED at the wire chokepoint (`AcpSessionHandle.set_model`
+  → `acp.client.resolve_usable_model(preferred, advertised)`) for every model
+  chosen on the caller's behalf (not an explicit user pick), and it mirrors the
+  interactive path's reset-to-default (`_wire_model_id`): a served id is sent;
+  `"auto"` is sent ONLY when the backend advertises it; and anything else —
+  `"auto"` on a partition that doesn't serve it, or an unentitled
+  concrete id — resolves to `""`, meaning **inherit the session's backend
+  default** (the served model `session/new` assigned). So background one-liners,
+  tips, the contradiction sweep, and inherited/cold-start applies never put an
+  unserved model (or a literal unavailable `"auto"`) on the wire. A reactive
+  retry in `run_bg_oneliner` (`_rejected_model_from_error` tags the rejection,
+  then retries once with the first advertised model) stays as a thin backstop for
+  the fail-open case where `advertised` was unknown at send time. An EXPLICIT
+  user pick is the opposite: it must `raise` (`model_is_unusable`), never
+  silently substitute — a user who chose a model should see an error, not another
+  model.
+- All model dropdowns/pickers MUST source their options from the available-models
+  endpoint (`GET /api/models`, which reflects the account's advertised set), never
+  a static in-code list. The picker offers `"auto"` only when it is advertised (or
+  entitlement is unknown); otherwise the first advertised model leads.
 - To deliberately run a class of work on a cheaper model, use
   `agent.role_models.<role>` (roles: `background`, `subagent`) resolved through
   `AgentConfig.resolve_model(role)` — the ONLY sanctioned place to pin a model.
@@ -140,10 +163,11 @@ silent-until-first-prompt shape.
   fallbacks off the user-facing default path.
 - When checking whether an account may use a model id, use the shared predicate
   `acp.client.model_is_unusable(id, advertised)` with `advertised_model_ids(...)`
-  — the SAME check the session-init withhold uses — so the picker, the config
-  validator, and the wire cannot disagree. It compares within one namespace
-  (kiro's advertised ids are exactly the ids `set_model` accepts) and treats an
-  empty/unknown advertised set as "allow", so never hand-roll a membership test.
+  — the SAME check the session-init withhold and `resolve_usable_model` use — so
+  the picker, the config validator, and the wire cannot disagree. It compares
+  within one namespace (kiro's advertised ids are exactly the ids `set_model`
+  accepts) and treats an empty/unknown advertised set as "allow", so never
+  hand-roll a membership test.
 
 `code-review.yml` carries a deterministic tripwire that fails on a newly added
 hardcoded model literal outside `model_registry*`, the config schema, and tests.

--- a/config-baseline.json
+++ b/config-baseline.json
@@ -17,6 +17,8 @@
         "approval_mode": "auto",
         "streaming": true,
         "model": "auto",
+        "role_models": {},
+        "role_efforts": {},
         "reasoning_effort": "",
         "provider": "acp",
         "default_agent": "",
@@ -105,6 +107,62 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": "auto"
+    },
+    {
+      "path": "agent.role_models",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Per-role models",
+      "help": "Optional per-task-class model overrides. Keys: 'background' (lite / heartbeat background workers) and 'subagent' (spawned sub-agents). An empty value or 'auto' defers to the chat default (agent.model) and then to the provider default, so an unpinned role stays usable on every subscription tier. Pin a cheaper model here to run background / sub-agent work on it without changing the interactive chat default.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": {}
+    },
+    {
+      "path": "agent.role_models.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "*",
+      "help": "",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": null
+    },
+    {
+      "path": "agent.role_efforts",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Per-role reasoning effort",
+      "help": "Optional per-task-class reasoning effort, paired with role_models (keys: 'background', 'subagent'). Empty for a role inherits the chat default (agent.reasoning_effort) and then the provider/model default. Only applies on reasoning-capable models.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": {}
+    },
+    {
+      "path": "agent.role_efforts.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "*",
+      "help": "",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": null
     },
     {
       "path": "agent.reasoning_effort",
@@ -197,7 +255,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Allow Unsandboxed Execution",
-      "help": "When true, allow agent subprocesses to execute without any sandbox backend (fail-open). When false (default), wrap_argv raises a RuntimeError if no sandbox backend is available and mode is not 'off', preventing unsandboxed execution entirely (fail-closed). This is distinct from sandbox_allow_no_isolation which only controls warning severity — this field controls whether execution proceeds at all.",
+      "help": "When true, allow agent subprocesses to execute without any sandbox backend (fail-open). When false (default), wrap_argv raises a RuntimeError if no sandbox backend is available and mode is not 'off', preventing unsandboxed execution entirely (fail-closed). This is distinct from sandbox_allow_no_isolation which only controls warning severity — this field controls whether execution proceeds at all. The default is platform-independent: on a host with no backend (any Windows host, a Linux kernel refusing user namespaces) `kirocrew setup` OFFERS this opt-in interactively and writes it only on an explicit yes, so unconfined execution stays operator-declared and is never enabled implicitly by the platform.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": false
@@ -1550,7 +1608,7 @@
         "archive_after_days": 90,
         "pending_ttl_days": 30,
         "generate_scripts": true,
-        "judge_model": "claude-haiku-4.5",
+        "judge_model": "auto",
         "extra_paths": []
       }
     },
@@ -1731,10 +1789,10 @@
       "sensitive": false,
       "tags": [],
       "label": "Skill Judge Model",
-      "help": "Cheap model used for the dedupe judge and the advisory pending review. Kept separate from the main chat model to bound cost.",
+      "help": "Model used for the dedupe judge and the advisory pending review. Defaults to \"auto\" to inherit the account's governed model; the value only gates whether the judge runs (any truthy value enables it) — the judge turn itself runs on the shared background session.",
       "hasChildren": false,
       "enumValues": null,
-      "defaultValue": "claude-haiku-4.5"
+      "defaultValue": "auto"
     },
     {
       "path": "skills.extra_paths",
@@ -3928,7 +3986,7 @@
         "tips_cadence_hours": 6.0,
         "tips_snooze_hours": 48.0,
         "tips_recency_decay": 0.6,
-        "tips_model": "claude-haiku-4.5",
+        "tips_model": "auto",
         "tips_explore_ratio": 0.2,
         "gitlab_hosts": []
       }
@@ -4431,10 +4489,10 @@
       "sensitive": false,
       "tags": [],
       "label": "Tips Model",
-      "help": "Model ID for tips generation (pinned to Haiku-class for cost efficiency).",
+      "help": "Model ID for tips generation. Defaults to \"auto\" so it inherits the account's governed model; a hardcoded id can be rejected on accounts or partitions that do not serve it.",
       "hasChildren": false,
       "enumValues": null,
-      "defaultValue": "claude-haiku-4.5"
+      "defaultValue": "auto"
     },
     {
       "path": "dashboard.tips_explore_ratio",

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -654,7 +654,7 @@ class DashboardConfig:
     tips_cadence_hours: float = 6.0    # min hours between surfaced tips (server-side gate; clamped >= 0)
     tips_snooze_hours: float = 48.0    # hours before a snoozed tip is eligible again (clamped >= 0)
     tips_recency_decay: float = 0.6    # weighted-random newer-bias decay (clamped to [0, 1])
-    tips_model: str = "claude-haiku-4.5"  # model for tips generation (pinned to Haiku for cost)
+    tips_model: str = "auto"  # model for tips generation ("auto" inherits the account's governed model)
     tips_explore_ratio: float = 0.2    # probability of random catalog pick vs personalized (clamped to [0, 1])
 
 @dataclass

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -63,10 +63,21 @@ when done. See [acp-client.md](acp-client.md) for `AcpRuntime` /
 `AcpSessionHandle`.
 
 **Cheapest-model bg tasks**: the categorical/classification background tasks
-force `claude-haiku-4.5` via a best-effort per-session `set_model` (guarded so
-backends that can't switch fall through to their default): folder-icon
-(`chat_folders.py`), link-summary (`chat_nav.py`), and lesson-contradiction
-check (`dashboard/handlers/cron.py`).
+(folder-icon `chat_folders.py`, link-summary `chat_nav.py`, session title
+`chat_title.py`, session-summary `handlers/sessions.py`, STT endpointing
+`stt_stream.py`, and the lesson-contradiction check `dashboard/handlers/cron.py`,
+plus tips generation) express a `"auto"` model preference and pass it to a
+best-effort per-session `set_model`. The wire chokepoint
+(`AcpSessionHandle.set_model` → `resolve_usable_model`) mirrors the interactive
+`_wire_model_id`: it sends a served id, sends `"auto"` only when the backend
+advertises it, and for anything else — `"auto"` where a partition doesn't serve
+it, or an unentitled concrete id — resolves to `""` and **skips the
+send**, inheriting the session's served backend default. So these tasks never
+put an unserved model or a literal unavailable `"auto"` on the wire (which would
+fail with `Invalid model ID`). A reactive retry in `run_bg_oneliner`
+(retry once with the first advertised model on a mid-prompt rejection) remains a
+thin backstop for the fail-open case where the advertised set was unknown at
+send time.
 
 ## Key Behaviors
 

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -654,6 +654,14 @@ class AcpError(Exception):
     def __init__(self, *args: object, transient: bool | None = None) -> None:
         super().__init__(*args)
         self.transient = transient
+        # Reactive-fallback metadata, set by :func:`_raise_acp_error` when a
+        # prompt-time error names a rejected model (so run_bg_oneliner can retry
+        # once with a served model). Guarded so AcpModelUnavailable — which sets
+        # ``advertised`` BEFORE calling super().__init__ — is not clobbered.
+        if not hasattr(self, "rejected_model"):
+            self.rejected_model: str | None = None
+        if not hasattr(self, "advertised"):
+            self.advertised: list[str] = []
 
 
 class AcpTimeoutError(AcpError):
@@ -745,6 +753,10 @@ _NOT_LOGGED_IN_MESSAGE = (
 # string); throttle, auth, and the 5xx family match the combined
 # `data + message` haystack so a 5xx token in either field is caught.
 _RE_MODEL_UNAVAILABLE = re.compile(r"[Tt]he model '([^']+)' is not available")
+# MPS ValidationException wording for a model the partition/account does not
+# serve — distinct from the "is not available" capacity string above. Covers the
+# ``auto`` sentinel in partitions that do not serve it.
+_RE_INVALID_MODEL_ID = re.compile(r"[Ii]nvalid model ID:\s*([^\s,;'\"]+)")
 _RE_THROTTLE_NAMED = re.compile(
     r"\b(ThrottlingException|TooManyRequestsException|ServiceQuotaExceededException)\b"
 )
@@ -951,6 +963,43 @@ def model_is_unusable(model_id: str, advertised: Sequence[str] | None) -> bool:
     return wanted not in {m.strip().lower() for m in advertised if m and m.strip()}
 
 
+def resolve_usable_model(preferred: str, advertised: Sequence[str] | None) -> str:
+    """Resolve a SUBSTITUTE (non-explicit) model choice to what the account can
+    run, mirroring the interactive path's reset-to-default (``_wire_model_id``).
+
+    Returns ``""`` to mean **"do NOT override — inherit the session's backend
+    default"** (the served model ``session/new`` already assigned), so the wire
+    never receives a model the partition does not serve. Rules:
+
+      - empty ``preferred``           -> ``""`` (already inheriting the default);
+      - ``advertised`` unknown/empty  -> ``""`` for the ``"auto"`` sentinel (never
+        send a literal ``"auto"`` we cannot verify — some partitions do not
+        serve it), else trust a concrete caller-supplied id (nothing to check
+        it against);
+      - ``"auto"``                    -> ``"auto"`` IFF the backend advertises it,
+        else ``""`` — exactly ``_wire_model_id``'s
+        ``"auto" if "auto" in advertised else ""``;
+      - concrete + usable             -> that id;
+      - concrete + not served         -> ``""`` (inherit the served default rather
+        than substituting a possibly-unavailable ``"auto"``).
+
+    The EXPLICIT user-pick paths do NOT use this: they ``raise``
+    (``model_is_unusable``) so a user who chose a model sees an error, not a swap.
+    A reactive retry (``run_bg_oneliner``) remains a thin backstop for the
+    fail-open case where ``advertised`` was unknown at send time.
+    """
+    if not preferred:
+        return ""
+    if not advertised:
+        return "" if preferred == "auto" else preferred
+    ids = [m for m in advertised if m and m.strip()]
+    if preferred == "auto":
+        return "auto" if not model_is_unusable("auto", ids) else ""
+    if not model_is_unusable(preferred, ids):
+        return preferred
+    return ""
+
+
 def _format_acp_error(error: object, available_models: Sequence[str] | None = None) -> str:
     """Format a JSON-RPC error from the ACP backend into actionable user text.
 
@@ -1150,6 +1199,23 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
 _PROMPT_BUSY_RE = re.compile(r"already in progress", re.IGNORECASE)
 
 
+def _rejected_model_from_error(error: object) -> str | None:
+    """Return the model id a prompt-time error reports as invalid/unavailable.
+
+    Powers the reactive fallback in ``run_bg_oneliner``: on the SUBSTITUTE
+    (background) path, a rejected model is retried once against the account's
+    advertised list. Matches both the MPS ``Invalid model ID: X``
+    ValidationException (including the ``auto`` sentinel where a partition does
+    not serve it) and the ``The model 'X' is not
+    available`` wording. Returns None when the error names no specific model.
+    """
+    if not isinstance(error, dict):
+        return None
+    data = f"{error.get('data', '')} {error.get('message', '')}"
+    m = _RE_INVALID_MODEL_ID.search(data) or _RE_MODEL_UNAVAILABLE.search(data)
+    return m.group(1) if m else None
+
+
 def _raise_acp_error(error: object, available_models: Sequence[str] | None = None) -> None:
     """Format and raise the appropriate AcpError subclass for *error*.
 
@@ -1168,7 +1234,14 @@ def _raise_acp_error(error: object, available_models: Sequence[str] | None = Non
         raw_data = f"{error.get('data', '')} {error.get('message', '')}"
     if _PROMPT_BUSY_RE.search(raw_data):
         raise AcpPromptBusy(formatted)
-    raise AcpError(formatted, transient=_is_transient_raw_error(error, available_models))
+    err = AcpError(formatted, transient=_is_transient_raw_error(error, available_models))
+    # Tag a model-rejection so the SUBSTITUTE (background) retry layer can pick a
+    # served model; harmless on every other error (attributes just stay unset).
+    rejected = _rejected_model_from_error(error)
+    if rejected:
+        err.rejected_model = rejected
+        err.advertised = list(available_models or [])
+    raise err
 
 
 # Matches claude-agent-acp policy-substitution advisories:

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -44,6 +44,7 @@ from kiro_crew.acp.client import (
     _is_safe_oauth_url,
     _is_tool_interrupted_marker,
     _raise_acp_error,
+    resolve_usable_model,
 )
 from kiro_crew.acp.liveness import (
     EVIDENCE_ESTABLISHED_FLAT,
@@ -552,23 +553,41 @@ class AcpSessionHandle:
         )
 
     async def set_model(self, model_id: str) -> None:
-        """Switch model via session/set_model."""
+        """Switch model via session/set_model.
+
+        This is the shared-runtime SUBSTITUTE path (background one-liners, tips,
+        contradiction sweep, and any caller that did not pre-guard an explicit
+        user pick). ``resolve_usable_model`` maps the request to what the account
+        can run: a served id is sent; ``"auto"`` is sent only when the backend
+        advertises it; and anything else — ``"auto"`` on a partition that doesn't
+        serve it, or an unentitled concrete id — resolves to ``""``,
+        meaning **inherit the session's backend default** (the served model
+        ``session/new`` assigned). So this path never puts an unserved model on
+        the wire, exactly like the interactive ``_wire_model_id``
+        reset-to-default. Explicit user picks raise instead, upstream in
+        ``AcpSessionProvider.set_model`` / ``AcpClient.set_model``.
+        """
+        resolved = resolve_usable_model(model_id, self._advertised_model_ids())
+        if not resolved:
+            # Inherit the backend default — nothing to send. For the ephemeral
+            # _bg session the current model IS session/new's served default.
+            return
         await self._runtime.send_request(
             METHOD_SET_MODEL,
-            set_model_params(self._session_id, model_id),
+            set_model_params(self._session_id, resolved),
         )
-        self._model = model_id
+        self._model = resolved
         # Parity with AcpClient.set_model: keep _resolved_model_id in sync so
         # _backfill_context_window looks up the NEW model's window after a switch
         # (otherwise the context meter converts pct against the stale session/new
         # model until the next session refresh).
-        self._resolved_model_id = model_id
+        self._resolved_model_id = resolved
         # Also rebase the meter stats themselves — the old model's window and
         # its authoritative usage_update no longer describe this session
         # (mirrors AcpClient.set_model).
         win = (
-            model_registry.model_window(model_id)
-            if model_registry.has_known_window(model_id)
+            model_registry.model_window(resolved)
+            if model_registry.has_known_window(resolved)
             else None
         )
         self.last_prompt_stats.rebase_to_window(win or 0)

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2097,10 +2097,12 @@ class DashboardConfig:
         ),
     )
     tips_model: str = field(
-        default="claude-haiku-4.5",
+        default="auto",
         metadata=_meta(
             "Tips Model",
-            "Model ID for tips generation (pinned to Haiku-class for cost efficiency).",
+            "Model ID for tips generation. Defaults to \"auto\" so it inherits the "
+            "account's governed model; a hardcoded id can be rejected on accounts "
+            "or partitions that do not serve it.",
         ),
     )
     tips_explore_ratio: float = field(
@@ -2328,11 +2330,13 @@ class SkillsConfig:
         ),
     )
     judge_model: str = field(
-        default="claude-haiku-4.5",
+        default="auto",
         metadata=_meta(
             "Skill Judge Model",
-            "Cheap model used for the dedupe judge and the advisory pending review. "
-            "Kept separate from the main chat model to bound cost.",
+            "Model used for the dedupe judge and the advisory pending review. "
+            "Defaults to \"auto\" to inherit the account's governed model; the "
+            "value only gates whether the judge runs (any truthy value enables "
+            "it) — the judge turn itself runs on the shared background session.",
         ),
     )
     extra_paths: list[str] = field(
@@ -4878,7 +4882,7 @@ class KiroCrewConfig:
                 tips_recency_decay=_safe_float(
                     dashboard_data.get("tips_recency_decay", 0.6), 0.6, lo=0.0, hi=1.0
                 ),
-                tips_model=str(dashboard_data.get("tips_model", "claude-haiku-4.5")),
+                tips_model=str(dashboard_data.get("tips_model", "auto")),
                 tips_explore_ratio=_safe_float(
                     dashboard_data.get("tips_explore_ratio", 0.2), 0.2, lo=0.0, hi=1.0
                 ),
@@ -5076,7 +5080,7 @@ class KiroCrewConfig:
                 pending_ttl_days=_safe_int(skills_data.get("pending_ttl_days", 30), 30),
                 generate_scripts=bool(skills_data.get("generate_scripts", True)),
                 judge_model=str(
-                    skills_data.get("judge_model", "claude-haiku-4.5") or "claude-haiku-4.5"
+                    skills_data.get("judge_model", "auto") or "auto"
                 ),
                 extra_paths=[
                     p for p in _safe_list(skills_data.get("extra_paths")) if isinstance(p, str)

--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -69,7 +69,10 @@ def _is_single_emoji(s: str) -> bool:
     return clusters == 1
 
 
-_FOLDER_ICON_MODEL = "claude-haiku-4.5"
+# "auto" = inherit the session's governed default (run_bg_oneliner skips the
+# override for auto). A hardcoded model id 400s on accounts/partitions that do
+# not serve it.
+_FOLDER_ICON_MODEL = "auto"
 
 
 # Folder color palette — the identity mark a user picks for a folder in the

--- a/src/kiro_crew/dashboard/chat_nav.py
+++ b/src/kiro_crew/dashboard/chat_nav.py
@@ -66,7 +66,10 @@ def _build_link_summary_prompt(links: list[dict]) -> str:
     return _LINK_SUMMARY_PROMPT.format(items="\n".join(items))
 
 
-_LINK_SUMMARY_MODEL = "claude-haiku-4.5"
+# "auto" = inherit the session's governed default (run_bg_oneliner skips the
+# override for auto). A hardcoded model id 400s on accounts/partitions that do
+# not serve it.
+_LINK_SUMMARY_MODEL = "auto"
 
 
 async def _resolve_link_summaries(state: DashboardState, links: list[dict]) -> list[str]:

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -41,12 +41,14 @@ _TITLE_SOURCE_SCAN_LIMIT = _TITLE_TEXT_LIMIT + _TITLE_MAX_ATTACHMENT_FILES * (
     _TITLE_MAX_ATTACHMENT_PATH_LENGTH + 32
 )
 
-# Titling is a trivial 3-6 word task, so pin it to the cheapest/fastest model
-# (Haiku) rather than the kirocrew-lite default ("auto" on the kiro-cli path).
-# Applied per-session via set_model so heavier background work (compaction,
-# optimizer) keeps the lite agent's default model. Best-effort: a failed
-# override just falls back to the session's default model.
-_TITLE_MODEL = "claude-haiku-4.5"
+# Titling is a trivial 3-6 word task. It formerly pinned Haiku for cost, but a
+# hardcoded model id is not governance-aware: on an account/partition that does
+# not serve that model (e.g. where Haiku is unavailable) the wire
+# rejects it with ``Invalid model ID``. ``"auto"`` means "inherit
+# the session's governed default" — ``run_bg_oneliner`` skips the per-session
+# set_model override for auto, so titling runs on the backend-resolved entitled
+# model instead of a literal the account may not have.
+_TITLE_MODEL = "auto"
 
 # Per-word delay for the word-by-word title reveal animation. LLM chunk
 # streaming arrives in a sub-second burst (too fast to perceive), so the reveal

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -18,13 +18,8 @@ from kiro_crew.dashboard.cron_inject import (
     inject_cron_result_to_dashboard,
 )
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.messaging.link import is_channel_session_key
-from kiro_crew.providers.base import (
-    EVENT_COMPLETE,
-    EVENT_PERMISSION_REQUEST,
-    EVENT_TEXT_CHUNK,
-    EVENT_TOOL_CALL,
-)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import (
     _MODEL_NAME_RE,
@@ -71,7 +66,7 @@ _CONTRADICTION_PROMPT = (
     "Respond with exactly one word: CONTRADICTORY, COMPLEMENTARY, or UNRELATED."
 )
 
-_CONTRADICTION_MODEL = "claude-haiku-4.5"
+_CONTRADICTION_MODEL = "auto"  # inherit the governed default; a hardcoded id 400s where unavailable
 # Per-candidate cap on the background contradiction verdict. The sweep runs
 # fire-and-forget after the lesson is already persisted, so this bounds a hung
 # model call rather than gating the write path.
@@ -92,54 +87,13 @@ async def _classify_contradiction(state: DashboardState, prompt: str) -> str:
     ``_CONTRADICTION_TIMEOUT``. Returns the first upper-cased token of the
     model's reply (e.g. ``"CONTRADICTORY"``), or ``""`` on empty output.
     """
-    session = await state.sessions.get_bg_session()
-    text = ""
-    try:
-        # Contradiction check is a trivial binary classification — run on the
-        # cheapest model. Best-effort: fall through on the session's default
-        # model if the backend can't switch.
-        _set_model = getattr(session, "set_model", None)
-        if _set_model is not None:
-            try:
-                await _set_model(_CONTRADICTION_MODEL)
-            except Exception:
-                pass
-
-        async def _stream() -> None:
-            nonlocal text
-            async for event in session.prompt(prompt):
-                if event.kind == EVENT_TEXT_CHUNK:
-                    text += event.text
-                elif event.kind == EVENT_TOOL_CALL:
-                    # A tool-free classification should never dispatch a tool,
-                    # but an auto-approved tool arrives here WITHOUT a preceding
-                    # permission request (nothing to reject). Audit it so no
-                    # invocation escapes the SEL log (every tool invocation emits
-                    # a SEL event).
-                    _sel().log_tool_invocation(
-                        session_key="_bg",
-                        tool_name=getattr(event, "title", "unknown"),
-                        outcome="allowed",
-                        source="contradiction_check",
-                    )
-                elif event.kind == EVENT_PERMISSION_REQUEST:
-                    # The classification is tool-free; deny any tool the model
-                    # tries to call. Audit the denial (every permission decision
-                    # emits a SEL event) before rejecting, mirroring the
-                    # suggestions bg path.
-                    _sel().log_tool_invocation(
-                        session_key="_bg",
-                        tool_name=getattr(event, "title", "unknown"),
-                        outcome="denied",
-                        source="contradiction_check",
-                    )
-                    await session.reject_tool(event.request_id)
-                elif event.kind == EVENT_COMPLETE:
-                    break
-
-        await asyncio.wait_for(_stream(), timeout=_CONTRADICTION_TIMEOUT)
-    finally:
-        await session.destroy()
+    text = await run_bg_oneliner(
+        state.sessions,
+        prompt,
+        model=_CONTRADICTION_MODEL,
+        sel_source="contradiction_check",
+        timeout=_CONTRADICTION_TIMEOUT,
+    )
     stripped = text.strip()
     return stripped.upper().split()[0] if stripped else ""
 

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -690,7 +690,7 @@ async def api_sessions(request: web.Request) -> web.Response:
 
 
 _SUMMARIZE_MAX_SESSIONS = 8  # bound cost/latency: only the top-N get an LLM pass
-_SUMMARIZE_MODEL = "claude-haiku-4.5"  # cheap/fast — a one-liner needs no heavy model
+_SUMMARIZE_MODEL = "auto"  # inherit the governed default; a hardcoded id 400s where unavailable
 _SUMMARIZE_MSG_LIMIT = 12  # messages fed to the summarizer per session
 _SUMMARIZE_TIMEOUT_SECS = 30  # per-session deadline so one stalled prompt can't pin the shared _bg session
 _SUMMARIZE_PROMPT = (

--- a/src/kiro_crew/dashboard/stt_stream.py
+++ b/src/kiro_crew/dashboard/stt_stream.py
@@ -60,10 +60,12 @@ _active_sessions = 0
 # ── Semantic endpointing (stt.endpointing, default off) ──
 # On each stable Transcribe `final`, a fast background model judges whether the
 # user has finished a complete request; a COMPLETE verdict emits an `endpoint`
-# frame so the frontend can auto-submit. Pinned to the cheap Haiku-class model
-# (parity with title/tip generation). Debounced so mid-utterance finals don't
-# each fire a model call, and single-flight so at most one bg call runs at once.
-_ENDPOINT_MODEL = "claude-haiku-4.5"
+# frame so the frontend can auto-submit. "auto" inherits the session's governed
+# default (run_bg_oneliner skips the override for auto) — a hardcoded model id
+# 400s on accounts/partitions that do not serve it.
+# Debounced so mid-utterance finals don't each fire a model call, and
+# single-flight so at most one bg call runs at once.
+_ENDPOINT_MODEL = "auto"
 _ENDPOINT_DEBOUNCE_SECS = 0.35
 _ENDPOINT_TIMEOUT_SECS = 5.0
 _ENDPOINT_PROMPT = (

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -274,38 +274,95 @@ async def run_bg_oneliner(
     """
     session = await sessions.get_bg_session()
 
-    async def _drive() -> str:
+    def _first_advertised_fallback(advertised: Any, rejected: str | None) -> str | None:
+        """First advertised model that is neither the rejected id nor the
+        ``"auto"`` sentinel — the reactive replacement when the preferred model
+        is refused mid-prompt."""
+        rej = (rejected or "").strip().lower()
+        for m in advertised or []:
+            if not isinstance(m, str) or not m.strip():
+                continue
+            low = m.strip().lower()
+            if low == rej or low == "auto":
+                continue
+            return m
+        return None
+
+    async def _drive(model_to_use: str | None) -> str:
         text = ""
         set_model = getattr(session, "set_model", None)
-        if model and set_model is not None:
+        # Pass the caller's preference (often the governed "auto") to set_model,
+        # which resolves it against the session's advertised model list at the
+        # wire chokepoint (AcpSessionHandle.set_model -> resolve_usable_model):
+        # a hardcoded/unentitled id, or "auto" on a partition that does not serve
+        # it, is swapped for the first advertised model instead of
+        # reaching the wire and failing mid-prompt with Invalid model ID.
+        # Best-effort: a failed override falls back to the default.
+        if model_to_use and set_model is not None:
             try:
-                await set_model(model)
+                await set_model(model_to_use)
             except Exception:
-                logger.debug("bg oneliner: model override to %s failed; using default", model)
+                logger.debug(
+                    "bg oneliner: model override to %s failed; using default", model_to_use
+                )
         async for event in session.prompt(prompt):
             if event.kind == EVENT_TEXT_CHUNK:
                 text += event.text
             elif event.kind == EVENT_PERMISSION_REQUEST:
-                await session.reject_tool(event.request_id)
-                # Every permission decision must be audited — always emit the
-                # SEL denial event (backend-security-controls). ``sel_source``
-                # carries a non-empty default so callers that don't attribute a
-                # feature still produce an audit record.
+                # Audit the denial BEFORE rejecting: every permission decision
+                # must be SEL-logged (backend-security-controls), and a
+                # reject_tool transport failure must NOT skip the audit.
+                # ``sel_source`` carries a non-empty default so callers that
+                # don't attribute a feature still produce an audit record.
                 _sel().log_tool_invocation(
                     session_key=sel_session_key,
-                    tool_name="unknown",
+                    tool_name=getattr(event, "title", "unknown") or "unknown",
                     outcome="denied",
                     source=sel_source or "bg_oneliner",
                     request_id=str(event.request_id),
+                )
+                await session.reject_tool(event.request_id)
+            elif event.kind == EVENT_TOOL_CALL:
+                # Tool-free by contract, but an AUTO-APPROVED tool arrives with no
+                # permission request to reject — audit it so no invocation escapes
+                # the SEL log (backend-security-controls; mirrors the cron/
+                # contradiction bg path this helper subsumes).
+                _sel().log_tool_invocation(
+                    session_key=sel_session_key,
+                    tool_name=getattr(event, "title", "unknown") or "unknown",
+                    outcome="allowed",
+                    source=sel_source or "bg_oneliner",
                 )
             elif event.kind == EVENT_COMPLETE:
                 break
         return text
 
-    try:
+    async def _run(model_to_use: str | None) -> str:
         if timeout is not None:
-            return await asyncio.wait_for(_drive(), timeout)
-        return await _drive()
+            return await asyncio.wait_for(_drive(model_to_use), timeout)
+        return await _drive(model_to_use)
+
+    try:
+        try:
+            return await _run(model)
+        except AcpError as exc:
+            # Reactive fallback: the model was rejected mid-prompt — e.g. "auto"
+            # on a partition that does not serve it, or any id the
+            # account cannot run. The advertised list can't be used
+            # to gate "auto" statically (it is a sentinel, never advertised), so
+            # this is the layer that turns your spec's "else the first available
+            # model" into action: retry ONCE with the first advertised model that
+            # is neither the rejected id nor "auto". Only fires when the raise-time
+            # classifier tagged a rejected model AND named an advertised set.
+            rejected = getattr(exc, "rejected_model", None)
+            advertised = getattr(exc, "advertised", None) or []
+            fallback = _first_advertised_fallback(advertised, rejected) if rejected else None
+            if not fallback:
+                raise
+            logger.warning(
+                "bg oneliner: model %r rejected; retrying once with %r", rejected, fallback
+            )
+            return await _run(fallback)
     finally:
         await session.destroy()
 

--- a/src/kiro_crew/tips.py
+++ b/src/kiro_crew/tips.py
@@ -23,10 +23,9 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.paths import config_dir
 from kiro_crew.context import ContextBuilder
+from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.platform_compat import restrict_to_owner
-from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, EVENT_TEXT_CHUNK
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-from kiro_crew.sel import sel
 from kiro_crew.tips_allowlist import TIP_DOC_ALLOWLIST
 from kiro_crew.tips_text import truncate_summary
 
@@ -726,50 +725,21 @@ async def generate_tips(state: DashboardState) -> list[dict]:  # type: ignore[ty
         dismissed_ids=", ".join(st.dismissed) or "none",
     )
 
+    loop2 = asyncio.get_running_loop()
+    cfg = await loop2.run_in_executor(None, KiroCrewConfig.load)
+    tips_model = cfg.dashboard.tips_model
+    # Delegate acquire / pin-model / drive / reject-tools / destroy — and the
+    # reactive model-rejection fallback — to run_bg_oneliner.
+    # tips_model (default "auto") is resolved at the wire chokepoint; a rejected
+    # model is retried once against the advertised list. Any failure or timeout
+    # degrades to the catalog fallback.
     try:
-        session = await state.sessions.get_bg_session()
+        text = await run_bg_oneliner(
+            state.sessions, prompt, model=tips_model, sel_source="tips", timeout=90
+        )
     except Exception:
-        logger.debug("Background session unavailable for tips")
+        logger.warning("Tips generation failed; using catalog fallback", exc_info=True)
         return _fallback_tips(cache.catalog, st)
-
-    text = ""
-    try:
-        # Pin to Haiku-class model for cost efficiency (per-session override,
-        # same pattern as chat_title.py). Best-effort: if the backend cannot
-        # switch, falls through on the session's default model.
-        loop2 = asyncio.get_running_loop()
-        cfg = await loop2.run_in_executor(None, KiroCrewConfig.load)
-        tips_model = cfg.dashboard.tips_model
-        _set_model = getattr(session, "set_model", None)
-        if _set_model is not None:
-            try:
-                await _set_model(tips_model)
-            except Exception:
-                logger.debug("Tips model override to %s failed; using default", tips_model)
-
-        async def _stream() -> str:
-            nonlocal text
-            async for event in session.prompt(prompt):
-                if event.kind == EVENT_TEXT_CHUNK:
-                    text += event.text
-                elif event.kind == EVENT_PERMISSION_REQUEST:
-                    sel().log_tool_invocation(
-                        session_key="_bg",
-                        tool_name=getattr(event, "title", "unknown"),
-                        outcome="denied",
-                        source="tips",
-                    )
-                    await session.reject_tool(event.request_id)
-                elif event.kind == EVENT_COMPLETE:
-                    break
-            return text
-
-        await asyncio.wait_for(_stream(), timeout=90)
-    except asyncio.TimeoutError:
-        logger.warning("Tips generation timed out")
-        return _fallback_tips(cache.catalog, st)
-    finally:
-        await session.destroy()
 
     tips = _parse_tips(text)
     if tips:

--- a/test/test_lesson_contradiction.py
+++ b/test/test_lesson_contradiction.py
@@ -119,9 +119,11 @@ class TestResolveContradictions:
         result = await _resolve_contradictions(state, "Do NOT use X format", candidates)
 
         assert result == ["lesson.old"]
-        # Model was pinned to the cheap contradiction model and the ephemeral
-        # handle was destroyed.
-        session.set_model.assert_awaited_once_with("claude-haiku-4.5")
+        # The contradiction model preference ("auto", the governed default) is
+        # passed to set_model, which resolves it against the advertised list at
+        # the wire chokepoint (AcpSessionHandle.set_model). The fake bg session
+        # just records the requested value. The ephemeral handle is destroyed.
+        session.set_model.assert_awaited_once_with("auto")
         session.destroy.assert_awaited_once()
 
     async def test_complementary_verdict_keeps_lesson(self):
@@ -157,7 +159,9 @@ class TestResolveContradictions:
         state.sessions.get_bg_session = AsyncMock(return_value=session)
 
         candidates = [{"key": "lesson.old", "rule": "Use X", "similarity": 0.6}]
-        with patch.object(cron, "_sel") as mock_sel:
+        # SEL logging now happens inside run_bg_oneliner (cron delegates to it),
+        # so patch where the name is looked up, not cron._sel.
+        with patch("kiro_crew.llm_helpers._sel") as mock_sel:
             result = await cron._resolve_contradictions(state, "Do NOT use X", candidates)
 
         assert result == ["lesson.old"]
@@ -179,7 +183,8 @@ class TestResolveContradictions:
         state.sessions.get_bg_session = AsyncMock(return_value=session)
 
         candidates = [{"key": "lesson.x", "rule": "r", "similarity": 0.6}]
-        with patch.object(cron, "_sel") as mock_sel:
+        # SEL logging now happens inside run_bg_oneliner (cron delegates to it).
+        with patch("kiro_crew.llm_helpers._sel") as mock_sel:
             result = await cron._resolve_contradictions(state, "new", candidates)
 
         assert result == []  # UNRELATED verdict keeps the lesson

--- a/test/test_resolve_usable_model.py
+++ b/test/test_resolve_usable_model.py
@@ -1,0 +1,48 @@
+"""Unit tests for the unified model resolver `resolve_usable_model`.
+
+The resolver is the SUBSTITUTE path (background one-liners, session-default /
+inherited apply, warm-pool re-apply): given a preferred model and the backend's
+advertised list, it returns a model the account can actually run. Precedence:
+preferred-if-usable -> "auto"-if-advertised -> first-advertised -> "auto".
+
+The load-bearing new constraint: "auto" is NOT universally
+available — some partitions do not serve it — so it is validated
+against the advertised list like any other id, never assumed usable.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.acp.client import resolve_usable_model
+
+
+class TestResolveUsableModel:
+    def test_advertised_unknown_trusts_concrete_but_inherits_for_auto(self) -> None:
+        # Empty/None advertised = entitlement unknowable: trust a concrete id,
+        # but never send a literal "auto" we cannot verify -> "" (inherit default).
+        assert resolve_usable_model("claude-haiku-4.5", []) == "claude-haiku-4.5"
+        assert resolve_usable_model("anything", []) == "anything"
+        assert resolve_usable_model("auto", None) == ""
+
+    def test_preferred_usable_is_kept(self) -> None:
+        adv = ["claude-sonnet-4.6", "claude-haiku-4.5", "auto"]
+        assert resolve_usable_model("claude-haiku-4.5", adv) == "claude-haiku-4.5"
+
+    def test_concrete_unentitled_inherits_default(self) -> None:
+        # A concrete id the account cannot run -> "" (inherit the served backend
+        # default), NOT a possibly-unavailable "auto". Free-tier case.
+        assert resolve_usable_model("claude-haiku-4.5", ["claude-sonnet-4.6"]) == ""
+
+    def test_auto_sent_only_when_advertised(self) -> None:
+        # Mirror _wire_model_id: "auto" IFF the backend advertises it.
+        assert resolve_usable_model("auto", ["auto", "claude-sonnet-4.6"]) == "auto"
+
+    def test_auto_not_advertised_inherits_default(self) -> None:
+        # Some partitions don't serve auto -> "" (inherit default), never send auto.
+        assert resolve_usable_model("auto", ["gpt-5.6-terra", "gpt-5.6-luna"]) == ""
+
+    def test_case_insensitive_membership(self) -> None:
+        adv = ["Claude-Haiku-4.5"]
+        assert resolve_usable_model("claude-haiku-4.5", adv) == "claude-haiku-4.5"
+
+    def test_empty_preferred_inherits_default(self) -> None:
+        assert resolve_usable_model("", ["claude-sonnet-4.6", "gpt-5.6-terra"]) == ""

--- a/test/test_run_bg_oneliner.py
+++ b/test/test_run_bg_oneliner.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from kiro_crew.acp.client import AcpError, _rejected_model_from_error
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, EVENT_TEXT_CHUNK
 from kiro_crew.llm_helpers import run_bg_oneliner
 
@@ -55,6 +56,37 @@ async def test_accumulates_text_and_sets_model_and_destroys():
     out = await run_bg_oneliner(_FakeSessions(sess), "p", model="claude-haiku-4.5")
     assert out == "hello world"
     assert sess.model == "claude-haiku-4.5"
+    assert sess.destroyed is True
+
+
+@pytest.mark.asyncio
+async def test_auto_model_is_passed_to_set_model_for_wire_resolution():
+    """``model="auto"`` IS forwarded to set_model. The real wire chokepoint
+    (AcpSessionHandle.set_model -> resolve_usable_model) turns it into a usable
+    id against the advertised list — "auto" where advertised, else the first
+    advertised model — so a partition that doesn't serve auto never
+    gets a raw ``auto`` on the wire. The fake session just records
+    the requested value; resolver behavior is covered in test_acp_client."""
+    sess = _FakeSession([
+        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="hi"),
+        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+    ])
+    out = await run_bg_oneliner(_FakeSessions(sess), "p", model="auto")
+    assert out == "hi"
+    assert sess.model == "auto"
+    assert sess.destroyed is True
+
+
+@pytest.mark.asyncio
+async def test_empty_model_does_not_override_session_default():
+    """An empty model string inherits the session default (no set_model call)."""
+    sess = _FakeSession([
+        SimpleNamespace(kind=EVENT_TEXT_CHUNK, text="hi"),
+        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+    ])
+    out = await run_bg_oneliner(_FakeSessions(sess), "p", model="")
+    assert out == "hi"
+    assert sess.model is None
     assert sess.destroyed is True
 
 
@@ -108,4 +140,131 @@ async def test_propagates_error_and_destroys():
     sess = _FakeSession([], raise_on_prompt=True)
     with pytest.raises(RuntimeError, match="boom"):
         await run_bg_oneliner(_FakeSessions(sess), "p")
+    assert sess.destroyed is True
+
+
+# ── Reactive retry-on-model-rejection (option A) ──
+
+
+class _RejectThenSucceedSession:
+    """First ``prompt()`` raises a model-rejection ``AcpError`` (as
+    ``_raise_acp_error`` tags it); the second yields text. Records every
+    ``set_model`` call so the test can assert the fallback model was applied."""
+
+    def __init__(self, rejected: str, advertised: list, success_text: str = "ok"):
+        self._calls = 0
+        self._rejected = rejected
+        self._advertised = advertised
+        self._text = success_text
+        self.models: list = []
+        self.destroyed = False
+
+    async def set_model(self, model):
+        self.models.append(model)
+
+    async def prompt(self, _prompt):
+        self._calls += 1
+        if self._calls == 1:
+            err = AcpError("model rejected", transient=False)
+            err.rejected_model = self._rejected
+            err.advertised = list(self._advertised)
+            raise err
+        for e in [
+            SimpleNamespace(kind=EVENT_TEXT_CHUNK, text=self._text),
+            SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+        ]:
+            yield e
+
+    async def reject_tool(self, request_id):
+        pass
+
+    async def destroy(self):
+        self.destroyed = True
+
+
+@pytest.mark.asyncio
+async def test_reactive_retry_on_rejection_uses_first_advertised():
+    """When the preferred model is refused mid-prompt (e.g. "auto" on a
+    partition that doesn't serve it), retry ONCE with the first
+    advertised model that is neither the rejected id nor "auto"."""
+    sess = _RejectThenSucceedSession("auto", ["gpt-5.6-terra", "gpt-5.6-luna"])
+    out = await run_bg_oneliner(_FakeSessions(sess), "p", model="auto")
+    assert out == "ok"
+    assert sess.models == ["auto", "gpt-5.6-terra"]
+    assert sess.destroyed is True
+
+
+@pytest.mark.asyncio
+async def test_reactive_retry_reraises_when_no_usable_fallback():
+    """No advertised model other than the rejected id / "auto" → nothing safe to
+    retry with, so the error propagates (caller decides fail-open)."""
+    sess = _RejectThenSucceedSession("auto", ["auto"])
+    with pytest.raises(AcpError):
+        await run_bg_oneliner(_FakeSessions(sess), "p", model="auto")
+    assert sess.destroyed is True
+
+
+@pytest.mark.asyncio
+async def test_non_rejection_error_is_not_retried():
+    """A generic AcpError with no rejected_model tag is not a model rejection —
+    it must propagate unchanged (no retry), and the session is destroyed."""
+    class _BoomSession(_FakeSession):
+        async def prompt(self, _p):
+            raise AcpError("backend boom")
+            yield  # pragma: no cover
+
+    sess = _BoomSession([])
+    with pytest.raises(AcpError, match="backend boom"):
+        await run_bg_oneliner(_FakeSessions(sess), "p", model="auto")
+    assert sess.destroyed is True
+
+
+class TestRejectedModelClassifier:
+    def test_matches_invalid_model_id(self):
+        assert (
+            _rejected_model_from_error({"data": "Invalid model ID: claude-haiku-4.5"})
+            == "claude-haiku-4.5"
+        )
+
+    def test_matches_invalid_model_id_auto_in_message(self):
+        assert _rejected_model_from_error({"message": "Invalid model ID: auto"}) == "auto"
+
+    def test_matches_model_not_available(self):
+        assert (
+            _rejected_model_from_error({"data": "The model 'opus-x' is not available"})
+            == "opus-x"
+        )
+
+    def test_returns_none_for_unrelated_error(self):
+        assert _rejected_model_from_error({"data": "ThrottlingException: slow down"}) is None
+
+    def test_returns_none_for_non_dict(self):
+        assert _rejected_model_from_error("nonsense") is None
+
+
+@pytest.mark.asyncio
+async def test_permission_denial_is_audited_even_if_reject_fails(monkeypatch):
+    """Audit-before-reject: the SEL denial is emitted BEFORE ``reject_tool``, so a
+    ``reject_tool`` transport failure cannot skip the audit (every permission
+    decision must be logged; backend-security-controls)."""
+    logged: list = []
+    import kiro_crew.llm_helpers as mod
+
+    monkeypatch.setattr(
+        mod, "_sel",
+        lambda: SimpleNamespace(log_tool_invocation=lambda **kw: logged.append(kw)),
+    )
+
+    class _RejectRaises(_FakeSession):
+        async def reject_tool(self, request_id):
+            raise RuntimeError("transport down")
+
+    sess = _RejectRaises([
+        SimpleNamespace(kind=EVENT_PERMISSION_REQUEST, request_id="r1", text=""),
+        SimpleNamespace(kind=EVENT_COMPLETE, text=""),
+    ])
+    with pytest.raises(RuntimeError, match="transport down"):
+        await run_bg_oneliner(_FakeSessions(sess), "p", sel_source="unit")
+    # Denial was audited despite reject_tool failing, and the handle was destroyed.
+    assert logged and logged[0]["outcome"] == "denied"
     assert sess.destroyed is True

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -1261,7 +1261,7 @@ class TestConfigClamping:
     def test_tips_model_default(self) -> None:
         from kiro_crew.config.loader import DashboardConfig
         cfg = DashboardConfig()
-        assert cfg.tips_model == "claude-haiku-4.5"
+        assert cfg.tips_model == "auto"
 
     def test_tips_explore_ratio_default(self) -> None:
         from kiro_crew.config.loader import DashboardConfig
@@ -1311,10 +1311,10 @@ class TestConfigClamping:
         """tips_model read as string from dashboard data."""
         from kiro_crew.config.loader import KiroCrewConfig
 
-        # Default config should have the haiku model
+        # Default config inherits the account's governed model via "auto"
         cfg = KiroCrewConfig.load()
         assert isinstance(cfg.dashboard.tips_model, str)
-        assert cfg.dashboard.tips_model == "claude-haiku-4.5"
+        assert cfg.dashboard.tips_model == "auto"
 
 
 class TestOptOutState:


### PR DESCRIPTION
## Problem
Background/utility LLM features hardcoded `claude-haiku-4.5` and pushed it as an explicit per-session `set_model` override. On accounts/partitions that do not serve that model, this fails at prompt time with `ValidationException: Invalid model ID` — the driver behind the GovCloud spike in **P485986014** (1070 × `Invalid model ID: claude-haiku-4.5`, plus `Invalid model ID: auto`). The features affected fire automatically (session title, folder icon, link-label summary, session summary, STT dictation endpointing, lesson-contradiction sweep, tips, skill-dedupe judge), so a few accounts generated a large background error volume without any user selecting the model.

## Why it matters
These are error-rate–alarming, cross-partition failures for real customers (GovCloud, and any partition/entitlement without Haiku or without the `auto` sentinel — e.g. PDT/OSU). They are invisible until the background turn runs, and they inflate the service's 4xx error rate.

## Fix (symptom → root cause → change)
- **Symptom:** background turns 400 with `Invalid model ID: <hardcoded>` (and `Invalid model ID: auto`).
- **Root cause:** a hardcoded model id (or the raw `auto` sentinel) was sent to the wire regardless of what the account/partition actually serves. `auto` is a client sentinel that is never a member of the backend's advertised list, so its availability cannot be checked by list-membership.
- **Change:** introduce `resolve_usable_model(preferred, advertised)` and apply it at the shared wire chokepoint `AcpSessionHandle.set_model`, mirroring the interactive path's `_wire_model_id` reset-to-default:
  - send a served concrete id;
  - send `"auto"` **only when the backend advertises it**;
  - otherwise resolve to `""` → **skip the send and inherit the session's served backend default** (`session/new`'s `currentModelId`). So the wire never receives an unserved model or a literal unavailable `auto`.
  - The six hardcoded `claude-haiku-4.5` constants and the `tips_model`/`judge_model` config defaults now default to `"auto"` (`config-baseline.json` regenerated deterministically via `scripts/generate_config_baseline.py`).
  - `run_bg_oneliner` keeps a **thin reactive backstop**: on a mid-prompt model rejection it retries once with the first advertised model (`_rejected_model_from_error` classifies the rejection, incl. the `Invalid model ID: X` wording) — this only matters in the fail-open case where the advertised set was unknown at send time.
  - `tips` and the lesson-contradiction sweep now **delegate to `run_bg_oneliner`**, so all background features share one audited, retry-capable path (tool/permission SEL auditing moved into the shared helper).
- Explicit user model picks are unchanged: they still `raise` `AcpModelUnavailable` (a user who chose a model should see an error, not a silent swap).

## Tests
- `test/test_resolve_usable_model.py` (new): the resolver's full decision table — served id kept, `auto` sent only when advertised, `auto`/unentitled concrete → `""` (inherit default), unknown-advertised trusts a concrete id but inherits for `auto`, case-insensitive membership.
- `test/test_run_bg_oneliner.py`: reactive retry uses the first advertised model on a tagged rejection; re-raises when no usable fallback; non-rejection errors are not retried; `_rejected_model_from_error` classifier (matches `Invalid model ID: X`, `The model 'X' is not available`, `auto`).
- `test/test_lesson_contradiction.py`: updated for cron's delegation to `run_bg_oneliner` (SEL audit patch target moved to where the name is now looked up).
- `test/test_tips.py`: `tips_model` default is now `auto`.
- Existing `test_cc_models_endpoint`, `test_acp_client`, `test_acp_session_provider`, `test_config_baseline` remain green.

## Manual verification
N/A — unit coverage is sufficient. No user-visible UI change (backend model-resolution + config defaults + docs). Local gate green on the rebased tree: 842 targeted tests pass, isort/flake8 clean, mypy clean on changed files (the only mypy errors are pre-existing `os.*xattr` macOS typeshed stubs in untouched `hooks.py`).

## Screenshots
N/A — no user-facing UI change.
