### PR TITLE
ci: skip the opposite surface's single-surface tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,108 @@ concurrency:
   # ~1.4min median merge gap, main gets periodic verdicts instead of none.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Tests that need capabilities the GH Actions runners lack (Linux-namespace
+# sandbox, a real git/gh, or POSIX rmtree/path assumptions). Deselected on
+# EVERY backend pytest invocation -- full AND reduced, Linux AND Windows --
+# from this single source so the lists cannot drift apart. They drifted once:
+# the reduced (frontend-only) runs omitted these, and the surface selector
+# legitimately lists test_dogfood_learnings.py as cross-surface, so a reduced
+# run re-ran a file the full run excludes and failed the shards. A --deselect
+# of a path a given run did not collect is a harmless no-op, so the reduced
+# runs carry the full list safely. Expanded UNQUOTED on purpose so it
+# word-splits into separate args (no deselect path contains a space).
+env:
+  BACKEND_DESELECTS: >-
+    --deselect=test/test_script_hooks.py
+    --deselect=test/test_cron_script.py
+    --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py
+    --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py
+    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
+    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py
+    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py
+    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
+    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_capture.py
+    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
+    --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_perf_track_propose.py
+
 jobs:
+  # ── Surface detection (issue #1556) ──────────────────────────────────
+  # Most tests only exercise their own surface, so a single-surface diff can
+  # skip the opposite suite's *provably* single-surface files. The selector
+  # (scripts/ci-surface-tests.py) is deny-by-default: every cross-surface
+  # parity guard -- and anything it cannot classify -- stays in the must-run
+  # set, so a heuristic miss costs CI time, never a skipped guard.
+  #
+  # only_backend / only_frontend are computed here ONCE. `backend` is a
+  # catch-all, so every changed file is exactly one of frontend / meta /
+  # backend: a diff that touches two buckets (or meta) leaves BOTH flags false
+  # and the full matrix runs.
+  changes:
+    name: Detect changed surface
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # dorny/paths-filter reads the PR's changed-file list from the GitHub REST
+    # API on pull_request events -> needs pull-requests:read. Job-level
+    # permissions REPLACE the top-level grant, so contents:read is restated.
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      only_backend: ${{ steps.decide.outputs.only_backend }}
+      only_frontend: ${{ steps.decide.outputs.only_frontend }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          # 'some-with-excludes': a file matches a filter when it matches at
+          # least one pattern AND none of the negated ones. That lets `backend`
+          # be a true CATCH-ALL ("every changed file that is not frontend and not
+          # meta") instead of an allowlist that would have to be complete to be
+          # safe. Every changed file therefore lands in exactly one bucket, which
+          # is what makes "only_X means only X changed" literally true -- an
+          # unrecognised path (docs/**, *.md, a new root file) counts as backend
+          # rather than silently riding along under a narrowed suite.
+          # NOTE: this quantifier requires >= v4.0.3 (added upstream in PR #322);
+          # v4.0.2 rejects the input and throws, so do not lower the pin.
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            frontend:
+              - 'website/**'
+            meta:
+              - '.github/**'
+              - 'scripts/**'
+            backend:
+              - '**'
+              - '!website/**'
+              - '!.github/**'
+              - '!scripts/**'
+
+      - name: Decide surface
+        id: decide
+        env:
+          FRONTEND: ${{ steps.filter.outputs.frontend }}
+          BACKEND: ${{ steps.filter.outputs.backend }}
+          META: ${{ steps.filter.outputs.meta }}
+          # Escape hatch: the ci-full-run label forces the full matrix. NOTE:
+          # this workflow does not listen for the `labeled` event (that would
+          # re-run everything on every bot label), so the label takes effect on
+          # the NEXT push, not the instant it is applied.
+          FULL_RUN: ${{ contains(github.event.pull_request.labels.*.name, 'ci-full-run') }}
+        run: |
+          # A surface is "only" when it changed and NO other bucket did.
+          # `backend` is a catch-all, so an unrecognised path counts as backend
+          # and cannot ride along under a narrowed suite.
+          only_backend=false; only_frontend=false
+          if [ "$FULL_RUN" != "true" ] && [ "$META" != "true" ]; then
+            if [ "$BACKEND" = "true" ] && [ "$FRONTEND" != "true" ]; then only_backend=true; fi
+            if [ "$FRONTEND" = "true" ] && [ "$BACKEND" != "true" ]; then only_frontend=true; fi
+          fi
+          echo "only_backend=$only_backend"   >> "$GITHUB_OUTPUT"
+          echo "only_frontend=$only_frontend" >> "$GITHUB_OUTPUT"
+          echo "backend=$BACKEND frontend=$FRONTEND meta=$META full_run=$FULL_RUN -> only_backend=$only_backend only_frontend=$only_frontend"
+
   scrub-lint:
     name: De-Amazon Scrub Lint
     runs-on: ubuntu-latest
@@ -135,6 +236,7 @@ jobs:
 
   backend-test:
     name: Backend Tests
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -171,6 +273,32 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[voice,desktop]" --group dev
 
+      - name: Select test scope
+        id: scope
+        env:
+          ONLY_FRONTEND: ${{ needs.changes.outputs.only_frontend }}
+          TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
+        # A frontend-only diff cannot affect a backend test that never touches
+        # the frontend surface, so we run only the files the selector could NOT
+        # prove single-surface (every parity guard, plus anything unclassified).
+        # Every failure path here falls back to the FULL suite on purpose --
+        # never trade a missed test for a faster run.
+        run: |
+          if [ "$ONLY_FRONTEND" != "true" ]; then
+            echo "reduced=false" >> "$GITHUB_OUTPUT"
+            echo "Full backend suite (diff is not frontend-only)."
+            exit 0
+          fi
+          rc=0
+          python3 scripts/ci-surface-tests.py --surface backend --summary > "$TARGETS_FILE" || rc=$?
+          if [ "$rc" != "0" ] || [ ! -s "$TARGETS_FILE" ]; then
+            echo "::warning::surface selector unusable (rc=$rc) -- running the FULL backend suite."
+            echo "reduced=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "reduced=true" >> "$GITHUB_OUTPUT"
+          echo "Reduced scope: $(wc -l < "$TARGETS_FILE") cross-surface backend file(s)."
+
       - name: Run tests (shard ${{ matrix.group }}/${{ env.SHARD_COUNT }})
         # pytest-split slices the suite into SHARD_COUNT balanced groups. With a
         # committed .test_durations file the split is balanced by *recorded time*,
@@ -183,21 +311,28 @@ jobs:
         # a partial data file merged later by the coverage-combine job. 3.10
         # passes --no-cov (overriding setup.cfg's forced --cov) for a trace-free,
         # faster run.
+        env:
+          REDUCED: ${{ steps.scope.outputs.reduced }}
+          TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
         run: |
+          # Reduced scope (frontend-only diff): run just the cross-surface
+          # files, still sharded, with coverage off -- a subset's coverage is
+          # not comparable to the repo floor, so Coverage Combine/Gate skip the
+          # backend lane for this run (see coverage-gate).
+          if [ "$REDUCED" = "true" ]; then
+            TARGETS=()
+            while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then TARGETS+=("$line"); fi; done < "$TARGETS_FILE"
+            pytest -q -n auto --timeout=120 \
+              --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
+              --no-cov \
+              $BACKEND_DESELECTS \
+              "${TARGETS[@]}"
+            exit 0
+          fi
           pytest -q -n auto --timeout=120 \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
             ${{ matrix.python-version == '3.12' && '--cov=kiro_crew' || '--no-cov' }} \
-            --deselect=test/test_script_hooks.py \
-            --deselect=test/test_cron_script.py \
-            --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py \
-            --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_capture.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_perf_track_propose.py
+            $BACKEND_DESELECTS
         # Deselected tests require capabilities unavailable on GH Actions:
         #   test_script_hooks, test_cron_script: Linux namespace sandbox (unshare NEWNS)
         #   ops_mission_control test_ledger_sync_git, test_schedule_file: the same
@@ -224,7 +359,7 @@ jobs:
         #     job of their own is a follow-up, tracked in the PR body.
 
       - name: Stage shard coverage data
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.12' && steps.scope.outputs.reduced != 'true'
         # Fold any xdist parallel data files into a single .coverage (no-op if
         # pytest-cov already combined this shard), then name it per-shard so the
         # combine job can merge all shards with `coverage combine`.
@@ -234,7 +369,7 @@ jobs:
           mv .coverage ".coverage.${{ matrix.group }}"
 
       - name: Upload shard coverage
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.12' && steps.scope.outputs.reduced != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-shard-${{ matrix.group }}
@@ -254,6 +389,7 @@ jobs:
   # run the same tests measurably slower.
   backend-test-windows:
     name: Backend Tests (Windows)
+    needs: [changes]
     runs-on: windows-latest
     # windows-latest runs the same shards measurably slower than POSIX.
     timeout-minutes: 40
@@ -283,24 +419,50 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[voice,desktop]" --group dev
 
+      - name: Select test scope
+        id: scope
+        # bash (Git Bash on windows-latest), not pwsh -- same reason as the test
+        # step below. Mirrors the POSIX backend-test selector exactly.
+        shell: bash
+        env:
+          ONLY_FRONTEND: ${{ needs.changes.outputs.only_frontend }}
+          TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
+        run: |
+          if [ "$ONLY_FRONTEND" != "true" ]; then
+            echo "reduced=false" >> "$GITHUB_OUTPUT"
+            echo "Full backend suite (diff is not frontend-only)."
+            exit 0
+          fi
+          rc=0
+          python3 scripts/ci-surface-tests.py --surface backend --summary > "$TARGETS_FILE" || rc=$?
+          if [ "$rc" != "0" ] || [ ! -s "$TARGETS_FILE" ]; then
+            echo "::warning::surface selector unusable (rc=$rc) -- running the FULL backend suite."
+            echo "reduced=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "reduced=true" >> "$GITHUB_OUTPUT"
+          echo "Reduced scope: $(wc -l < "$TARGETS_FILE") cross-surface backend file(s)."
+
       - name: Run tests (Windows shard ${{ matrix.group }}/${{ env.SHARD_COUNT }})
         # bash (Git Bash on windows-latest), not pwsh: the invocation shares
         # the POSIX job's line-continuation and env-interpolation syntax.
         shell: bash
+        env:
+          REDUCED: ${{ steps.scope.outputs.reduced }}
+          TARGETS_FILE: ${{ runner.temp }}/backend-targets.txt
         run: |
+          if [ "$REDUCED" = "true" ]; then
+            TARGETS=()
+            while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then TARGETS+=("$line"); fi; done < "$TARGETS_FILE"
+            pytest -q -n auto --timeout=180 --no-cov \
+              --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
+              $BACKEND_DESELECTS \
+              "${TARGETS[@]}"
+            exit 0
+          fi
           pytest -q -n auto --timeout=180 --no-cov \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
-            --deselect=test/test_script_hooks.py \
-            --deselect=test/test_cron_script.py \
-            --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py \
-            --deselect=src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_capture.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py \
-            --deselect=src/kiro_crew/apps/builtins/auto_improvement/tests/test_perf_track_propose.py
+            $BACKEND_DESELECTS
         # Same deselects as backend-test (the Linux-namespace sandbox tests are
         # unavailable here too). The ops git/gh suites are deselected for a second reason as
         # well: they drive a real POSIX `git`/`gh` and the namespace-sandbox job that DOES run
@@ -423,7 +585,11 @@ jobs:
 
   coverage-combine:
     name: Coverage Combine
-    needs: backend-test
+    needs: [backend-test, changes]
+    # A frontend-only diff runs the backend suite as a coverage-free subset, so
+    # there are no shard artifacts to combine. Coverage Gate asserts this job is
+    # exactly `skipped` in that case, and `success` otherwise.
+    if: needs.changes.outputs.only_frontend != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -486,7 +652,7 @@ jobs:
     name: Coverage Gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [coverage-combine, frontend-test]
+    needs: [coverage-combine, frontend-test, backend-test, changes]
     # Always run so the required check emits a real verdict. Without
     # `if: always()`, a failing OR skipped dependency would SKIP this job, and
     # GitHub treats a skipped required check as SATISFIED -- silently defeating
@@ -499,26 +665,61 @@ jobs:
         env:
           CC: ${{ needs.coverage-combine.result }}
           FE: ${{ needs.frontend-test.result }}
+          BE: ${{ needs.backend-test.result }}
+          ONLY_BACKEND: ${{ needs.changes.outputs.only_backend }}
+          ONLY_FRONTEND: ${{ needs.changes.outputs.only_frontend }}
         run: |
-          echo "coverage-combine=$CC  frontend-test=$FE"
-          if [ "$CC" != "success" ] || [ "$FE" != "success" ]; then
-            echo "::error::Upstream coverage jobs did not succeed (coverage-combine=$CC, frontend-test=$FE) -- failing closed."
+          echo "coverage-combine=$CC  frontend-test=$FE  backend-test=$BE  only_backend=$ONLY_BACKEND  only_frontend=$ONLY_FRONTEND"
+          # Empty flags mean the surface-detection job never reported (it failed
+          # or was cancelled) -- its verdict can't be trusted, so fail closed.
+          if [ -z "$ONLY_BACKEND" ] || [ -z "$ONLY_FRONTEND" ]; then
+            echo "::error::surface detection (changes) never reported -- failing closed."
+            exit 1
+          fi
+          # Both test jobs always RUN (only their scope narrows), so both must
+          # always have succeeded -- a subset run that fails is still a failure.
+          # backend-test is checked explicitly because on a frontend-only diff
+          # coverage-combine is skipped by design and would otherwise be the only
+          # signal, masking a failed reduced backend suite.
+          if [ "$FE" != "success" ]; then
+            echo "::error::frontend-test=$FE -- failing closed."
+            exit 1
+          fi
+          if [ "$BE" != "success" ]; then
+            echo "::error::backend-test=$BE -- failing closed."
+            exit 1
+          fi
+          # Backend coverage lane: required to succeed, EXCEPT on a frontend-only
+          # diff where the backend suite ran as a coverage-free subset and
+          # coverage-combine is therefore skipped by design. Anything else
+          # (failure, cancellation, dependency-skip, or a run that happened when
+          # it shouldn't have) fails closed.
+          if [ "$ONLY_FRONTEND" = "true" ]; then
+            if [ "$CC" != "skipped" ]; then
+              echo "::error::coverage-combine=$CC but this run was frontend-only (expected exactly 'skipped') -- inconsistent."
+              exit 1
+            fi
+          elif [ "$CC" != "success" ]; then
+            echo "::error::coverage-combine=$CC -- failing closed."
             exit 1
           fi
 
       - name: Download backend coverage
+        if: needs.coverage-combine.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-backend
           path: backend-cov
 
       - name: Download frontend coverage
+        if: needs.changes.outputs.only_backend != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-frontend
           path: frontend-cov
 
       - name: Check backend coverage (min 70%)
+        if: needs.coverage-combine.result == 'success'
         run: |
           F=backend-cov/coverage.xml
           test -f "$F" || { echo "::error::coverage.xml missing from coverage-backend artifact"; exit 1; }
@@ -535,6 +736,7 @@ jobs:
           PY
 
       - name: Check frontend coverage (min 60%)
+        if: needs.changes.outputs.only_backend != 'true'
         run: |
           F=$(find frontend-cov -name 'cobertura*.xml' 2>/dev/null | head -1)
           test -n "$F" || { echo "::error::cobertura report missing from coverage-frontend artifact"; exit 1; }
@@ -740,6 +942,7 @@ jobs:
 
   frontend-test:
     name: Frontend Tests
+    needs: [changes]
     runs-on: ubuntu-latest
     # vitest + coverage is the longest ubuntu job (~23 min observed max).
     timeout-minutes: 50
@@ -756,6 +959,39 @@ jobs:
         working-directory: website
         run: npm ci --no-audit --no-fund
 
+      - name: Select test scope
+        id: scope
+        env:
+          ONLY_BACKEND: ${{ needs.changes.outputs.only_backend }}
+          TARGETS_FILE: ${{ runner.temp }}/frontend-targets.txt
+        # Mirror of the backend selector: a backend-only diff cannot affect a
+        # spec that never touches the backend surface. Cross-surface specs (and
+        # anything unclassified) still run. Any failure falls back to the FULL
+        # suite rather than silently narrowing it.
+        run: |
+          if [ "$ONLY_BACKEND" != "true" ]; then
+            echo "reduced=false" >> "$GITHUB_OUTPUT"
+            echo "Full frontend suite (diff is not backend-only)."
+            exit 0
+          fi
+          rc=0
+          python3 scripts/ci-surface-tests.py --surface frontend --summary > "$TARGETS_FILE.all" || rc=$?
+          if [ "$rc" != "0" ] || [ ! -s "$TARGETS_FILE.all" ]; then
+            echo "::warning::surface selector unusable (rc=$rc) -- running the FULL frontend suite."
+            echo "reduced=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # vitest runs with cwd=website and only covers website/src; the
+          # Electron shell specs belong to electron-test, which stays always-on.
+          sed -n 's#^website/##p' "$TARGETS_FILE.all" | grep -v '^electron/' > "$TARGETS_FILE" || true
+          if [ ! -s "$TARGETS_FILE" ]; then
+            echo "::warning::no in-scope cross-surface specs resolved -- running the FULL frontend suite."
+            echo "reduced=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "reduced=true" >> "$GITHUB_OUTPUT"
+          echo "Reduced scope: $(wc -l < "$TARGETS_FILE") cross-surface spec(s)."
+
       - name: Unit tests
         working-directory: website
         env:
@@ -767,6 +1003,8 @@ jobs:
           # Same expression as `frontend-lint`: the base branch on a PR, the commit the
           # push replaced on a push to main.
           I18N_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          REDUCED: ${{ steps.scope.outputs.reduced }}
+          TARGETS_FILE: ${{ runner.temp }}/frontend-targets.txt
         # `actions/checkout` fetches depth 1, so the base is not present and
         # `git diff`/`git show` against it would fail. Fetch just that one commit, and
         # fail the step if it cannot be fetched — the gates throw on an unresolvable
@@ -775,9 +1013,19 @@ jobs:
           I18N_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
             "$I18N_BASE_REF" 'the diff-scoped i18n test gates')" || exit 1
           export I18N_BASE_REF
-          npx vitest run --coverage
+          if [ "$REDUCED" = "true" ]; then
+            # Subset run (backend-only diff): coverage of a subset is not
+            # comparable to the repo floor, so it is not collected and the
+            # Coverage Gate skips the frontend lane for this run.
+            TARGETS=()
+            while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then TARGETS+=("$line"); fi; done < "$TARGETS_FILE"
+            npx vitest run "${TARGETS[@]}"
+          else
+            npx vitest run --coverage
+          fi
 
       - name: Upload coverage
+        if: steps.scope.outputs.reduced != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-frontend

--- a/scripts/ci-surface-tests.py
+++ b/scripts/ci-surface-tests.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Select the test files that must still run when a diff touches ONE surface.
+
+Why this exists
+---------------
+Most of this repo's tests only exercise their own surface, so a backend-only
+diff has no way to affect the frontend specs (and vice versa). Skipping the
+opposite surface's tests on a single-surface diff is a large CI saving.
+
+The catch is that a minority of tests are *cross-surface parity guards*: they
+live in one suite but assert against the OTHER surface's source (e.g. a pytest
+test that reads ``website/src/utils/sanitize.ts`` to prove the redaction mirror
+still matches, or an Electron test that reads
+``src/kiro_crew/computer_use/permissions.py``). Skipping one of those is how a
+drift bug ships green.
+
+So this script does NOT try to enumerate the guards (a list that must be
+complete to be safe). It inverts the question and enumerates only the files it
+can *positively prove* are single-surface. Everything else -- every guard, every
+file it cannot classify, every file added tomorrow -- lands in the must-run set
+and keeps running. A mistake in the heuristic therefore costs CI time, not a
+skipped guard.
+
+Usage
+-----
+    ci-surface-tests.py --surface backend    # pytest files that must still run
+    ci-surface-tests.py --surface frontend   # vitest/electron specs that must run
+
+Prints one repo-relative path per line (empty output = nothing needs to run).
+``--summary`` adds counts on stderr. Exit 2 on a usage/environment error, in
+which case the caller MUST fall back to running the full suite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# What counts as "the other surface" for a BACKEND (pytest) file.
+#
+# Deliberately broad: a bare mention of the frontend tree, the Electron shell,
+# the packaging/signing inputs, the skills tree or a TS/TSX filename is enough
+# to keep the file in the must-run set. Over-matching only costs CI time.
+# ---------------------------------------------------------------------------
+_BACKEND_FOREIGN = re.compile(
+    r"""
+      website              # the frontend tree, in any quoting/joining style
+    | electron
+    | packaging            # build-desktop.sh, signing entitlements, ...
+    | node_modules
+    | \bskills\b           # repo-root skills/ tree (read by some guards)
+    | \bdocker\b
+    | \.tsx?\b             # a TypeScript filename appearing in an assertion
+    | \.mjs\b
+    | \.plist\b
+    | entitlements
+    | \bnpm\b
+    | vitest
+    | playwright
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# ---------------------------------------------------------------------------
+# What counts as "the other surface" for a FRONTEND (vitest / electron) file.
+#
+# Two distinct escape styles both have to be caught, which is exactly what an
+# eyeball grep kept missing:
+#   1. string literals   -- '../../../src/kiro_crew/connections/registry.json'
+#   2. path segments     -- path.resolve(__dirname, '..', '..', '..', 'test')
+# ---------------------------------------------------------------------------
+_FRONTEND_FOREIGN = re.compile(
+    r"""
+      (?:\.\./){3,}                                  # ../../../ escape upward
+    | \.\.[\\/]\.\.[\\/]\.\.                          # ../../.. joined form
+    | (?:['"]\.\.['"]\s*,\s*){2,}                     # '..', '..', ... segments
+    | kiro_crew                                       # backend package by name
+    | \bpackaging\b
+    | \bskills\b
+    | test[\\/]fixtures                               # shared parity fixtures
+    | \bdocker\b
+    | \.py\b                                          # a Python file in an assertion
+    """,
+    re.VERBOSE,
+)
+
+# Backend test roots. MUST cover every entry in setup.cfg `testpaths` --
+# test_ci_surface_tests.py asserts exactly that, because an unenumerated root is
+# worse than an unclassified file: the reduced run passes explicit paths, so a
+# root that is never walked never runs at all (it does not fall back to
+# "keep running" the way an unclassifiable file does).
+_BACKEND_ROOTS = ("test", "transfer", "src/kiro_crew/apps/builtins")
+_BACKEND_GLOBS = ("test_*.py",)
+
+# Frontend spec roots. MUST cover every root in vitest's `test.include`
+# (website/vite.config.ts) -- test_ci_surface_tests.py asserts that, for the same
+# reason as _BACKEND_ROOTS: an unenumerated root is never walked, so it never
+# runs at all rather than falling back to "keep running".
+# website/electron is scanned too (its guards belong to the always-on
+# electron-test job); the frontend-test scope step filters it out before handing
+# paths to vitest.
+_FRONTEND_SPECS = (
+    ("website/src", ("*.test.ts", "*.test.tsx")),
+    ("website/integration", ("*.test.ts", "*.test.tsx")),
+    ("website/electron", ("*.test.js",)),
+)
+
+
+def _repo_root() -> Path:
+    """Resolve the repo root from this file's location (scripts/<me>)."""
+    return Path(__file__).resolve().parents[1]
+
+
+def _iter_files(root: Path, rel_dir: str, globs: tuple[str, ...]) -> list[Path]:
+    base = root / rel_dir
+    if not base.is_dir():
+        return []
+    found: list[Path] = []
+    for pattern in globs:
+        found.extend(base.rglob(pattern))
+    return [p for p in found if p.is_file() and "node_modules" not in p.parts]
+
+
+def _is_cross_surface(path: Path, pattern: re.Pattern[str]) -> bool:
+    """True when the file mentions the other surface -- or cannot be read.
+
+    Fail CLOSED: an unreadable/undecodable file is treated as cross-surface so
+    it keeps running. Never let an IO error silently drop a guard.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return True
+    return bool(pattern.search(text))
+
+
+def collect(surface: str) -> list[str]:
+    """Repo-relative paths that must still run for a single-surface diff."""
+    root = _repo_root()
+    must_run: list[str] = []
+
+    if surface == "backend":
+        for rel_dir in _BACKEND_ROOTS:
+            for path in _iter_files(root, rel_dir, _BACKEND_GLOBS):
+                if _is_cross_surface(path, _BACKEND_FOREIGN):
+                    must_run.append(path.relative_to(root).as_posix())
+    else:
+        for rel_dir, globs in _FRONTEND_SPECS:
+            for path in _iter_files(root, rel_dir, globs):
+                if _is_cross_surface(path, _FRONTEND_FOREIGN):
+                    must_run.append(path.relative_to(root).as_posix())
+
+    return sorted(set(must_run))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--surface",
+        required=True,
+        choices=("backend", "frontend"),
+        help="which suite to select files from",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="also print counts to stderr",
+    )
+    args = parser.parse_args(argv)
+
+    paths = collect(args.surface)
+
+    if args.summary:
+        root = _repo_root()
+        if args.surface == "backend":
+            total = sum(
+                len(_iter_files(root, d, _BACKEND_GLOBS)) for d in _BACKEND_ROOTS
+            )
+        else:
+            total = sum(len(_iter_files(root, d, g)) for d, g in _FRONTEND_SPECS)
+        print(
+            f"{args.surface}: {len(paths)} must-run / {total} total "
+            f"({total - len(paths)} provably single-surface, skippable)",
+            file=sys.stderr,
+        )
+
+    for rel in paths:
+        print(rel)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    sys.exit(main())

--- a/test/test_ci_surface_tests.py
+++ b/test/test_ci_surface_tests.py
@@ -1,0 +1,190 @@
+"""Tests for the CI surface-test selector (``scripts/ci-surface-tests.py``).
+
+The selector decides which tests must still run when a diff touches only ONE
+surface. Its contract is **deny-by-default**: it may only skip a file it can
+positively prove is single-surface, so a heuristic miss costs CI time rather
+than silently dropping a cross-surface parity guard.
+
+These tests pin that contract, because the failure mode they guard against is
+invisible: a guard quietly stops running and the drift it protects against
+ships green.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "scripts" / "ci-surface-tests.py"
+
+
+def _load_selector():
+    """Import the hyphenated script by path (not a normal module name)."""
+    spec = importlib.util.spec_from_file_location("ci_surface_tests", _SCRIPT)
+    assert spec and spec.loader, "could not build an import spec for the selector"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def selector():
+    return _load_selector()
+
+
+def test_script_exists_and_is_executable() -> None:
+    assert _SCRIPT.is_file(), f"missing selector script: {_SCRIPT}"
+
+
+# Known cross-surface parity guards. Each of these lives in one suite but
+# asserts against the OTHER surface's source, so each MUST stay in the must-run
+# set. Audited 2026-08-06; extend this list when a new guard is added.
+_BACKEND_GUARDS = (
+    "test/test_redaction_mirror_parity.py",
+    "test/test_dashboard_security_headers.py",
+    "test/test_model_registry_parity.py",
+    "test/test_builtin_app_assets.py",
+    "test/test_recovery_card_parity.py",
+    "test/test_artifact_import_parity.py",
+    "test/test_windows_signing_contract.py",
+    "test/test_meetings_routes.py",
+    # Under the third testpath root -- these were silently unscanned until
+    # src/kiro_crew/apps/builtins was added to _BACKEND_ROOTS.
+    "src/kiro_crew/apps/builtins/design_critique/tests/test_manifest.py",
+    "src/kiro_crew/apps/builtins/crew_companion/tests/test_manifest.py",
+    "src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py",
+)
+
+_FRONTEND_GUARDS = (
+    "website/src/test/appManifest.test.ts",
+    "website/src/test/featureRequestLabels.test.ts",
+    "website/src/test/themeCssCorpus.test.tsx",
+    "website/src/test/serveDist.routes.test.ts",
+    "website/electron/test/packaging.test.js",
+    "website/electron/test/external-scheme.test.js",
+    "website/electron/test/home-dir.test.js",
+)
+
+
+@pytest.mark.parametrize("guard", _BACKEND_GUARDS)
+def test_backend_guards_are_never_skipped(selector, guard: str) -> None:
+    """A pytest file that reads frontend source must stay in the must-run set."""
+    # Assert existence rather than skipping: a rename must FAIL here so this
+    # audited list gets updated, instead of silently going stale as a green skip.
+    assert (_REPO_ROOT / guard).exists(), (
+        f"{guard} was renamed or removed -- update _BACKEND_GUARDS so the audited "
+        "cross-surface list cannot go stale."
+    )
+    assert guard in selector.collect("backend"), (
+        f"{guard} reads the frontend surface but was classified single-surface; "
+        "it would be SKIPPED on a frontend-only diff, defeating the guard."
+    )
+
+
+@pytest.mark.parametrize("guard", _FRONTEND_GUARDS)
+def test_frontend_guards_are_never_skipped(selector, guard: str) -> None:
+    """A spec that reads backend source must stay in the must-run set."""
+    assert (_REPO_ROOT / guard).exists(), (
+        f"{guard} was renamed or removed -- update _FRONTEND_GUARDS so the audited "
+        "cross-surface list cannot go stale."
+    )
+    assert guard in selector.collect("frontend"), (
+        f"{guard} reads the backend surface but was classified single-surface; "
+        "it would be SKIPPED on a backend-only diff, defeating the guard."
+    )
+
+
+def test_backend_roots_cover_every_configured_testpath() -> None:
+    """Every setup.cfg `testpaths` entry must be a scanned root.
+
+    This is the contract that actually keeps the selector honest. A test file
+    under an unenumerated root is not "unclassified but still running" -- the
+    reduced run passes explicit paths, so it never runs at all. Adding a new
+    testpath without adding it here must fail loudly.
+    """
+    import configparser
+
+    parser = configparser.ConfigParser()
+    parser.read(_REPO_ROOT / "setup.cfg")
+    configured = parser.get("tool:pytest", "testpaths").split()
+    assert configured, "setup.cfg declares no testpaths -- selector cannot be verified"
+    missing = [p for p in configured if p not in _load_selector()._BACKEND_ROOTS]
+    assert not missing, (
+        f"setup.cfg testpaths {missing} are not scanned by the selector's "
+        "_BACKEND_ROOTS, so every test under them would be SKIPPED (never run) "
+        "on a frontend-only diff. Add them to _BACKEND_ROOTS."
+    )
+
+
+def test_frontend_spec_roots_cover_vitest_include(selector) -> None:
+    """Every root in vitest's `test.include` must be a scanned frontend root.
+
+    The mirror of the backend contract above. vitest overrides `include` in
+    website/vite.config.ts, so that list -- not the vitest default -- is the
+    authoritative set of specs the frontend job runs. A root missing here is
+    dropped wholesale on a backend-only diff.
+    """
+    config = (_REPO_ROOT / "website" / "vite.config.ts").read_text(encoding="utf-8")
+    # The test-config include is the one listing *.test.* globs (the other
+    # `include:` in this file belongs to the coverage config).
+    block = re.search(r"include:\s*\[([^\]]*\.test\.[^\]]*)\]", config)
+    assert block, "could not locate vitest test.include in website/vite.config.ts"
+    globs = re.findall(r"['\"]([^'\"]+)['\"]", block.group(1))
+    assert globs, "vitest test.include parsed empty"
+
+    scanned = {d for d, _ in selector._FRONTEND_SPECS}
+    missing = sorted(
+        f"website/{g.split('/', 1)[0]}"
+        for g in globs
+        if f"website/{g.split('/', 1)[0]}" not in scanned
+    )
+    assert not missing, (
+        f"vitest test.include covers {missing}, which the selector's "
+        "_FRONTEND_SPECS does not scan -- those specs would be SKIPPED (never "
+        "run) on a backend-only diff. Add them to _FRONTEND_SPECS."
+    )
+
+
+def test_selection_is_a_strict_subset(selector) -> None:
+    """The must-run set must be smaller than the suite (else there is no saving)."""
+    backend = selector.collect("backend")
+    frontend = selector.collect("frontend")
+    assert backend, "expected at least one cross-surface backend file"
+    assert frontend, "expected at least one cross-surface frontend spec"
+    total_backend = sum(
+        len(selector._iter_files(_REPO_ROOT, d, selector._BACKEND_GLOBS))
+        for d in selector._BACKEND_ROOTS
+    )
+    assert len(backend) < total_backend, "selector skipped nothing -- no CI saving"
+
+
+def test_unreadable_file_is_treated_as_cross_surface(selector, tmp_path) -> None:
+    """Fail CLOSED: an IO error must keep the file running, not drop it."""
+    missing = tmp_path / "does-not-exist.py"
+    assert selector._is_cross_surface(missing, selector._BACKEND_FOREIGN) is True
+
+
+def test_pure_backend_file_is_classified_single_surface(selector, tmp_path) -> None:
+    """A file with no other-surface reference is skippable (the actual saving)."""
+    pure = tmp_path / "test_pure.py"
+    pure.write_text("from kiro_crew import config\n\n\ndef test_x():\n    assert config\n")
+    assert selector._is_cross_surface(pure, selector._BACKEND_FOREIGN) is False
+
+
+def test_frontend_escape_patterns_are_detected(selector, tmp_path) -> None:
+    """Both escape styles must be caught -- the string form AND the segment form."""
+    literal = tmp_path / "a.test.ts"
+    literal.write_text("import x from '../../../src/kiro_crew/connections/registry.json'\n")
+    assert selector._is_cross_surface(literal, selector._FRONTEND_FOREIGN) is True
+
+    segments = tmp_path / "b.test.js"
+    segments.write_text("const R = path.resolve(__dirname, '..', '..', '..', 'test');\n")
+    assert selector._is_cross_surface(segments, selector._FRONTEND_FOREIGN) is True
+
+    inside = tmp_path / "c.test.tsx"
+    inside.write_text("import { Button } from '../../components/ui'\n")
+    assert selector._is_cross_surface(inside, selector._FRONTEND_FOREIGN) is False


### PR DESCRIPTION
## Problem

Every PR runs the full CI matrix regardless of what it touches. A frontend-only diff runs all 8 backend shards plus 4 Windows shards; a backend-only diff runs the whole vitest suite. Most of those tests cannot be affected by the diff at all (#1556).

## Why it matters

Wasted compute and slower feedback on every PR, plus noise that buries the checks that actually matter, and needless fork-approval toil.

## Fix (symptoms → root cause → change)

Symptom: irrelevant tests run on single-surface PRs. Root cause: jobs have no notion of which surface a diff touches.

The obvious fix — gate a whole suite on changed paths — is **unsafe in this repo**, and that is the crux. A minority of tests are **cross-surface parity guards**: they live in one suite but assert against the *other* surface's source. Examples: backend `test_redaction_mirror_parity.py` reads `website/src/utils/sanitize.ts` (credential-redaction parity); `website/electron/test/external-scheme.test.js` reads `src/kiro_crew/computer_use/permissions.py`. Skipping one of those is exactly how a drift bug ships green, and an allowlist of "paths that make a suite skippable" has to be **complete** to be safe — it never is.

So the logic is inverted. `scripts/ci-surface-tests.py` enumerates only the files it can positively **prove** are single-surface; everything else — every parity guard, every file it cannot classify, every file added tomorrow — stays in the must-run set. A heuristic miss therefore costs CI time, never a skipped guard. It fails closed on an unreadable file, and **every** failure path in the workflow falls back to running the full suite.

A new `changes` job computes `only_backend` / `only_frontend` once. `backend` is a **catch-all** filter (`['**', '!website/**', '!.github/**', '!scripts/**']`), so every changed file lands in exactly one bucket and "only_X" literally means only X changed — a diff touching two buckets, or meta paths, leaves both flags false and the full matrix runs. On a single-surface diff the opposite suite narrows:

| Diff | Effect |
|---|---|
| frontend-only | `backend-test` + `backend-test-windows` run **223 of 1033** files |
| backend-only | `frontend-test` runs **81 of 758** spec files |
| anything else | full matrix, unchanged |

The catch-all requires `dorny/paths-filter >= v4.0.3` for the `some-with-excludes` quantifier (v4.0.2 rejects the input and throws), so the pin moves v4.0.2 → v4.0.3 `ceb8a2b8`.

**The scanned roots matter more than the classifier.** An unenumerated root is worse than an unclassified file: the reduced run passes explicit paths, so a root that is never walked never runs *at all*, instead of falling back to "keep running". The selector therefore walks every root in `setup.cfg` `testpaths` (`test`, `transfer`, `src/kiro_crew/apps/builtins`) and every root in vitest's `test.include` (`website/src`, `website/integration`) — and the test suite asserts that, so adding a testpath or vitest include without adding it here fails loudly.

`electron-test`, `frontend-lint`, `backend-lint` and the sandbox job stay always-on: they are whole-project gates or hold cross-surface guards, and subsetting them buys little.

Coverage Gate keeps its fail-closed contract as an explicit invariant. A narrowed run collects no coverage (a subset's coverage is not comparable to the repo floor), so Coverage Combine is skipped on a frontend-only diff, and the gate asserts: `backend-test` **and** `frontend-test` must always succeed (only their scope narrows — `backend-test` is checked directly so a failed reduced run cannot hide behind a by-design skipped Combine); backend coverage is required unless the run was frontend-only (where Combine must be exactly `skipped`); empty surface flags — the detection job never reported — fail closed.

## Tests

`test/test_ci_surface_tests.py` (new, 25 cases) pins the deny-by-default contract:
- 18 known parity guards can never be classified single-surface — and it **asserts they exist**, so a rename forces the list to be updated instead of silently becoming a green skip.
- Every `setup.cfg` testpath and every vitest include root is a scanned root (the two checks that catch the "root never walked" class).
- Both frontend escape styles are detected: `'../../..'` string literals **and** `path.resolve(__dirname, '..', '..', '..')` segment lists.
- An unreadable file is treated as cross-surface (fails closed).

Also verified locally: flake8 / isort / mypy clean, YAML valid, and the reduced 223-file selection collects cleanly under pytest.

## Manual verification

N/A — CI workflow change; correctness is exercised by CI on this PR. This PR touches `.github/**` → `meta` → it runs the **full matrix on itself**, which is the conservative branch. The narrowing paths are covered by the unit tests above.

## Known limitations

- The classifier reads each file's text, not its import graph, so an *indirect* cross-surface dependency (a test importing a helper that reads the other surface) is a structural residual risk. Both local reviewers probed for one and found no live instance; the always-run default means a miss costs CI time rather than a lost guard.
- The `ci-full-run` label forces the full matrix but takes effect on the **next push** — this workflow does not subscribe to the `labeled` event, because that would re-run everything on every bot label. Documented in-code at the `FULL_RUN` step.
- On the rare selector-fallback path (frontend-only diff *and* the selector errors), the backend shards run with coverage but Combine is skipped, so the 70% backend floor is not enforced for that run. Harmless — a frontend-only diff cannot move backend coverage — and the gate stays fail-closed.

## Attribution

Supersedes #1560. Original authorship by @RohanK6 is preserved on the commit; the implementation was reworked from the original path-gating approach to the deny-by-default selector after path-allowlisting proved unsafe in review (fixes folded in as committer).

Closes #1556
