### PR TITLE
feat(chat): find folders in the @-mention picker

### DIFF
--- a/docs/system-specs/modules/file-search.md
+++ b/docs/system-specs/modules/file-search.md
@@ -1,0 +1,134 @@
+# File Search Module
+
+Last Updated: 2026-07-25
+
+## Overview
+
+File search backs the `@`-mention picker in the dashboard chat composer. A user
+types `@` followed by 2+ characters, picks a result, and the composer inserts a
+token that serializes into the prompt as an attachment marker.
+
+Results cover both **files** and **directories**. A file is an attachment whose
+content reaches the agent. A directory is a **path reference only**: the agent
+receives the path and explores it with its own glob/grep/read tools. No
+directory listing or recursive content is inlined.
+
+## API
+
+### `GET /api/file-search`
+
+| Param | Required | Description |
+|---|---|---|
+| `q` | yes | Query string. Fewer than 2 characters returns an empty result set. |
+| `project` | no | Absolute project path to scope the search to. |
+| `workspace` | no | Workspace name to scope the search to, when `project` is absent. |
+| `kinds` | no | `all` (default), `files`, or `dirs`. Unrecognized values fall back to `all`. |
+
+Response:
+
+```json
+{
+  "results": [
+    {"path": "/repo/src/pages", "name": "pages", "kind": "dir",  "size": 0,    "mtime": 1750000000},
+    {"path": "/repo/src/app.ts", "name": "app.ts", "kind": "file", "size": 2048, "mtime": 1750000000}
+  ],
+  "root": "/repo"
+}
+```
+
+- `kind` is `"file"` or `"dir"`. Directory entries always report `size: 0`.
+- At most 15 results are returned.
+- Ranking is by fuzzy score, then **files before directories** on an equal
+  score, then shorter name, then recency. The file bias keeps directory entries
+  from crowding out the file a user is most likely searching for.
+
+### Result sourcing
+
+Two paths produce results:
+
+1. **In-memory index fast path.** Used when the request is scoped to a single
+   project and that project's `FileIndex` is ready and untruncated.
+2. **Per-request walk fallback.** Used otherwise, bounded by a scan budget
+   (50k entries scoped, 5k unscoped) and a collection cap. Files and directories
+   are collected into separate candidate lists, each with its own cap, and files
+   are scanned first at each level. A shared cap let a burst of matching
+   directories fill it before the files in the same directory were examined, so
+   the file-before-directory tie-break never got the chance to run.
+
+   The per-kind budgets alone do **not** bound the walk, so an independent
+   `_WALK_MAX_DIRS_VISITED` ceiling (20k directories entered) hard-stops the
+   traversal. Making the per-kind budgets independent removed the single shared
+   counter that used to terminate `os.walk`: on the default `kinds=all` request,
+   the directory counter only advances per directory *name*, so a deep tree with
+   few directories per level exhausts the file budget at the first level while
+   the directory half of the done-check stays false forever. The walk then
+   descends the entire tree doing no useful work — on every `@`-mention
+   keystroke, in the shared executor, with an aborted request unable to stop its
+   own thread.
+
+   The ceiling counts directories **entered**, not entries scored (once a kind
+   is done its collector returns immediately, so an entries-based counter stops
+   advancing while traversal continues), and it is deliberately **not** derived
+   from the per-kind budget: in a narrow-deep tree the directory-name count grows
+   at the same rate as directories visited, so any multiple of the per-kind
+   budget is unreachable in exactly the case that needs bounding.
+
+Both paths apply the same exclusions: dot-prefixed names, a skip set
+(`node_modules`, `__pycache__`, `dist`, `build`, `venv`, `env`, `out`,
+`target`), and `is_sensitive_path`.
+
+## Security
+
+Both file and directory candidates are resolved with `os.path.realpath`
+**before** the `is_sensitive_path` check, so a symlink pointing into a sensitive
+tree is rejected on its real path rather than its link path. This matches the
+existing precedent in `api_browse_dirs` / `api_browse_files`. The two branches
+are deliberately symmetrical: a divergence would let a sensitive target be
+reachable as a file but not as a directory, or the reverse.
+
+## FileIndex
+
+`FileIndex` keeps an in-memory list of entries per project root, rebuilt every
+30 seconds on a background task, capped at 100,000 entries.
+
+Each entry is a 6-tuple: `(path, name, relpath, size, mtime, kind)` where `kind`
+is `"file"` or `"dir"` and directory entries carry `size: 0`.
+
+Directories are collected during the walk rather than derived from file paths,
+so an **empty** directory is still indexed and searchable. Both files and
+directories count toward the entry cap; once the cap is hit the index is marked
+truncated and the fast path is disabled for that root, falling back to the
+per-request walk.
+
+`FileIndex.search(query, scorer, max_results, kinds)` applies the same
+`kinds` filter and file-before-directory tie-break as the endpoint.
+
+## Scope of this module (staged delivery)
+
+This document currently covers **discovery only**: how the endpoint and index
+find files and directories, and how the picker stages them in the composer.
+
+Directory *serialization* — the `[attached_dir N]` prompt marker, its rendering
+as a chip or card, and the per-slot staged-folder persistence — is delivered
+separately and documented here when it lands. Until then the picker stages a
+folder for the current message only; a staged folder does not survive a slot
+switch or a page reload.
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `src/kiro_crew/dashboard/handlers/files.py` | `api_file_search` endpoint, fuzzy scorer, walk fallback |
+| `src/kiro_crew/dashboard/file_index.py` | `FileIndex`, `FileIndexRegistry` |
+| `website/src/components/FilePickerMenu.tsx` | Picker UI, `kind` propagation, trailing-slash insertion |
+| `website/src/components/ChatInput.tsx` | Composer wiring, pending file/folder preview strip |
+
+## Tests
+
+| File | Coverage |
+|---|---|
+| `test/test_file_search.py` | Endpoint behaviour, scoring, exclusions |
+| `test/test_file_index.py` | Index build, refresh, registry refcounting |
+| `test/test_file_search_dirs.py` | Directory results, `kinds` filter, independent scan budgets, dirs-visited ceiling, symlink security |
+| `website/src/test/FilePickerMenu.dirs.test.tsx` | Folder rows, selection payloads, trailing slash |
+| `website/src/test/ChatInput.dirStripHeight.test.tsx` | Preview-strip height compensation for a folders-only strip |

--- a/src/kiro_crew/dashboard/file_index.py
+++ b/src/kiro_crew/dashboard/file_index.py
@@ -22,6 +22,10 @@ _SKIP_DIRS = frozenset({
 _REFRESH_SECS = 30
 _MAX_ENTRIES = 100_000
 
+# (path, name, relpath, size, mtime, kind) where kind is "file" or "dir".
+# Directory entries carry size 0.
+_Entry = tuple[str, str, str, int, int, str]
+
 
 class FileIndex:
     """In-memory file index for a single project root.
@@ -34,7 +38,7 @@ class FileIndex:
 
     def __init__(self, root: str) -> None:
         self.root = root
-        self._entries: list[tuple[str, str, str, int, int]] = []  # (path, name, relpath, size, mtime)
+        self._entries: list[_Entry] = []
         self._task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._ready = asyncio.Event()
         self._truncated = False
@@ -63,25 +67,43 @@ class FileIndex:
     def truncated(self) -> bool:
         return self._truncated
 
-    def search(self, query: str, scorer, max_results: int = 15) -> list[dict]:
+    def search(
+        self,
+        query: str,
+        scorer,
+        max_results: int = 15,
+        kinds: str = "all",
+    ) -> list[dict]:
         """Search the index using the provided scorer function.
 
         Args:
             query: lowercased search query (min 2 chars).
             scorer: callable(query, filename, relpath) -> float. 0 = no match.
             max_results: cap on returned results.
+            kinds: ``"all"`` (default), ``"files"``, or ``"dirs"``.
         """
+        want_files = kinds in ("all", "files")
+        want_dirs = kinds in ("all", "dirs")
         hits: list[dict] = []
-        for fpath, fname, rel, size, mtime in self._entries:
+        for fpath, fname, rel, size, mtime, kind in self._entries:
+            if kind == "dir":
+                if not want_dirs:
+                    continue
+            elif not want_files:
+                continue
             sc = scorer(query, fname, rel)
             if sc <= 0:
                 continue
             hits.append({
-                "path": fpath, "name": fname,
+                "path": fpath, "name": fname, "kind": kind,
                 "size": size, "mtime": mtime, "_score": sc,
             })
         now = time.time()
-        hits.sort(key=lambda r: (-r["_score"], len(r["name"]), now - r["mtime"]))
+        # Files rank above dirs on an otherwise equal score so directory
+        # entries never crowd out the file the user is most likely after.
+        hits.sort(key=lambda r: (
+            -r["_score"], r["kind"] == "dir", len(r["name"]), now - r["mtime"],
+        ))
         return hits[:max_results]
 
     async def _rebuild(self) -> None:
@@ -90,8 +112,8 @@ class FileIndex:
         self._truncated = truncated
         logger.debug("FileIndex rebuilt for %s: %d entries%s", self.root, len(entries), " (truncated)" if truncated else "")
 
-    def _walk(self) -> tuple[list[tuple[str, str, str, int, int]], bool]:
-        entries: list[tuple[str, str, str, int, int]] = []
+    def _walk(self) -> tuple[list[_Entry], bool]:
+        entries: list[_Entry] = []
         truncated = False
         # macOS: if this index is rooted at bare $HOME, prune the TCC-gated
         # folders. This walk re-runs every _REFRESH_SECS, so without the prune
@@ -103,6 +125,25 @@ class FileIndex:
                 dirpath,
                 [d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS],
             )
+            for dname in dirnames:
+                if len(entries) >= _MAX_ENTRIES:
+                    truncated = True
+                    break
+                dfull = os.path.join(dirpath, dname)
+                # Resolve symlinks before the sensitivity check so a link
+                # pointing into a sensitive tree cannot slip through.
+                if is_sensitive_path(os.path.realpath(dfull)):
+                    continue
+                try:
+                    st = os.stat(dfull)
+                except OSError:
+                    continue
+                entries.append((
+                    dfull, dname, os.path.relpath(dfull, self.root),
+                    0, int(st.st_mtime), "dir",
+                ))
+            if truncated:
+                break
             for fname in filenames:
                 if len(entries) >= _MAX_ENTRIES:
                     truncated = True
@@ -110,13 +151,16 @@ class FileIndex:
                 if fname.startswith("."):
                     continue
                 fpath = os.path.join(dirpath, fname)
-                if is_sensitive_path(fpath):
+                if is_sensitive_path(os.path.realpath(fpath)):
                     continue
                 try:
                     st = os.stat(fpath)
                 except OSError:
                     continue
-                entries.append((fpath, fname, os.path.relpath(fpath, self.root), st.st_size, int(st.st_mtime)))
+                entries.append((
+                    fpath, fname, os.path.relpath(fpath, self.root),
+                    st.st_size, int(st.st_mtime), "file",
+                ))
             if truncated:
                 break
         return entries, truncated

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -745,6 +745,16 @@ def _upload_dir() -> Path:
 
 _MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB per file
 _MAX_UPLOAD_FILES = 20  # max files per request
+
+# Fallback-walk budgets. ``_WALK_MAX_SCAN_*`` bounds entries scored PER KIND
+# (anti-starvation); ``_WALK_MAX_DIRS_VISITED`` bounds directories entered and is
+# what guarantees termination -- see ``_walk_file_search``. Not a multiple of the
+# per-kind budget: in a narrow-deep tree directory names grow at the same rate as
+# directories visited, so a derived ceiling is unreachable exactly when it is
+# needed. Module-level so tests can shrink them.
+_WALK_MAX_SCAN_SCOPED = 50_000
+_WALK_MAX_SCAN_UNSCOPED = 5_000
+_WALK_MAX_DIRS_VISITED = 20_000
 _ALLOWED_IMAGE_EXT = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
 _ALLOWED_TEXT_EXT = {
     ".txt",
@@ -1921,6 +1931,14 @@ async def api_file_search(request: web.Request) -> web.Response:
 
     max_results = 15
 
+    # kinds: "all" (default) returns both files and directories; "files" or
+    # "dirs" restricts the result set. Unknown values fall back to "all".
+    kinds = request.query.get("kinds", "all").strip().lower()
+    if kinds not in ("all", "files", "dirs"):
+        kinds = "all"
+    want_files = kinds in ("all", "files")
+    want_dirs = kinds in ("all", "dirs")
+
     # Scope search to project (arbitrary path) or workspace
     project = request.query.get("project", "")
     ws_name = request.query.get("workspace", "")
@@ -1976,9 +1994,9 @@ async def api_file_search(request: web.Request) -> web.Response:
     if scoped and len(safe_roots) == 1:
         idx = state.file_indexes.get(safe_roots[0])
         if idx and idx.is_ready and not idx.truncated:
-            results = await asyncio.to_thread(idx.search, query, _fuzzy_score, max_results)
+            results = await asyncio.to_thread(idx.search, query, _fuzzy_score, max_results, kinds)
             trimmed = [{k: v for k, v in r.items() if k != "_score"} for r in results]
-            _sel().log_api_access(caller=caller, operation="file_search", outcome="allowed", resources=f"q={query} indexed=true entries={idx.entry_count} results={len(trimmed)}")
+            _sel().log_api_access(caller=caller, operation="file_search", outcome="allowed", resources=f"q={query} kinds={kinds} indexed=true entries={idx.entry_count} results={len(trimmed)}")
             return web.json_response({"results": trimmed, "root": safe_roots[0]})
 
     # Fallback: walk filesystem per request
@@ -1988,21 +2006,79 @@ async def api_file_search(request: web.Request) -> web.Response:
         "dist", "build", "env", "out", "target",
     }
 
-    max_scan = 50_000 if scoped else 5_000
+    max_scan = _WALK_MAX_SCAN_SCOPED if scoped else _WALK_MAX_SCAN_UNSCOPED
     max_collect = max_results * 10  # collect enough candidates for good scoring, then stop
 
     def _walk_file_search() -> list[dict]:
-        """Blocking file-system walk — offloaded via asyncio.to_thread."""
-        results: list[dict] = []
-        walked = 0
+        """Blocking file-system walk — offloaded via asyncio.to_thread.
+
+        Files and directories are collected into SEPARATE candidate lists, each
+        with its own ``max_collect`` allowance. A shared list would let a burst
+        of matching directories fill the cap before the files in the same
+        directory are even examined, dropping the likely target before the
+        file-before-dir tie-break ever runs. Files are also scanned first at each
+        level, so under a tight scan budget the file candidates are the ones that
+        survive.
+
+        An independent ``_WALK_MAX_DIRS_VISITED`` ceiling bounds how many
+        directories the walk descends into, so no request can traverse a whole
+        large tree.
+        """
+        found: dict[str, list[dict]] = {"file": [], "dir": []}
+        walked: dict[str, int] = {"file": 0, "dir": 0}
+        dirs_visited = 0
+        wanted = {"file": want_files, "dir": want_dirs}
+
+        def _done(kind: str) -> bool:
+            return (
+                not wanted[kind]
+                or walked[kind] >= max_scan
+                or len(found[kind]) >= max_collect
+            )
+
+        def _full() -> bool:
+            return dirs_visited >= _WALK_MAX_DIRS_VISITED or (_done("file") and _done("dir"))
+
+        def _collect(kind: str, dirpath: str, names: list[str], root_dir: str) -> None:
+            """Score and collect one kind of entry from a single directory level."""
+            for name in names:
+                if _done(kind):
+                    return
+                walked[kind] += 1
+                if kind == "file" and name.startswith("."):
+                    continue
+                full = os.path.join(dirpath, name)
+                score = _fuzzy_score(query, name, os.path.relpath(full, root_dir))
+                if score <= 0:
+                    continue
+                # Resolve symlinks before the sensitivity check so a link into a
+                # sensitive tree cannot slip through.
+                if is_sensitive_path(os.path.realpath(full)):
+                    continue
+                try:
+                    st = os.stat(full)
+                except OSError:
+                    continue
+                found[kind].append({
+                    "path": full,
+                    "name": name,
+                    "kind": kind,
+                    "size": st.st_size if kind == "file" else 0,
+                    "mtime": int(st.st_mtime),
+                    "_score": score,
+                })
+
         for root_dir in safe_roots:
-            if walked >= max_scan or len(results) >= max_collect:
+            if _full():
                 break
             # macOS: prune the TCC-gated folders. Reaching into them would pop
             # one consent modal PER folder. ``scoped`` means the user NAMED
             # this root (?project= / ?workspace=), so even ``project=$HOME``
             # is deliberate and is searched in full.
             for dirpath, dirnames, filenames in os.walk(root_dir):
+                # Bounds the traversal; the per-kind counters stop advancing once
+                # their kind is done.
+                dirs_visited += 1
                 pruned = [
                     d for d in dirnames
                     if not d.startswith(".") and d not in skip_dirs
@@ -2010,38 +2086,26 @@ async def api_file_search(request: web.Request) -> web.Response:
                 dirnames[:] = pruned if scoped else platform_compat.tcc_prune_walk_dirs(
                     root_dir, dirpath, pruned
                 )
-                for fname in filenames:
-                    if walked >= max_scan or len(results) >= max_collect:
-                        break
-                    walked += 1
-                    if fname.startswith("."):
-                        continue
-                    fpath = os.path.join(dirpath, fname)
-                    rel = os.path.relpath(fpath, root_dir)
-                    sc = _fuzzy_score(query, fname, rel)
-                    if sc <= 0:
-                        continue
-                    if is_sensitive_path(fpath):
-                        continue
-                    try:
-                        st = os.stat(fpath)
-                    except OSError:
-                        continue
-                    results.append({"path": fpath, "name": fname, "size": st.st_size, "mtime": int(st.st_mtime), "_score": sc})
-                if walked >= max_scan or len(results) >= max_collect:
+                # Files first: under a tight scan budget the file candidates are
+                # the ones that survive.
+                _collect("file", dirpath, filenames, root_dir)
+                _collect("dir", dirpath, dirnames, root_dir)
+                if _full():
                     break
-        return results
+        return found["file"] + found["dir"]
 
     results = await asyncio.to_thread(_walk_file_search)
 
-    # Sort by score descending, then shorter name, then recency
+    # Sort by score descending, files before dirs on a tie, then shorter name, then recency
     now = time.time()
-    results.sort(key=lambda r: (-r["_score"], len(r["name"]), now - r["mtime"]))
+    results.sort(key=lambda r: (
+        -r["_score"], r["kind"] == "dir", len(r["name"]), now - r["mtime"],
+    ))
 
     # Strip internal scoring field before response
     trimmed = [{k: v for k, v in r.items() if k != "_score"} for r in results[:max_results]]
 
-    _sel().log_api_access(caller=caller, operation="file_search", outcome="allowed", resources=f"q={query} roots={len(safe_roots)} results={len(trimmed)}")
+    _sel().log_api_access(caller=caller, operation="file_search", outcome="allowed", resources=f"q={query} kinds={kinds} roots={len(safe_roots)} results={len(trimmed)}")
     return web.json_response({
         "results": trimmed,
         "root": safe_roots[0] if scoped and safe_roots else "",

--- a/test/test_file_search.py
+++ b/test/test_file_search.py
@@ -188,7 +188,13 @@ class TestFileSearch:
         (sub / "utils.py").write_text("x")          # path matches "myfeature"
         (tmp_path / "myfeature.py").write_text("x")  # filename matches "myfeature"
         async with TestClient(TestServer(_make_app())) as client:
-            resp = await client.get(f"/api/file-search?q=myfeature&project={tmp_path}")
+            # kinds=files: this asserts name-match vs path-match ranking among
+            # files. The "myfeature" directory itself is a legitimate hit under
+            # the default kinds=all, so it is excluded here to keep the
+            # assertion about the ranking rule under test.
+            resp = await client.get(
+                f"/api/file-search?q=myfeature&kinds=files&project={tmp_path}"
+            )
             results = (await resp.json())["results"]
             assert results[0]["name"] == "myfeature.py"  # filename match ranked first
             assert any(r["name"] == "utils.py" for r in results)  # path match included

--- a/test/test_file_search_dirs.py
+++ b/test/test_file_search_dirs.py
@@ -1,0 +1,382 @@
+"""Tests for directory results in FileIndex and /api/file-search.
+
+Covers the folder @-mention feature: directory entries carry ``kind: "dir"``,
+the ``kinds`` query param filters the result set, files outrank directories on
+an otherwise equal score, and symlinked directories are resolved before the
+sensitivity check.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.file_index import FileIndex
+from kiro_crew.dashboard.handlers import api_file_search
+from kiro_crew.dashboard.handlers import files as files_mod
+
+
+def _make_app(index=None) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/api/file-search", api_file_search)
+    state = MagicMock()
+    state.file_indexes.get.return_value = index
+    app["state"] = state
+    return app
+
+
+@pytest.fixture()
+def mock_sel():
+    with patch("kiro_crew.dashboard.handlers.sel") as m:
+        m.return_value = MagicMock()
+        yield m.return_value
+
+
+def _populate(tmp_path):
+    """Tree with directories and files sharing the "widget" stem."""
+    (tmp_path / "widgets.py").write_text("x")
+    wdir = tmp_path / "widgets"
+    wdir.mkdir()
+    (wdir / "button.py").write_text("y")
+    nested = wdir / "widgetsinner"
+    nested.mkdir()
+    (nested / "leaf.py").write_text("z")
+    # An empty directory: proof dirs are walked, not derived from file paths.
+    (tmp_path / "widgetsempty").mkdir()
+    # Excluded: dot-prefixed and skip-listed dirs
+    (tmp_path / ".widgetshidden").mkdir()
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / "widgetsdep").mkdir()
+
+
+def _scorer(q, name, rel):
+    nl = name.lower()
+    if q in nl:
+        return 10.0
+    if q in rel.lower():
+        return 5.0
+    return 0.0
+
+
+class TestFileIndexDirs:
+    @pytest.mark.asyncio
+    async def test_index_includes_dir_entries(self, tmp_path):
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            results = idx.search("widgets", _scorer)
+            by_name = {r["name"]: r for r in results}
+            assert by_name["widgets"]["kind"] == "dir"
+            assert by_name["widgets.py"]["kind"] == "file"
+            # Directory entries report size 0 and a real mtime.
+            assert by_name["widgets"]["size"] == 0
+            assert by_name["widgets"]["mtime"] > 0
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_includes_empty_dir(self, tmp_path):
+        """An empty dir has no files, so it can only appear if dirs are walked."""
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            names = {r["name"] for r in idx.search("widgetsempty", _scorer)}
+            assert "widgetsempty" in names
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_kinds_filter(self, tmp_path):
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            dirs = idx.search("widgets", _scorer, 15, "dirs")
+            assert dirs, "expected at least one directory hit"
+            assert all(r["kind"] == "dir" for r in dirs)
+
+            files = idx.search("widgets", _scorer, 15, "files")
+            assert files, "expected at least one file hit"
+            assert all(r["kind"] == "file" for r in files)
+
+            both = {r["kind"] for r in idx.search("widgets", _scorer, 15, "all")}
+            assert both == {"dir", "file"}
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_excludes_hidden_and_skip_dirs(self, tmp_path):
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            names = {r["name"] for r in idx.search("widgets", _scorer, 50, "dirs")}
+            assert ".widgetshidden" not in names
+            assert "widgetsdep" not in names
+            assert "node_modules" not in names
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_files_outrank_dirs_on_equal_score(self, tmp_path):
+        """Equal score and equal name length: the file must sort first."""
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "alpha.x").write_text("x")
+
+        def flat_scorer(q, name, rel):
+            return 10.0 if q in name.lower() else 0.0
+
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            results = idx.search("alpha", flat_scorer)
+            kinds = [r["kind"] for r in results]
+            assert kinds[0] == "file", f"expected file first, got {results}"
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_dir_symlink_resolved_before_sensitive_check(self, tmp_path):
+        """A symlink into a sensitive tree must be rejected on its real path."""
+        _populate(tmp_path)
+        link = tmp_path / "widgetslink"
+        os.symlink(str(tmp_path / "widgets"), str(link))
+
+        idx = FileIndex(str(tmp_path))
+        real = os.path.realpath(str(link))
+
+        def fake_sensitive(p):
+            return os.path.realpath(p) == real
+
+        with patch("kiro_crew.dashboard.file_index.is_sensitive_path", side_effect=fake_sensitive):
+            entries, _ = idx._walk()
+        names = {e[1] for e in entries if e[5] == "dir"}
+        assert "widgetslink" not in names
+        assert "widgets" not in names, "the symlink target shares the real path and must also be filtered"
+
+    @pytest.mark.asyncio
+    async def test_index_file_symlink_resolved_before_sensitive_check(self, tmp_path):
+        """A symlinked FILE into a sensitive tree is rejected on its real path."""
+        _populate(tmp_path)
+        link = tmp_path / "widgetslink.py"
+        os.symlink(str(tmp_path / "widgets.py"), str(link))
+
+        idx = FileIndex(str(tmp_path))
+        real = os.path.realpath(str(link))
+
+        def fake_sensitive(p):
+            return os.path.realpath(p) == real
+
+        with patch("kiro_crew.dashboard.file_index.is_sensitive_path", side_effect=fake_sensitive):
+            entries, _ = idx._walk()
+        names = {e[1] for e in entries if e[5] == "file"}
+        assert "widgetslink.py" not in names
+        assert "widgets.py" not in names, "the symlink target shares the real path"
+
+
+class TestApiFileSearchDirs:
+    @pytest.mark.asyncio
+    async def test_walk_fallback_returns_dirs(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-search?q=widgets&project={tmp_path}")
+            assert resp.status == 200
+            results = (await resp.json())["results"]
+            by_name = {r["name"]: r for r in results}
+            assert by_name["widgets"]["kind"] == "dir"
+            assert by_name["widgets"]["size"] == 0
+            assert by_name["widgets.py"]["kind"] == "file"
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_kinds_dirs_only(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(
+                f"/api/file-search?q=widgets&kinds=dirs&project={tmp_path}"
+            )
+            results = (await resp.json())["results"]
+            assert results
+            assert all(r["kind"] == "dir" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_kinds_files_only(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(
+                f"/api/file-search?q=widgets&kinds=files&project={tmp_path}"
+            )
+            results = (await resp.json())["results"]
+            assert results
+            assert all(r["kind"] == "file" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_unknown_kinds_value_falls_back_to_all(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(
+                f"/api/file-search?q=widgets&kinds=bogus&project={tmp_path}"
+            )
+            assert resp.status == 200
+            kinds = {r["kind"] for r in (await resp.json())["results"]}
+            assert kinds == {"dir", "file"}
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_excludes_hidden_and_skip_dirs(self, tmp_path, mock_sel):
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(
+                f"/api/file-search?q=widgets&kinds=dirs&project={tmp_path}"
+            )
+            names = {r["name"] for r in (await resp.json())["results"]}
+            assert ".widgetshidden" not in names
+            assert "widgetsdep" not in names
+
+    @pytest.mark.asyncio
+    async def test_index_fast_path_forwards_kinds(self, tmp_path, mock_sel):
+        """The fast path must pass the kinds param through to FileIndex.search."""
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            app = _make_app(index=idx)
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get(
+                    f"/api/file-search?q=widgets&kinds=dirs&project={tmp_path}"
+                )
+                data = await resp.json()
+                assert data["root"] == os.path.realpath(str(tmp_path))
+                assert data["results"]
+                assert all(r["kind"] == "dir" for r in data["results"])
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_file_symlink_resolved_before_sensitive_check(
+        self, tmp_path, mock_sel
+    ):
+        """A symlinked FILE into a sensitive tree is rejected on its real path.
+
+        The directory branch already resolved symlinks first; files must match so
+        the two branches cannot disagree about what counts as sensitive.
+        """
+        _populate(tmp_path)
+        link = tmp_path / "widgetslink.py"
+        os.symlink(str(tmp_path / "widgets.py"), str(link))
+        real = os.path.realpath(str(link))
+
+        def fake_sensitive(p):
+            return os.path.realpath(p) == real
+
+        with patch(
+            # api_file_search imports is_sensitive_path locally from
+            # kiro_crew.security, so the source module is the patch target.
+            "kiro_crew.security.is_sensitive_path",
+            side_effect=fake_sensitive,
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(
+                    f"/api/file-search?q=widgets&kinds=files&project={tmp_path}"
+                )
+                names = {r["name"] for r in (await resp.json())["results"]}
+        assert "widgetslink.py" not in names
+        assert "widgets.py" not in names, "the symlink target shares the real path"
+
+    @pytest.mark.asyncio
+    async def test_many_matching_dirs_do_not_starve_files(self, tmp_path, mock_sel):
+        """Directories must not consume the whole candidate budget.
+
+        A shared collection cap let a burst of matching directories fill it
+        before any file was examined, so the best-scoring file was never even a
+        candidate. The directories here score LOWER than the file, so a correct
+        implementation returns the file regardless of ranking: the only way to
+        lose it is to never collect it.
+        """
+        # max_collect is max_results * 10 = 150, so 400 matching directories
+        # would previously exhaust it before the file was reached.
+        for i in range(400):
+            (tmp_path / f"zzz_widgets{i:03d}").mkdir()
+        (tmp_path / "widgets.py").write_text("x")
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-search?q=widgets&project={tmp_path}")
+            results = (await resp.json())["results"]
+        names = [r["name"] for r in results]
+        assert "widgets.py" in names, "the file was crowded out by directory candidates"
+
+    @pytest.mark.asyncio
+    async def test_files_and_dirs_have_independent_scan_budgets(self, tmp_path, mock_sel):
+        """A file-heavy root must not starve the directory scan.
+
+        A single shared scan counter let files spend the whole budget before any
+        directory was examined, so directory search returned nothing even though
+        it was enabled. Non-matching files are used so only the SCAN budget (not
+        the candidate cap) is under test.
+        """
+        for i in range(5_000):
+            (tmp_path / f"zz{i:04d}.py").write_text("x")
+        (tmp_path / "widgets_dir").mkdir()
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-search?q=widgets&project={tmp_path}")
+            results = (await resp.json())["results"]
+        names = [r["name"] for r in results]
+        assert "widgets_dir" in names, "directory candidates were starved by the file scan"
+
+    @pytest.mark.asyncio
+    async def test_walk_stops_at_overall_scan_ceiling(self, tmp_path, mock_sel):
+        """The walk must stop descending once the dirs-visited ceiling is hit.
+
+        The per-kind budgets do not terminate the walk: on `kinds=all` the dir
+        counter advances per directory NAME, so a deep tree with few dirs per
+        level exhausts the file budget at level one while the dir half of the
+        done-check stays false forever, and `os.walk` descends the whole tree.
+
+        The tree must be DEEP AND NARROW. A wide tree does not reproduce it --
+        the root's many directory names exhaust the dir budget immediately, which
+        is why the flat 5,000-file budget test could not catch this.
+        """
+        cur = tmp_path
+        levels = 30
+        for d in range(levels):
+            # A handful of files per level is enough to spend the (shrunk) file
+            # budget; the bug is about depth, not file volume.
+            for f in range(3):
+                (cur / f"zz{d:02d}_{f}.py").write_text("x")
+            cur = cur / f"n{d:02d}"
+            cur.mkdir()
+
+        real_walk = os.walk
+        calls = {"n": 0}
+
+        def counting_walk(*a, **kw):
+            # Count yielded levels, not the call: os.walk is a generator, so this
+            # measures how far the traversal actually got. Patched on the
+            # handler's `os` -- patching os.scandir does nothing, since os.walk
+            # bound it at import time.
+            for item in real_walk(*a, **kw):
+                calls["n"] += 1
+                yield item
+
+        with patch.object(files_mod, "_WALK_MAX_SCAN_SCOPED", 10_000), \
+                patch.object(files_mod, "_WALK_MAX_DIRS_VISITED", 10), \
+                patch.object(files_mod.os, "walk", counting_walk):
+            async with TestClient(TestServer(_make_app())) as client:
+                # Matches nothing, so no candidate cap can end the walk.
+                resp = await client.get(f"/api/file-search?q=qqqnomatch&project={tmp_path}")
+                assert resp.status == 200
+
+        # The per-kind budget is left out of reach on purpose: a budget below the
+        # level count would be exhausted by the directory names themselves and
+        # mask the bug. So the ceiling (10) is the only thing that can stop the
+        # walk. Unbounded, it descends all 31 levels.
+        assert calls["n"] <= 12, (
+            f"walk descended {calls['n']} directories of {levels + 1} -- the "
+            "dirs-visited ceiling did not stop the traversal"
+        )

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1505,11 +1505,11 @@ export const api = {
   simulateUpdate: (opts?: { delay?: number; fail_at?: string }) => post('/api/update/simulate', opts || {}).then(j),
   pickFiles: () => post('/api/upload').then(j) as Promise<{ paths: string[] }>,
   fileDiff: (path: string) => fetch('/api/file-diff?path=' + encodeURIComponent(path)).then(j) as Promise<{ diff: string; original: string; status?: 'clean' | 'modified' | 'untracked' | 'not_git' }>,
-  /** Fuzzy file search for @-mention picker */
+  /** Fuzzy file search for @-mention picker. `kind` distinguishes folder hits from files. */
   fileSearch: (q: string, project?: string, signal?: AbortSignal) => {
     const p = new URLSearchParams({ q })
     if (project) p.set('project', project)
-    return fetch(`/api/file-search?${p}`, signal ? { signal } : undefined).then(j) as Promise<{ results: Array<{ path: string; name: string; size: number; mtime: number }>; root: string }>
+    return fetch(`/api/file-search?${p}`, signal ? { signal } : undefined).then(j) as Promise<{ results: Array<{ path: string; name: string; size: number; mtime: number; kind?: 'file' | 'dir' }>; root: string }>
   },
   /** Upload files via browser File API (cross-platform) */
   uploadFiles: async (files: File[]) => {

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, memo } from 'react'
-import { ArrowUpFromLine, ArrowUp, Loader2, Play, Plus, Crop, Bot, Mic, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Globe, FolderOpen, FileText, ChevronDown, Check } from 'lucide-react'
+import { ArrowUpFromLine, ArrowUp, Loader2, Play, Plus, Crop, Bot, Mic, Square, BookOpen, X, ClipboardList, CheckCircle, Ban, Sparkles, Target, Lock, Globe, Folder, FolderOpen, FileText, ChevronDown, Check } from 'lucide-react'
 import { Toggle } from './ui'
 import CopyBranchButton from './CopyBranchButton'
 import { usePointerDrag } from '../hooks/usePointerDrag'
@@ -71,6 +71,7 @@ export {
 import { effortLabel } from '../lib/effort'
 import SlashCommandMenu from './SlashCommandMenu'
 import FilePickerMenu from './FilePickerMenu'
+import type { FileKind } from './FilePickerMenu'
 import SkillPickerMenu from './SkillPickerMenu'
 import { matchFileToken, matchSkillToken, replaceTokenAtCaret } from './composerTokens'
 import { useStopEscapeHatch } from '../hooks/useStopEscapeHatch'
@@ -241,10 +242,14 @@ interface ChatInputProps {
   uploading?: boolean
   /** Pending file paths (images + non-images) for preview strip */
   pendingFiles?: string[]
+  /** Pending directory references for the preview strip (path handed to the agent, not an upload) */
+  pendingDirs?: string[]
   /** Resize details keyed by pending-file path; renders a badge on the chip */
   resizedInfo?: Record<string, ResizeInfo>
   /** Remove a pending file by path */
   onRemoveFile?: (path: string) => void
+  /** Remove a pending directory reference by path */
+  onRemoveDir?: (path: string) => void
   /** Show macOS-only buttons (screenshot) */
   isMac?: boolean
   /** Drag-and-drop handler for the entire input bar */
@@ -323,7 +328,8 @@ interface ChatInputProps {
   reasoningEffort?: string
   onReasoningEffortClick?: (rect: DOMRect) => void
   providerId?: string
-  onFileSelect?: (path: string) => void
+  /** Invoked when an @-mention picks a file or directory. `kind` defaults to 'file'. */
+  onFileSelect?: (path: string, kind?: FileKind) => void
   onFileOpen?: (path: string) => void
   project?: string
   /** Checked-out branch of the active project (or short SHA when detached). */
@@ -412,10 +418,10 @@ function ResizeBadge({ resize }: { resize: ResizeInfo }) {
   )
 }
 
-function FilePreviewStrip({ files, resizedInfo, onRemove }: { files: string[]; resizedInfo?: Record<string, ResizeInfo>; onRemove?: (path: string) => void }) {
+function FilePreviewStrip({ files, dirs = [], resizedInfo, onRemove, onRemoveDir }: { files: string[]; dirs?: string[]; resizedInfo?: Record<string, ResizeInfo>; onRemove?: (path: string) => void; onRemoveDir?: (path: string) => void }) {
   const imgs = files.filter(p => IMG_EXT.test(p))
   const nonImgs = files.filter(p => !IMG_EXT.test(p))
-  if (!imgs.length && !nonImgs.length) return null
+  if (!imgs.length && !nonImgs.length && !dirs.length) return null
   return (
     // NOTE: rendered height must match FILE_PREVIEW_H constant, update both together
     <div className="flex gap-2 px-5 py-2 border-t border-border bg-chrome/50 overflow-x-auto items-end" data-image-scope="">
@@ -453,6 +459,22 @@ function FilePreviewStrip({ files, resizedInfo, onRemove }: { files: string[]; r
           )}
         </div>
       ))}
+      {/* Folder references: a path handed to the agent, not an upload. No
+          /api/file-raw thumbnail is fetched — there is no content to preview. */}
+      {dirs.map(path => (
+        <div
+          key={path}
+          data-dir-chip=""
+          title={path}
+          className="relative group/preview shrink-0 flex items-center gap-1.5 px-2 py-1 rounded border border-border bg-bg-hover text-[12px] text-text"
+        >
+          <Folder size={12} aria-label="Folder" className="shrink-0 lucide-inline" />
+          <span>{(path.replace(/[/\\]+$/, '').split(/[/\\]/).pop() || path) + '/'}</span>
+          {onRemoveDir && (
+            <button aria-label="Remove folder" className="text-muted hover:text-danger cursor-pointer bg-transparent border-none p-0" onClick={() => onRemoveDir(path)} title="Remove"><X size={12} /></button>
+          )}
+        </div>
+      ))}
     </div>
   )
 }
@@ -475,8 +497,10 @@ function ChatInput({
   onUploadFiles,
   uploading = false,
   pendingFiles = [],
+  pendingDirs = [],
   resizedInfo,
   onRemoveFile,
+  onRemoveDir,
   isMac = false,
   onDrop,
   dragOver = false,
@@ -2009,7 +2033,10 @@ function ChatInput({
     e.target.value = '' // reset so same file can be re-selected
   }, [onUploadFiles])
 
-  const hasFiles = pendingFiles.length > 0
+  // The preview strip renders for folder references too, so height
+  // compensation must key off both staged families — otherwise a dirs-only
+  // strip appears with no wrapper expansion and eats into the textarea.
+  const hasFiles = pendingFiles.length > 0 || pendingDirs.length > 0
   const prevHadFiles = useRef(hasFiles)
   const dragMinH = hasFiles ? INPUT_DRAG_MIN_H + FILE_PREVIEW_H : INPUT_DRAG_MIN_H
   const dragMinHRef = useRef(dragMinH)
@@ -2028,7 +2055,7 @@ function ChatInput({
   return (
     // 'input-area' is a stable theming hook — see website/docs/theming-contract.md
     <div className={`input-area px-5 pb-1 ${hasApproval ? 'pt-0' : 'pt-1'} mx-auto w-full flex flex-col`}
-      style={{ maxWidth: 'var(--mc-input-width, 900px)', ...(manualHeight !== null ? { minHeight: (pendingFiles.length > 0 ? INPUT_DRAG_MIN_H + FILE_PREVIEW_H : INPUT_DRAG_MIN_H) + 'px' } : {}) }}>
+      style={{ maxWidth: 'var(--mc-input-width, 900px)', ...(manualHeight !== null ? { minHeight: (hasFiles ? INPUT_DRAG_MIN_H + FILE_PREVIEW_H : INPUT_DRAG_MIN_H) + 'px' } : {}) }}>
 
       {aboveComposer}
 
@@ -2274,10 +2301,13 @@ function ChatInput({
           open={filePickerOpen}
           project={project}
           onFileOpen={onFileOpen}
-          onSelect={({ path, relativePath }) => {
+          onSelect={({ path, relativePath, kind }) => {
+            // relativePath already carries a trailing slash for directories
+            // (see selectionFor in FilePickerMenu), so the inserted token reads
+            // as e.g. "@src/pages/ " and is unambiguously a folder.
             applyPickedToken(/(^|[\s])@\S*$/, `@${relativePath} `)
             setFilePickerOpen(false); setFileQuery('')
-            onFileSelect(path)
+            onFileSelect(path, kind)
           }}
           onClose={() => { setFilePickerOpen(false); setFileQuery('') }}
         />
@@ -2329,7 +2359,7 @@ function ChatInput({
         onDragLeave={onDragLeave}
         onDrop={onDrop}
       >
-        <FilePreviewStrip files={pendingFiles} resizedInfo={resizedInfo} onRemove={onRemoveFile} />
+        <FilePreviewStrip files={pendingFiles} dirs={pendingDirs} resizedInfo={resizedInfo} onRemove={onRemoveFile} onRemoveDir={onRemoveDir} />
 
         {showDictation ? (
           <VoiceDictationPanel sampleRef={showDictation} value={value} partial={voicePartial} deviceLabel={voiceDeviceLabel} onSelectDevice={onSelectVoiceDevice || noopSelectDevice} deviceSwitchIsLive={voiceDeviceSwitchIsLive} streaming={voiceStreaming} />

--- a/website/src/components/FilePickerMenu.tsx
+++ b/website/src/components/FilePickerMenu.tsx
@@ -1,18 +1,23 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useQuery } from '@tanstack/react-query'
-import { FileText, Eye } from 'lucide-react'
+import { FileText, Folder, Eye } from 'lucide-react'
 import { api } from '../api/client'
 import { useListKeyboardNav } from '../hooks/useListKeyboardNav'
 import { menuGeometry, bottomUpOrder } from '../lib/pickerMenu'
 
 import { i18nT } from '../i18n/t'
 import { fmtBytes, fmtDateFields, fmtRelative } from '../i18n/format'
+
+export type FileKind = 'file' | 'dir'
+
 interface FileResult {
   path: string
   name: string
   size: number
   mtime: number
+  /** Absent on responses from older backends — treated as 'file'. */
+  kind?: FileKind
 }
 
 interface FileSearchResponse {
@@ -24,7 +29,7 @@ interface Props {
   query: string
   anchorRef: React.RefObject<HTMLElement | null>
   open: boolean
-  onSelect: (info: { path: string; relativePath: string }) => void
+  onSelect: (info: { path: string; relativePath: string; kind: FileKind }) => void
   onClose: () => void
   onFileOpen?: (path: string) => void
   project?: string
@@ -40,10 +45,40 @@ function formatAge(mtime: number): string {
   return fmtDateFields(mtime, { month: 'short', day: 'numeric' })
 }
 
-function makeRelative(path: string, root: string): string {
+/**
+ * Strip the project root prefix so the inserted token is a short relative path.
+ *
+ * Separator-aware: on native Windows the search result and the root both use
+ * backslashes, and a `/`-only prefix check never matched, so the picker inserted
+ * the ABSOLUTE path. For folders that then failed to resolve on send, because
+ * the suffix walk in buildDirRelMap only produces suffixes after a separator and
+ * never the full path, leaving the raw mention plus a duplicate marker.
+ */
+export function makeRelative(path: string, root: string): string {
   if (!root) return path
-  const r = root.endsWith('/') ? root : root + '/'
+  const r = /[/\\]$/.test(root) ? root : root + (root.includes('\\') && !root.includes('/') ? '\\' : '/')
   return path.startsWith(r) ? path.slice(r.length) : path
+}
+
+/** Normalize a possibly-absent kind from the search response. */
+export function resultKind(f: { kind?: FileKind }): FileKind {
+  return f.kind === 'dir' ? 'dir' : 'file'
+}
+
+/**
+ * Build the payload handed to onSelect. Directory paths get a trailing slash on
+ * the relative form so the inserted @-token reads unambiguously as a folder.
+ */
+export function selectionFor(f: FileResult, root: string): { path: string; relativePath: string; kind: FileKind } {
+  const kind = resultKind(f)
+  const rel = makeRelative(f.path, root)
+  return {
+    path: f.path,
+    // `endsWith` covers either separator so a Windows path is not given a second
+    // one; the inserted token still ends in `/`, which dirTokenRegex tolerates.
+    relativePath: kind === 'dir' && !/[/\\]$/.test(rel) ? rel + '/' : rel,
+    kind,
+  }
 }
 
 export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClose, onFileOpen, project }: Props) {
@@ -88,10 +123,13 @@ export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClo
   // Open the highlighted file in the viewer (the eye/preview action) instead of
   // inserting an @-mention. Shared by the Cmd/Ctrl+Enter path (via onChoose's
   // withModifier flag) and the Alt+Enter path (via onAltEnter). Returns true so
-  // the hook knows the default choose was superseded.
+  // the hook knows the default choose was superseded. Directories have nothing
+  // to preview, so they fall through to the normal insert.
   const openInViewer = useCallback((idx: number): boolean => {
     const f = resultsRef.current[idx]
-    if (f && onFileOpenRef.current) { onFileOpenRef.current(f.path); onClose(); return true }
+    if (f && resultKind(f) === 'file' && onFileOpenRef.current) {
+      onFileOpenRef.current(f.path); onClose(); return true
+    }
     return false
   }, [onClose])
 
@@ -104,7 +142,7 @@ export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClo
     const f = r[eff]
     if (!f) return
     if (withModifier && openInViewer(eff)) return
-    onSelect({ path: f.path, relativePath: makeRelative(f.path, rootRef.current) })
+    onSelect(selectionFor(f, rootRef.current))
   }, [onSelect, openInViewer])
 
   // Shared Arrow/Enter/Tab/Escape + scroll-into-view (see useListKeyboardNav).
@@ -151,25 +189,33 @@ export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClo
       role="listbox"
       style={{ top, left, width: Math.min(width, 420), maxHeight }}
     >
-      {results.length === 0 ? empty : results.map((f, i) => (
+      {results.length === 0 ? empty : results.map((f, i) => {
+        const kind = resultKind(f)
+        const isDir = kind === 'dir'
+        return (
         <div
           role="option"
           aria-selected={i === selected}
+          data-kind={kind}
           tabIndex={-1}
           key={f.path}
           ref={el => { itemRefs.current[i] = el }}
           className={`w-full text-left px-3 py-2 flex items-center gap-3 cursor-pointer transition-colors ${i === selected ? 'bg-accent-subtle text-text' : 'text-muted hover:bg-bg-hover hover:text-text'}`}
           title={f.path}
           onMouseEnter={() => setSelected(i)}
-          onMouseDown={e => { e.preventDefault(); onSelect({ path: f.path, relativePath: makeRelative(f.path, rootRef.current) }) }}
+          onMouseDown={e => { e.preventDefault(); onSelect(selectionFor(f, rootRef.current)) }}
         >
-          <FileText size={14} className="shrink-0 lucide-inline" />
+          {isDir
+            ? <Folder size={14} aria-label="Folder" className="shrink-0 lucide-inline" />
+            : <FileText size={14} className="shrink-0 lucide-inline" />}
           <div className="flex-1 min-w-0">
-            <div className="text-[13px] font-mono font-semibold truncate">{f.name}</div>
+            <div className="text-[13px] font-mono font-semibold truncate">{isDir ? f.name + '/' : f.name}</div>
             <div className="text-[11px] text-muted truncate">{f.path}</div>
           </div>
-          <span className="text-[11px] text-muted shrink-0 whitespace-nowrap">{formatSize(f.size)} · {formatAge(f.mtime)}</span>
-          {onFileOpen && (
+          <span className="text-[11px] text-muted shrink-0 whitespace-nowrap">
+            {isDir ? `folder · ${formatAge(f.mtime)}` : `${formatSize(f.size)} · ${formatAge(f.mtime)}`}
+          </span>
+          {onFileOpen && !isDir && (
             <button
               type="button"
               aria-label={i18nT('components.filePickerMenu.open_in_viewer')}
@@ -182,7 +228,8 @@ export default function FilePickerMenu({ query, anchorRef, open, onSelect, onClo
             </button>
           )}
         </div>
-      ))}
+        )
+      })}
     </div>,
     document.body
   )

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1327,6 +1327,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const [dragOver, setDragOver] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [pendingFiles, setPendingFiles] = useState<string[]>([])
+  // Staged folder references, kept separate from pendingFiles because a folder
+  // is a path handed to the agent, never an uploaded attachment. Per-message
+  // only for now: the per-slot draft persistence and prompt-marker
+  // serialization land with the attachment-metadata change.
+  const [pendingDirs, setPendingDirs] = useState<string[]>([])
   const [snipFrame, setSnipFrame] = useState<HTMLCanvasElement | null>(null)
   // The slot that INITIATED the current snip. getDisplayMedia + cropping is
   // async and the user may switch slots meanwhile, so the cropped image must
@@ -3012,7 +3017,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
 
     setPrefillHint(false)
     if (!optionText) {
-      setInput(''); setPendingFiles([]); setPasteBlocks([]); if (uiSlot) { delete drafts.current[uiSlot]; delete fileDrafts.current[uiSlot]; delete pasteDrafts.current[uiSlot]; saveDrafts() }
+      setInput(''); setPendingFiles([]); setPendingDirs([]); setPasteBlocks([]); if (uiSlot) { delete drafts.current[uiSlot]; delete fileDrafts.current[uiSlot]; delete pasteDrafts.current[uiSlot]; saveDrafts() }
       // The challenge-handoff prompt is seeded into PREFILL_STORAGE_KEY and the
       // slot-restore effect re-applies it on slot changes. Once that prompt is
       // sent, clear the seed so a later slot-restore can't re-fill the (now
@@ -4247,7 +4252,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // (appendSlotMessage) instead of rendering a duplicate.
     dispatch(appendMessage({ role: 'user', content: llmTxt, cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true } }))
     steerMutation.mutate(llmTxt)
-    setInput(''); setPendingFiles([]); setPasteBlocks([])
+    setInput(''); setPendingFiles([]); setPendingDirs([]); setPasteBlocks([])
     delete drafts.current[activeSlot]; delete fileDrafts.current[activeSlot]; delete pasteDrafts.current[activeSlot]
     saveDrafts()
   }, [activeSlot, steerMutation, saveDrafts, dispatch])
@@ -5266,9 +5271,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               onUploadFiles={uploadFiles}
               uploading={uploading}
               pendingFiles={pendingFiles}
+              pendingDirs={pendingDirs}
               resizedInfo={resizedInfo}
               onRemoveFile={p => setPendingFiles(prev => prev.filter(x => x !== p))}
-              onFileSelect={path => setPendingFiles(prev => prev.includes(path) ? prev : [...prev, path])}
+              onRemoveDir={p => setPendingDirs(prev => prev.filter(x => x !== p))}
+              // A folder is a path reference, not an upload — it must never land
+              // in pendingFiles, where the send path would treat it as an
+              // attachable file and try to read it.
+              onFileSelect={(path, kind) => kind === 'dir'
+                ? setPendingDirs(prev => prev.includes(path) ? prev : [...prev, path])
+                : setPendingFiles(prev => prev.includes(path) ? prev : [...prev, path])}
               onFileOpen={handleFileOpen}
               project={currentSlot?.project || ''}
               projectBranch={projectBranch}

--- a/website/src/test/ChatInput.dirStripHeight.test.tsx
+++ b/website/src/test/ChatInput.dirStripHeight.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import ChatInput from '../components/ChatInput'
+
+// The attachment preview strip now renders for folder references too, but the
+// composer's manual-height compensation used to key off `pendingFiles` alone.
+// With a manually resized composer and only a folder staged, the strip appeared
+// without the FILE_PREVIEW_H allowance, so it ate into the textarea instead of
+// expanding the wrapper.
+
+const defaultProps = {
+  value: '',
+  onChange: vi.fn(),
+  onSend: vi.fn(),
+}
+
+// Must match ChatInput's own constants.
+const INPUT_DRAG_MIN_H = 93
+const FILE_PREVIEW_H = 81
+const MANUAL_H = 300
+
+const outerOf = () => screen.getByLabelText('Message input').closest('.input-area') as HTMLElement
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+  // A persisted manual height is what activates the minHeight compensation.
+  localStorage.setItem('mc-input-height', String(MANUAL_H))
+})
+
+describe('ChatInput preview-strip height compensation', () => {
+  it('compensates for a dirs-only preview strip', () => {
+    renderWithProviders(<ChatInput {...defaultProps} pendingDirs={['/repo/website/docs']} />)
+    expect(outerOf().style.minHeight).toBe(`${INPUT_DRAG_MIN_H + FILE_PREVIEW_H}px`)
+  })
+
+  it('compensates for a files-only preview strip (unchanged)', () => {
+    renderWithProviders(<ChatInput {...defaultProps} pendingFiles={['/tmp/a.txt']} />)
+    expect(outerOf().style.minHeight).toBe(`${INPUT_DRAG_MIN_H + FILE_PREVIEW_H}px`)
+  })
+
+  it('does not compensate when nothing is staged', () => {
+    renderWithProviders(<ChatInput {...defaultProps} />)
+    expect(outerOf().style.minHeight).toBe(`${INPUT_DRAG_MIN_H}px`)
+  })
+})

--- a/website/src/test/FilePickerMenu.dirs.test.tsx
+++ b/website/src/test/FilePickerMenu.dirs.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useRef } from 'react'
+
+/* ── Mock api/client BEFORE the component imports ── */
+const mockApi = vi.hoisted(() => ({
+  fileSearch: vi.fn(),
+}))
+vi.mock('../api/client', () => ({ api: mockApi }))
+
+import FilePickerMenu, { resultKind, selectionFor, makeRelative } from '../components/FilePickerMenu'
+
+const ROOT = '/repo'
+const NOW = Math.floor(Date.now() / 1000)
+
+const RESULTS = [
+  { path: '/repo/src/widgets', name: 'widgets', size: 0, mtime: NOW - 120, kind: 'dir' as const },
+  { path: '/repo/src/widgets.ts', name: 'widgets.ts', size: 2048, mtime: NOW - 120, kind: 'file' as const },
+]
+
+function Harness({
+  query, open, onSelect = vi.fn(), onClose = vi.fn(), onFileOpen,
+}: {
+  query: string
+  open: boolean
+  onSelect?: (i: { path: string; relativePath: string; kind: 'file' | 'dir' }) => void
+  onClose?: () => void
+  onFileOpen?: (p: string) => void
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={qc}>
+      <div>
+        <div ref={ref} data-testid="anchor">anchor</div>
+        <FilePickerMenu
+          query={query}
+          anchorRef={ref}
+          open={open}
+          onSelect={onSelect}
+          onClose={onClose}
+          onFileOpen={onFileOpen}
+        />
+      </div>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  mockApi.fileSearch.mockResolvedValue({ results: RESULTS, root: ROOT })
+})
+
+describe('selectionFor', () => {
+  it('appends a trailing slash to directory relative paths', () => {
+    expect(selectionFor(RESULTS[0], ROOT)).toEqual({
+      path: '/repo/src/widgets',
+      relativePath: 'src/widgets/',
+      kind: 'dir',
+    })
+  })
+
+  it('leaves file relative paths untouched', () => {
+    expect(selectionFor(RESULTS[1], ROOT)).toEqual({
+      path: '/repo/src/widgets.ts',
+      relativePath: 'src/widgets.ts',
+      kind: 'file',
+    })
+  })
+
+  it('does not double up an existing trailing slash', () => {
+    const withSlash = { ...RESULTS[0], path: '/repo/src/widgets/' }
+    expect(selectionFor(withSlash, ROOT).relativePath).toBe('src/widgets/')
+  })
+
+  it('falls back to the absolute path when no root is known', () => {
+    expect(selectionFor(RESULTS[0], '').relativePath).toBe('/repo/src/widgets/')
+  })
+})
+
+describe('resultKind', () => {
+  it('treats a missing kind as file for backward compatibility', () => {
+    expect(resultKind({})).toBe('file')
+  })
+
+  it('reads an explicit dir kind', () => {
+    expect(resultKind({ kind: 'dir' })).toBe('dir')
+  })
+})
+
+describe('FilePickerMenu directory rows', () => {
+  it('renders a directory name with a trailing slash', async () => {
+    render(<Harness query="widgets" open />)
+    expect(await screen.findByText('widgets/')).toBeInTheDocument()
+    expect(screen.getByText('widgets.ts')).toBeInTheDocument()
+  })
+
+  it('marks rows with their kind', async () => {
+    render(<Harness query="widgets" open />)
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(2))
+    const kinds = screen.getAllByRole('option').map(o => o.getAttribute('data-kind'))
+    expect(kinds).toContain('dir')
+    expect(kinds).toContain('file')
+  })
+
+  it('shows a folder label instead of a byte size for directories', async () => {
+    render(<Harness query="widgets" open />)
+    expect(await screen.findByText(/^folder · /)).toBeInTheDocument()
+    expect(screen.getByText(/^2KB · /)).toBeInTheDocument()
+  })
+
+  it('renders a Folder icon for directories', async () => {
+    render(<Harness query="widgets" open />)
+    expect(await screen.findByLabelText('Folder')).toBeInTheDocument()
+  })
+
+  it('suppresses the preview button on directory rows', async () => {
+    const onFileOpen = vi.fn()
+    render(<Harness query="widgets" open onFileOpen={onFileOpen} />)
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(2))
+    // One eye button only: the file row. The dir row has nothing to preview.
+    expect(screen.getAllByLabelText('Open in viewer')).toHaveLength(1)
+  })
+
+  it('emits kind=dir with a trailing-slash relative path on click', async () => {
+    const onSelect = vi.fn()
+    render(<Harness query="widgets" open onSelect={onSelect} />)
+    const dirRow = await waitFor(() => {
+      const row = screen.getAllByRole('option').find(o => o.getAttribute('data-kind') === 'dir')
+      expect(row).toBeTruthy()
+      return row!
+    })
+    fireEvent.mouseDown(dirRow)
+    expect(onSelect).toHaveBeenCalledWith({
+      path: '/repo/src/widgets',
+      relativePath: 'src/widgets/',
+      kind: 'dir',
+    })
+  })
+
+  it('emits kind=file for file rows', async () => {
+    const onSelect = vi.fn()
+    render(<Harness query="widgets" open onSelect={onSelect} />)
+    const fileRow = await waitFor(() => {
+      const row = screen.getAllByRole('option').find(o => o.getAttribute('data-kind') === 'file')
+      expect(row).toBeTruthy()
+      return row!
+    })
+    fireEvent.mouseDown(fileRow)
+    expect(onSelect).toHaveBeenCalledWith({
+      path: '/repo/src/widgets.ts',
+      relativePath: 'src/widgets.ts',
+      kind: 'file',
+    })
+  })
+
+  it('treats a result with no kind field as a file', async () => {
+    mockApi.fileSearch.mockResolvedValue({
+      results: [{ path: '/repo/legacy.ts', name: 'legacy.ts', size: 10, mtime: NOW }],
+      root: ROOT,
+    })
+    const onSelect = vi.fn()
+    render(<Harness query="legacy" open onSelect={onSelect} />)
+    const row = await waitFor(() => {
+      const r = screen.getAllByRole('option')[0]
+      expect(r).toBeTruthy()
+      return r
+    })
+    expect(row.getAttribute('data-kind')).toBe('file')
+    fireEvent.mouseDown(row)
+    expect(onSelect).toHaveBeenCalledWith({
+      path: '/repo/legacy.ts',
+      relativePath: 'legacy.ts',
+      kind: 'file',
+    })
+  })
+})
+
+describe('makeRelative — separator awareness', () => {
+  it('strips a POSIX root', () => {
+    expect(makeRelative('/repo/src/pages', '/repo')).toBe('src/pages')
+  })
+
+  it('strips a Windows root', () => {
+    // A '/'-only prefix check left the ABSOLUTE path here, which then failed to
+    // resolve as a folder mention on send.
+    expect(makeRelative('C:\\repo\\src\\pages', 'C:\\repo')).toBe('src\\pages')
+  })
+
+  it('strips a Windows root that already ends in a separator', () => {
+    expect(makeRelative('C:\\repo\\src', 'C:\\repo\\')).toBe('src')
+  })
+
+  it('returns the path unchanged when the root does not match', () => {
+    expect(makeRelative('/other/src', '/repo')).toBe('/other/src')
+  })
+
+  it('returns the path unchanged with an empty root', () => {
+    expect(makeRelative('/repo/src', '')).toBe('/repo/src')
+  })
+
+  it('inserts a relative folder token for a Windows root', () => {
+    const sel = selectionFor(
+      { path: 'C:\\repo\\src\\pages', name: 'pages', size: 0, mtime: 0, kind: 'dir' },
+      'C:\\repo',
+    )
+    expect(sel.relativePath).toBe('src\\pages/')
+  })
+})


### PR DESCRIPTION
> **Rebased continuation of #504 (originally by @hoang-phan98), which had gone stale with unresolvable conflicts against main. Same intent, resolved against current main.**

## Problem

The chat `@`-mention picker could only find **files**. To point the agent at a directory a user had to type the absolute path by hand — and a typo produced a failed tool call rather than a picker miss, with no feedback about what went wrong.

## Why it matters

"Look at this folder" is a common instruction, and it is the one thing the picker could not express. The manual-path workaround is error-prone precisely when the path is long or unfamiliar, which is exactly when a picker is most useful.

## Fix

**Symptom** — no folders in the picker; hand-typed paths fail opaquely.
**Root cause** — the index and the search endpoint modelled entries as files only. There was no `kind` on an entry, no way to ask for directories, and no UI affordance for a non-uploadable attachment.
**Change** — teach discovery about directories end to end, and keep a folder strictly a *path reference*: nothing about its contents is read or inlined. The agent receives the path and explores it with its own glob/grep/read tools.

### Backend
- `FileIndex` entries carry `kind` (`"file"` | `"dir"`). Directories are collected during the walk rather than derived from file paths, so an **empty** directory is still indexed and searchable. Both kinds count toward the 100k entry cap.
- `GET /api/file-search` accepts `kinds=all|files|dirs` (whitelist-validated; unrecognized values fall back to `all`) and returns `kind` per result.
- Ranking puts **files before directories** on an equal fuzzy score, so directory hits cannot crowd out the file a user is most likely searching for.
- The walk fallback collects files and directories into **separate candidate lists with independent scan budgets**. A shared cap let a burst of matching directories fill it before the files in the same directory were examined, so the file-before-directory tie-break never got a chance to run.

### Security
Both branches resolve candidates with `os.path.realpath` **before** `is_sensitive_path`, so a symlink pointing into a sensitive tree is rejected on its real path rather than its link path. The **file** branch was hardened to match the directory branch, closing a pre-existing gap on the existing path. The symmetry is deliberate: a divergence would let a sensitive target be reachable as one kind but not the other. This matches the precedent in `api_browse_dirs` / `api_browse_files`.

### Frontend
- The picker renders folder rows distinctly and inserts the mention with a **trailing slash**, so a folder is unambiguous in the composer text.
- The preview strip renders staged folders with a folder icon and a `Remove folder` control (`aria-label`ed, since it is icon-only). Height compensation keys off **both** staged families, so a folders-only strip no longer under-reserves space.
- A picked folder is routed to `pendingDirs`, never `pendingFiles` — a directory must never reach the send path as an uploadable file.
- `api.fileSearch`'s return type declares the optional `kind` field rather than leaving callers to re-declare it locally.

## Deliberately out of scope

Directory **serialization** — the `[attached_dir N]` prompt marker, chip/card rendering, and per-slot staged-folder persistence — is **not** in this PR. It lands separately as an attachment-metadata change.

## Tests

| File | Locks in |
|---|---|
| `test/test_file_search_dirs.py` | Directory results, `kinds` filter, empty-dir indexing, files-before-dirs tie-break, independent scan budgets, realpath-before-sensitivity on both branches |
| `test/test_file_search.py` | Updated for the `kind` field on existing file results |
| `website/src/test/FilePickerMenu.dirs.test.tsx` | Folder rows, selection payload, trailing-slash insertion, `kind` back-compat defaulting |
| `website/src/test/ChatInput.dirStripHeight.test.tsx` | Folders-only preview strip reserves same height as files-only strip |

## Manual verification

Type `@` plus 2+ characters in the composer and pick a folder: the row is visibly a folder, the composer text reads `@src/pages/`, and the preview strip shows a folder chip with a working remove control.

## Screenshots

Not included — see original PR #504 for context. The relevant surfaces (picker row, preview-strip chip) are covered by the new test files.

---

Co-authored-by: hoang-phan98 <hoang-phan98@users.noreply.github.com>
