### PR TITLE
fix(dashboard): report the session pin's real scope instead of asserting it

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -260,8 +260,25 @@ cloudflared tunnel --url http://localhost:5476 run kirocrew
 
 With [ngrok](https://ngrok.com/docs) the equivalent is
 `ngrok http --domain=kirocrew.example.com 5476`.
-[Tailscale Funnel](https://tailscale.com/kb/1223/funnel) also works and keeps
-the service inside your tailnet.
+
+**If you use Tailscale, prefer `tailscale serve` over Funnel.** The two are not
+the same and the difference is the whole security story:
+
+- [`tailscale serve`](https://tailscale.com/kb/1242/tailscale-serve) publishes the
+  dashboard **only inside your tailnet** — nothing is reachable from the public
+  internet, you get TLS and a stable MagicDNS hostname, and who can reach it is
+  governed by your tailnet ACLs. This is the better answer for the phone case:
+  ```bash
+  tailscale serve --bg --https 443 http://127.0.0.1:5476
+  ```
+  Then set `dashboard.url` to `https://<machine>.<tailnet>.ts.net` (below) so the
+  origin allowlist and the `Host` barrier accept it.
+- [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) does the opposite: it
+  puts the service **on the public internet**, like cloudflared and ngrok. Use it
+  only if you actually want public ingress.
+
+A shared corporate tailnet is not a private network — every member who can reach
+the Serve endpoint is inside your trust boundary, so keep the ACL narrow.
 
 Then set the URL in `~/.kiro/crew/config.json` and restart:
 
@@ -284,13 +301,25 @@ the tunnel. Keep the tunnel process running (tmux, or the provider's own
 service installer such as `cloudflared service install`).
 
 > **A tunnel puts your dashboard on the public internet.** Token auth is always
-> mounted, tokens are HMAC-signed and IP-pinned, and the DNS-rebinding `Host`
-> barrier applies to every non-probe request. Even so, prefer a provider that
-> adds its own authentication layer (Cloudflare Access, a Tailscale-private
-> funnel) and keep session lifetimes short. Note also that config-write and
-> secret-reveal endpoints refuse tunnelled requests: `is_direct_local_request()`
-> treats any request carrying `Forwarded` / `X-Forwarded-*` / `X-Real-IP` as
-> remote, and every standard tunnel and reverse proxy attaches those.
+> mounted, tokens are HMAC-signed, and the DNS-rebinding `Host` barrier applies to
+> every non-probe request.
+>
+> **Do not count on IP pinning here.** A token is pinned to the address that first
+> used it — but every tunnel above runs on *this* host and connects to the gateway
+> from loopback, so the address it pins to is the tunnel process, not your phone.
+> One pin is then satisfied by anyone who reaches the dashboard through that same
+> tunnel, for the life of the session (up to 20 hours; `kirocrew token` defaults
+> straight to `20h`). For the same reason the audit trail records the caller as
+> `127.0.0.1` rather than a client address. Security Posture → Dashboard token
+> auth reports which of the two states you are actually in.
+>
+> So the real controls for a tunnelled dashboard are the provider's own auth layer
+> (Cloudflare Access, or `tailscale serve`, which keeps the service inside your
+> tailnet instead of publishing it) plus short session lifetimes — not the pin.
+> Note also that config-write and secret-reveal endpoints refuse tunnelled requests:
+> `is_direct_local_request()` treats any request carrying `Forwarded` /
+> `X-Forwarded-*` / `X-Real-IP` as remote, and every standard tunnel and reverse
+> proxy attaches those.
 
 ### Getting a link on your phone
 

--- a/src/kiro_crew/dashboard/origin.py
+++ b/src/kiro_crew/dashboard/origin.py
@@ -111,6 +111,45 @@ def is_direct_local_request(request: web.Request) -> bool:
     return not any(h in request.headers for h in _PROXY_FORWARD_HEADERS)
 
 
+def is_proxied_request(request: web.Request) -> bool:
+    """Return ``True`` when ``request.remote`` is a PROXY rather than the client.
+
+    The question this answers is narrow and specific: *can anything keyed on
+    ``request.remote`` identify one client?* It cannot when a proxy terminated
+    the connection, because then every client behind that proxy presents the
+    same address.
+
+    The signal is the presence of any :data:`_PROXY_FORWARD_HEADERS` entry, and
+    **peer locality is deliberately NOT part of the test**. Two proxy shapes
+    exist and both collapse the address:
+
+    * **same-host** — a tunnel or reverse proxy on this machine (cloudflared,
+      ngrok, ``tailscale serve``, a local nginx) connecting from loopback; and
+    * **upstream** — a proxy on *another* host (an nginx box, a container
+      bridge, a LAN jump host) in front of a widened bind
+      (``KIROCREW_BIND``), which presents a NON-loopback peer.
+
+    An earlier version of this predicate required a loopback peer, on the
+    premise that a non-loopback peer is the client itself. That premise is only
+    true when no upstream proxy exists — with one, the non-loopback peer is the
+    proxy and the address is just as shared. Scoping to loopback therefore
+    reported the second shape as per-client, reproducing exactly the untrue
+    claim this predicate was added to remove.
+
+    Accepted trade-off, stated because it is a deliberate direction: a client
+    that sends a forwarding header with no proxy in the path (a transparent
+    forward proxy, a misconfigured client) is reported as proxied when its
+    address is in fact its own. That is an OVER-warning. On a surface whose job
+    is to say whether a security control is effective, over-warning is the safe
+    error and under-warning is not.
+
+    This is NOT the inverse of :func:`is_direct_local_request`, which also
+    requires loopback because it answers a different question ("is this the
+    local machine", for the secret-reveal and config-write gates).
+    """
+    return any(h in request.headers for h in _PROXY_FORWARD_HEADERS)
+
+
 def is_https_request(request: web.Request) -> bool:
     """Return ``True`` when the browser reached the dashboard over HTTPS.
 

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -24,7 +24,11 @@ from typing import Any
 from aiohttp import web
 
 from kiro_crew import platform_compat
-from kiro_crew.dashboard.origin import is_https_request, is_loopback
+from kiro_crew.dashboard.origin import (
+    is_https_request,
+    is_loopback,
+    is_proxied_request,
+)
 from kiro_crew.dashboard.refresh_tokens import (
     MAX_REFRESH_TTL_SECS,
     REFRESH_COOKIE_PATH,
@@ -246,7 +250,9 @@ class TokenStateManager:
         self._max_nonces = max_concurrent_nonces
         # OrderedDict maintains insertion order for O(1) oldest eviction
         self._nonces: OrderedDict[str, float] = OrderedDict()
-        self._ip_bindings: dict[str, tuple[str, float]] = {}  # token → (ip, exp)
+        # Observation latches for the Security Posture surface only — never read
+        # by an auth decision. See bind_ip() / proxied_pin_observed().
+        self._ip_bindings: dict[str, tuple[str, float, bool]] = {}  # token → (ip, exp, proxied)
         self._consumed: dict[str, float] = {}  # token → exp
 
     def register_nonce(self, nonce: str, expiry: float) -> str | None:
@@ -274,10 +280,41 @@ class TokenStateManager:
             self._nonces.move_to_end(nonce)
             return True, ""
 
-    def bind_ip(self, token: str, ip: str, session_exp: float) -> None:
-        """Bind a token to a client IP address."""
+    def bind_ip(self, token: str, ip: str, session_exp: float, proxied: bool = False) -> None:
+        """Bind a token to a client IP address.
+
+        ``proxied`` records that *ip* came from a same-host proxy rather than
+        from the client itself, which means this binding pins the token to the
+        proxy and is therefore shared by every client behind it. It is an
+        observation for the Security Posture surface only — it does not change
+        the binding or how :meth:`check_ip` compares it.
+        """
         with self._lock:
-            self._ip_bindings[token] = (ip, session_exp)
+            self._ip_bindings[token] = (ip, session_exp, proxied)
+
+    def proxied_pin_observed(self, now: float) -> bool | None:
+        """Report the pin scope of the sessions that are LIVE at *now*.
+
+        ``None`` = no session is currently pinned, so there is no scope to
+        report — which is NOT the same as "pins are effective" and must not be
+        rendered as if it were. ``True`` = at least one live session is pinned to
+        a same-host proxy's address and is therefore shared by every client
+        behind it. ``False`` = live sessions are pinned to client addresses.
+
+        Derived from the bindings rather than from a latch, deliberately. A latch
+        would outlive the sessions it describes: one tunnelled login would report
+        SHARED until the gateway restarted, even after that session expired and
+        the user went back to direct access — the same class of stale claim this
+        reporting exists to remove.
+
+        Filters on ``exp`` rather than trusting :meth:`evict_expired` to have
+        run, so the answer never depends on when eviction last happened.
+        """
+        with self._lock:
+            live_proxied = [p for _, exp, p in self._ip_bindings.values() if exp > now]
+            if not live_proxied:
+                return None
+            return any(live_proxied)
 
     def check_ip(self, token: str, ip: str) -> bool:
         """Check if token is bound to the given IP (or unbound)."""
@@ -310,7 +347,7 @@ class TokenStateManager:
         """Remove all expired entries from all state stores."""
         with self._lock:
             # Evict expired IP bindings
-            expired_tokens = [t for t, (_, exp) in self._ip_bindings.items() if exp < now]
+            expired_tokens = [t for t, (_, exp, _p) in self._ip_bindings.items() if exp < now]
             for t in expired_tokens:
                 self._ip_bindings.pop(t, None)
             # Evict consumed tokens independently using their own expiry
@@ -920,9 +957,29 @@ def _evict_expired() -> None:
     _state.evict_expired(time.time())
 
 
-def bind_token_ip(token: str, ip: str, session_exp: float = 0.0) -> None:
-    """Bind a token to a client IP for session validation."""
-    _state.bind_ip(token, ip, session_exp or time.time() + MAX_SESSION_TTL_SECS)
+def bind_token_ip(
+    token: str, ip: str, session_exp: float = 0.0, proxied: bool = False
+) -> None:
+    """Bind a token to a client IP for session validation.
+
+    ``proxied`` is an observation only (see ``_TokenState.bind_ip``): it records
+    that *ip* is a same-host proxy's address rather than the client's, so the
+    Security Posture surface can report that the pin is shared. It never changes
+    the binding or the comparison.
+    """
+    _state.bind_ip(token, ip, session_exp or time.time() + MAX_SESSION_TTL_SECS, proxied)
+
+
+def proxied_pin_observed() -> bool | None:
+    """Report the pin scope of the sessions live right now.
+
+    ``None`` = nothing is currently pinned (no scope to report), ``True`` = at
+    least one live session is pinned to a same-host proxy address and is
+    therefore shared by every client behind it, ``False`` = live sessions are
+    pinned to client addresses. Recovers on its own once proxied sessions
+    expire — no gateway restart needed.
+    """
+    return _state.proxied_pin_observed(time.time())
 
 
 def check_token_ip(token: str, ip: str) -> bool:
@@ -1580,8 +1637,16 @@ def token_auth_middleware(
                 # an in-memory check and is cheap enough to run inline.
                 await asyncio.to_thread(_get_revoked_store().revoke, _link_nonce, session_exp)
             # Bind the SESSION token (what becomes the cookie) to the client IP,
-            # not the consumed URL token.
-            bind_token_ip(session_token, client_ip, session_exp)
+            # not the consumed URL token. ``proxied`` is recorded so Security
+            # Posture can tell the user whether that pin is per-client or shared
+            # with everyone behind a same-host tunnel — it does not affect the
+            # binding itself.
+            bind_token_ip(
+                session_token,
+                client_ip,
+                session_exp,
+                is_proxied_request(request),
+            )
 
             # Token-consumption anchor seam (Default: no-op, OSS-identical). A
             # Slack challenge-redirect link, once opened on a verified device,

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -904,7 +904,33 @@ def _token_auth_items() -> list[PostureItem]:
     # read at call time — the documented circular-import exception, and it keeps
     # the advertised windows derived from the enforcing module rather than
     # restated as literals that could drift.
-    from kiro_crew.dashboard.token_auth import LINK_WINDOW_SECS, MAX_SESSION_TTL_SECS
+    from kiro_crew.dashboard.token_auth import (
+        LINK_WINDOW_SECS,
+        MAX_SESSION_TTL_SECS,
+        proxied_pin_observed,
+    )
+
+    # Tri-state, deliberately, and derived from the LIVE bindings so it recovers
+    # on its own. A pin that has collapsed onto a same-host proxy's loopback
+    # address is NOT the control this row used to advertise, and "nothing is
+    # pinned right now" is not evidence that pins are effective — rendering
+    # either as the plain claim is the failure this row is being corrected for.
+    _pinned = proxied_pin_observed()
+    if _pinned is None:
+        _pin_detail = (
+            "A session is bound to the address that first used it. No session is "
+            "currently pinned, so the effective scope is not known yet"
+        )
+    elif _pinned:
+        _pin_detail = (
+            "SHARED, not per-client: sessions are binding to a proxy's address rather than a "
+            "client's — either a same-host tunnel (cloudflared / ngrok / tailscale serve) or a "
+            "reverse proxy in front of this gateway — so every client reaching the dashboard "
+            "through it satisfies the same pin. Reach the dashboard directly, or over a "
+            "transport that preserves the client address, for the pin to identify one client"
+        )
+    else:
+        _pin_detail = "A session is bound to the client address that first used it"
 
     return [
         PostureItem(
@@ -913,7 +939,7 @@ def _token_auth_items() -> list[PostureItem]:
         ),
         PostureItem(
             label="IP pinning",
-            detail="A token is bound to the IP that first used it",
+            detail=_pin_detail,
         ),
         PostureItem(
             label="Single-use link nonce",

--- a/test/test_session_pin_scope.py
+++ b/test/test_session_pin_scope.py
@@ -1,0 +1,164 @@
+"""Session-pin truthfulness: the pin's effective scope must be reported, not asserted.
+
+Two halves, and the seam between them is the point:
+
+* ``is_proxied_request`` must report BOTH proxy shapes — a same-host tunnel
+  (loopback peer) and an upstream proxy on another host (non-loopback peer) —
+  because both make ``request.remote`` a shared address. Peer locality is not
+  part of the test; that is what distinguishes it from
+  ``is_direct_local_request``.
+* The Security Posture ``token_auth`` row must render three distinct states,
+  never render "nothing pinned" as if the control were effective — the same
+  failure mode as a check that never ran being drawn as a check that passed —
+  and must be derived from the LIVE bindings so a single tunnelled login does
+  not pin the row to SHARED for the rest of the gateway's life.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew.dashboard.origin import is_direct_local_request, is_proxied_request
+from kiro_crew.security_posture import build_posture_snapshot
+
+
+def _req(remote: str, headers: dict[str, str] | None = None):
+    """Minimal request double: both predicates read only .remote and .headers."""
+    return SimpleNamespace(remote=remote, headers=headers or {})
+
+
+class TestProxiedPredicate:
+    def test_plain_loopback_is_not_proxied(self) -> None:
+        assert is_proxied_request(_req("127.0.0.1")) is False
+
+    def test_plain_non_loopback_client_is_not_proxied(self) -> None:
+        """A widened bind with a direct client sends no forwarding header."""
+        assert is_proxied_request(_req("203.0.113.7")) is False
+
+    @pytest.mark.parametrize(
+        "header",
+        ["Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "X-Real-IP"],
+    )
+    def test_same_host_proxy_is_proxied(self, header: str) -> None:
+        assert is_proxied_request(_req("127.0.0.1", {header: "203.0.113.7"})) is True
+
+    def test_ipv6_loopback_counts(self) -> None:
+        assert is_proxied_request(_req("::1", {"X-Forwarded-For": "203.0.113.7"})) is True
+
+    def test_UPSTREAM_proxy_on_another_host_is_also_proxied(self) -> None:
+        """The case an earlier, loopback-scoped version of this got wrong.
+
+        An nginx box / container bridge / LAN jump host in front of a widened
+        ``KIROCREW_BIND`` presents a NON-loopback peer — but that peer is the
+        proxy, not the client, so the address is just as shared. Reporting it as
+        per-client would reproduce the untrue claim this predicate removes.
+        """
+        req = _req("10.0.0.5", {"X-Forwarded-For": "203.0.113.7"})
+        assert is_proxied_request(req) is True
+        # Distinct from is_direct_local_request, which stays loopback-scoped
+        # because it answers "is this the local machine".
+        assert is_direct_local_request(req) is False
+
+    def test_empty_remote_without_headers_is_not_proxied(self) -> None:
+        assert is_proxied_request(_req("")) is False
+
+
+def _pin_detail() -> str:
+    control = next(c for c in build_posture_snapshot()["controls"] if c["key"] == "token_auth")
+    return next(i["detail"] for i in control["items"] if i["label"] == "IP pinning")
+
+
+@pytest.fixture(autouse=True)
+def _reset_pin_bindings():
+    """Isolate the binding table — it is process-global by design."""
+    from kiro_crew.dashboard import token_auth
+
+    state = token_auth._state
+    before = dict(state._ip_bindings)
+    state._ip_bindings.clear()
+    yield
+    state._ip_bindings.clear()
+    state._ip_bindings.update(before)
+
+
+def _live() -> float:
+    """An expiry far enough out that the binding counts as live."""
+    return time.time() + 3600
+
+
+class TestPostureReportsEffectivePinScope:
+    def test_nothing_pinned_is_reported_as_not_known_yet_not_as_effective(self) -> None:
+        """A pin nobody is exercising is not evidence the pin works."""
+        from kiro_crew.dashboard.token_auth import proxied_pin_observed
+
+        assert proxied_pin_observed() is None
+        detail = _pin_detail()
+        assert "not known yet" in detail
+        # Must not claim the per-client property it has not observed.
+        assert "client address that first used it" not in detail
+
+    def test_direct_bind_reports_per_client(self) -> None:
+        from kiro_crew.dashboard.token_auth import bind_token_ip, proxied_pin_observed
+
+        bind_token_ip("t-direct", "203.0.113.7", _live(), False)
+        assert proxied_pin_observed() is False
+        assert "client address that first used it" in _pin_detail()
+
+    def test_proxied_bind_reports_shared_pin(self) -> None:
+        """The state the guide used to advertise as a mitigation."""
+        from kiro_crew.dashboard.token_auth import bind_token_ip, proxied_pin_observed
+
+        bind_token_ip("t-proxied", "127.0.0.1", _live(), True)
+        assert proxied_pin_observed() is True
+        detail = _pin_detail()
+        assert "SHARED, not per-client" in detail
+        assert "proxy's address" in detail
+
+    def test_one_live_proxied_binding_dominates(self) -> None:
+        """SHARED while ANY live session is proxied — the dangerous state wins."""
+        from kiro_crew.dashboard.token_auth import bind_token_ip, proxied_pin_observed
+
+        bind_token_ip("t-direct", "203.0.113.7", _live(), False)
+        bind_token_ip("t-proxied", "127.0.0.1", _live(), True)
+        assert proxied_pin_observed() is True
+
+    def test_report_recovers_when_the_proxied_session_expires(self) -> None:
+        """The reason this is derived rather than latched.
+
+        A single tunnelled login must not pin the posture row to SHARED for the
+        rest of the gateway's life. Once that session is no longer live and only
+        direct ones remain, the row has to say per-client again — a stale SHARED
+        is the same class of untrue claim this row exists to remove.
+        """
+        from kiro_crew.dashboard.token_auth import bind_token_ip, proxied_pin_observed
+
+        bind_token_ip("t-proxied", "127.0.0.1", time.time() - 1, True)  # already expired
+        bind_token_ip("t-direct", "203.0.113.7", _live(), False)
+        assert proxied_pin_observed() is False
+        assert "client address that first used it" in _pin_detail()
+
+    def test_all_sessions_expired_reports_not_known_rather_than_stale(self) -> None:
+        from kiro_crew.dashboard.token_auth import bind_token_ip, proxied_pin_observed
+
+        bind_token_ip("t-proxied", "127.0.0.1", time.time() - 1, True)
+        assert proxied_pin_observed() is None
+
+    def test_answer_does_not_depend_on_when_eviction_ran(self) -> None:
+        """Expiry is filtered directly, so lazy eviction cannot change the report."""
+        from kiro_crew.dashboard import token_auth
+
+        token_auth.bind_token_ip("t-proxied", "127.0.0.1", time.time() - 1, True)
+        before_evict = token_auth.proxied_pin_observed()
+        token_auth._state.evict_expired(time.time())
+        assert token_auth.proxied_pin_observed() == before_evict is None
+
+    def test_observation_never_changes_the_binding_itself(self) -> None:
+        """The flag is reporting only — check_ip must be unaffected by it."""
+        from kiro_crew.dashboard.token_auth import bind_token_ip, check_token_ip
+
+        bind_token_ip("t-proxied", "127.0.0.1", _live(), True)
+        assert check_token_ip("t-proxied", "127.0.0.1") is True
+        assert check_token_ip("t-proxied", "203.0.113.7") is False


### PR DESCRIPTION
Phase 1 of the tailnet-access RFC (doc PR #1748). Touches no auth *decision* and no egress path.

## Problem

Two surfaces tell the user their dashboard session is IP-pinned. Behind every tunnel the guide recommends, it is not.

The pin is taken from `request.remote` (the `client_ip` capture in the auth middleware). cloudflared, ngrok and `tailscale serve` all run **on the gateway host** and connect to the loopback-bound gateway from `127.0.0.1`. So:

- the pin binds to the tunnel process, not the client — one pin is satisfied by anyone arriving through that tunnel, for the life of the session (up to the 20h `MAX_SESSION_TTL_SECS`; `kirocrew token` defaults straight to `20h`);
- Security Posture -> Dashboard token auth states flatly *"A token is bound to the IP that first used it"*, with no way for the user to see that theirs has collapsed;
- `docs/guides/remote-and-mobile.md` offers that pin as a **mitigation** for the public exposure it warns about two sentences earlier.

Separately, the same guide lists **Tailscale Funnel** as the option that "keeps the service inside your tailnet". That is backwards — Funnel is the public-ingress mode. `tailscale serve`, the tailnet-only mode, was not mentioned at all.

## Why it matters

A user reading either surface will size their session TTL and their willingness to expose the dashboard against a control that is not operating. The guide actively points them at the *public* Tailscale mode while describing it as the private one.

## Fix (symptom -> root cause -> change)

The symptom is a true-sounding claim on two surfaces. The root cause is that both restate a property of the *code* (the bound address is compared on every request) without accounting for the *deployment* (that address may be a proxy). So neither surface is made to promise less — they are made to **report what actually happened**.

**1. One predicate for "is `request.remote` the client at all"** — `origin.py::is_proxied_request()`. True when any `_PROXY_FORWARD_HEADERS` entry is present, and **peer locality is deliberately not part of the test**, because two proxy shapes both collapse the address:

| Shape | Peer | Pin identifies one client? |
|---|---|---|
| no proxy (local browser, or direct client on a widened `KIROCREW_BIND`) | any, no fwd headers | yes |
| **same-host** tunnel — cloudflared / ngrok / `tailscale serve` / local nginx | loopback | **no — bound to the proxy** |
| **upstream** proxy — nginx box, container bridge, LAN jump host | non-loopback | **no — bound to the proxy** |

Accepted trade-off, stated because it is a chosen direction: a client that sends a forwarding header with no proxy in the path is reported as proxied. That is an **over**-warning, which is the safe error for a surface whose job is to say whether a control is effective.

This is **not** the inverse of `is_direct_local_request()`, which stays loopback-scoped because it answers a different question ("is this the local machine", for the secret-reveal and config-write gates).

**2. Observation, not enforcement** — the binding record gains a `proxied` flag (`_ip_bindings` value becomes `(ip, exp, proxied)`), set from `is_proxied_request(request)` at the one bind site. Nothing reads it in an auth decision; the address comparison is byte-for-byte unchanged, and a test pins that with the flag set.

**3. Tri-state posture row, derived from the LIVE bindings** — `security_posture.py::_token_auth_items()`:

- **nothing live** -> says the effective scope *is not known yet*. It must not render as the working control: a check that never ran is not a check that passed.
- **live, none proxied** -> the original claim, now earned.
- **any live binding proxied** -> `SHARED, not per-client`, naming both proxy shapes and what to do about it.

Derived rather than latched **on purpose**: a latch would outlive the sessions it describes, so one tunnelled login would report SHARED until the gateway restarted even after that session expired and the user went back to direct access — the same class of stale claim this row exists to remove. Expiry is filtered directly rather than trusting lazy eviction to have run, so the answer never depends on when eviction last happened.

**4. Guide correction, scoped to all three tunnels** — not just the Tailscale rows. The claim is equally false for cloudflared and ngrok, so fixing one and leaving two would be knowingly shipping a wrong doc at no saving (this resolves the RFC's OQ6, adjudicated in the RFC PR). The note now says what the pin actually binds to, that the audit `caller` reads `127.0.0.1` for the same reason, points at the posture row, and names the real controls (provider auth + short TTLs). `tailscale serve` is documented as its own path with the Funnel distinction made explicit.

## Tests

`test/session_pin_scope` (18 tests):

- **Predicate** — plain loopback and a plain non-loopback client are both not proxied; each of the five forwarding headers individually triggers it; `::1` counts; **an upstream proxy on another host is proxied** *and* `is_direct_local_request()` is separately asserted False, pinning that the two predicates answer different questions.
- **Posture** — nothing-live reports "not known yet" *and* is asserted **not** to contain the per-client claim; a direct bind reports per-client; a proxied bind reports `SHARED`; one live proxied binding dominates a direct one; **the report recovers once the proxied session expires**; all-expired reports not-known rather than stale; the answer does not change across an `evict_expired()` call.
- **Non-interference** — the address check accepts the bound address and rejects another *with the observation flag set*, so the flag cannot start gating auth unnoticed.

An autouse fixture saves/restores the process-global binding table.

## Manual verification

N/A — the posture row is asserted through `build_posture_snapshot()`, the same path the HTTP endpoint serves, and the guide change is prose. Not covered by unit tests: how the longer detail string wraps in the Security Posture UI (no layout change, existing row).

## What this deliberately does NOT do

- **Does not fix the pin.** Repairing it needs a verified peer identity — RFC Phase 3, which touches the auth path and wants adversarial review. This PR makes the state honest and visible; tracked as #1762.
- **Does not touch `is_direct_local_request()`.** Config-write and secret-reveal endpoints keep refusing proxied requests.
- **Does not change any binding, comparison, or TTL.**
- **Does not break down the count** of proxied vs direct live sessions. Raised as a Design Review suggestion; deferred as a Phase-2 follow-up rather than widening this PR.

## Gates

`pytest` 381 passed (this file + `test_security_posture` / `test_dashboard_origin` / the auth suite), `isort`, `flake8 -j 1`, `mypy` 1.14.1 pin-matched with no `faiss` (728 files) — all clean. `docs-lint`, `brand-lint`, `scrub-lint` green.
