### PR TITLE
ci: evaluate fork AI reviews in PR Readiness so a green fork can pass

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -26,6 +26,14 @@ on:
       - Design Review
       - UX Review
       - CodeQL
+      # Stage-2 fork AI reviewers. They run from the default branch via
+      # `workflow_run` (on CI's completion), so their own completion must
+      # re-trigger this job to publish the fork PR's real verdict once the
+      # reviews land -- otherwise the fork verdict freezes at `checking`.
+      - Fork Opus 5 Review
+      - Fork GPT 5.6 Review
+      - Fork Design Review
+      - Fork UX Review
     # `completed` publishes the real verdict. `requested`/`in_progress` exist so
     # a monitored workflow flipping BACK to running -- most commonly a re-run of
     # a reviewer (e.g. Opus 5 re-run after a human override) -- re-triggers this
@@ -105,10 +113,17 @@ jobs:
     # key, and the step below resolves it to a PR (skipping cleanly when no
     # open PR owns it), so admitting every pull_request run is correct and the
     # non-PR events are already excluded by the event check.
+    #
+    # `workflow_run.event == 'workflow_run'` is admitted so the Stage-2 fork AI
+    # reviewers (fork-*-review.yml, themselves triggered by CI's workflow_run)
+    # re-trigger this job when they complete -- that is how a fork PR's verdict
+    # refreshes to "passed" once its reviews land. Which workflows can fire this
+    # is already fenced by the `on.workflow_run.workflows` allowlist above.
     if: >-
       github.event_name != 'workflow_run'
       || github.event.workflow_run.event == 'pull_request'
       || github.event.workflow_run.event == 'dynamic'
+      || github.event.workflow_run.event == 'workflow_run'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -226,16 +241,20 @@ jobs:
           )
           skipped=()
           if [ "$FORK" = "true" ]; then
-            # Fork PRs cannot receive repository OIDC credentials or secrets,
-            # and this repository's managed default-setup CodeQL workflow is
-            # not scheduled for fork heads. Public CI, build, and static review
-            # still determine readiness.
-            skipped+=(
-              "CodeQL (fork PR)"
-              "Opus 5 Review (fork PR)"
-              "GPT 5.6 Review (fork PR)"
-              "Design Review (fork PR)"
-              "UX Review (fork PR)"
+            # A fork head cannot run the repository's managed default-setup
+            # CodeQL, so that lane stays ineligible. The AI code reviews DO run
+            # on forks: the privileged Stage-2 fork-*-review.yml pipeline fires
+            # on CI completion from the default branch and posts a check-run
+            # named exactly like the same-repo lane ("Opus 5 Review", etc.).
+            # Read those results from the head SHA's check-runs (checkrun:
+            # specs) so a fully-reviewed green fork can reach "passed" instead
+            # of being forced to a maintainer-review verdict.
+            skipped+=("CodeQL (fork PR)")
+            workflow_specs+=(
+              "checkrun:Opus 5 Review|Opus 5 Review"
+              "checkrun:GPT 5.6 Review|GPT 5.6 Review"
+              "checkrun:Design Review|Design Review"
+              "checkrun:UX Review|UX Review"
             )
           else
             workflow_specs+=(
@@ -253,6 +272,50 @@ jobs:
           for spec in "${workflow_specs[@]}"; do
             file="${spec%%|*}"
             label="${spec#*|}"
+            if [[ "$file" == checkrun:* ]]; then
+              # Fork AI-review lane: the verdict lives in the head SHA's
+              # check-runs, not a PR-bound workflow run (the fork reviewer runs
+              # via workflow_run from the default branch, so its workflow-run
+              # head ref does not bind back to the fork). The same-repo lane
+              # posts a `skipped` check-run under this same name on a fork, and
+              # the GPT lane posts several passes -- so collapse ALL check-runs
+              # of this name: any still running -> pending; any failure-class
+              # -> fail; else any success/neutral -> pass; only skipped (the
+              # real review has not posted yet) -> pending.
+              cname="${file#checkrun:}"
+              enc="$(jq -rn --arg v "$cname" '$v | @uri')"
+              cruns="$(gh api --method GET \
+                "repos/$REPO/commits/$SHA/check-runs?check_name=$enc&per_page=100")"
+              total="$(jq '.check_runs | length' <<<"$cruns")"
+              incomplete="$(jq '[.check_runs[]
+                | select(.status != "completed")] | length' <<<"$cruns")"
+              fail="$(jq '[.check_runs[]
+                | select(.status == "completed"
+                    and (.conclusion | IN("failure","timed_out","cancelled",
+                                           "action_required","stale",
+                                           "startup_failure")))] | length' <<<"$cruns")"
+              pass="$(jq '[.check_runs[]
+                | select(.status == "completed"
+                    and (.conclusion | IN("success","neutral")))] | length' <<<"$cruns")"
+              if [ "$total" -eq 0 ] || [ "$incomplete" -gt 0 ]; then
+                pending+=("$label (not started)")
+              elif [ "$label" = "Design Review" ] || [ "$label" = "UX Review" ]; then
+                # Advisory: once the real review posts any decisive result it
+                # never blocks; only-skipped means it has not posted yet.
+                if [ "$fail" -gt 0 ] || [ "$pass" -gt 0 ]; then
+                  passed+=("$label (advisory)")
+                else
+                  pending+=("$label (not started)")
+                fi
+              elif [ "$fail" -gt 0 ]; then
+                failed+=("$label (failure)")
+              elif [ "$pass" -gt 0 ]; then
+                passed+=("$label")
+              else
+                pending+=("$label (not started)")
+              fi
+              continue
+            fi
             if [ "$file" = "dynamic/github-code-scanning/codeql" ]; then
               runs="$(gh api --method GET \
                 "repos/$REPO/actions/runs?event=dynamic&head_sha=$SHA&per_page=100")"
@@ -355,21 +418,13 @@ jobs:
             label="readiness: checking"
             status_state="pending"
             description="${#waiting[@]} readiness check(s) still pending"
-          elif [ "$FORK" = "true" ]; then
-            # Fork PRs structurally CANNOT run the AI code reviews (Opus/GPT/
-            # Design/UX) or CodeQL -- those are guarded off on fork
-            # heads and cannot be made to run there. Passing public CI/Build/
-            # Code Review is therefore NOT full validation, so a fork PR must
-            # never reach "passed". Emit a dedicated RED (failure) terminal
-            # verdict instead: it is unmistakable in the merge box and, as a
-            # required status check, blocks an accidental merge of code the AI
-            # reviewers never saw. A maintainer must review manually, or re-run
-            # validation from a trusted in-repo branch, before merge.
-            state="maintainer_review"
-            label="readiness: maintainer review"
-            status_state="failure"
-            description="Fork PR — AI reviews could not run; maintainer review required before merge"
           else
+            # Fork PRs reach this branch too: the AI code reviews run on forks
+            # via the Stage-2 fork-*-review.yml pipeline and are evaluated above
+            # from the head SHA's check-runs, so a fully-green fork is fully
+            # validated (CodeQL is the only ineligible lane, listed as a
+            # non-blocking "Not eligible" note) and earns "passed" like any
+            # same-repo PR.
             state="passed"
             label="readiness: passed"
             status_state="success"
@@ -389,12 +444,6 @@ jobs:
             echo "- PR: #$PR"
             echo "- Revision: \`$SHA\`"
             echo "- Passed components: ${#passed[@]}"
-            if [ "$state" = "maintainer_review" ]; then
-              echo
-              echo "> ⚠️ **Fork PR — automated AI code reviews (Opus/GPT/Design/UX) and CodeQL cannot run on a fork head.**"
-              echo "> Passing public CI/Build/Code Review is NOT full validation. A maintainer must review manually,"
-              echo "> or re-run validation from a trusted in-repo branch, before this PR is merged."
-            fi
             if [ "${#skipped[@]}" -gt 0 ]; then
               echo
               echo "**Not eligible**"
@@ -434,7 +483,6 @@ jobs:
           label_specs=(
             "readiness: checking|BFDADC|Automated validation is still running"
             "readiness: action required|D73A4A|A blocking check or review needs attention"
-            "readiness: maintainer review|B60205|Fork PR — AI reviews could not run; maintainer must review before merge"
             "readiness: passed|0E8A16|Eligible automated validation passed for the current revision"
           )
           existing_labels="$(gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name')"

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -263,17 +263,34 @@ class TestPrReadiness:
             assert workflow_name in workflow
         assert 'success|skipped) passed+=("$label")' in workflow
 
-    def test_fork_readiness_omits_unavailable_review_lanes(self) -> None:
+    def test_fork_readiness_reads_ai_reviews_from_check_runs(self) -> None:
+        # A fork head cannot run default-setup CodeQL, but the AI code reviews
+        # DO run on forks via the Stage-2 fork-*-review.yml pipeline, which
+        # posts check-runs under the same names the same-repo lanes use.
+        # Readiness evaluates those from the head SHA's check-runs so a fully
+        # green fork reaches "passed" -- never the old blanket skip or the
+        # maintainer-review dead end.
         workflow = _workflow("pr-readiness.yml")
 
         assert "isCrossRepository" in workflow
         assert '[ "$FORK" = "true" ]' in workflow
+        # CodeQL stays the only ineligible fork lane.
         assert '"CodeQL (fork PR)"' in workflow
-        assert '"GPT 5.6 Review (fork PR)"' in workflow
-        fork_branch = workflow.index('if [ "$FORK" = "true" ]; then')
-        same_repo_branch = workflow.index("else", fork_branch)
-        codeql_spec = workflow.index('"dynamic/github-code-scanning/codeql|CodeQL"')
-        assert same_repo_branch < codeql_spec
+        # AI reviews are now monitored on forks via check-run specs.
+        assert '"checkrun:Opus 5 Review|Opus 5 Review"' in workflow
+        assert '"checkrun:GPT 5.6 Review|GPT 5.6 Review"' in workflow
+        assert '"checkrun:Design Review|Design Review"' in workflow
+        assert '"checkrun:UX Review|UX Review"' in workflow
+        assert "commits/$SHA/check-runs?check_name=$enc" in workflow
+        # The blanket fork skip and the maintainer-review verdict are gone.
+        assert '"GPT 5.6 Review (fork PR)"' not in workflow
+        assert 'state="maintainer_review"' not in workflow
+        assert "AI reviews could not run" not in workflow
+        # Stage-2 fork reviewers re-trigger readiness on completion so the
+        # green verdict actually lands.
+        assert "Fork Opus 5 Review" in workflow
+        assert "Fork GPT 5.6 Review" in workflow
+        assert "github.event.workflow_run.event == 'workflow_run'" in workflow
 
     def test_external_check_polling_counts_each_pass_once(self) -> None:
         workflow = _workflow("pr-readiness.yml")


### PR DESCRIPTION
## Problem
On a fork PR, the `PR Readiness` status sits red/stale ("N blocking readiness item(s)" or a hard `maintainer review`) even when every check has passed. Concretely, PR #1742 (a fork PR) has all of CI, Build, Code Review green and Opus/GPT/Design/UX **passing** — yet readiness never reaches `passed`.

## Why it matters
Fork PRs are the external-contributor path. Readiness was hard-coded to assume "AI reviews cannot run on a fork," so it skipped those lanes and forced a red `maintainer_review` verdict — permanently un-green, regardless of the actual (passing) review results. That is a confusing, discouraging contributor experience and makes the readiness signal meaningless for forks.

## Fix (symptom → root cause → change)
- Symptom: a fully-green fork PR shows readiness red/stuck.
- Root cause: the evaluator's fork branch skips Opus/GPT/Design/UX and the terminal verdict short-circuits forks to `maintainer_review`. But this repo *does* review forks — the privileged Stage-2 `fork-*-review.yml` pipeline runs on CI completion and posts check-runs named exactly like the same-repo lanes (`Opus 5 Review`, etc.). Readiness simply wasn't reading them. Their premise ("AI reviews could not run") is false.
- Change:
  1. **Evaluate fork AI reviews from the head SHA's check-runs.** The fork reviewers run via `workflow_run` from the default branch, so their *workflow-run* head ref does not bind back to the fork — but the **check-runs they post are attributed to the fork head**. New `checkrun:` specs read `GET /commits/{sha}/check-runs?check_name=<name>` and collapse duplicate-named runs (the same-repo lane posts a `skipped` copy; GPT posts several passes): any still-running → pending; any failure-class → block (Opus/GPT); else any success/neutral → pass; only-skipped (real review not posted yet) → pending. Design/UX stay advisory.
  2. **CodeQL remains the only ineligible fork lane** (default-setup CodeQL is not scheduled on fork heads), listed as a non-blocking "Not eligible" note.
  3. **Drop the terminal `maintainer_review` verdict** so a fully-green fork falls through to `passed` like any same-repo PR. (The label stays in the cleanup lists so PRs previously stuck on it are migrated clean.)
  4. **Re-trigger on fork-reviewer completion.** Add `Fork Opus/GPT/Design/UX Review` to the `workflow_run` allowlist and admit `workflow_run.event == 'workflow_run'` through the job gate, so the verdict refreshes to `passed` once the reviews land instead of freezing at `checking`. Which workflows can fire this stays fenced by the allowlist.

## Tests
`test/test_ai_review_workflows.py`: replaced `test_fork_readiness_omits_unavailable_review_lanes` with `test_fork_readiness_reads_ai_reviews_from_check_runs`, asserting the fork branch monitors the four AI reviews via `checkrun:` specs, reads them from the head SHA's check-runs, keeps CodeQL as the only ineligible lane, drops the `maintainer_review` verdict + "AI reviews could not run" text, and re-triggers on the Stage-2 reviewers. Full `test_ai_review_workflows.py` (33) + `test_workflow_permissions.py` / `test_github_workflow_security.py` (11) pass; YAML validates.

## Manual verification
Replayed the collapse logic against PR #1742's real head SHA check-runs: `Opus 5 Review → PASS`, `GPT 5.6 Review → PASS` (3 skipped + 1 success), `Design Review → PASS (advisory)`, `UX Review → PASS (advisory)`. Combined with green CI/Build/Code Review and CodeQL as a non-blocking skip, the verdict resolves to **passed** — exactly the intended outcome.
