### PR TITLE
fix(history): keep turn persistence off the event loop and order slot rows against foreign writes

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -170,6 +170,57 @@ no longer destroy older turns.
   patiently to a bounded deadline. The same discipline applies to every other
   session-JSONL writer: `clear_closed` (resume un-flags `closed` under `_locked`,
   offloaded via `asyncio.to_thread`) and all `history.py` mutators hold `_locked`.
+- **Turn persistence is offloaded through ONE choke point**
+  (`save_conversation_turn_off_loop`, `llm_helpers.py`): `save_conversation_turn`
+  makes TWO `append` calls, so an on-loop caller pays ~24 ms of loop time per turn
+  AND takes `_locked`'s single non-blocking acquire — dropping the durable copy
+  exactly when another writer is active. Every async caller (the Slack handler,
+  gateway, and transport dispatch) awaits the choke point rather than restating
+  the offload, and `test_persist_off_loop.py` is an AST build gate that fails if
+  any `async def` body calls `save_conversation_turn` directly. Unlike
+  `append_off_loop`, the choke point **awaits** the write: its callers go on to
+  refresh a dashboard tab or hand the session to consolidation, both of which read
+  the transcript back.
+- **A turn is an atomic PAIR, and offloading is what makes that need saying.**
+  `append` locks per ROW, so two concurrent turn-writes for one session can land
+  as `user_A, user_B, assistant_A, assistant_B` — turns that no longer pair up,
+  and which no ordering pass can repair because every row's `ts` is individually
+  correct. On the event loop this was impossible: a synchronous
+  `save_conversation_turn` never yields between its two appends, so the
+  single-threaded loop made the pair atomic *by accident*. Moving the write to a
+  worker thread removes exactly that accidental guarantee. So
+  `ConversationLog.atomic_appends(key)` is the required companion to the offload,
+  not an optional extra: **any caller that offloads MULTIPLE appends for one
+  session must hold it around the whole group.** `_locked` is reentrant for the
+  same key on the same thread, so the per-row locks inside `append` reuse the
+  held lock. Enter it off the loop only — it takes the same fail-fast-on-loop
+  acquire path as `append`.
+- **Row ordering has two writers with different floor sources.** Both
+  `ConversationLog.append` and `_ChatSlot.append` stamp each row strictly after
+  its predecessor via `monotonic_transcript_ts`, so a `ts` sort reproduces write
+  order even on a host whose clock cannot separate two writes (Windows ticks in
+  ~15.6 ms steps). They learn about that predecessor differently, and the
+  asymmetry is deliberate:
+  - `ConversationLog.append` reads the authoritative on-disk tail (`_last_row_ts`)
+    under the cross-process flock, so it sees every committed row.
+  - `_ChatSlot.append` runs on the event loop, where a `stat` plus a tail read per
+    append would violate the no-blocking-call-on-event-loop rule. It floors on
+    `latest_transcript_ts(window_tail, slot._disk_tail_ts)` — both in-process
+    reads. `_disk_tail_ts` is refreshed at the save boundary, inside the `_locked`
+    section where the foreign lines are already parsed, so it costs nothing.
+
+  The window is NOT a superset of the file: a genuinely foreign on-disk row is
+  preserved without being folded into `slot.messages`, so without the cached tail
+  the slot's next row could TIE it. A foreign row arriving *between* two saves is
+  still invisible until the next one — the reachable shape (a subagent/cron append
+  observed at the following flush) is closed, the general case is not, and that
+  bound is intentional rather than an oversight. The floor is monotone by
+  construction: `latest_transcript_ts` only ever selects a *later* candidate, so it
+  can move a row forward but never backward. It **skips** candidates it cannot
+  parse, because `transcript_sort_key` deliberately buckets unparseable values
+  AFTER every real instant (right for display order, backwards for a floor) — one
+  corrupt row would otherwise win the comparison, be discarded by the stamper as
+  unparseable, and switch the ordering guarantee off for that session.
 - **On-loop offload discipline is enforced, not convention-only**: the offload
   invariant above was previously guaranteed only by convention — a future
   contributor calling a raw mutator (`append` / `update_metadata` / `set_title`

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -29,6 +29,7 @@ from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
 from kiro_crew.history import (
     _archive_lines,
     carry_provenance,
+    latest_transcript_ts,
     transcript_sort_key,
     update_metadata_off_loop,
 )
@@ -985,6 +986,30 @@ def _build_message_entry(m: dict) -> dict | None:
 _TRANSIENT_ROLES = frozenset({"chunk", "done", "streaming", "queued", "permission"})
 
 
+def _foreign_tail_ts(foreign_lines: list[str]) -> str | None:
+    """The newest parseable ``ts`` among *foreign_lines*, or ``None``.
+
+    Named and single-sourced so "how a slot learns the disk tail" is one thing a
+    reader can find, rather than a loop inlined in the save. Sits beside
+    :func:`_interleave_foreign_lines` because they consume the same input: those
+    lines are on-disk rows this slot never observed, which is exactly why they are
+    the rows its ordering floor would otherwise miss.
+
+    Malformed lines are skipped rather than propagated -- a corrupt row must not
+    become the floor (``latest_transcript_ts`` refuses unparseable candidates for
+    the same reason).
+    """
+    tail: str | None = None
+    for line in foreign_lines:
+        try:
+            row_ts = json.loads(line).get("ts")
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if isinstance(row_ts, str):
+            tail = latest_transcript_ts(tail, row_ts)
+    return tail
+
+
 def _interleave_foreign_lines(
     window_entries: list[dict],
     window_lines: list[str],
@@ -1515,6 +1540,21 @@ def _save_slot_to_history(
                     )
             payload = meta_str + frozen_prefix + "".join(
                 _interleave_foreign_lines(window_entries, window_lines, foreign_lines)
+            )
+
+            # Refresh the slot's ordering floor from what is actually going to
+            # disk, foreign rows included. This is the only place the slot can
+            # learn about a row it never observed: the lock is already held and
+            # the foreign lines are already in hand, whereas reading the tail per
+            # append would put file I/O on the event loop. It does not make the
+            # slot fully symmetric with ConversationLog.append -- a foreign row
+            # arriving BETWEEN two saves stays invisible until the next one -- but
+            # it closes the reachable shape, where a subagent/cron append is
+            # observed at the next flush. The monotone rule itself lives on the
+            # slot (note_disk_tail), so this cannot move the floor backwards.
+            slot.note_disk_tail(
+                _foreign_tail_ts(foreign_lines),
+                window_entries[-1].get("ts") if window_entries else None,
             )
 
             # Rewrite paths (rewind/regenerate/fork) intentionally TRUNCATE the

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -28,7 +28,7 @@ from kiro_crew.config.loader import DASHBOARD_PORT, config_dir
 from kiro_crew.constants import OPTIONS_RE_LINE
 from kiro_crew.dashboard.chat_compaction_notice import deliver_channel_compaction_notice
 from kiro_crew.dashboard.side_state import SideState
-from kiro_crew.history import monotonic_transcript_ts
+from kiro_crew.history import latest_transcript_ts, monotonic_transcript_ts
 from kiro_crew.knowledge.store import KnowledgeStore
 from kiro_crew.messaging.link import (
     SLACK_NAMESPACE,
@@ -861,6 +861,7 @@ class _ChatSlot:
         "_channel_window_mtime",
         "_disk_older_count",
         "_disk_window_len",
+        "_disk_tail_ts",
         "_frozen_prefix_cache",
         "_pending_rewrite",
         "_file_changes",
@@ -1078,7 +1079,18 @@ class _ChatSlot:
         # watermark is what makes the #8 trim credit safe. It is NOT a fragile
         # "what to append" counter — saves always re-serialize the WHOLE window.
         self._disk_window_len: int = 0
-        # Cached frozen-prefix bytes for the append-safe save model.
+        # The newest ``ts`` seen on disk at the last save, INCLUDING rows this
+        # slot never observed. A subagent, cron, or CLI appending to a session a
+        # live tab also has open writes rows that ``_save_slot_to_history``
+        # preserves as "foreign" without ever folding them into ``messages`` --
+        # so the window is not a superset of the file, and flooring the next
+        # append on the window tail alone can tie a foreign row's timestamp.
+        # Cached rather than read per append: consulting the file here would put
+        # a stat plus a bounded read on the event loop, which AUTOSDE's
+        # no-blocking-call-on-event-loop rule forbids. Refreshed at the save
+        # boundary, where the lock is already held and the foreign lines are
+        # already parsed.
+        self._disk_tail_ts: str | None = None        # Cached frozen-prefix bytes for the append-safe save model.
         # The session file is FROZEN-PREFIX (the first _disk_older_count on-disk
         # message lines, OLDER than the in-memory window) + a fresh re-serialize
         # of the whole window. The prefix is never rewritten, so a restart that
@@ -1219,6 +1231,20 @@ class _ChatSlot:
             "current": current,
         }
 
+    def note_disk_tail(self, *candidates: str | None) -> None:
+        """Record the newest ``ts`` known to be ON DISK for this session.
+
+        The save boundary is the only place a slot can learn about a row it never
+        observed (see ``_disk_tail_ts``), so it calls this with whatever it just
+        wrote -- foreign rows included. Keeping the update here rather than
+        assigning the attribute from the persistence module means the **monotone**
+        rule lives with the field it guards: the floor may only ever move FORWARD.
+        A save that moved it backwards would re-open the same-``ts`` tie the floor
+        exists to prevent, and unparseable candidates are skipped rather than
+        ranked (``latest_transcript_ts``), so one corrupt row cannot capture it.
+        """
+        self._disk_tail_ts = latest_transcript_ts(self._disk_tail_ts, *candidates)
+
     def append(
         self,
         role: str,
@@ -1240,9 +1266,19 @@ class _ChatSlot:
             # the clock does not tick between two appends. An explicit *ts*
             # (a row replayed from a channel transcript) is preserved verbatim
             # -- rewriting it would reorder the replay it came from.
+            #
+            # The floor is the later of the window tail and the last on-disk tail
+            # this slot was told about, because the window is NOT a superset of
+            # the file: a row written by another process is preserved as a
+            # foreign line without entering ``messages``, so flooring on the
+            # window alone leaves it un-ordered-against. Both candidates are
+            # in-process reads -- no file I/O on the event loop.
             "ts": ts
             or monotonic_transcript_ts(
-                self.messages[-1].get("ts") if self.messages else None,
+                latest_transcript_ts(
+                    self.messages[-1].get("ts") if self.messages else None,
+                    self._disk_tail_ts,
+                ),
                 datetime.now(timezone.utc),
             ),
         }

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -708,6 +708,49 @@ def _redact_at_write_boundary(role: str, content: str) -> str:
     return content
 
 
+def latest_transcript_ts(*candidates: str | None) -> str | None:
+    """The latest of several candidate predecessor timestamps, or ``None``.
+
+    A writer can have more than one row to order itself against, and the two
+    writers of a session transcript learn about predecessors differently:
+    :meth:`ConversationLog.append` reads the authoritative file tail under the
+    cross-process flock, while the dashboard's ``_ChatSlot.append`` runs on the
+    event loop and may only consult in-process state (a ``stat`` plus a file read
+    per append is what ``AUTOSDE.yaml``'s ``no-blocking-call-on-event-loop`` rule
+    forbids). The slot therefore floors on the later of its in-memory window tail
+    and the last on-disk tail it was told about at the previous save.
+
+    Comparison goes through :func:`transcript_sort_key`, never string ordering:
+    rows carry two stored formats (aware and naive isoformat), so ``"a" > "b"``
+    on the raw strings compares different domains and can pick the earlier row.
+
+    An UNPARSEABLE candidate is skipped rather than ranked. ``transcript_sort_key``
+    deliberately buckets a value it cannot parse *after* every real instant, so
+    that a corrupt line displays at the end of a transcript rather than in the
+    middle of the conversation. That is right for sorting and wrong for a floor:
+    ranked, one malformed ``ts`` would win here, and
+    :func:`monotonic_transcript_ts` ignores a previous value it cannot parse — so
+    a single corrupt row on disk would silently switch the whole ordering
+    guarantee off and let the next row tie its predecessor again.
+
+    ``None`` and empty candidates are ignored too, so a caller can pass a value it
+    does not have yet without branching. Returns ``None`` when nothing usable was
+    supplied — which correctly means "no floor", not "floor of zero".
+    """
+    best: str | None = None
+    best_key: tuple[int, float] | None = None
+    for candidate in candidates:
+        if not candidate:
+            continue
+        key = transcript_sort_key(candidate)
+        if key[0] != 0:
+            # Unparseable: see the docstring. Not a usable floor.
+            continue
+        if best_key is None or key > best_key:
+            best, best_key = candidate, key
+    return best
+
+
 #: Default upper bound on the number of distinct session keys held in the
 #: in-memory transcript / metadata caches.  The previous implementation used
 #: plain ``dict`` caches that grew one entry per session key touched and never
@@ -1075,6 +1118,34 @@ class ConversationLog:
                     # executor load). The deferred release re-checks depth and
                     # its own fd under the guard, so a reuse cancels it.
                     self._schedule_flock_release(key, lock_key, state[0])
+
+    @contextlib.contextmanager
+    def atomic_appends(self, key: str) -> Iterator[None]:
+        """Group several appends to one session into ONE indivisible write.
+
+        :meth:`append` locks per ROW, so two callers each writing a
+        user+assistant PAIR can interleave into ``user_A, user_B, assistant_A,
+        assistant_B`` -- a transcript whose turns no longer pair up, and which no
+        timestamp ordering can repair because every row's ``ts`` is correct.
+
+        The hazard is specific to concurrent writers. A caller running ON the
+        event loop could not hit it: ``save_conversation_turn`` never awaits
+        between its two appends, so the single-threaded loop made the pair
+        effectively atomic. It appears exactly when a caller does the right thing
+        and moves the write OFF the loop, because two worker threads then run
+        those pairs concurrently. So this is the companion any multi-append
+        caller needs alongside the offload, not an optional extra.
+
+        ``_locked`` is reentrant for the same key on the same thread, so the
+        per-row locks inside ``append`` reuse the lock held here rather than
+        deadlocking on it.
+
+        Enter this OFF the event loop. It takes the same acquire path as
+        ``append``, which fails fast with :class:`HistoryLockTimeout` on a
+        running loop rather than blocking it.
+        """
+        with self._locked(key):
+            yield
 
     def _schedule_flock_release(self, key: str, lock_key: str, fd: int) -> None:
         """Release+close *fd* off the loop iff the entry is still idle.

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -838,3 +838,59 @@ def save_conversation_turn(
             source_thread=source_thread,
             source_user=source_user,
         )
+
+
+async def save_conversation_turn_off_loop(
+    log: ConversationLog,
+    key: str,
+    user_text: str,
+    assistant_text: str,
+    source_thread: str | None = None,
+    source_user: str | None = None,
+    agent: str | None = None,
+) -> None:
+    """Save a turn without blocking (or fail-fast-dropping on) the event loop.
+
+    :func:`save_conversation_turn` makes TWO ``ConversationLog.append`` calls, and
+    append acquires a cross-process flock and writes to disk -- ~12 ms each on a
+    large transcript. Called directly from an ``async def`` that is worse than
+    slow: on a running loop ``_locked`` makes a single NON-blocking acquire and
+    raises :class:`~kiro_crew.history.HistoryLockTimeout` on any concurrent
+    holder, and most callers swallow that, so the durable copy was dropped
+    exactly when another writer was active. Off the loop the same primitive takes
+    the patient poll-to-deadline path instead.
+
+    This is the single choke point for every async caller, so the offload cannot
+    be forgotten at a new call site and the ten Slack sites do not each restate
+    it.
+
+    Unlike :func:`~kiro_crew.history.append_off_loop`, this **awaits** the write
+    rather than firing it at the executor and returning. That difference is
+    deliberate: callers here go on to refresh a dashboard tab or hand the session
+    to consolidation, both of which read the transcript back, so the turn has to
+    be on disk before the caller continues. ``append_off_loop`` has no such
+    reader and can afford to be fire-and-forget.
+
+    The whole turn is written under one :meth:`~kiro_crew.history.ConversationLog.atomic_appends`
+    hold. ``append`` locks per ROW, so without it two concurrent turns for the
+    same session could interleave into ``user_A, user_B, assistant_A,
+    assistant_B`` -- turns that no longer pair up, which no timestamp ordering can
+    repair because each row's ``ts`` is individually correct. On the loop that was
+    impossible (a synchronous caller never yields between its two appends), so the
+    hazard is introduced BY offloading and has to be closed here rather than
+    inherited.
+    """
+
+    def _write() -> None:
+        with log.atomic_appends(key):
+            save_conversation_turn(
+                log,
+                key,
+                user_text,
+                assistant_text,
+                source_thread=source_thread,
+                source_user=source_user,
+                agent=agent,
+            )
+
+    await asyncio.to_thread(_write)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -133,7 +133,7 @@ from kiro_crew.llm_helpers import (
     PromptBusyExhaustedError,
     ToolApprovalPolicy,
     provider_last_turn_usage,
-    save_conversation_turn,
+    save_conversation_turn_off_loop,
     stream_and_collect,
 )
 from kiro_crew.mcp_gateway import is_gateway_supported
@@ -2947,7 +2947,7 @@ class GatewayOrchestrator:
                 safe_nudge, _ = redact_credentials(safe_nudge)
                 safe_response, _ = redact_exfiltration_urls(response or "")
                 safe_response, _ = redact_credentials(safe_response)
-                save_conversation_turn(
+                await save_conversation_turn_off_loop(
                     self.conv_log,
                     key,
                     safe_nudge,
@@ -4317,7 +4317,7 @@ class GatewayOrchestrator:
                                 safe_announce, _ = redact_credentials(safe_announce)
                                 safe_response, _ = redact_exfiltration_urls(response or "")
                                 safe_response, _ = redact_credentials(safe_response)
-                                save_conversation_turn(
+                                await save_conversation_turn_off_loop(
                                     self.conv_log,
                                     parent_key,
                                     safe_announce,

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -67,7 +67,7 @@ from kiro_crew.hooks import (
     safe_read_file_bytes,
     validate_file_path,
 )
-from kiro_crew.llm_helpers import record_interaction_event, save_conversation_turn
+from kiro_crew.llm_helpers import record_interaction_event, save_conversation_turn_off_loop
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import canonical_key
 from kiro_crew.platform import current_context
@@ -2402,7 +2402,9 @@ async def maybe_handle_keyword_command(
         if spawn_reply:
             await slack.post_message(channel, spawn_reply, reply_ts)
             if conversation_log and not _is_slack_restricted(session_key):
-                save_conversation_turn(
+                # Offloaded via the shared choke point -- see
+                # save_conversation_turn_off_loop for why every async caller must.
+                await save_conversation_turn_off_loop(
                     conversation_log,
                     session_key,
                     text,
@@ -2419,7 +2421,7 @@ async def maybe_handle_keyword_command(
         if run_reply:
             await slack.post_message(channel, run_reply, reply_ts)
             if conversation_log and not _is_slack_restricted(session_key):
-                save_conversation_turn(
+                await save_conversation_turn_off_loop(
                     conversation_log,
                     session_key,
                     text,
@@ -2436,7 +2438,7 @@ async def maybe_handle_keyword_command(
         if cron_reply:
             await slack.post_message(channel, cron_reply, reply_ts)
             if conversation_log and not _is_slack_restricted(session_key):
-                save_conversation_turn(
+                await save_conversation_turn_off_loop(
                     conversation_log,
                     session_key,
                     text,
@@ -2616,7 +2618,7 @@ async def handle_message(
         if hook_result.action == HOOK_REPLY:
             await slack.post_message(channel, hook_result.text, reply_ts)
             if conversation_log and not _is_slack_restricted(session_key):
-                save_conversation_turn(
+                await save_conversation_turn_off_loop(
                     conversation_log,
                     session_key,
                     text,
@@ -3599,7 +3601,7 @@ async def handle_message(
             except Exception:
                 logger.debug("Failed to delete thinking placeholder", exc_info=True)
         if conversation_log and not _is_slack_restricted(session_key):
-            save_conversation_turn(
+            await save_conversation_turn_off_loop(
                 conversation_log,
                 session_key,
                 text,
@@ -3700,7 +3702,7 @@ async def handle_message(
         logger.info("Review mode: ephemeral draft sent to %s in %s", user_id, channel)
         # Persist conversation (draft counts as a turn)
         if conversation_log and not _is_slack_restricted(session_key):
-            save_conversation_turn(
+            await save_conversation_turn_off_loop(
                 conversation_log,
                 session_key,
                 text,
@@ -3857,7 +3859,9 @@ async def handle_message(
     # ── Persist conversation history ──
     _skip_writes = _is_slack_restricted(session_key)
     if conversation_log and not _skip_writes:
-        save_conversation_turn(
+        # The per-turn hot path: two appends every turn, so this is where the
+        # ~12ms of loop time was paid most often.
+        await save_conversation_turn_off_loop(
             conversation_log,
             session_key,
             text,

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import HOOK_REPLY, TOOL_AUTO_APPROVE, TOOL_DENY
-from kiro_crew.llm_helpers import save_conversation_turn
+from kiro_crew.llm_helpers import save_conversation_turn_off_loop
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import canonical_key
@@ -230,7 +230,7 @@ async def handle_message_transport(
         if hook_result.action == HOOK_REPLY:
             await slack.post_message(channel, hook_result.text, reply_ts)
             if conversation_log and not _is_slack_restricted(session_key):
-                save_conversation_turn(
+                await save_conversation_turn_off_loop(
                     conversation_log,
                     session_key,
                     text,
@@ -548,8 +548,7 @@ async def handle_message_transport(
                             source_user=user_id,
                         )
                 else:
-                    await asyncio.to_thread(
-                        save_conversation_turn,
+                    await save_conversation_turn_off_loop(
                         conversation_log,
                         session_key,
                         text,

--- a/test/test_persist_off_loop.py
+++ b/test/test_persist_off_loop.py
@@ -1,0 +1,453 @@
+"""Build gate + tests: the Slack persist path stays off the event loop (#1699),
+and a slot orders its rows against foreign on-disk rows (#1689).
+
+## Why a gate and not just tests
+
+``save_conversation_turn`` makes TWO ``ConversationLog.append`` calls, and append
+is not cheap: ~11.8 ms on a 1.6 MB / 400-row transcript, dominated by the flock
+acquire and the write path, and it scales with transcript size because rotation
+reads and rewrites the whole file. Called from an ``async def`` without
+offloading, that is ~24 ms per turn of event-loop time no other coroutine can
+use.
+
+Worse than the latency: ``_locked`` makes only ONE non-blocking acquire when it
+detects a running loop and raises ``HistoryLockTimeout`` if it fails, so an
+on-loop caller **drops the durable write** exactly when another writer is
+active — and most of these call sites swallow that in a best-effort ``except``.
+Off the loop there is no running loop in the worker thread, so ``_locked`` takes
+the patient poll-to-deadline path instead.
+
+``history.py`` already warns (with ``stack_info``) when append runs on the loop,
+but a warning is only as good as someone reading logs. This gate is the
+deterministic form: a NEW Slack call site cannot persist a turn on the loop
+without failing the build.
+
+The offloaded form passes the gate for free. ``asyncio.to_thread(save_conversation_turn, …)``
+passes the function as a bare ``Name`` — it is not a *call* at that point — so
+only the on-loop shape is ever flagged. A ``# loop-ok: <reason>`` trailing
+comment suppresses a line that is genuinely safe; every suppression must state
+its reason so the exception is auditable and greppable.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import io
+import pathlib
+import tokenize
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.history import latest_transcript_ts, monotonic_transcript_ts, transcript_sort_key
+
+_BANNED_FUNC = "save_conversation_turn"
+_SUPPRESS = "loop-ok"
+
+# A nested def/lambda is a different execution frame (a sync helper, a thread
+# target, an offloaded callable); a nested async def is walked on its own.
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+
+
+# ── STRUCTURAL tier ───────────────────────────────────────────────────────────
+
+
+def _src_root() -> pathlib.Path:
+    """Locate the kiro_crew source tree (import-first, repo-path fallback)."""
+    try:
+        import kiro_crew  # noqa: PLC0415
+
+        return pathlib.Path(kiro_crew.__file__).resolve().parent
+    except Exception:
+        return pathlib.Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+
+
+def _bound_names(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """How a module might name the persist helper.
+
+    Returns ``(direct, modules)``:
+      * ``direct`` -- locals bound by ``from ... import save_conversation_turn``,
+        ``as``-renames included, so a bare ``sct(...)`` still resolves.
+      * ``modules`` -- locals bound to the module that DEFINES it, so the
+        attribute form ``llm_helpers.save_conversation_turn(...)`` resolves too.
+
+    Both forms are needed or the gate is one import away from being evaded, which
+    would make it worse than no gate: it would report green while the defect it
+    exists to prevent walked straight past it.
+    """
+    direct: set[str] = set()
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.endswith("llm_helpers"):
+                    modules.add(alias.asname or alias.name.split(".")[-1])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == _BANNED_FUNC:
+                    direct.add(alias.asname or alias.name)
+                elif alias.name == "llm_helpers":
+                    modules.add(alias.asname or alias.name)
+    return direct, modules
+
+
+def _suppressed_lines(source: str) -> set[int]:
+    """Lines carrying a genuine ``# loop-ok`` COMMENT, not a substring.
+
+    Tokenizing rather than substring-scanning means a ``loop-ok`` inside a string
+    literal does NOT suppress, while a real trailing comment does.
+    """
+    out: set[int] = set()
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT and _SUPPRESS in tok.string:
+                out.add(tok.start[0])
+    except (tokenize.TokenError, IndentationError):
+        pass
+    return out
+
+
+def _scope_calls(node: ast.AST):
+    """Yield Call nodes reachable from *node* without crossing a nested scope."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, _NESTED_SCOPES):
+            continue
+        if isinstance(child, ast.Call):
+            yield child
+        yield from _scope_calls(child)
+
+
+def find_violations(source: str, path: str = "<source>") -> list[tuple[str, int]]:
+    """Return ``(path, lineno)`` for on-loop ``save_conversation_turn`` calls."""
+    tree = ast.parse(source)
+    direct, modules = _bound_names(tree)
+    if not (direct or modules):
+        return []
+    suppressed = _suppressed_lines(source)
+    out: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        for call in _scope_calls(node):
+            func = call.func
+            hit = (isinstance(func, ast.Name) and func.id in direct) or (
+                isinstance(func, ast.Attribute)
+                and func.attr == _BANNED_FUNC
+                and isinstance(func.value, ast.Name)
+                and func.value.id in modules
+            )
+            if not hit:
+                continue
+            span = range(call.lineno, (call.end_lineno or call.lineno) + 1)
+            if any(ln in suppressed for ln in span):
+                continue
+            out.append((path, call.lineno))
+    return out
+
+
+def collect_repo_violations() -> list[tuple[str, int]]:
+    """Scan every ``kiro_crew/**/*.py`` for an on-loop turn persist."""
+    root = _src_root()
+    base = root.parent
+    out: list[tuple[str, int]] = []
+    for py in sorted(root.rglob("*.py")):
+        try:
+            src = py.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        try:
+            rel = str(py.relative_to(base))
+        except ValueError:  # pragma: no cover - defensive
+            rel = str(py)
+        try:
+            out.extend(find_violations(src, rel))
+        except SyntaxError:  # pragma: no cover - defensive
+            continue
+    return out
+
+
+def test_no_turn_is_persisted_on_the_event_loop() -> None:
+    """save_conversation_turn must never be CALLED inside an async def body."""
+    violations = collect_repo_violations()
+    if violations:
+        detail = "\n".join(f"  {path}:{lineno}" for path, lineno in violations)
+        raise AssertionError(
+            "save_conversation_turn called directly inside an `async def` body.\n\n"
+            "It makes two ConversationLog.append calls (~24ms of loop time per "
+            "turn on a large transcript), and on the loop `_locked` makes a "
+            "single non-blocking acquire and raises HistoryLockTimeout under "
+            "contention — so the durable write is DROPPED exactly when another "
+            "writer is active. Offload it:\n"
+            "    await asyncio.to_thread(save_conversation_turn, log, key, ...)\n"
+            "If an on-loop call is genuinely correct, add a trailing "
+            "'# loop-ok: <reason>' comment.\n\n"
+            f"{detail}"
+        )
+
+
+# ── Meta-tests: prove the detector fires and stays quiet ─────────────────────
+
+
+def test_detector_flags_an_on_loop_call() -> None:
+    src = (
+        "from kiro_crew.llm_helpers import save_conversation_turn\n"
+        "async def f(log, k):\n"
+        "    save_conversation_turn(log, k, 'a', 'b')\n"
+    )
+    assert [v[1] for v in find_violations(src)] == [3]
+
+
+def test_detector_flags_an_aliased_on_loop_call() -> None:
+    """A one-import rename must not defeat the gate."""
+    src = (
+        "from kiro_crew.llm_helpers import save_conversation_turn as sct\n"
+        "async def f(log, k):\n"
+        "    sct(log, k, 'a', 'b')\n"
+    )
+    assert [v[1] for v in find_violations(src)] == [3]
+
+
+def test_detector_flags_the_attribute_form() -> None:
+    """Importing the MODULE must not be a way around the gate."""
+    src = (
+        "from kiro_crew import llm_helpers\n"
+        "async def f(log, k):\n"
+        "    llm_helpers.save_conversation_turn(log, k, 'a', 'b')\n"
+    )
+    assert [v[1] for v in find_violations(src)] == [3]
+
+
+def test_detector_flags_an_aliased_module_attribute_call() -> None:
+    src = (
+        "import kiro_crew.llm_helpers as lh\n"
+        "async def f(log, k):\n"
+        "    lh.save_conversation_turn(log, k, 'a', 'b')\n"
+    )
+    assert [v[1] for v in find_violations(src)] == [3]
+
+
+def test_detector_ignores_a_same_named_method_on_another_object() -> None:
+    """An unrelated object that happens to share the name must not trip it."""
+    src = (
+        "from kiro_crew import llm_helpers\n"
+        "async def f(store, log, k):\n"
+        "    store.save_conversation_turn(log, k, 'a', 'b')\n"
+    )
+    assert find_violations(src) == []
+
+
+def test_detector_accepts_the_offloaded_form() -> None:
+    """to_thread receives the function as a bare Name, so it is not a call."""
+    src = (
+        "import asyncio\n"
+        "from kiro_crew.llm_helpers import save_conversation_turn\n"
+        "async def f(log, k):\n"
+        "    await asyncio.to_thread(save_conversation_turn, log, k, 'a', 'b')\n"
+    )
+    assert find_violations(src) == []
+
+
+def test_detector_ignores_a_sync_caller() -> None:
+    """A sync function is not on the loop; only async bodies are in scope."""
+    src = (
+        "from kiro_crew.llm_helpers import save_conversation_turn\n"
+        "def f(log, k):\n"
+        "    save_conversation_turn(log, k, 'a', 'b')\n"
+    )
+    assert find_violations(src) == []
+
+
+def test_detector_ignores_a_nested_sync_helper_inside_an_async_body() -> None:
+    """A nested def is a separate frame — typically the thread target itself."""
+    src = (
+        "from kiro_crew.llm_helpers import save_conversation_turn\n"
+        "async def f(log, k):\n"
+        "    def _do():\n"
+        "        save_conversation_turn(log, k, 'a', 'b')\n"
+        "    return _do\n"
+    )
+    assert find_violations(src) == []
+
+
+def test_loop_ok_comment_suppresses() -> None:
+    src = (
+        "from kiro_crew.llm_helpers import save_conversation_turn\n"
+        "async def f(log, k):\n"
+        "    save_conversation_turn(log, k, 'a', 'b')  # loop-ok: empty test log\n"
+    )
+    assert find_violations(src) == []
+
+
+def test_loop_ok_inside_a_string_does_not_suppress() -> None:
+    src = (
+        "from kiro_crew.llm_helpers import save_conversation_turn\n"
+        "async def f(log, k):\n"
+        '    save_conversation_turn(log, k, "loop-ok", "b")\n'
+    )
+    assert [v[1] for v in find_violations(src)] == [3]
+
+
+def test_every_slack_persist_site_goes_through_the_choke_point() -> None:
+    """The converse of the gate: the Slack modules DO still persist turns.
+
+    Without this, deleting every call site would make the gate pass vacuously.
+    Asserted against the choke point rather than a raw ``to_thread`` count,
+    because collapsing the eleven identical offload hunks into
+    ``save_conversation_turn_off_loop`` is the point -- a new async caller now
+    inherits the offload instead of restating it.
+    """
+    root = _src_root()
+    sites = 0
+    for name in ("handler.py", "gateway.py", "transport_dispatch.py"):
+        tree = ast.parse((root / "slack" / name).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "save_conversation_turn_off_loop"
+            ):
+                sites += 1
+    assert sites >= 11, f"expected the known Slack persist sites, found {sites}"
+
+
+def test_the_choke_point_offloads_and_is_awaitable() -> None:
+    """The choke point must actually offload, and callers must be able to await it.
+
+    A synchronous helper would satisfy the AST gate (no direct call in an async
+    body) while still running the write on the loop -- the gate would then be
+    theatre. And callers go on to read the transcript back, so the write has to be
+    awaited rather than fired at the executor.
+    """
+    import inspect
+
+    from kiro_crew.llm_helpers import save_conversation_turn_off_loop
+
+    assert inspect.iscoroutinefunction(save_conversation_turn_off_loop)
+    src = inspect.getsource(save_conversation_turn_off_loop)
+    assert "to_thread" in src, "the choke point does not offload the write"
+    assert "await" in src, "the choke point does not await the write"
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_turns_do_not_interleave(tmp_path) -> None:
+    """A turn is a PAIR, and offloading made the pair breakable.
+
+    ``append`` locks per ROW. On the event loop that was harmless: a synchronous
+    ``save_conversation_turn`` never yields between its two appends, so the pair
+    was effectively atomic. Dispatching it to worker threads makes two concurrent
+    turns for the same session genuinely interleavable into
+    ``user_A, user_B, assistant_A, assistant_B`` -- turns that no longer pair up,
+    which no timestamp ordering can repair because every row's ``ts`` is
+    individually correct.
+
+    The barrier makes this DETERMINISTIC in both directions rather than a race:
+    each writer pauses after its user row and waits for the other to reach the
+    same point. Holding the turn lock, the second writer cannot get that far, so
+    the wait times out and the pairs stay intact. WITHOUT the lock both writers
+    arrive, the barrier trips, and the rows interleave every time.
+    """
+    import threading
+
+    from kiro_crew.history import ConversationLog
+    from kiro_crew.llm_helpers import save_conversation_turn_off_loop
+
+    log = ConversationLog(tmp_path / "history")
+    key = "s1"
+    both_wrote_user = threading.Barrier(2, timeout=1.0)
+    real_append = ConversationLog.append
+
+    def _append_then_pause(self, k, role, content, **kw):
+        real_append(self, k, role, content, **kw)
+        if role == "user":
+            try:
+                both_wrote_user.wait()
+            except threading.BrokenBarrierError:
+                pass  # the turn lock kept the other writer out -- the pass case
+
+    with patch.object(ConversationLog, "append", _append_then_pause):
+        await asyncio.gather(
+            save_conversation_turn_off_loop(log, key, "u1", "a1"),
+            save_conversation_turn_off_loop(log, key, "u2", "a2"),
+        )
+
+    rows = [(r["role"], r["content"]) for r in log.read_messages(key)]
+    assert len(rows) == 4, f"expected four rows, got {rows}"
+    for user_row, assistant_row in (rows[0:2], rows[2:4]):
+        assert user_row[0] == "user" and assistant_row[0] == "assistant", (
+            f"turns interleaved: {rows}"
+        )
+        assert user_row[1][1:] == assistant_row[1][1:], (
+            f"an assistant row was paired with the wrong user row: {rows}"
+        )
+
+
+# ── latest_transcript_ts: the shared floor combiner ──────────────────────────
+
+
+class TestLatestTranscriptTs:
+    def test_it_picks_the_later_candidate(self) -> None:
+        early = "2026-08-06T04:00:00.000000+00:00"
+        late = "2026-08-06T04:00:00.000001+00:00"
+        assert latest_transcript_ts(early, late) == late
+        assert latest_transcript_ts(late, early) == late
+
+    def test_it_ignores_missing_candidates(self) -> None:
+        ts = "2026-08-06T04:00:00.000000+00:00"
+        assert latest_transcript_ts(None, ts, "") == ts
+        assert latest_transcript_ts(None, None) is None
+        assert latest_transcript_ts() is None
+
+    def test_it_compares_the_two_stored_formats_in_one_domain(self) -> None:
+        """Rows carry both aware and naive isoformat, so string order is wrong.
+
+        A naive local timestamp can sort AFTER an aware UTC one as raw strings
+        while being earlier in real time. Comparing through transcript_sort_key
+        is what makes the floor correct rather than lexicographic.
+        """
+        aware = "2026-08-06T04:00:00.000000+00:00"
+        naive_later = datetime.now().replace(microsecond=0).isoformat()
+        picked = latest_transcript_ts(aware, naive_later)
+        assert transcript_sort_key(picked) == max(
+            transcript_sort_key(aware), transcript_sort_key(naive_later)
+        )
+
+
+# ── #1689: a slot orders against a foreign on-disk row ───────────────────────
+#
+# The behavioural coverage for that lives in test_transcript_row_ordering.py,
+# which owns transcript ordering and already carries the colliding-clock
+# simulator these cases need (class TestTheDashboardWriterAndAForeignRow).
+
+
+def test_the_stamper_still_advances_on_a_stalled_clock() -> None:
+    """Guard the primitive the floor feeds, so a floor bug cannot hide here."""
+    instant = "2026-08-06T04:00:00.000000+00:00"
+    stamped = monotonic_transcript_ts(instant, datetime.fromisoformat(instant))
+    assert transcript_sort_key(stamped) > transcript_sort_key(instant)
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-timestamp", "2026-13-45T99:99:99"])
+def test_a_corrupt_ts_is_skipped_not_ranked(bad: str) -> None:
+    """An unparseable candidate must never win, or the floor switches OFF.
+
+    transcript_sort_key buckets what it cannot parse AFTER every real instant, so
+    ranking candidates by it would let one corrupt row beat a valid timestamp.
+    monotonic_transcript_ts then ignores the unparseable floor it was handed and
+    emits the bare clock reading -- which on a coarse-tick host ties the row it
+    was supposed to sort after. One bad line on disk would disable the guarantee
+    for the whole session.
+
+    The earlier version of this test asserted ``in (good, bad)``, which passed
+    for exactly the broken behaviour it was meant to catch.
+    """
+    good = "2026-08-06T04:00:00.000000+00:00"
+    assert latest_transcript_ts(bad, good) == good
+    assert latest_transcript_ts(good, bad) == good
+
+
+@pytest.mark.parametrize("bad", ["not-a-timestamp", "2026-13-45T99:99:99"])
+def test_all_candidates_corrupt_yields_no_floor(bad: str) -> None:
+    """No usable floor means None -- never a bogus value the stamper will drop."""
+    assert latest_transcript_ts(bad, bad) is None

--- a/test/test_slack_transport_dispatch.py
+++ b/test/test_slack_transport_dispatch.py
@@ -726,10 +726,14 @@ class TestHydrationBeforeHook:
         monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", lambda *a, **k: None)
 
         saved: list = []
+
+        async def _fake_save(*a, **k):
+            saved.append((a, k))
+
         monkeypatch.setattr(
             transport_dispatch,
-            "save_conversation_turn",
-            lambda *a, **k: saved.append((a, k)),
+            "save_conversation_turn_off_loop",
+            _fake_save,
         )
 
         class _CtxBuilder:

--- a/test/test_transcript_row_ordering.py
+++ b/test/test_transcript_row_ordering.py
@@ -230,3 +230,117 @@ class TestTheDashboardWriter:
             slot.append("user", "replayed", ts=original)
 
         assert slot.messages[-1]["ts"] == original
+
+
+class TestTheDashboardWriterAndAForeignRow:
+    """A row the slot never observed must still be ordered against.
+
+    ``ConversationLog.append`` floors on the on-disk tail under the cross-process
+    flock, so it sees every committed row. ``_ChatSlot.append`` runs on the event
+    loop and may only read in-process state -- a ``stat`` plus a file read per
+    append is what ``AUTOSDE.yaml``'s ``no-blocking-call-on-event-loop`` rule
+    forbids -- so it floors on its in-memory window.
+
+    Those are not the same set. ``_save_slot_to_history`` deliberately preserves a
+    genuinely foreign on-disk row without folding it into ``slot.messages``, so a
+    row can live in the file forever and never become a floor candidate. Under a
+    colliding clock the slot's next append then produces a ``ts`` that TIES the
+    foreign row, which is exactly the ambiguity the stamper exists to prevent.
+
+    The fix caches the last known disk tail on the slot and floors on the later of
+    the two, refreshed at the save boundary where the lock is already held.
+    """
+
+    def test_a_foreign_disk_row_is_ordered_against(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+
+        with colliding_clock("kiro_crew.dashboard.state", at=_INSTANT):
+            slot.append("user", "run the job")
+            window_tail = slot.messages[-1]["ts"]
+            # A subagent wrote this under the flock one microsecond later. It is
+            # on disk and will be preserved as a foreign line; the slot never
+            # observed it, so before the fix it was not a floor candidate.
+            foreign = _parse_transcript_ts(window_tail) + timedelta(microseconds=1)
+            slot._disk_tail_ts = foreign.isoformat()
+
+            slot.append("assistant", "acknowledged")
+
+        assert transcript_sort_key(slot.messages[-1]["ts"]) > transcript_sort_key(
+            slot._disk_tail_ts
+        ), "the slot's row ties or precedes a foreign on-disk row"
+
+    def test_a_stale_cached_tail_does_not_drag_a_row_backwards(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+
+        with colliding_clock("kiro_crew.dashboard.state", at=_INSTANT):
+            slot.append("user", "later row", ts=(_INSTANT + timedelta(seconds=5)).isoformat())
+            slot._disk_tail_ts = _INSTANT.isoformat()  # older than the window tail
+            slot.append("assistant", "reply")
+
+        assert _sorts_strictly_ascending(slot.messages)
+
+    def test_a_replayed_row_still_keeps_its_timestamp(self, tmp_path, monkeypatch):
+        """The extra floor candidate must not restamp an explicit ts."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot._disk_tail_ts = "2099-01-01T00:00:00.000000+00:00"  # far in the future
+        original = "2026-01-01T00:00:00+00:00"
+
+        with colliding_clock("kiro_crew.dashboard.state", at=_INSTANT):
+            slot.append("user", "replayed", ts=original)
+
+        assert slot.messages[-1]["ts"] == original
+
+    def test_no_cached_tail_behaves_exactly_as_before(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        assert slot._disk_tail_ts is None
+
+        with colliding_clock("kiro_crew.dashboard.state", at=_INSTANT):
+            slot.append("user", "the question")
+            slot.append("assistant", "the reply")
+
+        assert _sorts_strictly_ascending(slot.messages)
+
+    def test_the_save_boundary_records_a_foreign_rows_ts(self, tmp_path, monkeypatch):
+        """The save is the ONLY place the slot can learn a foreign row's ts.
+
+        Without this the cache would never populate and the floor above would be
+        permanently ``None`` -- the fix would be inert.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.conversation_log = ConversationLog(tmp_path / "history")
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "hello")
+        _save_slot_to_history(state, slot, force=True)
+
+        # Another process appends to the same transcript. The slot never sees it.
+        state.conversation_log.append(slot.key, "assistant", "from a subagent")
+        _save_slot_to_history(state, slot, force=True)
+
+        assert slot._disk_tail_ts, "the save recorded no disk tail at all"
+
+    def test_the_cached_tail_never_moves_backwards(self, tmp_path, monkeypatch):
+        """A save must not regress the floor -- that would re-open the tie."""
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.conversation_log = ConversationLog(tmp_path / "history")
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "hello")
+
+        future = "2099-01-01T00:00:00.000000+00:00"
+        slot._disk_tail_ts = future
+        _save_slot_to_history(state, slot, force=True)
+
+        assert slot._disk_tail_ts == future, "a save regressed the ordering floor"


### PR DESCRIPTION
## Problem

Two defects in how a session transcript gets written, both in the same critical
section.

**#1699 — turn persistence ran on the event loop.** `save_conversation_turn`
makes two `ConversationLog.append` calls, and append is not cheap: ~11.8 ms on a
1.6 MB / 400-row transcript, dominated by the flock acquire and the write path,
and it scales with transcript size because rotation reads and rewrites the whole
file. Ten Slack call sites called it directly from `async def` bodies, so that
was ~24 ms of event-loop time per turn no other coroutine could use.

The latency is the smaller half. `history.py`'s `_locked` makes only **one
non-blocking** flock acquire when it detects a running loop and raises
`HistoryLockTimeout` if it fails — and most of these sites swallow that in a
best-effort `except`. So the durable copy of a turn was **dropped precisely when
another writer was active**, silently.

**#1689 — the two writers of a transcript floor their timestamps on different
things.** `ConversationLog.append` reads the on-disk file tail under the
cross-process flock, so it sees every committed row. `_ChatSlot.append` reads the
in-memory window. Those are not the same set: `_save_slot_to_history`
deliberately preserves a genuinely *foreign* on-disk row without folding it into
`slot.messages`, so a row can live in the file forever and never be a floor
candidate. On a coarse-tick host (Windows advances the clock in ~15.6 ms steps)
the slot's next append reads the same instant and produces a `ts` that **ties**
the foreign row — reviving exactly the ambiguity #1657 removed. A subagent, cron,
or CLI appending to a session a live dashboard tab also has open is the reachable
shape.

## Why it matters

A dropped `save_conversation_turn` means a turn the user can see in Slack is
absent from the transcript — so the dashboard tab, session resume, and
consolidation never learn it happened. Two rows with an identical `ts` mean a
reader can render the answer above the question.

Neither failure announces itself: no error, no log, no failing check.

## Fix (symptom → root cause → change)

**#1699.** Root cause: the call was synchronous inside `async def`, so it both
blocked the loop and took `_locked`'s impatient acquire path.

Added **`save_conversation_turn_off_loop`** (`llm_helpers.py`) as the single
choke point, and routed **eleven** call sites through it — the ten this PR
offloads plus the pre-existing `transport_dispatch.py:552`, which was already
using a hand-rolled `asyncio.to_thread` and was the odd one out. In the worker
thread there is no running loop, so `_locked` takes the **patient**
poll-to-deadline path (bounded by `_FLOCK_ACQUIRE_TIMEOUT_S = 10.0`), which is
what stops the write being droppable. `history.py:97-102` names
`asyncio.to_thread` as the sanctioned offload.

Two design points worth stating, because both were reconsidered during review:

- **`append_off_loop` cannot be reused.** It accepts only `agent=` — no
  `source_thread` / `source_user`, which every Slack caller passes. Using it
  would silently drop provenance.
- **The choke point `await`s, unlike `append_off_loop`, which is
  fire-and-forget.** That divergence from the family it is named after is
  deliberate: these callers go on to refresh a dashboard tab or hand the session
  to consolidation, and both read the transcript back, so the row has to be on
  disk before the caller continues. `append_off_loop` has no such reader.

An earlier revision of this PR instead inlined `await asyncio.to_thread(
save_conversation_turn, …)` at each of the ten sites, on the stated grounds that a
wrapper would break tests which patch the symbol by module attribute. **That
reasoning was wrong on the facts and has been reversed.** Checking the tests
rather than trusting a survey of them: exactly **one** test patches by module
attribute (`test_slack_transport_dispatch.py`), and it is now re-pointed at the
new name with an async double. The other two assert on `log.append` through a
`MagicMock`, which the wrapper still exercises unchanged. Letting one test's patch
target dictate production shape was the wrong trade even if it had been three.

**#1689.** Root cause: the slot had no way to learn about a row it never
observed, and giving it one naively means a `stat` plus a file read per append —
which `AUTOSDE.yaml`'s `no-blocking-call-on-event-loop` rule (blocking) forbids,
and is why #1657 left this open. Change: a cached `_ChatSlot._disk_tail_ts`,
refreshed at the **save boundary** where `_locked` is already held and the
foreign lines are already parsed (so it costs nothing), and a new
`latest_transcript_ts()` combiner so the slot floors on the later of window-tail
and cached-tail. No file I/O is added to the event loop.

`latest_transcript_ts` **skips** candidates it cannot parse rather than ranking
them. `transcript_sort_key` deliberately buckets an unparseable value *after*
every real instant so a corrupt line renders at the end of a transcript instead
of mid-conversation — correct for sorting, backwards for a floor. Ranked, one
malformed `ts` would win, `monotonic_transcript_ts` would discard it as
unparseable, and the guarantee would switch off. Worse, since `_disk_tail_ts` is
itself a candidate at every save, the bad value would stick for the process
lifetime and leave that slot with **no** floor at all — worse than before this
PR. Both local review mirrors independently found this.

### New public `ConversationLog` surface: `atomic_appends(key)`

Offloading the write introduced a second hazard that had to be closed in the same
change, and it is worth stating as a contract rather than an implementation
detail, because it applies to **any** future caller:

> `append` locks per **row**. A turn is a **pair** of rows. So two concurrent
> turn-writes for one session can land as
> `user_A, user_B, assistant_A, assistant_B` — turns that no longer pair up, and
> which no ordering pass can repair, because every row's `ts` is individually
> correct.

On the event loop this could not happen: `save_conversation_turn` is synchronous
and never yields between its two appends, so the single-threaded loop made the
pair atomic **by accident**. Dispatching it to a worker thread — the correct fix
for #1699 — removes exactly that accidental guarantee. The hazard is therefore
*created* by doing the right thing, which is why it belongs here rather than in a
follow-up.

`ConversationLog.atomic_appends(key)` is the companion: a context manager that
groups several appends into one indivisible write. **Any caller that offloads
MULTIPLE appends for one session must hold it around the whole group.** `_locked`
is reentrant for the same key on the same thread, so the per-row locks inside
`append` reuse the held lock rather than deadlocking. Enter it off the loop only —
it takes the same fail-fast-on-loop acquire path as `append`.

It lives on `ConversationLog` rather than being a private `_locked` reach-in from
`llm_helpers` so the invariant is owned by the class that owns the lock, and the
next caller composing multiple appends has a supported way to do it instead of
copying private access. Documented in
`docs/system-specs/modules/history.md` alongside the offload discipline.

### Known residual gap on #1689 — deliberate, not an oversight

The #1689 fix is **partial by design**, and this is the bound so it is not
rediscovered later as a new bug:

> A foreign row that arrives **between two saves** is not a floor candidate until
> the next save refreshes `_disk_tail_ts`. Within that window the original tie is
> still possible.

Closing the general case requires the slot to read the file tail per append,
which is exactly what the event-loop rule forbids — so the reachable shape (a
subagent/cron append, observed at the following flush) is closed and the rest is
accepted. The partial fix cannot regress anything: `latest_transcript_ts` only
ever selects a *later* candidate, so the floor moves a row forward but never
backward, and a slot that never sees a foreign row behaves exactly as on `main`.
Documented in `docs/system-specs/modules/history.md` alongside the contract.

## Tests

`test/test_persist_off_loop.py` (new) — the off-loop gate:

- **Structural**: an AST scan asserts no `async def` body *calls*
  `save_conversation_turn`, run against the real tree. It resolves `as`-renames,
  the module-attribute form (`llm_helpers.save_conversation_turn`), and aliased
  modules, so a single import cannot defeat it.
- **Anti-vacuity converse**: eleven calls to the choke point must exist, so
  deleting every call site cannot make the gate pass by emptiness.
- **`test_the_choke_point_offloads_and_is_awaitable`**: a *synchronous* helper
  would satisfy the AST gate while still writing on the loop — which would make
  the gate theatre. Asserts it is a coroutine function that awaits a `to_thread`.
- **Meta-tests** prove the detector fires (direct call, `as`-rename, attribute
  form, aliased module) and stays quiet (offloaded form, sync caller, nested sync
  helper inside an async body, same-named method on an unrelated object, a genuine
  `# loop-ok`), and that a `loop-ok` inside a *string literal* does NOT suppress.
- **`test_two_concurrent_turns_do_not_interleave`**: deterministic in BOTH
  directions rather than a race. A barrier makes each writer pause after its
  user row and wait for the other to reach the same point: holding the turn
  lock the second writer cannot get that far, so the wait times out and the
  pairs stay intact; without the lock both arrive, the barrier trips, and the
  rows interleave every time.
- **`latest_transcript_ts`**: picks the later candidate, ignores missing ones,
  compares the two stored formats in one domain (not lexicographically), skips a
  corrupt candidate rather than ranking it, and returns `None` when every
  candidate is corrupt.

`test/test_transcript_row_ordering.py` (extended, class
`TestTheDashboardWriterAndAForeignRow`) — the #1689 behaviour, added to the suite
that owns transcript ordering so it reuses that file's `colliding_clock`
simulator: a foreign disk row is ordered against; a stale cached tail does not
drag a row backwards; a replayed row keeps its verbatim `ts`; no cached tail
behaves exactly as before; the save boundary records a foreign row's `ts` (without
which the fix would be inert); and a save never moves the cached floor backwards.

**Non-vacuity was verified, not assumed.** Reverting the #1689 floor to the
window-only form makes `test_a_foreign_disk_row_is_ordered_against` fail;
restoring it passes. Reverting the corrupt-`ts` skip fails 4 tests. The
corrupt-`ts` case originally had a weaker assertion (`in (good, bad)`) that passed
for exactly the broken behaviour — it is now `== good`.

## Manual verification

N/A — unit coverage is sufficient and stronger than manual checking here. Both
defects need conditions that are constructed in tests and impractical by hand: a
clock parked inside one 15.6 ms tick, and a foreign on-disk row that is
deliberately never folded into the in-memory window. The full backend suite was
also diffed against `origin/main` to confirm no new failures (the remaining ones
are pre-existing on this host: `ops_mission_control` git-sync tests, and
`test_sandbox_*` which fail on Linux with `unshare(CLONE_NEWUSER)` EPERM).

## Screenshots

N/A — no user-visible UI change.

Closes #1699.
Closes #1689.
