### PR TITLE
fix(autopilot): stop a hung stage wedging the slot and abandoning live subagents

### DIFF
--- a/src/kiro_crew/context_management.py
+++ b/src/kiro_crew/context_management.py
@@ -129,6 +129,16 @@ class OrchestrationTracker:
         return (time.monotonic() - self._stage_start) > self._stage_timeout
 
     @property
+    def stage_timeout_seconds(self) -> int:
+        """Configured per-stage timeout in seconds (0 = disabled).
+
+        Public accessor for callers that need the raw budget -- e.g. the
+        orchestrator's ``asyncio.wait_for`` around a stage turn and its
+        subagent-wait poll cap, both of which derive from this value.
+        """
+        return self._stage_timeout
+
+    @property
     def timeout_human(self) -> str:
         """Human-friendly timeout string, e.g. '30m' or '1m30s'."""
         s = self._stage_timeout

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -14,6 +14,7 @@ from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.context_management import OrchestrationTracker
 from kiro_crew.dashboard.chat_runner import _run_chat, _start_next_queued_turn
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+from kiro_crew.dashboard.turn_dispatch import _bounded_turn
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import SecurityEvent, sel
@@ -266,7 +267,56 @@ async def _stage_loop(
             )
             slot.append("user", context, "msg msg-u auto-go")
             try:
-                await _run_chat(state, slot, context)
+                # `_bounded_turn`, NOT `asyncio.wait_for`. `_run_chat` CATCHES
+                # CancelledError (it flushes the partial assistant output and
+                # returns), so wait_for would absorb its own deadline: the inner
+                # task completes "normally", wait_for hands back a value instead
+                # of raising, and a half-finished stage would advance as if it
+                # had succeeded. `_bounded_turn` records that its own timer
+                # fired and raises on that observed fact, so a swallowed
+                # cancellation still surfaces. See its docstring in
+                # turn_dispatch.py -- it exists for exactly this trap.
+                #
+                # A falsy stage_timeout_seconds means "disabled" everywhere else
+                # in the tracker, so skip the ceiling entirely rather than
+                # passing 0, which would cut every stage instantly.
+                _turn_timeout = tracker.stage_timeout_seconds
+                if _turn_timeout:
+                    await _bounded_turn(_run_chat(state, slot, context), _turn_timeout)
+                else:
+                    await _run_chat(state, slot, context)
+            except (asyncio.TimeoutError, TimeoutError):
+                # `_bounded_turn` raises builtin TimeoutError; on 3.10
+                # asyncio.TimeoutError is a DIFFERENT class, so catch both (the
+                # convention already used by _run_pending_synthesis).
+                logger.error(
+                    "Stage %d exceeded its %ds ceiling for slot %s",
+                    stage_num, tracker.stage_timeout_seconds, slot.key,
+                )
+                _timeout_msg = (
+                    f"⏱️ Stage {stage_num} timed out after {tracker.timeout_human}. "
+                    "Auto-run stopped."
+                )
+                slot._auto_run = False
+                slot.append("assistant", _timeout_msg, "msg msg-a")
+                state.broadcast_ws(
+                    "chat_append",
+                    {"slot": slot.key, "html": _timeout_msg, "cls": "msg msg-a"},
+                )
+                sel().log(
+                    SecurityEvent(
+                        event_id=uuid.uuid4().hex,
+                        timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                        event_type="auto_run_timeout",
+                        caller_identity=f"dashboard:{slot.key}",
+                        agent=getattr(slot, "agent", ""),
+                        source="dashboard",
+                        operation="stage_turn_ceiling",
+                        outcome="stopped",
+                        resources=f"slot={slot.key},stage={stage_num}",
+                    )
+                )
+                break
             except Exception:
                 logger.exception("_run_chat failed during stage %d for slot %s", stage_num, slot.key)
                 _err_msg = f"❌ Stage {stage_num} failed due to an internal error. Auto-run stopped."
@@ -296,6 +346,19 @@ async def _stage_loop(
 
             # Wait for pending subagents spawned during this stage
             _sa_rounds = 0
+            # Dynamic poll cap. Each poll sleeps 2s, so `stage_timeout // 4`
+            # rounds ≈ half the stage timeout in wall-clock, hard-capped at 450
+            # rounds (15 min). This replaces a fixed 150 (5 min), which was far
+            # shorter than a subagent's own 30-min budget and abandoned
+            # legitimate long-running analysis agents mid-flight.
+            # A falsy stage timeout means "disabled", so fall back to the 15-min
+            # ceiling rather than 0 (which would skip the wait entirely).
+            # Worst case per stage is therefore turn-timeout + subagent-wait;
+            # the total-plan watchdog (separate follow-up) bounds the run.
+            if tracker.stage_timeout_seconds:
+                _sa_max_rounds = min(tracker.stage_timeout_seconds // 4, 450)
+            else:
+                _sa_max_rounds = 450
             session_key = f"dashboard:{slot.key}"
             if state.subagents is None:
                 # Fail-closed: subagent manager missing — stop auto-run
@@ -369,7 +432,7 @@ async def _stage_loop(
                 )
                 while (
                     _pending
-                    and _sa_rounds < 150
+                    and _sa_rounds < _sa_max_rounds
                     and not slot._stopping
                 ):
                     _sa_rounds += 1
@@ -414,14 +477,16 @@ async def _stage_loop(
                     )
                 )
                 break
-            if _sa_rounds >= 150:
+            if _sa_rounds >= _sa_max_rounds:
+                _wait_secs = _sa_rounds * 2
                 logger.warning(
-                    "Stage %d: subagent wait exhausted after %ds for slot %s",
-                    stage_num, _sa_rounds * 2, slot.key,
+                    "Stage %d: subagent wait exhausted after %ds (%d rounds, cap %d) for slot %s",
+                    stage_num, _wait_secs, _sa_rounds, _sa_max_rounds, slot.key,
                 )
                 slot._auto_run = False
                 _sa_msg = (
-                    f"⚠️ Stage {stage_num}: subagent wait exhausted after 5 minutes. "
+                    f"⚠️ Stage {stage_num}: subagent wait exhausted after "
+                    f"{_wait_secs // 60} minutes. "
                     "Auto-run stopped — some results may be incomplete."
                 )
                 slot.append("assistant", _sa_msg, "msg msg-a")

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -5253,6 +5253,116 @@ class TestOrchestratorPlanGateArming:
             "no phantom stage beyond the live plan size may be built"
         )
 
+    # ── P0 hardening: stage turn ceiling + subagent wait cap ──
+
+    @staticmethod
+    def _orch_state():
+        """Minimal DashboardState double for driving _stage_loop."""
+        state = MagicMock()
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for = MagicMock(return_value=[])
+        return state
+
+    @pytest.mark.asyncio
+    async def test_stage_loop_times_out_a_stage_that_swallows_cancellation(
+        self, tmp_path, monkeypatch
+    ):
+        """The real `_run_chat` CATCHES CancelledError (flushes partial output and
+        returns), so `asyncio.wait_for` would absorb its own deadline and let a
+        half-finished stage advance as a success. The fake here reproduces that
+        exact semantic -- a bare `sleep()` would propagate the cancellation and
+        pass even against the broken implementation, which is why this test uses
+        a swallowing turn."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+        from kiro_crew.context_management import OrchestrationTracker
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        state = self._orch_state()
+        slot = _ChatSlot("hang-test", mode="orchestrator")
+        slot._stage_titles = ["A", "B"]
+        # 1s budget so the ceiling fires well inside the test's runtime.
+        slot._orch_tracker = OrchestrationTracker(stage_timeout_seconds=1)
+        slot._auto_run = True
+
+        swallowed = False
+
+        async def _hang_and_swallow(s, sl, msg, **kw):
+            nonlocal swallowed
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                # Exactly what _run_chat does: absorb it and return normally.
+                swallowed = True
+                return None
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_orchestrator._run_chat", _hang_and_swallow
+        )
+
+        await asyncio.wait_for(_stage_loop(state, slot, auto_run=True), timeout=30)
+
+        assert swallowed, "the fake must have absorbed the cancellation (the real path)"
+        assert slot._auto_run is False, "a stage cut at the ceiling must stop auto-run"
+        assert any(
+            "timed out" in m.get("content", "") for m in slot.messages
+        ), "the user must see a timeout card, not a silently-advanced stage"
+        seps = [m["content"] for m in slot.messages if "stage-sep" in m.get("cls", "")]
+        assert not any("Stage 2" in s for s in seps), (
+            "a cut stage must NOT advance to the next one"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stage_loop_disabled_timeout_does_not_abort_instantly(
+        self, tmp_path, monkeypatch
+    ):
+        """stage_timeout_seconds=0 means 'disabled' (see is_stage_timed_out), so
+        it must become wait_for(None) — passing 0 through would time out every
+        stage before its turn began."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+        from kiro_crew.context_management import OrchestrationTracker
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        state = self._orch_state()
+        slot = _ChatSlot("no-timeout", mode="orchestrator")
+        slot._stage_titles = ["A"]
+        slot._orch_tracker = OrchestrationTracker(stage_timeout_seconds=0)
+
+        ran = 0
+
+        async def _ok(s, sl, msg, **kw):
+            nonlocal ran
+            ran += 1
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _ok)
+
+        await _stage_loop(state, slot, auto_run=True)
+
+        assert ran == 1, "a disabled timeout must let the stage turn actually run"
+        assert not any(
+            "timed out" in m.get("content", "") for m in slot.messages
+        ), "no timeout card may be emitted when the timeout is disabled"
+
+    def test_subagent_wait_cap_scales_with_stage_timeout(self):
+        """The poll cap tracks the stage budget instead of a fixed 5 min, and a
+        disabled timeout falls back to the ceiling rather than 0 (which would
+        skip the subagent wait entirely)."""
+        from kiro_crew.context_management import OrchestrationTracker
+
+        def cap(timeout: int) -> int:
+            t = OrchestrationTracker(stage_timeout_seconds=timeout)
+            return min(t.stage_timeout_seconds // 4, 450) if t.stage_timeout_seconds else 450
+
+        assert cap(1800) == 450, "default 30m budget -> 15 min of subagent wait"
+        assert cap(600) == 150, "a 10m budget scales down proportionally"
+        assert cap(7200) == 450, "a huge budget is still capped at the 15 min ceiling"
+        assert cap(0) == 450, "disabled timeout must NOT collapse the wait to zero"
+
 
 # ── Tests: plan execution via Go/Go All button simulation ──
 


### PR DESCRIPTION
## Problem

An autopilot plan running longer than ~15 minutes had two ways to stall that `_stage_loop` could not recover from:

1. **A stage turn that never returned held the slot forever.** The 30-minute stage budget was unreachable, so the session stayed locked with no way out short of killing the gateway.
2. **A stage that spawned subagents gave up on them after 5 minutes** and reported "results may be incomplete" — while those subagents were still running, against their own 30-minute budget.

## Why it matters

Autopilot exists to carry out long work unattended. Wedging a slot indefinitely, or discarding analysis a subagent is still producing, both turn a long plan into wasted time the user only discovers when they come back.

## Fix

### 1. Indefinite hang → bound the stage turn

`is_stage_timed_out()` was only consulted at the **top** of each loop iteration, so a `_run_chat` that never returned (wedged ACP, tool deadlock, stuck upstream) could not be cut off from inside the `await`. The budget was unreachable.

Now wrapped in **`_bounded_turn`**, the existing ceiling primitive — deliberately **not** `asyncio.wait_for`. `_run_chat` **catches** `CancelledError` (`chat_runner.py`: it flushes the partial assistant output and returns), so `wait_for` would absorb its own deadline: the inner task completes "normally", `wait_for` hands back a value instead of raising, and **a half-finished stage would advance as a success** — worse than the hang. `_bounded_turn` records that its own timer fired and raises on that observed fact; its docstring documents this exact trap.

Two details:
- `_bounded_turn` raises **builtin** `TimeoutError`. On 3.10 that is a different class from `asyncio.TimeoutError`, and CI covers 3.10, so both are caught — the form `_run_pending_synthesis` already uses.
- A falsy `stage_timeout_seconds` means "disabled" everywhere else in the tracker, so the ceiling is **skipped** rather than armed with `0` (which would cut every stage instantly).

### 2. Abandoned subagents → scale the wait to the stage budget

The poll cap was a fixed 150 rounds (5 min) against a subagent's own 30-minute budget — cutting a stage off at 1/6th of the agent's allowed runtime.

Now `min(stage_timeout // 4, 450)` rounds (~half the stage timeout in wall-clock, hard-capped at 15 min), with the disabled-timeout case falling back to the ceiling rather than `0`, which would have skipped the wait entirely. The exhaustion message reports the time actually waited instead of a hardcoded "5 minutes".

Also adds a public `OrchestrationTracker.stage_timeout_seconds` property so the orchestrator reads the budget through a supported accessor instead of the private `_stage_timeout`. Both fixes need it.

## Scope — what was removed

An earlier revision of this PR also added a **recovery watchdog** that armed an AutoNudge loop when the stage loop exited abnormally. **It has been removed and deferred.**

Reasons:
- It reaches out of autopilot into a **shared, concurrent, SEL-audited service**. AutoNudge's semantics — one loop per slot, arming *replaces*, a capped loop is *deactivated but retained*, and `_find_by_slot` applies no `active` filter — mean correct exclusive arming needs an **atomic add-if-absent primitive that does not exist yet**. Every review finding on the prior revisions landed on this one piece; the two fixes above drew none.
- Its incremental value was narrower than it first appeared: the abnormal-exit paths **already report to the user in chat** (`❌ Stage N failed due to an internal error. Auto-run stopped.`, plus the fail-closed and wait-exhaustion messages). And the failures that genuinely go silent — process death, gateway restart, orphan sweep — never run the `finally` where the nudge was armed, so it did not cover them.

Deferred with the other P1–P3 autopilot findings in #1783. Doing it properly means starting from "which failures actually go silent" and adding the primitive deliberately, not hand-rolling an arm call from the orchestrator.

## Tests

3 new cases in `test/test_dashboard_chat.py`:

| Test | What it locks in |
|---|---|
| `test_stage_loop_times_out_a_stage_that_swallows_cancellation` | The fake `_run_chat` deliberately **swallows** `CancelledError`, reproducing production semantics — a bare `sleep()` propagates cancellation and would pass even against the broken `wait_for` form. Also asserts the **next stage never starts**, so a cut stage cannot advance as a success. |
| `test_stage_loop_disabled_timeout_does_not_abort_instantly` | `stage_timeout_seconds=0` means disabled, not "instant". |
| subagent cap test | The cap scales with the stage budget, including the `0` → ceiling fallback. |

Full file: **489 passed**. `flake8` / `isort` / `mypy` / `docs-lint` clean.

## Manual verification

N/A — unit coverage is sufficient. Both changes are timing/control-flow paths in `_stage_loop` with no user-visible surface of their own; the ceiling test drives the real `_stage_loop` with a cancellation-swallowing turn, which is the behaviour that made the naive fix wrong.

## Screenshots

N/A — no user-visible UI change.
