### PR TITLE
fix(skills): record hotness only on body delivery, not trigger match

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -2242,6 +2242,11 @@ class ContextBuilder:
                     if content:
                         stripped = self.skills.strip_frontmatter(content)
                         parts.append(f"[Skill: {name}]\n{stripped}\n[End of skill]\n\n")
+                        # Record use only when the body is actually delivered --
+                        # a trigger match that never reaches the prompt (false
+                        # positive, pointer-only, or undelivered) must not earn
+                        # ranking weight in the lazy-load hotness ledger.
+                        self.skills._record_use(name)
                 hint = self.skills.trigger_hint(pointer_only)
                 if hint:
                     parts.append(hint)

--- a/src/kiro_crew/skill_usage.py
+++ b/src/kiro_crew/skill_usage.py
@@ -7,8 +7,9 @@ often they've actually been used) and leaves the long tail discoverable via the
 
 Design mirrors an MCP-gateway-style warm-pool ``HotKeyStore``: an in-memory
 tally per key with a time-based TTL and atomic persistence — but simplified for
-a *synchronous* caller. Skill usage is recorded from ``get_triggered_skills`` / ``load_skill``
-(sync, once per message / load), not from an async event-loop hot path, so:
+a *synchronous* caller. Skill usage is recorded from the body-delivery loop in the context builder
+(sync, once per triggered body actually injected) and from ``load_skill``
+via ``resolve_dollar_skills``, not from an async event-loop hot path, so:
 
 * ``record`` bumps an in-memory counter and only touches disk on a debounce
   (at most once per ``_FLUSH_DEBOUNCE_SECS``), so the per-message path stays
@@ -83,7 +84,7 @@ class SkillUsageLedger:
             last_seen = self._last_seen.get(key, 0.0)
         return (float(hits), max(last_seen, recency_boost))
 
-    # --- write path (used by get_triggered_skills / load_skill) ----------
+    # --- write path (used by body-delivery in context builder / resolve_dollar_skills) ----------
 
     def record(self, key: str) -> None:
         """Bump ``key``'s usage. In-memory O(1); flushes to disk on a debounce.
@@ -104,7 +105,7 @@ class SkillUsageLedger:
                 self._last_flush = now
                 should_flush = True
         if should_flush:
-            # record() runs on the gateway event loop (via get_triggered_skills /
+            # record() runs on the gateway event loop (via the body-delivery loop /
             # resolve_dollar_skills), so the blocking file write is offloaded to a
             # daemon thread. flush() snapshots the tally under the lock before any
             # IO, so a background write is safe and keeps the loop unblocked.

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -2290,13 +2290,6 @@ class SkillsLoader:
         scored.sort(key=lambda x: x[1], reverse=True)
         triggered = [name for name, _ in scored[: self._max_triggered]]
 
-        # Record usage — a trigger match is the authoritative "this skill was
-        # relevant" signal that feeds the lazy-load hotness ranking in
-        # get_context, independently of whether the agent goes on to read the
-        # file.
-        for name in triggered:
-            self._record_use(name)
-
         # Emit ONE audit event for the matched + denied sets rather than one per
         # skill. Previously this wrote a SEL entry for every skill (incl. every
         # non-match) on every message — N synchronous writes per message that

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -395,6 +395,29 @@ class TestTriggeredSkills:
         monkeypatch.setattr("kiro_crew.skills.sel", lambda: MagicMock())
         assert loader.get_triggered_skills("anything") == []
 
+    def test_trigger_match_does_not_record_usage(self, tmp_path, monkeypatch):
+        """A trigger match must not earn ranking weight in the ledger.
+
+        Only body delivery (the context builder calling _record_use after
+        load_skill succeeds) should update the hotness ranking. False-positive
+        trigger matches must not drift the top-K toward skills the agent never
+        reads.
+        """
+        loader = self._loader_with_skill(tmp_path, "tiny url", monkeypatch)
+
+        # Confirm the skill triggers on the message
+        triggered = loader.get_triggered_skills("make a tiny url for me")
+        assert "tiny-url" in triggered
+
+        # The ledger must still be at zero: a match alone is not a delivery
+        assert loader._usage is not None
+        assert loader._usage.score("tiny-url")[0] == 0.0
+
+        # Simulating body delivery (what context.py does after load_skill)
+        # must update the ledger
+        loader._record_use("tiny-url")
+        assert loader._usage.score("tiny-url")[0] == 1.0
+
 
 class TestSkillsCRUD:
     def test_create_skill(self, tmp_path):


### PR DESCRIPTION
## Summary

- `_record_use()` was called in `get_triggered_skills()` on every trigger match, before any delivery decision. False-positive matches (e.g. `computer-use` triggering on words like "click" or "app") earned ranking weight even when the skill body was never injected.
- Moved `_record_use()` to the body-delivery loop in `context.py`, after `load_skill()` confirms the content. Only skills whose body is actually injected now earn a hotness hit.
- Pointer-only skills (`inject_on_trigger: false`) and undelivered false positives no longer affect the lazy-load ranking.

Fixes #1731

## Test plan

- [x] New test `test_trigger_match_does_not_record_usage` in `TestTriggeredSkills`: confirms the ledger stays at zero after `get_triggered_skills()` and increments only after an explicit `_record_use()` call (simulating body delivery).
- [x] Full `TestTriggeredSkills` suite passes (9 tests).
- [x] `test_skill_usage.py` passes (all ledger tests unchanged).
- [x] `test_skill_trigger_pointer.py` passes (26 tests).
- [x] `test_skills.py` full suite passes (112 tests total including the new one).