### PR TITLE
fix(slack): make one safe render pipeline the only way text reaches Slack

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5223,16 +5223,17 @@ async def _run_chat(
                 from kiro_crew.slack.format import (  # circular: slack.format -> dashboard.state -> chat
                     build_options_blocks,
                     extract_options,
-                    split_message,
-                    to_slack_mrkdwn,
+                    render_for_slack,
                 )
 
-                _mirror_text = to_slack_mrkdwn(assistant_text)
-                _mirror_text = redact_exfiltration_urls(_mirror_text)[0]
-                _mirror_text = redact_credentials(_mirror_text)[0]
-                _mirror_text, _mirror_options = extract_options(_mirror_text)
+                # Extract the OPTIONS tag from the RAW text, before rendering.
+                # It is a plain-text marker, so pulling it off after conversion
+                # means whatever conversion did to the tail decides whether the
+                # controls render at all -- and a >39,000-char turn used to lose
+                # the tag entirely to to_slack_mrkdwn's self-truncation.
+                _mirror_body, _mirror_options = extract_options(assistant_text)
 
-                for _part in split_message(_mirror_text):
+                for _part in render_for_slack(_mirror_body):
                     await state.slack_client.post_message(_mirror_chan, _part, _mirror_thread)
                 if _mirror_options:
                     await state.slack_client.post_blocks(

--- a/src/kiro_crew/dashboard/chat_slack.py
+++ b/src/kiro_crew/dashboard/chat_slack.py
@@ -23,13 +23,7 @@ from kiro_crew.platform.context import redact_via_context
 from kiro_crew.security import redact_and_truncate
 from kiro_crew.sel import sel
 from kiro_crew.slack.channel_resolver import _CACHE_FILENAME, ChannelNameResolver
-from kiro_crew.slack.format import (
-    SLACK_MAX_TEXT,
-    SLACK_MSG_LIMIT,
-    split_message,
-    strip_ansi,
-    to_slack_mrkdwn,
-)
+from kiro_crew.slack.format import render_for_slack
 from kiro_crew.sync_bridge import handoff_to_slack
 
 logger = logging.getLogger(__name__)
@@ -70,54 +64,16 @@ _USER_ICON = "\U0001f9d1"
 _AGENT_ICON = "\U0001f916"
 
 
-def _format_backfill_parts(content: str) -> list[str]:
-    """Normalise, redact, convert to Slack mrkdwn, redact again, then split.
+def _format_backfill_parts(content: str, icon: str) -> list[str]:
+    """Render one transcript row into postable Slack parts, icon included.
 
-    ANSI escapes are stripped FIRST, before any redaction. ``to_slack_mrkdwn``
-    strips them itself, and that strip can *reassemble* a credential the escapes
-    had broken up -- so a secret written as ``AKIA<esc>IOSF...`` is invisible to
-    the regex until the strip happens. Normalising up front means the first
-    redaction pass sees the credential whole, while the text is still one piece.
-    Redacting per block after the strip is NOT equivalent: if the split boundary
-    falls inside the credential, each block holds only an unmatchable fragment
-    and two adjacent posts reassemble it for the reader.
-
-    Redaction then runs over the whole normalised text, because
-    ``to_slack_mrkdwn`` self-truncates at ``SLACK_MAX_TEXT`` before converting:
-    converting first would cut a credential at that boundary and leave a prefix
-    the regex no longer matches.
-
-    It runs a second time on each converted block, because conversion can still
-    reorder or drop characters (inline markup, link rewriting) in ways that
-    reveal a secret only afterwards. Redacting on both sides of the transform is
-    what makes the guarantee independent of what conversion does to the bytes.
-
-    The pre-split into blocks below the limit exists for that same truncation
-    reason: converting the whole message and splitting after would silently drop
-    everything past 39,000 characters -- the tail loss the 2,000-char cap used to
-    cause, just further out. Blocks are halved against the limit so a conversion
-    that *grows* text (table and mermaid rewriting) still cannot reach it.
-
-    When -- and only when -- that split actually produces more than one block,
-    tables are left as raw markdown. ``_convert_tables`` keys a table's labels off
-    the first ``|`` row it sees, so a block beginning part-way through a table
-    adopts a DATA row as its header: that row's values are then only ever emitted
-    as labels (and vanish entirely if no data rows follow it, because
-    ``_flush_table`` returns early on an empty body), while every later row is
-    labelled with the wrong names. Raw pipes read worse on mobile than the
-    vertical-list conversion, which is why this is not the default -- but a
-    message that never splits keeps the nicer rendering, and one that does keeps
-    all of its rows.
+    Thin delegate to :func:`kiro_crew.slack.format.render_for_slack`, which owns
+    the redact/convert/split ordering this path used to implement privately. The
+    icon is passed as the prefix rather than prepended afterwards: decorating a
+    maximally-sized part after the split pushed it past ``SLACK_MSG_LIMIT`` by
+    the width of the icon plus its space.
     """
-    cleaned = redact_via_context(strip_ansi(content or ""))
-    blocks = split_message(cleaned, limit=SLACK_MAX_TEXT // 2)
-    # A single block IS the whole message, so no table can be straddled.
-    keep_tables = len(blocks) > 1
-    parts: list[str] = []
-    for block in blocks:
-        converted = redact_via_context(to_slack_mrkdwn(block, keep_tables=keep_tables))
-        parts.extend(split_message(converted, limit=SLACK_MSG_LIMIT))
-    return parts
+    return render_for_slack(content, prefix=f"{icon} ", redactor=redact_via_context)
 
 
 async def drain_slack_backfill(
@@ -163,8 +119,8 @@ async def drain_slack_backfill(
 
     for row in selection.first_turn:
         icon = _USER_ICON if row.get("role") == "user" else _AGENT_ICON
-        for part in _format_backfill_parts(backfill_content(row)):
-            if not await _post(f"{icon} {part}"):
+        for part in _format_backfill_parts(backfill_content(row), icon):
+            if not await _post(part):
                 return
 
     if selection.skipped_turns and selection.recent:
@@ -182,8 +138,8 @@ async def drain_slack_backfill(
 
     for row in selection.recent_rows:
         icon = _USER_ICON if row.get("role") == "user" else _AGENT_ICON
-        for part in _format_backfill_parts(backfill_content(row)):
-            if not await _post(f"{icon} {part}"):
+        for part in _format_backfill_parts(backfill_content(row), icon):
+            if not await _post(part):
                 return
 
 

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -313,14 +313,30 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "the same output-boundary reason as the app activity log.",
     ),
     (
+        "Slack render pipeline",
+        "slack/format.py",
+        "The Slack RENDERING boundary: text that is converted to mrkdwn goes "
+        "through render_for_slack / render_one_for_slack, and a build gate "
+        "(test_slack_render_pipeline.py) fails if any module calls "
+        "to_slack_mrkdwn itself. Both helpers strip ANSI and run "
+        "redact_via_context BEFORE conversion and again after, because neither "
+        "ordering is safe alone -- the ANSI strip inside to_slack_mrkdwn "
+        "reassembles a credential the escapes had broken up, while its 39k "
+        "self-truncation cuts one into an unmatchable prefix. Text is pre-split "
+        "below that ceiling so conversion never truncates, and OPTIONS choice "
+        "labels are redacted before the Block Kit slices. SCOPE, stated exactly: "
+        "the gate polices the CONVERSION primitive, not the Slack API calls -- a "
+        "path that posts raw text without ever converting it is not covered here "
+        "and relies on its own redaction.",
+    ),
+    (
         "Slack session mirror",
         "dashboard/chat_slack.py",
         "Thread titles and the conversation history seeded into a newly linked "
         "thread. Titles go through redact_and_truncate (redaction BEFORE "
         "truncation, so a truncation boundary cannot split and hide a "
-        "credential); history goes through redact_via_context BEFORE mrkdwn "
-        "conversion, because to_slack_mrkdwn self-truncates at 39k and would "
-        "otherwise cut a credential into an unmatchable prefix.",
+        "credential); history is delegated to the shared Slack render pipeline "
+        "above with redact_via_context injected as its redactor.",
     ),
     (
         "Configured-channel session mirror",

--- a/src/kiro_crew/slack/format.py
+++ b/src/kiro_crew/slack/format.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import re
+from typing import Callable, NamedTuple
 
 from kiro_crew.constants import OPTIONS_RE_LINE
+from kiro_crew.platform.context import redact_via_context
 
 SLACK_MAX_TEXT = 39_000
 
@@ -45,14 +47,47 @@ def extract_options(text: str) -> tuple[str, list[str]]:
     return cleaned, choices
 
 
-def build_options_blocks(choices: list[str]) -> list[dict]:
+def _redact_choices(
+    choices: list[str],
+    redactor: Callable[[str], str] | None,
+) -> list[str]:
+    """Normalise and redact OPTIONS choices before they are put on Slack.
+
+    Choice text is LLM-authored and reaches Slack through Block Kit, which no
+    redactor covers: ``build_options_blocks`` embeds it in a ``plain_text``
+    label and in the button ``value`` that is echoed back into the session on
+    submit. So a turn ending ``[OPTIONS: Retry with AKIA… | Abort]`` would put
+    the key on the wire and then read it back.
+
+    Redaction happens HERE, at the sink, rather than at each caller, for the
+    same reason the message pipeline was hoisted: a caller that extracts the
+    tag from raw text (which it must, so conversion's 39,000-char truncation
+    cannot eat the tag) would otherwise hand over unscanned choices, and every
+    future caller would have to remember. It runs BEFORE the ``[:75]`` / ``[:150]``
+    slices below, because slicing first can cut a credential into a prefix the
+    regex no longer matches -- the same hazard as the conversion ceiling.
+    """
+    if redactor is None:
+        redactor = redact_via_context
+    # redact_for_display, not the bare redactor: a selected choice is echoed back
+    # in a mrkdwn summary, so Slack strips its markup and a backtick- or
+    # emphasis-split key would be whole on screen -- the same vector as the body.
+    return [redact_for_display(choice or "", redactor)[0] for choice in choices]
+
+
+def build_options_blocks(
+    choices: list[str],
+    *,
+    redactor: Callable[[str], str] | None = None,
+) -> list[dict]:
     """Build Slack Block Kit checkboxes + Send button for multi-select OPTIONS."""
+    safe = _redact_choices(choices[:10], redactor)  # checkboxes support up to 10
     options = [
         {
             "text": {"type": "plain_text", "text": choice[:75]},
             "value": choice[:150],
         }
-        for choice in choices[:10]  # checkboxes support up to 10
+        for choice in safe
     ]
     return [
         {
@@ -74,13 +109,18 @@ def build_options_blocks(choices: list[str]) -> list[dict]:
     ]
 
 
-def build_options_selected_blocks(choices: list[str], selected_indices: list[int] | int) -> list[dict]:
+def build_options_selected_blocks(
+    choices: list[str],
+    selected_indices: list[int] | int,
+    *,
+    redactor: Callable[[str], str] | None = None,
+) -> list[dict]:
     """Render OPTIONS as static text with selected choices highlighted."""
     if isinstance(selected_indices, int):
         selected_indices = [selected_indices]
     selected_set = set(selected_indices)
     parts = []
-    for i, choice in enumerate(choices[:10]):
+    for i, choice in enumerate(_redact_choices(choices[:10], redactor)):
         if i in selected_set:
             parts.append(f"*{choice[:72]}*")
         else:
@@ -138,8 +178,43 @@ def build_link_dashboard_button() -> dict:
     }
 
 
-def to_slack_mrkdwn(text: str, *, keep_tables: bool = False) -> str:
-    """Convert LLM markdown to Slack mrkdwn format."""
+def ends_inside_code_fence(text: str, start: bool = False) -> bool:
+    """Whether *text* leaves the reader inside a ``` fenced block.
+
+    Companion to ``to_slack_mrkdwn(..., in_code=...)``: a caller that converts
+    text in blocks uses this to carry fence state from one block to the next.
+    Counts the same toggles the converter does, so the two cannot disagree.
+    """
+    in_code = start
+    for line in text.split("\n"):
+        if line.strip().startswith("```"):
+            in_code = not in_code
+    return in_code
+
+
+def to_slack_mrkdwn(text: str, *, keep_tables: bool = False, in_code: bool = False) -> str:
+    """Convert LLM markdown to Slack mrkdwn format.
+
+    **Do not call this to put text on Slack.** Use :func:`render_for_slack` (or
+    :func:`render_one_for_slack`) instead — a build gate
+    (``test_slack_render_pipeline.py``) fails if any module outside this one calls
+    this function, and there are currently zero such callers.
+
+    The reason is not style. This function strips ANSI escapes and self-truncates
+    at ``SLACK_MAX_TEXT`` before converting, and each of those defeats credential
+    redaction from a different side, so there is no ordering a call site can pick
+    that is safe on its own: redact-then-convert lets the ANSI strip *reassemble*
+    a credential the escapes had split, and convert-then-redact lets the
+    truncation cut one into an unmatchable prefix. The render helpers exist to
+    hold the only ordering that closes both.
+
+    ``in_code`` says the text BEGINS inside a ``` fenced block. It exists for
+    callers that convert in blocks: fence state is per-call, so a block starting
+    mid-fence would otherwise be treated as prose and have its code lines rewritten
+    by inline conversion. A fenced region can be longer than any block size, so
+    choosing cut points cannot avoid this -- the state has to be carried. Use
+    :func:`ends_inside_code_fence` to compute it for the next block.
+    """
     text = strip_ansi(text)
 
     if len(text) > SLACK_MAX_TEXT:
@@ -153,12 +228,14 @@ def to_slack_mrkdwn(text: str, *, keep_tables: bool = False) -> str:
             cut = SLACK_MAX_TEXT
         text = f"{text[:cut]}\n\n_…truncated ({len(text)} chars total)_"
 
-    if not keep_tables:
-        text = _convert_tables(text)
-    text = _convert_mermaid(text)
+    # Table and mermaid conversion scan for their own markers, which a block
+    # opening mid-fence would find INSIDE code. Skip both while in a fence.
+    if not in_code:
+        if not keep_tables:
+            text = _convert_tables(text)
+        text = _convert_mermaid(text)
 
     out: list[str] = []
-    in_code = False
     for line in text.split("\n"):
         stripped = line.strip()
         if stripped.startswith("```"):
@@ -395,3 +472,370 @@ def split_message(text: str, limit: int = SLACK_MSG_LIMIT) -> list[str]:
             parts.append(text[:cut])
         text = remainder
     return parts
+
+
+_EMPHASIS_RUN = re.compile(r"[*_~`]+")
+# ``[label](url)`` (Markdown) and ``<url|label>`` (Slack mrkdwn). Both DISPLAY only
+# the label, so the url is invisible to a reader and the label joins whatever
+# surrounds it -- which makes them a splitter, exactly like ``**``.
+#
+# The opening delimiter is excluded from every inner class (no ``[`` inside the
+# Markdown label, no ``<`` inside the Slack one). That is not cosmetic: with ``[``
+# allowed, input like ``[[[[[[...`` makes each start position consume the whole
+# remaining string before failing to find ``]``, so the scan is quadratic in the
+# length of attacker-supplied text (CodeQL ``py/polynomial-redos``). Excluding it
+# makes a failed start fail immediately, which matters because this runs on every
+# outbound message. A label containing a literal ``[`` is simply not collapsed --
+# safe, since the fallback is to scan the text as written.
+_MD_LINK = re.compile(r"\[([^\[\]\n]*)\]\(([^()\n]*)\)")
+_SLACK_LINK = re.compile(r"<([^<>|\n]*)\|([^<>\n]*)>")
+
+
+def _canonicalize_display(text: str) -> str:
+    """Reduce *text* to what Slack will actually SHOW a reader.
+
+    Two families of markup, one property: Slack removes them at render time, so a
+    credential broken across them is whole on screen while every literal scan sees
+    it broken.
+
+    * **links** collapse to their label -- ``[AKIA](https://x)REST`` displays as
+      the joined key, with the url nowhere in sight;
+    * **emphasis / code delimiters** vanish -- ``AKIA**REST**`` likewise.
+
+    Links are reduced FIRST: a url can itself contain ``_`` or ``~``, and dropping
+    those before the url is removed would corrupt the label boundaries.
+    """
+    out = _MD_LINK.sub(r"\1", text)
+    out = _SLACK_LINK.sub(r"\2", out)
+    return _EMPHASIS_RUN.sub("", out)
+
+
+def redact_for_display(text: str, redactor: Callable[[str], str]) -> tuple[str, bool]:
+    """Redact *text* against what Slack will actually DISPLAY, not just the bytes.
+
+    Two normalisations, for the same underlying reason: a transformation applied
+    *after* the scan can reassemble a credential the scanner saw as broken.
+
+    1. **ANSI escapes** -- stripped outright, because they are display noise with
+       no meaning to preserve.
+    2. **Link markup and emphasis/code delimiters** -- these DO carry meaning, so
+       they cannot simply be deleted. Instead the canonical (display) form is
+       scanned as well. Neither ``AKIA**<rest>**`` nor ``[AKIA](https://x)<rest>``
+       matches a credential pattern as written, yet Slack renders the markup away
+       and shows the reader an intact key.
+
+    When the canonical form reveals a secret that the literal form hid, the
+    canonical text is emitted -- so the message loses that markup. That is
+    deliberate and one-directional: formatting is worth less than a credential, and
+    the downgrade only happens on a message that actually contains one.
+
+    Returns:
+        ``(safe_text, redacted)``. ``redacted`` is True when the redactor changed
+        anything, by either route -- callers that already published the text rely
+        on it to go back and replace what is visible.
+    """
+    stripped = strip_ansi(text or "")
+    safe = redactor(stripped)
+    changed = safe != stripped
+
+    canonical = _canonicalize_display(safe)
+    if canonical != safe:
+        canonical_safe = redactor(canonical)
+        if canonical_safe != canonical:
+            # The markup was hiding a credential from the scan. Emit the canonical,
+            # redacted form: losing formatting beats leaking the key.
+            return canonical_safe, True
+    return safe, changed
+
+
+def _render_blocks(
+    text: str,
+    *,
+    presplit: Callable[[str, int], list[str]],
+    keep_tables: bool | None,
+    redactor: Callable[[str], str],
+) -> tuple[list[str], bool]:
+    """THE ordering core, shared by both public render forms.
+
+    ``strip_ansi -> redact -> pre-split -> convert -> redact``, once. The two
+    public forms differ only in how they ASSEMBLE the result (separate posts vs
+    one joined message) and in which pre-splitter they need; the security-critical
+    part -- the order these steps run in -- lives here so an ordering fix cannot
+    land in one form and silently miss the other.
+
+    Args:
+        text: Raw text.
+        presplit: How to cut the normalised text into conversion-sized blocks.
+            The multi-part form uses ``split_message`` (its blocks become separate
+            posts, so its continuation markers are wanted); the collapsed form
+            uses :func:`_lossless_blocks` (its blocks are rejoined, so the split
+            must be invisible).
+        keep_tables: ``True`` forces raw tables; ``None``/``False`` derives it from
+            whether a split occurred. The flag can only ADD rawness -- see
+            :func:`render_one_for_slack`.
+        redactor: Text-to-text redactor.
+
+    Returns:
+        ``(converted_blocks, redaction_fired)``. ``converted_blocks`` is empty when
+        there was nothing to say. ``redaction_fired`` is True when either pass
+        changed the text -- the signal a caller that already published the text
+        needs in order to go back and replace it.
+    """
+    changed = False
+
+    def _redact(value: str) -> str:
+        """Redact, remembering whether it actually changed anything.
+
+        Only the redactor's effect counts. The ANSI strip also changes text, but
+        stripping escapes is normalisation, not a disclosure that was caught.
+        """
+        nonlocal changed
+        out = redactor(value)
+        if out != value:
+            changed = True
+        return out
+
+    # First pass goes through redact_for_display, which also cross-checks the
+    # delimiter-canonical form -- Slack renders emphasis away, so a key split by
+    # ``**`` is whole to the reader while both literal scans miss it.
+    cleaned, first_changed = redact_for_display(text, redactor)
+    changed = changed or first_changed
+    if not cleaned.strip():
+        return [], changed
+
+    blocks = presplit(cleaned, SLACK_MAX_TEXT // 2)
+    # A single block IS the whole message, so no table can be straddled.
+    resolved_keep_tables = bool(keep_tables) or len(blocks) > 1
+    out: list[str] = []
+    # Fence state is per-conversion-call, so it has to be carried across blocks: a
+    # block that opens mid-``` would otherwise have its code lines rewritten as
+    # prose. A fenced region can exceed the block size, so no cut point avoids it.
+    in_code = False
+    for block in blocks:
+        out.append(
+            _redact(to_slack_mrkdwn(block, keep_tables=resolved_keep_tables, in_code=in_code))
+        )
+        in_code = ends_inside_code_fence(block, in_code)
+    return out, changed
+
+
+def render_for_slack(
+    text: str,
+    *,
+    limit: int = SLACK_MSG_LIMIT,
+    prefix: str = "",
+    header: str = "",
+    redactor: Callable[[str], str] | None = None,
+) -> list[str]:
+    """Render arbitrary text into postable Slack messages, redacting safely.
+
+    This is the ONLY supported way to put text on Slack. It exists because the
+    two obvious orderings of redact-vs-convert are each unsafe on their own, so
+    a call site that picks one is exposed to whichever hazard it did not pick:
+
+    - **redact then convert** — ``to_slack_mrkdwn`` calls :func:`strip_ansi`,
+      and that strip *reassembles* a credential the escapes had broken up. A key
+      written as ``AKIA<esc>IOSF…`` does not match the credential regex on the
+      way in and arrives at Slack whole.
+    - **convert then redact** — ``to_slack_mrkdwn`` self-truncates at
+      ``SLACK_MAX_TEXT`` before converting, so it can cut a credential in half
+      before the regex ever runs, leaving an unmatchable prefix on the wire (and
+      silently dropping everything past 39,000 characters).
+
+    The pipeline that holds is therefore::
+
+        strip_ansi -> redact -> pre-split -> convert -> redact -> split
+
+    Normalising first means the first redaction sees the credential whole while
+    the text is still one piece. Pre-splitting below ``SLACK_MAX_TEXT`` means
+    conversion never reaches its own truncation, so neither the tail nor a
+    secret is cut there; blocks are halved against the limit so a conversion
+    that *grows* text (table and mermaid rewriting) still cannot reach it.
+    Redaction runs a second time on each converted block because conversion can
+    still reorder or drop characters (inline markup, link rewriting) in ways
+    that reveal a secret only afterwards — redacting on both sides of the
+    transform is what makes the guarantee independent of what conversion does to
+    the bytes.
+
+    When — and only when — the pre-split produces more than one block, tables are
+    left as raw markdown. ``_convert_tables`` keys a table's labels off the first
+    ``|`` row it sees, so a block beginning part-way through a table adopts a
+    DATA row as its header: that row's values are then only emitted as labels
+    (and vanish entirely if no rows follow, because ``_flush_table`` returns
+    early on an empty body). Raw pipes read worse on mobile, which is why this is
+    not the default — but a message that never splits keeps the nicer rendering,
+    and one that does keeps all of its rows.
+
+    Args:
+        text: Raw text to render. ``None``-ish and blank input yields ``[]``.
+        limit: Per-message character ceiling, ``prefix`` included. Callers with a
+            tighter budget than Slack's (cron uses 3,000) pass their own.
+        prefix: Prepended to every returned part and charged against ``limit``,
+            so a decorated part cannot overflow. Splitting first and decorating
+            afterwards is what made the backfill's icon overflow the limit.
+        header: A caption for the FIRST part only -- ``"⏰ *Cron: name*"`` and
+            friends. Redacted but NOT converted, because these captions are
+            already Slack mrkdwn and ``to_slack_mrkdwn`` would re-interpret their
+            ``*bold*``. Skipping conversion is exactly why a caption needs its own
+            redaction pass, and why doing it HERE rather than at each call site
+            matters: captions are usually built from LLM-authored data (a cron's
+            name comes from the ``cron_add`` tool), so a hand-rolled
+            ``header + parts[0]`` has to remember to redact every single time --
+            the same per-site-memory failure this function removes for bodies. One
+            site had already forgotten.
+        redactor: Text-to-text redactor. Defaults to the platform-context shim
+            :func:`kiro_crew.platform.context.redact_via_context`, which is
+            fail-closed and honours a host's own credential policy. Injectable so
+            tests can assert ordering without composing a platform context.
+
+    Returns:
+        Ready-to-post strings, each already prefixed and within ``limit``.
+        Empty when there is nothing to say, so callers can post unconditionally --
+        EXCEPT when a ``header`` was given, which always yields at least the
+        header, so a caller that attaches an action block to the first part still
+        has a message to attach it to.
+    """
+    if redactor is None:
+        redactor = redact_via_context
+
+    safe_header = redact_for_display(header, redactor)[0] if header else ""
+    # split_message here (not _lossless_blocks): these blocks become SEPARATE
+    # posts, so its continuation markers are wanted rather than an artefact.
+    converted_blocks, _ = _render_blocks(
+        text,
+        presplit=lambda t, n: split_message(t, limit=n),
+        keep_tables=None,
+        redactor=redactor,
+    )
+    if not converted_blocks:
+        return [safe_header] if safe_header else []
+
+    # Charge prefix and header against the limit rather than adding them
+    # afterwards. The header only lands on the first part, but the whole body is
+    # split against the reduced limit: giving the first chunk its own limit would
+    # mean splitting twice, and over-reserving a caption's worth of characters on
+    # later parts is cheaper than being wrong about the ceiling.
+    body_limit = max(1, limit - len(prefix) - len(safe_header))
+    parts: list[str] = []
+    for converted in converted_blocks:
+        parts.extend(f"{prefix}{part}" for part in split_message(converted, limit=body_limit))
+    if safe_header:
+        parts[0] = safe_header + parts[0]
+    return parts
+
+
+def _lossless_blocks(text: str, limit: int) -> list[str]:
+    """Split *text* into blocks whose concatenation is EXACTLY *text*.
+
+    For the INTERNAL pre-split of a message that will be joined back together.
+    :func:`split_message` cannot be used for that: it is built for splitting into
+    separate posts, so it appends a ``CONTINUATION`` marker and ``lstrip``s
+    newlines at the boundary. That makes it lossy in a way no single rejoin can
+    undo -- joining with ``""`` drops a newline it consumed, and joining with
+    ``"\\n"`` INVENTS one inside a long unbroken line. A 19,501-character
+    single-line response would gain a line break that was never in the text.
+
+    Here the newline stays in the left block, so ``"".join(result) == text``
+    holds character for character. A line boundary is still preferred inside the
+    window, so conversion only ever sees a mid-line cut when the text genuinely
+    has no newline to cut at.
+    """
+    if len(text) <= limit:
+        return [text] if text else []
+    blocks: list[str] = []
+    while len(text) > limit:
+        cut = text.rfind("\n", 0, limit)
+        # +1 keeps the newline on the left block; a window with no newline
+        # (rfind -> -1) or one at index 0 falls back to a hard cut at the limit.
+        cut = cut + 1 if cut > 0 else limit
+        blocks.append(text[:cut])
+        text = text[cut:]
+    if text:
+        blocks.append(text)
+    return blocks
+
+
+class SlackRender(NamedTuple):
+    """One rendered Slack message, plus whether redaction changed anything.
+
+    The flag exists because a caller can need to ACT on the fact that redaction
+    fired, not merely receive the redacted text. Slack's streaming path is that
+    case: it has already posted the answer incrementally, and it overwrites that
+    visible message ONLY when it learns the final text had to be redacted. If the
+    render absorbed the redaction silently, the caller would see clean text,
+    conclude nothing had happened, and leave the unredacted stream on screen.
+    """
+
+    text: str
+    redacted: bool
+
+
+def render_one_for_slack(
+    text: str,
+    *,
+    limit: int = SLACK_MAX_TEXT,
+    keep_tables: bool | None = None,
+    redactor: Callable[[str], str] | None = None,
+) -> SlackRender:
+    """Same pipeline as :func:`render_for_slack`, collapsed to ONE message.
+
+    For sinks that take a single string and manage their own presentation --
+    Slack's streaming ``stop_stream`` / ``chat.update``, and the review-mode
+    draft block. Those cannot accept a parts list without reshaping the live
+    turn path, but they still need the ordering guarantee, so they share the
+    pipeline through this form instead of calling ``to_slack_mrkdwn`` directly.
+
+    The difference from :func:`render_for_slack` is only what happens at the
+    ceiling. Conversion is still kept away from its own ``SLACK_MAX_TEXT``
+    self-truncation by pre-splitting, so a credential can neither be reassembled
+    by the ANSI strip nor cut in half before the regex runs. What cannot be
+    preserved is the tail: a single message has nowhere to put it. So the
+    overflow is cut HERE, after both redaction passes, and announced -- rather
+    than being silently dropped inside a conversion the caller cannot see.
+
+    Args:
+        text: Raw text to render.
+        limit: Character ceiling for the returned message.
+        keep_tables: Force markdown tables to stay raw. This flag can only ever
+            ADD rawness -- it cannot switch the straddle guard off. When the text
+            had to be pre-split, tables stay raw regardless of what the caller
+            passed, because a block beginning part-way through a table adopts a
+            DATA row as its header and that row's values are then lost silently.
+            Forcing raw costs rendering quality; forcing conversion would cost
+            data, so only the first direction is a caller's to choose.
+        redactor: See :func:`render_for_slack`.
+
+    Returns:
+        A :class:`SlackRender`. ``text`` is ``""`` when there is nothing to say;
+        ``redacted`` is True when either redaction pass changed the text, which is
+        the signal a caller that already published the text needs in order to go
+        back and replace it.
+    """
+    if redactor is None:
+        redactor = redact_via_context
+
+    # _lossless_blocks here (not split_message): these blocks are REJOINED into
+    # one message, so the pre-split must leave no trace -- no continuation marker
+    # and no invented or swallowed newline at a boundary.
+    converted_blocks, changed = _render_blocks(
+        text,
+        presplit=_lossless_blocks,
+        keep_tables=keep_tables,
+        redactor=redactor,
+    )
+    if not converted_blocks:
+        return SlackRender("", changed)
+
+    # Joined with "" because _lossless_blocks kept every boundary character in the
+    # block it came from, so the pre-split is invisible in the result.
+    rendered = "".join(converted_blocks)
+
+    if len(rendered) > limit:
+        cut = rendered[:limit].rfind("\n")
+        if cut <= 0:
+            cut = limit
+        notice = f"\n\n_…truncated ({len(rendered)} chars total)_"
+        # Charge the notice against the ceiling so the result really fits.
+        cut = max(1, min(cut, limit - len(notice)))
+        rendered = rendered[:cut] + notice
+    return SlackRender(rendered, changed)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -172,8 +172,7 @@ from kiro_crew.slack.format import (
     build_cron_ack_block,
     build_options_blocks,
     extract_options,
-    split_message,
-    to_slack_mrkdwn,
+    render_for_slack,
 )
 from kiro_crew.slack.handler import (
     _get_agent_for_session,
@@ -301,6 +300,27 @@ _BACKGROUND_APPROVAL_SOURCES = frozenset({"cron", "heartbeat", "taskrunner", "au
 # Slack Block Kit section.text hard limit is 3000 chars.
 # We split cron output at this boundary so each chunk fits in a section block.
 _CRON_MSG_LIMIT = 3000
+
+
+def _heartbeat_slack_parts(title: str, result_text: str) -> list[str]:
+    """Render a heartbeat completion into postable Slack parts.
+
+    Shared by all four heartbeat delivery branches so they cannot drift. Two
+    things it fixes relative to the per-branch f-string it replaces:
+
+    - **It splits.** Those branches posted one unsplit message, and Slack
+      rejects anything past ~40,000 characters outright -- so a long heartbeat
+      result was silently lost rather than truncated.
+    - **It redacts around the transform.** ``_deliver_result`` redacts
+      ``result_text`` at its head, but ``to_slack_mrkdwn`` strips ANSI escapes
+      and that strip can reassemble a credential the escapes had broken up.
+      Redacting again after conversion is what closes that.
+
+    The ``💓 *title*`` caption goes through ``header=``, which redacts it without
+    converting (it is already Slack mrkdwn) and charges it against the limit.
+    """
+    return render_for_slack(result_text, header=f"💓 *{title}*\n\n")
+
 
 # Volatile patterns stripped before hashing cron results for dedup.
 _VOLATILE_RE = re.compile(
@@ -1622,14 +1642,16 @@ class GatewayOrchestrator:
         if not channel:
             logger.warning("Cron %s: no channel resolved for subagent response", parent_key)
             return False
-        # Defense-in-depth: redact at the Slack boundary so this helper is safe
-        # even if a future caller forgets to pre-redact (security-controls).
-        text, _ = redact_exfiltration_urls(text)
-        text, _ = redact_credentials(text)
         # render [OPTIONS: ...] tags as interactive buttons, matching
         # the interactive-handler / subagent-completion / dashboard-mirror paths.
+        # Extracted from the raw text: the tag is a plain-text marker, so pulling
+        # it off before conversion is what makes the controls independent of what
+        # conversion (and its 39,000-char self-truncation) does to the tail.
         text, options = extract_options(text)
-        for part in split_message(to_slack_mrkdwn(text), limit=_CRON_MSG_LIMIT):
+        # render_for_slack IS the redaction boundary here -- it normalises ANSI
+        # first so a credential broken up by escapes cannot be reassembled by the
+        # strip inside to_slack_mrkdwn, and redacts again after conversion.
+        for part in render_for_slack(text, limit=_CRON_MSG_LIMIT):
             await self.slack.post_message(channel, part, thread_ts)
         if options:
             try:
@@ -2370,10 +2392,18 @@ class GatewayOrchestrator:
                                 job.created_by or self._owner_id, job.name
                             )
                         if channel:
-                            redacted, _ = redact_exfiltration_urls(result_text)
-                            redacted, _ = redact_credentials(redacted)
-                            post_text = f"⏰ *Cron: {job.name}*\n\n{to_slack_mrkdwn(redacted)}"
-                            parts = split_message(post_text, limit=_CRON_MSG_LIMIT)
+                            # The caption is redacted-but-not-converted by
+                            # render_for_slack's header= seam, which also charges
+                            # it against the limit. Doing it there rather than
+                            # here is the point: a cron name is LLM-authored (the
+                            # agent can create crons via cron_add), and the
+                            # hand-rolled version of this had already forgotten to
+                            # redact it once.
+                            parts = render_for_slack(
+                                result_text,
+                                limit=_CRON_MSG_LIMIT,
+                                header=f"⏰ *Cron: {job.name}*\n\n",
+                            )
                             # First part as Block Kit message with ack button
                             blocks: list[dict] = [
                                 {
@@ -2934,9 +2964,7 @@ class GatewayOrchestrator:
         # turn itself already ran, so failures here don't fail the cycle).
         try:
             if response:
-                reply_text, _ = redact_exfiltration_urls(to_slack_mrkdwn(response))
-                reply_text, _ = redact_credentials(reply_text)
-                for part in split_message(reply_text):
+                for part in render_for_slack(response):
                     await self.slack.post_message(channel, part, thread_ts)
         except Exception:
             logger.exception("AutoNudge: slack posting failed for %s (turn ran)", key)
@@ -3453,8 +3481,8 @@ class GatewayOrchestrator:
                 try:
                     channel = await self.slack.open_dm(self._owner_id)
                     if channel:
-                        post = f"💓 *{title}*\n\n{to_slack_mrkdwn(result_text)}"
-                        await self.slack.post_message(channel, post)
+                        for post in _heartbeat_slack_parts(title, result_text):
+                            await self.slack.post_message(channel, post)
                 except Exception:
                     logger.exception("Heartbeat Slack delivery failed")
             return
@@ -3465,13 +3493,13 @@ class GatewayOrchestrator:
             try:
                 if self.slack and len(parts) == 3:
                     chan, ts = parts[1], parts[2]
-                    post = f"💓 *{title}*\n\n{to_slack_mrkdwn(result_text)}"
-                    await self.slack.post_message(chan, post, ts)
+                    for post in _heartbeat_slack_parts(title, result_text):
+                        await self.slack.post_message(chan, post, ts)
                 elif self.slack and self._owner_id:
                     chan = await self.slack.open_dm(self._owner_id)
                     if chan:
-                        post = f"💓 *{title}*\n\n{to_slack_mrkdwn(result_text)}"
-                        await self.slack.post_message(chan, post)
+                        for post in _heartbeat_slack_parts(title, result_text):
+                            await self.slack.post_message(chan, post)
             except Exception:
                 logger.exception("Heartbeat Slack delivery failed")
             if self.dashboard_state:
@@ -3483,8 +3511,8 @@ class GatewayOrchestrator:
             try:
                 channel = await self.slack.open_dm(self._owner_id)
                 if channel:
-                    post = f"💓 *{title}*\n\n{to_slack_mrkdwn(result_text)}"
-                    await self.slack.post_message(channel, post)
+                    for post in _heartbeat_slack_parts(title, result_text):
+                        await self.slack.post_message(channel, post)
             except Exception:
                 logger.exception("Heartbeat Slack delivery failed")
         if self.dashboard_state:
@@ -4261,12 +4289,12 @@ class GatewayOrchestrator:
                                     self.sessions.get_channel(parent_key) if self.sessions else None
                                 ) or await self.slack.open_dm(self._owner_id)
                                 if channel:
-                                    reply_text, _ = redact_exfiltration_urls(
-                                        to_slack_mrkdwn(response)
-                                    )
-                                    reply_text, _ = redact_credentials(reply_text)
-                                    reply_text, options = extract_options(reply_text)
-                                    for part in split_message(reply_text):
+                                    # OPTIONS off the RAW text, then render: the
+                                    # tag is plain text, so extracting it after
+                                    # conversion made the controls hostage to
+                                    # to_slack_mrkdwn's 39,000-char truncation.
+                                    reply_text, options = extract_options(response)
+                                    for part in render_for_slack(reply_text):
                                         await self.slack.post_message(channel, part, parent_key)
                                     try:
                                         elapsed = (

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -101,9 +101,10 @@ from kiro_crew.slack.format import (
     SLACK_MSG_LIMIT,
     TRUNCATION_NOTICE,
     _convert_tables,
+    extract_options,
+    render_one_for_slack,
     split_message,
     strip_thinking_tags,
-    to_slack_mrkdwn,
 )
 from kiro_crew.slack.sessions_view import (
     _SESSIONS_DEFAULT_LIMIT,
@@ -3618,11 +3619,33 @@ async def handle_message(
             thinking_accumulated += ("\n\n" if thinking_accumulated else "") + inline_thinking
 
     actually_streamed = use_slack_stream and bool(stream_ts)
-    final_text = (
-        to_slack_mrkdwn(accumulated, keep_tables=actually_streamed) if accumulated else _NO_RESPONSE
-    )
+    # render_one_for_slack normalises ANSI and redacts BEFORE converting, then
+    # again after. Converting first (as this did) let to_slack_mrkdwn's ANSI strip
+    # reassemble a credential the escapes had broken up, and let its 39,000-char
+    # self-truncation cut one in half before the regex below could match it.
+    # keep_tables is forced here because Slack's rich streaming renderer draws
+    # tables itself when the stream actually started.
+    #
+    # _render_redacted carries whether that internal redaction fired. It is
+    # load-bearing, not informational: the answer has ALREADY been posted
+    # incrementally, and the only thing that replaces the visible copy is the
+    # final-update condition below. The outer passes cannot supply that signal
+    # any more, because by the time they run the render has already cleaned the
+    # text and they find nothing left to redact.
+    # Extract the OPTIONS tag from the RAW accumulated text, BEFORE rendering.
+    # It is a plain-text marker at the very end of the turn, so rendering first
+    # makes the controls hostage to the render's size ceiling: a >39,000-char
+    # answer ending in [OPTIONS: ...] is truncated, the tag goes with the tail,
+    # and the buttons silently never appear. Matches the ordering used by the
+    # cron, subagent-completion and dashboard-mirror paths.
+    _body_text, options = extract_options(accumulated) if accumulated else ("", [])
 
-    # Scan for URL exfiltration before posting to Slack (link previews auto-fetch)
+    _render = render_one_for_slack(_body_text, keep_tables=actually_streamed)
+    final_text = _render.text or _NO_RESPONSE
+    _render_redacted = _render.redacted
+
+    # Second pass at the boundary: the decorator seam below can still introduce
+    # text, and these warning lists drive the final chat_update decision.
     final_text, exfil_warnings = redact_exfiltration_urls(final_text)
     for w in exfil_warnings:
         logger.warning("Exfiltration URL redacted in response: %s", w)
@@ -3630,10 +3653,7 @@ async def handle_message(
     for w in cred_warnings:
         logger.warning("Credential redacted in response: %s", w)
 
-    # Extract OPTIONS buttons from response and post as Block Kit
-    from kiro_crew.slack.format import extract_options
-
-    clean_text, options = extract_options(final_text)
+    clean_text = final_text
 
     # Outbound-reply decorator seam (Default: identity, OSS-identical). The model
     # has finished speaking, so this is the outbound half of an active
@@ -3728,11 +3748,17 @@ async def handle_message(
     if use_slack_stream and stream_ts:
         # Rich AI renderer is now locked in by stop_stream above.
         # Only overwrite via chat_update when redaction modified the text —
-        # either per-chunk during streaming (_stream_had_redaction) or caught
-        # by the final scan (exfil_warnings/cred_warnings). The security
-        # invariant requires the final visible message reflect the redacted
-        # accumulated text; all other cases leave the rich render intact.
-        if _stream_had_redaction or exfil_warnings or cred_warnings:
+        # either per-chunk during streaming (_stream_had_redaction), inside the
+        # final render (_render_redacted), or caught by the post-decorator scan
+        # (exfil_warnings/cred_warnings). The security invariant requires the
+        # final visible message reflect the redacted accumulated text; all other
+        # cases leave the rich render intact.
+        #
+        # _render_redacted is the one that catches an ANSI-obfuscated credential:
+        # the per-chunk StreamRedactor sees raw chunks and does not strip escapes,
+        # so it can miss one that only becomes matchable after normalisation —
+        # and the post-decorator scan sees text the render has already cleaned.
+        if _stream_had_redaction or _render_redacted or exfil_warnings or cred_warnings:
             fallback_text = _convert_tables(clean_text) if clean_text else _NO_RESPONSE
             await _safe_final_update(
                 slack, channel, stream_ts, fallback_text or _NO_RESPONSE, reply_ts
@@ -3751,7 +3777,10 @@ async def handle_message(
     # reads reasoning → answer. Otherwise (the stream started before any
     # reasoning arrived) fall back to a post after the answer.
     if thinking_accumulated and _show_thinking:
-        thinking_mrkdwn = to_slack_mrkdwn(thinking_accumulated)
+        # thinking_accumulated is built from raw event text and, unlike the answer
+        # stream, has no StreamRedactor upstream -- so this render is its ONLY
+        # redaction. Ordering matters most here for that reason.
+        thinking_mrkdwn = render_one_for_slack(thinking_accumulated).text
         thinking_mrkdwn, exfil_warnings = redact_exfiltration_urls(thinking_mrkdwn)
         for w in exfil_warnings:
             logger.warning("Exfiltration URL redacted in thinking: %s", w)

--- a/test/test_cron_thread_routing.py
+++ b/test/test_cron_thread_routing.py
@@ -288,8 +288,10 @@ class TestSubagentDoneCancelsBeforeRelease:
         p1, p2 = self._patches()
         with (
             patch("kiro_crew.slack.gateway.stream_and_collect", new_callable=AsyncMock, return_value="ok"),
-            patch("kiro_crew.slack.gateway.to_slack_mrkdwn", return_value="ok"),
-            patch("kiro_crew.slack.gateway.split_message", return_value=["ok"]),
+            # gateway renders through the shared Slack pipeline now, so this is
+            # the one seam to stub -- patching to_slack_mrkdwn/split_message
+            # individually no longer intercepts anything.
+            patch("kiro_crew.slack.gateway.render_for_slack", return_value=["ok"]),
             p1, p2,
         ):
             await subagent_done(info)

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -1060,6 +1061,81 @@ class TestInitCron:
 
         assert result == "cron result"
         assert job.last_result == "cron result"
+
+    @pytest.mark.asyncio
+    async def test_cron_name_is_redacted_before_delivery(self):
+        """A cron NAME is LLM-authored text on its way to Slack.
+
+        The name is interpolated into the ``⏰ *Cron: …*`` header, which stays
+        outside the render pipeline on purpose (it is already Slack mrkdwn, so
+        converting it would re-interpret its ``*bold*``). Skipping conversion also
+        means skipping the pipeline's redaction, so the name needs its own pass --
+        an agent can create a cron via the ``cron_add`` tool, so a credential can
+        land in that field and ride into the channel header.
+        """
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        orch = _make_orchestrator(slack_enabled=True, owner_id="U1")
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.build_message = MagicMock(return_value=("full msg", None))
+        orch.ctx_builder.hooks = MagicMock()
+        orch.subagent_mgr = MagicMock()
+        orch.subagent_mgr.running = []
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.slack = MagicMock()
+        orch.slack.open_dm = AsyncMock(return_value="D_U1")
+        orch.slack.post_blocks = AsyncMock(return_value="ts1")
+        orch.slack.post_message = AsyncMock()
+
+        with patch("kiro_crew.slack.gateway.CronService") as mock_cs:
+            mock_cs_inst = MagicMock()
+            mock_cs_inst.start = AsyncMock()
+            mock_cs_inst.start_reaper = MagicMock()
+            mock_cs_inst.register_active_session_key = MagicMock()
+            mock_cs_inst.clear_active_session_key = MagicMock()
+            mock_cs.return_value = mock_cs_inst
+            mock_cs.create = AsyncMock(return_value=mock_cs_inst)
+            await orch._init_cron()
+
+        callback = mock_cs.create.call_args[1]["on_job"]
+
+        job = MagicMock()
+        job.script = ""
+        job.command = ""
+        job.id = "j1"
+        job.name = f"nightly {secret} sweep"
+        job.persistent_session = True
+        job.agent_sequence = []
+        job.agent_id = None
+        job.channel = ""
+        job.created_by = "U1"
+        job.approval_mode = "auto"
+        job.env = None
+        job.acked_items = []
+        job.silent = False
+        job.thread_ts = None
+        job.last_posted_hash = ""
+        job.consecutive_dupes = 0
+        job.last_posted_at = 0.0
+        job.last_failure_hash = ""
+        job.last_failure_at = 0.0
+        job.consecutive_failures = 0
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="cron result",
+        ):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:j1", "run task"),
+            ):
+                await callback(job)
+
+        orch.slack.post_blocks.assert_awaited()
+        delivered = json.dumps(orch.slack.post_blocks.call_args.args)
+        assert secret not in delivered, "a credential in the cron name reached Slack"
+        assert secret[:8] not in delivered, "a credential fragment reached Slack"
 
     @pytest.mark.asyncio
     async def test_cron_callback_dedup_suppresses(self):
@@ -4088,24 +4164,45 @@ class TestDeliverCronResponse:
     async def test_redacts_before_posting(self):
         # Defense-in-depth: the helper must redact at the Slack boundary even
         # if the caller already redacted (security-controls).
+        #
+        # Asserted on the OUTCOME rather than on which redactor got called. The
+        # boundary is now render_for_slack (which runs redact_via_context on both
+        # sides of the mrkdwn conversion), so a mock-call assertion against
+        # gateway.redact_credentials would only prove the old wiring still
+        # existed -- it would pass for a path that redacted nothing and fail for
+        # a correct path that redacts somewhere else. What must be true is that
+        # the secret does not reach Slack.
         orch, slack = self._orch_with_slack()
         orch.sessions.get_channel = MagicMock(return_value="C123")
-        with (
-            patch(
-                "kiro_crew.slack.gateway.redact_exfiltration_urls",
-                return_value=("urlsafe", []),
-            ) as rurl,
-            patch(
-                "kiro_crew.slack.gateway.redact_credentials",
-                return_value=("REDACTED", []),
-            ) as rcred,
-        ):
-            posted = await orch._deliver_cron_response("cron:job1", "tok http://evil.example")
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        posted = await orch._deliver_cron_response("cron:job1", f"tok {secret}")
 
         assert posted is True
-        rurl.assert_called_once()
-        rcred.assert_called_once()
-        assert "REDACTED" in slack.post_message.call_args.args[1]
+        body = slack.post_message.call_args.args[1]
+        assert secret not in body
+        assert secret[:8] not in body, "a credential fragment reached Slack"
+
+    @pytest.mark.asyncio
+    async def test_redacts_a_credential_ansi_escapes_had_split(self):
+        """The reassembly hazard, at this call site.
+
+        An escape sequence dropped into the middle of a key hides it from the
+        credential regex, and the ANSI strip inside to_slack_mrkdwn puts it back
+        together -- so a path that redacts BEFORE normalising posts the key
+        intact. This is the case the old redact-then-convert ordering here got
+        wrong, and it is why the shared pipeline strips ANSI first.
+        """
+        orch, slack = self._orch_with_slack()
+        orch.sessions.get_channel = MagicMock(return_value="C123")
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        obfuscated = secret[:4] + "\x1b[0m" + secret[4:]
+        posted = await orch._deliver_cron_response("cron:job1", f"tok {obfuscated}")
+
+        assert posted is True
+        body = slack.post_message.call_args.args[1]
+        assert secret not in body, "the ANSI strip reassembled the credential"
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/test/test_slack_render_pipeline.py
+++ b/test/test_slack_render_pipeline.py
@@ -1,0 +1,793 @@
+"""Build gate + behaviour tests for the single Slack render pipeline (#1712).
+
+``to_slack_mrkdwn`` is not a safe thing to call directly. It strips ANSI escapes
+and self-truncates at ``SLACK_MAX_TEXT`` before converting, and each of those
+defeats credential redaction from a different side:
+
+- **redact then convert** -- the ANSI strip *reassembles* a credential the
+  escapes had broken up, so ``AKIA<esc>IOSF...`` sails past the regex and lands
+  on Slack whole.
+- **convert then redact** -- the 39,000-char self-truncation cuts a credential in
+  half before the regex runs, leaving an unmatchable prefix on the wire.
+
+So there is no ordering a call site can pick that is safe on its own, and before
+this gate every Slack egress path picked one independently: eleven of twelve were
+exposed to one hazard or the other, and the one correct pipeline lived in a
+private helper in ``dashboard/chat_slack.py`` that nobody else could inherit.
+
+Two tiers, deliberately:
+
+  STRUCTURAL tier -- :func:`test_no_module_converts_slack_markdown_directly`.
+  An AST scan asserting that ``slack/format.py`` is the ONLY module in
+  ``kiro_crew`` that calls ``to_slack_mrkdwn``. This is what makes alignment a
+  property of the code's shape rather than of whether an author remembered:
+  a newly added egress path cannot render its own way without failing the build,
+  which is precisely the guarantee a per-call-site convention cannot give.
+
+  **Scope, stated so it is not over-read:** this gate polices the CONVERSION
+  primitive, not the Slack API calls. A path that posts raw text to Slack without
+  ever converting it is NOT covered — it skips redaction and still passes the
+  build. Covering that would mean gating ``post_message`` / ``post_blocks``, which
+  carry a great deal of legitimately non-agent text (status lines, error notices,
+  captions) and so cannot be banned outright the way a conversion call can; it is
+  a judgment-tier problem, not a deterministic one. ``security_posture.py`` states
+  the same bound, deliberately, rather than claiming every Slack path is enforced.
+
+  BEHAVIOURAL tier -- the ordering tests below. They prove the pipeline the
+  structural tier funnels everyone into actually closes both hazards, in both
+  the multi-part (:func:`render_for_slack`) and single-message
+  (:func:`render_one_for_slack`) forms.
+
+Escape hatch: a genuinely-justified direct call may carry a trailing
+``# render-ok: <reason>`` comment. Every suppression must state its reason so the
+exception is auditable in review and greppable later.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import json
+import pathlib
+import re
+import tokenize
+
+import pytest
+
+from kiro_crew.slack.format import (
+    CONTINUATION,
+    SLACK_MAX_TEXT,
+    SLACK_MSG_LIMIT,
+    build_options_blocks,
+    build_options_selected_blocks,
+    ends_inside_code_fence,
+    render_for_slack,
+    render_one_for_slack,
+)
+
+# The conversion primitive nobody outside format.py may call.
+_BANNED_FUNC = "to_slack_mrkdwn"
+_OWNER_MODULE = "kiro_crew/slack/format.py"
+
+# Trailing-comment marker that suppresses a single flagged call.
+_SUPPRESS = "render-ok"
+
+# A representative AWS access key ID: matched by the credential regex, and long
+# enough that a straddling cut leaves a recognisable prefix behind.
+_SECRET = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _fake_redactor(text: str) -> str:
+    """Stand-in for the platform redactor: exact, injected, no context needed.
+
+    The real ``redact_via_context`` needs a composed PlatformContext, which would
+    make these ordering tests depend on platform composition rather than on the
+    pipeline. Injecting a redactor keeps the assertions about ORDER.
+    """
+    return text.replace(_SECRET, "[REDACTED]")
+
+
+# ── STRUCTURAL tier ───────────────────────────────────────────────────────────
+
+
+def _src_root() -> pathlib.Path:
+    """Locate the kiro_crew source tree (import-first, repo-path fallback)."""
+    try:
+        import kiro_crew  # noqa: PLC0415
+
+        return pathlib.Path(kiro_crew.__file__).resolve().parent
+    except Exception:
+        return pathlib.Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+
+
+def _aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """Resolve how a module might name the banned function.
+
+    Returns ``(bare_names, module_names)``:
+      * ``bare_names`` -- locals bound by a ``from ... import to_slack_mrkdwn``,
+        including ``as`` renames, so a bare ``tsm(...)`` still resolves.
+      * ``module_names`` -- locals bound to the ``slack.format`` MODULE, so
+        ``fmt.to_slack_mrkdwn(...)`` resolves too.
+
+    Without both, a single aliased import would silently defeat the gate.
+    """
+    bare: set[str] = set()
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.endswith("slack.format"):
+                    modules.add(alias.asname or alias.name.split(".")[-1])
+        elif isinstance(node, ast.ImportFrom):
+            if not (node.module or "").endswith("slack.format"):
+                continue
+            for alias in node.names:
+                if alias.name == _BANNED_FUNC:
+                    bare.add(alias.asname or alias.name)
+    return bare, modules
+
+
+def _suppressed_lines(source: str) -> set[int]:
+    """Lines carrying a genuine ``# render-ok`` COMMENT, not a substring.
+
+    Tokenizing rather than substring-scanning means a ``render-ok`` inside a
+    string literal does NOT suppress, while a real trailing comment does.
+    """
+    out: set[int] = set()
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT and _SUPPRESS in tok.string:
+                out.add(tok.start[0])
+    except (tokenize.TokenError, IndentationError):
+        pass
+    return out
+
+
+def find_violations(source: str, path: str = "<source>") -> list[tuple[str, int, str]]:
+    """Return ``(path, lineno, name)`` for direct ``to_slack_mrkdwn`` calls."""
+    tree = ast.parse(source)
+    bare, modules = _aliases(tree)
+    suppressed = _suppressed_lines(source)
+    out: list[tuple[str, int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name: str | None = None
+        if isinstance(func, ast.Name) and func.id in bare:
+            name = func.id
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == _BANNED_FUNC
+            and isinstance(func.value, ast.Name)
+            and func.value.id in modules
+        ):
+            name = f"{func.value.id}.{func.attr}"
+        if name is None:
+            continue
+        span = range(node.lineno, (node.end_lineno or node.lineno) + 1)
+        if any(ln in suppressed for ln in span):
+            continue
+        out.append((path, node.lineno, name))
+    return out
+
+
+def collect_repo_violations() -> list[tuple[str, int, str]]:
+    """Scan every ``kiro_crew/**/*.py`` except the owning module."""
+    root = _src_root()
+    base = root.parent
+    out: list[tuple[str, int, str]] = []
+    for py in sorted(root.rglob("*.py")):
+        try:
+            rel = str(py.relative_to(base))
+        except ValueError:  # pragma: no cover - defensive
+            rel = str(py)
+        if rel.replace("\\", "/").endswith(_OWNER_MODULE):
+            continue
+        try:
+            src = py.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        try:
+            out.extend(find_violations(src, rel))
+        except SyntaxError:  # pragma: no cover - defensive
+            continue
+    return out
+
+
+def test_no_module_converts_slack_markdown_directly() -> None:
+    """Only slack/format.py may call to_slack_mrkdwn.
+
+    This is the omission detector. A new Slack egress path that renders its own
+    way -- and therefore picks one of the two unsafe orderings -- fails here
+    instead of shipping a silent credential-disclosure path.
+    """
+    violations = collect_repo_violations()
+    if violations:
+        detail = "\n".join(
+            f"  {path}:{lineno}  {name}(...)" for path, lineno, name in violations
+        )
+        raise AssertionError(
+            "to_slack_mrkdwn called outside kiro_crew/slack/format.py.\n\n"
+            "Neither redact-then-convert nor convert-then-redact is safe on its "
+            "own (the ANSI strip reassembles split credentials; the 39,000-char "
+            "self-truncation cuts them in half). Use render_for_slack() for a "
+            "parts list, or render_one_for_slack() for a single-string sink.\n"
+            "If a direct call is genuinely correct, add a trailing "
+            "'# render-ok: <reason>' comment.\n\n"
+            f"{detail}"
+        )
+
+
+# ── Meta-tests: prove the detector both fires and stays quiet ─────────────────
+
+
+def test_detector_flags_a_bare_aliased_call() -> None:
+    src = (
+        "from kiro_crew.slack.format import to_slack_mrkdwn as tsm\n"
+        "def f(t):\n"
+        "    return tsm(t)\n"
+    )
+    assert [v[1] for v in find_violations(src)] == [3]
+
+
+def test_detector_flags_a_module_attribute_call() -> None:
+    src = (
+        "import kiro_crew.slack.format as fmt\n"
+        "def f(t):\n"
+        "    return fmt.to_slack_mrkdwn(t)\n"
+    )
+    assert [v[1] for v in find_violations(src)] == [3]
+
+
+def test_detector_ignores_same_named_method_on_other_objects() -> None:
+    """A method that merely shares the name must not trip the gate."""
+    src = "def f(renderer, t):\n    return renderer.to_slack_mrkdwn(t)\n"
+    assert find_violations(src) == []
+
+
+def test_detector_ignores_the_shared_helpers() -> None:
+    src = (
+        "from kiro_crew.slack.format import render_for_slack\n"
+        "def f(t):\n"
+        "    return render_for_slack(t)\n"
+    )
+    assert find_violations(src) == []
+
+
+def test_render_ok_comment_suppresses() -> None:
+    src = (
+        "from kiro_crew.slack.format import to_slack_mrkdwn\n"
+        "def f(t):\n"
+        "    return to_slack_mrkdwn(t)  # render-ok: no egress, formats a local preview\n"
+    )
+    assert find_violations(src) == []
+
+
+def test_render_ok_inside_a_string_does_not_suppress() -> None:
+    src = (
+        "from kiro_crew.slack.format import to_slack_mrkdwn\n"
+        "def f():\n"
+        '    return to_slack_mrkdwn("render-ok")\n'
+    )
+    assert [v[1] for v in find_violations(src)] == [3]
+
+
+# ── BEHAVIOURAL tier: the pipeline closes both hazards ───────────────────────
+
+
+class TestRenderForSlackOrdering:
+    """render_for_slack: the multi-part form."""
+
+    def test_ansi_split_credential_is_not_reassembled(self) -> None:
+        """redact-then-convert hazard: the ANSI strip must not rebuild a secret.
+
+        The escape makes the key invisible to the regex, and ``to_slack_mrkdwn``
+        removes it -- so a pipeline that redacts before normalising hands Slack
+        the whole key. Normalising FIRST is what closes this.
+        """
+        obfuscated = _SECRET[:4] + "\x1b[0m" + _SECRET[4:]
+        body = "\n".join(render_for_slack(f"key is {obfuscated}", redactor=_fake_redactor))
+        assert _SECRET not in body
+        assert "[REDACTED]" in body
+
+    def test_credential_at_the_conversion_ceiling_is_not_halved(self) -> None:
+        """convert-then-redact hazard: the 39k self-truncation must not cut it.
+
+        The filler is newline-free so ``rfind`` cannot snap the cut elsewhere,
+        and the secret starts 10 chars before the ceiling -- so convert-first
+        leaves exactly its first 10 characters behind. A secret placed wholly
+        past the boundary would just be deleted, which is why the obvious
+        version of this test proves nothing.
+        """
+        filler = "x" * (SLACK_MAX_TEXT - 10)
+        assert "\n" not in filler
+        body = "\n".join(render_for_slack(filler + _SECRET, redactor=_fake_redactor))
+        assert _SECRET not in body
+        assert _SECRET[:8] not in body, "a truncated credential prefix reached Slack"
+
+    def test_credential_straddling_the_presplit_boundary_is_redacted(self) -> None:
+        """The hard case: obfuscated AND cut across two posts.
+
+        Redacting per block after the strip is not equivalent -- each block would
+        hold an unmatchable fragment, both would redact clean individually, and
+        the two adjacent posts would hand the reader the whole key.
+        """
+        obfuscated = _SECRET[:6] + "\x1b[0m" + _SECRET[6:]
+        cut = SLACK_MAX_TEXT // 2 - len(CONTINUATION)
+        filler = "q" * (cut - 12)
+        content = filler + obfuscated + ("z" * 200)
+        assert len(filler) < cut < len(filler) + len(obfuscated), (
+            "the credential must straddle the cut for this test to mean anything"
+        )
+        body = "".join(render_for_slack(content, redactor=_fake_redactor))
+        assert _SECRET not in body
+        assert _SECRET[:8] not in body
+
+    def test_tail_past_the_conversion_ceiling_survives(self) -> None:
+        """Pre-splitting is what stops conversion silently dropping the tail."""
+        marker = "TAILMARKER"
+        content = ("y" * (SLACK_MAX_TEXT + 5_000)) + marker
+        body = "".join(render_for_slack(content, redactor=_fake_redactor))
+        assert marker in body
+
+    def test_every_part_fits_the_limit_including_the_prefix(self) -> None:
+        """The prefix is charged against the limit, not bolted on afterwards.
+
+        Decorating a maximally-sized part after the split is what pushed the
+        backfill's icon-prefixed messages past SLACK_MSG_LIMIT.
+        """
+        parts = render_for_slack(
+            "z" * (SLACK_MSG_LIMIT * 3), prefix="🤖 ", redactor=_fake_redactor
+        )
+        assert len(parts) > 1
+        assert all(p.startswith("🤖 ") for p in parts)
+        assert all(len(p) <= SLACK_MSG_LIMIT for p in parts)
+
+    def test_blank_input_yields_no_parts(self) -> None:
+        """Callers can post unconditionally: nothing to say means nothing posted."""
+        assert render_for_slack("", redactor=_fake_redactor) == []
+        assert render_for_slack("   \n\t ", redactor=_fake_redactor) == []
+
+    def test_tables_convert_when_the_message_is_whole(self) -> None:
+        table = "| a | b |\n| - | - |\n| 1 | 2 |"
+        body = "\n".join(render_for_slack(table, redactor=_fake_redactor))
+        assert "*a:*" in body, "a single-block message should get the mobile rendering"
+
+    def test_tables_stay_raw_when_a_split_occurred(self) -> None:
+        """A block starting mid-table would adopt a DATA row as its header."""
+        rows = "\n".join(f"| r{i} | v{i} |" for i in range(4_000))
+        table = f"| a | b |\n| - | - |\n{rows}"
+        assert len(table) > SLACK_MAX_TEXT // 2, "this test needs an actual split"
+        body = "".join(render_for_slack(table, redactor=_fake_redactor))
+        assert "| r3999 | v3999 |" in body, "rows must survive as raw pipes"
+
+
+class TestHeaderCaptionsAreRedactedAtTheSeam:
+    """A caption skips conversion, so it needs its own redaction pass.
+
+    Captions like ``⏰ *Cron: <name>*`` are already Slack mrkdwn, so they must not
+    go through ``to_slack_mrkdwn`` -- which also means they skip the pipeline's
+    redaction. They are usually built from LLM-authored data (a cron's name comes
+    from the ``cron_add`` tool), and the hand-rolled ``header + parts[0]`` this
+    replaces had already forgotten to redact one.
+    """
+
+    def test_a_credential_in_the_caption_is_redacted(self) -> None:
+        parts = render_for_slack(
+            "body", header=f"⏰ *Cron: {_SECRET}*\n\n", redactor=_fake_redactor
+        )
+        assert _SECRET not in "".join(parts)
+        assert "[REDACTED]" in parts[0]
+
+    def test_the_caption_is_not_converted(self) -> None:
+        """Conversion would re-interpret the caption's own *bold*."""
+        parts = render_for_slack("body", header="⏰ *Cron: nightly*\n\n", redactor=_fake_redactor)
+        assert parts[0].startswith("⏰ *Cron: nightly*")
+
+    def test_the_caption_lands_on_the_first_part_only(self) -> None:
+        parts = render_for_slack(
+            "z" * (SLACK_MSG_LIMIT * 3), header="CAP\n\n", redactor=_fake_redactor
+        )
+        assert len(parts) > 1
+        assert parts[0].startswith("CAP")
+        assert not any(p.startswith("CAP") for p in parts[1:])
+
+    def test_the_caption_is_charged_against_the_limit(self) -> None:
+        """Attaching it after splitting is what overflowed the limit before."""
+        header = "H" * 200 + "\n\n"
+        parts = render_for_slack(
+            "z" * (SLACK_MSG_LIMIT * 3),
+            limit=SLACK_MSG_LIMIT,
+            header=header,
+            redactor=_fake_redactor,
+        )
+        assert all(len(p) <= SLACK_MSG_LIMIT for p in parts), (
+            "a caption pushed a part past the limit"
+        )
+
+    def test_an_empty_body_still_yields_the_caption(self) -> None:
+        """The cron path attaches an ack button to the first part."""
+        assert render_for_slack("", header="CAP", redactor=_fake_redactor) == ["CAP"]
+
+    def test_no_caption_still_yields_nothing_for_empty_text(self) -> None:
+        assert render_for_slack("", redactor=_fake_redactor) == []
+
+
+class TestFencedCodeSurvivesThePreSplit:
+    """A ``` block longer than the pre-split window must not be rewritten.
+
+    Fence state is per-conversion-call. Convert in blocks without carrying it and
+    the block that opens mid-fence is treated as prose, so ``_convert_inline``
+    rewrites the CODE -- turning `**x**` inside a code sample into Slack bold, and
+    mangling anything markdown-shaped the user is quoting verbatim. A fenced region
+    can be longer than any block size, so no choice of cut point avoids this.
+    """
+
+    def _long_fence(self) -> str:
+        """A fenced block that is guaranteed to straddle the pre-split."""
+        marker = "**not_bold_in_code**"
+        filler = "\n".join(f"line {i} {marker}" for i in range(1_200))
+        assert len(filler) > SLACK_MAX_TEXT // 2, "the fence must straddle a block boundary"
+        return f"```python\n{filler}\n```"
+
+    def test_code_inside_a_straddling_fence_is_not_converted(self) -> None:
+        out = render_one_for_slack(
+            self._long_fence(), keep_tables=True, redactor=_fake_redactor
+        ).text
+        assert "truncated" not in out, "this fixture must fit in one message"
+        assert "**not_bold_in_code**" in out, "inline conversion rewrote fenced code"
+        assert "*not_bold_in_code*" not in out.replace("**not_bold_in_code**", "")
+
+    def test_the_multipart_form_carries_fence_state_too(self) -> None:
+        """Counted, not merely present.
+
+        The FIRST block opens the fence itself, so it converts correctly with or
+        without the carry -- an `in body` assertion is satisfied by block 1 alone
+        and passes against the bug. Counting every line proves the LATER blocks
+        were also treated as code.
+        """
+        body = "".join(render_for_slack(self._long_fence(), redactor=_fake_redactor))
+        assert body.count("**not_bold_in_code**") == 1_200, (
+            "later blocks lost fence state and had their code rewritten"
+        )
+
+    def test_the_fence_tracker_agrees_with_the_converter(self) -> None:
+        assert ends_inside_code_fence("```py\nx = 1") is True
+        assert ends_inside_code_fence("```py\nx = 1\n```") is False
+        assert ends_inside_code_fence("plain text") is False
+        # Carries a start state in, so blocks can be chained.
+        assert ends_inside_code_fence("still in code", start=True) is True
+        assert ends_inside_code_fence("```", start=True) is False
+
+
+class TestRenderOneForSlackOrdering:
+    """render_one_for_slack: the collapsed form used by the streaming sinks."""
+
+    def test_ansi_split_credential_is_not_reassembled(self) -> None:
+        obfuscated = _SECRET[:4] + "\x1b[0m" + _SECRET[4:]
+        out = render_one_for_slack(f"key is {obfuscated}", redactor=_fake_redactor).text
+        assert _SECRET not in out
+        assert "[REDACTED]" in out
+
+    def test_credential_at_the_conversion_ceiling_is_not_halved(self) -> None:
+        filler = "x" * (SLACK_MAX_TEXT - 10)
+        out = render_one_for_slack(filler + _SECRET, redactor=_fake_redactor).text
+        assert _SECRET not in out
+        assert _SECRET[:8] not in out
+
+    def test_it_reports_that_redaction_fired(self) -> None:
+        """The streaming caller REPLACES an already-posted message on this flag.
+
+        The answer is streamed incrementally by a per-chunk redactor that sees
+        raw chunks and does not strip ANSI, so it can miss a credential that only
+        becomes matchable after normalisation. Nothing downstream can recover the
+        signal either -- the post-render scan sees text this call already cleaned.
+        So if this flag were not reported, the unredacted stream would stay
+        visible on screen.
+        """
+        obfuscated = _SECRET[:4] + "\x1b[0m" + _SECRET[4:]
+        assert render_one_for_slack(f"key {obfuscated}", redactor=_fake_redactor).redacted
+
+    def test_it_reports_no_redaction_for_clean_text(self) -> None:
+        """Otherwise the flag would fire every turn and the overwrite is pointless."""
+        assert not render_one_for_slack("just an ordinary answer", redactor=_fake_redactor).redacted
+
+    def test_stripping_ansi_alone_is_not_reported_as_redaction(self) -> None:
+        """Normalisation is not a disclosure that was caught."""
+        assert not render_one_for_slack("plain \x1b[0m text", redactor=_fake_redactor).redacted
+
+    def test_overflow_is_announced_not_silently_dropped(self) -> None:
+        out = render_one_for_slack("y" * (SLACK_MAX_TEXT * 2), redactor=_fake_redactor).text
+        assert len(out) <= SLACK_MAX_TEXT
+        assert "truncated" in out, "a single-message sink must SAY it lost the tail"
+
+    def test_keep_tables_can_be_forced_by_the_caller(self) -> None:
+        """The streaming sink renders tables itself, so it forces raw pipes."""
+        table = "| a | b |\n| - | - |\n| 1 | 2 |"
+        assert "| a | b |" in render_one_for_slack(
+            table, keep_tables=True, redactor=_fake_redactor
+        ).text
+        assert (
+            "*a:*"
+            in render_one_for_slack(table, keep_tables=False, redactor=_fake_redactor).text
+        )
+
+    def test_keep_tables_can_only_add_rawness_never_remove_it(self) -> None:
+        """An explicit False must NOT defeat the straddle guard.
+
+        The streaming caller passes ``keep_tables=actually_streamed``, which is
+        False on every turn where start_stream returned None. If False forced
+        conversion, each pre-split block would convert independently: a block
+        beginning on a table DATA row makes _convert_tables adopt that row as
+        headers, and _flush_table drops it entirely when no rows follow. So the
+        flag is advisory in one direction only.
+        """
+        rows = "\n".join(f"| r{i} | v{i} |" for i in range(1_500))
+        table = f"| a | b |\n| - | - |\n{rows}"
+        # Sized deliberately between the two ceilings: past the pre-split
+        # boundary (so more than one block is converted) but under the
+        # single-message limit (so nothing is lost to truncation instead, which
+        # would make the assertion below prove the wrong thing).
+        assert SLACK_MAX_TEXT // 2 < len(table) < SLACK_MAX_TEXT
+        out = render_one_for_slack(table, keep_tables=False, redactor=_fake_redactor).text
+        assert "truncated" not in out, "the fixture outgrew the single-message limit"
+        assert "| r1499 | v1499 |" in out, "an explicit False lost table rows to the split"
+        assert "*a:*" not in out, "tables were converted across a split boundary"
+
+    def test_a_long_unbroken_line_gains_no_invented_newline(self) -> None:
+        """The internal pre-split must be invisible in the result.
+
+        A response with no newline in it at all still exceeds the pre-split
+        window, so it is cut mid-line. Rejoining those blocks with "\\n" would
+        insert a line break the model never wrote -- corrupting the text at
+        character 19,484 of a 19,501-character response.
+        """
+        text = "z" * (SLACK_MAX_TEXT // 2 + 1)
+        assert "\n" not in text
+        out = render_one_for_slack(text, redactor=_fake_redactor).text
+        assert "truncated" not in out, "this fixture must fit in one message"
+        assert "\n" not in out, "the pre-split invented a newline"
+        assert out == text, "the pre-split was not lossless"
+
+    def test_newlines_at_a_block_boundary_survive_exactly(self) -> None:
+        """The converse: a boundary newline must not be swallowed either.
+
+        split_message lstrips newlines at its cut, so joining ITS blocks with ""
+        would silently delete one. The internal splitter keeps the newline on the
+        left block instead, so both directions hold.
+        """
+        line = "a" * 100
+        text = "\n".join([line] * (SLACK_MAX_TEXT // 2 // 101 + 60))
+        assert len(text) > SLACK_MAX_TEXT // 2, "must pre-split"
+        out = render_one_for_slack(text, keep_tables=True, redactor=_fake_redactor).text
+        assert "truncated" not in out, "this fixture must fit in one message"
+        assert out.count("\n") == text.count("\n"), "a boundary newline was lost or added"
+
+    def test_internal_split_markers_do_not_reach_the_message(self) -> None:
+        """The pre-split is internal; its CONTINUATION must not survive the join.
+
+        Blocks are joined back into ONE message here, so a leftover marker renders
+        a visible "(continued…)" where nothing was continued.
+        """
+        text = "y" * (SLACK_MAX_TEXT // 2 + 5_000)
+        out = render_one_for_slack(text, redactor=_fake_redactor).text
+        assert CONTINUATION.strip() not in out
+        assert "continued" not in out
+
+    def test_a_response_just_under_the_limit_keeps_its_tail(self) -> None:
+        """Marker padding must not tip a fits-exactly response into truncation.
+
+        The pre-split adds a CONTINUATION per block. Joined, that padding pushes a
+        38,990-char response past 39,000, and the tail is then replaced by the
+        truncation notice -- losing valid content to an internal bookkeeping
+        artefact rather than to the real size limit.
+        """
+        marker = "TAILMARKER"
+        text = ("z" * (SLACK_MAX_TEXT - 10 - len(marker))) + marker
+        assert len(text) < SLACK_MAX_TEXT
+        assert len(text) > SLACK_MAX_TEXT // 2, "must pre-split for this to mean anything"
+        out = render_one_for_slack(text, redactor=_fake_redactor).text
+        assert "truncated" not in out, "a response that fits was truncated anyway"
+        assert marker in out, "the tail was lost"
+
+    def test_blank_input_yields_empty_string(self) -> None:
+        assert render_one_for_slack("", redactor=_fake_redactor).text == ""
+        assert render_one_for_slack("  \n ", redactor=_fake_redactor).text == ""
+
+
+class TestOptionsChoicesAreRedacted:
+    """OPTIONS choice labels are Slack egress too, and Block Kit covers nobody.
+
+    The tag is extracted from RAW text on purpose -- conversion self-truncates at
+    39,000 characters and would eat the tag -- so the choices arrive unscanned and
+    must be redacted at the sink that renders them.
+    """
+
+    def test_checkbox_labels_and_values_are_redacted(self) -> None:
+        blocks = build_options_blocks(
+            [f"Retry with {_SECRET}", "Abort"], redactor=_fake_redactor
+        )
+        payload = json.dumps(blocks)
+        assert _SECRET not in payload
+        assert "[REDACTED]" in payload
+
+    def test_the_button_value_is_redacted_before_it_is_sliced(self) -> None:
+        """The value is echoed back into the session on submit.
+
+        ``value`` is ``choice[:150]``. Slicing first can cut a credential into a
+        prefix the regex no longer matches, so redaction has to precede the
+        slice -- the same ordering hazard as the conversion ceiling.
+        """
+        pad = "p" * 140
+        blocks = build_options_blocks([pad + _SECRET], redactor=_fake_redactor)
+        value = blocks[0]["elements"][0]["options"][0]["value"]
+        assert _SECRET[:8] not in value, "a credential fragment survived into the value"
+
+    def test_an_ansi_split_credential_in_a_choice_is_redacted(self) -> None:
+        obfuscated = _SECRET[:4] + "\x1b[0m" + _SECRET[4:]
+        payload = json.dumps(build_options_blocks([obfuscated], redactor=_fake_redactor))
+        assert _SECRET not in payload
+
+    def test_the_selected_view_is_redacted_too(self) -> None:
+        payload = json.dumps(
+            build_options_selected_blocks(
+                [f"Retry with {_SECRET}", "Abort"], [0], redactor=_fake_redactor
+            )
+        )
+        assert _SECRET not in payload
+
+    def test_ordinary_choices_are_unchanged(self) -> None:
+        """Redaction must be identity for text that holds no secret."""
+        blocks = build_options_blocks(["Merge it now", "Show me the diff"])
+        labels = [o["text"]["text"] for o in blocks[0]["elements"][0]["options"]]
+        assert labels == ["Merge it now", "Show me the diff"]
+
+
+def test_default_redactor_is_the_platform_shim() -> None:
+    """Left to itself, the pipeline must use the fail-closed context redactor.
+
+    An injectable redactor is only safe if the DEFAULT is the canonical one --
+    otherwise a caller that omits it silently gets no redaction at all.
+    """
+    import kiro_crew.slack.format as fmt
+
+    src = pathlib.Path(fmt.__file__).read_text(encoding="utf-8")
+    assert src.count("redact_via_context") >= 2, (
+        "both render helpers must default to redact_via_context"
+    )
+
+
+@pytest.mark.parametrize("limit", [1, 5, len(CONTINUATION), len(CONTINUATION) + 1])
+def test_pathological_limits_terminate(limit: int) -> None:
+    """A limit at or below the continuation marker must not spin forever."""
+    parts = render_for_slack("a\nb\nc\n" * 50, limit=limit, redactor=_fake_redactor)
+    assert parts
+
+
+class TestEmphasisDelimiterRedaction:
+    """Emphasis delimiters must not smuggle a credential past redaction.
+
+    Same shape as the ANSI vector this module exists for: a transformation applied
+    AFTER the scan reassembles what the scanner saw as broken. Here the
+    transformation is Slack's own renderer, which consumes ``*`` / ``_`` / ``~`` /
+    backticks and shows the reader the joined text.
+    """
+
+    KEY = "AKIAIOSFODNN7EXAMPLE"
+
+    def _reader_sees(self, wire: str) -> str:
+        """Approximate what Slack DISPLAYS: links show their label, delimiters go."""
+        out = re.sub(r"\[([^\]\n]*)\]\([^)\n]*\)", r"\1", wire)
+        out = re.sub(r"<(?:[^>|\n]*)\|([^>\n]*)>", r"\1", out)
+        for delim in ("**", "*", "__", "_", "~~", "~", "`"):
+            out = out.replace(delim, "")
+        return out
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "AKIA**IOSFODNN7EXAMPLE**",
+            "AKIAIOSF**ODNN**7EXAMPLE",
+            "AKIAIOSF_ODNN_7EXAMPLE",
+            "AKIAIOSF~~ODNN~~7EXAMPLE",
+            "AKIAIOSF`ODNN`7EXAMPLE",
+        ],
+    )
+    def test_delimiter_split_key_never_reaches_a_reader(self, payload):
+        rendered = render_one_for_slack(f"credential: {payload}")
+        assert self.KEY not in self._reader_sees(rendered.text)
+        # The flag is load-bearing: the streaming path uses it to overwrite text it
+        # already published, so a silent redaction would leave the key on screen.
+        assert rendered.redacted is True
+
+    def test_plain_key_still_redacted(self):
+        """Control -- keeps the suite honest if the redactor stops firing at all."""
+        rendered = render_one_for_slack(f"credential: {self.KEY}")
+        assert self.KEY not in rendered.text
+        assert rendered.redacted is True
+
+    def test_ordinary_emphasis_survives_when_nothing_is_secret(self):
+        """The downgrade is one-directional: no credential, no formatting loss."""
+        rendered = render_one_for_slack("this is **bold** and _italic_ text")
+        assert "*bold*" in rendered.text
+        assert "_italic_" in rendered.text
+        assert rendered.redacted is False
+
+    def test_header_is_canonicalised_too(self):
+        """A caption is redacted but NOT converted, so it needs the same guard."""
+        parts = render_for_slack("body", header="key AKIA**IOSFODNN7EXAMPLE** ")
+        assert self.KEY not in self._reader_sees("".join(parts))
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "[AKIA](https://example.com)IOSFODNN7EXAMPLE",
+            "AKIAIOSF[ODNN](https://example.com)7EXAMPLE",
+            "<https://example.com|AKIA>IOSFODNN7EXAMPLE",
+        ],
+    )
+    def test_link_markup_cannot_smuggle_a_key(self, payload):
+        """A link DISPLAYS only its label, so the url is an invisible splitter."""
+        rendered = render_one_for_slack(f"credential: {payload}")
+        assert self.KEY not in self._reader_sees(rendered.text)
+        assert rendered.redacted is True
+
+    def test_ordinary_link_survives(self):
+        """Links are only collapsed for the SCAN -- real links must still work."""
+        rendered = render_one_for_slack("see [docs](https://example.com) please")
+        # Exact form, not a substring check: asserting a host appears *somewhere*
+        # would also pass if the url had been mangled into the wrong position.
+        assert rendered.text == "see <https://example.com|docs> please"
+        assert rendered.redacted is False
+
+    @pytest.mark.parametrize(
+        "choice",
+        [
+            "use AKIAIOSF`ODNN`7EXAMPLE",
+            "use AKIA**IOSFODNN7EXAMPLE**",
+            "use [AKIA](https://example.com)IOSFODNN7EXAMPLE",
+        ],
+    )
+    def test_options_choices_get_the_display_guard(self, choice):
+        """A selected choice is echoed back as mrkdwn, so it has the same vector."""
+        blocks = json.dumps(build_options_blocks([choice]))
+        assert self.KEY not in self._reader_sees(blocks)
+
+    @pytest.mark.parametrize(
+        "pattern_name, required",
+        [
+            # Each negated class must exclude the delimiters that BOUND it: the
+            # Markdown label sits in [...], its url in (...); both halves of a
+            # Slack link sit in <...>.
+            ("_MD_LINK", [("\\[", "\\]"), ("(", ")")]),
+            ("_SLACK_LINK", [("<", ">"), ("<", ">")]),
+        ],
+    )
+    def test_link_patterns_exclude_their_own_delimiters(self, pattern_name, required):
+        """Structural guard against re-introducing polynomial backtracking.
+
+        Asserted on the pattern source rather than by timing, deliberately: a
+        wall-clock ratio test for this flakes on a loaded runner (this repo already
+        carries one such test that has to be ignored), while the property that
+        actually prevents the blow-up is static.
+
+        If a negated class admits a delimiter that bounds it, input like
+        ``[[[[[[...`` makes every start position consume the rest of the string
+        before failing, which is quadratic in attacker-supplied text on the egress
+        path (CodeQL ``py/polynomial-redos``). Excluding those delimiters makes a
+        doomed start fail in constant time.
+        """
+        from kiro_crew.slack import format as fmt
+
+        classes = re.findall(r"\[\^((?:\\.|[^\]\\])*)\]", getattr(fmt, pattern_name).pattern)
+        assert len(classes) == len(required), (
+            f"{pattern_name} has {len(classes)} negated classes, expected "
+            f"{len(required)} -- update this test alongside the pattern"
+        )
+        for cls, delims in zip(classes, required):
+            for delim in delims:
+                assert delim in cls, (
+                    f"{pattern_name} negated class [^{cls}] admits {delim!r}, "
+                    f"which reintroduces polynomial backtracking"
+                )


### PR DESCRIPTION
## Problem

Text on its way to Slack goes through `to_slack_mrkdwn`, which does two things
before it converts anything: it strips ANSI escapes, and it self-truncates at
`SLACK_MAX_TEXT` (39,000). Each of those defeats credential redaction — from a
different side:

| Ordering | What breaks |
|---|---|
| `redact` → `convert` | The ANSI strip **reassembles** a credential the escapes had split. `AKIA<esc>IOSF…` doesn't match the regex on the way in, and arrives at Slack whole. |
| `convert` → `redact` | The 39,000-char self-truncation **cuts a credential in half** before the regex runs, leaving an unmatchable prefix on the wire — and silently drops the tail. |

So there is no ordering a call site can pick that is safe on its own. Every
Slack egress path picked one independently, and 11 of 12 were exposed to one
hazard or the other. Measured on this branch against the real redactor:

| Ordering | ANSI-split key | Key at the 39K ceiling |
|---|---|---|
| `redact` → `convert` | **leaks the whole key** | clean |
| `convert` → `redact` | clean | **leaks a fragment** |
| this PR's pipeline | clean | clean |

The correct pipeline was worked out in #1688 but lived in a private helper in
`dashboard/chat_slack.py`, so no other caller could inherit it.

Two further defects fell out of the audit:

- **The four heartbeat delivery sites never split at all.** They posted one
  unsplit message, and Slack rejects anything past ~40,000 characters outright —
  so a long heartbeat result was *lost*, not truncated.
- **OPTIONS choice labels were never redacted anywhere.** `build_options_blocks`
  puts `choice[:75]` in a `plain_text` label and `choice[:150]` in the button
  `value` that is echoed back into the session on submit, with no redactor and
  with the slice ahead of any scan. On `main` this was masked at three call sites
  purely because they happened to extract the tag from already-redacted text.

## Why it matters

A credential or a link-preview-triggering URL in agent output reaching a Slack
channel is a disclosure to everyone in that channel, and for the OPTIONS path it
is then read back into the session. The failure is silent in every case: nothing
logs, nothing fails, the message just contains the secret. The heartbeat case
loses user-visible output with no warning.

## Fix (symptom → root cause → change)

**Symptom:** secrets survive on some Slack paths and not others; long heartbeat
results vanish. **Root cause:** the redact/convert/split ordering was a
per-call-site decision, and the one correct ordering was private to one module.
**Change:** make the ordering a property of the code's shape.

1. **`slack/format.py` owns the pipeline.** `render_for_slack()` returns postable
   parts; `render_one_for_slack()` returns one message for the streaming sinks
   that cannot take a list. Both run
   `strip_ansi → redact → pre-split → convert → redact → split`, with the
   redactor injectable and defaulting to the fail-closed `redact_via_context`.
2. **All 12 call sites retrofitted** — `slack/gateway.py` (8, including
   `:4264`, which #1712 does not list and had the same convert-first hazard),
   `slack/handler.py` (2), `dashboard/chat_runner.py` (1), and
   `dashboard/chat_slack.py`, whose private helper becomes a 1-line delegate.
   `split_message` is now unused in `gateway.py`, which is the check that nothing
   was left behind.
3. **A build gate makes it structural.** An AST scan asserts `slack/format.py`
   is the only module that calls `to_slack_mrkdwn`. A newly added egress path
   cannot render its own way — and therefore cannot pick an unsafe ordering —
   without failing the build. Alias-resolving (`as`-renames and module-qualified
   access), `tokenize`-based so a string literal cannot suppress, with a
   `# render-ok: <reason>` escape hatch. There are zero suppressions in `src/`.
4. **The heartbeat sites split**, via one shared helper so the four cannot drift.
5. **OPTIONS choices are redacted at the sink**, before the `[:75]`/`[:150]`
   slices. Fixing it in `build_options_blocks` /
   `build_options_selected_blocks` rather than at the call sites closes it for
   every caller, including the ones that never had the incidental protection.
6. **`keep_tables` can only ADD rawness.** When the text had to be pre-split,
   tables stay raw regardless of what the caller passed: a block beginning
   part-way through a table makes `_convert_tables` adopt a DATA row as its
   header, and `_flush_table` drops that row entirely when none follow. Forcing
   raw costs rendering quality; forcing conversion would cost data.
7. **`render_one_for_slack` reports whether redaction fired.** The streaming path
   has already posted the answer incrementally and overwrites the visible copy
   *only* on that signal. Redacting inside the render would otherwise leave the
   post-render scan with nothing to find, and an ANSI-obfuscated credential the
   per-chunk `StreamRedactor` missed would stay on screen.

`security_posture.py` registers `slack/format.py` as the Slack egress redaction
sink and re-describes the `chat_slack.py` entry, so the posture prose matches
where the code now redacts.

## Tests

`test/test_slack_render_pipeline.py` (new):

- **Structural** — `to_slack_mrkdwn` is called nowhere outside `slack/format.py`,
  run against the real tree. Six meta-tests prove the detector both fires
  (bare alias, module attribute) and stays quiet (same-named method on another
  object, shared helpers, a genuine `# render-ok`, and a `render-ok` inside a
  string literal, which must NOT suppress).
- **Ordering** — both hazards, in both helper forms: an ANSI-split key is not
  reassembled; a key 10 chars before the 39K ceiling is not halved; a key that
  is *both* obfuscated *and* straddling the pre-split boundary is caught; the
  tail past the ceiling survives.
- **Limits** — every part fits `limit` with the prefix charged against it; blank
  input yields no parts; pathological limits at/below the continuation marker
  terminate.
- **Tables** — converted when the message is whole, raw when a split occurred,
  and raw even when the caller passed `keep_tables=False`.
- **OPTIONS choices** — label, button `value` (with the secret positioned so a
  slice-first implementation leaves a fragment), the ANSI-split variant, the
  selected-choices view, and identity for ordinary text.
- **The redaction signal** — reported when redaction fires, not reported for
  clean text, and not reported for an ANSI strip alone.

`test_slack_gateway.py::test_redacts_before_posting` was asserting redaction by
*which mock got called*, which only proved the old wiring existed — it would pass
for a path that redacted nothing. Rewritten to assert the outcome (the secret
does not reach Slack), plus a new sibling for the ANSI-reassembly case at that
call site. `test_cron_thread_routing.py` now patches the single render seam.

## Manual verification

N/A — unit coverage is sufficient and stronger here than manual checking would
be: the hazards are exact-boundary cases (a credential straddling a 19,500-char
pre-split, a key 10 characters before a 39,000-char ceiling) that are
constructed precisely in tests and would be luck to hit by hand. Non-vacuity was
verified separately by running each historical ordering against the same
payloads and confirming each leaks where the table above says it does.

## Screenshots

N/A — no user-visible UI change. The rendering change is to Slack message text;
its observable effect is covered by the ordering tests above.

Closes #1712.
