### PR TITLE
fix(lessons): stop dropping the negative clause; embed CLI writes

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -53,6 +53,7 @@ from kiro_crew.eval.runner import EvalRunner, format_results, score_by_dimension
 from kiro_crew.eval.scenario import AssertionType, load_scenario, load_scenarios
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.learn import Lesson, LessonStore
+from kiro_crew.mcp_core import _resolve_session_key
 from kiro_crew.security import (
     BUILTIN_DENY_PATTERNS,
     is_sensitive_path,
@@ -1290,6 +1291,76 @@ async def _run_eval(args: argparse.Namespace) -> None:
     print(f"\nResults saved to:\n  {report_path}\n  {json_path}")
 
 
+def _gateway_add_lesson(rule: str, category: str, negative: str | None = None) -> bool:
+    """Best-effort: have a RUNNING gateway write the lesson so it gets embedded.
+
+    The CLI deliberately never loads the 610MB GGUF itself -- ``make_sync_embed_fn``
+    is non-blocking and returns None until the model is resident, so a one-shot
+    process would either pay a full model load on every invocation or persist
+    embedding=NULL (invisible to vector retrieval; keyword-only at weight 0.4 in
+    hybrid search). Delegating puts the write in the process that already holds the
+    model, which additionally runs ``write_lesson``'s >0.85-cosine semantic dedup
+    and a background contradiction sweep -- both of which a vector-less local write
+    silently skips.
+
+    Returns True ONLY if the gateway accepted the write. Every failure path --
+    gateway not running, stale ``dashboard.url``, no resolvable session key,
+    non-2xx, or an error body -- returns False so the caller degrades to an
+    unembedded local write plus a warning.
+
+    ponytail: no retry/backoff. Best-effort by design; the local write is the
+    fallback, so an unhealthy gateway costs at most the 2s probe + 10s post.
+    """
+    try:
+        cfg = KiroCrewConfig.load()
+        _host, port = parse_dashboard_url(cfg.dashboard.url)
+        secret = (config_dir() / ".local_secret").read_text().strip()
+    except Exception:
+        return False
+    if not secret:
+        return False
+    # POST /api/lessons rejects anonymous writes (400 "missing X-Session-Key") and
+    # validates the key against live slots / restricted keys / persisted history.
+    # Reuse the hardened resolver (env var, then PID-file ancestor walk) rather than
+    # sending the UI's literal "dashboard:ui" -- impersonating it would misattribute
+    # the write in the security event log. A plain terminal has no session, so it
+    # correctly falls through to the local path.
+    try:
+        session_key = _resolve_session_key()
+    except Exception:
+        session_key = os.environ.get("KIROCREW_SESSION_KEY", "")
+    if not session_key:
+        return False
+    base = f"http://localhost:{port}"
+    try:  # liveness probe first: a dead port fails in ms, so the CLI never stalls
+        with urllib.request.urlopen(f"{base}/api/health", timeout=2) as resp:
+            if resp.status != 200:
+                return False
+    except Exception:
+        return False
+    body: dict[str, str] = {"rule": rule, "category": category}
+    if negative:
+        body["negative"] = negative
+    req = urllib.request.Request(
+        f"{base}/api/lessons",
+        data=json.dumps(body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "X-Internal-Secret": secret,
+            "X-Session-Key": session_key,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if resp.status not in (200, 201):
+                return False
+            payload = json.loads(resp.read() or b"{}")
+    except Exception:
+        return False
+    return not (isinstance(payload, dict) and payload.get("error"))
+
+
 def _learn(args: argparse.Namespace) -> None:
     """Save, list, or remove learned corrections."""
 
@@ -1304,8 +1375,21 @@ def _learn(args: argparse.Namespace) -> None:
             rule = args.rule
             category = args.category
             negative = getattr(args, "negative", None)
-            if vs.write_lesson(rule, category, negative):
-                neg = f" ({negative})" if negative else ""
+            neg = f" ({negative})" if negative else ""
+            # Best-effort embedding: delegate to a running gateway, which holds the
+            # model resident; otherwise write locally WITHOUT a vector and say so.
+            # Delegation is unconditional -- the REST route now passes ``negative``
+            # through to write_lesson (it previously hardcoded None and dropped the
+            # clause), so nothing is lost by preferring the embedded path.
+            if _gateway_add_lesson(rule, category, negative):
+                print(f"Saved: {rule}{neg} [{category}] (embedded via gateway)")
+            elif vs.write_lesson(rule, category, negative):
+                print(
+                    "Warning: gateway not running -- saved WITHOUT an embedding, so "
+                    "this lesson will not be found by semantic search until it is "
+                    "backfilled.",
+                    file=sys.stderr,
+                )
                 print(f"Saved: {rule}{neg} [{category}]")
             else:
                 lesson = Lesson(

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -624,6 +624,56 @@ async def api_cron_history_all(request: web.Request) -> web.Response:
     return web.json_response({"runs": runs, "total": total})
 
 
+# write_lesson() joins a lesson and its NOT-clause as f"{rule} — NOT: {negative}",
+# so a stored lesson that already carries a negative reads "<rule> — NOT: <neg>".
+_LESSON_NEGATIVE_SEP = " — NOT: "
+
+
+def _enrich_exact_lesson(vs: Any, rule: str, negative: str, source: str = "user_explicit") -> bool:
+    """Attach ``negative`` to an existing lesson whose rule text is exactly ``rule``.
+
+    ``write_lesson``'s substring dedup returns False when ``rule`` is contained in an
+    existing lesson -- always true when re-submitting the same rule -- so adding a
+    negative to an existing lesson was silently swallowed while this route still
+    returned HTTP 200.
+
+    The update is NON-DESTRUCTIVE: the enriched value is written back under the SAME
+    key via ``set_semantic``, which validates before upserting, so a rejected
+    replacement leaves the stored lesson exactly as it was. Nothing is ever deleted,
+    so an existing superset lesson -- which would make ``write_lesson`` refuse the
+    follow-up write -- cannot cost us the original.
+
+    The stored embedding is deliberately left alone: ``write_lesson`` embeds the RULE
+    only, and the rule text is unchanged here; only the NOT-clause is appended.
+
+    Returns True when the row already carries this clause or was enriched, so the
+    caller can skip ``write_lesson``.
+    """
+    wanted = rule.strip().casefold()
+    for row in vs.get_lessons():
+        try:
+            existing = json.loads(row["value_json"])
+        except Exception:
+            continue
+        if not isinstance(existing, str):
+            continue
+        base = existing.split(_LESSON_NEGATIVE_SEP, 1)[0]
+        # Case-INSENSITIVE, matching write_lesson's own dedup (``rule_lower in
+        # existing_lower``). A case-sensitive test would miss a case variant, fall
+        # through to write_lesson, and have the clause dropped by that same dedup.
+        if base.strip().casefold() != wanted:
+            continue
+        # Keep the stored rule's own casing: write_lesson would have kept the existing
+        # entry, so re-casing someone's lesson here would be a gratuitous edit.
+        target = f"{base.strip()}{_LESSON_NEGATIVE_SEP}{negative}"
+        if existing == target:
+            return True  # already carries this clause
+        if vs.set_semantic(row["key"], target, row["confidence"], source) is None:
+            return True
+        return False  # rejected (e.g. injection scan) -- original left untouched
+    return False
+
+
 async def api_lessons_create(request: web.Request) -> web.Response:
     """POST /api/lessons — add a lesson (vector store or JSONL fallback)."""
     from kiro_crew.learn import Lesson  # noqa: F811
@@ -759,6 +809,11 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         return web.json_response({"error": "rule is required"}, status=400)
     category = cleaned.get("category", "knowledge")
     scope = cleaned.get("scope", "global")
+    # LEARN_ADD_SCHEMA accepts and validates ``negative``, but both write paths
+    # below previously discarded it (write_lesson got a literal None; the JSONL
+    # Lesson omitted the kwarg), so every NOT-clause sent to this route -- from
+    # the learn_add MCP tool, the dashboard, or the CLI -- was silently lost.
+    negative = cleaned.get("negative") or None
     # Write to vector store if available, else JSONL
     vs = _get_memory(state).vector_store
     if vs:
@@ -773,6 +828,14 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         # embed and the write would otherwise commit it into the wrong space.
         rule_emb_generation = vs.space_generation
         rule_emb = await asyncio.to_thread(vs.embed_lesson, rule)
+        # A re-submission that only ADDS a negative to an existing identical rule is
+        # refused by write_lesson's substring dedup, so enrich that row in place
+        # instead — non-destructive, same key, validated before upsert (see
+        # _enrich_exact_lesson). Nothing is deleted, so a superset lesson that would
+        # make the follow-up write_lesson refuse cannot cost us the original.
+        enriched = False
+        if negative:
+            enriched = await asyncio.to_thread(_enrich_exact_lesson, vs, rule, negative)
         # Persist the lesson immediately so the request returns fast. The
         # contradiction sweep below makes a per-candidate LLM call (~27s each);
         # running it inline would exceed the MCP client's 30s timeout while the
@@ -780,15 +843,16 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         # for a lesson that was actually saved (and re-saved on every retry).
         # Writing first, then sweeping in the background, keeps the slow LLM call
         # off the request path.
-        await asyncio.to_thread(
-            vs.write_lesson,
-            rule,
-            category,
-            None,
-            "user_explicit",
-            rule_emb,
-            rule_emb_generation,
-        )
+        if not enriched:
+            await asyncio.to_thread(
+                vs.write_lesson,
+                rule,
+                category,
+                negative,
+                "user_explicit",
+                rule_emb,
+                rule_emb_generation,
+            )
         candidates = await asyncio.to_thread(
             vs.find_contradiction_candidates, rule, 0.4, 0.85, rule_emb
         )
@@ -804,12 +868,33 @@ async def api_lessons_create(request: web.Request) -> web.Response:
             state._background_tasks.add(task)
             task.add_done_callback(state._background_tasks.discard)
     else:
-        lesson = Lesson(rule=rule, category=category, ts=datetime.now(timezone.utc).isoformat())
-        if scope == "workspace":
-            ws = cleaned.get("workspace")
-            _get_lessons(state, ws).save(lesson)
-        else:
-            state.lessons.save(lesson)
+        lesson = Lesson(
+            rule=rule,
+            category=category,
+            negative=negative,
+            ts=datetime.now(timezone.utc).isoformat(),
+        )
+        store = _get_lessons(state, cleaned.get("workspace")) if scope == "workspace" else state.lessons
+        # LessonStore.save() skips an exact rule duplicate, so the add-a-negative
+        # resubmission is swallowed on this path too. remove() is SUBSTRING-based,
+        # so it is only safe when the rule text appears in exactly one record:
+        # "use foo" would otherwise also delete "always use foo carefully". Skip the
+        # replace when any non-exact substring match exists and keep the original.
+        if negative:
+            wanted = rule.strip().casefold()
+            records = store.load_all()
+            # casefold throughout: LessonStore.save() and remove() are both
+            # case-insensitive, so a case-sensitive test here would miss the exact
+            # duplicate AND fail to spot a case-variant superset that remove() would
+            # happily delete.
+            has_exact = any(le.rule.strip().casefold() == wanted for le in records)
+            has_other_substring_match = any(
+                le.rule.strip().casefold() != wanted and wanted in le.rule.casefold()
+                for le in records
+            )
+            if has_exact and not has_other_substring_match:
+                store.remove(rule)
+        store.save(lesson)
     state.push_refresh("lessons")
     return web.json_response({"ok": True})
 

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -3986,6 +3986,14 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             return f"Error: {_gov_mem}"
         scope = args.get("scope", "global")
         payload: dict[str, str] = {"rule": rule, "category": category, "scope": scope}
+        # The tool schema advertises ``negative`` -- and the ``rule`` description
+        # explicitly tells the model to prefer it over inlining a "-- NOT: ..."
+        # clause -- but this payload never forwarded it, so the clause was dropped
+        # client-side before /api/lessons could see it. The route validates the
+        # field via LEARN_ADD_SCHEMA and passes it through to write_lesson.
+        negative = args.get("negative", "")
+        if negative:
+            payload["negative"] = negative
         if scope == "workspace":
             ws = args.get("workspace", "")
             if not ws:


### PR DESCRIPTION
Rebased continuation of #625 (originally by @patrigao), which had gone stale with unresolvable conflicts against main. Same intent, resolved against current main.

---

## Problem

`negative` ("what NOT to do") is plumbed through the `learn_add` MCP tool schema,
`LEARN_ADD_SCHEMA` validation, the `Lesson` dataclass, `write_lesson()`, and the
CLI's `--negative` flag — but **never through the HTTP hop**. Any NOT-clause
submitted over the network was silently discarded, at two independent layers:

1. **`mcp_core.learn_add` never forwarded it.** The tool schema advertises
   `negative`, and the `rule` description explicitly instructs the model to
   *"Put 'what not to do' in the separate 'negative' field rather than inlining a
   long '-- NOT: ...' clause"* — yet the `/api/lessons` payload only carried
   `rule`/`category`/`scope`/`workspace`, so the clause was lost client-side.

2. **`api_lessons_create` discarded it.** It validates `negative` via
   `LEARN_ADD_SCHEMA`, then passed a literal `None` to `write_lesson` and omitted
   the kwarg from the JSONL `Lesson` fallback.

A third, related defect in the same feature:

3. **`learn add` (CLI) wrote unembedded lessons.** It built `VectorMemoryStore`
   with no `embed_fn`, so `write_lesson` took its `if self.embed_fn else None`
   branch and persisted `embedding=NULL`. Those lessons are invisible to vector
   retrieval (keyword score only, weight 0.4 in hybrid search) and silently skip
   the `>0.85` cosine semantic dedup that `write_lesson`'s own docstring
   advertises. The command still printed `Saved:` and exited 0.

## Why this looks accidental rather than intended

- The dashboard UI is the route's original caller and has **no negative input** —
  there is no `negative` anywhere in `website/src`. Both the client payload and
  the handler carry exactly the UI's field set, so `None` was *correct by
  omission* until the MCP tool began advertising the parameter.
- Nobody writes "prefer the separate `negative` field" guidance for a parameter
  they intend to throw away.
- There is precedent for this drift in the schema's own comment: *"scope/workspace:
  … this schema was created before that feature landed and never listed them."*
  Here it is the mirror image — schema leads, handler lags.

## Changes

- `mcp_core.py`: forward `negative` into the `/api/lessons` payload when present.
- `dashboard/handlers/cron.py`: read the validated `negative` and pass it to
  `write_lesson`, and set it on the JSONL `Lesson` fallback. Enrich an existing
  lesson in place when a negative is supplied for an already-persisted rule.
- `cli_commands.py`: `learn add` delegates to a **running** gateway (which already
  holds the embedding model resident), so the lesson is embedded *and* deduped by
  the process that can do it. If the gateway is unreachable it writes locally
  without a vector and **warns on stderr**, so the degradation is never silent.

## Design notes

- The CLI deliberately does **not** load the GGUF itself. `make_sync_embed_fn` is
  non-blocking and returns `None` until the model is resident, so a one-shot
  process would either pay a full model load per invocation or write `NULL`.
  Delegation keeps the CLI thin.
- Session key resolution reuses `_resolve_session_key()` (env var, then PID-file
  ancestor walk) rather than sending the UI's literal `"dashboard:ui"`, so CLI
  writes are not misattributed in the security event log.

## Testing

- `py_compile` clean on all three files.
- Conflict resolution preserved main's newer `rule_emb_generation` parameter
  while applying the PR's `negative` passthrough fix.
