### PR TITLE
docs: fix Windows install gaps (workspace env var, CONTRIBUTING mismatch)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,9 @@ tell you in a paragraph.
 
 ## Prerequisites
 
-- macOS or Linux (Windows is not supported by the `kiro-cli` backend)
+- macOS, Linux, or Windows (native source install — see
+  [docs/guides/windows-install.md](docs/guides/windows-install.md) for Windows-specific
+  prerequisites, the `venv` activation step, and per-feature parity notes)
 - Python ≥ 3.9
 - Node.js ≥ 18 and npm (for the frontend)
 - The `kiro-cli` agent on your `PATH`, logged in (`kiro-cli login`) — it is the

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -95,6 +95,22 @@ complete the device-code flow in the browser. The dashboard opens automatically
 after `kiro-cli whoami` succeeds. This setup runs on the gateway machine, which
 may be different from the computer running the browser.
 
+If your default drive is low on space, redirect KiroCrew's config/data home and
+workspace before running `setup`:
+
+```powershell
+$env:KIROCREW_HOME = "D:\kiro-crew-home"
+$env:KIROCREW_WORKSPACE = "D:\kirocrew-workspace"
+kirocrew setup
+```
+
+Note: the `kirocrew setup` workspace-path prompt does not read
+`KIROCREW_WORKSPACE` when computing its *displayed default* — pressing Enter
+on that prompt still falls back to the platform default under your home
+directory. Type the desired path explicitly at the prompt (or pass it via
+`KIROCREW_WORKSPACE` and confirm it matches before accepting). The env var is
+otherwise honored everywhere else at runtime.
+
 `kirocrew` lands in `.venv\Scripts\`. If a launched (non-shell)
 gateway can't find the built-in `kirocrew-cron` / `kirocrew-core` MCP servers,
 that dir is appended to the MCP spawn `PATH` automatically


### PR DESCRIPTION
Rebased continuation of #816 (originally by @PNg-HA), which had gone stale — the doc it edited was moved to `docs/guides/`. Same intent, re-targeted onto the current path.

## Gap validity vs current main

| Gap | Status |
|-----|--------|
| Sandbox config (`sandbox_allow_unsandboxed_exec` step missing from Quick Start) | **Already fixed on main** — dedicated "unsandboxed-exec opt-in" section now exists with more detail than the original PR. Dropped. |
| `KIROCREW_HOME` / `KIROCREW_WORKSPACE` env vars for redirecting off a full drive | **Still missing** — carried forward. |
| CONTRIBUTING.md claiming Windows is unsupported | **Still present** (line 38). Carried forward, link updated to new doc path. |

## Changes

- **CONTRIBUTING.md**: Replace "macOS or Linux (Windows is not supported…)" with a pointer to `docs/guides/windows-install.md`.
- **docs/guides/windows-install.md**: Add section documenting `KIROCREW_HOME` / `KIROCREW_WORKSPACE` env vars and the setup wizard's displayed-default quirk.

## Testing

Docs-only. No code changes.

Co-authored-by: PNg-HA <PNg-HA@users.noreply.github.com>
